### PR TITLE
Add config for new bots

### DIFF
--- a/.labels.yml
+++ b/.labels.yml
@@ -1,0 +1,6 @@
+labels:
+  - Bug
+  - Improvement
+  - Infrastructure
+  - New Feature
+triage_label: Triage

--- a/.policy.yml
+++ b/.policy.yml
@@ -1,0 +1,10 @@
+policy:
+  approval:
+  - One of the reviewers has approved
+
+approval_rules:
+- name: One of the reviewers has approved
+  requires:
+    count: 1
+    teams:
+    - "acts-project/reviewers"


### PR DESCRIPTION
Adds config for policybot, which will enforce approval by review, and a bot checking correct labeling.