### PR TITLE
Run coverage job on master and PR to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: Build
 
 on:
-  - push
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_ubuntu:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,7 +1,10 @@
 name: Checks
 
 on:
-  - push
+  push:
+  pull_request:
+    branches:
+      - master
 
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,12 @@
-name: coverage
+name: Coverage
 
 on:
-  - pull_request
+  push:
+      branches:
+        - master
+    pull_request:
+      branches:
+        - master
 
 jobs:
   build_debug:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,11 +2,11 @@ name: Coverage
 
 on:
   push:
-      branches:
-        - master
-    pull_request:
-      branches:
-        - master
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build_debug:


### PR DESCRIPTION
Previously, the coverage job only ran on PRs. This prevents codecov from showing coverage diffs, since there is not base branch