### PR TITLE
Removing clone functionality

### DIFF
--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -191,12 +191,6 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
     return *this;
   }
 
-  /// @brief clone - charged/netural
-  /// virtual constructor for type creation without casting
-  SingleBoundTrackParameters<ChargePolicy>* clone() const {
-    return new SingleBoundTrackParameters<ChargePolicy>(*this);
-  }
-
   /// @brief set method for parameter updates
   /// obviously only allowed on non-const objects
   //

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -111,12 +111,6 @@ class SingleCurvilinearTrackParameters
     return *this;
   }
 
-  /// @brief clone - charged/netural
-  /// virtual constructor for type creation without casting
-  SingleTrackParameters<ChargePolicy>* clone() const {
-    return new SingleCurvilinearTrackParameters<ChargePolicy>(*this);
-  }
-
   /// @brief update of the track parameterisation
   /// only possible on non-const objects, enable for local parameters
   ///

--- a/Core/include/Acts/EventData/SingleFreeParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeParameters.hpp
@@ -118,13 +118,6 @@ class SingleFreeParameters {
         std::forward<const SingleFreeParameters<ChargePolicy>>(copy));
   }
 
-  /// @brief Heap copy constructor
-  ///
-  /// @return Heap allocated copy of `*this`
-  SingleFreeParameters<ChargePolicy>* clone() const {
-    return new SingleFreeParameters<ChargePolicy>(*this);
-  }
-
   /// @brief Access all parameters
   ///
   /// @return Vector containing the store parameters

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -85,8 +85,6 @@ class CuboidVolumeBounds : public VolumeBounds {
 
   ~CuboidVolumeBounds() override = default;
 
-  CuboidVolumeBounds* clone() const override;
-
   VolumeBounds::BoundsType type() const final { return VolumeBounds::eCuboid; }
 
   /// Return the bound values as dynamically sized vector
@@ -141,10 +139,6 @@ class CuboidVolumeBounds : public VolumeBounds {
   /// will throw a logic_exception if consistency is not given
   void checkConsistency() noexcept(false);
 };
-
-inline CuboidVolumeBounds* CuboidVolumeBounds::clone() const {
-  return new CuboidVolumeBounds(*this);
-}
 
 inline bool CuboidVolumeBounds::inside(const Vector3D& pos, double tol) const {
   return (std::abs(pos.x()) <= get(eHalfLengthX) + tol &&

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -73,8 +73,6 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
 
   ~CutoutCylinderVolumeBounds() override = default;
 
-  VolumeBounds* clone() const override;
-
   VolumeBounds::BoundsType type() const final {
     return VolumeBounds::eCutoutCylinder;
   }

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -134,8 +134,6 @@ class CylinderVolumeBounds : public VolumeBounds {
 
   CylinderVolumeBounds& operator=(const CylinderVolumeBounds& cylbo) = default;
 
-  CylinderVolumeBounds* clone() const override;
-
   VolumeBounds::BoundsType type() const final {
     return VolumeBounds::eCylinder;
   }
@@ -207,10 +205,6 @@ class CylinderVolumeBounds : public VolumeBounds {
   template <class T>
   T& dumpT(T& tstream) const;
 };
-
-inline CylinderVolumeBounds* CylinderVolumeBounds::clone() const {
-  return new CylinderVolumeBounds(*this);
-}
 
 inline bool CylinderVolumeBounds::inside(const Vector3D& pos,
                                          double tol) const {

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -46,8 +46,6 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
 
   ~GenericCuboidVolumeBounds() override = default;
 
-  VolumeBounds* clone() const override;
-
   VolumeBounds::BoundsType type() const final {
     return VolumeBounds::eGenericCuboid;
   }

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -100,8 +100,6 @@ class TrapezoidVolumeBounds : public VolumeBounds {
 
   ~TrapezoidVolumeBounds() override = default;
 
-  TrapezoidVolumeBounds* clone() const override;
-
   VolumeBounds::BoundsType type() const final {
     return VolumeBounds::eTrapezoid;
   }
@@ -168,10 +166,6 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   template <class T>
   T& dumpT(T& dt) const;
 };
-
-inline TrapezoidVolumeBounds* TrapezoidVolumeBounds::clone() const {
-  return new TrapezoidVolumeBounds(*this);
-}
 
 template <class T>
 T& TrapezoidVolumeBounds::dumpT(T& dt) const {

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -63,9 +63,6 @@ class Volume : public virtual GeometryObject {
   /// @param vol is the source volume to be copied
   Volume& operator=(const Volume& vol);
 
-  /// Pseudo-constructor
-  virtual Volume* clone() const;
-
   /// Return methods for geometry transform
   const Transform3D& transform() const;
 

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -59,10 +59,6 @@ class VolumeBounds {
 
   virtual ~VolumeBounds() = default;
 
-  ///  clone() method to make deep copy in Volume copy constructor and for
-  /// assigment operator  of the Surface class.
-  virtual VolumeBounds* clone() const = 0;
-
   /// Return the bounds type - for persistency optimization
   ///
   /// @return is a BoundsType enum

--- a/Core/include/Acts/Surfaces/AnnulusBounds.hpp
+++ b/Core/include/Acts/Surfaces/AnnulusBounds.hpp
@@ -69,8 +69,6 @@ class AnnulusBounds : public DiscBounds {
 
   AnnulusBounds(const AnnulusBounds& source) = default;
 
-  AnnulusBounds* clone() const final;
-
   SurfaceBounds::BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector
@@ -215,10 +213,6 @@ class AnnulusBounds : public DiscBounds {
   double squaredNorm(const Vector2D& v,
                      const Eigen::Matrix<double, 2, 2>& weight) const;
 };
-
-inline AnnulusBounds* AnnulusBounds::clone() const {
-  return new AnnulusBounds(m_values);
-}
 
 inline SurfaceBounds::BoundsType AnnulusBounds::type() const {
   return SurfaceBounds::eAnnulus;

--- a/Core/include/Acts/Surfaces/ConeBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConeBounds.hpp
@@ -71,8 +71,6 @@ class ConeBounds : public SurfaceBounds {
 
   ~ConeBounds() override = default;
 
-  ConeBounds* clone() const final;
-
   BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -83,12 +83,6 @@ class ConeSurface : public Surface {
   /// @param other is the source surface for the assignment
   ConeSurface& operator=(const ConeSurface& other);
 
-  /// Clone method into a concrete type of ConeSurface with shift
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<ConeSurface> clone(const GeometryContext& gctx,
-                                     const Transform3D& shift) const;
-
   /// The binning position method - is overloaded for r-type binning
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -260,13 +254,6 @@ class ConeSurface : public Surface {
   detail::RealQuadraticEquation intersectionSolver(
       const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const;
-
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  ConeSurface* clone_impl(const GeometryContext& gctx,
-                          const Transform3D& shift) const override;
 };
 
 #include "Acts/Surfaces/detail/ConeSurface.ipp"

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
@@ -93,8 +93,6 @@ class ConvexPolygonBounds : public ConvexPolygonBoundsBase {
 
   ~ConvexPolygonBounds() override = default;
 
-  ConvexPolygonBounds<N>* clone() const final;
-
   BoundsType type() const final;
 
   /// Return whether a local 2D point lies inside of the bounds defined by this
@@ -153,10 +151,6 @@ class ConvexPolygonBounds<PolygonDynamic> : public ConvexPolygonBoundsBase {
   /// This will throw if the vertices do not form a convex polygon.
   /// @param vertices The list of vertices.
   ConvexPolygonBounds(const std::vector<Vector2D>& vertices);
-
-  /// Return a copy of this bounds object.
-  /// @return The cloned instance
-  ConvexPolygonBounds<PolygonDynamic>* clone() const final;
 
   /// Return the bounds type of this bounds object.
   /// @return The bounds type

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
@@ -117,11 +117,6 @@ Acts::ConvexPolygonBounds<N>::ConvexPolygonBounds(
 }
 
 template <int N>
-Acts::ConvexPolygonBounds<N>* Acts::ConvexPolygonBounds<N>::clone() const {
-  return new ConvexPolygonBounds<N>(*this);
-}
-
-template <int N>
 Acts::SurfaceBounds::BoundsType Acts::ConvexPolygonBounds<N>::type() const {
   return SurfaceBounds::eConvexPolygon;
 }
@@ -158,10 +153,6 @@ Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::ConvexPolygonBounds(
     const std::vector<Vector2D>& vertices)
     : m_vertices(vertices.begin(), vertices.end()),
       m_boundingBox(makeBoundingBox(vertices)) {}
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>*
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::clone() const {
-  return new Acts::ConvexPolygonBounds<Acts::PolygonDynamic>(*this);
-}
 
 Acts::SurfaceBounds::BoundsType
 Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::type() const {

--- a/Core/include/Acts/Surfaces/CylinderBounds.hpp
+++ b/Core/include/Acts/Surfaces/CylinderBounds.hpp
@@ -68,8 +68,6 @@ class CylinderBounds : public SurfaceBounds {
 
   ~CylinderBounds() override = default;
 
-  CylinderBounds* clone() const final;
-
   BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -86,13 +86,6 @@ class CylinderSurface : public Surface {
   /// @param other is the source cylinder for the copy
   CylinderSurface& operator=(const CylinderSurface& other);
 
-  /// Clone method into a concrete type of CylinderSurface with shift
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<CylinderSurface> clone(const GeometryContext& gctx,
-                                         const Transform3D& shift) const;
-
   /// The binning position method - is overloaded for r-type binning
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -230,13 +223,6 @@ class CylinderSurface : public Surface {
   std::shared_ptr<const CylinderBounds> m_bounds;  //!< bounds (shared)
 
  private:
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  CylinderSurface* clone_impl(const GeometryContext& gctx,
-                              const Transform3D& shift) const override;
-
   /// Implementation of the intersection solver
   ///
   ///  <b>mathematical motivation:</b>

--- a/Core/include/Acts/Surfaces/DiamondBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiamondBounds.hpp
@@ -62,8 +62,6 @@ class DiamondBounds : public PlanarBounds {
 
   ~DiamondBounds() override = default;
 
-  DiamondBounds* clone() const final;
-
   BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -112,13 +112,6 @@ class DiscSurface : public Surface {
   /// @param other The source sourface for the assignment
   DiscSurface& operator=(const DiscSurface& other);
 
-  /// Clone method into a concrete type of DiscSurface with shift
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<DiscSurface> clone(const GeometryContext& gctx,
-                                     const Transform3D& shift) const;
-
   /// Return the surface type
   SurfaceType type() const override;
 
@@ -319,14 +312,6 @@ class DiscSurface : public Surface {
 
  protected:
   std::shared_ptr<const DiscBounds> m_bounds;  ///< bounds (shared)
-
- private:
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  DiscSurface* clone_impl(const GeometryContext& gctx,
-                          const Transform3D& shift) const override;
 };
 
 #include "Acts/Surfaces/detail/DiscSurface.ipp"

--- a/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
@@ -61,8 +61,6 @@ class DiscTrapezoidBounds : public DiscBounds {
 
   ~DiscTrapezoidBounds() override = default;
 
-  DiscTrapezoidBounds* clone() const final;
-
   SurfaceBounds::BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/EllipseBounds.hpp
+++ b/Core/include/Acts/Surfaces/EllipseBounds.hpp
@@ -67,8 +67,6 @@ class EllipseBounds : public PlanarBounds {
 
   ~EllipseBounds() override = default;
 
-  EllipseBounds* clone() const final;
-
   BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/InfiniteBounds.hpp
+++ b/Core/include/Acts/Surfaces/InfiniteBounds.hpp
@@ -23,8 +23,6 @@ class InfiniteBounds : public SurfaceBounds {
 
   ~InfiniteBounds() override = default;
 
-  InfiniteBounds* clone() const final { return new InfiniteBounds(); }
-
   SurfaceBounds::BoundsType type() const final {
     return SurfaceBounds::eBoundless;
   }

--- a/Core/include/Acts/Surfaces/LineBounds.hpp
+++ b/Core/include/Acts/Surfaces/LineBounds.hpp
@@ -43,8 +43,6 @@ class LineBounds : public SurfaceBounds {
 
   ~LineBounds() override = default;
 
-  LineBounds* clone() const final;
-
   BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/PerigeeSurface.hpp
+++ b/Core/include/Acts/Surfaces/PerigeeSurface.hpp
@@ -55,13 +55,6 @@ class PerigeeSurface : public LineSurface {
   /// Default Constructor - deleted
   PerigeeSurface() = delete;
 
-  /// Clone method into a concrete type of PerigeeSurface with shift
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<PerigeeSurface> clone(const GeometryContext& gctx,
-                                        const Transform3D& shift) const;
-
   /// Assignment operator
   ///
   /// @param other is the source surface to be assigned
@@ -90,14 +83,6 @@ class PerigeeSurface : public LineSurface {
   /// @return A list of vertices and a face/facett description of it
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       size_t /*ignored*/) const final;
-
- private:
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  PerigeeSurface* clone_impl(const GeometryContext& gctx,
-                             const Transform3D& shift) const override;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -81,13 +81,6 @@ class PlaneSurface : public Surface {
   /// @param other The source PlaneSurface for assignment
   PlaneSurface& operator=(const PlaneSurface& other);
 
-  /// Clone method into a concrete type of PlaneSurface with shift
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<PlaneSurface> clone(const GeometryContext& gctx,
-                                      const Transform3D& shift) const;
-
   /// Normal vector return
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -207,12 +200,6 @@ class PlaneSurface : public Surface {
   std::shared_ptr<const PlanarBounds> m_bounds;
 
  private:
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  PlaneSurface* clone_impl(const GeometryContext& gctx,
-                           const Transform3D& shift) const override;
 };
 
 #include "Acts/Surfaces/detail/PlaneSurface.ipp"

--- a/Core/include/Acts/Surfaces/RadialBounds.hpp
+++ b/Core/include/Acts/Surfaces/RadialBounds.hpp
@@ -58,8 +58,6 @@ class RadialBounds : public DiscBounds {
 
   ~RadialBounds() override = default;
 
-  RadialBounds* clone() const final;
-
   SurfaceBounds::BoundsType type() const final;
 
   /// Return the bound values as dynamically sized vector

--- a/Core/include/Acts/Surfaces/RectangleBounds.hpp
+++ b/Core/include/Acts/Surfaces/RectangleBounds.hpp
@@ -62,8 +62,6 @@ class RectangleBounds : public PlanarBounds {
 
   ~RectangleBounds() override = default;
 
-  RectangleBounds* clone() const final;
-
   BoundsType type() const final;
 
   std::vector<double> values() const final;

--- a/Core/include/Acts/Surfaces/StrawSurface.hpp
+++ b/Core/include/Acts/Surfaces/StrawSurface.hpp
@@ -80,13 +80,6 @@ class StrawSurface : public LineSurface {
   /// @param other is the source surface for copying
   StrawSurface& operator=(const StrawSurface& other);
 
-  /// Clone method into a concrete type of StrawSurface with shift
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<StrawSurface> clone(const GeometryContext& gctx,
-                                      const Transform3D& shift) const;
-
   /// Return the surface type
   SurfaceType type() const final;
 
@@ -103,14 +96,6 @@ class StrawSurface : public LineSurface {
   /// @return A list of vertices and a face/facett description of it
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       size_t lseg) const final;
-
- private:
-  /// Clone method implementation
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  StrawSurface* clone_impl(const GeometryContext& gctx,
-                           const Transform3D& shift) const override;
 };
 
 inline Surface::SurfaceType StrawSurface::type() const {

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -148,25 +148,6 @@ class Surface : public virtual GeometryObject,
   /// @param sf Source surface for the comparison
   virtual bool operator!=(const Surface& sf) const;
 
-  /// Clone method with shift - cloning without shift is not sensible
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  std::shared_ptr<Surface> clone(const GeometryContext& gctx,
-                                 const Transform3D& shift) const {
-    return std::shared_ptr<Surface>(this->clone_impl(gctx, shift));
-  }
-
- private:
-  /// Implementation method for clone. Returns a bare pointer that is
-  /// wrapped into a shared pointer by ::clone(). This is needed for
-  /// covariant overload of this method.
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param shift applied to the surface
-  virtual Surface* clone_impl(const GeometryContext& gctx,
-                              const Transform3D& shift) const = 0;
-
  public:
   /// Return method for the Surface type to avoid dynamic casts
   virtual SurfaceType type() const = 0;

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -47,12 +47,6 @@ class SurfaceBounds {
 
   virtual ~SurfaceBounds() = default;
 
-  /// clone() method to make deep copy in Surface copy constructor and for
-  /// assigment operator of the Surface class
-  ///
-  /// @return is a newly created object
-  virtual SurfaceBounds* clone() const = 0;
-
   /// Return the bounds type - for persistency optimization
   ///
   /// @return is a BoundsType enum

--- a/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
@@ -60,8 +60,6 @@ class TrapezoidBounds : public PlanarBounds {
 
   ~TrapezoidBounds() override;
 
-  TrapezoidBounds* clone() const final;
-
   BoundsType type() const final;
 
   std::vector<double> values() const final;

--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -142,8 +142,6 @@ class BinUtility {
 
   /// Virtual Destructor
   ~BinUtility() = default;
-  /// Implizit Constructor
-  BinUtility* clone() const { return new BinUtility(*this); }
 
   /// return the binning data vector
   const std::vector<BinningData>& binningData() const { return m_binningData; }

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -7,9 +7,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Geometry/CutoutCylinderVolumeBounds.hpp"
-
-#include <memory>
-#include <vector>
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
@@ -19,9 +16,8 @@
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/IVisualization.hpp"
 
-Acts::VolumeBounds* Acts::CutoutCylinderVolumeBounds::clone() const {
-  return new CutoutCylinderVolumeBounds(*this);
-}
+#include <memory>
+#include <vector>
 
 bool Acts::CutoutCylinderVolumeBounds::inside(const Acts::Vector3D& gpos,
                                               double tol) const {

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -37,10 +37,6 @@ Acts::GenericCuboidVolumeBounds::GenericCuboidVolumeBounds(
   construct();
 }
 
-Acts::VolumeBounds* Acts::GenericCuboidVolumeBounds::clone() const {
-  return new GenericCuboidVolumeBounds(*this);
-}
-
 bool Acts::GenericCuboidVolumeBounds::inside(const Acts::Vector3D& gpos,
                                              double tol) const {
   constexpr std::array<size_t, 6> vtxs = {0, 4, 0, 1, 2, 1};

--- a/Core/src/Geometry/LayerArrayCreator.cpp
+++ b/Core/src/Geometry/LayerArrayCreator.cpp
@@ -205,11 +205,18 @@ std::shared_ptr<Acts::Surface> Acts::LayerArrayCreator::createNavigationSurface(
   // navigation surface
   std::shared_ptr<Surface> navigationSurface;
   // for everything else than a cylinder it's a copy with shift
-  if (layerSurface.type() != Surface::Cylinder) {
+  if (layerSurface.type() == Surface::Plane) {
     // create a transform that does the shift
     Transform3D shift = Transform3D(Translation3D(translation));
-    navigationSurface = layerSurface.clone(gctx, shift);
-  } else {
+    const PlaneSurface* plane =
+        dynamic_cast<const PlaneSurface*>(&layerSurface);
+    navigationSurface = Surface::makeShared<PlaneSurface>(gctx, *plane, shift);
+  } else if (layerSurface.type() == Surface::Disc) {
+    // create a transform that does the shift
+    Transform3D shift = Transform3D(Translation3D(translation));
+    const DiscSurface* disc = dynamic_cast<const DiscSurface*>(&layerSurface);
+    navigationSurface = Surface::makeShared<DiscSurface>(gctx, *disc, shift);
+  } else if (layerSurface.type() == Surface::Cylinder) {
     // get the bounds
     const CylinderBounds* cBounds =
         dynamic_cast<const CylinderBounds*>(&(layerSurface.bounds()));
@@ -225,6 +232,8 @@ std::shared_ptr<Acts::Surface> Acts::LayerArrayCreator::createNavigationSurface(
         std::make_shared<CylinderBounds>(navigationR, halflengthZ);
     navigationSurface =
         Surface::makeShared<CylinderSurface>(navTrasform, cylinderBounds);
+  } else {
+    ACTS_WARNING("Not implemented.");
   }
   return navigationSurface;
 }

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -85,10 +85,6 @@ Acts::Volume& Acts::Volume::operator=(const Acts::Volume& vol) {
   return *this;
 }
 
-Acts::Volume* Acts::Volume::clone() const {
-  return new Acts::Volume(*this);
-}
-
 bool Acts::Volume::inside(const Acts::Vector3D& gpos, double tol) const {
   if (!m_transform) {
     return (volumeBounds()).inside(gpos, tol);

--- a/Core/src/Surfaces/ConeBounds.cpp
+++ b/Core/src/Surfaces/ConeBounds.cpp
@@ -34,10 +34,6 @@ Acts::ConeBounds::ConeBounds(const std::array<double, eSize>& values) noexcept(
   checkConsistency();
 }
 
-Acts::ConeBounds* Acts::ConeBounds::clone() const {
-  return new ConeBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::ConeBounds::type() const {
   return SurfaceBounds::eCone;
 }

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -155,16 +155,6 @@ std::string Acts::ConeSurface::name() const {
   return "Acts::ConeSurface";
 }
 
-std::shared_ptr<Acts::ConeSurface> Acts::ConeSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<ConeSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::ConeSurface* Acts::ConeSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new ConeSurface(gctx, *this, shift);
-}
-
 const Acts::Vector3D Acts::ConeSurface::normal(
     const GeometryContext& gctx, const Acts::Vector2D& lposition) const {
   // (cos phi cos alpha, sin phi cos alpha, sgn z sin alpha)

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -16,10 +16,6 @@
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
-Acts::CylinderBounds* Acts::CylinderBounds::clone() const {
-  return new CylinderBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::CylinderBounds::type() const {
   return SurfaceBounds::eCylinder;
 }

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -142,16 +142,6 @@ std::string Acts::CylinderSurface::name() const {
   return "Acts::CylinderSurface";
 }
 
-std::shared_ptr<Acts::CylinderSurface> Acts::CylinderSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<CylinderSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::CylinderSurface* Acts::CylinderSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new CylinderSurface(gctx, *this, shift);
-}
-
 const Acts::Vector3D Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector2D& lposition) const {
   double phi = lposition[Acts::eLOC_RPHI] / m_bounds->get(CylinderBounds::eR);

--- a/Core/src/Surfaces/DiamondBounds.cpp
+++ b/Core/src/Surfaces/DiamondBounds.cpp
@@ -12,10 +12,6 @@
 #include <iomanip>
 #include <iostream>
 
-Acts::DiamondBounds* Acts::DiamondBounds::clone() const {
-  return new DiamondBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::DiamondBounds::type() const {
   return SurfaceBounds::eDiamond;
 }

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -135,16 +135,6 @@ std::string Acts::DiscSurface::name() const {
   return "Acts::DiscSurface";
 }
 
-std::shared_ptr<Acts::DiscSurface> Acts::DiscSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<DiscSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::DiscSurface* Acts::DiscSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new DiscSurface(gctx, *this, shift);
-}
-
 const Acts::SurfaceBounds& Acts::DiscSurface::bounds() const {
   if (m_bounds) {
     return (*(m_bounds.get()));

--- a/Core/src/Surfaces/DiscTrapezoidBounds.cpp
+++ b/Core/src/Surfaces/DiscTrapezoidBounds.cpp
@@ -20,10 +20,6 @@ Acts::DiscTrapezoidBounds::DiscTrapezoidBounds(double halfXminR,
   checkConsistency();
 }
 
-Acts::DiscTrapezoidBounds* Acts::DiscTrapezoidBounds::clone() const {
-  return new DiscTrapezoidBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::DiscTrapezoidBounds::type() const {
   return SurfaceBounds::eDiscTrapezoid;
 }

--- a/Core/src/Surfaces/EllipseBounds.cpp
+++ b/Core/src/Surfaces/EllipseBounds.cpp
@@ -17,10 +17,6 @@
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
-Acts::EllipseBounds* Acts::EllipseBounds::clone() const {
-  return new EllipseBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::EllipseBounds::type() const {
   return SurfaceBounds::eEllipse;
 }

--- a/Core/src/Surfaces/LineBounds.cpp
+++ b/Core/src/Surfaces/LineBounds.cpp
@@ -11,10 +11,6 @@
 #include <iomanip>
 #include <iostream>
 
-Acts::LineBounds* Acts::LineBounds::clone() const {
-  return new LineBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::LineBounds::type() const {
   return SurfaceBounds::eLine;
 }

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -38,16 +38,6 @@ Acts::PerigeeSurface& Acts::PerigeeSurface::operator=(
   return *this;
 }
 
-std::shared_ptr<Acts::PerigeeSurface> Acts::PerigeeSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<PerigeeSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::PerigeeSurface* Acts::PerigeeSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new PerigeeSurface(gctx, *this, shift);
-}
-
 Acts::Surface::SurfaceType Acts::PerigeeSurface::type() const {
   return Surface::Perigee;
 }

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -101,16 +101,6 @@ std::string Acts::PlaneSurface::name() const {
   return "Acts::PlaneSurface";
 }
 
-std::shared_ptr<Acts::PlaneSurface> Acts::PlaneSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<PlaneSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::PlaneSurface* Acts::PlaneSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new PlaneSurface(gctx, *this, shift);
-}
-
 const Acts::SurfaceBounds& Acts::PlaneSurface::bounds() const {
   if (m_bounds) {
     return (*m_bounds.get());

--- a/Core/src/Surfaces/RadialBounds.cpp
+++ b/Core/src/Surfaces/RadialBounds.cpp
@@ -14,10 +14,6 @@
 #include <iomanip>
 #include <iostream>
 
-Acts::RadialBounds* Acts::RadialBounds::clone() const {
-  return new RadialBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::RadialBounds::type() const {
   return SurfaceBounds::eDisc;
 }

--- a/Core/src/Surfaces/RectangleBounds.cpp
+++ b/Core/src/Surfaces/RectangleBounds.cpp
@@ -13,10 +13,6 @@
 #include <iomanip>
 #include <iostream>
 
-Acts::RectangleBounds* Acts::RectangleBounds::clone() const {
-  return new RectangleBounds(*this);
-}
-
 bool Acts::RectangleBounds::inside(const Acts::Vector2D& lposition,
                                    const Acts::BoundaryCheck& bcheck) const {
   return bcheck.isInside(lposition, m_min, m_max);

--- a/Core/src/Surfaces/StrawSurface.cpp
+++ b/Core/src/Surfaces/StrawSurface.cpp
@@ -45,16 +45,6 @@ Acts::StrawSurface& Acts::StrawSurface::operator=(const StrawSurface& other) {
   return *this;
 }
 
-std::shared_ptr<Acts::StrawSurface> Acts::StrawSurface::clone(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return std::shared_ptr<StrawSurface>(this->clone_impl(gctx, shift));
-}
-
-Acts::StrawSurface* Acts::StrawSurface::clone_impl(
-    const GeometryContext& gctx, const Transform3D& shift) const {
-  return new StrawSurface(gctx, *this, shift);
-}
-
 Acts::Polyhedron Acts::StrawSurface::polyhedronRepresentation(
     const GeometryContext& gctx, size_t lseg) const {
   // Prepare vertices and faces

--- a/Core/src/Surfaces/TrapezoidBounds.cpp
+++ b/Core/src/Surfaces/TrapezoidBounds.cpp
@@ -14,10 +14,6 @@
 
 Acts::TrapezoidBounds::~TrapezoidBounds() = default;
 
-Acts::TrapezoidBounds* Acts::TrapezoidBounds::clone() const {
-  return new TrapezoidBounds(*this);
-}
-
 Acts::SurfaceBounds::BoundsType Acts::TrapezoidBounds::type() const {
   return SurfaceBounds::eTrapezoid;
 }

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
@@ -49,11 +49,6 @@ class LineSurfaceStub : public LineSurface {
                   const Transform3D& t)
       : GeometryObject(), LineSurface(gctx, ls, t) { /* nop */
   }
-  /// pure virtual functions of baseclass implemented here
-  std::shared_ptr<LineSurfaceStub> clone(const GeometryContext& /*gctx*/,
-                                         const Transform3D& /*unused*/) const {
-    return nullptr;
-  }
 
   /// Return method for the Surface type to avoid dynamic casts
   SurfaceType type() const final { return Surface::Straw; }
@@ -72,12 +67,6 @@ class LineSurfaceStub : public LineSurface {
   Polyhedron polyhedronRepresentation(const GeometryContext& /*gctx*/,
                                       size_t /*lseg*/) const final {
     return Polyhedron({}, {}, {});
-  }
-
- private:
-  Surface* clone_impl(const GeometryContext& /*gctx*/,
-                      const Transform3D& /*unused*/) const {
-    return nullptr;
   }
 };
 }  // namespace Test

--- a/Tests/UnitTests/Core/EventData/FreeParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/FreeParametersTests.cpp
@@ -57,9 +57,6 @@ BOOST_AUTO_TEST_CASE(free_initialization) {
   FreeParameters fpMoveConstr(FreeParameters(covCpy, params));
   BOOST_TEST(fpMoveConstr == fp);
 
-  FreeParameters* fpCopy = fp.clone();
-  BOOST_TEST(*fpCopy == fp);
-
   // Test copy assignment
   FreeParameters fpCopyAssignment = fp;
   BOOST_TEST(fpCopyAssignment == fp);
@@ -87,9 +84,6 @@ BOOST_AUTO_TEST_CASE(free_initialization) {
   covCpy = *cov;
   NeutralFreeParameters nfpMoveConstr(NeutralFreeParameters(covCpy, params));
   BOOST_TEST(nfpMoveConstr == nfp);
-
-  NeutralFreeParameters* nfpCopy = nfp.clone();
-  BOOST_TEST(*nfpCopy == nfp);
 
   // Test copy assignment
   NeutralFreeParameters nfpCopyAssignment = nfp;

--- a/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
@@ -250,7 +250,7 @@ void runTest(const propagator_t& prop, double pT, double phi, double theta,
 
   // move forward step by step through the surfaces
   const TrackParameters* sParameters = &start;
-  std::vector<const TrackParameters*> stepParameters;
+  std::vector<std::unique_ptr<const BoundParameters>> stepParameters;
   for (auto& fwdSteps : fwdMaterial.materialInteractions) {
     if (debugModeFwdStep) {
       std::cout << ">>> Forward step : "
@@ -275,9 +275,10 @@ void runTest(const propagator_t& prop, double pT, double phi, double theta,
     fwdStepStepMaterialInL0 += fwdStepMaterial.materialInL0;
 
     if (fwdStep.endParameters != nullptr) {
-      sParameters = fwdStep.endParameters->clone();
       // make sure the parameters do not run out of scope
-      stepParameters.push_back(sParameters);
+      stepParameters.push_back(
+          std::make_unique<BoundParameters>((*fwdStep.endParameters.get())));
+      sParameters = stepParameters.back().get();
     }
   }
   // final destination surface
@@ -364,9 +365,10 @@ void runTest(const propagator_t& prop, double pT, double phi, double theta,
     bwdStepStepMaterialInL0 += bwdStepMaterial.materialInL0;
 
     if (bwdStep.endParameters != nullptr) {
-      sParameters = bwdStep.endParameters->clone();
       // make sure the parameters do not run out of scope
-      stepParameters.push_back(sParameters);
+      stepParameters.push_back(
+          std::make_unique<BoundParameters>(*(bwdStep.endParameters.get())));
+      sParameters = stepParameters.back().get();
     }
   }
   // final destination surface

--- a/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
@@ -78,10 +78,6 @@ BOOST_AUTO_TEST_CASE(AnnulusBoundsProperties) {
   /// Test construction with radii and default sector
   AnnulusBounds aBounds(minRadius, maxRadius, minPhi, maxPhi, offset);
 
-  /// Test clone
-  auto pClonedAnnulusBounds = aBounds.clone();
-  BOOST_CHECK_NE(pClonedAnnulusBounds, nullptr);
-  delete pClonedAnnulusBounds;
   //
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(aBounds.type(), SurfaceBounds::eAnnulus);

--- a/Tests/UnitTests/Core/Surfaces/ConeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeBoundsTests.cpp
@@ -55,9 +55,6 @@ BOOST_AUTO_TEST_CASE(ConeBoundsConstruction) {
   BOOST_TEST_CHECKPOINT("Copy constructor");
   ConeBounds copyConstructedConeBounds(fiveParamConstructedConeBounds);
   BOOST_CHECK_EQUAL(copyConstructedConeBounds, fiveParamConstructedConeBounds);
-  auto pClonedConeBounds = fiveParamConstructedConeBounds.clone();
-  BOOST_CHECK_EQUAL(*pClonedConeBounds, fiveParamConstructedConeBounds);
-  delete pClonedConeBounds;
 }
 
 // Streaning and recreation test

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -93,10 +93,6 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceProperties) {
   auto coneSurfaceObject =
       Surface::makeShared<ConeSurface>(pTransform, alpha, symmetric);
   //
-  auto pClonedConeSurface =
-      coneSurfaceObject->clone(tgContext, Transform3D::Identity());
-  BOOST_CHECK_EQUAL(pClonedConeSurface->type(), Surface::Cone);
-  //
   /// Test type (redundant)
   BOOST_CHECK_EQUAL(coneSurfaceObject->type(), Surface::Cone);
   //

--- a/Tests/UnitTests/Core/Surfaces/CylinderBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderBoundsTests.cpp
@@ -88,11 +88,6 @@ BOOST_AUTO_TEST_CASE(CylinderBoundsProperties) {
   CylinderBounds cylinderBoundsSegment(nominalRadius, nominalHalfLength,
                                        halfphi, averagePhi);
 
-  /// test for clone
-  auto pCylinderBoundsClone = cylinderBoundsObject.clone();
-  BOOST_CHECK_NE(pCylinderBoundsClone, nullptr);
-  delete pCylinderBoundsClone;
-
   /// test for type()
   BOOST_CHECK_EQUAL(cylinderBoundsObject.type(), SurfaceBounds::eCylinder);
 

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -89,10 +89,6 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
   auto cylinderSurfaceObject =
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ);
   //
-  auto pClonedCylinderSurface =
-      cylinderSurfaceObject->clone(testContext, Transform3D::Identity());
-  BOOST_CHECK_EQUAL(pClonedCylinderSurface->type(), Surface::Cylinder);
-  //
   /// Test type (redundant)
   BOOST_CHECK_EQUAL(cylinderSurfaceObject->type(), Surface::Cylinder);
   //

--- a/Tests/UnitTests/Core/Surfaces/DiamondBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiamondBoundsTests.cpp
@@ -52,9 +52,6 @@ BOOST_AUTO_TEST_CASE(DiamondBoundsProperties) {
   /// Test clone
   DiamondBounds diamondBoundsObject(minHalfX, midHalfX, maxHalfX, halfY1,
                                     halfY2);
-  auto pClonedDiamondBoundsObject = diamondBoundsObject.clone();
-  BOOST_CHECK_NE(pClonedDiamondBoundsObject, nullptr);
-  delete pClonedDiamondBoundsObject;
   //
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(diamondBoundsObject.type(), SurfaceBounds::eDiamond);

--- a/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
@@ -108,9 +108,6 @@ BOOST_AUTO_TEST_CASE(DiscTrapezoidBoundsProperties) {
   /// Test clone
   DiscTrapezoidBounds DiscTrapezoidBoundsObject(minHalfX, maxHalfX, rMin, rMax,
                                                 averagePhi);
-  auto pClonedDiscTrapezoidBounds = DiscTrapezoidBoundsObject.clone();
-  BOOST_CHECK_NE(pClonedDiscTrapezoidBounds, nullptr);
-  delete pClonedDiscTrapezoidBounds;
   //
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(DiscTrapezoidBoundsObject.type(),

--- a/Tests/UnitTests/Core/Surfaces/EllipseBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/EllipseBoundsTests.cpp
@@ -109,9 +109,6 @@ BOOST_AUTO_TEST_CASE(EllipseBoundsProperties) {
   /// Test clone
   EllipseBounds ellipseBoundsObject(minRad0, maxRad0, minRad1, maxRad1,
                                     phiSector, averagePhi);
-  auto pClonedEllipseBoundsObject = ellipseBoundsObject.clone();
-  BOOST_CHECK_NE(pClonedEllipseBoundsObject, nullptr);
-  delete pClonedEllipseBoundsObject;
   //
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(ellipseBoundsObject.type(), SurfaceBounds::eEllipse);

--- a/Tests/UnitTests/Core/Surfaces/InfiniteBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/InfiniteBoundsTests.cpp
@@ -41,11 +41,6 @@ BOOST_AUTO_TEST_CASE(InfiniteBoundsProperties) {
   BOOST_TEST_MESSAGE("Perhaps the following should be inf?");
   BOOST_CHECK_EQUAL(infiniteBoundsObject.distanceToBoundary(anyVector), 0.);
 
-  /// test for clone
-  auto pInfiniteBoundsClone = infiniteBoundsObject.clone();
-  BOOST_CHECK_NE(pInfiniteBoundsClone, nullptr);
-  delete pInfiniteBoundsClone;
-
   /// test for dump
   boost::test_tools::output_test_stream dumpOuput;
   infiniteBoundsObject.toStream(dumpOuput);

--- a/Tests/UnitTests/Core/Surfaces/LineBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineBoundsTests.cpp
@@ -73,11 +73,6 @@ BOOST_AUTO_TEST_CASE(LineBoundsProperties) {
   double nominalHalfLength{20.};
   LineBounds lineBoundsObject(nominalRadius, nominalHalfLength);
 
-  /// test for clone
-  auto pLineBoundsClone = lineBoundsObject.clone();
-  BOOST_CHECK_NE(pLineBoundsClone, nullptr);
-  delete pLineBoundsClone;
-
   /// test for type()
   BOOST_CHECK_EQUAL(lineBoundsObject.type(), SurfaceBounds::eLine);
 

--- a/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
@@ -67,9 +67,6 @@ BOOST_AUTO_TEST_CASE(PerigeeSurfaceProperties) {
   /// Test clone method
   Vector3D unitXYZ{1., 1., 1.};
   auto perigeeSurfaceObject = Surface::makeShared<PerigeeSurface>(unitXYZ);
-  auto pClonedPerigeeSurface =
-      perigeeSurfaceObject->clone(tgContext, Transform3D::Identity());
-  BOOST_CHECK_EQUAL(pClonedPerigeeSurface->type(), Surface::Perigee);
   //
   /// Test type (redundant)
   BOOST_CHECK_EQUAL(perigeeSurfaceObject->type(), Surface::Perigee);

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -77,27 +77,11 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
   auto pTransform = std::make_shared<const Transform3D>(translation);
   auto planeSurfaceObject =
       Surface::makeShared<PlaneSurface>(pTransform, rBounds);
-  //
-  auto pClonedPlaneSurface =
-      planeSurfaceObject->clone(tgContext, Transform3D::Identity());
-  BOOST_CHECK_EQUAL(pClonedPlaneSurface->type(), Surface::Plane);
-  // Test clone method with translation
-  auto pClonedShiftedPlaneSurface =
-      planeSurfaceObject->clone(tgContext, *pTransform.get());
-  // Does it exist at all in a decent state?
-  BOOST_CHECK_EQUAL(pClonedShiftedPlaneSurface->type(), Surface::Plane);
   // Is it in the right place?
   Translation3D translation2{0., 2., 4.};
   auto pTransform2 = std::make_shared<const Transform3D>(translation2);
   auto planeSurfaceObject2 =
       Surface::makeShared<PlaneSurface>(pTransform2, rBounds);
-  // these two surfaces should be equivalent now (prematurely testing equality
-  // also)
-  BOOST_CHECK(*pClonedShiftedPlaneSurface == *planeSurfaceObject2);
-  // and, trivially, the shifted cloned surface should be different from the
-  // original
-  BOOST_CHECK(*pClonedShiftedPlaneSurface != *planeSurfaceObject);
-  //
   /// Test type (redundant)
   BOOST_CHECK_EQUAL(planeSurfaceObject->type(), Surface::Plane);
   //

--- a/Tests/UnitTests/Core/Surfaces/RadialBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/RadialBoundsTests.cpp
@@ -85,13 +85,8 @@ BOOST_AUTO_TEST_CASE(RadialBoundsException) {
 /// Unit tests for RadialBounds properties
 BOOST_AUTO_TEST_CASE(RadialBoundsProperties) {
   double minRadius(1.0), maxRadius(5.0), halfPhiSector(M_PI / 8.0);
-  /// Test clone
-  RadialBounds radialBoundsObject(minRadius, maxRadius, halfPhiSector);
-  auto pClonedRadialBounds = radialBoundsObject.clone();
-  BOOST_CHECK_NE(pClonedRadialBounds, nullptr);
-  delete pClonedRadialBounds;
-  //
   /// Test type() (redundant; already used in constructor confirmation)
+  RadialBounds radialBoundsObject(minRadius, maxRadius, halfPhiSector);
   BOOST_CHECK_EQUAL(radialBoundsObject.type(), SurfaceBounds::eDisc);
   //
   /// Test distanceToBoundary

--- a/Tests/UnitTests/Core/Surfaces/RectangleBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/RectangleBoundsTests.cpp
@@ -119,19 +119,6 @@ BOOST_AUTO_TEST_CASE(RectangleBoundsAssignment) {
       assignedVertices.cbegin(), assignedVertices.cend());
 }
 
-BOOST_AUTO_TEST_CASE(RectangleBoundsClone) {
-  const double halfX(10.), halfY(5.);
-  RectangleBounds rectA(halfX, halfY);
-  auto rectB = rectA.clone();
-  BOOST_CHECK_NE(rectB, nullptr);
-  const auto& originalVertices = rectA.vertices();
-  const auto& clonedVertices = rectB->vertices();
-  BOOST_CHECK_EQUAL_COLLECTIONS(originalVertices.cbegin(),
-                                originalVertices.cend(),
-                                clonedVertices.cbegin(), clonedVertices.cend());
-  delete rectB;
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace Test
 

--- a/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
@@ -83,10 +83,6 @@ BOOST_AUTO_TEST_CASE(StrawSurfaceProperties) {
   auto strawSurfaceObject =
       Surface::makeShared<StrawSurface>(pTransform, radius, halfZ);
   //
-  auto pClonedStrawSurface =
-      strawSurfaceObject->clone(tgContext, Transform3D::Identity());
-  BOOST_CHECK_EQUAL(pClonedStrawSurface->type(), Surface::Straw);
-  //
   /// Test type (redundant)
   BOOST_CHECK_EQUAL(strawSurfaceObject->type(), Surface::Straw);
   //

--- a/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
@@ -26,7 +26,6 @@ class SurfaceBoundsStub : public SurfaceBounds {
 
   ~SurfaceBoundsStub() override { /*nop*/
   }
-  SurfaceBounds* clone() const final { return nullptr; }
   BoundsType type() const final { return SurfaceBounds::eOther; }
   std::vector<double> values() const override { return m_values; }
   bool inside(const Vector2D& /*lpos*/,

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -29,12 +29,6 @@ class SurfaceStub : public Surface {
   ~SurfaceStub() override { /*nop */
   }
 
-  /// Implicit constructor
-  Surface* clone(const GeometryContext& /*gctx*/,
-                 const Transform3D& /*shift = nullptr*/) const {
-    return nullptr;
-  }
-
   /// Return method for the Surface type to avoid dynamic casts
   SurfaceType type() const final { return Surface::Other; }
 
@@ -113,10 +107,5 @@ class SurfaceStub : public Surface {
  private:
   /// the bounds of this surface
   std::shared_ptr<const PlanarBounds> m_bounds;
-
-  SurfaceStub* clone_impl(const GeometryContext& /*gctx*/,
-                          const Transform3D& /* shift */) const override {
-    return nullptr;
-  }
 };
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Surfaces/TrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/TrapezoidBoundsTests.cpp
@@ -78,10 +78,6 @@ BOOST_AUTO_TEST_CASE(TrapezoidBoundsProperties, *utf::expected_failures(3)) {
   double minHalfX(1.), maxHalfX(6.), halfY(2.);
   //
   TrapezoidBounds trapezoidBoundsObject(minHalfX, maxHalfX, halfY);
-  /// Test clone
-  auto pClonedTrapezoidBounds = trapezoidBoundsObject.clone();
-  BOOST_CHECK_NE(pClonedTrapezoidBounds, nullptr);
-  delete pClonedTrapezoidBounds;
   //
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(trapezoidBoundsObject.type(), SurfaceBounds::eTrapezoid);


### PR DESCRIPTION
This PR removes the redundant `clone()` framework from geometry and event data model.

Cloning has only be used twice in the entire code:
* for navigation layers it will vanish once they will be deprecated.
* in the material collection test is has just been replaced by copy construction


