### PR TITLE
WIP Introduce common covariance computation

### DIFF
--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -354,8 +354,7 @@ class KalmanFitter {
           targetReached(state, stepper, *targetSurface)) {
         ACTS_VERBOSE("Completing");
         // Transport & bind the parameter to the final surface
-        auto fittedState =
-            stepper.boundState(state.stepping, *targetSurface, true);
+        auto fittedState = stepper.boundState(state.stepping, *targetSurface);
         // Assign the fitted parameters
         result.fittedParameters = std::get<BoundParameters>(fittedState);
         // Break the navigation for stopping the Propagation
@@ -478,7 +477,7 @@ class KalmanFitter {
 
         // Transport & bind the state to the current surface
         auto [boundParams, jacobian, pathLength] =
-            stepper.boundState(state.stepping, *surface, true);
+            stepper.boundState(state.stepping, *surface);
 
         // add a full TrackState entry multi trajectory
         // (this allocates storage for all components, we will set them later)
@@ -579,7 +578,7 @@ class KalmanFitter {
 
             // Transport & bind the state to the current surface
             auto [boundParams, jacobian, pathLength] =
-                stepper.boundState(state.stepping, *surface, true);
+                stepper.boundState(state.stepping, *surface);
 
             // Fill the track state
             trackStateProxy.predicted() = boundParams.parameters();
@@ -591,7 +590,7 @@ class KalmanFitter {
 
             // Transport & get curvilinear state instead of bound state
             auto [curvilinearParams, jacobian, pathLength] =
-                stepper.curvilinearState(state.stepping, true);
+                stepper.curvilinearState(state.stepping);
 
             // Fill the track state
             trackStateProxy.predicted() = curvilinearParams.parameters();
@@ -650,7 +649,7 @@ class KalmanFitter {
 
         // Transport & bind the state to the current surface
         auto [boundParams, jacobian, pathLength] =
-            stepper.boundState(state.stepping, *surface, true);
+            stepper.boundState(state.stepping, *surface);
 
         // Create a detached track state proxy
         auto tempTrackTip =
@@ -715,13 +714,13 @@ class KalmanFitter {
           ACTS_VERBOSE("Detected hole on " << surface->geoID()
                                            << " in backward filtering");
           if (state.stepping.covTransport) {
-            stepper.covarianceTransport(state.stepping, *surface, true);
+            stepper.covarianceTransport(state.stepping, *surface);
           }
         } else {
           ACTS_VERBOSE("Detected in-sensitive surface "
                        << surface->geoID() << " in backward filtering");
           if (state.stepping.covTransport) {
-            stepper.covarianceTransport(state.stepping, true);
+            stepper.covarianceTransport(state.stepping);
           }
         }
 

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -399,15 +399,12 @@ class AtlasStepper {
   ///
   /// @param [in] state State that will be presented as @c BoundState
   /// @param [in] surface The surface to which we bind the state
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A bound state:
   ///   - the parameters at the surface
   ///   - the stepwise jacobian towards it
   ///   - and the path length (from start - for ordering)
-  BoundState boundState(State& state, const Surface& surface,
-                        bool /*unused*/) const {
+  BoundState boundState(State& state, const Surface& surface) const {
     // the convert method invalidates the state (in case it's reused)
     state.state_ready = false;
 
@@ -420,7 +417,7 @@ class AtlasStepper {
     std::unique_ptr<const Covariance> cov = nullptr;
     std::optional<Covariance> covOpt = std::nullopt;
     if (state.covTransport) {
-      covarianceTransport(state, surface, true);
+      covarianceTransport(state, surface);
       covOpt = state.cov;
     }
 
@@ -437,14 +434,12 @@ class AtlasStepper {
   ///
   ///
   /// @param [in] state State that will be presented as @c CurvilinearState
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A curvilinear state:
   ///   - the curvilinear parameters at given position
   ///   - the stepweise jacobian towards it
   ///   - and the path length (from start - for ordering)
-  CurvilinearState curvilinearState(State& state, bool /*unused*/) const {
+  CurvilinearState curvilinearState(State& state) const {
     // the convert method invalidates the state (in case it's reused)
     state.state_ready = false;
     //
@@ -454,7 +449,7 @@ class AtlasStepper {
 
     std::optional<Covariance> covOpt = std::nullopt;
     if (state.covTransport) {
-      covarianceTransport(state, true);
+      covarianceTransport(state);
       covOpt = state.cov;
     }
 
@@ -659,11 +654,9 @@ class AtlasStepper {
   /// or direction of the state
   ///
   /// @param [in,out] state State of the stepper
-  /// @param [in] reinitialize is a flag to steer whether the state should be
-  /// reinitialized at the new position
   ///
   /// @return the full transport jacobian
-  void covarianceTransport(State& state, bool /*unused*/) const {
+  void covarianceTransport(State& state) const {
     double P[60];
     for (unsigned int i = 0; i < 60; ++i) {
       P[i] = state.pVector[i];
@@ -814,10 +807,7 @@ class AtlasStepper {
   ///
   /// @param [in,out] state State of the stepper
   /// @param [in] surface is the surface to which the covariance is forwarded to
-  /// @param [in] reinitialize is a flag to steer whether the state should be
-  /// reinitialized at the new position
-  void covarianceTransport(State& state, const Surface& surface,
-                           bool /*unused*/) const {
+  void covarianceTransport(State& state, const Surface& surface) const {
     Acts::Vector3D gp(state.pVector[0], state.pVector[1], state.pVector[2]);
     Acts::Vector3D mom(state.pVector[4], state.pVector[5], state.pVector[6]);
     mom /= std::abs(state.pVector[7]);

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -183,6 +183,22 @@ class EigenStepper {
     return m_bField.getField(pos, state.fieldCache);
   }
 
+  /// Global free parameters vector.
+  ///
+  /// @param state Current stepper state
+  FreeVector parameters(const State& state) const {
+    FreeVector params;
+    params[eFreePos0] = state.pos[0];
+    params[eFreePos1] = state.pos[1];
+    params[eFreePos2] = state.pos[2];
+    params[eFreeTime] = state.t;
+    params[eFreeDir0] = state.dir[0];
+    params[eFreeDir1] = state.dir[1];
+    params[eFreeDir2] = state.dir[2];
+    params[eFreeQOverP] = (state.q != 0) ? (state.q / state.p) : (1 / state.p);
+    return params;
+  }
+
   /// Global particle position accessor
   ///
   /// @param state [in] The stepping state (thread-local cache)

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -280,15 +280,12 @@ class EigenStepper {
   ///
   /// @param [in] state State that will be presented as @c BoundState
   /// @param [in] surface The surface to which we bind the state
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A bound state:
   ///   - the parameters at the surface
   ///   - the stepwise jacobian towards it (from last bound)
   ///   - and the path length (from start - for ordering)
-  BoundState boundState(State& state, const Surface& surface,
-                        bool reinitialize = true) const;
+  BoundState boundState(State& state, const Surface& surface) const;
 
   /// Create and return a curvilinear state at the current position
   ///
@@ -296,15 +293,12 @@ class EigenStepper {
   /// to the current position and creates a curvilinear state.
   ///
   /// @param [in] state State that will be presented as @c CurvilinearState
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A curvilinear state:
   ///   - the curvilinear parameters at given position
   ///   - the stepweise jacobian towards it (from last bound)
   ///   - and the path length (from start - for ordering)
-  CurvilinearState curvilinearState(State& state,
-                                    bool reinitialize = true) const;
+  CurvilinearState curvilinearState(State& state) const;
 
   /// Method to update a stepper state to the some parameters
   ///
@@ -326,11 +320,9 @@ class EigenStepper {
   /// or direction of the state
   ///
   /// @param [in,out] state State of the stepper
-  /// @param [in] reinitialize is a flag to steer whether the state should be
-  /// reinitialized at the new position
   ///
   /// @return the full transport jacobian
-  void covarianceTransport(State& state, bool reinitialize = false) const;
+  void covarianceTransport(State& state) const;
 
   /// Method for on-demand transport of the covariance
   /// to a new curvilinear frame at current position,
@@ -340,11 +332,8 @@ class EigenStepper {
   ///
   /// @param [in,out] state State of the stepper
   /// @param [in] surface is the surface to which the covariance is forwarded to
-  /// @param [in] reinitialize is a flag to steer whether the state should be
-  /// reinitialized at the new position
   /// @note no check is done if the position is actually on the surface
-  void covarianceTransport(State& state, const Surface& surface,
-                           bool reinitialize = true) const;
+  void covarianceTransport(State& state, const Surface& surface) const;
 
   /// Perform a Runge-Kutta track parameter propagation step
   ///

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -14,17 +14,15 @@ Acts::EigenStepper<B, E, A>::EigenStepper(B bField)
 
 template <typename B, typename E, typename A>
 auto Acts::EigenStepper<B, E, A>::boundState(State& state,
-                                             const Surface& surface,
-                                             bool reinitialize) const
+                                             const Surface& surface) const
     -> BoundState {
-  return detail::boundState(state, surface, reinitialize);
+  return detail::boundState(state, surface);
 }
 
 template <typename B, typename E, typename A>
-auto Acts::EigenStepper<B, E, A>::curvilinearState(State& state,
-                                                   bool reinitialize) const
+auto Acts::EigenStepper<B, E, A>::curvilinearState(State& state) const
     -> CurvilinearState {
-  return detail::curvilinearState(state, reinitialize);
+  return detail::curvilinearState(state);
 }
 
 template <typename B, typename E, typename A>
@@ -52,16 +50,14 @@ void Acts::EigenStepper<B, E, A>::update(State& state,
 }
 
 template <typename B, typename E, typename A>
-void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state,
-                                                      bool reinitialize) const {
-  detail::covarianceTransport(state, reinitialize);
+void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state) const {
+  detail::covarianceTransport(state);
 }
 
 template <typename B, typename E, typename A>
-void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state,
-                                                      const Surface& surface,
-                                                      bool reinitialize) const {
-  detail::covarianceTransport(state, reinitialize, &surface);
+void Acts::EigenStepper<B, E, A>::covarianceTransport(
+    State& state, const Surface& surface) const {
+  detail::covarianceTransport(state, &surface);
 }
 
 template <typename B, typename E, typename A>

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -56,13 +56,23 @@ void Acts::EigenStepper<B, E, A>::update(State& state,
 
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state) const {
-  detail::transportCovarianceToCurvilinear(state);
+  detail::updateJacobiansToCurvilinear(parameters(state), state.jacToGlobal,
+                                       state.jacTransport, state.derivative,
+                                       state.jacobian);
+  if (state.covTransport) {
+    state.cov = state.jacobian * state.cov * state.jacobian.transpose();
+  }
 }
 
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(
     State& state, const Surface& surface) const {
-  detail::transportCovarianceToBound(state, surface);
+  detail::updateJacobiansToBound(parameters(state), surface, state.geoContext,
+                                 state.jacToGlobal, state.jacTransport,
+                                 state.derivative, state.jacobian);
+  if (state.covTransport) {
+    state.cov = state.jacobian * state.cov * state.jacobian.transpose();
+  }
 }
 
 template <typename B, typename E, typename A>

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -51,13 +51,13 @@ void Acts::EigenStepper<B, E, A>::update(State& state,
 
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state) const {
-  detail::covarianceTransport(state);
+  detail::transportCovarianceToCurvilinear(state);
 }
 
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(
     State& state, const Surface& surface) const {
-  detail::covarianceTransport(state, &surface);
+  detail::transportCovarianceToBound(state, surface);
 }
 
 template <typename B, typename E, typename A>

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -16,13 +16,18 @@ template <typename B, typename E, typename A>
 auto Acts::EigenStepper<B, E, A>::boundState(State& state,
                                              const Surface& surface) const
     -> BoundState {
-  return detail::boundState(state, surface);
+  return {detail::makeBoundParameters(parameters(state), state.cov,
+                                      state.covTransport, surface,
+                                      state.geoContext),
+          state.jacobian, state.pathAccumulated};
 }
 
 template <typename B, typename E, typename A>
 auto Acts::EigenStepper<B, E, A>::curvilinearState(State& state) const
     -> CurvilinearState {
-  return detail::curvilinearState(state);
+  return {detail::makeCurvilinearParameters(parameters(state), state.cov,
+                                            state.covTransport),
+          state.jacobian, state.pathAccumulated};
 }
 
 template <typename B, typename E, typename A>

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -6,6 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Propagator/detail/CovarianceEngine.hpp"
+
 template <typename B, typename E, typename A>
 Acts::EigenStepper<B, E, A>::EigenStepper(B bField)
     : m_bField(std::move(bField)) {}
@@ -15,49 +17,14 @@ auto Acts::EigenStepper<B, E, A>::boundState(State& state,
                                              const Surface& surface,
                                              bool reinitialize) const
     -> BoundState {
-  // Transport the covariance to here
-  std::optional<Covariance> covOpt = std::nullopt;
-  if (state.covTransport) {
-    covarianceTransport(state, surface, reinitialize);
-    covOpt = state.cov;
-  }
-  // Create the bound parameters
-  BoundParameters parameters(state.geoContext, std::move(covOpt), state.pos,
-                             state.p * state.dir, state.q, state.t,
-                             surface.getSharedPtr());
-  // Create the bound state
-  BoundState bState{std::move(parameters), state.jacobian,
-                    state.pathAccumulated};
-  // Reset the jacobian to identity
-  if (reinitialize) {
-    state.jacobian = Jacobian::Identity();
-  }
-  /// Return the State
-  return bState;
+  return detail::boundState(state, surface, reinitialize);
 }
 
 template <typename B, typename E, typename A>
 auto Acts::EigenStepper<B, E, A>::curvilinearState(State& state,
                                                    bool reinitialize) const
     -> CurvilinearState {
-  // Transport the covariance to here
-  std::optional<Covariance> covOpt = std::nullopt;
-  if (state.covTransport) {
-    covarianceTransport(state, reinitialize);
-    covOpt = state.cov;
-  }
-  // Create the curvilinear parameters
-  CurvilinearParameters parameters(std::move(state.cov), state.pos,
-                                   state.p * state.dir, state.q, state.t);
-  // Create the bound state
-  CurvilinearState curvState{std::move(parameters), state.jacobian,
-                             state.pathAccumulated};
-  // Reset the jacobian to identity
-  if (reinitialize) {
-    state.jacobian = Jacobian::Identity();
-  }
-  /// Return the State
-  return curvState;
+  return detail::curvilinearState(state, reinitialize);
 }
 
 template <typename B, typename E, typename A>
@@ -87,120 +54,14 @@ void Acts::EigenStepper<B, E, A>::update(State& state,
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state,
                                                       bool reinitialize) const {
-  // Optimized trigonometry on the propagation direction
-  const double x = state.dir(0);  // == cos(phi) * sin(theta)
-  const double y = state.dir(1);  // == sin(phi) * sin(theta)
-  const double z = state.dir(2);  // == cos(theta)
-  // can be turned into cosine/sine
-  const double cosTheta = z;
-  const double sinTheta = sqrt(x * x + y * y);
-  const double invSinTheta = 1. / sinTheta;
-  const double cosPhi = x * invSinTheta;
-  const double sinPhi = y * invSinTheta;
-  // prepare the jacobian to curvilinear
-  FreeToBoundMatrix jacToCurv = FreeToBoundMatrix::Zero();
-  if (std::abs(cosTheta) < s_curvilinearProjTolerance) {
-    // We normally operate in curvilinear coordinates defined as follows
-    jacToCurv(0, 0) = -sinPhi;
-    jacToCurv(0, 1) = cosPhi;
-    jacToCurv(1, 0) = -cosPhi * cosTheta;
-    jacToCurv(1, 1) = -sinPhi * cosTheta;
-    jacToCurv(1, 2) = sinTheta;
-  } else {
-    // Under grazing incidence to z, the above coordinate system definition
-    // becomes numerically unstable, and we need to switch to another one
-    const double c = sqrt(y * y + z * z);
-    const double invC = 1. / c;
-    jacToCurv(0, 1) = -z * invC;
-    jacToCurv(0, 2) = y * invC;
-    jacToCurv(1, 0) = c;
-    jacToCurv(1, 1) = -x * y * invC;
-    jacToCurv(1, 2) = -x * z * invC;
-  }
-  // Time parameter
-  jacToCurv(5, 3) = 1;
-  // Directional and momentum parameters for curvilinear
-  jacToCurv(2, 4) = -sinPhi * invSinTheta;
-  jacToCurv(2, 5) = cosPhi * invSinTheta;
-  jacToCurv(3, 6) = -invSinTheta;
-  jacToCurv(4, 7) = 1;
-  // Apply the transport from the steps on the jacobian
-  state.jacToGlobal = state.jacTransport * state.jacToGlobal;
-  // Transport the covariance
-  ActsRowVectorD<3> normVec(state.dir);
-  const BoundRowVector sfactors =
-      normVec *
-      state.jacToGlobal.template topLeftCorner<3, eBoundParametersSize>();
-  // The full jacobian is ([to local] jacobian) * ([transport] jacobian)
-  const Jacobian jacFull =
-      jacToCurv * (state.jacToGlobal - state.derivative * sfactors);
-  // Apply the actual covariance transport
-  state.cov = (jacFull * state.cov * jacFull.transpose());
-  // Reinitialize if asked to do so
-  // this is useful for interruption calls
-  if (reinitialize) {
-    // reset the jacobians
-    state.jacToGlobal = BoundToFreeMatrix::Zero();
-    state.jacTransport = FreeMatrix::Identity();
-    // fill the jacobian to global for next transport
-    state.jacToGlobal(0, eLOC_0) = -sinPhi;
-    state.jacToGlobal(0, eLOC_1) = -cosPhi * cosTheta;
-    state.jacToGlobal(1, eLOC_0) = cosPhi;
-    state.jacToGlobal(1, eLOC_1) = -sinPhi * cosTheta;
-    state.jacToGlobal(2, eLOC_1) = sinTheta;
-    state.jacToGlobal(3, eT) = 1.;
-    state.jacToGlobal(4, ePHI) = -sinTheta * sinPhi;
-    state.jacToGlobal(4, eTHETA) = cosTheta * cosPhi;
-    state.jacToGlobal(5, ePHI) = sinTheta * cosPhi;
-    state.jacToGlobal(5, eTHETA) = cosTheta * sinPhi;
-    state.jacToGlobal(6, eTHETA) = -sinTheta;
-    state.jacToGlobal(7, eQOP) = 1.;
-  }
-  // Store The global and bound jacobian (duplication for the moment)
-  state.jacobian = jacFull * state.jacobian;
+  detail::covarianceTransport(state, reinitialize);
 }
 
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state,
                                                       const Surface& surface,
                                                       bool reinitialize) const {
-  using VectorHelpers::phi;
-  using VectorHelpers::theta;
-
-  // Initialize the transport final frame jacobian
-  FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
-  // initalize the jacobian to local, returns the transposed ref frame
-  auto rframeT = surface.initJacobianToLocal(state.geoContext, jacToLocal,
-                                             state.pos, state.dir);
-  // Update the jacobian with the transport from the steps
-  state.jacToGlobal = state.jacTransport * state.jacToGlobal;
-  // calculate the form factors for the derivatives
-  const BoundRowVector sVec = surface.derivativeFactors(
-      state.geoContext, state.pos, state.dir, rframeT, state.jacToGlobal);
-  // the full jacobian is ([to local] jacobian) * ([transport] jacobian)
-  const Jacobian jacFull =
-      jacToLocal * (state.jacToGlobal - state.derivative * sVec);
-  // Apply the actual covariance transport
-  state.cov = (jacFull * state.cov * jacFull.transpose());
-  // Reinitialize if asked to do so
-  // this is useful for interruption calls
-  if (reinitialize) {
-    // reset the jacobians
-    state.jacToGlobal = BoundToFreeMatrix::Zero();
-    state.jacTransport = FreeMatrix::Identity();
-    // reset the derivative
-    state.derivative = FreeVector::Zero();
-    // fill the jacobian to global for next transport
-    Vector2D loc{0., 0.};
-    surface.globalToLocal(state.geoContext, state.pos, state.dir, loc);
-    BoundVector pars;
-    pars << loc[eLOC_0], loc[eLOC_1], phi(state.dir), theta(state.dir),
-        state.q / state.p, state.t;
-    surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, state.pos,
-                                 state.dir, pars);
-  }
-  // Store The global and bound jacobian (duplication for the moment)
-  state.jacobian = jacFull * state.jacobian;
+  detail::covarianceTransport(state, reinitialize, &surface);
 }
 
 template <typename B, typename E, typename A>

--- a/Core/include/Acts/Propagator/MaterialInteractor.hpp
+++ b/Core/include/Acts/Propagator/MaterialInteractor.hpp
@@ -125,9 +125,8 @@ struct MaterialInteractor {
 
     // To integrate process noise, we need to transport
     // the covariance to the current position in space
-    // the 'true' indicates re-initializaiton of the further transport
     if (d.performCovarianceTransport) {
-      stepper.covarianceTransport(state.stepping, true);
+      stepper.covarianceTransport(state.stepping);
     }
     // Apply the material interactions
     d.updateState(state, stepper);

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -134,7 +134,7 @@ auto Acts::Propagator<S, N>::propagate(
   if (result.ok()) {
     auto& propRes = *result;
     /// Convert into return type and fill the result object
-    auto curvState = m_stepper.curvilinearState(state.stepping, true);
+    auto curvState = m_stepper.curvilinearState(state.stepping);
     auto& curvParameters = std::get<CurvilinearParameters>(curvState);
     // Fill the end parameters
     propRes.endParameters = std::make_unique<const CurvilinearParameters>(
@@ -201,7 +201,7 @@ auto Acts::Propagator<S, N>::propagate(
   if (result.ok()) {
     auto& propRes = *result;
     // Compute the final results and mark the propagation as successful
-    auto bs = m_stepper.boundState(state.stepping, target, true);
+    auto bs = m_stepper.boundState(state.stepping, target);
     auto& boundParameters = std::get<BoundParameters>(bs);
     // Fill the end parameters
     propRes.endParameters =

--- a/Core/include/Acts/Propagator/StepperConcept.hpp
+++ b/Core/include/Acts/Propagator/StepperConcept.hpp
@@ -104,15 +104,15 @@ namespace concept {
         static_assert(time_exists, "time method not found");
         constexpr static bool overstep_exists = has_method<const S, double, overstep_t, const state&>;
         static_assert(overstep_exists, "overstepLimit method not found");
-        constexpr static bool bound_state_method_exists= has_method<const S, typename S::BoundState, bound_state_method_t, state&, const Surface&, bool>;
+        constexpr static bool bound_state_method_exists= has_method<const S, typename S::BoundState, bound_state_method_t, state&, const Surface&>;
         static_assert(bound_state_method_exists, "boundState method not found");
-        constexpr static bool curvilinear_state_method_exists = has_method<const S, typename S::CurvilinearState, curvilinear_state_method_t, state&, bool>;
+        constexpr static bool curvilinear_state_method_exists = has_method<const S, typename S::CurvilinearState, curvilinear_state_method_t, state&>;
         static_assert(curvilinear_state_method_exists, "curvilinearState method not found");
         constexpr static bool update_method_exists = require<has_method<const S, void, update_t, state&, const BoundParameters&>,
                                                              has_method<const S, void, update_t, state&, const Vector3D&, const Vector3D&, double, double>>;
         static_assert(update_method_exists, "update method not found");
-        constexpr static bool covariance_transport_exists = require<has_method<const S, void, covariance_transport_t, state&, bool>,
-                                                                    has_method<const S, void, covariance_transport_t, state&, const Surface&, bool>>;
+        constexpr static bool covariance_transport_exists = require<has_method<const S, void, covariance_transport_t, state&>,
+                                                                    has_method<const S, void, covariance_transport_t, state&, const Surface&>>;
         static_assert(covariance_transport_exists, "covarianceTransport method not found");
         constexpr static bool update_surface_exists = has_method<const S, Intersection::Status, update_surface_status_t, state&, const Surface&, const BoundaryCheck&>;
         static_assert(update_surface_exists, "updateSurfaceStatus method not found");

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <cmath>
-#include <functional>
+#include <tuple>
 
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -241,29 +241,24 @@ class StraightLineStepper {
   ///
   /// @param [in] state State that will be presented as @c BoundState
   /// @param [in] surface The surface to which we bind the state
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A bound state:
   ///   - the parameters at the surface
   ///   - the stepwise jacobian towards it (from last bound)
   ///   - and the path length (from start - for ordering)
-  BoundState boundState(State& state, const Surface& surface,
-                        bool reinitialize) const;
+  BoundState boundState(State& state, const Surface& surface) const;
 
   /// Create and return a curvilinear state at the current position
   ///
   /// @brief This creates a curvilinear state.
   ///
   /// @param [in] state State that will be presented as @c CurvilinearState
-  /// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-  /// i.e. if this is an intermediate state of a larger propagation
   ///
   /// @return A curvilinear state:
   ///   - the curvilinear parameters at given position
   ///   - the stepweise jacobian towards it (from last bound)
   ///   - and the path length (from start - for ordering)
-  CurvilinearState curvilinearState(State& state, bool reinitialize) const;
+  CurvilinearState curvilinearState(State& state) const;
 
   /// Method to update a stepper state to the some parameters
   ///
@@ -286,10 +281,7 @@ class StraightLineStepper {
   /// or direction of the state - for the moment a dummy method
   ///
   /// @param [in,out] state State of the stepper
-  /// @param [in] reinitialize is a flag to steer whether the
-  ///        state should be reinitialized at the new
-  ///        position
-  void covarianceTransport(State& state, bool reinitialize = false) const;
+  void covarianceTransport(State& state) const;
 
   /// Method for on-demand transport of the covariance
   /// to a new curvilinear frame at current  position,
@@ -300,13 +292,9 @@ class StraightLineStepper {
   /// @param [in,out] state The stepper state
   /// @param [in] surface is the surface to which the covariance is
   ///        forwarded to
-  /// @param [in] reinitialize is a flag to steer whether the
-  ///        state should be reinitialized at the new
-  ///        position
   /// @note no check is done if the position is actually on the surface
   ///
-  void covarianceTransport(State& state, const Surface& surface,
-                           bool reinitialize = false) const;
+  void covarianceTransport(State& state, const Surface& surface) const;
 
   /// Perform a straight line propagation step
   ///

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -146,6 +146,22 @@ class StraightLineStepper {
     return Vector3D(0., 0., 0.);
   }
 
+  /// Global free parameters vector.
+  ///
+  /// @param state Current stepper state
+  FreeVector parameters(const State& state) const {
+    FreeVector params;
+    params[eFreePos0] = state.pos[0];
+    params[eFreePos1] = state.pos[1];
+    params[eFreePos2] = state.pos[2];
+    params[eFreeTime] = state.t;
+    params[eFreeDir0] = state.dir[0];
+    params[eFreeDir1] = state.dir[1];
+    params[eFreeDir2] = state.dir[2];
+    params[eFreeQOverP] = (state.q != 0) ? (state.q / state.p) : (1 / state.p);
+    return params;
+  }
+
   /// Global particle position accessor
   ///
   /// @param state [in] The stepping state (thread-local cache)

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -34,15 +34,13 @@ namespace detail {
 /// @tparam result_t Defines the return type
 /// @param [in] state State that will be presented as @c BoundState
 /// @param [in] surface The surface to which we bind the state
-/// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-/// i.e. if this is an intermediate state of a larger propagation
 ///
 /// @return A bound state:
 ///   - the parameters at the surface
 ///   - the stepwise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
 std::tuple<BoundParameters, BoundMatrix, double> boundState(
-    StepperState& state, const Surface& surface, bool reinitialize);
+    StepperState& state, const Surface& surface);
 
 /// Create and return a curvilinear state at the current position
 ///
@@ -50,28 +48,24 @@ std::tuple<BoundParameters, BoundMatrix, double> boundState(
 ///
 /// @tparam result_t Defines the return type
 /// @param [in] state State that will be presented as @c CurvilinearState
-/// @param [in] reinitialize Boolean flag whether reinitialization is needed,
-/// i.e. if this is an intermediate state of a larger propagation
 ///
 /// @return A curvilinear state:
 ///   - the curvilinear parameters at given position
 ///   - the stepweise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
 std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
-    StepperState& state, bool reinitialize);
+    StepperState& state);
 
 /// @brief Method for on-demand transport of the covariance to a new frame at
 /// current position in parameter space
 ///
 /// @param [in,out] state The stepper state
-/// @param [in] toLocal Boolean flag whether the result is in local parameters
 /// @param [in] surface is the surface to which the covariance is
 ///        forwarded to
 /// @note No check is done if the position is actually on the surface
 ///
 /// @return Projection jacobian from global to bound parameters
-void covarianceTransport(StepperState& state, bool reinitialize,
-                         const Surface* surface = nullptr);
+void covarianceTransport(StepperState& state, const Surface* surface = nullptr);
 
 }  // namespace detail
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -28,31 +28,33 @@ namespace detail {
 /// calculations are identical for @c StraightLineStepper and @c EigenStepper.
 /// As a consequence the methods can be located in a seperate file.
 
-/// Construct a bound state at the current position.
+/// Construct bound parameters at the current position.
 ///
-/// @param [in] state State that will be presented as @c BoundState
-/// @param [in] surface The surface to which we bind the state
-/// @return A bound state:
-///   - the bound parameters at the surface
-///   - the stepwise jacobian towards it (from last bound)
-///   - and the path length (from start - for ordering)
+/// @param [in] freeParams free parameters vector
+/// @param [in] boundCov bound covariance matrix
+/// @param [in] covIsValid whether the covariance matrix contains valid entries
+/// @param [in] surface surface on which the parameters are bound to
+/// @param [in] geoCtx geometry context
+/// @return bound parameters on the surface
 ///
 /// @note Assumes that the position is already on the surface and covariance
 ///       (optionally) has already been transported.
-std::tuple<BoundParameters, BoundMatrix, double> boundState(
-    const StepperState& state, const Surface& surface);
+BoundParameters makeBoundParameters(const FreeVector& freeParams,
+                                    const BoundSymMatrix& boundCov,
+                                    bool covIsValid, const Surface& surface,
+                                    const GeometryContext& geoCtx);
 
 /// Construct a curvilinear state at the current position
 ///
-/// @param [in] state State that will be presented as @c CurvilinearState
-/// @return A curvilinear state:
-///   - the curvilinear parameters at given position
-///   - the stepwise jacobian towards it (from last bound)
-///   - and the path length (from start - for ordering)
+/// @param [in] freeParams free parameters vector
+/// @param [in] curvilinearCov curvilinear covariance matrix
+/// @param [in] covIsValid whether the covariance matrix contains valid entries
+/// @return curvilinear parameters at the current position
 ///
 /// @note Assumes that the covariance (optionally) has already been transported.
-std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
-    const StepperState& state);
+CurvilinearParameters makeCurvilinearParameters(
+    const FreeVector& freeParams, const BoundSymMatrix& curvilinearCov,
+    bool covIsValid);
 
 /// Transport covariance to the bound state on an arbitrary surface.
 ///

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -56,25 +56,43 @@ CurvilinearParameters makeCurvilinearParameters(
     const FreeVector& freeParams, const BoundSymMatrix& curvilinearCov,
     bool covIsValid);
 
-/// Transport covariance to the bound state on an arbitrary surface.
+/// Compute the combined jacobian to bound parameters on a surface.
 ///
-/// @param [in,out] state The stepper state
-/// @param [in] surface is the surface to which the covariance is forwarded to
+/// @param [in] freeParams free parameters vector
+/// @param [in] surface target surface for the bound parameters
+/// @param [in] geoCtx geometry context
+/// @param [in,out] jacToGlobal Jacobian from initial bound to free parameters
+/// @param [in,out] jacTransport Transport Jacobian in free parameters
+/// @param [in,out] derivative Stepper derivative
+/// @param [out] jacobian from initial bound to target bound parameters.
 ///
-/// @note This assumes that the current global parameter state has already been
-///       propagated to be on the surface.
+/// @note This assumes that the current global parameter state has already
+///       been propagated to be on the surface.
 ///
-/// The Jacobians are reset such that they represent the propagation starting at
-/// the surface.
-void transportCovarianceToBound(StepperState& state, const Surface& surface);
+/// The partial Jacobians are reset such that they represent the propagation
+/// starting at the surface.
+void updateJacobiansToBound(const FreeVector& freeParams,
+                            const Surface& surface,
+                            const GeometryContext& geoCtx,
+                            BoundToFreeMatrix& jacToGlobal,
+                            FreeMatrix& jacTransport, FreeVector& derivative,
+                            BoundMatrix& jacobian);
 
-/// Transport covariance to the bound state on the current curvilinear frame.
+/// Compute the combined Jacobian to curvilinear parameters.
 ///
-/// @param [in,out] state The stepper state
+/// @param [in] freeParams free parameters vector
+/// @param [in,out] jacToGlobal Jacobian from initial bound to free parameters
+/// @param [in,out] jacTransport Transport Jacobian in free parameters
+/// @param [in,out] derivative Stepper derivative
+/// @param [out] jacobian from initial bound to target curvilinear parameters.
 ///
-/// The Jacobians are reset such that they represent the propagation starting at
-/// the current curvilinear frame.
-void transportCovarianceToCurvilinear(StepperState& state);
+/// The partial Jacobians are reset such that they represent the propagation
+/// starting at current curvilinear frame.
+void updateJacobiansToCurvilinear(const FreeVector& freeParams,
+                                  BoundToFreeMatrix& jacToGlobal,
+                                  FreeMatrix& jacTransport,
+                                  FreeVector& derivative,
+                                  BoundMatrix& jacobian);
 
 }  // namespace detail
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,12 +8,8 @@
 
 #pragma once
 
-#include <cmath>
-#include <tuple>
-
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Propagator/StepperState.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 namespace Acts {
@@ -21,12 +17,6 @@ namespace Acts {
 class Surface;
 
 namespace detail {
-
-/// @brief These functions perform the transport of a covariance matrix using
-/// given Jacobians. The required data is provided by a @p StepperState object
-/// with some additional data. Since this is a purely algebraic problem the
-/// calculations are identical for @c StraightLineStepper and @c EigenStepper.
-/// As a consequence the methods can be located in a seperate file.
 
 /// Construct bound parameters at the current position.
 ///

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -28,42 +28,36 @@ namespace detail {
 /// calculations are identical for @c StraightLineStepper and @c EigenStepper.
 /// As a consequence the methods can be located in a seperate file.
 
-/// Create and return the bound state at the current position.
+/// Construct a bound state at the current position.
 ///
 /// @param [in] state State that will be presented as @c BoundState
 /// @param [in] surface The surface to which we bind the state
 /// @return A bound state:
-///   - the parameters at the surface
+///   - the bound parameters at the surface
 ///   - the stepwise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
 ///
-/// @warning Calls the covariance transport internally and modifies the state
-///          accordingly on every call, but only if the covariance transport is
-///          enabled. Multiple calls at the same position can thus lead to
-///          ill-defined outputs.
+/// @note Assumes that the position is already on the surface and covariance
+///       (optionally) has already been transported.
 std::tuple<BoundParameters, BoundMatrix, double> boundState(
-    StepperState& state, const Surface& surface);
+    const StepperState& state, const Surface& surface);
 
-/// Create and return a curvilinear state at the current position
+/// Construct a curvilinear state at the current position
 ///
 /// @param [in] state State that will be presented as @c CurvilinearState
 /// @return A curvilinear state:
 ///   - the curvilinear parameters at given position
-///   - the stepweise jacobian towards it (from last bound)
+///   - the stepwise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
 ///
-/// @warning Calls the covariance transport internally and modifies the state
-///          accordingly on every call, but only if the covariance transport is
-///          enabled. Multiple calls at the same position can thus lead to
-///          ill-defined outputs.
+/// @note Assumes that the covariance (optionally) has already been transported.
 std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
-    StepperState& state);
+    const StepperState& state);
 
 /// Transport covariance to the bound state on an arbitrary surface.
 ///
 /// @param [in,out] state The stepper state
-/// @param [in] surface is the surface to which the covariance is
-///        forwarded to
+/// @param [in] surface is the surface to which the covariance is forwarded to
 ///
 /// @note This assumes that the current global parameter state has already been
 ///       propagated to be on the surface.

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -9,50 +9,53 @@
 #pragma once
 
 #include <cmath>
-#include <functional>
+#include <tuple>
 
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Propagator/StepperState.hpp"
-#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 namespace Acts {
+
+class Surface;
+
+namespace detail {
 
 /// @brief These functions perform the transport of a covariance matrix using
 /// given Jacobians. The required data is provided by a @p StepperState object
 /// with some additional data. Since this is a purely algebraic problem the
 /// calculations are identical for @c StraightLineStepper and @c EigenStepper.
 /// As a consequence the methods can be located in a seperate file.
-namespace detail {
 
-/// Create and return the bound state at the current position
+/// Create and return the bound state at the current position.
 ///
-/// @brief It does not check if the transported state is at the surface, this
-/// needs to be guaranteed by the propagator
-///
-/// @tparam result_t Defines the return type
 /// @param [in] state State that will be presented as @c BoundState
 /// @param [in] surface The surface to which we bind the state
-///
 /// @return A bound state:
 ///   - the parameters at the surface
 ///   - the stepwise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
+///
+/// @warning Calls the covariance transport internally and modifies the state
+///          accordingly on every call, but only if the covariance transport is
+///          enabled. Multiple calls at the same position can thus lead to
+///          ill-defined outputs.
 std::tuple<BoundParameters, BoundMatrix, double> boundState(
     StepperState& state, const Surface& surface);
 
 /// Create and return a curvilinear state at the current position
 ///
-/// @brief This creates a curvilinear state.
-///
-/// @tparam result_t Defines the return type
 /// @param [in] state State that will be presented as @c CurvilinearState
-///
 /// @return A curvilinear state:
 ///   - the curvilinear parameters at given position
 ///   - the stepweise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
+///
+/// @warning Calls the covariance transport internally and modifies the state
+///          accordingly on every call, but only if the covariance transport is
+///          enabled. Multiple calls at the same position can thus lead to
+///          ill-defined outputs.
 std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
     StepperState& state);
 

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -1,0 +1,77 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <cmath>
+#include <functional>
+
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Propagator/StepperState.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+
+namespace Acts {
+
+/// @brief These functions perform the transport of a covariance matrix using
+/// given Jacobians. The required data is provided by a @p StepperState object
+/// with some additional data. Since this is a purely algebraic problem the
+/// calculations are identical for @c StraightLineStepper and @c EigenStepper.
+/// As a consequence the methods can be located in a seperate file.
+namespace detail {
+
+/// Create and return the bound state at the current position
+///
+/// @brief It does not check if the transported state is at the surface, this
+/// needs to be guaranteed by the propagator
+///
+/// @tparam result_t Defines the return type
+/// @param [in] state State that will be presented as @c BoundState
+/// @param [in] surface The surface to which we bind the state
+/// @param [in] reinitialize Boolean flag whether reinitialization is needed,
+/// i.e. if this is an intermediate state of a larger propagation
+///
+/// @return A bound state:
+///   - the parameters at the surface
+///   - the stepwise jacobian towards it (from last bound)
+///   - and the path length (from start - for ordering)
+std::tuple<BoundParameters, BoundMatrix, double> boundState(
+    StepperState& state, const Surface& surface, bool reinitialize);
+
+/// Create and return a curvilinear state at the current position
+///
+/// @brief This creates a curvilinear state.
+///
+/// @tparam result_t Defines the return type
+/// @param [in] state State that will be presented as @c CurvilinearState
+/// @param [in] reinitialize Boolean flag whether reinitialization is needed,
+/// i.e. if this is an intermediate state of a larger propagation
+///
+/// @return A curvilinear state:
+///   - the curvilinear parameters at given position
+///   - the stepweise jacobian towards it (from last bound)
+///   - and the path length (from start - for ordering)
+std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
+    StepperState& state, bool reinitialize);
+
+/// @brief Method for on-demand transport of the covariance to a new frame at
+/// current position in parameter space
+///
+/// @param [in,out] state The stepper state
+/// @param [in] toLocal Boolean flag whether the result is in local parameters
+/// @param [in] surface is the surface to which the covariance is
+///        forwarded to
+/// @note No check is done if the position is actually on the surface
+///
+/// @return Projection jacobian from global to bound parameters
+void covarianceTransport(StepperState& state, bool reinitialize,
+                         const Surface* surface = nullptr);
+
+}  // namespace detail
+}  // namespace Acts

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -59,16 +59,26 @@ std::tuple<BoundParameters, BoundMatrix, double> boundState(
 std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
     StepperState& state);
 
-/// @brief Method for on-demand transport of the covariance to a new frame at
-/// current position in parameter space
+/// Transport covariance to the bound state on an arbitrary surface.
 ///
 /// @param [in,out] state The stepper state
 /// @param [in] surface is the surface to which the covariance is
 ///        forwarded to
-/// @note No check is done if the position is actually on the surface
 ///
-/// @return Projection jacobian from global to bound parameters
-void covarianceTransport(StepperState& state, const Surface* surface = nullptr);
+/// @note This assumes that the current global parameter state has already been
+///       propagated to be on the surface.
+///
+/// The Jacobians are reset such that they represent the propagation starting at
+/// the surface.
+void transportCovarianceToBound(StepperState& state, const Surface& surface);
+
+/// Transport covariance to the bound state on the current curvilinear frame.
+///
+/// @param [in,out] state The stepper state
+///
+/// The Jacobians are reset such that they represent the propagation starting at
+/// the current curvilinear frame.
+void transportCovarianceToCurvilinear(StepperState& state);
 
 }  // namespace detail
 }  // namespace Acts

--- a/Core/src/Propagator/CMakeLists.txt
+++ b/Core/src/Propagator/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources_local(
   PRIVATE
     StraightLineStepper.cpp
     detail/PointwiseMaterialInteraction.cpp
+    detail/CovarianceEngine.cpp
 )

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -12,14 +12,13 @@
 namespace Acts {
 
 std::tuple<BoundParameters, BoundMatrix, double>
-StraightLineStepper::boundState(State& state, const Surface& surface,
-                                bool reinitialize) const {
-  return detail::boundState(state, surface, reinitialize);
+StraightLineStepper::boundState(State& state, const Surface& surface) const {
+  return detail::boundState(state, surface);
 }
 
 std::tuple<CurvilinearParameters, BoundMatrix, double>
-StraightLineStepper::curvilinearState(State& state, bool reinitialize) const {
-  return detail::curvilinearState(state, reinitialize);
+StraightLineStepper::curvilinearState(State& state) const {
+  return detail::curvilinearState(state);
 }
 
 void StraightLineStepper::update(State& state,
@@ -44,14 +43,12 @@ void StraightLineStepper::update(State& state, const Vector3D& uposition,
   state.t = time;
 }
 
-void StraightLineStepper::covarianceTransport(State& state,
-                                              bool reinitialize) const {
-  detail::covarianceTransport(state, reinitialize);
+void StraightLineStepper::covarianceTransport(State& state) const {
+  detail::covarianceTransport(state);
 }
 
 void StraightLineStepper::covarianceTransport(State& state,
-                                              const Surface& surface,
-                                              bool reinitialize) const {
-  detail::covarianceTransport(state, reinitialize, &surface);
+                                              const Surface& surface) const {
+  detail::covarianceTransport(state, &surface);
 }
 }  // namespace Acts

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -7,53 +7,19 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Propagator/StraightLineStepper.hpp"
+#include "Acts/Propagator/detail/CovarianceEngine.hpp"
 
 namespace Acts {
 
 std::tuple<BoundParameters, BoundMatrix, double>
 StraightLineStepper::boundState(State& state, const Surface& surface,
                                 bool reinitialize) const {
-  // Transport the covariance to here
-  std::optional<Covariance> cov = std::nullopt;
-  if (state.covTransport) {
-    covarianceTransport(state, surface, reinitialize);
-    cov = state.cov;
-  }
-  // Create the bound parameters
-  BoundParameters parameters(state.geoContext, cov, state.pos,
-                             state.p * state.dir, state.q, state.t,
-                             surface.getSharedPtr());
-  // Create the bound state
-  BoundState bState{std::move(parameters), state.jacobian,
-                    state.pathAccumulated};
-  // Reset the jacobian to identity
-  if (reinitialize) {
-    state.jacobian = Jacobian::Identity();
-  }
-  /// Return the State
-  return bState;
+  return detail::boundState(state, surface, reinitialize);
 }
 
 std::tuple<CurvilinearParameters, BoundMatrix, double>
 StraightLineStepper::curvilinearState(State& state, bool reinitialize) const {
-  // Transport the covariance to here
-  std::optional<Covariance> cov = std::nullopt;
-  if (state.covTransport) {
-    covarianceTransport(state, reinitialize);
-    cov = state.cov;
-  }
-  // Create the curvilinear parameters
-  CurvilinearParameters parameters(cov, state.pos, state.p * state.dir, state.q,
-                                   state.t);
-  // Create the bound state
-  CurvilinearState curvState{std::move(parameters), state.jacobian,
-                             state.pathAccumulated};
-  // Reset the jacobian to identity
-  if (reinitialize) {
-    state.jacobian = Jacobian::Identity();
-  }
-  /// Return the State
-  return curvState;
+  return detail::curvilinearState(state, reinitialize);
 }
 
 void StraightLineStepper::update(State& state,
@@ -80,117 +46,12 @@ void StraightLineStepper::update(State& state, const Vector3D& uposition,
 
 void StraightLineStepper::covarianceTransport(State& state,
                                               bool reinitialize) const {
-  // Optimized trigonometry on the propagation direction
-  const double x = state.dir(0);  // == cos(phi) * sin(theta)
-  const double y = state.dir(1);  // == sin(phi) * sin(theta)
-  const double z = state.dir(2);  // == cos(theta)
-  // can be turned into cosine/sine
-  const double cosTheta = z;
-  const double sinTheta = sqrt(x * x + y * y);
-  const double invSinTheta = 1. / sinTheta;
-  const double cosPhi = x * invSinTheta;
-  const double sinPhi = y * invSinTheta;
-  // prepare the jacobian to curvilinear
-  FreeToBoundMatrix jacToCurv = FreeToBoundMatrix::Zero();
-  if (std::abs(cosTheta) < s_curvilinearProjTolerance) {
-    // We normally operate in curvilinear coordinates defined as follows
-    jacToCurv(0, 0) = -sinPhi;
-    jacToCurv(0, 1) = cosPhi;
-    jacToCurv(1, 0) = -cosPhi * cosTheta;
-    jacToCurv(1, 1) = -sinPhi * cosTheta;
-    jacToCurv(1, 2) = sinTheta;
-  } else {
-    // Under grazing incidence to z, the above coordinate system definition
-    // becomes numerically unstable, and we need to switch to another one
-    const double c = sqrt(y * y + z * z);
-    const double invC = 1. / c;
-    jacToCurv(0, 1) = -z * invC;
-    jacToCurv(0, 2) = y * invC;
-    jacToCurv(1, 0) = c;
-    jacToCurv(1, 1) = -x * y * invC;
-    jacToCurv(1, 2) = -x * z * invC;
-  }
-  // Time parameter
-  jacToCurv(5, 3) = 1.;
-  // Directional and momentum parameters for curvilinear
-  jacToCurv(2, 4) = -sinPhi * invSinTheta;
-  jacToCurv(2, 5) = cosPhi * invSinTheta;
-  jacToCurv(3, 6) = -invSinTheta;
-  jacToCurv(4, 7) = 1.;
-  // Apply the transport from the steps on the jacobian
-  state.jacToGlobal = state.jacTransport * state.jacToGlobal;
-  // Transport the covariance
-  ActsRowVectorD<3> normVec(state.dir);
-  const BoundRowVector sfactors =
-      normVec *
-      state.jacToGlobal.template topLeftCorner<3, eBoundParametersSize>();
-  // The full jacobian is ([to local] jacobian) * ([transport] jacobian)
-  const Jacobian jacFull =
-      jacToCurv * (state.jacToGlobal - state.derivative * sfactors);
-  // Apply the actual covariance transport
-  state.cov = (jacFull * state.cov * jacFull.transpose());
-  // Reinitialize if asked to do so
-  // this is useful for interruption calls
-  if (reinitialize) {
-    // reset the jacobians
-    state.jacToGlobal = BoundToFreeMatrix::Zero();
-    state.jacTransport = FreeMatrix::Identity();
-    // fill the jacobian to global for next transport
-    state.jacToGlobal(0, eLOC_0) = -sinPhi;
-    state.jacToGlobal(0, eLOC_1) = -cosPhi * cosTheta;
-    state.jacToGlobal(1, eLOC_0) = cosPhi;
-    state.jacToGlobal(1, eLOC_1) = -sinPhi * cosTheta;
-    state.jacToGlobal(2, eLOC_1) = sinTheta;
-    state.jacToGlobal(3, eT) = 1;
-    state.jacToGlobal(4, ePHI) = -sinTheta * sinPhi;
-    state.jacToGlobal(4, eTHETA) = cosTheta * cosPhi;
-    state.jacToGlobal(5, ePHI) = sinTheta * cosPhi;
-    state.jacToGlobal(5, eTHETA) = cosTheta * sinPhi;
-    state.jacToGlobal(6, eTHETA) = -sinTheta;
-    state.jacToGlobal(7, eQOP) = 1;
-  }
-  // Store The global and bound jacobian (duplication for the moment)
-  state.jacobian = jacFull * state.jacobian;
+  detail::covarianceTransport(state, reinitialize);
 }
 
 void StraightLineStepper::covarianceTransport(State& state,
                                               const Surface& surface,
                                               bool reinitialize) const {
-  using VectorHelpers::phi;
-  using VectorHelpers::theta;
-  // Initialize the transport final frame jacobian
-  FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
-  // initalize the jacobian to local, returns the transposed ref frame
-  auto rframeT = surface.initJacobianToLocal(state.geoContext, jacToLocal,
-                                             state.pos, state.dir);
-  // Update the jacobian with the transport from the steps
-  state.jacToGlobal = state.jacTransport * state.jacToGlobal;
-  // calculate the form factors for the derivatives
-  const BoundRowVector sVec = surface.derivativeFactors(
-      state.geoContext, state.pos, state.dir, rframeT, state.jacToGlobal);
-  // the full jacobian is ([to local] jacobian) * ([transport] jacobian)
-  const Jacobian jacFull =
-      jacToLocal * (state.jacToGlobal - state.derivative * sVec);
-  // Apply the actual covariance transport
-  state.cov = (jacFull * state.cov * jacFull.transpose());
-  // Reinitialize if asked to do so
-  // this is useful for interruption calls
-  if (reinitialize) {
-    // reset the jacobians
-    state.jacToGlobal = BoundToFreeMatrix::Zero();
-    state.jacTransport = FreeMatrix::Identity();
-    // reset the derivative
-    state.derivative = FreeVector::Zero();
-    // fill the jacobian to global for next transport
-    Vector2D loc{0., 0.};
-    surface.globalToLocal(state.geoContext, state.pos, state.dir, loc);
-    BoundVector pars;
-    pars << loc[eLOC_0], loc[eLOC_1], phi(state.dir), theta(state.dir),
-        state.q / state.p, state.t;
-    surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, state.pos,
-                                 state.dir, pars);
-  }
-  // Store The global and bound jacobian (duplication for the moment)
-  state.jacobian = jacFull * state.jacobian;
+  detail::covarianceTransport(state, reinitialize, &surface);
 }
 }  // namespace Acts

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -51,4 +51,5 @@ void StraightLineStepper::covarianceTransport(State& state,
                                               const Surface& surface) const {
   detail::covarianceTransport(state, &surface);
 }
+
 }  // namespace Acts

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Propagator/StraightLineStepper.hpp"
+
 #include "Acts/Propagator/detail/CovarianceEngine.hpp"
 
 namespace Acts {
@@ -44,12 +45,12 @@ void StraightLineStepper::update(State& state, const Vector3D& uposition,
 }
 
 void StraightLineStepper::covarianceTransport(State& state) const {
-  detail::covarianceTransport(state);
+  detail::transportCovarianceToCurvilinear(state);
 }
 
 void StraightLineStepper::covarianceTransport(State& state,
                                               const Surface& surface) const {
-  detail::covarianceTransport(state, &surface);
+  detail::transportCovarianceToBound(state, surface);
 }
 
 }  // namespace Acts

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -14,12 +14,17 @@ namespace Acts {
 
 std::tuple<BoundParameters, BoundMatrix, double>
 StraightLineStepper::boundState(State& state, const Surface& surface) const {
-  return detail::boundState(state, surface);
+  return {detail::makeBoundParameters(parameters(state), state.cov,
+                                      state.covTransport, surface,
+                                      state.geoContext),
+          state.jacobian, state.pathAccumulated};
 }
 
 std::tuple<CurvilinearParameters, BoundMatrix, double>
 StraightLineStepper::curvilinearState(State& state) const {
-  return detail::curvilinearState(state);
+  return {detail::makeCurvilinearParameters(parameters(state), state.cov,
+                                            state.covTransport),
+          state.jacobian, state.pathAccumulated};
 }
 
 void StraightLineStepper::update(State& state,

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -50,12 +50,22 @@ void StraightLineStepper::update(State& state, const Vector3D& uposition,
 }
 
 void StraightLineStepper::covarianceTransport(State& state) const {
-  detail::transportCovarianceToCurvilinear(state);
+  detail::updateJacobiansToCurvilinear(parameters(state), state.jacToGlobal,
+                                       state.jacTransport, state.derivative,
+                                       state.jacobian);
+  if (state.covTransport) {
+    state.cov = state.jacobian * state.cov * state.jacobian.transpose();
+  }
 }
 
 void StraightLineStepper::covarianceTransport(State& state,
                                               const Surface& surface) const {
-  detail::transportCovarianceToBound(state, surface);
+  detail::updateJacobiansToBound(parameters(state), surface, state.geoContext,
+                                 state.jacToGlobal, state.jacTransport,
+                                 state.derivative, state.jacobian);
+  if (state.covTransport) {
+    state.cov = state.jacobian * state.cov * state.jacobian.transpose();
+  }
 }
 
 }  // namespace Acts

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -8,6 +8,8 @@
 
 #include "Acts/Propagator/detail/CovarianceEngine.hpp"
 
+#include "Acts/Surfaces/Surface.hpp"
+
 namespace Acts {
 namespace {
 /// Some type defs

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -154,35 +154,24 @@ void applyDerivativeCorrectionCurvilinear(const Vector3D& unitDirection,
 namespace detail {
 
 std::tuple<BoundParameters, BoundMatrix, double> boundState(
-    StepperState& state, const Surface& surface) {
-  // Transport the covariance to here
-  std::optional<BoundSymMatrix> cov = std::nullopt;
-  if (state.covTransport) {
-    // Initialize the transport final frame jacobian
-    transportCovarianceToBound(state, surface);
-    cov = state.cov;
-  }
+    const StepperState& state, const Surface& surface) {
+  // Construct the optional covariance
+  auto cov = state.covTransport ? std::make_optional(state.cov) : std::nullopt;
   // Create the bound parameters
   BoundParameters parameters(state.geoContext, std::move(cov), state.pos,
                              state.p * state.dir, state.q, state.t,
                              surface.getSharedPtr());
-  // Create the bound state
   return std::make_tuple(std::move(parameters), state.jacobian,
                          state.pathAccumulated);
 }
 
 std::tuple<CurvilinearParameters, BoundMatrix, double> curvilinearState(
-    StepperState& state) {
-  // Transport the covariance to here
-  std::optional<BoundSymMatrix> cov = std::nullopt;
-  if (state.covTransport) {
-    transportCovarianceToCurvilinear(state);
-    cov = state.cov;
-  }
+    const StepperState& state) {
+  // Construct the optional covariance
+  auto cov = state.covTransport ? std::make_optional(state.cov) : std::nullopt;
   // Create the curvilinear parameters
   CurvilinearParameters parameters(std::move(cov), state.pos,
                                    state.p * state.dir, state.q, state.t);
-  // Create the bound state
   return std::make_tuple(std::move(parameters), state.jacobian,
                          state.pathAccumulated);
 }

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -1,0 +1,244 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Propagator/detail/CovarianceEngine.hpp"
+
+namespace Acts {
+namespace {
+/// Some type defs
+using Jacobian = BoundMatrix;
+using Covariance = BoundSymMatrix;
+using BoundState = std::tuple<BoundParameters, Jacobian, double>;
+using CurvilinearState = std::tuple<CurvilinearParameters, Jacobian, double>;
+
+/// @brief Evaluate the projection Jacobian from free to curvilinear parameters
+///
+/// @param [in] state State that will be projected
+///
+/// @return Projection Jacobian
+FreeToBoundMatrix freeToCurvilinearJacobian(const StepperState& state) {
+  // Optimized trigonometry on the propagation direction
+  const double x = state.dir(0);  // == cos(phi) * sin(theta)
+  const double y = state.dir(1);  // == sin(phi) * sin(theta)
+  const double z = state.dir(2);  // == cos(theta)
+  // can be turned into cosine/sine
+  const double cosTheta = z;
+  const double sinTheta = sqrt(x * x + y * y);
+  const double invSinTheta = 1. / sinTheta;
+  const double cosPhi = x * invSinTheta;
+  const double sinPhi = y * invSinTheta;
+  // prepare the jacobian to curvilinear
+  FreeToBoundMatrix jacToCurv = FreeToBoundMatrix::Zero();
+  if (std::abs(cosTheta) < s_curvilinearProjTolerance) {
+    // We normally operate in curvilinear coordinates defined as follows
+    jacToCurv(0, 0) = -sinPhi;
+    jacToCurv(0, 1) = cosPhi;
+    jacToCurv(1, 0) = -cosPhi * cosTheta;
+    jacToCurv(1, 1) = -sinPhi * cosTheta;
+    jacToCurv(1, 2) = sinTheta;
+  } else {
+    // Under grazing incidence to z, the above coordinate system definition
+    // becomes numerically unstable, and we need to switch to another one
+    const double c = sqrt(y * y + z * z);
+    const double invC = 1. / c;
+    jacToCurv(0, 1) = -z * invC;
+    jacToCurv(0, 2) = y * invC;
+    jacToCurv(1, 0) = c;
+    jacToCurv(1, 1) = -x * y * invC;
+    jacToCurv(1, 2) = -x * z * invC;
+  }
+  // Time parameter
+  jacToCurv(5, 3) = 1.;
+  // Directional and momentum parameters for curvilinear
+  jacToCurv(2, 4) = -sinPhi * invSinTheta;
+  jacToCurv(2, 5) = cosPhi * invSinTheta;
+  jacToCurv(3, 6) = -invSinTheta;
+  jacToCurv(4, 7) = 1.;
+
+  return jacToCurv;
+}
+
+/// @brief This function treats the modifications of the jacobian related to the
+/// projection onto a surface. Since a variation of the start parameters within
+/// a given uncertainty would lead to a variation of the end parameters, these
+/// need to be propagated onto the target surface. This an approximated approach
+/// to treat the (assumed) small change.
+///
+/// @param [in] state The current state
+/// @param [in] surface The surface onto which the projection should be
+/// performed
+/// @note The parameter @p surface is only required if projected to bound
+/// parameters. In the case of curvilinear parameters the geometry and the
+/// position is known and the calculation can be simplified
+///
+/// @return The projection jacobian from global end parameters to its local
+/// equivalent
+const FreeToBoundMatrix surfaceDerivative(StepperState& state,
+                                          const Surface* surface = nullptr) {
+  // Set the surface projection contributions
+  // If no surface is specified it is curvilinear
+  if (surface == nullptr) {
+    // Transport the covariance
+    const ActsRowVectorD<3> normVec(state.dir);
+    const BoundRowVector sfactors =
+        normVec * state.jacToGlobal.template topLeftCorner<3, BoundParsDim>();
+    state.jacToGlobal -= state.derivative * sfactors;
+    // Since the jacobian to local needs to calculated for the bound parameters
+    // here, it is convenient to do the same here
+    return freeToCurvilinearJacobian(state);
+  }
+  // Else it is bound
+  else {
+    // Initialize the transport final frame jacobian
+    FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
+    // Initalize the jacobian to local, returns the transposed ref frame
+    auto rframeT = surface->initJacobianToLocal(state.geoContext, jacToLocal,
+                                                state.pos, state.dir);
+    // Calculate the form factors for the derivatives
+    const BoundRowVector sVec = surface->derivativeFactors(
+        state.geoContext, state.pos, state.dir, rframeT, state.jacToGlobal);
+    state.jacToGlobal -= state.derivative * sVec;
+    // Return the jacobian to local
+    return jacToLocal;
+  }
+}
+
+/// @brief This function reinitialises the @p state member @p jacToGlobal.
+///
+/// @param [in, out] state The state object
+/// @param [in] surface The surface the represents the local parametrisation
+/// @note The surface is only required for bound parameters since it serves to
+/// derive the jacobian from it. In the case of curvilinear parameters this is
+/// not needed and can be evaluated without any surface.
+void reinitializeJacToGlobal(StepperState& state,
+                             const Surface* surface = nullptr) {
+  using VectorHelpers::phi;
+  using VectorHelpers::theta;
+
+  // Reset the jacobian
+  state.jacToGlobal = BoundToFreeMatrix::Zero();
+
+  // Fill the jacobian to global for next transport
+  // If treating curvilinear parameters
+  if (surface == nullptr) {
+    // TODO: This was calculated before - can it be reused?
+    // Optimized trigonometry on the propagation direction
+    const double x = state.dir(0);  // == cos(phi) * sin(theta)
+    const double y = state.dir(1);  // == sin(phi) * sin(theta)
+    const double z = state.dir(2);  // == cos(theta)
+    // can be turned into cosine/sine
+    const double cosTheta = z;
+    const double sinTheta = sqrt(x * x + y * y);
+    const double invSinTheta = 1. / sinTheta;
+    const double cosPhi = x * invSinTheta;
+    const double sinPhi = y * invSinTheta;
+
+    state.jacToGlobal(0, eLOC_0) = -sinPhi;
+    state.jacToGlobal(0, eLOC_1) = -cosPhi * cosTheta;
+    state.jacToGlobal(1, eLOC_0) = cosPhi;
+    state.jacToGlobal(1, eLOC_1) = -sinPhi * cosTheta;
+    state.jacToGlobal(2, eLOC_1) = sinTheta;
+    state.jacToGlobal(3, eT) = 1;
+    state.jacToGlobal(4, ePHI) = -sinTheta * sinPhi;
+    state.jacToGlobal(4, eTHETA) = cosTheta * cosPhi;
+    state.jacToGlobal(5, ePHI) = sinTheta * cosPhi;
+    state.jacToGlobal(5, eTHETA) = cosTheta * sinPhi;
+    state.jacToGlobal(6, eTHETA) = -sinTheta;
+    state.jacToGlobal(7, eQOP) = 1;
+  }
+  // If treating bound parameters
+  else {
+    Vector2D loc{0., 0.};
+    surface->globalToLocal(state.geoContext, state.pos, state.dir, loc);
+    BoundVector pars;
+    pars << loc[eLOC_0], loc[eLOC_1], phi(state.dir), theta(state.dir),
+        state.q / state.p, state.t;
+    surface->initJacobianToGlobal(state.geoContext, state.jacToGlobal,
+                                  state.pos, state.dir, pars);
+  }
+}
+
+/// @brief Reinitializes the jacobians of @p state and its components
+///
+/// @param [in, out] state The state of the stepper
+/// @param [in] surface Representing surface of the stepper state
+void reinitializeJacobians(StepperState& state,
+                           const Surface* surface = nullptr) {
+  state.jacobian = Jacobian::Identity();
+  state.jacTransport = FreeMatrix::Identity();
+  state.derivative = FreeVector::Zero();
+  reinitializeJacToGlobal(state, surface);
+}
+}  // namespace
+
+namespace detail {
+
+BoundState boundState(StepperState& state, const Surface& surface,
+                      bool reinitialize) {
+  // Transport the covariance to here
+  std::optional<BoundSymMatrix> cov = std::nullopt;
+  if (state.covTransport) {
+    // Initialize the transport final frame jacobian
+    covarianceTransport(state, reinitialize, &surface);
+    cov = state.cov;
+  }
+  // Create the bound parameters
+  BoundParameters parameters(state.geoContext, cov, state.pos,
+                             state.p * state.dir, state.q, state.t,
+                             surface.getSharedPtr());
+  // Create the bound state
+  BoundState result = std::make_tuple(std::move(parameters), state.jacobian,
+                                      state.pathAccumulated);
+  // Reinitialize if asked to do so
+  // this is useful for interruption calls
+  if (reinitialize) {
+    reinitializeJacobians(state, &surface);
+  }
+  return result;
+}
+
+CurvilinearState curvilinearState(StepperState& state, bool reinitialize) {
+  // Transport the covariance to here
+  std::optional<BoundSymMatrix> cov = std::nullopt;
+  if (state.covTransport) {
+    covarianceTransport(state, reinitialize);
+    cov = state.cov;
+  }
+  // Create the curvilinear parameters
+  CurvilinearParameters parameters(cov, state.pos, state.p * state.dir, state.q,
+                                   state.t);
+  // Create the bound state
+  CurvilinearState result = std::make_tuple(
+      std::move(parameters), state.jacobian, state.pathAccumulated);
+  // Reinitialize if asked to do so
+  // this is useful for interruption calls
+  if (reinitialize) {
+    reinitializeJacobians(state);
+  }
+  return result;
+}
+
+void covarianceTransport(StepperState& state, bool reinitialize,
+                         const Surface* surface) {
+  state.jacToGlobal = state.jacTransport * state.jacToGlobal;
+
+  const FreeToBoundMatrix jacToLocal = surfaceDerivative(state, surface);
+  const Jacobian jacFull = jacToLocal * state.jacToGlobal;
+
+  // Apply the actual covariance transport
+  state.cov = jacFull * state.cov * jacFull.transpose();
+
+  if (reinitialize) {
+    reinitializeJacobians(state, surface);
+  }
+
+  // Store The global and bound jacobian (duplication for the moment)
+  state.jacobian = jacFull * state.jacobian;
+}
+}  // namespace detail
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
@@ -68,7 +68,7 @@ struct StepWiseActor {
     auto surface = state.navigation.currentSurface;
     if (surface and surface->associatedDetectorElement()) {
       // Create a bound state and log the jacobian
-      auto boundState = stepper.boundState(state.stepping, *surface, true);
+      auto boundState = stepper.boundState(state.stepping, *surface);
       result.jacobians.push_back(std::move(std::get<Jacobian>(boundState)));
       result.paths.push_back(std::get<double>(boundState));
     }

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -138,10 +138,7 @@ struct PropagatorState {
       return state.stepSize.toString();
     }
 
-    BoundState boundState(State& state, const Surface& surface,
-                          bool reinitialize = true) const {
-      // suppress unused warning
-      (void)reinitialize;
+    BoundState boundState(State& state, const Surface& surface) const {
       BoundParameters parameters(tgContext, std::nullopt, state.pos,
                                  state.p * state.dir, state.q, state.t,
                                  surface.getSharedPtr());
@@ -150,9 +147,7 @@ struct PropagatorState {
       return bState;
     }
 
-    CurvilinearState curvilinearState(State& state,
-                                      bool reinitialize = true) const {
-      (void)reinitialize;
+    CurvilinearState curvilinearState(State& state) const {
       CurvilinearParameters parameters(std::nullopt, state.pos,
                                        state.p * state.dir, state.q, state.t);
       // Create the bound state
@@ -167,11 +162,10 @@ struct PropagatorState {
                 const Vector3D& /*udirection*/, double /*up*/,
                 double /*time*/) const {}
 
-    void covarianceTransport(State& /*state*/,
-                             bool /*reinitialize = false*/) const {}
+    void covarianceTransport(State& /*state*/) const {}
 
-    void covarianceTransport(State& /*unused*/, const Surface& /*surface*/,
-                             bool /*reinitialize = false*/) const {}
+    void covarianceTransport(State& /*unused*/,
+                             const Surface& /*surface*/) const {}
 
     Vector3D getField(State& /*state*/, const Vector3D& /*pos*/) const {
       // get the field from the cell


### PR DESCRIPTION
Add a common covariance transport engine for EigenStepper and StraightLineStepper without introducing a shared StepperState object.

This contains previously proposed changes by @FabianKlimpel with additional modification. The covariance engine helpers are split to use the Jacobian matrices directly. To reduce the number of parameters, EigenStepper and StraightLineStepper provide an accessor to a combined free parameter vector.

This supercedes https://gitlab.cern.ch/acts/acts-core/-/merge_requests/705 and https://gitlab.cern.ch/acts/acts-core/-/merge_requests/726 and obsoletes https://gitlab.cern.ch/acts/acts-core/-/merge_requests/704.