### PR TITLE
Miscellaneous AtlasStepper and EigenStepper fixes, AtlasStepper docs

### DIFF
--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -255,7 +255,7 @@ class AtlasStepper {
     /// X  ->P[0]  dX /   P[ 8]   P[16]   P[24]   P[32]   P[40]  P[48]
     /// Y  ->P[1]  dY /   P[ 9]   P[17]   P[25]   P[33]   P[41]  P[49]
     /// Z  ->P[2]  dZ /   P[10]   P[18]   P[26]   P[34]   P[42]  P[50]
-    /// T  ->P[3]  dT/	  P[11]   P[19]   P[27]   P[35]   P[43]  P[51]
+    /// T  ->P[3]  dT/    P[11]   P[19]   P[27]   P[35]   P[43]  P[51]
     /// Ax ->P[4]  dAx/   P[12]   P[20]   P[28]   P[36]   P[44]  P[52]
     /// Ay ->P[5]  dAy/   P[13]   P[21]   P[29]   P[37]   P[45]  P[53]
     /// Az ->P[6]  dAz/   P[14]   P[22]   P[30]   P[38]   P[46]  P[54]
@@ -1167,9 +1167,10 @@ class AtlasStepper {
       //
       // This is (h2 * (sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>())
       // in EigenStepper
-      double EST = 2. * h * (std::abs((A1 + A6) - (A3 + A4)) +
-                             std::abs((B1 + B6) - (B3 + B4)) +
-                             std::abs((C1 + C6) - (C3 + C4)));
+      double EST =
+          2. * h *
+          (std::abs((A1 + A6) - (A3 + A4)) + std::abs((B1 + B6) - (B3 + B4)) +
+           std::abs((C1 + C6) - (C3 + C4)));
       if (EST > state.options.tolerance) {
         h = h * .5;
         //        dltm = 0.;

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -1075,7 +1075,7 @@ class AtlasStepper {
   template <typename propagator_state_t>
   Result<double> step(propagator_state_t& state) const {
     // we use h for keeping the nominclature with the original atlas code
-    double h = state.stepping.stepSize;
+    auto& h = state.stepping.stepSize;
     bool Jac = state.stepping.useJacobian;
 
     double* R = &(state.stepping.pVector[0]);  // Coordinates

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -1149,11 +1149,11 @@ class AtlasStepper {
 
       // Test approximation quality on give step and possible step reduction
       //
-      double EST = 2. * (std::abs((A1 + A6) - (A3 + A4)) +
-                         std::abs((B1 + B6) - (B3 + B4)) +
-                         std::abs((C1 + C6) - (C3 + C4)));
-      if (EST > 0.0001) {
-        h *= .5;
+      double EST = 2. * h * (std::abs((A1 + A6) - (A3 + A4)) +
+                             std::abs((B1 + B6) - (B3 + B4)) +
+                             std::abs((C1 + C6) - (C3 + C4)));
+      if (EST > state.options.tolerance) {
+        h = h * .5;
         //        dltm = 0.;
         continue;
       }

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -225,7 +225,7 @@ Acts::Result<double> Acts::EigenStepper<B, E, A>::step(
   // size, going up to the point where it can return an estimate of the local
   // integration error. The results are stated in the local variables above,
   // allowing integration to continue once the error is deemed satisfactory
-  const auto tryRungeKuttaStep = [&](const double h) -> bool {
+  const auto tryRungeKuttaStep = [&](const ConstrainedStep& h) -> bool {
     // State the square and half of the step size
     h2 = h * h;
     half_h = h * 0.5;
@@ -260,7 +260,8 @@ Acts::Result<double> Acts::EigenStepper<B, E, A>::step(
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
     return (error_estimate <= state.options.tolerance) &&
-           (error_estimate >= state.options.tolerance / 10);
+           ((h.currentType() != ConstrainedStep::accuracy) ||
+            (error_estimate >= state.options.tolerance / 10));
   };
 
   double stepSizeScaling = 1.;

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -259,7 +259,8 @@ Acts::Result<double> Acts::EigenStepper<B, E, A>::step(
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
-    return (error_estimate <= state.options.tolerance);
+    return (error_estimate <= state.options.tolerance)
+           && (error_estimate >= state.options.tolerance / 10);
   };
 
   double stepSizeScaling = 1.;

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -259,8 +259,8 @@ Acts::Result<double> Acts::EigenStepper<B, E, A>::step(
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
-    return (error_estimate <= state.options.tolerance)
-           && (error_estimate >= state.options.tolerance / 10);
+    return (error_estimate <= state.options.tolerance) &&
+           (error_estimate >= state.options.tolerance / 10);
   };
 
   double stepSizeScaling = 1.;


### PR DESCRIPTION
Some time ago, Andi studied the AtlasStepper and EigenStepper and found that they did not perform the same number of steps for a given propagation job.

As it turns out, the reason for this is that the AtlasStepper used an incorrect expression of the step error estimate. In the ATL-SOFT-PUB-2009-001 terminology that is used by the EigenStepper, the error estimate that was computed by the AtlasStepper was `h * | k1 - k2 - k3 + k4 |` when it actually should have been `h^2 * | k1 - k2 - k3 + k4 |`.

This PR fixes that along with a few more minor problems of the AtlasStepper and EigenStepper:

- The AtlasStepper tolerance used to be hardcoded. It now correctly honors the tolerance set in the propagation options.
- After performing a propagation step, the AtlasStepper would not save it back into `state.stepping.stepSize`, instead starting over from the initial step size on every propagation step. This performance problem is now resolved.
- The EigenStepper would correctly decrease its step size until the propagation error tolerance is met, but never increase it again after that. This does not make sense in the complicated magnetic field maps that the adaptive step selection algorithms were designed for, where the step size should be allowed to go up and down depending on how "difficult" the magnetic field region is.

Since it took me half a day to reverse-engineer how the AtlasStepper works, I thought I would also leave around my notes on how the various quantities that it computes relate to those computed by the EigenStepper (which are themselves very close to the terminology used by ATL-SOFT-PUB-2009-001), so that the next person who needs to work on the AtlasStepper suffers less. If you think this is inappropriate, feel free to ping me and I'll remove the offending commit from this PR.

I would like to also investigate the poor performance of covariance transport, but since #83 is going to perform major changes in this area of the code, I think it's best for me to stop this PR at its current stage and wait for #83 to be merged in before continuing the stepper optimization work.