### PR TITLE
Gaussian vertex seedfinder cleanup and performance updates

### DIFF
--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.hpp
@@ -21,6 +21,7 @@ class GaussianTrackDensity {
  public:
   /// @brief The State struct
   struct State {
+    State(unsigned int nTracks) : trackDensityState(nTracks) {}
     // The track density
     // Defaulted to Gaussian shaped density function
     TrackDensity trackDensity;

--- a/Core/include/Acts/Vertexing/TrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/TrackDensity.hpp
@@ -23,7 +23,9 @@ class TrackDensity {
  public:
   /// @brief Struct to store information for a single track
   struct TrackEntry {
+    // Default constructor
     TrackEntry() = default;
+    // Constructor initializing all members
     TrackEntry(double z, double c0in, double c1in, double c2in, double zMin,
                double zMax)
         : z(z),
@@ -33,9 +35,6 @@ class TrackDensity {
           lowerBound(zMin),
           upperBound(zMax) {}
 
-    // Dummy constructor for binary search
-    TrackEntry(double z) : z(z), lowerBound(z), upperBound(z) {}
-
     double z = 0;
     // Cached information for a single track
     // z-independent term in exponent
@@ -44,7 +43,9 @@ class TrackDensity {
     double c1 = 0;
     // quadratic coefficient in exponent
     double c2 = 0;
+    // The lower bound
     double lowerBound = 0;
+    // The upper bound
     double upperBound = 0;
   };
 
@@ -57,10 +58,10 @@ class TrackDensity {
 
   /// @brief The State struct
   struct State {
-    double maxZRange = 0;
-
-    // Maps to cache track information
-    std::vector<TrackEntry> trackMap;
+    // Constructor with size track map
+    State(unsigned int nTracks) { trackEntries.reserve(nTracks); }
+    // Vector to cache track information
+    std::vector<TrackEntry> trackEntries;
   };
 
   /// Default constructor
@@ -133,7 +134,7 @@ class TrackDensity {
     // add the contribution for one track to the density.
     // will internally check if the z coordinate is within
     // the bounds of the track
-    void addTrack(const TrackEntry& entry);
+    void addTrackToDensity(const TrackEntry& entry);
     // retrieve the density and its derivatives
     inline double density() const { return m_density; }
     inline double firstDerivative() const { return m_firstDerivative; }

--- a/Core/include/Acts/Vertexing/TrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/TrackDensity.hpp
@@ -126,21 +126,22 @@ class TrackDensity {
                       double& secondDerivative) const;
 
  private:
-  // helper to handle the evaluation of the parametrised track density
-  class TrackDensityEval {
+  // Helper class to evaluate and store track density at specific position
+  class TrackDensityStore {
    public:
-    // initialise with the z coordinate at which the density is to be evaluated
-    TrackDensityEval(double z_coordinate) : m_z(z_coordinate) {}
-    // add the contribution for one track to the density.
-    // will internally check if the z coordinate is within
-    // the bounds of the track
+    // Initialise at the z coordinate at which the density is to be evaluated
+    TrackDensityStore(double z_coordinate) : m_z(z_coordinate) {}
+
+    // Add the contribution of a single track to the density
     void addTrackToDensity(const TrackEntry& entry);
-    // retrieve the density and its derivatives
+
+    // Retrieve the density and its derivatives
     inline double density() const { return m_density; }
     inline double firstDerivative() const { return m_firstDerivative; }
     inline double secondDerivative() const { return m_secondDerivative; }
 
    private:
+    // Store density and derivatives for z position m_z
     double m_z;
     double m_density{0};
     double m_firstDerivative{0};

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
@@ -11,7 +11,7 @@ auto Acts::TrackDensityVertexFinder<vfitter_t, track_density_t>::find(
     const std::vector<const InputTrack_t*>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<std::vector<Vertex<InputTrack_t>>> {
-  typename track_density_t::State densityState;
+  typename track_density_t::State densityState(trackVector.size());
 
   std::vector<BoundParameters> trackList;
   trackList.reserve(trackVector.size());

--- a/Tests/UnitTests/Core/Vertexing/AMVFTestData.ipp
+++ b/Tests/UnitTests/Core/Vertexing/AMVFTestData.ipp
@@ -48,7 +48,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.87738057299842411e-10 * 1. / (1_MeV),
       1.96217863793276324e-09 * 1. / (1_MeV),
       -2.89474607768885319e-13 * 1. / (1_MeV),
-      2.95636293223822122e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.95636293223822122e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams0 =
       BoundParameters(gctx, std::move(covMat0), params0, perigeeSurface);
   tracks.push_back(boundParams0);
@@ -72,7 +72,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.01729661445370942e-08 * 1. / (1_MeV),
       1.12351950637584698e-08 * 1. / (1_MeV),
       -2.85976888807477401e-11 * 1. / (1_MeV),
-      1.26268676070573349e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.26268676070573349e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams1 =
       BoundParameters(gctx, std::move(covMat1), params1, perigeeSurface);
   tracks.push_back(boundParams1);
@@ -95,7 +95,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.65331046074031372e-11 * 1. / (1_MeV),
       2.36859555262461008e-11 * 1. / (1_MeV),
       4.89767384223879453e-14 * 1. / (1_MeV),
-      2.01368720417934022e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.01368720417934022e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams2 =
       BoundParameters(gctx, std::move(covMat2), params2, perigeeSurface);
   tracks.push_back(boundParams2);
@@ -118,7 +118,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.07193522414496703e-09 * 1. / (1_MeV),
       7.46303764303131372e-10 * 1. / (1_MeV),
       3.22868607412569302e-13 * 1. / (1_MeV),
-      6.43069972272591883e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.43069972272591883e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams3 =
       BoundParameters(gctx, std::move(covMat3), params3, perigeeSurface);
   tracks.push_back(boundParams3);
@@ -141,7 +141,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.15978667666583788e-10 * 1. / (1_MeV),
       4.44398634319667074e-11 * 1. / (1_MeV),
       -1.68471064059951095e-12 * 1. / (1_MeV),
-      5.01555231808420432e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.01555231808420432e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams4 =
       BoundParameters(gctx, std::move(covMat4), params4, perigeeSurface);
   tracks.push_back(boundParams4);
@@ -165,7 +165,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.11541037258698699e-09 * 1. / (1_MeV),
       3.75976367980382885e-09 * 1. / (1_MeV),
       2.80142049328043291e-12 * 1. / (1_MeV),
-      6.64618290957541547e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.64618290957541547e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams5 =
       BoundParameters(gctx, std::move(covMat5), params5, perigeeSurface);
   tracks.push_back(boundParams5);
@@ -188,7 +188,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.1216330790963481e-09 * 1. / (1_MeV),
       2.01812436010421032e-09 * 1. / (1_MeV),
       5.98997883150413798e-11 * 1. / (1_MeV),
-      7.336908858235347e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.336908858235347e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams6 =
       BoundParameters(gctx, std::move(covMat6), params6, perigeeSurface);
   tracks.push_back(boundParams6);
@@ -212,7 +212,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.06284200946168232e-10 * 1. / (1_MeV),
       2.35086178574079181e-10 * 1. / (1_MeV),
       1.15397785221538584e-12 * 1. / (1_MeV),
-      4.62566573586342678e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.62566573586342678e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams7 =
       BoundParameters(gctx, std::move(covMat7), params7, perigeeSurface);
   tracks.push_back(boundParams7);
@@ -235,7 +235,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.11104877714145611e-09 * 1. / (1_MeV),
       4.01226430794326207e-09 * 1. / (1_MeV),
       7.61584071858783847e-13 * 1. / (1_MeV),
-      3.27873631023045675e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.27873631023045675e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams8 =
       BoundParameters(gctx, std::move(covMat8), params8, perigeeSurface);
   tracks.push_back(boundParams8);
@@ -258,7 +258,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.13962752714581741e-10 * 1. / (1_MeV),
       8.40703862829191019e-11 * 1. / (1_MeV),
       -1.33380435332641628e-12 * 1. / (1_MeV),
-      1.12903610072212501e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.12903610072212501e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams9 =
       BoundParameters(gctx, std::move(covMat9), params9, perigeeSurface);
   tracks.push_back(boundParams9);
@@ -282,7 +282,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.96614965526505315e-10 * 1. / (1_MeV),
       9.9924929691409935e-10 * 1. / (1_MeV),
       1.78960551097981704e-12 * 1. / (1_MeV),
-      7.76793473294956627e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.76793473294956627e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams10 =
       BoundParameters(gctx, std::move(covMat10), params10, perigeeSurface);
   tracks.push_back(boundParams10);
@@ -305,7 +305,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.41630691182238931e-09 * 1. / (1_MeV),
       3.74836269648672209e-09 * 1. / (1_MeV),
       7.0596004861697542e-11 * 1. / (1_MeV),
-      1.38257211235170985e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.38257211235170985e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams11 =
       BoundParameters(gctx, std::move(covMat11), params11, perigeeSurface);
   tracks.push_back(boundParams11);
@@ -328,7 +328,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.44353971236399676e-08 * 1. / (1_MeV),
       2.04097502268213299e-08 * 1. / (1_MeV),
       -8.79447815502355232e-13 * 1. / (1_MeV),
-      3.13229303605666587e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.13229303605666587e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams12 =
       BoundParameters(gctx, std::move(covMat12), params12, perigeeSurface);
   tracks.push_back(boundParams12);
@@ -351,7 +351,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.5122350796412209e-09 * 1. / (1_MeV),
       8.99447573145401141e-09 * 1. / (1_MeV),
       1.01639646010204121e-13 * 1. / (1_MeV),
-      7.34017638337469691e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.34017638337469691e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams13 =
       BoundParameters(gctx, std::move(covMat13), params13, perigeeSurface);
   tracks.push_back(boundParams13);
@@ -374,7 +374,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.18971032423624985e-10 * 1. / (1_MeV),
       1.23485013066819254e-08 * 1. / (1_MeV),
       3.9118155474036915e-11 * 1. / (1_MeV),
-      4.91916063438679885e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.91916063438679885e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams14 =
       BoundParameters(gctx, std::move(covMat14), params14, perigeeSurface);
   tracks.push_back(boundParams14);
@@ -397,7 +397,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.50129287353289466e-11 * 1. / (1_MeV),
       3.32995301645455374e-10 * 1. / (1_MeV),
       -2.86168849963761193e-13 * 1. / (1_MeV),
-      3.81985762465397727e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.81985762465397727e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams15 =
       BoundParameters(gctx, std::move(covMat15), params15, perigeeSurface);
   tracks.push_back(boundParams15);
@@ -420,7 +420,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.54305280465676383e-08 * 1. / (1_MeV),
       2.90396851494721417e-08 * 1. / (1_MeV),
       -1.14583522129541419e-10 * 1. / (1_MeV),
-      6.01911798181475888e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.01911798181475888e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams16 =
       BoundParameters(gctx, std::move(covMat16), params16, perigeeSurface);
   tracks.push_back(boundParams16);
@@ -443,7 +443,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.13684226275355482e-08 * 1. / (1_MeV),
       2.71004393542162535e-08 * 1. / (1_MeV),
       8.98558886340603463e-12 * 1. / (1_MeV),
-      3.11804027042228427e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.11804027042228427e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams17 =
       BoundParameters(gctx, std::move(covMat17), params17, perigeeSurface);
   tracks.push_back(boundParams17);
@@ -466,7 +466,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.12250899201718451e-08 * 1. / (1_MeV),
       6.7895997118531728e-09 * 1. / (1_MeV),
       -1.03714183548395548e-12 * 1. / (1_MeV),
-      4.68583748192141769e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.68583748192141769e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams18 =
       BoundParameters(gctx, std::move(covMat18), params18, perigeeSurface);
   tracks.push_back(boundParams18);
@@ -489,7 +489,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.77873236221157013e-10 * 1. / (1_MeV),
       8.3325729033356906e-11 * 1. / (1_MeV),
       -4.19827894841714947e-12 * 1. / (1_MeV),
-      1.43134245775278224e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.43134245775278224e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams19 =
       BoundParameters(gctx, std::move(covMat19), params19, perigeeSurface);
   tracks.push_back(boundParams19);
@@ -513,7 +513,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.25566461565313107e-08 * 1. / (1_MeV),
       6.00420036495892829e-09 * 1. / (1_MeV),
       -1.98670297988379238e-12 * 1. / (1_MeV),
-      6.28335161678705845e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.28335161678705845e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams20 =
       BoundParameters(gctx, std::move(covMat20), params20, perigeeSurface);
   tracks.push_back(boundParams20);
@@ -537,7 +537,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.29747367549304477e-10 * 1. / (1_MeV),
       9.64028556852257677e-11 * 1. / (1_MeV),
       -1.6225318684374243e-12 * 1. / (1_MeV),
-      1.46339776234405416e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.46339776234405416e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams21 =
       BoundParameters(gctx, std::move(covMat21), params21, perigeeSurface);
   tracks.push_back(boundParams21);
@@ -561,7 +561,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.192286442570364e-08 * 1. / (1_MeV),
       1.32897993796644671e-10 * 1. / (1_MeV),
       -1.04379022097924494e-10 * 1. / (1_MeV),
-      1.09507943078096526e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.09507943078096526e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams22 =
       BoundParameters(gctx, std::move(covMat22), params22, perigeeSurface);
   tracks.push_back(boundParams22);
@@ -585,7 +585,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.4435441037029841e-09 * 1. / (1_MeV),
       8.7867543161386892e-11 * 1. / (1_MeV),
       -5.37524150950671376e-11 * 1. / (1_MeV),
-      1.83543284737464063e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.83543284737464063e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams23 =
       BoundParameters(gctx, std::move(covMat23), params23, perigeeSurface);
   tracks.push_back(boundParams23);
@@ -608,7 +608,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.63255285816454836e-10 * 1. / (1_MeV),
       1.09902161546833325e-10 * 1. / (1_MeV),
       1.02436393801765789e-12 * 1. / (1_MeV),
-      1.77089365307331326e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.77089365307331326e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams24 =
       BoundParameters(gctx, std::move(covMat24), params24, perigeeSurface);
   tracks.push_back(boundParams24);
@@ -631,7 +631,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.09798679472868797e-10 * 1. / (1_MeV),
       8.99215162966161182e-10 * 1. / (1_MeV),
       8.86034124151153122e-12 * 1. / (1_MeV),
-      1.49597105536525277e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.49597105536525277e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams25 =
       BoundParameters(gctx, std::move(covMat25), params25, perigeeSurface);
   tracks.push_back(boundParams25);
@@ -655,7 +655,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.12260566358553804e-09 * 1. / (1_MeV),
       9.80197960016773152e-11 * 1. / (1_MeV),
       -1.97182050693094459e-11 * 1. / (1_MeV),
-      2.83151215148269575e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.83151215148269575e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams26 =
       BoundParameters(gctx, std::move(covMat26), params26, perigeeSurface);
   tracks.push_back(boundParams26);
@@ -678,7 +678,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       8.91128192470317596e-11 * 1. / (1_MeV),
       1.26289836850190108e-09 * 1. / (1_MeV),
       2.02230046547630554e-12 * 1. / (1_MeV),
-      1.52509879725037933e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.52509879725037933e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams27 =
       BoundParameters(gctx, std::move(covMat27), params27, perigeeSurface);
   tracks.push_back(boundParams27);
@@ -701,7 +701,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.06704265685090959e-10 * 1. / (1_MeV),
       2.06696790491209021e-10 * 1. / (1_MeV),
       1.00703744558876763e-12 * 1. / (1_MeV),
-      2.83601007261546911e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.83601007261546911e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams28 =
       BoundParameters(gctx, std::move(covMat28), params28, perigeeSurface);
   tracks.push_back(boundParams28);
@@ -724,7 +724,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.22367109538203667e-09 * 1. / (1_MeV),
       6.84218014584375542e-10 * 1. / (1_MeV),
       -9.11246232266255587e-12 * 1. / (1_MeV),
-      1.55326706358094313e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.55326706358094313e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams29 =
       BoundParameters(gctx, std::move(covMat29), params29, perigeeSurface);
   tracks.push_back(boundParams29);
@@ -747,7 +747,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.20784296654136601e-10 * 1. / (1_MeV),
       2.52688458153465702e-09 * 1. / (1_MeV),
       9.90579325614409665e-12 * 1. / (1_MeV),
-      9.43339711900748057e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.43339711900748057e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams30 =
       BoundParameters(gctx, std::move(covMat30), params30, perigeeSurface);
   tracks.push_back(boundParams30);
@@ -772,7 +772,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.86168612064016744e-09 * 1. / (1_MeV),
       1.75686917916454533e-09 * 1. / (1_MeV),
       1.22169439162607638e-12 * 1. / (1_MeV),
-      3.16079003248592727e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.16079003248592727e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams31 =
       BoundParameters(gctx, std::move(covMat31), params31, perigeeSurface);
   tracks.push_back(boundParams31);
@@ -795,7 +795,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.60722406707723369e-09 * 1. / (1_MeV),
       7.82772160913690927e-09 * 1. / (1_MeV),
       -2.69885970530160845e-12 * 1. / (1_MeV),
-      1.721506964758035e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.721506964758035e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams32 =
       BoundParameters(gctx, std::move(covMat32), params32, perigeeSurface);
   tracks.push_back(boundParams32);
@@ -818,7 +818,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.48754668083118025e-10 * 1. / (1_MeV),
       6.53490602957053302e-10 * 1. / (1_MeV),
       5.22664500397267715e-13 * 1. / (1_MeV),
-      1.14117890484544127e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.14117890484544127e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams33 =
       BoundParameters(gctx, std::move(covMat33), params33, perigeeSurface);
   tracks.push_back(boundParams33);
@@ -841,7 +841,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.83093285269249633e-08 * 1. / (1_MeV),
       1.48782651378673617e-08 * 1. / (1_MeV),
       -8.52575602760203913e-12 * 1. / (1_MeV),
-      2.77564138340125055e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.77564138340125055e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams34 =
       BoundParameters(gctx, std::move(covMat34), params34, perigeeSurface);
   tracks.push_back(boundParams34);
@@ -865,7 +865,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.2860188976227197e-10 * 1. / (1_MeV),
       2.07668118549997414e-09 * 1. / (1_MeV),
       8.60400887008258369e-12 * 1. / (1_MeV),
-      3.06659697635325301e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.06659697635325301e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams35 =
       BoundParameters(gctx, std::move(covMat35), params35, perigeeSurface);
   tracks.push_back(boundParams35);
@@ -888,7 +888,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.22042667667872301e-08 * 1. / (1_MeV),
       9.93307233918962727e-09 * 1. / (1_MeV),
       5.92305231785808206e-11 * 1. / (1_MeV),
-      8.93205231999871785e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.93205231999871785e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams36 =
       BoundParameters(gctx, std::move(covMat36), params36, perigeeSurface);
   tracks.push_back(boundParams36);
@@ -912,7 +912,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.01687609353752231e-09 * 1. / (1_MeV),
       4.11041373461571408e-09 * 1. / (1_MeV),
       -2.55342842411113774e-12 * 1. / (1_MeV),
-      9.23438478461768852e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.23438478461768852e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams37 =
       BoundParameters(gctx, std::move(covMat37), params37, perigeeSurface);
   tracks.push_back(boundParams37);
@@ -935,7 +935,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.69743203747746844e-09 * 1. / (1_MeV),
       3.91247397541968152e-10 * 1. / (1_MeV),
       -2.82010017781291024e-11 * 1. / (1_MeV),
-      8.54110965980980907e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.54110965980980907e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams38 =
       BoundParameters(gctx, std::move(covMat38), params38, perigeeSurface);
   tracks.push_back(boundParams38);
@@ -958,7 +958,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.81287484533099953e-10 * 1. / (1_MeV),
       7.63262387403224464e-10 * 1. / (1_MeV),
       1.08505726379481843e-12 * 1. / (1_MeV),
-      1.69044726133771306e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.69044726133771306e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams39 =
       BoundParameters(gctx, std::move(covMat39), params39, perigeeSurface);
   tracks.push_back(boundParams39);
@@ -981,7 +981,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.45698149891952607e-09 * 1. / (1_MeV),
       6.72217443687235182e-10 * 1. / (1_MeV),
       -2.50821896355620095e-11 * 1. / (1_MeV),
-      1.938233948339807e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.938233948339807e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams40 =
       BoundParameters(gctx, std::move(covMat40), params40, perigeeSurface);
   tracks.push_back(boundParams40);
@@ -1004,7 +1004,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.32950012849014807e-10 * 1. / (1_MeV),
       1.78440131718612806e-09 * 1. / (1_MeV),
       -7.30460799902715398e-12 * 1. / (1_MeV),
-      2.19001535656238033e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.19001535656238033e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams41 =
       BoundParameters(gctx, std::move(covMat41), params41, perigeeSurface);
   tracks.push_back(boundParams41);
@@ -1027,7 +1027,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.39200094119792923e-09 * 1. / (1_MeV),
       2.08122633356299761e-09 * 1. / (1_MeV),
       5.02372502596273887e-12 * 1. / (1_MeV),
-      2.24156318506807395e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.24156318506807395e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams42 =
       BoundParameters(gctx, std::move(covMat42), params42, perigeeSurface);
   tracks.push_back(boundParams42);
@@ -1051,7 +1051,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.99780771762925697e-09 * 1. / (1_MeV),
       6.36599567289482473e-10 * 1. / (1_MeV),
       -6.36775855132313344e-11 * 1. / (1_MeV),
-      1.53753346859852869e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.53753346859852869e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams43 =
       BoundParameters(gctx, std::move(covMat43), params43, perigeeSurface);
   tracks.push_back(boundParams43);
@@ -1076,7 +1076,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.23756334365082546e-09 * 1. / (1_MeV),
       4.89069275340707137e-10 * 1. / (1_MeV),
       -5.57887414635642927e-11 * 1. / (1_MeV),
-      1.4045833940379282e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.4045833940379282e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams44 =
       BoundParameters(gctx, std::move(covMat44), params44, perigeeSurface);
   tracks.push_back(boundParams44);
@@ -1099,7 +1099,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.46718705987526794e-09 * 1. / (1_MeV),
       2.79242397856570532e-09 * 1. / (1_MeV),
       -6.9029270759318352e-13 * 1. / (1_MeV),
-      2.4027510883706249e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.4027510883706249e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams45 =
       BoundParameters(gctx, std::move(covMat45), params45, perigeeSurface);
   tracks.push_back(boundParams45);
@@ -1123,7 +1123,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.20706515105713893e-10 * 1. / (1_MeV),
       4.8877497815574335e-10 * 1. / (1_MeV),
       5.48951242834580673e-13 * 1. / (1_MeV),
-      4.31213008009190268e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.31213008009190268e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams46 =
       BoundParameters(gctx, std::move(covMat46), params46, perigeeSurface);
   tracks.push_back(boundParams46);
@@ -1147,7 +1147,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.50668591753161066e-09 * 1. / (1_MeV),
       4.53229459790751107e-09 * 1. / (1_MeV),
       3.54234059812463208e-12 * 1. / (1_MeV),
-      6.56103088525483713e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.56103088525483713e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams47 =
       BoundParameters(gctx, std::move(covMat47), params47, perigeeSurface);
   tracks.push_back(boundParams47);
@@ -1171,7 +1171,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.04730203134838935e-09 * 1. / (1_MeV),
       1.3563696615201376e-09 * 1. / (1_MeV),
       -2.78975801873471684e-12 * 1. / (1_MeV),
-      2.97016820860473985e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.97016820860473985e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams48 =
       BoundParameters(gctx, std::move(covMat48), params48, perigeeSurface);
   tracks.push_back(boundParams48);
@@ -1195,7 +1195,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.79285333931827184e-10 * 1. / (1_MeV),
       8.74314611771519845e-11 * 1. / (1_MeV),
       -9.77849218642090565e-12 * 1. / (1_MeV),
-      1.17200834540837073e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.17200834540837073e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams49 =
       BoundParameters(gctx, std::move(covMat49), params49, perigeeSurface);
   tracks.push_back(boundParams49);
@@ -1218,7 +1218,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.97977172285195535e-10 * 1. / (1_MeV),
       2.0784715645265731e-09 * 1. / (1_MeV),
       7.96588919931270625e-12 * 1. / (1_MeV),
-      4.46022628552977807e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.46022628552977807e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams50 =
       BoundParameters(gctx, std::move(covMat50), params50, perigeeSurface);
   tracks.push_back(boundParams50);
@@ -1241,7 +1241,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.69241003100018407e-09 * 1. / (1_MeV),
       3.36582393282827341e-09 * 1. / (1_MeV),
       -7.96709832496419101e-12 * 1. / (1_MeV),
-      7.49710918346302435e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.49710918346302435e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams51 =
       BoundParameters(gctx, std::move(covMat51), params51, perigeeSurface);
   tracks.push_back(boundParams51);
@@ -1264,7 +1264,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.58039148376204822e-10 * 1. / (1_MeV),
       6.72005839541690491e-11 * 1. / (1_MeV),
       6.38826446714830372e-13 * 1. / (1_MeV),
-      8.76188607345368409e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.76188607345368409e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams52 =
       BoundParameters(gctx, std::move(covMat52), params52, perigeeSurface);
   tracks.push_back(boundParams52);
@@ -1288,7 +1288,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       9.09945816895274824e-09 * 1. / (1_MeV),
       5.96647706005148785e-09 * 1. / (1_MeV),
       5.6513620234422192e-12 * 1. / (1_MeV),
-      1.10141243347960938e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.10141243347960938e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams53 =
       BoundParameters(gctx, std::move(covMat53), params53, perigeeSurface);
   tracks.push_back(boundParams53);
@@ -1311,7 +1311,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.24438577982619877e-09 * 1. / (1_MeV),
       8.36903947194818426e-09 * 1. / (1_MeV),
       6.22930295116186707e-12 * 1. / (1_MeV),
-      1.3151608968531292e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.3151608968531292e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams54 =
       BoundParameters(gctx, std::move(covMat54), params54, perigeeSurface);
   tracks.push_back(boundParams54);
@@ -1334,7 +1334,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.51670403755547486e-09 * 1. / (1_MeV),
       2.79668441371068291e-09 * 1. / (1_MeV),
       4.93865123861046129e-11 * 1. / (1_MeV),
-      8.41345951241301293e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.41345951241301293e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams55 =
       BoundParameters(gctx, std::move(covMat55), params55, perigeeSurface);
   tracks.push_back(boundParams55);
@@ -1358,7 +1358,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       9.45078749853857351e-09 * 1. / (1_MeV),
       1.01155494796444282e-08 * 1. / (1_MeV),
       1.71955939069872652e-10 * 1. / (1_MeV),
-      3.56558282899044343e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.56558282899044343e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams56 =
       BoundParameters(gctx, std::move(covMat56), params56, perigeeSurface);
   tracks.push_back(boundParams56);
@@ -1382,7 +1382,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.39220428270368834e-09 * 1. / (1_MeV),
       5.68860497435955863e-09 * 1. / (1_MeV),
       -4.49134917661611488e-11 * 1. / (1_MeV),
-      2.06098235699947452e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.06098235699947452e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams57 =
       BoundParameters(gctx, std::move(covMat57), params57, perigeeSurface);
   tracks.push_back(boundParams57);
@@ -1406,7 +1406,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.04190472154705827e-08 * 1. / (1_MeV),
       5.32616098447415082e-09 * 1. / (1_MeV),
       1.99585598211435834e-12 * 1. / (1_MeV),
-      5.44141676162013255e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.44141676162013255e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams58 =
       BoundParameters(gctx, std::move(covMat58), params58, perigeeSurface);
   tracks.push_back(boundParams58);
@@ -1430,7 +1430,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.37905357060564215e-09 * 1. / (1_MeV),
       4.48106445691990887e-09 * 1. / (1_MeV),
       1.57469333177652749e-11 * 1. / (1_MeV),
-      1.41142181275810685e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.41142181275810685e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams59 =
       BoundParameters(gctx, std::move(covMat59), params59, perigeeSurface);
   tracks.push_back(boundParams59);
@@ -1454,7 +1454,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.00878031112618562e-10 * 1. / (1_MeV),
       8.08198329216027338e-10 * 1. / (1_MeV),
       1.74801379954387645e-12 * 1. / (1_MeV),
-      1.40280183302810002e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.40280183302810002e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams60 =
       BoundParameters(gctx, std::move(covMat60), params60, perigeeSurface);
   tracks.push_back(boundParams60);
@@ -1477,7 +1477,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       8.37675468431534094e-11 * 1. / (1_MeV),
       1.08576617849883842e-09 * 1. / (1_MeV),
       5.47754434165355313e-12 * 1. / (1_MeV),
-      1.96000368712923034e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.96000368712923034e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams61 =
       BoundParameters(gctx, std::move(covMat61), params61, perigeeSurface);
   tracks.push_back(boundParams61);
@@ -1500,7 +1500,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.52506139410446467e-09 * 1. / (1_MeV),
       8.02502888738918489e-09 * 1. / (1_MeV),
       -5.04380269074694918e-12 * 1. / (1_MeV),
-      1.86463025575456243e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.86463025575456243e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams62 =
       BoundParameters(gctx, std::move(covMat62), params62, perigeeSurface);
   tracks.push_back(boundParams62);
@@ -1524,7 +1524,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.49091147779785594e-09 * 1. / (1_MeV),
       5.9837667986473886e-10 * 1. / (1_MeV),
       -1.46674673345839605e-11 * 1. / (1_MeV),
-      1.54105235516954764e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.54105235516954764e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams63 =
       BoundParameters(gctx, std::move(covMat63), params63, perigeeSurface);
   tracks.push_back(boundParams63);
@@ -1548,7 +1548,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.84401452515339684e-09 * 1. / (1_MeV),
       1.42819207588526508e-09 * 1. / (1_MeV),
       1.15087456059600686e-12 * 1. / (1_MeV),
-      2.95290424057181866e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.95290424057181866e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams64 =
       BoundParameters(gctx, std::move(covMat64), params64, perigeeSurface);
   tracks.push_back(boundParams64);
@@ -1572,7 +1572,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.77799777456030559e-10 * 1. / (1_MeV),
       2.44350119045523328e-09 * 1. / (1_MeV),
       2.43993447359552124e-11 * 1. / (1_MeV),
-      6.30697091774656826e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.30697091774656826e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams65 =
       BoundParameters(gctx, std::move(covMat65), params65, perigeeSurface);
   tracks.push_back(boundParams65);
@@ -1595,7 +1595,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.57911033053770427e-09 * 1. / (1_MeV),
       5.61496221132519249e-09 * 1. / (1_MeV),
       -1.76572689736880453e-12 * 1. / (1_MeV),
-      1.27183083509230244e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.27183083509230244e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams66 =
       BoundParameters(gctx, std::move(covMat66), params66, perigeeSurface);
   tracks.push_back(boundParams66);
@@ -1618,7 +1618,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.59919585012054894e-09 * 1. / (1_MeV),
       3.61592933955667245e-09 * 1. / (1_MeV),
       9.31555819953937805e-12 * 1. / (1_MeV),
-      6.02211544520336872e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.02211544520336872e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams67 =
       BoundParameters(gctx, std::move(covMat67), params67, perigeeSurface);
   tracks.push_back(boundParams67);
@@ -1641,7 +1641,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -7.3861724702695647e-11 * 1. / (1_MeV),
       3.08626652913981362e-09 * 1. / (1_MeV),
       9.8161963481123767e-12 * 1. / (1_MeV),
-      4.41570460751883331e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.41570460751883331e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams68 =
       BoundParameters(gctx, std::move(covMat68), params68, perigeeSurface);
   tracks.push_back(boundParams68);
@@ -1664,7 +1664,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.95526672562874677e-09 * 1. / (1_MeV),
       1.75117724904492434e-09 * 1. / (1_MeV),
       6.37842082317695236e-12 * 1. / (1_MeV),
-      1.73160132066474404e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.73160132066474404e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams69 =
       BoundParameters(gctx, std::move(covMat69), params69, perigeeSurface);
   tracks.push_back(boundParams69);
@@ -1687,7 +1687,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.91598206364535424e-08 * 1. / (1_MeV),
       1.76141434145594417e-08 * 1. / (1_MeV),
       8.73307509198330779e-12 * 1. / (1_MeV),
-      2.64328670063207483e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.64328670063207483e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams70 =
       BoundParameters(gctx, std::move(covMat70), params70, perigeeSurface);
   tracks.push_back(boundParams70);
@@ -1710,7 +1710,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.93974344917808111e-09 * 1. / (1_MeV),
       6.29499582429645186e-10 * 1. / (1_MeV),
       -6.71150128191831827e-12 * 1. / (1_MeV),
-      1.96153805004373183e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.96153805004373183e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams71 =
       BoundParameters(gctx, std::move(covMat71), params71, perigeeSurface);
   tracks.push_back(boundParams71);
@@ -1733,7 +1733,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.76165411298313188e-08 * 1. / (1_MeV),
       1.9855251791033252e-08 * 1. / (1_MeV),
       1.52908464521253004e-11 * 1. / (1_MeV),
-      3.20209747606270412e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.20209747606270412e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams72 =
       BoundParameters(gctx, std::move(covMat72), params72, perigeeSurface);
   tracks.push_back(boundParams72);
@@ -1757,7 +1757,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.92212069047691244e-09 * 1. / (1_MeV),
       7.86957679995017337e-09 * 1. / (1_MeV),
       1.43532649831609989e-11 * 1. / (1_MeV),
-      2.18980167332460951e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.18980167332460951e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams73 =
       BoundParameters(gctx, std::move(covMat73), params73, perigeeSurface);
   tracks.push_back(boundParams73);
@@ -1782,7 +1782,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.25027250869408224e-09 * 1. / (1_MeV),
       8.03748117560459975e-09 * 1. / (1_MeV),
       -1.69302933545922802e-11 * 1. / (1_MeV),
-      2.06939729241462089e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.06939729241462089e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams74 =
       BoundParameters(gctx, std::move(covMat74), params74, perigeeSurface);
   tracks.push_back(boundParams74);
@@ -1806,7 +1806,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.53148133943496205e-10 * 1. / (1_MeV),
       2.55990108225490642e-09 * 1. / (1_MeV),
       -2.28893257339241436e-11 * 1. / (1_MeV),
-      9.44539516045672656e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.44539516045672656e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams75 =
       BoundParameters(gctx, std::move(covMat75), params75, perigeeSurface);
   tracks.push_back(boundParams75);
@@ -1829,7 +1829,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.26706283098581222e-08 * 1. / (1_MeV),
       1.77332557811301974e-09 * 1. / (1_MeV),
       -1.58479619806951909e-10 * 1. / (1_MeV),
-      4.6452456464729508e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.6452456464729508e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams76 =
       BoundParameters(gctx, std::move(covMat76), params76, perigeeSurface);
   tracks.push_back(boundParams76);
@@ -1852,7 +1852,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.33223192345790811e-09 * 1. / (1_MeV),
       3.68501084222524602e-09 * 1. / (1_MeV),
       -1.26932170430756531e-12 * 1. / (1_MeV),
-      7.21128712299901053e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.21128712299901053e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams77 =
       BoundParameters(gctx, std::move(covMat77), params77, perigeeSurface);
   tracks.push_back(boundParams77);
@@ -1875,7 +1875,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       8.4659628993769127e-11 * 1. / (1_MeV),
       1.9813795664012159e-09 * 1. / (1_MeV),
       2.44401588800591696e-11 * 1. / (1_MeV),
-      6.28857244056035825e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.28857244056035825e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams78 =
       BoundParameters(gctx, std::move(covMat78), params78, perigeeSurface);
   tracks.push_back(boundParams78);
@@ -1899,7 +1899,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       9.56806544278803705e-10 * 1. / (1_MeV),
       1.02398276394864458e-09 * 1. / (1_MeV),
       -9.30864559448818034e-13 * 1. / (1_MeV),
-      1.72951982596591947e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.72951982596591947e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams79 =
       BoundParameters(gctx, std::move(covMat79), params79, perigeeSurface);
   tracks.push_back(boundParams79);
@@ -1923,7 +1923,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.29938534403212134e-08 * 1. / (1_MeV),
       8.36922640021012843e-09 * 1. / (1_MeV),
       -5.38086858591292421e-12 * 1. / (1_MeV),
-      1.47779136150383295e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.47779136150383295e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams80 =
       BoundParameters(gctx, std::move(covMat80), params80, perigeeSurface);
   tracks.push_back(boundParams80);
@@ -1946,7 +1946,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.54823960396222519e-11 * 1. / (1_MeV),
       4.58229751365888916e-09 * 1. / (1_MeV),
       9.7695621439726223e-12 * 1. / (1_MeV),
-      1.47325138200038452e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.47325138200038452e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams81 =
       BoundParameters(gctx, std::move(covMat81), params81, perigeeSurface);
   tracks.push_back(boundParams81);
@@ -1969,7 +1969,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.14987267373142885e-10 * 1. / (1_MeV),
       4.44175415702797833e-09 * 1. / (1_MeV),
       8.83536325828199794e-12 * 1. / (1_MeV),
-      5.34931300644192476e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.34931300644192476e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams82 =
       BoundParameters(gctx, std::move(covMat82), params82, perigeeSurface);
   tracks.push_back(boundParams82);
@@ -1993,7 +1993,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.27171510114886803e-09 * 1. / (1_MeV),
       1.99936639608643397e-09 * 1. / (1_MeV),
       1.04279595331346869e-12 * 1. / (1_MeV),
-      1.92760772621536347e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.92760772621536347e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams83 =
       BoundParameters(gctx, std::move(covMat83), params83, perigeeSurface);
   tracks.push_back(boundParams83);
@@ -2016,7 +2016,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.79593641161986059e-09 * 1. / (1_MeV),
       3.53139150458423765e-09 * 1. / (1_MeV),
       6.19247327016922366e-12 * 1. / (1_MeV),
-      1.26404206546304465e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.26404206546304465e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams84 =
       BoundParameters(gctx, std::move(covMat84), params84, perigeeSurface);
   tracks.push_back(boundParams84);
@@ -2039,7 +2039,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.99086836094690827e-09 * 1. / (1_MeV),
       7.23939037737933651e-09 * 1. / (1_MeV),
       4.05519853361521036e-12 * 1. / (1_MeV),
-      1.97367219789690296e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.97367219789690296e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams85 =
       BoundParameters(gctx, std::move(covMat85), params85, perigeeSurface);
   tracks.push_back(boundParams85);
@@ -2062,7 +2062,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.77891238924622843e-09 * 1. / (1_MeV),
       3.13812114656612788e-08 * 1. / (1_MeV),
       1.32123927173378508e-10 * 1. / (1_MeV),
-      8.04692867895084873e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.04692867895084873e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams86 =
       BoundParameters(gctx, std::move(covMat86), params86, perigeeSurface);
   tracks.push_back(boundParams86);
@@ -2086,7 +2086,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.70578310628897577e-09 * 1. / (1_MeV),
       1.44265069638837021e-09 * 1. / (1_MeV),
       -3.51121860297362421e-11 * 1. / (1_MeV),
-      5.05374214698761648e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.05374214698761648e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams87 =
       BoundParameters(gctx, std::move(covMat87), params87, perigeeSurface);
   tracks.push_back(boundParams87);
@@ -2109,7 +2109,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.50207485117721545e-09 * 1. / (1_MeV),
       7.44695559286270222e-09 * 1. / (1_MeV),
       -5.58945405173847072e-11 * 1. / (1_MeV),
-      2.93490870495460854e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.93490870495460854e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams88 =
       BoundParameters(gctx, std::move(covMat88), params88, perigeeSurface);
   tracks.push_back(boundParams88);
@@ -2132,7 +2132,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.2657516143838364e-09 * 1. / (1_MeV),
       1.09973686096897418e-08 * 1. / (1_MeV),
       -3.86199606571132037e-11 * 1. / (1_MeV),
-      3.39196892795712301e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.39196892795712301e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams89 =
       BoundParameters(gctx, std::move(covMat89), params89, perigeeSurface);
   tracks.push_back(boundParams89);
@@ -2156,7 +2156,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.14540254121542699e-09 * 1. / (1_MeV),
       4.70571016940573361e-09 * 1. / (1_MeV),
       -1.76163300018645983e-11 * 1. / (1_MeV),
-      1.11767643751203849e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.11767643751203849e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams90 =
       BoundParameters(gctx, std::move(covMat90), params90, perigeeSurface);
   tracks.push_back(boundParams90);
@@ -2179,7 +2179,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.18162424846205697e-10 * 1. / (1_MeV),
       2.39365529077948547e-09 * 1. / (1_MeV),
       1.11281704892510676e-11 * 1. / (1_MeV),
-      9.21146006693795982e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.21146006693795982e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams91 =
       BoundParameters(gctx, std::move(covMat91), params91, perigeeSurface);
   tracks.push_back(boundParams91);
@@ -2202,7 +2202,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.86785150218537236e-08 * 1. / (1_MeV),
       1.37035759118268963e-08 * 1. / (1_MeV),
       2.14949156818848357e-12 * 1. / (1_MeV),
-      1.74355599402709061e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.74355599402709061e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams92 =
       BoundParameters(gctx, std::move(covMat92), params92, perigeeSurface);
   tracks.push_back(boundParams92);
@@ -2225,7 +2225,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.06383037100379797e-09 * 1. / (1_MeV),
       2.66714797310526465e-09 * 1. / (1_MeV),
       1.22675320789893397e-11 * 1. / (1_MeV),
-      4.13053515002648197e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.13053515002648197e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams93 =
       BoundParameters(gctx, std::move(covMat93), params93, perigeeSurface);
   tracks.push_back(boundParams93);
@@ -2248,7 +2248,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.16283304523887763e-09 * 1. / (1_MeV),
       1.096216345456462e-08 * 1. / (1_MeV),
       2.56585402895446448e-14 * 1. / (1_MeV),
-      2.29805854901066198e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.29805854901066198e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams94 =
       BoundParameters(gctx, std::move(covMat94), params94, perigeeSurface);
   tracks.push_back(boundParams94);
@@ -2271,7 +2271,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.24775989820321723e-09 * 1. / (1_MeV),
       1.02343642189694215e-08 * 1. / (1_MeV),
       -1.77698327525688441e-11 * 1. / (1_MeV),
-      2.43435688274118434e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.43435688274118434e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams95 =
       BoundParameters(gctx, std::move(covMat95), params95, perigeeSurface);
   tracks.push_back(boundParams95);
@@ -2295,7 +2295,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.58794985364503272e-10 * 1. / (1_MeV),
       4.51877708122468826e-09 * 1. / (1_MeV),
       -7.18296901266119286e-13 * 1. / (1_MeV),
-      1.78482867374540888e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.78482867374540888e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams96 =
       BoundParameters(gctx, std::move(covMat96), params96, perigeeSurface);
   tracks.push_back(boundParams96);
@@ -2318,7 +2318,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.86386577268916162e-09 * 1. / (1_MeV),
       1.4339166470730082e-08 * 1. / (1_MeV),
       -1.41501241215600609e-10 * 1. / (1_MeV),
-      4.72637817772181279e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.72637817772181279e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams97 =
       BoundParameters(gctx, std::move(covMat97), params97, perigeeSurface);
   tracks.push_back(boundParams97);
@@ -2342,7 +2342,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.9036311873074078e-08 * 1. / (1_MeV),
       8.19782135067778202e-09 * 1. / (1_MeV),
       7.26578444477865009e-12 * 1. / (1_MeV),
-      1.17719708980779103e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.17719708980779103e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams98 =
       BoundParameters(gctx, std::move(covMat98), params98, perigeeSurface);
   tracks.push_back(boundParams98);
@@ -2367,7 +2367,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.90113700709114385e-10 * 1. / (1_MeV),
       8.35848601602763903e-09 * 1. / (1_MeV),
       -1.22177379055824259e-11 * 1. / (1_MeV),
-      3.21954796156376233e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.21954796156376233e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams99 =
       BoundParameters(gctx, std::move(covMat99), params99, perigeeSurface);
   tracks.push_back(boundParams99);
@@ -2392,7 +2392,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.47131199620464829e-09 * 1. / (1_MeV),
       1.75584896641553984e-09 * 1. / (1_MeV),
       -1.43857092852611679e-12 * 1. / (1_MeV),
-      1.24140029852948253e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.24140029852948253e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams100 =
       BoundParameters(gctx, std::move(covMat100), params100, perigeeSurface);
   tracks.push_back(boundParams100);
@@ -2416,7 +2416,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.11640035508361721e-10 * 1. / (1_MeV),
       8.47974964267322053e-09 * 1. / (1_MeV),
       5.47351419013377902e-11 * 1. / (1_MeV),
-      2.47352943683054605e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.47352943683054605e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams101 =
       BoundParameters(gctx, std::move(covMat101), params101, perigeeSurface);
   tracks.push_back(boundParams101);
@@ -2440,7 +2440,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.44465634156851802e-09 * 1. / (1_MeV),
       4.84297827278802643e-09 * 1. / (1_MeV),
       7.89285090595557677e-12 * 1. / (1_MeV),
-      1.05506943459676705e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.05506943459676705e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams102 =
       BoundParameters(gctx, std::move(covMat102), params102, perigeeSurface);
   tracks.push_back(boundParams102);
@@ -2464,7 +2464,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.42294422890168881e-09 * 1. / (1_MeV),
       5.03852824195809614e-09 * 1. / (1_MeV),
       -5.69843357485556815e-11 * 1. / (1_MeV),
-      1.89580739995420799e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.89580739995420799e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams103 =
       BoundParameters(gctx, std::move(covMat103), params103, perigeeSurface);
   tracks.push_back(boundParams103);
@@ -2488,7 +2488,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.11084620426846086e-09 * 1. / (1_MeV),
       3.807619848578843e-09 * 1. / (1_MeV),
       -9.50285600530462166e-11 * 1. / (1_MeV),
-      1.29019364636384637e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.29019364636384637e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams104 =
       BoundParameters(gctx, std::move(covMat104), params104, perigeeSurface);
   tracks.push_back(boundParams104);
@@ -2513,7 +2513,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.65990164654914017e-09 * 1. / (1_MeV),
       1.21273109287785646e-08 * 1. / (1_MeV),
       -1.74774216671551251e-11 * 1. / (1_MeV),
-      3.28096633195329446e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.28096633195329446e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams105 =
       BoundParameters(gctx, std::move(covMat105), params105, perigeeSurface);
   tracks.push_back(boundParams105);
@@ -2536,7 +2536,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.3903210045338403e-10 * 1. / (1_MeV),
       1.13733623250742995e-08 * 1. / (1_MeV),
       -6.31956258410507594e-12 * 1. / (1_MeV),
-      2.37201536190667639e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.37201536190667639e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams106 =
       BoundParameters(gctx, std::move(covMat106), params106, perigeeSurface);
   tracks.push_back(boundParams106);
@@ -2561,7 +2561,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.87936821571313464e-09 * 1. / (1_MeV),
       8.397331774157027e-09 * 1. / (1_MeV),
       4.17575815132199387e-11 * 1. / (1_MeV),
-      1.90833182589500439e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.90833182589500439e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams107 =
       BoundParameters(gctx, std::move(covMat107), params107, perigeeSurface);
   tracks.push_back(boundParams107);
@@ -2585,7 +2585,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.66653208275732943e-09 * 1. / (1_MeV),
       2.74010143274654739e-09 * 1. / (1_MeV),
       4.4716062401029798e-11 * 1. / (1_MeV),
-      9.70698590951890594e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.70698590951890594e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams108 =
       BoundParameters(gctx, std::move(covMat108), params108, perigeeSurface);
   tracks.push_back(boundParams108);
@@ -2609,7 +2609,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.08024475744600902e-09 * 1. / (1_MeV),
       8.22356836237723778e-09 * 1. / (1_MeV),
       3.42299696660580778e-11 * 1. / (1_MeV),
-      2.54714332958982936e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.54714332958982936e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams109 =
       BoundParameters(gctx, std::move(covMat109), params109, perigeeSurface);
   tracks.push_back(boundParams109);
@@ -2633,7 +2633,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.71900525614601273e-08 * 1. / (1_MeV),
       2.38844165520381005e-08 * 1. / (1_MeV),
       1.81008924621221718e-12 * 1. / (1_MeV),
-      4.11227746299758223e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.11227746299758223e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams110 =
       BoundParameters(gctx, std::move(covMat110), params110, perigeeSurface);
   tracks.push_back(boundParams110);
@@ -2656,7 +2656,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.3446639759563834e-09 * 1. / (1_MeV),
       3.63856481310620549e-09 * 1. / (1_MeV),
       -1.73298870890743619e-12 * 1. / (1_MeV),
-      8.13164466317850554e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.13164466317850554e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams111 =
       BoundParameters(gctx, std::move(covMat111), params111, perigeeSurface);
   tracks.push_back(boundParams111);
@@ -2681,7 +2681,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.57354143788096226e-08 * 1. / (1_MeV),
       7.3705206571867806e-09 * 1. / (1_MeV),
       -1.36270420577401879e-12 * 1. / (1_MeV),
-      9.7393829112668584e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.7393829112668584e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams112 =
       BoundParameters(gctx, std::move(covMat112), params112, perigeeSurface);
   tracks.push_back(boundParams112);
@@ -2704,7 +2704,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.04180315460180327e-08 * 1. / (1_MeV),
       1.4268675855279823e-08 * 1. / (1_MeV),
       -5.77783317368770183e-12 * 1. / (1_MeV),
-      1.32142283226777124e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.32142283226777124e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams113 =
       BoundParameters(gctx, std::move(covMat113), params113, perigeeSurface);
   tracks.push_back(boundParams113);
@@ -2728,7 +2728,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.16003452981261856e-08 * 1. / (1_MeV),
       2.46257505980399243e-08 * 1. / (1_MeV),
       -2.25280483073948522e-11 * 1. / (1_MeV),
-      4.48457743162933298e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.48457743162933298e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams114 =
       BoundParameters(gctx, std::move(covMat114), params114, perigeeSurface);
   tracks.push_back(boundParams114);
@@ -2751,7 +2751,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.60630576356142156e-09 * 1. / (1_MeV),
       7.60358813812795812e-09 * 1. / (1_MeV),
       3.89686466885357287e-11 * 1. / (1_MeV),
-      9.49285094975493848e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.49285094975493848e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams115 =
       BoundParameters(gctx, std::move(covMat115), params115, perigeeSurface);
   tracks.push_back(boundParams115);
@@ -2775,7 +2775,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.18182893772007853e-09 * 1. / (1_MeV),
       1.74822784071129361e-08 * 1. / (1_MeV),
       -2.45815925497200098e-12 * 1. / (1_MeV),
-      4.33391877940891845e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.33391877940891845e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams116 =
       BoundParameters(gctx, std::move(covMat116), params116, perigeeSurface);
   tracks.push_back(boundParams116);
@@ -2798,7 +2798,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       8.72212302001908086e-09 * 1. / (1_MeV),
       1.49552172231130049e-08 * 1. / (1_MeV),
       3.10238162026694015e-11 * 1. / (1_MeV),
-      2.30750710206173437e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.30750710206173437e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams117 =
       BoundParameters(gctx, std::move(covMat117), params117, perigeeSurface);
   tracks.push_back(boundParams117);
@@ -2822,7 +2822,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.29354667260461022e-08 * 1. / (1_MeV),
       1.20551713367857255e-08 * 1. / (1_MeV),
       -1.71918312121670268e-11 * 1. / (1_MeV),
-      1.72003744580706552e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.72003744580706552e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams118 =
       BoundParameters(gctx, std::move(covMat118), params118, perigeeSurface);
   tracks.push_back(boundParams118);
@@ -2846,7 +2846,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.13544688641597921e-08 * 1. / (1_MeV),
       1.39122962799931803e-08 * 1. / (1_MeV),
       6.08338264527575119e-12 * 1. / (1_MeV),
-      1.86805737545370221e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.86805737545370221e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams119 =
       BoundParameters(gctx, std::move(covMat119), params119, perigeeSurface);
   tracks.push_back(boundParams119);
@@ -2870,7 +2870,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.37860649239220225e-09 * 1. / (1_MeV),
       6.35917118456449052e-09 * 1. / (1_MeV),
       -2.51583629069704591e-11 * 1. / (1_MeV),
-      1.78077538826038051e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.78077538826038051e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams120 =
       BoundParameters(gctx, std::move(covMat120), params120, perigeeSurface);
   tracks.push_back(boundParams120);
@@ -2894,7 +2894,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.28310247664964105e-10 * 1. / (1_MeV),
       3.05175081762309306e-10 * 1. / (1_MeV),
       1.64157138196977762e-13 * 1. / (1_MeV),
-      5.16425357338645696e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.16425357338645696e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams121 =
       BoundParameters(gctx, std::move(covMat121), params121, perigeeSurface);
   tracks.push_back(boundParams121);
@@ -2918,7 +2918,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.3685986667229676e-09 * 1. / (1_MeV),
       5.47590882437587651e-09 * 1. / (1_MeV),
       -1.07937619402598992e-11 * 1. / (1_MeV),
-      1.73649483681259653e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.73649483681259653e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams122 =
       BoundParameters(gctx, std::move(covMat122), params122, perigeeSurface);
   tracks.push_back(boundParams122);
@@ -2941,7 +2941,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.32173469014469017e-09 * 1. / (1_MeV),
       3.09126253015111042e-09 * 1. / (1_MeV),
       9.00985395948335217e-11 * 1. / (1_MeV),
-      8.96472895917099777e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.96472895917099777e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams123 =
       BoundParameters(gctx, std::move(covMat123), params123, perigeeSurface);
   tracks.push_back(boundParams123);
@@ -2965,7 +2965,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.73743427737471889e-09 * 1. / (1_MeV),
       5.19150014241903916e-09 * 1. / (1_MeV),
       1.1663553056713431e-11 * 1. / (1_MeV),
-      1.38518113645957897e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.38518113645957897e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams124 =
       BoundParameters(gctx, std::move(covMat124), params124, perigeeSurface);
   tracks.push_back(boundParams124);
@@ -2989,7 +2989,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       6.41373777463503296e-10 * 1. / (1_MeV),
       1.15319447682158026e-08 * 1. / (1_MeV),
       -4.6401369967705386e-12 * 1. / (1_MeV),
-      3.61465746223643691e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.61465746223643691e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams125 =
       BoundParameters(gctx, std::move(covMat125), params125, perigeeSurface);
   tracks.push_back(boundParams125);
@@ -3012,7 +3012,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.42274967363324924e-08 * 1. / (1_MeV),
       6.17048734091374837e-09 * 1. / (1_MeV),
       1.20738678057781713e-12 * 1. / (1_MeV),
-      6.87515253061654619e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.87515253061654619e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams126 =
       BoundParameters(gctx, std::move(covMat126), params126, perigeeSurface);
   tracks.push_back(boundParams126);
@@ -3037,7 +3037,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.31633021184019983e-08 * 1. / (1_MeV),
       9.78682020756434252e-09 * 1. / (1_MeV),
       2.37236751652554644e-12 * 1. / (1_MeV),
-      8.74325264965669646e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.74325264965669646e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams127 =
       BoundParameters(gctx, std::move(covMat127), params127, perigeeSurface);
   tracks.push_back(boundParams127);
@@ -3061,7 +3061,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.15057697948470685e-08 * 1. / (1_MeV),
       1.37170909103508374e-08 * 1. / (1_MeV),
       3.36288899333749929e-11 * 1. / (1_MeV),
-      3.38668010302356493e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.38668010302356493e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams128 =
       BoundParameters(gctx, std::move(covMat128), params128, perigeeSurface);
   tracks.push_back(boundParams128);
@@ -3085,7 +3085,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.07847367917163246e-08 * 1. / (1_MeV),
       5.46013101705028866e-09 * 1. / (1_MeV),
       8.12217710906210286e-12 * 1. / (1_MeV),
-      8.87762224843768877e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.87762224843768877e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams129 =
       BoundParameters(gctx, std::move(covMat129), params129, perigeeSurface);
   tracks.push_back(boundParams129);
@@ -3109,7 +3109,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.6111436767727037e-09 * 1. / (1_MeV),
       4.3871518926068891e-09 * 1. / (1_MeV),
       1.25136088613115525e-11 * 1. / (1_MeV),
-      1.55834969928214662e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.55834969928214662e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams130 =
       BoundParameters(gctx, std::move(covMat130), params130, perigeeSurface);
   tracks.push_back(boundParams130);
@@ -3134,7 +3134,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.84215790760252208e-09 * 1. / (1_MeV),
       1.07852728031145877e-08 * 1. / (1_MeV),
       -7.1469095279936026e-12 * 1. / (1_MeV),
-      2.20003334994167687e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.20003334994167687e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams131 =
       BoundParameters(gctx, std::move(covMat131), params131, perigeeSurface);
   tracks.push_back(boundParams131);
@@ -3158,7 +3158,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.55052024057200266e-09 * 1. / (1_MeV),
       1.13634723345292126e-08 * 1. / (1_MeV),
       -4.93303581762030017e-11 * 1. / (1_MeV),
-      3.97582966549236971e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.97582966549236971e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams132 =
       BoundParameters(gctx, std::move(covMat132), params132, perigeeSurface);
   tracks.push_back(boundParams132);
@@ -3182,7 +3182,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.0856143118849151e-09 * 1. / (1_MeV),
       1.1170956971681221e-08 * 1. / (1_MeV),
       -1.05152517914159529e-11 * 1. / (1_MeV),
-      3.04403169337774671e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.04403169337774671e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams133 =
       BoundParameters(gctx, std::move(covMat133), params133, perigeeSurface);
   tracks.push_back(boundParams133);
@@ -3206,7 +3206,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.07928525134701817e-09 * 1. / (1_MeV),
       5.18060114302286267e-09 * 1. / (1_MeV),
       2.16936360639539862e-12 * 1. / (1_MeV),
-      1.35624275698909003e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.35624275698909003e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams134 =
       BoundParameters(gctx, std::move(covMat134), params134, perigeeSurface);
   tracks.push_back(boundParams134);
@@ -3229,7 +3229,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -7.78615764923604825e-09 * 1. / (1_MeV),
       7.02699563203032516e-09 * 1. / (1_MeV),
       6.04537737743006593e-12 * 1. / (1_MeV),
-      1.35220848407335836e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.35220848407335836e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams135 =
       BoundParameters(gctx, std::move(covMat135), params135, perigeeSurface);
   tracks.push_back(boundParams135);
@@ -3253,7 +3253,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.75455883099119192e-09 * 1. / (1_MeV),
       4.75511246715568753e-09 * 1. / (1_MeV),
       2.56252285968062862e-11 * 1. / (1_MeV),
-      1.62369812040097372e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.62369812040097372e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams136 =
       BoundParameters(gctx, std::move(covMat136), params136, perigeeSurface);
   tracks.push_back(boundParams136);
@@ -3276,7 +3276,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.09467237202718329e-08 * 1. / (1_MeV),
       1.51901283557160921e-08 * 1. / (1_MeV),
       -5.89799137780591859e-12 * 1. / (1_MeV),
-      1.66225588849044925e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.66225588849044925e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams137 =
       BoundParameters(gctx, std::move(covMat137), params137, perigeeSurface);
   tracks.push_back(boundParams137);
@@ -3300,7 +3300,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.15116273492404661e-09 * 1. / (1_MeV),
       4.16595730488154716e-09 * 1. / (1_MeV),
       -4.21540260659907555e-12 * 1. / (1_MeV),
-      7.92930027193605724e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.92930027193605724e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams138 =
       BoundParameters(gctx, std::move(covMat138), params138, perigeeSurface);
   tracks.push_back(boundParams138);
@@ -3324,7 +3324,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.87564726794623446e-09 * 1. / (1_MeV),
       8.98278177902545255e-09 * 1. / (1_MeV),
       1.52214832118640255e-11 * 1. / (1_MeV),
-      2.85946016864713215e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.85946016864713215e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams139 =
       BoundParameters(gctx, std::move(covMat139), params139, perigeeSurface);
   tracks.push_back(boundParams139);
@@ -3348,7 +3348,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.83245686148190731e-10 * 1. / (1_MeV),
       1.1015992963213548e-08 * 1. / (1_MeV),
       1.69476858439270149e-11 * 1. / (1_MeV),
-      3.93277660437618692e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.93277660437618692e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams140 =
       BoundParameters(gctx, std::move(covMat140), params140, perigeeSurface);
   tracks.push_back(boundParams140);
@@ -3372,7 +3372,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.84955003459008438e-09 * 1. / (1_MeV),
       6.42585697371379892e-09 * 1. / (1_MeV),
       -2.99674425730772401e-11 * 1. / (1_MeV),
-      2.4992743985485788e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.4992743985485788e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams141 =
       BoundParameters(gctx, std::move(covMat141), params141, perigeeSurface);
   tracks.push_back(boundParams141);
@@ -3395,7 +3395,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.53787934713242592e-08 * 1. / (1_MeV),
       1.80691074173165322e-08 * 1. / (1_MeV),
       -8.35165165596293098e-12 * 1. / (1_MeV),
-      4.57582055579663916e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.57582055579663916e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams142 =
       BoundParameters(gctx, std::move(covMat142), params142, perigeeSurface);
   tracks.push_back(boundParams142);
@@ -3418,7 +3418,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.39605428797278291e-09 * 1. / (1_MeV),
       3.63950477953687594e-09 * 1. / (1_MeV),
       3.22132744873936636e-12 * 1. / (1_MeV),
-      3.18471672644538017e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.18471672644538017e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams143 =
       BoundParameters(gctx, std::move(covMat143), params143, perigeeSurface);
   tracks.push_back(boundParams143);
@@ -3441,7 +3441,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -4.9073936291752883e-09 * 1. / (1_MeV),
       6.20080490265058224e-09 * 1. / (1_MeV),
       4.19473349424168581e-12 * 1. / (1_MeV),
-      6.42161740449509466e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.42161740449509466e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams144 =
       BoundParameters(gctx, std::move(covMat144), params144, perigeeSurface);
   tracks.push_back(boundParams144);
@@ -3465,7 +3465,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.8766189110419867e-09 * 1. / (1_MeV),
       1.21477695022017926e-08 * 1. / (1_MeV),
       8.96597163070042405e-12 * 1. / (1_MeV),
-      3.91443821801118474e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.91443821801118474e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams145 =
       BoundParameters(gctx, std::move(covMat145), params145, perigeeSurface);
   tracks.push_back(boundParams145);
@@ -3488,7 +3488,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -3.38021765880820443e-09 * 1. / (1_MeV),
       6.11745668929922213e-09 * 1. / (1_MeV),
       -3.86232878211289549e-11 * 1. / (1_MeV),
-      2.21742652017908881e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.21742652017908881e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams146 =
       BoundParameters(gctx, std::move(covMat146), params146, perigeeSurface);
   tracks.push_back(boundParams146);
@@ -3512,7 +3512,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.53499877322050493e-08 * 1. / (1_MeV),
       4.56613110250769837e-08 * 1. / (1_MeV),
       2.77175608301356693e-11 * 1. / (1_MeV),
-      7.42934380681958828e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.42934380681958828e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams147 =
       BoundParameters(gctx, std::move(covMat147), params147, perigeeSurface);
   tracks.push_back(boundParams147);
@@ -3536,7 +3536,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.99118715573116921e-09 * 1. / (1_MeV),
       5.11517095198890007e-09 * 1. / (1_MeV),
       -3.45854711927653862e-12 * 1. / (1_MeV),
-      8.50769107940685387e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.50769107940685387e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams148 =
       BoundParameters(gctx, std::move(covMat148), params148, perigeeSurface);
   tracks.push_back(boundParams148);
@@ -3559,7 +3559,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.86525491239922761e-10 * 1. / (1_MeV),
       1.17735415136484234e-08 * 1. / (1_MeV),
       -1.33592110665984887e-11 * 1. / (1_MeV),
-      3.07479458561132901e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.07479458561132901e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams149 =
       BoundParameters(gctx, std::move(covMat149), params149, perigeeSurface);
   tracks.push_back(boundParams149);
@@ -3582,7 +3582,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.91422448133011881e-09 * 1. / (1_MeV),
       4.84814135648083373e-09 * 1. / (1_MeV),
       -3.26867840396934173e-12 * 1. / (1_MeV),
-      1.01995072110394602e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.01995072110394602e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams150 =
       BoundParameters(gctx, std::move(covMat150), params150, perigeeSurface);
   tracks.push_back(boundParams150);
@@ -3605,7 +3605,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.06928217588898346e-08 * 1. / (1_MeV),
       9.51416150401782656e-09 * 1. / (1_MeV),
       -4.0379007049062301e-11 * 1. / (1_MeV),
-      2.35979236151706573e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.35979236151706573e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams151 =
       BoundParameters(gctx, std::move(covMat151), params151, perigeeSurface);
   tracks.push_back(boundParams151);
@@ -3629,7 +3629,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.15039861676908778e-09 * 1. / (1_MeV),
       1.3347851460192395e-08 * 1. / (1_MeV),
       9.51450535762684209e-12 * 1. / (1_MeV),
-      2.52067755557305873e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.52067755557305873e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams152 =
       BoundParameters(gctx, std::move(covMat152), params152, perigeeSurface);
   tracks.push_back(boundParams152);
@@ -3654,7 +3654,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.09070433346646154e-09 * 1. / (1_MeV),
       1.04858623295484113e-08 * 1. / (1_MeV),
       -2.62710156705971042e-11 * 1. / (1_MeV),
-      4.00474514661297576e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.00474514661297576e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams153 =
       BoundParameters(gctx, std::move(covMat153), params153, perigeeSurface);
   tracks.push_back(boundParams153);
@@ -3678,7 +3678,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.11154383882071719e-08 * 1. / (1_MeV),
       2.12308161941993043e-08 * 1. / (1_MeV),
       -9.05413371576357781e-11 * 1. / (1_MeV),
-      6.28650798084606777e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.28650798084606777e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams154 =
       BoundParameters(gctx, std::move(covMat154), params154, perigeeSurface);
   tracks.push_back(boundParams154);
@@ -3702,7 +3702,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.34245812546777072e-08 * 1. / (1_MeV),
       8.68476512257556142e-09 * 1. / (1_MeV),
       -1.19444645168272657e-11 * 1. / (1_MeV),
-      8.34616611933292063e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.34616611933292063e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams155 =
       BoundParameters(gctx, std::move(covMat155), params155, perigeeSurface);
   tracks.push_back(boundParams155);
@@ -3726,7 +3726,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.20886185541909694e-09 * 1. / (1_MeV),
       1.01717537862091531e-08 * 1. / (1_MeV),
       -7.31342694223202373e-12 * 1. / (1_MeV),
-      2.3365928636387423e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.3365928636387423e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams156 =
       BoundParameters(gctx, std::move(covMat156), params156, perigeeSurface);
   tracks.push_back(boundParams156);
@@ -3749,7 +3749,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.66739114473183283e-09 * 1. / (1_MeV),
       8.84959810661187708e-09 * 1. / (1_MeV),
       2.42683894231848255e-12 * 1. / (1_MeV),
-      1.96425084530993388e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.96425084530993388e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams157 =
       BoundParameters(gctx, std::move(covMat157), params157, perigeeSurface);
   tracks.push_back(boundParams157);
@@ -3772,7 +3772,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.72504289628637471e-09 * 1. / (1_MeV),
       1.01751060319750463e-08 * 1. / (1_MeV),
       2.72996826709048491e-11 * 1. / (1_MeV),
-      2.86495771550931977e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.86495771550931977e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams158 =
       BoundParameters(gctx, std::move(covMat158), params158, perigeeSurface);
   tracks.push_back(boundParams158);
@@ -3796,7 +3796,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.87684603862415885e-08 * 1. / (1_MeV),
       1.36753554668844785e-08 * 1. / (1_MeV),
       -3.39037168618683865e-12 * 1. / (1_MeV),
-      3.48178236242446815e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.48178236242446815e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams159 =
       BoundParameters(gctx, std::move(covMat159), params159, perigeeSurface);
   tracks.push_back(boundParams159);
@@ -3820,7 +3820,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.69162268005727335e-08 * 1. / (1_MeV),
       1.83230555024144881e-08 * 1. / (1_MeV),
       -1.87734052287320618e-11 * 1. / (1_MeV),
-      3.79933057237380467e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.79933057237380467e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams160 =
       BoundParameters(gctx, std::move(covMat160), params160, perigeeSurface);
   tracks.push_back(boundParams160);
@@ -3845,7 +3845,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.60400630155777733e-09 * 1. / (1_MeV),
       5.3323840067832493e-09 * 1. / (1_MeV),
       -2.71866026406819207e-11 * 1. / (1_MeV),
-      1.68986658000136458e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.68986658000136458e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams161 =
       BoundParameters(gctx, std::move(covMat161), params161, perigeeSurface);
   tracks.push_back(boundParams161);
@@ -3868,7 +3868,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.28089131983040278e-08 * 1. / (1_MeV),
       1.47520025775196756e-08 * 1. / (1_MeV),
       -6.9067412337676577e-12 * 1. / (1_MeV),
-      3.46785045124420321e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.46785045124420321e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams162 =
       BoundParameters(gctx, std::move(covMat162), params162, perigeeSurface);
   tracks.push_back(boundParams162);
@@ -3892,7 +3892,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -6.36132286347180259e-10 * 1. / (1_MeV),
       8.91432167580867079e-09 * 1. / (1_MeV),
       -4.62705821113891289e-11 * 1. / (1_MeV),
-      2.9073463081452644e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.9073463081452644e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams163 =
       BoundParameters(gctx, std::move(covMat163), params163, perigeeSurface);
   tracks.push_back(boundParams163);
@@ -3916,7 +3916,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.58618417511969728e-10 * 1. / (1_MeV),
       4.70134905851354349e-11 * 1. / (1_MeV),
       -5.34156221200548834e-12 * 1. / (1_MeV),
-      6.18826441912273539e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.18826441912273539e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams164 =
       BoundParameters(gctx, std::move(covMat164), params164, perigeeSurface);
   tracks.push_back(boundParams164);
@@ -3940,7 +3940,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -7.61741612270504069e-09 * 1. / (1_MeV),
       7.96054784235342818e-09 * 1. / (1_MeV),
       -1.95104992239772127e-11 * 1. / (1_MeV),
-      1.81045026192983016e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.81045026192983016e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams165 =
       BoundParameters(gctx, std::move(covMat165), params165, perigeeSurface);
   tracks.push_back(boundParams165);
@@ -3963,7 +3963,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.41325547148110521e-09 * 1. / (1_MeV),
       1.05514606536829556e-08 * 1. / (1_MeV),
       -6.6186235709197681e-11 * 1. / (1_MeV),
-      1.90290047608066004e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.90290047608066004e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams166 =
       BoundParameters(gctx, std::move(covMat166), params166, perigeeSurface);
   tracks.push_back(boundParams166);
@@ -3986,7 +3986,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.11273110436170716e-09 * 1. / (1_MeV),
       1.32070729647698356e-08 * 1. / (1_MeV),
       4.26309578361557248e-11 * 1. / (1_MeV),
-      3.20331428049769329e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.20331428049769329e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams167 =
       BoundParameters(gctx, std::move(covMat167), params167, perigeeSurface);
   tracks.push_back(boundParams167);
@@ -4010,7 +4010,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.35561789668739302e-09 * 1. / (1_MeV),
       1.23193818731095067e-08 * 1. / (1_MeV),
       1.03376886437529416e-11 * 1. / (1_MeV),
-      2.40058611877813632e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.40058611877813632e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams168 =
       BoundParameters(gctx, std::move(covMat168), params168, perigeeSurface);
   tracks.push_back(boundParams168);
@@ -4035,7 +4035,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -5.41191330879136116e-09 * 1. / (1_MeV),
       7.90020084251383031e-10 * 1. / (1_MeV),
       -2.55639621894285378e-12 * 1. / (1_MeV),
-      6.093434784526508e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.093434784526508e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams169 =
       BoundParameters(gctx, std::move(covMat169), params169, perigeeSurface);
   tracks.push_back(boundParams169);
@@ -4058,7 +4058,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.46103911881579324e-08 * 1. / (1_MeV),
       5.5197340225094278e-09 * 1. / (1_MeV),
       2.78956850716596797e-11 * 1. / (1_MeV),
-      1.16566450936161914e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.16566450936161914e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams170 =
       BoundParameters(gctx, std::move(covMat170), params170, perigeeSurface);
   tracks.push_back(boundParams170);
@@ -4081,7 +4081,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.10417192350336677e-09 * 1. / (1_MeV),
       2.88464097247522637e-09 * 1. / (1_MeV),
       3.38702398090118851e-11 * 1. / (1_MeV),
-      5.12816594744336385e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      5.12816594744336385e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams171 =
       BoundParameters(gctx, std::move(covMat171), params171, perigeeSurface);
   tracks.push_back(boundParams171);
@@ -4106,7 +4106,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.04544462489257834e-08 * 1. / (1_MeV),
       8.95910636378094416e-09 * 1. / (1_MeV),
       1.04135839016089135e-11 * 1. / (1_MeV),
-      9.13651862499698098e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      9.13651862499698098e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams172 =
       BoundParameters(gctx, std::move(covMat172), params172, perigeeSurface);
   tracks.push_back(boundParams172);
@@ -4131,7 +4131,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       2.47498208313890995e-09 * 1. / (1_MeV),
       6.99034330539053411e-10 * 1. / (1_MeV),
       2.24057572896354012e-11 * 1. / (1_MeV),
-      2.14914561841306195e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.14914561841306195e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams173 =
       BoundParameters(gctx, std::move(covMat173), params173, perigeeSurface);
   tracks.push_back(boundParams173);
@@ -4155,7 +4155,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.42796441483104706e-11 * 1. / (1_MeV),
       4.7992442755515698e-10 * 1. / (1_MeV),
       2.21547914401007548e-12 * 1. / (1_MeV),
-      8.28479385789337996e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.28479385789337996e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams174 =
       BoundParameters(gctx, std::move(covMat174), params174, perigeeSurface);
   tracks.push_back(boundParams174);
@@ -4178,7 +4178,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.83345569355485214e-08 * 1. / (1_MeV),
       1.41475994510483018e-08 * 1. / (1_MeV),
       -8.89617608490651688e-12 * 1. / (1_MeV),
-      2.89176599332918727e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.89176599332918727e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams175 =
       BoundParameters(gctx, std::move(covMat175), params175, perigeeSurface);
   tracks.push_back(boundParams175);
@@ -4201,7 +4201,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       3.18549795465229701e-09 * 1. / (1_MeV),
       9.45920987209876617e-10 * 1. / (1_MeV),
       2.81623324330943026e-13 * 1. / (1_MeV),
-      7.16269968684124514e-12 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.16269968684124514e-12 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams176 =
       BoundParameters(gctx, std::move(covMat176), params176, perigeeSurface);
   tracks.push_back(boundParams176);
@@ -4225,7 +4225,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.60214482748251599e-09 * 1. / (1_MeV),
       8.70000260399467453e-09 * 1. / (1_MeV),
       3.34801528438062845e-11 * 1. / (1_MeV),
-      2.40241548876696243e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.40241548876696243e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams177 =
       BoundParameters(gctx, std::move(covMat177), params177, perigeeSurface);
   tracks.push_back(boundParams177);
@@ -4249,7 +4249,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.1712654493269838e-08 * 1. / (1_MeV),
       4.60434144629863134e-08 * 1. / (1_MeV),
       6.61054698516293509e-11 * 1. / (1_MeV),
-      8.71379024491858445e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.71379024491858445e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams178 =
       BoundParameters(gctx, std::move(covMat178), params178, perigeeSurface);
   tracks.push_back(boundParams178);
@@ -4274,7 +4274,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.23777402096878229e-09 * 1. / (1_MeV),
       3.72169224602511146e-09 * 1. / (1_MeV),
       -8.61261950846322556e-12 * 1. / (1_MeV),
-      7.60389459730781425e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      7.60389459730781425e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams179 =
       BoundParameters(gctx, std::move(covMat179), params179, perigeeSurface);
   tracks.push_back(boundParams179);
@@ -4297,7 +4297,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       4.75892992516188328e-11 * 1. / (1_MeV),
       2.24457480954691427e-11 * 1. / (1_MeV),
       3.80890047398306893e-14 * 1. / (1_MeV),
-      2.13997019432067559e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.13997019432067559e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams180 =
       BoundParameters(gctx, std::move(covMat180), params180, perigeeSurface);
   tracks.push_back(boundParams180);
@@ -4320,7 +4320,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.86788811100685945e-09 * 1. / (1_MeV),
       8.14523789406513383e-09 * 1. / (1_MeV),
       -4.34128100864560213e-11 * 1. / (1_MeV),
-      2.69415295628405715e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.69415295628405715e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams181 =
       BoundParameters(gctx, std::move(covMat181), params181, perigeeSurface);
   tracks.push_back(boundParams181);
@@ -4343,7 +4343,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       6.8980626296848663e-10 * 1. / (1_MeV),
       2.57034296242806379e-11 * 1. / (1_MeV),
       2.18691904163845164e-12 * 1. / (1_MeV),
-      3.96474248830908094e-13 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.96474248830908094e-13 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams182 =
       BoundParameters(gctx, std::move(covMat182), params182, perigeeSurface);
   tracks.push_back(boundParams182);
@@ -4368,7 +4368,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -9.53412665718049786e-09 * 1. / (1_MeV),
       7.55984162080033033e-09 * 1. / (1_MeV),
       -1.19858856846402273e-10 * 1. / (1_MeV),
-      2.77350448163460328e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.77350448163460328e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams183 =
       BoundParameters(gctx, std::move(covMat183), params183, perigeeSurface);
   tracks.push_back(boundParams183);
@@ -4391,7 +4391,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.85121059683026354e-08 * 1. / (1_MeV),
       2.734052899630625e-08 * 1. / (1_MeV),
       -3.56882818335140094e-11 * 1. / (1_MeV),
-      8.01815225326407699e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      8.01815225326407699e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams184 =
       BoundParameters(gctx, std::move(covMat184), params184, perigeeSurface);
   tracks.push_back(boundParams184);
@@ -4416,7 +4416,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.84281636372081495e-08 * 1. / (1_MeV),
       3.82825795137663461e-08 * 1. / (1_MeV),
       -5.28708663533158423e-11 * 1. / (1_MeV),
-      1.09044751006592833e-09 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.09044751006592833e-09 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams185 =
       BoundParameters(gctx, std::move(covMat185), params185, perigeeSurface);
   tracks.push_back(boundParams185);
@@ -4439,7 +4439,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -7.43175254803814895e-09 * 1. / (1_MeV),
       1.2513898586729675e-08 * 1. / (1_MeV),
       9.64087163963260696e-12 * 1. / (1_MeV),
-      2.39039704696963895e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.39039704696963895e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams186 =
       BoundParameters(gctx, std::move(covMat186), params186, perigeeSurface);
   tracks.push_back(boundParams186);
@@ -4462,7 +4462,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.16318519179297501e-09 * 1. / (1_MeV),
       1.78538275775300426e-08 * 1. / (1_MeV),
       -2.57140078054900237e-12 * 1. / (1_MeV),
-      3.88259702166493526e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.88259702166493526e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams187 =
       BoundParameters(gctx, std::move(covMat187), params187, perigeeSurface);
   tracks.push_back(boundParams187);
@@ -4486,7 +4486,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       5.06151582160123152e-09 * 1. / (1_MeV),
       2.94694781059607752e-08 * 1. / (1_MeV),
       -8.07723581241271915e-12 * 1. / (1_MeV),
-      1.11964115756535421e-09 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.11964115756535421e-09 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams188 =
       BoundParameters(gctx, std::move(covMat188), params188, perigeeSurface);
   tracks.push_back(boundParams188);
@@ -4509,7 +4509,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       6.98047989676528565e-09 * 1. / (1_MeV),
       1.3794266136933136e-08 * 1. / (1_MeV),
       1.88533015927685212e-10 * 1. / (1_MeV),
-      2.06299227700768029e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.06299227700768029e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams189 =
       BoundParameters(gctx, std::move(covMat189), params189, perigeeSurface);
   tracks.push_back(boundParams189);
@@ -4532,7 +4532,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.65364516509722375e-10 * 1. / (1_MeV),
       9.13941830794303589e-09 * 1. / (1_MeV),
       2.02537558480182913e-11 * 1. / (1_MeV),
-      1.74747369352523663e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.74747369352523663e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams190 =
       BoundParameters(gctx, std::move(covMat190), params190, perigeeSurface);
   tracks.push_back(boundParams190);
@@ -4555,7 +4555,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       7.69202591235202105e-08 * 1. / (1_MeV),
       1.18979733649928015e-08 * 1. / (1_MeV),
       4.99503482968757551e-12 * 1. / (1_MeV),
-      1.1102829766684863e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.1102829766684863e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams191 =
       BoundParameters(gctx, std::move(covMat191), params191, perigeeSurface);
   tracks.push_back(boundParams191);
@@ -4578,7 +4578,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -2.73285579882235462e-07 * 1. / (1_MeV),
       3.3253261709379142e-08 * 1. / (1_MeV),
       -1.22599704885134249e-11 * 1. / (1_MeV),
-      2.39606362528732575e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.39606362528732575e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams192 =
       BoundParameters(gctx, std::move(covMat192), params192, perigeeSurface);
   tracks.push_back(boundParams192);
@@ -4602,7 +4602,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.2205651249153285e-09 * 1. / (1_MeV),
       2.09396062746074539e-08 * 1. / (1_MeV),
       5.33983405657483665e-11 * 1. / (1_MeV),
-      3.6832190075664073e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      3.6832190075664073e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams193 =
       BoundParameters(gctx, std::move(covMat193), params193, perigeeSurface);
   tracks.push_back(boundParams193);
@@ -4626,7 +4626,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.35539555434146533e-10 * 1. / (1_MeV),
       4.95433244701872377e-09 * 1. / (1_MeV),
       1.62498821676485166e-12 * 1. / (1_MeV),
-      4.37339504888445418e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      4.37339504888445418e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams194 =
       BoundParameters(gctx, std::move(covMat194), params194, perigeeSurface);
   tracks.push_back(boundParams194);
@@ -4651,7 +4651,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -8.53100318867495256e-09 * 1. / (1_MeV),
       3.65227707433702304e-09 * 1. / (1_MeV),
       9.05586100425189466e-13 * 1. / (1_MeV),
-      2.24803491793990062e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      2.24803491793990062e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams195 =
       BoundParameters(gctx, std::move(covMat195), params195, perigeeSurface);
   tracks.push_back(boundParams195);
@@ -4674,7 +4674,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       1.76497106084476643e-08 * 1. / (1_MeV),
       1.09182558397378106e-08 * 1. / (1_MeV),
       -1.84419314901396339e-12 * 1. / (1_MeV),
-      6.27720861401392938e-11 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      6.27720861401392938e-11 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams196 =
       BoundParameters(gctx, std::move(covMat196), params196, perigeeSurface);
   tracks.push_back(boundParams196);
@@ -4697,7 +4697,7 @@ std::vector<BoundParameters> getAthenaTracks() {
       -1.8757136234213445e-08 * 1. / (1_MeV),
       8.81223262771924531e-09 * 1. / (1_MeV),
       -3.63880446087211061e-11 * 1. / (1_MeV),
-      1.12412849861964759e-10 * 1. / (1_MeV), 0, 0, 0, 0, 0, 0, 1;
+      1.12412849861964759e-10 * 1. / (1_MeV * 1_MeV), 0, 0, 0, 0, 0, 0, 1;
   auto boundParams197 =
       BoundParameters(gctx, std::move(covMat197), params197, perigeeSurface);
   tracks.push_back(boundParams197);


### PR DESCRIPTION
There was a lot of unnecessary stuff going on in the gaussian track density vertex seed finder, that could be cleaned up. The physics performance has not changed, giving identical results with better CPU performance. 
Closes #97 .
