### PR TITLE
Have CTest display test output if a test fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
 jobs:
   build_ubuntu:
     runs-on: ubuntu-18.04

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+
 jobs:
   build_debug:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Relevant documentation : https://cmake.org/cmake/help/v3.1/manual/ctest.1.html .

I think a global env flag is reasonable, since we want all ctest jobs to do this and the env variable name is unambiguous enough that there is no risk of perturbating anything else.