### PR TITLE
Fix the tryRungeKuttaStepper

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -133,9 +133,7 @@ Acts::Result<double> Acts::EigenStepper<B, E, A>::step(
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
-    return (error_estimate <= state.options.tolerance) &&
-           ((h.currentType() != ConstrainedStep::accuracy) ||
-            (error_estimate >= state.options.tolerance / 10));
+    return (error_estimate <= state.options.tolerance);
   };
 
   double stepSizeScaling = 1.;


### PR DESCRIPTION
This PR will fix the stepping failure by replacing the return statement with its older form, `return (error_estimate <= state.options.tolerance);` as @HadrienG2  suggested in issue #142.
