### PR TITLE
Fix fatras example nullptrs

### DIFF
--- a/Examples/Run/Fatras/AlignedFatrasExample.cpp
+++ b/Examples/Run/Fatras/AlignedFatrasExample.cpp
@@ -10,5 +10,5 @@
 #include "FatrasMain.hpp"
 
 int main(int argc, char* argv[]) {
-  return FW::fatrasMain(argc, argv, std::shared_ptr<AlignedDetector>());
+  return FW::fatrasMain(argc, argv, std::make_shared<AlignedDetector>());
 }

--- a/Examples/Run/Fatras/PayloadFatrasExample.cpp
+++ b/Examples/Run/Fatras/PayloadFatrasExample.cpp
@@ -10,5 +10,5 @@
 #include "FatrasMain.hpp"
 
 int main(int argc, char* argv[]) {
-  return FW::fatrasMain(argc, argv, std::shared_ptr<PayloadDetector>());
+  return FW::fatrasMain(argc, argv, std::make_shared<PayloadDetector>());
 }


### PR DESCRIPTION
Some Fatras examples pass in a null `shared_ptr` in a place where a valid detector pointer is expected. They shouldn't do that.