### PR TITLE
Fix the bug to identify majority particle

### DIFF
--- a/Examples/Framework/include/ACTFW/EventData/TruthFitTrack.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/TruthFitTrack.hpp
@@ -137,7 +137,7 @@ struct TruthFitTrack {
       // sort by hit count, i.e. majority particle first
       std::sort(particleHitCount.begin(), particleHitCount.end(),
                 [](const ParticleHitCount& lhs, const ParticleHitCount& rhs) {
-                  return lhs.hitCount < rhs.hitCount;
+                  return lhs.hitCount > rhs.hitCount;
                 });
     }
 

--- a/Examples/Framework/src/Validation/ProtoTrackClassification.cpp
+++ b/Examples/Framework/src/Validation/ProtoTrackClassification.cpp
@@ -40,7 +40,7 @@ void FW::identifyContributingParticles(
   // sort by hit count, i.e. majority particle first
   auto compareHitCount = [](const ParticleHitCount& lhs,
                             const ParticleHitCount& rhs) {
-    return lhs.hitCount < rhs.hitCount;
+    return lhs.hitCount > rhs.hitCount;
   };
   std::sort(particleHitCount.begin(), particleHitCount.end(), compareHitCount);
 }


### PR DESCRIPTION
This PR is splitted from #162  and will fix the bug to sort number of hits to identify majority particle.