### PR TITLE
Use HierarchicalGeometryContainer to simplfiy CKF source link selection

### DIFF
--- a/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
+++ b/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
@@ -36,7 +36,7 @@ struct GeometryCKFCriteria {
   size_t numSourcelinksCutOff = std::numeric_limits<size_t>::max();
 
   // The constructor
-  GeometryCKFCriteria(GeometryID id, double chi2, double num)
+  GeometryCKFCriteria(GeometryID id, double chi2, size_t num)
       : id(id), chi2CutOff(chi2), numSourcelinksCutOff(num) {}
 
   // The geometry identifier getter

--- a/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
+++ b/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
@@ -126,11 +126,10 @@ struct CKFSourceLinkSelector {
     auto surface = &predictedParams.referenceSurface();
     auto geoID = surface->geoID();
 
-    // Find the cutoff value for the surface in the hierarchical geometry
-    // container. If not found, use global cutoff value
+    // Find the cutoff values for the surface in the hierarchical geometry
+    // container. If not found, use global cutoff values
     double chi2CutOff = std::numeric_limits<double>::max();
     size_t numSourcelinksCutOff = std::numeric_limits<size_t>::max();
-    // -> Get the allowed maximum chi2 on this surface
     auto criteria_it = m_config.criteriaContainer.find(geoID);
     if (criteria_it != m_config.criteriaContainer.end()) {
       chi2CutOff = criteria_it->chi2CutOff;

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -62,6 +62,11 @@ struct ExtendedMinimalSourceLink {
   }
 };
 
+// helper function to create geometry ids
+GeometryID makeId(int volume, int layer = 0, int sensitive = 0) {
+  return GeometryID().setVolume(volume).setLayer(layer).setSensitive(sensitive);
+}
+
 // A few initialisations and definitionas
 using SourceLink = ExtendedMinimalSourceLink;
 using Jacobian = BoundParameters::CovMatrix_t;
@@ -289,20 +294,25 @@ BOOST_AUTO_TEST_CASE(comb_kalman_filter_zero_field) {
                                 SourceLinkSelector>;
 
   using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
+  using Chi2Container =
+      Acts::HierarchicalGeometryContainer<GeometryElement<double>>;
+  // Implement different chi2 cutoff at different detector level
+  // NB: pixel volumeID = 2, strip volumeID= 3
+  std::vector<GeometryElement<double>> elements = {
+      {makeId(2, 2), 8.0},  // pixel layer 2 chi2 cutoff: 8.0
+      {makeId(2, 4), 7.0},  // pixel layer 4 chi2 cutoff: 7.0
+      {makeId(2), 7.0},     // pixel volume chi2 cutoff: 7.0
+      {makeId(3), 8.0},     // strip volume chi2 cutoff: 8.0
+  };
   SourceLinkSelectorConfig sourcelinkSelectorConfig;
-  // Implement different chi2 criteria for different pixel (volumeID: 2)
-  // layers:
-  //-> layer 2: 8
-  //-> layer 4: 7
-  sourcelinkSelectorConfig.layerMaxChi2 = {{2, {{2, 8}, {4, 7}}}};
-  // Implement different chi2 criteria for pixel (volumeID: 2) and strip
-  // (volumeID: 3):
-  //-> pixel: 7
-  //-> strip: 8
-  sourcelinkSelectorConfig.volumeMaxChi2 = {{2, 7}, {3, 8}};
-  sourcelinkSelectorConfig.maxChi2 = 8;
-  // Set the allowed maximum number of source links to be large enough
-  sourcelinkSelectorConfig.maxNumSourcelinksOnSurface = 100;
+  // Chi2 cutoff at detector sensitive/layer/volume level implemented via
+  // hierarchical geometry container
+  sourcelinkSelectorConfig.chi2CutOffContainer =
+      Chi2Container(std::move(elements));
+  // Chi2 cutoff at global level
+  sourcelinkSelectorConfig.globalChi2CutOff = 8;
+  // Cutoff for number of source links at global level
+  sourcelinkSelectorConfig.globalNumSourcelinksCutOff = 10;
 
   CombinatorialKalmanFilter cKF(
       rPropagator,

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -294,21 +294,21 @@ BOOST_AUTO_TEST_CASE(comb_kalman_filter_zero_field) {
                                 SourceLinkSelector>;
 
   using SourceLinkSelectorConfig = typename SourceLinkSelector::Config;
-  using Chi2Container =
-      Acts::HierarchicalGeometryContainer<GeometryElement<double>>;
-  // Implement different chi2 cutoff at different detector level
+  using CKFCriteriaContainer =
+      Acts::HierarchicalGeometryContainer<GeometryCKFCriteria>;
+  // Implement different chi2/nSourceLinks cutoff at different detector level
   // NB: pixel volumeID = 2, strip volumeID= 3
-  std::vector<GeometryElement<double>> elements = {
-      {makeId(2, 2), 8.0},  // pixel layer 2 chi2 cutoff: 8.0
-      {makeId(2, 4), 7.0},  // pixel layer 4 chi2 cutoff: 7.0
-      {makeId(2), 7.0},     // pixel volume chi2 cutoff: 7.0
-      {makeId(3), 8.0},     // strip volume chi2 cutoff: 8.0
+  std::vector<GeometryCKFCriteria> elements = {
+      {makeId(2, 2), 8.0, 5},  // pixel layer 2 chi2/nSourceLinks cutoff: 8.0/5
+      {makeId(2, 4), 7.0, 5},  // pixel layer 4 chi2/nSourceLinks cutoff: 7.0/5
+      {makeId(2), 7.0, 5},     // pixel volume chi2/nSourceLinks cutoff: 7.0/5
+      {makeId(3), 8.0, 5},     // strip volume chi2/nSourceLinks cutoff: 8.0/5
   };
   SourceLinkSelectorConfig sourcelinkSelectorConfig;
-  // Chi2 cutoff at detector sensitive/layer/volume level implemented via
-  // hierarchical geometry container
-  sourcelinkSelectorConfig.chi2CutOffContainer =
-      Chi2Container(std::move(elements));
+  // CKF source link selection criteria at detector sensitive/layer/volume level
+  // implemented via hierarchical geometry container
+  sourcelinkSelectorConfig.criteriaContainer =
+      CKFCriteriaContainer(std::move(elements));
   // Chi2 cutoff at global level
   sourcelinkSelectorConfig.globalChi2CutOff = 8;
   // Cutoff for number of source links at global level


### PR DESCRIPTION
This PR simplify the CKF source link selection by using the hierarchical geometry container for the selection criteria.