### PR TITLE
Extend TruthFitTrack for CKF results

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -28,6 +28,7 @@ struct TrajectoryState {
   size_t nOutliers = 0;
   size_t nHoles = 0;
   double chi2Sum = 0;
+  size_t NDF = 0;
 };
 
 using TrajectoryStateContainer =
@@ -49,6 +50,7 @@ TrajectoryState trajectoryState(
   multiTraj.visitBackwards(entryIndex, [&](const auto& state) {
     trajState.nStates++;
     trajState.chi2Sum += state.chi2();
+    trajState.NDF += state.calibratedSize();
     auto typeFlags = state.typeFlags();
     if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
       trajState.nMeasurements++;
@@ -89,6 +91,7 @@ TrajectoryStateContainer trajectoryState(
     auto& trajState = trajStateContainer[volume];
     trajState.nStates++;
     trajState.chi2Sum += state.chi2();
+    trajState.NDF += state.calibratedSize();
     auto typeFlags = state.typeFlags();
     if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
       trajState.nMeasurements++;

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -1,0 +1,107 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+#include <functional>
+#include <unordered_map>
+
+#include "Acts/EventData/MultiTrajectory.hpp"
+
+namespace Acts {
+
+namespace MultiTrajectoryHelpers {
+
+/// @brief Struct for brief trajectory summary info
+/// @TODO: add nSharedHits
+///
+struct TrajectoryState {
+  size_t nStates = 0;
+  size_t nMeasurements = 0;
+  size_t nOutliers = 0;
+  size_t nHoles = 0;
+  double chi2Sum = 0;
+};
+
+using SubDetectorClassifier = std::function<bool(const Acts::GeometryID&)>;
+using SubDetectorClassifierContainer =
+    std::unordered_map<std::string, SubDetectorClassifier>;
+using TrajectoryStateContainer =
+    std::unordered_map<std::string, TrajectoryState>;
+
+/// @brief Getter for global trajectory info
+///
+/// @tparam source_link_t Type of source link
+///
+/// @param multiTraj The MultiTrajectory object
+/// @param entryIndex The entry index of trajectory to investigate
+///
+/// @return The trajectory summary info
+template <typename source_link_t>
+TrajectoryState trajectoryState(
+    const Acts::MultiTrajectory<source_link_t>& multiTraj,
+    const size_t& entryIndex) {
+  TrajectoryState trajState;
+  multiTraj.visitBackwards(entryIndex, [&](const auto& state) {
+    trajState.nStates++;
+    trajState.chi2Sum += state.chi2();
+    auto typeFlags = state.typeFlags();
+    if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
+      trajState.nMeasurements++;
+    } else if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
+      trajState.nOutliers++;
+    } else if (typeFlags.test(Acts::TrackStateFlag::HoleFlag)) {
+      trajState.nHoles++;
+    }
+  });
+  return trajState;
+}
+
+/// @brief Getter for trajectory info for different sub-detectors
+///
+/// @tparam source_link_t Type of source link
+///
+/// @param multiTraj The MultiTrajectory object
+/// @param entryIndex The entry index of trajectory to investigate
+/// @param subDetClassifierContainer The container for classifiers to classfify
+/// track states at different sub-detectors.
+///
+/// @return The trajectory summary info at different sub-detectors
+template <typename source_link_t>
+TrajectoryStateContainer trajectoryState(
+    const Acts::MultiTrajectory<source_link_t>& multiTraj,
+    const size_t& entryIndex,
+    const SubDetectorClassifierContainer& subDetClassifierContainer) {
+  TrajectoryStateContainer trajStateContainer;
+  multiTraj.visitBackwards(entryIndex, [&](const auto& state) {
+    // Get the geometry identifier of the reference surface
+    auto geoID = state.referenceSurface().geoID();
+    // Loop over all the classifiers
+    for (const auto& [detName, detClassifier] : subDetClassifierContainer) {
+      if (not detClassifier(geoID)) {
+        continue;
+      }
+      // The trajectory state corresponding to this classifier
+      auto& trajState = trajStateContainer[detName];
+      trajState.nStates++;
+      trajState.chi2Sum += state.chi2();
+      auto typeFlags = state.typeFlags();
+      if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
+        trajState.nMeasurements++;
+      } else if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
+        trajState.nOutliers++;
+      } else if (typeFlags.test(Acts::TrackStateFlag::HoleFlag)) {
+        trajState.nHoles++;
+      }
+    }  // end of loop for the classifiers
+  });
+  return trajStateContainer;
+}
+
+}  // namespace MultiTrajectoryHelpers
+
+}  // namespace Acts

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -87,13 +87,13 @@ TrajectoryStateContainer trajectoryState(
       }
     }
     if (volumeName.empty()) {
-      // Skip if the volume name is not found
-      return false;
+      // Skip the state if the volume name is not found
+      return true;
     }
     auto it = std::find(subDetName.begin(), subDetName.end(), volumeName);
     if (it == subDetName.end()) {
-      // Skip if track info for this sub-detector is not requested
-      return false;
+      // Skip the state if track info for this sub-detector is not requested
+      return true;
     }
     // The trajectory state corresponding to this classifier
     auto& trajState = trajStateContainer[volumeName];

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -31,7 +31,8 @@ struct TrajectoryState {
   size_t NDF = 0;
 };
 
-using TrajectoryStateContainer =
+// Container for trajectory summary info at a specific volume
+using VolumeTrajectoryStateContainer =
     std::unordered_map<GeometryID::Value, TrajectoryState>;
 
 /// @brief Getter for global trajectory info
@@ -72,12 +73,13 @@ TrajectoryState trajectoryState(
 /// track states at different sub-detectors.
 /// @param volumeIds The container for sub-detector Ids
 ///
-/// @return The trajectory summary info at different sub-detectors
+/// @return The trajectory summary info at different sub-detectors (i.e.
+/// different volumes)
 template <typename source_link_t>
-TrajectoryStateContainer trajectoryState(
+VolumeTrajectoryStateContainer trajectoryState(
     const Acts::MultiTrajectory<source_link_t>& multiTraj,
     const size_t& entryIndex, const std::vector<GeometryID::Value>& volumeIds) {
-  TrajectoryStateContainer trajStateContainer;
+  VolumeTrajectoryStateContainer trajStateContainer;
   multiTraj.visitBackwards(entryIndex, [&](const auto& state) {
     // Get the volume Id of this surface
     const auto& geoID = state.referenceSurface().geoID();

--- a/Examples/Algorithms/Fitting/src/FittingAlgorithm.cpp
+++ b/Examples/Algorithms/Fitting/src/FittingAlgorithm.cpp
@@ -102,14 +102,15 @@ FW::ProcessCode FW::FittingAlgorithm::execute(
         ACTS_VERBOSE("  momentum: " << params.momentum().transpose());
         // Construct a truth fit track using trajectory and
         // track parameter
-        trajectories.emplace_back(fitOutput.trackTip,
+        trajectories.emplace_back(std::move(params),
                                   std::move(fitOutput.fittedStates),
-                                  std::move(params));
+                                  fitOutput.trackTip);
       } else {
         ACTS_DEBUG("No fitted paramemeters for track " << itrack);
         // Construct a truth fit track using trajectory
-        trajectories.emplace_back(fitOutput.trackTip,
-                                  std::move(fitOutput.fittedStates));
+        trajectories.emplace_back(std::nullopt,
+                                  std::move(fitOutput.fittedStates),
+                                  fitOutput.trackTip);
       }
     } else {
       ACTS_WARNING("Fit failed for track " << itrack << " with error"

--- a/Examples/Algorithms/Fitting/src/FittingAlgorithm.cpp
+++ b/Examples/Algorithms/Fitting/src/FittingAlgorithm.cpp
@@ -65,7 +65,7 @@ FW::ProcessCode FW::FittingAlgorithm::execute(
 
     // We can have empty tracks which must give empty fit results
     if (protoTrack.empty()) {
-      trajectories.push_back(TruthFitTrack());
+      trajectories.push_back(SimMultiTrajectory());
       ACTS_WARNING("Empty track " << itrack << " found.");
       continue;
     }
@@ -116,7 +116,7 @@ FW::ProcessCode FW::FittingAlgorithm::execute(
       ACTS_WARNING("Fit failed for track " << itrack << " with error"
                                            << result.error());
       // Fit failed, but still create a empty truth fit track
-      trajectories.push_back(TruthFitTrack());
+      trajectories.push_back(SimMultiTrajectory());
     }
   }
 

--- a/Examples/Framework/CMakeLists.txt
+++ b/Examples/Framework/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   ActsExamplesFramework SHARED
+  src/EventData/SimMultiTrajectory.cpp
   src/Framework/BareAlgorithm.cpp
   src/Framework/BareService.cpp
   src/Framework/RandomNumbers.cpp

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <optional>
 #include <utility>
 
@@ -20,23 +18,24 @@
 
 namespace FW {
 
-/// @brief struct for truth fitting result
+/// @brief Struct for truth fitting/finding result
 ///
-/// @Todo Use a track proxy or helper to retrieve the detailed info, such as
-/// number of measurments, holes, truth info etc.
-struct TruthFitTrack {
+/// It contains a MultiTrajectory with a list of entry indices for different
+/// tracks and fitted parameters for those tracks
+struct SimMultiTrajectory {
  public:
   // Default constructor
-  TruthFitTrack() = default;
+  SimMultiTrajectory() = default;
 
   /// Constructor from fitted trajectory and fitted track parameter
   ///
   /// @param parameters The fitted track parameter
   /// @param trajectory The fitted multiTrajectory
   /// @param tTip The fitted multiTrajectory entry point
-  TruthFitTrack(std::optional<Acts::BoundParameters> parameters,
-                std::optional<Acts::MultiTrajectory<SimSourceLink>> trajectory,
-                size_t tTip = SIZE_MAX)
+  SimMultiTrajectory(
+      std::optional<Acts::BoundParameters> parameters,
+      std::optional<Acts::MultiTrajectory<SimSourceLink>> trajectory,
+      size_t tTip = SIZE_MAX)
       : m_trackTip(tTip) {
     if (parameters) {
       m_trackParameters = std::move(*parameters);
@@ -48,28 +47,28 @@ struct TruthFitTrack {
 
   /// @brief Copy constructor
   ///
-  /// @param rhs is the source TruthFitTrack
-  TruthFitTrack(const TruthFitTrack& rhs)
+  /// @param rhs is the source SimMultiTrajectory
+  SimMultiTrajectory(const SimMultiTrajectory& rhs)
       : m_trackParameters(rhs.m_trackParameters),
         m_trajectory(rhs.m_trajectory),
         m_trackTip(rhs.m_trackTip) {}
 
   /// Copy move constructor
   ///
-  /// @param rhs is the source TruthFitTrack
-  TruthFitTrack(TruthFitTrack&& rhs)
+  /// @param rhs is the source SimMultiTrajectory
+  SimMultiTrajectory(SimMultiTrajectory&& rhs)
       : m_trackParameters(std::move(rhs.m_trackParameters)),
         m_trajectory(std::move(rhs.m_trajectory)),
         m_trackTip(std::move(rhs.m_trackTip)) {}
 
   /// @brief Default destructor
   ///
-  ~TruthFitTrack() = default;
+  ~SimMultiTrajectory() = default;
 
   /// @brief assignment operator
   ///
-  /// @param rhs is the source TruthFitTrack
-  TruthFitTrack& operator=(const TruthFitTrack& rhs) {
+  /// @param rhs is the source SimMultiTrajectory
+  SimMultiTrajectory& operator=(const SimMultiTrajectory& rhs) {
     m_trackParameters = rhs.m_trackParameters;
     m_trajectory = rhs.m_trajectory;
     m_trackTip = rhs.m_trackTip;
@@ -78,8 +77,8 @@ struct TruthFitTrack {
 
   /// @brief assignment move operator
   ///
-  /// @param rhs is the source TruthFitTrack
-  TruthFitTrack& operator=(TruthFitTrack&& rhs) {
+  /// @param rhs is the source SimMultiTrajectory
+  SimMultiTrajectory& operator=(SimMultiTrajectory&& rhs) {
     m_trackParameters = std::move(rhs.m_trackParameters);
     m_trajectory = std::move(rhs.m_trajectory);
     m_trackTip = std::move(rhs.m_trackTip);
@@ -131,10 +130,10 @@ struct TruthFitTrack {
   }
 
   /// Indicator for having fitted track parameter or not
-  bool hasTrackParameters() const { return m_trackParameters!=std::nullopt; }
+  bool hasTrackParameters() const { return m_trackParameters != std::nullopt; }
 
   /// Indicator for having fitted trajectory or not
-  bool hasTrajectory() const { return m_trajectory!=std::nullopt; }
+  bool hasTrajectory() const { return m_trajectory != std::nullopt; }
 
   /// Get the truth particle counts to help identify majority particle
   std::vector<ParticleHitCount> identifyMajorityParticle() const {

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -135,10 +135,14 @@ struct SimMultiTrajectory {
   /// @return Whether having multiTrajectory or not
   bool hasTrajectory() const { return m_multiTrajectory != std::nullopt; }
 
-  /// @brief Indicator of fitted track parameters
+  /// @brief Indicator of fitted track parameters for one trajectory
+  ///
+  /// @param entryIndex The trajectory entry index
   ///
   /// @return Whether having fitted track parameters or not
-  bool hasTrackParameters() const { return !m_trackParameters.empty(); }
+  bool hasTrackParameters(const size_t& entryIndex) const {
+    return m_trackParameters.count(entryIndex) > 0;
+  }
 
   /// @brief Getter for multiTrajectory
   ///
@@ -158,17 +162,13 @@ struct SimMultiTrajectory {
   ///
   /// @return The fitted track parameters of the trajectory
   const Acts::BoundParameters& trackParameters(const size_t& entryIndex) const {
-    if (not m_trackParameters.empty()) {
-      auto it = m_trackParameters.find(entryIndex);
-      if (it != m_trackParameters.end()) {
-        return it->second;
-      } else {
-        throw std::runtime_error(
-            "No fitted track parameters for trajectory with entry index = " +
-            std::to_string(entryIndex));
-      }
+    auto it = m_trackParameters.find(entryIndex);
+    if (it != m_trackParameters.end()) {
+      return it->second;
     } else {
-      throw std::runtime_error("No fitted track parameters available!");
+      throw std::runtime_error(
+          "No fitted track parameters for trajectory with entry index = " +
+          std::to_string(entryIndex));
     }
   }
 

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <utility>
 
 #include "ACTFW/EventData/SimSourceLink.hpp"

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -19,49 +19,6 @@
 namespace FW {
 using IndexedParams = std::unordered_map<size_t, Acts::BoundParameters>;
 
-namespace MultiTrajectoryHelpers {
-
-/// @brief Struct for brief trajectory summary info
-///
-struct TrajectoryState {
-  size_t nStates = 0;
-  size_t nMeasurements = 0;
-  size_t nOutliers = 0;
-  size_t nHoles = 0;
-  double chi2Sum = 0;
-};
-
-/// @brief Getter for trajectory info
-/// @Todo: add method to get trajectory info for sub-detectors
-///
-/// @tparam source_link_t Type of source link
-///
-/// @param multiTraj The MultiTrajectory object
-/// @param entryIndex The entry index of trajectory to investigate
-///
-/// @return The trajectory summary information
-template <typename source_link_t>
-TrajectoryState trajectoryState(
-    const Acts::MultiTrajectory<source_link_t>& multiTraj,
-    const size_t& entryIndex) {
-  TrajectoryState trajState;
-  multiTraj.visitBackwards(entryIndex, [&](const auto& state) {
-    trajState.nStates++;
-    trajState.chi2Sum += state.chi2();
-    auto typeFlags = state.typeFlags();
-    if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
-      trajState.nMeasurements++;
-    } else if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
-      trajState.nOutliers++;
-    } else if (typeFlags.test(Acts::TrackStateFlag::HoleFlag)) {
-      trajState.nHoles++;
-    }
-  });
-  return trajState;
-}
-
-}  // namespace MultiTrajectoryHelpers
-
 /// @brief Struct for truth track fitting/finding result with
 /// Acts::KalmanFitter/Acts::CombinatorialKalmanFilter
 ///

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -135,42 +135,7 @@ struct SimMultiTrajectory {
   ///
   /// @return The truth particle counts in ascending order
   std::vector<ParticleHitCount> identifyMajorityParticle(
-      const size_t& entryIndex) const {
-    std::vector<ParticleHitCount> particleHitCount;
-    particleHitCount.reserve(10);
-    if (m_multiTrajectory) {
-      (*m_multiTrajectory).visitBackwards(entryIndex, [&](const auto& state) {
-        // No truth info with non-measurement state
-        if (not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag)) {
-          return true;
-        }
-        // Find the truth particle associated with this state
-        const auto particleId = state.uncalibrated().truthHit().particleId();
-        // Find if the particle already exists
-        auto it = std::find_if(particleHitCount.begin(), particleHitCount.end(),
-                               [=](const ParticleHitCount& phc) {
-                                 return phc.particleId == particleId;
-                               });
-
-        // Either increase count if we saw the particle before or add it
-        if (it != particleHitCount.end()) {
-          it->hitCount += 1;
-        } else {
-          particleHitCount.push_back({particleId, 1u});
-        }
-        return true;
-      });
-    }
-    if (not particleHitCount.empty()) {
-      // sort by hit count, i.e. majority particle first
-      std::sort(particleHitCount.begin(), particleHitCount.end(),
-                [](const ParticleHitCount& lhs, const ParticleHitCount& rhs) {
-                  return lhs.hitCount > rhs.hitCount;
-                });
-    }
-
-    return particleHitCount;
-  }
+      const size_t& entryIndex) const;
 
  private:
   // The optional fitted multiTrajectory

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -32,6 +32,7 @@ struct TrajectoryState {
 };
 
 /// @brief Getter for trajectory info
+/// @Todo: add method to get trajectory info for sub-detectors
 ///
 /// @tparam source_link_t Type of source link
 ///
@@ -39,9 +40,8 @@ struct TrajectoryState {
 /// @param entryIndex The entry index of trajectory to investigate
 ///
 /// @return The trajectory summary information
-/// @Todo: add method to get trajectory info for sub-detectors
 template <typename source_link_t>
-static TrajectoryState trajectoryState(
+TrajectoryState trajectoryState(
     const Acts::MultiTrajectory<source_link_t>& multiTraj,
     const size_t& entryIndex) {
   TrajectoryState trajState;
@@ -57,7 +57,7 @@ static TrajectoryState trajectoryState(
       trajState.nHoles++;
     }
   });
-  return std::move(trajState);
+  return trajState;
 }
 
 }  // namespace MultiTrajectoryHelpers
@@ -212,7 +212,7 @@ struct SimMultiTrajectory {
                 });
     }
 
-    return std::move(particleHitCount);
+    return particleHitCount;
   }
 
  private:

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -29,10 +29,11 @@ using IndexedParams = std::unordered_map<size_t, Acts::BoundParameters>;
 /// trajectories in the MultiTrajectory.
 struct SimMultiTrajectory {
  public:
-  // Default constructor
+  /// @brief Default constructor
+  ///
   SimMultiTrajectory() = default;
 
-  /// Constructor from multiTrajectory and fitted track parameters
+  /// @brief Constructor from multiTrajectory and fitted track parameters
   ///
   /// @param multiTraj The multiTrajectory
   /// @param tTips The entry indices for trajectories in multiTrajectory
@@ -55,7 +56,7 @@ struct SimMultiTrajectory {
         m_trackTips(rhs.m_trackTips),
         m_trackParameters(rhs.m_trackParameters) {}
 
-  /// Copy move constructor
+  /// @brief Copy move constructor
   ///
   /// @param rhs The source SimMultiTrajectory
   SimMultiTrajectory(SimMultiTrajectory&& rhs)

--- a/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/SimMultiTrajectory.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <optional>
 #include <utility>
 
 #include "ACTFW/EventData/SimSourceLink.hpp"
@@ -27,6 +26,8 @@ using IndexedParams = std::unordered_map<size_t, Acts::BoundParameters>;
 /// In case of track fitting, there is at most one trajectory in the
 /// MultiTrajectory; In case of track finding, there could be multiple
 /// trajectories in the MultiTrajectory.
+///
+/// @note The MultiTrajectory is thought to be empty if there is no entry index
 struct SimMultiTrajectory {
  public:
   /// @brief Default constructor
@@ -39,14 +40,12 @@ struct SimMultiTrajectory {
   /// @param tTips The entry indices for trajectories in multiTrajectory
   /// @param parameters The fitted track parameters indexed by trajectory entry
   /// index
-  SimMultiTrajectory(
-      std::optional<Acts::MultiTrajectory<SimSourceLink>> multiTraj,
-      const std::vector<size_t>& tTips, const IndexedParams& parameters)
-      : m_trackTips(tTips), m_trackParameters(parameters) {
-    if (multiTraj) {
-      m_multiTrajectory = std::move(*multiTraj);
-    }
-  }
+  SimMultiTrajectory(const Acts::MultiTrajectory<SimSourceLink>& multiTraj,
+                     const std::vector<size_t>& tTips,
+                     const IndexedParams& parameters)
+      : m_multiTrajectory(multiTraj),
+        m_trackTips(tTips),
+        m_trackParameters(parameters) {}
 
   /// @brief Copy constructor
   ///
@@ -88,12 +87,16 @@ struct SimMultiTrajectory {
     return *this;
   }
 
-  /// @brief Indicator of multiTrajectory
+  /// @brief Indicator if a trajectory exists
   ///
-  /// @return Whether having multiTrajectory or not
-  bool hasTrajectory() const { return m_multiTrajectory != std::nullopt; }
+  /// @param entryIndex The trajectory entry index
+  ///
+  /// @return Whether there is trajectory with provided entry index
+  bool hasTrajectory(const size_t& entryIndex) const {
+    return std::count(m_trackTips.begin(), m_trackTips.end(), entryIndex) > 0;
+  }
 
-  /// @brief Indicator of fitted track parameters for one trajectory
+  /// @brief Indicator if there is fitted track parameters for one trajectory
   ///
   /// @param entryIndex The trajectory entry index
   ///
@@ -105,13 +108,11 @@ struct SimMultiTrajectory {
   /// @brief Getter for multiTrajectory
   ///
   /// @return The multiTrajectory with trajectory entry indices
+  ///
+  /// @note It could return an empty multiTrajectory
   std::pair<std::vector<size_t>, Acts::MultiTrajectory<SimSourceLink>>
   trajectory() const {
-    if (m_multiTrajectory and not m_trackTips.empty()) {
-      return std::make_pair(m_trackTips, *m_multiTrajectory);
-    } else {
-      throw std::runtime_error("No multiTrajectory available!");
-    };
+    return std::make_pair(m_trackTips, m_multiTrajectory);
   }
 
   /// @brief Getter of fitted track parameters for one trajectory
@@ -139,14 +140,13 @@ struct SimMultiTrajectory {
       const size_t& entryIndex) const;
 
  private:
-  // The optional fitted multiTrajectory
-  std::optional<Acts::MultiTrajectory<SimSourceLink>> m_multiTrajectory{
-      std::nullopt};
+  // The multiTrajectory
+  Acts::MultiTrajectory<SimSourceLink> m_multiTrajectory;
 
   // The entry indices of trajectories stored in multiTrajectory
   std::vector<size_t> m_trackTips = {};
 
-  // The optional Parameters at the provided surface
+  // The fitted parameters at the provided surface for individual trajectories
   IndexedParams m_trackParameters = {};
 };
 

--- a/Examples/Framework/include/ACTFW/EventData/Track.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/Track.hpp
@@ -13,8 +13,8 @@
 
 #include <vector>
 
+#include "ACTFW/EventData/SimMultiTrajectory.hpp"
 #include "ACTFW/EventData/SimSourceLink.hpp"
-#include "ACTFW/EventData/TruthFitTrack.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 
@@ -29,6 +29,6 @@ using TrackParametersContainer = std::vector<TrackParameters>;
 using Trajectory = Acts::MultiTrajectory<SimSourceLink>;
 
 /// Container for the truth fitting track
-using TrajectoryContainer = std::vector<TruthFitTrack>;
+using TrajectoryContainer = std::vector<SimMultiTrajectory>;
 
 }  // namespace FW

--- a/Examples/Framework/include/ACTFW/EventData/Track.hpp
+++ b/Examples/Framework/include/ACTFW/EventData/Track.hpp
@@ -28,7 +28,7 @@ using TrackParametersContainer = std::vector<TrackParameters>;
 /// MultiTrajectory definition
 using Trajectory = Acts::MultiTrajectory<SimSourceLink>;
 
-/// Container for the truth fitting track
+/// Container for the truth fitting/finding track(s)
 using TrajectoryContainer = std::vector<SimMultiTrajectory>;
 
 }  // namespace FW

--- a/Examples/Framework/src/EventData/SimMultiTrajectory.cpp
+++ b/Examples/Framework/src/EventData/SimMultiTrajectory.cpp
@@ -1,0 +1,49 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ACTFW/EventData/SimMultiTrajectory.hpp"
+
+std::vector<FW::ParticleHitCount>
+FW::SimMultiTrajectory::identifyMajorityParticle(
+    const size_t& entryIndex) const {
+  std::vector<FW::ParticleHitCount> particleHitCount;
+  particleHitCount.reserve(10);
+  if (m_multiTrajectory) {
+    (*m_multiTrajectory).visitBackwards(entryIndex, [&](const auto& state) {
+      // No truth info with non-measurement state
+      if (not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag)) {
+        return true;
+      }
+      // Find the truth particle associated with this state
+      const auto particleId = state.uncalibrated().truthHit().particleId();
+      // Find if the particle already exists
+      auto it = std::find_if(particleHitCount.begin(), particleHitCount.end(),
+                             [=](const FW::ParticleHitCount& phc) {
+                               return phc.particleId == particleId;
+                             });
+
+      // Either increase count if we saw the particle before or add it
+      if (it != particleHitCount.end()) {
+        it->hitCount += 1;
+      } else {
+        particleHitCount.push_back({particleId, 1u});
+      }
+      return true;
+    });
+  }
+  if (not particleHitCount.empty()) {
+    // sort by hit count, i.e. majority particle first
+    std::sort(
+        particleHitCount.begin(), particleHitCount.end(),
+        [](const FW::ParticleHitCount& lhs, const FW::ParticleHitCount& rhs) {
+          return lhs.hitCount > rhs.hitCount;
+        });
+  }
+
+  return particleHitCount;
+}

--- a/Examples/Framework/src/EventData/SimMultiTrajectory.cpp
+++ b/Examples/Framework/src/EventData/SimMultiTrajectory.cpp
@@ -13,8 +13,11 @@ FW::SimMultiTrajectory::identifyMajorityParticle(
     const size_t& entryIndex) const {
   std::vector<FW::ParticleHitCount> particleHitCount;
   particleHitCount.reserve(10);
-  if (m_multiTrajectory) {
-    (*m_multiTrajectory).visitBackwards(entryIndex, [&](const auto& state) {
+  if (not m_trackTips.empty()) {
+    if (not hasTrajectory(entryIndex)) {
+      return particleHitCount;
+    }
+    m_multiTrajectory.visitBackwards(entryIndex, [&](const auto& state) {
       // No truth info with non-measurement state
       if (not state.typeFlags().test(Acts::TrackStateFlag::MeasurementFlag)) {
         return true;

--- a/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -94,21 +94,18 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
 
   // Loop over all trajectories
   for (const auto& traj : trajectories) {
-    if (not traj.hasTrajectory()) {
-      ACTS_WARNING("No multiTrajectory available.");
-      continue;
-    }
     // The trajectory entry indices and the multiTrajectory
     const auto& [trackTips, mj] = traj.trajectory();
+    if (trackTips.empty()) {
+      ACTS_WARNING("Empty multiTrajectory.");
+      continue;
+    }
+
     // Check the size of the trajectory entry indices. For track fitting, there
     // should be at most one trajectory
     if (trackTips.size() > 1) {
       ACTS_ERROR("Track fitting should not result in multiple trajectories.");
       return ProcessCode::ABORT;
-    }
-    if (trackTips.empty()) {
-      ACTS_WARNING("No trajectory entry index found.");
-      continue;
     }
     // Get the entry index for the single trajectory
     auto& trackTip = trackTips.front();

--- a/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -88,7 +88,7 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
   std::lock_guard<std::mutex> lock(m_writeMutex);
 
   // All reconstructed trajectories with truth info
-  std::map<ActsFatras::Barcode, TruthFitTrack> reconTrajectories;
+  std::map<ActsFatras::Barcode, SimMultiTrajectory> reconTrajectories;
 
   // Loop over all trajectories
   for (const auto& traj : trajectories) {

--- a/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -8,13 +8,14 @@
 
 #include "ACTFW/Io/Performance/TrackFitterPerformanceWriter.hpp"
 
-#include <Acts/Utilities/Helpers.hpp>
 #include <TFile.h>
 #include <TTree.h>
 #include <stdexcept>
 
 #include "ACTFW/EventData/SimParticle.hpp"
 #include "ACTFW/Utilities/Paths.hpp"
+#include "Acts/EventData/MultiTrajectoryHelpers.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 
 using Acts::VectorHelpers::eta;
 
@@ -128,7 +129,8 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
     reconTrajectories.emplace(ip->particleId(), traj);
 
     // Collect the trajectory summary info
-    auto trajState = MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
+    auto trajState =
+        Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
     // Fill the trajectory summary info
     m_trackSummaryPlotTool.fill(m_trackSummaryPlotCache, *ip, trajState.nStates,
                                 trajState.nMeasurements, trajState.nOutliers,

--- a/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ACTFW/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -93,6 +93,7 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
   // Loop over all trajectories
   for (const auto& traj : trajectories) {
     if (not traj.hasTrajectory()) {
+      ACTS_WARNING("No multiTrajectory available.");
       continue;
     }
     // The trajectory entry indices and the multiTrajectory
@@ -113,11 +114,13 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
     // Get the majority truth particle for this trajectory
     const auto particleHitCount = traj.identifyMajorityParticle(trackTip);
     if (particleHitCount.empty()) {
+      ACTS_WARNING("No truth particle associated with this trajectory.");
       continue;
     }
     // Find the truth particle for the majority barcode
     const auto ip = particles.find(particleHitCount.front().particleId);
     if (ip == particles.end()) {
+      ACTS_WARNING("Majority particle not found in the particles collection.");
       continue;
     }
 
@@ -132,7 +135,7 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
                                 trajState.nHoles);
 
     // Fill the residual plots if the track has fitted parameter
-    if (traj.hasTrackParameters()) {
+    if (traj.hasTrackParameters(trackTip)) {
       m_resPlotTool.fill(m_resPlotCache, ctx.geoContext, *ip,
                          traj.trackParameters(trackTip));
     }
@@ -145,9 +148,11 @@ FW::ProcessCode FW::TrackFitterPerformanceWriter::writeT(
   for (const auto& particle : particles) {
     const auto it = reconTrajectories.find(particle.particleId());
     if (it != reconTrajectories.end()) {
+      // The trajectory entry indices
+      const auto& trackTips = it->second.trajectory().first;
       // when the trajectory is reconstructed
       m_effPlotTool.fill(m_effPlotCache, particle,
-                         it->second.hasTrackParameters());
+                         it->second.hasTrackParameters(trackTips.front()));
     } else {
       // when the trajectory is NOT reconstructed
       m_effPlotTool.fill(m_effPlotCache, particle, false);

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -17,6 +17,7 @@
 #include "ACTFW/Utilities/Paths.hpp"
 #include "Acts/EventData/Measurement.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
+#include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
@@ -286,7 +287,8 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
     auto& trackTip = trackTips.front();
 
     // Collect the trajectory summary info
-    auto trajState = MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
+    auto trajState =
+        Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
     m_nMeasurements = trajState.nMeasurements;
     m_nStates = trajState.nStates;
 

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -267,21 +267,18 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
   int iTraj = 0;
   for (const auto& traj : trajectories) {
     m_trajNr = iTraj;
-    if (not traj.hasTrajectory()) {
-      continue;
-    }
 
     // The trajectory entry indices and the multiTrajectory
     const auto& [trackTips, mj] = traj.trajectory();
+    if (trackTips.empty()) {
+      ACTS_WARNING("Empty multiTrajectory.");
+      continue;
+    }
     // Check the size of the trajectory entry indices. For track fitting, there
     // should be at most one trajectory
     if (trackTips.size() > 1) {
       ACTS_ERROR("Track fitting should not result in multiple trajectories.");
       return ProcessCode::ABORT;
-    }
-    if (trackTips.empty()) {
-      ACTS_WARNING("No trajectory entry index found.");
-      continue;
     }
     // Get the entry index for the single trajectory
     auto& trackTip = trackTips.front();

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -267,7 +267,6 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
   for (const auto& traj : trajectories) {
     m_trajNr = iTraj;
     if (not traj.hasTrajectory()) {
-      ACTS_WARNING("No multiTrajectory available.");
       continue;
     }
 
@@ -323,7 +322,7 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
     // Get the fitted track parameter
     m_hasFittedParams = false;
-    if (traj.hasTrackParameters()) {
+    if (traj.hasTrackParameters(trackTip)) {
       m_hasFittedParams = true;
       const auto& boundParam = traj.trackParameters(trackTip);
       const auto& parameter = boundParam.parameters();


### PR DESCRIPTION
The PR includes the following changes:
- Add `MultiTrajectoryHelpers` to help retrieve trajectory info like nHits, nHoles etc.
- Rename the `TruthFitTrack` to `SimMultiTrajectory`
- Extend the `SimMultiTrajectory` to cases with multiple trajectories
- Adapt the `TrackFitterPerformanceWriter` and `RooTrajectoryWriter` to use `SimMultiTrajectory`