### PR TITLE
Add C++17 flag to ActsCustomLogger

### DIFF
--- a/Examples/Run/Misc/CMakeLists.txt
+++ b/Examples/Run/Misc/CMakeLists.txt
@@ -9,6 +9,10 @@ target_include_directories(
   ActsExampleCustomLogger
   PRIVATE ${PROJECT_SOURCE_DIR}/Core/include)
 
+target_compile_features(
+  ActsCustomLogger
+  PUBLIC cxx_std_17)
+
 add_executable(
   ActsTabulateEnergyLoss
   TabulateEnergyLoss.cpp)


### PR DESCRIPTION
This didn't compile locally for me since `ActsCustomLogger` does not declare a dependency on `ActsCore`, and therefore doesn't get the C++17 standard set on it.