### PR TITLE
Fix the macOS CI build

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,7 +39,7 @@ jobs:
           brew install cmake eigen ninja
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.0c6ff39.tar.gz | tar -xzC /usr/local/acts
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
         run: >
           cmake -B build -S src

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,7 +39,7 @@ jobs:
           brew install cmake eigen ninja
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.10c99bb.tar.gz | tar -xzC /usr/local/acts
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.0c6ff39.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
         run: >
           cmake -B build -S src

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -36,17 +36,16 @@ jobs:
           path: src
       - name: Install dependencies
         run: >
-          brew install boost cmake eigen ninja tbb xerces-c
+          brew install cmake eigen ninja
           && mkdir deps
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS_10.15_deps.tar.gz | tar -xzC deps
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.10c99bb.tar.gz | tar -xzC deps
       - name: Configure
         run: >
-          source deps/bin/thisroot.sh
-          && cmake -B build -S src
+          cmake -B build -S src
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_PREFIX_PATH=../deps
+          -DCMAKE_PREFIX_PATH=/usr/local/acts
           -DACTS_BUILD_EVERYTHING=on
           -DACTS_BUILD_DD4HEP_PLUGIN=on
       - name: Build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -35,20 +35,20 @@ jobs:
         with:
           path: src
       - name: Install dependencies
-        run: brew install boost cmake eigen ninja tbb
+        run: >
+          brew install boost cmake eigen ninja tbb xerces-c
+          && mkdir deps
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS_10.15_deps.tar.gz | tar -xzC deps
       - name: Configure
         run: >
-          cmake -B build -S src
+          source deps/bin/thisroot.sh
+          && cmake -B build -S src
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
-          -DACTS_BUILD_DIGITIZATION_PLUGIN=on
-          -DACTS_BUILD_IDENTIFICATION_PLUGIN=on
-          -DACTS_BUILD_JSON_PLUGIN=on
-          -DACTS_BUILD_FATRAS=on
-          -DACTS_BUILD_BENCHMARKS=on
-          -DACTS_BUILD_INTEGRATIONTESTS=on
-          -DACTS_BUILD_UNITTESTS=on
+          -DCMAKE_PREFIX_PATH=../deps
+          -DACTS_BUILD_EVERYTHING=on
+          -DACTS_BUILD_DD4HEP_PLUGIN=on
       - name: Build
         run: cmake --build build  --
       - name: Unit tests

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Install dependencies
         run: >
           brew install cmake eigen ninja
-          && mkdir deps
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.10c99bb.tar.gz | tar -xzC deps
+          && sudo mkdir /usr/local/acts
+          && sudo chown $USER /usr/local/acts
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.10c99bb.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
         run: >
           cmake -B build -S src


### PR DESCRIPTION
... for now. DD4hep should build again, and hopefully we're now more robust since the dependencies now include fixed version builds of 

- boost
- tbb
- xercesc
- heppdt
- pythia8
- root
- geant4
- hepmc3
- dd4hep

These dependencies are build automatically at https://github.com/acts-project/ci-dependencies/, the master branch deploys to https://acts.web.cern.ch/ACTS/ci/macOS/, the commit hash to pull is hard coded in the CI in this repo.
