### PR TITLE
Reduce size of debug symbols in coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
           cmake -B build -S .
           -GNinja
           -DCMAKE_BUILD_TYPE=Debug
-          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_FLAGS="-Werror -gz -g1"
           -DACTS_BUILD_DD4HEP_PLUGIN=off
           -DACTS_BUILD_DIGITIZATION_PLUGIN=on
           -DACTS_BUILD_IDENTIFICATION_PLUGIN=on


### PR DESCRIPTION
This is an attempt at keeping the coverage job disk usage below the 14GB limit. It sets `-g1 and -gz` which compresses the debug info (thanks @HadrienG2)