### PR TITLE
Fix the smoothing gain matrix

### DIFF
--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -85,7 +85,9 @@ class GainMatrixSmoother {
                      << prev_ts.predictedCovariance().inverse());
 
         // Gain smoothing matrix
-        G = ts.filteredCovariance() * ts.jacobian().transpose() *
+        // NB: The jacobian stored in a state is the jacobian from previous
+        // state to this state in forward propagation
+        G = ts.filteredCovariance() * prev_ts.jacobian().transpose() *
             prev_ts.predictedCovariance().inverse();
 
         if (G.hasNaN()) {


### PR DESCRIPTION
Since the jacobian stored in a track state is between the previous state and this state (instead of between this state and the following state), when calculating the KF smoothing gain matrix for state `k-1`, the jacobian used in the formalism should be that stored in state `k`.