### PR TITLE
Clean up BenchmarkTool statistics

### DIFF
--- a/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
+++ b/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
@@ -261,8 +261,7 @@ BOOST_AUTO_TEST_CASE(assume_read) {
   std::cout << "assumeRead: " << assumeread << std::endl;
   const double tuple_return_iter_ns = tuple_return.iterTimeAverage().count();
   const double assumeRead_iter_ns = assumeread.iterTimeAverage().count();
-  BOOST_CHECK_LT(std::abs(tuple_return_iter_ns - assumeRead_iter_ns),
-                 5. * tuple_return.iterTimeError().count());
+  CHECK_CLOSE_REL(tuple_return_iter_ns, assumeRead_iter_ns, 1e-2);
 }
 #endif
 
@@ -291,8 +290,7 @@ BOOST_AUTO_TEST_CASE(assume_written) {
   std::cout << "2x(sqrt sum): " << sqrt_2sums << std::endl;
   const double sqrt_sum_iter_ns = sqrt_sum.iterTimeAverage().count();
   const double sqrt_2sums_iter_ns = sqrt_2sums.iterTimeAverage().count();
-  BOOST_CHECK_LT(std::abs(2. * sqrt_sum_iter_ns - sqrt_2sums_iter_ns),
-                 5. * sqrt_sum.iterTimeError().count());
+  CHECK_CLOSE_REL(2. * sqrt_sum_iter_ns, sqrt_2sums_iter_ns, 1e-2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
+++ b/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
@@ -79,20 +79,20 @@ BOOST_AUTO_TEST_CASE(micro_benchmark_result) {
   CHECK_CLOSE_REL(thirdq.count() / 1000., (420. + 4000.) / 2., 1e-6);
 
   const auto robustRTStddev = res.runTimeRobustStddev();
-  CHECK_CLOSE_REL(robustRTStddev.count(),
-                  (thirdq - firstq).count() / 1.349, 1e-3);
+  CHECK_CLOSE_REL(robustRTStddev.count(), (thirdq - firstq).count() / 1.349,
+                  1e-3);
 
   const auto runTimeError = res.runTimeError();
   CHECK_CLOSE_REL(
-    runTimeError.count(),
-    1.2533 * robustRTStddev.count() / std::sqrt(res.run_timings.size()), 1e-3);
+      runTimeError.count(),
+      1.2533 * robustRTStddev.count() / std::sqrt(res.run_timings.size()),
+      1e-3);
 
   CHECK_CLOSE_REL(res.iterTimeAverage().count(),
                   res.runTimeMedian().count() / res.iters_per_run, 1e-6);
 
-  CHECK_CLOSE_REL(
-      res.iterTimeError().count(),
-      runTimeError.count() / std::sqrt(res.iters_per_run), 1e-6);
+  CHECK_CLOSE_REL(res.iterTimeError().count(),
+                  runTimeError.count() / std::sqrt(res.iters_per_run), 1e-6);
 
   std::ostringstream os;
   os << res;

--- a/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
+++ b/Tests/UnitTests/Benchmarks/BenchmarkTools.cpp
@@ -174,9 +174,10 @@ BOOST_AUTO_TEST_CASE(micro_benchmark) {
   // For example, here, the microbenchmark loop isn't optimized out even though
   // each iteration does literally nothing. If it were optimized out, the time
   // per iteration would change, since we wouldn't get linear scaling anymore.
-  const auto nop_x10 = microBenchmark([] {}, 10 * bench_iters);
+  auto nop = [] {};
+  const auto nop_x10 = microBenchmark(nop, 10 * bench_iters);
   std::cout << "nop (10x iters): " << nop_x10 << std::endl;
-  const auto nop_x100 = microBenchmark([] {}, 100 * bench_iters);
+  const auto nop_x100 = microBenchmark(nop, 100 * bench_iters);
   std::cout << "nop (100x iters): " << nop_x100 << std::endl;
   const double nop_x10_iter_ns = nop_x10.iterTimeAverage().count();
   const double nop_x100_iter_ns = nop_x100.iterTimeAverage().count();


### PR DESCRIPTION
So, I recently opened yet another stats book in the hope of finally becoming a little less miserably bad at statistical analysis, and that led me to notice a couple of new issues with the stats computed by `BenchmarkTools`.

Therefore, this PR...

- Fixes the invalid definition of standard error on median run time
- Clarifies mathematical hypotheses of the underlying statistical analysis (FWIW, I know from manual data inspection that some of them are not well verified by some of our microbenchmarks, and have plans to try to improve upon this in the future...)
- Recommends having many iterations per run (we do rely on the hypothesis of a normal run time distribution in quite a few places)
- Fixes invalid error bars (need a 1.96 factor wrt standard error in order to use the de factor standard 95% confidence intervals, assuming normality)