### PR TITLE
Introduce ConeVolumeBounds

### DIFF
--- a/Core/include/Acts/Geometry/BoundarySurfaceFace.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceFace.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// BoundarySurfaceFace.h, Acts project
-///////////////////////////////////////////////////////////////////
-
 #pragma once
 
 #include <iostream>
@@ -59,9 +55,6 @@ enum BoundarySurfaceFace {
   undefinedFace = 99
 
 };
-
-/// @brief specify the inside/outside with respect to the normal vector
-enum BoundaryOrientation { insideVolume = -1, outsideVolume = 1 };
 
 inline std::ostream& operator<<(std::ostream& os, BoundarySurfaceFace& face) {
   os << "BoundarySurfaceFace::";

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// BoundarySurfaceT.h, Acts project
-///////////////////////////////////////////////////////////////////
-
 #pragma once
 #include <memory>
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
@@ -24,34 +20,34 @@ class Surface;
 
 /// @class BoundarySurfaceT
 ///
+/// @tparam  volume_t the type of volume.
+///
 /// The boundary surface class combines a Surface with the information of a
 /// volume.
 /// It's templated in the type of volume in order to allow for a return type tat
-/// is usable
-/// in the navigation stream.
+/// is usable in the navigation stream.
 ///
-/// @note inside/outside definitions are given by the normal vector of the
-/// surface
+/// @note along/oppose definitions are given with respet to the normal vector
+/// of the boundary surface.
 ///
-/// @todo change to one schema with BinnedArray0D and along/opposite
-/// nominclature
+/// @todo change to one schema with BinnedArray0D
 
-template <class T>
+template <class volume_t>
 class BoundarySurfaceT {
   /// declare the TrackingVolume as friend
-  friend T;
+  friend volume_t;
 
-  using VolumePtr = std::shared_ptr<const T>;
+  using VolumePtr = std::shared_ptr<const volume_t>;
   using VolumeArray = BinnedArray<VolumePtr>;
 
  public:
   /// Default Constructor
   BoundarySurfaceT()
       : m_surface(nullptr),
-        m_insideVolume(nullptr),
-        m_outsideVolume(nullptr),
-        m_insideVolumeArray(nullptr),
-        m_outsideVolumeArray(nullptr) {}
+        m_oppositeVolume(nullptr),
+        m_alongVolume(nullptr),
+        m_oppositeVolumeArray(nullptr),
+        m_alongVolumeArray(nullptr) {}
 
   /// Constructor for a Boundary with exact two Volumes attached to it
   /// - usually used in a volume constructor
@@ -59,13 +55,13 @@ class BoundarySurfaceT {
   /// @param surface The unqiue surface the boundary represents
   /// @param inside The inside volume the bounday surface points to
   /// @param outside The outside volume the boundary surface points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface, const T* inside,
-                   const T* outside)
+  BoundarySurfaceT(std::shared_ptr<const Surface> surface,
+                   const volume_t* inside, const volume_t* outside)
       : m_surface(std::move(surface)),
-        m_insideVolume(inside),
-        m_outsideVolume(outside),
-        m_insideVolumeArray(nullptr),
-        m_outsideVolumeArray(nullptr) {}
+        m_oppositeVolume(inside),
+        m_alongVolume(outside),
+        m_oppositeVolumeArray(nullptr),
+        m_alongVolumeArray(nullptr) {}
 
   /// Constructor for a Boundary with exact two Volumes attached to it
   /// - usually used in a volume constructor
@@ -76,10 +72,10 @@ class BoundarySurfaceT {
   BoundarySurfaceT(std::shared_ptr<const Surface> surface, VolumePtr inside,
                    VolumePtr outside)
       : m_surface(std::move(surface)),
-        m_insideVolume(inside.get()),
-        m_outsideVolume(outside.get()),
-        m_insideVolumeArray(nullptr),
-        m_outsideVolumeArray(nullptr) {}
+        m_oppositeVolume(inside.get()),
+        m_alongVolume(outside.get()),
+        m_oppositeVolumeArray(nullptr),
+        m_alongVolumeArray(nullptr) {}
 
   /// Constructor for a Boundary with exact multiple Volumes attached to it
   /// - usually used in a volume constructor
@@ -92,10 +88,10 @@ class BoundarySurfaceT {
                    std::shared_ptr<const VolumeArray> insideArray,
                    std::shared_ptr<const VolumeArray> outsideArray)
       : m_surface(std::move(surface)),
-        m_insideVolume(nullptr),
-        m_outsideVolume(nullptr),
-        m_insideVolumeArray(insideArray),
-        m_outsideVolumeArray(outsideArray) {}
+        m_oppositeVolume(nullptr),
+        m_alongVolume(nullptr),
+        m_oppositeVolumeArray(insideArray),
+        m_alongVolumeArray(outsideArray) {}
 
   /// Get the next Volume depending on GlobalPosition, GlobalMomentum, dir on
   /// the TrackParameters and the requested direction
@@ -106,18 +102,19 @@ class BoundarySurfaceT {
   /// @param dir is an aditional direction corrective
   ///
   /// @return The attached volume at that position
-  virtual const T* attachedVolume(const GeometryContext& gctx,
-                                  const Vector3D& pos, const Vector3D& mom,
-                                  NavigationDirection pdir) const;
+  virtual const volume_t* attachedVolume(const GeometryContext& gctx,
+                                         const Vector3D& pos,
+                                         const Vector3D& mom,
+                                         NavigationDirection pdir) const;
 
   /// templated onBoundary method
   ///
-  /// @tparam pars are the parameters to be checked
+  /// @tparam parameters_t are the parameters to be checked
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param pars The parameters used for this call
-  template <class P>
-  bool onBoundary(const GeometryContext& gctx, const P& pars) const {
+  template <class parameters_t>
+  bool onBoundary(const GeometryContext& gctx, const parameters_t& pars) const {
     return surfaceRepresentation().isOnSurface(gctx, pars);
   }
 
@@ -133,7 +130,7 @@ class BoundarySurfaceT {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param volume The volume to be attached
   /// @param inout The boundary orientation @todo update to along/opposite
-  void attachVolume(const T* volume, BoundaryOrientation inout);
+  void attachVolume(const volume_t* volume, BoundaryOrientation inout);
 
   /// Helper method: attach a Volume to this BoundarySurfaceT
   /// this is done during the geometry construction.
@@ -147,54 +144,54 @@ class BoundarySurfaceT {
   /// the represented surface by this
   std::shared_ptr<const Surface> m_surface;
   /// the inside (w.r.t. normal vector) volume to point to if only one exists
-  const T* m_insideVolume;
+  const volume_t* m_oppositeVolume;
   /// the outside (w.r.t. normal vector) volume to point to if only one exists
-  const T* m_outsideVolume;
+  const volume_t* m_alongVolume;
   /// the inside (w.r.t. normal vector) volume array to point to
-  std::shared_ptr<const VolumeArray> m_insideVolumeArray;
+  std::shared_ptr<const VolumeArray> m_oppositeVolumeArray;
   /// the outside (w.r.t. normal vector) volume array to point to
-  std::shared_ptr<const VolumeArray> m_outsideVolumeArray;
+  std::shared_ptr<const VolumeArray> m_alongVolumeArray;
 };
 
-template <class T>
-inline const Surface& BoundarySurfaceT<T>::surfaceRepresentation() const {
+template <class volume_t>
+inline const Surface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
+    const {
   return (*(m_surface.get()));
 }
 
-template <class T>
-void BoundarySurfaceT<T>::attachVolume(const T* volume,
-                                       BoundaryOrientation inout) {
+template <class volume_t>
+void BoundarySurfaceT<volume_t>::attachVolume(const volume_t* volume,
+                                              BoundaryOrientation inout) {
   if (inout == insideVolume) {
-    m_insideVolume = volume;
+    m_oppositeVolume = volume;
   } else {
-    m_outsideVolume = volume;
+    m_alongVolume = volume;
   }
 }
 
-template <class T>
-void BoundarySurfaceT<T>::attachVolumeArray(
+template <class volume_t>
+void BoundarySurfaceT<volume_t>::attachVolumeArray(
     const std::shared_ptr<const VolumeArray> volumes,
     BoundaryOrientation inout) {
   if (inout == insideVolume) {
-    m_insideVolumeArray = volumes;
+    m_oppositeVolumeArray = volumes;
   } else {
-    m_outsideVolumeArray = volumes;
+    m_alongVolumeArray = volumes;
   }
 }
 
-template <class T>
-const T* BoundarySurfaceT<T>::attachedVolume(const GeometryContext& gctx,
-                                             const Vector3D& pos,
-                                             const Vector3D& mom,
-                                             NavigationDirection pdir) const {
-  const T* attVolume = nullptr;
+template <class volume_t>
+const volume_t* BoundarySurfaceT<volume_t>::attachedVolume(
+    const GeometryContext& gctx, const Vector3D& pos, const Vector3D& mom,
+    NavigationDirection pdir) const {
+  const volume_t* attVolume = nullptr;
   // dot product with normal vector to distinguish inside/outside
   if ((surfaceRepresentation().normal(gctx, pos)).dot(pdir * mom) > 0.) {
-    attVolume = m_outsideVolumeArray ? m_outsideVolumeArray->object(pos).get()
-                                     : m_outsideVolume;
+    attVolume = m_alongVolumeArray ? m_alongVolumeArray->object(pos).get()
+                                   : m_alongVolume;
   } else {
-    attVolume = m_insideVolumeArray ? m_insideVolumeArray->object(pos).get()
-                                    : m_insideVolume;
+    attVolume = m_oppositeVolumeArray ? m_oppositeVolumeArray->object(pos).get()
+                                      : m_oppositeVolume;
   }
   return attVolume;
 }

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -129,16 +129,16 @@ class BoundarySurfaceT {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param volume The volume to be attached
-  /// @param inout The boundary orientation @todo update to along/opposite
-  void attachVolume(const volume_t* volume, BoundaryOrientation inout);
+  /// @param navDir The navigation direction for attaching
+  void attachVolume(const volume_t* volume, NavigationDirection navDir);
 
   /// Helper method: attach a Volume to this BoundarySurfaceT
   /// this is done during the geometry construction.
   ///
   /// @param volumes The volume array to be attached
-  /// @param inout The boundary orientation @todo update to along/opposite
+  /// @param navDir The navigation direction for attaching
   void attachVolumeArray(std::shared_ptr<const VolumeArray> volumes,
-                         BoundaryOrientation inout);
+                         NavigationDirection navDir);
 
  protected:
   /// the represented surface by this
@@ -161,8 +161,8 @@ inline const Surface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
 
 template <class volume_t>
 void BoundarySurfaceT<volume_t>::attachVolume(const volume_t* volume,
-                                              BoundaryOrientation inout) {
-  if (inout == insideVolume) {
+                                              NavigationDirection navDir) {
+  if (navDir == backward) {
     m_oppositeVolume = volume;
   } else {
     m_alongVolume = volume;
@@ -172,8 +172,8 @@ void BoundarySurfaceT<volume_t>::attachVolume(const volume_t* volume,
 template <class volume_t>
 void BoundarySurfaceT<volume_t>::attachVolumeArray(
     const std::shared_ptr<const VolumeArray> volumes,
-    BoundaryOrientation inout) {
-  if (inout == insideVolume) {
+    NavigationDirection navDir) {
+  if (navDir == backward) {
     m_oppositeVolumeArray = volumes;
   } else {
     m_alongVolumeArray = volumes;
@@ -183,10 +183,10 @@ void BoundarySurfaceT<volume_t>::attachVolumeArray(
 template <class volume_t>
 const volume_t* BoundarySurfaceT<volume_t>::attachedVolume(
     const GeometryContext& gctx, const Vector3D& pos, const Vector3D& mom,
-    NavigationDirection pdir) const {
+    NavigationDirection navDir) const {
   const volume_t* attVolume = nullptr;
   // dot product with normal vector to distinguish inside/outside
-  if ((surfaceRepresentation().normal(gctx, pos)).dot(pdir * mom) > 0.) {
+  if ((surfaceRepresentation().normal(gctx, pos)).dot(navDir * mom) > 0.) {
     attVolume = m_alongVolumeArray ? m_alongVolumeArray->object(pos).get()
                                    : m_alongVolume;
   } else {

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -1,0 +1,228 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/Volume.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+
+#include <cmath>
+
+namespace Acts {
+
+class Surface;
+class CylinderBounds;
+class ConeBounds;
+class RadialBounds;
+class PlanarBounds;
+class Volume;
+
+/// @class ConeVolumeBounds
+///
+/// Volume bound class for describing conical volumes
+/// either with cylindrical inlay or outer boundary, it also allows
+/// for a sectoral description
+class ConeVolumeBounds : public VolumeBounds {
+ public:
+  /// @enum BoundValues for readability
+  enum BoundValues : unsigned int {
+    eInnerAlpha = 0,
+    eInnerOffsetZ = 1,
+    eOuterAlpha = 2,
+    eOuterOffsetZ = 3,
+    eHalfLengthZ = 4,
+    eAveragePhi = 5,
+    eHalfPhiSector = 6,
+    eSize = 7
+  };
+
+  ConeVolumeBounds() = delete;
+
+  /// Constructor - for general cone-cone setups
+  ///
+  /// @param innerAlpha The opening angle of the inner cone (0 if no cone)
+  /// @param innerOffsetZ The tip  z position in of the inner cone, w.r.t center
+  /// @param outerAlpha  The opening angle of the outer cone (0 if no cone)
+  /// @param outerOffsetZ The tip  z position in of the outer cone, w.r.t center
+  /// @param halflengthZ The minimum z value of the inner and outer cones
+  /// @param avergePhi The phi orientation of the sector
+  /// @param halfPhiSector The opening angle phi sector
+  ConeVolumeBounds(double innerAlpha, double innerTipZ, double outerAlpha,
+                   double outerOffsetZ, double halflengthZ, double averagePhi,
+                   double halfPhiSector) noexcept(false);
+
+  /// Constructor - for general cylidner-cone setups
+  ///
+  /// @param cylinderR The inner radius of the cylinder
+  /// @param alpha  The opening angle of the cone (0 if no cone)
+  /// @param offsetZ The tip  z position in of the cone, w.r.t center
+  /// @param halflengthZ The minimum z value of the inner and outer cones
+  /// @param avergePhi The phi orientation of the sector (defaulted to 0)
+  /// @param halfPhiSector The opening angle phi sector
+  ///
+  /// @note depending on cylinderR > coneR it is constructing a cone with
+  /// cylindrical cutout or a cylinder with conical cutout
+  ConeVolumeBounds(double cylinderR, double alpha, double offsetZ,
+                   double halflengthZ, double averagePhi,
+                   double halfPhiSector) noexcept(false);
+
+  /// Constructor - from a fixed size array
+  ///
+  /// @param values The bound values
+  ConeVolumeBounds(const std::array<double, eSize>& values) noexcept(false)
+      : m_values(values) {
+    checkConsistency();
+    buildSurfaceBounds();
+  }
+
+  ConeVolumeBounds(const ConeVolumeBounds& cobo) = default;
+
+  ~ConeVolumeBounds() override = default;
+
+  ConeVolumeBounds& operator=(const ConeVolumeBounds& cobo) = default;
+
+  VolumeBounds::BoundsType type() const final { return VolumeBounds::eCone; }
+
+  /// Return the bound values as dynamically sized vector
+  ///
+  /// @return this returns a copy of the internal values
+  std::vector<double> values() const final;
+
+  /// This method checks if position in the 3D volume
+  /// frame is inside the cylinder
+  ///
+  /// @param pos is the position in volume frame to be checked
+  /// @param tol is the absolute tolerance to be applied
+  bool inside(const Vector3D& pos, double tol = 0.) const final;
+
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
+  ///
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
+
+  /// Construct bounding box for this shape
+  /// @param trf Optional transform
+  /// @param envelope Optional envelope to add / subtract from min/max
+  /// @param entity Entity to associate this bounding box with
+  /// @return Constructed bounding box
+  Volume::BoundingBox boundingBox(const Transform3D* trf = nullptr,
+                                  const Vector3D& envelope = {0, 0, 0},
+                                  const Volume* entity = nullptr) const final;
+
+  /// Access to the bound values
+  /// @param bValue the class nested enum for the array access
+  double get(BoundValues bValue) const { return m_values[bValue]; }
+
+  // Return the derived innerRmin
+  double innerRmin() const;
+
+  // Return the derived innerRmin
+  double innerRmax() const;
+
+  // Return the derived inner tan(alpha)
+  double innerTanAlpha() const;
+
+  // Return the derived outerRmin
+  double outerRmin() const;
+
+  // Return the derived outerRmax
+  double outerRmax() const;
+
+  // Return the derived outer tan(alpha)
+  double outerTanAlpha() const;
+
+  /// Output Method for std::ostream
+  ///
+  /// @param sl is ostream operator to be dumped into
+  std::ostream& toStream(std::ostream& sl) const override;
+
+ private:
+  /// Check the input values for consistency,
+  /// will throw a logic_exception if consistency is not given
+  void checkConsistency() noexcept(false);
+
+  /// Create the surface bounds
+  void buildSurfaceBounds();
+
+  /// Templated dump methos
+  /// @tparam stream_t The type of the stream for dumping
+  /// @param dt The stream object
+  template <class stream_t>
+  stream_t& dumpT(stream_t& dt) const;
+
+  /// The bound values
+  std::array<double, eSize> m_values;
+  std::shared_ptr<CylinderBounds> m_innerCylinderBounds{nullptr};
+  std::shared_ptr<ConeBounds> m_innerConeBounds{nullptr};
+  std::shared_ptr<ConeBounds> m_outerConeBounds{nullptr};
+  std::shared_ptr<CylinderBounds> m_outerCylinderBounds{nullptr};
+  std::shared_ptr<RadialBounds> m_negativeDiscBounds{nullptr};
+  std::shared_ptr<RadialBounds> m_positiveDiscBounds{nullptr};
+  std::shared_ptr<PlanarBounds> m_sectorBounds{nullptr};
+
+  /// Derived values
+  double m_innerRmin = 0.;
+  double m_innerRmax = 0.;
+  double m_innerTanAlpha = 0.;
+  double m_outerRmin = 0.;
+  double m_outerRmax = 0.;
+  double m_outerTanAlpha = 0.;
+};
+
+inline double ConeVolumeBounds::innerRmin() const {
+  return m_innerRmin;
+}
+
+inline double ConeVolumeBounds::innerRmax() const {
+  return m_innerRmax;
+}
+
+inline double ConeVolumeBounds::innerTanAlpha() const {
+  return m_innerTanAlpha;
+}
+
+inline double ConeVolumeBounds::outerRmin() const {
+  return m_outerRmin;
+}
+
+inline double ConeVolumeBounds::outerRmax() const {
+  return m_outerRmax;
+}
+
+inline double ConeVolumeBounds::outerTanAlpha() const {
+  return m_outerTanAlpha;
+};
+
+inline std::vector<double> ConeVolumeBounds::values() const {
+  std::vector<double> valvector;
+  valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
+  return valvector;
+}
+
+template <class stream_t>
+stream_t& ConeVolumeBounds::dumpT(stream_t& dt) const {
+  dt << std::setiosflags(std::ios::fixed);
+  dt << std::setprecision(5);
+  dt << "Acts::ConeVolumeBounds : (innerAlpha, innerOffsetZ, outerAlpha,";
+  dt << "  outerOffsetZ, halflenghZ, averagePhi, halfPhiSector) = ";
+  dt << get(eInnerAlpha) << ", " << get(eInnerOffsetZ) << ", ";
+  dt << get(eOuterAlpha) << ", " << get(eOuterOffsetZ) << ", ";
+  dt << get(eHalfLengthZ) << ", " << get(eAveragePhi) << std::endl;
+  return dt;
+}
+}  // namespace Acts

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -47,7 +47,7 @@ class Surface;
 class CuboidVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
-  enum BoundValues : int {
+  enum BoundValues : unsigned int {
     eHalfLengthX = 0,
     eHalfLengthY = 1,
     eHalfLengthZ = 2,
@@ -120,14 +120,14 @@ class CuboidVolumeBounds : public VolumeBounds {
                                   const Vector3D& envelope = {0, 0, 0},
                                   const Volume* entity = nullptr) const final;
 
+  /// Access to the bound values
+  /// @param bValue the class nested enum for the array access
+  double get(BoundValues bValue) const { return m_values[bValue]; }
+
   /// Output Method for std::ostream
   ///
   /// @param sl is ostream operator to be dumped into
   std::ostream& toStream(std::ostream& sl) const override;
-
-  /// Access to the bound values
-  /// @param bValue the class nested enum for the array access
-  double get(BoundValues bValue) const { return m_values[bValue]; }
 
  private:
   /// Templated dumpT method

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -26,7 +26,7 @@ class Surface;
 
 /// @class CuboidVolumeBounds
 ///
-/// Bounds for a cubical Volume, the decomposeToSurfaces method creates a
+/// Bounds for a cubical Volume, the orientedSurfaces(...) method creates a
 /// vector of 6 surfaces:
 ///
 ///  BoundarySurfaceFace [index]:
@@ -44,8 +44,6 @@ class Surface;
 ///    - positiveFaceXY [5] : Rectangular Acts::PlaneSurface, parallel to \f$ zx
 /// \f$ plane at positive \f$ y \f$
 ///
-///  @image html CuboidVolumeBounds_decomp.gif
-
 class CuboidVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
@@ -100,16 +98,18 @@ class CuboidVolumeBounds : public VolumeBounds {
   /// @param tol is the absolute tolerance to be applied
   bool inside(const Vector3D& pos, double tol = 0.) const override;
 
-  /// Method to decompose the Bounds into boundarySurfaces
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
   ///
-  /// @param transformPtr is the transfrom of the volume
-  SurfacePtrVector decomposeToSurfaces(
-      const Transform3D* transformPtr) const override;
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  std::vector<NavigationDirection> boundaryOrientations() const override;
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform
@@ -143,10 +143,6 @@ class CuboidVolumeBounds : public VolumeBounds {
   std::shared_ptr<const RectangleBounds> m_yzBounds{nullptr};
   std::shared_ptr<const RectangleBounds> m_zxBounds{nullptr};
 
-  /// The orientation of the bounding surfaces
-  std::vector<NavigationDirection> m_boundaryOrientations = {
-      forward, backward, forward, backward, forward, backward};
-
   /// Create the surface bounds
   void buildSurfaceBounds();
 
@@ -165,11 +161,6 @@ inline std::vector<double> CuboidVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
-}
-
-inline std::vector<NavigationDirection>
-CuboidVolumeBounds::boundaryOrientations() const {
-  return m_boundaryOrientations;
 }
 
 inline void CuboidVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -71,6 +71,7 @@ class CuboidVolumeBounds : public VolumeBounds {
   CuboidVolumeBounds(const std::array<double, eSize>& values) noexcept(false)
       : m_values(values) {
     checkConsistency();
+    buildSurfaceBounds();
   }
 
   /// Copy Constructor
@@ -125,15 +126,20 @@ class CuboidVolumeBounds : public VolumeBounds {
 
  private:
   /// Templated dumpT method
-  template <class T>
-  T& dumpT(T& dt) const;
+  /// @tparam stream_t The type fo the dump stream
+  /// @param dt The dump stream object
+  template <class stream_t>
+  stream_t& dumpT(stream_t& dt) const;
 
   /// The bound values ordered in a fixed size array
   std::array<double, eSize> m_values;
 
-  std::shared_ptr<const RectangleBounds> m_xyBounds = nullptr;
-  std::shared_ptr<const RectangleBounds> m_yzBounds = nullptr;
-  std::shared_ptr<const RectangleBounds> m_zxBounds = nullptr;
+  std::shared_ptr<const RectangleBounds> m_xyBounds{nullptr};
+  std::shared_ptr<const RectangleBounds> m_yzBounds{nullptr};
+  std::shared_ptr<const RectangleBounds> m_zxBounds{nullptr};
+
+  /// Create the surface bounds
+  void buildSurfaceBounds();
 
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given
@@ -160,8 +166,8 @@ inline void CuboidVolumeBounds::checkConsistency() noexcept(false) {
   }
 }
 
-template <class T>
-T& CuboidVolumeBounds::dumpT(T& dt) const {
+template <class stream_t>
+stream_t& CuboidVolumeBounds::dumpT(stream_t& dt) const {
   dt << std::setiosflags(std::ios::fixed);
   dt << std::setprecision(5);
   dt << "Acts::CuboidVolumeBounds: (halfLengthX, halfLengthY, halfLengthZ) = ";

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -106,6 +106,11 @@ class CuboidVolumeBounds : public VolumeBounds {
   SurfacePtrVector decomposeToSurfaces(
       const Transform3D* transformPtr) const override;
 
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  std::vector<NavigationDirection> boundaryOrientations() const override;
+
   /// Construct bounding box for this shape
   /// @param trf Optional transform
   /// @param envelope Optional envelope to add / subtract from min/max
@@ -138,6 +143,10 @@ class CuboidVolumeBounds : public VolumeBounds {
   std::shared_ptr<const RectangleBounds> m_yzBounds{nullptr};
   std::shared_ptr<const RectangleBounds> m_zxBounds{nullptr};
 
+  /// The orientation of the bounding surfaces
+  std::vector<NavigationDirection> m_boundaryOrientations = {
+      forward, backward, forward, backward, forward, backward};
+
   /// Create the surface bounds
   void buildSurfaceBounds();
 
@@ -156,6 +165,11 @@ inline std::vector<double> CuboidVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
+}
+
+inline std::vector<NavigationDirection>
+CuboidVolumeBounds::boundaryOrientations() const {
+  return m_boundaryOrientations;
 }
 
 inline void CuboidVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -102,6 +102,11 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
       const Transform3D* transform = nullptr) const override;
 
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  std::vector<NavigationDirection> boundaryOrientations() const override;
+
   /// Construct bounding box for this shape
   ///
   /// @param trf Optional transform
@@ -132,6 +137,11 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   std::shared_ptr<const DiscBounds> m_outerDiscBounds{nullptr};
   std::shared_ptr<const DiscBounds> m_innerDiscBounds{nullptr};
 
+  /// The orientation of the bounding surfaces
+  std::vector<NavigationDirection> m_boundaryOrientations = {
+      forward, backward, backward, forward,
+      forward, backward, forward,  forward};
+
   /// Create the surface bound objects
   void buildSurfaceBounds();
 
@@ -144,6 +154,11 @@ inline std::vector<double> CutoutCylinderVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
+}
+
+inline std::vector<NavigationDirection>
+CutoutCylinderVolumeBounds::boundaryOrientations() const {
+  return m_boundaryOrientations;
 }
 
 inline void CutoutCylinderVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -93,19 +93,18 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   /// @return Whether the point is inside or not.
   bool inside(const Vector3D& gpos, double tol = 0) const override;
 
-  /// Method to decompose the Bounds into Surfaces
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
   ///
-  /// @param transform is the transform to position the surfaces in 3D space
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
   ///
-  /// @return vector of surfaces from the decopmosition
+  /// It will throw an exception if the orientation prescription is not adequate
   ///
-  std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
       const Transform3D* transform = nullptr) const override;
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  std::vector<NavigationDirection> boundaryOrientations() const override;
 
   /// Construct bounding box for this shape
   ///
@@ -137,11 +136,6 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   std::shared_ptr<const DiscBounds> m_outerDiscBounds{nullptr};
   std::shared_ptr<const DiscBounds> m_innerDiscBounds{nullptr};
 
-  /// The orientation of the bounding surfaces
-  std::vector<NavigationDirection> m_boundaryOrientations = {
-      forward,  backward, backward, forward,
-      backward, forward,  forward,  forward};
-
   /// Create the surface bound objects
   void buildSurfaceBounds();
 
@@ -154,11 +148,6 @@ inline std::vector<double> CutoutCylinderVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
-}
-
-inline std::vector<NavigationDirection>
-CutoutCylinderVolumeBounds::boundaryOrientations() const {
-  return m_boundaryOrientations;
 }
 
 inline void CutoutCylinderVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -139,8 +139,8 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
 
   /// The orientation of the bounding surfaces
   std::vector<NavigationDirection> m_boundaryOrientations = {
-      forward, backward, backward, forward,
-      forward, backward, forward,  forward};
+      forward,  backward, backward, forward,
+      backward, forward,  forward,  forward};
 
   /// Create the surface bound objects
   void buildSurfaceBounds();

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -11,8 +11,6 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Surfaces/CylinderSurface.hpp"
-#include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
@@ -23,6 +21,9 @@
 namespace Acts {
 
 class IVisualization;
+
+class CylinderBounds;
+class DiscBounds;
 
 /// Class which implements a cutout cylinder. This shape is bascially a
 /// cylinder, with another, smaller cylinder subtracted from the center.
@@ -35,6 +36,7 @@ class IVisualization;
 /// --------- hlZ -------
 ///
 ///
+/// @todo add sectoral cutouts
 class CutoutCylinderVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
@@ -60,6 +62,7 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
                              double hlZc) noexcept(false)
       : m_values({rmin, rmed, rmax, hlZ, hlZc}) {
     checkConsistency();
+    buildSurfaceBounds();
   }
 
   /// Constructor - from a fixed size array
@@ -69,6 +72,7 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
       false)
       : m_values(values) {
     checkConsistency();
+    buildSurfaceBounds();
   }
 
   ~CutoutCylinderVolumeBounds() override = default;
@@ -120,6 +124,16 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
 
  private:
   std::array<double, eSize> m_values;
+
+  // The surface bound objects
+  std::shared_ptr<const CylinderBounds> m_innerCylinderBounds{nullptr};
+  std::shared_ptr<const CylinderBounds> m_cutoutCylinderBounds{nullptr};
+  std::shared_ptr<const CylinderBounds> m_outerCylinderBounds{nullptr};
+  std::shared_ptr<const DiscBounds> m_outerDiscBounds{nullptr};
+  std::shared_ptr<const DiscBounds> m_innerDiscBounds{nullptr};
+
+  /// Create the surface bound objects
+  void buildSurfaceBounds();
 
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -31,7 +31,7 @@ class IVisualization;
 
 /// @class CylinderVolumeBounds
 ///
-/// Bounds for a cylindrical Volume, the decomposeToSurfaces method creates a
+/// Bounds for a cylindrical Volume, the orientedSurfaces(..) method creates a
 /// vector of up to 6 surfaces:
 ///
 /// case A) 3 Surfaces (full cylindrical tube):
@@ -69,7 +69,6 @@ class IVisualization;
 //                          Rectangular Acts::PlaneSurface attached to
 ///                 [0] and [1] at positive \f$ \phi \f$
 ///
-///  @image html CylinderVolumeBounds_decomp.gif
 
 class CylinderVolumeBounds : public VolumeBounds {
  public:
@@ -148,16 +147,18 @@ class CylinderVolumeBounds : public VolumeBounds {
   /// @param tol is the tolerance for the check
   bool inside(const Vector3D& pos, double tol = 0.) const override;
 
-  /// Method to decompose the Bounds into boundarySurfaces
-  /// @param transformPtr is the transform where the boundary surfaces are
-  /// situated
-  std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
-      const Transform3D* transformPtr = nullptr) const override;
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  std::vector<NavigationDirection> boundaryOrientations() const override;
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
+  ///
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform
@@ -197,10 +198,6 @@ class CylinderVolumeBounds : public VolumeBounds {
   /// Bounds of the sector planes
   std::shared_ptr<const PlanarBounds> m_sectorPlaneBounds{nullptr};
 
-  /// The orientation of the bounding surfaces
-  std::vector<NavigationDirection> m_boundaryOrientations = {
-      forward, backward, backward, forward, forward, backward};
-
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given
   void checkConsistency() noexcept(false);
@@ -208,9 +205,11 @@ class CylinderVolumeBounds : public VolumeBounds {
   /// Helper method to create the surface bounds
   void buildSurfaceBounds();
 
-  /// templated dumpT method
-  template <class T>
-  T& dumpT(T& tstream) const;
+  /// Templated dumpT method
+  /// @tparam stream_t The type fo the dump stream
+  /// @param dt The dump stream object
+  template <class stream_t>
+  stream_t& dumpT(stream_t& dt) const;
 };
 
 inline bool CylinderVolumeBounds::inside(const Vector3D& pos,
@@ -245,8 +244,8 @@ inline double CylinderVolumeBounds::binningBorder(BinningValue bValue) const {
   return VolumeBounds::binningBorder(bValue);
 }
 
-template <class T>
-T& CylinderVolumeBounds::dumpT(T& tstream) const {
+template <class stream_t>
+stream_t& CylinderVolumeBounds::dumpT(stream_t& tstream) const {
   tstream << std::setiosflags(std::ios::fixed);
   tstream << std::setprecision(5);
   tstream << "Acts::CylinderVolumeBounds: (rMin, rMax, halfZ, halfPhi, "
@@ -260,11 +259,6 @@ inline std::vector<double> CylinderVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
-}
-
-inline std::vector<NavigationDirection>
-CylinderVolumeBounds::boundaryOrientations() const {
-  return m_boundaryOrientations;
 }
 
 inline void CylinderVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -154,6 +154,11 @@ class CylinderVolumeBounds : public VolumeBounds {
   std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
       const Transform3D* transformPtr = nullptr) const override;
 
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  std::vector<NavigationDirection> boundaryOrientations() const override;
+
   /// Construct bounding box for this shape
   /// @param trf Optional transform
   /// @param envelope Optional envelope to add / subtract from min/max
@@ -191,6 +196,10 @@ class CylinderVolumeBounds : public VolumeBounds {
   std::shared_ptr<const RadialBounds> m_discBounds{nullptr};
   /// Bounds of the sector planes
   std::shared_ptr<const PlanarBounds> m_sectorPlaneBounds{nullptr};
+
+  /// The orientation of the bounding surfaces
+  std::vector<NavigationDirection> m_boundaryOrientations = {
+      forward, backward, backward, forward, forward, backward};
 
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given
@@ -251,6 +260,11 @@ inline std::vector<double> CylinderVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
+}
+
+inline std::vector<NavigationDirection>
+CylinderVolumeBounds::boundaryOrientations() const {
+  return m_boundaryOrientations;
 }
 
 inline void CylinderVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -73,7 +73,7 @@ class IVisualization;
 class CylinderVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
-  enum BoundValues {
+  enum BoundValues : unsigned int {
     eMinR = 0,
     eMaxR = 1,
     eHalfLengthZ = 2,

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -11,8 +11,6 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Surfaces/CylinderSurface.hpp"
-#include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
@@ -185,11 +183,11 @@ class CylinderVolumeBounds : public VolumeBounds {
  private:
   /// The internal version of the bounds can be float/double
   std::array<double, eSize> m_values;
-  /// Bounds of the inner CylinderSurfaces
+  /// Bounds of the inner CylinderBounds
   std::shared_ptr<const CylinderBounds> m_innerCylinderBounds{nullptr};
-  /// Bounds of the inner CylinderSurfaces
+  /// Bounds of the inner CylinderBounds
   std::shared_ptr<const CylinderBounds> m_outerCylinderBounds{nullptr};
-  /// Bounds of the bottom/top DiscSurface
+  /// Bounds of the bottom/top Radial
   std::shared_ptr<const RadialBounds> m_discBounds{nullptr};
   /// Bounds of the sector planes
   std::shared_ptr<const PlanarBounds> m_sectorPlaneBounds{nullptr};

--- a/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// CylinderVolumeHelper.h, Acts project
-///////////////////////////////////////////////////////////////////
-
 #pragma once
 
 #ifndef ACTS_TOOLS_TAKESMALLERBIGGER

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -63,23 +63,18 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   /// @return boolean indicating if the position is inside
   bool inside(const Vector3D& gpos, double tol = 0.) const override;
 
-  /// Method to decompose the Bounds into Surfaces
-  /// the Volume can turn them into BoundarySurfaces
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
   ///
   /// @param transform is the 3D transform to be applied to the boundary
   /// surfaces to position them in 3D space
-  /// @note this is factory method
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
-      const Transform3D* transform) const override;
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  ///
-  /// At creation all normal vectors are pointing outside
-  std::vector<NavigationDirection> boundaryOrientations() const override;
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform
@@ -104,18 +99,9 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   std::array<Vector3D, 8> m_vertices;
   std::array<Vector3D, 6> m_normals;
 
-  /// The orientation of the bounding surfaces
-  std::vector<NavigationDirection> m_boundaryOrientations = {
-      backward, backward, backward, backward, backward, backward};
-
   /// Private helper method to contruct the Volume bounds
   /// to be called by the constructors, from the ordered input vertices
   void construct() noexcept(false);
 };
-
-inline std::vector<NavigationDirection>
-GenericCuboidVolumeBounds::boundaryOrientations() const {
-  return m_boundaryOrientations;
-}
 
 }  // namespace Acts

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -74,6 +74,13 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
       const Transform3D* transform) const override;
 
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  ///
+  /// At creation all normal vectors are pointing outside
+  std::vector<NavigationDirection> boundaryOrientations() const override;
+
   /// Construct bounding box for this shape
   /// @param trf Optional transform
   /// @param envelope Optional envelope to add / subtract from min/max
@@ -97,9 +104,18 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   std::array<Vector3D, 8> m_vertices;
   std::array<Vector3D, 6> m_normals;
 
+  /// The orientation of the bounding surfaces
+  std::vector<NavigationDirection> m_boundaryOrientations = {
+      backward, backward, backward, backward, backward, backward};
+
   /// Private helper method to contruct the Volume bounds
   /// to be called by the constructors, from the ordered input vertices
   void construct() noexcept(false);
-  ;
 };
+
+inline std::vector<NavigationDirection>
+GenericCuboidVolumeBounds::boundaryOrientations() const {
+  return m_boundaryOrientations;
+}
+
 }  // namespace Acts

--- a/Core/include/Acts/Geometry/ITrackingVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/ITrackingVolumeBuilder.hpp
@@ -47,12 +47,12 @@ class ITrackingVolumeBuilder {
   /// ITrackingVolumeBuilder interface method
   ///
   /// @param gctx is the geometry context for witch the volume is built
-  /// @param insideVolume is an (optional) volume to be wrapped
+  /// @param oppositeVolume is an (optional) volume to be wrapped
   /// @param outsideBounds is an (optional) outside confinement
   ///
   /// @return shared pointer to a newly created TrackingVolume
   virtual MutableTrackingVolumePtr trackingVolume(
-      const GeometryContext& gctx, TrackingVolumePtr insideVolume = nullptr,
+      const GeometryContext& gctx, TrackingVolumePtr oppositeVolume = nullptr,
       VolumeBoundsPtr outsideBounds = nullptr) const = 0;
 };
 

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrapezoidVolumeBounds.h, Acts project
-///////////////////////////////////////////////////////////////////
-
 #pragma once
 
 #include "Acts/Geometry/Volume.hpp"
@@ -28,7 +24,7 @@ class TrapezoidBounds;
 
 /// @class TrapezoidVolumeBounds
 ///
-/// Bounds for a trapezoidal shaped Volume, the decomposeToSurfaces method
+/// Bounds for a trapezoidal shaped Volume, the orientedSurface(...) method
 /// creates a vector of 6 surfaces:
 ///
 ///  BoundarySurfaceFace [index]:
@@ -47,8 +43,6 @@ class TrapezoidBounds;
 ///                             parallel to \f$ zx \f$ plane at negative \f$y\f$
 ///  - positiveFaceZX     [5] : Rectangular  Acts::PlaneSurface,
 ///                             parallel to \f$ zx \f$ plane at positive \f$y\f$
-///
-///  @image html TrapezoidVolumeBounds_decomp.gif
 
 class TrapezoidVolumeBounds : public VolumeBounds {
  public:
@@ -118,19 +112,18 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   /// @return boolean indicator if position is inside
   bool inside(const Vector3D& pos, double tol = 0.) const override;
 
-  /// Method to decompose the Bounds into Surfaces
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
   ///
-  /// @param transformPtr is the transform to position the surfaces in 3D space
-  /// @note this is a factory method
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
   ///
-  /// @return vector of surfaces from the decopmosition
-  std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
-      const Transform3D* transformPtr) const override;
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  std::vector<NavigationDirection> boundaryOrientations() const override;
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform
@@ -162,10 +155,6 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   /// The face PlaneSurface parallel to local zx plane, positive local y
   std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsTop{nullptr};
 
-  /// The orientation of the bounding surfaces
-  std::vector<NavigationDirection> m_boundaryOrientations = {
-      forward, backward, forward, backward, forward, backward};
-
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given
   void checkConsistency() noexcept(false);
@@ -196,11 +185,6 @@ inline std::vector<double> TrapezoidVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
-}
-
-inline std::vector<NavigationDirection>
-TrapezoidVolumeBounds::boundaryOrientations() const {
-  return m_boundaryOrientations;
 }
 
 inline void TrapezoidVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -127,6 +127,11 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   std::vector<std::shared_ptr<const Surface>> decomposeToSurfaces(
       const Transform3D* transformPtr) const override;
 
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  std::vector<NavigationDirection> boundaryOrientations() const override;
+
   /// Construct bounding box for this shape
   /// @param trf Optional transform
   /// @param envelope Optional envelope to add / subtract from min/max
@@ -157,6 +162,10 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   /// The face PlaneSurface parallel to local zx plane, positive local y
   std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsTop{nullptr};
 
+  /// The orientation of the bounding surfaces
+  std::vector<NavigationDirection> m_boundaryOrientations = {
+      forward, backward, forward, backward, forward, backward};
+
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given
   void checkConsistency() noexcept(false);
@@ -165,12 +174,14 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   void buildSurfaceBounds();
 
   /// Templated dump methos
-  template <class T>
-  T& dumpT(T& dt) const;
+  /// @tparam stream_t The type of the stream for dumping
+  /// @param dt The stream object
+  template <class stream_t>
+  stream_t& dumpT(stream_t& dt) const;
 };
 
-template <class T>
-T& TrapezoidVolumeBounds::dumpT(T& dt) const {
+template <class stream_t>
+stream_t& TrapezoidVolumeBounds::dumpT(stream_t& dt) const {
   dt << std::setiosflags(std::ios::fixed);
   dt << std::setprecision(5);
   dt << "Acts::TrapezoidVolumeBounds: (minhalfX, halfY, halfZ, alpha, beta) "
@@ -185,6 +196,11 @@ inline std::vector<double> TrapezoidVolumeBounds::values() const {
   std::vector<double> valvector;
   valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
   return valvector;
+}
+
+inline std::vector<NavigationDirection>
+TrapezoidVolumeBounds::boundaryOrientations() const {
+  return m_boundaryOrientations;
 }
 
 inline void TrapezoidVolumeBounds::checkConsistency() noexcept(false) {

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -47,7 +47,7 @@ class TrapezoidBounds;
 class TrapezoidVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for acces / streaming
-  enum BoundValues {
+  enum BoundValues : unsigned int {
     eHalfLengthXnegY = 0,  //!< halflength in x at negative y
     eHalfLengthXposY = 1,  //!< halflength in x at positive y
     eHalfLengthY = 2,      //!< halflength in y

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -147,16 +147,15 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   /// The internal version of the bounds can be float/double
   std::array<double, eSize> m_values;
   /// The face PlaneSurface parallel to local xy plane
-  std::shared_ptr<const TrapezoidBounds> m_faceXYTrapezoidBounds = nullptr;
+  std::shared_ptr<const TrapezoidBounds> m_faceXYTrapezoidBounds{nullptr};
   /// Thhe face PlaneSurface attached to alpha (negative local x)
-  std::shared_ptr<const RectangleBounds> m_faceAlphaRectangleBounds = nullptr;
+  std::shared_ptr<const RectangleBounds> m_faceAlphaRectangleBounds{nullptr};
   /// The face PlaneSurface attached to beta (positive local x)
-  std::shared_ptr<const RectangleBounds> m_faceBetaRectangleBounds = nullptr;
+  std::shared_ptr<const RectangleBounds> m_faceBetaRectangleBounds{nullptr};
   /// The face PlaneSurface parallel to local zx plane, negative local y
-  std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsBottom =
-      nullptr;
+  std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsBottom{nullptr};
   /// The face PlaneSurface parallel to local zx plane, positive local y
-  std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsTop = nullptr;
+  std::shared_ptr<const RectangleBounds> m_faceZXRectangleBoundsTop{nullptr};
 
   /// Check the input values for consistency,
   /// will throw a logic_exception if consistency is not given

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -26,6 +26,15 @@ using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;
 using SurfacePtr = std::shared_ptr<const Surface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
 
+// Planar definitions to help construct the boundary surfaces
+static const Transform3D s_planeXY = Transform3D::Identity();
+static const Transform3D s_planeYZ =
+    AngleAxis3D(0.5 * M_PI, Vector3D::UnitY()) *
+    AngleAxis3D(0.5 * M_PI, Vector3D::UnitZ()) * Transform3D::Identity();
+static const Transform3D s_planeZX =
+    AngleAxis3D(-0.5 * M_PI, Vector3D::UnitX()) *
+    AngleAxis3D(-0.5 * M_PI, Vector3D::UnitZ()) * Transform3D::Identity();
+
 /// @class VolumeBounds
 ///
 /// Pure Absract Base Class for Volume bounds.
@@ -35,11 +44,9 @@ using SurfacePtrVector = std::vector<SurfacePtr>;
 /// Each type of Acts::VolumeBounds has to implement a decomposeToSurfaces() and
 /// a inside() method.
 ///
-/// The orientation of the Surfaces are in a way that the normal vector points
-/// to the outside world.
-///
 /// The Volume, retrieving a set of Surfaces from the VolumeBounds, can turn the
 /// Surfaces into BoundarySurfaces.
+
 class VolumeBounds {
  public:
   // @enum BoundsType

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -25,6 +25,8 @@ using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;
 
 using SurfacePtr = std::shared_ptr<const Surface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
+using OrientedSurface = std::pair<SurfacePtr, NavigationDirection>;
+using OrientedSurfaces = std::vector<OrientedSurface>;
 
 // Planar definitions to help construct the boundary surfaces
 static const Transform3D s_planeXY = Transform3D::Identity();
@@ -94,6 +96,24 @@ class VolumeBounds {
   /// @return a vector of surfaces bounding this volume
   virtual SurfacePtrVector decomposeToSurfaces(
       const Transform3D* transform) const = 0;
+
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
+  ///
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(const Transform3D* transform) const
+      noexcept(false);
+
+  /// The decopmosed boundary surface oprientation, i.e.
+  /// a vector of navigation directions into the volume
+  /// given the normal vector on the surface
+  virtual std::vector<NavigationDirection> boundaryOrientations() const = 0;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -24,7 +24,6 @@ class VolumeBounds;
 using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;
 
 using SurfacePtr = std::shared_ptr<const Surface>;
-using SurfacePtrVector = std::vector<SurfacePtr>;
 using OrientedSurface = std::pair<SurfacePtr, NavigationDirection>;
 using OrientedSurfaces = std::vector<OrientedSurface>;
 
@@ -43,7 +42,7 @@ static const Transform3D s_planeZX =
 ///
 /// Acts::VolumeBounds are a set of up to six confining Surfaces that are stored
 /// in a std::vector.
-/// Each type of Acts::VolumeBounds has to implement a decomposeToSurfaces() and
+/// Each type of Acts::VolumeBounds has to implement a orientedSurfaces() and
 /// a inside() method.
 ///
 /// The Volume, retrieving a set of Surfaces from the VolumeBounds, can turn the
@@ -87,16 +86,6 @@ class VolumeBounds {
   /// @return boolean indicating if the position is inside
   virtual bool inside(const Vector3D& gpos, double tol = 0.) const = 0;
 
-  /// Method to decompose the Bounds into Surfaces
-  /// the Volume can turn them into BoundarySurfaces
-  ///
-  /// @param transform is the 3D transform to be applied to the boundary
-  /// surfaces to position them in 3D space
-  ///
-  /// @return a vector of surfaces bounding this volume
-  virtual SurfacePtrVector decomposeToSurfaces(
-      const Transform3D* transform) const = 0;
-
   /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
   /// according navigation direction into the volume given the normal
   /// vector on the surface
@@ -107,13 +96,8 @@ class VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(const Transform3D* transform) const
-      noexcept(false);
-
-  /// The decopmosed boundary surface oprientation, i.e.
-  /// a vector of navigation directions into the volume
-  /// given the normal vector on the surface
-  virtual std::vector<NavigationDirection> boundaryOrientations() const = 0;
+  virtual OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const = 0;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
@@ -8,44 +8,6 @@
 
 #include "Acts/Utilities/ThrowAssert.hpp"
 
-std::ostream& Acts::ConvexPolygonBoundsBase::toStream(std::ostream& sl) const {
-  std::vector<Vector2D> vtxs = vertices();
-  sl << "Acts::ConvexPolygonBounds<" << vtxs.size() << ">: vertices: [x, y]\n";
-  for (size_t i = 0; i < vtxs.size(); i++) {
-    const auto& vtx = vtxs[i];
-    if (i > 0) {
-      sl << ",";
-      sl << "\n";
-    }
-    sl << "[" << vtx.x() << ", " << vtx.y() << "]";
-  }
-  return sl;
-}
-
-template <typename coll_t>
-Acts::RectangleBounds Acts::ConvexPolygonBoundsBase::makeBoundingBox(
-    const coll_t& vertices) {
-  Vector2D vmax, vmin;
-  vmax = vertices[0];
-  vmin = vertices[0];
-
-  for (size_t i = 1; i < vertices.size(); i++) {
-    vmax = vmax.cwiseMax(vertices[i]);
-    vmin = vmin.cwiseMin(vertices[i]);
-  }
-
-  return {vmin, vmax};
-}
-
-std::vector<double> Acts::ConvexPolygonBoundsBase::values() const {
-  std::vector<double> values;
-  for (const auto& vtx : vertices()) {
-    values.push_back(vtx.x());
-    values.push_back(vtx.y());
-  }
-  return values;
-}
-
 template <typename coll_t>
 void Acts::ConvexPolygonBoundsBase::convex_impl(
     const coll_t& vertices) noexcept(false) {
@@ -84,6 +46,21 @@ void Acts::ConvexPolygonBoundsBase::convex_impl(
       }
     }
   }
+}
+
+template <typename coll_t>
+Acts::RectangleBounds Acts::ConvexPolygonBoundsBase::makeBoundingBox(
+    const coll_t& vertices) {
+  Vector2D vmax, vmin;
+  vmax = vertices[0];
+  vmin = vertices[0];
+
+  for (size_t i = 1; i < vertices.size(); i++) {
+    vmax = vmax.cwiseMax(vertices[i]);
+    vmin = vmin.cwiseMin(vertices[i]);
+  }
+
+  return {vmin, vmax};
 }
 
 template <int N>
@@ -146,40 +123,5 @@ const Acts::RectangleBounds& Acts::ConvexPolygonBounds<N>::boundingBox() const {
 
 template <int N>
 void Acts::ConvexPolygonBounds<N>::checkConsistency() const noexcept(false) {
-  convex_impl(m_vertices);
-}
-
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::ConvexPolygonBounds(
-    const std::vector<Vector2D>& vertices)
-    : m_vertices(vertices.begin(), vertices.end()),
-      m_boundingBox(makeBoundingBox(vertices)) {}
-
-Acts::SurfaceBounds::BoundsType
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::type() const {
-  return SurfaceBounds::eConvexPolygon;
-}
-
-bool Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::inside(
-    const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
-  return bcheck.isInside(lposition, m_vertices);
-}
-
-double Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::distanceToBoundary(
-    const Acts::Vector2D& lposition) const {
-  return BoundaryCheck(true).distance(lposition, m_vertices);
-}
-
-std::vector<Acts::Vector2D> Acts::ConvexPolygonBounds<
-    Acts::PolygonDynamic>::vertices(unsigned int /*lseg*/) const {
-  return {m_vertices.begin(), m_vertices.end()};
-}
-
-const Acts::RectangleBounds&
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::boundingBox() const {
-  return m_boundingBox;
-}
-
-void Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::checkConsistency() const
-    noexcept(false) {
   convex_impl(m_vertices);
 }

--- a/Core/src/Geometry/AbstractVolume.cpp
+++ b/Core/src/Geometry/AbstractVolume.cpp
@@ -28,25 +28,22 @@ Acts::AbstractVolume::boundarySurfaces() const {
 }
 
 void Acts::AbstractVolume::createBoundarySurfaces() {
-  // transform Surfaces To BoundarySurfaces
-  std::vector<std::shared_ptr<const Surface>> surfaces =
-      Volume::volumeBounds().decomposeToSurfaces(m_transform.get());
+  using Boundary = BoundarySurfaceT<AbstractVolume>;
 
-  // counter to flip the inner/outer position for Cylinders
-  int sfCounter = 0;
-  size_t sfNumber = surfaces.size();
+  // Transform Surfaces To BoundarySurfaces
+  auto orientedSurfaces =
+      Volume::volumeBounds().orientedSurfaces(m_transform.get());
 
-  for (auto& sf : surfaces) {
-    // flip inner/outer for cylinders
-    AbstractVolume* inner =
-        (sf->type() == Surface::Cylinder && sfCounter == 3 && sfNumber > 3)
-            ? nullptr
-            : this;
-    AbstractVolume* outer = (inner) != nullptr ? nullptr : this;
-    // create the boundary surface
-    BoundarySurfacePtr bSurface =
-        std::make_shared<const BoundarySurfaceT<AbstractVolume>>(std::move(sf),
-                                                                 inner, outer);
-    m_boundarySurfaces.push_back(bSurface);
+  m_boundarySurfaces.reserve(orientedSurfaces.size());
+  for (auto& osf : orientedSurfaces) {
+    AbstractVolume* opposite = nullptr;
+    AbstractVolume* along = nullptr;
+    if (osf.second == backward) {
+      opposite = this;
+    } else {
+      along = this;
+    }
+    m_boundarySurfaces.push_back(std::make_shared<const Boundary>(
+        std::move(osf.first), opposite, along));
   }
 }

--- a/Core/src/Geometry/AbstractVolume.cpp
+++ b/Core/src/Geometry/AbstractVolume.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// AbstractVolume.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/AbstractVolume.hpp"
 #include <iostream>
 #include <utility>

--- a/Core/src/Geometry/BinUtility.cpp
+++ b/Core/src/Geometry/BinUtility.cpp
@@ -6,14 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// BinUtility.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
-// Trk
 #include "Acts/Utilities/BinUtility.hpp"
-
-// STD/STL
 #include <iostream>
 
 /**Overload of << operator for std::ostream for debug output*/

--- a/Core/src/Geometry/CMakeLists.txt
+++ b/Core/src/Geometry/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources_local(
     AbstractVolume.cpp
     BinUtility.cpp
     ConeLayer.cpp
+    ConeVolumeBounds.cpp
     CuboidVolumeBounds.cpp
     CuboidVolumeBuilder.cpp
     CutoutCylinderVolumeBounds.cpp

--- a/Core/src/Geometry/ConeLayer.cpp
+++ b/Core/src/Geometry/ConeLayer.cpp
@@ -6,15 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// ConeLayer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
-#include <utility>
-
 #include "Acts/Geometry/ConeLayer.hpp"
 #include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+
+#include <utility>
 
 Acts::ConeLayer::ConeLayer(std::shared_ptr<const Transform3D> transform,
                            std::shared_ptr<const ConeBounds> cbounds,

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -17,12 +17,9 @@
 
 Acts::CuboidVolumeBounds::CuboidVolumeBounds(double halex, double haley,
                                              double halez)
-    : VolumeBounds(),
-      m_values({halex, haley, halez}),
-      m_xyBounds(std::make_shared<const RectangleBounds>(halex, haley)),
-      m_yzBounds(std::make_shared<const RectangleBounds>(haley, halez)),
-      m_zxBounds(std::make_shared<const RectangleBounds>(halez, halex)) {
+    : VolumeBounds(), m_values({halex, haley, halez}) {
   checkConsistency();
+  buildSurfaceBounds();
 }
 
 Acts::CuboidVolumeBounds::CuboidVolumeBounds(const CuboidVolumeBounds& bobo)
@@ -101,4 +98,13 @@ Acts::Volume::BoundingBox Acts::CuboidVolumeBounds::boundingBox(
 
   Volume::BoundingBox box(entity, vmin - envelope, vmax + envelope);
   return trf == nullptr ? box : box.transformed(*trf);
+}
+
+void Acts::CuboidVolumeBounds::buildSurfaceBounds() {
+  m_xyBounds = std::make_shared<const RectangleBounds>(get(eHalfLengthX),
+                                                       get(eHalfLengthY));
+  m_yzBounds = std::make_shared<const RectangleBounds>(get(eHalfLengthY),
+                                                       get(eHalfLengthZ));
+  m_zxBounds = std::make_shared<const RectangleBounds>(get(eHalfLengthZ),
+                                                       get(eHalfLengthX));
 }

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -48,7 +48,6 @@ Acts::SurfacePtrVector Acts::CuboidVolumeBounds::decomposeToSurfaces(
   // The transform - apply when given
   Transform3D transform =
       (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
-  const Transform3D* tTransform = nullptr;
 
   SurfacePtrVector rSurfaces;
   rSurfaces.reserve(6);
@@ -86,7 +85,7 @@ Acts::SurfacePtrVector Acts::CuboidVolumeBounds::decomposeToSurfaces(
       std::make_shared<const Transform3D>(
           transform * Translation3D(0., get(eHalfLengthY), 0.) * s_planeZX),
       m_zxBounds));
-  // return the surfaces
+
   return rSurfaces;
 }
 

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -45,58 +45,47 @@ Acts::CuboidVolumeBounds& Acts::CuboidVolumeBounds::operator=(
 
 Acts::SurfacePtrVector Acts::CuboidVolumeBounds::decomposeToSurfaces(
     const Transform3D* transformPtr) const {
-  // the transform - apply when given
+  // The transform - apply when given
   Transform3D transform =
       (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
   const Transform3D* tTransform = nullptr;
 
   SurfacePtrVector rSurfaces;
   rSurfaces.reserve(6);
-  // face surfaces xy -------------------------------------
+  // Face surfaces xy -------------------------------------
   //   (1) - at negative local z
-  tTransform =
-      new Transform3D(transform * AngleAxis3D(M_PI, Vector3D(0., 1., 0.)) *
-                      Translation3D(Vector3D(0., 0., get(eHalfLengthZ))));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_xyBounds));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., 0., -get(eHalfLengthZ))),
+      m_xyBounds));
+
   //   (2) - at positive local z
-  tTransform = new Transform3D(
-      transform * Translation3D(Vector3D(0., 0., get(eHalfLengthZ))));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_xyBounds));
-  // face surfaces yz -------------------------------------
-  // transmute cyclical
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., 0., get(eHalfLengthZ))),
+      m_xyBounds));
+  // Face surfaces yz -------------------------------------
   //   (3) - at negative local x
-  tTransform =
-      new Transform3D(transform * AngleAxis3D(M_PI, Vector3D(0., 0., 1.)) *
-                      Translation3D(Vector3D(get(eHalfLengthX), 0., 0)) *
-                      AngleAxis3D(0.5 * M_PI, Vector3D(0., 1., 0)) *
-                      AngleAxis3D(0.5 * M_PI, Vector3D(0., 0., 1.)));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_yzBounds));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(-get(eHalfLengthX), 0., 0.) * s_planeYZ),
+      m_yzBounds));
   //   (4) - at positive local x
-  tTransform = new Transform3D(
-      transform * Translation3D(Vector3D(get(eHalfLengthX), 0., 0.)) *
-      AngleAxis3D(0.5 * M_PI, Vector3D(0., 1., 0.)) *
-      AngleAxis3D(0.5 * M_PI, Vector3D(0., 0., 1.)));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_yzBounds));
-  // face surfaces zx -------------------------------------
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(get(eHalfLengthX), 0., 0.) * s_planeYZ),
+      m_yzBounds));
+  // Face surfaces zx -------------------------------------
   //   (5) - at negative local y
-  tTransform =
-      new Transform3D(transform * AngleAxis3D(M_PI, Vector3D(1., 0., 0.)) *
-                      Translation3D(Vector3D(0., get(eHalfLengthY), 0.)) *
-                      AngleAxis3D(-0.5 * M_PI, Vector3D(0., 1., 0.)) *
-                      AngleAxis3D(-0.5 * M_PI, Vector3D(1., 0., 0.)));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_zxBounds));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX),
+      m_zxBounds));
   //   (6) - at positive local y
-  tTransform = new Transform3D(
-      transform * Translation3D(Vector3D(0., get(eHalfLengthY), 0.)) *
-      AngleAxis3D(-0.5 * M_PI, Vector3D(0., 1., 0.)) *
-      AngleAxis3D(-0.5 * M_PI, Vector3D(1., 0., 0.)));
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_zxBounds));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., get(eHalfLengthY), 0.) * s_planeZX),
+      m_zxBounds));
   // return the surfaces
   return rSurfaces;
 }

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -40,50 +40,55 @@ Acts::CuboidVolumeBounds& Acts::CuboidVolumeBounds::operator=(
   return *this;
 }
 
-Acts::SurfacePtrVector Acts::CuboidVolumeBounds::decomposeToSurfaces(
+Acts::OrientedSurfaces Acts::CuboidVolumeBounds::orientedSurfaces(
     const Transform3D* transformPtr) const {
   // The transform - apply when given
   Transform3D transform =
       (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
 
-  SurfacePtrVector rSurfaces;
-  rSurfaces.reserve(6);
+  OrientedSurfaces oSurfaces;
+  oSurfaces.reserve(6);
   // Face surfaces xy -------------------------------------
   //   (1) - at negative local z
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  auto sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(0., 0., -get(eHalfLengthZ))),
-      m_xyBounds));
-
+      m_xyBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (2) - at positive local z
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(0., 0., get(eHalfLengthZ))),
-      m_xyBounds));
+      m_xyBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
   // Face surfaces yz -------------------------------------
   //   (3) - at negative local x
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(-get(eHalfLengthX), 0., 0.) * s_planeYZ),
-      m_yzBounds));
+      m_yzBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (4) - at positive local x
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(get(eHalfLengthX), 0., 0.) * s_planeYZ),
-      m_yzBounds));
+      m_yzBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
   // Face surfaces zx -------------------------------------
   //   (5) - at negative local y
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX),
-      m_zxBounds));
+      m_zxBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (6) - at positive local y
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+  sf = Surface::makeShared<PlaneSurface>(
       std::make_shared<const Transform3D>(
           transform * Translation3D(0., get(eHalfLengthY), 0.) * s_planeZX),
-      m_zxBounds));
+      m_zxBounds);
+  oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
 
-  return rSurfaces;
+  return oSurfaces;
 }
 
 std::ostream& Acts::CuboidVolumeBounds::toStream(std::ostream& sl) const {

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -48,7 +48,7 @@ Acts::CutoutCylinderVolumeBounds::decomposeToSurfaces(
     const Transform3D* transform) const {
   std::vector<std::shared_ptr<const Acts::Surface>> surfaces;
 
-  // transform copy
+  // Transform copy
   std::shared_ptr<const Transform3D> trf;
   if (transform != nullptr) {
     trf = std::make_shared<const Transform3D>(*transform);

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -60,49 +60,45 @@ Acts::CylinderVolumeBounds::decomposeToSurfaces(
   std::vector<std::shared_ptr<const Surface>> rSurfaces;
   rSurfaces.reserve(6);
 
-  // set the transform
+  // Set the transform
   Transform3D transform =
       (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
   auto trfShared = std::make_shared<Transform3D>(transform);
 
-  const Transform3D* tTransform = nullptr;
-  Vector3D cylCenter(transform.translation());
-
-  // bottom Disc (negative z)
-  tTransform =
-      new Transform3D(transform * AngleAxis3D(M_PI, Vector3D(1., 0., 0.)) *
-                      Translation3D(Vector3D(0., 0., get(eHalfLengthZ))));
+  // [0] Bottom Disc (negative z)
   rSurfaces.push_back(Surface::makeShared<DiscSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_discBounds));
-  // top Disc (positive z)
-  tTransform = new Transform3D(
-      transform * Translation3D(Vector3D(0., 0., get(eHalfLengthZ))));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., 0., -get(eHalfLengthZ))),
+      m_discBounds));
+  // [1] Top Disc (positive z)
   rSurfaces.push_back(Surface::makeShared<DiscSurface>(
-      std::shared_ptr<const Transform3D>(tTransform), m_discBounds));
+      std::make_shared<const Transform3D>(
+          transform * Translation3D(0., 0., get(eHalfLengthZ))),
+      m_discBounds));
 
-  // outer Cylinder - shares the transform
+  // [2] Outer Cylinder
   rSurfaces.push_back(
       Surface::makeShared<CylinderSurface>(trfShared, m_outerCylinderBounds));
 
-  // innermost Cylinder
+  // [3] Inner Cylinder (optional)
   if (m_innerCylinderBounds != nullptr) {
     rSurfaces.push_back(
         Surface::makeShared<CylinderSurface>(trfShared, m_innerCylinderBounds));
   }
 
-  // the cylinder is sectoral
+  // [4] & [5] - Sectoral planes (optional)
   if (m_sectorPlaneBounds != nullptr) {
     // sectorPlane 1 (negative phi)
     const Transform3D* sp1Transform = new Transform3D(
         transform * AngleAxis3D(-get(eHalfPhiSector), Vector3D(0., 0., 1.)) *
-        Translation3D(Vector3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.)) *
+        Translation3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.) *
         AngleAxis3D(M_PI / 2, Vector3D(1., 0., 0.)));
     rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
         std::shared_ptr<const Transform3D>(sp1Transform), m_sectorPlaneBounds));
     // sectorPlane 2 (positive phi)
     const Transform3D* sp2Transform = new Transform3D(
         transform * AngleAxis3D(get(eHalfPhiSector), Vector3D(0., 0., 1.)) *
-        Translation3D(Vector3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.)) *
+        Translation3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.) *
         AngleAxis3D(-M_PI / 2, Vector3D(1., 0., 0.)));
     rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
         std::shared_ptr<const Transform3D>(sp2Transform), m_sectorPlaneBounds));

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// CylinderVolumeHelper.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/CylinderVolumeHelper.hpp"
 #include <cmath>
 #include "Acts/Geometry/AbstractVolume.hpp"

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -7,18 +7,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Geometry/GenericCuboidVolumeBounds.hpp"
-
+#include "Acts/Geometry/Volume.hpp"
 #include "Acts/Surfaces/ConvexPolygonBounds.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 #include "Acts/Visualization/IVisualization.hpp"
 
 #include <array>
 #include <ostream>
-
-#include "Acts/Geometry/Volume.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 
 Acts::GenericCuboidVolumeBounds::GenericCuboidVolumeBounds(
     const std::array<Acts::Vector3D, 8>& vertices) noexcept(false)

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -130,13 +130,13 @@ void Acts::TrackingVolume::connectDenseBoundarySurfaces(
         auto mutableBs =
             std::const_pointer_cast<BoundarySurfaceT<TrackingVolume>>(
                 boundSur.at(i));
-        if (mutableBs->m_insideVolume != nullptr &&
-            mutableBs->m_outsideVolume == nullptr) {
+        if (mutableBs->m_oppositeVolume != nullptr &&
+            mutableBs->m_alongVolume == nullptr) {
           bo = BoundaryOrientation::outsideVolume;
           mutableBs->attachVolume(this, bo);
         } else {
-          if (mutableBs->m_insideVolume == nullptr &&
-              mutableBs->m_outsideVolume != nullptr) {
+          if (mutableBs->m_oppositeVolume == nullptr &&
+              mutableBs->m_alongVolume != nullptr) {
             bo = BoundaryOrientation::insideVolume;
             mutableBs->attachVolume(this, bo);
           }

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrackingVolume.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include <functional>
 #include <utility>
 
@@ -113,7 +109,7 @@ const Acts::TrackingVolumeBoundaries& Acts::TrackingVolume::boundarySurfaces()
 void Acts::TrackingVolume::connectDenseBoundarySurfaces(
     MutableTrackingVolumeVector& confinedDenseVolumes) {
   if (!confinedDenseVolumes.empty()) {
-    BoundaryOrientation bo;
+    NavigationDirection navDir;
     // Walk over each dense volume
     for (auto& confDenseVol : confinedDenseVolumes) {
       // Walk over each boundary surface of the volume
@@ -132,13 +128,13 @@ void Acts::TrackingVolume::connectDenseBoundarySurfaces(
                 boundSur.at(i));
         if (mutableBs->m_oppositeVolume != nullptr &&
             mutableBs->m_alongVolume == nullptr) {
-          bo = BoundaryOrientation::outsideVolume;
-          mutableBs->attachVolume(this, bo);
+          navDir = forward;
+          mutableBs->attachVolume(this, navDir);
         } else {
           if (mutableBs->m_oppositeVolume == nullptr &&
               mutableBs->m_alongVolume != nullptr) {
-            bo = BoundaryOrientation::insideVolume;
-            mutableBs->attachVolume(this, bo);
+            navDir = backward;
+            mutableBs->attachVolume(this, navDir);
           }
         }
 
@@ -152,27 +148,23 @@ void Acts::TrackingVolume::connectDenseBoundarySurfaces(
 }
 
 void Acts::TrackingVolume::createBoundarySurfaces() {
-  // transform Surfaces To BoundarySurfaces
-  std::vector<std::shared_ptr<const Surface>> surfaces =
-      Volume::volumeBounds().decomposeToSurfaces(m_transform.get());
+  using Boundary = BoundarySurfaceT<TrackingVolume>;
 
-  // counter to flip the inner/outer position for Cylinders
-  int sfCounter = 0;
-  size_t sfNumber = surfaces.size();
+  // Transform Surfaces To BoundarySurfaces
+  auto orientedSurfaces =
+      Volume::volumeBounds().orientedSurfaces(m_transform.get());
 
-  for (auto& sf : surfaces) {
-    // flip inner/outer for cylinders
-    TrackingVolume* inner =
-        (sf->type() == Surface::Cylinder && sfCounter == 3 && sfNumber > 3)
-            ? nullptr
-            : this;
-    TrackingVolume* outer = (inner) != nullptr ? nullptr : this;
-    // create the boundary surface
-    m_boundarySurfaces.push_back(
-        std::make_shared<const BoundarySurfaceT<TrackingVolume>>(std::move(sf),
-                                                                 inner, outer));
-    // increase the counter
-    ++sfCounter;
+  m_boundarySurfaces.reserve(orientedSurfaces.size());
+  for (auto& osf : orientedSurfaces) {
+    TrackingVolume* opposite = nullptr;
+    TrackingVolume* along = nullptr;
+    if (osf.second == backward) {
+      opposite = this;
+    } else {
+      along = this;
+    }
+    m_boundarySurfaces.push_back(std::make_shared<const Boundary>(
+        std::move(osf.first), opposite, along));
   }
 }
 
@@ -193,8 +185,8 @@ void Acts::TrackingVolume::glueTrackingVolume(const GeometryContext& gctx,
   Vector3D nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation
-  BoundaryOrientation bOrientation =
-      (nvector.dot(distance) > 0.) ? outsideVolume : insideVolume;
+  NavigationDirection navDir =
+      (nvector.dot(distance) > 0.) ? forward : backward;
   // The easy case :
   // - no glue volume descriptors on either side
   if ((m_glueVolumeDescriptor == nullptr) ||
@@ -202,7 +194,7 @@ void Acts::TrackingVolume::glueTrackingVolume(const GeometryContext& gctx,
     // the boundary orientation
     auto mutableBSurfaceMine =
         std::const_pointer_cast<BoundarySurfaceT<TrackingVolume>>(bSurfaceMine);
-    mutableBSurfaceMine->attachVolume(neighbor, bOrientation);
+    mutableBSurfaceMine->attachVolume(neighbor, navDir);
     // Make sure you keep the boundary material if there
     const Surface& neighborSurface =
         neighbor->m_boundarySurfaces.at(bsfNeighbor)->surfaceRepresentation();
@@ -239,8 +231,8 @@ void Acts::TrackingVolume::glueTrackingVolumes(
   Vector3D nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation
-  BoundaryOrientation bOrientation =
-      (nvector.dot(distance) > 0.) ? outsideVolume : insideVolume;
+  NavigationDirection navDir =
+      (nvector.dot(distance) > 0.) ? forward : backward;
   // the easy case :
   // - no glue volume descriptors on either side
   if ((m_glueVolumeDescriptor == nullptr) ||
@@ -248,7 +240,7 @@ void Acts::TrackingVolume::glueTrackingVolumes(
     // the boundary orientation
     auto mutableBSurfaceMine =
         std::const_pointer_cast<BoundarySurfaceT<TrackingVolume>>(bSurfaceMine);
-    mutableBSurfaceMine->attachVolumeArray(neighbors, bOrientation);
+    mutableBSurfaceMine->attachVolumeArray(neighbors, navDir);
     // now set it to the neighbor volumes - the optised way
     for (auto& nVolume : neighbors->arrayObjects()) {
       auto mutableNVolume = std::const_pointer_cast<TrackingVolume>(nVolume);

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -79,21 +79,21 @@ Acts::TrapezoidVolumeBounds::decomposeToSurfaces(
   double topShift = poshOffset + neghOffset;
 
   // Face surfaces yz
-  //   (3) - At point A, attached to alpha opening angle
-  Vector3D faPosition(get(eHalfLengthXnegY) + poshOffset, 0., 0.);
-  auto faTransform = std::make_shared<Transform3D>(
-      transform * Translation3D(faPosition) *
-      AngleAxis3D(-0.5 * M_PI + get(eAlpha), Vector3D(0., 0., 1.)) * s_planeYZ);
-  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
-      faTransform, m_faceAlphaRectangleBounds));
-
-  //   (4) - At point B, attached to beta opening angle
+  // (3) - At point B, attached to beta opening angle
   Vector3D fbPosition(-get(eHalfLengthXnegY) + neghOffset, 0., 0.);
   auto fbTransform = std::make_shared<Transform3D>(
       transform * Translation3D(fbPosition) *
       AngleAxis3D(-0.5 * M_PI + get(eBeta), Vector3D(0., 0., 1.)) * s_planeYZ);
   rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
       fbTransform, m_faceBetaRectangleBounds));
+
+  // (4) - At point A, attached to alpha opening angle
+  Vector3D faPosition(get(eHalfLengthXnegY) + poshOffset, 0., 0.);
+  auto faTransform = std::make_shared<Transform3D>(
+      transform * Translation3D(faPosition) *
+      AngleAxis3D(-0.5 * M_PI + get(eAlpha), Vector3D(0., 0., 1.)) * s_planeYZ);
+  rSurfaces.push_back(Surface::makeShared<PlaneSurface>(
+      faTransform, m_faceAlphaRectangleBounds));
 
   // Face surfaces zx
   //   (5) - At negative local y

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -6,12 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrapezoidVolumeBounds.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/TrapezoidVolumeBounds.hpp"
-
 #include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"

--- a/Core/src/Geometry/VolumeBounds.cpp
+++ b/Core/src/Geometry/VolumeBounds.cpp
@@ -6,11 +6,26 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// VolumeBounds.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/VolumeBounds.hpp"
+
+Acts::OrientedSurfaces Acts::VolumeBounds::orientedSurfaces(
+    const Transform3D* transform) const noexcept(false) {
+  // Get the raw surfaces first
+  auto rawSurfaces = decomposeToSurfaces(transform);
+  auto orientations = boundaryOrientations();
+
+  OrientedSurfaces oSurfaces;
+  oSurfaces.reserve(rawSurfaces.size());
+  if (rawSurfaces.size() > orientations.size()) {
+    throw std::invalid_argument(
+        "VolumeBounds: not enough surface orientations given.");
+  }
+  //  Fill the surface vector and the associated orientataions
+  for (size_t is = 0; is < rawSurfaces.size(); ++is) {
+    oSurfaces.push_back(OrientedSurface(rawSurfaces[is], orientations[is]));
+  }
+  return oSurfaces;
+}
 
 /**Overload of << operator for std::ostream for debug output*/
 std::ostream& Acts::operator<<(std::ostream& sl, const Acts::VolumeBounds& vb) {

--- a/Core/src/Geometry/VolumeBounds.cpp
+++ b/Core/src/Geometry/VolumeBounds.cpp
@@ -8,25 +8,6 @@
 
 #include "Acts/Geometry/VolumeBounds.hpp"
 
-Acts::OrientedSurfaces Acts::VolumeBounds::orientedSurfaces(
-    const Transform3D* transform) const noexcept(false) {
-  // Get the raw surfaces first
-  auto rawSurfaces = decomposeToSurfaces(transform);
-  auto orientations = boundaryOrientations();
-
-  OrientedSurfaces oSurfaces;
-  oSurfaces.reserve(rawSurfaces.size());
-  if (rawSurfaces.size() > orientations.size()) {
-    throw std::invalid_argument(
-        "VolumeBounds: not enough surface orientations given.");
-  }
-  //  Fill the surface vector and the associated orientataions
-  for (size_t is = 0; is < rawSurfaces.size(); ++is) {
-    oSurfaces.push_back(OrientedSurface(rawSurfaces[is], orientations[is]));
-  }
-  return oSurfaces;
-}
-
 /**Overload of << operator for std::ostream for debug output*/
 std::ostream& Acts::operator<<(std::ostream& sl, const Acts::VolumeBounds& vb) {
   return vb.toStream(sl);

--- a/Core/src/Surfaces/CMakeLists.txt
+++ b/Core/src/Surfaces/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources_local(
     AnnulusBounds.cpp
     ConeBounds.cpp
     ConeSurface.cpp
+    ConvexPolygonBounds.cpp
     CylinderBounds.cpp
     CylinderSurface.cpp
     DiamondBounds.cpp

--- a/Core/src/Surfaces/ConvexPolygonBounds.cpp
+++ b/Core/src/Surfaces/ConvexPolygonBounds.cpp
@@ -1,0 +1,67 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Surfaces/ConvexPolygonBounds.hpp"
+
+std::ostream& Acts::ConvexPolygonBoundsBase::toStream(std::ostream& sl) const {
+  std::vector<Vector2D> vtxs = vertices();
+  sl << "Acts::ConvexPolygonBounds<" << vtxs.size() << ">: vertices: [x, y]\n";
+  for (size_t i = 0; i < vtxs.size(); i++) {
+    const auto& vtx = vtxs[i];
+    if (i > 0) {
+      sl << ",";
+      sl << "\n";
+    }
+    sl << "[" << vtx.x() << ", " << vtx.y() << "]";
+  }
+  return sl;
+}
+
+std::vector<double> Acts::ConvexPolygonBoundsBase::values() const {
+  std::vector<double> values;
+  for (const auto& vtx : vertices()) {
+    values.push_back(vtx.x());
+    values.push_back(vtx.y());
+  }
+  return values;
+}
+
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::ConvexPolygonBounds(
+    const std::vector<Vector2D>& vertices)
+    : m_vertices(vertices.begin(), vertices.end()),
+      m_boundingBox(makeBoundingBox(vertices)) {}
+
+Acts::SurfaceBounds::BoundsType
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::type() const {
+  return SurfaceBounds::eConvexPolygon;
+}
+
+bool Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::inside(
+    const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
+  return bcheck.isInside(lposition, m_vertices);
+}
+
+double Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::distanceToBoundary(
+    const Acts::Vector2D& lposition) const {
+  return BoundaryCheck(true).distance(lposition, m_vertices);
+}
+
+std::vector<Acts::Vector2D> Acts::ConvexPolygonBounds<
+    Acts::PolygonDynamic>::vertices(unsigned int /*lseg*/) const {
+  return {m_vertices.begin(), m_vertices.end()};
+}
+
+const Acts::RectangleBounds&
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::boundingBox() const {
+  return m_boundingBox;
+}
+
+void Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::checkConsistency() const
+    noexcept(false) {
+  convex_impl(m_vertices);
+}

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/ObjTestWriter.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/ObjTestWriter.hpp
@@ -19,7 +19,7 @@
 
 namespace Acts {
 
-using IdentifiedPolyderon = std::tuple<std::string, bool, Polyhedron>;
+using IdentifiedPolyhedron = std::tuple<std::string, bool, Polyhedron>;
 
 namespace Test {
 
@@ -87,7 +87,7 @@ struct ObjTestWriter {
   /// It will draw the polyhedron and create a file, the boolean
   /// steers whether the obj should be triangulated
   /// @param iphs The Identified Polyhedrons (= with name and boolean)
-  static void writeObj(const std::vector<IdentifiedPolyderon>& iphs) {
+  static void writeObj(const std::vector<IdentifiedPolyhedron>& iphs) {
     for (const auto& iph : iphs) {
       std::ofstream ostream;
       ostream.open(std::get<std::string>(iph) + ".obj");

--- a/Tests/UnitTests/Core/Geometry/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Geometry/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_unittest(AlignmentContextTests AlignmentContextTests.cpp)
+add_unittest(ConeVolumeBoundsTests ConeVolumeBoundsTests.cpp)
 add_unittest(CuboidVolumeBoundsTests CuboidVolumeBoundsTests.cpp)
 add_unittest(CuboidVolumeBuilderTests CuboidVolumeBuilderTests.cpp)
 add_unittest(CutoutCylinderVolumeBoundsTests CutoutCylinderVolumeBoundsTests.cpp)

--- a/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
@@ -1,0 +1,90 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Geometry/ConeVolumeBounds.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Tests/CommonHelpers/ObjTestWriter.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Units.hpp"
+
+namespace tt = boost::test_tools;
+
+namespace Acts {
+
+using namespace UnitLiterals;
+
+// Create a test context
+GeometryContext tgContext = GeometryContext();
+
+namespace Test {
+
+BOOST_AUTO_TEST_SUITE(VolumeBounds)
+
+BOOST_AUTO_TEST_CASE(ConeVolumeBoundsTests) {
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
+
+  // Single solid Cone
+  ConeVolumeBounds solidCone(0., 0., 0.45, 50_mm, 50_mm, 0., M_PI);
+
+  // Test correct parameter return
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eInnerAlpha) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eInnerOffsetZ) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eOuterAlpha) == 0.45);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eOuterOffsetZ) == 50.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eHalfLengthZ) == 50.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eAveragePhi) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eHalfPhiSector) == M_PI);
+  // Derived quantities
+  BOOST_TEST(solidCone.innerTanAlpha() == 0.);
+  BOOST_TEST(solidCone.innerRmin() == 0.);
+  BOOST_TEST(solidCone.innerRmax() == 0.);
+  BOOST_TEST(solidCone.outerTanAlpha() == std::tan(0.45));
+
+  double outerRmax = 100_mm * solidCone.outerTanAlpha();
+  BOOST_TEST(solidCone.outerRmin() == 0.);
+  BOOST_TEST(solidCone.outerRmax() == outerRmax);
+
+  auto solidConeSurfaces = solidCone.orientedSurfaces();
+  BOOST_TEST(solidConeSurfaces.size() == 2);
+
+  // Single solid Cone - with cut off
+  ConeVolumeBounds cutOffCone(0., 0., 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffConeSurfaces = cutOffCone.orientedSurfaces();
+  BOOST_TEST(cutOffConeSurfaces.size() == 3);
+
+  // Cone - Cone inlay
+  ConeVolumeBounds cutOffHollowCone(0.35, 70_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowConeSurfaces = cutOffHollowCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowConeSurfaces.size() == 4);
+
+  // Sectoral Cone - Cone inlay
+  ConeVolumeBounds cutOffHollowSectoralCone(0.35, 70_mm, 0.45, 80_mm, 50_mm, 0.,
+                                            0.456);
+  auto cutOffHollowSectoralConeSurfaces =
+      cutOffHollowSectoralCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowSectoralConeSurfaces.size() == 6);
+
+  // Sectoral Cone - Hollow Cone
+  ConeVolumeBounds cutOffHollowCylCone(10_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowCylConeSurfaces = cutOffHollowCylCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowCylConeSurfaces.size() == 4);
+
+  // Single Hollow Cylinder - Cone inlay
+  ConeVolumeBounds cutOffHollowConeCyl(120_mm, 0.35, 70_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowConeCylSurfaces = cutOffHollowConeCyl.orientedSurfaces();
+  BOOST_TEST(cutOffHollowConeCylSurfaces.size() == 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace Test
+
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
@@ -93,18 +93,9 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeProperties) {
 
 BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
   CuboidVolumeBounds box(5, 8, 7);
-
-  auto cvbSurfaces = box.decomposeToSurfaces(nullptr);
-  BOOST_TEST(cvbSurfaces.size(), 6);
-
-  auto cvbOrientations = box.boundaryOrientations();
-
-  std::vector<NavigationDirection> refOrientations = {
-      forward, backward, forward, backward, forward, backward};
-
-  BOOST_CHECK(cvbOrientations == refOrientations);
-
   auto cvbOrientedSurfaces = box.orientedSurfaces(nullptr);
+
+  BOOST_TEST(cvbOrientedSurfaces.size(), (size_t)6);
 
   for (auto& os : cvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsInside) {
 
 BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
-  std::vector<IdentifiedPolyderon> tPolyhedrons;
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
 
   auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -198,6 +198,36 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   ObjTestWriter::writeObj(tPolyhedrons);
 }
 
+BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
+  GeometryContext tgContext = GeometryContext();
+
+  CutoutCylinderVolumeBounds ccvb(5, 10, 15, 30, 25);
+
+  std::vector<NavigationDirection> refOrientations = {
+      forward,  backward, backward, forward,
+      backward, forward,  forward,  forward};
+
+  auto ccvbOrientations = ccvb.boundaryOrientations();
+
+  BOOST_CHECK(refOrientations == ccvbOrientations);
+
+  auto ccvbOrientedSurfaces = ccvb.orientedSurfaces(nullptr);
+  BOOST_TEST(ccvbOrientedSurfaces.size(), 8);
+
+  for (auto& os : ccvbOrientedSurfaces) {
+    auto geoCtx = GeometryContext();
+    auto onSurface = os.first->binningPosition(geoCtx, binR);
+    auto osNormal = os.first->normal(geoCtx, onSurface);
+    double nDir = (double)os.second;
+    // Check if you step inside the volume with the oriented normal
+    auto insideCcvb = onSurface + nDir * osNormal;
+    auto outsideCCvb = onSurface - nDir * osNormal;
+
+    BOOST_CHECK(ccvb.inside(insideCcvb));
+    BOOST_CHECK(!ccvb.inside(outsideCCvb));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace Test
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -171,14 +171,15 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
   std::vector<IdentifiedPolyderon> tPolyhedrons;
 
-  auto combineAndDecompose = [&](const SurfacePtrVector& surfaces,
+  auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {
     std::string writeBase = std::string("CutoutCylinderVolumeBounds") + name;
 
     Polyhedron phCombined;
     size_t is = 0;
     for (const auto& sf : surfaces) {
-      Polyhedron phComponent = sf->polyhedronRepresentation(tgContext, 72);
+      Polyhedron phComponent =
+          sf.first->polyhedronRepresentation(tgContext, 72);
       phCombined.merge(phComponent);
       tPolyhedrons.push_back(
           {writeBase + std::string("_comp_") + std::to_string(is++), false,
@@ -192,7 +193,7 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   CHECK_CLOSE_ABS(box.min(), Vector3D(-15, -15, -30), 1e-6);
   CHECK_CLOSE_ABS(box.max(), Vector3D(15, 15, 30), 1e-6);
 
-  auto ccvbSurfaces = ccvb.decomposeToSurfaces();
+  auto ccvbSurfaces = ccvb.orientedSurfaces(nullptr);
   combineAndDecompose(ccvbSurfaces, "");
   ObjTestWriter::writeObj("CutoutCylinderVolumeBounds_BB", box);
   ObjTestWriter::writeObj(tPolyhedrons);
@@ -202,14 +203,6 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
   GeometryContext tgContext = GeometryContext();
 
   CutoutCylinderVolumeBounds ccvb(5, 10, 15, 30, 25);
-
-  std::vector<NavigationDirection> refOrientations = {
-      forward,  backward, backward, forward,
-      backward, forward,  forward,  forward};
-
-  auto ccvbOrientations = ccvb.boundaryOrientations();
-
-  BOOST_CHECK(refOrientations == ccvbOrientations);
 
   auto ccvbOrientedSurfaces = ccvb.orientedSurfaces(nullptr);
   BOOST_TEST(ccvbOrientedSurfaces.size(), 8);

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -293,6 +293,35 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   ObjTestWriter::writeObj(tPolyhedrons);
 }
 
+BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
+  GeometryContext tgContext = GeometryContext();
+
+  CylinderVolumeBounds cvb(5, 10, 20);
+
+  std::vector<NavigationDirection> refOrientations = {
+      forward, backward, backward, forward, forward, backward};
+
+  auto cvbOrientations = cvb.boundaryOrientations();
+
+  BOOST_CHECK(refOrientations == cvbOrientations);
+
+  auto cvbOrientedSurfaces = cvb.orientedSurfaces(nullptr);
+  BOOST_TEST(cvbOrientedSurfaces.size(), 4);
+
+  for (auto& os : cvbOrientedSurfaces) {
+    auto geoCtx = GeometryContext();
+    auto onSurface = os.first->binningPosition(geoCtx, binR);
+    auto osNormal = os.first->normal(geoCtx, onSurface);
+    double nDir = (double)os.second;
+    // Check if you step inside the volume with the oriented normal
+    auto insideCvb = onSurface + nDir * osNormal;
+    auto outsideCvb = onSurface - nDir * osNormal;
+
+    BOOST_CHECK(cvb.inside(insideCvb));
+    BOOST_CHECK(!cvb.inside(outsideCvb));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -223,7 +223,7 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
 
 BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
-  std::vector<IdentifiedPolyderon> tPolyhedrons;
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
 
   auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -207,12 +207,12 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsDecomposeToSurfaces,
       transformPtr->rotation().col(2).dot(
           boundarySurfaces.at(1)->normal(tgContext, Acts::Vector2D(0., 0.))),
       1., 1e-12);
-  // negative disc durface should point in negative direction in the frame of
+  // negative disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
       transformPtr->rotation().col(2).dot(
           boundarySurfaces.at(0)->normal(tgContext, Acts::Vector2D(0., 0.))),
-      -1., 1e-12);
+      1., 1e-12);
   // test in r
   CHECK_CLOSE_REL(boundarySurfaces.at(3)->center(tgContext), pos, 1e-12);
   CHECK_CLOSE_REL(boundarySurfaces.at(2)->center(tgContext), pos, 1e-12);

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -33,19 +33,19 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsConstruction) {
 
   // Test different construciton modes: solid
   CylinderVolumeBounds solidCylinder(0., rmax, halfz);
-  BOOST_CHECK_EQUAL(solidCylinder.decomposeToSurfaces().size(), 3);
+  BOOST_CHECK_EQUAL(solidCylinder.orientedSurfaces().size(), 3);
 
   // Test different construciton modes: sectoral solid
   CylinderVolumeBounds solidCylinderSector(0., rmax, halfz, halfphi);
-  BOOST_CHECK_EQUAL(solidCylinderSector.decomposeToSurfaces().size(), 5);
+  BOOST_CHECK_EQUAL(solidCylinderSector.orientedSurfaces().size(), 5);
 
   // Test different construciton modes: tube
   CylinderVolumeBounds tubeCylinder(rmin, rmax, halfz);
-  BOOST_CHECK_EQUAL(tubeCylinder.decomposeToSurfaces().size(), 4);
+  BOOST_CHECK_EQUAL(tubeCylinder.orientedSurfaces().size(), 4);
 
   // Test different construciton modes: sectoral tube
   CylinderVolumeBounds tubeCylinderSector(rmin, rmax, halfz, halfphi);
-  BOOST_CHECK_EQUAL(tubeCylinderSector.decomposeToSurfaces().size(), 6);
+  BOOST_CHECK_EQUAL(tubeCylinderSector.orientedSurfaces().size(), 6);
 
   CylinderVolumeBounds original(rmin, rmax, halfz, halfphi, avgphi);
 
@@ -140,8 +140,8 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsAccess) {
   BOOST_CHECK_EQUAL(cvBounds.get(CylinderVolumeBounds::eAveragePhi), avgphi);
 }
 
-/// Unit test for testing the decomposeToSurfaces() function
-BOOST_DATA_TEST_CASE(CylinderVolumeBoundsDecomposeToSurfaces,
+/// Unit test for testing the orientedSurfaces() function
+BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
                      bdata::random(-M_PI, M_PI) ^ bdata::random(-M_PI, M_PI) ^
                          bdata::random(-M_PI, M_PI) ^ bdata::random(-10., 10.) ^
                          bdata::random(-10., 10.) ^ bdata::random(-10., 10.) ^
@@ -174,21 +174,24 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsDecomposeToSurfaces,
   auto transformPtr =
       std::const_pointer_cast<const Transform3D>(mutableTransformPtr);
   // get the boundary surfaces
-  std::vector<std::shared_ptr<const Acts::Surface>> boundarySurfaces =
-      cylBounds.decomposeToSurfaces(transformPtr.get());
+  auto boundarySurfaces = cylBounds.orientedSurfaces(transformPtr.get());
   // Test
 
   // check if difference is halfZ - sign and direction independent
-  CHECK_CLOSE_REL((pos - boundarySurfaces.at(0)->center(tgContext)).norm(),
-                  cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
-  CHECK_CLOSE_REL((pos - boundarySurfaces.at(1)->center(tgContext)).norm(),
-                  cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
+  CHECK_CLOSE_REL(
+      (pos - boundarySurfaces.at(0).first->center(tgContext)).norm(),
+      cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
+  CHECK_CLOSE_REL(
+      (pos - boundarySurfaces.at(1).first->center(tgContext)).norm(),
+      cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
   // transform to local
-  double posDiscPosZ =
-      (transformPtr->inverse() * boundarySurfaces.at(1)->center(tgContext)).z();
+  double posDiscPosZ = (transformPtr->inverse() *
+                        boundarySurfaces.at(1).first->center(tgContext))
+                           .z();
   double centerPosZ = (transformPtr->inverse() * pos).z();
-  double negDiscPosZ =
-      (transformPtr->inverse() * boundarySurfaces.at(0)->center(tgContext)).z();
+  double negDiscPosZ = (transformPtr->inverse() *
+                        boundarySurfaces.at(0).first->center(tgContext))
+                           .z();
   // check if center of disc boundaries lies in the middle in z
   BOOST_CHECK_LT(centerPosZ, posDiscPosZ);
   BOOST_CHECK_GT(centerPosZ, negDiscPosZ);
@@ -204,32 +207,33 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsDecomposeToSurfaces,
   // positive disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transformPtr->rotation().col(2).dot(
-          boundarySurfaces.at(1)->normal(tgContext, Acts::Vector2D(0., 0.))),
+      transformPtr->rotation().col(2).dot(boundarySurfaces.at(1).first->normal(
+          tgContext, Acts::Vector2D(0., 0.))),
       1., 1e-12);
   // negative disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transformPtr->rotation().col(2).dot(
-          boundarySurfaces.at(0)->normal(tgContext, Acts::Vector2D(0., 0.))),
+      transformPtr->rotation().col(2).dot(boundarySurfaces.at(0).first->normal(
+          tgContext, Acts::Vector2D(0., 0.))),
       1., 1e-12);
   // test in r
-  CHECK_CLOSE_REL(boundarySurfaces.at(3)->center(tgContext), pos, 1e-12);
-  CHECK_CLOSE_REL(boundarySurfaces.at(2)->center(tgContext), pos, 1e-12);
+  CHECK_CLOSE_REL(boundarySurfaces.at(3).first->center(tgContext), pos, 1e-12);
+  CHECK_CLOSE_REL(boundarySurfaces.at(2).first->center(tgContext), pos, 1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
   std::vector<IdentifiedPolyderon> tPolyhedrons;
 
-  auto combineAndDecompose = [&](const SurfacePtrVector& surfaces,
+  auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {
     std::string writeBase = std::string("CylinderVolumeBounds_") + name;
 
     Polyhedron phCombined;
     size_t is = 0;
     for (const auto& sf : surfaces) {
-      Polyhedron phComponent = sf->polyhedronRepresentation(tgContext, 72);
+      Polyhedron phComponent =
+          sf.first->polyhedronRepresentation(tgContext, 72);
       phCombined.merge(phComponent);
       tPolyhedrons.push_back(
           {writeBase + std::string("_comp_") + std::to_string(is++), false,
@@ -241,7 +245,7 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   float tol = 1e-4;
 
   CylinderVolumeBounds cvb(0., 5, 10);
-  auto cvbSurfaces = cvb.decomposeToSurfaces();
+  auto cvbSurfaces = cvb.orientedSurfaces();
   combineAndDecompose(cvbSurfaces, "Solid");
   auto bb = cvb.boundingBox();
   ObjTestWriter::writeObj("CylinderVolumeBounds_Solid_BB", bb);
@@ -263,7 +267,7 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   BOOST_CHECK_EQUAL(bb.entity(), nullptr);
   BOOST_CHECK_EQUAL(bb.max(), Vector3D(8, 8, 12));
   BOOST_CHECK_EQUAL(bb.min(), Vector3D(-8, -8, -12));
-  cvbSurfaces = cvb.decomposeToSurfaces();
+  cvbSurfaces = cvb.orientedSurfaces();
   combineAndDecompose(cvbSurfaces, "Tube");
   ObjTestWriter::writeObj("CylinderVolumeBounds_Tube_BB", bb);
 
@@ -274,7 +278,7 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   CHECK_CLOSE_ABS(bb.max(), Vector3D(8, 8 * std::sin(angle), 13), tol);
   CHECK_CLOSE_ABS(
       bb.min(), Vector3D(5 * std::cos(angle), -8 * std::sin(angle), -13), tol);
-  cvbSurfaces = cvb.decomposeToSurfaces();
+  cvbSurfaces = cvb.orientedSurfaces();
   combineAndDecompose(cvbSurfaces, "TubeSector");
   ObjTestWriter::writeObj("CylinderVolumeBounds_TubeSector_BB", bb);
 
@@ -297,13 +301,6 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
   GeometryContext tgContext = GeometryContext();
 
   CylinderVolumeBounds cvb(5, 10, 20);
-
-  std::vector<NavigationDirection> refOrientations = {
-      forward, backward, backward, forward, forward, backward};
-
-  auto cvbOrientations = cvb.boundaryOrientations();
-
-  BOOST_CHECK(refOrientations == cvbOrientations);
 
   auto cvbOrientedSurfaces = cvb.orientedSurfaces(nullptr);
   BOOST_TEST(cvbOrientedSurfaces.size(), 4);

--- a/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(construction_test) {
   BOOST_CHECK(cubo.inside({2.2, 1, 1}, 0.3));
 }
 
-BOOST_AUTO_TEST_CASE(decomposeToSurfaces) {
+BOOST_AUTO_TEST_CASE(BenericCuboidBoundsOrientedSurfaces) {
   std::array<Vector3D, 8> vertices;
   vertices = {{{0, 0, 0},
                {2, 0, 0},
@@ -73,12 +73,12 @@ BOOST_AUTO_TEST_CASE(decomposeToSurfaces) {
     return false;
   };
 
-  auto surfaces = cubo.decomposeToSurfaces(nullptr);
+  auto surfaces = cubo.orientedSurfaces(nullptr);
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
       Vector3D glob;
-      srf->localToGlobal(gctx, vtx, {}, glob);
+      srf.first->localToGlobal(gctx, vtx, {}, glob);
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(glob, vertices));
     }
@@ -94,12 +94,12 @@ BOOST_AUTO_TEST_CASE(decomposeToSurfaces) {
                {0, 1, 1}}};
   cubo = GenericCuboidVolumeBounds(vertices);
 
-  surfaces = cubo.decomposeToSurfaces(nullptr);
+  surfaces = cubo.orientedSurfaces(nullptr);
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
       Vector3D glob;
-      srf->localToGlobal(gctx, vtx, {}, glob);
+      srf.first->localToGlobal(gctx, vtx, {}, glob);
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(glob, vertices));
     }
@@ -109,12 +109,12 @@ BOOST_AUTO_TEST_CASE(decomposeToSurfaces) {
   trf = Translation3D(Vector3D(0, 8, -5)) *
         AngleAxis3D(M_PI / 3., Vector3D(1, -3, 9).normalized());
 
-  surfaces = cubo.decomposeToSurfaces(&trf);
+  surfaces = cubo.orientedSurfaces(&trf);
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
       Vector3D glob;
-      srf->localToGlobal(gctx, vtx, {}, glob);
+      srf.first->localToGlobal(gctx, vtx, {}, glob);
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(trf.inverse() * glob, vertices));
     }
@@ -195,17 +195,9 @@ BOOST_AUTO_TEST_CASE(GenericCuboidVolumeBoundarySurfaces) {
                {0, 2, 2}}};
 
   GenericCuboidVolumeBounds cubo(vertices);
-  auto gcvbSurfaces = cubo.decomposeToSurfaces(nullptr);
-  BOOST_TEST(gcvbSurfaces.size(), 6);
-
-  auto gcvbOrientations = cubo.boundaryOrientations();
-
-  std::vector<NavigationDirection> refOrientations = {
-      backward, backward, backward, backward, backward, backward};
-
-  BOOST_CHECK(gcvbOrientations == refOrientations);
 
   auto gcvbOrientedSurfaces = cubo.orientedSurfaces(nullptr);
+  BOOST_TEST(gcvbOrientedSurfaces.size(), 6);
 
   for (auto& os : gcvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
@@ -43,7 +43,7 @@ GeometryContext tgContext = GeometryContext();
     CHECK_CLOSE_ABS(VectorHelpers::phi(v), (a), tolerance); \
   }
 
-using SrfVec = SurfacePtrVector;
+using SrfVec = std::vector<std::shared_ptr<const Surface>>;
 
 void draw_surfaces(const SrfVec& surfaces, const std::string& fname) {
   std::ofstream os;
@@ -80,7 +80,8 @@ void draw_surfaces(const SrfVec& surfaces, const std::string& fname) {
 struct LayerCreatorFixture {
   std::shared_ptr<const SurfaceArrayCreator> p_SAC;
   std::shared_ptr<LayerCreator> p_LC;
-  SurfacePtrVector m_surfaces;
+
+  std::vector<std::shared_ptr<const Surface>> m_surfaces;
 
   LayerCreatorFixture() {
     p_SAC = std::make_shared<const SurfaceArrayCreator>(
@@ -234,7 +235,7 @@ struct LayerCreatorFixture {
 BOOST_AUTO_TEST_SUITE(Tools)
 
 BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
-  SurfacePtrVector srf;
+  std::vector<std::shared_ptr<const Surface>> srf;
 
   srf = makeBarrel(30, 7, 2, 1.5);
   draw_surfaces(srf, "LayerCreator_createCylinderLayer_BRL_1.obj");
@@ -327,7 +328,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(LayerCreator_createDiscLayer, LayerCreatorFixture) {
-  SurfacePtrVector surfaces;
+  std::vector<std::shared_ptr<const Surface>> surfaces;
   auto ringa = fullPhiTestSurfacesEC(30, 0, 0, 10);
   surfaces.insert(surfaces.end(), ringa.begin(), ringa.end());
   auto ringb = fullPhiTestSurfacesEC(30, 0, 0, 15);

--- a/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
@@ -50,17 +50,9 @@ BOOST_AUTO_TEST_CASE(bounding_box_creation) {
 BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
   TrapezoidVolumeBounds tvb(5, 10, 8, 4);
 
-  auto tvbSurfaces = tvb.decomposeToSurfaces(nullptr);
-  BOOST_TEST(tvbSurfaces.size(), 6);
-
-  auto tvbOrientations = tvb.boundaryOrientations();
-
-  std::vector<NavigationDirection> refOrientations = {
-      forward, backward, forward, backward, forward, backward};
-
-  BOOST_CHECK(tvbOrientations == refOrientations);
-
   auto tvbOrientedSurfaces = tvb.orientedSurfaces(nullptr);
+  BOOST_TEST(tvbOrientedSurfaces.size(), 6);
+
   for (auto& os : tvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();
     auto osCenter = os.first->center(geoCtx);

--- a/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
@@ -56,7 +56,7 @@ namespace Acts {
 
 using namespace UnitLiterals;
 
-using IdentifiedPolyderon = std::tuple<std::string, bool, Polyhedron>;
+using IdentifiedPolyhedron = std::tuple<std::string, bool, Polyhedron>;
 
 namespace Test {
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_SUITE(Surfaces)
 
 /// Unit tests for Cone Surfaces
 BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double hzpmin = 10_mm;
   double hzpos = 35_mm;
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
   ObjTestWriter::writeSectorPlanesObj("CylinderShiftedSectorPlanes", phiSector,
                                       averagePhi, 1.5 * r, 1.5 * hZ);
 
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   for (const auto& mode : testModes) {
     unsigned int segments = std::get<unsigned int>(mode);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
 
 /// Unit tests for Disc Surfaces
 BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double innerR = 10_mm;
   double outerR = 25_mm;
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
 
 /// Unit tests for Plane Surfaces
 BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double rhX = 10_mm;
   double rhY = 25_mm;

--- a/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   CHECK_CLOSE_REL(value0_xyz, value4_xyz, 1e-10);
 }
 
-/// Unit test for testing the decomposeToSurfaces() function
+/// Unit test for symmetric data
 BOOST_DATA_TEST_CASE(
     bfield_symmetry_random,
     bdata::random(

--- a/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Visualization/IVisualization.hpp"
 
 #include "Acts/Geometry/AbstractVolume.hpp"
+#include "Acts/Geometry/ConeVolumeBounds.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/GenericCuboidVolumeBounds.hpp"
@@ -61,6 +62,58 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   Visualization::drawVolume(helper, *cuboid, gctx, Transform3D::Identity(), 72,
                             triangulate, boxColor);
   write("Volumes_CuboidVolume");
+
+  //----------------------------------------------------
+  // Cone volume section
+  IVisualization::ColorType coneColor = {255, 171, 3};
+
+  // Single solid Cone
+  auto solidCone =
+      std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 5., 5., 0., M_PI);
+  auto cone = std::make_shared<AbstractVolume>(identity, solidCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeSolid");
+
+  // Single solid Cone - with cut off
+  auto cutOffCone =
+      std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 8., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeSolidCutOff");
+
+  // Cone - Cone inlay
+  auto cutOffHollowCone =
+      std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5, 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeCone");
+
+  // Sectoral Cone - Cone inlay
+  auto cutOffHollowSectoralCone =
+      std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5., 0., 0.456);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowSectoralCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeConeSectoral");
+
+  // Single Hollow Cone - cylindrical inlay
+  auto cutOffHollowCylCone =
+      std::make_shared<ConeVolumeBounds>(1., 0.45, 8., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCylCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeCylinder");
+
+  // Single Hollow Cylinder - Cone inlay
+  auto cutOffHollowConeCyl =
+      std::make_shared<ConeVolumeBounds>(12., 0.35, 7., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowConeCyl);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeCylinderCone");
 
   //----------------------------------------------------
   // Cylinder volume section


### PR DESCRIPTION
This PR introduces `ConeVolumeBounds` in almost all varieties:

- [x] solid cone
- [x] cut off cone
- [x] hollow cone-cone (cone inside a cone)
- [x] hollow cone-cylinder (cylinder cutout of a cone)
- [x] hollow cylinder-cone (cone cutout of a cylinder)

It relies on #196 to be merged in.