### PR TITLE
Introducing ConeVolumeBounds

### DIFF
--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -113,7 +113,7 @@ class ConeVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D* transform = nullptr) const final;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform
@@ -149,7 +149,7 @@ class ConeVolumeBounds : public VolumeBounds {
   /// Output Method for std::ostream
   ///
   /// @param sl is ostream operator to be dumped into
-  std::ostream& toStream(std::ostream& sl) const override;
+  std::ostream& toStream(std::ostream& sl) const final;
 
  private:
   /// Check the input values for consistency,

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -1,0 +1,228 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/Volume.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+
+#include <cmath>
+
+namespace Acts {
+
+class Surface;
+class CylinderBounds;
+class ConeBounds;
+class RadialBounds;
+class PlanarBounds;
+class Volume;
+
+/// @class ConeVolumeBounds
+///
+/// Volume bound class for describing conical volumes
+/// either with cylindrical inlay or outer boundary, it also allows
+/// for a sectoral description
+class ConeVolumeBounds : public VolumeBounds {
+ public:
+  /// @enum BoundValues for readability
+  enum BoundValues : unsigned int {
+    eInnerAlpha = 0,
+    eInnerOffsetZ = 1,
+    eOuterAlpha = 2,
+    eOuterOffsetZ = 3,
+    eHalfLengthZ = 4,
+    eAveragePhi = 5,
+    eHalfPhiSector = 6,
+    eSize = 7
+  };
+
+  ConeVolumeBounds() = delete;
+
+  /// Constructor - for general cone-cone setups
+  ///
+  /// @param innerAlpha The opening angle of the inner cone (0 if no cone)
+  /// @param innerOffsetZ The tip  z position in of the inner cone, w.r.t center
+  /// @param outerAlpha  The opening angle of the outer cone (0 if no cone)
+  /// @param outerOffsetZ The tip  z position in of the outer cone, w.r.t center
+  /// @param halflengthZ The minimum z value of the inner and outer cones
+  /// @param avergePhi The phi orientation of the sector
+  /// @param halfPhiSector The opening angle phi sector
+  ConeVolumeBounds(double innerAlpha, double innerTipZ, double outerAlpha,
+                   double outerOffsetZ, double halflengthZ, double averagePhi,
+                   double halfPhiSector) noexcept(false);
+
+  /// Constructor - for general cylidner-cone setups
+  ///
+  /// @param cylinderR The inner radius of the cylinder
+  /// @param alpha  The opening angle of the cone (0 if no cone)
+  /// @param offsetZ The tip  z position in of the cone, w.r.t center
+  /// @param halflengthZ The minimum z value of the inner and outer cones
+  /// @param avergePhi The phi orientation of the sector (defaulted to 0)
+  /// @param halfPhiSector The opening angle phi sector
+  ///
+  /// @note depending on cylinderR > coneR it is constructing a cone with
+  /// cylindrical cutout or a cylinder with conical cutout
+  ConeVolumeBounds(double cylinderR, double alpha, double offsetZ,
+                   double halflengthZ, double averagePhi,
+                   double halfPhiSector) noexcept(false);
+
+  /// Constructor - from a fixed size array
+  ///
+  /// @param values The bound values
+  ConeVolumeBounds(const std::array<double, eSize>& values) noexcept(false)
+      : m_values(values) {
+    checkConsistency();
+    buildSurfaceBounds();
+  }
+
+  ConeVolumeBounds(const ConeVolumeBounds& cobo) = default;
+
+  ~ConeVolumeBounds() override = default;
+
+  ConeVolumeBounds& operator=(const ConeVolumeBounds& cobo) = default;
+
+  VolumeBounds::BoundsType type() const final { return VolumeBounds::eCone; }
+
+  /// Return the bound values as dynamically sized vector
+  ///
+  /// @return this returns a copy of the internal values
+  std::vector<double> values() const final;
+
+  /// This method checks if position in the 3D volume
+  /// frame is inside the cylinder
+  ///
+  /// @param pos is the position in volume frame to be checked
+  /// @param tol is the absolute tolerance to be applied
+  bool inside(const Vector3D& pos, double tol = 0.) const final;
+
+  /// Oriented surfaces, i.e. the decomposed boundary surfaces and the
+  /// according navigation direction into the volume given the normal
+  /// vector on the surface
+  ///
+  /// @param transform is the 3D transform to be applied to the boundary
+  /// surfaces to position them in 3D space
+  ///
+  /// It will throw an exception if the orientation prescription is not adequate
+  ///
+  /// @return a vector of surfaces bounding this volume
+  OrientedSurfaces orientedSurfaces(
+      const Transform3D* transform = nullptr) const override;
+
+  /// Construct bounding box for this shape
+  /// @param trf Optional transform
+  /// @param envelope Optional envelope to add / subtract from min/max
+  /// @param entity Entity to associate this bounding box with
+  /// @return Constructed bounding box
+  Volume::BoundingBox boundingBox(const Transform3D* trf = nullptr,
+                                  const Vector3D& envelope = {0, 0, 0},
+                                  const Volume* entity = nullptr) const final;
+
+  /// Access to the bound values
+  /// @param bValue the class nested enum for the array access
+  double get(BoundValues bValue) const { return m_values[bValue]; }
+
+  // Return the derived innerRmin
+  double innerRmin() const;
+
+  // Return the derived innerRmin
+  double innerRmax() const;
+
+  // Return the derived inner tan(alpha)
+  double innerTanAlpha() const;
+
+  // Return the derived outerRmin
+  double outerRmin() const;
+
+  // Return the derived outerRmax
+  double outerRmax() const;
+
+  // Return the derived outer tan(alpha)
+  double outerTanAlpha() const;
+
+  /// Output Method for std::ostream
+  ///
+  /// @param sl is ostream operator to be dumped into
+  std::ostream& toStream(std::ostream& sl) const override;
+
+ private:
+  /// Check the input values for consistency,
+  /// will throw a logic_exception if consistency is not given
+  void checkConsistency() noexcept(false);
+
+  /// Create the surface bounds
+  void buildSurfaceBounds();
+
+  /// Templated dump methos
+  /// @tparam stream_t The type of the stream for dumping
+  /// @param dt The stream object
+  template <class stream_t>
+  stream_t& dumpT(stream_t& dt) const;
+
+  /// The bound values
+  std::array<double, eSize> m_values;
+  std::shared_ptr<CylinderBounds> m_innerCylinderBounds{nullptr};
+  std::shared_ptr<ConeBounds> m_innerConeBounds{nullptr};
+  std::shared_ptr<ConeBounds> m_outerConeBounds{nullptr};
+  std::shared_ptr<CylinderBounds> m_outerCylinderBounds{nullptr};
+  std::shared_ptr<RadialBounds> m_negativeDiscBounds{nullptr};
+  std::shared_ptr<RadialBounds> m_positiveDiscBounds{nullptr};
+  std::shared_ptr<PlanarBounds> m_sectorBounds{nullptr};
+
+  /// Derived values
+  double m_innerRmin = 0.;
+  double m_innerRmax = 0.;
+  double m_innerTanAlpha = 0.;
+  double m_outerRmin = 0.;
+  double m_outerRmax = 0.;
+  double m_outerTanAlpha = 0.;
+};
+
+inline double ConeVolumeBounds::innerRmin() const {
+  return m_innerRmin;
+}
+
+inline double ConeVolumeBounds::innerRmax() const {
+  return m_innerRmax;
+}
+
+inline double ConeVolumeBounds::innerTanAlpha() const {
+  return m_innerTanAlpha;
+}
+
+inline double ConeVolumeBounds::outerRmin() const {
+  return m_outerRmin;
+}
+
+inline double ConeVolumeBounds::outerRmax() const {
+  return m_outerRmax;
+}
+
+inline double ConeVolumeBounds::outerTanAlpha() const {
+  return m_outerTanAlpha;
+};
+
+inline std::vector<double> ConeVolumeBounds::values() const {
+  std::vector<double> valvector;
+  valvector.insert(valvector.begin(), m_values.begin(), m_values.end());
+  return valvector;
+}
+
+template <class stream_t>
+stream_t& ConeVolumeBounds::dumpT(stream_t& dt) const {
+  dt << std::setiosflags(std::ios::fixed);
+  dt << std::setprecision(5);
+  dt << "Acts::ConeVolumeBounds : (innerAlpha, innerOffsetZ, outerAlpha,";
+  dt << "  outerOffsetZ, halflenghZ, averagePhi, halfPhiSector) = ";
+  dt << get(eInnerAlpha) << ", " << get(eInnerOffsetZ) << ", ";
+  dt << get(eOuterAlpha) << ", " << get(eOuterOffsetZ) << ", ";
+  dt << get(eHalfLengthZ) << ", " << get(eAveragePhi) << std::endl;
+  return dt;
+}
+}  // namespace Acts

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -40,7 +40,7 @@ class ConeVolumeBounds : public VolumeBounds {
     eHalfLengthZ = 4,
     eAveragePhi = 5,
     eHalfPhiSector = 6,
-    eSize = 7
+    eSize
   };
 
   ConeVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -47,7 +47,7 @@ class Surface;
 class CuboidVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
-  enum BoundValues : int {
+  enum BoundValues : unsigned int {
     eHalfLengthX = 0,
     eHalfLengthY = 1,
     eHalfLengthZ = 2,
@@ -120,14 +120,14 @@ class CuboidVolumeBounds : public VolumeBounds {
                                   const Vector3D& envelope = {0, 0, 0},
                                   const Volume* entity = nullptr) const final;
 
+  /// Access to the bound values
+  /// @param bValue the class nested enum for the array access
+  double get(BoundValues bValue) const { return m_values[bValue]; }
+
   /// Output Method for std::ostream
   ///
   /// @param sl is ostream operator to be dumped into
   std::ostream& toStream(std::ostream& sl) const override;
-
-  /// Access to the bound values
-  /// @param bValue the class nested enum for the array access
-  double get(BoundValues bValue) const { return m_values[bValue]; }
 
  private:
   /// Templated dumpT method

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -51,7 +51,7 @@ class CuboidVolumeBounds : public VolumeBounds {
     eHalfLengthX = 0,
     eHalfLengthY = 1,
     eHalfLengthZ = 2,
-    eSize = 3
+    eSize
   };
 
   CuboidVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -46,7 +46,7 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
     eMaxR = 2,
     eHalfLengthZ = 3,
     eHalfLengthZcutout = 4,
-    eSize = 5
+    eSize
   };
 
   CutoutCylinderVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -78,7 +78,7 @@ class CylinderVolumeBounds : public VolumeBounds {
     eHalfLengthZ = 2,
     eHalfPhiSector = 3,
     eAveragePhi = 4,
-    eSize = 5
+    eSize
   };
 
   CylinderVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -72,7 +72,7 @@ class IVisualization;
 class CylinderVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for streaming and access
-  enum BoundValues {
+  enum BoundValues : unsigned int {
     eMinR = 0,
     eMaxR = 1,
     eHalfLengthZ = 2,

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -54,7 +54,7 @@ class TrapezoidVolumeBounds : public VolumeBounds {
     eHalfLengthZ = 3,      //!< halflength in z
     eAlpha = 4,            //!< opening angle alpha (in point A)
     eBeta = 5,             //!< opening angle beta  (in point B)
-    eSize = 6              //!< length of the bounds vector
+    eSize                  //!< length of the bounds vector
   };
 
   TrapezoidVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -47,7 +47,7 @@ class TrapezoidBounds;
 class TrapezoidVolumeBounds : public VolumeBounds {
  public:
   /// @enum BoundValues for acces / streaming
-  enum BoundValues {
+  enum BoundValues : unsigned int {
     eHalfLengthXnegY = 0,  //!< halflength in x at negative y
     eHalfLengthXposY = 1,  //!< halflength in x at positive y
     eHalfLengthY = 2,      //!< halflength in y

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.ipp
@@ -8,44 +8,6 @@
 
 #include "Acts/Utilities/ThrowAssert.hpp"
 
-std::ostream& Acts::ConvexPolygonBoundsBase::toStream(std::ostream& sl) const {
-  std::vector<Vector2D> vtxs = vertices();
-  sl << "Acts::ConvexPolygonBounds<" << vtxs.size() << ">: vertices: [x, y]\n";
-  for (size_t i = 0; i < vtxs.size(); i++) {
-    const auto& vtx = vtxs[i];
-    if (i > 0) {
-      sl << ",";
-      sl << "\n";
-    }
-    sl << "[" << vtx.x() << ", " << vtx.y() << "]";
-  }
-  return sl;
-}
-
-template <typename coll_t>
-Acts::RectangleBounds Acts::ConvexPolygonBoundsBase::makeBoundingBox(
-    const coll_t& vertices) {
-  Vector2D vmax, vmin;
-  vmax = vertices[0];
-  vmin = vertices[0];
-
-  for (size_t i = 1; i < vertices.size(); i++) {
-    vmax = vmax.cwiseMax(vertices[i]);
-    vmin = vmin.cwiseMin(vertices[i]);
-  }
-
-  return {vmin, vmax};
-}
-
-std::vector<double> Acts::ConvexPolygonBoundsBase::values() const {
-  std::vector<double> values;
-  for (const auto& vtx : vertices()) {
-    values.push_back(vtx.x());
-    values.push_back(vtx.y());
-  }
-  return values;
-}
-
 template <typename coll_t>
 void Acts::ConvexPolygonBoundsBase::convex_impl(
     const coll_t& vertices) noexcept(false) {
@@ -84,6 +46,21 @@ void Acts::ConvexPolygonBoundsBase::convex_impl(
       }
     }
   }
+}
+
+template <typename coll_t>
+Acts::RectangleBounds Acts::ConvexPolygonBoundsBase::makeBoundingBox(
+    const coll_t& vertices) {
+  Vector2D vmax, vmin;
+  vmax = vertices[0];
+  vmin = vertices[0];
+
+  for (size_t i = 1; i < vertices.size(); i++) {
+    vmax = vmax.cwiseMax(vertices[i]);
+    vmin = vmin.cwiseMin(vertices[i]);
+  }
+
+  return {vmin, vmax};
 }
 
 template <int N>
@@ -146,40 +123,5 @@ const Acts::RectangleBounds& Acts::ConvexPolygonBounds<N>::boundingBox() const {
 
 template <int N>
 void Acts::ConvexPolygonBounds<N>::checkConsistency() const noexcept(false) {
-  convex_impl(m_vertices);
-}
-
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::ConvexPolygonBounds(
-    const std::vector<Vector2D>& vertices)
-    : m_vertices(vertices.begin(), vertices.end()),
-      m_boundingBox(makeBoundingBox(vertices)) {}
-
-Acts::SurfaceBounds::BoundsType
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::type() const {
-  return SurfaceBounds::eConvexPolygon;
-}
-
-bool Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::inside(
-    const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
-  return bcheck.isInside(lposition, m_vertices);
-}
-
-double Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::distanceToBoundary(
-    const Acts::Vector2D& lposition) const {
-  return BoundaryCheck(true).distance(lposition, m_vertices);
-}
-
-std::vector<Acts::Vector2D> Acts::ConvexPolygonBounds<
-    Acts::PolygonDynamic>::vertices(unsigned int /*lseg*/) const {
-  return {m_vertices.begin(), m_vertices.end()};
-}
-
-const Acts::RectangleBounds&
-Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::boundingBox() const {
-  return m_boundingBox;
-}
-
-void Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::checkConsistency() const
-    noexcept(false) {
   convex_impl(m_vertices);
 }

--- a/Core/src/Geometry/CMakeLists.txt
+++ b/Core/src/Geometry/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources_local(
     AbstractVolume.cpp
     BinUtility.cpp
     ConeLayer.cpp
+    ConeVolumeBounds.cpp
     CuboidVolumeBounds.cpp
     CuboidVolumeBuilder.cpp
     CutoutCylinderVolumeBounds.cpp

--- a/Core/src/Surfaces/CMakeLists.txt
+++ b/Core/src/Surfaces/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources_local(
     AnnulusBounds.cpp
     ConeBounds.cpp
     ConeSurface.cpp
+    ConvexPolygonBounds.cpp
     CylinderBounds.cpp
     CylinderSurface.cpp
     DiamondBounds.cpp

--- a/Core/src/Surfaces/ConvexPolygonBounds.cpp
+++ b/Core/src/Surfaces/ConvexPolygonBounds.cpp
@@ -1,0 +1,67 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Surfaces/ConvexPolygonBounds.hpp"
+
+std::ostream& Acts::ConvexPolygonBoundsBase::toStream(std::ostream& sl) const {
+  std::vector<Vector2D> vtxs = vertices();
+  sl << "Acts::ConvexPolygonBounds<" << vtxs.size() << ">: vertices: [x, y]\n";
+  for (size_t i = 0; i < vtxs.size(); i++) {
+    const auto& vtx = vtxs[i];
+    if (i > 0) {
+      sl << ",";
+      sl << "\n";
+    }
+    sl << "[" << vtx.x() << ", " << vtx.y() << "]";
+  }
+  return sl;
+}
+
+std::vector<double> Acts::ConvexPolygonBoundsBase::values() const {
+  std::vector<double> values;
+  for (const auto& vtx : vertices()) {
+    values.push_back(vtx.x());
+    values.push_back(vtx.y());
+  }
+  return values;
+}
+
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::ConvexPolygonBounds(
+    const std::vector<Vector2D>& vertices)
+    : m_vertices(vertices.begin(), vertices.end()),
+      m_boundingBox(makeBoundingBox(vertices)) {}
+
+Acts::SurfaceBounds::BoundsType
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::type() const {
+  return SurfaceBounds::eConvexPolygon;
+}
+
+bool Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::inside(
+    const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
+  return bcheck.isInside(lposition, m_vertices);
+}
+
+double Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::distanceToBoundary(
+    const Acts::Vector2D& lposition) const {
+  return BoundaryCheck(true).distance(lposition, m_vertices);
+}
+
+std::vector<Acts::Vector2D> Acts::ConvexPolygonBounds<
+    Acts::PolygonDynamic>::vertices(unsigned int /*lseg*/) const {
+  return {m_vertices.begin(), m_vertices.end()};
+}
+
+const Acts::RectangleBounds&
+Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::boundingBox() const {
+  return m_boundingBox;
+}
+
+void Acts::ConvexPolygonBounds<Acts::PolygonDynamic>::checkConsistency() const
+    noexcept(false) {
+  convex_impl(m_vertices);
+}

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/ObjTestWriter.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/ObjTestWriter.hpp
@@ -19,7 +19,7 @@
 
 namespace Acts {
 
-using IdentifiedPolyderon = std::tuple<std::string, bool, Polyhedron>;
+using IdentifiedPolyhedron = std::tuple<std::string, bool, Polyhedron>;
 
 namespace Test {
 
@@ -87,7 +87,7 @@ struct ObjTestWriter {
   /// It will draw the polyhedron and create a file, the boolean
   /// steers whether the obj should be triangulated
   /// @param iphs The Identified Polyhedrons (= with name and boolean)
-  static void writeObj(const std::vector<IdentifiedPolyderon>& iphs) {
+  static void writeObj(const std::vector<IdentifiedPolyhedron>& iphs) {
     for (const auto& iph : iphs) {
       std::ofstream ostream;
       ostream.open(std::get<std::string>(iph) + ".obj");

--- a/Tests/UnitTests/Core/Geometry/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Geometry/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_unittest(AlignmentContextTests AlignmentContextTests.cpp)
+add_unittest(ConeVolumeBoundsTests ConeVolumeBoundsTests.cpp)
 add_unittest(CuboidVolumeBoundsTests CuboidVolumeBoundsTests.cpp)
 add_unittest(CuboidVolumeBuilderTests CuboidVolumeBuilderTests.cpp)
 add_unittest(CutoutCylinderVolumeBoundsTests CutoutCylinderVolumeBoundsTests.cpp)

--- a/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
@@ -83,6 +83,28 @@ BOOST_AUTO_TEST_CASE(ConeVolumeBoundsTests) {
   BOOST_TEST(cutOffHollowConeCylSurfaces.size() == 4);
 }
 
+BOOST_AUTO_TEST_CASE(ConeVolumeBoundsSurfaceOrientation) {
+  GeometryContext tgContext = GeometryContext();
+
+  ConeVolumeBounds hcone(10_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
+
+  auto cvbOrientedSurfaces = hcone.orientedSurfaces(nullptr);
+  BOOST_TEST(cvbOrientedSurfaces.size(), 4);
+
+  auto geoCtx = GeometryContext();
+  Vector3D xaxis(1., 0., 0.);
+  Vector3D yaxis(0., 1., 0.);
+  Vector3D zaxis(0., 0., 1.);
+
+  for (auto& os : cvbOrientedSurfaces) {
+    // Test the orientation of the boundary surfaces
+    auto rot = os.first->transform(geoCtx).rotation();
+    BOOST_CHECK(rot.col(0).isApprox(xaxis));
+    BOOST_CHECK(rot.col(1).isApprox(yaxis));
+    BOOST_CHECK(rot.col(2).isApprox(zaxis));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
@@ -1,0 +1,90 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Geometry/ConeVolumeBounds.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Tests/CommonHelpers/ObjTestWriter.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Units.hpp"
+
+namespace tt = boost::test_tools;
+
+namespace Acts {
+
+using namespace UnitLiterals;
+
+// Create a test context
+GeometryContext tgContext = GeometryContext();
+
+namespace Test {
+
+BOOST_AUTO_TEST_SUITE(VolumeBounds)
+
+BOOST_AUTO_TEST_CASE(ConeVolumeBoundsTests) {
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
+
+  // Single solid Cone
+  ConeVolumeBounds solidCone(0., 0., 0.45, 50_mm, 50_mm, 0., M_PI);
+
+  // Test correct parameter return
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eInnerAlpha) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eInnerOffsetZ) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eOuterAlpha) == 0.45);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eOuterOffsetZ) == 50.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eHalfLengthZ) == 50.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eAveragePhi) == 0.);
+  BOOST_TEST(solidCone.get(ConeVolumeBounds::eHalfPhiSector) == M_PI);
+  // Derived quantities
+  BOOST_TEST(solidCone.innerTanAlpha() == 0.);
+  BOOST_TEST(solidCone.innerRmin() == 0.);
+  BOOST_TEST(solidCone.innerRmax() == 0.);
+  BOOST_TEST(solidCone.outerTanAlpha() == std::tan(0.45));
+
+  double outerRmax = 100_mm * solidCone.outerTanAlpha();
+  BOOST_TEST(solidCone.outerRmin() == 0.);
+  BOOST_TEST(solidCone.outerRmax() == outerRmax);
+
+  auto solidConeSurfaces = solidCone.orientedSurfaces();
+  BOOST_TEST(solidConeSurfaces.size() == 2);
+
+  // Single solid Cone - with cut off
+  ConeVolumeBounds cutOffCone(0., 0., 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffConeSurfaces = cutOffCone.orientedSurfaces();
+  BOOST_TEST(cutOffConeSurfaces.size() == 3);
+
+  // Cone - Cone inlay
+  ConeVolumeBounds cutOffHollowCone(0.35, 70_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowConeSurfaces = cutOffHollowCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowConeSurfaces.size() == 4);
+
+  // Sectoral Cone - Cone inlay
+  ConeVolumeBounds cutOffHollowSectoralCone(0.35, 70_mm, 0.45, 80_mm, 50_mm, 0.,
+                                            0.456);
+  auto cutOffHollowSectoralConeSurfaces =
+      cutOffHollowSectoralCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowSectoralConeSurfaces.size() == 6);
+
+  // Sectoral Cone - Hollow Cone
+  ConeVolumeBounds cutOffHollowCylCone(10_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowCylConeSurfaces = cutOffHollowCylCone.orientedSurfaces();
+  BOOST_TEST(cutOffHollowCylConeSurfaces.size() == 4);
+
+  // Single Hollow Cylinder - Cone inlay
+  ConeVolumeBounds cutOffHollowConeCyl(120_mm, 0.35, 70_mm, 50_mm, 0., M_PI);
+  auto cutOffHollowConeCylSurfaces = cutOffHollowConeCyl.orientedSurfaces();
+  BOOST_TEST(cutOffHollowConeCylSurfaces.size() == 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace Test
+
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsInside) {
 
 BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
-  std::vector<IdentifiedPolyderon> tPolyhedrons;
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
 
   auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   ObjTestWriter::writeObj(tPolyhedrons);
 }
 
-BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
+BOOST_AUTO_TEST_CASE(CylinderVolumeOrientedBoundaries) {
   GeometryContext tgContext = GeometryContext();
 
   CylinderVolumeBounds cvb(5, 10, 20);

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -223,7 +223,7 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
 
 BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
   GeometryContext tgContext = GeometryContext();
-  std::vector<IdentifiedPolyderon> tPolyhedrons;
+  std::vector<IdentifiedPolyhedron> tPolyhedrons;
 
   auto combineAndDecompose = [&](const OrientedSurfaces& surfaces,
                                  const std::string& name) -> void {

--- a/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
@@ -56,7 +56,7 @@ namespace Acts {
 
 using namespace UnitLiterals;
 
-using IdentifiedPolyderon = std::tuple<std::string, bool, Polyhedron>;
+using IdentifiedPolyhedron = std::tuple<std::string, bool, Polyhedron>;
 
 namespace Test {
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_SUITE(Surfaces)
 
 /// Unit tests for Cone Surfaces
 BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double hzpmin = 10_mm;
   double hzpos = 35_mm;
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
   ObjTestWriter::writeSectorPlanesObj("CylinderShiftedSectorPlanes", phiSector,
                                       averagePhi, 1.5 * r, 1.5 * hZ);
 
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   for (const auto& mode : testModes) {
     unsigned int segments = std::get<unsigned int>(mode);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
 
 /// Unit tests for Disc Surfaces
 BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double innerR = 10_mm;
   double outerR = 25_mm;
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
 
 /// Unit tests for Plane Surfaces
 BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
-  std::vector<IdentifiedPolyderon> testTypes;
+  std::vector<IdentifiedPolyhedron> testTypes;
 
   double rhX = 10_mm;
   double rhY = 25_mm;

--- a/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Visualization/IVisualization.hpp"
 
 #include "Acts/Geometry/AbstractVolume.hpp"
+#include "Acts/Geometry/ConeVolumeBounds.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/GenericCuboidVolumeBounds.hpp"
@@ -61,6 +62,58 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   Visualization::drawVolume(helper, *cuboid, gctx, Transform3D::Identity(), 72,
                             triangulate, boxColor);
   write("Volumes_CuboidVolume");
+
+  //----------------------------------------------------
+  // Cone volume section
+  IVisualization::ColorType coneColor = {255, 171, 3};
+
+  // Single solid Cone
+  auto solidCone =
+      std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 5., 5., 0., M_PI);
+  auto cone = std::make_shared<AbstractVolume>(identity, solidCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeSolid");
+
+  // Single solid Cone - with cut off
+  auto cutOffCone =
+      std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 8., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeSolidCutOff");
+
+  // Cone - Cone inlay
+  auto cutOffHollowCone =
+      std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5, 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeCone");
+
+  // Sectoral Cone - Cone inlay
+  auto cutOffHollowSectoralCone =
+      std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5., 0., 0.456);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowSectoralCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeConeSectoral");
+
+  // Single Hollow Cone - cylindrical inlay
+  auto cutOffHollowCylCone =
+      std::make_shared<ConeVolumeBounds>(1., 0.45, 8., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCylCone);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeConeCylinder");
+
+  // Single Hollow Cylinder - Cone inlay
+  auto cutOffHollowConeCyl =
+      std::make_shared<ConeVolumeBounds>(12., 0.35, 7., 5., 0., M_PI);
+  cone = std::make_shared<AbstractVolume>(identity, cutOffHollowConeCyl);
+  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
+                            triangulate, coneColor);
+  write("Volumes_ConeVolumeCylinderCone");
 
   //----------------------------------------------------
   // Cylinder volume section


### PR DESCRIPTION
Cherry-pick of `ConeBounds` introduction.

It replaces #198 (more information there).

Despite having introducing `ConeBounds` it also fixes a bug & a spelling mistake:
- [x] the ConvexPolygonBounds had non-inlined code in the `.ipp` which gave a linking error in the `ConeVolumeBounds` (and thus is needed by this PR)
- [x] the `Polyhedron` was misspelled in several places

Unfortunately I do not have separate commits for the latter, but I think the changes are still limited.
