### PR TITLE
Use template for source link container in CKF

### DIFF
--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -1141,8 +1141,8 @@ class CombinatorialKalmanFilter {
   findTracks(const source_link_container_t& sourcelinks,
              const start_parameters_t& sParameters,
              const comb_kalman_filter_options_t& tfOptions) const {
-    using source_link_t = typename source_link_container_t::value_type;
-    static_assert(SourceLinkConcept<source_link_t>,
+    using SourceLink = typename source_link_container_t::value_type;
+    static_assert(SourceLinkConcept<SourceLink>,
                   "Source link does not fulfill SourceLinkConcept");
 
     static_assert(
@@ -1156,7 +1156,7 @@ class CombinatorialKalmanFilter {
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyways, so the map can own them.
     ACTS_VERBOSE("Preparing " << sourcelinks.size() << " input measurements");
-    std::unordered_map<const Surface*, std::vector<source_link_t>>
+    std::unordered_map<const Surface*, std::vector<SourceLink>>
         inputMeasurements;
     for (const auto& sl : sourcelinks) {
       const Surface* srf = &sl.referenceSurface();
@@ -1164,9 +1164,8 @@ class CombinatorialKalmanFilter {
     }
 
     // Create the ActionList and AbortList
-    using CombinatorialKalmanFilterAborter =
-        Aborter<source_link_t, parameters_t>;
-    using CombinatorialKalmanFilterActor = Actor<source_link_t, parameters_t>;
+    using CombinatorialKalmanFilterAborter = Aborter<SourceLink, parameters_t>;
+    using CombinatorialKalmanFilterActor = Actor<SourceLink, parameters_t>;
     using CombinatorialKalmanFilterResult =
         typename CombinatorialKalmanFilterActor::result_type;
     using Actors = ActionList<CombinatorialKalmanFilterActor>;

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -1117,8 +1117,7 @@ class CombinatorialKalmanFilter {
   /// Fit implementation of the foward filter, calls the
   /// the forward filter and backward smoother
   ///
-  /// @tparam source_link_t Source link type identifying uncalibrated input
-  /// measurements.
+  /// @tparam source_link_container_t Source link container type
   /// @tparam start_parameters_t Type of the initial parameters
   /// @tparam comb_kalman_filter_options_t Type of the CombinatorialKalmanFilter
   /// options
@@ -1134,13 +1133,15 @@ class CombinatorialKalmanFilter {
   /// the track finding.
   ///
   /// @return the output as an output track
-  template <typename source_link_t, typename start_parameters_t,
+  template <typename source_link_container_t, typename start_parameters_t,
             typename comb_kalman_filter_options_t,
             typename parameters_t = BoundParameters>
-  Result<CombinatorialKalmanFilterResult<source_link_t>> findTracks(
-      const std::vector<source_link_t>& sourcelinks,
-      const start_parameters_t& sParameters,
-      const comb_kalman_filter_options_t& tfOptions) const {
+  Result<CombinatorialKalmanFilterResult<
+      typename source_link_container_t::value_type>>
+  findTracks(const source_link_container_t& sourcelinks,
+             const start_parameters_t& sParameters,
+             const comb_kalman_filter_options_t& tfOptions) const {
+    using source_link_t = typename source_link_container_t::value_type;
     static_assert(SourceLinkConcept<source_link_t>,
                   "Source link does not fulfill SourceLinkConcept");
 

--- a/Examples/Algorithms/TrackFinding/include/ACTFW/TrackFinding/TrackFindingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ACTFW/TrackFinding/TrackFindingAlgorithm.hpp
@@ -31,7 +31,7 @@ class TrackFindingAlgorithm final : public BareAlgorithm {
   using CKFOptions =
       Acts::CombinatorialKalmanFilterOptions<Acts::CKFSourceLinkSelector>;
   using TrackFinderFunction = std::function<TrackFinderResult(
-      const std::vector<SimSourceLink>&, const TrackParameters&,
+      const SimSourceLinkContainer&, const TrackParameters&,
       const CKFOptions&)>;
 
   /// Create the track finder function implementation.

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -45,15 +45,6 @@ FW::ProcessCode FW::TrackFindingAlgorithm::execute(
   auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
       Acts::Vector3D{0., 0., 0.});
 
-  // Prepare input measurements for CKF which takes all measurements in one
-  // event. NB: The conversion from boost::flat_multiset to std::vector is
-  // performed below
-  std::vector<SimSourceLink> trackSourceLinks;
-  trackSourceLinks.reserve(sourceLinks.size());
-  for (const auto& sl : sourceLinks) {
-    trackSourceLinks.push_back(sl);
-  }
-
   // Perform the track finding for each starting parameter
   // @TODO: use seeds from track seeding algorithm as starting parameter
   for (std::size_t iseed = 0; iseed < initialParameters.size(); ++iseed) {
@@ -65,7 +56,7 @@ FW::ProcessCode FW::TrackFindingAlgorithm::execute(
         m_cfg.sourcelinkSelectorCfg, &(*pSurface));
 
     ACTS_DEBUG("Invoke track finding seeded by truth particle " << iseed);
-    auto result = m_cfg.findTracks(trackSourceLinks, initialParams, ckfOptions);
+    auto result = m_cfg.findTracks(sourceLinks, initialParams, ckfOptions);
     if (result.ok()) {
       // Get the track finding output object
       const auto& trackFindingOutput = result.value();

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmTrackFinderFunction.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmTrackFinderFunction.cpp
@@ -29,7 +29,7 @@ struct TrackFinderFunctionImpl {
   TrackFinderFunctionImpl(TrackFinder&& f) : trackFinder(std::move(f)) {}
 
   FW::TrackFindingAlgorithm::TrackFinderResult operator()(
-      const std::vector<FW::SimSourceLink>& sourceLinks,
+      const FW::SimSourceLinkContainer& sourceLinks,
       const FW::TrackParameters& initialParameters,
       const Acts::CombinatorialKalmanFilterOptions<Acts::CKFSourceLinkSelector>&
           options) const {


### PR DESCRIPTION
This PR makes the CKF templated on the source link container (instead of using `std::vector`).
This could avoid redundant container conversion from `boost::flat_multiset` to `std::vector`.