### PR TITLE
Faster local documentation builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Configure
         run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
       - name: Build
-        run: cmake --build build -- docs
+        run: cmake --build build -- docs-with-api
       - uses: actions/upload-artifact@v2
         with:
           name: acts-docs

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,47 +1,71 @@
 # to be compatible with readthedocs.org, the documentation build is always
-# in-source (as opposed to the configurable out-of-source build directory for
-# the code) and is fully driven by the sphinx tool. Doxygen (to extract the
-# source code ) is called automatically by sphinx as well. That also means
-# that the CMake dependency handling does not apply and is ignored here.
+# in-source; as opposed to the configurable out-of-source build directory for
+# the code. when running running on readthedocs.org, the build is fully driven
+# by Sphinx, including running Doxygen.
+#
+# this CMake-based build is only intended for local development. Doxygen is
+# run separate from Sphinx to avoid running it when no code has change. since
+# the full documentation with automatic generation of API docs take O(10mins)
+# to build, the default `docs` target does not include the API docs generation
+# but includes the Sphinx-Doxygen integration (breathe).
+#
+# the full documentation as on readthedocs.org can be build via the additional
+# `docs-with-api` target.
+#
+# WARNING: after you ran `docs-with-api` the regular `docs` target will
+#          accidentaly pick up the auto-generated api files. remove the
+#          `_build` and the `api` directory manually to avoid this.
 
-set(output_doctrees ${CMAKE_CURRENT_SOURCE_DIR}/_build/doctrees)
-set(output_html ${CMAKE_CURRENT_SOURCE_DIR}/_build/html)
+# this should match the INPUT declaration in the Doxyfile
+# CONFIGURE_DEPENDS ensures that adding/removing files leads to reprocessing
+file(
+  GLOB_RECURSE doxygen_sources
+  ../Core/include/*.hpp
+  ../Fatras/include/*.hpp
+  ../Plugins/include/*.hpp)
 
-# this is a debug target that is not part of the regular documentation build
-# only intended to diagnose issues with the Doxygen configuration
-add_custom_target(
-  run-doxygen
+set(doxygen_index ${CMAKE_CURRENT_SOURCE_DIR}/_build/doxygen-xml/index.xml)
+set(sphinx_doctrees ${CMAKE_CURRENT_SOURCE_DIR}/_build/doctrees)
+set(sphinx_html ${CMAKE_CURRENT_SOURCE_DIR}/_build/html)
+
+add_custom_command(
+  OUTPUT ${doxygen_index}
   COMMAND ${DOXYGEN_EXECUTABLE}
+  DEPENDS ${doxygen_sources} Doxyfile
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Run Doxygen")
+  COMMENT "Parse source code documentation with Doxygen")
 
-# standard documentation target to build the full documentation
-# this can take quite a long time due to the auto-generation of the
+# this is a debug target to diagnose issues with the Doxygen configuration
+add_custom_target(run-doxygen DEPENDS ${doxygen_index})
+
+# standard target to build the documentation without automatic API generation
 add_custom_target(
   docs
   COMMAND
     ${Sphinx_EXECUTABLE}
       -b html
-      -d ${output_doctrees}
+      -d ${sphinx_doctrees}
       -j auto
-      -t use_doxygen
       ${CMAKE_CURRENT_SOURCE_DIR}
-      ${output_html}
+      ${sphinx_html}
+  DEPENDS ${doxygen_index}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Build documentation")
-# helper target for faster iterations without the doxygen API docs
+  COMMENT "Build documentation WITHOUT API documentation")
+# extended target to build the full documentation with automatic API generation
 add_custom_target(
-  docs-without-doxygen
+  docs-with-api
   COMMAND
     ${Sphinx_EXECUTABLE}
       -b html
-      -d ${output_doctrees}
+      -d ${sphinx_doctrees}
       -j auto
+      -t use_exhale
       ${CMAKE_CURRENT_SOURCE_DIR}
-      ${output_html}
+      ${sphinx_html}
+  DEPENDS ${doxygen_index}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMENT "Build documentation (without Doxygen)")
+  COMMENT "Build full documentation")
 
 install(
-  DIRECTORY ${output_html}/
+  DIRECTORY ${sphinx_html}/
   DESTINATION ${CMAKE_INSTALL_DOCDIR}/Acts OPTIONAL)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -773,9 +773,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../Core \
-                         ../Fatras \
-                         ../Plugins
+INPUT                  = ../Core/include \
+                         ../Fatras/include \
+                         ../Plugins/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -121,6 +121,49 @@ However, if you have the necessary prerequisites installed it should be
 possible to use it locally. Acts developers regularly use different
 recent Linux distributions and macOS to build and develop Acts.
 
+## Building the documentation
+
+The documentation uses [Doxygen][doxygen] to extract the source code
+documentation and [Sphinx][sphinx] with the [Breathe][breathe] and
+[Exhale][exhale] extensions to generate the documentation website. To build the
+documentation locally, you need to have [Doxygen][doxygen] installed from your
+package manager. [Sphinx][sphinx] and its extensions can be installed using the
+Python package manager via
+
+```console
+cd <path/to/repository>
+# --user installs to a user-specific directory instead of the system
+pip install --user -r docs/requirements
+```
+
+To activate the documentation build targets, the `ACTS_BUILD_DOCS` option has to be set
+
+```console
+cmake -B <build-dir> -S <path/to/repository> -DACTS_BUILD_DOCS=on
+```
+
+Then the documentation can be build with either of the following two build
+targets
+
+```console
+cmake --build <build-dir> docs # default fast option
+# or
+cmake --build <build-dir> docs-with-api # full documentation
+```
+
+The default option includes the Doxygen, Sphinx, and the Breathe extension, i.e.
+the source code information can be used in the manually written documentation
+but the full API documentation is not generated. The second target builds the
+full documentation using Exhale to automatically generate the API documentation.
+This is equivalent to the public [Read the Docs][rtd_acts] documentation, but
+the build takes around ten minutes to finish.
+
+[doxygen]: https://doxygen.nl/
+[sphinx]: https://www.sphinx-doc.org
+[breathe]: https://breathe.readthedocs.io
+[exhale]: https://exhale.readthedocs.io
+[rtd_acts]: https://acts.readthedocs.io
+
 ## Using Acts
 
 When using Acts in your own CMake-based project, you need to include the


### PR DESCRIPTION
This changes the build configuration for local documentation builds. The default `docs` target builds the documentation without the automatic api generation but with the Sphinx/Doxygen bridge available. The full documentation can now be built via the `docs-with-api` instead. The default target should be fast and allow quick feedback. For the local build, Doxygen is also run separately from Sphinx and only if the source code changes. On readthedocs.org, all steps are run by Sphinx as before.