### PR TITLE
Remove std::move in some HepMC3 code

### DIFF
--- a/Examples/Io/HepMC3/src/HepMC3Event.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Event.cpp
@@ -233,10 +233,10 @@ std::vector<std::unique_ptr<FW::SimParticle>> FW::HepMC3Event::particles(
 
   // Translate all particles
   for (auto& genParticle : genParticles)
-    actsParticles.push_back(std::move(
-        simPart.particle(std::make_shared<HepMC3::GenParticle>(*genParticle))));
+    actsParticles.push_back(
+        simPart.particle(std::make_shared<HepMC3::GenParticle>(*genParticle)));
 
-  return std::move(actsParticles);
+  return actsParticles;
 }
 
 std::vector<std::unique_ptr<FW::SimVertex>> FW::HepMC3Event::vertices(
@@ -248,10 +248,10 @@ std::vector<std::unique_ptr<FW::SimVertex>> FW::HepMC3Event::vertices(
 
   // Translate all vertices
   for (auto& genVertex : genVertices) {
-    actsVertices.push_back(std::move(simVert.processVertex(
-        std::make_shared<HepMC3::GenVertex>(*genVertex))));
+    actsVertices.push_back(
+        simVert.processVertex(std::make_shared<HepMC3::GenVertex>(*genVertex)));
   }
-  return std::move(actsVertices);
+  return actsVertices;
 }
 
 std::vector<std::unique_ptr<FW::SimParticle>> FW::HepMC3Event::beams(
@@ -263,9 +263,9 @@ std::vector<std::unique_ptr<FW::SimParticle>> FW::HepMC3Event::beams(
 
   // Translate beam particles and store the result
   for (auto& genBeam : genBeams)
-    actsBeams.push_back(std::move(
-        simPart.particle(std::make_shared<HepMC3::GenParticle>(*genBeam))));
-  return std::move(actsBeams);
+    actsBeams.push_back(
+        simPart.particle(std::make_shared<HepMC3::GenParticle>(*genBeam)));
+  return actsBeams;
 }
 
 std::vector<std::unique_ptr<FW::SimParticle>> FW::HepMC3Event::finalState(

--- a/Examples/Io/HepMC3/src/HepMC3Particle.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Particle.cpp
@@ -34,8 +34,8 @@ std::unique_ptr<FW::SimVertex> FW::HepMC3Particle::productionVertex(
 
   // Return the vertex if it exists
   if (particle->production_vertex())
-    return std::move(simVert.processVertex(
-        std::make_shared<HepMC3::GenVertex>(*particle->production_vertex())));
+    return simVert.processVertex(
+        std::make_shared<HepMC3::GenVertex>(*particle->production_vertex()));
   else
     return nullptr;
 }
@@ -46,8 +46,8 @@ std::unique_ptr<FW::SimVertex> FW::HepMC3Particle::endVertex(
 
   // Return the vertex if it exists
   if (particle->end_vertex())
-    return std::move(simVert.processVertex(
-        std::make_shared<HepMC3::GenVertex>(*(particle->end_vertex()))));
+    return simVert.processVertex(
+        std::make_shared<HepMC3::GenVertex>(*(particle->end_vertex())));
   else
     return nullptr;
 }

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -18,7 +18,7 @@
 ///
 /// Straight forward example of reading a HepMC3 file.
 ///
-int main(int argc, char* argv[]) {
+int main(int /*argc*/, char** /*argv*/) {
   FW::HepMC3ReaderAscii simReader;
 
   std::cout << "Preparing reader " << std::flush;


### PR DESCRIPTION
This fixes some warnings on my machine, and the `std::move`s are
unnecessary anyway.