### PR TITLE
FOR DEMONSTRATION ONLY: test for surface approacher

### DIFF
--- a/Examples/Algorithms/Propagation/include/ACTFW/Propagation/MeasurementApproacher.hpp
+++ b/Examples/Algorithms/Propagation/include/ACTFW/Propagation/MeasurementApproacher.hpp
@@ -1,0 +1,80 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <vector>
+#include "Acts/Utilities/Definitions.hpp"
+
+namespace Acts {
+
+/// This is a simple3D measurement generator
+struct MeasurementApproacher {
+  /// Simple result struct to be returned
+  /// It collects the generated measurements
+  struct this_result {
+    std::vector<Vector3D> approaches = {};
+    std::vector<Vector3D> mts = {};
+    std::vector<Vector3D>::iterator mt = mts.end();
+  };
+
+  using result_type = this_result;
+
+  std::vector<Vector3D> measurements = {};
+
+  /// Actor that remembers the volumes passed
+  ///
+  /// @tparam propagator_state_t is the type of the Propagator state
+  /// it is not used in this stepper
+  /// @tparam stepper_t Type of the stepper
+  ///
+  /// @param state is the mutable propagator state object
+  /// @param result is the mutable result state object
+  template <typename propagator_state_t, typename stepper_t>
+  void operator()(propagator_state_t& state, const stepper_t& stepper,
+                  result_type& result) const {
+    // Initialize the radii if necessary
+    if (result.mts.empty() and result.mt == result.mts.end()) {
+      result.mts = measurements;
+      result.mt = result.mts.begin();
+    } else if (result.mt == result.mts.end()) {
+      return;
+    }
+
+    auto measurement = (*result.mt);
+
+    // Get the position & direction
+    auto position = stepper.position(state.stepping);
+    auto direction = stepper.direction(state.stepping);
+
+    // Let's create a hyperplane at the measurement point
+    using Plane = Eigen::Hyperplane<double, 3>;
+    using Line = Eigen::ParametrizedLine<double, 3>;
+
+    // Make the plane and intersect
+    auto plane = Plane(direction, measurement);
+    auto line = Line::Through(position, position + direction);
+    double path = line.intersection(plane);
+    if (std::abs(path) < s_onSurfaceTolerance) {
+      result.approaches.push_back(position);
+      ++result.mt;
+      return;
+    }
+
+    stepper.setStepSize(state.stepping, path);
+    return;
+  }
+
+  /// Pure observer interface
+  /// - this does not apply to the output collector
+  template <typename propagator_state_t, typename stepper_t>
+  void operator()(propagator_state_t& /*state*/,
+                  const stepper_t& /*unused*/) const {}
+};
+
+}  // namespace Acts

--- a/Examples/Algorithms/Propagation/include/ACTFW/Propagation/MeasurementGenerator.hpp
+++ b/Examples/Algorithms/Propagation/include/ACTFW/Propagation/MeasurementGenerator.hpp
@@ -1,0 +1,99 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <vector>
+#include "Acts/Utilities/Definitions.hpp"
+
+namespace Acts {
+
+/// This is a simple3D measurement generator
+struct MeasurementGenerator {
+  /// Simple result struct to be returned
+  /// It collects the generated measurements
+  struct this_result {
+    std::vector<Vector3D> spacepoints = {};
+    std::vector<double> rts = {};
+    std::vector<double>::iterator rt = rts.end();
+  };
+
+  using result_type = this_result;
+
+  std::vector<double> radii = {};
+
+  /// Actor that remembers the volumes passed
+  ///
+  /// @tparam propagator_state_t is the type of the Propagator state
+  /// it is not used in this stepper
+  /// @tparam stepper_t Type of the stepper
+  ///
+  /// @param state is the mutable propagator state object
+  /// @param result is the mutable result state object
+  template <typename propagator_state_t, typename stepper_t>
+  void operator()(propagator_state_t& state, const stepper_t& stepper,
+                  result_type& result) const {
+    // Initialize the radii if necessary
+    if (result.rts.empty() and result.rt == result.rts.end()) {
+      result.rts = radii;
+      result.rt = result.rts.begin();
+    } else if (result.rt == result.rts.end()) {
+      return;
+    }
+
+    // Get the position
+    auto position = stepper.position(state.stepping);
+    double r = VectorHelpers::perp(position);
+    // Check if you are on a radius
+    double R = (*result.rt);
+    auto dr = R - r;
+    if (std::abs(dr) < s_onSurfaceTolerance) {
+      result.spacepoints.push_back(position);
+      ++result.rt;
+      return;
+    }
+
+    // Calculate and Adapt the step size
+    auto direction = stepper.direction(state.stepping);
+
+    // Get the transformation matrtix
+    Vector3D caxis(0., 0., 1);
+
+    // Check documentation for explanation
+    Vector3D pcXcd = position.cross(caxis);
+    Vector3D ldXcd = direction.cross(caxis);
+    double a = ldXcd.dot(ldXcd);
+    double b = 2. * (ldXcd.dot(pcXcd));
+    double c = pcXcd.dot(pcXcd) - (R * R);
+    // And solve the qaudratic equation
+    auto rqe = detail::RealQuadraticEquation(a, b, c);
+
+    double path = 0.;
+    if (result.rt == result.rts.begin()) {
+      // always take the positive one for the first step
+      path = rqe.first < 0 ? rqe.second : rqe.first;
+    } else {
+      // take the closest in case of overstepping
+      path = rqe.first * rqe.first < rqe.second * rqe.second ? rqe.first
+                                                             : rqe.second;
+    }
+
+    Vector3D solution = position + path * direction;
+    double dS = std::copysign((solution - position).norm(), path);
+    stepper.setStepSize(state.stepping, dS);
+    return;
+  }
+
+  /// Pure observer interface
+  /// - this does not apply to the output collector
+  template <typename propagator_state_t, typename stepper_t>
+  void operator()(propagator_state_t& /*state*/,
+                  const stepper_t& /*unused*/) const {}
+};
+
+}  // namespace Acts

--- a/Examples/Algorithms/Propagation/include/ACTFW/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ACTFW/Propagation/PropagationAlgorithm.hpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <memory>
 #include <optional>
+#include <random>
 
 #include "ACTFW/Framework/BareAlgorithm.hpp"
 #include "ACTFW/Framework/ProcessCode.hpp"
@@ -32,6 +33,9 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Units.hpp"
+#include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
+#include "MeasurementApproacher.hpp"
+#include "MeasurementGenerator.hpp"
 
 using namespace Acts::UnitLiterals;
 
@@ -150,12 +154,14 @@ class PropagationAlgorithm : public BareAlgorithm {
   /// @param [in] context The Context for this call
   /// @param [in] startParameters the start parameters
   /// @param [in] pathLengthe the path limit of this propagation
+  /// @param [in] gauss distribution
   ///
   /// @return collection of Propagation steps for further analysis
   template <typename parameters_t>
-  PropagationOutput executeTest(
-      const AlgorithmContext& context, const parameters_t& startParameters,
-      double pathLength = std::numeric_limits<double>::max()) const;
+  PropagationOutput executeTest(const AlgorithmContext& context,
+                                const parameters_t& startParameters,
+                                double pathLength, FW::RandomEngine& rnd,
+                                std::normal_distribution<double>& gauss) const;
 };
 
 #include "PropagationAlgorithm.ipp"


### PR DESCRIPTION
This PR is for demonstration only and is not to be merged.

It will be closed after the ACTS workshop, however, the code for the `MeasurementApproacher` is a good starting point for the TPC discussion.

It's a modification of the `PropagationAlgorithm`  which is extended with two actors:
* `MeasurementGenerator`
* `MeasurementApproacher`

This generates hits on given radii:

![Screenshot 2020-05-28 at 14 42 19](https://user-images.githubusercontent.com/26623879/83143022-996f6b80-a0f1-11ea-96fd-ecc64ef3155c.png)
