### PR TITLE
Do not default-construct the stepper field input

### DIFF
--- a/Core/include/Acts/MagneticField/SharedBField.hpp
+++ b/Core/include/Acts/MagneticField/SharedBField.hpp
@@ -23,6 +23,9 @@ class SharedBField {
   // typedef wrapped BField's cache type
   using Cache = typename BField::Cache;
 
+  /// Disallow construction without a valid underlying field.
+  SharedBField() = delete;
+
   /// Constructur with a shared pointer from a shared pointer.
   /// @note Since it is a shared field, we enforce it to be const
   /// @tparam bField is the shared BField to be stored

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <functional>
+
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
@@ -297,7 +298,7 @@ class AtlasStepper {
     size_t debugMsgWidth = 50;
   };
 
-  AtlasStepper(bfield_t bField = bfield_t()) : m_bField(std::move(bField)){};
+  AtlasStepper(bfield_t bField) : m_bField(std::move(bField)){};
 
   /// Get the field for the stepping
   /// It checks first if the access is still within the Cell,

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -80,10 +80,10 @@ class AtlasStepper {
       const auto Vp = pars.parameters();
 
       double Sf, Cf, Ce, Se;
-      Sf = sin(Vp(2));
-      Cf = cos(Vp(2));
-      Se = sin(Vp(3));
-      Ce = cos(Vp(3));
+      Sf = sin(Vp[eBoundPhi]);
+      Cf = cos(Vp[eBoundPhi]);
+      Se = sin(Vp[eBoundTheta]);
+      Ce = cos(Vp[eBoundTheta]);
 
       pVector[0] = pos(0);
       pVector[1] = pos(1);
@@ -92,7 +92,7 @@ class AtlasStepper {
       pVector[4] = Cf * Se;
       pVector[5] = Sf * Se;
       pVector[6] = Ce;
-      pVector[7] = Vp[4];
+      pVector[7] = Vp[eBoundQOverP];
 
       // @todo: remove magic numbers - is that the charge ?
       if (std::abs(pVector[7]) < .000000000000001) {

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -170,7 +170,7 @@ class EigenStepper {
   };
 
   /// Constructor requires knowledge of the detector's magnetic field
-  EigenStepper(BField bField = BField());
+  EigenStepper(BField bField);
 
   /// Get the field for the stepping, it checks first if the access is still
   /// within the Cell, and updates the cell if necessary.

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -12,228 +12,324 @@
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/Propagator/AtlasStepper.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
-
-namespace tt = boost::test_tools;
+#include "Acts/Utilities/Units.hpp"
 
 namespace Acts {
 namespace Test {
 
+using namespace Acts::UnitLiterals;
 using Covariance = BoundSymMatrix;
 using Jacobian = BoundMatrix;
+using Stepper = AtlasStepper<ConstantBField>;
 
-/// @brief Simplified propagator state
-struct PropState {
-  /// @brief Constructor
-  PropState(AtlasStepper<ConstantBField>::State sState) : stepping(sState) {}
-  /// State of the Atlas stepper
-  AtlasStepper<ConstantBField>::State stepping;
-  /// Propagator options which only carry the relevant components
+/// Simplified propagator state.
+struct MockPropagatorState {
+  MockPropagatorState(Stepper::State stepperState)
+      : stepping(std::move(stepperState)) {}
+
+  /// Stepper state.
+  Stepper::State stepping;
+  /// Propagator options with only the relevant components.
   struct {
-    double mass = 42.;
-    double tolerance = 1e-4;
+    double mass = 1_GeV;
+    double tolerance = 10_um;
   } options;
 };
 
-/// These tests are aiming to test whether the state setup is working properly
-BOOST_AUTO_TEST_CASE(atlas_stepper_state_test) {
-  // Set up some variables
-  GeometryContext tgContext = GeometryContext();
-  MagneticFieldContext mfContext = MagneticFieldContext();
-  NavigationDirection ndir = backward;
-  double stepSize = 123.;
-  double tolerance = 234.;
-  ConstantBField bField(Vector3D(1., 2.5, 33.33));
+// epsilon for floating point comparisons
+static constexpr auto eps = 1024 * std::numeric_limits<double>::epsilon();
 
-  Vector3D pos(1., 2., 3.);
-  Vector3D mom(4., 5., 6.);
-  Vector3D dir = mom.normalized();
-  double time = 7.;
-  double charge = -1.;
+// propagation settings
+static constexpr auto stepSize = 10_mm;
+static constexpr auto tolerance = 10_um;
+static constexpr NavigationDirection navDir = backward;
+static const ConstantBField magneticField(Vector3D(0.1_T, -0.2_T, 2_T));
 
-  // Test charged parameters without covariance matrix
-  CurvilinearParameters cp(std::nullopt, pos, mom, charge, time);
-  AtlasStepper<ConstantBField>::State asState(tgContext, mfContext, cp, ndir,
-                                              stepSize, tolerance);
+// initial parameter state
+static const Vector3D pos(1_mm, -1_mm, 2_mm);
+static constexpr auto time = 2_ns;
+static const Vector3D unitDir = Vector3D(-2, 2, 1).normalized();
+static constexpr auto absMom = 1_GeV;
+static const Vector3D mom = absMom * unitDir;
+static constexpr auto charge = -1_e;
+static const Covariance cov = Covariance::Identity();
 
-  // Test the result & compare with the input/test for reasonable members
-  BOOST_TEST(!asState.covTransport);
-  BOOST_TEST(asState.covariance == nullptr);
-  BOOST_TEST(asState.pVector[0] == pos.x());
-  BOOST_TEST(asState.pVector[1] == pos.y());
-  BOOST_TEST(asState.pVector[2] == pos.z());
-  BOOST_TEST(asState.pVector[3] == time);
-  CHECK_CLOSE_ABS(asState.pVector[4], dir.x(), 1e-6);
-  CHECK_CLOSE_ABS(asState.pVector[5], dir.y(), 1e-6);
-  CHECK_CLOSE_ABS(asState.pVector[6], dir.z(), 1e-6);
-  BOOST_TEST(asState.pVector[7] == charge / mom.norm());
-  BOOST_TEST(asState.navDir == ndir);
-  BOOST_TEST(asState.pathAccumulated == 0.);
-  BOOST_TEST(asState.stepSize == ndir * stepSize);
-  BOOST_TEST(asState.previousStepSize == 0.);
-  BOOST_TEST(asState.tolerance == tolerance);
+// context objects
+static const GeometryContext geoCtx;
+static const MagneticFieldContext magCtx;
 
-  // Test with covariance matrix
-  Covariance cov = 8. * Covariance::Identity();
-  cp = CurvilinearParameters(cov, pos, mom, charge, time);
-  asState = AtlasStepper<ConstantBField>::State(tgContext, mfContext, cp, ndir,
-                                                stepSize, tolerance);
-  BOOST_TEST(asState.covTransport);
-  BOOST_TEST(*asState.covariance == cov);
+BOOST_AUTO_TEST_SUITE(AtlasStepper)
+
+// test state construction from parameters w/o covariance
+BOOST_AUTO_TEST_CASE(ConstructState) {
+  Stepper::State state(
+      geoCtx, magCtx,
+      CurvilinearParameters(std::nullopt, pos, mom, charge, time), navDir,
+      stepSize, tolerance);
+
+  BOOST_TEST(!state.covTransport);
+  BOOST_TEST(state.covariance == nullptr);
+  BOOST_TEST(state.pVector[0] == pos.x());
+  BOOST_TEST(state.pVector[1] == pos.y());
+  BOOST_TEST(state.pVector[2] == pos.z());
+  BOOST_TEST(state.pVector[3] == time);
+  CHECK_CLOSE_ABS(state.pVector[4], unitDir.x(), eps);
+  CHECK_CLOSE_ABS(state.pVector[5], unitDir.y(), eps);
+  CHECK_CLOSE_ABS(state.pVector[6], unitDir.z(), eps);
+  BOOST_TEST(state.pVector[7] == charge / absMom);
+  BOOST_TEST(state.navDir == navDir);
+  BOOST_TEST(state.pathAccumulated == 0.);
+  BOOST_TEST(state.stepSize == navDir * stepSize);
+  BOOST_TEST(state.previousStepSize == 0.);
+  BOOST_TEST(state.tolerance == tolerance);
 }
 
-/// These tests are aiming to test the functions of the AtlasStepper>
-/// The numerical correctness of the stepper is tested in the integration tests
-BOOST_AUTO_TEST_CASE(atlas_stepper_test) {
-  // Set up some variables for the state
-  GeometryContext tgContext = GeometryContext();
-  MagneticFieldContext mfContext = MagneticFieldContext();
-  NavigationDirection ndir = backward;
-  double stepSize = 123.;
-  double tolerance = 234.;
-  ConstantBField bField(Vector3D(1., 2.5, 33.33));
+// test state construction from parameters w/ covariance
+BOOST_AUTO_TEST_CASE(ConstructStateWithCovariance) {
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
 
-  // Construct the parameters
-  Vector3D pos(1., 2., 3.);
-  Vector3D mom(4., 5., 6.);
-  double time = 7.;
-  double charge = -1.;
-  Covariance cov = 8. * Covariance::Identity();
-  CurvilinearParameters cp(cov, pos, mom, charge, time);
+  BOOST_TEST(state.covTransport);
+  BOOST_TEST(*state.covariance == cov);
+  BOOST_TEST(state.pVector[0] == pos.x());
+  BOOST_TEST(state.pVector[1] == pos.y());
+  BOOST_TEST(state.pVector[2] == pos.z());
+  BOOST_TEST(state.pVector[3] == time);
+  CHECK_CLOSE_ABS(state.pVector[4], unitDir.x(), eps);
+  CHECK_CLOSE_ABS(state.pVector[5], unitDir.y(), eps);
+  CHECK_CLOSE_ABS(state.pVector[6], unitDir.z(), eps);
+  BOOST_TEST(state.pVector[7] == charge / absMom);
+  BOOST_TEST(state.navDir == navDir);
+  BOOST_TEST(state.pathAccumulated == 0.);
+  BOOST_TEST(state.stepSize == navDir * stepSize);
+  BOOST_TEST(state.previousStepSize == 0.);
+  BOOST_TEST(state.tolerance == tolerance);
+}
 
-  // Build the state and the stepper
-  AtlasStepper<ConstantBField>::State asState(tgContext, mfContext, cp, ndir,
-                                              stepSize, tolerance);
-  AtlasStepper<ConstantBField> as(bField);
+// test stepper getters for particle state
+BOOST_AUTO_TEST_CASE(Getters) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
 
-  // Test the getters
-  BOOST_TEST(as.position(asState) == pos);
-  CHECK_CLOSE_ABS(as.direction(asState), mom.normalized(), 1e-6);
-  BOOST_TEST(as.momentum(asState) == mom.norm());
-  BOOST_TEST(as.charge(asState) == charge);
-  BOOST_TEST(as.time(asState) == time);
+  CHECK_CLOSE_ABS(stepper.position(state), pos, eps);
+  CHECK_CLOSE_ABS(stepper.time(state), time, eps);
+  CHECK_CLOSE_ABS(stepper.direction(state), unitDir, eps);
+  CHECK_CLOSE_ABS(stepper.momentum(state), absMom, eps);
+  BOOST_TEST(stepper.charge(state) == charge);
+}
 
-  // BOOST_TEST(as.overstepLimit(asState) == tolerance);
+// test stepper update methods with bound state as input
+BOOST_AUTO_TEST_CASE(UpdateFromBound) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
 
-  // Step size modifies
-  const std::string originalStepSize = asState.stepSize.toString();
+  auto newPos = (pos + Vector3D(1_mm, 2_mm, 3_mm)).eval();
+  auto newTime = time + 20_ns;
+  auto newUnitDir = (unitDir + Vector3D(1, -1, -1)).normalized();
+  auto newAbsMom = 0.9 * absMom;
+  auto newMom = (newAbsMom * newUnitDir).eval();
 
-  as.setStepSize(asState, 1337.);
-  BOOST_TEST(asState.previousStepSize == ndir * stepSize);
-  BOOST_TEST(asState.stepSize == 1337.);
+  // example surface and bound parameters at the updated position
+  auto plane = Surface::makeShared<PlaneSurface>(newPos, newUnitDir);
+  BoundParameters params(geoCtx, cov, newPos, newMom, charge, newTime, plane);
 
-  as.releaseStepSize(asState);
-  BOOST_TEST(asState.stepSize == -123.);
-  BOOST_TEST(as.outputStepSize(asState) == originalStepSize);
+  // WARNING for some reason there seems to be an additional flag that makes
+  //         the update method not do anything when it is set. Why?
+  state.state_ready = false;
+  stepper.update(state, params);
+  CHECK_CLOSE_ABS(stepper.position(state), newPos, eps);
+  CHECK_CLOSE_ABS(stepper.time(state), newTime, eps);
+  CHECK_CLOSE_ABS(stepper.direction(state), newUnitDir, eps);
+  CHECK_CLOSE_ABS(stepper.momentum(state), newAbsMom, eps);
+  BOOST_TEST(stepper.charge(state) == charge);
+}
 
-  // Test the curvilinear state construction
-  auto curvState = as.curvilinearState(asState);
-  auto curvPars = std::get<0>(curvState);
-  CHECK_CLOSE_ABS(curvPars.position(), cp.position(), 1e-6);
-  CHECK_CLOSE_ABS(curvPars.momentum(), cp.momentum(), 1e-6);
-  CHECK_CLOSE_ABS(curvPars.charge(), cp.charge(), 1e-6);
-  CHECK_CLOSE_ABS(curvPars.time(), cp.time(), 1e-6);
-  BOOST_TEST(curvPars.covariance().has_value());
-  BOOST_TEST(*curvPars.covariance() != cov);
-  CHECK_CLOSE_COVARIANCE(std::get<1>(curvState),
-                         BoundMatrix(BoundMatrix::Identity()), 1e-6);
-  CHECK_CLOSE_ABS(std::get<2>(curvState), 0., 1e-6);
+// test stepper update methods with individual components as input
+BOOST_AUTO_TEST_CASE(UpdateFromComponents) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
 
-  // Test the update method
-  Vector3D newPos(2., 4., 8.);
-  Vector3D newMom(3., 9., 27.);
-  double newTime(321.);
-  as.update(asState, newPos, newMom.normalized(), newMom.norm(), newTime);
-  BOOST_TEST(as.position(asState) == newPos);
-  BOOST_TEST(as.direction(asState) == newMom.normalized());
-  BOOST_TEST(as.momentum(asState) == newMom.norm());
-  BOOST_TEST(as.charge(asState) == charge);
-  BOOST_TEST(as.time(asState) == newTime);
+  auto newPos = (pos + Vector3D(1_mm, 2_mm, 3_mm)).eval();
+  auto newTime = time + 20_ns;
+  auto newUnitDir = (unitDir + Vector3D(1, -1, -1)).normalized();
+  auto newAbsMom = 0.9 * absMom;
 
-  // The covariance transport
-  asState.cov = cov;
-  as.covarianceTransport(asState);
-  BOOST_TEST(asState.cov != cov);
+  stepper.update(state, newPos, newUnitDir, newAbsMom, newTime);
+  CHECK_CLOSE_ABS(stepper.position(state), newPos, eps);
+  CHECK_CLOSE_ABS(stepper.time(state), newTime, eps);
+  CHECK_CLOSE_ABS(stepper.direction(state), newUnitDir, eps);
+  CHECK_CLOSE_ABS(stepper.momentum(state), newAbsMom, eps);
+  BOOST_TEST(stepper.charge(state) == charge);
+}
 
-  // Perform a step without and with covariance transport
-  asState.cov = cov;
-  PropState ps(asState);
+// test building a bound state object from the stepper state
+BOOST_AUTO_TEST_CASE(BuildBound) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
+  // example surface at the current state position
+  auto plane = Surface::makeShared<PlaneSurface>(pos, unitDir);
 
-  ps.stepping.covTransport = false;
-  double h = as.step(ps).value();
-  BOOST_TEST(ps.stepping.stepSize == ndir * stepSize);
-  BOOST_TEST(ps.stepping.stepSize == h);
-  CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, 1e-6);
-  BOOST_TEST(as.position(ps.stepping).norm() > newPos.norm());
-  CHECK_CLOSE_ABS(as.direction(ps.stepping), newMom.normalized(), 1e-6);
-  BOOST_TEST(as.momentum(ps.stepping) == newMom.norm());
-  BOOST_TEST(as.charge(ps.stepping) == charge);
-  BOOST_TEST(as.time(ps.stepping) < newTime);
+  auto&& [pars, jac, pathLength] = stepper.boundState(state, *plane);
+  // check parameters
+  CHECK_CLOSE_ABS(pars.position(), pos, eps);
+  CHECK_CLOSE_ABS(pars.time(), time, eps);
+  CHECK_CLOSE_ABS(pars.momentum(), mom, eps);
+  BOOST_TEST(pars.charge() == charge);
+  BOOST_TEST(pars.covariance().has_value());
+  BOOST_TEST(*pars.covariance() != cov);
+  // check Jacobian. should be identity since there was no propagation yet
+  CHECK_CLOSE_ABS(jac, Jacobian(Jacobian::Identity()), eps);
+  // check propagation length
+  CHECK_CLOSE_ABS(pathLength, 0., eps);
+}
 
-  ps.stepping.covTransport = true;
-  double h2 = as.step(ps).value();
-  BOOST_TEST(ps.stepping.stepSize == ndir * stepSize);
-  BOOST_TEST(h2 == h);
-  CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, 1e-6);
-  BOOST_TEST(as.position(ps.stepping).norm() > newPos.norm());
-  CHECK_CLOSE_ABS(as.direction(ps.stepping), newMom.normalized(), 1e-6);
-  BOOST_TEST(as.momentum(ps.stepping) == newMom.norm());
-  BOOST_TEST(as.charge(ps.stepping) == charge);
-  BOOST_TEST(as.time(ps.stepping) < newTime);
+// test building a curvilinear state object from the stepper state
+BOOST_AUTO_TEST_CASE(BuildCurvilinear) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
 
-  /// Repeat with surface related methods
-  auto plane = Surface::makeShared<PlaneSurface>(pos, mom.normalized());
-  BoundParameters bp(tgContext, cov, pos, mom, charge, time, plane);
-  asState = AtlasStepper<ConstantBField>::State(tgContext, mfContext, cp, ndir,
-                                                stepSize, tolerance);
+  auto&& [pars, jac, pathLength] = stepper.curvilinearState(state);
+  // check parameters
+  CHECK_CLOSE_ABS(pars.position(), pos, eps);
+  CHECK_CLOSE_ABS(pars.time(), time, eps);
+  CHECK_CLOSE_ABS(pars.momentum(), mom, eps);
+  BOOST_TEST(pars.charge() == charge);
+  BOOST_TEST(pars.covariance().has_value());
+  BOOST_TEST(*pars.covariance() != cov);
+  // check Jacobian. should be identity since there was no propagation yet
+  CHECK_CLOSE_ABS(jac, Jacobian(Jacobian::Identity()), eps);
+  // check propagation length
+  CHECK_CLOSE_ABS(pathLength, 0., eps);
+}
 
-  // Test the intersection in the context of a surface
-  auto targetSurface = Surface::makeShared<PlaneSurface>(
-      pos + ndir * 2. * mom.normalized(), mom.normalized());
-  as.updateSurfaceStatus(asState, *targetSurface, BoundaryCheck(false));
-  BOOST_TEST(asState.stepSize.value(ConstrainedStep::actor), ndir * 2.);
+// test step method without covariance transport
+BOOST_AUTO_TEST_CASE(Step) {
+  Stepper stepper(magneticField);
+  MockPropagatorState state(Stepper::State(
+      geoCtx, magCtx, CurvilinearParameters(cov, pos, mom, charge, time),
+      navDir, stepSize, tolerance));
+  state.stepping.covTransport = false;
 
-  // Test the step size modification in the context of a surface
-  as.updateStepSize(
-      asState,
-      targetSurface->intersect(asState.geoContext, as.position(asState),
-                               asState.navDir * as.direction(asState), false),
+  // ensure step does not result in an error
+  auto res = stepper.step(state);
+  BOOST_TEST(res.ok());
+
+  // extract the actual step size
+  auto h = res.value();
+  BOOST_TEST(state.stepping.stepSize == navDir * stepSize);
+  BOOST_TEST(state.stepping.stepSize == h);
+
+  // check that the position has moved
+  auto deltaPos = (stepper.position(state.stepping) - pos).eval();
+  BOOST_TEST(0 < deltaPos.norm());
+  // check that time has changed
+  auto deltaTime = stepper.time(state.stepping) - time;
+  BOOST_TEST(0 < std::abs(deltaTime));
+  // check that the direction was rotated
+  auto projDir = stepper.direction(state.stepping).dot(unitDir);
+  BOOST_TEST(projDir < 1);
+
+  // momentum and charge should not change
+  CHECK_CLOSE_ABS(stepper.momentum(state.stepping), absMom, eps);
+  BOOST_TEST(stepper.charge(state.stepping) == charge);
+}
+
+// test step method with covariance transport
+BOOST_AUTO_TEST_CASE(StepWithCovariance) {
+  Stepper stepper(magneticField);
+  MockPropagatorState state(Stepper::State(
+      geoCtx, magCtx, CurvilinearParameters(cov, pos, mom, charge, time),
+      navDir, stepSize, tolerance));
+  state.stepping.covTransport = true;
+
+  // ensure step does not result in an error
+  auto res = stepper.step(state);
+  BOOST_TEST(res.ok());
+
+  // extract the actual step size
+  auto h = res.value();
+  BOOST_TEST(state.stepping.stepSize == navDir * stepSize);
+  BOOST_TEST(state.stepping.stepSize == h);
+
+  // check that the position has moved
+  auto deltaPos = (stepper.position(state.stepping) - pos).eval();
+  BOOST_TEST(0 < deltaPos.norm());
+  // check that time has changed
+  auto deltaTime = stepper.time(state.stepping) - time;
+  BOOST_TEST(0 < std::abs(deltaTime));
+  // check that the direction was rotated
+  auto projDir = stepper.direction(state.stepping).dot(unitDir);
+  BOOST_TEST(projDir < 1);
+
+  // momentum and charge should not change
+  CHECK_CLOSE_ABS(stepper.momentum(state.stepping), absMom, eps);
+  BOOST_TEST(stepper.charge(state.stepping) == charge);
+
+  stepper.covarianceTransport(state.stepping);
+  BOOST_TEST(state.stepping.cov != cov);
+}
+
+BOOST_AUTO_TEST_CASE(StepSize) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
+
+  // TODO figure out why this fails and what it should be
+  // BOOST_TEST(stepper.overstepLimit(state) == tolerance);
+
+  stepper.setStepSize(state, 5_cm);
+  BOOST_TEST(state.previousStepSize == navDir * stepSize);
+  BOOST_TEST(state.stepSize == 5_cm);
+
+  stepper.releaseStepSize(state);
+  BOOST_TEST(state.stepSize == navDir * stepSize);
+}
+
+// test step size modification with target surfaces
+BOOST_AUTO_TEST_CASE(StepSizeSurface) {
+  Stepper stepper(magneticField);
+  Stepper::State state(geoCtx, magCtx,
+                       CurvilinearParameters(cov, pos, mom, charge, time),
+                       navDir, stepSize, tolerance);
+
+  auto distance = 10_mm;
+  auto target = Surface::makeShared<PlaneSurface>(
+      pos + navDir * distance * unitDir, unitDir);
+
+  stepper.updateSurfaceStatus(state, *target, BoundaryCheck(false));
+  BOOST_TEST(state.stepSize.value(ConstrainedStep::actor) == navDir * distance);
+
+  // test the step size modification in the context of a surface
+  stepper.updateStepSize(
+      state,
+      target->intersect(state.geoContext, stepper.position(state),
+                        state.navDir * stepper.direction(state), false),
       false);
-  BOOST_TEST(asState.stepSize == 2.);
-  asState.stepSize = ndir * stepSize;
-  as.updateStepSize(
-      asState,
-      targetSurface->intersect(asState.geoContext, as.position(asState),
-                               asState.navDir * as.direction(asState), false),
+  BOOST_TEST(state.stepSize == distance);
+
+  // start with a different step size
+  state.stepSize = navDir * stepSize;
+  stepper.updateStepSize(
+      state,
+      target->intersect(state.geoContext, stepper.position(state),
+                        state.navDir * stepper.direction(state), false),
       true);
-  BOOST_TEST(asState.stepSize == 2.);
-
-  // Test the bound state construction
-  auto boundState = as.boundState(asState, *plane);
-  auto boundPars = std::get<0>(boundState);
-  CHECK_CLOSE_ABS(boundPars.position(), bp.position(), 1e-6);
-  CHECK_CLOSE_ABS(boundPars.momentum(), bp.momentum(), 1e-6);
-  CHECK_CLOSE_ABS(boundPars.charge(), bp.charge(), 1e-6);
-  CHECK_CLOSE_ABS(boundPars.time(), bp.time(), 1e-6);
-  BOOST_TEST(boundPars.covariance().has_value());
-  BOOST_TEST(*boundPars.covariance() != cov);
-  CHECK_CLOSE_COVARIANCE(std::get<1>(boundState),
-                         BoundMatrix(BoundMatrix::Identity()), 1e-6);
-  CHECK_CLOSE_ABS(std::get<2>(boundState), 0., 1e-6);
-
-  // Update in context of a surface
-  BoundParameters bpTarget(tgContext, 2. * cov, 2. * pos, 2. * mom,
-                           -1. * charge, 2. * time, targetSurface);
-  as.update(asState, bpTarget);
-  BOOST_TEST(as.position(asState) == 2. * pos);
-  CHECK_CLOSE_ABS(as.direction(asState), mom.normalized(), 1e-6);
-  BOOST_TEST(as.momentum(asState) == 2. * mom.norm());
-  BOOST_TEST(as.charge(asState) == -1. * charge);
-  BOOST_TEST(as.time(asState) == 2. * time);
-  CHECK_CLOSE_COVARIANCE(*asState.covariance, Covariance(2. * cov), 1e-6);
-
-  // Transport the covariance in the context of a surface
-  as.covarianceTransport(asState, *plane);
-  BOOST_TEST(asState.cov != cov);
+  BOOST_TEST(state.stepSize == distance);
 }
+
+BOOST_AUTO_TEST_SUITE_END()
+
 }  // namespace Test
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(atlas_stepper_test) {
   // Build the state and the stepper
   AtlasStepper<ConstantBField>::State asState(tgContext, mfContext, cp, ndir,
                                               stepSize, tolerance);
-  AtlasStepper<ConstantBField> as;
+  AtlasStepper<ConstantBField> as(bField);
 
   // Test the getters
   BOOST_TEST(as.position(asState) == pos);


### PR DESCRIPTION
Does exactly what the title says. This fixes a build issue on GCC 10.