### PR TITLE
Fix bound parameters visualization

### DIFF
--- a/Core/include/Acts/Visualization/EventDataVisualization.hpp
+++ b/Core/include/Acts/Visualization/EventDataVisualization.hpp
@@ -193,8 +193,8 @@ static inline void drawBoundParameters(
                    0.025, 0.05, 2., 72, pcolor);
 
   if (parameters.covariance().has_value()) {
-    auto lposition =
-        parameters.getParameterSet().getParameters().template block<2, 1>(0, 0);
+    auto paramVec = parameters.parameters();
+    auto lposition = paramVec.template block<2, 1>(0, 0);
 
     // Draw the local covariance
     const auto& covariance = *parameters.covariance();


### PR DESCRIPTION
This PR includes a simple fix to the `drawBoundParameters` function. 
Before this fix, the ellipse showing covariance of local position is displaced from the cone showing the covariance of momentum direction as below:
![image](https://user-images.githubusercontent.com/30073719/83558449-ebd0d380-a4c7-11ea-93a4-9044d81ceea4.png)
After the fix, they origin of the cone overlaps with the center of the ellipse as expected:
![image](https://user-images.githubusercontent.com/30073719/83558611-20dd2600-a4c8-11ea-936b-5d165e963f7d.png)


