### PR TITLE
Replace auto keywords in KalmanVertexUpdaters by explicit types

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -526,9 +526,9 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
     const double otherZPos = otherPos[eZ];
     const double otherZCov = otherCov(eZ, eZ);
 
-    const auto deltaPos = otherPos - candidatePos;
-    const auto deltaZPos = otherZPos - candidateZPos;
-    const auto sumCovZ = otherZCov + candidateZCov;
+    const SpacePointVector deltaPos = otherPos - candidatePos;
+    const double deltaZPos = otherZPos - candidateZPos;
+    const double sumCovZ = otherZCov + candidateZCov;
 
     double significance;
     if (not m_cfg.do3dSplitting) {
@@ -540,7 +540,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
       }
     } else {
       // Use full 3d information for significance
-      auto sumCov = candidateCov + otherCov;
+      SpacePointSymMatrix sumCov = candidateCov + otherCov;
       significance =
           std::sqrt(deltaPos.dot((sumCov.inverse().eval()) * deltaPos));
     }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -325,9 +325,9 @@ template <typename input_track_t, typename linearizer_t>
 bool Acts::AdaptiveMultiVertexFitter<
     input_track_t, linearizer_t>::checkSmallShift(State& state) const {
   for (auto vtx : state.vertexCollection) {
-    auto diff = state.vtxInfoMap[vtx].oldPosition.template head<3>() -
-                vtx->fullPosition().template head<3>();
-    const auto& vtxWgt =
+    Vector3D diff = state.vtxInfoMap[vtx].oldPosition.template head<3>() -
+                    vtx->fullPosition().template head<3>();
+    ActsSymMatrixD<3> vtxWgt =
         (vtx->fullCovariance().template block<3, 3>(0, 0)).inverse();
     double relativeShift = diff.dot(vtxWgt * diff);
     if (relativeShift > m_cfg.maxRelativeShift) {


### PR DESCRIPTION
This PR removes all unnecessary ```auto``` keywords in the ```KalmanVertexUpdater``` and ```KalmanVertexTrackUpdater``` and replaces them with the explicit types instead. Some recent, already fixed (and extremely hard to find) bugs appeared only in release (and not debug) build mode due to weird behaviour in the combined usage of ```auto``` and Eigens ```.block<>``` operations (in a different place). 
//Edit: AMVFitter and AMVFinder have also been updated.