### PR TITLE
Add a test data directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR
 set(Boost_NO_BOOST_CMAKE ON) # disable new cmake features from Boost 1.70 on
 find_package(Boost 1.69 REQUIRED COMPONENTS filesystem program_options unit_test_framework)
 find_package(Eigen 3.2.9 REQUIRED)
+find_package(Filesystem REQUIRED)
 
 # optional packages
 #

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DataDirectory.cpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DataDirectory.cpp
@@ -1,0 +1,21 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
+
+#include <filesystem>
+
+std::string Acts::Test::getDataPath(std::string_view relativePath) {
+  using std::filesystem::path;
+
+  path dataDir(ACTS_TEST_DATA_DIR);
+  path absPath = dataDir / path(relativePath);
+  // ensure absolute, consistent path
+  // weakly_canonical allows non-existing trailing components
+  return weakly_canonical(absPath).string();
+}

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DataDirectory.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DataDirectory.hpp
@@ -1,0 +1,23 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace Acts {
+namespace Test {
+
+/// Get the full path to a file in the test data directory.
+///
+/// @param relativePath file path relative to the data directory
+std::string getDataPath(std::string_view relativePath);
+
+}  // namespace Test
+}  // namespace Acts

--- a/Tests/CommonHelpers/CMakeLists.txt
+++ b/Tests/CommonHelpers/CMakeLists.txt
@@ -1,7 +1,19 @@
-add_library(ActsTestsCommonHelpers INTERFACE)
+# get the path of the test data directory
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../Data" acts_test_data_dir)
+
+add_library(
+  ActsTestsCommonHelpers SHARED
+  Acts/Tests/CommonHelpers/DataDirectory.cpp)
+target_compile_definitions(
+  ActsTestsCommonHelpers
+  PRIVATE "ACTS_TEST_DATA_DIR=\"${acts_test_data_dir}\"")
+target_compile_features(
+  ActsTestsCommonHelpers
+  PUBLIC cxx_std_17)
 target_include_directories(
   ActsTestsCommonHelpers
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_link_libraries(
   ActsTestsCommonHelpers
-  INTERFACE ActsCore)
+  INTERFACE ActsCore
+  PRIVATE std::filesystem)

--- a/Tests/Data/README.md
+++ b/Tests/Data/README.md
@@ -1,0 +1,15 @@
+# Small test data files
+
+**WARNING** All test files must be below 64kb in size.
+
+This folder contains small test files, e.g. input data or comparison
+references, for various parts of the test suite. These files should be
+kept as small as possible. Access should always occur via the `getDataPath`
+helper functions from the `CommonHelpers` package:
+
+```cpp
+#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
+
+...
+auto path = Acts::Tests::getDataPath("some-data-file.csv");
+```

--- a/Tests/IntegrationTests/CMakeLists.txt
+++ b/Tests/IntegrationTests/CMakeLists.txt
@@ -32,6 +32,7 @@ endmacro()
 
 add_integrationtest(BVHNavigation BVHNavigationTest.cpp)
 add_integrationtest(InterpolatedSolenoidBField InterpolatedSolenoidBFieldTest.cpp)
+add_integrationtest(PrintDataDirectory PrintDataDirectory.cpp)
 add_integrationtest(Propagation PropagationTests.cpp)
 
 add_subdirectory_if(Fatras ACTS_BUILD_FATRAS)

--- a/Tests/IntegrationTests/PrintDataDirectory.cpp
+++ b/Tests/IntegrationTests/PrintDataDirectory.cpp
@@ -1,0 +1,24 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This is an example on how to access data from the test data directory.
+// It is not really an integration test, but since it does not use the
+// the unit test framework, placing it into the integration tests directory
+// is the least akward place.
+
+#include <cstddef>
+#include <iostream>
+
+#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
+
+int main(void) {
+  std::cout << Acts::Test::getDataPath("") << std::endl;
+  std::cout << Acts::Test::getDataPath("missing-dir/does_not_exists.txt")
+            << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -1,0 +1,230 @@
+# Originally from
+# https://github.com/vector-of-bool/CMakeCM/blob/master/modules/FindFilesystem.cmake
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+
+FindFilesystem
+##############
+
+This module supports the C++17 standard library's filesystem utilities. Use the
+:imp-target:`std::filesystem` imported target to
+
+Options
+*******
+
+The ``COMPONENTS`` argument to this module supports the following values:
+
+.. find-component:: Experimental
+    :name: fs.Experimental
+
+    Allows the module to find the "experimental" Filesystem TS version of the
+    Filesystem library. This is the library that should be used with the
+    ``std::experimental::filesystem`` namespace.
+
+.. find-component:: Final
+    :name: fs.Final
+
+    Finds the final C++17 standard version of the filesystem library.
+
+If no components are provided, behaves as if the
+:find-component:`fs.Final` component was specified.
+
+If both :find-component:`fs.Experimental` and :find-component:`fs.Final` are
+provided, first looks for ``Final``, and falls back to ``Experimental`` in case
+of failure. If ``Final`` is found, :imp-target:`std::filesystem` and all
+:ref:`variables <fs.variables>` will refer to the ``Final`` version.
+
+
+Imported Targets
+****************
+
+.. imp-target:: std::filesystem
+
+    The ``std::filesystem`` imported target is defined when any requested
+    version of the C++ filesystem library has been found, whether it is
+    *Experimental* or *Final*.
+
+    If no version of the filesystem library is available, this target will not
+    be defined.
+
+    .. note::
+        This target has ``cxx_std_17`` as an ``INTERFACE``
+        :ref:`compile language standard feature <req-lang-standards>`. Linking
+        to this target will automatically enable C++17 if no later standard
+        version is already required on the linking target.
+
+
+.. _fs.variables:
+
+Variables
+*********
+
+.. variable:: CXX_FILESYSTEM_IS_EXPERIMENTAL
+
+    Set to ``TRUE`` when the :find-component:`fs.Experimental` version of C++
+    filesystem library was found, otherwise ``FALSE``.
+
+.. variable:: CXX_FILESYSTEM_HAVE_FS
+
+    Set to ``TRUE`` when a filesystem header was found.
+
+.. variable:: CXX_FILESYSTEM_HEADER
+
+    Set to either ``filesystem`` or ``experimental/filesystem`` depending on
+    whether :find-component:`fs.Final` or :find-component:`fs.Experimental` was
+    found.
+
+.. variable:: CXX_FILESYSTEM_NAMESPACE
+
+    Set to either ``std::filesystem`` or ``std::experimental::filesystem``
+    depending on whether :find-component:`fs.Final` or
+    :find-component:`fs.Experimental` was found.
+
+
+Examples
+********
+
+Using `find_package(Filesystem)` with no component arguments:
+
+.. code-block:: cmake
+
+    find_package(Filesystem REQUIRED)
+
+    add_executable(my-program main.cpp)
+    target_link_libraries(my-program PRIVATE std::filesystem)
+
+
+#]=======================================================================]
+
+
+if(TARGET std::filesystem)
+    # This module has already been processed. Don't do it again.
+    return()
+endif()
+
+include(CMakePushCheckState)
+include(CheckIncludeFileCXX)
+include(CheckCXXSourceCompiles)
+
+cmake_push_check_state()
+
+set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
+
+# All of our tests required C++17 or later
+set(CMAKE_CXX_STANDARD 17)
+
+# Normalize and check the component list we were given
+set(want_components ${Filesystem_FIND_COMPONENTS})
+if(Filesystem_FIND_COMPONENTS STREQUAL "")
+    set(want_components Final)
+endif()
+
+# Warn on any unrecognized components
+set(extra_components ${want_components})
+list(REMOVE_ITEM extra_components Final Experimental)
+foreach(component IN LISTS extra_components)
+    message(WARNING "Extraneous find_package component for Filesystem: ${component}")
+endforeach()
+
+# Detect which of Experimental and Final we should look for
+set(find_experimental TRUE)
+set(find_final TRUE)
+if(NOT "Final" IN_LIST want_components)
+    set(find_final FALSE)
+endif()
+if(NOT "Experimental" IN_LIST want_components)
+    set(find_experimental FALSE)
+endif()
+
+if(find_final)
+    check_include_file_cxx("filesystem" _CXX_FILESYSTEM_HAVE_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_HEADER)
+    if(_CXX_FILESYSTEM_HAVE_HEADER)
+        # We found the non-experimental header. Don't bother looking for the
+        # experimental one.
+        set(find_experimental FALSE)
+    endif()
+else()
+    set(_CXX_FILESYSTEM_HAVE_HEADER FALSE)
+endif()
+
+if(find_experimental)
+    check_include_file_cxx("experimental/filesystem" _CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    mark_as_advanced(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+else()
+    set(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER FALSE)
+endif()
+
+if(_CXX_FILESYSTEM_HAVE_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header filesystem)
+    set(_fs_namespace std::filesystem)
+elseif(_CXX_FILESYSTEM_HAVE_EXPERIMENTAL_HEADER)
+    set(_have_fs TRUE)
+    set(_fs_header experimental/filesystem)
+    set(_fs_namespace std::experimental::filesystem)
+else()
+    set(_have_fs FALSE)
+endif()
+
+set(CXX_FILESYSTEM_HAVE_FS ${_have_fs} CACHE BOOL "TRUE if we have the C++ filesystem headers")
+set(CXX_FILESYSTEM_HEADER ${_fs_header} CACHE STRING "The header that should be included to obtain the filesystem APIs")
+set(CXX_FILESYSTEM_NAMESPACE ${_fs_namespace} CACHE STRING "The C++ namespace that contains the filesystem APIs")
+
+set(_found FALSE)
+
+if(CXX_FILESYSTEM_HAVE_FS)
+    # We have some filesystem library available. Do link checks
+    string(CONFIGURE [[
+        #include <@CXX_FILESYSTEM_HEADER@>
+
+        int main() {
+            auto cwd = @CXX_FILESYSTEM_NAMESPACE@::current_path();
+            return static_cast<int>(cwd.string().size());
+        }
+    ]] code @ONLY)
+
+    # Try to compile a simple filesystem program without any linker flags
+    check_cxx_source_compiles("${code}" CXX_FILESYSTEM_NO_LINK_NEEDED)
+
+    set(can_link ${CXX_FILESYSTEM_NO_LINK_NEEDED})
+
+    if(NOT CXX_FILESYSTEM_NO_LINK_NEEDED)
+        set(prev_libraries ${CMAKE_REQUIRED_LIBRARIES})
+        # Add the libstdc++ flag
+        set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lstdc++fs)
+        check_cxx_source_compiles("${code}" CXX_FILESYSTEM_STDCPPFS_NEEDED)
+        set(can_link ${CXX_FILESYSTEM_STDCPPFS_NEEDED})
+        if(NOT CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            # Try the libc++ flag
+            set(CMAKE_REQUIRED_LIBRARIES ${prev_libraries} -lc++fs)
+            check_cxx_source_compiles("${code}" CXX_FILESYSTEM_CPPFS_NEEDED)
+            set(can_link ${CXX_FILESYSTEM_CPPFS_NEEDED})
+        endif()
+    endif()
+
+    if(can_link)
+        add_library(std::filesystem INTERFACE IMPORTED)
+        target_compile_features(std::filesystem INTERFACE cxx_std_17)
+        set(_found TRUE)
+
+        if(CXX_FILESYSTEM_NO_LINK_NEEDED)
+            # Nothing to add...
+        elseif(CXX_FILESYSTEM_STDCPPFS_NEEDED)
+            target_link_libraries(std::filesystem INTERFACE -lstdc++fs)
+        elseif(CXX_FILESYSTEM_CPPFS_NEEDED)
+            target_link_libraries(std::filesystem INTERFACE -lc++fs)
+        endif()
+    endif()
+endif()
+
+cmake_pop_check_state()
+
+set(Filesystem_FOUND ${_found} CACHE BOOL "TRUE if we can compile and link a program using std::filesystem" FORCE)
+
+if(Filesystem_FIND_REQUIRED AND NOT Filesystem_FOUND)
+    message(FATAL_ERROR "Cannot Compile simple program using std::filesystem")
+endif()


### PR DESCRIPTION
This adds the `Tests/Data` directory for test-related data files and adds a `getDataPath()` utility to access them.

The implementation hard-codes the data path at compile time for the following reasons:
* Avoid unnecessary copies from source to build directory.
* Allow usage in unit tests where there is no access to `argv`.
* Tests are *never* installed. Hard coding the path is therefore not an issue.

This also includes a cmake module for handling `std::filesystem`. This also prepares for #193.