### PR TITLE
ProtoLayer/Extent changes

### DIFF
--- a/Core/include/Acts/Geometry/Extent.hpp
+++ b/Core/include/Acts/Geometry/Extent.hpp
@@ -33,7 +33,7 @@ struct Extent {
   static constexpr Range maxrange = {maxval, -maxval};
 
   // The different ranges
-  std::vector<Range> ranges = std::vector<Range>(9, maxrange);
+  std::vector<Range> ranges{(int)binValues, maxrange};
 
   // Constructor
   Extent() = default;
@@ -80,10 +80,13 @@ struct Extent {
 
   /// Access the minimum parameter
   /// @param bval the binning identification
+  double& min(BinningValue bval) { return ranges[bval].first; }
+
   double min(BinningValue bval) const { return ranges[bval].first; }
 
   /// Access the max parameter
   /// @param bval the binning identification
+  double& max(BinningValue bval) { return ranges[bval].second; }
   double max(BinningValue bval) const { return ranges[bval].second; }
 
   /// Access the medium parameter

--- a/Core/include/Acts/Geometry/Extent.hpp
+++ b/Core/include/Acts/Geometry/Extent.hpp
@@ -82,11 +82,16 @@ struct Extent {
   /// @param bval the binning identification
   double& min(BinningValue bval) { return ranges[bval].first; }
 
+  /// Access the minimum parameter
+  /// @param bval the binning identification
   double min(BinningValue bval) const { return ranges[bval].first; }
 
   /// Access the max parameter
   /// @param bval the binning identification
   double& max(BinningValue bval) { return ranges[bval].second; }
+
+  /// Access the max parameter
+  /// @param bval the binning identification
   double max(BinningValue bval) const { return ranges[bval].second; }
 
   /// Access the medium parameter

--- a/Core/include/Acts/Geometry/ProtoLayer.hpp
+++ b/Core/include/Acts/Geometry/ProtoLayer.hpp
@@ -29,7 +29,7 @@ struct ProtoLayer {
 
   /// The envelope parameters
   using Range = std::pair<double, double>;
-  std::vector<Range> envelope = std::vector<Range>((int)binValues, {0., 0.});
+  std::vector<Range> envelope{(int)binValues, {0., 0.}};
 
   /// Constructor
   ///
@@ -58,22 +58,22 @@ struct ProtoLayer {
   /// Get the parameters : min
   /// @param bval The accessed binning value
   /// @param addenv The steering if enevlope is added or not
-  double min(BinningValue bval, bool addenv = true);
+  double min(BinningValue bval, bool addenv = true) const;
 
   // Get the  parameters : max
   /// @param bval The accessed binning value
   /// @param addenv The steering if enevlope is added or not
-  double max(BinningValue bval, bool addenv = true);
+  double max(BinningValue bval, bool addenv = true) const;
 
   // Get the  parameters : max
   /// @param bval The accessed binning value
   /// @param addenv The steering if enevlope is added or not
-  double medium(BinningValue bval, bool addenv = true);
+  double medium(BinningValue bval, bool addenv = true) const;
 
   // Get the  parameters : max
   /// @param bval The accessed binning value
   /// @param addenv The steering if enevlope is added or not
-  double range(BinningValue bval, bool addenv = true);
+  double range(BinningValue bval, bool addenv = true) const;
 
   /// Output to ostream
   /// @param sl the input ostream

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -55,17 +55,17 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
 
   ACTS_VERBOSE("Creating a cylindrical Layer:");
   ACTS_VERBOSE(" - with layer R     = " << layerR);
-  ACTS_VERBOSE(" - from R min/max   = " << protoLayer.min(binR) << " / "
-                                        << protoLayer.max(binR));
+  ACTS_VERBOSE(" - from R min/max   = " << protoLayer.min(binR, false) << " / "
+                                        << protoLayer.max(binR, false));
   ACTS_VERBOSE(" - with R thickness = " << layerThickness);
   ACTS_VERBOSE("   - incl envelope  = " << protoLayer.envelope[binR].first
                                         << " / "
                                         << protoLayer.envelope[binR].second);
 
   ACTS_VERBOSE(" - with z min/max   = "
-               << protoLayer.min(binZ) << " (-"
+               << protoLayer.min(binZ, false) << " (-"
                << protoLayer.envelope[binZ].first << ") / "
-               << protoLayer.max(binZ) << " (+"
+               << protoLayer.max(binZ, false) << " (+"
                << protoLayer.envelope[binZ].second << ")");
 
   ACTS_VERBOSE(" - z center         = " << layerZ);
@@ -81,8 +81,9 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
     ACTS_VERBOSE(" - layer z shift  = " << -layerZ);
   }
 
-  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi) << " / "
-                                        << protoLayer.max(binPhi));
+  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi, false)
+                                        << " / "
+                                        << protoLayer.max(binPhi, false));
   ACTS_VERBOSE(" - # of modules     = " << surfaces.size() << " ordered in ( "
                                         << binsPhi << " x " << binsZ << ")");
   std::unique_ptr<SurfaceArray> sArray;
@@ -128,16 +129,16 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
   // adjust the layer radius
   ACTS_VERBOSE("Creating a cylindrical Layer:");
   ACTS_VERBOSE(" - with layer R     = " << layerR);
-  ACTS_VERBOSE(" - from R min/max   = " << protoLayer.min(binR) << " / "
-                                        << protoLayer.max(binR));
+  ACTS_VERBOSE(" - from R min/max   = " << protoLayer.min(binR, false) << " / "
+                                        << protoLayer.max(binR, false));
   ACTS_VERBOSE(" - with R thickness = " << layerThickness);
   ACTS_VERBOSE("   - incl envelope  = " << protoLayer.envelope[binR].first
                                         << " / "
                                         << protoLayer.envelope[binR].second);
   ACTS_VERBOSE(" - with z min/max   = "
-               << protoLayer.min(binZ) << " (-"
+               << protoLayer.min(binZ, false) << " (-"
                << protoLayer.envelope[binZ].first << ") / "
-               << protoLayer.max(binZ) << " (+"
+               << protoLayer.max(binZ, false) << " (+"
                << protoLayer.envelope[binZ].second << ")");
   ACTS_VERBOSE(" - z center         = " << layerZ);
   ACTS_VERBOSE(" - halflength z     = " << layerHalfZ);
@@ -151,8 +152,9 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
     ACTS_VERBOSE(" - layer z shift    = " << -layerZ);
   }
 
-  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi) << " / "
-                                        << protoLayer.max(binPhi));
+  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi, false)
+                                        << " / "
+                                        << protoLayer.max(binPhi, false));
   ACTS_VERBOSE(" - # of modules     = " << surfaces.size() << "");
 
   // create the surface array
@@ -196,19 +198,20 @@ Acts::MutableLayerPtr Acts::LayerCreator::discLayer(
   // adjust the layer radius
   ACTS_VERBOSE("Creating a disk Layer:");
   ACTS_VERBOSE(" - at Z position    = " << layerZ);
-  ACTS_VERBOSE(" - from Z min/max   = " << protoLayer.min(binZ) << " / "
-                                        << protoLayer.max(binZ));
+  ACTS_VERBOSE(" - from Z min/max   = " << protoLayer.min(binZ, false) << " / "
+                                        << protoLayer.max(binZ, false));
   ACTS_VERBOSE(" - with Z thickness = " << layerThickness);
   ACTS_VERBOSE("   - incl envelope  = " << protoLayer.envelope[binZ].first
                                         << " / "
                                         << protoLayer.envelope[binZ].second);
   ACTS_VERBOSE(" - with R min/max   = "
-               << protoLayer.min(binR) << " (-"
+               << protoLayer.min(binR, false) << " (-"
                << protoLayer.envelope[binR].first << ") / "
-               << protoLayer.max(binR) << " (+"
+               << protoLayer.max(binR, false) << " (+"
                << protoLayer.envelope[binR].second << ")");
-  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi) << " / "
-                                        << protoLayer.max(binPhi));
+  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi, false)
+                                        << " / "
+                                        << protoLayer.max(binPhi, false));
   ACTS_VERBOSE(" - # of modules    = " << surfaces.size() << " ordered in ( "
                                        << binsR << " x " << binsPhi << ")");
 
@@ -259,19 +262,20 @@ Acts::MutableLayerPtr Acts::LayerCreator::discLayer(
   // adjust the layer radius
   ACTS_VERBOSE("Creating a disk Layer:");
   ACTS_VERBOSE(" - at Z position    = " << layerZ);
-  ACTS_VERBOSE(" - from Z min/max   = " << protoLayer.min(binZ) << " / "
-                                        << protoLayer.max(binZ));
+  ACTS_VERBOSE(" - from Z min/max   = " << protoLayer.min(binZ, false) << " / "
+                                        << protoLayer.max(binZ, false));
   ACTS_VERBOSE(" - with Z thickness = " << layerThickness);
   ACTS_VERBOSE("   - incl envelope  = " << protoLayer.envelope[binZ].first
                                         << " / "
                                         << protoLayer.envelope[binZ].second);
   ACTS_VERBOSE(" - with R min/max   = "
-               << protoLayer.min(binR) << " (-"
+               << protoLayer.min(binR, false) << " (-"
                << protoLayer.envelope[binR].first << ") / "
-               << protoLayer.max(binR) << " (+"
+               << protoLayer.max(binR, false) << " (+"
                << protoLayer.envelope[binR].second << ")");
-  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi) << " / "
-                                        << protoLayer.max(binPhi));
+  ACTS_VERBOSE(" - with phi min/max = " << protoLayer.min(binPhi, false)
+                                        << " / "
+                                        << protoLayer.max(binPhi, false));
   ACTS_VERBOSE(" - # of modules     = " << surfaces.size());
 
   // create the layer transforms if not given

--- a/Core/src/Geometry/ProtoLayer.cpp
+++ b/Core/src/Geometry/ProtoLayer.cpp
@@ -34,25 +34,25 @@ ProtoLayer::ProtoLayer(
   measure(gctx, m_surfaces);
 }
 
-double ProtoLayer::min(BinningValue bval, bool addenv) {
+double ProtoLayer::min(BinningValue bval, bool addenv) const {
   if (addenv) {
     return extent.min(bval) - envelope[bval].first;
   }
   return extent.min(bval);
 }
 
-double ProtoLayer::max(BinningValue bval, bool addenv) {
+double ProtoLayer::max(BinningValue bval, bool addenv) const {
   if (addenv) {
     return extent.max(bval) + envelope[bval].second;
   }
   return extent.max(bval);
 }
 
-double ProtoLayer::medium(BinningValue bval, bool addenv) {
+double ProtoLayer::medium(BinningValue bval, bool addenv) const {
   return 0.5 * (min(bval, addenv) + max(bval, addenv));
 }
 
-double ProtoLayer::range(BinningValue bval, bool addenv) {
+double ProtoLayer::range(BinningValue bval, bool addenv) const {
   return std::abs(max(bval, addenv) - min(bval, addenv));
 }
 


### PR DESCRIPTION
- Makes a few `ProtoLayer` methods const that can be const
- Fixes some output in `LayerCreator` that incorrectly reported extent with or without envelopes
- Makes Extent editable (I need this in Athena)
- Simplify vector used in Extent.