### PR TITLE
Run CI on release branches

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 jobs:
   format:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
Currently the CI only runs on pushes to master, and on PRs that go into master.
This PR changes this (hopefully) to also run on release/* branches.