### PR TITLE
Add configuration for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 60
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,7 +6,7 @@ daysUntilClose: 60
 exemptLabels:
   - pinned
 # Label to use when marking an issue as stale
-staleLabel: stale
+staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
See https://probot.github.io/apps/stale/
This should mark issues as stale after 30 days with a label `stale`, and close them after 60
days.

Looks good, @msmk0?