### PR TITLE
Backport: Change seed vertex break condition in AMVF

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -59,7 +59,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
 
     ACTS_DEBUG("Position of current vertex candidate after seeding: "
                << vtxCandidate.fullPosition());
-    if (vtxCandidate.position().z() == 0.) {
+    if (vtxCandidate.position().z() ==
+        vertexingOptions.vertexConstraint.position().z()) {
       ACTS_DEBUG(
           "No seed found anymore. Break and stop primary vertex finding.");
       allVertices.pop_back();


### PR DESCRIPTION
The vertex seed finders return a vertex at the position of the vertex constraint if no more seed can be found. The AMVF should therefore check for the constraint z position rather than ```z==0``` as a break condition. This change has already been available in a different branch for AMVF timing measurements and was unfortunately not ported into master yet.