### PR TITLE
Remove unnecessary/unused elements from (C)KF

### DIFF
--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -23,7 +23,6 @@ namespace Acts {
 ///
 /// @tparam parameters_t Type of the track parameters
 /// @tparam jacobian_t Type of the Jacobian
-template <typename parameters_t>
 class GainMatrixSmoother {
  public:
   /// @brief Gain Matrix smoother implementation
@@ -48,15 +47,14 @@ class GainMatrixSmoother {
   ///
   /// @return The smoothed track parameters at the first measurement state
   template <typename source_link_t>
-  Result<parameters_t> operator()(const GeometryContext& gctx,
+  Result<void> operator()(const GeometryContext& gctx,
                                   MultiTrajectory<source_link_t>& trajectory,
                                   size_t entryIndex) const {
     ACTS_VERBOSE("Invoked GainMatrixSmoother on entry index: " << entryIndex);
     using namespace boost::adaptors;
 
     // using ParVector_t = typename parameters_t::ParVector_t;
-    using CovMatrix = typename parameters_t::CovMatrix_t;
-    using GainMatrix = CovMatrix;
+    using Matrix_t = ActsSymMatrixD<MultiTrajectory<source_link_t>::ParametersSize>;
 
     // For the last state: smoothed is filtered - also: switch to next
     ACTS_VERBOSE("Getting previous track state");
@@ -66,7 +64,7 @@ class GainMatrixSmoother {
     prev_ts.smoothedCovariance() = prev_ts.filteredCovariance();
 
     // Smoothing gain matrix
-    GainMatrix G;
+    Matrix_t G;
 
     // make sure there is more than one track state
     std::optional<std::error_code> error{std::nullopt};  // assume ok
@@ -135,8 +133,8 @@ class GainMatrixSmoother {
         // If not, make one (could do more) attempt to replace it with the
         // nearest semi-positive def matrix,
         // but it could still be non semi-positive
-        CovMatrix smoothedCov = ts.smoothedCovariance();
-        if (not detail::covariance_helper<CovMatrix>::validate(smoothedCov)) {
+        Matrix_t smoothedCov = ts.smoothedCovariance();
+        if (not detail::covariance_helper<Matrix_t>::validate(smoothedCov)) {
           ACTS_DEBUG(
               "Smoothed covariance is not positive definite. Could result in "
               "negative covariance!");
@@ -155,7 +153,7 @@ class GainMatrixSmoother {
     }
 
     // construct parameters from last track state
-    return prev_ts.smoothedParameters(gctx);
+    return Result<void>::success();
   }
 
   /// Pointer to a logger that is owned by the parent, KalmanFilter

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -48,13 +48,14 @@ class GainMatrixSmoother {
   /// @return The smoothed track parameters at the first measurement state
   template <typename source_link_t>
   Result<void> operator()(const GeometryContext& gctx,
-                                  MultiTrajectory<source_link_t>& trajectory,
-                                  size_t entryIndex) const {
+                          MultiTrajectory<source_link_t>& trajectory,
+                          size_t entryIndex) const {
     ACTS_VERBOSE("Invoked GainMatrixSmoother on entry index: " << entryIndex);
     using namespace boost::adaptors;
 
     // using ParVector_t = typename parameters_t::ParVector_t;
-    using Matrix_t = ActsSymMatrixD<MultiTrajectory<source_link_t>::ParametersSize>;
+    using Matrix_t =
+        ActsSymMatrixD<MultiTrajectory<source_link_t>::ParametersSize>;
 
     // For the last state: smoothed is filtered - also: switch to next
     ACTS_VERBOSE("Getting previous track state");

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -53,8 +53,7 @@ class GainMatrixSmoother {
     ACTS_VERBOSE("Invoked GainMatrixSmoother on entry index: " << entryIndex);
     using namespace boost::adaptors;
 
-    // using ParVector_t = typename parameters_t::ParVector_t;
-    using Matrix_t =
+    using Matrix =
         ActsSymMatrixD<MultiTrajectory<source_link_t>::ParametersSize>;
 
     // For the last state: smoothed is filtered - also: switch to next
@@ -65,7 +64,7 @@ class GainMatrixSmoother {
     prev_ts.smoothedCovariance() = prev_ts.filteredCovariance();
 
     // Smoothing gain matrix
-    Matrix_t G;
+    Matrix G;
 
     // make sure there is more than one track state
     std::optional<std::error_code> error{std::nullopt};  // assume ok
@@ -134,8 +133,8 @@ class GainMatrixSmoother {
         // If not, make one (could do more) attempt to replace it with the
         // nearest semi-positive def matrix,
         // but it could still be non semi-positive
-        Matrix_t smoothedCov = ts.smoothedCovariance();
-        if (not detail::covariance_helper<Matrix_t>::validate(smoothedCov)) {
+        Matrix smoothedCov = ts.smoothedCovariance();
+        if (not detail::covariance_helper<Matrix>::validate(smoothedCov)) {
           ACTS_DEBUG(
               "Smoothed covariance is not positive definite. Could result in "
               "negative covariance!");

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -23,11 +23,6 @@
 namespace Acts {
 
 /// @brief Update step of Kalman Filter using gain matrix formalism
-///
-/// @tparam parameters_t Type of the parameters to be filtered
-/// @tparam jacobian_t Type of the Transport jacobian
-///
-template <typename parameters_t>
 class GainMatrixUpdater {
  public:
   /// Explicit constructor
@@ -62,9 +57,6 @@ class GainMatrixUpdater {
         typename MultiTrajectory<SourceLink>::TrackStateProxy;
     static_assert(std::is_same_v<track_state_t, TrackStateProxy>,
                   "Given track state type is not a track state proxy");
-
-    using CovMatrix_t = typename parameters_t::CovMatrix_t;
-    using ParVector_t = typename parameters_t::ParVector_t;
 
     // we should definitely have an uncalibrated measurement here
     assert(trackState.hasUncalibrated());

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -196,8 +196,7 @@ class KalmanFitter {
   KalmanFitter(propagator_t pPropagator,
                std::unique_ptr<const Logger> logger =
                    getDefaultLogger("KalmanFilter", Logging::INFO))
-      : m_propagator(std::move(pPropagator)),
-        m_logger(logger.release()) {}
+      : m_propagator(std::move(pPropagator)), m_logger(logger.release()) {}
 
  private:
   /// The propgator for the transport and material update
@@ -219,7 +218,6 @@ class KalmanFitter {
   template <typename source_link_t, typename parameters_t>
   class Actor {
    public:
-
     /// Broadcast the result_type
     using result_type = KalmanFitterResult<source_link_t>;
 
@@ -908,7 +906,8 @@ class KalmanFitter {
   auto fit(const std::vector<source_link_t>& sourcelinks,
            const start_parameters_t& sParameters,
            const KalmanFitterOptions<outlier_finder_t>& kfOptions) const
-      -> std::enable_if_t<!isDirectNavigator, Result<KalmanFitterResult<source_link_t>>> {
+      -> std::enable_if_t<!isDirectNavigator,
+                          Result<KalmanFitterResult<source_link_t>>> {
     static_assert(SourceLinkConcept<source_link_t>,
                   "Source link does not fulfill SourceLinkConcept");
 
@@ -947,7 +946,7 @@ class KalmanFitter {
     // also set logger on updater and smoother
     kalmanActor.m_updater.m_logger = m_logger;
     kalmanActor.m_smoother.m_logger = m_logger;
-    
+
     // Run the fitter
     auto result = m_propagator.template propagate(sParameters, kalmanOptions);
 
@@ -1000,7 +999,8 @@ class KalmanFitter {
            const start_parameters_t& sParameters,
            const KalmanFitterOptions<outlier_finder_t>& kfOptions,
            const std::vector<const Surface*>& sSequence) const
-      -> std::enable_if_t<isDirectNavigator, Result<KalmanFitterResult<source_link_t>>> {
+      -> std::enable_if_t<isDirectNavigator,
+                          Result<KalmanFitterResult<source_link_t>>> {
     static_assert(SourceLinkConcept<source_link_t>,
                   "Source link does not fulfill SourceLinkConcept");
 

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -971,7 +971,7 @@ class KalmanFitter {
     }
 
     // Return the converted Track
-    return std::move(kalmanResult);
+    return kalmanResult;
   }
 
   /// Fit implementation of the foward filter, calls the
@@ -1069,7 +1069,7 @@ class KalmanFitter {
     }
 
     // Return the converted Track
-    return std::move(kalmanResult);
+    return kalmanResult;
   }
 };
 

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -125,9 +125,6 @@ struct KalmanFitterResult {
   // Indicator if smoothing has been done.
   bool smoothed = false;
 
-  // Indicator if initialization has been performed.
-  bool initialized = false;
-
   // Indicator if the propagation state has been reset
   bool reset = false;
 
@@ -279,16 +276,6 @@ class KalmanFitter {
         // We only do this after the backward-propagation starting layer has
         // been processed
         result.reset = false;
-      }
-
-      // Initialization:
-      // - Only when track states are not set
-      if (!result.initialized) {
-        // -> Move the TrackState vector
-        // -> Feed the KalmanSequencer with the measurements to be fitted
-        ACTS_VERBOSE("Initializing");
-        initialize(state, stepper, result);
-        result.initialized = true;
       }
 
       // Update:
@@ -928,12 +915,11 @@ class KalmanFitter {
   /// @return the output as an output track
   template <typename source_link_t, typename start_parameters_t,
             typename kalman_fitter_options_t,
-            typename parameters_t = BoundParameters,
-            typename result_t = Result<KalmanFitterResult<source_link_t>>>
+            typename parameters_t = BoundParameters>
   auto fit(const std::vector<source_link_t>& sourcelinks,
            const start_parameters_t& sParameters,
            const kalman_fitter_options_t& kfOptions) const
-      -> std::enable_if_t<!isDirectNavigator, result_t> {
+      -> std::enable_if_t<!isDirectNavigator, Result<KalmanFitterResult<source_link_t>>> {
     static_assert(SourceLinkConcept<source_link_t>,
                   "Source link does not fulfill SourceLinkConcept");
 
@@ -1028,13 +1014,12 @@ class KalmanFitter {
   /// @return the output as an output track
   template <typename source_link_t, typename start_parameters_t,
             typename kalman_fitter_options_t,
-            typename parameters_t = BoundParameters,
-            typename result_t = Result<KalmanFitterResult<source_link_t>>>
+            typename parameters_t = BoundParameters>
   auto fit(const std::vector<source_link_t>& sourcelinks,
            const start_parameters_t& sParameters,
            const kalman_fitter_options_t& kfOptions,
            const std::vector<const Surface*>& sSequence) const
-      -> std::enable_if_t<isDirectNavigator, result_t> {
+      -> std::enable_if_t<isDirectNavigator, Result<KalmanFitterResult<source_link_t>>> {
     static_assert(SourceLinkConcept<source_link_t>,
                   "Source link does not fulfill SourceLinkConcept");
 

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -355,10 +355,9 @@ class KalmanFitter {
               state.data().ismoothed = detail_lt::IndexData::kInvalid;
             }
           });
-
-          // Remember the track fitting is done
-          result.finished = true;
         }
+        // Remember the track fitting is done
+        result.finished = true;
       }
     }
 

--- a/Core/include/Acts/Fitter/detail/VoidKalmanComponents.hpp
+++ b/Core/include/Acts/Fitter/detail/VoidKalmanComponents.hpp
@@ -30,19 +30,6 @@ struct VoidKalmanComponents {
                                    const parameters_t& /*pars*/) const {
     return m;
   }
-
-  /// @brief void measurement converter only moves the
-  /// the measurement through for further processing
-  ///
-  /// @tparam measurement_container_t Type of the measurement
-  ///
-  /// @param ms Measurements to be moved through
-  ///
-  /// @return moved measurements
-  template <typename measurements_t>
-  Result<measurements_t> operator()(measurements_t ms) const {
-    return std::move(ms);
-  }
 };
 
 /// @brief Void measurement calibrator for filtering

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -1176,7 +1176,7 @@ class CombinatorialKalmanFilter {
     }
 
     // Return the converted Track
-    return std::move(combKalmanResult);
+    return combKalmanResult;
   }
 
 };  // namespace Acts

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -1227,7 +1227,7 @@ class CombinatorialKalmanFilter {
     }
 
     // Return the converted Track
-    return m_outputConverter(std::move(combKalmanResult));
+    return std::move(combKalmanResult);
   }
 
 };  // namespace Acts

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -156,9 +156,6 @@ struct CombinatorialKalmanFilterResult {
   // The index for the current smoothing track
   size_t iSmoothed = 0;
 
-  // Indicator if initialization has been performed.
-  bool initialized = false;
-
   // Indicator if the propagation state has been reset
   bool reset = false;
 
@@ -185,8 +182,6 @@ struct CombinatorialKalmanFilterResult {
 /// @tparam source_link_selector_t Type of the source link selector class
 /// @tparam branch_stopper_t Type of the branch stopper class
 /// @tparam calibrator_t Type of the calibrator class
-/// @tparam input_converter_t Type of the input converter class
-/// @tparam output_converter_t Type of the output converter class
 ///
 /// The CombinatorialKalmanFilter contains an Actor and a Sequencer sub-class.
 /// The Sequencer has to be part of the Navigator of the Propagator
@@ -208,20 +203,12 @@ struct CombinatorialKalmanFilterResult {
 /// CombinatorialKalmanFilter, measurement ordering needs to be figured out by
 /// the navigation of the propagator.
 ///
-/// The Input converter is a converter that transforms the input
-/// measurement/track/segments into a set of FittableMeasurements
-///
-/// The Output converter is a converter that transforms the
-/// set of track states into a given track/track particle class
-///
 /// The void components are provided mainly for unit testing.
 template <typename propagator_t, typename updater_t = VoidKalmanUpdater,
           typename smoother_t = VoidKalmanSmoother,
           typename source_link_selector_t = CKFSourceLinkSelector,
           typename branch_stopper_t = VoidBranchStopper,
-          typename calibrator_t = VoidMeasurementCalibrator,
-          typename input_converter_t = VoidKalmanComponents,
-          typename output_converter_t = VoidKalmanComponents>
+          typename calibrator_t = VoidMeasurementCalibrator>
 class CombinatorialKalmanFilter {
  public:
   /// Shorthand definition
@@ -236,23 +223,13 @@ class CombinatorialKalmanFilter {
   CombinatorialKalmanFilter(
       propagator_t pPropagator,
       std::unique_ptr<const Logger> logger =
-          getDefaultLogger("CombinatorialKalmanFilter", Logging::INFO),
-      input_converter_t pInputCnv = input_converter_t(),
-      output_converter_t pOutputCnv = output_converter_t())
+          getDefaultLogger("CombinatorialKalmanFilter", Logging::INFO))
       : m_propagator(std::move(pPropagator)),
-        m_inputConverter(std::move(pInputCnv)),
-        m_outputConverter(std::move(pOutputCnv)),
         m_logger(logger.release()) {}
 
  private:
   /// The propgator for the transport and material update
   propagator_t m_propagator;
-
-  /// The input converter to Fittable measurements
-  input_converter_t m_inputConverter;
-
-  /// The output converter into a given format
-  output_converter_t m_outputConverter;
 
   /// Logger getter to support macros
   const Logger& logger() const { return *m_logger; }
@@ -270,22 +247,12 @@ class CombinatorialKalmanFilter {
   template <typename source_link_t, typename parameters_t>
   class Actor {
    public:
-    using TrackStateType = TrackState<source_link_t, parameters_t>;
     using TipState = CombinatorialKalmanFilterTipState;
     using BoundState = std::tuple<BoundParameters, BoundMatrix, double>;
     using CurvilinearState =
         std::tuple<CurvilinearParameters, BoundMatrix, double>;
     /// Broadcast the result_type
     using result_type = CombinatorialKalmanFilterResult<source_link_t>;
-
-    /// Explicit constructor with updater and calibrator
-    Actor(updater_t pUpdater = updater_t(), smoother_t pSmoother = smoother_t(),
-          source_link_selector_t pSourceLinkSelector = source_link_selector_t(),
-          branch_stopper_t pBranchStopper = branch_stopper_t(),
-          calibrator_t pCalibrator = calibrator_t())
-        : m_updater(std::move(pUpdater)),
-          m_smoother(std::move(pSmoother)),
-          m_calibrator(std::move(pCalibrator)) {}
 
     /// The target surface
     const Surface* targetSurface = nullptr;
@@ -331,13 +298,6 @@ class CombinatorialKalmanFilter {
         state.navigation.navigationStage = KalmanNavigator::Stage::layerTarget;
         // We only do this after the reset layer has been processed
         result.reset = false;
-      }
-
-      // Initialization:
-      // - Only when track states are not set
-      if (!result.initialized) {
-        ACTS_VERBOSE("Initializing");
-        result.initialized = true;
       }
 
       // Update:
@@ -1099,9 +1059,9 @@ class CombinatorialKalmanFilter {
   template <typename source_link_t, typename parameters_t>
   class Aborter {
    public:
-    /// Broadcast the result_type
+	/// Broadcast the result_type
     using action_type = Actor<source_link_t, parameters_t>;
-
+    
     template <typename propagator_state_t, typename stepper_t,
               typename result_t>
     bool operator()(propagator_state_t& /*state*/, const stepper_t& /*stepper*/,
@@ -1119,8 +1079,6 @@ class CombinatorialKalmanFilter {
   ///
   /// @tparam source_link_container_t Source link container type
   /// @tparam start_parameters_t Type of the initial parameters
-  /// @tparam comb_kalman_filter_options_t Type of the CombinatorialKalmanFilter
-  /// options
   /// @tparam parameters_t Type of parameters used for local parameters
   ///
   /// @param sourcelinks The fittable uncalibrated measurements
@@ -1134,24 +1092,15 @@ class CombinatorialKalmanFilter {
   ///
   /// @return the output as an output track
   template <typename source_link_container_t, typename start_parameters_t,
-            typename comb_kalman_filter_options_t,
             typename parameters_t = BoundParameters>
   Result<CombinatorialKalmanFilterResult<
       typename source_link_container_t::value_type>>
   findTracks(const source_link_container_t& sourcelinks,
              const start_parameters_t& sParameters,
-             const comb_kalman_filter_options_t& tfOptions) const {
+             const CombinatorialKalmanFilterOptions<source_link_selector_t>& tfOptions) const {
     using SourceLink = typename source_link_container_t::value_type;
     static_assert(SourceLinkConcept<SourceLink>,
                   "Source link does not fulfill SourceLinkConcept");
-
-    static_assert(
-        std::is_same<
-            source_link_selector_t,
-            typename comb_kalman_filter_options_t::SourceLinkSelector>::value,
-        "Inconsistent type of source link selector between "
-        "CombinatorialKalmanFilter and "
-        " CombinatorialKalmanFilter options");
 
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyways, so the map can own them.

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -220,12 +220,11 @@ class CombinatorialKalmanFilter {
   CombinatorialKalmanFilter() = delete;
 
   /// Constructor from arguments
-  CombinatorialKalmanFilter(
-      propagator_t pPropagator,
-      std::unique_ptr<const Logger> logger =
-          getDefaultLogger("CombinatorialKalmanFilter", Logging::INFO))
-      : m_propagator(std::move(pPropagator)),
-        m_logger(logger.release()) {}
+  CombinatorialKalmanFilter(propagator_t pPropagator,
+                            std::unique_ptr<const Logger> logger =
+                                getDefaultLogger("CombinatorialKalmanFilter",
+                                                 Logging::INFO))
+      : m_propagator(std::move(pPropagator)), m_logger(logger.release()) {}
 
  private:
   /// The propgator for the transport and material update
@@ -1059,9 +1058,9 @@ class CombinatorialKalmanFilter {
   template <typename source_link_t, typename parameters_t>
   class Aborter {
    public:
-	/// Broadcast the result_type
+    /// Broadcast the result_type
     using action_type = Actor<source_link_t, parameters_t>;
-    
+
     template <typename propagator_state_t, typename stepper_t,
               typename result_t>
     bool operator()(propagator_state_t& /*state*/, const stepper_t& /*stepper*/,
@@ -1097,7 +1096,8 @@ class CombinatorialKalmanFilter {
       typename source_link_container_t::value_type>>
   findTracks(const source_link_container_t& sourcelinks,
              const start_parameters_t& sParameters,
-             const CombinatorialKalmanFilterOptions<source_link_selector_t>& tfOptions) const {
+             const CombinatorialKalmanFilterOptions<source_link_selector_t>&
+                 tfOptions) const {
     using SourceLink = typename source_link_container_t::value_type;
     static_assert(SourceLinkConcept<SourceLink>,
                   "Source link does not fulfill SourceLinkConcept");

--- a/Examples/Algorithms/Fitting/src/FittingAlgorithmFitterFunction.cpp
+++ b/Examples/Algorithms/Fitting/src/FittingAlgorithmFitterFunction.cpp
@@ -46,8 +46,8 @@ struct FitterFunctionImpl {
 FW::FittingAlgorithm::FitterFunction FW::FittingAlgorithm::makeFitterFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     Options::BFieldVariant magneticField, Acts::Logging::Level lvl) {
-  using Updater = Acts::GainMatrixUpdater<Acts::BoundParameters>;
-  using Smoother = Acts::GainMatrixSmoother<Acts::BoundParameters>;
+  using Updater = Acts::GainMatrixUpdater;
+  using Smoother = Acts::GainMatrixSmoother;
 
   // unpack the magnetic field variant and instantiate the corresponding fitter.
   return std::visit(

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmTrackFinderFunction.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmTrackFinderFunction.cpp
@@ -42,8 +42,8 @@ FW::TrackFindingAlgorithm::TrackFinderFunction
 FW::TrackFindingAlgorithm::makeTrackFinderFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     Options::BFieldVariant magneticField, Acts::Logging::Level lvl) {
-  using Updater = Acts::GainMatrixUpdater<Acts::BoundParameters>;
-  using Smoother = Acts::GainMatrixSmoother<Acts::BoundParameters>;
+  using Updater = Acts::GainMatrixUpdater;
+  using Smoother = Acts::GainMatrixSmoother;
 
   // unpack the magnetic field variant and instantiate the corresponding track
   // finder.

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
 
   // "smooth" these three track states
 
-  GainMatrixSmoother<BoundParameters> gms;
+  GainMatrixSmoother gms;
   BOOST_CHECK(gms(tgContext, traj, ts_idx).ok());
 
   // Regression tests, only tests very basic correctness of the math, but tests

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   ts.pathLength() = 0.;
 
   // Gain matrix update and filtered state
-  GainMatrixUpdater<BoundParameters> gmu;
+  GainMatrixUpdater gmu;
 
   BOOST_CHECK(ts.hasFiltered());
   BOOST_CHECK(ts.hasCalibrated());

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
 
   const Surface* rSurface = &rStart.referenceSurface();
 
-  using Updater = GainMatrixUpdater<BoundParameters>;
-  using Smoother = GainMatrixSmoother<BoundParameters>;
+  using Updater = GainMatrixUpdater;
+  using Smoother = GainMatrixSmoother;
   using KalmanFitter =
       KalmanFitter<RecoPropagator, Updater, Smoother, MinimalOutlierFinder>;
 

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -286,8 +286,8 @@ BOOST_AUTO_TEST_CASE(comb_kalman_filter_zero_field) {
   using RecoPropagator = Propagator<RecoStepper, Navigator>;
   RecoPropagator rPropagator(rStepper, rNavigator);
 
-  using Updater = GainMatrixUpdater<BoundParameters>;
-  using Smoother = GainMatrixSmoother<BoundParameters>;
+  using Updater = GainMatrixUpdater;
+  using Smoother = GainMatrixSmoother;
   using SourceLinkSelector = CKFSourceLinkSelector;
   using CombinatorialKalmanFilter =
       CombinatorialKalmanFilter<RecoPropagator, Updater, Smoother,

--- a/Tests/UnitTests/Core/Visualization/EventDataVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataVisualizationBase.hpp
@@ -254,8 +254,8 @@ static inline std::string testMultiTrajectory(IVisualization& helper) {
 
   const Surface* rSurface = &rStart.referenceSurface();
 
-  using Updater = GainMatrixUpdater<BoundParameters>;
-  using Smoother = GainMatrixSmoother<BoundParameters>;
+  using Updater = GainMatrixUpdater;
+  using Smoother = GainMatrixSmoother;
   using KalmanFitter = KalmanFitter<RecoPropagator, Updater, Smoother>;
 
   KalmanFitter kFitter(rPropagator,


### PR DESCRIPTION
This PR removes unnecessary template parameters from the the (C)KF and the gain matrix formulation. Additionally unused variables, typedefs and a function are removed in this cleanup.