### PR TITLE
Change stalebot days until close time

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 60
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
I think I misunderstood how this number is interpreted. I set it to 60,
but that means 60 days after the issue is marked stale it will be
deleted. This PR changes that number down to 14, which means after 30+14
= 44 days an issue without any activity other than this bot will be
closed.