### PR TITLE
Set default build type to RelWithDebInfo

### DIFF
--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -1,8 +1,7 @@
 # Acts compiler flags
 if (NOT CMAKE_BUILD_TYPE)
-  set(_default_build_type RelWithDebInfo)
-  set(CMAKE_BUILD_TYPE ${_default_build_type} CACHE STRING "Build type configuration")
-  message(STATUS "Setting default build type: ${_default_build_type}")
+  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type configuration" FORCE)
+  message(STATUS "Setting default build type: ${CMAKE_BUILD_TYPE}")
 endif() 
 
 set(ACTS_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wunused-local-typedefs")

--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -1,4 +1,10 @@
 # Acts compiler flags
+if (NOT CMAKE_BUILD_TYPE)
+  set(_default_build_type RelWithDebInfo)
+  set(CMAKE_BUILD_TYPE ${_default_build_type} CACHE STRING "Build type configuration")
+  message(STATUS "Setting default build type: ${_default_build_type}")
+endif() 
+
 set(ACTS_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wunused-local-typedefs")
 set(ACTS_CXX_FLAGS_DEBUG "--coverage")
 set(ACTS_CXX_FLAGS_MINSIZEREL "")

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -266,7 +266,7 @@ documentation](https://cmake.org/documentation/).
 
 | Option               | Description |
 |----------------------|-------------|
-| CMAKE_BUILD_TYPE     | Build type, e.g. Debug or Release; affects compiler flags |
+| CMAKE_BUILD_TYPE     | Build type, e.g. Debug or Release; affects compiler flags <br/> (if not specified **`RelWithDebInfo`** will be used as a default) |
 | CMAKE_CXX_COMPILER   | Which C++ compiler to use, e.g. g++ or clang++ |
 | CMAKE_INSTALL_PREFIX | Where to install Acts to |
 | CMAKE_PREFIX_PATH    | Search path for external packages |


### PR DESCRIPTION
As discussed in #228, we currently don't set a default build type. This
PR sets `CMAKE_BUILD_TYPE` to `RelWithDebInfo` if it is not set
explicitly.