### PR TITLE
Clean up the version header

### DIFF
--- a/Core/ActsVersion.hpp.in
+++ b/Core/ActsVersion.hpp.in
@@ -1,26 +1,29 @@
-#ifndef ActsVersion_h
-#define ActsVersion_h
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <string_view>
+#pragma once
 
 //  Caution: this is the only Acts header that is guaranteed
 //  to change with every Acts release. Including this header
 //  will cause a recompile every time a new Acts version is
 //  used.
 
-// clang-format off
 namespace Acts {
+
+// clang-format does not like the CMake @...@ replacement variables
+// clang-format off
 constexpr unsigned int VersionMajor = @PROJECT_VERSION_MAJOR@u;
 constexpr unsigned int VersionMinor = @PROJECT_VERSION_MINOR@u;
 constexpr unsigned int VersionPatch = @PROJECT_VERSION_PATCH@u;
-constexpr unsigned int Version
-    = 10000u * VersionMajor + 100u * VersionMinor + VersionPatch;
-constexpr std::string_view CommitHash = "@_acts_commit_hash@";
-constexpr std::string_view CommitHashShort = "@_acts_commit_hash_short@";
-}  // namespace Acts
 // clang-format on
+constexpr unsigned int Version =
+    10000u * VersionMajor + 100u * VersionMinor + VersionPatch;
+constexpr const char* const CommitHash = "@_acts_commit_hash@";
+constexpr const char* const CommitHashShort = "@_acts_commit_hash_short@";
 
-// for backward compatibility
-#define ACTS_VERSION Acts::Version
-
-#endif  // ActsVersion_h
+}  // namespace Acts

--- a/Tests/UnitTests/Core/CMakeLists.txt
+++ b/Tests/UnitTests/Core/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_unittest(Version VersionTests.cpp)
+
 add_subdirectory(EventData)
 add_subdirectory(Fitter)
 add_subdirectory(Geometry)

--- a/Tests/UnitTests/Core/VersionTests.cpp
+++ b/Tests/UnitTests/Core/VersionTests.cpp
@@ -1,0 +1,32 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// the purpose of these tests is to ensure that the version header is valid and
+// the exported parameters are accessible. otherwise, there would is no code
+// that actually includes the version header.
+
+#include <boost/test/unit_test.hpp>
+#include <string_view>
+
+#include "Acts/ActsVersion.hpp"
+
+BOOST_AUTO_TEST_CASE(Version) {
+  // the only way to get a zero version would be zero for all components
+  BOOST_TEST(0u < Acts::Version);
+  // these tests are not really useful as the version components can be any
+  // value. they are there so we touch all variables and ensure that they are
+  // accessible.
+  BOOST_TEST(0u <= Acts::VersionMajor);
+  BOOST_TEST(0u <= Acts::VersionMinor);
+  BOOST_TEST(0u <= Acts::VersionPatch);
+}
+
+BOOST_AUTO_TEST_CASE(CommitHash) {
+  BOOST_TEST(not std::string_view(Acts::CommitHash).empty());
+  BOOST_TEST(not std::string_view(Acts::CommitHashShort).empty());
+}


### PR DESCRIPTION
Also adds a unit test so the version header is actually included somewhere.

Fixes #28.