### PR TITLE
Drop the SLC6 build from CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -65,9 +65,6 @@ jobs:
         lcg:
           - 95apython3
           - 96
-        exclude:
-          - os: slc6
-            lcg: 96
     env:
       SETUP: /opt/lcg_view/setup.sh
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -62,7 +62,6 @@ jobs:
       matrix:
         os:
           - centos7
-          - slc6
         lcg:
           - 95apython3
           - 96

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -95,8 +95,7 @@ $ cd <source>
 $ source CI/setup_lcg95.sh # or setup_lcg96.sh
 ```
 
-This activates a compatible release variant regardless of whether you are on
-*SLC 6* or on *CentOS 7*.
+This activates a compatible release variant on *CentOS 7*.
 
 After sourcing the setup script, you can build Acts as described above. The
 following commands will build Acts in the `<source>/build` directory with the
@@ -121,8 +120,6 @@ continous integration setup and come with all dependencies pre-installed.
     LCG release 95apython3
 -   `centos7-lcg96`: based on CentOS 7 with HEP-specific software from LCG
     release 96
--   `slc6-lcg95apython3`: based on SLC 6 with HEP-specific software from LCG
-    release 95apython3
 
 To use these locally, you first need to pull the relevant images from the
 registry. The current version is always tagged as `master.


### PR DESCRIPTION
This could help alleviate pressure on the CI.