### PR TITLE
Adding SurfaceArray visualization

### DIFF
--- a/Core/include/Acts/Visualization/EventDataVisualization.hpp
+++ b/Core/include/Acts/Visualization/EventDataVisualization.hpp
@@ -23,7 +23,8 @@
 #include <optional>
 
 namespace Acts {
-namespace Visualization {
+
+namespace EventDataVisualization {
 
 /// Helper to find the egen values and corr angle
 ///
@@ -180,8 +181,9 @@ static inline void drawBoundParameters(
     double outOfPlane = 0.1) {
   // First, if necessary, draw the surface
   if (drawParameterSurface) {
-    drawSurface(helper, parameters.referenceSurface(), gctx,
-                Transform3D::Identity(), lseg, false, scolor);
+    GeometryVisualization::drawSurface(helper, parameters.referenceSurface(),
+                                       gctx, Transform3D::Identity(), lseg,
+                                       false, scolor);
   }
 
   // Draw the parameter shaft and cone
@@ -193,8 +195,9 @@ static inline void drawBoundParameters(
                           ? 0.25 * p * momentumScale * direction
                           : Vector3D(0., 0., 0.);
 
-  drawArrowForward(helper, position, position + p * momentumScale * direction,
-                   0.025, 0.05, 2., 72, pcolor);
+  GeometryVisualization::drawArrowForward(
+      helper, position, position + p * momentumScale * direction, 0.025, 0.05,
+      2., 72, pcolor);
 
   if (parameters.covariance().has_value()) {
     auto paramVec = parameters.parameters();
@@ -277,8 +280,9 @@ static inline void drawMultiTrajectory(
 
     // First, if necessary, draw the surface
     if (drawParameterSurface) {
-      drawSurface(helper, state.referenceSurface(), gctx,
-                  Transform3D::Identity(), lseg, false, scolor);
+      GeometryVisualization::drawSurface(helper, state.referenceSurface(), gctx,
+                                         Transform3D::Identity(), lseg, false,
+                                         scolor);
     }
 
     // Second, if necessary and present, draw the calibrated measurement (only
@@ -299,9 +303,8 @@ static inline void drawMultiTrajectory(
     if (drawPredictedParameters and state.hasPredicted()) {
       drawBoundParameters(
           helper,
-          Acts::BoundParameters(gctx, state.predictedCovariance(),
-                                state.predicted(),
-                                state.referenceSurface().getSharedPtr()),
+          BoundParameters(gctx, state.predictedCovariance(), state.predicted(),
+                          state.referenceSurface().getSharedPtr()),
           gctx, momentumScale, locErrorScale, angularErrorScale, false, 72,
           ppcolor, scolor, outOfPlanes.at(1));
     }
@@ -309,9 +312,8 @@ static inline void drawMultiTrajectory(
     if (drawFilteredParameters and state.hasFiltered()) {
       drawBoundParameters(
           helper,
-          Acts::BoundParameters(gctx, state.filteredCovariance(),
-                                state.filtered(),
-                                state.referenceSurface().getSharedPtr()),
+          BoundParameters(gctx, state.filteredCovariance(), state.filtered(),
+                          state.referenceSurface().getSharedPtr()),
           gctx, momentumScale, locErrorScale, angularErrorScale, false, 72,
           fpcolor, scolor, outOfPlanes.at(2));
     }
@@ -319,9 +321,8 @@ static inline void drawMultiTrajectory(
     if (drawSmoothedParameters and state.hasSmoothed()) {
       drawBoundParameters(
           helper,
-          Acts::BoundParameters(gctx, state.smoothedCovariance(),
-                                state.smoothed(),
-                                state.referenceSurface().getSharedPtr()),
+          BoundParameters(gctx, state.smoothedCovariance(), state.smoothed(),
+                          state.referenceSurface().getSharedPtr()),
           gctx, momentumScale, locErrorScale, angularErrorScale, false, 72,
           spcolor, scolor, outOfPlanes.at(3));
     }
@@ -329,5 +330,5 @@ static inline void drawMultiTrajectory(
   });
 }
 
-}  // namespace Visualization
+}  // namespace EventDataVisualization
 }  // namespace Acts

--- a/Core/include/Acts/Visualization/GeometryVisualization.hpp
+++ b/Core/include/Acts/Visualization/GeometryVisualization.hpp
@@ -8,235 +8,146 @@
 
 #pragma once
 
-#include "Acts/Geometry/Polyhedron.hpp"
-#include "Acts/Surfaces/ConeBounds.hpp"
-#include "Acts/Surfaces/ConeSurface.hpp"
-#include "Acts/Surfaces/CylinderBounds.hpp"
-#include "Acts/Surfaces/CylinderSurface.hpp"
-#include "Acts/Surfaces/DiscSurface.hpp"
-#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Geometry/AbstractVolume.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/UnitVectors.hpp"
 #include "Acts/Visualization/IVisualization.hpp"
 
 namespace Acts {
 
-namespace Visualization {
+struct GeometryVisualization {
+  /// Helper method to Surface objects
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param surface The surface to be drawn
+  /// @param gctx The geometry context for which it is drawn
+  /// @param transform An option additional transform
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param triangulate The (optional) boolean diretive to triangulate the
+  /// faces
+  /// @param color the (optional) color of the object to be written
+  static void drawSurface(
+      IVisualization& helper, const Surface& surface,
+      const GeometryContext& gctx,
+      const Transform3D& transform = Transform3D::Identity(), size_t lseg = 72,
+      bool triangulate = false,
+      const IVisualization::ColorType& color = {120, 120, 120});
 
-/// Helper method to Surface objects
-///
-/// @param helper [in, out] The visualization helper
-/// @param surface The surface to be drawn
-/// @param gctx The geometry context for which it is drawn
-/// @param transform An option additional transform
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param triangulate The (optional) boolean diretive to triangulate the faces
-/// @param color the (optional) color of the object to be written
-static inline void drawSurface(
-    IVisualization& helper, const Surface& surface, const GeometryContext& gctx,
-    const Transform3D& transform = Transform3D::Identity(), size_t lseg = 72,
-    bool triangulate = false,
-    const IVisualization::ColorType& color = {120, 120, 120}) {
-  // Drawing the polyhedron representation of surfaces
-  Polyhedron phedron = surface.polyhedronRepresentation(gctx, lseg);
-  phedron.move(transform);
-  phedron.draw(helper, triangulate, color);
-}
+  /// Helper method to Surface objects
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param surfaceArray The surface to be drawn
+  /// @param gctx The geometry context for which it is drawn
+  /// @param binning The binning prescritotion, if empty, the grid is not drawn
+  /// @param transform An option additional transform
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param triangulate The (optional) boolean diretive to triangulate the
+  /// faces
+  /// @param sfcolor the (optional) color for the surfaces
+  /// @param gcolor the (otional) color of the grid
+  static void drawSurfaceArray(
+      IVisualization& helper, const SurfaceArray& surfaceArray,
+      const GeometryContext& gctx, std::vector<BinningValue> binning = {},
+      const Transform3D& transform = Transform3D::Identity(), size_t lseg = 72,
+      bool triangulate = false,
+      const IVisualization::ColorType& sfcolor = {120, 120, 120},
+      const IVisualization::ColorType& gcolor = {200, 0, 0});
 
-/// Helper method for volume objects
-///
-/// @tparam volume_t the templated volume class
-///
-/// @param helper [in, out] The visualization helper
-/// @param volume The surface to be drawn
-/// @param gctx The geometry context for which it is drawn
-/// @param transform An option additional transform
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param triangulate The (optional) boolean diretive to triangulate the faces
-/// @param color the (optional) color of the object to be written
-template <typename volume_t>
-inline void drawVolume(IVisualization& helper, const volume_t& volume,
-                       const GeometryContext& gctx,
-                       const Transform3D& transform = Transform3D::Identity(),
-                       size_t lseg = 72, bool triangulate = false,
-                       const IVisualization::ColorType& color = {120, 120,
-                                                                 120}) {
-  // Drawing the polyhedron representation of surfaces
-  auto bSurfaces = volume.boundarySurfaces();
-  for (const auto& bs : bSurfaces) {
-    drawSurface(helper, bs->surfaceRepresentation(), gctx, transform, lseg,
-                triangulate, color);
-  }
-}
+  /// Helper method for volume objects
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param volume The surface to be drawn
+  /// @param gctx The geometry context for which it is drawn
+  /// @param transform An option additional transform
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param triangulate The (optional) boolean diretive to triangulate the
+  /// faces
+  /// @param color the (optional) color of the object to be written
+  static void drawVolume(IVisualization& helper, const AbstractVolume& volume,
+                         const GeometryContext& gctx,
+                         const Transform3D& transform = Transform3D::Identity(),
+                         size_t lseg = 72, bool triangulate = false,
+                         const IVisualization::ColorType& color = {120, 120,
+                                                                   120});
 
-/// Helper method to draw lines - base for all lines
-///
-/// @param helper [in, out] The visualization helper
-/// @param start The start point
-/// @param end The end point
-/// @param thickness of the line, if bigger 0, approximated by cylinder
-/// @param arrows [ -1 | 0 | 1 | 2 ] = [ start | none | end | both ]
-/// @param arrowLength wrt halflength
-/// @param arrowWidth wrt thickness
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param color the (optional) color of the object to be written
-static inline void drawSegmentBase(
-    IVisualization& helper, const Vector3D& start, const Vector3D& end,
-    double thickness, int arrows = 0, double arrowLength = 0.,
-    double arrowWidth = 0., size_t lseg = 72,
-    const IVisualization::ColorType& color = {120, 120, 120}) {
-  // Draw the parameter shaft and cone
-  auto direction = Vector3D(end - start).normalized();
-  double hlength = 0.5 * Vector3D(end - start).norm();
+  /// Helper method to draw lines - base for all lines
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param start The start point
+  /// @param end The end point
+  /// @param thickness of the line, if bigger 0, approximated by cylinder
+  /// @param arrows [ -1 | 0 | 1 | 2 ] = [ start | none | end | both ]
+  /// @param arrowLength wrt halflength
+  /// @param arrowWidth wrt thickness
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param color the (optional) color of the object to be written
+  static void drawSegmentBase(IVisualization& helper, const Vector3D& start,
+                              const Vector3D& end, double thickness,
+                              int arrows = 0, double arrowLength = 0.,
+                              double arrowWidth = 0., size_t lseg = 72,
+                              const IVisualization::ColorType& color = {
+                                  120, 120, 120});
 
-  auto unitVectors = makeCurvilinearUnitVectors(direction);
-  RotationMatrix3D lrotation;
-  lrotation.col(0) = unitVectors.first;
-  lrotation.col(1) = unitVectors.second;
-  lrotation.col(2) = direction;
+  /// Convenience function : line
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param start The start point
+  /// @param end The end point
+  /// @param thickness of the line, if bigger 0, approximated by cylinder
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param color the (optional) color of the object to be written
+  static void drawSegment(IVisualization& helper, const Vector3D& start,
+                          const Vector3D& end, double thickness,
+                          size_t lseg = 72,
+                          const IVisualization::ColorType& color = {20, 120,
+                                                                    120});
 
-  Vector3D lcenter = 0.5 * (start + end);
-  double alength = arrowLength * (2 * hlength);
+  /// Convenience function : arrow pointing back
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param start The start point
+  /// @param end The end point
+  /// @param thickness of the line, if bigger 0, approximated by cylinder
+  /// @param arrowLength wrt halflength
+  /// @param arrorWidth wrt thickness
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param color the (optional) color of the object to be written
+  static void drawArrowBackward(
+      IVisualization& helper, const Vector3D& start, const Vector3D& end,
+      double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
+      const IVisualization::ColorType& color = {120, 120, 120});
 
-  if (arrows == 2) {
-    hlength -= alength;
-  } else if (arrows != 0) {
-    hlength -= 0.5 * alength;
-    lcenter -= Vector3D(arrows * 0.5 * alength * direction);
-  }
+  /// Convenience function : arrow pointing forwad
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param start The start point
+  /// @param end The end point
+  /// @param thickness of the line, if bigger 0, approximated by cylinder
+  /// @param arrowLength wrt halflength
+  /// @param arrorWidth wrt thickness
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param color the (optional) color of the object to be written
+  static void drawArrowForward(
+      IVisualization& helper, const Vector3D& start, const Vector3D& end,
+      double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
+      const IVisualization::ColorType& color = {120, 120, 120});
 
-  // Line - draw a line
-  if (thickness > 0.) {
-    auto ltransform = std::make_shared<Transform3D>(Transform3D::Identity());
-    ltransform->prerotate(lrotation);
-    ltransform->pretranslate(lcenter);
-
-    auto lbounds = std::make_shared<CylinderBounds>(thickness, hlength);
-    auto line = Surface::makeShared<CylinderSurface>(ltransform, lbounds);
-
-    drawSurface(helper, *line, GeometryContext(), Transform3D::Identity(), lseg,
-                false, color);
-  } else {
-    helper.line(start, end, color);
-  }
-
-  // Arrowheads - if configured
-  if (arrows != 0) {
-    double awith = thickness * arrowWidth;
-    double alpha = atan2(thickness * arrowWidth, alength);
-    auto plateBounds = std::make_shared<RadialBounds>(thickness, awith);
-
-    if (arrows > 0) {
-      auto aetransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aetransform->prerotate(lrotation);
-      aetransform->pretranslate(end);
-      // Arrow cone
-      auto coneBounds = std::make_shared<ConeBounds>(alpha, -alength, 0.);
-      auto cone = Surface::makeShared<ConeSurface>(aetransform, coneBounds);
-      drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
-                  lseg, false, color);
-      // Arrow end plate
-      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aptransform->prerotate(lrotation);
-      aptransform->pretranslate(Vector3D(end - alength * direction));
-
-      auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
-      drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),
-                  lseg, false, color);
-    }
-    if (arrows < 0 or arrows == 2) {
-      auto astransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      astransform->prerotate(lrotation);
-      astransform->pretranslate(start);
-
-      // Arrow cone
-      auto coneBounds = std::make_shared<ConeBounds>(alpha, 0., alength);
-      auto cone = Surface::makeShared<ConeSurface>(astransform, coneBounds);
-      drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
-                  lseg, false, color);
-      // Arrow end plate
-      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aptransform->prerotate(lrotation);
-      aptransform->pretranslate(Vector3D(start + alength * direction));
-
-      auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
-      drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),
-                  lseg, false, color);
-    }
-  }
-}
-
-/// Convenience function : line
-///
-/// @param helper [in, out] The visualization helper
-/// @param start The start point
-/// @param end The end point
-/// @param thickness of the line, if bigger 0, approximated by cylinder
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param color the (optional) color of the object to be written
-static inline void drawSegment(IVisualization& helper, const Vector3D& start,
-                               const Vector3D& end, double thickness,
-                               size_t lseg = 72,
-                               const IVisualization::ColorType& color = {
-                                   20, 120, 120}) {
-  drawSegmentBase(helper, start, end, thickness, 0, 0., 0., lseg, color);
-}
-
-/// Convenience function : arrow pointing back
-///
-/// @param helper [in, out] The visualization helper
-/// @param start The start point
-/// @param end The end point
-/// @param thickness of the line, if bigger 0, approximated by cylinder
-/// @param arrowLength wrt halflength
-/// @param arrorWidth wrt thickness
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param color the (optional) color of the object to be written
-static inline void drawArrowBackward(
-    IVisualization& helper, const Vector3D& start, const Vector3D& end,
-    double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
-    const IVisualization::ColorType& color = {120, 120, 120}) {
-  drawSegmentBase(helper, start, end, thickness, -1, arrowLength, arrowWidth,
-                  lseg, color);
-}
-
-/// Convenience function : arrow pointing forwad
-///
-/// @param helper [in, out] The visualization helper
-/// @param start The start point
-/// @param end The end point
-/// @param thickness of the line, if bigger 0, approximated by cylinder
-/// @param arrowLength wrt halflength
-/// @param arrorWidth wrt thickness
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param color the (optional) color of the object to be written
-static inline void drawArrowForward(
-    IVisualization& helper, const Vector3D& start, const Vector3D& end,
-    double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
-    const IVisualization::ColorType& color = {120, 120, 120}) {
-  drawSegmentBase(helper, start, end, thickness, 1, arrowLength, arrowWidth,
-                  lseg, color);
-}
-
-/// Convenience function : arrow pointing both directions
-///
-/// @param helper [in, out] The visualization helper
-/// @param start The start point
-/// @param end The end point
-/// @param thickness of the line, if bigger 0, approximated by cylinder
-/// @param arrowLength wrt halflength
-/// @param arrorWidth wrt thickness
-/// @param lseg The number of segments for a full arch (if needed)
-/// @param color the (optional) color of the object to be written
-static inline void drawArrowsBoth(
-    IVisualization& helper, const Vector3D& start, const Vector3D& end,
-    double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
-    const IVisualization::ColorType& color = {120, 120, 120}) {
-  drawSegmentBase(helper, start, end, thickness, 2, arrowLength, arrowWidth,
-                  lseg, color);
-}
-
-}  // namespace Visualization
+  /// Convenience function : arrow pointing both directions
+  ///
+  /// @param helper [in, out] The visualization helper
+  /// @param start The start point
+  /// @param end The end point
+  /// @param thickness of the line, if bigger 0, approximated by cylinder
+  /// @param arrowLength wrt halflength
+  /// @param arrorWidth wrt thickness
+  /// @param lseg The number of segments for a full arch (if needed)
+  /// @param color the (optional) color of the object to be written
+  static void drawArrowsBoth(
+      IVisualization& helper, const Vector3D& start, const Vector3D& end,
+      double thickness, double arrowLength, double arrowWidth, size_t lseg = 72,
+      const IVisualization::ColorType& color = {120, 120, 120});
+};
 
 }  // namespace Acts

--- a/Core/src/Visualization/CMakeLists.txt
+++ b/Core/src/Visualization/CMakeLists.txt
@@ -2,4 +2,5 @@ target_sources_local(
   ActsCore
   PRIVATE
     IVisualization.cpp
+    GeometryVisualization.cpp
 )

--- a/Core/src/Visualization/GeometryVisualization.cpp
+++ b/Core/src/Visualization/GeometryVisualization.cpp
@@ -1,0 +1,225 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Visualization/GeometryVisualization.hpp"
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
+#include "Acts/Geometry/Polyhedron.hpp"
+#include "Acts/Surfaces/ConeBounds.hpp"
+#include "Acts/Surfaces/ConeSurface.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/Surfaces/DiscSurface.hpp"
+#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Utilities/UnitVectors.hpp"
+
+void Acts::GeometryVisualization::drawSurface(
+    IVisualization& helper, const Surface& surface, const GeometryContext& gctx,
+    const Transform3D& transform, size_t lseg, bool triangulate,
+    const IVisualization::ColorType& color) {
+  // Drawing the polyhedron representation of surfaces
+  Polyhedron phedron = surface.polyhedronRepresentation(gctx, lseg);
+  phedron.move(transform);
+  phedron.draw(helper, triangulate, color);
+}
+
+void Acts::GeometryVisualization::drawSurfaceArray(
+    IVisualization& helper, const SurfaceArray& surfaceArray,
+    const GeometryContext& gctx, std::vector<BinningValue> binning,
+    const Transform3D& transform, size_t lseg, bool triangulate,
+    const IVisualization::ColorType& sfcolor,
+    const IVisualization::ColorType& gcolor) {
+  // Draw all the surfaces
+  Extent arrayExtent;
+  for (const auto& sf : surfaceArray.surfaces()) {
+    drawSurface(helper, *sf, gctx, transform, lseg, triangulate, sfcolor);
+    auto sfExtent = sf->polyhedronRepresentation(gctx, 1).extent();
+    arrayExtent.extend(sfExtent);
+  }
+
+  double thickness = 0.25;
+  // Draw the grid itself
+  auto axes = surfaceArray.getAxes();
+  if (not binning.empty() and binning.size() == 2 and axes.size() == 2) {
+    // Cylinder surface array
+    if (binning[0] == binPhi and binning[1] == binZ) {
+      double R = arrayExtent.medium(binR);
+      auto phiValues = axes[0]->getBinEdges();
+      auto zValues = axes[1]->getBinEdges();
+      // Longitudinal lines
+      for (auto phi : phiValues) {
+        for (size_t iz = 1; iz < zValues.size(); ++iz) {
+          double cphi = std::cos(phi);
+          double sphi = std::sin(phi);
+          Vector3D p1(R * cphi, R * sphi, zValues[iz]);
+          Vector3D p0(R * cphi, R * sphi, zValues[iz - 1]);
+          drawSegment(helper, p0, p1, 0.5 * thickness, 4, gcolor);
+        }
+        for (auto z : zValues) {
+          CylinderVolumeBounds cvb(R - 0.5 * thickness, R + 0.5 * thickness,
+                                   0.5 * thickness);
+          auto cvbOrientedSurfaces = cvb.orientedSurfaces();
+          for (auto cvbSf : cvbOrientedSurfaces) {
+            drawSurface(helper, *cvbSf.first, gctx,
+                        Translation3D(0., 0., z) * Transform3D::Identity(), 72,
+                        triangulate, gcolor);
+          }
+        }
+      }
+    } else if (binning[0] == binR and binning[1] == binPhi) {
+      double z = arrayExtent.medium(binZ);
+      auto rValues = axes[0]->getBinEdges();
+      auto phiValues = axes[1]->getBinEdges();
+      for (auto r : rValues) {
+        CylinderVolumeBounds cvb(r - 0.5 * thickness, r + 0.5 * thickness,
+                                 0.5 * thickness);
+        auto cvbOrientedSurfaces = cvb.orientedSurfaces();
+        for (auto cvbSf : cvbOrientedSurfaces) {
+          drawSurface(helper, *cvbSf.first, gctx,
+                      Translation3D(0., 0., z) * Transform3D::Identity(), 72,
+                      triangulate, gcolor);
+        }
+      }
+      double rMin = axes[0]->getMin();
+      double rMax = axes[0]->getMax();
+      for (auto phi : phiValues) {
+        double cphi = std::cos(phi);
+        double sphi = std::sin(phi);
+        Vector3D p1(rMax * cphi, rMax * sphi, z);
+        Vector3D p0(rMin * cphi, rMin * sphi, z);
+        drawSegment(helper, p0, p1, 0.5 * thickness, 4, gcolor);
+      }
+    }
+  }
+}
+
+void Acts::GeometryVisualization::drawVolume(
+    IVisualization& helper, const AbstractVolume& volume,
+    const GeometryContext& gctx, const Transform3D& transform, size_t lseg,
+    bool triangulate, const IVisualization::ColorType& color) {
+  // Drawing the polyhedron representation of surfaces
+  auto bSurfaces = volume.boundarySurfaces();
+  for (const auto& bs : bSurfaces) {
+    drawSurface(helper, bs->surfaceRepresentation(), gctx, transform, lseg,
+                triangulate, color);
+  }
+}
+
+void Acts::GeometryVisualization::drawSegmentBase(
+    IVisualization& helper, const Vector3D& start, const Vector3D& end,
+    double thickness, int arrows, double arrowLength, double arrowWidth,
+    size_t lseg, const IVisualization::ColorType& color) {
+  // Draw the parameter shaft and cone
+  auto direction = Vector3D(end - start).normalized();
+  double hlength = 0.5 * Vector3D(end - start).norm();
+
+  auto unitVectors = makeCurvilinearUnitVectors(direction);
+  RotationMatrix3D lrotation;
+  lrotation.col(0) = unitVectors.first;
+  lrotation.col(1) = unitVectors.second;
+  lrotation.col(2) = direction;
+
+  Vector3D lcenter = 0.5 * (start + end);
+  double alength = arrowLength * (2 * hlength);
+
+  if (arrows == 2) {
+    hlength -= alength;
+  } else if (arrows != 0) {
+    hlength -= 0.5 * alength;
+    lcenter -= Vector3D(arrows * 0.5 * alength * direction);
+  }
+
+  // Line - draw a line
+  if (thickness > 0.) {
+    auto ltransform = std::make_shared<Transform3D>(Transform3D::Identity());
+    ltransform->prerotate(lrotation);
+    ltransform->pretranslate(lcenter);
+
+    auto lbounds = std::make_shared<CylinderBounds>(thickness, hlength);
+    auto line = Surface::makeShared<CylinderSurface>(ltransform, lbounds);
+
+    drawSurface(helper, *line, GeometryContext(), Transform3D::Identity(), lseg,
+                false, color);
+  } else {
+    helper.line(start, end, color);
+  }
+
+  // Arrowheads - if configured
+  if (arrows != 0) {
+    double awith = thickness * arrowWidth;
+    double alpha = atan2(thickness * arrowWidth, alength);
+    auto plateBounds = std::make_shared<RadialBounds>(thickness, awith);
+
+    if (arrows > 0) {
+      auto aetransform = std::make_shared<Transform3D>(Transform3D::Identity());
+      aetransform->prerotate(lrotation);
+      aetransform->pretranslate(end);
+      // Arrow cone
+      auto coneBounds = std::make_shared<ConeBounds>(alpha, -alength, 0.);
+      auto cone = Surface::makeShared<ConeSurface>(aetransform, coneBounds);
+      drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
+                  lseg, false, color);
+      // Arrow end plate
+      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
+      aptransform->prerotate(lrotation);
+      aptransform->pretranslate(Vector3D(end - alength * direction));
+
+      auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
+      drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),
+                  lseg, false, color);
+    }
+    if (arrows < 0 or arrows == 2) {
+      auto astransform = std::make_shared<Transform3D>(Transform3D::Identity());
+      astransform->prerotate(lrotation);
+      astransform->pretranslate(start);
+
+      // Arrow cone
+      auto coneBounds = std::make_shared<ConeBounds>(alpha, 0., alength);
+      auto cone = Surface::makeShared<ConeSurface>(astransform, coneBounds);
+      drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
+                  lseg, false, color);
+      // Arrow end plate
+      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
+      aptransform->prerotate(lrotation);
+      aptransform->pretranslate(Vector3D(start + alength * direction));
+
+      auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
+      drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),
+                  lseg, false, color);
+    }
+  }
+}
+
+void Acts::GeometryVisualization::drawSegment(
+    IVisualization& helper, const Vector3D& start, const Vector3D& end,
+    double thickness, size_t lseg, const IVisualization::ColorType& color) {
+  drawSegmentBase(helper, start, end, thickness, 0, 0., 0., lseg, color);
+}
+
+void Acts::GeometryVisualization::drawArrowBackward(
+    IVisualization& helper, const Vector3D& start, const Vector3D& end,
+    double thickness, double arrowLength, double arrowWidth, size_t lseg,
+    const IVisualization::ColorType& color) {
+  drawSegmentBase(helper, start, end, thickness, -1, arrowLength, arrowWidth,
+                  lseg, color);
+}
+
+void Acts::GeometryVisualization::drawArrowForward(
+    IVisualization& helper, const Vector3D& start, const Vector3D& end,
+    double thickness, double arrowLength, double arrowWidth, size_t lseg,
+    const IVisualization::ColorType& color) {
+  drawSegmentBase(helper, start, end, thickness, 1, arrowLength, arrowWidth,
+                  lseg, color);
+}
+
+void Acts::GeometryVisualization::drawArrowsBoth(
+    IVisualization& helper, const Vector3D& start, const Vector3D& end,
+    double thickness, double arrowLength, double arrowWidth, size_t lseg,
+    const IVisualization::ColorType& color) {
+  drawSegmentBase(helper, start, end, thickness, 2, arrowLength, arrowWidth,
+                  lseg, color);
+}

--- a/Tests/UnitTests/Core/Geometry/ProtoLayerHelperTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ProtoLayerHelperTests.cpp
@@ -70,8 +70,9 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
 
   IVisualization::ColorType unsortedColor = {252, 160, 0};
   for (auto& sf : cylinderSurfaces) {
-    Visualization::drawSurface(objVis, *sf, tgContext, Transform3D::Identity(),
-                               1, false, unsortedColor);
+    GeometryVisualization::drawSurface(objVis, *sf, tgContext,
+                                       Transform3D::Identity(), 1, false,
+                                       unsortedColor);
   }
   // Draw the all surfaces
   write(objVis, "ProtoLayerHelper_CylinderLayers_unsorted", true);
@@ -92,8 +93,8 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   for (auto& layer : radialLayers) {
     for (auto& sf : layer.surfaces()) {
       auto color = sortedColors[il];
-      Visualization::drawSurface(objVis, *sf, tgContext,
-                                 Transform3D::Identity(), 1, false, color);
+      GeometryVisualization::drawSurface(
+          objVis, *sf, tgContext, Transform3D::Identity(), 1, false, color);
     }
     ++il;
   }
@@ -124,8 +125,9 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   }
 
   for (auto& sf : discSurfaces) {
-    Visualization::drawSurface(objVis, *sf, tgContext, Transform3D::Identity(),
-                               1, false, unsortedColor);
+    GeometryVisualization::drawSurface(objVis, *sf, tgContext,
+                                       Transform3D::Identity(), 1, false,
+                                       unsortedColor);
   }
   // Draw the all surfaces
   write(objVis, "ProtoLayerHelper_DiscLayers_unsorted", true);
@@ -138,9 +140,9 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   il = 0;
   for (auto& layer : discLayersZ) {
     for (auto& sf : layer.surfaces()) {
-      Visualization::drawSurface(objVis, *sf, tgContext,
-                                 Transform3D::Identity(), 1, false,
-                                 sortedColors[il]);
+      GeometryVisualization::drawSurface(objVis, *sf, tgContext,
+                                         Transform3D::Identity(), 1, false,
+                                         sortedColors[il]);
     }
     ++il;
   }
@@ -173,8 +175,9 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   }
 
   for (auto& sf : ringSurfaces) {
-    Visualization::drawSurface(objVis, *sf, tgContext, Transform3D::Identity(),
-                               1, false, unsortedColor);
+    GeometryVisualization::drawSurface(objVis, *sf, tgContext,
+                                       Transform3D::Identity(), 1, false,
+                                       unsortedColor);
   }
   // Draw the all surfaces
   write(objVis, "ProtoLayerHelper_RingLayers_unsorted", true);
@@ -193,8 +196,8 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
     for (auto& layer : lSorted) {
       dColor[ir] -= il * 50;
       for (auto& sf : layer.surfaces()) {
-        Visualization::drawSurface(objVis, *sf, tgContext,
-                                   Transform3D::Identity(), 1, false, dColor);
+        GeometryVisualization::drawSurface(
+            objVis, *sf, tgContext, Transform3D::Identity(), 1, false, dColor);
       }
       ++il;
     }

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -20,6 +20,8 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Visualization/GeometryVisualization.hpp"
+#include "Acts/Visualization/ObjVisualization.hpp"
 
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
@@ -545,6 +547,13 @@ BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_dependentBinCounts,
   auto axes = sArray->getAxes();
   BOOST_CHECK_EQUAL(axes.at(0)->getNBins(), 3u);
   BOOST_CHECK_EQUAL(axes.at(1)->getNBins(), 10u);
+
+  // Write the surrace array with grid
+  ObjVisualization objVis;
+  GeometryVisualization::drawSurfaceArray(
+      objVis, *sArray, tgContext, {binR, binPhi}, Transform3D::Identity(), 1,
+      false, {120, 120, 0}, {200, 0, 0});
+  objVis.write("SurfaceArrayCreator_EndcapGrid");
 }
 
 BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_completeBinning,
@@ -573,6 +582,13 @@ BOOST_FIXTURE_TEST_CASE(SurfaceArrayCreator_completeBinning,
       std::make_tuple(std::move(phiAxis), std::move(zAxis)));
   sl->fill(tgContext, brlRaw);
   SurfaceArray sa(std::move(sl), brl);
+
+  // Write the surrace array with grid
+  ObjVisualization objVis;
+  GeometryVisualization::drawSurfaceArray(objVis, sa, tgContext, {binPhi, binZ},
+                                          Transform3D::Identity(), 1, false,
+                                          {120, 120, 0}, {200, 0, 0});
+  objVis.write("SurfaceArrayCreator_BarrelGrid");
 
   // actually filled SA
   for (const auto& srf : brl) {

--- a/Tests/UnitTests/Core/Visualization/EventDataVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataVisualizationBase.hpp
@@ -91,7 +91,7 @@ static inline std::string testBoundParameters(IVisualization& helper) {
       -2.85e-11, 0, -2.11 - 07, -4.017e-08, 1.123e-08, -2.85 - 11, 1.26e-10, 0,
       0, 0, 0, 0, 0, 1;
 
-  Visualization::drawBoundParameters(
+  EventDataVisualization::drawBoundParameters(
       helper, BoundParameters(gctx, std::move(cov), pars, plane), gctx,
       momentumScale, localErrorScale, directionErrorScale, true, 72, pcolor,
       scolor);
@@ -284,7 +284,7 @@ static inline std::string testMultiTrajectory(IVisualization& helper) {
   const IVisualization::ColorType& fpcolor = {92, 149, 255};
   const IVisualization::ColorType& spcolor = {20, 120, 20};
 
-  Visualization::drawMultiTrajectory(
+  EventDataVisualization::drawMultiTrajectory(
       helper, fittedTrack.fittedStates, fittedTrack.trackTip, tgContext,
       momentumScale, localErrorScale, directionErrorScale, true, true, true,
       true, true, 50, scolor, mcolor, ppcolor, fpcolor, spcolor);

--- a/Tests/UnitTests/Core/Visualization/PrimitivesVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/PrimitivesVisualizationBase.hpp
@@ -45,7 +45,8 @@ static inline std::string test(IVisualization& helper) {
   IVisualization::ColorType lineColor = {0, 0, 250};
   Vector3D start = {1., 1., 1.};
   Vector3D end = {4., 4., 4.};
-  Acts::Visualization::drawSegment(helper, start, end, 0.1, 72, lineColor);
+  Acts::GeometryVisualization::drawSegment(helper, start, end, 0.1, 72,
+                                           lineColor);
   helper.write("Primitives_Line");
   helper.write(ss);
   helper.write(ss);
@@ -54,25 +55,25 @@ static inline std::string test(IVisualization& helper) {
   // Arrows visualization ------------------------------------------------
   start = {1., 0., 0.};
   end = {4., 0., 0.};
-  Acts::Visualization::drawArrowForward(helper, start, end, 0.1, 0.1, 3., 72,
-                                        {0, 75, 0});
+  Acts::GeometryVisualization::drawArrowForward(helper, start, end, 0.1, 0.1,
+                                                3., 72, {0, 75, 0});
 
   start = {1., 2., 0.};
   end = {4., 2., 0.};
-  Acts::Visualization::drawArrowBackward(helper, start, end, 0.1, 0.1, 3., 72,
-                                         {0, 150, 0});
+  Acts::GeometryVisualization::drawArrowBackward(helper, start, end, 0.1, 0.1,
+                                                 3., 72, {0, 150, 0});
 
   start = {1., 4., 0.};
   end = {4., 4., 0.};
-  Acts::Visualization::drawArrowsBoth(helper, start, end, 0.1, 0.1, 3., 72,
-                                      {0, 250, 0});
+  Acts::GeometryVisualization::drawArrowsBoth(helper, start, end, 0.1, 0.1, 3.,
+                                              72, {0, 250, 0});
   helper.write("Primitives_Arrows");
   helper.write(ss);
   helper.clear();
 
   // Error visualization: local ---------------------------------------------
   IVisualization::ColorType surfaceColor = {120, 250, 0};
-  Acts::Visualization::drawSurface(
+  Acts::GeometryVisualization::drawSurface(
       helper, *plane, gctx, Transform3D::Identity(), 72, false, surfaceColor);
 
   IVisualization::ColorType errorColor = {250, 0, 0};
@@ -84,7 +85,7 @@ static inline std::string test(IVisualization& helper) {
   cov << s0 * s0, r01 * s0 * s1, r01 * s0 * s1, s1 * s1;
 
   Vector2D lcentered{0., 0.};
-  Acts::Visualization::drawCovarianceCartesian(
+  Acts::EventDataVisualization::drawCovarianceCartesian(
       helper, lcentered, cov, plane->transform(gctx), {3}, 10., 72, errorColor);
 
   helper.write("Primitives_CartesianError");
@@ -92,7 +93,7 @@ static inline std::string test(IVisualization& helper) {
   helper.clear();
 
   // Error visualization: angular ---------------------------------------------
-  Acts::Visualization::drawSurface(
+  Acts::GeometryVisualization::drawSurface(
       helper, *plane, gctx, Transform3D::Identity(), 72, false, surfaceColor);
 
   // Error visualization
@@ -109,10 +110,10 @@ static inline std::string test(IVisualization& helper) {
 
   double directionScale = 5.;
 
-  Acts::Visualization::drawCovarianceAngular(
+  Acts::EventDataVisualization::drawCovarianceAngular(
       helper, origin, direction, cov, {3}, directionScale, 10., 72, errorColor);
 
-  Acts::Visualization::drawArrowForward(
+  Acts::GeometryVisualization::drawArrowForward(
       helper, origin + 0.5 * directionScale * direction,
       origin + 1.2 * directionScale * direction, 0.02, 0.1, 5., 72,
       {10, 10, 10});

--- a/Tests/UnitTests/Core/Visualization/PrimitivesVisualizationTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/PrimitivesVisualizationTests.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(VisualizationHelpers) {
   // No correlation, fully summetric
   ActsSymMatrixD<2> covariance;
   covariance << 4., 0., 0., 4.;
-  auto decops = Acts::Visualization::decomposeCovariance(covariance);
+  auto decops = Acts::EventDataVisualization::decomposeCovariance(covariance);
   BOOST_CHECK(decops[0] == 4.);
   BOOST_CHECK(decops[1] == 4.);
   BOOST_CHECK(decops[2] == 0.);
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(VisualizationHelpers) {
   // Fully positively correlated
   covariance.setZero();
   covariance << 4., 4., 4., 4.;
-  decops = Acts::Visualization::decomposeCovariance(covariance);
+  decops = Acts::EventDataVisualization::decomposeCovariance(covariance);
   BOOST_CHECK(decops[0] == 8.);
   BOOST_CHECK(decops[1] == 0.);
   CHECK_CLOSE_ABS(decops[2], M_PI / 4, 0.0001);
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(VisualizationHelpers) {
   // Fully negatively correlated
   covariance.setZero();
   covariance << 4., -4., -4., 4.;
-  decops = Acts::Visualization::decomposeCovariance(covariance);
+  decops = Acts::EventDataVisualization::decomposeCovariance(covariance);
   BOOST_CHECK(decops[0] == 8.);
   BOOST_CHECK(decops[1] == 0.);
   CHECK_CLOSE_ABS(decops[2], 3 * M_PI / 4, 0.0001);
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(VisualizationHelpers) {
   // Correlation coefficient 0.5 (off-diagonal: 3*2*0.5)
   covariance.setZero();
   covariance << 4., 2., 2., 4.;
-  decops = Acts::Visualization::decomposeCovariance(covariance);
+  decops = Acts::EventDataVisualization::decomposeCovariance(covariance);
   BOOST_CHECK(decops[0] == 6.);
   BOOST_CHECK(decops[1] == 2.);
   CHECK_CLOSE_ABS(decops[2], M_PI / 4, 0.0001);
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(VisualizationHelpers) {
   // Correlation coefficient -0.5 & different diagonal (off-diagonal: 3*2*0.5)
   covariance.setZero();
   covariance << 9., -3., -3, 4.;
-  decops = Acts::Visualization::decomposeCovariance(covariance);
+  decops = Acts::EventDataVisualization::decomposeCovariance(covariance);
   CHECK_CLOSE_ABS(decops[0], 10.4051, 0.0001);
   CHECK_CLOSE_ABS(decops[1], 2.59488, 0.0001);
   CHECK_CLOSE_ABS(decops[2], 2.70356, 0.0001);

--- a/Tests/UnitTests/Core/Visualization/SurfaceVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/SurfaceVisualizationBase.hpp
@@ -81,8 +81,8 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       std::make_shared<ConeBounds>(coneAlpha, -coneCutZ, coneMaxZ);
   auto cone = Surface::makeShared<ConeSurface>(identity, coneBounds);
   coneSurfaces.push_back(cone);
-  Visualization::drawSurface(helper, *cone, gctx, Transform3D::Identity(), 72,
-                             triangulate, coneColor);
+  GeometryVisualization::drawSurface(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Surfaces_ConeSurface");
 
   // Sectoral Cone
@@ -90,8 +90,8 @@ static inline std::string test(IVisualization& helper, bool triangulate,
                                             halfPhiSector);
   cone = Surface::makeShared<ConeSurface>(identity, coneBounds);
   coneSurfaces.push_back(cone);
-  Visualization::drawSurface(helper, *cone, gctx, Transform3D::Identity(), 72,
-                             triangulate, coneColor);
+  GeometryVisualization::drawSurface(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Surfaces_ConeSurfaceSector");
 
   // Sectoral Cone Shifted
@@ -99,8 +99,8 @@ static inline std::string test(IVisualization& helper, bool triangulate,
                                             halfPhiSector, centralPhi);
   cone = Surface::makeShared<ConeSurface>(identity, coneBounds);
   coneSurfaces.push_back(cone);
-  Visualization::drawSurface(helper, *cone, gctx, Transform3D::Identity(), 72,
-                             triangulate, coneColor);
+  GeometryVisualization::drawSurface(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Surfaces_ConeSurfaceSectorShifted");
 
   // All in one for radial bounds
@@ -110,8 +110,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       Transform3D(Translation3D{0.75 * coneMaxZ, 0., 0.})};
 
   for (size_t ic = 0; ic < coneSurfaces.size(); ++ic) {
-    Visualization::drawSurface(helper, *coneSurfaces[ic], gctx, threeCones[ic],
-                               72, triangulate, coneColor);
+    GeometryVisualization::drawSurface(helper, *coneSurfaces[ic], gctx,
+                                       threeCones[ic], 72, triangulate,
+                                       coneColor);
   }
   write("Surfaces_All_ConeSurfaces");
 
@@ -129,16 +130,18 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto cylinder =
       Surface::makeShared<CylinderSurface>(identity, cylinderBounds);
   cylinderSurfaces.push_back(cylinder);
-  Visualization::drawSurface(helper, *cylinder, gctx, Transform3D::Identity(),
-                             72, triangulate, cylinderColor);
+  GeometryVisualization::drawSurface(helper, *cylinder, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     cylinderColor);
   write("Surfaces_CylinderSurface");
   // Sectoral Cone
   cylinderBounds = std::make_shared<CylinderBounds>(
       cylinderRadius, cylinderHalfZ, halfPhiSector);
   cylinder = Surface::makeShared<CylinderSurface>(identity, cylinderBounds);
   cylinderSurfaces.push_back(cylinder);
-  Visualization::drawSurface(helper, *cylinder, gctx, Transform3D::Identity(),
-                             72, triangulate, cylinderColor);
+  GeometryVisualization::drawSurface(helper, *cylinder, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     cylinderColor);
   write("Surfaces_CylinderSurfaceSector");
 
   // Sectoral Cone Shifted
@@ -146,8 +149,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       cylinderRadius, cylinderHalfZ, halfPhiSector, centralPhi);
   cylinder = Surface::makeShared<CylinderSurface>(identity, cylinderBounds);
   cylinderSurfaces.push_back(cylinder);
-  Visualization::drawSurface(helper, *cylinder, gctx, Transform3D::Identity(),
-                             72, triangulate, cylinderColor);
+  GeometryVisualization::drawSurface(helper, *cylinder, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     cylinderColor);
   write("Surfaces_CylinderSurfaceSectorShifted");
 
   // All in one for radial bounds
@@ -157,9 +161,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       Transform3D(Translation3D{2.5 * cylinderRadius, 0., 0.})};
 
   for (size_t ic = 0; ic < cylinderSurfaces.size(); ++ic) {
-    Visualization::drawSurface(helper, *cylinderSurfaces[ic], gctx,
-                               threeCylinders[ic], 72, triangulate,
-                               cylinderColor);
+    GeometryVisualization::drawSurface(helper, *cylinderSurfaces[ic], gctx,
+                                       threeCylinders[ic], 72, triangulate,
+                                       cylinderColor);
   }
   write("Surfaces_All_CylinderSurfaces");
 
@@ -173,9 +177,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
 
     auto bbBounds = std::make_shared<RectangleBounds>(rBounds);
     auto bbSurface = Surface::makeShared<PlaneSurface>(identity, bbBounds);
-    Visualization::drawSurface(helper, *bbSurface, gctx,
-                               Transform3D::Identity(), 72, triangulate,
-                               bbColor);
+    GeometryVisualization::drawSurface(helper, *bbSurface, gctx,
+                                       Transform3D::Identity(), 72, triangulate,
+                                       bbColor);
     write(bbPath);
   };
 
@@ -192,16 +196,16 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto radialBounds = std::make_shared<RadialBounds>(0., discRmax);
   auto disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceFull");
 
   // Full Sectoral Disc
   radialBounds = std::make_shared<RadialBounds>(0., discRmax, halfPhiSector);
   disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceFullSector");
 
   // Full Sectoral Shifted Disc
@@ -209,16 +213,16 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       std::make_shared<RadialBounds>(0., discRmax, halfPhiSector, centralPhi);
   disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceFullSectorShifted");
 
   // Full Ring
   radialBounds = std::make_shared<RadialBounds>(discRmin, discRmax);
   disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceRing");
 
   // Full Sectoral Rin g
@@ -226,8 +230,8 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       std::make_shared<RadialBounds>(discRmin, discRmax, halfPhiSector);
   disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceRingSector");
 
   // Full Sectoral Shifted Ring
@@ -235,8 +239,8 @@ static inline std::string test(IVisualization& helper, bool triangulate,
                                                 halfPhiSector, centralPhi);
   disc = Surface::makeShared<DiscSurface>(identity, radialBounds);
   radialSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discColor);
+  GeometryVisualization::drawSurface(
+      helper, *disc, gctx, Transform3D::Identity(), 72, triangulate, discColor);
   write("Surfaces_DiscSurfaceRingSectorShifted");
 
   // All in one for radial bounds
@@ -248,8 +252,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       Transform3D(Translation3D{0., -1.5 * discRmax, 0.}),
       Transform3D(Translation3D{2.5 * discRmax, -1.5 * discRmax, 0.})};
   for (size_t ir = 0; ir < radialSurfaces.size(); ++ir) {
-    Visualization::drawSurface(helper, *radialSurfaces[ir], gctx, sixDiscs[ir],
-                               72, triangulate, discColor);
+    GeometryVisualization::drawSurface(helper, *radialSurfaces[ir], gctx,
+                                       sixDiscs[ir], 72, triangulate,
+                                       discColor);
   }
   write("Surfaces_All_DiscSurfaces_RadialBounds");
 
@@ -263,8 +268,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       discRmin, discRmax, annulusMinPhi, annulusMaxPhi, offset);
   disc = Surface::makeShared<DiscSurface>(identity, annulus);
   anomalDiscSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discAnomalColor);
+  GeometryVisualization::drawSurface(helper, *disc, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     discAnomalColor);
   write("Surfaces_DiscAnulusBounds");
 
   double discTrapezoidHxRmin = 3.;
@@ -273,8 +279,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       discTrapezoidHxRmin, discTrapezoidHxRmax, discRmin, discRmax);
   disc = Surface::makeShared<DiscSurface>(identity, discTrapezoid);
   anomalDiscSurfaces.push_back(disc);
-  Visualization::drawSurface(helper, *disc, gctx, Transform3D::Identity(), 72,
-                             triangulate, discAnomalColor);
+  GeometryVisualization::drawSurface(helper, *disc, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     discAnomalColor);
   write("Surfaces_DiscTrapezoidBounds");
 
   // All in one for radial bounds
@@ -282,8 +289,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       Transform3D(Translation3D{-5., 0., 0.}),
       Transform3D(Translation3D{5., 0., 0.})};
   for (size_t id = 0; id < anomalDiscSurfaces.size(); ++id) {
-    Visualization::drawSurface(helper, *anomalDiscSurfaces[id], gctx,
-                               sixDiscs[id], 72, triangulate, discAnomalColor);
+    GeometryVisualization::drawSurface(helper, *anomalDiscSurfaces[id], gctx,
+                                       sixDiscs[id], 72, triangulate,
+                                       discAnomalColor);
   }
   write("Surfaces_All_DiscSurfaces_AnomalBounds");
 
@@ -302,8 +310,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       std::make_shared<EllipseBounds>(0., 0., ellipseR1min, ellipseR1max);
   auto plane = Surface::makeShared<PlaneSurface>(identity, ellipse);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(ellipse->boundingBox(), name);
 
@@ -313,8 +322,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
                                             ellipseR1min, ellipseR1max);
   plane = Surface::makeShared<PlaneSurface>(identity, ellipse);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(ellipse->boundingBox(), name);
 
@@ -324,8 +334,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       ellipseR0min, ellipseR0max, ellipseR1min, ellipseR1max, halfPhiSector);
   plane = Surface::makeShared<PlaneSurface>(identity, ellipse);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(ellipse->boundingBox(), name);
 
@@ -335,8 +346,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto triangle = std::make_shared<ConvexPolygonBounds<3>>(tvertices);
   plane = Surface::makeShared<PlaneSurface>(identity, triangle);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(triangle->boundingBox(), name);
 
@@ -346,8 +358,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   triangle = std::make_shared<ConvexPolygonBounds<3>>(tvertices);
   plane = Surface::makeShared<PlaneSurface>(identity, triangle);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(triangle->boundingBox(), name);
 
@@ -358,8 +371,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       std::make_shared<ConvexPolygonBounds<PolygonDynamic>>(tvertices);
   plane = Surface::makeShared<PlaneSurface>(identity, dynamicpolygon);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(dynamicpolygon->boundingBox(), name);
 
@@ -368,8 +382,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto diamond = std::make_shared<DiamondBounds>(3., 6., 2., 2., 4.);
   plane = Surface::makeShared<PlaneSurface>(identity, diamond);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(diamond->boundingBox(), name);
 
@@ -378,8 +393,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto rectangle = std::make_shared<RectangleBounds>(2., 3.);
   plane = Surface::makeShared<PlaneSurface>(identity, rectangle);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(rectangle->boundingBox(), name);
 
@@ -388,8 +404,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   rectangle =
       std::make_shared<RectangleBounds>(Vector2D{1., 2.}, Vector2D{15., 12.});
   plane = Surface::makeShared<PlaneSurface>(identity, rectangle);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(rectangle->boundingBox(), name);
 
@@ -398,8 +415,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto trapezoid = std::make_shared<TrapezoidBounds>(2., 5., 3.);
   plane = Surface::makeShared<PlaneSurface>(identity, trapezoid);
   planarSurfaces.push_back(plane);
-  Visualization::drawSurface(helper, *plane, gctx, Transform3D::Identity(), 72,
-                             triangulate, planeColor);
+  GeometryVisualization::drawSurface(helper, *plane, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     planeColor);
   write(name);
   writeBoundingBox2D(trapezoid->boundingBox(), name);
 
@@ -415,8 +433,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
       Transform3D(Translation3D{0., 10., 0.}),
       Transform3D(Translation3D{10., 10., 0.})};
   for (size_t ip = 0; ip < planarSurfaces.size(); ++ip) {
-    Visualization::drawSurface(helper, *planarSurfaces[ip], gctx,
-                               ninePlanes[ip], 72, triangulate, planeColor);
+    GeometryVisualization::drawSurface(helper, *planarSurfaces[ip], gctx,
+                                       ninePlanes[ip], 72, triangulate,
+                                       planeColor);
   }
   write("Surfaces_All_PlaneSurfaces");
 
@@ -427,8 +446,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   name = "Surfaces_StrawSurface";
   auto tube = std::make_shared<LineBounds>(2., 20.);
   auto straw = Surface::makeShared<StrawSurface>(identity, tube);
-  Visualization::drawSurface(helper, *straw, gctx, Transform3D::Identity(), 72,
-                             triangulate, strawColor);
+  GeometryVisualization::drawSurface(helper, *straw, gctx,
+                                     Transform3D::Identity(), 72, triangulate,
+                                     strawColor);
   write(name);
 
   return cStream.str();

--- a/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/VolumeVisualizationBase.hpp
@@ -59,8 +59,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
 
   auto box = std::make_shared<CuboidVolumeBounds>(4., 3., 6.);
   auto cuboid = std::make_shared<AbstractVolume>(identity, box);
-  Visualization::drawVolume(helper, *cuboid, gctx, Transform3D::Identity(), 72,
-                            triangulate, boxColor);
+  GeometryVisualization::drawVolume(helper, *cuboid, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    boxColor);
   write("Volumes_CuboidVolume");
 
   //----------------------------------------------------
@@ -71,48 +72,48 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto solidCone =
       std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 5., 5., 0., M_PI);
   auto cone = std::make_shared<AbstractVolume>(identity, solidCone);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeSolid");
 
   // Single solid Cone - with cut off
   auto cutOffCone =
       std::make_shared<ConeVolumeBounds>(0., 0., 0.45, 8., 5., 0., M_PI);
   cone = std::make_shared<AbstractVolume>(identity, cutOffCone);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeSolidCutOff");
 
   // Cone - Cone inlay
   auto cutOffHollowCone =
       std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5, 0., M_PI);
   cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCone);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeConeCone");
 
   // Sectoral Cone - Cone inlay
   auto cutOffHollowSectoralCone =
       std::make_shared<ConeVolumeBounds>(0.35, 7., 0.45, 8., 5., 0., 0.456);
   cone = std::make_shared<AbstractVolume>(identity, cutOffHollowSectoralCone);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeConeConeSectoral");
 
   // Single Hollow Cone - cylindrical inlay
   auto cutOffHollowCylCone =
       std::make_shared<ConeVolumeBounds>(1., 0.45, 8., 5., 0., M_PI);
   cone = std::make_shared<AbstractVolume>(identity, cutOffHollowCylCone);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeConeCylinder");
 
   // Single Hollow Cylinder - Cone inlay
   auto cutOffHollowConeCyl =
       std::make_shared<ConeVolumeBounds>(12., 0.35, 7., 5., 0., M_PI);
   cone = std::make_shared<AbstractVolume>(identity, cutOffHollowConeCyl);
-  Visualization::drawVolume(helper, *cone, gctx, Transform3D::Identity(), 72,
-                            triangulate, coneColor);
+  GeometryVisualization::drawVolume(
+      helper, *cone, gctx, Transform3D::Identity(), 72, triangulate, coneColor);
   write("Volumes_ConeVolumeCylinderCone");
 
   //----------------------------------------------------
@@ -126,22 +127,25 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   auto fullCylinder =
       std::make_shared<CylinderVolumeBounds>(0., cylinderOuterR, cylinderHalfZ);
   auto cylinder = std::make_shared<AbstractVolume>(identity, fullCylinder);
-  Visualization::drawVolume(helper, *cylinder, gctx, Transform3D::Identity(),
-                            72, triangulate, cylinderColor);
+  GeometryVisualization::drawVolume(helper, *cylinder, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    cylinderColor);
   write("Volumes_CylinderVolumeFull");
 
   auto tubeCylinder = std::make_shared<CylinderVolumeBounds>(
       cylinderInnerR, cylinderOuterR, cylinderHalfZ);
   cylinder = std::make_shared<AbstractVolume>(identity, tubeCylinder);
-  Visualization::drawVolume(helper, *cylinder, gctx, Transform3D::Identity(),
-                            72, triangulate, cylinderColor);
+  GeometryVisualization::drawVolume(helper, *cylinder, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    cylinderColor);
   write("Volumes_CylinderVolumeTube");
 
   tubeCylinder = std::make_shared<CylinderVolumeBounds>(
       cylinderInnerR, cylinderOuterR, cylinderHalfZ, halfPhiSector);
   cylinder = std::make_shared<AbstractVolume>(identity, tubeCylinder);
-  Visualization::drawVolume(helper, *cylinder, gctx, Transform3D::Identity(),
-                            72, triangulate, cylinderColor);
+  GeometryVisualization::drawVolume(helper, *cylinder, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    cylinderColor);
   write("Volumes_CylinderVolumeTubeSector");
 
   //----------------------------------------------------
@@ -158,8 +162,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
                {0, 1, 1}}};
   auto genericCuboid = std::make_shared<GenericCuboidVolumeBounds>(vertices);
   auto generic = std::make_shared<AbstractVolume>(identity, genericCuboid);
-  Visualization::drawVolume(helper, *generic, gctx, Transform3D::Identity(), 72,
-                            triangulate, genericColor);
+  GeometryVisualization::drawVolume(helper, *generic, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    genericColor);
   write("Volumes_GenericCuboidVolume");
 
   //----------------------------------------------------
@@ -167,9 +172,9 @@ static inline std::string test(IVisualization& helper, bool triangulate,
   IVisualization::ColorType trapezoidColor = {23, 196, 22};
   auto trapezoid = std::make_shared<TrapezoidVolumeBounds>(2., 4., 5., 6.);
   auto trapezoidVolume = std::make_shared<AbstractVolume>(identity, trapezoid);
-  Visualization::drawVolume(helper, *trapezoidVolume, gctx,
-                            Transform3D::Identity(), 72, triangulate,
-                            trapezoidColor);
+  GeometryVisualization::drawVolume(helper, *trapezoidVolume, gctx,
+                                    Transform3D::Identity(), 72, triangulate,
+                                    trapezoidColor);
   write("Volumes_TrapezoidVolume");
 
   return cStream.str();


### PR DESCRIPTION
As shown in the briefing meeting, this allows to visualize the grid of surface arrays.

I also moves the code from the GeometryVisualization from inlined to a compilation unit.

<img width="614" alt="Screenshot 2020-06-12 at 09 12 07" src="https://user-images.githubusercontent.com/26623879/84509917-b5b00280-acc4-11ea-8dbc-8641d23bb2da.png">

<img width="676" alt="Screenshot 2020-06-12 at 09 13 27" src="https://user-images.githubusercontent.com/26623879/84509921-b8aaf300-acc4-11ea-8c46-cfeac3b30038.png">
