### PR TITLE
Fix CCVB outer disk boundary sized (backport of #261)

### DIFF
--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -159,7 +159,7 @@ void Acts::CutoutCylinderVolumeBounds::buildSurfaceBounds() {
   m_outerCylinderBounds =
       std::make_shared<CylinderBounds>(get(eMaxR), get(eHalfLengthZ));
 
-  m_innerDiscBounds = std::make_shared<RadialBounds>(get(eMinR), get(eMaxR));
+  m_innerDiscBounds = std::make_shared<RadialBounds>(get(eMinR), get(eMedR));
 
-  m_outerDiscBounds = std::make_shared<RadialBounds>(get(eMedR), get(eMaxR));
+  m_outerDiscBounds = std::make_shared<RadialBounds>(get(eMinR), get(eMaxR));
 }


### PR DESCRIPTION
Previously, this was rMin -> rMax for the inner disks, and rMed -> rMax
for the outer disks. This has been changed to rMin -> rMed and rMin ->
rMax, respectively.