### PR TITLE
More AMVF performance upgrades

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -252,15 +252,6 @@ class AdaptiveMultiVertexFinder {
   void setConstraintAfterSeeding(Vertex<InputTrack_t>& currentConstraint,
                                  const Vertex<InputTrack_t>& seedVertex) const;
 
-  /// @brief Estimates delta Z between a track and a vertex position
-  ///
-  /// @param track The track
-  /// @param vtxPos The vertex position
-  ///
-  /// @return The delta Z estimate
-  double estimateDeltaZ(const BoundParameters& track,
-                        const Vector3D& vtxPos) const;
-
   /// @brief Calculates the IP significance of a track to a given vertex
   ///
   /// @param track The track

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -187,23 +187,6 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 }
 
 template <typename vfitter_t, typename sfinder_t>
-auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::estimateDeltaZ(
-    const BoundParameters& track, const Vector3D& vtxPos) const -> double {
-  Vector3D trackPos = track.position();
-
-  double phi = track.parameters()[ParID_t::ePHI];
-  double th = track.parameters()[ParID_t::eTHETA];
-
-  double X = trackPos[eX] - vtxPos.x();
-  double Y = trackPos[eY] - vtxPos.y();
-
-  double deltaZ = trackPos[eZ] - vtxPos.z() -
-                  1. / std::tan(th) * (X * std::cos(phi) + Y * std::sin(phi));
-
-  return deltaZ;
-}
-
-template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getIPSignificance(
     const InputTrack_t* track, const Vertex<InputTrack_t>& vtx,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
@@ -247,7 +230,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     auto params = m_extractParameters(*trk);
     // If track is too far away from vertex, do not consider checking the IP
     // significance
-    if (std::abs(estimateDeltaZ(params, vtx.position())) >
+    if (std::abs(vtx.position()[eZ] - params.parameters()[ParID_t::eLOC_Z0]) >
         m_cfg.tracksMaxZinterval) {
       continue;
     }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -230,7 +230,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     auto params = m_extractParameters(*trk);
     // If track is too far away from vertex, do not consider checking the IP
     // significance
-    if (std::abs(params.position()[eZ]-vtx.position()[eZ]) >
+    if (std::abs(params.position()[eZ] - vtx.position()[eZ]) >
         m_cfg.tracksMaxZinterval) {
       continue;
     }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -230,7 +230,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     auto params = m_extractParameters(*trk);
     // If track is too far away from vertex, do not consider checking the IP
     // significance
-    if (std::abs(vtx.position()[eZ] - params.parameters()[ParID_t::eLOC_Z0]) >
+    if (std::abs(params.position()[eZ]-vtx.position()[eZ]) >
         m_cfg.tracksMaxZinterval) {
       continue;
     }


### PR DESCRIPTION
This PR removes the ```estimateDeltaZ``` function (which contributed 5.5% to the overall AMVF timing, see below) and replaces it with a simple z position diff check which is way less expensive and gives the same outputs.

<img width="893" alt="Screenshot 2020-06-23 at 14 20 35" src="https://user-images.githubusercontent.com/62748548/85402876-bc5c3680-b55c-11ea-9dd2-6790e8508e6e.png">
