### PR TITLE
Fix Volume material mapping

### DIFF
--- a/Core/include/Acts/Material/AccumulatedVolumeMaterial.hpp
+++ b/Core/include/Acts/Material/AccumulatedVolumeMaterial.hpp
@@ -28,12 +28,12 @@ class AccumulatedVolumeMaterial {
   Material average();
 
  private:
-  float m_totalX0{std::numeric_limits<float>::infinity()};
-  float m_totalL0{std::numeric_limits<float>::infinity()};
-  float m_totalAr{0.};
-  float m_totalZ{0.};
-  float m_totalRho{0.};
-  float m_thickness{1.};
+  double m_totalX0{std::numeric_limits<double>::infinity()};
+  double m_totalL0{std::numeric_limits<double>::infinity()};
+  double m_totalAr{0.};
+  double m_totalZ{0.};
+  double m_totalRho{0.};
+  double m_thickness{1.};
   unsigned int m_materialEntries{0};
   unsigned int m_vacuumEntries{0};
 };

--- a/Core/src/Material/AccumulatedVolumeMaterial.cpp
+++ b/Core/src/Material/AccumulatedVolumeMaterial.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Material/AccumulatedVolumeMaterial.hpp"
+
 #include <iostream>
 
 void Acts::AccumulatedVolumeMaterial::accumulate(

--- a/Core/src/Material/AccumulatedVolumeMaterial.cpp
+++ b/Core/src/Material/AccumulatedVolumeMaterial.cpp
@@ -13,12 +13,12 @@
 void Acts::AccumulatedVolumeMaterial::accumulate(
     const MaterialProperties& mat) {
   // Replace the vacuum by matter or add matter to matter
-  if (m_totalX0 == std::numeric_limits<float>::infinity()) {
+  if (m_totalX0 == std::numeric_limits<double>::infinity()) {
     m_totalX0 = mat.thickness() / mat.material().X0();
   } else {
     m_totalX0 += mat.thickness() / mat.material().X0();
   }
-  if (m_totalL0 == std::numeric_limits<float>::infinity()) {
+  if (m_totalL0 == std::numeric_limits<double>::infinity()) {
     m_totalL0 = mat.thickness() / mat.material().L0();
   } else {
     m_totalL0 += mat.thickness() / mat.material().L0();

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -313,9 +313,7 @@ void Acts::VolumeMaterialMapper::mapMaterialTrack(
         float remainder = rmIter->materialProperties.thickness() -
                           m_cfg.mappingStep * volumeStep;
         properties.scaleThickness(m_cfg.mappingStep / properties.thickness());
-        mState.recordedMaterial[volIter->volume->geoID()].push_back(
-            std::pair(properties, rmIter->position));
-        for (int step = 1; step <= volumeStep; step++) {
+        for (int step = 0; step <= volumeStep; step++) {
           // Create additional extrapolated point for the grid mapping
           extraDirection = rmIter->direction;
           extraDirection =

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Material/VolumeMaterialMapper.hpp"
+
 #include "Acts/EventData/NeutralTrackParameters.hpp"
 #include "Acts/Material/HomogeneousVolumeMaterial.hpp"
 #include "Acts/Material/InterpolatedMaterialMap.hpp"

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -313,13 +313,14 @@ void Acts::VolumeMaterialMapper::mapMaterialTrack(
         float remainder = rmIter->materialProperties.thickness() -
                           m_cfg.mappingStep * volumeStep;
         properties.scaleThickness(m_cfg.mappingStep / properties.thickness());
-        for (int step = 0; step <= volumeStep; step++) {
-          // Create additional extrapolated point for the grid mapping
-          extraDirection = rmIter->direction;
-          extraDirection =
-              extraDirection * (m_cfg.mappingStep / extraDirection.norm());
-          extraPosition = rmIter->position + step * extraDirection;
-          if (step == volumeStep) {
+        // Get the direction of the Geantino in the volume
+        extraDirection = rmIter->direction;
+        extraDirection =
+            extraDirection * (m_cfg.mappingStep / extraDirection.norm());
+        for (int extraStep = 0; extraStep <= volumeStep; extraStep++) {
+          // Create additional extrapolated points for the grid mapping
+          extraPosition = rmIter->position + extraStep * extraDirection;
+          if (extraStep == volumeStep) {
             // adjust the thickness of the last extrapolated step
             properties.scaleThickness(remainder / properties.thickness());
           }


### PR DESCRIPTION
Solve two issue with the volume material mapping :

- When the sampling step size of the volume was larger than the distance between two geantino interaction this would result in an incorrect thickness for the material Step.

- Replace float by double for the accumulated volume material as if the number of step per bin became too large this would result in rounding error. 