### PR TITLE
Check for removable tracks in GridDensityVertexFinder

### DIFF
--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -14,22 +14,23 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
   // Remove density contributions from tracks removed from track collection
   if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&
       !state.tracksToRemove.empty()) {
-    // Bool to check if removable tracks, that pass selection, still exist 
+    // Bool to check if removable tracks, that pass selection, still exist
     bool couldRemoveTracks = false;
     for (auto trk : state.tracksToRemove) {
       if (not state.trackSelectionMap.at(trk)) {
         // Track was never added to grid, so cannot remove it
         continue;
       }
-      couldRemoveTracks = true; 
+      couldRemoveTracks = true;
       auto binAndTrackGrid = state.binAndTrackGridMap.at(trk);
       m_cfg.gridDensity.removeTrackGridFromMainGrid(
           binAndTrackGrid.first, binAndTrackGrid.second, state.mainGrid);
     }
-    if(not couldRemoveTracks){
+    if (not couldRemoveTracks) {
       // No tracks were removed anymore
       // Return empty seed
-      std::vector<Vertex<InputTrack_t>> seedVec{Vertex<InputTrack_t>(Vector3D(0,0,0))};
+      std::vector<Vertex<InputTrack_t>> seedVec{
+          Vertex<InputTrack_t>(Vector3D(0, 0, 0))};
       return seedVec;
     }
   } else {
@@ -130,6 +131,6 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::
   if (discriminant < 0) {
     return false;
   }
-  
+
   return true;
 }

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -28,9 +28,10 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
     }
     if (not couldRemoveTracks) {
       // No tracks were removed anymore
-      // Return empty seed
+      // Return empty seed, i.e. vertex at constraint position
+      // (Note: Upstream finder should check for this break condition)
       std::vector<Vertex<InputTrack_t>> seedVec{
-          Vertex<InputTrack_t>(Vector3D(0, 0, 0))};
+          vertexingOptions.vertexConstraint};
       return seedVec;
     }
   } else {

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -14,14 +14,23 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
   // Remove density contributions from tracks removed from track collection
   if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&
       !state.tracksToRemove.empty()) {
+    // Bool to check if removable tracks, that pass selection, still exist 
+    bool couldRemoveTracks = false;
     for (auto trk : state.tracksToRemove) {
       if (not state.trackSelectionMap.at(trk)) {
         // Track was never added to grid, so cannot remove it
         continue;
       }
+      couldRemoveTracks = true; 
       auto binAndTrackGrid = state.binAndTrackGridMap.at(trk);
       m_cfg.gridDensity.removeTrackGridFromMainGrid(
           binAndTrackGrid.first, binAndTrackGrid.second, state.mainGrid);
+    }
+    if(not couldRemoveTracks){
+      // No tracks were removed anymore
+      // Return empty seed
+      std::vector<Vertex<InputTrack_t>> seedVec{Vertex<InputTrack_t>(Vector3D(0,0,0))};
+      return seedVec;
     }
   } else {
     state.mainGrid = ActsVectorF<mainGridSize>::Zero();
@@ -121,5 +130,6 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::
   if (discriminant < 0) {
     return false;
   }
+  
   return true;
 }


### PR DESCRIPTION
This PR introduces a check if removable tracks (that pass the seed finder track selection) still exist.
Previously, the seed track collection could have had still tracks that were never added to the density grid (since they did not pass the internal seed finder track selection) and hence the seed finder could not remove them from the grid. The client AMVF would then just continue iterating and removing all of these tracks one by one. This check directly stops the seeding and vertex finding process and speeds up things dramatically.