### PR TITLE
Improvement of the Mapping Example

### DIFF
--- a/Examples/Algorithms/MaterialMapping/include/ACTFW/MaterialMapping/MaterialMappingOptions.hpp
+++ b/Examples/Algorithms/MaterialMapping/include/ACTFW/MaterialMapping/MaterialMappingOptions.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -32,10 +32,15 @@ void addMaterialMappingOptions(aopt_t& opt) {
                     "Collection name of the material tracks for reading.")(
       "mat-mapping-emptybins", po::value<bool>()->default_value(true),
       "Empty bin correction (recommended). Corrects for vaccuum/emtpy "
-      "assigments.")("mat-mapping-type",
-                     po::value<std::string>()->default_value("surface"),
-                     "Either surface (default) or volume, element on which the "
-                     "material is mapped.");
+      "assigments.")("mat-mapping-surfaces",
+                     po::value<bool>()->default_value(true),
+                     "Map the material onto the selected surfaces")(
+      "mat-mapping-volumes", po::value<bool>()->default_value(false),
+      "Map the material into the selected material volumes")(
+      "mat-mapping-volume-stepsize",
+      po::value<float>()->default_value(std::numeric_limits<float>::infinity()),
+      "Step size of the sampling of volume material for the mapping "
+      "(should be smaller than the size of the bins in depth)");
 }
 
 }  // namespace Options

--- a/Examples/Run/Common/src/MaterialMappingBase.cpp
+++ b/Examples/Run/Common/src/MaterialMappingBase.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -64,19 +64,15 @@ int materialMappingExample(int argc, char* argv[],
   Acts::GeometryContext geoContext;
   Acts::MagneticFieldContext mfContext;
 
-  // Get a Navigator
-  Acts::Navigator navigator(tGeometry);
-
   // Straight line stepper
   using SlStepper = Acts::StraightLineStepper;
   using Propagator = Acts::Propagator<SlStepper, Acts::Navigator>;
-  // Make stepper and propagator
-  SlStepper stepper;
-  Propagator propagator(std::move(stepper), std::move(navigator));
 
   auto matCollection = vm["mat-mapping-collection"].template as<std::string>();
-  auto mappingtype = vm["mat-mapping-type"].template as<std::string>();
-  if (mappingtype != "surface" && mappingtype != "volume") {
+  auto mapSurface = vm["mat-mapping-surfaces"].template as<bool>();
+  auto mapVolume = vm["mat-mapping-volumes"].template as<bool>();
+  auto volumeStep = vm["mat-mapping-volume-stepsize"].template as<float>();
+  if (!mapSurface && !mapVolume) {
     return EXIT_FAILURE;
   }
   // ---------------------------------------------------------------------------------
@@ -98,16 +94,28 @@ int materialMappingExample(int argc, char* argv[],
 
   /// The material mapping algorithm
   FW::MaterialMapping::Config mmAlgConfig(geoContext, mfContext);
-  if (mappingtype == "surface") {
-    /// The material mapper
+  if (mapSurface) {
+    // Get a Navigator
+    Acts::Navigator navigator(tGeometry);
+    // Make stepper and propagator
+    SlStepper stepper;
+    Propagator propagator(std::move(stepper), std::move(navigator));
+    /// The material surface mapper
     Acts::SurfaceMaterialMapper::Config smmConfig;
     auto smm = std::make_shared<Acts::SurfaceMaterialMapper>(
         smmConfig, std::move(propagator),
         Acts::getDefaultLogger("SurfaceMaterialMapper", logLevel));
     mmAlgConfig.materialSurfaceMapper = smm;
-  } else if (mappingtype == "volume") {
-    /// The material mapper
+  }
+  if (mapVolume) {
+    // Get a Navigator
+    Acts::Navigator navigator(tGeometry);
+    // Make stepper and propagator
+    SlStepper stepper;
+    Propagator propagator(std::move(stepper), std::move(navigator));
+    /// The material volume mapper
     Acts::VolumeMaterialMapper::Config vmmConfig;
+    vmmConfig.mappingStep = volumeStep;
     auto vmm = std::make_shared<Acts::VolumeMaterialMapper>(
         vmmConfig, std::move(propagator),
         Acts::getDefaultLogger("VolumeMaterialMapper", logLevel));
@@ -128,7 +136,7 @@ int materialMappingExample(int argc, char* argv[],
     mmAlgConfig.materialWriters.push_back(
         std::make_shared<RootWriter>(std::move(rmwImpl)));
 
-    if (mappingtype == "surface") {
+    if (mapSurface) {
       // Write the propagation steps as ROOT TTree
       FW::RootMaterialTrackWriter::Config matTrackWriterRootConfig;
       matTrackWriterRootConfig.filePath = materialFileName + "_tracks.root";


### PR DESCRIPTION
Modify the mapping algorithm in the examples to allow to map surface and volume at the same time (instead of doing it one after the other).

Added 3 option to the mapping : 
  - mat-mapping-surfaces that determine if material is mapped on surface (true by default)
  - mat-mapping-volumes that determine if material is mapped on volume (false by default)
  - mat-mapping-volume-stepsize that correspond to that size of the extra step used to sample the material on the volume, infinite by default (no additional step created) 