### PR TITLE
changed the weight for Ar and Z

### DIFF
--- a/Core/src/Material/MaterialProperties.cpp
+++ b/Core/src/Material/MaterialProperties.cpp
@@ -40,6 +40,7 @@ Acts::MaterialProperties::MaterialProperties(
   double Ar = 0.0;
   double Z = 0.0;
   double weight = 0.0;
+  double atoms = 0.0;
   double thickness = 0.0;
   double thicknessInX0 = 0.0;
   double thicknessInL0 = 0.0;
@@ -48,18 +49,19 @@ Acts::MaterialProperties::MaterialProperties(
     const auto& mat = layer.material();
     // weight of the layer assuming a unit area, i.e. volume = thickness*1*1
     const auto layerWeight = mat.massDensity() * layer.thickness();
-    // Ar,Z are weighted by mass
-    Ar += mat.Ar() * layerWeight;
-    Z += mat.Z() * layerWeight;
+    // Ar,Z are weighted proportionally to the number of atoms
+    Ar += mat.Ar() * layerWeight / Ar;
+    Z += mat.Z() * layerWeight / Ar;
     weight += layerWeight;
+    atoms += layerWeight / Ar;
     // thickness and relative thickness in X0,L0 are strictly additive
     thickness += layer.thickness();
     thicknessInX0 += layer.thicknessInX0();
     thicknessInL0 += layer.thicknessInL0();
   }
   // store averaged material constants
-  Ar /= weight;
-  Z /= weight;
+  Ar /= atoms;
+  Z /= atoms;
   // this is weight/volume w/ volume = thickness*unitArea = thickness*1*1
   const auto density = weight / thickness;
   const auto X0 = thickness / thicknessInX0;


### PR DESCRIPTION
Following Issue #30 the value of Ar and Z for multiple layers were averaged using the mass of the layers which is not correct. Instead we proposed to use weight/Ar Which is proportional to the number of atoms. This is not exact as the atomic mass is slightly different from the mass number but should still be more accurate than the previous method. 