### PR TITLE
Fix compiler warning in VerticesHelper

### DIFF
--- a/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
+++ b/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
@@ -10,14 +10,12 @@
 
 #include <utility>
 #include <vector>
+
 #include "Acts/Utilities/Definitions.hpp"
 
 namespace Acts {
-
 namespace detail {
-
-/// @brief Helper method for set of vertices for polyhedrons
-/// drawing and inside/outside checks
+/// Helper methods for polyhedron vertices drawing and inside/outside checks.
 namespace VerticesHelper {
 
 /// A method that inserts the cartesian extrema points and segments
@@ -27,44 +25,10 @@ namespace VerticesHelper {
 /// @param phiMax the maximum Phi of the bounds object
 /// @param phiRef is a vector of reference phi values to be included as well
 /// @param phiTolerance is the tolerance for reference phi insertion
-///
 /// @return a vector
-static std::vector<double> phiSegments(double phiMin = -M_PI,
-                                       double phiMax = M_PI,
-                                       std::vector<double> phiRefs = {},
-                                       double phiTolerance = 1e-6) {
-  // This is to ensure that the extrema are built regardless of number
-  // of segments
-  std::vector<double> phiSegments;
-  std::vector<double> quarters = {-M_PI, -0.5 * M_PI, 0., 0.5 * M_PI, M_PI};
-  // It does not cover the full azimuth
-  if (phiMin != -M_PI or phiMax != M_PI) {
-    phiSegments.push_back(phiMin);
-    for (unsigned int iq = 1; iq < 4; ++iq) {
-      if (phiMin < quarters[iq] and phiMax > quarters[iq]) {
-        phiSegments.push_back(quarters[iq]);
-      }
-    }
-    phiSegments.push_back(phiMax);
-  } else {
-    phiSegments = quarters;
-  }
-  // Insert the reference phis if
-  if (not phiRefs.empty()) {
-    for (const auto& phiRef : phiRefs) {
-      // Trying to find the right patch
-      auto match = std::find_if(
-          phiSegments.begin(), phiSegments.end(), [&](double phiSeg) {
-            return std::abs(phiSeg - phiRef) < phiTolerance;
-          });
-      if (match == phiSegments.end()) {
-        phiSegments.push_back(phiRef);
-      }
-    }
-    std::sort(phiSegments.begin(), phiSegments.end());
-  }
-  return phiSegments;
-}
+std::vector<double> phiSegments(double phiMin = -M_PI, double phiMax = M_PI,
+                                const std::vector<double>& phiRefs = {},
+                                double phiTolerance = 1e-6);
 
 /// Helper method to create a regular 2 or 3 D segment
 ///  between two phi values
@@ -101,7 +65,7 @@ void createSegment(std::vector<vertex_t>& vertices,
   }
 }
 
-/// Vertices on an ellipse-like bound object
+/// Construct vertices on an ellipse-like bound object.
 ///
 /// @param innerRx The radius of the inner ellipse (in x), 0 if sector
 /// @param innerRy The radius of the inner ellipse (in y), 0 if sector
@@ -110,74 +74,27 @@ void createSegment(std::vector<vertex_t>& vertices,
 /// @param avgPhi The phi direction of the center if sector
 /// @param halfPhi The half phi sector if sector
 /// @param lseg The number of segments for for a full 2*pi segment
-///
 /// @return a vector of 2d-vectors
-static std::vector<Vector2D> ellispoidVertices(double innerRx, double innerRy,
-                                               double outerRx, double outerRy,
-                                               double avgPhi = 0.,
-                                               double halfPhi = M_PI,
-                                               unsigned int lseg = 1) {
-  // List of vertices counter-clockwise starting at smallest phi w.r.t center,
-  // for both inner/outer ring/segment
-  std::vector<Acts::Vector2D> rvertices;  // return vertices
-  std::vector<Acts::Vector2D> ivertices;  // inner vertices
-  std::vector<Acts::Vector2D> overtices;  // outer verices
+std::vector<Vector2D> ellispoidVertices(double innerRx, double innerRy,
+                                        double outerRx, double outerRy,
+                                        double avgPhi = 0.,
+                                        double halfPhi = M_PI,
+                                        unsigned int lseg = 1);
 
-  bool innerExists = (innerRx > 0. and innerRy > 0.);
-  bool closed = std::abs(halfPhi - M_PI) < s_onSurfaceTolerance;
-
-  // Get the phi segments from the helper method
-  auto phiSegs = detail::VerticesHelper::phiSegments(
-      avgPhi - halfPhi, avgPhi + halfPhi, {avgPhi});
-
-  // The inner (if exists) and outer bow
-  for (unsigned int iseg = 0; iseg < phiSegs.size() - 1; ++iseg) {
-    int addon = (iseg == phiSegs.size() - 2 and not closed) ? 1 : 0;
-    if (innerExists) {
-      detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
-          ivertices, {innerRx, innerRy}, phiSegs[iseg], phiSegs[iseg + 1], lseg,
-          addon);
-    }
-    detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
-        overtices, {outerRx, outerRy}, phiSegs[iseg], phiSegs[iseg + 1], lseg,
-        addon);
-  }
-
-  // We want to keep the same counter-clockwise orientation for displaying
-  if (not innerExists) {
-    if (not closed) {
-      // Add the center case we have a sector
-      rvertices.push_back(Vector2D(0., 0.));
-    }
-    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
-  } else if (not closed) {
-    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
-    rvertices.insert(rvertices.end(), ivertices.rbegin(), ivertices.rend());
-  } else {
-    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
-    rvertices.insert(rvertices.end(), ivertices.begin(), ivertices.end());
-  }
-  return rvertices;
-}
-
-/// Vertices on an disc/wheel-like bound object
+/// Construct vertices on an disc/wheel-like bound object.
 ///
 /// @param innerR The radius of the inner circle (sector)
 /// @param outerR The radius of the outer circle (sector)
 /// @param avgPhi The phi direction of the center if sector
 /// @param halfPhi The half phi sector if sector
 /// @param lseg The number of segments for for a full 2*pi segment
-///
 /// @return a vector of 2d-vectors
-static std::vector<Vector2D> circularVertices(double innerR, double outerR,
-                                              double avgPhi = 0.,
-                                              double halfPhi = M_PI,
-                                              unsigned int lseg = 1) {
-  return ellispoidVertices(innerR, innerR, outerR, outerR, avgPhi, halfPhi,
-                           lseg);
-}
+std::vector<Vector2D> circularVertices(double innerR, double outerR,
+                                       double avgPhi = 0.,
+                                       double halfPhi = M_PI,
+                                       unsigned int lseg = 1);
 
-/// Check if the point is inside the polygon w/o any tolerances
+/// Check if the point is inside the polygon w/o any tolerances.
 ///
 /// @tparam vertex_container_t is an iterable container
 ///
@@ -223,7 +140,7 @@ bool isInsidePolygon(const vertex_t& point,
   return true;
 }
 
-/// Check if the point is inside the rectangle
+/// Check if the point is inside the rectangle.
 ///
 /// @tparam vertex_t is vector with [0],[1] access
 ///
@@ -240,32 +157,14 @@ bool isInsideRectangle(const vertex_t& point, const vertex_t& lowerLeft,
          (lowerLeft[1] <= point[1]) && (point[1] < upperRight[1]);
 }
 
-/// This method checks if a cloud of points are on 2D hyper-plane in 3D space
+/// This method checks if a cloud of points are on 2D hyper-plane in 3D space.
 ///
 /// @param vertices The list of vertices to test
 /// @param tolerance The allowed out of plane tolerance
-///
-/// It bails out at the first moment a point is outside the hyper plane
 /// @return boolean to indicate if all points are inside/outside
-static bool onHyperPlane(const std::vector<Vector3D>& vertices,
-                         double tolerance = s_onSurfaceTolerance) {
-  // Obvious always on one surface
-  if (vertices.size() < 4) {
-    return true;
-  }
-  // Create the hyperplane
-  auto hyperPlane = Eigen::Hyperplane<double, 3>::Through(
-      vertices[0], vertices[1], vertices[2]);
-  for (size_t ip = 3; ip < vertices.size(); ++ip) {
-    if (hyperPlane.absDistance(vertices[ip]) > tolerance) {
-      return false;
-    }
-  }
-  return true;
-}
+bool onHyperPlane(const std::vector<Vector3D>& vertices,
+                  double tolerance = s_onSurfaceTolerance);
 
-};  // namespace VerticesHelper
-
+}  // namespace VerticesHelper
 }  // namespace detail
-
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
+++ b/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
@@ -75,7 +75,7 @@ void createSegment(std::vector<vertex_t>& vertices,
 /// @param halfPhi The half phi sector if sector
 /// @param lseg The number of segments for for a full 2*pi segment
 /// @return a vector of 2d-vectors
-std::vector<Vector2D> ellispoidVertices(double innerRx, double innerRy,
+std::vector<Vector2D> ellipsoidVertices(double innerRx, double innerRy,
                                         double outerRx, double outerRy,
                                         double avgPhi = 0.,
                                         double halfPhi = M_PI,

--- a/Core/src/Surfaces/CMakeLists.txt
+++ b/Core/src/Surfaces/CMakeLists.txt
@@ -22,4 +22,5 @@ target_sources_local(
     SurfaceArray.cpp
     TrapezoidBounds.cpp
     detail/AlignmentHelper.cpp
+    VerticesHelper.cpp
 )

--- a/Core/src/Surfaces/EllipseBounds.cpp
+++ b/Core/src/Surfaces/EllipseBounds.cpp
@@ -117,7 +117,7 @@ double Acts::EllipseBounds::distanceToBoundary(
 
 std::vector<Acts::Vector2D> Acts::EllipseBounds::vertices(
     unsigned int lseg) const {
-  return detail::VerticesHelper::ellispoidVertices(
+  return detail::VerticesHelper::ellipsoidVertices(
       get(eInnerRx), get(eInnerRy), get(eOuterRx), get(eOuterRy),
       get(eAveragePhi), get(eHalfPhiSector), lseg);
 }

--- a/Core/src/Surfaces/VerticesHelper.cpp
+++ b/Core/src/Surfaces/VerticesHelper.cpp
@@ -1,0 +1,115 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Surfaces/detail/VerticesHelper.hpp"
+
+std::vector<double> Acts::detail::VerticesHelper::phiSegments(
+    double phiMin, double phiMax, const std::vector<double>& phiRefs,
+    double phiTolerance) {
+  // This is to ensure that the extrema are built regardless of number
+  // of segments
+  std::vector<double> phiSegments;
+  std::vector<double> quarters = {-M_PI, -0.5 * M_PI, 0., 0.5 * M_PI, M_PI};
+  // It does not cover the full azimuth
+  if (phiMin != -M_PI or phiMax != M_PI) {
+    phiSegments.push_back(phiMin);
+    for (unsigned int iq = 1; iq < 4; ++iq) {
+      if (phiMin < quarters[iq] and phiMax > quarters[iq]) {
+        phiSegments.push_back(quarters[iq]);
+      }
+    }
+    phiSegments.push_back(phiMax);
+  } else {
+    phiSegments = quarters;
+  }
+  // Insert the reference phis if
+  if (not phiRefs.empty()) {
+    for (const auto& phiRef : phiRefs) {
+      // Trying to find the right patch
+      auto match = std::find_if(
+          phiSegments.begin(), phiSegments.end(), [&](double phiSeg) {
+            return std::abs(phiSeg - phiRef) < phiTolerance;
+          });
+      if (match == phiSegments.end()) {
+        phiSegments.push_back(phiRef);
+      }
+    }
+    std::sort(phiSegments.begin(), phiSegments.end());
+  }
+  return phiSegments;
+}
+
+std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::ellispoidVertices(
+    double innerRx, double innerRy, double outerRx, double outerRy,
+    double avgPhi, double halfPhi, unsigned int lseg) {
+  // List of vertices counter-clockwise starting at smallest phi w.r.t center,
+  // for both inner/outer ring/segment
+  std::vector<Vector2D> rvertices;  // return vertices
+  std::vector<Vector2D> ivertices;  // inner vertices
+  std::vector<Vector2D> overtices;  // outer verices
+
+  bool innerExists = (innerRx > 0. and innerRy > 0.);
+  bool closed = std::abs(halfPhi - M_PI) < s_onSurfaceTolerance;
+
+  // Get the phi segments from the helper method
+  auto phiSegs = detail::VerticesHelper::phiSegments(
+      avgPhi - halfPhi, avgPhi + halfPhi, {avgPhi});
+
+  // The inner (if exists) and outer bow
+  for (unsigned int iseg = 0; iseg < phiSegs.size() - 1; ++iseg) {
+    int addon = (iseg == phiSegs.size() - 2 and not closed) ? 1 : 0;
+    if (innerExists) {
+      createSegment(ivertices, {innerRx, innerRy}, phiSegs[iseg],
+                    phiSegs[iseg + 1], lseg, addon, Vector2D::Zero(),
+                    Transform2D::Identity());
+    }
+    createSegment(overtices, {outerRx, outerRy}, phiSegs[iseg],
+                  phiSegs[iseg + 1], lseg, addon, Vector2D::Zero(),
+                  Transform2D::Identity());
+  }
+
+  // We want to keep the same counter-clockwise orientation for displaying
+  if (not innerExists) {
+    if (not closed) {
+      // Add the center case we have a sector
+      rvertices.push_back(Vector2D(0., 0.));
+    }
+    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
+  } else if (not closed) {
+    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
+    rvertices.insert(rvertices.end(), ivertices.rbegin(), ivertices.rend());
+  } else {
+    rvertices.insert(rvertices.end(), overtices.begin(), overtices.end());
+    rvertices.insert(rvertices.end(), ivertices.begin(), ivertices.end());
+  }
+  return rvertices;
+}
+
+std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::circularVertices(
+    double innerR, double outerR, double avgPhi, double halfPhi,
+    unsigned int lseg) {
+  return ellispoidVertices(innerR, innerR, outerR, outerR, avgPhi, halfPhi,
+                           lseg);
+}
+
+bool Acts::detail::VerticesHelper::onHyperPlane(
+    const std::vector<Acts::Vector3D>& vertices, double tolerance) {
+  // Obvious always on one surface
+  if (vertices.size() < 4) {
+    return true;
+  }
+  // Create the hyperplane
+  auto hyperPlane = Eigen::Hyperplane<double, 3>::Through(
+      vertices[0], vertices[1], vertices[2]);
+  for (size_t ip = 3; ip < vertices.size(); ++ip) {
+    if (hyperPlane.absDistance(vertices[ip]) > tolerance) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/Core/src/Surfaces/VerticesHelper.cpp
+++ b/Core/src/Surfaces/VerticesHelper.cpp
@@ -44,7 +44,7 @@ std::vector<double> Acts::detail::VerticesHelper::phiSegments(
   return phiSegments;
 }
 
-std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::ellispoidVertices(
+std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::ellipsoidVertices(
     double innerRx, double innerRy, double outerRx, double outerRy,
     double avgPhi, double halfPhi, unsigned int lseg) {
   // List of vertices counter-clockwise starting at smallest phi w.r.t center,
@@ -93,7 +93,7 @@ std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::ellispoidVertices(
 std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::circularVertices(
     double innerR, double outerR, double avgPhi, double halfPhi,
     unsigned int lseg) {
-  return ellispoidVertices(innerR, innerR, outerR, outerR, avgPhi, halfPhi,
+  return ellipsoidVertices(innerR, innerR, outerR, outerR, avgPhi, halfPhi,
                            lseg);
 }
 

--- a/Core/src/Surfaces/VerticesHelper.cpp
+++ b/Core/src/Surfaces/VerticesHelper.cpp
@@ -64,13 +64,13 @@ std::vector<Acts::Vector2D> Acts::detail::VerticesHelper::ellispoidVertices(
   for (unsigned int iseg = 0; iseg < phiSegs.size() - 1; ++iseg) {
     int addon = (iseg == phiSegs.size() - 2 and not closed) ? 1 : 0;
     if (innerExists) {
-      createSegment(ivertices, {innerRx, innerRy}, phiSegs[iseg],
-                    phiSegs[iseg + 1], lseg, addon, Vector2D::Zero(),
-                    Transform2D::Identity());
+      createSegment<Vector2D, Transform2D>(ivertices, {innerRx, innerRy},
+                                           phiSegs[iseg], phiSegs[iseg + 1],
+                                           lseg, addon);
     }
-    createSegment(overtices, {outerRx, outerRy}, phiSegs[iseg],
-                  phiSegs[iseg + 1], lseg, addon, Vector2D::Zero(),
-                  Transform2D::Identity());
+    createSegment<Vector2D, Transform2D>(overtices, {outerRx, outerRy},
+                                         phiSegs[iseg], phiSegs[iseg + 1], lseg,
+                                         addon);
   }
 
   // We want to keep the same counter-clockwise orientation for displaying


### PR DESCRIPTION
Move non-template function implementations to a `.cpp` file. This fixes compiler warnings that appear with #267.