### PR TITLE
Make the material classification numbers an opaque vector

### DIFF
--- a/Core/include/Acts/Material/Material.hpp
+++ b/Core/include/Acts/Material/Material.hpp
@@ -20,11 +20,11 @@ namespace Acts {
 /// The following parameters are used to specify the material and its
 /// interactions with traversing particles:
 ///
-/// *   X0:  radiation length (native length units)
-/// *   L0:  nuclear interaction length (native length units)
-/// *   Ar:  relative atomic mass (unitless number)
-/// *   Z:   atomic number (unitless number)
-/// *   rho: mass density (native mass unit / (native length unit)³)
+/// - radiation length X0 (native length units)
+/// - nuclear interaction length L0 (native length units)
+/// - relative atomic mass Ar (unitless number)
+/// - nuclear charge number Z (elementary charge e)
+/// - mass density rho (native mass unit / (native length unit)³)
 ///
 /// The parameters can be effective or average parameters when e.g. a mixture
 /// of materials is described.
@@ -68,11 +68,11 @@ class Material {
   constexpr float L0() const { return m_l0; }
   /// Return the relative atomic mass.
   constexpr float Ar() const { return m_ar; }
-  /// Return the atomic number.
+  /// Return the nuclear charge number.
   constexpr float Z() const { return m_z; }
   /// Return the mass density.
   constexpr float massDensity() const { return m_rho; }
-  /// Return the electron density in mol / (native length unit)³.
+  /// Return the molar electron density in mol / (native length unit)³.
   ///
   /// Use mol instead of the real number of electrons to avoid large numbers
   /// which could result in numerical instabilities somewhere else.

--- a/Core/include/Acts/Material/Material.hpp
+++ b/Core/include/Acts/Material/Material.hpp
@@ -30,15 +30,6 @@ namespace Acts {
 /// of materials is described.
 class Material {
  public:
-  /// Index of the parameters in the encoded parameters vector.
-  enum Param {
-    eX0 = 0,
-    eL0 = 1,
-    eAr = 2,
-    eZ = 3,
-    eRho = 4,
-  };
-
   /// Construct a vacuum representation.
   Material() = default;
   /// Construct from material parameters.
@@ -80,7 +71,7 @@ class Material {
   /// Return the mean electron excitation energy.
   float meanExcitationEnergy() const;
 
-  /// Encode the properties into a parameter vector.
+  /// Encode the properties into an opaque parameters vector.
   ActsVectorF<5> classificationNumbers() const;
 
  private:

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -13,9 +13,20 @@
 
 #include "Acts/Utilities/Units.hpp"
 
+namespace {
+enum MaterialClassificationNumberIndices {
+  eRadiationLength = 0,
+  eInteractionLength = 1,
+  eRelativeAtomicMass = 2,
+  eNuclearCharge = 3,
+  eMassDensity = 4,
+};
+}
+
 Acts::Material::Material(const ActsVectorF<5>& parameters)
-    : Material(parameters[eX0], parameters[eL0], parameters[eAr],
-               parameters[eZ], parameters[eRho]) {}
+    : Material(parameters[eRadiationLength], parameters[eInteractionLength],
+               parameters[eRelativeAtomicMass], parameters[eNuclearCharge],
+               parameters[eMassDensity]) {}
 
 float Acts::Material::molarElectronDensity() const {
   using namespace Acts::UnitLiterals;
@@ -51,11 +62,11 @@ float Acts::Material::meanExcitationEnergy() const {
 
 Acts::ActsVectorF<5> Acts::Material::classificationNumbers() const {
   ActsVectorF<5> parameters;
-  parameters[eX0] = m_x0;
-  parameters[eL0] = m_l0;
-  parameters[eAr] = m_ar;
-  parameters[eZ] = m_z;
-  parameters[eRho] = m_rho;
+  parameters[eRadiationLength] = m_x0;
+  parameters[eInteractionLength] = m_l0;
+  parameters[eRelativeAtomicMass] = m_ar;
+  parameters[eNuclearCharge] = m_z;
+  parameters[eMassDensity] = m_rho;
   return parameters;
 }
 

--- a/Tests/UnitTests/Core/Material/MaterialTests.cpp
+++ b/Tests/UnitTests/Core/Material/MaterialTests.cpp
@@ -6,14 +6,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
-
 #include <limits>
 
 #include "Acts/Material/Material.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Tests/CommonHelpers/PredefinedMaterials.hpp"
 #include "Acts/Utilities/Units.hpp"
+
+namespace bdata = boost::unit_test::data;
 
 using namespace Acts::UnitLiterals;
 
@@ -56,25 +58,23 @@ BOOST_AUTO_TEST_CASE(Units) {
   CHECK_CLOSE_REL(silicon.meanExcitationEnergy(), SiI, eps);
 }
 
-// encode values as classification vector
-static Acts::ActsVectorF<5> makeSiClassificationNumbers() {
-  Acts::ActsVectorF<5> values;
-  values[Acts::Material::eX0] = Acts::Test::makeSilicon().X0();
-  values[Acts::Material::eL0] = Acts::Test::makeSilicon().L0();
-  values[Acts::Material::eAr] = Acts::Test::makeSilicon().Ar();
-  values[Acts::Material::eZ] = Acts::Test::makeSilicon().Z();
-  values[Acts::Material::eRho] = Acts::Test::makeSilicon().massDensity();
-  return values;
-}
+BOOST_DATA_TEST_CASE(EncodingDecodingRoundtrip,
+                     bdata::make({
+                         Acts::Material(),
+                         Acts::Material(1, 2, 3, 4, 5),
+                         Acts::Test::makeBeryllium(),
+                         Acts::Test::makeSilicon(),
+                     }),
+                     material) {
+  // encode material
+  Acts::ActsVectorF<5> numbers0 = material.classificationNumbers();
+  // construct from encoded numbers
+  Acts::Material fromNumbers(numbers0);
+  // encode material again
+  Acts::ActsVectorF<5> numbers1 = fromNumbers.classificationNumbers();
 
-BOOST_AUTO_TEST_CASE(classification_numbers) {
-  const auto numbers = makeSiClassificationNumbers();
-  Acts::Material fromNumbers(numbers);
-  Acts::Material manual = Acts::Test::makeSilicon();
-
-  BOOST_TEST(fromNumbers == manual);
-  CHECK_CLOSE_REL(fromNumbers.classificationNumbers(), numbers, eps);
-  CHECK_CLOSE_REL(manual.classificationNumbers(), numbers, eps);
+  BOOST_TEST(material == fromNumbers);
+  BOOST_TEST(numbers0 == numbers1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Material/MaterialTests.cpp
+++ b/Tests/UnitTests/Core/Material/MaterialTests.cpp
@@ -22,21 +22,21 @@ static constexpr auto eps = 2 * std::numeric_limits<float>::epsilon();
 static constexpr float SiNe = 1.160954941 / 1_cm3;
 static constexpr float SiI = 172.042290036_eV;
 
-BOOST_AUTO_TEST_SUITE(material)
+BOOST_AUTO_TEST_SUITE(Material)
 
-BOOST_AUTO_TEST_CASE(construct_vacuum) {
+BOOST_AUTO_TEST_CASE(ConstructVacuum) {
   // default constructor builds invalid material a.k.a. vacuum
   Acts::Material vacuum;
   BOOST_TEST(!vacuum);
 }
 
-BOOST_AUTO_TEST_CASE(construct_something) {
+BOOST_AUTO_TEST_CASE(ConstructSomething) {
   // anything with non-zero Ar is a valid material
   Acts::Material notVacuum(1, 2, 3, 4, 5);
   BOOST_TEST(!!notVacuum);
 }
 
-BOOST_AUTO_TEST_CASE(units) {
+BOOST_AUTO_TEST_CASE(Units) {
   Acts::Material silicon = Acts::Test::makeSilicon();
 
   // check values w/ different units if possible


### PR DESCRIPTION
Remove the public `enum` within the `Material` class that describes the content of the classification numbers vector. The classification numbers can still be used to stored the encoded material information. In order to interpret it, a `Material` object has to be constructed again.

The functionality was no used in the code base and removing it will make it easier to change the internal parametrization as planned in #31. Should also fix compiler warning regarding enum name clashes that show up in #267.