### PR TITLE
Allow navigation initialisation from a given volume

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -454,7 +454,8 @@ class Navigator {
     if (state.navigation.startSurface &&
         state.navigation.startSurface->associatedLayer()) {
       debugLog(state, [&] {
-        return std::string("Fast start initialization through association from Surface.");
+        return std::string(
+            "Fast start initialization through association from Surface.");
       });
       // assign the current layer and volume by association
       state.navigation.startLayer =
@@ -464,43 +465,43 @@ class Navigator {
       // Set the start volume as current volume
       state.navigation.currentVolume = state.navigation.startVolume;
     } else {
-		if(state.navigation.startVolume)
-		{
-			debugLog(state, [&] {
-			return std::string("Fast start initialization through association from Volume.");
-		  });
-		  state.navigation.startLayer = state.navigation.startVolume->associatedLayer(
-						state.geoContext, stepper.position(state.stepping));
-		  // Set the start volume as current volume
-		  state.navigation.currentVolume = state.navigation.startVolume;
-		}
-		else
-		{
-      debugLog(state, [&] {
-        return std::string("Slow start initialization through search.");
-      });
-      // current volume and layer search through global search
-      debugLog(state, [&] {
-        std::stringstream dstream;
-        dstream << "Starting from position "
-                << toString(stepper.position(state.stepping));
-        dstream << " and direction "
-                << toString(stepper.direction(state.stepping));
-        return dstream.str();
-      });
-      state.navigation.startVolume = trackingGeometry->lowestTrackingVolume(
-          state.geoContext, stepper.position(state.stepping));
-      state.navigation.startLayer =
-          state.navigation.startVolume
-              ? state.navigation.startVolume->associatedLayer(
-                    state.geoContext, stepper.position(state.stepping))
-              : nullptr;
-      // Set the start volume as current volume
-      state.navigation.currentVolume = state.navigation.startVolume;
       if (state.navigation.startVolume) {
-        debugLog(state, [&] { return std::string("Start volume resolved."); });
+        debugLog(state, [&] {
+          return std::string(
+              "Fast start initialization through association from Volume.");
+        });
+        state.navigation.startLayer =
+            state.navigation.startVolume->associatedLayer(
+                state.geoContext, stepper.position(state.stepping));
+        // Set the start volume as current volume
+        state.navigation.currentVolume = state.navigation.startVolume;
+      } else {
+        debugLog(state, [&] {
+          return std::string("Slow start initialization through search.");
+        });
+        // current volume and layer search through global search
+        debugLog(state, [&] {
+          std::stringstream dstream;
+          dstream << "Starting from position "
+                  << toString(stepper.position(state.stepping));
+          dstream << " and direction "
+                  << toString(stepper.direction(state.stepping));
+          return dstream.str();
+        });
+        state.navigation.startVolume = trackingGeometry->lowestTrackingVolume(
+            state.geoContext, stepper.position(state.stepping));
+        state.navigation.startLayer =
+            state.navigation.startVolume
+                ? state.navigation.startVolume->associatedLayer(
+                      state.geoContext, stepper.position(state.stepping))
+                : nullptr;
+        // Set the start volume as current volume
+        state.navigation.currentVolume = state.navigation.startVolume;
+        if (state.navigation.startVolume) {
+          debugLog(state,
+                   [&] { return std::string("Start volume resolved."); });
+        }
       }
-  }
     }
     return;
   }

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -242,7 +242,7 @@ class Navigator {
     debugLog(state, [&] { return std::string("Entering navigator::status."); });
 
     // (a) Pre-stepping call from propgator
-    if (not state.navigation.startVolume) {
+    if (not state.navigation.startVolume or not state.navigation.startSurface) {
       // Initialize and return
       initialize(state, stepper);
       return;
@@ -454,7 +454,7 @@ class Navigator {
     if (state.navigation.startSurface &&
         state.navigation.startSurface->associatedLayer()) {
       debugLog(state, [&] {
-        return std::string("Fast start initialization through association.");
+        return std::string("Fast start initialization through association from Surface.");
       });
       // assign the current layer and volume by association
       state.navigation.startLayer =
@@ -464,6 +464,18 @@ class Navigator {
       // Set the start volume as current volume
       state.navigation.currentVolume = state.navigation.startVolume;
     } else {
+		if(state.navigation.startVolume)
+		{
+			debugLog(state, [&] {
+			return std::string("Fast start initialization through association from Volume.");
+		  });
+		  state.navigation.startLayer = state.navigation.startVolume->associatedLayer(
+						state.geoContext, stepper.position(state.stepping));
+		  // Set the start volume as current volume
+		  state.navigation.currentVolume = state.navigation.startVolume;
+		}
+		else
+		{
       debugLog(state, [&] {
         return std::string("Slow start initialization through search.");
       });
@@ -488,6 +500,7 @@ class Navigator {
       if (state.navigation.startVolume) {
         debugLog(state, [&] { return std::string("Start volume resolved."); });
       }
+  }
     }
     return;
   }

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -226,12 +226,12 @@ void step(stepper_state_t& sstate) {
 /// @param [in] navLay Number of navigation layers
 /// @param [in] navBound Number of navigation boundaries
 /// @param [in] extSurf Number of external surfaces
-bool testNavigatorStateVectors(Navigator::State& state, size_t navSurf, size_t navLay, size_t navBound, size_t extSurf)
-{
+bool testNavigatorStateVectors(Navigator::State& state, size_t navSurf,
+                               size_t navLay, size_t navBound, size_t extSurf) {
   return ((state.navSurfaces.size() == navSurf) &&
-  (state.navLayers.size() == navLay) && 
-  (state.navBoundaries.size() == navBound) &&
-  (state.externalSurfaces.size() == extSurf));
+          (state.navLayers.size() == navLay) &&
+          (state.navBoundaries.size() == navBound) &&
+          (state.externalSurfaces.size() == extSurf));
 }
 
 /// @brief Method for testing pointers in @c Navigator::State
@@ -246,18 +246,18 @@ bool testNavigatorStateVectors(Navigator::State& state, size_t navSurf, size_t n
 /// @param [in] targetVol Target volume
 /// @param [in] targetLay Target layer
 /// @param [in] targetSurf Target surface
-bool testNavigatorStatePointers(Navigator::State& state, const TrackingVolume* worldVol, const TrackingVolume* startVol, const Layer* startLay, 
-const Surface* startSurf, const Surface* currSurf, const TrackingVolume* currVol, const TrackingVolume* targetVol, const Layer* targetLay, const Surface* targetSurf)
-{  
-  return ((state.worldVolume == worldVol) &&
-  (state.startVolume == startVol) &&
-  (state.startLayer == startLay) &&
-  (state.startSurface == startSurf) &&
-  (state.currentSurface == currSurf) &&
-  (state.currentVolume == currVol) &&
-  (state.targetVolume == targetVol) &&
-  (state.targetLayer == targetLay) &&
-  (state.targetSurface == targetSurf));
+bool testNavigatorStatePointers(
+    Navigator::State& state, const TrackingVolume* worldVol,
+    const TrackingVolume* startVol, const Layer* startLay,
+    const Surface* startSurf, const Surface* currSurf,
+    const TrackingVolume* currVol, const TrackingVolume* targetVol,
+    const Layer* targetLay, const Surface* targetSurf) {
+  return (
+      (state.worldVolume == worldVol) && (state.startVolume == startVol) &&
+      (state.startLayer == startLay) && (state.startSurface == startSurf) &&
+      (state.currentSurface == currSurf) && (state.currentVolume == currVol) &&
+      (state.targetVolume == targetVol) && (state.targetLayer == targetLay) &&
+      (state.targetSurface == targetSurf));
 }
 // the surface cache & the creation of the geometry
 
@@ -268,13 +268,13 @@ auto tGeometry = cGeometry();
 bool debug = true;
 
 BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
-	// create a navigator
+  // create a navigator
   Navigator navigator;
-navigator.resolveSensitive = false;
+  navigator.resolveSensitive = false;
   navigator.resolveMaterial = false;
   navigator.resolvePassive = false;
-  
-// position and direction vector
+
+  // position and direction vector
   Vector3D position(0., 0., 0);
   Vector3D momentum(1., 1., 0);
 
@@ -295,15 +295,19 @@ navigator.resolveSensitive = false;
   // Run without anything present
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr));
   state.options.debugString.clear();
-  
+
   // Run with geometry but without resolving
   navigator.trackingGeometry = tGeometry;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
-state.options.debugString.clear();
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr));
+  state.options.debugString.clear();
 
   // Run with geometry and resolving but broken navigation for various reasons
   navigator.resolveSensitive = true;
@@ -314,14 +318,18 @@ state.options.debugString.clear();
   state.navigation.targetReached = true;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
-state.options.debugString.clear();
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr));
+  state.options.debugString.clear();
   // b) Beacause of no target surface
   state.navigation.targetReached = false;
   state.navigation.targetSurface = nullptr;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr, nullptr,
+                                        nullptr, nullptr, nullptr));
   state.options.debugString.clear();
   // c) Because the target surface is reached
   const Surface* startSurf = tGeometry->getBeamline();
@@ -330,10 +338,12 @@ state.options.debugString.clear();
   state.navigation.targetSurface = targetSurf;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, targetSurf, nullptr, nullptr, nullptr, targetSurf));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                        nullptr, nullptr, targetSurf, nullptr,
+                                        nullptr, nullptr, targetSurf));
   std::cout << state.options.debugString << std::endl;
   state.options.debugString.clear();
-  
+
   //
   // (2) Test the initialisation
   //
@@ -342,28 +352,34 @@ state.options.debugString.clear();
   state.stepping.pos << 0., 0., 0.;
   const TrackingVolume* worldVol = tGeometry->highestTrackingVolume();
   const TrackingVolume* startVol = tGeometry->lowestTrackingVolume(
-          state.geoContext, stepper.position(state.stepping));
+      state.geoContext, stepper.position(state.stepping));
   const Layer* startLay = startVol->associatedLayer(
-                    state.geoContext, stepper.position(state.stepping));
+      state.geoContext, stepper.position(state.stepping));
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol, startLay, nullptr, nullptr, startVol, nullptr, nullptr, nullptr));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
+                                        startLay, nullptr, nullptr, startVol,
+                                        nullptr, nullptr, nullptr));
   state.options.debugString.clear();
-  
+
   // b) Initialise having a start surface
   state.navigation = Navigator::State();
   state.navigation.startSurface = startSurf;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol, startLay, startSurf, startSurf, startVol, nullptr, nullptr, nullptr));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
+                                        startLay, startSurf, startSurf,
+                                        startVol, nullptr, nullptr, nullptr));
   state.options.debugString.clear();
-  
+
   // c) Initialise having a start volume
   state.navigation = Navigator::State();
   state.navigation.startVolume = startVol;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol, startLay, nullptr, nullptr, startVol, nullptr, nullptr, nullptr));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
+                                        startLay, nullptr, nullptr, startVol,
+                                        nullptr, nullptr, nullptr));
   state.options.debugString.clear();
 }
 

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -248,17 +248,7 @@ bool testNavigatorStateVectors(Navigator::State& state, size_t navSurf, size_t n
 /// @param [in] targetSurf Target surface
 bool testNavigatorStatePointers(Navigator::State& state, const TrackingVolume* worldVol, const TrackingVolume* startVol, const Layer* startLay, 
 const Surface* startSurf, const Surface* currSurf, const TrackingVolume* currVol, const TrackingVolume* targetVol, const Layer* targetLay, const Surface* targetSurf)
-{
-  std::cout << (state.worldVolume == worldVol) <<
-  (state.startVolume == startVol) <<
-  (state.startLayer == startLay) <<
-  (state.startSurface == startSurf) <<
-  (state.currentSurface == currSurf) <<
-  (state.currentVolume == currVol) <<
-  (state.targetVolume == targetVol) <<
-  (state.targetLayer == targetLay) <<
-  (state.targetSurface == targetSurf) << std::endl;
-  
+{  
   return ((state.worldVolume == worldVol) &&
   (state.startVolume == startVol) &&
   (state.startLayer == startLay) &&
@@ -368,16 +358,13 @@ state.options.debugString.clear();
   BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol, startLay, startSurf, startSurf, startVol, nullptr, nullptr, nullptr));
   state.options.debugString.clear();
   
-  /// @param [in] worldVol World volume
-/// @param [in] startVol Start volume
-/// @param [in] startLay Start layer
-/// @param [in] startSurf Start surface
-/// @param [in] currSurf Current surface
-/// @param [in] currVol Current volume
-/// @param [in] targetVol Target volume
-/// @param [in] targetLay Target layer
-/// @param [in] targetSurf Target surface
-
+  // c) Initialise having a start volume
+  state.navigation = Navigator::State();
+  state.navigation.startVolume = startVol;
+  navigator.status(state, stepper);
+  BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol, startLay, nullptr, nullptr, startVol, nullptr, nullptr, nullptr));
+  state.options.debugString.clear();
 }
 
 BOOST_AUTO_TEST_CASE(Navigator_target_methods) {

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -298,7 +298,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
                                         nullptr, nullptr, nullptr, nullptr,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
 
   // Run with geometry but without resolving
   navigator.trackingGeometry = tGeometry;
@@ -307,7 +306,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
                                         nullptr, nullptr, nullptr, nullptr,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
 
   // Run with geometry and resolving but broken navigation for various reasons
   navigator.resolveSensitive = true;
@@ -321,7 +319,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
                                         nullptr, nullptr, nullptr, nullptr,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
   // b) Beacause of no target surface
   state.navigation.targetReached = false;
   state.navigation.targetSurface = nullptr;
@@ -330,7 +327,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
                                         nullptr, nullptr, nullptr, nullptr,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
   // c) Because the target surface is reached
   const Surface* startSurf = tGeometry->getBeamline();
   state.stepping.pos = startSurf->center(state.geoContext);
@@ -341,8 +337,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
                                         nullptr, nullptr, targetSurf, nullptr,
                                         nullptr, nullptr, targetSurf));
-  std::cout << state.options.debugString << std::endl;
-  state.options.debugString.clear();
 
   //
   // (2) Test the initialisation
@@ -360,7 +354,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
                                         startLay, nullptr, nullptr, startVol,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
 
   // b) Initialise having a start surface
   state.navigation = Navigator::State();
@@ -370,7 +363,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
                                         startLay, startSurf, startSurf,
                                         startVol, nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
 
   // c) Initialise having a start volume
   state.navigation = Navigator::State();
@@ -380,7 +372,6 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   BOOST_TEST(testNavigatorStatePointers(state.navigation, worldVol, startVol,
                                         startLay, nullptr, nullptr, startVol,
                                         nullptr, nullptr, nullptr));
-  state.options.debugString.clear();
 }
 
 BOOST_AUTO_TEST_CASE(Navigator_target_methods) {

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -227,7 +227,48 @@ auto tGeometry = cGeometry();
 // the debug boolean
 bool debug = true;
 
-BOOST_AUTO_TEST_CASE(Navigator_methods) {
+BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
+	// create a navigator
+  Navigator navigator;
+  //~ navigator.trackingGeometry = tGeometry;
+  //~ navigator.resolveSensitive = true;
+  //~ navigator.resolveMaterial = true;
+  //~ navigator.resolvePassive = false;
+
+// position and direction vector
+  Vector3D position(0., 0., 0);
+  Vector3D momentum(1., 1., 0);
+
+  // the propagator cache
+  PropagatorState state;
+  state.options.debug = debug;
+
+  // the stepper cache
+  state.stepping.pos = position;
+  state.stepping.dir = momentum.normalized();
+
+  // Stepper
+  PropagatorState::Stepper stepper;
+
+  // (1) Test the inactivity
+  navigator.status(state, stepper);
+  
+  BOOST_CHECK_EQUAL(state.navigation.navSurfaces.size(), 0u);
+  BOOST_CHECK_EQUAL(state.navigation.navLayers.size(), 0u);
+  BOOST_CHECK_EQUAL(state.navigation.navBoundaries.size(), 0u);
+  BOOST_CHECK_EQUAL(state.navigation.externalSurfaces.size(), 0u);
+  BOOST_CHECK_EQUAL(state.navigation.worldVolume, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.startVolume, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.startLayer, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.startSurface, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.currentSurface, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.currentVolume, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.targetVolume, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.targetLayer, nullptr);
+  BOOST_CHECK_EQUAL(state.navigation.targetSurface, nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(Navigator_target_methods) {
   // create a navigator
   Navigator navigator;
   navigator.trackingGeometry = tGeometry;

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -112,8 +112,10 @@ struct PropagatorState {
     Intersection::Status updateSurfaceStatus(
         State& state, const Surface& surface,
         const BoundaryCheck& bcheck) const {
-      return detail::updateSingleSurfaceStatus<Stepper>(*this, state, surface,
+			auto status = detail::updateSingleSurfaceStatus<Stepper>(*this, state, surface,
                                                         bcheck);
+                                                       std::cout << "status: " << static_cast<int>(status) << std::endl;
+      return status;
     }
 
     template <typename object_intersection_t>
@@ -331,10 +333,11 @@ navigator.resolveSensitive = false;
   BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
   // c) Because the target surface is reached
   auto curvParams = std::get<CurvilinearParameters>(stepper.curvilinearState(state.stepping));
-  state.navigation.targetSurface = &curvParams.referenceSurface();
+  const Surface* targetSurf = &curvParams.referenceSurface();
+  state.navigation.targetSurface = targetSurf;
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, &curvParams.referenceSurface(), nullptr, nullptr, nullptr, &curvParams.referenceSurface()));
+  BOOST_TEST(testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, targetSurf, nullptr, nullptr, nullptr, targetSurf));
   
   //
   // (2) Test the initialisation
@@ -345,7 +348,8 @@ navigator.resolveSensitive = false;
   const TrackingVolume* worldVol = tGeometry->highestTrackingVolume();
   const TrackingVolume* startVol = tGeometry->lowestTrackingVolume(
           state.geoContext, stepper.position(state.stepping));
-  const Layer* startLay = state.navigation.startVolume->associatedLayer(
+  std::cout << startVol << std::endl;
+  const Layer* startLay = startVol->associatedLayer(
                     state.geoContext, stepper.position(state.stepping));
   navigator.status(state, stepper);
   BOOST_TEST(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -289,7 +289,9 @@ navigator.resolveSensitive = false;
   // Stepper
   PropagatorState::Stepper stepper;
 
-  // (1) Test the inactivity
+  //
+  // (1) Test for inactivity
+  //
   navigator.status(state, stepper);
   // Run without anything present
   testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
@@ -297,6 +299,40 @@ navigator.resolveSensitive = false;
   
   // Run with geometry but without resolving
   navigator.trackingGeometry = tGeometry;
+  navigator.status(state, stepper);
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+  // Run with geometry and resolving but broken navigation for various reasons
+  navigator.resolveSensitive = true;
+  navigator.resolveMaterial = true;
+  navigator.resolvePassive = true;
+  state.navigation.navigationBreak = true;
+  // a) Because target is reached
+  state.navigation.targetReached = true;
+  navigator.status(state, stepper);
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  // b) Beacause of no target surface
+  state.navigation.targetReached = false;
+  state.navigation.targetSurface = nullptr;
+  navigator.status(state, stepper);
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  // c) Because the target surface is reached
+  auto curvParams = std::get<CurvilinearParameters>(stepper.curvilinearState(state.stepping));
+  state.navigation.targetSurface = &curvParams.referenceSurface();
+  navigator.status(state, stepper);
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  
+  // Clean-up the state
+  state.navigation.targetSurface = nullptr;
+  state.navigation.navigationBreak = false;
+  
+  //
+  // (2) Test the initialisation
+  //
   navigator.status(state, stepper);
   testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
   testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -219,6 +219,46 @@ void step(stepper_state_t& sstate) {
   return;
 }
 
+/// @brief Method for testing vectors in @c Navigator::State
+///
+/// @param [in] state Navigator state
+/// @param [in] navSurf Number of navigation surfaces
+/// @param [in] navLay Number of navigation layers
+/// @param [in] navBound Number of navigation boundaries
+/// @param [in] extSurf Number of external surfaces
+void testNavigatorStateVectors(Navigator::State& state, size_t navSurf, size_t navLay, size_t navBound, size_t extSurf)
+{
+  BOOST_CHECK_EQUAL(state.navSurfaces.size(), navSurf);
+  BOOST_CHECK_EQUAL(state.navLayers.size(), navLay);
+  BOOST_CHECK_EQUAL(state.navBoundaries.size(), navBound);
+  BOOST_CHECK_EQUAL(state.externalSurfaces.size(), extSurf);
+}
+
+/// @brief Method for testing pointers in @c Navigator::State
+///
+/// @param [in] state Navigation state
+/// @param [in] worldVol World volume
+/// @param [in] startVol Start volume
+/// @param [in] startLay Start layer
+/// @param [in] startSurf Start surface
+/// @param [in] currSurf Current surface
+/// @param [in] currVol Current volume
+/// @param [in] targetVol Target volume
+/// @param [in] targetLay Target layer
+/// @param [in] targetSurf Target surface
+void testNavigatorStatePointers(Navigator::State& state, const TrackingVolume* worldVol, const TrackingVolume* startVol, const Layer* startLay, 
+const Surface* startSurf, const Surface* currSurf, const TrackingVolume* currVol, const TrackingVolume* targetVol, const Layer* targetLay, const Surface* targetSurf)
+{
+  BOOST_CHECK_EQUAL(state.worldVolume, worldVol);
+  BOOST_CHECK_EQUAL(state.startVolume, startVol);
+  BOOST_CHECK_EQUAL(state.startLayer, startLay);
+  BOOST_CHECK_EQUAL(state.startSurface, startSurf);
+  BOOST_CHECK_EQUAL(state.currentSurface, currSurf);
+  BOOST_CHECK_EQUAL(state.currentVolume, currVol);
+  BOOST_CHECK_EQUAL(state.targetVolume, targetVol);
+  BOOST_CHECK_EQUAL(state.targetLayer, targetLay);
+  BOOST_CHECK_EQUAL(state.targetSurface, targetSurf);
+}
 // the surface cache & the creation of the geometry
 
 CylindricalTrackingGeometry cGeometry(tgContext);
@@ -230,11 +270,10 @@ bool debug = true;
 BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
 	// create a navigator
   Navigator navigator;
-  //~ navigator.trackingGeometry = tGeometry;
-  //~ navigator.resolveSensitive = true;
-  //~ navigator.resolveMaterial = true;
-  //~ navigator.resolvePassive = false;
-
+navigator.resolveSensitive = false;
+  navigator.resolveMaterial = false;
+  navigator.resolvePassive = false;
+  
 // position and direction vector
   Vector3D position(0., 0., 0);
   Vector3D momentum(1., 1., 0);
@@ -252,20 +291,16 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
 
   // (1) Test the inactivity
   navigator.status(state, stepper);
+  // Run without anything present
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   
-  BOOST_CHECK_EQUAL(state.navigation.navSurfaces.size(), 0u);
-  BOOST_CHECK_EQUAL(state.navigation.navLayers.size(), 0u);
-  BOOST_CHECK_EQUAL(state.navigation.navBoundaries.size(), 0u);
-  BOOST_CHECK_EQUAL(state.navigation.externalSurfaces.size(), 0u);
-  BOOST_CHECK_EQUAL(state.navigation.worldVolume, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.startVolume, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.startLayer, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.startSurface, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.currentSurface, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.currentVolume, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.targetVolume, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.targetLayer, nullptr);
-  BOOST_CHECK_EQUAL(state.navigation.targetSurface, nullptr);
+  // Run with geometry but without resolving
+  navigator.trackingGeometry = tGeometry;
+  navigator.status(state, stepper);
+  testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u);
+  testNavigatorStatePointers(state.navigation, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  
 }
 
 BOOST_AUTO_TEST_CASE(Navigator_target_methods) {


### PR DESCRIPTION
The current `Navigator` workflow allows a fast initialisation iff a `startSurface` and no `startVolume` is set. Given the inverse scenario, a slow lookup from the world volume is started, ignoring a potential set `startVolume`. This PR adds the possibility to start also from a given volume.