### PR TITLE
Remove SpacePoint

### DIFF
--- a/Core/include/Acts/Utilities/Helpers.hpp
+++ b/Core/include/Acts/Utilities/Helpers.hpp
@@ -192,90 +192,14 @@ inline ActsMatrixD<3, 3> cross(const ActsMatrixD<3, 3>& m, const Vector3D& v) {
   return r;
 }
 
-/// @brief Access to the time component of input parameter
-///
-/// @param spacePointVec The SpacePointVector
-/// @return Reference to the time component
-inline ParValue_t& time(SpacePointVector& spacePointVec) {
-  return spacePointVec[3];
+/// Access the three-position components in a four-position vector.
+inline auto position(const Vector4D& pos4) {
+  return pos4.segment<3>(ePos0);
 }
 
-/// @brief Const overload access to the
-/// time component of input parameter
-///
-/// @param spacePointVec The SpacePointVector
-/// @return Reference to the time component
-inline const ParValue_t& time(const SpacePointVector& spacePointVec) {
-  return spacePointVec[3];
-}
-
-/// @brief Access to the time component of input parameter
-///
-/// @param boundVec The BoundVector
-/// @return Reference to the time component
-inline ParValue_t& time(BoundVector& boundVec) {
-  return boundVec[eT];
-}
-
-/// @brief Const overload access to the
-/// time component of input parameter
-///
-/// @param boundVec The BoundVector
-/// @return Reference to the time component
-inline const ParValue_t& time(const BoundVector& boundVec) {
-  return boundVec[eT];
-}
-
-/// @brief Access to the time component of input parameter
-///
-/// @param freeVec The FreeVector
-/// @return Reference to the time component
-inline ParValue_t& time(FreeVector& freeVec) {
-  return freeVec[7];
-}
-
-/// @brief Const overload access to the
-/// time component of input parameter
-///
-/// @param freeVec The FreeVector
-/// @return Reference to the time component
-inline const ParValue_t& time(const FreeVector& freeVec) {
-  return freeVec[7];
-}
-
-/// @brief Access to the position components of input parameter
-///
-/// @param spacePointVec The SpacePointVector
-/// @return Reference to the position components
-inline auto position(SpacePointVector& spacePointVec) {
-  return spacePointVec.head<3>();
-}
-
-/// @brief Const overload access to the
-/// position components of input parameter
-///
-/// @param spacePointVec The SpacePointVector
-/// @return Reference to the position components
-inline auto position(const SpacePointVector& spacePointVec) {
-  return spacePointVec.head<3>();
-}
-
-/// @brief Access to the
-/// position components of input parameter
-///
-/// @param freeVec The SpacePointVector
-/// @return Reference to the position components
-inline auto position(FreeVector& freeVec) {
-  return freeVec.head<3>();
-}
-
-/// @brief Const overload access to the
-/// position components of input parameter
-///
-/// @param freeVec The SpacePointVector
-/// @return Reference to the position components
-inline auto position(const FreeVector& freeVec) {
-  return freeVec.head<3>();
+/// Access the three-position components in a free parameters vector.
+inline auto position(const FreeVector& params) {
+  return params.segment<3>(eFreePos0);
 }
 
 }  // namespace VectorHelpers

--- a/Core/include/Acts/Utilities/ParameterDefinitions.hpp
+++ b/Core/include/Acts/Utilities/ParameterDefinitions.hpp
@@ -78,6 +78,9 @@ enum BoundParametersIndices : unsigned int {
   eT = eBoundTime,
 };
 
+/// Underlying fundamental scalar type for bound track parameters.
+using BoundParametersScalar = double;
+
 /// Components of a free track parameters vector.
 ///
 /// To be used to access components by named indices instead of just numbers.
@@ -104,37 +107,8 @@ enum FreeParametersIndices : unsigned int {
   eFreeParametersSize,
 };
 
-/// Components of a space point vector.
-///
-/// To be used to access components by named indices instead of just numbers.
-/// This must be a regular `enum` and not a scoped `enum class` to allow
-/// implicit conversion to an integer. The enum value are thus visible directly
-/// in `namespace Acts` and are prefixed to avoid naming collisions.
-///
-/// Within the same context either the position-like or the momentum-like
-/// indices must be used exclusively.
-enum SpacePointIndices : unsigned int {
-  // For position four-vectors
-  // The spatial position components must be stored as one continous block.
-  eSpacePos0 = 0u,
-  eSpacePos1 = eSpacePos0 + 1u,
-  eSpacePos2 = eSpacePos0 + 2u,
-  eSpaceTime = 3u,
-  // Last uninitialized value contains the total number of components
-  eSpacePointSize,
-  // Aliases for  momentum four-vectors to allow clearer code
-  eSpaceMom0 = eSpacePos0,
-  eSpaceMom1 = eSpacePos1,
-  eSpaceMom2 = eSpacePos2,
-  eSpaceEnergy = eSpaceTime,
-};
-
-/// Underlying fundamental scalar type for bound track parameters.
-using BoundParametersScalar = double;
 /// Underlying fundamental scalar type for free track parameters.
 using FreeParametersScalar = double;
-/// Underlying fundamental scalar type for space points.
-using SpacePointScalar = double;
 
 }  // namespace Acts
 #endif
@@ -161,16 +135,6 @@ static_assert(6 <= FreeParametersIndices::eFreeParametersSize,
 static_assert(std::is_floating_point_v<FreeParametersScalar>,
               "'FreeParametersScalar' must be a floating point type");
 
-// Ensure space point definition is valid.
-static_assert(std::is_enum_v<SpacePointIndices>,
-              "'SpacePointIndices' is not an enum type");
-static_assert(std::is_convertible_v<SpacePointIndices, size_t>,
-              "'SpacePointIndices' is not convertible to size_t");
-static_assert(3 <= SpacePointIndices::eSpacePointSize,
-              "Space points must have at least three components");
-static_assert(std::is_floating_point_v<SpacePointScalar>,
-              "'SpacePointScalar' must be a floating point type");
-
 // Ensure bound track parameter components/ indices are consistently defined.
 static_assert(eLOC_0 != eLOC_1, "Local parameters must be differents");
 static_assert(eLOC_R == eLOC_0 or eLOC_R == eLOC_1,
@@ -195,14 +159,6 @@ static_assert(eFreePos1 == eFreePos0 + 1u, "Position must be continous");
 static_assert(eFreePos2 == eFreePos0 + 2u, "Position must be continous");
 static_assert(eFreeDir1 == eFreeDir0 + 1u, "Direction must be continous");
 static_assert(eFreeDir2 == eFreeDir0 + 2u, "Direction must be continous");
-
-// Ensure space point components/ indices are consistently defined.
-static_assert(eSpacePos1 == eSpacePos0 + 1u, "Position must be continous");
-static_assert(eSpacePos2 == eSpacePos0 + 2u, "Position must be continous");
-static_assert(eSpacePos0 == eSpaceMom0, "Inconsisten position and momentum");
-static_assert(eSpacePos1 == eSpaceMom1, "Inconsisten position and momentum");
-static_assert(eSpacePos2 == eSpaceMom2, "Inconsisten position and momentum");
-static_assert(eSpaceTime == eSpaceEnergy, "Inconsistent time and energy");
 
 namespace detail {
 template <BoundParametersIndices>
@@ -283,11 +239,6 @@ struct ParametersSize<FreeParametersIndices> {
   static constexpr unsigned int size =
       static_cast<unsigned int>(FreeParametersIndices::eFreeParametersSize);
 };
-template <>
-struct ParametersSize<SpacePointIndices> {
-  static constexpr unsigned int size =
-      static_cast<unsigned int>(SpacePointIndices::eSpacePointSize);
-};
 }  // namespace detail
 
 /// Single bound track parameter type for value constrains.
@@ -345,14 +296,6 @@ using FreeMatrix =
     ActsMatrix<FreeParametersScalar, eFreeParametersSize, eFreeParametersSize>;
 using FreeSymMatrix = ActsSymMatrix<FreeParametersScalar, eFreeParametersSize>;
 
-// Matrix and vector types related to space points.
-
-using SpacePointVector = ActsVector<SpacePointScalar, eSpacePointSize>;
-using SpacePointRowVector = ActsRowVector<SpacePointScalar, eSpacePointSize>;
-using SpacePointSymMatrix =
-    ActsMatrix<SpacePointScalar, eSpacePointSize, eSpacePointSize>;
-using SpacePointSymMatrix = ActsSymMatrix<SpacePointScalar, eSpacePointSize>;
-
 // Mapping to bound track parameters.
 //
 // Assumes that matrices represent maps from another space into the space of
@@ -361,8 +304,6 @@ using SpacePointSymMatrix = ActsSymMatrix<SpacePointScalar, eSpacePointSize>;
 
 using FreeToBoundMatrix = ActsMatrix<BoundParametersScalar,
                                      eBoundParametersSize, eFreeParametersSize>;
-using SpacePointToBoundMatrix =
-    ActsMatrix<BoundParametersScalar, eBoundParametersSize, eSpacePointSize>;
 
 // Mapping to free track parameters.
 //
@@ -372,18 +313,6 @@ using SpacePointToBoundMatrix =
 
 using BoundToFreeMatrix =
     ActsMatrix<FreeParametersScalar, eFreeParametersSize, eBoundParametersSize>;
-using SpacePointToFreeMatrix =
-    ActsMatrix<FreeParametersScalar, eFreeParametersSize, eSpacePointSize>;
-
-// Mapping to space points.
-//
-// Assumes that matrices represent maps from another space into the space point
-// space. Thus, the space point scalar type is sufficient to retain accuracy.
-
-using BoundToSpacePointMatrix =
-    ActsMatrix<SpacePointScalar, eSpacePointSize, eBoundParametersSize>;
-using FreeToSpacePointMatrix =
-    ActsMatrix<SpacePointScalar, eSpacePointSize, eFreeParametersSize>;
 
 // For backward compatibility. New code must use the more explicit
 // `BoundParameters{Indices,Scalar,Traits}...` types.

--- a/Core/include/Acts/Vertexing/AMVFInfo.hpp
+++ b/Core/include/Acts/Vertexing/AMVFInfo.hpp
@@ -21,8 +21,7 @@ template <typename input_track_t>
 struct VertexInfo {
   VertexInfo() = default;
 
-  VertexInfo(const Acts::Vertex<input_track_t>& vtx,
-             const Acts::SpacePointVector& pos)
+  VertexInfo(const Acts::Vertex<input_track_t>& vtx, const Acts::Vector4D& pos)
       : constraintVertex(vtx),
         linPoint(pos),
         oldPosition(pos),
@@ -32,13 +31,13 @@ struct VertexInfo {
   Acts::Vertex<input_track_t> constraintVertex;
 
   // The linearization point
-  Acts::SpacePointVector linPoint{Acts::SpacePointVector::Zero()};
+  Acts::Vector4D linPoint{Acts::Vector4D::Zero()};
 
   // Old position from last iteration
-  Acts::SpacePointVector oldPosition{Acts::SpacePointVector::Zero()};
+  Acts::Vector4D oldPosition{Acts::Vector4D::Zero()};
 
   // The seed position
-  Acts::SpacePointVector seedPosition{Acts::SpacePointVector::Zero()};
+  Acts::Vector4D seedPosition{Acts::Vector4D::Zero()};
 
   // Needs relinearization bool
   bool relinearize = true;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -167,7 +167,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
                               const Vertex<InputTrack_t>& seedVertex) const
     -> void {
   if (m_cfg.useBeamSpotConstraint) {
-    if (currentConstraint.fullCovariance() == SpacePointSymMatrix::Zero()) {
+    if (currentConstraint.fullCovariance() == SymMatrix4D::Zero()) {
       ACTS_WARNING(
           "No constraint provided, but useBeamSpotConstraint set to true.");
     }
@@ -177,7 +177,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     }
   } else {
     currentConstraint.setFullPosition(seedVertex.fullPosition());
-    currentConstraint.setFullCovariance(SpacePointSymMatrix::Identity() *
+    currentConstraint.setFullCovariance(SymMatrix4D::Identity() *
                                         m_cfg.looseConstrValue);
     currentConstraint.setFitQuality(m_cfg.defaultConstrFitQuality);
   }
@@ -195,7 +195,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getIPSignificance(
   // it probably should be used.
   Vertex<InputTrack_t> newVtx = vtx;
   if (not m_cfg.useVertexCovForIPEstimation) {
-    newVtx.setFullCovariance(SpacePointSymMatrix::Zero());
+    newVtx.setFullCovariance(SymMatrix4D::Zero());
   }
 
   auto estRes = m_cfg.ipEstimator.estimateImpactParameters(
@@ -278,7 +278,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
       }
     }
     if (nearTrackFound) {
-      vtx.setFullPosition(SpacePointVector(0., 0., newZ, 0.));
+      vtx.setFullPosition(Vector4D(0., 0., newZ, 0.));
 
       // Update vertex info for current vertex
       fitterState.vtxInfoMap[&vtx] =
@@ -496,8 +496,8 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
     const Vertex<InputTrack_t>& vtx,
     const std::vector<Vertex<InputTrack_t>*>& allVertices) const -> bool {
-  const SpacePointVector& candidatePos = vtx.fullPosition();
-  const SpacePointSymMatrix& candidateCov = vtx.fullCovariance();
+  const Vector4D& candidatePos = vtx.fullPosition();
+  const SymMatrix4D& candidateCov = vtx.fullCovariance();
   const double candidateZPos = candidatePos[eZ];
   const double candidateZCov = candidateCov(eZ, eZ);
 
@@ -505,12 +505,12 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
     if (&vtx == otherVtx) {
       continue;
     }
-    const SpacePointVector& otherPos = otherVtx->fullPosition();
-    const SpacePointSymMatrix& otherCov = otherVtx->fullCovariance();
+    const Vector4D& otherPos = otherVtx->fullPosition();
+    const SymMatrix4D& otherCov = otherVtx->fullCovariance();
     const double otherZPos = otherPos[eZ];
     const double otherZCov = otherCov(eZ, eZ);
 
-    const SpacePointVector deltaPos = otherPos - candidatePos;
+    const Vector4D deltaPos = otherPos - candidatePos;
     const double deltaZPos = otherZPos - candidateZPos;
     const double sumCovZ = otherZCov + candidateZCov;
 
@@ -524,7 +524,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
       }
     } else {
       // Use full 3d information for significance
-      SpacePointSymMatrix sumCov = candidateCov + otherCov;
+      SymMatrix4D sumCov = candidateCov + otherCov;
       significance =
           std::sqrt(deltaPos.dot((sumCov.inverse().eval()) * deltaPos));
     }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -63,8 +63,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
       // in previous iteration afterwards
       currentVtxInfo.oldPosition = currentVtx->fullPosition();
 
-      SpacePointVector dist =
-          currentVtxInfo.oldPosition - currentVtxInfo.linPoint;
+      Vector4D dist = currentVtxInfo.oldPosition - currentVtxInfo.linPoint;
       double perpDist = std::sqrt(dist[0] * dist[0] + dist[1] * dist[1]);
       // Determine if relinearization is needed
       if (perpDist > m_cfg.maxDistToLinPoint) {
@@ -75,7 +74,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
       }
       // Determine if constraint vertex exist
       if (state.vtxInfoMap[currentVtx].constraintVertex.fullCovariance() !=
-          SpacePointSymMatrix::Zero()) {
+          SymMatrix4D::Zero()) {
         currentVtx->setFullPosition(
             state.vtxInfoMap[currentVtx].constraintVertex.fullPosition());
         currentVtx->setFitQuality(
@@ -84,7 +83,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
             state.vtxInfoMap[currentVtx].constraintVertex.fullCovariance());
       }
 
-      else if (currentVtx->fullCovariance() == SpacePointSymMatrix::Zero()) {
+      else if (currentVtx->fullCovariance() == SymMatrix4D::Zero()) {
         return VertexingError::NoCovariance;
       }
       double weight =

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -19,7 +19,8 @@ namespace {
 /// @brief Struct to cache track-specific matrix operations in Billoir fitter
 template <typename input_track_t>
 struct BilloirTrack {
-  using Jacobian = Acts::ActsMatrixD<Acts::eBoundParametersSize, 4>;
+  using Jacobian = Acts::ActsMatrix<Acts::BoundParametersScalar,
+                                    Acts::eBoundParametersSize, 4>;
 
   BilloirTrack(const input_track_t* params, Acts::LinearizedTrack lTrack)
       : originalTrack(params), linTrack(std::move(lTrack)) {}

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -19,7 +19,7 @@ namespace {
 /// @brief Struct to cache track-specific matrix operations in Billoir fitter
 template <typename input_track_t>
 struct BilloirTrack {
-  using Jacobian = Acts::SpacePointToBoundMatrix;
+  using Jacobian = Acts::ActsMatrixD<Acts::eBoundParametersSize, 4>;
 
   BilloirTrack(const input_track_t* params, Acts::LinearizedTrack lTrack)
       : originalTrack(params), linTrack(std::move(lTrack)) {}
@@ -43,19 +43,14 @@ struct BilloirTrack {
 ///
 /// @brief Struct to cache vertex-specific matrix operations in Billoir fitter
 struct BilloirVertex {
-  BilloirVertex() = default;
-
-  Acts::SpacePointSymMatrix Amat{
-      Acts::SpacePointSymMatrix::Zero()};  // Amat  = sum{DiMat^T * Wi * DiMat}
-  Acts::SpacePointVector Tvec{
-      Acts::SpacePointVector::Zero()};  // Tvec  = sum{DiMat^T * Wi * dqi}
-  Acts::SpacePointSymMatrix BCBmat{
-      Acts::SpacePointSymMatrix::Zero()};  // BCBmat =
-                                           // sum{BiMat
-                                           // * Ci^-1 *
-                                           // BiMat^T}
-  Acts::SpacePointVector BCUvec{
-      Acts::SpacePointVector::Zero()};  // BCUvec = sum{BiMat * Ci^-1 * UiVec}
+  // Amat  = sum{DiMat^T * Wi * DiMat}
+  Acts::SymMatrix4D Amat = Acts::SymMatrix4D::Zero();
+  // Tvec  = sum{DiMat^T * Wi * dqi}
+  Acts::Vector4D Tvec = Acts::Vector4D::Zero();
+  // BCBmat = sum{BiMat * Ci^-1 * BiMat^T}
+  Acts::SymMatrix4D BCBmat = Acts::SymMatrix4D::Zero();
+  // BCUvec = sum{BiMat * Ci^-1 * UiVec}
+  Acts::Vector4D BCUvec = Acts::Vector4D::Zero();
 };
 
 }  // end anonymous namespace
@@ -94,7 +89,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
   std::vector<Vector3D> trackMomenta;
 
-  SpacePointVector linPoint(vertexingOptions.vertexConstraint.fullPosition());
+  Vector4D linPoint(vertexingOptions.vertexConstraint.fullPosition());
 
   Vertex<input_track_t> fittedVertex;
 
@@ -138,14 +133,14 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
             qOverP - fQOvP, 0;
 
         // position jacobian (D matrix)
-        SpacePointToBoundMatrix Dmat;
+        ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> Dmat;
         Dmat = linTrack.positionJacobian;
 
         // momentum jacobian (E matrix)
         ActsMatrixD<eBoundParametersSize, 3> Emat;
         Emat = linTrack.momentumJacobian;
         // cache some matrix multiplications
-        BoundToSpacePointMatrix DtWmat;
+        ActsMatrixD<4, eBoundParametersSize> DtWmat;
         ActsMatrixD<3, eBoundParametersSize> EtWmat;
         BoundSymMatrix Wi = linTrack.weightAtPCA;
 
@@ -190,15 +185,14 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
     // calculate delta (billoirFrameOrigin-position), might be changed by the
     // beam-const
-    SpacePointVector Vdel =
-        billoirVertex.Tvec -
-        billoirVertex.BCUvec;  // Vdel = Tvec-sum{BiMat*Ci^-1*UiVec}
-    SpacePointSymMatrix VwgtMat =
+    Vector4D Vdel = billoirVertex.Tvec -
+                    billoirVertex.BCUvec;  // Vdel = Tvec-sum{BiMat*Ci^-1*UiVec}
+    SymMatrix4D VwgtMat =
         billoirVertex.Amat -
         billoirVertex.BCBmat;  // VwgtMat = Amat-sum{BiMat*Ci^-1*BiMat^T}
     if (isConstraintFit) {
       // this will be 0 for first iteration but != 0 from second on
-      SpacePointVector posInBilloirFrame =
+      Vector4D posInBilloirFrame =
           vertexingOptions.vertexConstraint.fullPosition() - linPoint;
 
       Vdel += vertexingOptions.vertexConstraint.fullCovariance().inverse() *
@@ -207,9 +201,9 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     }
 
     // cov(deltaV) = VwgtMat^-1
-    SpacePointSymMatrix covDeltaVmat = VwgtMat.inverse();
+    SymMatrix4D covDeltaVmat = VwgtMat.inverse();
     // deltaV = cov_(deltaV) * Vdel;
-    SpacePointVector deltaV = covDeltaVmat * Vdel;
+    Vector4D deltaV = covDeltaVmat * Vdel;
     //--------------------------------------------------------------------------------------
     // start momentum related calculations
 
@@ -247,7 +241,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
       // some intermediate calculations to get 5x5 matrix
       // cov(V,V), 4x4 matrix
-      SpacePointSymMatrix VVmat = covDeltaVmat;
+      SymMatrix4D VVmat = covDeltaVmat;
 
       // cov(V,P)
       ActsMatrixD<4, 3> VPmat = bTrack.BiMat;
@@ -284,7 +278,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
       // = calc. vtx in billoir frame - (    isConstraintFit pos. in billoir
       // frame )
 
-      SpacePointVector deltaTrk =
+      Vector4D deltaTrk =
           deltaV -
           (vertexingOptions.vertexConstraint.fullPosition() - linPoint);
 
@@ -304,7 +298,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     if (newChi2 < chi2) {
       chi2 = newChi2;
 
-      SpacePointVector vertexPos(linPoint);
+      Vector4D vertexPos(linPoint);
 
       fittedVertex.setFullPosition(vertexPos);
       fittedVertex.setFullCovariance(covDeltaVmat);

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -185,8 +185,8 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
     // calculate delta (billoirFrameOrigin-position), might be changed by the
     // beam-const
-    Vector4D Vdel = billoirVertex.Tvec -
-                    billoirVertex.BCUvec;  // Vdel = Tvec-sum{BiMat*Ci^-1*UiVec}
+    // Vdel = Tvec-sum{BiMat*Ci^-1*UiVec}
+    Vector4D Vdel = billoirVertex.Tvec - billoirVertex.BCUvec;
     SymMatrix4D VwgtMat =
         billoirVertex.Amat -
         billoirVertex.BCBmat;  // VwgtMat = Amat-sum{BiMat*Ci^-1*BiMat^T}

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
@@ -100,7 +100,7 @@ class HelicalTrackLinearizer {
   ///
   /// @return Linearized track
   Result<LinearizedTrack> linearizeTrack(const BoundParameters& params,
-                                         const SpacePointVector& linPoint,
+                                         const Vector4D& linPoint,
                                          const Acts::GeometryContext& gctx,
                                          const Acts::MagneticFieldContext& mctx,
                                          State& state) const;

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -11,7 +11,7 @@
 template <typename propagator_t, typename propagator_options_t>
 Acts::Result<Acts::LinearizedTrack> Acts::
     HelicalTrackLinearizer<propagator_t, propagator_options_t>::linearizeTrack(
-        const BoundParameters& params, const SpacePointVector& linPoint,
+        const BoundParameters& params, const Vector4D& linPoint,
         const Acts::GeometryContext& gctx,
         const Acts::MagneticFieldContext& mctx, State& state) const {
   Vector3D linPointPos = VectorHelpers::position(linPoint);
@@ -34,7 +34,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   }
 
   BoundVector paramsAtPCA = endParams->parameters();
-  SpacePointVector positionAtPCA = Vector4D::Zero();
+  Vector4D positionAtPCA = Vector4D::Zero();
   {
     auto pos = endParams->position();
     positionAtPCA[ePos0] = pos[ePos0];
@@ -114,7 +114,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   predParamsAtPCA[5] = 0.;
 
   // Fill position jacobian (D_k matrix), Eq. 5.36 in Ref(1)
-  SpacePointToBoundMatrix positionJacobian;
+  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> positionJacobian;
   positionJacobian.setZero();
   // First row
   positionJacobian(0, 0) = -sgnH * X / S;

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -34,14 +34,22 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   }
 
   BoundVector paramsAtPCA = endParams->parameters();
-  SpacePointVector positionAtPCA = SpacePointVector::Zero();
-  VectorHelpers::position(positionAtPCA) = endParams->position();
+  SpacePointVector positionAtPCA = Vector4D::Zero();
+  {
+    auto pos = endParams->position();
+    positionAtPCA[ePos0] = pos[ePos0];
+    positionAtPCA[ePos1] = pos[ePos1];
+    positionAtPCA[ePos2] = pos[ePos2];
+  }
   BoundSymMatrix parCovarianceAtPCA = *(endParams->covariance());
 
   if (endParams->covariance()->determinant() == 0) {
     // Use the original parameters
     paramsAtPCA = params.parameters();
-    VectorHelpers::position(positionAtPCA) = params.position();
+    auto pos = endParams->position();
+    positionAtPCA[ePos0] = pos[ePos0];
+    positionAtPCA[ePos1] = pos[ePos1];
+    positionAtPCA[ePos2] = pos[ePos2];
     parCovarianceAtPCA = *(params.covariance());
   }
 

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
@@ -39,11 +39,11 @@ namespace detail {
 /// @param vtxWeight Vertex weight matrix
 /// @param vtxCov Vertex covariance matrix
 /// @param newTrkParams New track parameter
-inline BoundMatrix createFullTrackCovariance(
-    const ActsSymMatrixD<3>& sMat,
-    const ActsMatrixD<eSpacePointSize, 3>& newTrkCov,
-    const SpacePointSymMatrix& vtxWeight, const SpacePointSymMatrix& vtxCov,
-    const BoundVector& newTrkParams);
+inline BoundMatrix createFullTrackCovariance(const ActsSymMatrixD<3>& sMat,
+                                             const ActsMatrixD<4, 3>& newTrkCov,
+                                             const SymMatrix4D& vtxWeight,
+                                             const SymMatrix4D& vtxCov,
+                                             const BoundVector& newTrkParams);
 
 }  // Namespace detail
 

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
@@ -39,7 +39,7 @@ namespace detail {
 /// @param vtxWeight Vertex weight matrix
 /// @param vtxCov Vertex covariance matrix
 /// @param newTrkParams New track parameter
-inline BoundMatrix createFullTrackCovariance(const ActsSymMatrixD<3>& sMat,
+inline BoundMatrix createFullTrackCovariance(const SymMatrix3D& sMat,
                                              const ActsMatrixD<4, 3>& newTrkCov,
                                              const SymMatrix4D& vtxWeight,
                                              const SymMatrix4D& vtxCov,

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -115,7 +115,7 @@ void Acts::KalmanVertexTrackUpdater::update(const GeometryContext& gctx,
 
 inline Acts::BoundMatrix
 Acts::KalmanVertexTrackUpdater::detail::createFullTrackCovariance(
-    const ActsSymMatrixD<3>& sMat, const ActsMatrixD<4, 3>& newTrkCov,
+    const SymMatrix3D& sMat, const ActsMatrixD<4, 3>& newTrkCov,
     const SymMatrix4D& vtxWeight, const SymMatrix4D& vtxCov,
     const BoundVector& newTrkParams) {
   // Now new momentum covariance

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -86,14 +86,13 @@ void Acts::KalmanVertexTrackUpdater::update(const GeometryContext& gctx,
 
   // Not yet 4d ready. This can be removed together will all head<> statements,
   // once time is consistently introduced to vertexing
-  ActsMatrixD<eSpacePointSize, 3> newFullTrkCov(
-      ActsMatrixD<eSpacePointSize, 3>::Zero());
+  ActsMatrixD<4, 3> newFullTrkCov(ActsMatrixD<4, 3>::Zero());
   newFullTrkCov.block<3, 3>(0, 0) = newTrkCov;
 
-  SpacePointSymMatrix vtxFullWeight(SpacePointSymMatrix::Zero());
+  SymMatrix4D vtxFullWeight(SymMatrix4D::Zero());
   vtxFullWeight.block<3, 3>(0, 0) = vtxWeight;
 
-  SpacePointSymMatrix vtxFullCov(SpacePointSymMatrix::Zero());
+  SymMatrix4D vtxFullCov(SymMatrix4D::Zero());
   vtxFullCov.block<3, 3>(0, 0) = vtxCov;
 
   const Acts::BoundMatrix fullPerTrackCov = detail::createFullTrackCovariance(
@@ -116,9 +115,8 @@ void Acts::KalmanVertexTrackUpdater::update(const GeometryContext& gctx,
 
 inline Acts::BoundMatrix
 Acts::KalmanVertexTrackUpdater::detail::createFullTrackCovariance(
-    const ActsSymMatrixD<3>& sMat,
-    const ActsMatrixD<eSpacePointSize, 3>& newTrkCov,
-    const SpacePointSymMatrix& vtxWeight, const SpacePointSymMatrix& vtxCov,
+    const ActsSymMatrixD<3>& sMat, const ActsMatrixD<4, 3>& newTrkCov,
+    const SymMatrix4D& vtxWeight, const SymMatrix4D& vtxCov,
     const BoundVector& newTrkParams) {
   // Now new momentum covariance
   ActsSymMatrixD<3> momCov =

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -101,8 +101,7 @@ void Acts::KalmanVertexTrackUpdater::update(const GeometryContext& gctx,
 
   // Create new refitted parameters
   std::shared_ptr<PerigeeSurface> perigeeSurface =
-      Surface::makeShared<PerigeeSurface>(
-          VectorHelpers::position(vtx.fullPosition()));
+      Surface::makeShared<PerigeeSurface>(vtx.position());
 
   BoundParameters refittedPerigee = BoundParameters(
       gctx, std::move(fullPerTrackCov), newTrkParams, perigeeSurface);

--- a/Core/include/Acts/Vertexing/LinearizedTrack.hpp
+++ b/Core/include/Acts/Vertexing/LinearizedTrack.hpp
@@ -47,10 +47,11 @@ struct LinearizedTrack {
   LinearizedTrack(const BoundVector& paramsAtPCA,
                   const BoundSymMatrix& parCovarianceAtPCA,
                   const BoundSymMatrix& parWeightAtPCA,
-                  const SpacePointVector& linPoint,
-                  const SpacePointToBoundMatrix& posJacobian,
+                  const Vector4D& linPoint,
+                  const ActsMatrix<BoundParametersScalar, eBoundParametersSize,
+                                   4>& posJacobian,
                   const ActsMatrixD<eBoundParametersSize, 3>& momJacobian,
-                  const SpacePointVector& position, const Vector3D& momentum,
+                  const Vector4D& position, const Vector3D& momentum,
                   const BoundVector& constTerm)
       : parametersAtPCA(paramsAtPCA),
         covarianceAtPCA(parCovarianceAtPCA),
@@ -65,11 +66,12 @@ struct LinearizedTrack {
   BoundVector parametersAtPCA{BoundVector::Zero()};
   BoundSymMatrix covarianceAtPCA{BoundSymMatrix::Zero()};
   BoundSymMatrix weightAtPCA{BoundSymMatrix::Zero()};
-  SpacePointVector linearizationPoint{SpacePointVector::Zero()};
-  SpacePointToBoundMatrix positionJacobian{SpacePointToBoundMatrix::Zero()};
+  Vector4D linearizationPoint{Vector4D::Zero()};
+  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> positionJacobian{
+      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero()};
   ActsMatrixD<eBoundParametersSize, 3> momentumJacobian{
       ActsMatrixD<eBoundParametersSize, 3>::Zero()};
-  SpacePointVector positionAtPCA{SpacePointVector::Zero()};
+  Vector4D positionAtPCA{Vector4D::Zero()};
   Vector3D momentumAtPCA{Vector3D::Zero()};
   BoundVector constantTerm{BoundVector::Zero()};
 };

--- a/Core/include/Acts/Vertexing/LinearizerConcept.hpp
+++ b/Core/include/Acts/Vertexing/LinearizerConcept.hpp
@@ -33,7 +33,7 @@ namespace concept {
 
          constexpr static bool linTrack_exists = has_method<const S, Result<LinearizedTrack>,
          linTrack_t, const BoundParameters&,
-                     const SpacePointVector&,
+                     const Vector4D&,
                      const Acts::GeometryContext&,
                      const Acts::MagneticFieldContext&,
                      typename S::State&>;

--- a/Core/include/Acts/Vertexing/Vertex.hpp
+++ b/Core/include/Acts/Vertexing/Vertex.hpp
@@ -33,14 +33,14 @@ class Vertex {
   /// @brief Construct for vertex at given 4d-position, sets covariance to zero
   ///
   /// @param position Vertex position
-  Vertex(const SpacePointVector& position);
+  Vertex(const Vector4D& position);
 
   /// @brief Vertex constructor
   ///
   /// @param position Vertex position
   /// @param covariance Position covariance matrix
   /// @param tracks Vector of tracks associated with the vertex
-  Vertex(const Vector3D& position, const ActsSymMatrixD<3>& covariance,
+  Vertex(const Vector3D& position, const SymMatrix3D& covariance,
          const std::vector<TrackAtVertex<input_track_t>>& tracks);
 
   /// @brief Vertex constructor
@@ -48,8 +48,7 @@ class Vertex {
   /// @param position Full vertex position
   /// @param covariance 4x4 covariance matrix
   /// @param tracks Vector of tracks associated with the vertex
-  Vertex(const SpacePointVector& position,
-         const SpacePointSymMatrix& covariance,
+  Vertex(const Vector4D& position, const SymMatrix4D& covariance,
          const std::vector<TrackAtVertex<input_track_t>>& tracks);
 
   /// @return Returns 3-position
@@ -59,13 +58,13 @@ class Vertex {
   ParValue_t time() const;
 
   /// @return Returns 4-position
-  const SpacePointVector& fullPosition() const;
+  const Vector4D& fullPosition() const;
 
   /// @return Returns position covariance
-  ActsSymMatrixD<3> covariance() const;
+  SymMatrix3D covariance() const;
 
   /// @return Returns 4x4 covariance
-  const SpacePointSymMatrix& fullCovariance() const;
+  const SymMatrix4D& fullCovariance() const;
 
   /// @return Returns vector of tracks associated with the vertex
   const std::vector<TrackAtVertex<input_track_t>>& tracks() const;
@@ -82,7 +81,7 @@ class Vertex {
   /// @brief Set position and time
   ///
   /// @param fullPosition Vertex position and time
-  void setFullPosition(const SpacePointVector& fullPosition);
+  void setFullPosition(const Vector4D& fullPosition);
 
   /// @brief Sets time
   ///
@@ -97,7 +96,7 @@ class Vertex {
   /// @brief Sets 4x4 covariance
   ///
   /// @param covariance The 4x4 covariance matrix
-  void setFullCovariance(const SpacePointSymMatrix& covariance);
+  void setFullCovariance(const SymMatrix4D& covariance);
 
   /// @param tracks Vector of tracks at vertex
   void setTracksAtVertex(
@@ -111,8 +110,8 @@ class Vertex {
   void setFitQuality(std::pair<double, double> fitQuality);
 
  private:
-  SpacePointVector m_position = SpacePointVector::Zero();
-  SpacePointSymMatrix m_covariance = SpacePointSymMatrix::Zero();
+  Vector4D m_position = Vector4D::Zero();
+  SymMatrix4D m_covariance = SymMatrix4D::Zero();
   std::vector<TrackAtVertex<input_track_t>> m_tracksAtVertex;
   double m_chiSquared = 0.;  // chi2 of the fit
   double m_numberDoF = 0.;   // number of degrees of freedom

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -14,12 +14,12 @@ Acts::Vertex<input_track_t>::Vertex(const Vector3D& position) {
 }
 
 template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const SpacePointVector& position)
+Acts::Vertex<input_track_t>::Vertex(const Vector4D& position)
     : m_position(position) {}
 
 template <typename input_track_t>
 Acts::Vertex<input_track_t>::Vertex(
-    const Vector3D& position, const ActsSymMatrixD<3>& covariance,
+    const Vector3D& position, const SymMatrix3D& covariance,
     const std::vector<TrackAtVertex<input_track_t>>& tracks)
     : m_tracksAtVertex(tracks) {
   m_position[ePos0] = position[ePos0];
@@ -30,7 +30,7 @@ Acts::Vertex<input_track_t>::Vertex(
 
 template <typename input_track_t>
 Acts::Vertex<input_track_t>::Vertex(
-    const SpacePointVector& position, const SpacePointSymMatrix& covariance,
+    const Vector4D& position, const SymMatrix4D& covariance,
     const std::vector<TrackAtVertex<input_track_t>>& tracks)
     : m_position(position),
       m_covariance(covariance),
@@ -47,8 +47,7 @@ Acts::ParValue_t Acts::Vertex<input_track_t>::time() const {
 }
 
 template <typename input_track_t>
-const Acts::SpacePointVector& Acts::Vertex<input_track_t>::fullPosition()
-    const {
+const Acts::Vector4D& Acts::Vertex<input_track_t>::fullPosition() const {
   return m_position;
 }
 
@@ -58,8 +57,7 @@ Acts::SymMatrix3D Acts::Vertex<input_track_t>::covariance() const {
 }
 
 template <typename input_track_t>
-const Acts::SpacePointSymMatrix& Acts::Vertex<input_track_t>::fullCovariance()
-    const {
+const Acts::SymMatrix4D& Acts::Vertex<input_track_t>::fullCovariance() const {
   return m_covariance;
 }
 
@@ -85,7 +83,7 @@ void Acts::Vertex<input_track_t>::setPosition(const Vector3D& position,
 
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setFullPosition(
-    const SpacePointVector& fullPosition) {
+    const Vector4D& fullPosition) {
   m_position = fullPosition;
 }
 
@@ -102,7 +100,7 @@ void Acts::Vertex<input_track_t>::setCovariance(const SymMatrix3D& covariance) {
 
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setFullCovariance(
-    const SpacePointSymMatrix& covariance) {
+    const SymMatrix4D& covariance) {
   m_covariance = covariance;
 }
 

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -7,29 +7,25 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const Vector3D& position)
-
-{
-  m_position.setZero();
-  VectorHelpers::position(m_position) = position;
+Acts::Vertex<input_track_t>::Vertex(const Vector3D& position) {
+  m_position[ePos0] = position[ePos0];
+  m_position[ePos1] = position[ePos1];
+  m_position[ePos2] = position[ePos2];
 }
 
 template <typename input_track_t>
 Acts::Vertex<input_track_t>::Vertex(const SpacePointVector& position)
-
-{
-  m_position = position;
-}
+    : m_position(position) {}
 
 template <typename input_track_t>
 Acts::Vertex<input_track_t>::Vertex(
     const Vector3D& position, const ActsSymMatrixD<3>& covariance,
     const std::vector<TrackAtVertex<input_track_t>>& tracks)
     : m_tracksAtVertex(tracks) {
-  m_position.setZero();
-  VectorHelpers::position(m_position) = position;
-  m_covariance.setZero();
-  m_covariance.block<3, 3>(0, 0) = covariance;
+  m_position[ePos0] = position[ePos0];
+  m_position[ePos1] = position[ePos1];
+  m_position[ePos2] = position[ePos2];
+  m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
 template <typename input_track_t>
@@ -47,7 +43,7 @@ Acts::Vector3D Acts::Vertex<input_track_t>::position() const {
 
 template <typename input_track_t>
 Acts::ParValue_t Acts::Vertex<input_track_t>::time() const {
-  return VectorHelpers::time(m_position);
+  return m_position[eTime];
 }
 
 template <typename input_track_t>
@@ -57,8 +53,8 @@ const Acts::SpacePointVector& Acts::Vertex<input_track_t>::fullPosition()
 }
 
 template <typename input_track_t>
-Acts::ActsSymMatrixD<3> Acts::Vertex<input_track_t>::covariance() const {
-  return m_covariance.block<3, 3>(0, 0);
+Acts::SymMatrix3D Acts::Vertex<input_track_t>::covariance() const {
+  return m_covariance.block<3, 3>(ePos0, ePos0);
 }
 
 template <typename input_track_t>
@@ -81,9 +77,10 @@ std::pair<double, double> Acts::Vertex<input_track_t>::fitQuality() const {
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setPosition(const Vector3D& position,
                                               ParValue_t time) {
-  m_position.setZero();
-  VectorHelpers::position(m_position) = position;
-  VectorHelpers::time(m_position) = time;
+  m_position[ePos0] = position[ePos0];
+  m_position[ePos1] = position[ePos1];
+  m_position[ePos2] = position[ePos2];
+  m_position[eTime] = time;
 }
 
 template <typename input_track_t>
@@ -94,14 +91,13 @@ void Acts::Vertex<input_track_t>::setFullPosition(
 
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setTime(ParValue_t time) {
-  VectorHelpers::time(m_position) = time;
+  m_position[eTime] = time;
 }
 
 template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setCovariance(
-    const ActsSymMatrixD<3>& covariance) {
+void Acts::Vertex<input_track_t>::setCovariance(const SymMatrix3D& covariance) {
   m_covariance.setZero();
-  m_covariance.block<3, 3>(0, 0) = covariance;
+  m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
 template <typename input_track_t>

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
@@ -97,9 +97,9 @@ auto Acts::ZScanVertexFinder<vfitter_t>::find(
   }
 
   // constraint x()/y() equals 0 if no constraint
-  SpacePointVector output(vertexingOptions.vertexConstraint.position().x(),
-                          vertexingOptions.vertexConstraint.position().y(),
-                          ZResult, vertexingOptions.vertexConstraint.time());
+  Vector4D output(vertexingOptions.vertexConstraint.position().x(),
+                  vertexingOptions.vertexConstraint.position().y(), ZResult,
+                  vertexingOptions.vertexConstraint.time());
   Vertex<InputTrack_t> vtxResult = Vertex<InputTrack_t>(output);
 
   // Vector to be filled with one single vertex

--- a/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
@@ -6,9 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <boost/test/unit_test.hpp>
-
 #include <bitset>
+#include <boost/test/unit_test.hpp>
 
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/Helpers.hpp"

--- a/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
@@ -158,91 +158,18 @@ BOOST_AUTO_TEST_CASE(shared_vector_helper_test) {
   }
 }
 
-BOOST_AUTO_TEST_CASE(time_helper_test) {
-  {
-    SpacePointVector spaceTimeVec = {1., 2., 3., 4.};
-    double t = time(spaceTimeVec);
-    BOOST_CHECK_EQUAL(spaceTimeVec[3], t);
+BOOST_AUTO_TEST_CASE(VectorHelpersPosition) {
+  Vector4D pos4 = Vector4D::Constant(-1);
+  pos4[ePos0] = 1;
+  pos4[ePos1] = 2;
+  pos4[ePos2] = 3;
+  BOOST_CHECK_EQUAL(position(pos4), Vector3D(1, 2, 3));
 
-    double newTime = 17;
-    time(spaceTimeVec) = newTime;
-    BOOST_CHECK_EQUAL(spaceTimeVec[3], newTime);
-
-    BoundVector boundVec;
-    boundVec << 1., 2., 3., 4., 5., 6.;
-    t = time(boundVec);
-    BOOST_CHECK_EQUAL(boundVec[eT], t);
-
-    newTime = 28;
-    time(boundVec) = newTime;
-    BOOST_CHECK_EQUAL(boundVec[eT], newTime);
-
-    FreeVector freeVec;
-    freeVec << 1., 2., 3., 4., 5., 6., 7., 8.;
-    t = time(freeVec);
-    BOOST_CHECK_EQUAL(freeVec[7], t);
-
-    newTime = 352;
-    time(freeVec) = newTime;
-    BOOST_CHECK_EQUAL(freeVec[7], newTime);
-  }
-
-  // same for const
-  {
-    // use temp object to initialize const vectors
-    SpacePointVector tempSpaceVec = {1., 2., 3., 4.};
-    const SpacePointVector spaceTimeVec(tempSpaceVec);
-    const double t1 = time(spaceTimeVec);
-    BOOST_CHECK_EQUAL(spaceTimeVec[3], t1);
-
-    BoundVector tempBoundVec;
-    tempBoundVec << 1., 2., 3., 4., 5., 6.;
-    const BoundVector boundVec(tempBoundVec);
-    const double t2 = time(boundVec);
-    BOOST_CHECK_EQUAL(boundVec[eT], t2);
-
-    FreeVector tempFreeVec;
-    tempFreeVec << 1., 2., 3., 4., 5., 6., 7., 8.;
-    const FreeVector freeVec(tempFreeVec);
-    const double t3 = time(freeVec);
-    BOOST_CHECK_EQUAL(freeVec[7], t3);
-  }
-}
-
-BOOST_AUTO_TEST_CASE(position_helper_test) {
-  {
-    SpacePointVector spaceTimeVec = {1., 2., 3., 4.};
-    Vector3D pos = position(spaceTimeVec);
-    BOOST_CHECK_EQUAL(spaceTimeVec.head<3>(), pos);
-
-    Vector3D newPos = {4., 7., 12.};
-    position(spaceTimeVec) = newPos;
-    BOOST_CHECK_EQUAL(spaceTimeVec.head<3>(), newPos);
-
-    FreeVector freeVec;
-    freeVec << 1., 2., 3., 4., 5., 6., 7., 8.;
-    pos = position(freeVec);
-    BOOST_CHECK_EQUAL(freeVec.head<3>(), pos);
-
-    newPos = {14., 17., 112.};
-    position(freeVec) = newPos;
-    BOOST_CHECK_EQUAL(freeVec.head<3>(), newPos);
-  }
-
-  // same for const
-  {
-    // use temp object to initialize const vectors
-    SpacePointVector tempSpaceVec = {1., 2., 3., 4.};
-    const SpacePointVector spaceTimeVec(tempSpaceVec);
-    const Vector3D pos1 = position(spaceTimeVec);
-    BOOST_CHECK_EQUAL(spaceTimeVec.head<3>(), pos1);
-
-    FreeVector tempFreeVec;
-    tempFreeVec << 1., 2., 3., 4., 5., 6., 7., 8.;
-    const FreeVector freeVec(tempFreeVec);
-    const Vector3D pos2 = position(freeVec);
-    BOOST_CHECK_EQUAL(freeVec.head<3>(), pos2);
-  }
+  FreeVector params = FreeVector::Constant(-1);
+  params[eFreePos0] = 1;
+  params[eFreePos1] = 2;
+  params[eFreePos2] = 3;
+  BOOST_CHECK_EQUAL(position(params), Vector3D(1, 2, 3));
 }
 
 template <size_t I>

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   for (auto& vtxPos : vtxPosVec) {
     Vertex<BoundParameters> vtx(vtxPos);
     // Set some vertex covariance
-    SpacePointSymMatrix posCovariance(SpacePointSymMatrix::Identity());
+    SymMatrix4D posCovariance(SymMatrix4D::Identity());
     vtx.setFullCovariance(posCovariance);
     // Add to vertex list
     vtxList.push_back(vtx);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
       magFieldContext);
 
   // The constraint vertex position covariance
-  SpacePointSymMatrix covConstr(SpacePointSymMatrix::Identity());
+  SymMatrix4D covConstr(SymMatrix4D::Identity());
   covConstr = covConstr * 1e+8;
   covConstr(3, 3) = 0.;
 

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -61,13 +61,13 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   // Constraint for vertex fit
   Vertex<BoundParameters> myConstraint;
   // Some abitrary values
-  SpacePointSymMatrix myCovMat = SpacePointSymMatrix::Zero();
+  SymMatrix4D myCovMat = SymMatrix4D::Zero();
   myCovMat(0, 0) = 30.;
   myCovMat(1, 1) = 30.;
   myCovMat(2, 2) = 30.;
   myCovMat(3, 3) = 30.;
   myConstraint.setFullCovariance(std::move(myCovMat));
-  myConstraint.setFullPosition(SpacePointVector(0, 0, 0, 0));
+  myConstraint.setFullPosition(Vector4D(0, 0, 0, 0));
 
   const std::vector<const BoundParameters*> emptyVector;
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   Vector3D origin(0., 0., 0.);
   BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
 
-  SpacePointSymMatrix zeroMat = SpacePointSymMatrix::Zero();
+  SymMatrix4D zeroMat = SymMatrix4D::Zero();
   BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
 
   fittedVertex =
@@ -150,13 +150,13 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
     // Constraint for vertex fit
     Vertex<BoundParameters> myConstraint;
     // Some abitrary values
-    SpacePointSymMatrix myCovMat = SpacePointSymMatrix::Zero();
+    SymMatrix4D myCovMat = SymMatrix4D::Zero();
     myCovMat(0, 0) = 30.;
     myCovMat(1, 1) = 30.;
     myCovMat(2, 2) = 30.;
     myCovMat(3, 3) = 30.;
     myConstraint.setFullCovariance(std::move(myCovMat));
-    myConstraint.setFullPosition(SpacePointVector(0, 0, 0, 0));
+    myConstraint.setFullPosition(Vector4D(0, 0, 0, 0));
     VertexingOptions<BoundParameters> vfOptions(geoContext, magFieldContext);
 
     VertexingOptions<BoundParameters> vfOptionsConstr(
@@ -288,13 +288,13 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
     // Constraint for vertex fit
     Vertex<InputTrack> myConstraint;
     // Some abitrary values
-    SpacePointSymMatrix myCovMat = SpacePointSymMatrix::Zero();
+    SymMatrix4D myCovMat = SymMatrix4D::Zero();
     myCovMat(0, 0) = 30.;
     myCovMat(1, 1) = 30.;
     myCovMat(2, 2) = 30.;
     myCovMat(3, 3) = 30.;
     myConstraint.setFullCovariance(std::move(myCovMat));
-    myConstraint.setFullPosition(SpacePointVector(0, 0, 0, 0));
+    myConstraint.setFullPosition(Vector4D(0, 0, 0, 0));
 
     VertexingOptions<InputTrack> vfOptions(geoContext, magFieldContext);
 

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -381,12 +381,12 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_parameter_estimation_test) {
   double y = vXYDist(gen);
   double z = vZDist(gen);
 
-  SpacePointVector vertexPosition(x, y, z, 0.);
+  Vector4D vertexPosition(x, y, z, 0.);
 
   // Constraint for vertex fit
   Vertex<BoundParameters> myConstraint;
   // Some abitrary values
-  SpacePointSymMatrix myCovMat = SpacePointSymMatrix::Zero();
+  SymMatrix4D myCovMat = SymMatrix4D::Zero();
   myCovMat(0, 0) = 30.;
   myCovMat(1, 1) = 30.;
   myCovMat(2, 2) = 30.;

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -276,10 +276,10 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     // Check if all vertices have been found with close z-values
     bool allVerticesFound = true;
     for (const auto& trueVertex : trueVertices) {
-      SpacePointVector truePos = trueVertex.fullPosition();
+      Vector4D truePos = trueVertex.fullPosition();
       bool currentVertexFound = false;
       for (const auto& recoVertex : vertexCollection) {
-        SpacePointVector recoPos = recoVertex.fullPosition();
+        Vector4D recoPos = recoVertex.fullPosition();
         // check only for close z distance
         double zDistance = std::abs(truePos[eZ] - recoPos[eZ]);
         if (zDistance < 2_mm) {
@@ -494,10 +494,10 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     // Check if all vertices have been found with close z-values
     bool allVerticesFound = true;
     for (const auto& trueVertex : trueVertices) {
-      SpacePointVector truePos = trueVertex.fullPosition();
+      Vector4D truePos = trueVertex.fullPosition();
       bool currentVertexFound = false;
       for (const auto& recoVertex : vertexCollectionUT) {
-        SpacePointVector recoPos = recoVertex.fullPosition();
+        Vector4D recoPos = recoVertex.fullPosition();
         // check only for close z distance
         double zDistance = std::abs(truePos[eZ] - recoPos[eZ]);
         if (zDistance < 2_mm) {

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
     // Linearized state of the track
     LinearizedTrack linTrack =
         linearizer
-            .linearizeTrack(params, SpacePointVector::Zero(), geoContext,
+            .linearizeTrack(params, Vector4D::Zero(), geoContext,
                             magFieldContext, linState)
             .value();
 

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
     // Linearized state of the track
     LinearizedTrack linTrack =
         linearizer
-            .linearizeTrack(params, SpacePointVector::Zero(), geoContext,
+            .linearizeTrack(params, Vector4D::Zero(), geoContext,
                             magFieldContext, state)
             .value();
 
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
     // Create a vertex
     Vector3D vtxPos(vXYDist(gen), vXYDist(gen), vZDist(gen));
     Vertex<BoundParameters> vtx(vtxPos);
-    vtx.setFullCovariance(SpacePointSymMatrix::Identity() * 0.01);
+    vtx.setFullCovariance(SymMatrix4D::Identity() * 0.01);
 
     // Update trkAtVertex with assumption of originating from vtx
     KalmanVertexUpdater::updateVertexWithTrack<BoundParameters>(vtx, trkAtVtx);

--- a/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
@@ -129,15 +129,16 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
-  SpacePointVector vecSPZero = SpacePointVector::Zero();
-  SpacePointToBoundMatrix matBound2SPZero = SpacePointToBoundMatrix::Zero();
+  Vector4D vecSPZero = Vector4D::Zero();
+  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> matBound2SPZero =
+      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero();
   ActsMatrixD<eBoundParametersSize, 3> matBound2MomZero =
       ActsMatrixD<eBoundParametersSize, 3>::Zero();
 
   for (const BoundParameters& parameters : tracks) {
     LinearizedTrack linTrack =
         linFactory
-            .linearizeTrack(parameters, SpacePointVector::Zero(), geoContext,
+            .linearizeTrack(parameters, Vector4D::Zero(), geoContext,
                             magFieldContext, state)
             .value();
 
@@ -221,15 +222,16 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_straightline_test) {
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
-  SpacePointVector vecSPZero = SpacePointVector::Zero();
-  SpacePointToBoundMatrix matBound2SPZero = SpacePointToBoundMatrix::Zero();
+  Vector4D vecSPZero = Vector4D::Zero();
+  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> matBound2SPZero =
+      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero();
   ActsMatrixD<eBoundParametersSize, 3> matBound2MomZero =
       ActsMatrixD<eBoundParametersSize, 3>::Zero();
 
   for (const BoundParameters& parameters : tracks) {
     LinearizedTrack linTrack =
         linFactory
-            .linearizeTrack(parameters, SpacePointVector::Zero(), geoContext,
+            .linearizeTrack(parameters, Vector4D::Zero(), geoContext,
                             magFieldContext, state)
             .value();
 


### PR DESCRIPTION
This removes all `SpacePoint` related types and definitions and replaces them with `Vector4D` and related types. Access to the vector components is always performed via enum values and the unused vector helpers are removed.

This is a followup to #143 and #286.