### PR TITLE
fix CUDA kernel syncthread usage

### DIFF
--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Seedfinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Seedfinder.ipp
@@ -213,7 +213,7 @@ Seedfinder<external_spacepoint_t, Acts::Cuda>::createSeedsForGroup(
   CpuMatrix<Triplet> TripletsPerSpM_cpu(nTrplPerSpMLimit, *nSpMcomp_cpu.get(),
                                         true);
   cudaStream_t cuStream;
-  cudaStreamCreate(&cuStream);
+  ACTS_CUDA_ERROR_CHECK(cudaStreamCreate(&cuStream));
 
   for (int i_m = 0; i_m <= *nSpMcomp_cpu.get(); i_m++) {
     cudaStreamSynchronize(cuStream);
@@ -292,6 +292,7 @@ Seedfinder<external_spacepoint_t, Acts::Cuda>::createSeedsForGroup(
       m_config.seedFilter->filterSeeds_1SpFixed(seedsPerSpM, outputVec);
     }
   }
+  ACTS_CUDA_ERROR_CHECK(cudaStreamDestroy(cuStream));
   return outputVec;
 }
 }  // namespace Acts

--- a/Plugins/Cuda/src/Seeding/Kernels.cu
+++ b/Plugins/Cuda/src/Seeding/Kernels.cu
@@ -669,26 +669,26 @@ __global__ void cuSearchTriplet(const int*   nSpTcompPerSpM,
     *nTrplPerSpB = *nTrplPerSpBLimit;
   }
   
-  int j = threadIdx.x;            
+  int jj = threadIdx.x;            
   
   // bubble sort tIndex
   for (int i = 0; i < *nTrplPerSpB/2+1; i++){
     if (threadIdx.x < *nTrplPerSpB){    
-      if (j % 2 == 0 && j<*nTrplPerSpB-1){
-	if (triplets[j+1].tIndex < triplets[j].tIndex){
-	  Triplet tempVal = triplets[j];
-	  triplets[j] = triplets[j+1];	  
-	  triplets[j+1] = tempVal;	  
+      if (jj % 2 == 0 && jj<*nTrplPerSpB-1){
+	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+	  Triplet tempVal = triplets[jj];
+	  triplets[jj] = triplets[jj+1];	  
+	  triplets[jj+1] = tempVal;
 	}
       }
     }
     __syncthreads();
     if (threadIdx.x < *nTrplPerSpB){    
-      if (j % 2 == 1 && j<*nTrplPerSpB-1){
-	if (triplets[j+1].tIndex < triplets[j].tIndex){
-	  Triplet tempVal = triplets[j];
-	  triplets[j] = triplets[j+1];
-	  triplets[j+1] = tempVal;
+      if (jj % 2 == 1 && jj<*nTrplPerSpB-1){
+	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+	  Triplet tempVal = triplets[jj];
+	  triplets[jj] = triplets[jj+1];
+	  triplets[jj+1] = tempVal;
 	}
       }
     }     

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
@@ -78,6 +78,7 @@ int main(int argc, char** argv) {
   bool help(false);
   bool quiet(false);
   bool allgroup(false);
+  bool do_cpu(true);
   int nGroupToIterate = 500;
   int skip = 0;
   int deviceID = 0;
@@ -85,7 +86,7 @@ int main(int argc, char** argv) {
   int nAvgTrplPerSpBLimit = 2;
 
   int opt;
-  while ((opt = getopt(argc, argv, "haf:n:s:d:l:m:q")) != -1) {
+  while ((opt = getopt(argc, argv, "haf:n:s:d:l:m:qG")) != -1) {
     switch (opt) {
       case 'a':
         allgroup = true;
@@ -110,6 +111,9 @@ int main(int argc, char** argv) {
         break;
       case 'q':
         quiet = true;
+        break;
+      case 'G':
+        do_cpu = false;
         break;
       case 'h':
         help = true;
@@ -140,6 +144,8 @@ int main(int argc, char** argv) {
                        "# spacepoints < ~200k"
                     << nTrplPerSpBLimit << std::endl;
           std::cout << "      -q : don't print out all found seeds"
+                    << std::endl;
+          std::cout << "      -G : only run on GPU, not CPU"
                     << std::endl;
         }
 
@@ -242,19 +248,21 @@ int main(int argc, char** argv) {
   std::vector<std::vector<Acts::Seed<SpacePoint>>> seedVector_cpu;
   groupIt = spGroup.begin();
 
-  for (int i_s = 0; i_s < skip; i_s++)
-    ++groupIt;
-  for (; !(groupIt == spGroup.end()); ++groupIt) {
-    seedVector_cpu.push_back(seedfinder_cpu.createSeedsForGroup(
-        groupIt.bottom(), groupIt.middle(), groupIt.top()));
-    group_count++;
-    if (allgroup == false) {
-      if (group_count >= nGroupToIterate)
+  if (do_cpu) {
+    for (int i_s = 0; i_s < skip; i_s++)
+      ++groupIt;
+    for (; !(groupIt == spGroup.end()); ++groupIt) {
+      seedVector_cpu.push_back(seedfinder_cpu.createSeedsForGroup(
+                                                                  groupIt.bottom(), groupIt.middle(), groupIt.top()));
+      group_count++;
+      if (allgroup == false) {
+        if (group_count >= nGroupToIterate)
         break;
+      }
     }
+    // auto timeMetric_cpu = seedfinder_cpu.getTimeMetric();
+    std::cout << "Analyzed " << group_count << " groups for CPU" << std::endl;
   }
-  // auto timeMetric_cpu = seedfinder_cpu.getTimeMetric();
-  std::cout << "Analyzed " << group_count << " groups for CPU" << std::endl;
 
   auto end_cpu = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsec_cpu = end_cpu - start_cpu;
@@ -290,16 +298,19 @@ int main(int argc, char** argv) {
   std::cout << std::endl;
   std::cout << "----------------------- Time Metric -----------------------"
             << std::endl;
-  std::cout << "                       CPU          CUDA        Speedup "
+  std::cout << "                       " << (do_cpu ? "CPU" : "   ")
+            << "          CUDA        " << (do_cpu ? "Speedup " : "")
             << std::endl;
-  std::cout << "Seedfinding_Time  " << std::setw(11) << cpuTime << "  "
+  std::cout << "Seedfinding_Time  " << std::setw(11)
+            << (do_cpu ? std::to_string(cpuTime) : "" ) << "  "
             << std::setw(11) << cudaTime << "  " << std::setw(11)
-            << cpuTime / cudaTime << std::endl;
+            << (do_cpu ? std::to_string(cpuTime / cudaTime) : "" ) << std::endl;
   double wallTime_cpu = cpuTime + preprocessTime;
   double wallTime_cuda = cudaTime + preprocessTime;
-  std::cout << "Wall_time         " << std::setw(11) << wallTime_cpu << "  "
+  std::cout << "Wall_time         " << std::setw(11)
+            << (do_cpu ? std::to_string(wallTime_cpu) : "") << "  "
             << std::setw(11) << wallTime_cuda << "  " << std::setw(11)
-            << wallTime_cpu / wallTime_cuda << std::endl;
+            << (do_cpu ? std::to_string(wallTime_cpu / wallTime_cuda) : "") << std::endl;
   std::cout << "-----------------------------------------------------------"
             << std::endl;
   std::cout << std::endl;
@@ -355,30 +366,34 @@ int main(int argc, char** argv) {
     }
   }
 
-  std::cout << nMatch << " seeds are matched" << std::endl;
-  std::cout << "Matching rate: " << float(nMatch) / nSeed_cpu * 100 << "%"
-            << std::endl;
+  if (do_cpu) {
+    std::cout << nMatch << " seeds are matched" << std::endl;
+    std::cout << "Matching rate: " << float(nMatch) / nSeed_cpu * 100 << "%"
+              << std::endl;
+  }
 
   if (!quiet) {
-    std::cout << "CPU Seed result:" << std::endl;
-
-    for (auto& regionVec : seedVector_cpu) {
-      for (size_t i = 0; i < regionVec.size(); i++) {
-        const Acts::Seed<SpacePoint>* seed = &regionVec[i];
-        const SpacePoint* sp = seed->sp()[0];
-        std::cout << " (" << sp->x() << ", " << sp->y() << ", " << sp->z()
-                  << ") ";
-        sp = seed->sp()[1];
-        std::cout << sp->surface << " (" << sp->x() << ", " << sp->y() << ", "
-                  << sp->z() << ") ";
-        sp = seed->sp()[2];
-        std::cout << sp->surface << " (" << sp->x() << ", " << sp->y() << ", "
-                  << sp->z() << ") ";
-        std::cout << std::endl;
+    if (do_cpu) {
+      std::cout << "CPU Seed result:" << std::endl;
+      
+      for (auto& regionVec : seedVector_cpu) {
+        for (size_t i = 0; i < regionVec.size(); i++) {
+          const Acts::Seed<SpacePoint>* seed = &regionVec[i];
+          const SpacePoint* sp = seed->sp()[0];
+          std::cout << " (" << sp->x() << ", " << sp->y() << ", " << sp->z()
+                    << ") ";
+          sp = seed->sp()[1];
+          std::cout << sp->surface << " (" << sp->x() << ", " << sp->y() << ", "
+                    << sp->z() << ") ";
+          sp = seed->sp()[2];
+          std::cout << sp->surface << " (" << sp->x() << ", " << sp->y() << ", "
+                    << sp->z() << ") ";
+          std::cout << std::endl;
+        }
       }
+      
+      std::cout << std::endl;
     }
-
-    std::cout << std::endl;
     std::cout << "CUDA Seed result:" << std::endl;
 
     for (auto& regionVec : seedVector_cuda) {

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
@@ -145,8 +145,7 @@ int main(int argc, char** argv) {
                     << nTrplPerSpBLimit << std::endl;
           std::cout << "      -q : don't print out all found seeds"
                     << std::endl;
-          std::cout << "      -G : only run on GPU, not CPU"
-                    << std::endl;
+          std::cout << "      -G : only run on GPU, not CPU" << std::endl;
         }
 
         exit(EXIT_FAILURE);
@@ -253,11 +252,11 @@ int main(int argc, char** argv) {
       ++groupIt;
     for (; !(groupIt == spGroup.end()); ++groupIt) {
       seedVector_cpu.push_back(seedfinder_cpu.createSeedsForGroup(
-                                                                  groupIt.bottom(), groupIt.middle(), groupIt.top()));
+          groupIt.bottom(), groupIt.middle(), groupIt.top()));
       group_count++;
       if (allgroup == false) {
         if (group_count >= nGroupToIterate)
-        break;
+          break;
       }
     }
     // auto timeMetric_cpu = seedfinder_cpu.getTimeMetric();
@@ -302,15 +301,16 @@ int main(int argc, char** argv) {
             << "          CUDA        " << (do_cpu ? "Speedup " : "")
             << std::endl;
   std::cout << "Seedfinding_Time  " << std::setw(11)
-            << (do_cpu ? std::to_string(cpuTime) : "" ) << "  "
-            << std::setw(11) << cudaTime << "  " << std::setw(11)
-            << (do_cpu ? std::to_string(cpuTime / cudaTime) : "" ) << std::endl;
+            << (do_cpu ? std::to_string(cpuTime) : "") << "  " << std::setw(11)
+            << cudaTime << "  " << std::setw(11)
+            << (do_cpu ? std::to_string(cpuTime / cudaTime) : "") << std::endl;
   double wallTime_cpu = cpuTime + preprocessTime;
   double wallTime_cuda = cudaTime + preprocessTime;
   std::cout << "Wall_time         " << std::setw(11)
             << (do_cpu ? std::to_string(wallTime_cpu) : "") << "  "
             << std::setw(11) << wallTime_cuda << "  " << std::setw(11)
-            << (do_cpu ? std::to_string(wallTime_cpu / wallTime_cuda) : "") << std::endl;
+            << (do_cpu ? std::to_string(wallTime_cpu / wallTime_cuda) : "")
+            << std::endl;
   std::cout << "-----------------------------------------------------------"
             << std::endl;
   std::cout << std::endl;
@@ -375,7 +375,7 @@ int main(int argc, char** argv) {
   if (!quiet) {
     if (do_cpu) {
       std::cout << "CPU Seed result:" << std::endl;
-      
+
       for (auto& regionVec : seedVector_cpu) {
         for (size_t i = 0; i < regionVec.size(); i++) {
           const Acts::Seed<SpacePoint>* seed = &regionVec[i];
@@ -391,7 +391,7 @@ int main(int argc, char** argv) {
           std::cout << std::endl;
         }
       }
-      
+
       std::cout << std::endl;
     }
     std::cout << "CUDA Seed result:" << std::endl;


### PR DESCRIPTION
calling __syncthreads in a conditional that depends on the threadID results in undefined behaviour.

Interestingly, this wasn't apparent on older versions of the NVidia drivers, but is now.

Also, added option to SeedFinderCudaTest to not run on CPU, so as to test the GPU faster for large input files.