### PR TITLE
Fix Result constructor

### DIFF
--- a/Core/include/Acts/Utilities/Result.hpp
+++ b/Core/include/Acts/Utilities/Result.hpp
@@ -28,7 +28,7 @@ class Result {
    * This is used by the factory static methods to set up
    * the variant unambiguously in all cases.
    */
-  Result(std::variant<T, E>&& var) : m_var(var) {}
+  Result(std::variant<T, E>&& var) : m_var(std::move(var)) {}
 
  public:
   /**


### PR DESCRIPTION
Ensure correct rvalue reference forwarding and use `default` implementations where possible. Update the `RiddersPropagator` to use explicit return types. This fix some remaining compiler warning for #267. 