### PR TITLE
Backport v0.27: Introduce bfield caching in vertexing and remove refitAfterBadVertex AMVF option

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - master
-      - 'releases/**'
+      - 'release/**'
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - master
-      - 'releases/**'
+      - 'release/**'
 
 jobs:
   format:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - master
-      - 'releases/**'
+      - 'release/**'
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -151,13 +151,6 @@ class AdaptiveMultiVertexFinder {
     // constraint is provided
     std::pair<double, double> defaultConstrFitQuality{0., -3.};
 
-    // Do an adaptive multi vertex fit after
-    // a bad vertex was removed.
-    // If false, the old fitter state is just copied,
-    // this should give the same results with better
-    // performance. To be further investigated.
-    bool refitAfterBadVertex = true;
-
     // Use the full available vertex covariance information after
     // seeding for the IP estimation. In original implementation
     // this is not (!) done, however, this is probably not correct.
@@ -376,21 +369,18 @@ class AdaptiveMultiVertexFinder {
       const std::vector<Vertex<InputTrack_t>*>& allVertices) const;
 
   /// @brief Method that deletes last vertex from list of all vertices
-  /// and either refits all vertices afterwards (if refitAfterBadVertex)
-  /// of reverts to the old state of the vertex fitter before the bad
-  /// vertex was added to the fit (if not refitAfterBadVertex).
+  /// and refits all vertices afterwards
   ///
   /// @param vtx The last added vertex which will be removed
   /// @param allVertices Vector containing the unique_ptr to vertices
   /// @param allVerticesPtr Vector containing the actual addresses
   /// @param fitterState The current vertex fitter state
-  /// @param oldFitterState The old vertex fitter state
   /// @param vertexingOptions Vertexing options
   Result<void> deleteLastVertex(
       Vertex<InputTrack_t>& vtx,
       std::vector<std::unique_ptr<Vertex<InputTrack_t>>>& allVertices,
       std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
-      FitterState_t& fitterState, FitterState_t& oldFitterState,
+      FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Prepares the output vector of vertices
@@ -399,7 +389,7 @@ class AdaptiveMultiVertexFinder {
   /// @param fitterState The vertex fitter state
   ///
   /// @return The output vertex collection
-  std::vector<Vertex<InputTrack_t>> getVertexOutputList(
+  Result<std::vector<Vertex<InputTrack_t>>> getVertexOutputList(
       const std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
       FitterState_t& fitterState) const;
 };

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -22,7 +22,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
   // Seed tracks
   std::vector<const InputTrack_t*> seedTracks = allTracks;
 
-  FitterState_t fitterState;
+  FitterState_t fitterState(vertexingOptions.magFieldContext);
   SeedFinderState_t seedFinderState;
 
   std::vector<std::unique_ptr<Vertex<InputTrack_t>>> allVertices;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -34,7 +34,6 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
   while (((m_cfg.addSingleTrackVertices && seedTracks.size() > 0) ||
           ((!m_cfg.addSingleTrackVertices) && seedTracks.size() > 1)) &&
          iteration < m_cfg.maxIterations) {
-
     // Tracks that are used for searching compatible tracks
     // near a vertex candidate
     std::vector<const InputTrack_t*> allTracks;
@@ -546,23 +545,24 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
     -> Result<void> {
   allVertices.pop_back();
   allVerticesPtr.pop_back();
-    // Update fitter state with removed vertex candidate
-    fitterState.removeVertexFromMultiMap(vtx);
+  // Update fitter state with removed vertex candidate
+  fitterState.removeVertexFromMultiMap(vtx);
 
-    // Do the fit with removed vertex
-    auto fitResult = m_cfg.vertexFitter.addVtxToFit(
-        fitterState, vtx, m_cfg.linearizer, vertexingOptions);
-    if (!fitResult.ok()) {
-      return fitResult.error();
-    }
-  
+  // Do the fit with removed vertex
+  auto fitResult = m_cfg.vertexFitter.addVtxToFit(
+      fitterState, vtx, m_cfg.linearizer, vertexingOptions);
+  if (!fitResult.ok()) {
+    return fitResult.error();
+  }
+
   return {};
 }
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getVertexOutputList(
     const std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
-    FitterState_t& fitterState) const -> Acts::Result<std::vector<Vertex<InputTrack_t>>> {
+    FitterState_t& fitterState) const
+    -> Acts::Result<std::vector<Vertex<InputTrack_t>>> {
   std::vector<Vertex<InputTrack_t>> outputVec;
   for (auto vtx : allVerticesPtr) {
     auto& outVtx = *vtx;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -34,8 +34,6 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
   while (((m_cfg.addSingleTrackVertices && seedTracks.size() > 0) ||
           ((!m_cfg.addSingleTrackVertices) && seedTracks.size() > 1)) &&
          iteration < m_cfg.maxIterations) {
-    // Cache old fitte state in case new vertex is bad vertex
-    FitterState_t oldFitterState = fitterState;
 
     // Tracks that are used for searching compatible tracks
     // near a vertex candidate
@@ -123,7 +121,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
     if (not keepVertex) {
       auto deleteVertexResult =
           deleteLastVertex(vtxCandidate, allVertices, allVerticesPtr,
-                           fitterState, oldFitterState, vertexingOptions);
+                           fitterState, vertexingOptions);
       if (not deleteVertexResult.ok()) {
         return deleteVertexResult.error();
       }
@@ -543,24 +541,11 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
     Vertex<InputTrack_t>& vtx,
     std::vector<std::unique_ptr<Vertex<InputTrack_t>>>& allVertices,
     std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
-    FitterState_t& fitterState, FitterState_t& oldFitterState,
+    FitterState_t& fitterState,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<void> {
   allVertices.pop_back();
   allVerticesPtr.pop_back();
-
-  if (!m_cfg.refitAfterBadVertex) {
-    fitterState.vertexCollection = oldFitterState.vertexCollection;
-    fitterState.annealingState = oldFitterState.annealingState;
-    fitterState.vtxInfoMap.clear();
-    for (const auto& vtx : allVerticesPtr) {
-      fitterState.vtxInfoMap.emplace(vtx, oldFitterState.vtxInfoMap[vtx]);
-    }
-    fitterState.trackToVerticesMultiMap =
-        oldFitterState.trackToVerticesMultiMap;
-    fitterState.tracksAtVerticesMap = oldFitterState.tracksAtVerticesMap;
-
-  } else {
     // Update fitter state with removed vertex candidate
     fitterState.removeVertexFromMultiMap(vtx);
 
@@ -570,14 +555,14 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
     if (!fitResult.ok()) {
       return fitResult.error();
     }
-  }
+  
   return {};
 }
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getVertexOutputList(
     const std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
-    FitterState_t& fitterState) const -> std::vector<Vertex<InputTrack_t>> {
+    FitterState_t& fitterState) const -> Acts::Result<std::vector<Vertex<InputTrack_t>>> {
   std::vector<Vertex<InputTrack_t>> outputVec;
   for (auto vtx : allVerticesPtr) {
     auto& outVtx = *vtx;
@@ -589,5 +574,5 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getVertexOutputList(
     outVtx.setTracksAtVertex(tracksAtVtx);
     outputVec.push_back(outVtx);
   }
-  return outputVec;
+  return Result<std::vector<Vertex<InputTrack_t>>>(outputVec);
 }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -52,9 +52,7 @@ class AdaptiveMultiVertexFitter {
   /// @brief The fitter state
   struct State {
     State(const Acts::MagneticFieldContext& mctx)
-    : ipState(mctx)
-    , linearizerState(mctx)
-    {}
+        : ipState(mctx), linearizerState(mctx) {}
     // Vertex collection to be fitted
     std::vector<Vertex<InputTrack_t>*> vertexCollection;
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -57,6 +57,12 @@ class AdaptiveMultiVertexFitter {
     // Annealing state
     AnnealingUtility::State annealingState;
 
+    // IPEstimator state
+    typename IPEstimator::State ipState;
+
+    // Linearizer state
+    typename Linearizer_t::State linearizerState;
+
     // Map to store vertices information
     std::map<Vertex<InputTrack_t>*, VertexInfo<InputTrack_t>> vtxInfoMap;
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -51,6 +51,10 @@ class AdaptiveMultiVertexFitter {
  public:
   /// @brief The fitter state
   struct State {
+    State(const Acts::MagneticFieldContext& mctx)
+    : ipState(mctx)
+    , linearizerState(mctx)
+    {}
     // Vertex collection to be fitted
     std::vector<Vertex<InputTrack_t>*> vertexCollection;
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -209,7 +209,7 @@ Acts::Result<void> Acts::
   for (const auto& trk : currentVtxInfo.trackLinks) {
     auto res = m_cfg.ipEst.estimate3DImpactParameters(
         vertexingOptions.geoContext, vertexingOptions.magFieldContext,
-        m_extractParameters(*trk), seedPos);
+        m_extractParameters(*trk), seedPos, state.ipState);
     if (!res.ok()) {
       return res.error();
     }
@@ -239,7 +239,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::
       auto res = m_cfg.ipEst.estimate3DImpactParameters(
           vertexingOptions.geoContext, vertexingOptions.magFieldContext,
           m_extractParameters(*trk),
-          VectorHelpers::position(currentVtxInfo.linPoint));
+          VectorHelpers::position(currentVtxInfo.linPoint), state.ipState);
       if (!res.ok()) {
         return res.error();
       }
@@ -282,7 +282,7 @@ Acts::Result<void> Acts::
             state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
-              vertexingOptions.geoContext, vertexingOptions.magFieldContext);
+              vertexingOptions.geoContext, vertexingOptions.magFieldContext, state.linearizerState);
           if (!result.ok()) {
             return result.error();
           }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -282,7 +282,8 @@ Acts::Result<void> Acts::
             state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
-              vertexingOptions.geoContext, vertexingOptions.magFieldContext, state.linearizerState);
+              vertexingOptions.geoContext, vertexingOptions.magFieldContext,
+              state.linearizerState);
           if (!result.ok()) {
             return result.error();
           }

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -43,6 +43,13 @@ class FullBilloirVertexFitter {
 
   struct State
   {
+    /// @brief The state constructor
+    ///
+    /// @param mctx The magnetic field context
+    State(const Acts::MagneticFieldContext& mctx)
+    : linearizerState(mctx)
+    {}
+    /// The linearizer state
     typename Linearizer_t::State linearizerState;
   };
 

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -41,14 +41,11 @@ class FullBilloirVertexFitter {
   using BField_t = typename linearizer_t::BField_t;
   using Linearizer_t = linearizer_t;
 
-  struct State
-  {
+  struct State {
     /// @brief The state constructor
     ///
     /// @param mctx The magnetic field context
-    State(const Acts::MagneticFieldContext& mctx)
-    : linearizerState(mctx)
-    {}
+    State(const Acts::MagneticFieldContext& mctx) : linearizerState(mctx) {}
     /// The linearizer state
     typename Linearizer_t::State linearizerState;
   };

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -41,6 +41,11 @@ class FullBilloirVertexFitter {
   using BField_t = typename linearizer_t::BField_t;
   using Linearizer_t = linearizer_t;
 
+  struct State
+  {
+    typename Linearizer_t::State linearizerState;
+  };
+
   struct Config {
     /// Maximum number of interations in fitter
     int maxIterations = 5;
@@ -67,12 +72,14 @@ class FullBilloirVertexFitter {
   /// @param paramVector Vector of track objects to fit vertex to
   /// @param linearizer The track linearizer
   /// @param vertexingOptions Vertexing options
+  /// @param state The state object
   ///
   /// @return Fitted vertex
   Result<Vertex<input_track_t>> fit(
       const std::vector<const input_track_t*>& paramVector,
       const linearizer_t& linearizer,
-      const VertexingOptions<input_track_t>& vertexingOptions) const;
+      const VertexingOptions<input_track_t>& vertexingOptions,
+      State& state) const;
 
  private:
   /// Configuration object

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -115,10 +115,9 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
         trackMomenta.push_back(Vector3D(phi, theta, qop));
       }
 
-      auto result = linearizer.linearizeTrack(trackParams, linPoint,
-                                              vertexingOptions.geoContext,
-                                              vertexingOptions.magFieldContext,
-                                              state.linearizerState);
+      auto result = linearizer.linearizeTrack(
+          trackParams, linPoint, vertexingOptions.geoContext,
+          vertexingOptions.magFieldContext, state.linearizerState);
       if (result.ok()) {
         const auto& linTrack = *result;
         const auto& parametersAtPCA = linTrack.parametersAtPCA;

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -65,7 +65,8 @@ Acts::Result<Acts::Vertex<input_track_t>>
 Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     const std::vector<const input_track_t*>& paramVector,
     const linearizer_t& linearizer,
-    const VertexingOptions<input_track_t>& vertexingOptions) const {
+    const VertexingOptions<input_track_t>& vertexingOptions,
+    State& state) const {
   double chi2 = std::numeric_limits<double>::max();
   double newChi2 = 0;
   unsigned int nTracks = paramVector.size();
@@ -116,7 +117,8 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
       auto result = linearizer.linearizeTrack(trackParams, linPoint,
                                               vertexingOptions.geoContext,
-                                              vertexingOptions.magFieldContext);
+                                              vertexingOptions.magFieldContext,
+                                              state.linearizerState);
       if (result.ok()) {
         const auto& linTrack = *result;
         const auto& parametersAtPCA = linTrack.parametersAtPCA;

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
@@ -48,6 +48,12 @@ class HelicalTrackLinearizer {
 
   /// @struct State struct
   struct State{
+    /// @brief The state constructor
+    ///
+    /// @param mctx The magnetic field context
+    State(const Acts::MagneticFieldContext& mctx)
+    : fieldCache(mctx)
+    {}
     /// Magnetic field cache
     typename BField_t::Cache fieldCache;
   };

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
@@ -46,6 +46,12 @@ class HelicalTrackLinearizer {
   using Propagator_t = propagator_t;
   using BField_t = typename Propagator_t::Stepper::BField;
 
+  /// @struct State struct
+  struct State{
+    /// Magnetic field cache
+    typename BField_t::Cache fieldCache;
+  };
+
   /// @brief Configuration struct
   struct Config {
     /// @ Config constructor if magnetic field is present
@@ -86,12 +92,14 @@ class HelicalTrackLinearizer {
   /// @param linPoint Linearization point
   /// @param gctx The geometry context
   /// @param mctx The magnetic field context
+  /// @param state The state object
   ///
   /// @return Linearized track
   Result<LinearizedTrack> linearizeTrack(
       const BoundParameters& params, const SpacePointVector& linPoint,
       const Acts::GeometryContext& gctx,
-      const Acts::MagneticFieldContext& mctx) const;
+      const Acts::MagneticFieldContext& mctx,
+      State& state) const;
 
  private:
   /// Configuration object

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.hpp
@@ -47,13 +47,11 @@ class HelicalTrackLinearizer {
   using BField_t = typename Propagator_t::Stepper::BField;
 
   /// @struct State struct
-  struct State{
+  struct State {
     /// @brief The state constructor
     ///
     /// @param mctx The magnetic field context
-    State(const Acts::MagneticFieldContext& mctx)
-    : fieldCache(mctx)
-    {}
+    State(const Acts::MagneticFieldContext& mctx) : fieldCache(mctx) {}
     /// Magnetic field cache
     typename BField_t::Cache fieldCache;
   };
@@ -101,11 +99,11 @@ class HelicalTrackLinearizer {
   /// @param state The state object
   ///
   /// @return Linearized track
-  Result<LinearizedTrack> linearizeTrack(
-      const BoundParameters& params, const SpacePointVector& linPoint,
-      const Acts::GeometryContext& gctx,
-      const Acts::MagneticFieldContext& mctx,
-      State& state) const;
+  Result<LinearizedTrack> linearizeTrack(const BoundParameters& params,
+                                         const SpacePointVector& linPoint,
+                                         const Acts::GeometryContext& gctx,
+                                         const Acts::MagneticFieldContext& mctx,
+                                         State& state) const;
 
  private:
   /// Configuration object

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -13,7 +13,8 @@ Acts::Result<Acts::LinearizedTrack> Acts::
     HelicalTrackLinearizer<propagator_t, propagator_options_t>::linearizeTrack(
         const BoundParameters& params, const SpacePointVector& linPoint,
         const Acts::GeometryContext& gctx,
-        const Acts::MagneticFieldContext& mctx) const {
+        const Acts::MagneticFieldContext& mctx,
+        State& state) const {
   Vector3D linPointPos = VectorHelpers::position(linPoint);
 
   const std::shared_ptr<PerigeeSurface> perigeeSurface =
@@ -62,8 +63,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   Vector3D momentumAtPCA(phiV, th, qOvP);
 
   // get B-field z-component at current position
-  double Bz = m_cfg.bField.getField(VectorHelpers::position(positionAtPCA))[eZ];
-
+  double Bz = m_cfg.bField.getField(VectorHelpers::position(positionAtPCA), state.fieldCache)[eZ];
   double rho;
   double rho2;
   // Curvature is infinite w/o b field

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -13,8 +13,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
     HelicalTrackLinearizer<propagator_t, propagator_options_t>::linearizeTrack(
         const BoundParameters& params, const SpacePointVector& linPoint,
         const Acts::GeometryContext& gctx,
-        const Acts::MagneticFieldContext& mctx,
-        State& state) const {
+        const Acts::MagneticFieldContext& mctx, State& state) const {
   Vector3D linPointPos = VectorHelpers::position(linPoint);
 
   const std::shared_ptr<PerigeeSurface> perigeeSurface =
@@ -63,7 +62,8 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   Vector3D momentumAtPCA(phiV, th, qOvP);
 
   // get B-field z-component at current position
-  double Bz = m_cfg.bField.getField(VectorHelpers::position(positionAtPCA), state.fieldCache)[eZ];
+  double Bz = m_cfg.bField.getField(VectorHelpers::position(positionAtPCA),
+                                    state.fieldCache)[eZ];
   double rho;
   double rho2;
   // Curvature is infinite w/o b field

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -42,6 +42,12 @@ class ImpactPointEstimator {
  public:
   /// @struct State struct
   struct State{
+    /// @brief The state constructor
+    ///
+    /// @param mctx The magnetic field context
+    State(const Acts::MagneticFieldContext& mctx)
+    : fieldCache(mctx)
+    {}
     /// Magnetic field cache
     typename BField_t::Cache fieldCache;
   };

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -40,6 +40,12 @@ class ImpactPointEstimator {
   using BField_t = typename propagator_t::Stepper::BField;
 
  public:
+  /// @struct State struct
+  struct State{
+    /// Magnetic field cache
+    typename BField_t::Cache fieldCache;
+  };
+
   /// @struct Configuration struct
   struct Config {
     /// @brief Config constructor if magnetic field is present
@@ -81,11 +87,13 @@ class ImpactPointEstimator {
   /// @param gctx The geometry context
   /// @param trkParams Track parameters
   /// @param vtxPos Position to calculate distance to
+  /// @param state The state object
   ///
   /// @return Distance
   Result<double> calculate3dDistance(const GeometryContext& gctx,
                                      const BoundParameters& trkParams,
-                                     const Vector3D& vtxPos) const;
+                                     const Vector3D& vtxPos,
+                                     State& state) const;
 
   /// @brief Creates track parameters bound to plane
   /// at point of closest approach in 3d to given
@@ -99,11 +107,12 @@ class ImpactPointEstimator {
   /// @param mctx The magnetic field context
   /// @param trkParams Track parameters
   /// @param vtxPos Reference position (vertex)
+  /// @param state The state object
   ///
   /// @return New track params
   Result<std::unique_ptr<const BoundParameters>> estimate3DImpactParameters(
       const GeometryContext& gctx, const Acts::MagneticFieldContext& mctx,
-      const BoundParameters& trkParams, const Vector3D& vtxPos) const;
+      const BoundParameters& trkParams, const Vector3D& vtxPos, State& state) const;
 
   /// @brief Estimates the compatibility of a
   /// track to a vertex position based on the 3d
@@ -161,10 +170,12 @@ class ImpactPointEstimator {
   ///   track and vtxPos, to be determined by method
   /// @param momDir Momentum direction, to be
   ///   determined by method
+  /// @param state The state object
   Result<void> getDistanceAndMomentum(const GeometryContext& gctx,
                                       const BoundParameters& trkParams,
                                       const Vector3D& vtxPos, Vector3D& deltaR,
-                                      Vector3D& momDir) const;
+                                      Vector3D& momDir,
+                                      State& state) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -41,13 +41,11 @@ class ImpactPointEstimator {
 
  public:
   /// @struct State struct
-  struct State{
+  struct State {
     /// @brief The state constructor
     ///
     /// @param mctx The magnetic field context
-    State(const Acts::MagneticFieldContext& mctx)
-    : fieldCache(mctx)
-    {}
+    State(const Acts::MagneticFieldContext& mctx) : fieldCache(mctx) {}
     /// Magnetic field cache
     typename BField_t::Cache fieldCache;
   };
@@ -118,7 +116,8 @@ class ImpactPointEstimator {
   /// @return New track params
   Result<std::unique_ptr<const BoundParameters>> estimate3DImpactParameters(
       const GeometryContext& gctx, const Acts::MagneticFieldContext& mctx,
-      const BoundParameters& trkParams, const Vector3D& vtxPos, State& state) const;
+      const BoundParameters& trkParams, const Vector3D& vtxPos,
+      State& state) const;
 
   /// @brief Estimates the compatibility of a
   /// track to a vertex position based on the 3d
@@ -180,8 +179,7 @@ class ImpactPointEstimator {
   Result<void> getDistanceAndMomentum(const GeometryContext& gctx,
                                       const BoundParameters& trkParams,
                                       const Vector3D& vtxPos, Vector3D& deltaR,
-                                      Vector3D& momDir,
-                                      State& state) const;
+                                      Vector3D& momDir, State& state) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -18,11 +18,12 @@ Acts::Result<double> Acts::ImpactPointEstimator<
     input_track_t, propagator_t,
     propagator_options_t>::calculate3dDistance(const GeometryContext& gctx,
                                                const BoundParameters& trkParams,
-                                               const Vector3D& vtxPos) const {
+                                               const Vector3D& vtxPos,
+                                               State& state) const {
   Vector3D deltaR;
   Vector3D momDir;
 
-  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir);
+  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
 
   if (!res.ok()) {
     return res.error();
@@ -39,11 +40,12 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     estimate3DImpactParameters(const GeometryContext& gctx,
                                const Acts::MagneticFieldContext& mctx,
                                const BoundParameters& trkParams,
-                               const Vector3D& vtxPos) const {
+                               const Vector3D& vtxPos,
+                               State& state) const {
   Vector3D deltaR;
   Vector3D momDir;
 
-  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir);
+  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
 
   if (!res.ok()) {
     return res.error();
@@ -188,7 +190,8 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     getDistanceAndMomentum(const GeometryContext& gctx,
                            const BoundParameters& trkParams,
                            const Vector3D& vtxPos, Vector3D& deltaR,
-                           Vector3D& momDir) const {
+                           Vector3D& momDir,
+                           State& state) const {
   Vector3D trkSurfaceCenter = trkParams.referenceSurface().center(gctx);
 
   double d0 = trkParams.parameters()[ParID_t::eLOC_D0];
@@ -202,7 +205,7 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   double cotTheta = 1. / std::tan(theta);
 
   // get B-field z-component at current position
-  double bZ = m_cfg.bField.getField(trkSurfaceCenter)[eZ];
+  double bZ = m_cfg.bField.getField(trkSurfaceCenter, state.fieldCache)[eZ];
 
   // The radius
   double r;

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -23,7 +23,8 @@ Acts::Result<double> Acts::ImpactPointEstimator<
   Vector3D deltaR;
   Vector3D momDir;
 
-  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
+  auto res =
+      getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
 
   if (!res.ok()) {
     return res.error();
@@ -40,12 +41,12 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     estimate3DImpactParameters(const GeometryContext& gctx,
                                const Acts::MagneticFieldContext& mctx,
                                const BoundParameters& trkParams,
-                               const Vector3D& vtxPos,
-                               State& state) const {
+                               const Vector3D& vtxPos, State& state) const {
   Vector3D deltaR;
   Vector3D momDir;
 
-  auto res = getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
+  auto res =
+      getDistanceAndMomentum(gctx, trkParams, vtxPos, deltaR, momDir, state);
 
   if (!res.ok()) {
     return res.error();
@@ -190,8 +191,7 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     getDistanceAndMomentum(const GeometryContext& gctx,
                            const BoundParameters& trkParams,
                            const Vector3D& vtxPos, Vector3D& deltaR,
-                           Vector3D& momDir,
-                           State& state) const {
+                           Vector3D& momDir, State& state) const {
   Vector3D trkSurfaceCenter = trkParams.referenceSurface().center(gctx);
 
   double d0 = trkParams.parameters()[ParID_t::eLOC_D0];

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -110,10 +110,7 @@ class IterativeVertexFinder {
   /// @struct State State struct
   struct State {
     State(const Acts::MagneticFieldContext& mctx)
-    : ipState(mctx)
-    , linearizerState(mctx)
-    , fitterState(mctx)
-    {}
+        : ipState(mctx), linearizerState(mctx), fitterState(mctx) {}
     /// The IP estimator state
     typename IPEstimator::State ipState;
     /// The inearizer state

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -109,6 +109,11 @@ class IterativeVertexFinder {
 
   /// @struct State State struct
   struct State {
+    State(const Acts::MagneticFieldContext& mctx)
+    : ipState(mctx)
+    , linearizerState(mctx)
+    , fitterState(mctx)
+    {}
     /// The IP estimator state
     typename IPEstimator::State ipState;
     /// The inearizer state
@@ -222,12 +227,14 @@ class IterativeVertexFinder {
   /// @param perigeesToFitOut Perigees to fit
   /// @param perigeesToFitSplitVertexOut Perigees to fit split vertex
   /// @param vertexingOptions Vertexing options
+  /// @param state The state object
   Result<void> fillPerigeesToFit(
       const std::vector<const InputTrack_t*>& perigeeList,
       const Vertex<InputTrack_t>& seedVertex,
       std::vector<const InputTrack_t*>& perigeesToFitOut,
       std::vector<const InputTrack_t*>& perigeesToFitSplitVertexOut,
-      const VertexingOptions<InputTrack_t>& vertexingOptions) const;
+      const VertexingOptions<InputTrack_t>& vertexingOptions,
+      State& state) const;
 
   /// @brief Function that reassigns tracks from other vertices
   ///        to the current vertex if they are more compatible

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -107,8 +107,15 @@ class IterativeVertexFinder {
     double cutOffTrackWeight = 0.01;
   };
 
-  /// @struct State State struct for fulfilling interface
-  struct State {};
+  /// @struct State State struct
+  struct State {
+    /// The IP estimator state
+    typename IPEstimator::State ipState;
+    /// The inearizer state
+    typename Linearizer_t::State linearizerState;
+    /// The fitter state
+    typename vfitter_t::State fitterState;
+  };
 
   /// @brief Constructor used if InputTrack_t type == BoundParameters
   ///
@@ -186,9 +193,11 @@ class IterativeVertexFinder {
   /// @param params Track parameters
   /// @param vertex The vertex
   /// @param vertexingOptions Vertexing options
+  /// @param state The state object
   Result<double> getCompatibility(
       const BoundParameters& params, const Vertex<InputTrack_t>& vertex,
-      const VertexingOptions<InputTrack_t>& vertexingOptions) const;
+      const VertexingOptions<InputTrack_t>& vertexingOptions,
+      State& state) const;
 
   /// @brief Function that removes used tracks compatible with
   /// current vertex (`myVertex`) from `perigeesToFit` and `seedTracks`
@@ -198,11 +207,13 @@ class IterativeVertexFinder {
   /// @param perigeesToFit Tracks used to fit `myVertex`
   /// @param seedTracks Tracks used for vertex seeding
   /// @param vertexingOptions Vertexing options
+  /// @param state The state object
   Result<void> removeUsedCompatibleTracks(
       Vertex<InputTrack_t>& myVertex,
       std::vector<const InputTrack_t*>& perigeesToFit,
       std::vector<const InputTrack_t*>& seedTracks,
-      const VertexingOptions<InputTrack_t>& vertexingOptions) const;
+      const VertexingOptions<InputTrack_t>& vertexingOptions,
+      State& state) const;
 
   /// @brief Function that fills vector with tracks compatible with seed vertex
   ///
@@ -227,6 +238,7 @@ class IterativeVertexFinder {
   /// @param seedTracks Seed tracks vector
   /// @param origTracks Vector of original track objects
   /// @param vertexingOptions Vertexing options
+  /// @param state The state object
   ///
   /// @return Bool if currentVertex is still a good vertex
   Result<bool> reassignTracksToNewVertex(
@@ -235,7 +247,8 @@ class IterativeVertexFinder {
       std::vector<const InputTrack_t*>& perigeesToFit,
       std::vector<const InputTrack_t*>& seedTracks,
       const std::vector<const InputTrack_t*>& origTracks,
-      const VertexingOptions<InputTrack_t>& vertexingOptions) const;
+      const VertexingOptions<InputTrack_t>& vertexingOptions,
+      State& state) const;
 
   /// @brief Counts all tracks that are significant for a vertex
   ///

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -9,8 +9,8 @@
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     const std::vector<const InputTrack_t*>& trackVector,
-    const VertexingOptions<InputTrack_t>& vertexingOptions,
-    State& state) const -> Result<std::vector<Vertex<InputTrack_t>>> {
+    const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
+    -> Result<std::vector<Vertex<InputTrack_t>>> {
   // Original tracks
   const std::vector<const InputTrack_t*>& origTracks = trackVector;
   // Tracks for seeding
@@ -37,8 +37,9 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     std::vector<const InputTrack_t*> perigeesToFitSplitVertex;
 
     // Fill vector with tracks to fit, only compatible with seed:
-    auto res = fillPerigeesToFit(seedTracks, seedVertex, perigeesToFit,
-                                 perigeesToFitSplitVertex, vertexingOptions, state);
+    auto res =
+        fillPerigeesToFit(seedTracks, seedVertex, perigeesToFit,
+                          perigeesToFitSplitVertex, vertexingOptions, state);
 
     if (!res.ok()) {
       return res.error();
@@ -51,16 +52,16 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     Vertex<InputTrack_t> currentSplitVertex;
 
     if (m_cfg.useBeamConstraint && !perigeesToFit.empty()) {
-      auto fitResult = m_cfg.vertexFitter.fit(perigeesToFit, m_cfg.linearizer,
-                                              vertexingOptions, state.fitterState);
+      auto fitResult = m_cfg.vertexFitter.fit(
+          perigeesToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
         return fitResult.error();
       }
     } else if (!m_cfg.useBeamConstraint && perigeesToFit.size() > 1) {
-      auto fitResult = m_cfg.vertexFitter.fit(perigeesToFit, m_cfg.linearizer,
-                                              vertexingOptions, state.fitterState);
+      auto fitResult = m_cfg.vertexFitter.fit(
+          perigeesToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
@@ -68,8 +69,9 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
       }
     }
     if (m_cfg.createSplitVertices && perigeesToFitSplitVertex.size() > 1) {
-      auto fitResult = m_cfg.vertexFitter.fit(
-          perigeesToFitSplitVertex, m_cfg.linearizer, vertexingOptions, state.fitterState);
+      auto fitResult =
+          m_cfg.vertexFitter.fit(perigeesToFitSplitVertex, m_cfg.linearizer,
+                                 vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentSplitVertex = std::move(*fitResult);
       } else {
@@ -98,9 +100,9 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
         // vertex is good vertex here
         // but add tracks which may have been missed
 
-        auto result = reassignTracksToNewVertex(vertexCollection, currentVertex,
-                                                perigeesToFit, seedTracks,
-                                                origTracks, vertexingOptions, state);
+        auto result = reassignTracksToNewVertex(
+            vertexCollection, currentVertex, perigeesToFit, seedTracks,
+            origTracks, vertexingOptions, state);
         if (!result.ok()) {
           return result.error();
         }
@@ -427,8 +429,8 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
           m_extractParameters(*(tracksIter->originalParams));
 
       // compute compatibility
-      auto resultNew =
-          getCompatibility(trackPerigee, currentVertex, vertexingOptions, state);
+      auto resultNew = getCompatibility(trackPerigee, currentVertex,
+                                        vertexingOptions, state);
       if (!resultNew.ok()) {
         return Result<bool>::failure(resultNew.error());
       }
@@ -484,16 +486,16 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
   // later
   currentVertex = Vertex<InputTrack_t>();
   if (m_cfg.useBeamConstraint && !perigeesToFit.empty()) {
-    auto fitResult = m_cfg.vertexFitter.fit(perigeesToFit, m_cfg.linearizer,
-                                            vertexingOptions, state.fitterState);
+    auto fitResult = m_cfg.vertexFitter.fit(
+        perigeesToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {
       return Result<bool>::success(false);
     }
   } else if (!m_cfg.useBeamConstraint && perigeesToFit.size() > 1) {
-    auto fitResult = m_cfg.vertexFitter.fit(perigeesToFit, m_cfg.linearizer,
-                                            vertexingOptions, state.fitterState);
+    auto fitResult = m_cfg.vertexFitter.fit(
+        perigeesToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -38,7 +38,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
 
     // Fill vector with tracks to fit, only compatible with seed:
     auto res = fillPerigeesToFit(seedTracks, seedVertex, perigeesToFit,
-                                 perigeesToFitSplitVertex, vertexingOptions);
+                                 perigeesToFitSplitVertex, vertexingOptions, state);
 
     if (!res.ok()) {
       return res.error();
@@ -332,7 +332,8 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillPerigeesToFit(
     const Vertex<InputTrack_t>& seedVertex,
     std::vector<const InputTrack_t*>& perigeesToFitOut,
     std::vector<const InputTrack_t*>& perigeesToFitSplitVertexOut,
-    const VertexingOptions<InputTrack_t>& vertexingOptions) const {
+    const VertexingOptions<InputTrack_t>& vertexingOptions,
+    State& state) const {
   int numberOfTracks = perigeeList.size();
 
   // Count how many tracks are used for fit

--- a/Core/include/Acts/Vertexing/LinearizerConcept.hpp
+++ b/Core/include/Acts/Vertexing/LinearizerConcept.hpp
@@ -22,6 +22,8 @@ namespace concept {
 
   template <typename T>
   using propagator_t = typename T::Propagator_t;
+  template <typename T>
+  using state_t = typename T::State;
 
   METHOD_TRAIT(linTrack_t, linearizeTrack);
 
@@ -33,15 +35,20 @@ namespace concept {
          linTrack_t, const BoundParameters&,
                      const SpacePointVector&,
                      const Acts::GeometryContext&,
-                     const Acts::MagneticFieldContext&>;
+                     const Acts::MagneticFieldContext&,
+                     typename S::State&>;
   
         static_assert(linTrack_exists, "linearizeTrack method not found");
 
         constexpr static bool propagator_exists = exists<propagator_t, S>;
         static_assert(propagator_exists, "Propagator type not found");
 
+        constexpr static bool state_exists = exists<state_t, S>;
+        static_assert(state_exists, "State type not found");
+
         constexpr static bool value = require<linTrack_exists,
-                                              propagator_exists>;
+                                              propagator_exists,
+                                              state_exists>;
       };
   // clang-format on
   }  // namespace Linearizer

--- a/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
@@ -25,6 +25,8 @@ namespace concept {
   using propagator_t = typename T::Propagator_t;
   template <typename T>
   using linearizer_t = typename T::Linearizer_t;
+  template <typename T>
+  using state_t = typename T::State;
 
   METHOD_TRAIT(fit_t, fit);
 
@@ -35,7 +37,8 @@ namespace concept {
          fit_t, 
          const std::vector<const typename S::InputTrack_t*>&, 
          const typename S::Linearizer_t&,
-         const VertexingOptions<typename S::InputTrack_t>&>;
+         const VertexingOptions<typename S::InputTrack_t>&,
+         typename S::State&>;
         static_assert(fit_exists, "fit method not found");
 
         constexpr static bool track_exists = exists<track_t, S>;
@@ -44,11 +47,14 @@ namespace concept {
         static_assert(propagator_exists, "Propagator type not found");
         constexpr static bool linearizer_exists = exists<linearizer_t, S>;
         static_assert(linearizer_exists, "Linearizer type not found");
+        constexpr static bool state_exists = exists<state_t, S>;
+        static_assert(state_exists, "State type not found");
 
         constexpr static bool value = require<fit_exists,
                                               track_exists,
                                               propagator_exists,
-                                              linearizer_exists>;
+                                              linearizer_exists,
+                                              state_exists>;
       };
   // clang-format on
   }  // namespace VertexFitter

--- a/Examples/Algorithms/Vertexing/include/ACTFW/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ACTFW/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "ACTFW/EventData/SimVertex.hpp"
 #include "ACTFW/Framework/BareAlgorithm.hpp"
 #include "ACTFW/Framework/ProcessCode.hpp"

--- a/Examples/Algorithms/Vertexing/include/ACTFW/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ACTFW/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "ACTFW/EventData/SimVertex.hpp"
 #include "ACTFW/Framework/BareAlgorithm.hpp"
 #include "ACTFW/Framework/ProcessCode.hpp"
 #include "ACTFW/Framework/WhiteBoard.hpp"

--- a/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
@@ -81,7 +81,7 @@ FW::ProcessCode FWE::IterativeVertexFinderAlgorithm::execute(
   finderCfg.maxVertices = 200;
   finderCfg.reassignTracksAfterFirstFit = true;
   VertexFinder finder(finderCfg);
-  VertexFinder::State state;
+  VertexFinder::State state(ctx.magFieldContext);
   VertexFinderOptions finderOpts(ctx.geoContext, ctx.magFieldContext);
 
   // Setup containers

--- a/Examples/Algorithms/Vertexing/src/VertexFitAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitAlgorithm.cpp
@@ -52,6 +52,7 @@ FW::ProcessCode FWE::VertexFitAlgorithm::execute(
   // Setup the vertex fitter
   VertexFitter::Config vertexFitterCfg;
   VertexFitter vertexFitter(vertexFitterCfg);
+  VertexFitter::State state(ctx.magFieldContext);
   // Setup the linearizer
   Linearizer::Config ltConfig(bField, propagator);
   Linearizer linearizer(ltConfig);
@@ -86,7 +87,7 @@ FW::ProcessCode FWE::VertexFitAlgorithm::execute(
       VertexFitterOptions vfOptions(ctx.geoContext, ctx.magFieldContext);
 
       auto fitRes =
-          vertexFitter.fit(inputTrackPtrCollection, linearizer, vfOptions);
+          vertexFitter.fit(inputTrackPtrCollection, linearizer, vfOptions, state);
       if (fitRes.ok()) {
         fittedVertex = *fitRes;
       } else {
@@ -105,7 +106,7 @@ FW::ProcessCode FWE::VertexFitAlgorithm::execute(
                                           theConstraint);
 
       auto fitRes = vertexFitter.fit(inputTrackPtrCollection, linearizer,
-                                     vfOptionsConstr);
+                                     vfOptionsConstr,state);
       if (fitRes.ok()) {
         fittedVertex = *fitRes;
       } else {

--- a/Examples/Algorithms/Vertexing/src/VertexFitAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitAlgorithm.cpp
@@ -86,8 +86,8 @@ FW::ProcessCode FWE::VertexFitAlgorithm::execute(
       // Vertex fitter options
       VertexFitterOptions vfOptions(ctx.geoContext, ctx.magFieldContext);
 
-      auto fitRes =
-          vertexFitter.fit(inputTrackPtrCollection, linearizer, vfOptions, state);
+      auto fitRes = vertexFitter.fit(inputTrackPtrCollection, linearizer,
+                                     vfOptions, state);
       if (fitRes.ok()) {
         fittedVertex = *fitRes;
       } else {
@@ -106,7 +106,7 @@ FW::ProcessCode FWE::VertexFitAlgorithm::execute(
                                           theConstraint);
 
       auto fitRes = vertexFitter.fit(inputTrackPtrCollection, linearizer,
-                                     vfOptionsConstr,state);
+                                     vfOptionsConstr, state);
       if (fitRes.ok()) {
         fittedVertex = *fitRes;
       } else {

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -509,7 +509,6 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
 
   Finder::Config finderConfig(std::move(fitter), seedFinder, ipEst, linearizer);
 
-  finderConfig.refitAfterBadVertex = false;
   // TODO: test this as well!
   // finderConfig.useBeamSpotConstraint = false;
 

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
     }
   }
 
-  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state;
+  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(magFieldContext);
 
   for (unsigned int iTrack = 0; iTrack < nTracksPerVtx * vtxPosVec.size();
        iTrack++) {
@@ -416,7 +416,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
 
   std::vector<Vertex<BoundParameters>*> vtxList;
 
-  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state;
+  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(magFieldContext);
 
   // The constraint vertex position covariance
   SpacePointSymMatrix covConstr(SpacePointSymMatrix::Identity());

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -177,7 +177,8 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
     }
   }
 
-  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(magFieldContext);
+  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(
+      magFieldContext);
 
   for (unsigned int iTrack = 0; iTrack < nTracksPerVtx * vtxPosVec.size();
        iTrack++) {
@@ -416,7 +417,8 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
 
   std::vector<Vertex<BoundParameters>*> vtxList;
 
-  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(magFieldContext);
+  AdaptiveMultiVertexFitter<BoundParameters, Linearizer>::State state(
+      magFieldContext);
 
   // The constraint vertex position covariance
   SpacePointSymMatrix covConstr(SpacePointSymMatrix::Identity());

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -55,8 +55,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   // Set up Billoir Vertex Fitter
   using VertexFitter = FullBilloirVertexFitter<BoundParameters, Linearizer>;
   VertexFitter::Config vertexFitterCfg;
-  VertexFitter billoirFitter(
-      vertexFitterCfg);
+  VertexFitter billoirFitter(vertexFitterCfg);
   VertexFitter::State state(magFieldContext);
 
   // Constraint for vertex fit
@@ -84,7 +83,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   SpacePointSymMatrix zeroMat = SpacePointSymMatrix::Zero();
   BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
 
-  fittedVertex = billoirFitter.fit(emptyVector, linearizer, vfOptions, state).value();
+  fittedVertex =
+      billoirFitter.fit(emptyVector, linearizer, vfOptions, state).value();
 
   BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
   BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
@@ -144,10 +144,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // Set up Billoir Vertex Fitter
     using VertexFitter = FullBilloirVertexFitter<BoundParameters, Linearizer>;
-    VertexFitter::Config
-        vertexFitterCfg;
-    VertexFitter billoirFitter(
-        vertexFitterCfg);
+    VertexFitter::Config vertexFitterCfg;
+    VertexFitter billoirFitter(vertexFitterCfg);
     VertexFitter::State state(magFieldContext);
     // Constraint for vertex fit
     Vertex<BoundParameters> myConstraint;
@@ -219,7 +217,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
     }
     // Do the fit with a constraint
     Vertex<BoundParameters> fittedVertexConstraint =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state)
+            .value();
     if (fittedVertexConstraint.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertexConstraint.position(), vertexPosition, 1_mm);
     }
@@ -283,8 +282,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
     // Set up Billoir Vertex Fitter
     using VertexFitter = FullBilloirVertexFitter<InputTrack, Linearizer>;
     VertexFitter::Config vertexFitterCfg;
-    VertexFitter billoirFitter(
-        vertexFitterCfg, extractParameters);
+    VertexFitter billoirFitter(vertexFitterCfg, extractParameters);
     VertexFitter::State state(magFieldContext);
 
     // Constraint for vertex fit
@@ -360,7 +358,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
     }
     // Do the fit with a constraint
     Vertex<InputTrack> fittedVertexConstraint =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state)
+            .value();
     if (fittedVertexConstraint.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertexConstraint.position(), vertexPosition, 1_mm);
     }

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   VertexFitter::Config vertexFitterCfg;
   VertexFitter billoirFitter(
       vertexFitterCfg);
-  VertexFitter::State state;
+  VertexFitter::State state(magFieldContext);
 
   // Constraint for vertex fit
   Vertex<BoundParameters> myConstraint;
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
         vertexFitterCfg;
     VertexFitter billoirFitter(
         vertexFitterCfg);
-    VertexFitter::State state;
+    VertexFitter::State state(magFieldContext);
     // Constraint for vertex fit
     Vertex<BoundParameters> myConstraint;
     // Some abitrary values
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
     VertexFitter::Config vertexFitterCfg;
     VertexFitter billoirFitter(
         vertexFitterCfg, extractParameters);
-    VertexFitter::State state;
+    VertexFitter::State state(magFieldContext);
 
     // Constraint for vertex fit
     Vertex<InputTrack> myConstraint;

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -53,9 +53,11 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   Linearizer linearizer(ltConfig);
 
   // Set up Billoir Vertex Fitter
-  FullBilloirVertexFitter<BoundParameters, Linearizer>::Config vertexFitterCfg;
-  FullBilloirVertexFitter<BoundParameters, Linearizer> billoirFitter(
+  using VertexFitter = FullBilloirVertexFitter<BoundParameters, Linearizer>;
+  VertexFitter::Config vertexFitterCfg;
+  VertexFitter billoirFitter(
       vertexFitterCfg);
+  VertexFitter::State state;
 
   // Constraint for vertex fit
   Vertex<BoundParameters> myConstraint;
@@ -74,7 +76,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
                                               myConstraint);
 
   Vertex<BoundParameters> fittedVertex =
-      billoirFitter.fit(emptyVector, linearizer, vfOptions).value();
+      billoirFitter.fit(emptyVector, linearizer, vfOptions, state).value();
 
   Vector3D origin(0., 0., 0.);
   BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
@@ -82,7 +84,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   SpacePointSymMatrix zeroMat = SpacePointSymMatrix::Zero();
   BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
 
-  fittedVertex = billoirFitter.fit(emptyVector, linearizer, vfOptions).value();
+  fittedVertex = billoirFitter.fit(emptyVector, linearizer, vfOptions, state).value();
 
   BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
   BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
@@ -141,10 +143,12 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
     unsigned int nTracks = nTracksDist(gen);
 
     // Set up Billoir Vertex Fitter
-    FullBilloirVertexFitter<BoundParameters, Linearizer>::Config
+    using VertexFitter = FullBilloirVertexFitter<BoundParameters, Linearizer>;
+    VertexFitter::Config
         vertexFitterCfg;
-    FullBilloirVertexFitter<BoundParameters, Linearizer> billoirFitter(
+    VertexFitter billoirFitter(
         vertexFitterCfg);
+    VertexFitter::State state;
     // Constraint for vertex fit
     Vertex<BoundParameters> myConstraint;
     // Some abitrary values
@@ -209,13 +213,13 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // Do the actual fit with 4 tracks without constraint
     Vertex<BoundParameters> fittedVertex =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptions).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptions, state).value();
     if (fittedVertex.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertex.position(), vertexPosition, 1_mm);
     }
     // Do the fit with a constraint
     Vertex<BoundParameters> fittedVertexConstraint =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state).value();
     if (fittedVertexConstraint.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertexConstraint.position(), vertexPosition, 1_mm);
     }
@@ -277,9 +281,11 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
         [](InputTrack params) { return params.parameters(); };
 
     // Set up Billoir Vertex Fitter
-    FullBilloirVertexFitter<InputTrack, Linearizer>::Config vertexFitterCfg;
-    FullBilloirVertexFitter<InputTrack, Linearizer> billoirFitter(
+    using VertexFitter = FullBilloirVertexFitter<InputTrack, Linearizer>;
+    VertexFitter::Config vertexFitterCfg;
+    VertexFitter billoirFitter(
         vertexFitterCfg, extractParameters);
+    VertexFitter::State state;
 
     // Constraint for vertex fit
     Vertex<InputTrack> myConstraint;
@@ -348,13 +354,13 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
 
     // Do the actual fit with 4 tracks without constraint
     Vertex<InputTrack> fittedVertex =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptions).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptions, state).value();
     if (fittedVertex.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertex.position(), vertexPosition, 1_mm);
     }
     // Do the fit with a constraint
     Vertex<InputTrack> fittedVertexConstraint =
-        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr).value();
+        billoirFitter.fit(tracksPtr, linearizer, vfOptionsConstr, state).value();
     if (fittedVertexConstraint.tracks().size() > 0) {
       CHECK_CLOSE_ABS(fittedVertexConstraint.position(), vertexPosition, 1_mm);
     }

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -79,11 +79,9 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
 
   // Set up the ImpactPointEstimator
   using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
-  IPEstimator::Config ipEstCfg(
-      bField, propagator);
+  IPEstimator::Config ipEstCfg(bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
   IPEstimator::State state(magFieldContext);
-
 
   // Reference position
   Vector3D refPosition(0., 0., 0.);
@@ -131,8 +129,8 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
     double transverseDist = std::sqrt(std::pow(d0, 2) + std::pow(z0, 2));
 
     // Estimate 3D distance
-    auto distanceRes =
-        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition, state);
+    auto distanceRes = ipEstimator.calculate3dDistance(geoContext, myTrack,
+                                                       refPosition, state);
     BOOST_CHECK(distanceRes.ok());
 
     double distance = *distanceRes;
@@ -200,8 +198,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
 
   // Set up the ImpactPointEstimator
   using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
-  IPEstimator::Config ipEstCfg(
-      bField, propagator);
+  IPEstimator::Config ipEstCfg(bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
   IPEstimator::State state(magFieldContext);
 
@@ -251,8 +248,8 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
                             perigeeSurface);
 
     // Estimate 3D distance
-    auto distanceRes =
-        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition, state);
+    auto distanceRes = ipEstimator.calculate3dDistance(geoContext, myTrack,
+                                                       refPosition, state);
     BOOST_CHECK(distanceRes.ok());
 
     distancesList.push_back(*distanceRes);
@@ -320,8 +317,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
 
   // Set up the ImpactPointEstimator
   using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
-  IPEstimator::Config ipEstCfg(
-      bField, propagator);
+  IPEstimator::Config ipEstCfg(bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
   IPEstimator::State state(magFieldContext);
 
@@ -338,7 +334,8 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
   // Some fixed track parameter values
   BoundParameters params1(geoContext, covMat, pos1, mom1, 1, 0, perigeeSurface);
 
-  auto res1 = ipEstimator.calculate3dDistance(geoContext, params1, vtxPos, state);
+  auto res1 =
+      ipEstimator.calculate3dDistance(geoContext, params1, vtxPos, state);
   BOOST_CHECK(res1.ok());
   double distance = (*res1);
 
@@ -403,8 +400,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_parameter_estimation_test) {
 
   // Set up the ImpactPointEstimator
   using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
-  IPEstimator::Config ipEstCfg(
-      bField, propagator);
+  IPEstimator::Config ipEstCfg(bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
   IPEstimator::State state(magFieldContext);
 

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
   IPEstimator::Config ipEstCfg(
       bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
-  IPEstimator::State state;
+  IPEstimator::State state(magFieldContext);
 
 
   // Reference position
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
   IPEstimator::Config ipEstCfg(
       bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
-  IPEstimator::State state;
+  IPEstimator::State state(magFieldContext);
 
   // Reference position
   Vector3D refPosition(0., 0., 0.);
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
   IPEstimator::Config ipEstCfg(
       bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
-  IPEstimator::State state;
+  IPEstimator::State state(magFieldContext);
 
   // Use same values as in Athena unit test
   Vector3D pos1(2_mm, 1_mm, -10_mm);
@@ -406,7 +406,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_parameter_estimation_test) {
   IPEstimator::Config ipEstCfg(
       bField, propagator);
   IPEstimator ipEstimator(ipEstCfg);
-  IPEstimator::State state;
+  IPEstimator::State state(magFieldContext);
 
   // Construct random track emerging from vicinity of vertex position
   // Vector to store track objects used for vertex fit

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -78,10 +78,12 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
   auto propagator = std::make_shared<Propagator>(stepper);
 
   // Set up the ImpactPointEstimator
-  ImpactPointEstimator<BoundParameters, Propagator>::Config ipEstCfg(
+  using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
+  IPEstimator::Config ipEstCfg(
       bField, propagator);
+  IPEstimator ipEstimator(ipEstCfg);
+  IPEstimator::State state;
 
-  ImpactPointEstimator<BoundParameters, Propagator> ipEstimator(ipEstCfg);
 
   // Reference position
   Vector3D refPosition(0., 0., 0.);
@@ -130,7 +132,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
 
     // Estimate 3D distance
     auto distanceRes =
-        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition);
+        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition, state);
     BOOST_CHECK(distanceRes.ok());
 
     double distance = *distanceRes;
@@ -146,7 +148,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
     }
 
     auto res = ipEstimator.estimate3DImpactParameters(
-        geoContext, magFieldContext, myTrack, refPosition);
+        geoContext, magFieldContext, myTrack, refPosition, state);
 
     BOOST_CHECK(res.ok());
 
@@ -197,10 +199,11 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
   auto propagator = std::make_shared<Propagator>(stepper);
 
   // Set up the ImpactPointEstimator
-  ImpactPointEstimator<BoundParameters, Propagator>::Config ipEstCfg(
+  using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
+  IPEstimator::Config ipEstCfg(
       bField, propagator);
-
-  ImpactPointEstimator<BoundParameters, Propagator> ipEstimator(ipEstCfg);
+  IPEstimator ipEstimator(ipEstCfg);
+  IPEstimator::State state;
 
   // Reference position
   Vector3D refPosition(0., 0., 0.);
@@ -249,13 +252,13 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
 
     // Estimate 3D distance
     auto distanceRes =
-        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition);
+        ipEstimator.calculate3dDistance(geoContext, myTrack, refPosition, state);
     BOOST_CHECK(distanceRes.ok());
 
     distancesList.push_back(*distanceRes);
 
     auto res = ipEstimator.estimate3DImpactParameters(
-        geoContext, magFieldContext, myTrack, refPosition);
+        geoContext, magFieldContext, myTrack, refPosition, state);
 
     BOOST_CHECK(res.ok());
 
@@ -316,10 +319,11 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
   auto propagator = std::make_shared<Propagator>(stepper);
 
   // Set up the ImpactPointEstimator
-  ImpactPointEstimator<BoundParameters, Propagator>::Config ipEstCfg(
+  using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
+  IPEstimator::Config ipEstCfg(
       bField, propagator);
-
-  ImpactPointEstimator<BoundParameters, Propagator> ipEstimator(ipEstCfg);
+  IPEstimator ipEstimator(ipEstCfg);
+  IPEstimator::State state;
 
   // Use same values as in Athena unit test
   Vector3D pos1(2_mm, 1_mm, -10_mm);
@@ -334,7 +338,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
   // Some fixed track parameter values
   BoundParameters params1(geoContext, covMat, pos1, mom1, 1, 0, perigeeSurface);
 
-  auto res1 = ipEstimator.calculate3dDistance(geoContext, params1, vtxPos);
+  auto res1 = ipEstimator.calculate3dDistance(geoContext, params1, vtxPos, state);
   BOOST_CHECK(res1.ok());
   double distance = (*res1);
 
@@ -343,7 +347,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_athena_test) {
   CHECK_CLOSE_ABS(distance, result, 0.00001_mm);
 
   auto res2 = ipEstimator.estimate3DImpactParameters(
-      geoContext, magFieldContext, params1, vtxPos);
+      geoContext, magFieldContext, params1, vtxPos, state);
   BOOST_CHECK(res2.ok());
   BoundParameters endParams = std::move(**res2);
   Vector3D surfaceCenter = endParams.referenceSurface().center(geoContext);
@@ -398,9 +402,11 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_parameter_estimation_test) {
   double z0_v = z;
 
   // Set up the ImpactPointEstimator
-  ImpactPointEstimator<BoundParameters, Propagator>::Config ipEstCfg(
+  using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
+  IPEstimator::Config ipEstCfg(
       bField, propagator);
-  ImpactPointEstimator<BoundParameters, Propagator> ipEstimator(ipEstCfg);
+  IPEstimator ipEstimator(ipEstCfg);
+  IPEstimator::State state;
 
   // Construct random track emerging from vicinity of vertex position
   // Vector to store track objects used for vertex fit

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     cfg.reassignTracksAfterFirstFit = true;
 
     VertexFinder finder(cfg);
-    VertexFinder::State state;
+    VertexFinder::State state(magFieldContext);
 
     // Vector to be filled with all tracks in current event
     std::vector<std::unique_ptr<const BoundParameters>> tracks;
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     cfg.reassignTracksAfterFirstFit = true;
 
     VertexFinder finder(cfg, extractParameters);
-    VertexFinder::State state;
+    VertexFinder::State state(magFieldContext);
 
     // Same for user track type tracks
     std::vector<std::unique_ptr<const InputTrack>> tracks;

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -83,8 +83,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
 
   // Set up ImpactPointEstimator, used for comparisons later
   using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
-  IPEstimator::Config ip3dEstConfig(
-      bField, propagator);
+  IPEstimator::Config ip3dEstConfig(bField, propagator);
   IPEstimator ip3dEst(ip3dEstConfig);
   IPEstimator::State state(magFieldContext);
 
@@ -164,7 +163,9 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
 
     // The new distance after update
     double newDistance =
-        ip3dEst.calculate3dDistance(geoContext, trkAtVtx.fittedParams, vtxPos, state)
+        ip3dEst
+            .calculate3dDistance(geoContext, trkAtVtx.fittedParams, vtxPos,
+                                 state)
             .value();
     if (debug) {
       std::cout << "Old distance: " << oldDistance << std::endl;

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -82,15 +82,17 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
   auto propagator = std::make_shared<Propagator>(stepper);
 
   // Set up ImpactPointEstimator, used for comparisons later
-  ImpactPointEstimator<BoundParameters, Propagator>::Config ip3dEstConfig(
+  using IPEstimator = ImpactPointEstimator<BoundParameters, Propagator>;
+  IPEstimator::Config ip3dEstConfig(
       bField, propagator);
-
-  ImpactPointEstimator<BoundParameters, Propagator> ip3dEst(ip3dEstConfig);
+  IPEstimator ip3dEst(ip3dEstConfig);
+  IPEstimator::State state(magFieldContext);
 
   // Set up HelicalTrackLinearizer, needed for linearizing the tracks
   // Linearizer for BoundParameters type test
   Linearizer::Config ltConfig(bField, propagator);
   Linearizer linearizer(ltConfig);
+  Linearizer::State linState(magFieldContext);
 
   // Create perigee surface at origin
   std::shared_ptr<PerigeeSurface> perigeeSurface =
@@ -135,7 +137,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
     LinearizedTrack linTrack =
         linearizer
             .linearizeTrack(params, SpacePointVector::Zero(), geoContext,
-                            magFieldContext)
+                            magFieldContext, linState)
             .value();
 
     // Create TrackAtVertex
@@ -157,12 +159,12 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
 
     // The old distance
     double oldDistance =
-        ip3dEst.calculate3dDistance(geoContext, fittedParamsCopy, vtxPos)
+        ip3dEst.calculate3dDistance(geoContext, fittedParamsCopy, vtxPos, state)
             .value();
 
     // The new distance after update
     double newDistance =
-        ip3dEst.calculate3dDistance(geoContext, trkAtVtx.fittedParams, vtxPos)
+        ip3dEst.calculate3dDistance(geoContext, trkAtVtx.fittedParams, vtxPos, state)
             .value();
     if (debug) {
       std::cout << "Old distance: " << oldDistance << std::endl;

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -84,6 +84,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
   // Linearizer for BoundParameters type test
   Linearizer::Config ltConfig(bField, propagator);
   Linearizer linearizer(ltConfig);
+  Linearizer::State state(magFieldContext);
 
   // Create perigee surface at origin
   std::shared_ptr<PerigeeSurface> perigeeSurface =
@@ -130,7 +131,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
     LinearizedTrack linTrack =
         linearizer
             .linearizeTrack(params, SpacePointVector::Zero(), geoContext,
-                            magFieldContext)
+                            magFieldContext, state)
             .value();
 
     // Create TrackAtVertex

--- a/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
@@ -125,6 +125,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
 
   Linearizer::Config ltConfig(bField, propagator);
   Linearizer linFactory(ltConfig);
+  Linearizer::State state;
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
@@ -137,7 +138,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
     LinearizedTrack linTrack =
         linFactory
             .linearizeTrack(parameters, SpacePointVector::Zero(), geoContext,
-                            magFieldContext)
+                            magFieldContext, state)
             .value();
 
     BOOST_CHECK_NE(linTrack.parametersAtPCA, vecBoundZero);
@@ -216,6 +217,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_straightline_test) {
   // magnetic field, which results in the extreme case of a straight line
   LinearizerStraightLine::Config ltConfig(propagator);
   LinearizerStraightLine linFactory(ltConfig);
+  LinearizerStraightLine::State state;
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
@@ -228,7 +230,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_straightline_test) {
     LinearizedTrack linTrack =
         linFactory
             .linearizeTrack(parameters, SpacePointVector::Zero(), geoContext,
-                            magFieldContext)
+                            magFieldContext, state)
             .value();
 
     BOOST_CHECK_NE(linTrack.parametersAtPCA, vecBoundZero);

--- a/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
 
   Linearizer::Config ltConfig(bField, propagator);
   Linearizer linFactory(ltConfig);
-  Linearizer::State state;
+  Linearizer::State state(magFieldContext);
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_straightline_test) {
   // magnetic field, which results in the extreme case of a straight line
   LinearizerStraightLine::Config ltConfig(propagator);
   LinearizerStraightLine linFactory(ltConfig);
-  LinearizerStraightLine::State state;
+  LinearizerStraightLine::State state(magFieldContext);
 
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();


### PR DESCRIPTION
This PR is similar to #306 but targets the release v0.27 branch.