### PR TITLE
Small CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ option(ACTS_BUILD_EXAMPLES_HEPMC3 "Build HepMC3-based code in the examples" OFF)
 option(ACTS_BUILD_EXAMPLES_PYTHIA8 "Build Pythia8-based code in the examples" OFF)
 # test related options
 option(ACTS_BUILD_BENCHMARKS "Build benchmarks" OFF)
-option(ACTS_BUILD_UNITTESTS "Build unit tests" OFF)
 option(ACTS_BUILD_INTEGRATIONTESTS "Build integration tests" OFF)
+option(ACTS_BUILD_UNITTESTS "Build unit tests" OFF)
 # other options
 option(ACTS_BUILD_DOCS "Build documentation" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,10 +188,10 @@ add_component_if(Fatras Fatras ACTS_BUILD_FATRAS)
 add_subdirectory_if(Examples ACTS_BUILD_EXAMPLES)
 
 # automated tests and benchmarks
-if(ACTS_BUILD_UNITTESTS OR ACTS_BUILD_INTEGRATIONTESTS)
+if(ACTS_BUILD_BENCHMARKS OR ACTS_BUILD_INTEGRATIONTESTS OR ACTS_BUILD_UNITTESTS)
   enable_testing() # must be set in the main CMakeLists.txt
+  add_subdirectory(Tests)
 endif()
-add_subdirectory(Tests)
 
 # documentation
 add_subdirectory_if(docs ACTS_BUILD_DOCS)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -246,8 +246,8 @@ components. q
 | ACTS_BUILD_EXAMPLES_HEPMC3            | Build HepMC3-based code in the examples |
 | ACTS_BUILD_EXAMPLES_PYTHIA8           | Build Pythia8-based code in the examples |
 | ACTS_BUILD_BENCHMARKS                 | Build benchmarks |
-| ACTS_BUILD_UNITTESTS                  | Build unit tests |
 | ACTS_BUILD_INTEGRATIONTESTS           | Build integration tests |
+| ACTS_BUILD_UNITTESTS                  | Build unit tests |
 | ACTS_BUILD_DOCS                       | Build documentation |
 
 All Acts-specific options are disabled or empty by default (except for


### PR DESCRIPTION
- Add `Tests` subdirectory only if at least one test-like option is active.
- Order test-related options alphabetically.
