### PR TITLE
Consistent nested track parameters vector/matrix types

### DIFF
--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -26,8 +26,9 @@ namespace Acts {
 template <class ChargePolicy>
 class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
  public:
-  using ParVector_t = typename SingleTrackParameters<ChargePolicy>::ParVector_t;
-  using CovMatrix_t = typename SingleTrackParameters<ChargePolicy>::CovMatrix_t;
+  using Scalar = BoundParametersScalar;
+  using ParametersVector = BoundVector;
+  using CovarianceMatrix = BoundSymMatrix;
 
   /// @brief Constructor of track parameters bound to a surface
   /// This is the constructor from global parameters, enabled only
@@ -44,8 +45,8 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, ChargedPolicy>::value, int> = 0>
   SingleBoundTrackParameters(const GeometryContext& gctx,
-                             std::optional<CovMatrix_t> cov,
-                             const ParVector_t& parValues,
+                             std::optional<CovarianceMatrix> cov,
+                             const ParametersVector& parValues,
                              std::shared_ptr<const Surface> surface)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov), parValues,
@@ -76,9 +77,9 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, ChargedPolicy>::value, int> = 0>
   SingleBoundTrackParameters(const GeometryContext& gctx,
-                             std::optional<CovMatrix_t> cov,
+                             std::optional<CovarianceMatrix> cov,
                              const Vector3D& position, const Vector3D& momentum,
-                             double dCharge, double dTime,
+                             Scalar dCharge, Scalar dTime,
                              std::shared_ptr<const Surface> surface)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov),
@@ -105,8 +106,8 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, NeutralPolicy>::value, int> = 0>
   SingleBoundTrackParameters(const GeometryContext& gctx,
-                             std::optional<CovMatrix_t> cov,
-                             const ParVector_t& parValues,
+                             std::optional<CovarianceMatrix> cov,
+                             const ParametersVector& parValues,
                              std::shared_ptr<const Surface> surface)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov), parValues,
@@ -137,9 +138,9 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, NeutralPolicy>::value, int> = 0>
   SingleBoundTrackParameters(const GeometryContext& gctx,
-                             std::optional<CovMatrix_t> cov,
+                             std::optional<CovarianceMatrix> cov,
                              const Vector3D& position, const Vector3D& momentum,
-                             double dTime,
+                             Scalar dTime,
                              std::shared_ptr<const Surface> surface)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov),
@@ -196,7 +197,7 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
   /// @param[in] gctx is the Context object that is forwarded to the surface
   ///            for local to global coordinate transformation
   template <ParID_t par>
-  void set(const GeometryContext& gctx, ParValue_t newValue) {
+  void set(const GeometryContext& gctx, Scalar newValue) {
     this->getParameterSet().template setParameter<par>(newValue);
     this->updateGlobalCoordinates(gctx, BoundParameterType<par>());
   }

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -26,8 +26,9 @@ template <typename ChargePolicy>
 class SingleCurvilinearTrackParameters
     : public SingleTrackParameters<ChargePolicy> {
  public:
-  /// type of covariance matrix
-  using CovMatrix_t = typename SingleTrackParameters<ChargePolicy>::CovMatrix_t;
+  using Scalar = BoundParametersScalar;
+  using ParametersVector = BoundVector;
+  using CovarianceMatrix = BoundSymMatrix;
 
   /// @brief constructor for curvilienear representation
   /// This is the constructor from global parameters, enabled only
@@ -39,10 +40,10 @@ class SingleCurvilinearTrackParameters
   /// @param[in] dCharge The charge of this track parameterisation
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, ChargedPolicy>::value, int> = 0>
-  SingleCurvilinearTrackParameters(std::optional<CovMatrix_t> cov,
+  SingleCurvilinearTrackParameters(std::optional<CovarianceMatrix> cov,
                                    const Vector3D& position,
-                                   const Vector3D& momentum, double dCharge,
-                                   double dTime)
+                                   const Vector3D& momentum, Scalar dCharge,
+                                   Scalar dTime)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov),
             detail::coordinate_transformation::global2curvilinear(
@@ -59,9 +60,9 @@ class SingleCurvilinearTrackParameters
   /// @param[in] momentum The global momentum of this track parameterisation
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, NeutralPolicy>::value, int> = 0>
-  SingleCurvilinearTrackParameters(std::optional<CovMatrix_t> cov,
+  SingleCurvilinearTrackParameters(std::optional<CovarianceMatrix> cov,
                                    const Vector3D& position,
-                                   const Vector3D& momentum, double dTime)
+                                   const Vector3D& momentum, Scalar dTime)
       : SingleTrackParameters<ChargePolicy>(
             std::move(cov),
             detail::coordinate_transformation::global2curvilinear(
@@ -125,7 +126,7 @@ class SingleCurvilinearTrackParameters
       ParID_t par,
       std::enable_if_t<std::is_same_v<BoundParameterType<par>, local_parameter>,
                        int> = 0>
-  void set(const GeometryContext& gctx, ParValue_t newValue) {
+  void set(const GeometryContext& gctx, Scalar newValue) {
     // set the parameter & update the new global position
     this->getParameterSet().template setParameter<par>(newValue);
     this->updateGlobalCoordinates(gctx, BoundParameterType<par>());
@@ -150,7 +151,7 @@ class SingleCurvilinearTrackParameters
             std::enable_if_t<
                 not std::is_same_v<BoundParameterType<par>, local_parameter>,
                 int> = 0>
-  void set(const GeometryContext& gctx, ParValue_t newValue) {
+  void set(const GeometryContext& gctx, Scalar newValue) {
     this->getParameterSet().template setParameter<par>(newValue);
     this->updateGlobalCoordinates(gctx, BoundParameterType<par>());
     // recreate the surface

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -82,7 +82,7 @@ class SingleFreeTrackParameters {
 
   /// @brief Access track parameter uncertainty
   ///
-  /// @tparam kIndex Identifier of the parameter index which will be retrieved
+  /// @tparam kIndex Identifier of the uncertainty index which will be retrieved
   ///
   /// @return Value of the requested parameter uncertainty
   template <FreeParametersIndices kIndex>
@@ -94,8 +94,6 @@ class SingleFreeTrackParameters {
   ///
   /// @note The ownership of the covariance matrix is @b not transferred
   /// with this call.
-  ///
-  /// @return Raw pointer to covariance matrix (can be a nullptr)
   ///
   /// @sa ParameterSet::getCovariance
   const std::optional<CovarianceMatrix>& covariance() const {
@@ -160,7 +158,7 @@ class SingleFreeTrackParameters {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param newValue The new updaed value
-  /// @tparam kIndex Identifier of the parameter index which will be retrieved
+  /// @tparam kIndex Identifier of the parameter index which will be set
   ///
   /// @note The context is not used here but makes the API consistent with
   /// @c SingleCurvilinearTrackParameters and @c SingleBoundTrackParameters

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -35,9 +35,9 @@ class SingleFreeTrackParameters {
                 "'Acts::NeutralPolicy");
 
  public:
-  /// Public typedefs
-  /// Type of covariance matrix
-  using CovMatrix_t = FreeSymMatrix;
+  using Scalar = FreeParametersScalar;
+  using ParametersVector = FreeVector;
+  using CovarianceMatrix = FreeSymMatrix;
 
   /// Construct track parameters for charged particles.
   ///
@@ -46,8 +46,8 @@ class SingleFreeTrackParameters {
   /// @param [in] parValues Vector with parameter values
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, ChargedPolicy>::value, int> = 0>
-  SingleFreeTrackParameters(std::optional<CovMatrix_t> cov,
-                            const FreeVector& parValues)
+  SingleFreeTrackParameters(std::optional<CovarianceMatrix> cov,
+                            const ParametersVector& parValues)
       : m_oParameters(std::move(cov), parValues),
         m_oChargePolicy(std::copysign(1., parValues[eFreeQOverP])) {}
 
@@ -58,8 +58,8 @@ class SingleFreeTrackParameters {
   /// @param [in] parValues Vector with parameter values
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, NeutralPolicy>::value, int> = 0>
-  SingleFreeTrackParameters(std::optional<CovMatrix_t> cov,
-                            const FreeVector& parValues)
+  SingleFreeTrackParameters(std::optional<CovarianceMatrix> cov,
+                            const ParametersVector& parValues)
       : m_oParameters(std::move(cov), parValues), m_oChargePolicy() {}
 
   // this class does not have a custom default constructor and thus should not
@@ -68,7 +68,7 @@ class SingleFreeTrackParameters {
   /// @brief Access all parameters
   ///
   /// @return Vector containing the store parameters
-  FreeVector parameters() const { return m_oParameters.getParameters(); }
+  ParametersVector parameters() const { return m_oParameters.getParameters(); }
 
   /// @brief Access to a single parameter
   ///
@@ -76,8 +76,8 @@ class SingleFreeTrackParameters {
   ///
   /// @return Value of the requested parameter
   template <FreeParametersIndices kIndex,
-            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> ParValue_t
-                get() const {
+            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> Scalar get()
+                const {
     return m_oParameters.template getParameter<kIndex>();
   }
 
@@ -88,7 +88,7 @@ class SingleFreeTrackParameters {
   ///
   /// @return Value of the requested parameter uncertainty
   template <FreeParametersIndices kIndex,
-            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> ParValue_t
+            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> Scalar
                 uncertainty() const {
     return m_oParameters.template getUncertainty<kIndex>();
   }
@@ -101,7 +101,7 @@ class SingleFreeTrackParameters {
   /// @return Raw pointer to covariance matrix (can be a nullptr)
   ///
   /// @sa ParameterSet::getCovariance
-  const std::optional<CovMatrix_t>& covariance() const {
+  const std::optional<CovarianceMatrix>& covariance() const {
     return m_oParameters.getCovariance();
   }
 
@@ -123,12 +123,12 @@ class SingleFreeTrackParameters {
   /// @brief retrieve electric charge
   ///
   /// @return value of electric charge
-  double charge() const { return m_oChargePolicy.getCharge(); }
+  Scalar charge() const { return m_oChargePolicy.getCharge(); }
 
   /// @brief retrieve time
   ///
   /// @return value of time
-  double time() const { return get<eFreeTime>(); }
+  Scalar time() const { return get<eFreeTime>(); }
 
   /// @brief access to the internally stored FreeParameterSet
   ///

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -75,21 +75,18 @@ class SingleFreeTrackParameters {
   /// @tparam kIndex Identifier of the parameter index which will be retrieved
   ///
   /// @return Value of the requested parameter
-  template <FreeParametersIndices kIndex,
-            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> Scalar get()
-                const {
+  template <FreeParametersIndices kIndex>
+  Scalar get() const {
     return m_oParameters.template getParameter<kIndex>();
   }
 
   /// @brief Access track parameter uncertainty
   ///
-  /// @tparam par Identifier of the parameter uncertainty index which will
-  /// be retrieved
+  /// @tparam kIndex Identifier of the parameter index which will be retrieved
   ///
   /// @return Value of the requested parameter uncertainty
-  template <FreeParametersIndices kIndex,
-            std::enable_if_t<kIndex<eFreeParametersSize, int> = 0> Scalar
-                uncertainty() const {
+  template <FreeParametersIndices kIndex>
+  Scalar uncertainty() const {
     return m_oParameters.template getUncertainty<kIndex>();
   }
 
@@ -161,16 +158,15 @@ class SingleFreeTrackParameters {
 
   /// @brief Update of the parameterisation
   ///
-  /// @tparam par The parameter index
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param newValue The new updaed value
+  /// @tparam kIndex Identifier of the parameter index which will be retrieved
   ///
   /// @note The context is not used here but makes the API consistent with
   /// @c SingleCurvilinearTrackParameters and @c SingleBoundTrackParameters
-  template <FreeParametersIndices par,
-            std::enable_if_t<par<eFreeParametersSize, int> = 0> void set(
-                const GeometryContext& /*gctx*/, ParValue_t newValue) {
-    m_oParameters.setParameter<par>(newValue);
+  template <FreeParametersIndices kIndex>
+  void set(const GeometryContext& /*gctx*/, Scalar newValue) {
+    m_oParameters.setParameter<kIndex>(newValue);
   }
 
   /// @brief Print information to output stream

--- a/Core/include/Acts/EventData/SingleTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleTrackParameters.hpp
@@ -104,8 +104,6 @@ class SingleTrackParameters {
   /// @note The ownership of the covariance matrix is @b not transferred with
   /// this call.
   ///
-  /// @return raw pointer to covariance matrix (can be a nullptr)
-  ///
   /// @sa ParameterSet::getCovariance
   const std::optional<CovarianceMatrix>& covariance() const {
     return getParameterSet().getCovariance();

--- a/Core/include/Acts/EventData/SingleTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleTrackParameters.hpp
@@ -42,12 +42,11 @@ class SingleTrackParameters {
 
  public:
   // public typedef's
-
+  using Scalar = BoundParametersScalar;
   /// vector type for stored track parameters
-  using ParVector_t = BoundVector;
-
+  using ParametersVector = BoundVector;
   /// type of covariance matrix
-  using CovMatrix_t = BoundSymMatrix;
+  using CovarianceMatrix = BoundSymMatrix;
 
   /// @brief default destructor
   virtual ~SingleTrackParameters() = default;
@@ -81,12 +80,12 @@ class SingleTrackParameters {
   /// @brief retrieve electric charge
   ///
   /// @return value of electric charge
-  double charge() const { return m_oChargePolicy.getCharge(); }
+  Scalar charge() const { return m_oChargePolicy.getCharge(); }
 
   /// @brief retrieve time
   ///
   /// @return value of time
-  double time() const { return get<ParDef::eT>(); }
+  Scalar time() const { return get<eBoundTime>(); }
 
   /// @brief access to the internally stored ParameterSet
   ///
@@ -108,7 +107,7 @@ class SingleTrackParameters {
   /// @return raw pointer to covariance matrix (can be a nullptr)
   ///
   /// @sa ParameterSet::getCovariance
-  const std::optional<CovMatrix_t>& covariance() const {
+  const std::optional<CovarianceMatrix>& covariance() const {
     return getParameterSet().getCovariance();
   }
 
@@ -117,7 +116,9 @@ class SingleTrackParameters {
   /// @return Eigen vector of dimension Acts::eBoundParametersSize with values
   /// of the track parameters
   ///         (in the order as defined by the ParID_t enumeration)
-  ParVector_t parameters() const { return getParameterSet().getParameters(); }
+  ParametersVector parameters() const {
+    return getParameterSet().getParameters();
+  }
 
   /// @brief access track parameter
   ///
@@ -126,8 +127,8 @@ class SingleTrackParameters {
   /// @return value of the requested track parameter
   ///
   /// @sa ParameterSet::get
-  template <ParID_t par>
-  ParValue_t get() const {
+  template <BoundParametersIndices par>
+  Scalar get() const {
     return getParameterSet().template getParameter<par>();
   }
 
@@ -136,16 +137,16 @@ class SingleTrackParameters {
   /// @tparam par identifier of track parameter which is to be retrieved
   ///
   /// @return value of the requested track parameter uncertainty
-  template <ParID_t par>
-  ParValue_t uncertainty() const {
+  template <BoundParametersIndices par>
+  Scalar uncertainty() const {
     return getParameterSet().template getUncertainty<par>();
   }
 
   /// @brief convenience method to retrieve transverse momentum
-  double pT() const { return VectorHelpers::perp(momentum()); }
+  Scalar pT() const { return VectorHelpers::perp(momentum()); }
 
   /// @brief convenience method to retrieve pseudorapidity
-  double eta() const { return VectorHelpers::eta(momentum()); }
+  Scalar eta() const { return VectorHelpers::eta(momentum()); }
 
   FullParameterSet& getParameterSet() { return m_oParameters; }
 
@@ -171,9 +172,9 @@ class SingleTrackParameters {
   /// @param momentum 3D vector with global momentum
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, ChargedPolicy>::value, int> = 0>
-  SingleTrackParameters(std::optional<CovMatrix_t> cov,
-                        const ParVector_t& parValues, const Vector3D& position,
-                        const Vector3D& momentum)
+  SingleTrackParameters(std::optional<CovarianceMatrix> cov,
+                        const ParametersVector& parValues,
+                        const Vector3D& position, const Vector3D& momentum)
       : m_oChargePolicy(
             detail::coordinate_transformation::parameters2charge(parValues)),
         m_oParameters(std::move(cov), parValues),
@@ -188,9 +189,9 @@ class SingleTrackParameters {
   /// @param momentum 3D vector with global momentum
   template <typename T = ChargePolicy,
             std::enable_if_t<std::is_same<T, NeutralPolicy>::value, int> = 0>
-  SingleTrackParameters(std::optional<CovMatrix_t> cov,
-                        const ParVector_t& parValues, const Vector3D& position,
-                        const Vector3D& momentum)
+  SingleTrackParameters(std::optional<CovarianceMatrix> cov,
+                        const ParametersVector& parValues,
+                        const Vector3D& position, const Vector3D& momentum)
       : m_oChargePolicy(),
         m_oParameters(std::move(cov), parValues),
         m_vPosition(position),

--- a/Core/include/Acts/EventData/TrackParametersConcept.hpp
+++ b/Core/include/Acts/EventData/TrackParametersConcept.hpp
@@ -20,9 +20,11 @@ using namespace Acts::concept;
 
 // nested types that must be available
 template <typename T>
-using TypeParametersVector = typename T::ParVector_t;
+using TypeScalar = typename T::Scalar;
 template <typename T>
-using TypeCovarianceMatrix = typename T::CovMatrix_t;
+using TypeParametersVector = typename T::ParametersVector;
+template <typename T>
+using TypeCovarianceMatrix = typename T::CovarianceMatrix;
 
 template <typename T>
 using ReturnTypeReferenceSurface =
@@ -43,6 +45,7 @@ using ReturnTypeCharge = decltype(std::declval<T>().charge());
 template <typename T>
 struct BoundTrackParametersConceptImpl {
   // check for required nested types
+  constexpr static bool hasTypeScalar = exists<TypeScalar, const T>;
   constexpr static bool hasTypeParametersVector =
       exists<TypeParametersVector, const T>;
   constexpr static bool hasTypeCovarianceMatrix =
@@ -66,6 +69,7 @@ struct BoundTrackParametersConceptImpl {
       identical_to<double, ReturnTypeCharge, const T>;
 
   // provide meaningful error messages in case of non-compliance
+  static_assert(hasTypeScalar, "Scalar type is missing");
   static_assert(hasTypeParametersVector, "Parameters vector type is missing");
   static_assert(hasTypeCovarianceMatrix, "Covariance matrix type is missing");
   static_assert(hasMethodReferenceSurface,
@@ -78,7 +82,7 @@ struct BoundTrackParametersConceptImpl {
   static_assert(hasMethodCharge, "Missing/ invvalid 'charge' method");
 
   constexpr static bool value =
-      require<hasTypeParametersVector, hasTypeCovarianceMatrix,
+      require<hasTypeScalar, hasTypeParametersVector, hasTypeCovarianceMatrix,
               hasMethodReferenceSurface, hasMethodParameters,
               hasMethodCovariance, hasMethodPosition, hasMethodTime,
               hasMethodMomentum, hasMethodCharge>;
@@ -87,6 +91,9 @@ struct BoundTrackParametersConceptImpl {
 template <typename T>
 struct FreeTrackParametersConceptImpl {
   // check for required nested types
+  constexpr static bool hasTypeScalar = exists<TypeScalar, const T>;
+  constexpr static bool hasTypeParametersVector =
+      exists<TypeParametersVector, const T>;
   constexpr static bool hasTypeCovarianceMatrix =
       exists<TypeCovarianceMatrix, const T>;
 
@@ -106,6 +113,8 @@ struct FreeTrackParametersConceptImpl {
       identical_to<double, ReturnTypeCharge, const T>;
 
   // provide meaningful error messages in case of non-compliance
+  static_assert(hasTypeScalar, "Scalar type is missing");
+  static_assert(hasTypeParametersVector, "Parameters vector type is missing");
   static_assert(hasTypeCovarianceMatrix, "Covariance matrix type is missing");
   static_assert(hasMethodParameters, "Missing/ invvalid 'parameters' method");
   static_assert(hasMethodCovariance, "Missing/ invvalid 'covariance' method");
@@ -115,9 +124,9 @@ struct FreeTrackParametersConceptImpl {
   static_assert(hasMethodCharge, "Missing/ invvalid 'charge' method");
 
   constexpr static bool value =
-      require<hasTypeCovarianceMatrix, hasMethodParameters, hasMethodCovariance,
-              hasMethodPosition, hasMethodTime, hasMethodMomentum,
-              hasMethodCharge>;
+      require<hasTypeScalar, hasTypeParametersVector, hasTypeCovarianceMatrix,
+              hasMethodParameters, hasMethodCovariance, hasMethodPosition,
+              hasMethodTime, hasMethodMomentum, hasMethodCharge>;
 };
 
 template <typename parameters_t>

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -38,7 +38,7 @@ std::pair<ActsMatrixX<BoundParametersScalar>,
 globalTrackParametersCovariance(
     const Acts::MultiTrajectory<source_link_t>& multiTraj,
     const size_t& entryIndex) {
-  using CovMatrix = typename parameters_t::CovMatrix_t;
+  using CovMatrix = typename parameters_t::CovarianceMatrix;
   using GainMatrix = CovMatrix;
 
   // The last smoothed state index

--- a/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
+++ b/Core/include/Acts/TrackFinder/CKFSourceLinkSelector.hpp
@@ -86,8 +86,6 @@ struct CKFSourceLinkSelector {
       std::vector<size_t>& sourcelinkCandidateIndices, bool& isOutlier) const {
     ACTS_VERBOSE("Invoked CKFSourceLinkSelector");
 
-    using CovMatrix_t = typename BoundParameters::CovMatrix_t;
-
     // Return error if no source link
     if (sourcelinks.empty()) {
       return CombinatorialKalmanFilterError::SourcelinkSelectionFailed;
@@ -123,22 +121,12 @@ struct CKFSourceLinkSelector {
             // The measurement surface should be the same as parameter surface
             assert(&calibrated.referenceSurface() == surface);
 
-            // type of measurement
-            using meas_t =
-                typename std::remove_const<typename std::remove_reference<
-                    decltype(calibrated)>::type>::type;
-            // measurement (local) parameter vector
-            using meas_par_t = typename meas_t::ParameterVector;
-            // type of projection
-            using projection_t = typename meas_t::Projection;
-
             // Take the projector (measurement mapping function)
-            const projection_t& H = calibrated.projector();
+            const auto& H = calibrated.projector();
             // Take the parameter covariance
-            const CovMatrix_t& predicted_covariance =
-                *predictedParams.covariance();
+            const auto& predicted_covariance = *predictedParams.covariance();
             // Get the residual
-            meas_par_t residual = calibrated.residual(predictedParams);
+            const auto& residual = calibrated.residual(predictedParams);
             // Get the chi2
             double chi2 = (residual.transpose() *
                            ((calibrated.covariance() +

--- a/Examples/Framework/include/ACTFW/Validation/ResPlotTool.hpp
+++ b/Examples/Framework/include/ACTFW/Validation/ResPlotTool.hpp
@@ -24,8 +24,6 @@ namespace FW {
 // truth_parameter)/smoothed_paramter_error, of track parameters at perigee
 // surface
 class ResPlotTool {
-  using ParVector_t = typename Acts::BoundParameters::ParVector_t;
-
  public:
   /// @brief Nested configuration struct
   struct Config {

--- a/Examples/Framework/src/Validation/ResPlotTool.cpp
+++ b/Examples/Framework/src/Validation/ResPlotTool.cpp
@@ -135,6 +135,7 @@ void FW::ResPlotTool::fill(ResPlotTool::ResPlotCache& resPlotCache,
                            const Acts::GeometryContext& gctx,
                            const ActsFatras::Particle& truthParticle,
                            const Acts::BoundParameters& fittedParamters) const {
+  using ParametersVector = Acts::BoundParameters::ParametersVector;
   using Acts::VectorHelpers::eta;
   using Acts::VectorHelpers::perp;
   using Acts::VectorHelpers::phi;
@@ -148,7 +149,7 @@ void FW::ResPlotTool::fill(ResPlotTool::ResPlotCache& resPlotCache,
   auto pSurface = &fittedParamters.referenceSurface();
 
   // get the truth position and momentum
-  ParVector_t truthParameter;
+  ParametersVector truthParameter = ParametersVector::Zero();
 
   // get the truth perigee parameter
   Acts::Vector2D local(0., 0.);

--- a/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
@@ -75,7 +75,7 @@ BOOST_DATA_TEST_CASE(
   // l_x, l_y, phi, theta, q/p (1/p), t
   std::array<double, 6> pars_array = {
       {-0.1234, 9.8765, 0.45, 0.888, 0.001, 21.}};
-  SingleBoundTrackParameters<ChargedPolicy>::ParVector_t pars;
+  SingleBoundTrackParameters<ChargedPolicy>::ParametersVector pars;
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 
@@ -182,7 +182,7 @@ BOOST_DATA_TEST_CASE(
   // now create parameters on this surface
   // r, phi, phi, theta, q/p (1/p), t
   std::array<double, 6> pars_array = {{125., 0.345, 0.45, 0.888, 0.001, 21.}};
-  SingleBoundTrackParameters<ChargedPolicy>::ParVector_t pars;
+  SingleBoundTrackParameters<ChargedPolicy>::ParametersVector pars;
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 
@@ -267,7 +267,7 @@ BOOST_DATA_TEST_CASE(
   // now create parameters on this surface
   // rPhi, a, phi, theta, q/p (1/p), t
   std::array<double, 6> pars_array = {{125., 343., 0.45, 0.888, 0.001, 21.}};
-  SingleBoundTrackParameters<ChargedPolicy>::ParVector_t pars;
+  SingleBoundTrackParameters<ChargedPolicy>::ParametersVector pars;
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 
@@ -362,7 +362,7 @@ BOOST_DATA_TEST_CASE(
   // now create parameters on this surface
   // d0, z0, phi, theta, q/p (1/p), t
   std::array<double, 6> pars_array = {{-0.7321, 22.5, 0.45, 0.888, 0.001, 21.}};
-  SingleBoundTrackParameters<ChargedPolicy>::ParVector_t pars;
+  SingleBoundTrackParameters<ChargedPolicy>::ParametersVector pars;
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 
@@ -436,7 +436,7 @@ BOOST_DATA_TEST_CASE(
   // now create parameters on this surface
   // r, z, phi, theta, q/p (1/p), t
   std::array<double, 6> pars_array = {{0.2321, 22.5, 0.45, 0.888, 0.001, 21.}};
-  SingleBoundTrackParameters<ChargedPolicy>::ParVector_t pars;
+  SingleBoundTrackParameters<ChargedPolicy>::ParametersVector pars;
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -39,8 +39,8 @@ CurvilinearParameters make_params() {
   return {cov, Vector3D(0, 0, 1), Vector3D(100, 1000, 400), -1, 0};
 }
 
-using ParVec_t = BoundParameters::ParVector_t;
-using CovMat_t = BoundParameters::CovMatrix_t;
+using ParVec_t = BoundParameters::ParametersVector;
+using CovMat_t = BoundParameters::CovarianceMatrix;
 
 struct TestTrackState {
   SourceLink sourceLink;

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -21,11 +21,9 @@
 namespace Acts {
 namespace Test {
 
-using Jacobian = BoundParameters::CovMatrix_t;
+using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
-
 using SourceLink = MinimalSourceLink;
-
 template <ParID_t... params>
 using MeasurementType = Measurement<SourceLink, params...>;
 

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -22,11 +22,9 @@
 namespace Acts {
 namespace Test {
 
-using Jacobian = BoundParameters::CovMatrix_t;
+using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
-
 using SourceLink = MinimalSourceLink;
-
 template <ParID_t... params>
 using MeasurementType = Measurement<SourceLink, params...>;
 

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -47,14 +47,13 @@ namespace Test {
 
 // A few initialisations and definitionas
 using SourceLink = MinimalSourceLink;
-using Jacobian = BoundParameters::CovMatrix_t;
+using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 
 using Resolution = std::pair<ParID_t, double>;
 using ElementResolution = std::vector<Resolution>;
 using VolumeResolution = std::map<GeometryID::Value, ElementResolution>;
 using DetectorResolution = std::map<GeometryID::Value, VolumeResolution>;
-
 using DebugOutput = DebugOutputActor;
 
 std::normal_distribution<double> gauss(0., 1.);

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -68,9 +68,8 @@ GeometryID makeId(int volume = 0, int layer = 0, int sensitive = 0) {
 
 // A few initialisations and definitionas
 using SourceLink = ExtendedMinimalSourceLink;
-using Jacobian = BoundParameters::CovMatrix_t;
+using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
-
 using Resolution = std::pair<ParID_t, double>;
 using ElementResolution = std::vector<Resolution>;
 using VolumeResolution = std::map<GeometryID::Value, ElementResolution>;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
     int vtxIdx = (int)(iTrack / nTracksPerVtx);
 
     // Construct random track parameters
-    BoundParameters::ParVector_t paramVec;
+    BoundParameters::ParametersVector paramVec;
     paramVec << d0Dist(gen), z0Dist(gen), phiDist(gen), thetaDist(gen),
         q / pTDist(gen), 0.;
 

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
     }
 
     // The track parameters
-    BoundParameters::ParVector_t paramVec;
+    BoundParameters::ParametersVector paramVec;
     paramVec << d0, z0, phiDist(gen), thetaDist(gen), q / pTDist(gen), 0.;
 
     // Corresponding surface
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_compatibility_test) {
     double z0 = z0Dist(gen);
 
     // The track parameters
-    BoundParameters::ParVector_t paramVec;
+    BoundParameters::ParametersVector paramVec;
     paramVec << d0, z0, phiDist(gen), thetaDist(gen), q / pTDist(gen), 0.;
 
     // Corresponding surface

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
     double q = qDist(gen) < 0 ? -1. : 1.;
 
     // Construct random track parameters
-    BoundParameters::ParVector_t paramVec;
+    BoundParameters::ParametersVector paramVec;
 
     paramVec << d0Dist(gen), z0Dist(gen), phiDist(gen), thetaDist(gen),
         q / pTDist(gen), 0.;

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
     double q = qDist(gen) < 0 ? -1. : 1.;
 
     // Construct random track parameters around origin
-    BoundParameters::ParVector_t paramVec;
+    BoundParameters::ParametersVector paramVec;
 
     paramVec << d0Dist(gen), z0Dist(gen), phiDist(gen), thetaDist(gen),
         q / pTDist(gen), 0.;

--- a/Tests/UnitTests/Core/Visualization/EventDataViewBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataViewBase.hpp
@@ -79,7 +79,8 @@ static inline std::string testBoundParameters(IVisualization& helper) {
   std::array<double, 6> pars_array = {
       {-0.1234, 4.8765, 0.45, 0.128, 0.001, 21.}};
 
-  BoundParameters::ParVector_t pars = BoundParameters::ParVector_t::Zero();
+  BoundParameters::ParametersVector pars =
+      BoundParameters::ParametersVector::Zero();
   pars << pars_array[0], pars_array[1], pars_array[2], pars_array[3],
       pars_array[4], pars_array[5];
 


### PR DESCRIPTION
This PR ensures consistently named nested typedefs for the underlying scalar/vector/matrix types of all concrete track parameters classes. All track parameters types provide `Scalar`, `ParametersVector`, and `CovarianveMatrix` typedefs. The longer names are chosen over just `Parameters` and `Covariance` to avoid any confusion between the raw vectors and the track parameters types (that store parameters and covariance). The `{Bound,Free}TrackParametersConcept` are adapted accordingly.

This is the second smaller PR split from #298.