### PR TITLE
Add print helpers for track parameters

### DIFF
--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -7,7 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/EventData/SingleTrackParameters.hpp"
+#include "Acts/EventData/detail/PrintParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
@@ -223,6 +225,15 @@ class SingleBoundTrackParameters : public SingleTrackParameters<ChargePolicy> {
 
  private:
   std::shared_ptr<const Surface> m_pSurface;
+
+  /// Print information to the output stream.
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const SingleBoundTrackParameters& tp) {
+    detail::printBoundParameters(
+        os, tp.referenceSurface(), tp.parameters(),
+        tp.covariance().has_value() ? &tp.covariance().value() : nullptr);
+    return os;
+  }
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -7,8 +7,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include <memory>
+
 #include "Acts/EventData/SingleTrackParameters.hpp"
+#include "Acts/EventData/detail/PrintParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 
@@ -177,5 +180,14 @@ class SingleCurvilinearTrackParameters
 
  private:
   std::shared_ptr<PlaneSurface> m_upSurface;
+
+  /// Print information to the output stream.
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const SingleCurvilinearTrackParameters& tp) {
+    detail::printBoundParameters(
+        os, tp.referenceSurface(), tp.parameters(),
+        tp.covariance().has_value() ? &tp.covariance().value() : nullptr);
+    return os;
+  }
 };
 }  // namespace Acts

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -165,17 +165,6 @@ class SingleFreeTrackParameters {
     m_oParameters.setParameter<kIndex>(newValue);
   }
 
-  /// Print information to the output stream.
-  ///
-  /// @param os The output stream
-  /// @return The modified output stream
-  std::ostream& print(std::ostream& os) const {
-    detail::printFreeParameters(
-        os, parameters(),
-        covariance().has_value() ? &covariance().value() : nullptr);
-    return os;
-  }
-
  private:
   FullFreeParameterSet
       m_oParameters;             ///< FreeParameterSet object holding the
@@ -186,7 +175,9 @@ class SingleFreeTrackParameters {
   /// Print information to the output stream.
   friend std::ostream& operator<<(std::ostream& os,
                                   const SingleFreeTrackParameters& tp) {
-    tp.print(os);
+    detail::printFreeParameters(
+        os, tp.parameters(),
+        tp.covariance().has_value() ? &tp.covariance().value() : nullptr);
     return os;
   }
 };

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -8,10 +8,8 @@
 
 #pragma once
 
-#include <iomanip>
-#include <ostream>
-
 #include "Acts/EventData/ParameterSet.hpp"
+#include "Acts/EventData/detail/PrintParameters.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 namespace Acts {
@@ -167,44 +165,15 @@ class SingleFreeTrackParameters {
     m_oParameters.setParameter<kIndex>(newValue);
   }
 
-  /// @brief Print information to output stream
+  /// Print information to the output stream.
   ///
-  /// @param [in, out] sl The output stream
-  ///
-  /// @return The modified output stream object @p sl
-  std::ostream& print(std::ostream& sl) const {
-    // Set stream output format
-    auto old_precision = sl.precision(7);
-    auto old_flags = sl.setf(std::ios::fixed);
-
-    // Fill stream with content
-    sl << " * FreeTrackParameters: ";
-    sl << parameters().transpose() << std::endl;
-    sl << " * charge: " << charge() << std::endl;
-    if (covariance().has_value()) {
-      sl << " * covariance matrix:\n" << *covariance() << std::endl;
-    } else {
-      sl << " * no covariance matrix stored" << std::endl;
-    }
-
-    // Reset stream format
-    sl.precision(old_precision);
-    sl.setf(old_flags);
-
-    return sl;
-  }
-
-  /// @brief Output stream operator
-  ///
-  /// Prints information about this object to the output stream
-  /// @param [in, out] out The output stream
-  /// @param [in] sfp The object that will be printed
-  ///
-  /// @return Modified output stream object
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const SingleFreeTrackParameters& sfp) {
-    sfp.print(out);
-    return out;
+  /// @param os The output stream
+  /// @return The modified output stream
+  std::ostream& print(std::ostream& os) const {
+    detail::printFreeParameters(
+        os, parameters(),
+        covariance().has_value() ? &covariance().value() : nullptr);
+    return os;
   }
 
  private:
@@ -213,5 +182,13 @@ class SingleFreeTrackParameters {
                                  /// parameter values and covariance matrix
   ChargePolicy m_oChargePolicy;  ///< charge policy object distinguishing
                                  /// between charged and neutral tracks
+
+  /// Print information to the output stream.
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const SingleFreeTrackParameters& tp) {
+    tp.print(os);
+    return os;
+  }
 };
+
 }  // namespace Acts

--- a/Core/include/Acts/EventData/SingleTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleTrackParameters.hpp
@@ -148,19 +148,6 @@ class SingleTrackParameters {
 
   FullParameterSet& getParameterSet() { return m_oParameters; }
 
-  /// @brief output stream operator
-  ///
-  /// Prints information about this object to the output stream using the
-  /// virtual
-  /// TrackParameters::print method.
-  ///
-  /// @return modified output stream object
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const SingleTrackParameters& stp) {
-    stp.print(out);
-    return out;
-  }
-
  protected:
   /// @brief standard constructor for track parameters of charged particles
   ///
@@ -257,35 +244,6 @@ class SingleTrackParameters {
                                const local_parameter& /*unused*/) {
     m_vPosition = detail::coordinate_transformation::parameters2globalPosition(
         gctx, getParameterSet().getParameters(), this->referenceSurface());
-  }
-
-  /// @brief print information to output stream
-  ///
-  /// @return modified output stream object
-  std::ostream& print(std::ostream& sl) const {
-    // set stream output format
-    auto old_precision = sl.precision(7);
-    auto old_flags = sl.setf(std::ios::fixed);
-
-    sl << " * TrackParameters: ";
-    sl << parameters().transpose() << std::endl;
-    sl << " * charge: " << charge() << std::endl;
-    if (covariance()) {
-      sl << " * covariance matrix:\n" << *covariance() << std::endl;
-    } else {
-      sl << " * covariance matrix:\nnull" << std::endl;
-    }
-    sl << " * corresponding global parameters:" << std::endl;
-    sl << " *    position  (x y z) = (" << position().transpose() << ")"
-       << std::endl;
-    sl << " *    momentum  (px py pz) = (" << momentum().transpose() << ")"
-       << std::endl;
-
-    // reset stream format
-    sl.precision(old_precision);
-    sl.setf(old_flags);
-
-    return sl;
   }
 
   ChargePolicy m_oChargePolicy;    ///< charge policy object distinguishing

--- a/Core/include/Acts/EventData/detail/PrintParameters.hpp
+++ b/Core/include/Acts/EventData/detail/PrintParameters.hpp
@@ -1,0 +1,40 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <iosfwd>
+
+#include "Acts/Utilities/ParameterDefinitions.hpp"
+
+namespace Acts {
+
+class Surface;
+
+namespace detail {
+
+/// Print bound track parameters content to the output stream.
+///
+/// @param os The output stream
+/// @param surface Bound parameters reference surface
+/// @param params Bound parameters vector
+/// @param cov Optional bound parameters covariance matrix
+void printBoundParameters(std::ostream& os, const Surface& surface,
+                          const BoundVector& params,
+                          const BoundSymMatrix* cov = nullptr);
+
+/// Print free track parameters content to the output stream.
+///
+/// @param os The output stream
+/// @param params Free parameters vector
+/// @param cov Optional free parameters covariance matrix
+void printFreeParameters(std::ostream& os, const FreeVector& params,
+                         const FreeMatrix* cov = nullptr);
+
+}  // namespace detail
+}  // namespace Acts

--- a/Core/src/EventData/CMakeLists.txt
+++ b/Core/src/EventData/CMakeLists.txt
@@ -4,4 +4,5 @@ target_sources_local(
     ChargedTrackParameters.cpp
     MeasurementHelpers.cpp
     NeutralTrackParameters.cpp
+    PrintParameters.cpp
 )

--- a/Core/src/EventData/PrintParameters.cpp
+++ b/Core/src/EventData/PrintParameters.cpp
@@ -1,0 +1,57 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/EventData/detail/PrintParameters.hpp"
+
+#include <ostream>
+
+#include "Acts/Surfaces/Surface.hpp"
+
+void Acts::detail::printBoundParameters(std::ostream& os,
+                                        const Acts::Surface& surface,
+                                        const Acts::BoundVector& params,
+                                        const Acts::BoundSymMatrix* cov) {
+  // Set stream output format
+  auto oldPrecision = os.precision(7);
+  auto oldFlags = os.setf(std::ios::fixed);
+
+  os << "BoundTrackParameters:\n";
+  os << "  parameters: " << params.transpose() << '\n';
+  if (cov) {
+    os << "  covariance:\n";
+    os << *cov << '\n';
+  } else {
+    os << "  no covariance stored\n";
+  }
+  os << "  on surface: " << surface.geoID() << ' ' << surface.name() << '\n';
+
+  // Reset stream format
+  os.setf(oldFlags);
+  os.precision(oldPrecision);
+}
+
+void Acts::detail::printFreeParameters(std::ostream& os,
+                                       const Acts::FreeVector& params,
+                                       const Acts::FreeMatrix* cov) {
+  // Set stream output format
+  auto oldPrecision = os.precision(7);
+  auto oldFlags = os.setf(std::ios::fixed);
+
+  os << "FreeTrackParameters:\n";
+  os << "  parameters: " << params.transpose() << '\n';
+  if (cov) {
+    os << "  covariance:\n";
+    os << *cov << '\n';
+  } else {
+    os << "  no covariance stored\n";
+  }
+
+  // Reset stream format
+  os.setf(oldFlags);
+  os.precision(oldPrecision);
+}


### PR DESCRIPTION
Add compiled print helper functions to remove `#include <iostream>` from the track parameters headers.

This is the third smaller PR split from #298.