### PR TITLE
RootTrajectoryWriter cleanup

### DIFF
--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -274,16 +274,15 @@ class Measurement {
   /// range (e.g.
   ///       residuals in \f$\phi\f$ are corrected).
   ///
-  /// @todo Implement check that TrackParameters are defined at the same Surface
-  /// as the Measurement is.
   /// @todo Implement validity check for residuals of local parameters.
   ///
   /// @param boundParameters reference bound parameters
+  /// @note The parameter ranges and the reference object of @p boundParameters are not tested
   ///
   /// @return vector with the residual parameter values (in valid range)
   ///
   /// @sa ParameterSet::residual
-  ParameterVector residual(const BoundVector& boundParameters) const {
+  ParameterVector residual(const ActsVectorD<ParamSet::kSizeMax>& boundParameters) const {
     return m_oParameters.residual(boundParameters);
   }
 

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -266,6 +266,26 @@ class Measurement {
   ParameterVector residual(const BoundParameters& trackPars) const {
     return m_oParameters.residual(trackPars.getParameterSet());
   }
+  
+  /// @brief calculate residual with respect to given track parameters
+  ///
+  /// @note It is checked that the residual for non-local parameters are in
+  /// valid
+  /// range (e.g.
+  ///       residuals in \f$\phi\f$ are corrected).
+  ///
+  /// @todo Implement check that TrackParameters are defined at the same Surface
+  /// as the Measurement is.
+  /// @todo Implement validity check for residuals of local parameters.
+  ///
+  /// @param boundParameters reference bound parameters
+  ///
+  /// @return vector with the residual parameter values (in valid range)
+  ///
+  /// @sa ParameterSet::residual
+  ParameterVector residual(const BoundVector& boundParameters) const {
+    return m_oParameters.residual(boundParameters);
+  }
 
   /// @brief equality operator
   ///

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -282,7 +282,8 @@ class Measurement {
   /// @return vector with the residual parameter values (in valid range)
   ///
   /// @sa ParameterSet::residual
-  ParameterVector residual(const ActsVectorD<ParamSet::kSizeMax>& boundParameters) const {
+  ParameterVector residual(const ActsVectorD<detail::ParametersSize<
+      parameter_indices_t>::size>& boundParameters) const {
     return m_oParameters.residual(boundParameters);
   }
 

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -266,7 +266,7 @@ class Measurement {
   ParameterVector residual(const BoundParameters& trackPars) const {
     return m_oParameters.residual(trackPars.getParameterSet());
   }
-  
+
   /// @brief calculate residual with respect to given track parameters
   ///
   /// @note It is checked that the residual for non-local parameters are in
@@ -277,13 +277,15 @@ class Measurement {
   /// @todo Implement validity check for residuals of local parameters.
   ///
   /// @param boundParameters reference bound parameters
-  /// @note The parameter ranges and the reference object of @p boundParameters are not tested
+  /// @note The parameter ranges and the reference object of @p boundParameters
+  /// are not tested
   ///
   /// @return vector with the residual parameter values (in valid range)
   ///
   /// @sa ParameterSet::residual
-  ParameterVector residual(const ActsVectorD<detail::ParametersSize<
-      parameter_indices_t>::size>& boundParameters) const {
+  ParameterVector residual(
+      const ActsVectorD<detail::ParametersSize<parameter_indices_t>::size>&
+          boundParameters) const {
     return m_oParameters.residual(boundParameters);
   }
 

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -477,7 +477,8 @@ class ParameterSet {
    * @brief calculate residual difference to full parameter vector
    *
    * Calculate the residual differences of the stored parameter values with
-   * respect to the corresponding parameter values in the full parameter vector. Hereby, the residual vector is defined as
+   * respect to the corresponding parameter values in the full parameter vector.
+   * Hereby, the residual vector is defined as
    *
    * \f[
    * \vec{r} = \left( \begin{array}{c} r_{i_1} \\ \vdots \\ r_{i_m} \end{array}
@@ -489,12 +490,15 @@ class ParameterSet {
    * \f]
    *
    * where \f$\mathrm{Proj}\f$ is the projection matrix, \f$\vec{v}\f$ is the
-   * vector of parameter values of this ParameterSet object and \f$\vec{v}^0\f$ is the full parameter value vector.
+   * vector of parameter values of this ParameterSet object and \f$\vec{v}^0\f$
+   * is the full parameter value vector.
    *
    * @param boundParameters Vector of bound parameters
-   * @note Constraint and cyclic parameter value ranges of @p boundParameters are not tested.
-   * @note It is not tested whether @p boundParameters is at the same reference object
-   * 
+   * @note Constraint and cyclic parameter value ranges of @p boundParameters
+   * are not tested.
+   * @note It is not tested whether @p boundParameters is at the same reference
+   * object
+   *
    * @return vector containing the residual parameter values of this
    * ParameterSet object
    *         with respect to the given full parameter vector
@@ -505,7 +509,7 @@ class ParameterSet {
     return detail::residual_calculator<parameter_indices_t, params...>::result(
         m_vValues, projector() * boundParameters);
   }
-  
+
   /**
    * @brief calculate residual difference to other parameter vector
    *

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -474,6 +474,38 @@ class ParameterSet {
   }
 
   /**
+   * @brief calculate residual difference to full parameter vector
+   *
+   * Calculate the residual differences of the stored parameter values with
+   * respect to the corresponding parameter values in the full parameter vector. Hereby, the residual vector is defined as
+   *
+   * \f[
+   * \vec{r} = \left( \begin{array}{c} r_{i_1} \\ \vdots \\ r_{i_m} \end{array}
+   * \right)
+   *  = \left( \begin{array}{c} v_{i_1} \\ \vdots \\ v_{i_m} \end{array} \right)
+   * -  \mathrm{Proj} \left( \begin{array}{c} v^0_{1} \\ \vdots \\ v^0_{N}
+   * \end{array} \right)
+   *  = \vec{v} - \mathrm{Proj} \left( \vec{v}^0 \right)
+   * \f]
+   *
+   * where \f$\mathrm{Proj}\f$ is the projection matrix, \f$\vec{v}\f$ is the
+   * vector of parameter values of this ParameterSet object and \f$\vec{v}^0\f$ is the full parameter value vector.
+   *
+   * @param boundParameters Vector of bound parameters
+   * @note Constraint and cyclic parameter value ranges of @p boundParameters are not tested
+   * 
+   * @return vector containing the residual parameter values of this
+   * ParameterSet object
+   *         with respect to the given full parameter vector
+   *
+   * @sa ParameterSet::projector
+   */
+  ParameterVector residual(const ActsVectorD<kSizeMax>& boundParameters) const {
+    return detail::residual_calculator<parameter_indices_t, params...>::result(
+        m_vValues, projector() * boundParameters);
+  }
+  
+  /**
    * @brief calculate residual difference to other parameter vector
    *
    * Calculate the residual differences of the stored parameter values with

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -492,7 +492,8 @@ class ParameterSet {
    * vector of parameter values of this ParameterSet object and \f$\vec{v}^0\f$ is the full parameter value vector.
    *
    * @param boundParameters Vector of bound parameters
-   * @note Constraint and cyclic parameter value ranges of @p boundParameters are not tested
+   * @note Constraint and cyclic parameter value ranges of @p boundParameters are not tested.
+   * @note It is not tested whether @p boundParameters is at the same reference object
    * 
    * @return vector containing the residual parameter values of this
    * ParameterSet object

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -424,14 +424,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       if (state.hasPredicted()) {
         predicted = true;
         m_nPredicted++;
-        Acts::BoundParameters parameter(
-            gctx, state.predictedCovariance(), state.predicted(),
-            surface.getSharedPtr());
+        auto parameters = state.predicted();
         auto covariance = state.predictedCovariance();
         // local hit residual info
         auto H = meas.projector();
         auto resCov = cov + H * covariance * H.transpose();
-        auto residual = meas.residual(parameter);
+        auto residual = meas.residual(state.predicted());
         m_res_x_hit.push_back(residual(Acts::eBoundLoc0));
         m_res_y_hit.push_back(residual(Acts::eBoundLoc1));
         m_err_x_hit.push_back(
@@ -447,25 +445,25 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         m_dim_hit.push_back(state.calibratedSize());
 
         // predicted parameter
-        m_eLOC0_prt.push_back(parameter.parameters()[Acts::eBoundLoc0]);
-        m_eLOC1_prt.push_back(parameter.parameters()[Acts::eBoundLoc1]);
-        m_ePHI_prt.push_back(parameter.parameters()[Acts::eBoundPhi]);
-        m_eTHETA_prt.push_back(parameter.parameters()[Acts::eBoundTheta]);
-        m_eQOP_prt.push_back(parameter.parameters()[Acts::eBoundQOverP]);
-        m_eT_prt.push_back(parameter.parameters()[Acts::eBoundTime]);
+        m_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0]);
+        m_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1]);
+        m_ePHI_prt.push_back(parameters[Acts::eBoundPhi]);
+        m_eTHETA_prt.push_back(parameters[Acts::eBoundTheta]);
+        m_eQOP_prt.push_back(parameters[Acts::eBoundQOverP]);
+        m_eT_prt.push_back(parameters[Acts::eBoundTime]);
 
         // predicted residual
-        m_res_eLOC0_prt.push_back(parameter.parameters()[Acts::eBoundLoc0] -
+        m_res_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0] -
                                   truthLOC0);
-        m_res_eLOC1_prt.push_back(parameter.parameters()[Acts::eBoundLoc1] -
+        m_res_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1] -
                                   truthLOC1);
-        m_res_ePHI_prt.push_back(parameter.parameters()[Acts::eBoundPhi] -
+        m_res_ePHI_prt.push_back(parameters[Acts::eBoundPhi] -
                                  truthPHI);
         m_res_eTHETA_prt.push_back(
-            parameter.parameters()[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_prt.push_back(parameter.parameters()[Acts::eBoundQOverP] -
+            parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_prt.push_back(parameters[Acts::eBoundQOverP] -
                                  truthQOP);
-        m_res_eT_prt.push_back(parameter.parameters()[Acts::eBoundTime] -
+        m_res_eT_prt.push_back(parameters[Acts::eBoundTime] -
                                truthTIME);
 
         // predicted parameter error
@@ -484,22 +482,22 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
         // predicted parameter pull
         m_pull_eLOC0_prt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc0] - truthLOC0) /
+            (parameters[Acts::eBoundLoc0] - truthLOC0) /
             sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
         m_pull_eLOC1_prt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc1] - truthLOC1) /
+            (parameters[Acts::eBoundLoc1] - truthLOC1) /
             sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
         m_pull_ePHI_prt.push_back(
-            (parameter.parameters()[Acts::eBoundPhi] - truthPHI) /
+            (parameters[Acts::eBoundPhi] - truthPHI) /
             sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
         m_pull_eTHETA_prt.push_back(
-            (parameter.parameters()[Acts::eBoundTheta] - truthTHETA) /
+            (parameters[Acts::eBoundTheta] - truthTHETA) /
             sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
         m_pull_eQOP_prt.push_back(
-            (parameter.parameters()[Acts::eBoundQOverP] - truthQOP) /
+            (parameters[Acts::eBoundQOverP] - truthQOP) /
             sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
         m_pull_eT_prt.push_back(
-            (parameter.parameters()[Acts::eBoundTime] - truthTIME) /
+            (parameters[Acts::eBoundTime] - truthTIME) /
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further predicted parameter info
@@ -559,30 +557,28 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       if (state.hasFiltered()) {
         filtered = true;
         m_nFiltered++;
-        Acts::BoundParameters parameter(
-            gctx, state.filteredCovariance(), state.filtered(),
-            state.referenceSurface().getSharedPtr());
+        auto parameters = state.filtered();
         auto covariance = state.filteredCovariance();
         // filtered parameter
-        m_eLOC0_flt.push_back(parameter.parameters()[Acts::eBoundLoc0]);
-        m_eLOC1_flt.push_back(parameter.parameters()[Acts::eBoundLoc1]);
-        m_ePHI_flt.push_back(parameter.parameters()[Acts::eBoundPhi]);
-        m_eTHETA_flt.push_back(parameter.parameters()[Acts::eBoundTheta]);
-        m_eQOP_flt.push_back(parameter.parameters()[Acts::eBoundQOverP]);
-        m_eT_flt.push_back(parameter.parameters()[Acts::eBoundTime]);
+        m_eLOC0_flt.push_back(parameters[Acts::eBoundLoc0]);
+        m_eLOC1_flt.push_back(parameters[Acts::eBoundLoc1]);
+        m_ePHI_flt.push_back(parameters[Acts::eBoundPhi]);
+        m_eTHETA_flt.push_back(parameters[Acts::eBoundTheta]);
+        m_eQOP_flt.push_back(parameters[Acts::eBoundQOverP]);
+        m_eT_flt.push_back(parameters[Acts::eBoundTime]);
 
         // filtered residual
-        m_res_eLOC0_flt.push_back(parameter.parameters()[Acts::eBoundLoc0] -
+        m_res_eLOC0_flt.push_back(parameters[Acts::eBoundLoc0] -
                                   truthLOC0);
-        m_res_eLOC1_flt.push_back(parameter.parameters()[Acts::eBoundLoc1] -
+        m_res_eLOC1_flt.push_back(parameters[Acts::eBoundLoc1] -
                                   truthLOC1);
-        m_res_ePHI_flt.push_back(parameter.parameters()[Acts::eBoundPhi] -
+        m_res_ePHI_flt.push_back(parameters[Acts::eBoundPhi] -
                                  truthPHI);
         m_res_eTHETA_flt.push_back(
-            parameter.parameters()[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_flt.push_back(parameter.parameters()[Acts::eBoundQOverP] -
+            parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_flt.push_back(parameters[Acts::eBoundQOverP] -
                                  truthQOP);
-        m_res_eT_flt.push_back(parameter.parameters()[Acts::eBoundTime] -
+        m_res_eT_flt.push_back(parameters[Acts::eBoundTime] -
                                truthTIME);
 
         // filtered parameter error
@@ -601,22 +597,22 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
         // filtered parameter pull
         m_pull_eLOC0_flt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc0] - truthLOC0) /
+            (parameters[Acts::eBoundLoc0] - truthLOC0) /
             sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
         m_pull_eLOC1_flt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc1] - truthLOC1) /
+            (parameters[Acts::eBoundLoc1] - truthLOC1) /
             sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
         m_pull_ePHI_flt.push_back(
-            (parameter.parameters()[Acts::eBoundPhi] - truthPHI) /
+            (parameters[Acts::eBoundPhi] - truthPHI) /
             sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
         m_pull_eTHETA_flt.push_back(
-            (parameter.parameters()[Acts::eBoundTheta] - truthTHETA) /
+            (parameters[Acts::eBoundTheta] - truthTHETA) /
             sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
         m_pull_eQOP_flt.push_back(
-            (parameter.parameters()[Acts::eBoundQOverP] - truthQOP) /
+            (parameters[Acts::eBoundQOverP] - truthQOP) /
             sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
         m_pull_eT_flt.push_back(
-            (parameter.parameters()[Acts::eBoundTime] - truthTIME) /
+            (parameters[Acts::eBoundTime] - truthTIME) /
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // more filtered parameter info
@@ -670,31 +666,29 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       if (state.hasSmoothed()) {
         smoothed = true;
         m_nSmoothed++;
-        Acts::BoundParameters parameter(
-            gctx, state.smoothedCovariance(), state.smoothed(),
-            state.referenceSurface().getSharedPtr());
+        auto parameters = state.smoothed();
         auto covariance = state.smoothedCovariance();
 
         // smoothed parameter
-        m_eLOC0_smt.push_back(parameter.parameters()[Acts::eBoundLoc0]);
-        m_eLOC1_smt.push_back(parameter.parameters()[Acts::eBoundLoc1]);
-        m_ePHI_smt.push_back(parameter.parameters()[Acts::eBoundPhi]);
-        m_eTHETA_smt.push_back(parameter.parameters()[Acts::eBoundTheta]);
-        m_eQOP_smt.push_back(parameter.parameters()[Acts::eBoundQOverP]);
-        m_eT_smt.push_back(parameter.parameters()[Acts::eBoundTime]);
+        m_eLOC0_smt.push_back(parameters[Acts::eBoundLoc0]);
+        m_eLOC1_smt.push_back(parameters[Acts::eBoundLoc1]);
+        m_ePHI_smt.push_back(parameters[Acts::eBoundPhi]);
+        m_eTHETA_smt.push_back(parameters[Acts::eBoundTheta]);
+        m_eQOP_smt.push_back(parameters[Acts::eBoundQOverP]);
+        m_eT_smt.push_back(parameters[Acts::eBoundTime]);
 
         // smoothed residual
-        m_res_eLOC0_smt.push_back(parameter.parameters()[Acts::eBoundLoc0] -
+        m_res_eLOC0_smt.push_back(parameters[Acts::eBoundLoc0] -
                                   truthLOC0);
-        m_res_eLOC1_smt.push_back(parameter.parameters()[Acts::eBoundLoc1] -
+        m_res_eLOC1_smt.push_back(parameters[Acts::eBoundLoc1] -
                                   truthLOC1);
-        m_res_ePHI_smt.push_back(parameter.parameters()[Acts::eBoundPhi] -
+        m_res_ePHI_smt.push_back(parameters[Acts::eBoundPhi] -
                                  truthPHI);
         m_res_eTHETA_smt.push_back(
-            parameter.parameters()[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_smt.push_back(parameter.parameters()[Acts::eBoundQOverP] -
+            parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_smt.push_back(parameters[Acts::eBoundQOverP] -
                                  truthQOP);
-        m_res_eT_smt.push_back(parameter.parameters()[Acts::eBoundTime] -
+        m_res_eT_smt.push_back(parameters[Acts::eBoundTime] -
                                truthTIME);
 
         // smoothed parameter error
@@ -713,22 +707,22 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
         // smoothed parameter pull
         m_pull_eLOC0_smt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc0] - truthLOC0) /
+            (parameters[Acts::eBoundLoc0] - truthLOC0) /
             sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0)));
         m_pull_eLOC1_smt.push_back(
-            (parameter.parameters()[Acts::eBoundLoc1] - truthLOC1) /
+            (parameters[Acts::eBoundLoc1] - truthLOC1) /
             sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1)));
         m_pull_ePHI_smt.push_back(
-            (parameter.parameters()[Acts::eBoundPhi] - truthPHI) /
+            (parameters[Acts::eBoundPhi] - truthPHI) /
             sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi)));
         m_pull_eTHETA_smt.push_back(
-            (parameter.parameters()[Acts::eBoundTheta] - truthTHETA) /
+            (parameters[Acts::eBoundTheta] - truthTHETA) /
             sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta)));
         m_pull_eQOP_smt.push_back(
-            (parameter.parameters()[Acts::eBoundQOverP] - truthQOP) /
+            (parameters[Acts::eBoundQOverP] - truthQOP) /
             sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP)));
         m_pull_eT_smt.push_back(
-            (parameter.parameters()[Acts::eBoundTime] - truthTIME) /
+            (parameters[Acts::eBoundTime] - truthTIME) /
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further smoothed parameter info

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -20,6 +20,7 @@
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Utilities/Helpers.hpp"
+#include "Acts/EventData/detail/coordinate_transformations.hpp"
 
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::perp;
@@ -501,14 +502,16 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further predicted parameter info
-        m_x_prt.push_back(parameter.position().x());
-        m_y_prt.push_back(parameter.position().y());
-        m_z_prt.push_back(parameter.position().z());
-        m_px_prt.push_back(parameter.momentum().x());
-        m_py_prt.push_back(parameter.momentum().y());
-        m_pz_prt.push_back(parameter.momentum().z());
-        m_pT_prt.push_back(parameter.pT());
-        m_eta_prt.push_back(eta(parameter.position()));
+        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        m_x_prt.push_back(freePosition.x());
+        m_y_prt.push_back(freePosition.y());
+        m_z_prt.push_back(freePosition.z());
+        m_px_prt.push_back(freeMomentum.x());
+        m_py_prt.push_back(freeMomentum.y());
+        m_pz_prt.push_back(freeMomentum.z());
+        m_pT_prt.push_back(perp(freeMomentum)));
+        m_eta_prt.push_back(eta(freePosition));
       } else {
         // push default values if no predicted parameter
         m_res_x_hit.push_back(-99.);
@@ -616,14 +619,16 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // more filtered parameter info
-        m_x_flt.push_back(parameter.position().x());
-        m_y_flt.push_back(parameter.position().y());
-        m_z_flt.push_back(parameter.position().z());
-        m_px_flt.push_back(parameter.momentum().x());
-        m_py_flt.push_back(parameter.momentum().y());
-        m_pz_flt.push_back(parameter.momentum().z());
-        m_pT_flt.push_back(parameter.pT());
-        m_eta_flt.push_back(eta(parameter.position()));
+        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        m_x_flt.push_back(freePosition.x());
+        m_y_flt.push_back(freePosition.y());
+        m_z_flt.push_back(freePosition.z());
+        m_px_flt.push_back(freeMomentum.x());
+        m_py_flt.push_back(freeMomentum.y());
+        m_pz_flt.push_back(freeMomentum.z());
+        m_pT_flt.push_back(perp(freeMomentum));
+        m_eta_flt.push_back(eta(freePosition));
         m_chi2.push_back(state.chi2());
       } else {
         // push default values if no filtered parameter
@@ -726,14 +731,16 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further smoothed parameter info
-        m_x_smt.push_back(parameter.position().x());
-        m_y_smt.push_back(parameter.position().y());
-        m_z_smt.push_back(parameter.position().z());
-        m_px_smt.push_back(parameter.momentum().x());
-        m_py_smt.push_back(parameter.momentum().y());
-        m_pz_smt.push_back(parameter.momentum().z());
-        m_pT_smt.push_back(parameter.pT());
-        m_eta_smt.push_back(eta(parameter.position()));
+        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        m_x_smt.push_back(freePosition.x());
+        m_y_smt.push_back(freePosition.y());
+        m_z_smt.push_back(freePosition.z());
+        m_px_smt.push_back(freeMomentum.x());
+        m_py_smt.push_back(freeMomentum.y());
+        m_pz_smt.push_back(freeMomentum.z());
+        m_pT_smt.push_back(perp(freeMomentum));
+        m_eta_smt.push_back(eta(freePosition));
       } else {
         // push default values if no smoothed parameter
         m_eLOC0_smt.push_back(-99.);

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -357,7 +357,7 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       }
       
       auto meas = std::get<Measurement>(*state.uncalibrated());
-      auto surface = meas.referenceObject();
+      auto& surface = meas.referenceObject();
 
       // get the geometry ID
       auto geoID = surface.geoID();
@@ -430,7 +430,7 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         // local hit residual info
         auto H = meas.projector();
         auto resCov = cov + H * covariance * H.transpose();
-        auto residual = meas.residual(state.predicted());
+        auto residual = meas.residual(parameters);
         m_res_x_hit.push_back(residual(Acts::eBoundLoc0));
         m_res_y_hit.push_back(residual(Acts::eBoundLoc1));
         m_err_x_hit.push_back(
@@ -502,15 +502,15 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further predicted parameter info
-        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
         m_x_prt.push_back(freePosition.x());
         m_y_prt.push_back(freePosition.y());
         m_z_prt.push_back(freePosition.z());
         m_px_prt.push_back(freeMomentum.x());
         m_py_prt.push_back(freeMomentum.y());
         m_pz_prt.push_back(freeMomentum.z());
-        m_pT_prt.push_back(perp(freeMomentum)));
+        m_pT_prt.push_back(perp(freeMomentum));
         m_eta_prt.push_back(eta(freePosition));
       } else {
         // push default values if no predicted parameter
@@ -619,8 +619,8 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // more filtered parameter info
-        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
         m_x_flt.push_back(freePosition.x());
         m_y_flt.push_back(freePosition.y());
         m_z_flt.push_back(freePosition.z());
@@ -731,8 +731,8 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further smoothed parameter info
-        const Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
+        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
         m_x_smt.push_back(freePosition.x());
         m_y_smt.push_back(freePosition.y());
         m_z_smt.push_back(freePosition.z());

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -19,8 +19,8 @@
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
-#include "Acts/Utilities/Helpers.hpp"
 #include "Acts/EventData/detail/coordinate_transformations.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::perp;
@@ -334,13 +334,10 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       m_eTHETA_fit = parameter[Acts::eBoundTheta];
       m_eQOP_fit = parameter[Acts::eBoundQOverP];
       m_eT_fit = parameter[Acts::eBoundTime];
-      m_err_eLOC0_fit =
-          sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0));
-      m_err_eLOC1_fit =
-          sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1));
+      m_err_eLOC0_fit = sqrt(covariance(Acts::eBoundLoc0, Acts::eBoundLoc0));
+      m_err_eLOC1_fit = sqrt(covariance(Acts::eBoundLoc1, Acts::eBoundLoc1));
       m_err_ePHI_fit = sqrt(covariance(Acts::eBoundPhi, Acts::eBoundPhi));
-      m_err_eTHETA_fit =
-          sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta));
+      m_err_eTHETA_fit = sqrt(covariance(Acts::eBoundTheta, Acts::eBoundTheta));
       m_err_eQOP_fit = sqrt(covariance(Acts::eBoundQOverP, Acts::eBoundQOverP));
       m_err_eT_fit = sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime));
     }
@@ -355,7 +352,7 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       if (not typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
         return true;
       }
-      
+
       auto meas = std::get<Measurement>(*state.uncalibrated());
       auto& surface = meas.referenceObject();
 
@@ -389,8 +386,8 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
       const auto& truthHit = state.uncalibrated().truthHit();
       // get local truth position
       Acts::Vector2D truthlocal;
-      surface.globalToLocal(
-          gctx, truthHit.position(), truthHit.unitDirection(), truthlocal);
+      surface.globalToLocal(gctx, truthHit.position(), truthHit.unitDirection(),
+                            truthlocal);
 
       // push the truth hit info
       m_t_x.push_back(truthHit.position().x());
@@ -433,10 +430,8 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         auto residual = meas.residual(parameters);
         m_res_x_hit.push_back(residual(Acts::eBoundLoc0));
         m_res_y_hit.push_back(residual(Acts::eBoundLoc1));
-        m_err_x_hit.push_back(
-            sqrt(resCov(Acts::eBoundLoc0, Acts::eBoundLoc0)));
-        m_err_y_hit.push_back(
-            sqrt(resCov(Acts::eBoundLoc1, Acts::eBoundLoc1)));
+        m_err_x_hit.push_back(sqrt(resCov(Acts::eBoundLoc0, Acts::eBoundLoc0)));
+        m_err_y_hit.push_back(sqrt(resCov(Acts::eBoundLoc1, Acts::eBoundLoc1)));
         m_pull_x_hit.push_back(
             residual(Acts::eBoundLoc0) /
             sqrt(resCov(Acts::eBoundLoc0, Acts::eBoundLoc0)));
@@ -454,18 +449,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         m_eT_prt.push_back(parameters[Acts::eBoundTime]);
 
         // predicted residual
-        m_res_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0] -
-                                  truthLOC0);
-        m_res_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1] -
-                                  truthLOC1);
-        m_res_ePHI_prt.push_back(parameters[Acts::eBoundPhi] -
-                                 truthPHI);
-        m_res_eTHETA_prt.push_back(
-            parameters[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_prt.push_back(parameters[Acts::eBoundQOverP] -
-                                 truthQOP);
-        m_res_eT_prt.push_back(parameters[Acts::eBoundTime] -
-                               truthTIME);
+        m_res_eLOC0_prt.push_back(parameters[Acts::eBoundLoc0] - truthLOC0);
+        m_res_eLOC1_prt.push_back(parameters[Acts::eBoundLoc1] - truthLOC1);
+        m_res_ePHI_prt.push_back(parameters[Acts::eBoundPhi] - truthPHI);
+        m_res_eTHETA_prt.push_back(parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_prt.push_back(parameters[Acts::eBoundQOverP] - truthQOP);
+        m_res_eT_prt.push_back(parameters[Acts::eBoundTime] - truthTIME);
 
         // predicted parameter error
         m_err_eLOC0_prt.push_back(
@@ -502,8 +491,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further predicted parameter info
-        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition =
+            Acts::detail::coordinate_transformation::parameters2globalPosition(
+                gctx, parameters, surface);
+        const Acts::Vector3D freeMomentum =
+            Acts::detail::coordinate_transformation::parameters2globalMomentum(
+                parameters);
         m_x_prt.push_back(freePosition.x());
         m_y_prt.push_back(freePosition.y());
         m_z_prt.push_back(freePosition.z());
@@ -571,18 +564,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         m_eT_flt.push_back(parameters[Acts::eBoundTime]);
 
         // filtered residual
-        m_res_eLOC0_flt.push_back(parameters[Acts::eBoundLoc0] -
-                                  truthLOC0);
-        m_res_eLOC1_flt.push_back(parameters[Acts::eBoundLoc1] -
-                                  truthLOC1);
-        m_res_ePHI_flt.push_back(parameters[Acts::eBoundPhi] -
-                                 truthPHI);
-        m_res_eTHETA_flt.push_back(
-            parameters[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_flt.push_back(parameters[Acts::eBoundQOverP] -
-                                 truthQOP);
-        m_res_eT_flt.push_back(parameters[Acts::eBoundTime] -
-                               truthTIME);
+        m_res_eLOC0_flt.push_back(parameters[Acts::eBoundLoc0] - truthLOC0);
+        m_res_eLOC1_flt.push_back(parameters[Acts::eBoundLoc1] - truthLOC1);
+        m_res_ePHI_flt.push_back(parameters[Acts::eBoundPhi] - truthPHI);
+        m_res_eTHETA_flt.push_back(parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_flt.push_back(parameters[Acts::eBoundQOverP] - truthQOP);
+        m_res_eT_flt.push_back(parameters[Acts::eBoundTime] - truthTIME);
 
         // filtered parameter error
         m_err_eLOC0_flt.push_back(
@@ -619,8 +606,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // more filtered parameter info
-        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition =
+            Acts::detail::coordinate_transformation::parameters2globalPosition(
+                gctx, parameters, surface);
+        const Acts::Vector3D freeMomentum =
+            Acts::detail::coordinate_transformation::parameters2globalMomentum(
+                parameters);
         m_x_flt.push_back(freePosition.x());
         m_y_flt.push_back(freePosition.y());
         m_z_flt.push_back(freePosition.z());
@@ -683,18 +674,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
         m_eT_smt.push_back(parameters[Acts::eBoundTime]);
 
         // smoothed residual
-        m_res_eLOC0_smt.push_back(parameters[Acts::eBoundLoc0] -
-                                  truthLOC0);
-        m_res_eLOC1_smt.push_back(parameters[Acts::eBoundLoc1] -
-                                  truthLOC1);
-        m_res_ePHI_smt.push_back(parameters[Acts::eBoundPhi] -
-                                 truthPHI);
-        m_res_eTHETA_smt.push_back(
-            parameters[Acts::eBoundTheta] - truthTHETA);
-        m_res_eQOP_smt.push_back(parameters[Acts::eBoundQOverP] -
-                                 truthQOP);
-        m_res_eT_smt.push_back(parameters[Acts::eBoundTime] -
-                               truthTIME);
+        m_res_eLOC0_smt.push_back(parameters[Acts::eBoundLoc0] - truthLOC0);
+        m_res_eLOC1_smt.push_back(parameters[Acts::eBoundLoc1] - truthLOC1);
+        m_res_ePHI_smt.push_back(parameters[Acts::eBoundPhi] - truthPHI);
+        m_res_eTHETA_smt.push_back(parameters[Acts::eBoundTheta] - truthTHETA);
+        m_res_eQOP_smt.push_back(parameters[Acts::eBoundQOverP] - truthQOP);
+        m_res_eT_smt.push_back(parameters[Acts::eBoundTime] - truthTIME);
 
         // smoothed parameter error
         m_err_eLOC0_smt.push_back(
@@ -731,8 +716,12 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
             sqrt(covariance(Acts::eBoundTime, Acts::eBoundTime)));
 
         // further smoothed parameter info
-        const Acts::Vector3D freePosition = Acts::detail::coordinate_transformation::parameters2globalPosition(gctx, parameters, surface); 
-        const Acts::Vector3D freeMomentum = Acts::detail::coordinate_transformation::parameters2globalMomentum(parameters);
+        const Acts::Vector3D freePosition =
+            Acts::detail::coordinate_transformation::parameters2globalPosition(
+                gctx, parameters, surface);
+        const Acts::Vector3D freeMomentum =
+            Acts::detail::coordinate_transformation::parameters2globalMomentum(
+                parameters);
         m_x_smt.push_back(freePosition.x());
         m_y_smt.push_back(freePosition.y());
         m_z_smt.push_back(freePosition.z());


### PR DESCRIPTION
Within this PR multiple smaller changes occur. 

1. The parameter indices are renamed to match the new pattern.
2. The reference surface is always picked from the uncalibrated `SourceLink`.
3. The constructions of `BoundParameters` were constructed in order to access member variables/methods that can be provided otherwise. This PR avoids all these constructor calls.
4. A single calculation of the residual to a measurement is needed. Due to the changes in 3. a residual function using a vector is added to the `ParameterSet` and `Measurement` API. 