### PR TITLE
Fix number of columns for projectors

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -356,10 +356,8 @@ class TrackStateProxy {
     IndexData& dataref = data();
     assert(dataref.iprojector != IndexData::kInvalid);
 
-    constexpr int max_measdim = MultiTrajectory<SourceLink>::MeasurementSizeMax;
-
-    static_assert(rows <= max_measdim, "Given projector has too many rows");
-    static_assert(cols <= max_measdim, "Given projector has too many columns");
+    static_assert(rows <= M, "Given projector has too many rows");
+    static_assert(cols <= N, "Given projector has too many columns");
 
     // set up full size projector with only zeros
     typename TrackStateProxy::Projector fullProjector =
@@ -367,7 +365,7 @@ class TrackStateProxy {
 
     // assign (potentially) smaller actual projector to matrix, preserving
     // zeroes outside of smaller matrix block.
-    fullProjector.template topLeftCorner<rows, max_measdim>() = projector;
+    fullProjector.template topLeftCorner<rows, cols>() = projector;
 
     // convert to bitset before storing
     m_traj->m_projectors[dataref.iprojector] = matrixToBitset(fullProjector);

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -600,7 +600,9 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(pc.meas3d->sourceLink(), ts.uncalibrated());
 
   // full projector, should be exactly equal
-  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax, MultiTrajectory<SourceLink>::ParametersSize> fullProj;
+  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
+              MultiTrajectory<SourceLink>::ParametersSize>
+      fullProj;
   fullProj.setZero();
   fullProj.topLeftCorner(pc.meas3d->size(),
                          MultiTrajectory<SourceLink>::ParametersSize) =

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -501,6 +501,7 @@ BOOST_AUTO_TEST_CASE(trackstate_proxy_cross_talk) {
 
 BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   constexpr size_t maxmeasdim = MultiTrajectory<SourceLink>::MeasurementSizeMax;
+  constexpr size_t maxparamdim = MultiTrajectory<SourceLink>::ParametersSize;
 
   MultiTrajectory<SourceLink> t;
   size_t index = t.addTrackState();
@@ -542,9 +543,9 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mCovFull.topLeftCorner(2, 2) = mCov;
   BOOST_CHECK_EQUAL(ts.calibratedCovariance(), mCovFull);
 
-  ActsSymMatrixD<maxmeasdim> projFull;
+  ActsMatrixD<maxmeasdim, maxparamdim> projFull;
   projFull.setZero();
-  projFull.topLeftCorner(m2.size(), maxmeasdim) = m2.projector();
+  projFull.topLeftCorner(m2.size(), maxparamdim) = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);
 }
 
@@ -599,10 +600,10 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(pc.meas3d->sourceLink(), ts.uncalibrated());
 
   // full projector, should be exactly equal
-  CovMat_t fullProj;
+  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax, MultiTrajectory<SourceLink>::ParametersSize> fullProj;
   fullProj.setZero();
   fullProj.topLeftCorner(pc.meas3d->size(),
-                         MultiTrajectory<SourceLink>::MeasurementSizeMax) =
+                         MultiTrajectory<SourceLink>::ParametersSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 


### PR DESCRIPTION
The number of columns for projectors in the `MultiTrajectory` is using the maximal size of the measurements instead of the track parameters size. This is fixed with this PR.