### PR TITLE
Fix parameter dimension in MultiTrajectory

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -357,7 +357,7 @@ class TrackStateProxy {
     assert(dataref.iprojector != IndexData::kInvalid);
 
     static_assert(rows <= M, "Given projector has too many rows");
-    static_assert(cols <= N, "Given projector has too many columns");
+    static_assert(cols <= eBoundParametersSize, "Given projector has too many columns");
 
     // set up full size projector with only zeros
     typename TrackStateProxy::Projector fullProjector =

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -357,7 +357,8 @@ class TrackStateProxy {
     assert(dataref.iprojector != IndexData::kInvalid);
 
     static_assert(rows <= M, "Given projector has too many rows");
-    static_assert(cols <= eBoundParametersSize, "Given projector has too many columns");
+    static_assert(cols <= eBoundParametersSize,
+                  "Given projector has too many columns");
 
     // set up full size projector with only zeros
     typename TrackStateProxy::Projector fullProjector =

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -187,7 +187,7 @@ class TrackStateProxy {
   template <bool RO = ReadOnly, bool ReadOnlyOther,
             typename = std::enable_if<!RO>>
   void copyFrom(
-      const TrackStateProxy<source_link_t, N, M, ReadOnlyOther>& other,
+      const TrackStateProxy<source_link_t, M, ReadOnlyOther>& other,
       TrackStatePropMask mask = TrackStatePropMask::All) {
     using PM = TrackStatePropMask;
     auto dest = getMask();

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -134,15 +134,14 @@ struct IndexData {
 /// Proxy object to access a single point on the trajectory.
 ///
 /// @tparam source_link_t Type to link back to an original measurement
-/// @tparam N         Number of track parameters
 /// @tparam M         Maximum number of measurement dimensions
 /// @tparam ReadOnly  true for read-only access to underlying storage
-template <typename source_link_t, size_t N, size_t M, bool ReadOnly = true>
+template <typename source_link_t, size_t M, bool ReadOnly = true>
 class TrackStateProxy {
  public:
   using SourceLink = source_link_t;
-  using Parameters = typename Types<N, ReadOnly>::CoefficientsMap;
-  using Covariance = typename Types<N, ReadOnly>::CovarianceMap;
+  using Parameters = typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
+  using Covariance = typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
 
@@ -152,10 +151,10 @@ class TrackStateProxy {
   // vector, but that's required for 1xN projection matrices below.
   constexpr static auto ProjectorFlags = Eigen::RowMajor | Eigen::AutoAlign;
   using Projector =
-      Eigen::Matrix<typename Covariance::Scalar, M, N, ProjectorFlags>;
+      Eigen::Matrix<typename Covariance::Scalar, M, eBoundParametersSize, ProjectorFlags>;
   using EffectiveProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
-                    ProjectorFlags, M, N>;
+                    ProjectorFlags, M, eBoundParametersSize>;
 
   /// Index within the trajectory.
   /// @return the index
@@ -605,17 +604,16 @@ template <typename source_link_t>
 class MultiTrajectory {
  public:
   enum {
-    ParametersSize = eBoundParametersSize,
     MeasurementSizeMax = eBoundParametersSize,
   };
   using SourceLink = source_link_t;
   using ConstTrackStateProxy =
-      detail_lt::TrackStateProxy<SourceLink, ParametersSize, MeasurementSizeMax,
+      detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax,
                                  true>;
-  using TrackStateProxy = detail_lt::TrackStateProxy<SourceLink, ParametersSize,
+  using TrackStateProxy = detail_lt::TrackStateProxy<SourceLink,
                                                      MeasurementSizeMax, false>;
 
-  using ProjectorBitset = std::bitset<ParametersSize * MeasurementSizeMax>;
+  using ProjectorBitset = std::bitset<eBoundParametersSize * MeasurementSizeMax>;
 
   /// Create an empty trajectory.
   MultiTrajectory() = default;
@@ -661,11 +659,11 @@ class MultiTrajectory {
  private:
   /// index to map track states to the corresponding
   std::vector<detail_lt::IndexData> m_index;
-  typename detail_lt::Types<ParametersSize>::StorageCoefficients m_params;
-  typename detail_lt::Types<ParametersSize>::StorageCovariance m_cov;
+  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_params;
+  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_cov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCovariance m_measCov;
-  typename detail_lt::Types<ParametersSize>::StorageCovariance m_jac;
+  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_jac;
   std::vector<SourceLink> m_sourceLinks;
   std::vector<ProjectorBitset> m_projectors;
 
@@ -675,9 +673,9 @@ class MultiTrajectory {
   // be handled in a smart way by moving but not sure.
   std::vector<std::shared_ptr<const Surface>> m_referenceSurfaces;
 
-  friend class detail_lt::TrackStateProxy<SourceLink, ParametersSize,
+  friend class detail_lt::TrackStateProxy<SourceLink,
                                           MeasurementSizeMax, true>;
-  friend class detail_lt::TrackStateProxy<SourceLink, ParametersSize,
+  friend class detail_lt::TrackStateProxy<SourceLink,
                                           MeasurementSizeMax, false>;
 };
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -140,8 +140,10 @@ template <typename source_link_t, size_t M, bool ReadOnly = true>
 class TrackStateProxy {
  public:
   using SourceLink = source_link_t;
-  using Parameters = typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
-  using Covariance = typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
+  using Parameters =
+      typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
+  using Covariance =
+      typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
 
@@ -150,8 +152,8 @@ class TrackStateProxy {
   // @TODO: Does not copy flags, because this fails: can't have col major row
   // vector, but that's required for 1xN projection matrices below.
   constexpr static auto ProjectorFlags = Eigen::RowMajor | Eigen::AutoAlign;
-  using Projector =
-      Eigen::Matrix<typename Covariance::Scalar, M, eBoundParametersSize, ProjectorFlags>;
+  using Projector = Eigen::Matrix<typename Covariance::Scalar, M,
+                                  eBoundParametersSize, ProjectorFlags>;
   using EffectiveProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
                     ProjectorFlags, M, eBoundParametersSize>;
@@ -186,9 +188,8 @@ class TrackStateProxy {
   ///       not allocated in the source track state proxy.
   template <bool RO = ReadOnly, bool ReadOnlyOther,
             typename = std::enable_if<!RO>>
-  void copyFrom(
-      const TrackStateProxy<source_link_t, M, ReadOnlyOther>& other,
-      TrackStatePropMask mask = TrackStatePropMask::All) {
+  void copyFrom(const TrackStateProxy<source_link_t, M, ReadOnlyOther>& other,
+                TrackStatePropMask mask = TrackStatePropMask::All) {
     using PM = TrackStatePropMask;
     auto dest = getMask();
     auto src = other.getMask() &
@@ -608,12 +609,12 @@ class MultiTrajectory {
   };
   using SourceLink = source_link_t;
   using ConstTrackStateProxy =
-      detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax,
-                                 true>;
-  using TrackStateProxy = detail_lt::TrackStateProxy<SourceLink,
-                                                     MeasurementSizeMax, false>;
+      detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, true>;
+  using TrackStateProxy =
+      detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, false>;
 
-  using ProjectorBitset = std::bitset<eBoundParametersSize * MeasurementSizeMax>;
+  using ProjectorBitset =
+      std::bitset<eBoundParametersSize * MeasurementSizeMax>;
 
   /// Create an empty trajectory.
   MultiTrajectory() = default;
@@ -673,10 +674,9 @@ class MultiTrajectory {
   // be handled in a smart way by moving but not sure.
   std::vector<std::shared_ptr<const Surface>> m_referenceSurfaces;
 
-  friend class detail_lt::TrackStateProxy<SourceLink,
-                                          MeasurementSizeMax, true>;
-  friend class detail_lt::TrackStateProxy<SourceLink,
-                                          MeasurementSizeMax, false>;
+  friend class detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, true>;
+  friend class detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax,
+                                          false>;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -50,8 +50,7 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const
-    -> Parameters {
+inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
   IndexData::IndexType idx;
   if (hasSmoothed()) {
     idx = data().ismoothed;
@@ -65,8 +64,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const
-    -> Covariance {
+inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const -> Covariance {
   IndexData::IndexType idx;
   if (hasSmoothed()) {
     idx = data().ismoothed;
@@ -79,8 +77,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::predicted() const
-    -> Parameters {
+inline auto TrackStateProxy<SL, M, ReadOnly>::predicted() const -> Parameters {
   assert(data().ipredicted != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ipredicted).data());
 }
@@ -93,8 +90,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::predictedCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::filtered() const
-    -> Parameters {
+inline auto TrackStateProxy<SL, M, ReadOnly>::filtered() const -> Parameters {
   assert(data().ifiltered != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ifiltered).data());
 }
@@ -107,8 +103,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::filteredCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::smoothed() const
-    -> Parameters {
+inline auto TrackStateProxy<SL, M, ReadOnly>::smoothed() const -> Parameters {
   assert(data().ismoothed != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ismoothed).data());
 }
@@ -121,15 +116,13 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::smoothedCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const
-    -> Covariance {
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const -> Covariance {
   assert(data().ijacobian != IndexData::kInvalid);
   return Covariance(m_traj->m_jac.col(data().ijacobian).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::projector() const
-    -> Projector {
+inline auto TrackStateProxy<SL, M, ReadOnly>::projector() const -> Projector {
   assert(data().iprojector != IndexData::kInvalid);
   return bitsetToMatrix<Projector>(m_traj->m_projectors[data().iprojector]);
 }

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -17,13 +17,13 @@
 
 namespace Acts {
 namespace detail_lt {
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline TrackStateProxy<SL, N, M, ReadOnly>::TrackStateProxy(
+template <typename SL, size_t M, bool ReadOnly>
+inline TrackStateProxy<SL, M, ReadOnly>::TrackStateProxy(
     ConstIf<MultiTrajectory<SL>, ReadOnly>& trajectory, size_t istate)
     : m_traj(&trajectory), m_istate(istate) {}
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-TrackStatePropMask TrackStateProxy<SL, N, M, ReadOnly>::getMask() const {
+template <typename SL, size_t M, bool ReadOnly>
+TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
   using PM = TrackStatePropMask;
   PM mask = PM::None;
   if (hasPredicted()) {
@@ -49,8 +49,8 @@ TrackStatePropMask TrackStateProxy<SL, N, M, ReadOnly>::getMask() const {
   return mask;
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::parameters() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const
     -> Parameters {
   IndexData::IndexType idx;
   if (hasSmoothed()) {
@@ -64,8 +64,8 @@ inline auto TrackStateProxy<SL, N, M, ReadOnly>::parameters() const
   return Parameters(m_traj->m_params.data.col(idx).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::covariance() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const
     -> Covariance {
   IndexData::IndexType idx;
   if (hasSmoothed()) {
@@ -78,85 +78,85 @@ inline auto TrackStateProxy<SL, N, M, ReadOnly>::covariance() const
   return Covariance(m_traj->m_cov.data.col(idx).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::predicted() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::predicted() const
     -> Parameters {
   assert(data().ipredicted != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ipredicted).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::predictedCovariance() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::predictedCovariance() const
     -> Covariance {
   assert(data().ipredicted != IndexData::kInvalid);
   return Covariance(m_traj->m_cov.col(data().ipredicted).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::filtered() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::filtered() const
     -> Parameters {
   assert(data().ifiltered != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ifiltered).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::filteredCovariance() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::filteredCovariance() const
     -> Covariance {
   assert(data().ifiltered != IndexData::kInvalid);
   return Covariance(m_traj->m_cov.col(data().ifiltered).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::smoothed() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::smoothed() const
     -> Parameters {
   assert(data().ismoothed != IndexData::kInvalid);
   return Parameters(m_traj->m_params.col(data().ismoothed).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::smoothedCovariance() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::smoothedCovariance() const
     -> Covariance {
   assert(data().ismoothed != IndexData::kInvalid);
   return Covariance(m_traj->m_cov.col(data().ismoothed).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::jacobian() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const
     -> Covariance {
   assert(data().ijacobian != IndexData::kInvalid);
   return Covariance(m_traj->m_jac.col(data().ijacobian).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::projector() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::projector() const
     -> Projector {
   assert(data().iprojector != IndexData::kInvalid);
   return bitsetToMatrix<Projector>(m_traj->m_projectors[data().iprojector]);
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::uncalibrated() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::uncalibrated() const
     -> const SourceLink& {
   assert(data().iuncalibrated != IndexData::kInvalid);
   return m_traj->m_sourceLinks[data().iuncalibrated];
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::calibrated() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::calibrated() const
     -> Measurement {
   assert(data().icalibrated != IndexData::kInvalid);
   return Measurement(m_traj->m_meas.col(data().icalibrated).data());
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::calibratedSourceLink() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::calibratedSourceLink() const
     -> const SourceLink& {
   assert(data().icalibratedsourcelink != IndexData::kInvalid);
   return m_traj->m_sourceLinks[data().icalibratedsourcelink];
 }
 
-template <typename SL, size_t N, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, N, M, ReadOnly>::calibratedCovariance() const
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::calibratedCovariance() const
     -> MeasurementCovariance {
   assert(data().icalibrated != IndexData::kInvalid);
   return MeasurementCovariance(

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -52,9 +52,6 @@ class GainMatrixSmoother {
     ACTS_VERBOSE("Invoked GainMatrixSmoother on entry index: " << entryIndex);
     using namespace boost::adaptors;
 
-    using Matrix =
-        ActsSymMatrixD<MultiTrajectory<source_link_t>::ParametersSize>;
-
     // For the last state: smoothed is filtered - also: switch to next
     ACTS_VERBOSE("Getting previous track state");
     auto prev_ts = trajectory.getTrackState(entryIndex);
@@ -63,7 +60,7 @@ class GainMatrixSmoother {
     prev_ts.smoothedCovariance() = prev_ts.filteredCovariance();
 
     // Smoothing gain matrix
-    Matrix G;
+    BoundSymMatrix G;
 
     // make sure there is more than one track state
     std::optional<std::error_code> error{std::nullopt};  // assume ok
@@ -132,8 +129,8 @@ class GainMatrixSmoother {
         // If not, make one (could do more) attempt to replace it with the
         // nearest semi-positive def matrix,
         // but it could still be non semi-positive
-        Matrix smoothedCov = ts.smoothedCovariance();
-        if (not detail::covariance_helper<Matrix>::validate(smoothedCov)) {
+        BoundSymMatrix smoothedCov = ts.smoothedCovariance();
+        if (not detail::covariance_helper<BoundSymMatrix>::validate(smoothedCov)) {
           ACTS_DEBUG(
               "Smoothed covariance is not positive definite. Could result in "
               "negative covariance!");

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -130,7 +130,8 @@ class GainMatrixSmoother {
         // nearest semi-positive def matrix,
         // but it could still be non semi-positive
         BoundSymMatrix smoothedCov = ts.smoothedCovariance();
-        if (not detail::covariance_helper<BoundSymMatrix>::validate(smoothedCov)) {
+        if (not detail::covariance_helper<BoundSymMatrix>::validate(
+                smoothedCov)) {
           ACTS_DEBUG(
               "Smoothed covariance is not positive definite. Could result in "
               "negative covariance!");

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -115,9 +115,7 @@ class GainMatrixUpdater {
 
           filtered = predicted + K * (calibrated - H * predicted);
           filtered_covariance =
-              (BoundSymMatrix::Identity() -
-               K * H) *
-              predicted_covariance;
+              (BoundSymMatrix::Identity() - K * H) * predicted_covariance;
           ACTS_VERBOSE("Filtered parameters: " << filtered.transpose());
           ACTS_VERBOSE("Filtered covariance:\n" << filtered_covariance);
 

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -115,8 +115,7 @@ class GainMatrixUpdater {
 
           filtered = predicted + K * (calibrated - H * predicted);
           filtered_covariance =
-              (ActsSymMatrixD<
-                   MultiTrajectory<SourceLink>::ParametersSize>::Identity() -
+              (BoundSymMatrix::Identity() -
                K * H) *
               predicted_covariance;
           ACTS_VERBOSE("Filtered parameters: " << filtered.transpose());

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mCovFull.topLeftCorner(2, 2) = mCov;
   BOOST_CHECK_EQUAL(ts.calibratedCovariance(), mCovFull);
 
-  ActsMatrixD<maxmeasdim, maxparamdim> projFull;
+  ActsMatrixD<maxmeasdim, eBoundParametersSize> projFull;
   projFull.setZero();
   projFull.topLeftCorner(m2.size(), maxparamdim) = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -603,8 +603,7 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
               eBoundParametersSize>
       fullProj;
   fullProj.setZero();
-  fullProj.topLeftCorner(pc.meas3d->size(),
-                         eBoundParametersSize) =
+  fullProj.topLeftCorner(pc.meas3d->size(), eBoundParametersSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -501,7 +501,6 @@ BOOST_AUTO_TEST_CASE(trackstate_proxy_cross_talk) {
 
 BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   constexpr size_t maxmeasdim = MultiTrajectory<SourceLink>::MeasurementSizeMax;
-  constexpr size_t maxparamdim = MultiTrajectory<SourceLink>::ParametersSize;
 
   MultiTrajectory<SourceLink> t;
   size_t index = t.addTrackState();
@@ -538,7 +537,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mParFull.head(2) = mPar;
   BOOST_CHECK_EQUAL(ts.calibrated(), mParFull);
 
-  ActsSymMatrixD<maxmeasdim> mCovFull;
+  BoundSymMatrix mCovFull;
   mCovFull.setZero();
   mCovFull.topLeftCorner(2, 2) = mCov;
   BOOST_CHECK_EQUAL(ts.calibratedCovariance(), mCovFull);
@@ -601,11 +600,11 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
 
   // full projector, should be exactly equal
   ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
-              MultiTrajectory<SourceLink>::ParametersSize>
+              eBoundParametersSize>
       fullProj;
   fullProj.setZero();
   fullProj.topLeftCorner(pc.meas3d->size(),
-                         MultiTrajectory<SourceLink>::ParametersSize) =
+                         eBoundParametersSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -544,7 +544,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
 
   ActsMatrixD<maxmeasdim, eBoundParametersSize> projFull;
   projFull.setZero();
-  projFull.topLeftCorner(m2.size(), maxparamdim) = m2.projector();
+  projFull.topLeftCorner(m2.size(), eBoundParametersSize) = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);
 }
 


### PR DESCRIPTION
The track parametrisation has `eBoundParametersSize` dimensions. As this is already fixed in the current `ParametersSize` in the `MultiTrajectory` and is therefore already constant, this PR replaces `ParametersSize` by `eBoundParametersSize`.