### PR TITLE
Allow storage of FreeParameters in MultiTrajectory

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -602,11 +602,11 @@ constexpr bool VisitorConcept = concept ::require<
 /// can be easily identified. Some functionality is provided to simplify
 /// iterating over specific sub-components.
 /// @tparam source_link_t Type to link back to an original measurement
-template <typename source_link_t>
+template <typename source_link_t, size_t measurement_size_max_t = eBoundParametersSize>
 class MultiTrajectory {
  public:
   enum {
-    MeasurementSizeMax = eBoundParametersSize,
+    MeasurementSizeMax = measurement_size_max_t,
   };
   using SourceLink = source_link_t;
   using ConstTrackStateProxy =

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -106,6 +106,12 @@ struct Types {
   using StorageCovariance =
       GrowableColumns<Eigen::Array<Scalar, Size * Size, Eigen::Dynamic, Flags>,
                       SizeIncrement>;
+  using StorageQuadraticJacobian =
+      GrowableColumns<Eigen::Array<Scalar, Size * Size, Eigen::Dynamic, Flags>,
+                      SizeIncrement>;
+  using StorageNonQuadraticJacobian =
+      GrowableColumns<Eigen::Array<Scalar, eBoundParametersSize * eFreeParametersSize, Eigen::Dynamic, Flags>,
+                      SizeIncrement>;
 };
 
 struct IndexData {
@@ -121,7 +127,10 @@ struct IndexData {
   IndexType ifreepredicted = kInvalid;
   IndexType ifreefiltered = kInvalid;
   IndexType ifreesmoothed = kInvalid;
-  IndexType ijacobian = kInvalid;
+  IndexType ijacobianboundtobound = kInvalid;
+  IndexType ijacobianboundtofree = kInvalid;
+  IndexType ijacobianfreetobound = kInvalid;
+  IndexType ijacobianfreetofree = kInvalid;
   IndexType iprojector = kInvalid;
 
   double chi2;
@@ -329,14 +338,6 @@ class TrackStateProxy {
   /// @return Whether it is set
   bool hasSmoothed() const { return data().ismoothed != IndexData::kInvalid; }
 
-  /// Returns the jacobian from the previous trackstate to this one
-  /// @return The jacobian matrix
-  Covariance jacobian() const;
-
-  /// Returns whether a jacobian is set for this trackstate
-  /// @return Whether it is set
-  bool hasJacobian() const { return data().ijacobian != IndexData::kInvalid; }
-
   /// Predicted track parameters vector
   /// @return The predicted parameters
   FreeParameters freePredicted() const;
@@ -372,6 +373,14 @@ class TrackStateProxy {
   /// Return whether smoothed parameters+covariance is set
   /// @return Whether it is set
   bool hasFreeSmoothed() const { return data().ifreesmoothed != IndexData::kInvalid; }
+  
+  /// Returns the jacobian from the previous trackstate to this one
+  /// @return The jacobian matrix
+  BoundSymMatrix jacobian() const;
+
+  /// Returns whether a jacobian is set for this trackstate
+  /// @return Whether it is set
+  bool hasJacobian() const { return data().ijacobianboundtobound != IndexData::kInvalid; }
   
   /// Returns the projector (measurement mapping function) for this track
   /// state. It is derived from the uncalibrated measurement
@@ -739,7 +748,10 @@ class MultiTrajectory {
   typename detail_lt::Types<eFreeParametersSize>::StorageCovariance m_freeCov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCovariance m_measCov;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_jac;
+  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticJacobian m_jacBoundBound;
+  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticJacobian m_jacBoundFree;
+  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticJacobian m_jacFreeBound;
+  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticJacobian m_jacFreeFree;
   std::vector<SourceLink> m_sourceLinks;
   std::vector<ProjectorBitset> m_projectors;
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -771,8 +771,7 @@ class MultiTrajectory {
   using TrackStateProxy =
       detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, false>;
 
-  using ProjectorBitset =
-      std::bitset<eFreeParametersSize * MeasurementSizeMax>;
+  using ProjectorBitset = std::bitset<eFreeParametersSize * MeasurementSizeMax>;
 
   /// Create an empty trajectory.
   MultiTrajectory() = default;

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -246,12 +246,24 @@ class TrackStateProxy {
       smoothedCovariance() = other.smoothedCovariance();
     }
 
+    if (ACTS_CHECK_BIT(src, PM::JacobianBoundToBound)) {
+      jacobianBoundToBound() = other.jacobianBoundToBound();
+    }
+    
+    if (ACTS_CHECK_BIT(src, PM::JacobianBoundToFree)) {
+      jacobianBoundToFree() = other.jacobianBoundToFree();
+    }
+    
+    if (ACTS_CHECK_BIT(src, PM::JacobianFreeToBound)) {
+      jacobianFreeToBound() = other.jacobianFreeToBound();
+    }
+    
+    if (ACTS_CHECK_BIT(src, PM::JacobianFreeToFree)) {
+      jacobianFreeToFree() = other.jacobianFreeToFree();
+    }
+    
     if (ACTS_CHECK_BIT(src, PM::Uncalibrated)) {
       uncalibrated() = other.uncalibrated();
-    }
-
-    if (ACTS_CHECK_BIT(src, PM::Jacobian)) {
-      jacobian() = other.jacobian();
     }
 
     if (ACTS_CHECK_BIT(src, PM::Calibrated)) {
@@ -376,11 +388,29 @@ class TrackStateProxy {
   
   /// Returns the jacobian from the previous trackstate to this one
   /// @return The jacobian matrix
-  BoundSymMatrix jacobian() const;
+  BoundSymMatrix jacobianBoundToBound() const;
 
   /// Returns whether a jacobian is set for this trackstate
   /// @return Whether it is set
-  bool hasJacobian() const { return data().ijacobianboundtobound != IndexData::kInvalid; }
+  bool hasJacobianBoundToBound() const { return data().ijacobianboundtobound != IndexData::kInvalid; }
+  
+  /// @copydoc jacobianBoundToBound()
+  BoundToFreeMatrix jacobianBoundToFree() const;
+
+  /// @copydoc hasJacobianBoundToBound()
+  bool hasJacobianBoundToFree() const { return data().ijacobianboundtofree != IndexData::kInvalid; }
+  
+  /// @copydoc jacobianBoundToBound()
+  FreeToBoundMatrix jacobianFreeToBound() const;
+
+  /// @copydoc hasJacobianBoundToBound()
+  bool hasJacobianFreeToBound() const { return data().ijacobianfreetobound != IndexData::kInvalid; }
+  
+  /// @copydoc jacobianBoundToBound()
+  FreeSymMatrix jacobianFreeToFree() const;
+
+  /// @copydoc hasJacobianBoundToBound()
+  bool hasJacobianFreeToFree() const { return data().ijacobianfreetofree != IndexData::kInvalid; }
   
   /// Returns the projector (measurement mapping function) for this track
   /// state. It is derived from the uncalibrated measurement

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -38,7 +38,7 @@ enum TrackStateFlag {
 using TrackStateType = std::bitset<TrackStateFlag::NumTrackStateFlags>;
 
 // forward declarations
-template <typename source_link_t>
+template <typename source_link_t, size_t measurement_size_max_t>
 class MultiTrajectory;
 class Surface;
 
@@ -146,6 +146,7 @@ class TrackStateProxy {
       typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
+  static constexpr size_t N = eFreeParametersSize; // TODO
 
   // as opposed to the types above, this is an actual Matrix (rather than a
   // map)
@@ -555,7 +556,7 @@ class TrackStateProxy {
 
  private:
   // Private since it can only be created by the trajectory.
-  TrackStateProxy(ConstIf<MultiTrajectory<SourceLink>, ReadOnly>& trajectory,
+  TrackStateProxy(ConstIf<MultiTrajectory<SourceLink, M>, ReadOnly>& trajectory,
                   size_t istate);
 
   const std::shared_ptr<const Surface>& referenceSurfacePointer() const {
@@ -563,7 +564,7 @@ class TrackStateProxy {
     return m_traj->m_referenceSurfaces[data().irefsurface];
   }
 
-  typename MultiTrajectory<SourceLink>::ProjectorBitset projectorBitset()
+  typename MultiTrajectory<SourceLink, M>::ProjectorBitset projectorBitset()
       const {
     assert(data().iprojector != IndexData::kInvalid);
     return m_traj->m_projectors[data().iprojector];
@@ -571,15 +572,15 @@ class TrackStateProxy {
 
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
   void setProjectorBitset(
-      typename MultiTrajectory<SourceLink>::ProjectorBitset proj) {
+      typename MultiTrajectory<SourceLink, M>::ProjectorBitset proj) {
     assert(data().iprojector != IndexData::kInvalid);
     m_traj->m_projectors[data().iprojector] = proj;
   }
 
-  ConstIf<MultiTrajectory<SourceLink>, ReadOnly>* m_traj;
+  ConstIf<MultiTrajectory<SourceLink, M>, ReadOnly>* m_traj;
   size_t m_istate;
 
-  friend class Acts::MultiTrajectory<SourceLink>;
+  friend class Acts::MultiTrajectory<SourceLink, M>;
 };
 
 // implement track state visitor concept

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -118,6 +118,9 @@ struct IndexData {
   IndexType ipredicted = kInvalid;
   IndexType ifiltered = kInvalid;
   IndexType ismoothed = kInvalid;
+  IndexType ipredictedfree = kInvalid;
+  IndexType ifilteredfree = kInvalid;
+  IndexType ismoothedfree = kInvalid;
   IndexType ijacobian = kInvalid;
   IndexType iprojector = kInvalid;
 
@@ -144,6 +147,8 @@ class TrackStateProxy {
       typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
   using Covariance =
       typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
+  using FreeParameters = typename Types<eFreeParametersSize, ReadOnly>::CoefficientsMap;
+  using FreeCovariance = typename Types<eFreeParametersSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
   static constexpr size_t N = eFreeParametersSize; // TODO
@@ -213,6 +218,21 @@ class TrackStateProxy {
     }
 
     if (ACTS_CHECK_BIT(src, PM::Smoothed)) {
+      smoothed() = other.smoothed();
+      smoothedCovariance() = other.smoothedCovariance();
+    }
+    
+    if (ACTS_CHECK_BIT(src, PM::PredictedFree)) {
+      predicted() = other.predicted();
+      predictedCovariance() = other.predictedCovariance();
+    }
+
+    if (ACTS_CHECK_BIT(src, PM::FilteredFree)) {
+      filtered() = other.filtered();
+      filteredCovariance() = other.filteredCovariance();
+    }
+
+    if (ACTS_CHECK_BIT(src, PM::SmoothedFree)) {
       smoothed() = other.smoothed();
       smoothedCovariance() = other.smoothedCovariance();
     }
@@ -664,6 +684,8 @@ class MultiTrajectory {
   std::vector<detail_lt::IndexData> m_index;
   typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_params;
   typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_cov;
+  typename detail_lt::Types<eFreeParametersSize>::StorageCoefficients m_freeParams;
+  typename detail_lt::Types<eFreeParametersSize>::StorageCovariance m_freeCov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCovariance m_measCov;
   typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_jac;

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -100,11 +100,16 @@ struct Types {
   using CoefficientsMap = Eigen::Map<ConstIf<Coefficients, ReadOnlyMaps>>;
   using CovarianceMap = Eigen::Map<ConstIf<Covariance, ReadOnlyMaps>>;
   using QuadraticJacobian = Eigen::Matrix<Scalar, Size, Size, Flags>;
-  using JacobianBoundToFree = Eigen::Matrix<Scalar, eFreeParametersSize, eBoundParametersSize, Flags>;
-  using JacobianFreeToBound = Eigen::Matrix<Scalar, eBoundParametersSize, eFreeParametersSize, Flags>;
-  using QuadraticJacobianMap = Eigen::Map<ConstIf<QuadraticJacobian, ReadOnlyMaps>>;
-  using JacobianBoundToFreeMap = Eigen::Map<ConstIf<JacobianBoundToFree, ReadOnlyMaps>>;
-  using JacobianFreeToBoundMap = Eigen::Map<ConstIf<JacobianFreeToBound, ReadOnlyMaps>>;
+  using JacobianBoundToFree =
+      Eigen::Matrix<Scalar, eFreeParametersSize, eBoundParametersSize, Flags>;
+  using JacobianFreeToBound =
+      Eigen::Matrix<Scalar, eBoundParametersSize, eFreeParametersSize, Flags>;
+  using QuadraticJacobianMap =
+      Eigen::Map<ConstIf<QuadraticJacobian, ReadOnlyMaps>>;
+  using JacobianBoundToFreeMap =
+      Eigen::Map<ConstIf<JacobianBoundToFree, ReadOnlyMaps>>;
+  using JacobianFreeToBoundMap =
+      Eigen::Map<ConstIf<JacobianFreeToBound, ReadOnlyMaps>>;
   // storage of multiple items in flat arrays
   using StorageCoefficients =
       GrowableColumns<Eigen::Array<Scalar, Size, Eigen::Dynamic, Flags>,
@@ -112,9 +117,10 @@ struct Types {
   using StorageQuadraticMatrix =
       GrowableColumns<Eigen::Array<Scalar, Size * Size, Eigen::Dynamic, Flags>,
                       SizeIncrement>;
-  using StorageNonQuadraticMatrix =
-      GrowableColumns<Eigen::Array<Scalar, eBoundParametersSize * eFreeParametersSize, Eigen::Dynamic, Flags>,
-                      SizeIncrement>;
+  using StorageNonQuadraticMatrix = GrowableColumns<
+      Eigen::Array<Scalar, eBoundParametersSize * eFreeParametersSize,
+                   Eigen::Dynamic, Flags>,
+      SizeIncrement>;
 };
 
 struct IndexData {
@@ -155,14 +161,22 @@ template <typename source_link_t, size_t M, bool ReadOnly = true>
 class TrackStateProxy {
  public:
   using SourceLink = source_link_t;
-  using BoundParameters = typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
-  using BoundCovariance = typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
-  using FreeParameters = typename Types<eFreeParametersSize, ReadOnly>::CoefficientsMap;
-  using FreeCovariance = typename Types<eFreeParametersSize, ReadOnly>::CovarianceMap;
-  using JacobianBoundToBound = typename Types<eBoundParametersSize, ReadOnly>::QuadraticJacobianMap;
-  using JacobianBoundToFree = typename Types<eBoundParametersSize, ReadOnly>::JacobianBoundToFreeMap;
-  using JacobianFreeToBound = typename Types<eFreeParametersSize, ReadOnly>::JacobianFreeToBoundMap;
-  using JacobianFreeToFree = typename Types<eFreeParametersSize, ReadOnly>::QuadraticJacobianMap;
+  using BoundParameters =
+      typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
+  using BoundCovariance =
+      typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
+  using FreeParameters =
+      typename Types<eFreeParametersSize, ReadOnly>::CoefficientsMap;
+  using FreeCovariance =
+      typename Types<eFreeParametersSize, ReadOnly>::CovarianceMap;
+  using JacobianBoundToBound =
+      typename Types<eBoundParametersSize, ReadOnly>::QuadraticJacobianMap;
+  using JacobianBoundToFree =
+      typename Types<eBoundParametersSize, ReadOnly>::JacobianBoundToFreeMap;
+  using JacobianFreeToBound =
+      typename Types<eFreeParametersSize, ReadOnly>::JacobianFreeToBoundMap;
+  using JacobianFreeToFree =
+      typename Types<eFreeParametersSize, ReadOnly>::QuadraticJacobianMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
 
@@ -171,8 +185,8 @@ class TrackStateProxy {
   // @TODO: Does not copy flags, because this fails: can't have col major row
   // vector, but that's required for 1xN projection matrices below.
   constexpr static auto ProjectorFlags = Eigen::RowMajor | Eigen::AutoAlign;
-  using Projector =
-      Eigen::Matrix<typename BoundCovariance::Scalar, M, eFreeParametersSize, ProjectorFlags>;
+  using Projector = Eigen::Matrix<typename BoundCovariance::Scalar, M,
+                                  eFreeParametersSize, ProjectorFlags>;
   using EffectiveBoundProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
                     ProjectorFlags, M, eBoundParametersSize>;
@@ -237,7 +251,7 @@ class TrackStateProxy {
       boundSmoothed() = other.boundSmoothed();
       boundSmoothedCovariance() = other.boundSmoothedCovariance();
     }
-    
+
     if (ACTS_CHECK_BIT(src, PM::FreePredicted)) {
       freePredicted() = other.freePredicted();
       freePredictedCovariance() = other.freePredictedCovariance();
@@ -256,19 +270,19 @@ class TrackStateProxy {
     if (ACTS_CHECK_BIT(src, PM::JacobianBoundToBound)) {
       jacobianBoundToBound() = other.jacobianBoundToBound();
     }
-    
+
     if (ACTS_CHECK_BIT(src, PM::JacobianBoundToFree)) {
       jacobianBoundToFree() = other.jacobianBoundToFree();
     }
-    
+
     if (ACTS_CHECK_BIT(src, PM::JacobianFreeToBound)) {
       jacobianFreeToBound() = other.jacobianFreeToBound();
     }
-    
+
     if (ACTS_CHECK_BIT(src, PM::JacobianFreeToFree)) {
       jacobianFreeToFree() = other.jacobianFreeToFree();
     }
-    
+
     if (ACTS_CHECK_BIT(src, PM::Uncalibrated)) {
       uncalibrated() = other.uncalibrated();
     }
@@ -331,7 +345,9 @@ class TrackStateProxy {
 
   /// Check whether the predicted parameters+covariance is set
   /// @return Whether it is set or not
-  bool hasBoundPredicted() const { return data().iboundpredicted != IndexData::kInvalid; }
+  bool hasBoundPredicted() const {
+    return data().iboundpredicted != IndexData::kInvalid;
+  }
 
   /// Filtered track parameters vector
   /// @return The filtered parameters
@@ -343,7 +359,9 @@ class TrackStateProxy {
 
   /// Return whether filtered parameters+covariance is set
   /// @return Whether it is set
-  bool hasBoundFiltered() const { return data().iboundfiltered != IndexData::kInvalid; }
+  bool hasBoundFiltered() const {
+    return data().iboundfiltered != IndexData::kInvalid;
+  }
 
   /// Smoothed track parameters vector
   /// @return The smoothed parameters
@@ -355,7 +373,9 @@ class TrackStateProxy {
 
   /// Return whether smoothed parameters+covariance is set
   /// @return Whether it is set
-  bool hasBoundSmoothed() const { return data().iboundsmoothed != IndexData::kInvalid; }
+  bool hasBoundSmoothed() const {
+    return data().iboundsmoothed != IndexData::kInvalid;
+  }
 
   /// Predicted track parameters vector
   /// @return The predicted parameters
@@ -367,7 +387,9 @@ class TrackStateProxy {
 
   /// Check whether the predicted parameters+covariance is set
   /// @return Whether it is set or not
-  bool hasFreePredicted() const { return data().ifreepredicted != IndexData::kInvalid; }
+  bool hasFreePredicted() const {
+    return data().ifreepredicted != IndexData::kInvalid;
+  }
 
   /// Filtered track parameters vector
   /// @return The filtered parameters
@@ -379,7 +401,9 @@ class TrackStateProxy {
 
   /// Return whether filtered parameters+covariance is set
   /// @return Whether it is set
-  bool hasFreeFiltered() const { return data().ifreefiltered != IndexData::kInvalid; }
+  bool hasFreeFiltered() const {
+    return data().ifreefiltered != IndexData::kInvalid;
+  }
 
   /// Smoothed track parameters vector
   /// @return The smoothed parameters
@@ -391,39 +415,52 @@ class TrackStateProxy {
 
   /// Return whether smoothed parameters+covariance is set
   /// @return Whether it is set
-  bool hasFreeSmoothed() const { return data().ifreesmoothed != IndexData::kInvalid; }
-  
+  bool hasFreeSmoothed() const {
+    return data().ifreesmoothed != IndexData::kInvalid;
+  }
+
   /// Returns the jacobian from the previous trackstate to this one
   /// @return The jacobian matrix
   JacobianBoundToBound jacobianBoundToBound() const;
 
   /// Returns whether a jacobian is set for this trackstate
   /// @return Whether it is set
-  bool hasJacobianBoundToBound() const { return data().ijacobianboundtobound != IndexData::kInvalid; }
-  
+  bool hasJacobianBoundToBound() const {
+    return data().ijacobianboundtobound != IndexData::kInvalid;
+  }
+
   /// @copydoc jacobianBoundToBound()
   JacobianBoundToFree jacobianBoundToFree() const;
 
   /// @copydoc hasJacobianBoundToBound()
-  bool hasJacobianBoundToFree() const { return data().ijacobianboundtofree != IndexData::kInvalid; }
-  
+  bool hasJacobianBoundToFree() const {
+    return data().ijacobianboundtofree != IndexData::kInvalid;
+  }
+
   /// @copydoc jacobianBoundToBound()
   JacobianFreeToBound jacobianFreeToBound() const;
 
   /// @copydoc hasJacobianBoundToBound()
-  bool hasJacobianFreeToBound() const { return data().ijacobianfreetobound != IndexData::kInvalid; }
-  
+  bool hasJacobianFreeToBound() const {
+    return data().ijacobianfreetobound != IndexData::kInvalid;
+  }
+
   /// @copydoc jacobianBoundToBound()
   JacobianFreeToFree jacobianFreeToFree() const;
 
   /// @copydoc hasJacobianBoundToBound()
-  bool hasJacobianFreeToFree() const { return data().ijacobianfreetofree != IndexData::kInvalid; }
-  
+  bool hasJacobianFreeToFree() const {
+    return data().ijacobianfreetofree != IndexData::kInvalid;
+  }
+
   /// Returns the projector (measurement mapping function) for this track
   /// state. It is derived from the uncalibrated measurement
   /// @note This function returns the overallocated projector. This means it
   /// is of dimension MxP, where M is the maximum number of measurement
-  /// dimensions and P the maximum number of parameters dimensions. The NxQ submatrix, where N is the actual dimension of the measurement and Q the actual dimension of the parameters, is located in the top left corner, everything else is zero.
+  /// dimensions and P the maximum number of parameters dimensions. The NxQ
+  /// submatrix, where N is the actual dimension of the measurement and Q the
+  /// actual dimension of the parameters, is located in the top left corner,
+  /// everything else is zero.
   /// @return The overallocated projector
   Projector projector() const;
 
@@ -450,7 +487,7 @@ class TrackStateProxy {
   EffectiveFreeProjector effectiveFreeProjector() const {
     return projector().topLeftCorner(data().measdim, eFreeParametersSize);
   }
-  
+
   /// Set the projector on this track state
   /// This will convert the projector to a more compact bitset representation
   /// and store it.
@@ -469,7 +506,8 @@ class TrackStateProxy {
     assert(dataref.iprojector != IndexData::kInvalid);
 
     static_assert(rows <= M, "Given projector has too many rows");
-    static_assert(cols <= eFreeParametersSize, "Given projector has too many columns");
+    static_assert(cols <= eFreeParametersSize,
+                  "Given projector has too many columns");
 
     // set up full size projector with only zeros
     typename TrackStateProxy::Projector fullProjector =
@@ -564,7 +602,7 @@ class TrackStateProxy {
     constexpr size_t measdim =
         Acts::Measurement<SourceLink, BoundParametersIndices,
                           params...>::size();
-	static_assert(measdim <= M, "Measurement has too many dimensions");
+    static_assert(measdim <= M, "Measurement has too many dimensions");
     dataref.measdim = measdim;
 
     assert(hasCalibrated());
@@ -608,7 +646,7 @@ class TrackStateProxy {
     constexpr size_t measdim =
         Acts::Measurement<SourceLink, BoundParametersIndices,
                           params...>::size();
-	static_assert(measdim <= M, "Measurement has too many dimensions");
+    static_assert(measdim <= M, "Measurement has too many dimensions");
     dataref.measdim = measdim;
 
     auto& traj = *m_traj;
@@ -720,7 +758,8 @@ constexpr bool VisitorConcept = concept ::require<
 /// can be easily identified. Some functionality is provided to simplify
 /// iterating over specific sub-components.
 /// @tparam source_link_t Type to link back to an original measurement
-template <typename source_link_t, size_t measurement_size_max_t = eBoundParametersSize>
+template <typename source_link_t,
+          size_t measurement_size_max_t = eBoundParametersSize>
 class MultiTrajectory {
  public:
   enum {
@@ -779,21 +818,30 @@ class MultiTrajectory {
  private:
   /// index to map track states to the corresponding
   std::vector<detail_lt::IndexData> m_index;
-  
-  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_boundParams;
-  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticMatrix m_boundCov;
-  
-  typename detail_lt::Types<eFreeParametersSize>::StorageCoefficients m_freeParams;
-  typename detail_lt::Types<eFreeParametersSize>::StorageQuadraticMatrix m_freeCov;
-  
+
+  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients
+      m_boundParams;
+  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticMatrix
+      m_boundCov;
+
+  typename detail_lt::Types<eFreeParametersSize>::StorageCoefficients
+      m_freeParams;
+  typename detail_lt::Types<eFreeParametersSize>::StorageQuadraticMatrix
+      m_freeCov;
+
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
-  typename detail_lt::Types<MeasurementSizeMax>::StorageQuadraticMatrix m_measCov;
-  
-  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticMatrix m_jacBoundToBound;
-  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticMatrix m_jacBoundToFree;
-  typename detail_lt::Types<eFreeParametersSize>::StorageNonQuadraticMatrix m_jacFreeToBound;
-  typename detail_lt::Types<eFreeParametersSize>::StorageQuadraticMatrix m_jacFreeToFree;
-  
+  typename detail_lt::Types<MeasurementSizeMax>::StorageQuadraticMatrix
+      m_measCov;
+
+  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticMatrix
+      m_jacBoundToBound;
+  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticMatrix
+      m_jacBoundToFree;
+  typename detail_lt::Types<eFreeParametersSize>::StorageNonQuadraticMatrix
+      m_jacFreeToBound;
+  typename detail_lt::Types<eFreeParametersSize>::StorageQuadraticMatrix
+      m_jacFreeToFree;
+
   std::vector<SourceLink> m_sourceLinks;
   std::vector<ProjectorBitset> m_projectors;
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -118,9 +118,9 @@ struct IndexData {
   IndexType ipredicted = kInvalid;
   IndexType ifiltered = kInvalid;
   IndexType ismoothed = kInvalid;
-  IndexType ipredictedfree = kInvalid;
-  IndexType ifilteredfree = kInvalid;
-  IndexType ismoothedfree = kInvalid;
+  IndexType ifreepredicted = kInvalid;
+  IndexType ifreefiltered = kInvalid;
+  IndexType ifreesmoothed = kInvalid;
   IndexType ijacobian = kInvalid;
   IndexType iprojector = kInvalid;
 
@@ -222,17 +222,17 @@ class TrackStateProxy {
       smoothedCovariance() = other.smoothedCovariance();
     }
     
-    if (ACTS_CHECK_BIT(src, PM::PredictedFree)) {
+    if (ACTS_CHECK_BIT(src, PM::FreePredicted)) {
       predicted() = other.predicted();
       predictedCovariance() = other.predictedCovariance();
     }
 
-    if (ACTS_CHECK_BIT(src, PM::FilteredFree)) {
+    if (ACTS_CHECK_BIT(src, PM::FreeFiltered)) {
       filtered() = other.filtered();
       filteredCovariance() = other.filteredCovariance();
     }
 
-    if (ACTS_CHECK_BIT(src, PM::SmoothedFree)) {
+    if (ACTS_CHECK_BIT(src, PM::FreeSmoothed)) {
       smoothed() = other.smoothed();
       smoothedCovariance() = other.smoothedCovariance();
     }
@@ -337,6 +337,42 @@ class TrackStateProxy {
   /// @return Whether it is set
   bool hasJacobian() const { return data().ijacobian != IndexData::kInvalid; }
 
+  /// Predicted track parameters vector
+  /// @return The predicted parameters
+  FreeParameters freePredicted() const;
+
+  /// Predicted track parameters covariance matrix.
+  /// @return The predicted track parameter covariance
+  FreeCovariance freePredictedCovariance() const;
+
+  /// Check whether the predicted parameters+covariance is set
+  /// @return Whether it is set or not
+  bool hasFreePredicted() const { return data().ifreepredicted != IndexData::kInvalid; }
+
+  /// Filtered track parameters vector
+  /// @return The filtered parameters
+  FreeParameters freeFiltered() const;
+
+  /// Filtered track parameters covariance matrix
+  /// @return The filtered parameters covariance
+  FreeCovariance freeFilteredCovariance() const;
+
+  /// Return whether filtered parameters+covariance is set
+  /// @return Whether it is set
+  bool hasFreeFiltered() const { return data().ifreefiltered != IndexData::kInvalid; }
+
+  /// Smoothed track parameters vector
+  /// @return The smoothed parameters
+  FreeParameters freeSmoothed() const;
+
+  /// Smoothed track parameters covariance matrix
+  /// @return the parameter covariance matrix
+  FreeCovariance freeSmoothedCovariance() const;
+
+  /// Return whether smoothed parameters+covariance is set
+  /// @return Whether it is set
+  bool hasFreeSmoothed() const { return data().ifreesmoothed != IndexData::kInvalid; }
+  
   /// Returns the projector (measurement mapping function) for this track
   /// state. It is derived from the uncalibrated measurement
   /// @note This function returns the overallocated projector. This means it

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -128,8 +128,8 @@ struct IndexData {
   IndexType irefsurface = kInvalid;
   IndexType iprevious = kInvalid;
   IndexType iboundpredicted = kInvalid;
-  IndexType ifiltered = kInvalid;
-  IndexType ismoothed = kInvalid;
+  IndexType iboundfiltered = kInvalid;
+  IndexType iboundsmoothed = kInvalid;
   IndexType ifreepredicted = kInvalid;
   IndexType ifreefiltered = kInvalid;
   IndexType ifreesmoothed = kInvalid;
@@ -233,14 +233,14 @@ class TrackStateProxy {
       boundPredictedCovariance() = other.boundPredictedCovariance();
     }
 
-    if (ACTS_CHECK_BIT(src, PM::Filtered)) {
-      filtered() = other.filtered();
-      filteredCovariance() = other.filteredCovariance();
+    if (ACTS_CHECK_BIT(src, PM::BoundFiltered)) {
+      boundFiltered() = other.boundFiltered();
+      boundFilteredCovariance() = other.boundFilteredCovariance();
     }
 
-    if (ACTS_CHECK_BIT(src, PM::Smoothed)) {
-      smoothed() = other.smoothed();
-      smoothedCovariance() = other.smoothedCovariance();
+    if (ACTS_CHECK_BIT(src, PM::BoundSmoothed)) {
+      boundSmoothed() = other.boundSmoothed();
+      boundSmoothedCovariance() = other.boundSmoothedCovariance();
     }
     
     if (ACTS_CHECK_BIT(src, PM::FreePredicted)) {
@@ -340,27 +340,27 @@ class TrackStateProxy {
 
   /// Filtered track parameters vector
   /// @return The filtered parameters
-  Parameters filtered() const;
+  Parameters boundFiltered() const;
 
   /// Filtered track parameters covariance matrix
   /// @return The filtered parameters covariance
-  Covariance filteredCovariance() const;
+  Covariance boundFilteredCovariance() const;
 
   /// Return whether filtered parameters+covariance is set
   /// @return Whether it is set
-  bool hasFiltered() const { return data().ifiltered != IndexData::kInvalid; }
+  bool hasBoundFiltered() const { return data().iboundfiltered != IndexData::kInvalid; }
 
   /// Smoothed track parameters vector
   /// @return The smoothed parameters
-  Parameters smoothed() const;
+  Parameters boundSmoothed() const;
 
   /// Smoothed track parameters covariance matrix
   /// @return the parameter covariance matrix
-  Covariance smoothedCovariance() const;
+  Covariance boundSmoothedCovariance() const;
 
   /// Return whether smoothed parameters+covariance is set
   /// @return Whether it is set
-  bool hasSmoothed() const { return data().ismoothed != IndexData::kInvalid; }
+  bool hasBoundSmoothed() const { return data().iboundsmoothed != IndexData::kInvalid; }
 
   /// Predicted track parameters vector
   /// @return The predicted parameters

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -160,7 +160,7 @@ class TrackStateProxy {
   using FreeCovariance = typename Types<eFreeParametersSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
-  static constexpr size_t N = eFreeParametersSize; // TODO
+  //~ static constexpr size_t N = eFreeParametersSize; // TODO
 
   // as opposed to the types above, this is an actual Matrix (rather than a
   // map)
@@ -172,6 +172,9 @@ class TrackStateProxy {
   using EffectiveProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
                     ProjectorFlags, M, eBoundParametersSize>;
+  using EffectiveFreeProjector =
+      Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
+                    ProjectorFlags, M, eFreeParametersSize>;
 
   /// Index within the trajectory.
   /// @return the index
@@ -440,7 +443,7 @@ class TrackStateProxy {
   /// is of dimension NxM, where N is the actual dimension of the
   /// measurement and M the dimension of free parameters.
   /// @return The effective projector
-  EffectiveProjector effectiveFreeProjector() const {
+  EffectiveFreeProjector effectiveFreeProjector() const {
     return projector().topLeftCorner(data().measdim, eFreeParametersSize);
   }
   

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -127,7 +127,7 @@ struct IndexData {
 
   IndexType irefsurface = kInvalid;
   IndexType iprevious = kInvalid;
-  IndexType ipredicted = kInvalid;
+  IndexType iboundpredicted = kInvalid;
   IndexType ifiltered = kInvalid;
   IndexType ismoothed = kInvalid;
   IndexType ifreepredicted = kInvalid;
@@ -228,9 +228,9 @@ class TrackStateProxy {
     }
 
     // we're sure now this has correct allocations, so just copy
-    if (ACTS_CHECK_BIT(src, PM::Predicted)) {
-      predicted() = other.predicted();
-      predictedCovariance() = other.predictedCovariance();
+    if (ACTS_CHECK_BIT(src, PM::BoundPredicted)) {
+      boundPredicted() = other.boundPredicted();
+      boundPredictedCovariance() = other.boundPredictedCovariance();
     }
 
     if (ACTS_CHECK_BIT(src, PM::Filtered)) {
@@ -244,18 +244,18 @@ class TrackStateProxy {
     }
     
     if (ACTS_CHECK_BIT(src, PM::FreePredicted)) {
-      predicted() = other.predicted();
-      predictedCovariance() = other.predictedCovariance();
+      freePredicted() = other.freePredicted();
+      freePredictedCovariance() = other.freePredictedCovariance();
     }
 
     if (ACTS_CHECK_BIT(src, PM::FreeFiltered)) {
-      filtered() = other.filtered();
-      filteredCovariance() = other.filteredCovariance();
+      freeFiltered() = other.freeFiltered();
+      freeFilteredCovariance() = other.freeFilteredCovariance();
     }
 
     if (ACTS_CHECK_BIT(src, PM::FreeSmoothed)) {
-      smoothed() = other.smoothed();
-      smoothedCovariance() = other.smoothedCovariance();
+      freeSmoothed() = other.freeSmoothed();
+      freeSmoothedCovariance() = other.freeSmoothedCovariance();
     }
 
     if (ACTS_CHECK_BIT(src, PM::JacobianBoundToBound)) {
@@ -328,15 +328,15 @@ class TrackStateProxy {
 
   /// Predicted track parameters vector
   /// @return The predicted parameters
-  Parameters predicted() const;
+  Parameters boundPredicted() const;
 
   /// Predicted track parameters covariance matrix.
   /// @return The predicted track parameter covariance
-  Covariance predictedCovariance() const;
+  Covariance boundPredictedCovariance() const;
 
   /// Check whether the predicted parameters+covariance is set
   /// @return Whether it is set or not
-  bool hasPredicted() const { return data().ipredicted != IndexData::kInvalid; }
+  bool hasBoundPredicted() const { return data().iboundpredicted != IndexData::kInvalid; }
 
   /// Filtered track parameters vector
   /// @return The filtered parameters
@@ -784,8 +784,8 @@ class MultiTrajectory {
  private:
   /// index to map track states to the corresponding
   std::vector<detail_lt::IndexData> m_index;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_params;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_cov;
+  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_boundParams;
+  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_boundCov;
   typename detail_lt::Types<eFreeParametersSize>::StorageCoefficients m_freeParams;
   typename detail_lt::Types<eFreeParametersSize>::StorageCovariance m_freeCov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -99,6 +99,12 @@ struct Types {
   using Covariance = Eigen::Matrix<Scalar, Size, Size, Flags>;
   using CoefficientsMap = Eigen::Map<ConstIf<Coefficients, ReadOnlyMaps>>;
   using CovarianceMap = Eigen::Map<ConstIf<Covariance, ReadOnlyMaps>>;
+  using QuadraticJacobian = Eigen::Matrix<Scalar, Size, Size, Flags>;
+  using JacobianBoundToFree = Eigen::Matrix<Scalar, eFreeParametersSize, eBoundParametersSize, Flags>;
+  using JacobianFreeToBound = Eigen::Matrix<Scalar, eBoundParametersSize, eFreeParametersSize, Flags>;
+  using QuadraticJacobianMap = Eigen::Map<ConstIf<QuadraticJacobian, ReadOnlyMaps>>;
+  using JacobianBoundToFreeMap = Eigen::Map<ConstIf<JacobianBoundToFree, ReadOnlyMaps>>;
+  using JacobianFreeToBoundMap = Eigen::Map<ConstIf<JacobianFreeToBound, ReadOnlyMaps>>;
   // storage of multiple items in flat arrays
   using StorageCoefficients =
       GrowableColumns<Eigen::Array<Scalar, Size, Eigen::Dynamic, Flags>,
@@ -158,9 +164,12 @@ class TrackStateProxy {
       typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
   using FreeParameters = typename Types<eFreeParametersSize, ReadOnly>::CoefficientsMap;
   using FreeCovariance = typename Types<eFreeParametersSize, ReadOnly>::CovarianceMap;
+  using JacobianBoundToBound = typename Types<eBoundParametersSize, ReadOnly>::QuadraticJacobianMap;
+  using JacobianBoundToFree = typename Types<eBoundParametersSize, ReadOnly>::JacobianBoundToFreeMap;
+  using JacobianFreeToBound = typename Types<eFreeParametersSize, ReadOnly>::JacobianFreeToBoundMap;
+  using JacobianFreeToFree = typename Types<eFreeParametersSize, ReadOnly>::QuadraticJacobianMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
-  //~ static constexpr size_t N = eFreeParametersSize; // TODO
 
   // as opposed to the types above, this is an actual Matrix (rather than a
   // map)
@@ -391,26 +400,26 @@ class TrackStateProxy {
   
   /// Returns the jacobian from the previous trackstate to this one
   /// @return The jacobian matrix
-  BoundSymMatrix jacobianBoundToBound() const;
+  JacobianBoundToBound jacobianBoundToBound() const;
 
   /// Returns whether a jacobian is set for this trackstate
   /// @return Whether it is set
   bool hasJacobianBoundToBound() const { return data().ijacobianboundtobound != IndexData::kInvalid; }
   
   /// @copydoc jacobianBoundToBound()
-  BoundToFreeMatrix jacobianBoundToFree() const;
+  JacobianBoundToFree jacobianBoundToFree() const;
 
   /// @copydoc hasJacobianBoundToBound()
   bool hasJacobianBoundToFree() const { return data().ijacobianboundtofree != IndexData::kInvalid; }
   
   /// @copydoc jacobianBoundToBound()
-  FreeToBoundMatrix jacobianFreeToBound() const;
+  JacobianFreeToBound jacobianFreeToBound() const;
 
   /// @copydoc hasJacobianBoundToBound()
   bool hasJacobianFreeToBound() const { return data().ijacobianfreetobound != IndexData::kInvalid; }
   
   /// @copydoc jacobianBoundToBound()
-  FreeSymMatrix jacobianFreeToFree() const;
+  JacobianFreeToFree jacobianFreeToFree() const;
 
   /// @copydoc hasJacobianBoundToBound()
   bool hasJacobianFreeToFree() const { return data().ijacobianfreetofree != IndexData::kInvalid; }
@@ -781,10 +790,10 @@ class MultiTrajectory {
   typename detail_lt::Types<eFreeParametersSize>::StorageCovariance m_freeCov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCovariance m_measCov;
-  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticJacobian m_jacBoundBound;
-  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticJacobian m_jacBoundFree;
-  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticJacobian m_jacFreeBound;
-  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticJacobian m_jacFreeFree;
+  typename detail_lt::Types<eBoundParametersSize>::StorageQuadraticJacobian m_jacBoundToBound;
+  typename detail_lt::Types<eBoundParametersSize>::StorageNonQuadraticJacobian m_jacBoundToFree;
+  typename detail_lt::Types<eFreeParametersSize>::StorageNonQuadraticJacobian m_jacFreeToBound;
+  typename detail_lt::Types<eFreeParametersSize>::StorageQuadraticJacobian m_jacFreeToFree;
   std::vector<SourceLink> m_sourceLinks;
   std::vector<ProjectorBitset> m_projectors;
 

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -19,7 +19,7 @@ namespace Acts {
 namespace detail_lt {
 template <typename SL, size_t M, bool ReadOnly>
 inline TrackStateProxy<SL, M, ReadOnly>::TrackStateProxy(
-    ConstIf<MultiTrajectory<SL>, ReadOnly>& trajectory, size_t istate)
+    ConstIf<MultiTrajectory<SL, M>, ReadOnly>& trajectory, size_t istate)
     : m_traj(&trajectory), m_istate(istate) {}
 
 template <typename SL, size_t M, bool ReadOnly>

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -67,7 +67,8 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
+inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const
+    -> BoundParameters {
   IndexData::IndexType idx;
   if (hasBoundSmoothed()) {
     idx = data().iboundsmoothed;
@@ -77,11 +78,12 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
     idx = data().ipredicted;
   }
 
-  return Parameters(m_traj->m_boundParams.data.col(idx).data());
+  return BoundParameters(m_traj->m_boundParams.data.col(idx).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const -> Covariance {
+inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const
+    -> BoundCovariance {
   IndexData::IndexType idx;
   if (hasBoundSmoothed()) {
     idx = data().iboundsmoothed;
@@ -90,49 +92,49 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const -> Covariance {
   } else {
     idx = data().ipredicted;
   }
-  return Covariance(m_traj->m_boundCov.data.col(idx).data());
+  return BoundCovariance(m_traj->m_boundCov.data.col(idx).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredicted() const
-    -> Parameters {
+    -> BoundParameters {
   assert(data().iboundpredicted != IndexData::kInvalid);
-  return Parameters(m_traj->m_boundParams.col(data().iboundpredicted).data());
+  return BoundParameters(m_traj->m_boundParams.col(data().iboundpredicted).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredictedCovariance() const
-    -> Covariance {
+    -> BoundCovariance {
   assert(data().iboundpredicted != IndexData::kInvalid);
-  return Covariance(m_traj->m_boundCov.col(data().iboundpredicted).data());
+  return BoundCovariance(m_traj->m_boundCov.col(data().iboundpredicted).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundFiltered() const
-    -> Parameters {
+    -> BoundParameters {
   assert(data().iboundfiltered != IndexData::kInvalid);
-  return Parameters(m_traj->m_boundParams.col(data().iboundfiltered).data());
+  return BoundParameters(m_traj->m_boundParams.col(data().iboundfiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundFilteredCovariance() const
-    -> Covariance {
+    -> BoundCovariance {
   assert(data().iboundfiltered != IndexData::kInvalid);
-  return Covariance(m_traj->m_boundCov.col(data().iboundfiltered).data());
+  return BoundCovariance(m_traj->m_boundCov.col(data().iboundfiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundSmoothed() const
-    -> Parameters {
+    -> BoundParameters {
   assert(data().iboundsmoothed != IndexData::kInvalid);
-  return Parameters(m_traj->m_boundParams.col(data().iboundsmoothed).data());
+  return BoundParameters(m_traj->m_boundParams.col(data().iboundsmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundSmoothedCovariance() const
-    -> Covariance {
+    -> BoundCovariance {
   assert(data().iboundsmoothed != IndexData::kInvalid);
-  return Covariance(m_traj->m_boundCov.col(data().iboundsmoothed).data());
+  return BoundCovariance(m_traj->m_boundCov.col(data().iboundsmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -29,11 +29,11 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
   if (hasBoundPredicted()) {
     mask |= PM::BoundPredicted;
   }
-  if (hasFiltered()) {
-    mask |= PM::Filtered;
+  if (hasBoundFiltered()) {
+    mask |= PM::BoundFiltered;
   }
-  if (hasSmoothed()) {
-    mask |= PM::Smoothed;
+  if (hasBoundSmoothed()) {
+    mask |= PM::BoundSmoothed;
   }
   if (hasFreePredicted()) {
     mask |= PM::FreePredicted;
@@ -69,10 +69,10 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
   IndexData::IndexType idx;
-  if (hasSmoothed()) {
-    idx = data().ismoothed;
-  } else if (hasFiltered()) {
-    idx = data().ifiltered;
+  if (hasBoundSmoothed()) {
+    idx = data().iboundsmoothed;
+  } else if (hasBoundFiltered()) {
+    idx = data().iboundfiltered;
   } else {
     idx = data().ipredicted;
   }
@@ -83,10 +83,10 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const -> Covariance {
   IndexData::IndexType idx;
-  if (hasSmoothed()) {
-    idx = data().ismoothed;
-  } else if (hasFiltered()) {
-    idx = data().ifiltered;
+  if (hasBoundSmoothed()) {
+    idx = data().iboundsmoothed;
+  } else if (hasBoundFiltered()) {
+    idx = data().iboundfiltered;
   } else {
     idx = data().ipredicted;
   }
@@ -108,29 +108,31 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredictedCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::filtered() const -> Parameters {
-  assert(data().ifiltered != IndexData::kInvalid);
-  return Parameters(m_traj->m_boundParams.col(data().ifiltered).data());
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundFiltered() const
+    -> Parameters {
+  assert(data().iboundfiltered != IndexData::kInvalid);
+  return Parameters(m_traj->m_boundParams.col(data().iboundfiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::filteredCovariance() const
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundFilteredCovariance() const
     -> Covariance {
-  assert(data().ifiltered != IndexData::kInvalid);
-  return Covariance(m_traj->m_boundCov.col(data().ifiltered).data());
+  assert(data().iboundfiltered != IndexData::kInvalid);
+  return Covariance(m_traj->m_boundCov.col(data().iboundfiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::smoothed() const -> Parameters {
-  assert(data().ismoothed != IndexData::kInvalid);
-  return Parameters(m_traj->m_boundParams.col(data().ismoothed).data());
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundSmoothed() const
+    -> Parameters {
+  assert(data().iboundsmoothed != IndexData::kInvalid);
+  return Parameters(m_traj->m_boundParams.col(data().iboundsmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::smoothedCovariance() const
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundSmoothedCovariance() const
     -> Covariance {
-  assert(data().ismoothed != IndexData::kInvalid);
-  return Covariance(m_traj->m_boundCov.col(data().ismoothed).data());
+  assert(data().iboundsmoothed != IndexData::kInvalid);
+  return Covariance(m_traj->m_boundCov.col(data().iboundsmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -263,16 +265,16 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     p.iboundpredicted = m_boundParams.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Filtered)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::BoundFiltered)) {
     m_boundParams.addCol();
     m_boundCov.addCol();
-    p.ifiltered = m_boundParams.size() - 1;
+    p.iboundfiltered = m_boundParams.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Smoothed)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::BoundSmoothed)) {
     m_boundParams.addCol();
     m_boundCov.addCol();
-    p.ismoothed = m_boundParams.size() - 1;
+    p.iboundsmoothed = m_boundParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::FreePredicted)) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -176,30 +176,30 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::freeSmoothedCovariance() const
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToBound() const
-    -> BoundSymMatrix {
+    -> JacobianBoundToBound {
   assert(data().ijacobianboundtobound != IndexData::kInvalid);
-  return BoundSymMatrix(m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
+  return JacobianBoundToBound(m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToFree() const
-    -> BoundToFreeMatrix {
+    -> JacobianBoundToFree {
   assert(data().ijacobianboundtofree != IndexData::kInvalid);
-  return BoundToFreeMatrix(m_traj->m_jacBoundToFree.col(data().ijacobianboundtofree).data());
+  return JacobianBoundToFree(m_traj->m_jacBoundToFree.col(data().ijacobianboundtofree).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToBound() const
-    -> FreeToBoundMatrix {
+    -> JacobianFreeToBound {
   assert(data().ijacobianfreetobound != IndexData::kInvalid);
-  return FreeToBoundMatrix(m_traj->m_jacFreeToBound.col(data().ijacobianfreetobound).data());
+  return JacobianFreeToBound(m_traj->m_jacFreeToBound.col(data().ijacobianfreetobound).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToFree() const
-    -> FreeSymMatrix {
+    -> JacobianFreeToFree {
   assert(data().ijacobianfreetofree != IndexData::kInvalid);
-  return FreeSymMatrix(m_traj->m_jacFreeToFree.col(data().ijacobianfreetofree).data());
+  return JacobianFreeToFree(m_traj->m_jacFreeToFree.col(data().ijacobianfreetofree).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -29,12 +29,20 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
   if (hasPredicted()) {
     mask |= PM::Predicted;
   }
-
   if (hasFiltered()) {
     mask |= PM::Filtered;
   }
   if (hasSmoothed()) {
     mask |= PM::Smoothed;
+  }
+  if (hasFreePredicted()) {
+    mask |= PM::FreePredicted;
+  }
+  if (hasFreeFiltered()) {
+    mask |= PM::FreeFiltered;
+  }
+  if (hasFreeSmoothed()) {
+    mask |= PM::FreeSmoothed;
   }
   if (hasJacobian()) {
     mask |= PM::Jacobian;
@@ -113,6 +121,48 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::smoothedCovariance() const
     -> Covariance {
   assert(data().ismoothed != IndexData::kInvalid);
   return Covariance(m_traj->m_cov.col(data().ismoothed).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freePredicted() const
+    -> FreeParameters {
+  assert(data().ifreepredicted != IndexData::kInvalid);
+  return FreeParameters(m_traj->m_freeParams.col(data().ifreepredicted).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freePredictedCovariance() const
+    -> FreeCovariance {
+  assert(data().ifreepredicted != IndexData::kInvalid);
+  return FreeCovariance(m_traj->m_freeCov.col(data().ifreepredicted).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freeFiltered() const
+    -> FreeParameters {
+  assert(data().ifreefiltered != IndexData::kInvalid);
+  return FreeParameters(m_traj->m_freeParams.col(data().ifreefiltered).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freeFilteredCovariance() const
+    -> FreeCovariance {
+  assert(data().ifreefiltered != IndexData::kInvalid);
+  return FreeCovariance(m_traj->m_freeCov.col(data().ifreefiltered).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freeSmoothed() const
+    -> FreeParameters {
+  assert(data().ifreesmoothed != IndexData::kInvalid);
+  return FreeParameters(m_traj->m_freeParams.col(data().ifreesmoothed).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::freeSmoothedCovariance() const
+    -> FreeCovariance {
+  assert(data().ifreesmoothed != IndexData::kInvalid);
+  return FreeCovariance(m_traj->m_freeCov.col(data().ifreesmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -201,19 +251,19 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
   if (ACTS_CHECK_BIT(mask, PropMask::FreePredicted)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ifreepredicted = m_params.size() - 1;
+    p.ifreepredicted = m_freeParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::FreeFiltered)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ifreefiltered = m_params.size() - 1;
+    p.ifreefiltered = m_freeParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::FreeSmoothed)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ifreesmoothed = m_params.size() - 1;
+    p.ifreesmoothed = m_freeParams.size() - 1;
   }
   
   if (ACTS_CHECK_BIT(mask, PropMask::Uncalibrated)) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -44,8 +44,17 @@ TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
   if (hasFreeSmoothed()) {
     mask |= PM::FreeSmoothed;
   }
-  if (hasJacobian()) {
-    mask |= PM::Jacobian;
+  if (hasJacobianBoundToBound()) {
+    mask |= PM::JacobianBoundToBound;
+  }
+  if (hasJacobianBoundToFree()) {
+    mask |= PM::JacobianBoundToFree;
+  }
+  if (hasJacobianFreeToBound()) {
+    mask |= PM::JacobianFreeToBound;
+  }
+  if (hasJacobianFreeToFree()) {
+    mask |= PM::JacobianFreeToFree;
   }
   if (hasUncalibrated()) {
     mask |= PM::Uncalibrated;
@@ -166,10 +175,31 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::freeSmoothedCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToBound() const
     -> BoundSymMatrix {
   assert(data().ijacobianboundtobound != IndexData::kInvalid);
   return BoundSymMatrix(m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToFree() const
+    -> BoundToFreeMatrix {
+  assert(data().ijacobianboundtofree != IndexData::kInvalid);
+  return BoundToFreeMatrix(m_traj->m_jacBoundToFree.col(data().ijacobianboundtofree).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToBound() const
+    -> FreeToBoundMatrix {
+  assert(data().ijacobianfreetobound != IndexData::kInvalid);
+  return FreeToBoundMatrix(m_traj->m_jacFreeToBound.col(data().ijacobianfreetobound).data());
+}
+
+template <typename SL, size_t M, bool ReadOnly>
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToFree() const
+    -> FreeSymMatrix {
+  assert(data().ijacobianfreetofree != IndexData::kInvalid);
+  return FreeSymMatrix(m_traj->m_jacFreeToFree.col(data().ijacobianfreetofree).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -244,11 +274,6 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     p.ismoothed = m_params.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Jacobian)) {
-    m_jac.addCol();
-    p.ijacobian = m_jac.size() - 1;
-  }
-
   if (ACTS_CHECK_BIT(mask, PropMask::FreePredicted)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
@@ -265,6 +290,26 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     m_freeParams.addCol();
     m_freeCov.addCol();
     p.ifreesmoothed = m_freeParams.size() - 1;
+  }
+  
+  if (ACTS_CHECK_BIT(mask, PropMask::JacobianBoundToBound)) {
+    m_jacBoundToBound.addCol();
+    p.ijacobianboundtobound = m_jacBoundToBound.size() - 1;
+  }
+  
+  if (ACTS_CHECK_BIT(mask, PropMask::JacobianBoundToFree)) {
+    m_jacBoundToFree.addCol();
+    p.ijacobianboundtofree = m_jacBoundToFree.size() - 1;
+  }
+  
+  if (ACTS_CHECK_BIT(mask, PropMask::JacobianFreeToBound)) {
+    m_jacFreeToBound.addCol();
+    p.ijacobianfreetobound = m_jacFreeToBound.size() - 1;
+  }
+  
+  if (ACTS_CHECK_BIT(mask, PropMask::JacobianFreeToFree)) {
+    m_jacFreeToFree.addCol();
+    p.ijacobianfreetofree = m_jacFreeToFree.size() - 1;
   }
   
   if (ACTS_CHECK_BIT(mask, PropMask::Uncalibrated)) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -26,8 +26,8 @@ template <typename SL, size_t M, bool ReadOnly>
 TrackStatePropMask TrackStateProxy<SL, M, ReadOnly>::getMask() const {
   using PM = TrackStatePropMask;
   PM mask = PM::None;
-  if (hasPredicted()) {
-    mask |= PM::Predicted;
+  if (hasBoundPredicted()) {
+    mask |= PM::BoundPredicted;
   }
   if (hasFiltered()) {
     mask |= PM::Filtered;
@@ -77,7 +77,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::parameters() const -> Parameters {
     idx = data().ipredicted;
   }
 
-  return Parameters(m_traj->m_params.data.col(idx).data());
+  return Parameters(m_traj->m_boundParams.data.col(idx).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -90,46 +90,47 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::covariance() const -> Covariance {
   } else {
     idx = data().ipredicted;
   }
-  return Covariance(m_traj->m_cov.data.col(idx).data());
+  return Covariance(m_traj->m_boundCov.data.col(idx).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::predicted() const -> Parameters {
-  assert(data().ipredicted != IndexData::kInvalid);
-  return Parameters(m_traj->m_params.col(data().ipredicted).data());
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredicted() const
+    -> Parameters {
+  assert(data().iboundpredicted != IndexData::kInvalid);
+  return Parameters(m_traj->m_boundParams.col(data().iboundpredicted).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::predictedCovariance() const
+inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredictedCovariance() const
     -> Covariance {
-  assert(data().ipredicted != IndexData::kInvalid);
-  return Covariance(m_traj->m_cov.col(data().ipredicted).data());
+  assert(data().iboundpredicted != IndexData::kInvalid);
+  return Covariance(m_traj->m_boundCov.col(data().iboundpredicted).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::filtered() const -> Parameters {
   assert(data().ifiltered != IndexData::kInvalid);
-  return Parameters(m_traj->m_params.col(data().ifiltered).data());
+  return Parameters(m_traj->m_boundParams.col(data().ifiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::filteredCovariance() const
     -> Covariance {
   assert(data().ifiltered != IndexData::kInvalid);
-  return Covariance(m_traj->m_cov.col(data().ifiltered).data());
+  return Covariance(m_traj->m_boundCov.col(data().ifiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::smoothed() const -> Parameters {
   assert(data().ismoothed != IndexData::kInvalid);
-  return Parameters(m_traj->m_params.col(data().ismoothed).data());
+  return Parameters(m_traj->m_boundParams.col(data().ismoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::smoothedCovariance() const
     -> Covariance {
   assert(data().ismoothed != IndexData::kInvalid);
-  return Covariance(m_traj->m_cov.col(data().ismoothed).data());
+  return Covariance(m_traj->m_boundCov.col(data().ismoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -256,22 +257,22 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
   m_referenceSurfaces.emplace_back(nullptr);
   p.irefsurface = m_referenceSurfaces.size() - 1;
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Predicted)) {
-    m_params.addCol();
-    m_cov.addCol();
-    p.ipredicted = m_params.size() - 1;
+  if (ACTS_CHECK_BIT(mask, PropMask::BoundPredicted)) {
+    m_boundParams.addCol();
+    m_boundCov.addCol();
+    p.iboundpredicted = m_boundParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::Filtered)) {
-    m_params.addCol();
-    m_cov.addCol();
-    p.ifiltered = m_params.size() - 1;
+    m_boundParams.addCol();
+    m_boundCov.addCol();
+    p.ifiltered = m_boundParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::Smoothed)) {
-    m_params.addCol();
-    m_cov.addCol();
-    p.ismoothed = m_params.size() - 1;
+    m_boundParams.addCol();
+    m_boundCov.addCol();
+    p.ismoothed = m_boundParams.size() - 1;
   }
 
   if (ACTS_CHECK_BIT(mask, PropMask::FreePredicted)) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -166,9 +166,10 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::freeSmoothedCovariance() const
 }
 
 template <typename SL, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const -> Covariance {
-  assert(data().ijacobian != IndexData::kInvalid);
-  return Covariance(m_traj->m_jac.col(data().ijacobian).data());
+inline auto TrackStateProxy<SL, M, ReadOnly>::jacobian() const
+    -> BoundSymMatrix {
+  assert(data().ijacobianboundtobound != IndexData::kInvalid);
+  return BoundSymMatrix(m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -198,22 +198,22 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     p.ijacobian = m_jac.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::PredictedFree)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::FreePredicted)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ipredictedfree = m_params.size() - 1;
+    p.ifreepredicted = m_params.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::FilteredFree)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::FreeFiltered)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ifilteredfree = m_params.size() - 1;
+    p.ifreefiltered = m_params.size() - 1;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::SmoothedFree)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::FreeSmoothed)) {
     m_freeParams.addCol();
     m_freeCov.addCol();
-    p.ismoothedfree = m_params.size() - 1;
+    p.ifreesmoothed = m_params.size() - 1;
   }
   
   if (ACTS_CHECK_BIT(mask, PropMask::Uncalibrated)) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -198,6 +198,24 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     p.ijacobian = m_jac.size() - 1;
   }
 
+  if (ACTS_CHECK_BIT(mask, PropMask::PredictedFree)) {
+    m_freeParams.addCol();
+    m_freeCov.addCol();
+    p.ipredictedfree = m_params.size() - 1;
+  }
+
+  if (ACTS_CHECK_BIT(mask, PropMask::FilteredFree)) {
+    m_freeParams.addCol();
+    m_freeCov.addCol();
+    p.ifilteredfree = m_params.size() - 1;
+  }
+
+  if (ACTS_CHECK_BIT(mask, PropMask::SmoothedFree)) {
+    m_freeParams.addCol();
+    m_freeCov.addCol();
+    p.ismoothedfree = m_params.size() - 1;
+  }
+  
   if (ACTS_CHECK_BIT(mask, PropMask::Uncalibrated)) {
     m_sourceLinks.emplace_back();
     p.iuncalibrated = m_sourceLinks.size() - 1;

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -99,7 +99,8 @@ template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundPredicted() const
     -> BoundParameters {
   assert(data().iboundpredicted != IndexData::kInvalid);
-  return BoundParameters(m_traj->m_boundParams.col(data().iboundpredicted).data());
+  return BoundParameters(
+      m_traj->m_boundParams.col(data().iboundpredicted).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -113,7 +114,8 @@ template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundFiltered() const
     -> BoundParameters {
   assert(data().iboundfiltered != IndexData::kInvalid);
-  return BoundParameters(m_traj->m_boundParams.col(data().iboundfiltered).data());
+  return BoundParameters(
+      m_traj->m_boundParams.col(data().iboundfiltered).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -127,7 +129,8 @@ template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::boundSmoothed() const
     -> BoundParameters {
   assert(data().iboundsmoothed != IndexData::kInvalid);
-  return BoundParameters(m_traj->m_boundParams.col(data().iboundsmoothed).data());
+  return BoundParameters(
+      m_traj->m_boundParams.col(data().iboundsmoothed).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -183,28 +186,32 @@ template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToBound() const
     -> JacobianBoundToBound {
   assert(data().ijacobianboundtobound != IndexData::kInvalid);
-  return JacobianBoundToBound(m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
+  return JacobianBoundToBound(
+      m_traj->m_jacBoundToBound.col(data().ijacobianboundtobound).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianBoundToFree() const
     -> JacobianBoundToFree {
   assert(data().ijacobianboundtofree != IndexData::kInvalid);
-  return JacobianBoundToFree(m_traj->m_jacBoundToFree.col(data().ijacobianboundtofree).data());
+  return JacobianBoundToFree(
+      m_traj->m_jacBoundToFree.col(data().ijacobianboundtofree).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToBound() const
     -> JacobianFreeToBound {
   assert(data().ijacobianfreetobound != IndexData::kInvalid);
-  return JacobianFreeToBound(m_traj->m_jacFreeToBound.col(data().ijacobianfreetobound).data());
+  return JacobianFreeToBound(
+      m_traj->m_jacFreeToBound.col(data().ijacobianfreetobound).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
 inline auto TrackStateProxy<SL, M, ReadOnly>::jacobianFreeToFree() const
     -> JacobianFreeToFree {
   assert(data().ijacobianfreetofree != IndexData::kInvalid);
-  return JacobianFreeToFree(m_traj->m_jacFreeToFree.col(data().ijacobianfreetofree).data());
+  return JacobianFreeToFree(
+      m_traj->m_jacFreeToFree.col(data().ijacobianfreetofree).data());
 }
 
 template <typename SL, size_t M, bool ReadOnly>
@@ -246,7 +253,7 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::calibratedCovariance() const
 
 template <typename SL, size_t MSM>
 inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
-                                                 size_t iprevious) {
+                                                      size_t iprevious) {
   using PropMask = TrackStatePropMask;
 
   m_index.emplace_back();
@@ -296,27 +303,27 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
     m_freeCov.addCol();
     p.ifreesmoothed = m_freeParams.size() - 1;
   }
-  
+
   if (ACTS_CHECK_BIT(mask, PropMask::JacobianBoundToBound)) {
     m_jacBoundToBound.addCol();
     p.ijacobianboundtobound = m_jacBoundToBound.size() - 1;
   }
-  
+
   if (ACTS_CHECK_BIT(mask, PropMask::JacobianBoundToFree)) {
     m_jacBoundToFree.addCol();
     p.ijacobianboundtofree = m_jacBoundToFree.size() - 1;
   }
-  
+
   if (ACTS_CHECK_BIT(mask, PropMask::JacobianFreeToBound)) {
     m_jacFreeToBound.addCol();
     p.ijacobianfreetobound = m_jacFreeToBound.size() - 1;
   }
-  
+
   if (ACTS_CHECK_BIT(mask, PropMask::JacobianFreeToFree)) {
     m_jacFreeToFree.addCol();
     p.ijacobianfreetofree = m_jacFreeToFree.size() - 1;
   }
-  
+
   if (ACTS_CHECK_BIT(mask, PropMask::Uncalibrated)) {
     m_sourceLinks.emplace_back();
     p.iuncalibrated = m_sourceLinks.size() - 1;
@@ -339,7 +346,8 @@ inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
 
 template <typename SL, size_t MSM>
 template <typename F>
-void MultiTrajectory<SL, MSM>::visitBackwards(size_t iendpoint, F&& callable) const {
+void MultiTrajectory<SL, MSM>::visitBackwards(size_t iendpoint,
+                                              F&& callable) const {
   static_assert(detail_lt::VisitorConcept<F, ConstTrackStateProxy>,
                 "Callable needs to satisfy VisitorConcept");
 

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -158,8 +158,8 @@ inline auto TrackStateProxy<SL, M, ReadOnly>::calibratedCovariance() const
 
 }  // namespace detail_lt
 
-template <typename SL>
-inline size_t MultiTrajectory<SL>::addTrackState(TrackStatePropMask mask,
+template <typename SL, size_t MSM>
+inline size_t MultiTrajectory<SL, MSM>::addTrackState(TrackStatePropMask mask,
                                                  size_t iprevious) {
   using PropMask = TrackStatePropMask;
 
@@ -218,9 +218,9 @@ inline size_t MultiTrajectory<SL>::addTrackState(TrackStatePropMask mask,
   return index;
 }
 
-template <typename SL>
+template <typename SL, size_t MSM>
 template <typename F>
-void MultiTrajectory<SL>::visitBackwards(size_t iendpoint, F&& callable) const {
+void MultiTrajectory<SL, MSM>::visitBackwards(size_t iendpoint, F&& callable) const {
   static_assert(detail_lt::VisitorConcept<F, ConstTrackStateProxy>,
                 "Callable needs to satisfy VisitorConcept");
 
@@ -245,9 +245,9 @@ void MultiTrajectory<SL>::visitBackwards(size_t iendpoint, F&& callable) const {
   }
 }
 
-template <typename SL>
+template <typename SL, size_t MSM>
 template <typename F>
-void MultiTrajectory<SL>::applyBackwards(size_t iendpoint, F&& callable) {
+void MultiTrajectory<SL, MSM>::applyBackwards(size_t iendpoint, F&& callable) {
   static_assert(detail_lt::VisitorConcept<F, TrackStateProxy>,
                 "Callable needs to satisfy VisitorConcept");
 

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -120,7 +120,7 @@ template <typename track_state_proxy_t>
 FreeVector freeFiltered(const GeometryContext& gctx,
                         const track_state_proxy_t& trackStateProxy) {
   return detail::coordinate_transformation::boundParameters2freeParameters(
-      gctx, trackStateProxy.filtered(), trackStateProxy.referenceSurface());
+      gctx, trackStateProxy.boundFiltered(), trackStateProxy.referenceSurface());
 }
 
 /// @brief Transforms the smoothed parameters from a @c TrackStateProxy to free
@@ -135,7 +135,7 @@ template <typename track_state_proxy_t>
 FreeVector freeSmoothed(const GeometryContext& gctx,
                         const track_state_proxy_t& trackStateProxy) {
   return detail::coordinate_transformation::boundParameters2freeParameters(
-      gctx, trackStateProxy.smoothed(), trackStateProxy.referenceSurface());
+      gctx, trackStateProxy.boundSmoothed(), trackStateProxy.referenceSurface());
 }
 }  // namespace MultiTrajectoryHelpers
 

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -120,7 +120,8 @@ template <typename track_state_proxy_t>
 FreeVector freeFiltered(const GeometryContext& gctx,
                         const track_state_proxy_t& trackStateProxy) {
   return detail::coordinate_transformation::boundParameters2freeParameters(
-      gctx, trackStateProxy.boundFiltered(), trackStateProxy.referenceSurface());
+      gctx, trackStateProxy.boundFiltered(),
+      trackStateProxy.referenceSurface());
 }
 
 /// @brief Transforms the smoothed parameters from a @c TrackStateProxy to free
@@ -135,7 +136,8 @@ template <typename track_state_proxy_t>
 FreeVector freeSmoothed(const GeometryContext& gctx,
                         const track_state_proxy_t& trackStateProxy) {
   return detail::coordinate_transformation::boundParameters2freeParameters(
-      gctx, trackStateProxy.boundSmoothed(), trackStateProxy.referenceSurface());
+      gctx, trackStateProxy.boundSmoothed(),
+      trackStateProxy.referenceSurface());
 }
 }  // namespace MultiTrajectoryHelpers
 

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -37,6 +37,7 @@ enum struct TrackStatePropMask : uint16_t {
   Uncalibrated = 1 << 10,
   Calibrated = 1 << 11,
 
+  BoundAll = Predicted + Filtered + Smoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
   All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };
 

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -22,8 +22,8 @@
 enum struct TrackStatePropMask : uint16_t {
   None = 0,
   BoundPredicted = 1 << 0,
-  Filtered = 1 << 1,
-  Smoothed = 1 << 2,
+  BoundFiltered = 1 << 1,
+  BoundSmoothed = 1 << 2,
   
   FreePredicted = 1 << 3,
   FreeFiltered = 1 << 4,
@@ -37,7 +37,7 @@ enum struct TrackStatePropMask : uint16_t {
   Uncalibrated = 1 << 10,
   Calibrated = 1 << 11,
 
-  BoundAll = BoundPredicted + Filtered + Smoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
+  BoundAll = BoundPredicted + BoundFiltered + BoundSmoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
   All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };
 

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,17 +19,21 @@
 /// a jacobian.
 /// The enum is used as a strong type wrapper around the bits to prevent
 /// autoconversion from integer
-enum struct TrackStatePropMask : uint8_t {
+enum struct TrackStatePropMask : uint16_t {
   None = 0,
   Predicted = 1 << 0,
   Filtered = 1 << 1,
   Smoothed = 1 << 2,
   Jacobian = 1 << 3,
+  
+  PredictedFree = 1 << 4,
+  FilteredFree = 1 << 5,
+  SmoothedFree = 1 << 6,
 
-  Uncalibrated = 1 << 4,
-  Calibrated = 1 << 5,
+  Uncalibrated = 1 << 7,
+  Calibrated = 1 << 8,
 
-  All = std::numeric_limits<uint8_t>::max(),  // should be all ones
+  All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };
 
 constexpr TrackStatePropMask operator|(TrackStatePropMask lhs,

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -21,7 +21,7 @@
 /// autoconversion from integer
 enum struct TrackStatePropMask : uint16_t {
   None = 0,
-  Predicted = 1 << 0,
+  BoundPredicted = 1 << 0,
   Filtered = 1 << 1,
   Smoothed = 1 << 2,
   
@@ -37,7 +37,7 @@ enum struct TrackStatePropMask : uint16_t {
   Uncalibrated = 1 << 10,
   Calibrated = 1 << 11,
 
-  BoundAll = Predicted + Filtered + Smoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
+  BoundAll = BoundPredicted + Filtered + Smoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
   All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };
 

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -24,14 +24,18 @@ enum struct TrackStatePropMask : uint16_t {
   Predicted = 1 << 0,
   Filtered = 1 << 1,
   Smoothed = 1 << 2,
-  Jacobian = 1 << 3,
   
-  FreePredicted = 1 << 4,
-  FreeFiltered = 1 << 5,
-  FreeSmoothed = 1 << 6,
+  FreePredicted = 1 << 3,
+  FreeFiltered = 1 << 4,
+  FreeSmoothed = 1 << 5,
 
-  Uncalibrated = 1 << 7,
-  Calibrated = 1 << 8,
+  JacobianBoundToBound = 1 << 6,
+  JacobianBoundToFree = 1 << 7,
+  JacobianFreeToBound = 1 << 8,
+  JacobianFreeToFree = 1 << 9,
+
+  Uncalibrated = 1 << 10,
+  Calibrated = 1 << 11,
 
   All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -24,7 +24,7 @@ enum struct TrackStatePropMask : uint16_t {
   BoundPredicted = 1 << 0,
   BoundFiltered = 1 << 1,
   BoundSmoothed = 1 << 2,
-  
+
   FreePredicted = 1 << 3,
   FreeFiltered = 1 << 4,
   FreeSmoothed = 1 << 5,
@@ -37,7 +37,8 @@ enum struct TrackStatePropMask : uint16_t {
   Uncalibrated = 1 << 10,
   Calibrated = 1 << 11,
 
-  BoundAll = BoundPredicted + BoundFiltered + BoundSmoothed + JacobianBoundToBound + Uncalibrated + Calibrated,
+  BoundAll = BoundPredicted + BoundFiltered + BoundSmoothed +
+             JacobianBoundToBound + Uncalibrated + Calibrated,
   All = std::numeric_limits<uint16_t>::max(),  // should be all ones
 };
 

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -26,9 +26,9 @@ enum struct TrackStatePropMask : uint16_t {
   Smoothed = 1 << 2,
   Jacobian = 1 << 3,
   
-  PredictedFree = 1 << 4,
-  FilteredFree = 1 << 5,
-  SmoothedFree = 1 << 6,
+  FreePredicted = 1 << 4,
+  FreeFiltered = 1 << 5,
+  FreeSmoothed = 1 << 6,
 
   Uncalibrated = 1 << 7,
   Calibrated = 1 << 8,

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -86,14 +86,14 @@ class GainMatrixSmoother {
         ACTS_VERBOSE("Filtered covariance:\n" << ts.filteredCovariance());
         ACTS_VERBOSE("Jacobian:\n" << ts.jacobianBoundToBound());
         ACTS_VERBOSE("Prev. predicted covariance\n"
-                     << prev_ts.predictedCovariance() << "\n, inverse: \n"
-                     << prev_ts.predictedCovariance().inverse());
+                     << prev_ts.boundPredictedCovariance() << "\n, inverse: \n"
+                     << prev_ts.boundPredictedCovariance().inverse());
 
         // Gain smoothing matrix
         // NB: The jacobian stored in a state is the jacobian from previous
         // state to this state in forward propagation
         G = ts.filteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
-            prev_ts.predictedCovariance().inverse();
+            prev_ts.boundPredictedCovariance().inverse();
 
         if (G.hasNaN()) {
           error = KalmanFitterError::SmoothFailed;  // set to error
@@ -107,11 +107,11 @@ class GainMatrixSmoother {
         ACTS_VERBOSE(
             "Prev. smoothed parameters: " << prev_ts.smoothed().transpose());
         ACTS_VERBOSE(
-            "Prev. predicted parameters: " << prev_ts.predicted().transpose());
+            "Prev. predicted parameters: " << prev_ts.boundPredicted().transpose());
 
         // Calculate the smoothed parameters
         ts.smoothed() =
-            ts.filtered() + G * (prev_ts.smoothed() - prev_ts.predicted());
+            ts.filtered() + G * (prev_ts.smoothed() - prev_ts.boundPredicted());
 
         ACTS_VERBOSE("Smoothed parameters are: " << ts.smoothed().transpose());
 
@@ -122,7 +122,7 @@ class GainMatrixSmoother {
         // And the smoothed covariance
         ts.smoothedCovariance() =
             ts.filteredCovariance() -
-            G * (prev_ts.predictedCovariance() - prev_ts.smoothedCovariance()) *
+            G * (prev_ts.boundPredictedCovariance() - prev_ts.smoothedCovariance()) *
                 G.transpose();
 
         // Check if the covariance matrix is semi-positive definite.

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -76,7 +76,7 @@ class GainMatrixSmoother {
         // covariances.
         assert(ts.hasFiltered());
         assert(ts.hasPredicted());
-        assert(ts.hasJacobian());
+        assert(ts.hasJacobianBoundToBound());
 
         // previous trackstate should have smoothed and predicted
         assert(prev_ts.hasSmoothed());
@@ -84,7 +84,7 @@ class GainMatrixSmoother {
 
         ACTS_VERBOSE("Calculate smoothing matrix:");
         ACTS_VERBOSE("Filtered covariance:\n" << ts.filteredCovariance());
-        ACTS_VERBOSE("Jacobian:\n" << ts.jacobian());
+        ACTS_VERBOSE("Jacobian:\n" << ts.jacobianBoundToBound());
         ACTS_VERBOSE("Prev. predicted covariance\n"
                      << prev_ts.predictedCovariance() << "\n, inverse: \n"
                      << prev_ts.predictedCovariance().inverse());
@@ -92,7 +92,7 @@ class GainMatrixSmoother {
         // Gain smoothing matrix
         // NB: The jacobian stored in a state is the jacobian from previous
         // state to this state in forward propagation
-        G = ts.filteredCovariance() * prev_ts.jacobian().transpose() *
+        G = ts.filteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
             prev_ts.predictedCovariance().inverse();
 
         if (G.hasNaN()) {

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -134,7 +134,8 @@ class GainMatrixSmoother {
         // nearest semi-positive def matrix,
         // but it could still be non semi-positive
         BoundSymMatrix smoothedCov = ts.boundSmoothedCovariance();
-        if (not detail::covariance_helper<BoundSymMatrix>::validate(smoothedCov)) {
+        if (not detail::covariance_helper<BoundSymMatrix>::validate(
+                smoothedCov)) {
           ACTS_DEBUG(
               "Smoothed covariance is not positive definite. Could result in "
               "negative covariance!");

--- a/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixSmoother.hpp
@@ -92,7 +92,8 @@ class GainMatrixSmoother {
         // Gain smoothing matrix
         // NB: The jacobian stored in a state is the jacobian from previous
         // state to this state in forward propagation
-        G = ts.boundFilteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
+        G = ts.boundFilteredCovariance() *
+            prev_ts.jacobianBoundToBound().transpose() *
             prev_ts.boundPredictedCovariance().inverse();
 
         if (G.hasNaN()) {
@@ -104,26 +105,29 @@ class GainMatrixSmoother {
 
         ACTS_VERBOSE("Calculate smoothed parameters:");
         ACTS_VERBOSE("Filtered parameters: " << ts.boundFiltered().transpose());
-        ACTS_VERBOSE(
-            "Prev. smoothed parameters: " << prev_ts.boundSmoothed().transpose());
-        ACTS_VERBOSE(
-            "Prev. predicted parameters: " << prev_ts.boundPredicted().transpose());
+        ACTS_VERBOSE("Prev. smoothed parameters: "
+                     << prev_ts.boundSmoothed().transpose());
+        ACTS_VERBOSE("Prev. predicted parameters: "
+                     << prev_ts.boundPredicted().transpose());
 
         // Calculate the smoothed parameters
         ts.boundSmoothed() =
-            ts.boundFiltered() + G * (prev_ts.boundSmoothed() - prev_ts.boundPredicted());
+            ts.boundFiltered() +
+            G * (prev_ts.boundSmoothed() - prev_ts.boundPredicted());
 
-        ACTS_VERBOSE("Smoothed parameters are: " << ts.boundSmoothed().transpose());
+        ACTS_VERBOSE(
+            "Smoothed parameters are: " << ts.boundSmoothed().transpose());
 
         ACTS_VERBOSE("Calculate smoothed covariance:");
         ACTS_VERBOSE("Prev. smoothed covariance:\n"
                      << prev_ts.boundSmoothedCovariance());
 
         // And the smoothed covariance
-        ts.boundSmoothedCovariance() =
-            ts.boundFilteredCovariance() -
-            G * (prev_ts.boundPredictedCovariance() - prev_ts.boundSmoothedCovariance()) *
-                G.transpose();
+        ts.boundSmoothedCovariance() = ts.boundFilteredCovariance() -
+                                       G *
+                                           (prev_ts.boundPredictedCovariance() -
+                                            prev_ts.boundSmoothedCovariance()) *
+                                           G.transpose();
 
         // Check if the covariance matrix is semi-positive definite.
         // If not, make one (could do more) attempt to replace it with the
@@ -137,7 +141,8 @@ class GainMatrixSmoother {
         }
         // Reset smoothed covariance
         ts.boundSmoothedCovariance() = smoothedCov;
-        ACTS_VERBOSE("Smoothed covariance is: \n" << ts.boundSmoothedCovariance());
+        ACTS_VERBOSE("Smoothed covariance is: \n"
+                     << ts.boundSmoothedCovariance());
 
         prev_ts = ts;
         return true;  // continue execution

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -64,7 +64,7 @@ class GainMatrixUpdater {
     // we should have predicted state set
     assert(trackState.hasBoundPredicted());
     // filtering should not have happened yet, but is allocated, therefore set
-    assert(trackState.hasFiltered());
+    assert(trackState.hasBoundFiltered());
 
     // read-only handles. Types are eigen maps to backing storage
     const auto predicted = trackState.boundPredicted();
@@ -75,8 +75,8 @@ class GainMatrixUpdater {
 
     // read-write handles. Types are eigen maps into backing storage.
     // This writes directly into the trajectory storage
-    auto filtered = trackState.filtered();
-    auto filtered_covariance = trackState.filteredCovariance();
+    auto filtered = trackState.boundFiltered();
+    auto filtered_covariance = trackState.boundFilteredCovariance();
 
     std::optional<std::error_code> error{std::nullopt};  // assume ok
     visit_measurement(

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -62,13 +62,13 @@ class GainMatrixUpdater {
     // there should be a calibrated measurement
     assert(trackState.hasCalibrated());
     // we should have predicted state set
-    assert(trackState.hasPredicted());
+    assert(trackState.hasBoundPredicted());
     // filtering should not have happened yet, but is allocated, therefore set
     assert(trackState.hasFiltered());
 
     // read-only handles. Types are eigen maps to backing storage
-    const auto predicted = trackState.predicted();
-    const auto predicted_covariance = trackState.predictedCovariance();
+    const auto predicted = trackState.boundPredicted();
+    const auto predicted_covariance = trackState.boundPredictedCovariance();
 
     ACTS_VERBOSE("Predicted parameters: " << predicted.transpose());
     ACTS_VERBOSE("Predicted covariance:\n" << predicted_covariance);

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -459,8 +459,8 @@ class KalmanFitter {
         trackStateProxy.uncalibrated() = sourcelink_it->second;
 
         // Fill the track state
-        trackStateProxy.predicted() = boundParams.parameters();
-        trackStateProxy.predictedCovariance() = *boundParams.covariance();
+        trackStateProxy.boundPredicted() = boundParams.parameters();
+        trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
         trackStateProxy.jacobianBoundToBound() = jacobian;
         trackStateProxy.pathLength() = pathLength;
 
@@ -471,7 +471,7 @@ class KalmanFitter {
               trackStateProxy.setCalibrated(calibrated);
             },
             m_calibrator(trackStateProxy.uncalibrated(),
-                         trackStateProxy.predicted()));
+                         trackStateProxy.boundPredicted()));
 
         // Get and set the type flags
         auto& typeFlags = trackStateProxy.typeFlags();
@@ -551,8 +551,8 @@ class KalmanFitter {
                 stepper.boundState(state.stepping, *surface);
 
             // Fill the track state
-            trackStateProxy.predicted() = boundParams.parameters();
-            trackStateProxy.predictedCovariance() = *boundParams.covariance();
+            trackStateProxy.boundPredicted() = boundParams.parameters();
+            trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
             trackStateProxy.jacobianBoundToBound() = jacobian;
             trackStateProxy.pathLength() = pathLength;
           } else {
@@ -563,8 +563,8 @@ class KalmanFitter {
                 stepper.curvilinearState(state.stepping);
 
             // Fill the track state
-            trackStateProxy.predicted() = curvilinearParams.parameters();
-            trackStateProxy.predictedCovariance() =
+            trackStateProxy.boundPredicted() = curvilinearParams.parameters();
+            trackStateProxy.boundPredictedCovariance() =
                 *curvilinearParams.covariance();
             trackStateProxy.jacobianBoundToBound() = jacobian;
             trackStateProxy.pathLength() = pathLength;
@@ -572,7 +572,7 @@ class KalmanFitter {
 
           // Set the filtered parameter index to be the same with predicted
           // parameter
-          trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
+          trackStateProxy.data().ifiltered = trackStateProxy.data().iboundpredicted;
 
           // We count the processed state
           ++result.processedStates;
@@ -632,8 +632,8 @@ class KalmanFitter {
         trackStateProxy.uncalibrated() = sourcelink_it->second;
 
         // Fill the track state
-        trackStateProxy.predicted() = boundParams.parameters();
-        trackStateProxy.predictedCovariance() = *boundParams.covariance();
+        trackStateProxy.boundPredicted() = boundParams.parameters();
+        trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
         trackStateProxy.jacobianBoundToBound() = jacobian;
         trackStateProxy.pathLength() = pathLength;
 
@@ -644,7 +644,7 @@ class KalmanFitter {
               trackStateProxy.setCalibrated(calibrated);
             },
             m_calibrator(trackStateProxy.uncalibrated(),
-                         trackStateProxy.predicted()));
+                         trackStateProxy.boundPredicted()));
 
         // If the update is successful, set covariance and
         auto updateRes = m_updater(state.geoContext, trackStateProxy, backward);

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -355,7 +355,8 @@ class KalmanFitter {
                 if (surface_it == result.passedAgainSurfaces.end()) {
                   // If backward filtering missed this surface, then there is
                   // no smoothed parameter
-                  trackState.data().iboundsmoothed = detail_lt::IndexData::kInvalid;
+                  trackState.data().iboundsmoothed =
+                      detail_lt::IndexData::kInvalid;
                 }
               });
         }
@@ -401,9 +402,9 @@ class KalmanFitter {
           state.navigation.currentVolume = state.navigation.startVolume;
 
           // Update the stepping state
-          stepper.resetState(state.stepping, st.boundFiltered(),
-                             st.boundFilteredCovariance(), st.referenceSurface(),
-                             backward, state.options.maxStepSize);
+          stepper.resetState(
+              state.stepping, st.boundFiltered(), st.boundFilteredCovariance(),
+              st.referenceSurface(), backward, state.options.maxStepSize);
 
           // For the last measurement state, smoothed is filtered
           st.boundSmoothed() = st.boundFiltered();
@@ -523,7 +524,8 @@ class KalmanFitter {
           // uncalibrated/calibrated measurement and filtered parameter
           result.trackTip = result.fittedStates.addTrackState(
               ~(TrackStatePropMask::Uncalibrated |
-                TrackStatePropMask::Calibrated | TrackStatePropMask::BoundFiltered),
+                TrackStatePropMask::Calibrated |
+                TrackStatePropMask::BoundFiltered),
               result.trackTip);
 
           // now get track state proxy back
@@ -552,7 +554,8 @@ class KalmanFitter {
 
             // Fill the track state
             trackStateProxy.boundPredicted() = boundParams.parameters();
-            trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
+            trackStateProxy.boundPredictedCovariance() =
+                *boundParams.covariance();
             trackStateProxy.jacobianBoundToBound() = jacobian;
             trackStateProxy.pathLength() = pathLength;
           } else {
@@ -572,7 +575,8 @@ class KalmanFitter {
 
           // Set the filtered parameter index to be the same with predicted
           // parameter
-          trackStateProxy.data().iboundfiltered = trackStateProxy.data().iboundpredicted;
+          trackStateProxy.data().iboundfiltered =
+              trackStateProxy.data().iboundpredicted;
 
           // We count the processed state
           ++result.processedStates;

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -461,7 +461,7 @@ class KalmanFitter {
         // Fill the track state
         trackStateProxy.predicted() = boundParams.parameters();
         trackStateProxy.predictedCovariance() = *boundParams.covariance();
-        trackStateProxy.jacobian() = jacobian;
+        trackStateProxy.jacobianBoundToBound() = jacobian;
         trackStateProxy.pathLength() = pathLength;
 
         // We have predicted parameters, so calibrate the uncalibrated input
@@ -553,7 +553,7 @@ class KalmanFitter {
             // Fill the track state
             trackStateProxy.predicted() = boundParams.parameters();
             trackStateProxy.predictedCovariance() = *boundParams.covariance();
-            trackStateProxy.jacobian() = jacobian;
+            trackStateProxy.jacobianBoundToBound() = jacobian;
             trackStateProxy.pathLength() = pathLength;
           } else {
             ACTS_VERBOSE("Detected in-sensitive surface " << surface->geoID());
@@ -566,7 +566,7 @@ class KalmanFitter {
             trackStateProxy.predicted() = curvilinearParams.parameters();
             trackStateProxy.predictedCovariance() =
                 *curvilinearParams.covariance();
-            trackStateProxy.jacobian() = jacobian;
+            trackStateProxy.jacobianBoundToBound() = jacobian;
             trackStateProxy.pathLength() = pathLength;
           }
 
@@ -634,7 +634,7 @@ class KalmanFitter {
         // Fill the track state
         trackStateProxy.predicted() = boundParams.parameters();
         trackStateProxy.predictedCovariance() = *boundParams.covariance();
-        trackStateProxy.jacobian() = jacobian;
+        trackStateProxy.jacobianBoundToBound() = jacobian;
         trackStateProxy.pathLength() = pathLength;
 
         // We have predicted parameters, so calibrate the uncalibrated input

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -449,7 +449,7 @@ class KalmanFitter {
         // add a full TrackState entry multi trajectory
         // (this allocates storage for all components, we will set them later)
         result.trackTip = result.fittedStates.addTrackState(
-            TrackStatePropMask::All, result.trackTip);
+            TrackStatePropMask::BoundAll, result.trackTip);
 
         // now get track state proxy back
         auto trackStateProxy =
@@ -623,7 +623,7 @@ class KalmanFitter {
 
         // Create a detached track state proxy
         auto tempTrackTip =
-            result.fittedStates.addTrackState(TrackStatePropMask::All);
+            result.fittedStates.addTrackState(TrackStatePropMask::BoundAll);
 
         // Get the detached track state proxy back
         auto trackStateProxy = result.fittedStates.getTrackState(tempTrackTip);

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -47,7 +47,7 @@ globalTrackParametersCovariance(
   size_t nSmoothedStates = 0;
   // Visit all the states
   multiTraj.visitBackwards(entryIndex, [&](const auto& ts) {
-    if (ts.hasSmoothed()) {
+    if (ts.hasBoundSmoothed()) {
       if (lastSmoothedIndex == SIZE_MAX) {
         lastSmoothedIndex = ts.index();
       }
@@ -72,13 +72,13 @@ globalTrackParametersCovariance(
                         eBoundParametersSize * (nProcessed + 1);
     // Fill the covariance of this state
     fullGlobalTrackParamsCov.block<eBoundParametersSize, eBoundParametersSize>(
-        iRow, iRow) = ts.smoothedCovariance();
+        iRow, iRow) = ts.boundSmoothedCovariance();
     // Fill the correlation between this state (indexed by i-1) and
     // beforehand smoothed states (indexed by j): C^n_{i-1, j}= G_{i-1} *
     // C^n_{i, j} for i <= j
     if (nProcessed > 0) {
       // Calculate the gain matrix
-      GainMatrix G = ts.filteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
+      GainMatrix G = ts.boundFilteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
                      prev_ts.boundPredictedCovariance().inverse();
       // Loop over the beforehand smoothed states
       for (size_t iProcessed = 1; iProcessed <= nProcessed; iProcessed++) {

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -78,7 +78,7 @@ globalTrackParametersCovariance(
     // C^n_{i, j} for i <= j
     if (nProcessed > 0) {
       // Calculate the gain matrix
-      GainMatrix G = ts.filteredCovariance() * prev_ts.jacobian().transpose() *
+      GainMatrix G = ts.filteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
                      prev_ts.predictedCovariance().inverse();
       // Loop over the beforehand smoothed states
       for (size_t iProcessed = 1; iProcessed <= nProcessed; iProcessed++) {

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -78,7 +78,8 @@ globalTrackParametersCovariance(
     // C^n_{i, j} for i <= j
     if (nProcessed > 0) {
       // Calculate the gain matrix
-      GainMatrix G = ts.boundFilteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
+      GainMatrix G = ts.boundFilteredCovariance() *
+                     prev_ts.jacobianBoundToBound().transpose() *
                      prev_ts.boundPredictedCovariance().inverse();
       // Loop over the beforehand smoothed states
       for (size_t iProcessed = 1; iProcessed <= nProcessed; iProcessed++) {

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -79,7 +79,7 @@ globalTrackParametersCovariance(
     if (nProcessed > 0) {
       // Calculate the gain matrix
       GainMatrix G = ts.filteredCovariance() * prev_ts.jacobianBoundToBound().transpose() *
-                     prev_ts.predictedCovariance().inverse();
+                     prev_ts.boundPredictedCovariance().inverse();
       // Loop over the beforehand smoothed states
       for (size_t iProcessed = 1; iProcessed <= nProcessed; iProcessed++) {
         const size_t iCol = iRow + eBoundParametersSize * iProcessed;

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -754,7 +754,7 @@ class CombinatorialKalmanFilter {
         trackStateProxy.predicted() = boundParams.parameters();
         trackStateProxy.predictedCovariance() = *boundParams.covariance();
       }
-      trackStateProxy.jacobian() = jacobian;
+      trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
 
       // Assign the uncalibrated&calibrated measurement to the track
@@ -840,7 +840,7 @@ class CombinatorialKalmanFilter {
       // Fill the track state
       trackStateProxy.predicted() = boundParams.parameters();
       trackStateProxy.predictedCovariance() = *boundParams.covariance();
-      trackStateProxy.jacobian() = jacobian;
+      trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
       // Set the surface
       trackStateProxy.setReferenceSurface(
@@ -885,7 +885,7 @@ class CombinatorialKalmanFilter {
       // Fill the track state
       trackStateProxy.predicted() = curvilinearParams.parameters();
       trackStateProxy.predictedCovariance() = *curvilinearParams.covariance();
-      trackStateProxy.jacobian() = jacobian;
+      trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
       // Set the surface
       trackStateProxy.setReferenceSurface(Surface::makeShared<PlaneSurface>(

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -572,7 +572,7 @@ class CombinatorialKalmanFilter {
           // already stored
           // -> filtered parameter for outlier
           auto stateMask =
-              (isPredictedShared ? ~TrackStatePropMask::Predicted
+              (isPredictedShared ? ~TrackStatePropMask::BoundPredicted
                                  : TrackStatePropMask::BoundAll) &
               (isSourcelinkShared ? ~TrackStatePropMask::Uncalibrated
                                   : TrackStatePropMask::BoundAll) &
@@ -745,14 +745,14 @@ class CombinatorialKalmanFilter {
       auto [boundParams, jacobian, pathLength] = boundState;
 
       // Fill the parametric part of the track state proxy
-      if ((not ACTS_CHECK_BIT(stateMask, TrackStatePropMask::Predicted)) and
+      if ((not ACTS_CHECK_BIT(stateMask, TrackStatePropMask::BoundPredicted)) and
           neighborTip != SIZE_MAX) {
         // The predicted parameter is already stored, just set the index
         auto neighborState = result.fittedStates.getTrackState(neighborTip);
-        trackStateProxy.data().ipredicted = neighborState.data().ipredicted;
+        trackStateProxy.data().iboundpredicted = neighborState.data().iboundpredicted;
       } else {
-        trackStateProxy.predicted() = boundParams.parameters();
-        trackStateProxy.predictedCovariance() = *boundParams.covariance();
+        trackStateProxy.boundPredicted() = boundParams.parameters();
+        trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
       }
       trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
@@ -773,7 +773,7 @@ class CombinatorialKalmanFilter {
             trackStateProxy.setCalibrated(calibrated);
           },
           m_calibrator(trackStateProxy.uncalibrated(),
-                       trackStateProxy.predicted()));
+                       trackStateProxy.boundPredicted()));
 
       // Get and set the type flags
       auto& typeFlags = trackStateProxy.typeFlags();
@@ -793,7 +793,7 @@ class CombinatorialKalmanFilter {
         // No Kalman update for outlier
         // Set the filtered parameter index to be the same with predicted
         // parameter
-        trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
+        trackStateProxy.data().ifiltered = trackStateProxy.data().iboundpredicted;
       } else {
         // Kalman update
         auto updateRes = m_updater(geoContext, trackStateProxy);
@@ -838,8 +838,8 @@ class CombinatorialKalmanFilter {
 
       auto [boundParams, jacobian, pathLength] = boundState;
       // Fill the track state
-      trackStateProxy.predicted() = boundParams.parameters();
-      trackStateProxy.predictedCovariance() = *boundParams.covariance();
+      trackStateProxy.boundPredicted() = boundParams.parameters();
+      trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
       trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
       // Set the surface
@@ -847,7 +847,7 @@ class CombinatorialKalmanFilter {
           boundParams.referenceSurface().getSharedPtr());
       // Set the filtered parameter index to be the same with predicted
       // parameter
-      trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
+      trackStateProxy.data().ifiltered = trackStateProxy.data().iboundpredicted;
 
       return currentTip;
     }
@@ -883,8 +883,8 @@ class CombinatorialKalmanFilter {
 
       auto [curvilinearParams, jacobian, pathLength] = curvilinearState;
       // Fill the track state
-      trackStateProxy.predicted() = curvilinearParams.parameters();
-      trackStateProxy.predictedCovariance() = *curvilinearParams.covariance();
+      trackStateProxy.boundPredicted() = curvilinearParams.parameters();
+      trackStateProxy.boundPredictedCovariance() = *curvilinearParams.covariance();
       trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
       // Set the surface
@@ -892,7 +892,7 @@ class CombinatorialKalmanFilter {
           curvilinearParams.position(), curvilinearParams.momentum()));
       // Set the filtered parameter index to be the same with predicted
       // parameter
-      trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
+      trackStateProxy.data().ifiltered = trackStateProxy.data().iboundpredicted;
 
       return currentTip;
     }

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -655,9 +655,9 @@ class CombinatorialKalmanFilter {
           // No source links on surface, add either hole or passive material
           // TrackState. No storage allocation for uncalibrated/calibrated
           // measurement and filtered parameter
-          auto stateMask =
-              ~(TrackStatePropMask::Uncalibrated |
-                TrackStatePropMask::Calibrated | TrackStatePropMask::BoundFiltered);
+          auto stateMask = ~(TrackStatePropMask::Uncalibrated |
+                             TrackStatePropMask::Calibrated |
+                             TrackStatePropMask::BoundFiltered);
 
           // Increment of number of processed states
           tipState.nStates++;
@@ -745,11 +745,13 @@ class CombinatorialKalmanFilter {
       auto [boundParams, jacobian, pathLength] = boundState;
 
       // Fill the parametric part of the track state proxy
-      if ((not ACTS_CHECK_BIT(stateMask, TrackStatePropMask::BoundPredicted)) and
+      if ((not ACTS_CHECK_BIT(stateMask,
+                              TrackStatePropMask::BoundPredicted)) and
           neighborTip != SIZE_MAX) {
         // The predicted parameter is already stored, just set the index
         auto neighborState = result.fittedStates.getTrackState(neighborTip);
-        trackStateProxy.data().iboundpredicted = neighborState.data().iboundpredicted;
+        trackStateProxy.data().iboundpredicted =
+            neighborState.data().iboundpredicted;
       } else {
         trackStateProxy.boundPredicted() = boundParams.parameters();
         trackStateProxy.boundPredictedCovariance() = *boundParams.covariance();
@@ -793,7 +795,8 @@ class CombinatorialKalmanFilter {
         // No Kalman update for outlier
         // Set the filtered parameter index to be the same with predicted
         // parameter
-        trackStateProxy.data().iboundfiltered = trackStateProxy.data().iboundpredicted;
+        trackStateProxy.data().iboundfiltered =
+            trackStateProxy.data().iboundpredicted;
       } else {
         // Kalman update
         auto updateRes = m_updater(geoContext, trackStateProxy);
@@ -847,7 +850,8 @@ class CombinatorialKalmanFilter {
           boundParams.referenceSurface().getSharedPtr());
       // Set the filtered parameter index to be the same with predicted
       // parameter
-      trackStateProxy.data().iboundfiltered = trackStateProxy.data().iboundpredicted;
+      trackStateProxy.data().iboundfiltered =
+          trackStateProxy.data().iboundpredicted;
 
       return currentTip;
     }
@@ -884,7 +888,8 @@ class CombinatorialKalmanFilter {
       auto [curvilinearParams, jacobian, pathLength] = curvilinearState;
       // Fill the track state
       trackStateProxy.boundPredicted() = curvilinearParams.parameters();
-      trackStateProxy.boundPredictedCovariance() = *curvilinearParams.covariance();
+      trackStateProxy.boundPredictedCovariance() =
+          *curvilinearParams.covariance();
       trackStateProxy.jacobianBoundToBound() = jacobian;
       trackStateProxy.pathLength() = pathLength;
       // Set the surface
@@ -892,7 +897,8 @@ class CombinatorialKalmanFilter {
           curvilinearParams.position(), curvilinearParams.momentum()));
       // Set the filtered parameter index to be the same with predicted
       // parameter
-      trackStateProxy.data().iboundfiltered = trackStateProxy.data().iboundpredicted;
+      trackStateProxy.data().iboundfiltered =
+          trackStateProxy.data().iboundpredicted;
 
       return currentTip;
     }

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -573,11 +573,11 @@ class CombinatorialKalmanFilter {
           // -> filtered parameter for outlier
           auto stateMask =
               (isPredictedShared ? ~TrackStatePropMask::Predicted
-                                 : TrackStatePropMask::All) &
+                                 : TrackStatePropMask::BoundAll) &
               (isSourcelinkShared ? ~TrackStatePropMask::Uncalibrated
-                                  : TrackStatePropMask::All) &
+                                  : TrackStatePropMask::BoundAll) &
               (isOutlier ? ~TrackStatePropMask::Filtered
-                         : TrackStatePropMask::All);
+                         : TrackStatePropMask::BoundAll);
 
           // Add measurement/outlier track state to the multitrajectory
           auto addStateRes = addSourcelinkState(

--- a/Core/include/Acts/Visualization/EventDataView.hpp
+++ b/Core/include/Acts/Visualization/EventDataView.hpp
@@ -247,19 +247,19 @@ struct EventDataView {
             predictedConfig, predictedConfig, ViewConfig(false));
       }
       // (b) filtered track parameters
-      if (filteredConfig.visible and state.hasFiltered()) {
+      if (filteredConfig.visible and state.hasBoundFiltered()) {
         drawBoundParameters(
             helper,
-            BoundParameters(gctx, state.filteredCovariance(), state.filtered(),
+            BoundParameters(gctx, state.boundFilteredCovariance(), state.boundFiltered(),
                             state.referenceSurface().getSharedPtr()),
             gctx, momentumScale, locErrorScale, angularErrorScale,
             filteredConfig, filteredConfig, ViewConfig(false));
       }
       // (c) smoothed track parameters
-      if (smoothedConfig.visible and state.hasSmoothed()) {
+      if (smoothedConfig.visible and state.hasBoundSmoothed()) {
         drawBoundParameters(
             helper,
-            BoundParameters(gctx, state.smoothedCovariance(), state.smoothed(),
+            BoundParameters(gctx, state.boundSmoothedCovariance(), state.boundSmoothed(),
                             state.referenceSurface().getSharedPtr()),
             gctx, momentumScale, locErrorScale, angularErrorScale,
             smoothedConfig, smoothedConfig, ViewConfig(false));

--- a/Core/include/Acts/Visualization/EventDataView.hpp
+++ b/Core/include/Acts/Visualization/EventDataView.hpp
@@ -237,11 +237,11 @@ struct EventDataView {
 
       // Last, if necessary and present, draw the track parameters
       // (a) predicted track parameters
-      if (predictedConfig.visible and state.hasPredicted()) {
+      if (predictedConfig.visible and state.hasBoundPredicted()) {
         drawBoundParameters(
             helper,
-            BoundParameters(gctx, state.predictedCovariance(),
-                            state.predicted(),
+            BoundParameters(gctx, state.boundPredictedCovariance(),
+                            state.boundPredicted(),
                             state.referenceSurface().getSharedPtr()),
             gctx, momentumScale, locErrorScale, angularErrorScale,
             predictedConfig, predictedConfig, ViewConfig(false));

--- a/Core/include/Acts/Visualization/EventDataView.hpp
+++ b/Core/include/Acts/Visualization/EventDataView.hpp
@@ -250,7 +250,8 @@ struct EventDataView {
       if (filteredConfig.visible and state.hasBoundFiltered()) {
         drawBoundParameters(
             helper,
-            BoundParameters(gctx, state.boundFilteredCovariance(), state.boundFiltered(),
+            BoundParameters(gctx, state.boundFilteredCovariance(),
+                            state.boundFiltered(),
                             state.referenceSurface().getSharedPtr()),
             gctx, momentumScale, locErrorScale, angularErrorScale,
             filteredConfig, filteredConfig, ViewConfig(false));
@@ -259,7 +260,8 @@ struct EventDataView {
       if (smoothedConfig.visible and state.hasBoundSmoothed()) {
         drawBoundParameters(
             helper,
-            BoundParameters(gctx, state.boundSmoothedCovariance(), state.boundSmoothed(),
+            BoundParameters(gctx, state.boundSmoothedCovariance(),
+                            state.boundSmoothed(),
                             state.referenceSurface().getSharedPtr()),
             gctx, momentumScale, locErrorScale, angularErrorScale,
             smoothedConfig, smoothedConfig, ViewConfig(false));

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -555,13 +555,13 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
       // get the filtered parameter
       bool filtered = false;
-      if (state.hasFiltered()) {
+      if (state.hasBoundFiltered()) {
         filtered = true;
         m_nFiltered++;
         Acts::BoundParameters parameter(
-            gctx, state.filteredCovariance(), state.filtered(),
+            gctx, state.boundFilteredCovariance(), state.boundFiltered(),
             state.referenceSurface().getSharedPtr());
-        auto covariance = state.filteredCovariance();
+        auto covariance = state.boundFilteredCovariance();
         // filtered parameter
         m_eLOC0_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);
         m_eLOC1_flt.push_back(parameter.parameters()[Acts::ParDef::eLOC_1]);
@@ -666,13 +666,13 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
       // get the smoothed parameter
       bool smoothed = false;
-      if (state.hasSmoothed()) {
+      if (state.hasBoundSmoothed()) {
         smoothed = true;
         m_nSmoothed++;
         Acts::BoundParameters parameter(
-            gctx, state.smoothedCovariance(), state.smoothed(),
+            gctx, state.boundSmoothedCovariance(), state.boundSmoothed(),
             state.referenceSurface().getSharedPtr());
-        auto covariance = state.smoothedCovariance();
+        auto covariance = state.boundSmoothedCovariance();
 
         // smoothed parameter
         m_eLOC0_smt.push_back(parameter.parameters()[Acts::ParDef::eLOC_0]);

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -420,13 +420,13 @@ FW::ProcessCode FW::RootTrajectoryWriter::writeT(
 
       // get the predicted parameter
       bool predicted = false;
-      if (state.hasPredicted()) {
+      if (state.hasBoundPredicted()) {
         predicted = true;
         m_nPredicted++;
         Acts::BoundParameters parameter(
-            gctx, state.predictedCovariance(), state.predicted(),
+            gctx, state.boundPredictedCovariance(), state.boundPredicted(),
             state.referenceSurface().getSharedPtr());
-        auto covariance = state.predictedCovariance();
+        auto covariance = state.boundPredictedCovariance();
         // local hit residual info
         auto H = meas.projector();
         auto resCov = cov + H * covariance * H.transpose();

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -306,8 +306,12 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(cnv(PM::None).none());  // all zeros
 
   // test orthogonality
-  std::array<PM, 12> values{PM::BoundPredicted, PM::BoundFiltered,     PM::BoundSmoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
-                           PM::JacobianBoundToBound, PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree,   PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 12> values{PM::BoundPredicted,       PM::BoundFiltered,
+                            PM::BoundSmoothed,        PM::FreePredicted,
+                            PM::FreeFiltered,         PM::FreeSmoothed,
+                            PM::JacobianBoundToBound, PM::JacobianBoundToFree,
+                            PM::JacobianFreeToBound,  PM::JacobianFreeToFree,
+                            PM::Uncalibrated,         PM::Calibrated};
   for (size_t i = 0; i < values.size(); i++) {
     for (size_t j = 0; j < values.size(); j++) {
       PM a = values[i];
@@ -599,10 +603,11 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(pc.meas3d->sourceLink(), ts.uncalibrated());
 
   // full projector, should be exactly equal
-  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax, eFreeParametersSize> fullProj;
+  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
+              eFreeParametersSize>
+      fullProj;
   fullProj.setZero();
-  fullProj.topLeftCorner(pc.meas3d->size(),
-                         eBoundParametersSize) =
+  fullProj.topLeftCorner(pc.meas3d->size(), eBoundParametersSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 
@@ -616,9 +621,10 @@ BOOST_AUTO_TEST_CASE(add_trackstate_allocations) {
 
   // this should allocate for all the components in the trackstate, plus
   // filtered
-  size_t i = t.addTrackState(
-      TrackStatePropMask::BoundPredicted | TrackStatePropMask::BoundFiltered |
-      TrackStatePropMask::Uncalibrated | TrackStatePropMask::JacobianBoundToBound);
+  size_t i = t.addTrackState(TrackStatePropMask::BoundPredicted |
+                             TrackStatePropMask::BoundFiltered |
+                             TrackStatePropMask::Uncalibrated |
+                             TrackStatePropMask::JacobianBoundToBound);
   auto tso = t.getTrackState(i);
   fillTrackState(tso, TrackStatePropMask::BoundPredicted);
   fillTrackState(tso, TrackStatePropMask::BoundFiltered);
@@ -639,8 +645,12 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   using PM = TrackStatePropMask;
   MultiTrajectory<SourceLink> mj;
 
-  std::array<PM, 12> values{PM::BoundPredicted, PM::BoundFiltered,     PM::BoundSmoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
-                           PM::JacobianBoundToBound,  PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree, PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 12> values{PM::BoundPredicted,       PM::BoundFiltered,
+                            PM::BoundSmoothed,        PM::FreePredicted,
+                            PM::FreeFiltered,         PM::FreeSmoothed,
+                            PM::JacobianBoundToBound, PM::JacobianBoundToFree,
+                            PM::JacobianFreeToBound,  PM::JacobianFreeToFree,
+                            PM::Uncalibrated,         PM::Calibrated};
 
   PM all = std::accumulate(values.begin(), values.end(), PM::None,
                            [](auto a, auto b) { return a | b; });
@@ -651,9 +661,10 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   ts = mj.getTrackState(mj.addTrackState(PM::BoundFiltered | PM::Calibrated));
   BOOST_CHECK(ts.getMask() == (PM::BoundFiltered | PM::Calibrated));
 
-  ts = mj.getTrackState(
-      mj.addTrackState(PM::BoundFiltered | PM::BoundSmoothed | PM::BoundPredicted));
-  BOOST_CHECK(ts.getMask() == (PM::BoundFiltered | PM::BoundSmoothed | PM::BoundPredicted));
+  ts = mj.getTrackState(mj.addTrackState(PM::BoundFiltered | PM::BoundSmoothed |
+                                         PM::BoundPredicted));
+  BOOST_CHECK(ts.getMask() ==
+              (PM::BoundFiltered | PM::BoundSmoothed | PM::BoundPredicted));
 
   for (PM mask : values) {
     ts = mj.getTrackState(mj.addTrackState(mask));
@@ -666,8 +677,9 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   MultiTrajectory<SourceLink> mj;
   auto mkts = [&](PM mask) { return mj.getTrackState(mj.addTrackState(mask)); };
 
-  std::array<PM, 6> values{PM::BoundPredicted, PM::BoundFiltered,     PM::BoundSmoothed,
-                           PM::JacobianBoundToBound,  PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 6> values{PM::BoundPredicted, PM::BoundFiltered,
+                           PM::BoundSmoothed,  PM::JacobianBoundToBound,
+                           PM::Uncalibrated,   PM::Calibrated};
 
   // orthogonal ones
 
@@ -725,7 +737,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   ots2.copyFrom(ts2);
 
   BOOST_CHECK_NE(ts1.boundPredicted(), ts2.boundPredicted());
-  BOOST_CHECK_NE(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
+  BOOST_CHECK_NE(ts1.boundPredictedCovariance(),
+                 ts2.boundPredictedCovariance());
   BOOST_CHECK_NE(ts1.boundFiltered(), ts2.boundFiltered());
   BOOST_CHECK_NE(ts1.boundFilteredCovariance(), ts2.boundFilteredCovariance());
   BOOST_CHECK_NE(ts1.boundSmoothed(), ts2.boundSmoothed());
@@ -747,11 +760,14 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   ts1.copyFrom(ts2);
 
   BOOST_CHECK_EQUAL(ts1.boundPredicted(), ts2.boundPredicted());
-  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(),
+                    ts2.boundPredictedCovariance());
   BOOST_CHECK_EQUAL(ts1.boundFiltered(), ts2.boundFiltered());
-  BOOST_CHECK_EQUAL(ts1.boundFilteredCovariance(), ts2.boundFilteredCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundFilteredCovariance(),
+                    ts2.boundFilteredCovariance());
   BOOST_CHECK_EQUAL(ts1.boundSmoothed(), ts2.boundSmoothed());
-  BOOST_CHECK_EQUAL(ts1.boundSmoothedCovariance(), ts2.boundSmoothedCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundSmoothedCovariance(),
+                    ts2.boundSmoothedCovariance());
 
   BOOST_CHECK_EQUAL(ts1.uncalibrated(), ts2.uncalibrated());
 
@@ -773,7 +789,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   ts1.copyFrom(ots1);                      // reset to original
   // is different again
   BOOST_CHECK_NE(ts1.boundPredicted(), ts2.boundPredicted());
-  BOOST_CHECK_NE(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
+  BOOST_CHECK_NE(ts1.boundPredictedCovariance(),
+                 ts2.boundPredictedCovariance());
 
   BOOST_CHECK_NE(ts1.calibratedSourceLink(), ts2.calibratedSourceLink());
   BOOST_CHECK_NE(ts1.calibrated(), ts2.calibrated());
@@ -790,7 +807,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
 
   // some components are same now
   BOOST_CHECK_EQUAL(ts1.boundPredicted(), ts2.boundPredicted());
-  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(),
+                    ts2.boundPredictedCovariance());
 
   BOOST_CHECK_EQUAL(ts1.calibratedSourceLink(), ts2.calibratedSourceLink());
   BOOST_CHECK_EQUAL(ts1.calibrated(), ts2.calibrated());

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mCovFull.topLeftCorner(2, 2) = mCov;
   BOOST_CHECK_EQUAL(ts.calibratedCovariance(), mCovFull);
 
-  ActsMatrixD<maxmeasdim, eBoundParametersSize> projFull;
+  ActsMatrixD<maxmeasdim, eFreeParametersSize> projFull;
   projFull.setZero();
   projFull.topLeftCorner(m2.size(), eBoundParametersSize) = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -599,11 +599,10 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(pc.meas3d->sourceLink(), ts.uncalibrated());
 
   // full projector, should be exactly equal
-  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
-              eBoundParametersSize>
-      fullProj;
+  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax, eFreeParametersSize> fullProj;
   fullProj.setZero();
-  fullProj.topLeftCorner(pc.meas3d->size(), eBoundParametersSize) =
+  fullProj.topLeftCorner(pc.meas3d->size(),
+                         eBoundParametersSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Filtered));
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Smoothed));
 
-  auto cnv = [](auto a) -> std::bitset<8> {
+  auto cnv = [](auto a) -> std::bitset<16> {
     return static_cast<std::underlying_type<PM>::type>(a);
   };
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -144,9 +144,9 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
   BoundParameters pred(gctx, predCov, predPar, plane);
   pc.predicted = pred;
-  if (ACTS_CHECK_BIT(mask, TrackStatePropMask::Predicted)) {
-    ts.predicted() = pred.parameters();
-    ts.predictedCovariance() = *pred.covariance();
+  if (ACTS_CHECK_BIT(mask, TrackStatePropMask::BoundPredicted)) {
+    ts.boundPredicted() = pred.parameters();
+    ts.boundPredictedCovariance() = *pred.covariance();
   }
 
   // filtered
@@ -200,7 +200,7 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
 BOOST_AUTO_TEST_CASE(multitrajectory_build) {
   MultiTrajectory<SourceLink> t;
-  TrackStatePropMask mask = TrackStatePropMask::Predicted;
+  TrackStatePropMask mask = TrackStatePropMask::BoundPredicted;
 
   // construct trajectory w/ multiple components
   auto i0 = t.addTrackState(mask);
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(multitrajectory_build) {
 
 BOOST_AUTO_TEST_CASE(visit_apply_abort) {
   MultiTrajectory<SourceLink> t;
-  TrackStatePropMask mask = TrackStatePropMask::Predicted;
+  TrackStatePropMask mask = TrackStatePropMask::BoundPredicted;
 
   // construct trajectory with three components
   auto i0 = t.addTrackState(mask);
@@ -290,8 +290,8 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(ACTS_CHECK_BIT(PM::All, PM::Uncalibrated));
   BOOST_CHECK(ACTS_CHECK_BIT(PM::All, PM::Calibrated));
 
-  auto bs4 = PM::Predicted | PM::JacobianBoundToBound | PM::Uncalibrated;
-  BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::Predicted));
+  auto bs4 = PM::BoundPredicted | PM::JacobianBoundToBound | PM::Uncalibrated;
+  BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::BoundPredicted));
   BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::Uncalibrated));
   BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::JacobianBoundToBound));
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Calibrated));
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(cnv(PM::None).none());  // all zeros
 
   // test orthogonality
-  std::array<PM, 12> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
+  std::array<PM, 12> values{PM::BoundPredicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
                            PM::JacobianBoundToBound, PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree,   PM::Uncalibrated, PM::Calibrated};
   for (size_t i = 0; i < values.size(); i++) {
     for (size_t j = 0; j < values.size(); j++) {
@@ -321,10 +321,10 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
     }
   }
 
-  BOOST_CHECK(cnv(PM::Predicted ^ PM::Filtered).count() == 2);
-  BOOST_CHECK(cnv(PM::Predicted ^ PM::Predicted).none());
-  BOOST_CHECK(~(PM::Predicted | PM::Calibrated) ==
-              (PM::All ^ PM::Predicted ^ PM::Calibrated));
+  BOOST_CHECK(cnv(PM::BoundPredicted ^ PM::Filtered).count() == 2);
+  BOOST_CHECK(cnv(PM::BoundPredicted ^ PM::BoundPredicted).none());
+  BOOST_CHECK(~(PM::BoundPredicted | PM::Calibrated) ==
+              (PM::All ^ PM::BoundPredicted ^ PM::Calibrated));
 
   PM base = PM::None;
   BOOST_CHECK(cnv(base) == 0);
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   MultiTrajectory<SourceLink> t;
 
   auto ts = t.getTrackState(t.addTrackState(PM::All));
-  BOOST_CHECK(ts.hasPredicted());
+  BOOST_CHECK(ts.hasBoundPredicted());
   BOOST_CHECK(ts.hasFiltered());
   BOOST_CHECK(ts.hasSmoothed());
   BOOST_CHECK(ts.hasUncalibrated());
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::None));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -364,8 +364,8 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasProjector());
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
-  ts = t.getTrackState(t.addTrackState(PM::Predicted));
-  BOOST_CHECK(ts.hasPredicted());
+  ts = t.getTrackState(t.addTrackState(PM::BoundPredicted));
+  BOOST_CHECK(ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Filtered));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Smoothed));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -392,7 +392,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Uncalibrated));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(ts.hasUncalibrated());
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Calibrated));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -410,7 +410,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::JacobianBoundToBound));
-  BOOST_CHECK(!ts.hasPredicted());
+  BOOST_CHECK(!ts.hasBoundPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
@@ -441,11 +441,11 @@ BOOST_AUTO_TEST_CASE(trackstate_proxy_cross_talk) {
   CovMat_t cov;
 
   v.setRandom();
-  ts.predicted() = v;
-  BOOST_CHECK_EQUAL(cts.predicted(), v);
+  ts.boundPredicted() = v;
+  BOOST_CHECK_EQUAL(cts.boundPredicted(), v);
   cov.setRandom();
-  ts.predictedCovariance() = cov;
-  BOOST_CHECK_EQUAL(cts.predictedCovariance(), cov);
+  ts.boundPredictedCovariance() = cov;
+  BOOST_CHECK_EQUAL(cts.boundPredictedCovariance(), cov);
 
   v.setRandom();
   ts.filtered() = v;
@@ -556,9 +556,9 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
 
   // now investigate the proxy
   // parameters
-  BOOST_CHECK(ts.hasPredicted());
-  BOOST_CHECK_EQUAL(pc.predicted->parameters(), ts.predicted());
-  BOOST_CHECK_EQUAL(*pc.predicted->covariance(), ts.predictedCovariance());
+  BOOST_CHECK(ts.hasBoundPredicted());
+  BOOST_CHECK_EQUAL(pc.predicted->parameters(), ts.boundPredicted());
+  BOOST_CHECK_EQUAL(*pc.predicted->covariance(), ts.boundPredictedCovariance());
 
   BOOST_CHECK(ts.hasFiltered());
   BOOST_CHECK_EQUAL(pc.filtered->parameters(), ts.filtered());
@@ -617,15 +617,15 @@ BOOST_AUTO_TEST_CASE(add_trackstate_allocations) {
   // this should allocate for all the components in the trackstate, plus
   // filtered
   size_t i = t.addTrackState(
-      TrackStatePropMask::Predicted | TrackStatePropMask::Filtered |
+      TrackStatePropMask::BoundPredicted | TrackStatePropMask::Filtered |
       TrackStatePropMask::Uncalibrated | TrackStatePropMask::JacobianBoundToBound);
   auto tso = t.getTrackState(i);
-  fillTrackState(tso, TrackStatePropMask::Predicted);
+  fillTrackState(tso, TrackStatePropMask::BoundPredicted);
   fillTrackState(tso, TrackStatePropMask::Filtered);
   fillTrackState(tso, TrackStatePropMask::Uncalibrated);
   fillTrackState(tso, TrackStatePropMask::JacobianBoundToBound);
 
-  BOOST_CHECK(tso.hasPredicted());
+  BOOST_CHECK(tso.hasBoundPredicted());
   BOOST_CHECK(tso.hasFiltered());
   BOOST_CHECK(!tso.hasSmoothed());
   BOOST_CHECK(tso.hasUncalibrated());
@@ -639,7 +639,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   using PM = TrackStatePropMask;
   MultiTrajectory<SourceLink> mj;
 
-  std::array<PM, 12> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
+  std::array<PM, 12> values{PM::BoundPredicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
                            PM::JacobianBoundToBound,  PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree, PM::Uncalibrated, PM::Calibrated};
 
   PM all = std::accumulate(values.begin(), values.end(), PM::None,
@@ -652,8 +652,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   BOOST_CHECK(ts.getMask() == (PM::Filtered | PM::Calibrated));
 
   ts = mj.getTrackState(
-      mj.addTrackState(PM::Filtered | PM::Smoothed | PM::Predicted));
-  BOOST_CHECK(ts.getMask() == (PM::Filtered | PM::Smoothed | PM::Predicted));
+      mj.addTrackState(PM::Filtered | PM::Smoothed | PM::BoundPredicted));
+  BOOST_CHECK(ts.getMask() == (PM::Filtered | PM::Smoothed | PM::BoundPredicted));
 
   for (PM mask : values) {
     ts = mj.getTrackState(mj.addTrackState(mask));
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   MultiTrajectory<SourceLink> mj;
   auto mkts = [&](PM mask) { return mj.getTrackState(mj.addTrackState(mask)); };
 
-  std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
+  std::array<PM, 6> values{PM::BoundPredicted, PM::Filtered,     PM::Smoothed,
                            PM::JacobianBoundToBound,  PM::Uncalibrated, PM::Calibrated};
 
   // orthogonal ones
@@ -686,30 +686,30 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
     }
   }
 
-  auto ts1 = mkts(PM::Filtered | PM::Predicted);  // this has both
+  auto ts1 = mkts(PM::Filtered | PM::BoundPredicted);  // this has both
   ts1.filtered().setRandom();
   ts1.filteredCovariance().setRandom();
-  ts1.predicted().setRandom();
-  ts1.predictedCovariance().setRandom();
+  ts1.boundPredicted().setRandom();
+  ts1.boundPredictedCovariance().setRandom();
 
   // ((src XOR dst) & src) == 0
-  auto ts2 = mkts(PM::Predicted);
-  ts2.predicted().setRandom();
-  ts2.predictedCovariance().setRandom();
+  auto ts2 = mkts(PM::BoundPredicted);
+  ts2.boundPredicted().setRandom();
+  ts2.boundPredictedCovariance().setRandom();
 
   // they are different before
-  BOOST_CHECK(ts1.predicted() != ts2.predicted());
-  BOOST_CHECK(ts1.predictedCovariance() != ts2.predictedCovariance());
+  BOOST_CHECK(ts1.boundPredicted() != ts2.boundPredicted());
+  BOOST_CHECK(ts1.boundPredictedCovariance() != ts2.boundPredictedCovariance());
 
   // ts1 -> ts2 fails
   BOOST_CHECK_THROW(ts2.copyFrom(ts1), std::runtime_error);
-  BOOST_CHECK(ts1.predicted() != ts2.predicted());
-  BOOST_CHECK(ts1.predictedCovariance() != ts2.predictedCovariance());
+  BOOST_CHECK(ts1.boundPredicted() != ts2.boundPredicted());
+  BOOST_CHECK(ts1.boundPredictedCovariance() != ts2.boundPredictedCovariance());
 
   // ts2 -> ts1 is ok
   ts1.copyFrom(ts2);
-  BOOST_CHECK(ts1.predicted() == ts2.predicted());
-  BOOST_CHECK(ts1.predictedCovariance() == ts2.predictedCovariance());
+  BOOST_CHECK(ts1.boundPredicted() == ts2.boundPredicted());
+  BOOST_CHECK(ts1.boundPredictedCovariance() == ts2.boundPredictedCovariance());
 
   size_t i0 = mj.addTrackState();
   size_t i1 = mj.addTrackState();
@@ -724,8 +724,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   ots1.copyFrom(ts1);
   ots2.copyFrom(ts2);
 
-  BOOST_CHECK_NE(ts1.predicted(), ts2.predicted());
-  BOOST_CHECK_NE(ts1.predictedCovariance(), ts2.predictedCovariance());
+  BOOST_CHECK_NE(ts1.boundPredicted(), ts2.boundPredicted());
+  BOOST_CHECK_NE(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
   BOOST_CHECK_NE(ts1.filtered(), ts2.filtered());
   BOOST_CHECK_NE(ts1.filteredCovariance(), ts2.filteredCovariance());
   BOOST_CHECK_NE(ts1.smoothed(), ts2.smoothed());
@@ -746,8 +746,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
 
   ts1.copyFrom(ts2);
 
-  BOOST_CHECK_EQUAL(ts1.predicted(), ts2.predicted());
-  BOOST_CHECK_EQUAL(ts1.predictedCovariance(), ts2.predictedCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundPredicted(), ts2.boundPredicted());
+  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
   BOOST_CHECK_EQUAL(ts1.filtered(), ts2.filtered());
   BOOST_CHECK_EQUAL(ts1.filteredCovariance(), ts2.filteredCovariance());
   BOOST_CHECK_EQUAL(ts1.smoothed(), ts2.smoothed());
@@ -767,13 +767,13 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   BOOST_CHECK_EQUAL(&ts1.referenceSurface(), &ts2.referenceSurface());
 
   // full copy proven to work. now let's do partial copy
-  ts2 = mkts(PM::Predicted | PM::JacobianBoundToBound | PM::Calibrated);
-  ts2.copyFrom(ots2, PM::Predicted | PM::JacobianBoundToBound |
+  ts2 = mkts(PM::BoundPredicted | PM::JacobianBoundToBound | PM::Calibrated);
+  ts2.copyFrom(ots2, PM::BoundPredicted | PM::JacobianBoundToBound |
                          PM::Calibrated);  // copy into empty ts, only copy some
   ts1.copyFrom(ots1);                      // reset to original
   // is different again
-  BOOST_CHECK_NE(ts1.predicted(), ts2.predicted());
-  BOOST_CHECK_NE(ts1.predictedCovariance(), ts2.predictedCovariance());
+  BOOST_CHECK_NE(ts1.boundPredicted(), ts2.boundPredicted());
+  BOOST_CHECK_NE(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
 
   BOOST_CHECK_NE(ts1.calibratedSourceLink(), ts2.calibratedSourceLink());
   BOOST_CHECK_NE(ts1.calibrated(), ts2.calibrated());
@@ -789,8 +789,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   ts1.copyFrom(ts2);
 
   // some components are same now
-  BOOST_CHECK_EQUAL(ts1.predicted(), ts2.predicted());
-  BOOST_CHECK_EQUAL(ts1.predictedCovariance(), ts2.predictedCovariance());
+  BOOST_CHECK_EQUAL(ts1.boundPredicted(), ts2.boundPredicted());
+  BOOST_CHECK_EQUAL(ts1.boundPredictedCovariance(), ts2.boundPredictedCovariance());
 
   BOOST_CHECK_EQUAL(ts1.calibratedSourceLink(), ts2.calibratedSourceLink());
   BOOST_CHECK_EQUAL(ts1.calibrated(), ts2.calibrated());

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -306,8 +306,8 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(cnv(PM::None).none());  // all zeros
 
   // test orthogonality
-  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
-                           PM::Jacobian,  PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed, PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
+                           PM::Jacobian,   PM::Uncalibrated, PM::Calibrated};
   for (size_t i = 0; i < values.size(); i++) {
     for (size_t j = 0; j < values.size(); j++) {
       PM a = values[i];
@@ -639,7 +639,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   using PM = TrackStatePropMask;
   MultiTrajectory<SourceLink> mj;
 
-  std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
+  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
                            PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
 
   PM all = std::accumulate(values.begin(), values.end(), PM::None,

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
 
   ActsMatrixD<maxmeasdim, eFreeParametersSize> projFull;
   projFull.setZero();
-  projFull.topLeftCorner(m2.size(), eBoundParametersSize) = m2.projector();
+  projFull.template topLeftCorner<decltype(m2)::size(), eBoundParametersSize>() = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);
 }
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -514,7 +514,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   BOOST_CHECK_EQUAL(ts.effectiveCalibrated(), pc.meas3d->parameters());
   BOOST_CHECK_EQUAL(ts.effectiveCalibratedCovariance(),
                     pc.meas3d->covariance());
-  BOOST_CHECK_EQUAL(ts.effectiveProjector(), pc.meas3d->projector());
+  BOOST_CHECK_EQUAL(ts.effectiveBoundProjector(), pc.meas3d->projector());
 
   // create new measurement
   SymMatrix2D mCov;
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   BOOST_CHECK_EQUAL(ts.calibratedSize(), 2u);
   BOOST_CHECK_EQUAL(ts.effectiveCalibrated(), mPar);
   BOOST_CHECK_EQUAL(ts.effectiveCalibratedCovariance(), mCov);
-  BOOST_CHECK_EQUAL(ts.effectiveProjector(), m2.projector());
+  BOOST_CHECK_EQUAL(ts.effectiveBoundProjector(), m2.projector());
 
   // check if overallocated part is zeroed correctly
   ActsVectorD<maxmeasdim> mParFull;
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(ts.jacobianBoundToBound(), pc.jacobian);
 
   BOOST_CHECK(ts.hasProjector());
-  BOOST_CHECK_EQUAL(ts.effectiveProjector(), pc.meas3d->projector());
+  BOOST_CHECK_EQUAL(ts.effectiveBoundProjector(), pc.meas3d->projector());
   // measurement properties
   BOOST_CHECK(ts.hasCalibrated());
   BOOST_CHECK_EQUAL(pc.meas3d->parameters(), ts.effectiveCalibrated());
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
 
   // projector with dynamic rows
   // should be exactly equal
-  BOOST_CHECK_EQUAL(ts.effectiveProjector(), pc.meas3d->projector());
+  BOOST_CHECK_EQUAL(ts.effectiveBoundProjector(), pc.meas3d->projector());
 }
 
 BOOST_AUTO_TEST_CASE(add_trackstate_allocations) {

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -306,8 +306,8 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(cnv(PM::None).none());  // all zeros
 
   // test orthogonality
-  std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
-                           PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
+                           PM::Jacobian,  PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed, PM::Uncalibrated, PM::Calibrated};
   for (size_t i = 0; i < values.size(); i++) {
     for (size_t j = 0; j < values.size(); j++) {
       PM a = values[i];

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -183,8 +183,8 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
   CovMat_t jac;
   jac.setRandom();
   pc.jacobian = jac;
-  if (ACTS_CHECK_BIT(mask, TrackStatePropMask::Jacobian)) {
-    ts.jacobian() = jac;
+  if (ACTS_CHECK_BIT(mask, TrackStatePropMask::JacobianBoundToBound)) {
+    ts.jacobianBoundToBound() = jac;
   }
 
   std::random_device rd;
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(multitrajectory_build) {
     BOOST_CHECK(!p.hasCalibrated());
     BOOST_CHECK(!p.hasFiltered());
     BOOST_CHECK(!p.hasSmoothed());
-    BOOST_CHECK(!p.hasJacobian());
+    BOOST_CHECK(!p.hasJacobianBoundToBound());
     BOOST_CHECK(!p.hasProjector());
   };
 
@@ -290,10 +290,10 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(ACTS_CHECK_BIT(PM::All, PM::Uncalibrated));
   BOOST_CHECK(ACTS_CHECK_BIT(PM::All, PM::Calibrated));
 
-  auto bs4 = PM::Predicted | PM::Jacobian | PM::Uncalibrated;
+  auto bs4 = PM::Predicted | PM::JacobianBoundToBound | PM::Uncalibrated;
   BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::Predicted));
   BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::Uncalibrated));
-  BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::Jacobian));
+  BOOST_CHECK(ACTS_CHECK_BIT(bs4, PM::JacobianBoundToBound));
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Calibrated));
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Filtered));
   BOOST_CHECK(!ACTS_CHECK_BIT(bs4, PM::Smoothed));
@@ -306,8 +306,8 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_operators) {
   BOOST_CHECK(cnv(PM::None).none());  // all zeros
 
   // test orthogonality
-  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
-                           PM::Jacobian,   PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 12> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
+                           PM::JacobianBoundToBound, PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree,   PM::Uncalibrated, PM::Calibrated};
   for (size_t i = 0; i < values.size(); i++) {
     for (size_t j = 0; j < values.size(); j++) {
       PM a = values[i];
@@ -353,7 +353,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(ts.hasUncalibrated());
   BOOST_CHECK(ts.hasCalibrated());
   BOOST_CHECK(ts.hasProjector());
-  BOOST_CHECK(ts.hasJacobian());
+  BOOST_CHECK(ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::None));
   BOOST_CHECK(!ts.hasPredicted());
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Predicted));
   BOOST_CHECK(ts.hasPredicted());
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Filtered));
   BOOST_CHECK(!ts.hasPredicted());
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Smoothed));
   BOOST_CHECK(!ts.hasPredicted());
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Uncalibrated));
   BOOST_CHECK(!ts.hasPredicted());
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
   ts = t.getTrackState(t.addTrackState(PM::Calibrated));
   BOOST_CHECK(!ts.hasPredicted());
@@ -407,16 +407,16 @@ BOOST_AUTO_TEST_CASE(trackstate_add_bitmask_method) {
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(ts.hasCalibrated());
   BOOST_CHECK(ts.hasProjector());
-  BOOST_CHECK(!ts.hasJacobian());
+  BOOST_CHECK(!ts.hasJacobianBoundToBound());
 
-  ts = t.getTrackState(t.addTrackState(PM::Jacobian));
+  ts = t.getTrackState(t.addTrackState(PM::JacobianBoundToBound));
   BOOST_CHECK(!ts.hasPredicted());
   BOOST_CHECK(!ts.hasFiltered());
   BOOST_CHECK(!ts.hasSmoothed());
   BOOST_CHECK(!ts.hasUncalibrated());
   BOOST_CHECK(!ts.hasCalibrated());
   BOOST_CHECK(!ts.hasProjector());
-  BOOST_CHECK(ts.hasJacobian());
+  BOOST_CHECK(ts.hasJacobianBoundToBound());
 }
 
 BOOST_AUTO_TEST_CASE(trackstate_proxy_cross_talk) {
@@ -489,8 +489,8 @@ BOOST_AUTO_TEST_CASE(trackstate_proxy_cross_talk) {
 
   CovMat_t jac;
   jac.setRandom();
-  ts.jacobian() = jac;
-  BOOST_CHECK_EQUAL(cts.jacobian(), jac);
+  ts.jacobianBoundToBound() = jac;
+  BOOST_CHECK_EQUAL(cts.jacobianBoundToBound(), jac);
 
   ts.chi2() = 98;
   BOOST_CHECK_EQUAL(cts.chi2(), 98u);
@@ -570,8 +570,8 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
 
   BOOST_CHECK_EQUAL(&ts.referenceSurface(), &pc.sourceLink.referenceSurface());
 
-  BOOST_CHECK(ts.hasJacobian());
-  BOOST_CHECK_EQUAL(ts.jacobian(), pc.jacobian);
+  BOOST_CHECK(ts.hasJacobianBoundToBound());
+  BOOST_CHECK_EQUAL(ts.jacobianBoundToBound(), pc.jacobian);
 
   BOOST_CHECK(ts.hasProjector());
   BOOST_CHECK_EQUAL(ts.effectiveProjector(), pc.meas3d->projector());
@@ -618,19 +618,19 @@ BOOST_AUTO_TEST_CASE(add_trackstate_allocations) {
   // filtered
   size_t i = t.addTrackState(
       TrackStatePropMask::Predicted | TrackStatePropMask::Filtered |
-      TrackStatePropMask::Uncalibrated | TrackStatePropMask::Jacobian);
+      TrackStatePropMask::Uncalibrated | TrackStatePropMask::JacobianBoundToBound);
   auto tso = t.getTrackState(i);
   fillTrackState(tso, TrackStatePropMask::Predicted);
   fillTrackState(tso, TrackStatePropMask::Filtered);
   fillTrackState(tso, TrackStatePropMask::Uncalibrated);
-  fillTrackState(tso, TrackStatePropMask::Jacobian);
+  fillTrackState(tso, TrackStatePropMask::JacobianBoundToBound);
 
   BOOST_CHECK(tso.hasPredicted());
   BOOST_CHECK(tso.hasFiltered());
   BOOST_CHECK(!tso.hasSmoothed());
   BOOST_CHECK(tso.hasUncalibrated());
   BOOST_CHECK(!tso.hasCalibrated());
-  BOOST_CHECK(tso.hasJacobian());
+  BOOST_CHECK(tso.hasJacobianBoundToBound());
 
   // remove some parts
 }
@@ -639,8 +639,8 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_getmask) {
   using PM = TrackStatePropMask;
   MultiTrajectory<SourceLink> mj;
 
-  std::array<PM, 9> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
-                           PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
+  std::array<PM, 12> values{PM::Predicted, PM::Filtered,     PM::Smoothed, PM::FreePredicted, PM::FreeFiltered,     PM::FreeSmoothed,
+                           PM::JacobianBoundToBound,  PM::JacobianBoundToFree, PM::JacobianFreeToBound, PM::JacobianFreeToFree, PM::Uncalibrated, PM::Calibrated};
 
   PM all = std::accumulate(values.begin(), values.end(), PM::None,
                            [](auto a, auto b) { return a | b; });
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   auto mkts = [&](PM mask) { return mj.getTrackState(mj.addTrackState(mask)); };
 
   std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
-                           PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
+                           PM::JacobianBoundToBound,  PM::Uncalibrated, PM::Calibrated};
 
   // orthogonal ones
 
@@ -739,7 +739,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   BOOST_CHECK_NE(ts1.calibratedSize(), ts2.calibratedSize());
   BOOST_CHECK_NE(ts1.projector(), ts2.projector());
 
-  BOOST_CHECK_NE(ts1.jacobian(), ts2.jacobian());
+  BOOST_CHECK_NE(ts1.jacobianBoundToBound(), ts2.jacobianBoundToBound());
   BOOST_CHECK_NE(ts1.chi2(), ts2.chi2());
   BOOST_CHECK_NE(ts1.pathLength(), ts2.pathLength());
   BOOST_CHECK_NE(&ts1.referenceSurface(), &ts2.referenceSurface());
@@ -761,14 +761,14 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   BOOST_CHECK_EQUAL(ts1.calibratedSize(), ts2.calibratedSize());
   BOOST_CHECK_EQUAL(ts1.projector(), ts2.projector());
 
-  BOOST_CHECK_EQUAL(ts1.jacobian(), ts2.jacobian());
+  BOOST_CHECK_EQUAL(ts1.jacobianBoundToBound(), ts2.jacobianBoundToBound());
   BOOST_CHECK_EQUAL(ts1.chi2(), ts2.chi2());
   BOOST_CHECK_EQUAL(ts1.pathLength(), ts2.pathLength());
   BOOST_CHECK_EQUAL(&ts1.referenceSurface(), &ts2.referenceSurface());
 
   // full copy proven to work. now let's do partial copy
-  ts2 = mkts(PM::Predicted | PM::Jacobian | PM::Calibrated);
-  ts2.copyFrom(ots2, PM::Predicted | PM::Jacobian |
+  ts2 = mkts(PM::Predicted | PM::JacobianBoundToBound | PM::Calibrated);
+  ts2.copyFrom(ots2, PM::Predicted | PM::JacobianBoundToBound |
                          PM::Calibrated);  // copy into empty ts, only copy some
   ts1.copyFrom(ots1);                      // reset to original
   // is different again
@@ -781,7 +781,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   BOOST_CHECK_NE(ts1.calibratedSize(), ts2.calibratedSize());
   BOOST_CHECK_NE(ts1.projector(), ts2.projector());
 
-  BOOST_CHECK_NE(ts1.jacobian(), ts2.jacobian());
+  BOOST_CHECK_NE(ts1.jacobianBoundToBound(), ts2.jacobianBoundToBound());
   BOOST_CHECK_NE(ts1.chi2(), ts2.chi2());
   BOOST_CHECK_NE(ts1.pathLength(), ts2.pathLength());
   BOOST_CHECK_NE(&ts1.referenceSurface(), &ts2.referenceSurface());
@@ -798,7 +798,7 @@ BOOST_AUTO_TEST_CASE(trackstateproxy_copy) {
   BOOST_CHECK_EQUAL(ts1.calibratedSize(), ts2.calibratedSize());
   BOOST_CHECK_EQUAL(ts1.projector(), ts2.projector());
 
-  BOOST_CHECK_EQUAL(ts1.jacobian(), ts2.jacobian());
+  BOOST_CHECK_EQUAL(ts1.jacobianBoundToBound(), ts2.jacobianBoundToBound());
   BOOST_CHECK_EQUAL(ts1.chi2(), ts2.chi2());              // always copied
   BOOST_CHECK_EQUAL(ts1.pathLength(), ts2.pathLength());  // always copied
   BOOST_CHECK_EQUAL(&ts1.referenceSurface(),

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -548,7 +548,9 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
 
   ActsMatrixD<maxmeasdim, eFreeParametersSize> projFull;
   projFull.setZero();
-  projFull.template topLeftCorner<decltype(m2)::size(), eBoundParametersSize>() = m2.projector();
+  projFull
+      .template topLeftCorner<decltype(m2)::size(), eBoundParametersSize>() =
+      m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);
 }
 

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.filtered() = parValues;
   ts.filteredCovariance() = covTrk;
   ts.pathLength() = 1.;
-  ts.jacobian().setIdentity();
+  ts.jacobianBoundToBound().setIdentity();
 
   ts_idx = traj.addTrackState(TrackStatePropMask::All, ts_idx);
   ts = traj.getTrackState(ts_idx);
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.filtered() = parValues;
   ts.filteredCovariance() = covTrk;
   ts.pathLength() = 2.;
-  ts.jacobian().setIdentity();
+  ts.jacobianBoundToBound().setIdentity();
 
   ts_idx = traj.addTrackState(TrackStatePropMask::All, ts_idx);
   ts = traj.getTrackState(ts_idx);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.filtered() = parValues;
   ts.filteredCovariance() = covTrk;
   ts.pathLength() = 3.;
-  ts.jacobian().setIdentity();
+  ts.jacobianBoundToBound().setIdentity();
 
   // "smooth" these three track states
 

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
 
   size_t ts_idx;
 
-  ts_idx = traj.addTrackState(TrackStatePropMask::All);
+  ts_idx = traj.addTrackState(TrackStatePropMask::BoundAll);
   auto ts = traj.getTrackState(ts_idx);
   ts.setReferenceSurface(plane1);
 
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.pathLength() = 1.;
   ts.jacobianBoundToBound().setIdentity();
 
-  ts_idx = traj.addTrackState(TrackStatePropMask::All, ts_idx);
+  ts_idx = traj.addTrackState(TrackStatePropMask::BoundAll, ts_idx);
   ts = traj.getTrackState(ts_idx);
   ts.setReferenceSurface(plane2);
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.pathLength() = 2.;
   ts.jacobianBoundToBound().setIdentity();
 
-  ts_idx = traj.addTrackState(TrackStatePropMask::All, ts_idx);
+  ts_idx = traj.addTrackState(TrackStatePropMask::BoundAll, ts_idx);
   ts = traj.getTrackState(ts_idx);
   ts.setReferenceSurface(plane3);
 

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -71,8 +71,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   BoundVector parValues;
   parValues << 0.3, 0.5, 0.5 * M_PI, 0., 1 / 100., 0.;
 
-  ts.predicted() = parValues;
-  ts.predictedCovariance() = covTrk;
+  ts.boundPredicted() = parValues;
+  ts.boundPredictedCovariance() = covTrk;
 
   parValues << 0.301, 0.503, 0.5 * M_PI, 0., 1 / 100., 0.;
 
@@ -86,8 +86,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.setReferenceSurface(plane2);
 
   parValues << 0.2, 0.5, 0.5 * M_PI, 0., 1 / 100., 0.;
-  ts.predicted() = parValues;
-  ts.predictedCovariance() = covTrk;
+  ts.boundPredicted() = parValues;
+  ts.boundPredictedCovariance() = covTrk;
 
   parValues << 0.27, 0.53, 0.5 * M_PI, 0., 1 / 100., 0.;
   ts.filtered() = parValues;
@@ -100,8 +100,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.setReferenceSurface(plane3);
 
   parValues << 0.35, 0.49, 0.5 * M_PI, 0., 1 / 100., 0.;
-  ts.predicted() = parValues;
-  ts.predictedCovariance() = covTrk;
+  ts.boundPredicted() = parValues;
+  ts.boundPredictedCovariance() = covTrk;
 
   parValues << 0.33, 0.43, 0.5 * M_PI, 0., 1 / 100., 0.;
   ts.filtered() = parValues;

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
 
   parValues << 0.301, 0.503, 0.5 * M_PI, 0., 1 / 100., 0.;
 
-  ts.filtered() = parValues;
-  ts.filteredCovariance() = covTrk;
+  ts.boundFiltered() = parValues;
+  ts.boundFilteredCovariance() = covTrk;
   ts.pathLength() = 1.;
   ts.jacobianBoundToBound().setIdentity();
 
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.boundPredictedCovariance() = covTrk;
 
   parValues << 0.27, 0.53, 0.5 * M_PI, 0., 1 / 100., 0.;
-  ts.filtered() = parValues;
-  ts.filteredCovariance() = covTrk;
+  ts.boundFiltered() = parValues;
+  ts.boundFilteredCovariance() = covTrk;
   ts.pathLength() = 2.;
   ts.jacobianBoundToBound().setIdentity();
 
@@ -104,8 +104,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   ts.boundPredictedCovariance() = covTrk;
 
   parValues << 0.33, 0.43, 0.5 * M_PI, 0., 1 / 100., 0.;
-  ts.filtered() = parValues;
-  ts.filteredCovariance() = covTrk;
+  ts.boundFiltered() = parValues;
+  ts.boundFilteredCovariance() = covTrk;
   ts.pathLength() = 3.;
   ts.jacobianBoundToBound().setIdentity();
 
@@ -118,36 +118,36 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   // for regressions in the result.
 
   auto ts1 = traj.getTrackState(0);
-  BOOST_CHECK(ts1.hasSmoothed());
-  BOOST_CHECK_NE(ts1.filtered(), ts1.smoothed());
+  BOOST_CHECK(ts1.hasBoundSmoothed());
+  BOOST_CHECK_NE(ts1.boundFiltered(), ts1.boundSmoothed());
 
   double tol = 1e-6;
 
   BoundVector expPars;
   expPars << 0.3510000, 0.4730000, 1.5707963, 0.0000000, 0.0100000, 0.0000000;
-  CHECK_CLOSE_ABS(ts1.smoothed(), expPars, tol);
+  CHECK_CLOSE_ABS(ts1.boundSmoothed(), expPars, tol);
   Covariance expCov;
   expCov.setIdentity();
   expCov.diagonal() << 0.0800000, 0.3000000, 1.0000000, 1.0000000, 1.0000000,
       1.0000000;
-  CHECK_CLOSE_ABS(ts1.smoothedCovariance(), expCov, tol);
+  CHECK_CLOSE_ABS(ts1.boundSmoothedCovariance(), expCov, tol);
 
   auto ts2 = traj.getTrackState(1);
-  BOOST_CHECK(ts2.hasSmoothed());
-  BOOST_CHECK_NE(ts2.filtered(), ts2.smoothed());
+  BOOST_CHECK(ts2.hasBoundSmoothed());
+  BOOST_CHECK_NE(ts2.boundFiltered(), ts2.boundSmoothed());
 
   expPars << 0.2500000, 0.4700000, 1.5707963, 0.0000000, 0.0100000, 0.0000000;
-  CHECK_CLOSE_ABS(ts2.smoothed(), expPars, tol);
-  CHECK_CLOSE_ABS(ts2.smoothedCovariance(), expCov, tol);
+  CHECK_CLOSE_ABS(ts2.boundSmoothed(), expPars, tol);
+  CHECK_CLOSE_ABS(ts2.boundSmoothedCovariance(), expCov, tol);
 
   auto ts3 = traj.getTrackState(2);
-  BOOST_CHECK(ts3.hasSmoothed());
+  BOOST_CHECK(ts3.hasBoundSmoothed());
   // last one, smoothed == filtered
-  BOOST_CHECK_EQUAL(ts3.filtered(), ts3.smoothed());
+  BOOST_CHECK_EQUAL(ts3.boundFiltered(), ts3.boundSmoothed());
 
   expPars << 0.3300000, 0.4300000, 1.5707963, 0.0000000, 0.0100000, 0.0000000;
-  CHECK_CLOSE_ABS(ts3.smoothed(), expPars, tol);
-  CHECK_CLOSE_ABS(ts3.smoothedCovariance(), expCov, tol);
+  CHECK_CLOSE_ABS(ts3.boundSmoothed(), expPars, tol);
+  CHECK_CLOSE_ABS(ts3.boundSmoothedCovariance(), expCov, tol);
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -87,8 +87,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   Vector3D expMomentum;
   expMomentum << 0.0000000, 80.9016994, 58.7785252;
 
-  BoundParameters filtered(tgContext, ts.boundFilteredCovariance(), ts.boundFiltered(),
-                           cylinder);
+  BoundParameters filtered(tgContext, ts.boundFilteredCovariance(),
+                           ts.boundFiltered(), cylinder);
 
   double expChi2 = 1.33958;
 

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   parValues << 0.3, 0.5, 0.5 * M_PI, 0.3 * M_PI, 0.01, 0.;
 
   MultiTrajectory<SourceLink> traj;
-  traj.addTrackState(TrackStatePropMask::All);
+  traj.addTrackState(TrackStatePropMask::BoundAll);
   auto ts = traj.getTrackState(0);
 
   ts.uncalibrated() = SourceLink{&meas};

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   // Gain matrix update and filtered state
   GainMatrixUpdater gmu;
 
-  BOOST_CHECK(ts.hasFiltered());
+  BOOST_CHECK(ts.hasBoundFiltered());
   BOOST_CHECK(ts.hasCalibrated());
   BOOST_CHECK(gmu(tgContext, ts).ok());
   // ref surface is same on measurements and parameters
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   Vector3D expMomentum;
   expMomentum << 0.0000000, 80.9016994, 58.7785252;
 
-  BoundParameters filtered(tgContext, ts.filteredCovariance(), ts.filtered(),
+  BoundParameters filtered(tgContext, ts.boundFilteredCovariance(), ts.boundFiltered(),
                            cylinder);
 
   double expChi2 = 1.33958;

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -57,8 +57,8 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   // "calibrate"
   std::visit([&](const auto& m) { ts.setCalibrated(m); }, meas);
 
-  ts.predicted() = parValues;
-  ts.predictedCovariance() = covTrk;
+  ts.boundPredicted() = parValues;
+  ts.boundPredictedCovariance() = covTrk;
   ts.pathLength() = 0.;
 
   // Gain matrix update and filtered state

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
   auto mj = fittedWithBwdFiltering.fittedStates;
   size_t nSmoothed = 0;
   mj.visitBackwards(trackTip, [&](const auto& state) {
-    if (state.hasSmoothed())
+    if (state.hasBoundSmoothed())
       nSmoothed++;
   });
   BOOST_CHECK_EQUAL(nSmoothed, 6u);


### PR DESCRIPTION
This PR allows the storage of FreeParameters inside the MultiTrajectory additonal to the bound ones. The applied storage concept is thereby extended by the corresponding member variables and methods.
**Edit**: After adding the components I realised that the used typedef would need to be renamed for consistency. Consequently many lines needed to be changed. The main changes are inside `MultiTrajectory.xpp` and `TrackStatePropMask.hpp`. These changes are then applied in the other files. If wished, I can split the renaming of the current parameters/typedefs/... off and make a separate PR out of it. 