### PR TITLE
Fix of the jsonToBinUtility

### DIFF
--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -883,8 +883,9 @@ Acts::BinUtility Acts::JsonGeometryConverter::jsonToBinUtility(
       min = bin[3][0];
       max = bin[3][1];
     }
+    return Acts::BinUtility(bins, min, max, bopt, bval);
   }
-  return Acts::BinUtility(bins, min, max, bopt, bval);
+  return Acts::BinUtility();
 }
 
 Acts::BinUtility Acts::JsonGeometryConverter::DefaultBin(

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -869,18 +869,20 @@ Acts::JsonGeometryConverter::jsonToMaterialMatrix(const json& data) {
 /// Create the BinUtility for this
 Acts::BinUtility Acts::JsonGeometryConverter::jsonToBinUtility(
     const json& bin) {
-  // finding the iterator position to determine the binning value
-  auto bit = std::find(Acts::binningValueNames.begin(),
-                       Acts::binningValueNames.end(), bin[0]);
-  size_t indx = std::distance(Acts::binningValueNames.begin(), bit);
-  Acts::BinningValue bval = Acts::BinningValue(indx);
-  Acts::BinningOption bopt = bin[1] == "open" ? Acts::open : Acts::closed;
-  unsigned int bins = bin[2];
-  float min = 0;
-  float max = 0;
-  if (bin[3].size() == 2) {
-    min = bin[3][0];
-    max = bin[3][1];
+  if (bin.size() >= 3) {
+    // finding the iterator position to determine the binning value
+    auto bit = std::find(Acts::binningValueNames.begin(),
+                         Acts::binningValueNames.end(), bin[0]);
+    size_t indx = std::distance(Acts::binningValueNames.begin(), bit);
+    Acts::BinningValue bval = Acts::BinningValue(indx);
+    Acts::BinningOption bopt = bin[1] == "open" ? Acts::open : Acts::closed;
+    unsigned int bins = bin[2];
+    float min = 0;
+    float max = 0;
+    if (bin.size() >= 4 && bin[3].size() == 2) {
+      min = bin[3][0];
+      max = bin[3][1];
+    }
   }
   return Acts::BinUtility(bins, min, max, bopt, bval);
 }


### PR DESCRIPTION
Fix an issue with the jsonToBinUtility. The bin the the json file can be 3 or 4 elements depending on if we read a geometry map or a material map. 
The old code was causing segfault within athena, that issue will be solve by this PR.