### PR TITLE
Fix usage of Boost.Test header in MaterialMapUtilsTest

### DIFF
--- a/Tests/UnitTests/Core/Utilities/MaterialMapUtilsTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/MaterialMapUtilsTests.cpp
@@ -7,7 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "Acts/EventData/SingleCurvilinearTrackParameters.hpp"
 #include "Acts/Geometry/CuboidVolumeBuilder.hpp"


### PR DESCRIPTION
We are now using the library-based version of Boost.Test, rather than the header-based version. But for some reason, this specific unit test retained the old usage. Which causes an invalid free of a global `std::string` from Boost.Test at runtime, when the test is built with clang.

The most likely explanation is that...

- A global variable ends up being defined twice, once by the header and once by the library.
- The linker manages to unify the two declarations since they are identical, so it does not error out.
- ...but it does not deduplicate the destructors, ergo an invalid free happens.

But I have no idea why that worked with GCC...