### PR TITLE
Allow KF fit without target surface

### DIFF
--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -249,6 +249,10 @@ class KalmanFitter {
     template <typename propagator_state_t, typename stepper_t>
     void operator()(propagator_state_t& state, const stepper_t& stepper,
                     result_type& result) const {
+      if (result.finished) {
+        return;
+      }
+
       ACTS_VERBOSE("KalmanFitter step");
 
       // This following is added due to the fact that the navigation
@@ -288,7 +292,8 @@ class KalmanFitter {
             ACTS_ERROR("Error in forward filter: " << res.error());
             result.result = res.error();
           }
-        } else if (state.stepping.navDir == backward) {
+        } else if (state.stepping.navDir == backward and
+                   result.forwardFiltered) {
           ACTS_VERBOSE("Perform backward filter step");
           auto res = backwardFilter(surface, state, stepper, result);
           if (!res.ok()) {
@@ -332,35 +337,51 @@ class KalmanFitter {
       // Post-finalization:
       // - Progress to target/reference surface and built the final track
       // parameters
-      if ((result.smoothed or state.stepping.navDir == backward) and
-          targetReached(state, stepper, *targetSurface) and
-          not result.finished) {
-        ACTS_VERBOSE("Completing");
-        // Transport & bind the parameter to the final surface
-        auto fittedState = stepper.boundState(state.stepping, *targetSurface);
-        // Assign the fitted parameters
-        result.fittedParameters = std::get<BoundParameters>(fittedState);
-        // Break the navigation for stopping the Propagation
-        state.navigation.navigationBreak = true;
+      if (result.smoothed or state.stepping.navDir == backward) {
+        if (targetSurface == nullptr) {
+          // If no target surface provided:
+          // -> Return an error when using backward filtering mode
+          // -> Fitting is finished here
+          if (backwardFiltering) {
+            ACTS_ERROR(
+                "The target surface needed for aborting backward propagation "
+                "is not provided");
+            result.result =
+                Result<void>(KalmanFitterError::BackwardUpdateFailed);
+          } else {
+            ACTS_VERBOSE(
+                "No target surface set. Completing without fitted track "
+                "parameter");
+            // Remember the track fitting is done
+            result.finished = true;
+          }
+        } else if (targetReached(state, stepper, *targetSurface)) {
+          ACTS_VERBOSE("Completing with fitted track parameter");
+          // Transport & bind the parameter to the final surface
+          auto fittedState = stepper.boundState(state.stepping, *targetSurface);
+          // Assign the fitted parameters
+          result.fittedParameters = std::get<BoundParameters>(fittedState);
 
-        // Reset smoothed status of states missed in backward filtering
-        if (backwardFiltering) {
-          result.fittedStates.applyBackwards(
-              result.trackTip, [&](auto trackState) {
-                auto fSurface = &trackState.referenceSurface();
-                auto surface_it = std::find_if(
-                    result.passedAgainSurfaces.begin(),
-                    result.passedAgainSurfaces.end(),
-                    [=](const Surface* s) { return s == fSurface; });
-                if (surface_it == result.passedAgainSurfaces.end()) {
-                  // If backward filtering missed this surface, then there is
-                  // no smoothed parameter
-                  trackState.data().ismoothed = detail_lt::IndexData::kInvalid;
-                }
-              });
+          // Reset smoothed status of states missed in backward filtering
+          if (backwardFiltering) {
+            result.fittedStates.applyBackwards(
+                result.trackTip, [&](auto trackState) {
+                  auto fSurface = &trackState.referenceSurface();
+                  auto surface_it = std::find_if(
+                      result.passedAgainSurfaces.begin(),
+                      result.passedAgainSurfaces.end(),
+                      [=](const Surface* s) { return s == fSurface; });
+                  if (surface_it == result.passedAgainSurfaces.end()) {
+                    // If backward filtering missed this surface, then there is
+                    // no smoothed parameter
+                    trackState.data().ismoothed =
+                        detail_lt::IndexData::kInvalid;
+                  }
+                });
+          }
+          // Remember the track fitting is done
+          result.finished = true;
         }
-        // Remember the track fitting is done
-        result.finished = true;
       }
     }
 
@@ -871,7 +892,7 @@ class KalmanFitter {
               typename result_t>
     bool operator()(propagator_state_t& /*state*/, const stepper_t& /*stepper*/,
                     const result_t& result) const {
-      if (!result.result.ok()) {
+      if (!result.result.ok() or result.finished) {
         return true;
       }
       return false;

--- a/Core/include/Acts/Fitter/KalmanFitter.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitter.hpp
@@ -979,7 +979,7 @@ class KalmanFitter {
     /// It could happen that the fit ends in zero processed states.
     /// The result gets meaningless so such case is regarded as fit failure.
     if (kalmanResult.result.ok() and not kalmanResult.processedStates) {
-      kalmanResult.result = Result<void>(KalmanFitterError::PropagationInVain);
+      kalmanResult.result = Result<void>(KalmanFitterError::NoMeasurementFound);
     }
 
     if (!kalmanResult.result.ok()) {
@@ -1077,7 +1077,7 @@ class KalmanFitter {
     /// It could happen that the fit ends in zero processed states.
     /// The result gets meaningless so such case is regarded as fit failure.
     if (kalmanResult.result.ok() and not kalmanResult.processedStates) {
-      kalmanResult.result = Result<void>(KalmanFitterError::PropagationInVain);
+      kalmanResult.result = Result<void>(KalmanFitterError::NoMeasurementFound);
     }
 
     if (!kalmanResult.result.ok()) {

--- a/Core/include/Acts/Fitter/KalmanFitterError.hpp
+++ b/Core/include/Acts/Fitter/KalmanFitterError.hpp
@@ -19,7 +19,7 @@ enum class KalmanFitterError {
   BackwardUpdateFailed = 2,
   SmoothFailed = 3,
   OutputConversionFailed = 4,
-  PropagationInVain = 5
+  NoMeasurementFound = 5
 };
 
 namespace detail {
@@ -39,7 +39,7 @@ class KalmanFitterErrorCategory : public std::error_category {
         return "Kalman smooth failed";
       case KalmanFitterError::OutputConversionFailed:
         return "Kalman output conversion failed";
-      case KalmanFitterError::PropagationInVain:
+      case KalmanFitterError::NoMeasurementFound:
         return "No measurement detected during the propagation";
       default:
         return "unknown";

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilter.hpp
@@ -382,7 +382,7 @@ class CombinatorialKalmanFilter {
         // Return error if forward filtering finds no tracks
         if (result.trackTips.empty()) {
           result.result =
-              Result<void>(CombinatorialKalmanFilterError::NoTracksFound);
+              Result<void>(CombinatorialKalmanFilterError::NoTrackFound);
         } else {
           if (not smoothing) {
             ACTS_VERBOSE("Finish forward Kalman filtering");

--- a/Core/include/Acts/TrackFinder/CombinatorialKalmanFilterError.hpp
+++ b/Core/include/Acts/TrackFinder/CombinatorialKalmanFilterError.hpp
@@ -19,7 +19,7 @@ enum class CombinatorialKalmanFilterError {
   SmoothFailed = 2,
   OutputConversionFailed = 3,
   SourcelinkSelectionFailed = 4,
-  NoTracksFound = 5,
+  NoTrackFound = 5,
   PropagationReachesMaxSteps = 6
 };
 
@@ -42,7 +42,7 @@ class CombinatorialKalmanFilterErrorCategory : public std::error_category {
         return "Kalman output conversion failed";
       case CombinatorialKalmanFilterError::SourcelinkSelectionFailed:
         return "Source link selection failed";
-      case CombinatorialKalmanFilterError::NoTracksFound:
+      case CombinatorialKalmanFilterError::NoTrackFound:
         return "No track is found";
       case CombinatorialKalmanFilterError::PropagationReachesMaxSteps:
         return "Propagation reaches max steps before track finding is "

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -401,6 +401,17 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
   CHECK_CLOSE_ABS(fittedParameters.parameters().template tail<1>(),
                   fittedAgainParameters.parameters().template tail<1>(), 1e-5);
 
+  // Fit without target surface
+  kfOptions.referenceSurface = nullptr;
+  fitRes = kFitter.fit(sourcelinks, rStart, kfOptions);
+  BOOST_CHECK(fitRes.ok());
+  auto fittedWithoutTargetSurface = *fitRes;
+  // Check if there is no fitted parameters
+  BOOST_CHECK(fittedWithoutTargetSurface.fittedParameters == std::nullopt);
+
+  // Reset the target surface
+  kfOptions.referenceSurface = rSurface;
+
   // Change the order of the sourcelinks
   std::vector<SourceLink> shuffledMeasurements = {
       sourcelinks[3], sourcelinks[2], sourcelinks[1],
@@ -471,6 +482,9 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
       nSmoothed++;
   });
   BOOST_CHECK_EQUAL(nSmoothed, 6u);
+
+  // Reset to use smoothing formalism
+  kfOptions.backwardFiltering = false;
 
   // Extract outliers from result of propagation.
   // This vector owns the outliers


### PR DESCRIPTION
We could expect that there is no target surface provided in the KF when fitted track parameter at an additional surface is not needed. For example, in the KF-based alignment, the fit is repeatedly done where we don't care about the fitted track parameter at a target surface. Currently, the `KalmanFitterOptions` could allow a null target surface, but the fit will actually break if no surface is provided. This PR includes the following changes:

- Allow non target surface in the KF
- Remove some redundancy to abort the KF/CKF propagation when track fitting/finding is supposed to finished
- Rename the KF/CKF error type