### PR TITLE
Json bin initialisation for rectangle bound

### DIFF
--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -322,11 +322,12 @@ Acts::JsonGeometryConverter::jsonToSurfaceMaterial(const json& material) {
   Acts::ISurfaceMaterial* sMaterial = nullptr;
   // The bin utility for deescribing the data
   Acts::BinUtility bUtility;
-  if (material.contains(m_cfg.transfokeys) and
-      not material[m_cfg.transfokeys].empty()) {
-    auto value = material[m_cfg.transfokeys];
-    bUtility = Acts::BinUtility(
-        std::make_shared<const Transform3D>(jsonToTransform(value)));
+  for (auto& [key, value] : material.items()) {
+    if (key == m_cfg.transfokeys and not value.empty()) {
+      bUtility = Acts::BinUtility(
+          std::make_shared<const Transform3D>(jsonToTransform(value)));
+      break;
+    }
   }
   // Convert the material
   Acts::MaterialPropertiesMatrix mpMatrix;
@@ -361,11 +362,12 @@ const Acts::IVolumeMaterial* Acts::JsonGeometryConverter::jsonToVolumeMaterial(
   Acts::IVolumeMaterial* vMaterial = nullptr;
   // The bin utility for deescribing the data
   Acts::BinUtility bUtility;
-  if (material.contains(m_cfg.transfokeys) and
-      not material[m_cfg.transfokeys].empty()) {
-    auto value = material[m_cfg.transfokeys];
-    bUtility = Acts::BinUtility(
-        std::make_shared<const Transform3D>(jsonToTransform(value)));
+  for (auto& [key, value] : material.items()) {
+    if (key == m_cfg.transfokeys and not value.empty()) {
+      bUtility = Acts::BinUtility(
+          std::make_shared<const Transform3D>(jsonToTransform(value)));
+      break;
+    }
   }
   // Convert the material
   std::vector<std::vector<float>> mmat;


### PR DESCRIPTION
Added the creation of a default bin utility for rectangle bound (sensor) in the json converter.
The contains method that was used for reading the BinUtility transform has been replace by a for loop as it is only available in nlohmann::json 3.7.0 and athena use 3.5.0 (for now this seems easier than having people change the json version use in athena). 