### PR TITLE
Bugfix in TGeoDetectorOptions

### DIFF
--- a/Examples/Detectors/TGeoDetector/include/ACTFW/TGeoDetector/TGeoDetectorOptions.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ACTFW/TGeoDetector/TGeoDetectorOptions.hpp
@@ -303,9 +303,10 @@ std::vector<Acts::TGeoLayerBuilder::Config> readTGeoLayerBuilderConfigs(
         lConfig.volumeName = volumeName[ncp][ti[ncp]];
         lConfig.sensorNames = splitAtOr(sensitiveNames[ncp][ti[ncp]]);
         lConfig.localAxes = sensitiveAxes[ncp][ti[ncp]];
+
         // Fill the parsing restrictions in r
         auto rR = rRange[ncp];
-        if (rRange.size() > ti[ncp]) {
+        if (rR.size() > ti[ncp]) {
           double rMin = rR[ti[ncp]].lower.value_or(0.);
           double rMax =
               rR[ti[ncp]].upper.value_or(std::numeric_limits<double>::max());
@@ -320,7 +321,7 @@ std::vector<Acts::TGeoLayerBuilder::Config> readTGeoLayerBuilderConfigs(
         }
         // Fill the parsing restrictions in z
         auto zR = zRange[ncp];
-        if (zRange.size() > ti[ncp]) {
+        if (zR.size() > ti[ncp]) {
           double zMin =
               zR[ti[ncp]].lower.value_or(-std::numeric_limits<double>::max());
           double zMax =

--- a/Plugins/TGeo/src/TGeoLayerBuilder.cpp
+++ b/Plugins/TGeo/src/TGeoLayerBuilder.cpp
@@ -157,6 +157,7 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
         gGeoManager->FindVolumeFast(layerCfg.volumeName.c_str());
     if (tVolume == nullptr) {
       tVolume = gGeoManager->GetTopVolume();
+      ACTS_DEBUG("- search volume is TGeo top volume");
     } else {
       ACTS_DEBUG("- setting search volume to " << tVolume->GetName());
     }
@@ -167,9 +168,16 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
       tgpOptions.targetNames = layerCfg.sensorNames;
       tgpOptions.parseRanges = layerCfg.parseRanges;
       tgpOptions.unit = m_cfg.unit;
-
       TGeoParser::State tgpState;
       tgpState.volume = tVolume;
+
+      ACTS_DEBUG("- applying  " << layerCfg.parseRanges.size()
+                                << " search restrictions.");
+      for (const auto& prange : layerCfg.parseRanges) {
+        ACTS_VERBOSE(" - range " << binningValueNames[prange.first]
+                                 << " within [ " << prange.second.first << ", "
+                                 << prange.second.second << "]");
+      }
 
       TGeoParser::select(tgpState, tgpOptions);
 


### PR DESCRIPTION
Bugfix that prevented more than 3 sub detectors to be properly parsed with the `TGeoPlugin`.

With this, we can make the HGTD appear :-)

![HGTD_mesh00](https://user-images.githubusercontent.com/26623879/90137486-fcc67c80-dd75-11ea-99f4-f0de0a3c9de5.png)
