### PR TITLE
Change policybot configuration: invalidate on push, contributors

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -8,3 +8,8 @@ approval_rules:
     count: 1
     teams:
     - "acts-project/reviewers"
+  options:
+    allow_author: false # just for completeness
+    allow_contributor: true # Update button 'contributions' should be ignored
+    invalidate_on_push: true
+    ignore_update_merges: true


### PR DESCRIPTION
Should invalidate reviews on push now, but ignore update merges. It will
(hopefully) also accept approvals by 'contributors', such as when an
approver clicks the 'Update branch' button.