### PR TITLE
Cuda fix

### DIFF
--- a/Plugins/Cuda/src/Seeding/Kernels.cu
+++ b/Plugins/Cuda/src/Seeding/Kernels.cu
@@ -679,35 +679,32 @@ __global__ void cuSearchTriplet(const int*   nSpTcompPerSpM,
   if (threadIdx.x == 0 && *nTrplPerSpB > *nTrplPerSpBLimit){
     *nTrplPerSpB = *nTrplPerSpBLimit;
   }
-  
+
+  __syncthreads();
   int jj = threadIdx.x;            
   
   // bubble sort tIndex
-
-  // Ensure that number of Trpl is smaller than its limit...
-  if (*nTrplPerSpB <= *nTrplPerSpBLimit){  
-    for (int i = 0; i < *nTrplPerSpB/2+1; i++){
-      if (threadIdx.x < *nTrplPerSpB){    
-	if (jj % 2 == 0 && jj<*nTrplPerSpB-1){
-	  if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+  for (int i = 0; i < *nTrplPerSpB/2+1; i++){
+    if (threadIdx.x < *nTrplPerSpB){    
+      if (jj % 2 == 0 && jj<*nTrplPerSpB-1){
+	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
 	  Triplet tempVal = triplets[jj];
 	  triplets[jj] = triplets[jj+1];	  
 	  triplets[jj+1] = tempVal;
-	  }
 	}
       }
-      __syncthreads();
-      if (threadIdx.x < *nTrplPerSpB){    
-	if (jj % 2 == 1 && jj<*nTrplPerSpB-1){
-	  if (triplets[jj+1].tIndex < triplets[jj].tIndex){
-	    Triplet tempVal = triplets[jj];
+    }
+    __syncthreads();
+    if (threadIdx.x < *nTrplPerSpB){    
+      if (jj % 2 == 1 && jj<*nTrplPerSpB-1){
+	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+	  Triplet tempVal = triplets[jj];
 	    triplets[jj] = triplets[jj+1];
 	    triplets[jj+1] = tempVal;
-	  }
 	}
-      }     
-      __syncthreads();
-    }
+      }
+    }     
+    __syncthreads();
   }
   __syncthreads();
 

--- a/Plugins/Cuda/src/Seeding/Kernels.cu
+++ b/Plugins/Cuda/src/Seeding/Kernels.cu
@@ -683,29 +683,32 @@ __global__ void cuSearchTriplet(const int*   nSpTcompPerSpM,
   int jj = threadIdx.x;            
   
   // bubble sort tIndex
-  for (int i = 0; i < *nTrplPerSpB/2+1; i++){
-    if (threadIdx.x < *nTrplPerSpB){    
-      if (jj % 2 == 0 && jj<*nTrplPerSpB-1){
-	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+
+  // Ensure that number of Trpl is smaller than its limit...
+  if (*nTrplPerSpB <= *nTrplPerSpBLimit){  
+    for (int i = 0; i < *nTrplPerSpB/2+1; i++){
+      if (threadIdx.x < *nTrplPerSpB){    
+	if (jj % 2 == 0 && jj<*nTrplPerSpB-1){
+	  if (triplets[jj+1].tIndex < triplets[jj].tIndex){
 	  Triplet tempVal = triplets[jj];
 	  triplets[jj] = triplets[jj+1];	  
 	  triplets[jj+1] = tempVal;
+	  }
 	}
       }
+      __syncthreads();
+      if (threadIdx.x < *nTrplPerSpB){    
+	if (jj % 2 == 1 && jj<*nTrplPerSpB-1){
+	  if (triplets[jj+1].tIndex < triplets[jj].tIndex){
+	    Triplet tempVal = triplets[jj];
+	    triplets[jj] = triplets[jj+1];
+	    triplets[jj+1] = tempVal;
+	  }
+	}
+      }     
+      __syncthreads();
     }
-    __syncthreads();
-    if (threadIdx.x < *nTrplPerSpB){    
-      if (jj % 2 == 1 && jj<*nTrplPerSpB-1){
-	if (triplets[jj+1].tIndex < triplets[jj].tIndex){
-	  Triplet tempVal = triplets[jj];
-	  triplets[jj] = triplets[jj+1];
-	  triplets[jj+1] = tempVal;
-	}
-      }
-    }     
-    __syncthreads();
   }
-  
   __syncthreads();
 
   // serial algorithm for seed filtering

--- a/Tests/UnitTests/Core/Seeding/SpacePoint.hpp
+++ b/Tests/UnitTests/Core/Seeding/SpacePoint.hpp
@@ -23,9 +23,7 @@ struct SpacePoint {
 };
 
 bool operator==(SpacePoint a, SpacePoint b) {
-  if (a.m_x == b.m_x && a.m_y == b.m_y && a.m_z == b.m_z &&
-      a.surface == b.surface && a.varianceR == b.varianceR &&
-      a.varianceZ == b.varianceZ) {
+  if ( (a.m_x-b.m_x)<1e-6 && (a.m_y-b.m_y)<1e-6 && (a.m_z-b.m_z)<1e-6) {
     return true;
   } else {
     return false;

--- a/Tests/UnitTests/Core/Seeding/SpacePoint.hpp
+++ b/Tests/UnitTests/Core/Seeding/SpacePoint.hpp
@@ -23,7 +23,8 @@ struct SpacePoint {
 };
 
 bool operator==(SpacePoint a, SpacePoint b) {
-  if ( (a.m_x-b.m_x)<1e-6 && (a.m_y-b.m_y)<1e-6 && (a.m_z-b.m_z)<1e-6) {
+  if ((a.m_x - b.m_x) < 1e-6 && (a.m_y - b.m_y) < 1e-6 &&
+      (a.m_z - b.m_z) < 1e-6) {
     return true;
   } else {
     return false;

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SpacePoint.hpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SpacePoint.hpp
@@ -23,9 +23,7 @@ struct SpacePoint {
 };
 
 bool operator==(SpacePoint a, SpacePoint b) {
-  if (a.m_x == b.m_x && a.m_y == b.m_y && a.m_z == b.m_z &&
-      a.surface == b.surface && a.varianceR == b.varianceR &&
-      a.varianceZ == b.varianceZ) {
+  if ( (a.m_x-b.m_x)<1e-6 && (a.m_y-b.m_y)<1e-6 && (a.m_z-b.m_z)<1e-6) {
     return true;
   } else {
     return false;

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SpacePoint.hpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SpacePoint.hpp
@@ -23,7 +23,8 @@ struct SpacePoint {
 };
 
 bool operator==(SpacePoint a, SpacePoint b) {
-  if ( (a.m_x-b.m_x)<1e-6 && (a.m_y-b.m_y)<1e-6 && (a.m_z-b.m_z)<1e-6) {
+  if ((a.m_x - b.m_x) < 1e-6 && (a.m_y - b.m_y) < 1e-6 &&
+      (a.m_z - b.m_z) < 1e-6) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
This adds two things:
1) Change the eqaul operator (again...) to consider data at the same location, which happened in [PR371](https://github.com/acts-project/acts/pull/371)
2) Fix a bug in Kernels.cu by putting syncthreads() in the right place. 
Without it, the code freezes with the data file provided at [PR371](https://github.com/acts-project/acts/pull/371)

I also tried to check brefiely when the agreement gets 100% by increasing the limits for the number of triplets stored
```
./ActsUnitTestSeedfinderCuda -f sp2.txt -q -l 2 -m 10    #-> 2.6 speedup | 92% matching rate
./ActsUnitTestSeedfinderCuda -f sp2.txt -q -l 2 -m 100   #-> 1.3 speedup | 99.8% matching rate  
./ActsUnitTestSeedfinderCuda -f sp2.txt -q -l 10 -m 500  #-> 0.7 speedup | 100% matching rate
```
`-l` is  a limit on the average number of triplets per bottom spacepoint. This is used for determining matrix size for triplets per middle space point.
`-m` is a limit on the number of triplets per bottom spacepoint.

Giving large values for those options slow the process in several ways: (1) Large CPU & GPU DRAM memory is declared (2) Large shared memory is declared which reduces the number of GPU blocks launched in parallel.

Since the number of triplets per bottom space point varies a lot, large value should be given to `-m` flag to get a good matching rate. Probably counting their numbers in advance before launching kernel function could be better for this kind of data distribution. However, doing it efficiently would be another task.





