### PR TITLE
Introduce Measurement constructor from covariance and vector

### DIFF
--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -95,16 +95,6 @@ class Measurement {
   ///
   /// Concrete class for all possible measurements.
   ///
-  /// @note Only a reference to the given surface/volume is stored. The user
-  /// must ensure that the lifetime of the @c Surface / @c Volume object
-  /// surpasses the lifetime of this Measurement object. The given parameter
-  /// values are interpreted as values to the parameters as defined in the class
-  /// template argument @c params.
-  ///
-  /// @attention The current design will fail if the in-memory location of
-  /// the @c Surface / @c Volume object is changed (e.g. if it is stored in a
-  /// container and this gets relocated).
-  ///
   /// @param referenceObject surface/volume origin of the measurement
   /// @param source object for this measurement
   /// @param cov covariance matrix of the measurement.
@@ -126,16 +116,6 @@ class Measurement {
   ///
   /// Concrete class for all possible measurements, built from properly
   /// formatted covariance matrix and parameter vector
-  ///
-  /// @note Only a reference to the given surface/volume is stored. The user
-  /// must ensure that the lifetime of the @c Surface / @c Volume object
-  /// surpasses the lifetime of this Measurement object. The given parameter
-  /// values are interpreted as values to the parameters as defined in the class
-  /// template argument @c params.
-  ///
-  /// @attention The current design will fail if the in-memory location of
-  /// the @c Surface / @c Volume object is changed (e.g. if it is stored in a
-  /// container and this gets relocated).
   ///
   /// @param referenceObject surface/volume origin of the measurement
   /// @param source object for this measurement

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -122,7 +122,34 @@ class Measurement {
     assert(m_pReferenceObject);
   }
 
-  /// @brief virtual destructor
+  /// @brief standard constructor for surface/volume measurements
+  ///
+  /// Concrete class for all possible measurements, built from properly
+  /// formatted covariance matrix and parameter vector
+  ///
+  /// @note Only a reference to the given surface/volume is stored. The user
+  /// must ensure that the lifetime of the @c Surface / @c Volume object
+  /// surpasses the lifetime of this Measurement object. The given parameter
+  /// values are interpreted as values to the parameters as defined in the class
+  /// template argument @c params.
+  ///
+  /// @attention The current design will fail if the in-memory location of
+  /// the @c Surface / @c Volume object is changed (e.g. if it is stored in a
+  /// container and this gets relocated).
+  ///
+  /// @param referenceObject surface/volume origin of the measurement
+  /// @param source object for this measurement
+  /// @param cov covariance matrix of the measurement
+  /// @param vec parameter vector of the measurement
+  Measurement(std::shared_ptr<const RefObject> referenceObject,
+              const source_link_t& source, CovarianceMatrix cov,
+              ParameterVector vec)
+      : m_oParameters(std::move(cov), std::move(vec)),
+        m_pReferenceObject(std::move(referenceObject)),
+        m_sourceLink(source) {
+    assert(m_pReferenceObject);
+  }
+
   virtual ~Measurement() = default;
 
   /// @brief copy constructor

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -134,8 +134,8 @@ class ParameterSet {
     if (cov) {
       m_optCovariance = std::move(*cov);
     }
-    detail::initialize_parset<parameter_indices_t, params...>::init(*this, head,
-                                                                    values...);
+    detail::initialize_parset<parameter_indices_t, params...>::init_vals(
+        *this, head, values...);
   }
 
   /**
@@ -156,8 +156,8 @@ class ParameterSet {
     if (cov) {
       m_optCovariance = std::move(*cov);
     }
-    detail::initialize_parset<parameter_indices_t, params...>::init(*this,
-                                                                    values);
+    detail::initialize_parset<parameter_indices_t, params...>::init_vec(*this,
+                                                                        values);
   }
 
   /**
@@ -295,8 +295,8 @@ class ParameterSet {
    * @param values vector of length #kNumberOfParameters
    */
   void setParameters(const ParameterVector& values) {
-    detail::initialize_parset<parameter_indices_t, params...>::init(*this,
-                                                                    values);
+    detail::initialize_parset<parameter_indices_t, params...>::init_vec(*this,
+                                                                        values);
   }
 
   /**

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -7,13 +7,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
-// STL include(s)
+
 #include <memory>
 #include <optional>
 #include <type_traits>
 #include <utility>
 
-// Acts includes
 #include "Acts/EventData/detail/full_parameter_set.hpp"
 #include "Acts/EventData/detail/initialize_parameter_set.hpp"
 #include "Acts/EventData/detail/make_projection_matrix.hpp"

--- a/Core/include/Acts/EventData/detail/initialize_parameter_set.hpp
+++ b/Core/include/Acts/EventData/detail/initialize_parameter_set.hpp
@@ -34,32 +34,32 @@ template <typename T, T first, T... others>
 struct initialize_parset<T, first, others...> {
   template <typename ParSetType, typename first_value_type,
             typename... other_value_types>
-  static void init(ParSetType& parSet, const first_value_type& v1,
-                   const other_value_types&... values) {
+  static void init_vals(ParSetType& parSet, const first_value_type& v1,
+                        const other_value_types&... values) {
     parSet.template setParameter<first>(v1);
-    initialize_parset<T, others...>::init(parSet, values...);
+    initialize_parset<T, others...>::init_vals(parSet, values...);
   }
 
   template <typename ParSetType>
-  static void init(ParSetType& parSet,
-                   const typename ParSetType::ParameterVector& values,
-                   const unsigned int& pos = 0) {
+  static void init_vec(ParSetType& parSet,
+                       const typename ParSetType::ParameterVector& values,
+                       const unsigned int& pos = 0) {
     parSet.template setParameter<first>(values(pos));
-    initialize_parset<T, others...>::init(parSet, values, pos + 1);
+    initialize_parset<T, others...>::init_vec(parSet, values, pos + 1);
   }
 };
 
 template <typename T, T last>
 struct initialize_parset<T, last> {
   template <typename ParSet_tType, typename last_value_type>
-  static void init(ParSet_tType& ParSet_t, const last_value_type& v1) {
+  static void init_vals(ParSet_tType& ParSet_t, const last_value_type& v1) {
     ParSet_t.template setParameter<last>(v1);
   }
 
   template <typename ParSetType>
-  static void init(ParSetType& parSet,
-                   const typename ParSetType::ParameterVector& values,
-                   const unsigned int& pos = 0) {
+  static void init_vec(ParSetType& parSet,
+                       const typename ParSetType::ParameterVector& values,
+                       const unsigned int& pos = 0) {
     parSet.template setParameter<last>(values(pos));
   }
 };

--- a/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
@@ -31,8 +31,11 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {},
-                                                    std::move(cov), -0.1, 0.45);
+  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {}, cov, -0.1,
+                                                    0.45);
+
+  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m_vec(cylinder, {}, cov,
+                                                        {-0.1, 0.45});
 
   std::default_random_engine generator(42);
 

--- a/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
+++ b/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
@@ -323,6 +323,33 @@ void free_random_residual_tests() {
  * -# ParameterSet::getUncertainty
  */
 BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
+  // One-dimensional constructions
+  ActsSymMatrixD<1> cov1D;
+  cov1D << 0.5;
+
+  ActsVectorD<1> vec1D;
+  vec1D << 0.1;
+
+  ParameterSet<BoundParametersIndices, eBoundLoc0> parSet_with_cov1D_real(cov1D,
+                                                                          0.1);
+
+  // This line does not compile
+  ParameterSet<BoundParametersIndices, eBoundLoc0> parSet_with_cov1D_vec1D(
+      cov1D, vec1D);
+
+  // Two-dimensional constructions
+  ActsSymMatrixD<2> cov2D;
+  cov2D << 0.5, 0., 0.8, 0.;
+
+  ActsVectorD<2> vec2D;
+  vec2D << 0.1, 0.3;
+
+  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>
+      parSet_with_cov2D_real(cov2D, 0.1, 0.3);
+
+  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>
+      parSet_with_cov2D_vec2D(cov2D, vec2D);
+
   // check template parameter based information
   BOOST_CHECK(
       (ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>::size() ==
@@ -339,9 +366,15 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
                             // failed tests due to angle range corrections
   Vector3D parValues(loc0, loc1, phi);
 
-  // parameter set with covariance matrix
+  // parameter set with covariance matrix, and three parameters as pack
   ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       parSet_with_cov(cov, loc0, loc1, phi);
+
+  // parameter set with covariance matrix, and a vector
+  ActsVectorD<3> vec;
+  vec << loc0, loc1, phi;
+  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+      parSet_with_cov_vec(cov, vec);
 
   // check number and type of stored parameters
   BOOST_CHECK(parSet_with_cov.size() == 3);


### PR DESCRIPTION
As discussed this morning, I encapsulated the problem from my work on the digitisation:
 * this PR will hopefully first fix the ambiguity in constructing parameter sets
 * then it should introduce a new `Measurement( ..., covariance, vector)` constructor