### PR TITLE
Propagator: Terminate normally in case of 0 steps

### DIFF
--- a/Core/include/Acts/Propagator/PropagatorError.hpp
+++ b/Core/include/Acts/Propagator/PropagatorError.hpp
@@ -14,7 +14,11 @@
 
 namespace Acts {
 // This is the custom error code enum
-enum class PropagatorError { Failure = 1, WrongDirection = 2 };
+enum class PropagatorError {
+  Failure = 1,
+  WrongDirection = 2,
+  StepCountLimitReached = 3
+};
 
 namespace detail {
 // Define a custom error code category derived from std::error_category


### PR DESCRIPTION
Previously, this would not set the `terminatedNormally`
flag, and cause an error printout. This switches this error printout to
an error, but prevent the case of zero steps triggering it.

/cc @baschlag 