### PR TITLE
refactor: Resolve build regression from #359

### DIFF
--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -113,7 +113,14 @@ class GainMatrixUpdater {
           ACTS_VERBOSE("Filtered covariance:\n" << filtered_covariance);
 
           // calculate filtered residual
-          const par_t residual = (calibrated - H * filtered);
+          //
+          // FIXME: Without separate residual construction and assignment, we
+          //        currently take a +0.7GB build memory consumption hit in the
+          //        EventDataView unit tests. Revisit this once Measurement
+          //        overhead problems (Acts issue #350) are sorted out.
+          //
+          par_t residual;
+          residual = calibrated - H * filtered;
           ACTS_VERBOSE("Residual: " << residual.transpose());
 
           trackState.chi2() =


### PR DESCRIPTION
It seems that Eigen matrix constructors from expression templates have more build-time overhead than the assignment operator equivalent. When that extra overhead is sent through the `visitMeasurement` code bloat multiplier (see #350 for context), that ultimately translates into a +0.7GB build RSS hit in `EventDataView3D` tests. Let's revert that part of #359 for now.