### PR TITLE
fix: clarify interactions charge parameter

### DIFF
--- a/Core/include/Acts/Material/Interactions.hpp
+++ b/Core/include/Acts/Material/Interactions.hpp
@@ -21,7 +21,7 @@ namespace Acts {
 /// @param pdg       Particle type PDG identifier
 /// @param m         Particle mass
 /// @param qOverP    Particle charge divided by absolute momentum
-/// @param q         Particle charge
+/// @param q         Particle charge, only the magnitude is considered
 ///
 /// This computes the mean energy loss -dE(x) through a material with
 /// the given properties, i.e. it computes
@@ -79,7 +79,7 @@ float computeEnergyLossLandauSigmaQOverP(const MaterialProperties& slab,
 /// @param pdg       Particle type PDG identifier
 /// @param m         Particle mass
 /// @param qOverP    Particle charge divided by absolute momentum
-/// @param q         Particle charge
+/// @param q         Particle charge, only the magnitude is considered
 ///
 /// This computes the mean energy loss -dE(x) using an approximative formula.
 /// Bremsstrahlung is always included; direct e+e- pair production and
@@ -100,7 +100,7 @@ float deriveEnergyLossRadiativeQOverP(const MaterialProperties& slab, int pdg,
 /// @param pdg       Particle type PDG identifier
 /// @param m         Particle mass
 /// @param qOverP    Particle charge divided by absolute momentum
-/// @param q         Particle charge
+/// @param q         Particle charge, only the magnitude is considered
 ///
 /// This computes the combined mean energy loss -dE(x) including ionisation and
 /// radiative effects. The computations are valid over a wide range of particle
@@ -132,7 +132,7 @@ float deriveEnergyLossModeQOverP(const MaterialProperties& slab, int pdg,
 /// @param pdg       Particle type PDG identifier
 /// @param m         Particle mass
 /// @param qOverP    Particle charge divided by absolute momentum
-/// @param q         Particle charge
+/// @param q         Particle charge, only the magnitude is considered
 float computeMultipleScatteringTheta0(const MaterialProperties& slab, int pdg,
                                       float m, float qOverP,
                                       float q = UnitConstants::e);

--- a/Core/src/Material/Interactions.cpp
+++ b/Core/src/Material/Interactions.cpp
@@ -134,10 +134,10 @@ inline float deriveDeltaHalf(float qOverP, const RelativisticQuantities& rq) {
 
 }  // namespace
 
-#define ASSERT_INPUTS(mass, qOverP, q)                              \
-  assert((0 < mass) and "Mass must be positive");                   \
-  assert((qOverP < 0) and (0 < qOverP) and "q/p must be non-zero"); \
-  assert((q < 0) and (0 < q) and "Charge must be non-zero");
+#define ASSERT_INPUTS(mass, qOverP, q)              \
+  assert((0 < mass) and "Mass must be positive");   \
+  assert((qOverP != 0) and "q/p must be non-zero"); \
+  assert((q != 0) and "Charge must be non-zero");
 
 float Acts::computeEnergyLossBethe(const MaterialProperties& slab,
                                    int /* unused */, float m, float qOverP,

--- a/Core/src/Material/Interactions.cpp
+++ b/Core/src/Material/Interactions.cpp
@@ -16,6 +16,7 @@
 using namespace Acts::UnitLiterals;
 
 namespace {
+
 // values from RPP2018 table 33.1
 // electron mass
 constexpr float Me = 0.5109989461_MeV;
@@ -56,6 +57,7 @@ inline float deriveBeta2(float qOverP, const RelativisticQuantities& rq) {
 inline float computeMassTerm(float mass, const RelativisticQuantities& rq) {
   return 2 * mass * rq.betaGamma * rq.betaGamma;
 }
+
 /// Compute mass term logarithmic derivative w/ respect to q/p.
 inline float logDeriveMassTerm(float qOverP) {
   // only need to compute d((beta*gamma)²)/(beta*gamma)²; rest cancels.
@@ -71,6 +73,7 @@ inline float computeWMax(float mass, const RelativisticQuantities& rq) {
   const auto denonimator = 1.0f + 2 * rq.gamma * mfrac + mfrac * mfrac;
   return nominator / denonimator;
 }
+
 /// Compute WMax logarithmic derivative w/ respect to q/p.
 inline float logDeriveWMax(float mass, float qOverP,
                            const RelativisticQuantities& rq) {
@@ -95,6 +98,7 @@ inline float computeEpsilon(float molarElectronDensity, float thickness,
                             const RelativisticQuantities& rq) {
   return 0.5f * K * molarElectronDensity * thickness * rq.q2OverBeta2;
 }
+
 /// Compute epsilon logarithmic derivative w/ respect to q/p.
 inline float logDeriveEpsilon(float qOverP, const RelativisticQuantities& rq) {
   // only need to compute d(q²/beta²)/(q²/beta²); everything else cancels.
@@ -118,6 +122,7 @@ inline float computeDeltaHalf(float meanExitationPotential,
   return std::log(rq.betaGamma) +
          std::log(plasmaEnergy / meanExitationPotential) - 0.5f;
 }
+
 /// Compute derivative w/ respect to q/p for the density correction.
 inline float deriveDeltaHalf(float qOverP, const RelativisticQuantities& rq) {
   // original equation is of the form
@@ -126,11 +131,13 @@ inline float deriveDeltaHalf(float qOverP, const RelativisticQuantities& rq) {
   //     d(beta*gamma)/(beta*gamma)
   return (rq.betaGamma < 10.0f) ? 0.0f : (-1.0f / qOverP);
 }
+
 }  // namespace
 
-#define ASSERT_INPUTS(mass, qOverP, q)            \
-  assert((0 < mass) and "Mass must be positive"); \
-  assert((0 < (qOverP * q)) and "Inconsistent q/p and q signs");
+#define ASSERT_INPUTS(mass, qOverP, q)                              \
+  assert((0 < mass) and "Mass must be positive");                   \
+  assert((qOverP < 0) and (0 < qOverP) and "q/p must be non-zero"); \
+  assert((q < 0) and (0 < q) and "Charge must be non-zero");
 
 float Acts::computeEnergyLossBethe(const MaterialProperties& slab,
                                    int /* unused */, float m, float qOverP,
@@ -262,6 +269,7 @@ float Acts::deriveEnergyLossLandauQOverP(const MaterialProperties& slab,
 }
 
 namespace {
+
 /// Convert Landau full-width-half-maximum to an equivalent Gaussian sigma,
 ///
 /// Full-width-half-maximum for a Gaussian is given as
@@ -272,6 +280,7 @@ namespace {
 inline float convertLandauFwhmToGaussianSigma(float fwhm) {
   return fwhm / (2 * std::sqrt(2 * std::log(2.0f)));
 }
+
 }  // namespace
 
 float Acts::computeEnergyLossLandauSigma(const MaterialProperties& slab,
@@ -314,15 +323,18 @@ float Acts::computeEnergyLossLandauSigmaQOverP(const MaterialProperties& slab,
   //           = -q/p² E/p = -(q/p)² * 1/(q*beta) = -(q/p)² * (q/beta) / q²
   //  var(q/p) = (q/p)^4 * (q/beta)² * (1/q)^4 * var(E)
   //           = (1/p)^4 * (q/beta)² * var(E)
+  // do not need to care about the sign since it is only used squared
   const auto pInv = qOverP / q;
   return std::sqrt(rq.q2OverBeta2) * pInv * pInv * sigmaE;
 }
 
 namespace {
+
 /// Compute mean energy loss from bremsstrahlung per radiation length.
 inline float computeBremsstrahlungLossMean(float mass, float energy) {
   return energy * (Me / mass) * (Me / mass);
 }
+
 /// Derivative of the bremsstrahlung loss per rad length with respect to energy.
 inline float deriveBremsstrahlungLossMeanE(float mass) {
   return (Me / mass) * (Me / mass);
@@ -359,6 +371,7 @@ inline float computeMuonDirectPairPhotoNuclearLossMean(double energy) {
     return MuonHigh0 + MuonHigh1 * energy;
   }
 }
+
 /// Derivative of the additional rad loss per rad length with respect to energy.
 inline float deriveMuonDirectPairPhotoNuclearLossMeanE(double energy) {
   if (energy < MuonHighLowThreshold) {
@@ -367,6 +380,7 @@ inline float deriveMuonDirectPairPhotoNuclearLossMeanE(double energy) {
     return MuonHigh1;
   }
 }
+
 }  // namespace
 
 float Acts::computeEnergyLossRadiative(const MaterialProperties& slab, int pdg,
@@ -381,6 +395,7 @@ float Acts::computeEnergyLossRadiative(const MaterialProperties& slab, int pdg,
   // relative radiation length
   const auto x = slab.thicknessInX0();
   // particle momentum and energy
+  // do not need to care about the sign since it is only used squared
   const auto momentum = q / qOverP;
   const auto energy = std::sqrt(m * m + momentum * momentum);
 
@@ -406,6 +421,7 @@ float Acts::deriveEnergyLossRadiativeQOverP(const MaterialProperties& slab,
   // relative radiation length
   const auto x = slab.thicknessInX0();
   // particle momentum and energy
+  // do not need to care about the sign since it is only used squared
   const auto momentum = q / qOverP;
   const auto energy = std::sqrt(m * m + momentum * momentum);
 
@@ -454,6 +470,7 @@ float Acts::deriveEnergyLossModeQOverP(const MaterialProperties& slab, int pdg,
 }
 
 namespace {
+
 /// Multiple scattering theta0 for minimum ionizing particles.
 inline float theta0Highland(float xOverX0, float momentumInv,
                             float q2OverBeta2) {
@@ -463,6 +480,7 @@ inline float theta0Highland(float xOverX0, float momentumInv,
   //                          = 2 * log(sqrt(x/X0) * (q/beta))
   return 13.6_MeV * momentumInv * t * (1.0f + 0.038f * 2 * std::log(t));
 }
+
 /// Multiple scattering theta0 for electrons.
 inline float theta0RossiGreisen(float xOverX0, float momentumInv,
                                 float q2OverBeta2) {
@@ -471,6 +489,7 @@ inline float theta0RossiGreisen(float xOverX0, float momentumInv,
   return 17.5_MeV * momentumInv * t *
          (1.0f + 0.125f * std::log10(10.0f * xOverX0));
 }
+
 }  // namespace
 
 float Acts::computeMultipleScatteringTheta0(const MaterialProperties& slab,


### PR DESCRIPTION
All interaction computations only consider the charge magnitude. This avoids unnecessary assertions in debug builds. The documentation is updated accordingly.

Includes some drive-by whitespace formatting.