### PR TITLE
refactor: Remove unnecessary const qualifiers

### DIFF
--- a/Core/include/Acts/Geometry/GeometryObject.hpp
+++ b/Core/include/Acts/Geometry/GeometryObject.hpp
@@ -57,8 +57,8 @@ class GeometryObject {
   /// @param bValue is the value in which you want to bin
   ///
   /// @return vector 3D used for the binning schema
-  virtual const Vector3D binningPosition(const GeometryContext& gctx,
-                                         BinningValue bValue) const = 0;
+  virtual Vector3D binningPosition(const GeometryContext& gctx,
+                                   BinningValue bValue) const = 0;
 
   /// Implement the binningValue
   ///

--- a/Core/include/Acts/Geometry/NavigationLayer.hpp
+++ b/Core/include/Acts/Geometry/NavigationLayer.hpp
@@ -47,8 +47,8 @@ class NavigationLayer : public Layer {
   ///  - as default the center is given, but may be overloaded
   ///
   /// @return The return vector can be used for binning in a TrackingVolume
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// Default Constructor - deleted
   NavigationLayer() = delete;
@@ -115,8 +115,8 @@ inline Surface& NavigationLayer::surfaceRepresentation() {
   return *(const_cast<Surface*>(m_surfaceRepresentation.get()));
 }
 
-inline const Vector3D NavigationLayer::binningPosition(
-    const GeometryContext& gctx, BinningValue bValue) const {
+inline Vector3D NavigationLayer::binningPosition(const GeometryContext& gctx,
+                                                 BinningValue bValue) const {
   return m_surfaceRepresentation->binningPosition(gctx, bValue);
 }
 

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -95,8 +95,8 @@ class Volume : public virtual GeometryObject {
   /// @param bValue is the binning value schema
   ///
   /// @return vector 3D that can be used for the binning
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const override;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const override;
 
  protected:
   std::shared_ptr<const Transform3D> m_transform;

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -86,8 +86,8 @@ class ConeSurface : public Surface {
   /// @param bValue defines the type of binning applied in the global frame
   ///
   /// @return The return type is a vector for positioning in the global frame
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// Return the surface type
   SurfaceType type() const override;
@@ -102,25 +102,25 @@ class ConeSurface : public Surface {
   /// @param momentum is the momentum used for the measurement frame
   /// construction
   /// @return matrix that indicates the measurement frame
-  const RotationMatrix3D referenceFrame(const GeometryContext& gctx,
-                                        const Vector3D& position,
-                                        const Vector3D& momentum) const final;
+  RotationMatrix3D referenceFrame(const GeometryContext& gctx,
+                                  const Vector3D& position,
+                                  const Vector3D& momentum) const final;
 
   /// Return method for surface normal information
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition is the local position at normal vector request
   /// @return Vector3D normal vector in global frame
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& lposition) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& lposition) const final;
 
   /// Return method for surface normal information
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position as normal vector base
   /// @return Vector3D normal vector in global frame
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector3D& position) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector3D& position) const final;
 
   /// Normal vector return without argument
   using Surface::normal;
@@ -130,7 +130,7 @@ class ConeSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   ///
   // @return This returns the local z axis
-  virtual const Vector3D rotSymmetryAxis(const GeometryContext& gctx) const;
+  virtual Vector3D rotSymmetryAxis(const GeometryContext& gctx) const;
 
   /// This method returns the ConeBounds by reference
   const ConeBounds& bounds() const final;
@@ -204,7 +204,7 @@ class ConeSurface : public Surface {
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3D& position) const final;
 
  protected:

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -89,8 +89,8 @@ class CylinderSurface : public Surface {
   /// @param bValue is the type of global binning to be done
   ///
   /// @return is the global position to be used for binning
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// Return the measurement frame - this is needed for alignment, in particular
   /// The measurement frame of a cylinder is the tangential plane at a given
@@ -100,9 +100,9 @@ class CylinderSurface : public Surface {
   /// @param position is the position where the measurement frame is defined
   /// @param momentum is the momentum vector (ignored)
   /// @return rotation matrix that defines the measurement frame
-  const RotationMatrix3D referenceFrame(const GeometryContext& gctx,
-                                        const Vector3D& position,
-                                        const Vector3D& momentum) const final;
+  RotationMatrix3D referenceFrame(const GeometryContext& gctx,
+                                  const Vector3D& position,
+                                  const Vector3D& momentum) const final;
 
   /// Return the surface type
   SurfaceType type() const override;
@@ -116,8 +116,8 @@ class CylinderSurface : public Surface {
   /// requested
   ///
   /// @return normal vector at the local position by value
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& lposition) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& lposition) const final;
 
   /// Return method for surface normal information
   /// @note for a Cylinder a local position is always required for the normal
@@ -128,8 +128,8 @@ class CylinderSurface : public Surface {
   /// requested
   ///
   /// @return normal vector at the global position by value
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector3D& position) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector3D& position) const final;
 
   /// Normal vector return without argument
   using Surface::normal;
@@ -139,7 +139,7 @@ class CylinderSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   ///
   /// @return  the z-Axis of transform
-  virtual const Vector3D rotSymmetryAxis(const GeometryContext& gctx) const;
+  virtual Vector3D rotSymmetryAxis(const GeometryContext& gctx) const;
 
   /// This method returns the CylinderBounds by reference
   const CylinderBounds& bounds() const final;
@@ -212,7 +212,7 @@ class CylinderSurface : public Surface {
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3D& position) const final;
 
  protected:

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -118,8 +118,8 @@ class DiscSurface : public Surface {
   /// @param lposition The local position is ignored
   ///
   /// @return a Vector3D by value
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& lposition) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& lposition) const final;
 
   /// Normal vector return without argument
   using Surface::normal;
@@ -131,8 +131,8 @@ class DiscSurface : public Surface {
   /// @param bValue The binning type to be used
   ///
   /// @return position that can beused for this binning
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// This method returns the bounds by reference
   const SurfaceBounds& bounds() const final;
@@ -168,7 +168,7 @@ class DiscSurface : public Surface {
   /// @param lpolar is a local position in polar coordinates
   ///
   /// @return values is local 2D position in cartesian coordinates  @todo check
-  const Vector2D localPolarToCartesian(const Vector2D& lpolar) const;
+  Vector2D localPolarToCartesian(const Vector2D& lpolar) const;
 
   /// Special method for Disc surface : local<->local transformations polar <->
   /// cartesian
@@ -176,7 +176,7 @@ class DiscSurface : public Surface {
   /// @param lcart is local 2D position in cartesian coordinates
   ///
   /// @return value is a local position in polar coordinates
-  const Vector2D localCartesianToPolar(const Vector2D& lcart) const;
+  Vector2D localCartesianToPolar(const Vector2D& lcart) const;
 
   /// Special method for DiscSurface : local<->local transformations polar <->
   /// cartesian
@@ -185,7 +185,7 @@ class DiscSurface : public Surface {
   /// @param locpol is a local position in polar coordinates
   ///
   /// @return values is local 2D position in cartesian coordinates
-  const Vector2D localPolarToLocalCartesian(const Vector2D& locpol) const;
+  Vector2D localPolarToLocalCartesian(const Vector2D& locpol) const;
 
   /// Special method for DiscSurface :  local<->global transformation when
   /// provided cartesian coordinates
@@ -194,8 +194,8 @@ class DiscSurface : public Surface {
   /// @param lposition is local 2D position in cartesian coordinates
   ///
   /// @return value is a global cartesian 3D position
-  const Vector3D localCartesianToGlobal(const GeometryContext& gctx,
-                                        const Vector2D& lposition) const;
+  Vector3D localCartesianToGlobal(const GeometryContext& gctx,
+                                  const Vector2D& lposition) const;
 
   /// Special method for DiscSurface : global<->local from cartesian coordinates
   ///
@@ -204,9 +204,9 @@ class DiscSurface : public Surface {
   /// @param tol The absoltue tolerance parameter
   ///
   /// @return value is a local polar
-  const Vector2D globalToLocalCartesian(const GeometryContext& gctx,
-                                        const Vector3D& position,
-                                        double tol = 0.) const;
+  Vector2D globalToLocalCartesian(const GeometryContext& gctx,
+                                  const Vector3D& position,
+                                  double tol = 0.) const;
 
   /// Initialize the jacobian from local to global
   /// the surface knows best, hence the calculation is done here.
@@ -235,9 +235,10 @@ class DiscSurface : public Surface {
   /// @param direction The direction at of the parameters
   ///
   /// @return the transposed reference frame (avoids recalculation)
-  const RotationMatrix3D initJacobianToLocal(
-      const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
-      const Vector3D& position, const Vector3D& direction) const final;
+  RotationMatrix3D initJacobianToLocal(const GeometryContext& gctx,
+                                       FreeToBoundMatrix& jacobian,
+                                       const Vector3D& position,
+                                       const Vector3D& direction) const final;
 
   /// Path correction due to incident of the track
   ///
@@ -311,7 +312,7 @@ class DiscSurface : public Surface {
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3D& position) const final;
 
  protected:

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -69,10 +69,7 @@ class LineSurface : public Surface {
               const Transform3D& transf);
 
  public:
-  /// Destructor - defaulted
   ~LineSurface() override = default;
-
-  /// Default Constructor - deleted
   LineSurface() = delete;
 
   /// Assignment operator
@@ -86,8 +83,8 @@ class LineSurface : public Surface {
   /// @param lposition is the local position is ignored
   ///
   /// @return a Vector3D by value
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& lposition) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& lposition) const final;
 
   /// Normal vector return without argument
   using Surface::normal;
@@ -99,8 +96,8 @@ class LineSurface : public Surface {
   /// @param bValue is the binning type to be used
   ///
   /// @return position that can beused for this binning
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// Return the measurement frame - this is needed for alignment, in particular
   ///
@@ -114,9 +111,9 @@ class LineSurface : public Surface {
   /// construction
   ///
   /// @return is a rotation matrix that indicates the measurement frame
-  const RotationMatrix3D referenceFrame(const GeometryContext& gctx,
-                                        const Vector3D& position,
-                                        const Vector3D& momentum) const final;
+  RotationMatrix3D referenceFrame(const GeometryContext& gctx,
+                                  const Vector3D& position,
+                                  const Vector3D& momentum) const final;
 
   /// Initialize the jacobian from local to global
   /// the surface knows best, hence the calculation is done here.
@@ -145,7 +142,7 @@ class LineSurface : public Surface {
   /// @param jacobian is the transport jacobian
   ///
   /// @return a five-dim vector
-  const BoundRowVector derivativeFactors(
+  BoundRowVector derivativeFactors(
       const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction, const RotationMatrix3D& rft,
       const BoundToFreeMatrix& jacobian) const final;
@@ -267,7 +264,7 @@ class LineSurface : public Surface {
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
-  const AlignmentRowVector alignmentToPathDerivative(
+  AlignmentRowVector alignmentToPathDerivative(
       const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
       const Vector3D& position, const Vector3D& direction) const final;
 
@@ -279,7 +276,7 @@ class LineSurface : public Surface {
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3D& position) const final;
 
  protected:

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -87,8 +87,8 @@ class PlaneSurface : public Surface {
   /// @param lposition is the local position is ignored
   ///
   /// return a Vector3D by value
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& lposition) const final;
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& lposition) const final;
 
   /// Normal vector return without argument
   using Surface::normal;
@@ -100,8 +100,8 @@ class PlaneSurface : public Surface {
   /// @param bValue is the binning type to be used
   ///
   /// @return position that can beused for this binning
-  const Vector3D binningPosition(const GeometryContext& gctx,
-                                 BinningValue bValue) const final;
+  Vector3D binningPosition(const GeometryContext& gctx,
+                           BinningValue bValue) const final;
 
   /// Return the surface type
   SurfaceType type() const override;
@@ -201,7 +201,7 @@ class PlaneSurface : public Surface {
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3D& position) const final;
 
  protected:

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -173,7 +173,7 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   ///
   /// @return center position by value
-  virtual const Vector3D center(const GeometryContext& gctx) const;
+  virtual Vector3D center(const GeometryContext& gctx) const;
 
   /// Return method for the normal vector of the surface
   /// The normal vector can only be generally defined at a given local position
@@ -184,8 +184,8 @@ class Surface : public virtual GeometryObject,
   /// constructed
   ///
   /// @return normal vector by value
-  virtual const Vector3D normal(const GeometryContext& gctx,
-                                const Vector2D& lposition) const = 0;
+  virtual Vector3D normal(const GeometryContext& gctx,
+                          const Vector2D& lposition) const = 0;
 
   /// Return method for the normal vector of the surface
   /// The normal vector can only be generally defined at a given local position
@@ -197,8 +197,8 @@ class Surface : public virtual GeometryObject,
 
   ///
   /// @return normal vector by value
-  virtual const Vector3D normal(const GeometryContext& gctx,
-                                const Vector3D& position) const;
+  virtual Vector3D normal(const GeometryContext& gctx,
+                          const Vector3D& position) const;
 
   /// Return method for the normal vector of the surface
   ///
@@ -207,7 +207,7 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   //
   /// @return normal vector by value
-  virtual const Vector3D normal(const GeometryContext& gctx) const {
+  virtual Vector3D normal(const GeometryContext& gctx) const {
     return normal(gctx, center(gctx));
   }
 
@@ -310,9 +310,9 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return RotationMatrix3D which defines the three axes of the measurement
   /// frame
-  virtual const Acts::RotationMatrix3D referenceFrame(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& momentum) const;
+  virtual Acts::RotationMatrix3D referenceFrame(const GeometryContext& gctx,
+                                                const Vector3D& position,
+                                                const Vector3D& momentum) const;
 
   /// Initialize the jacobian from local to global
   /// the surface knows best, hence the calculation is done here.
@@ -349,9 +349,10 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   ///
   /// @return the transposed reference frame (avoids recalculation)
-  virtual const RotationMatrix3D initJacobianToLocal(
-      const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
-      const Vector3D& position, const Vector3D& direction) const;
+  virtual RotationMatrix3D initJacobianToLocal(const GeometryContext& gctx,
+                                               FreeToBoundMatrix& jacobian,
+                                               const Vector3D& position,
+                                               const Vector3D& direction) const;
 
   /// Calculate the form factors for the derivatives
   /// the calculation is identical for all surfaces where the
@@ -369,7 +370,7 @@ class Surface : public virtual GeometryObject,
   /// @param jacobian is the transport jacobian
   ///
   /// @return a five-dim vector
-  virtual const BoundRowVector derivativeFactors(
+  virtual BoundRowVector derivativeFactors(
       const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction, const RotationMatrix3D& rft,
       const BoundToFreeMatrix& jacobian) const;
@@ -438,7 +439,7 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return Derivative of bound track parameters w.r.t. local frame
   /// alignment parameters
-  const AlignmentToBoundMatrix alignmentToBoundDerivative(
+  AlignmentToBoundMatrix alignmentToBoundDerivative(
       const GeometryContext& gctx, const FreeVector& derivatives,
       const Vector3D& position, const Vector3D& direction) const;
 
@@ -456,7 +457,7 @@ class Surface : public virtual GeometryObject,
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
-  virtual const AlignmentRowVector alignmentToPathDerivative(
+  virtual AlignmentRowVector alignmentToPathDerivative(
       const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
       const Vector3D& position, const Vector3D& direction) const;
 
@@ -468,9 +469,8 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return Derivative of bound local position w.r.t. position in local 3D
   /// cartesian coordinates
-  virtual const LocalCartesianToBoundLocalMatrix
-  localCartesianToBoundLocalDerivative(const GeometryContext& gctx,
-                                       const Vector3D& position) const = 0;
+  virtual LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+      const GeometryContext& gctx, const Vector3D& position) const = 0;
 
  protected:
   /// Transform3D definition that positions

--- a/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
@@ -87,7 +87,7 @@ inline SurfaceIntersection ConeSurface::intersect(
   return cIntersection;
 }
 
-inline const LocalCartesianToBoundLocalMatrix
+inline LocalCartesianToBoundLocalMatrix
 ConeSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position) const {
   using VectorHelpers::perp;

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline const Vector3D CylinderSurface::rotSymmetryAxis(
+inline Vector3D CylinderSurface::rotSymmetryAxis(
     const GeometryContext& gctx) const {
   // fast access via tranform matrix (and not rotation())
   return transform(gctx).matrix().block<3, 1>(0, 2);
@@ -112,7 +112,7 @@ inline SurfaceIntersection CylinderSurface::intersect(
   return cIntersection;
 }
 
-inline const LocalCartesianToBoundLocalMatrix
+inline LocalCartesianToBoundLocalMatrix
 CylinderSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position) const {
   using VectorHelpers::perp;

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -6,13 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline const Vector2D DiscSurface::localPolarToCartesian(
+inline Vector2D DiscSurface::localPolarToCartesian(
     const Vector2D& lpolar) const {
   return Vector2D(lpolar[eLOC_R] * cos(lpolar[eLOC_PHI]),
                   lpolar[eLOC_R] * sin(lpolar[eLOC_PHI]));
 }
 
-inline const Vector2D DiscSurface::localCartesianToPolar(
+inline Vector2D DiscSurface::localCartesianToPolar(
     const Vector2D& lcart) const {
   return Vector2D(
       sqrt(lcart[eLOC_X] * lcart[eLOC_X] + lcart[eLOC_Y] * lcart[eLOC_Y]),
@@ -65,7 +65,7 @@ inline void DiscSurface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian(7, eQOP) = 1;
 }
 
-inline const RotationMatrix3D DiscSurface::initJacobianToLocal(
+inline RotationMatrix3D DiscSurface::initJacobianToLocal(
     const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
     const Vector3D& position, const Vector3D& direction) const {
   using VectorHelpers::perp;
@@ -137,7 +137,7 @@ inline SurfaceIntersection DiscSurface::intersect(
   return {intersection, this};
 }
 
-inline const LocalCartesianToBoundLocalMatrix
+inline LocalCartesianToBoundLocalMatrix
 DiscSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position) const {
   using VectorHelpers::perp;
@@ -157,15 +157,15 @@ DiscSurface::localCartesianToBoundLocalDerivative(
   return loc3DToLocBound;
 }
 
-inline const Vector3D DiscSurface::normal(const GeometryContext& gctx,
-                                          const Vector2D& /*unused*/) const {
+inline Vector3D DiscSurface::normal(const GeometryContext& gctx,
+                                    const Vector2D& /*unused*/) const {
   // fast access via tranform matrix (and not rotation())
   const auto& tMatrix = transform(gctx).matrix();
   return Vector3D(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
 
-inline const Vector3D DiscSurface::binningPosition(const GeometryContext& gctx,
-                                                   BinningValue bValue) const {
+inline Vector3D DiscSurface::binningPosition(const GeometryContext& gctx,
+                                             BinningValue bValue) const {
   if (bValue == binR) {
     double r = m_bounds->binningValueR();
     double phi = m_bounds->binningValuePhi();

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -45,7 +45,7 @@ inline std::string LineSurface::name() const {
   return "Acts::LineSurface";
 }
 
-inline const RotationMatrix3D LineSurface::referenceFrame(
+inline RotationMatrix3D LineSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3D& /*unused*/,
     const Vector3D& momentum) const {
   RotationMatrix3D mFrame;
@@ -67,13 +67,13 @@ inline double LineSurface::pathCorrection(const GeometryContext& /*unused*/,
   return 1.;
 }
 
-inline const Vector3D LineSurface::binningPosition(
-    const GeometryContext& gctx, BinningValue /*bValue*/) const {
+inline Vector3D LineSurface::binningPosition(const GeometryContext& gctx,
+                                             BinningValue /*bValue*/) const {
   return center(gctx);
 }
 
-inline const Vector3D LineSurface::normal(const GeometryContext& gctx,
-                                          const Vector2D& /*lpos*/) const {
+inline Vector3D LineSurface::normal(const GeometryContext& gctx,
+                                    const Vector2D& /*lpos*/) const {
   const auto& tMatrix = transform(gctx).matrix();
   return Vector3D(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
@@ -181,7 +181,7 @@ inline void LineSurface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian.block<3, 1>(0, eTHETA) = dDThetaY * pars[eLOC_0] * ipdn;
 }
 
-inline const BoundRowVector LineSurface::derivativeFactors(
+inline BoundRowVector LineSurface::derivativeFactors(
     const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& direction, const RotationMatrix3D& rft,
     const BoundToFreeMatrix& jacobian) const {
@@ -210,7 +210,7 @@ inline const BoundRowVector LineSurface::derivativeFactors(
                          jacobian.block<3, eBoundParametersSize>(4, 0))));
 }
 
-inline const AlignmentRowVector LineSurface::alignmentToPathDerivative(
+inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
     const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
     const Vector3D& position, const Vector3D& direction) const {
   // The vector between position and center
@@ -239,7 +239,7 @@ inline const AlignmentRowVector LineSurface::alignmentToPathDerivative(
   return alignToPath;
 }
 
-inline const LocalCartesianToBoundLocalMatrix
+inline LocalCartesianToBoundLocalMatrix
 LineSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position) const {
   using VectorHelpers::phi;

--- a/Core/include/Acts/Surfaces/detail/PlaneSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/PlaneSurface.ipp
@@ -6,15 +6,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline const Vector3D PlaneSurface::normal(const GeometryContext& gctx,
-                                           const Vector2D& /*lpos*/) const {
+inline Vector3D PlaneSurface::normal(const GeometryContext& gctx,
+                                     const Vector2D& /*lpos*/) const {
   // fast access via tranform matrix (and not rotation())
   const auto& tMatrix = transform(gctx).matrix();
   return Vector3D(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
 
-inline const Vector3D PlaneSurface::binningPosition(
-    const GeometryContext& gctx, BinningValue /*bValue*/) const {
+inline Vector3D PlaneSurface::binningPosition(const GeometryContext& gctx,
+                                              BinningValue /*bValue*/) const {
   return center(gctx);
 }
 
@@ -47,7 +47,7 @@ inline SurfaceIntersection PlaneSurface::intersect(
   return {intersection, this};
 }
 
-inline const LocalCartesianToBoundLocalMatrix
+inline LocalCartesianToBoundLocalMatrix
 PlaneSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& /*unused*/, const Vector3D& /*unused*/) const {
   const LocalCartesianToBoundLocalMatrix loc3DToLocBound =

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -6,14 +6,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline const Vector3D Surface::center(const GeometryContext& gctx) const {
+inline Vector3D Surface::center(const GeometryContext& gctx) const {
   // fast access via tranform matrix (and not translation())
   auto tMatrix = transform(gctx).matrix();
   return Vector3D(tMatrix(0, 3), tMatrix(1, 3), tMatrix(2, 3));
 }
 
-inline const Acts::Vector3D Surface::normal(const GeometryContext& gctx,
-                                            const Vector3D& /*unused*/) const {
+inline Vector3D Surface::normal(const GeometryContext& gctx,
+                                const Vector3D& /*unused*/) const {
   return normal(gctx, s_origin2D);
 }
 
@@ -33,7 +33,7 @@ inline bool Surface::insideBounds(const Vector2D& lposition,
   return bounds().inside(lposition, bcheck);
 }
 
-inline const RotationMatrix3D Surface::referenceFrame(
+inline RotationMatrix3D Surface::referenceFrame(
     const GeometryContext& gctx, const Vector3D& /*unused*/,
     const Vector3D& /*unused*/) const {
   return transform(gctx).matrix().block<3, 3>(0, 0);
@@ -75,7 +75,7 @@ inline void Surface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian(7, eQOP) = 1;
 }
 
-inline const RotationMatrix3D Surface::initJacobianToLocal(
+inline RotationMatrix3D Surface::initJacobianToLocal(
     const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
     const Vector3D& position, const Vector3D& direction) const {
   // Optimized trigonometry on the propagation direction
@@ -106,7 +106,7 @@ inline const RotationMatrix3D Surface::initJacobianToLocal(
   return rframeT;
 }
 
-inline const BoundRowVector Surface::derivativeFactors(
+inline BoundRowVector Surface::derivativeFactors(
     const GeometryContext& /*unused*/, const Vector3D& /*unused*/,
     const Vector3D& direction, const RotationMatrix3D& rft,
     const BoundToFreeMatrix& jacobian) const {

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -63,8 +63,8 @@ Acts::Volume::Volume(const Volume& vol, const Transform3D* shift)
 
 Acts::Volume::~Volume() = default;
 
-const Acts::Vector3D Acts::Volume::binningPosition(
-    const GeometryContext& /*gctx*/, Acts::BinningValue bValue) const {
+Acts::Vector3D Acts::Volume::binningPosition(const GeometryContext& /*gctx*/,
+                                             Acts::BinningValue bValue) const {
   // for most of the binning types it is actually the center,
   // just for R-binning types the
   if (bValue == Acts::binR || bValue == Acts::binRPhi) {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -50,7 +50,7 @@ Acts::ConeSurface::ConeSurface(std::shared_ptr<const Transform3D> htrans,
   throw_assert(cbounds, "ConeBounds must not be nullptr");
 }
 
-const Acts::Vector3D Acts::ConeSurface::binningPosition(
+Acts::Vector3D Acts::ConeSurface::binningPosition(
     const GeometryContext& gctx, Acts::BinningValue bValue) const {
   const Vector3D& sfCenter = center(gctx);
 
@@ -76,12 +76,12 @@ Acts::ConeSurface& Acts::ConeSurface::operator=(const ConeSurface& other) {
   return *this;
 }
 
-const Acts::Vector3D Acts::ConeSurface::rotSymmetryAxis(
+Acts::Vector3D Acts::ConeSurface::rotSymmetryAxis(
     const GeometryContext& gctx) const {
   return std::move(transform(gctx).matrix().block<3, 1>(0, 2));
 }
 
-const Acts::RotationMatrix3D Acts::ConeSurface::referenceFrame(
+Acts::RotationMatrix3D Acts::ConeSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& /*unused*/) const {
   RotationMatrix3D mFrame;
@@ -148,7 +148,7 @@ std::string Acts::ConeSurface::name() const {
   return "Acts::ConeSurface";
 }
 
-const Acts::Vector3D Acts::ConeSurface::normal(
+Acts::Vector3D Acts::ConeSurface::normal(
     const GeometryContext& gctx, const Acts::Vector2D& lposition) const {
   // (cos phi cos alpha, sin phi cos alpha, sgn z sin alpha)
   double phi =
@@ -162,8 +162,8 @@ const Acts::Vector3D Acts::ConeSurface::normal(
                      : localNormal;
 }
 
-const Acts::Vector3D Acts::ConeSurface::normal(
-    const GeometryContext& gctx, const Acts::Vector3D& position) const {
+Acts::Vector3D Acts::ConeSurface::normal(const GeometryContext& gctx,
+                                         const Acts::Vector3D& position) const {
   // get it into the cylinder frame if needed
   // @todo respect opening angle
   Vector3D pos3D = position;

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -62,7 +62,7 @@ Acts::CylinderSurface& Acts::CylinderSurface::operator=(
 }
 
 // return the binning position for ordering in the BinnedArray
-const Acts::Vector3D Acts::CylinderSurface::binningPosition(
+Acts::Vector3D Acts::CylinderSurface::binningPosition(
     const GeometryContext& gctx, BinningValue bValue) const {
   const Acts::Vector3D& sfCenter = center(gctx);
   // special binning type for R-type methods
@@ -78,7 +78,7 @@ const Acts::Vector3D Acts::CylinderSurface::binningPosition(
 }
 
 // return the measurement frame: it's the tangential plane
-const Acts::RotationMatrix3D Acts::CylinderSurface::referenceFrame(
+Acts::RotationMatrix3D Acts::CylinderSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& /*unused*/) const {
   RotationMatrix3D mFrame;
@@ -133,14 +133,14 @@ std::string Acts::CylinderSurface::name() const {
   return "Acts::CylinderSurface";
 }
 
-const Acts::Vector3D Acts::CylinderSurface::normal(
+Acts::Vector3D Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector2D& lposition) const {
   double phi = lposition[Acts::eLOC_RPHI] / m_bounds->get(CylinderBounds::eR);
   Vector3D localNormal(cos(phi), sin(phi), 0.);
   return Vector3D(transform(gctx).matrix().block<3, 3>(0, 0) * localNormal);
 }
 
-const Acts::Vector3D Acts::CylinderSurface::normal(
+Acts::Vector3D Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector3D& position) const {
   const Transform3D& sfTransform = transform(gctx);
   // get it into the cylinder frame

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -94,7 +94,7 @@ Acts::Result<Acts::Vector2D> Acts::DiscSurface::globalToLocal(
   return Result<Acts::Vector2D>::success({perp(loc3Dframe), phi(loc3Dframe)});
 }
 
-const Acts::Vector2D Acts::DiscSurface::localPolarToLocalCartesian(
+Acts::Vector2D Acts::DiscSurface::localPolarToLocalCartesian(
     const Vector2D& locpol) const {
   const DiscTrapezoidBounds* dtbo =
       dynamic_cast<const Acts::DiscTrapezoidBounds*>(&(bounds()));
@@ -116,13 +116,13 @@ const Acts::Vector2D Acts::DiscSurface::localPolarToLocalCartesian(
                   locpol[Acts::eLOC_R] * sin(locpol[Acts::eLOC_PHI]));
 }
 
-const Acts::Vector3D Acts::DiscSurface::localCartesianToGlobal(
+Acts::Vector3D Acts::DiscSurface::localCartesianToGlobal(
     const GeometryContext& gctx, const Vector2D& lposition) const {
   Vector3D loc3Dframe(lposition[Acts::eLOC_X], lposition[Acts::eLOC_Y], 0.);
   return Vector3D(transform(gctx) * loc3Dframe);
 }
 
-const Acts::Vector2D Acts::DiscSurface::globalToLocalCartesian(
+Acts::Vector2D Acts::DiscSurface::globalToLocalCartesian(
     const GeometryContext& gctx, const Vector3D& position,
     double /*unused*/) const {
   Vector3D loc3Dframe = (transform(gctx).inverse()) * position;

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -50,7 +50,7 @@ bool Acts::Surface::isOnSurface(const GeometryContext& gctx,
   return false;
 }
 
-const Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
+Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
     const GeometryContext& gctx, const FreeVector& derivatives,
     const Vector3D& position, const Vector3D& direction) const {
   // The vector between position and center
@@ -109,7 +109,7 @@ const Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   return alignToBound;
 }
 
-const Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
+Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
     const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
     const Vector3D& position, const Vector3D& direction) const {
   // The vector between position and center

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -33,17 +33,16 @@ class SurfaceStub : public Surface {
   SurfaceType type() const final { return Surface::Other; }
 
   /// Return method for the normal vector of the surface
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector2D& /*lpos*/) const final {
+  Vector3D normal(const GeometryContext& gctx,
+                  const Vector2D& /*lpos*/) const final {
     return normal(gctx);
   }
 
-  const Vector3D normal(const GeometryContext& gctx,
-                        const Vector3D&) const final {
+  Vector3D normal(const GeometryContext& gctx, const Vector3D&) const final {
     return normal(gctx);
   }
 
-  const Vector3D normal(const GeometryContext& /*gctx*/) const final {
+  Vector3D normal(const GeometryContext& /*gctx*/) const final {
     return Vector3D{0., 0., 0.};
   }
 
@@ -74,8 +73,8 @@ class SurfaceStub : public Surface {
   }
 
   /// Inherited from GeometryObject base
-  const Vector3D binningPosition(const GeometryContext& /*txt*/,
-                                 BinningValue /*bValue*/) const final {
+  Vector3D binningPosition(const GeometryContext& /*txt*/,
+                           BinningValue /*bValue*/) const final {
     const Vector3D v{0.0, 0.0, 0.0};
     return v;
   }
@@ -107,7 +106,7 @@ class SurfaceStub : public Surface {
   }
 
   // Cartesian 3D to local bound derivative
-  const LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
+  LocalCartesianToBoundLocalMatrix localCartesianToBoundLocalDerivative(
       const GeometryContext& /*unused*/,
       const Vector3D& /*unused*/) const final {
     return LocalCartesianToBoundLocalMatrix::Identity();

--- a/docs/core/geometry.md
+++ b/docs/core/geometry.md
@@ -51,7 +51,7 @@ All geometry objects in Acts inherit from a virtual `GeometryObject` base class
      /// @param bValue is the value in which you want to bin
      ///
      /// @return vector 3D used for the binning schema
-     virtual const Vector3D
+     virtual Vector3D
      binningPosition(BinningValue bValue) const = 0;
     
      /// Implement the binningValue


### PR DESCRIPTION
This PR removes the unnecessary `const` qualifier within the `Surface` package in case of returning by value, e.g. 

```c++
const ReturnType bla() const 
```

is changed consistently to 

```c++
ReturnType bla() const
```

if `ReturnType` is an object returned by value.

It currently sits on top of #399 and thus is marked const, but is a single commit that can either be rebased after #399 is merged or cherry-picked.

BREAKING CHANGE: it changes the method signature of those return objects, but somewhat silently because clients could always convert into `const` or from `const` via copy/assignment.