### PR TITLE
refactor!: Surfaces: Change Transform3D storage by value

### DIFF
--- a/Core/include/Acts/Geometry/AbstractVolume.hpp
+++ b/Core/include/Acts/Geometry/AbstractVolume.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -44,18 +44,15 @@ class AbstractVolume : public Volume {
  public:
   /// Constructor with shared Transform3D*, VolumeBounds*
   ///
-  /// @param htrans is the transform 3D the positions the volume in global frame
+  /// @param transform is the transform 3D the positions the volume in global
+  /// frame
   /// @param volbounds is the boundary definition
-  AbstractVolume(std::shared_ptr<const Transform3D> htrans,
-                 VolumeBoundsPtr volbounds);
+  AbstractVolume(const Transform3D& transform, VolumeBoundsPtr volbounds);
 
   AbstractVolume(const AbstractVolume& vol) = default;
 
   AbstractVolume() = delete;
-
-  ~AbstractVolume() override;
-
-  /// Assignment operator - deleted
+  ~AbstractVolume() override = default;
   AbstractVolume& operator=(const AbstractVolume& vol) = delete;
 
   /// Method to return the BoundarySurfaces

--- a/Core/include/Acts/Geometry/AbstractVolume.hpp
+++ b/Core/include/Acts/Geometry/AbstractVolume.hpp
@@ -44,8 +44,7 @@ class AbstractVolume : public Volume {
  public:
   /// Constructor with shared Transform3D*, VolumeBounds*
   ///
-  /// @param transform is the transform 3D the positions the volume in global
-  /// frame
+  /// @param transform is the gobal 3d transformation into the volume frame
   /// @param volbounds is the boundary definition
   AbstractVolume(const Transform3D& transform, VolumeBoundsPtr volbounds);
 

--- a/Core/include/Acts/Geometry/ApproachDescriptor.hpp
+++ b/Core/include/Acts/Geometry/ApproachDescriptor.hpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// ApproachDescriptor.h, Acts project
-///////////////////////////////////////////////////////////////////
 
 #pragma once
 
@@ -32,8 +28,6 @@ class BoundaryCheck;
 class ApproachDescriptor {
  public:
   ApproachDescriptor() = default;
-
-  /// Virtual destructor
   virtual ~ApproachDescriptor() = default;
 
   /// @brief Register Layer

--- a/Core/include/Acts/Geometry/ConeLayer.hpp
+++ b/Core/include/Acts/Geometry/ConeLayer.hpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// ConeLayer.h, Acts project
-///////////////////////////////////////////////////////////////////
 
 #pragma once
 #include "Acts/Geometry/Layer.hpp"
@@ -41,27 +37,19 @@ class ConeLayer : virtual public ConeSurface, public Layer {
   ///
   /// @return is a shared pointer to a layer
   static MutableLayerPtr create(
-      std::shared_ptr<const Transform3D> transform,
-      std::shared_ptr<const ConeBounds> cbounds,
+      const Transform3D& transform, std::shared_ptr<const ConeBounds> cbounds,
       std::unique_ptr<SurfaceArray> surfaceArray, double thickness = 0.,
       std::unique_ptr<ApproachDescriptor> ad = nullptr,
       LayerType laytyp = Acts::active) {
-    return MutableLayerPtr(new ConeLayer(
-        std::move(transform), std::move(cbounds), std::move(surfaceArray),
-        thickness, std::move(ad), laytyp));
+    return MutableLayerPtr(new ConeLayer(transform, std::move(cbounds),
+                                         std::move(surfaceArray), thickness,
+                                         std::move(ad), laytyp));
   }
 
-  /// Default Constructor - delete
   ConeLayer() = delete;
-
-  /// Copy constructor of ConeLayer - delete
   ConeLayer(const ConeLayer& cla) = delete;
-
-  /// Assignment operator for ConeLayers - delete
-  ConeLayer& operator=(const ConeLayer&) = delete;
-
-  /// Destructor
   ~ConeLayer() override = default;
+  ConeLayer& operator=(const ConeLayer&) = delete;
 
   /// Transforms the layer into a Surface representation for extrapolation
   const ConeSurface& surfaceRepresentation() const override;
@@ -80,7 +68,7 @@ class ConeLayer : virtual public ConeSurface, public Layer {
   /// @param laytyp is the layer type
   ///
   /// @todo chage od and ad to unique_ptr
-  ConeLayer(std::shared_ptr<const Transform3D> transform,
+  ConeLayer(const Transform3D& transform,
             std::shared_ptr<const ConeBounds> cbounds,
             std::unique_ptr<SurfaceArray> surfaceArray, double thickness = 0.,
             std::unique_ptr<ApproachDescriptor> ade = nullptr,

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -83,9 +83,7 @@ class ConeVolumeBounds : public VolumeBounds {
   }
 
   ConeVolumeBounds(const ConeVolumeBounds& cobo) = default;
-
   ~ConeVolumeBounds() override = default;
-
   ConeVolumeBounds& operator=(const ConeVolumeBounds& cobo) = default;
 
   VolumeBounds::BoundsType type() const final { return VolumeBounds::eCone; }
@@ -113,7 +111,7 @@ class ConeVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const final;
+      const Transform3D& transform = Transform3D::Identity()) const final;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -109,7 +109,7 @@ class CuboidVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D& transform = Transform3D::Identity()) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/CuboidVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBuilder.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -49,9 +49,8 @@ class CuboidVolumeBuilder : public ITrackingVolumeBuilder {
     double thickness = 0.;
     // Constructor function for optional detector elements
     // Arguments are transform, rectangle bounds and thickness.
-    std::function<DetectorElementBase*(std::shared_ptr<const Transform3D>,
-                                       std::shared_ptr<const RectangleBounds>,
-                                       double)>
+    std::function<DetectorElementBase*(
+        const Transform3D&, std::shared_ptr<const RectangleBounds>, double)>
         detElementConstructor;
   };
 

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -104,7 +104,7 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D& transform = Transform3D::Identity()) const override;
 
   /// Construct bounding box for this shape
   ///

--- a/Core/include/Acts/Geometry/CylinderLayer.hpp
+++ b/Core/include/Acts/Geometry/CylinderLayer.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -43,7 +43,7 @@ class CylinderLayer : public CylinderSurface, public Layer {
   ///
   /// @return The return object is a shared poiter to the layer.
   static MutableLayerPtr create(
-      const std::shared_ptr<const Transform3D>& transform,
+      const Transform3D& transform,
       const std::shared_ptr<const CylinderBounds>& cbounds,
       std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
       double thickness = 0., std::unique_ptr<ApproachDescriptor> ad = nullptr,
@@ -53,17 +53,10 @@ class CylinderLayer : public CylinderSurface, public Layer {
                                              std::move(ad), laytyp));
   }
 
-  /// Copy constructor - deleted
   CylinderLayer(const CylinderLayer& cla) = delete;
-
-  /// Assignment operator for CylinderLayers - deleted
-  CylinderLayer& operator=(const CylinderLayer&) = delete;
-
-  /// Default Constructor
   CylinderLayer() = delete;
-
-  /// Destructor
   ~CylinderLayer() override = default;
+  CylinderLayer& operator=(const CylinderLayer&) = delete;
 
   /// Transforms the layer into a Surface representation
   /// This is for positioning and extrapolation
@@ -88,7 +81,7 @@ class CylinderLayer : public CylinderSurface, public Layer {
   /// @todo change ApproachDescriptor to unique_ptr
   ///
   /// @return The return object is a shared poiter to the layer.
-  CylinderLayer(const std::shared_ptr<const Transform3D>& transform,
+  CylinderLayer(const Transform3D& transform,
                 const std::shared_ptr<const CylinderBounds>& cBounds,
                 std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
                 double thickness = 0.,

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -127,7 +127,6 @@ class CylinderVolumeBounds : public VolumeBounds {
   CylinderVolumeBounds(const CylinderVolumeBounds& cylbo) = default;
 
   ~CylinderVolumeBounds() override = default;
-
   CylinderVolumeBounds& operator=(const CylinderVolumeBounds& cylbo) = default;
 
   VolumeBounds::BoundsType type() const final {
@@ -157,7 +156,7 @@ class CylinderVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D& transform = Transform3D::Identity()) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -78,7 +78,7 @@ class CylinderVolumeHelper : public ITrackingVolumeHelper {
       const GeometryContext& gctx, const LayerVector& layers,
       std::shared_ptr<const IVolumeMaterial> volumeMaterial,
       VolumeBoundsPtr volumeBounds, MutableTrackingVolumeVector mtvVector = {},
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = Transform3D::Identity(),
       const std::string& volumeName = "UndefinedVolume",
       BinningType bType = arbitrary) const override;
 
@@ -203,9 +203,9 @@ class CylinderVolumeHelper : public ITrackingVolumeHelper {
   bool estimateAndCheckDimension(
       const GeometryContext& gctx, const LayerVector& layers,
       const CylinderVolumeBounds*& cylinderVolumeBounds,
-      std::shared_ptr<const Transform3D>& transform, double& rMinClean,
-      double& rMaxClean, double& zMinClean, double& zMaxClean,
-      BinningValue& bValue, BinningType bType = arbitrary) const;
+      const Transform3D& transform, double& rMinClean, double& rMaxClean,
+      double& zMinClean, double& zMaxClean, BinningValue& bValue,
+      BinningType bType = arbitrary) const;
 
   /// Private method - interglue all volumes contained by a TrackingVolume
   /// and set the outside glue volumes in the descriptor

--- a/Core/include/Acts/Geometry/DiscLayer.hpp
+++ b/Core/include/Acts/Geometry/DiscLayer.hpp
@@ -41,7 +41,7 @@ class DiscLayer : virtual public DiscSurface, public Layer {
   ///
   /// @return a sharted pointer to the new layer
   static MutableLayerPtr create(
-      const std::shared_ptr<const Transform3D>& transform,
+      const Transform3D& transform,
       const std::shared_ptr<const DiscBounds>& dbounds,
       std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
       double thickness = 0., std::unique_ptr<ApproachDescriptor> ad = nullptr,
@@ -51,17 +51,10 @@ class DiscLayer : virtual public DiscSurface, public Layer {
                                          std::move(ad), laytyp));
   }
 
-  /// Default Constructor
   DiscLayer() = delete;
-
-  /// Copy constructor of DiscLayer - deleted
   DiscLayer(const DiscLayer& cla) = delete;
-
-  /// Assignment operator for DiscLayers - deleted
-  DiscLayer& operator=(const DiscLayer&) = delete;
-
-  /// Destructor
   ~DiscLayer() override = default;
+  DiscLayer& operator=(const DiscLayer&) = delete;
 
   /// Transforms the layer into a Surface representation for extrapolation
   /// @return This method returns a surface reference
@@ -83,7 +76,7 @@ class DiscLayer : virtual public DiscSurface, public Layer {
   /// @param thickness is the layer thickness (along the normal vector)
   /// @param ad is the approach descriptor that provides the approach surface
   /// @param laytyp is the layer taype
-  DiscLayer(const std::shared_ptr<const Transform3D>& transform,
+  DiscLayer(const Transform3D& transform,
             const std::shared_ptr<const DiscBounds>& dbounds,
             std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
             double thickness = 0.,

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -74,7 +74,7 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D& transform = Transform3D::Identity()) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/ILayerArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/ILayerArrayCreator.hpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 #include "Acts/Utilities/BinningType.hpp"

--- a/Core/include/Acts/Geometry/ILayerBuilder.hpp
+++ b/Core/include/Acts/Geometry/ILayerBuilder.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Core/include/Acts/Geometry/ITrackingVolumeHelper.hpp
+++ b/Core/include/Acts/Geometry/ITrackingVolumeHelper.hpp
@@ -64,7 +64,7 @@ class ITrackingVolumeHelper {
       const GeometryContext& gctx, const LayerVector& layers,
       std::shared_ptr<const IVolumeMaterial> volumeMaterial,
       VolumeBoundsPtr volumeBounds, MutableTrackingVolumeVector mtvVector = {},
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = Transform3D::Identity(),
       const std::string& volumeName = "UndefinedVolume",
       BinningType btype = arbitrary) const = 0;
 

--- a/Core/include/Acts/Geometry/LayerCreator.hpp
+++ b/Core/include/Acts/Geometry/LayerCreator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,12 +16,6 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <optional>
-
-#ifndef ACTS_LAYERCREATOR_TAKESMALLERBIGGER
-#define ACTS_LAYERCREATOR_TAKESMALLERBIGGER
-#define takeSmaller(current, test) current = current < test ? current : test
-#define takeBigger(current, test) current = current > test ? current : test
-#endif
 
 namespace Acts {
 
@@ -86,7 +80,7 @@ class LayerCreator {
       const GeometryContext& gctx,
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsPhi,
       size_t binsZ, std::optional<ProtoLayer> _protoLayer = std::nullopt,
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = s_idTransform,
       std::unique_ptr<ApproachDescriptor> ad = nullptr) const;
 
   /// returning a cylindrical layer
@@ -111,7 +105,7 @@ class LayerCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces,
       BinningType bTypePhi, BinningType bTypeZ,
       std::optional<ProtoLayer> _protoLayer = std::nullopt,
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = s_idTransform,
       std::unique_ptr<ApproachDescriptor> ad = nullptr) const;
 
   /// returning a disc layer
@@ -135,7 +129,7 @@ class LayerCreator {
       const GeometryContext& gctx,
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsR,
       size_t binsPhi, std::optional<ProtoLayer> _protoLayer = std::nullopt,
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = s_idTransform,
       std::unique_ptr<ApproachDescriptor> ad = nullptr) const;
 
   /// returning a disc layer
@@ -160,7 +154,7 @@ class LayerCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces, BinningType bTypeR,
       BinningType bTypePhi,
       std::optional<ProtoLayer> _protoLayer = std::nullopt,
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = s_idTransform,
       std::unique_ptr<ApproachDescriptor> ad = nullptr) const;
 
   /// returning a plane layer
@@ -189,7 +183,7 @@ class LayerCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t bins1,
       size_t bins2, BinningValue bValue,
       std::optional<ProtoLayer> _protoLayer = std::nullopt,
-      std::shared_ptr<const Transform3D> transform = nullptr,
+      const Transform3D& transform = s_idTransform,
       std::unique_ptr<ApproachDescriptor> ad = nullptr) const;
 
   /// Set the configuration object

--- a/Core/include/Acts/Geometry/PassiveLayerBuilder.hpp
+++ b/Core/include/Acts/Geometry/PassiveLayerBuilder.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Core/include/Acts/Geometry/PlaneLayer.hpp
+++ b/Core/include/Acts/Geometry/PlaneLayer.hpp
@@ -35,27 +35,19 @@ class PlaneLayer : virtual public PlaneSurface, public Layer {
   ///
   /// @return shared pointer to a PlaneLayer
   static MutableLayerPtr create(
-      std::shared_ptr<const Transform3D> transform,
-      std::shared_ptr<const PlanarBounds> pbounds,
+      const Transform3D& transform, std::shared_ptr<const PlanarBounds> pbounds,
       std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
       double thickness = 0., std::unique_ptr<ApproachDescriptor> ad = nullptr,
       LayerType laytyp = Acts::active) {
-    return MutableLayerPtr(new PlaneLayer(std::move(transform), pbounds,
+    return MutableLayerPtr(new PlaneLayer(transform, pbounds,
                                           std::move(surfaceArray), thickness,
                                           std::move(ad), laytyp));
   }
 
-  /// Default Constructor - deleted
   PlaneLayer() = delete;
-
-  /// Copy constructor of PlaneLayer - deleted
   PlaneLayer(const PlaneLayer& pla) = delete;
-
-  /// Assignment operator for PlaneLayers - deleted
-  PlaneLayer& operator=(const PlaneLayer&) = delete;
-
-  /// Destructor
   ~PlaneLayer() override = default;
+  PlaneLayer& operator=(const PlaneLayer&) = delete;
 
   /// Transforms the layer into a Surface representation for extrapolation
   /// @return returns a reference to a PlaneSurface
@@ -79,7 +71,7 @@ class PlaneLayer : virtual public PlaneSurface, public Layer {
   /// @param laytyp is the layer type
   ///
   /// @return shared pointer to a PlaneLayer
-  PlaneLayer(std::shared_ptr<const Transform3D> transform,
+  PlaneLayer(const Transform3D& transform,
              std::shared_ptr<const PlanarBounds>& pbounds,
              std::unique_ptr<SurfaceArray> surfaceArray = nullptr,
              double thickness = 0.,

--- a/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -115,7 +115,7 @@ class SurfaceArrayCreator {
       const GeometryContext& gctx,
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsPhi,
       size_t binsZ, std::optional<ProtoLayer> protoLayerOpt = std::nullopt,
-      const std::shared_ptr<const Transform3D>& transformOpt = nullptr) const;
+      const Transform3D& transform = s_idTransform) const;
 
   /// SurfaceArrayCreator interface method
   ///
@@ -139,7 +139,7 @@ class SurfaceArrayCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces,
       BinningType bTypePhi = equidistant, BinningType bTypeZ = equidistant,
       std::optional<ProtoLayer> protoLayerOpt = std::nullopt,
-      const std::shared_ptr<const Transform3D>& transformOpt = nullptr) const;
+      const Transform3D& transform = s_idTransform) const;
 
   /// SurfaceArrayCreator interface method
   /// - create an array on a disc, binned in r, phi when extremas and
@@ -154,14 +154,14 @@ class SurfaceArrayCreator {
   /// @param protoLayerOpt The proto layer containing the layer size
   /// @param binsPhi is the number of bins in phi for the surfaces
   /// @param binsR is the number of bin in R for the surfaces
-  /// @param transformOpt is the (optional) additional transform applied
+  /// @param transform is the (optional) additional transform applied
   ///
   /// @return a unique pointer a new SurfaceArray
   std::unique_ptr<SurfaceArray> surfaceArrayOnDisc(
       const GeometryContext& gctx,
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsR,
       size_t binsPhi, std::optional<ProtoLayer> protoLayerOpt = std::nullopt,
-      const std::shared_ptr<const Transform3D>& transformOpt = nullptr) const;
+      const Transform3D& transform = s_idTransform) const;
 
   /// SurfaceArrayCreator interface method
   ///
@@ -177,7 +177,7 @@ class SurfaceArrayCreator {
   /// @param protoLayerOpt The proto layer containing the layer size
   /// @param bTypeR the binning type in r direction (equidistant/aribtrary)
   /// @param bTypePhi the binning type in phi direction (equidistant/aribtrary)
-  /// @param transformOpt is the (optional) additional transform applied
+  /// @param transform is the (optional) additional transform applied
   ///
   /// @return a unique pointer a new SurfaceArray
   /// @note If there is more than on R-Ring, number of phi bins
@@ -188,7 +188,7 @@ class SurfaceArrayCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces, BinningType bTypeR,
       BinningType bTypePhi,
       std::optional<ProtoLayer> protoLayerOpt = std::nullopt,
-      const std::shared_ptr<const Transform3D>& transformOpt = nullptr) const;
+      const Transform3D& transform = s_idTransform) const;
 
   /// SurfaceArrayCreator interface method
   /// - create an array on a plane
@@ -207,7 +207,7 @@ class SurfaceArrayCreator {
   /// @param [in] bValue Direction of the aligned surfaces
   /// @param [in] bTypePhi the binning type in phi direction
   /// (equidistant/aribtrary)
-  /// @param [in] transformOpt is the (optional) additional transform applied
+  /// @param [in] transform is the (optional) additional transform applied
   ///
   /// @return a unique pointer a new SurfaceArray
   std::unique_ptr<SurfaceArray> surfaceArrayOnPlane(
@@ -215,7 +215,7 @@ class SurfaceArrayCreator {
       std::vector<std::shared_ptr<const Surface>> surfaces, size_t bins1,
       size_t bins2, BinningValue bValue,
       std::optional<ProtoLayer> protoLayerOpt = std::nullopt,
-      const std::shared_ptr<const Transform3D>& transformOpt = nullptr) const;
+      const Transform3D& transform = s_idTransform) const;
 
   /// Static check funtion for surface equivalent
   ///

--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -82,34 +82,34 @@ class TrackingVolume : public Volume {
   friend class TrackingGeometry;
 
  public:
+  TrackingVolume() = delete;
   ~TrackingVolume() override;
-
   TrackingVolume(const TrackingVolume&) = delete;
-
   TrackingVolume& operator=(const TrackingVolume&) = delete;
 
   /// Factory constructor for a container TrackingVolume
   /// - by definition a Vacuum volume
   ///
-  /// @param htrans is the global 3D transform to position the volume in space
+  /// @param transform is the global 3D transform to position the volume in
+  /// space
   /// @param volumeBounds is the description of the volume boundaries
   /// @param containedVolumes are the static volumes that fill this volume
   /// @param volumeName is a string identifier
   ///
   /// @return shared pointer to a new TrackingVolume
   static MutableTrackingVolumePtr create(
-      std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volumeBounds,
+      const Transform3D& transform, VolumeBoundsPtr volumeBounds,
       const std::shared_ptr<const TrackingVolumeArray>& containedVolumes =
           nullptr,
       const std::string& volumeName = "undefined") {
-    return MutableTrackingVolumePtr(
-        new TrackingVolume(std::move(htrans), std::move(volumeBounds),
-                           containedVolumes, volumeName));
+    return MutableTrackingVolumePtr(new TrackingVolume(
+        transform, std::move(volumeBounds), containedVolumes, volumeName));
   }
 
   /// Factory constructor for Tracking Volume with a bounding volume hierarchy
   ///
-  /// @param htrans is the global 3D transform to position the volume in space
+  /// @param transform is the global 3D transform to position the volume in
+  /// space
   /// @param volBounds is the description of the volume boundaries
   /// @param boxStore Vector owning the contained bounding boxes
   /// @param descendants Vector owning the child volumes
@@ -119,21 +119,22 @@ class TrackingVolume : public Volume {
   ///
   /// @return shared pointer to a new TrackingVolume
   static MutableTrackingVolumePtr create(
-      std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volbounds,
+      const Transform3D& transform, VolumeBoundsPtr volbounds,
       std::vector<std::unique_ptr<Volume::BoundingBox>> boxStore,
       std::vector<std::unique_ptr<const Volume>> descendants,
       const Volume::BoundingBox* top,
       std::shared_ptr<const IVolumeMaterial> volumeMaterial,
       const std::string& volumeName = "undefined") {
     return MutableTrackingVolumePtr(new TrackingVolume(
-        std::move(htrans), std::move(volbounds), std::move(boxStore),
+        transform, std::move(volbounds), std::move(boxStore),
         std::move(descendants), top, std::move(volumeMaterial), volumeName));
   }
 
   /// Factory constructor for Tracking Volumes with content
   /// - can not be a container volume
   ///
-  /// @param htrans is the global 3D transform to position the volume in space
+  /// @param transform is the global 3D transform to position the volume in
+  /// space
   /// @param volumeBounds is the description of the volume boundaries
   /// @param matprop is are materials of the tracking volume
   /// @param containedLayers is the confined layer array (optional)
@@ -142,14 +143,14 @@ class TrackingVolume : public Volume {
   ///
   /// @return shared pointer to a new TrackingVolume
   static MutableTrackingVolumePtr create(
-      std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volumeBounds,
+      const Transform3D& transform, VolumeBoundsPtr volumeBounds,
       std::shared_ptr<const IVolumeMaterial> volumeMaterial,
       std::unique_ptr<const LayerArray> containedLayers = nullptr,
       std::shared_ptr<const TrackingVolumeArray> containedVolumes = nullptr,
       MutableTrackingVolumeVector denseVolumes = {},
       const std::string& volumeName = "undefined") {
     return MutableTrackingVolumePtr(new TrackingVolume(
-        std::move(htrans), std::move(volumeBounds), std::move(volumeMaterial),
+        transform, std::move(volumeBounds), std::move(volumeMaterial),
         std::move(containedLayers), std::move(containedVolumes),
         std::move(denseVolumes), volumeName));
   }
@@ -350,24 +351,20 @@ class TrackingVolume : public Volume {
   void setMotherVolume(const TrackingVolume* mvol);
 
  protected:
-  /// Default constructor
-  TrackingVolume();
-
   /// Constructor for a container Volume
   /// - vacuum filled volume either as a for other tracking volumes
   ///
-  /// @param htrans is the global 3D transform to position the volume in space
+  /// @param transform is the global 3D transform to position the volume in
+  /// space
   /// @param volbounds is the description of the volume boundaries
   /// @param containedVolumeArray are the static volumes that fill this volume
   /// @param volumeName is a string identifier
-  TrackingVolume(std::shared_ptr<const Transform3D> htrans,
-                 VolumeBoundsPtr volbounds,
+  TrackingVolume(const Transform3D& transform, VolumeBoundsPtr volbounds,
                  const std::shared_ptr<const TrackingVolumeArray>&
                      containedVolumeArray = nullptr,
                  const std::string& volumeName = "undefined");
 
-  TrackingVolume(std::shared_ptr<const Transform3D> htrans,
-                 VolumeBoundsPtr volbounds,
+  TrackingVolume(const Transform3D& transform, VolumeBoundsPtr volbounds,
                  std::vector<std::unique_ptr<Volume::BoundingBox>> boxStore,
                  std::vector<std::unique_ptr<const Volume>> descendants,
                  const Volume::BoundingBox* top,
@@ -376,7 +373,8 @@ class TrackingVolume : public Volume {
 
   /// Constructor for a full equipped Tracking Volume
   ///
-  /// @param htrans is the global 3D transform to position the volume in space
+  /// @param transform is the global 3D transform to position the volume in
+  /// space
   /// @param volumeBounds is the description of the volume boundaries
   /// @param volumeMaterial is are materials of the tracking volume
   /// @param staticLayerArray is the confined layer array (optional)
@@ -385,7 +383,7 @@ class TrackingVolume : public Volume {
   /// @param denseVolumeVector  The contained dense volumes
   /// @param volumeName is a string identifier
   TrackingVolume(
-      std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volumeBounds,
+      const Transform3D& transform, VolumeBoundsPtr volumeBounds,
       std::shared_ptr<const IVolumeMaterial> volumeMaterial,
       std::unique_ptr<const LayerArray> staticLayerArray = nullptr,
       std::shared_ptr<const TrackingVolumeArray> containedVolumeArray = nullptr,

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -88,11 +88,9 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   }
 
   TrapezoidVolumeBounds(const TrapezoidVolumeBounds& trabo) = default;
-
+  ~TrapezoidVolumeBounds() override = default;
   TrapezoidVolumeBounds& operator=(const TrapezoidVolumeBounds& trabo) =
       default;
-
-  ~TrapezoidVolumeBounds() override = default;
 
   VolumeBounds::BoundsType type() const final {
     return VolumeBounds::eTrapezoid;
@@ -123,7 +121,7 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const override;
+      const Transform3D& transform = Transform3D::Identity()) const override;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -44,7 +44,7 @@ class Volume : public virtual GeometryObject {
   /// Copy Constructor - with optional shift
   ///
   /// @param vol is the source volume for the copy
-  /// @param shift is the optional shift applied after copying
+  /// @param shift is the optional shift applied as : shift * transform
   /// @note This will automatically build an oriented bounding box with an
   /// envelope value of (0.05, 0.05, 0.05)mm
   Volume(const Volume& vol, const Transform3D& shift = Transform3D::Identity());

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -33,16 +33,13 @@ class Volume : public virtual GeometryObject {
  public:
   using BoundingBox = AxisAlignedBoundingBox<Volume, double, 3>;
 
-  Volume();
-
   /// Explicit constructor with shared arguments
   ///
-  /// @param htrans is the transform to position the volume in 3D space
+  /// @param transform is the transform to position the volume in 3D space
   /// @param volbounds is the volume boundary definitions
   /// @note This will automatically build an oriented bounding box with an
   /// envelope value of (0.05, 0.05, 0.05)mm
-  Volume(const std::shared_ptr<const Transform3D>& htrans,
-         VolumeBoundsPtr volbounds);
+  Volume(const Transform3D& transform, VolumeBoundsPtr volbounds);
 
   /// Copy Constructor - with optional shift
   ///
@@ -50,9 +47,10 @@ class Volume : public virtual GeometryObject {
   /// @param shift is the optional shift applied after copying
   /// @note This will automatically build an oriented bounding box with an
   /// envelope value of (0.05, 0.05, 0.05)mm
-  Volume(const Volume& vol, const Transform3D* shift = nullptr);
+  Volume(const Volume& vol, const Transform3D& shift = Transform3D::Identity());
 
-  virtual ~Volume();
+  Volume() = delete;
+  virtual ~Volume() = default;
 
   /// Assignment operator
   ///
@@ -99,7 +97,7 @@ class Volume : public virtual GeometryObject {
                            BinningValue bValue) const override;
 
  protected:
-  std::shared_ptr<const Transform3D> m_transform;
+  Transform3D m_transform;
   Transform3D m_itransform;
   Vector3D m_center;
   VolumeBoundsPtr m_volumeBounds;
@@ -107,10 +105,7 @@ class Volume : public virtual GeometryObject {
 };
 
 inline const Transform3D& Volume::transform() const {
-  if (m_transform) {
-    return (*(m_transform.get()));
-  }
-  return Acts::s_idTransform;
+  return m_transform;
 }
 
 inline const Transform3D& Volume::itransform() const {

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -44,7 +44,7 @@ class Volume : public virtual GeometryObject {
   /// Copy Constructor - with optional shift
   ///
   /// @param vol is the source volume for the copy
-  /// @param shift is the optional shift applied as : shift * transform
+  /// @param shift is the optional shift applied as : shift * vol.transform()
   /// @note This will automatically build an oriented bounding box with an
   /// envelope value of (0.05, 0.05, 0.05)mm
   Volume(const Volume& vol, const Transform3D& shift = Transform3D::Identity());

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -98,7 +98,7 @@ class VolumeBounds {
   ///
   /// @return a vector of surfaces bounding this volume
   virtual OrientedSurfaces orientedSurfaces(
-      const Transform3D* transform = nullptr) const = 0;
+      const Transform3D& transform = Transform3D::Identity()) const = 0;
 
   /// Construct bounding box for this shape
   /// @param trf Optional transform

--- a/Core/include/Acts/Geometry/detail/DefaultDetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/detail/DefaultDetectorElementBase.hpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// DefaultDetectorElementBase.hpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #pragma once
 
@@ -31,10 +27,7 @@ class Surface;
 ///
 class DetectorElementBase {
  public:
-  /// Constructor
   DetectorElementBase() = default;
-
-  /// Virtual Destructor
   virtual ~DetectorElementBase() = default;
 
   /// Return the transform for the Element proxy mechanism

--- a/Core/include/Acts/Geometry/detail/TrackingVolume.ipp
+++ b/Core/include/Acts/Geometry/detail/TrackingVolume.ipp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrackingVolume.ipp, Acts project
-///////////////////////////////////////////////////////////////////
-
 inline const Acts::Layer* TrackingVolume::associatedLayer(
     const GeometryContext& /*gctx*/, const Vector3D& position) const {
   // confined static layers - highest hierarchy

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -35,27 +35,27 @@ class ConeSurface : public Surface {
  protected:
   /// Constructor form HepTransform and an opening angle
   ///
-  /// @param htrans is the transform to place to cone in a 3D frame
+  /// @param transform is the transform to place to cone in a 3D frame
   /// @param alpha is the opening angle of the cone
   /// @param symmetric indicates if the cones are built to +/1 z
-  ConeSurface(std::shared_ptr<const Transform3D> htrans, double alpha,
+  ConeSurface(const Transform3D& transform, double alpha,
               bool symmetric = false);
 
   /// Constructor form HepTransform and an opening angle
   ///
-  /// @param htrans is the transform that places the cone in the global frame
+  /// @param transform is the transform that places the cone in the global frame
   /// @param alpha is the opening angle of the cone
   /// @param zmin is the z range over which the cone spans
   /// @param zmax is the z range over which the cone spans
   /// @param halfPhi is the openen angle for cone ssectors
-  ConeSurface(std::shared_ptr<const Transform3D> htrans, double alpha,
-              double zmin, double zmax, double halfPhi = M_PI);
+  ConeSurface(const Transform3D& transform, double alpha, double zmin,
+              double zmax, double halfPhi = M_PI);
 
   /// Constructor from HepTransform and ConeBounds
   ///
-  /// @param htrans is the transform that places the cone in the global frame
+  /// @param transform is the transform that places the cone in the global frame
   /// @param cbounds is the boundary class, the bounds must exit
-  ConeSurface(std::shared_ptr<const Transform3D> htrans,
+  ConeSurface(const Transform3D& transform,
               const std::shared_ptr<const ConeBounds>& cbounds);
 
   /// Copy constructor
@@ -67,9 +67,9 @@ class ConeSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transfrom applied after copying
   ConeSurface(const GeometryContext& gctx, const ConeSurface& other,
-              const Transform3D& transf);
+              const Transform3D& shift);
 
  public:
   ~ConeSurface() override = default;

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -44,7 +44,7 @@ class CylinderSurface : public Surface {
 
   /// Constructor from Transform3D and CylinderBounds
   ///
-  /// @param transform transform to position the surface
+  /// @param transform The transform to position the surface
   /// @param radius The radius of the cylinder
   /// @param halfz The half length in z
   /// @param halfphi The half opening angle
@@ -54,9 +54,7 @@ class CylinderSurface : public Surface {
 
   /// Constructor from Transform3D and CylinderBounds arguments
   ///
-  /// @param transform transform to position the surface
-  /// @note if transform == nullptr, the cylinder is positioned around
-  /// (0.,0.,0.)
+  /// @param transform The transform to position the surface
   /// @param cbounds is a shared pointer to a cylindeer bounds object,
   /// it must exist (assert test)
   CylinderSurface(const Transform3D& transform,

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -44,21 +44,22 @@ class CylinderSurface : public Surface {
 
   /// Constructor from Transform3D and CylinderBounds
   ///
-  /// @param htrans transform to position the surface, can be nullptr
+  /// @param transform transform to position the surface
   /// @param radius The radius of the cylinder
   /// @param halfz The half length in z
   /// @param halfphi The half opening angle
   /// @param avphi The phi value from which the opening angle spans (both sides)
-  CylinderSurface(std::shared_ptr<const Transform3D> htrans, double radius,
-                  double halfz, double halfphi = M_PI, double avphi = 0.);
+  CylinderSurface(const Transform3D& transform, double radius, double halfz,
+                  double halfphi = M_PI, double avphi = 0.);
 
   /// Constructor from Transform3D and CylinderBounds arguments
   ///
-  /// @param htrans transform to position the surface, can be nullptr
-  /// @note if htrans == nullptr, the cylinder is positioned around (0.,0.,0.)
+  /// @param transform transform to position the surface
+  /// @note if transform == nullptr, the cylinder is positioned around
+  /// (0.,0.,0.)
   /// @param cbounds is a shared pointer to a cylindeer bounds object,
   /// it must exist (assert test)
-  CylinderSurface(std::shared_ptr<const Transform3D> htrans,
+  CylinderSurface(const Transform3D& transform,
                   const std::shared_ptr<const CylinderBounds>& cbounds);
 
   /// Copy constructor
@@ -70,9 +71,9 @@ class CylinderSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transfrom applied after copying
   CylinderSurface(const GeometryContext& gctx, const CylinderSurface& other,
-                  const Transform3D& transf);
+                  const Transform3D& shift);
 
  public:
   ~CylinderSurface() override = default;

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -48,36 +48,33 @@ class DiscSurface : public Surface {
  protected:
   /// Constructor for Discs from Transform3D, \f$ r_{min}, r_{max} \f$
   ///
-  /// @param htrans is transform that places the disc in the global 3D space
-  /// (can be nullptr)
+  /// @param transform is transform that places the disc in the global 3D space
   /// @param rmin The inner radius of the disc surface
   /// @param rmax The outer radius of the disc surface
   /// @param hphisec The opening angle of the disc surface and is optional
   ///        the default is a full disc
-  DiscSurface(std::shared_ptr<const Transform3D> htrans, double rmin,
-              double rmax, double hphisec = M_PI);
+  DiscSurface(const Transform3D& transform, double rmin, double rmax,
+              double hphisec = M_PI);
 
   /// Constructor for Discs from Transform3D, \f$ r_{min}, r_{max}, hx_{min},
   /// hx_{max} \f$
   /// This is n this case you have DiscTrapezoidBounds
   ///
-  /// @param htrans is transform that places the disc in the global 3D space
-  /// (can be nullptr)
+  /// @param transform is transform that places the disc in the global 3D space
   /// @param minhalfx The half length in x at minimal r
   /// @param maxhalfx The half length in x at maximal r
   /// @param maxR The inner radius of the disc surface
   /// @param minR The outer radius of the disc surface
   /// @param avephi The position in phi (default is 0.)
   /// @param stereo The optional stereo angle
-  DiscSurface(std::shared_ptr<const Transform3D> htrans, double minhalfx,
-              double maxhalfx, double maxR, double minR, double avephi = 0.,
-              double stereo = 0.);
+  DiscSurface(const Transform3D& transform, double minhalfx, double maxhalfx,
+              double maxR, double minR, double avephi = 0., double stereo = 0.);
 
   /// Constructor for Discs from Transform3D and shared DiscBounds
   ///
-  /// @param htrans The transform that positions the disc in global 3D
+  /// @param transform The transform that positions the disc in global 3D
   /// @param dbounds The disc bounds describing the surface coverage
-  DiscSurface(std::shared_ptr<const Transform3D> htrans,
+  DiscSurface(const Transform3D& transform,
               std::shared_ptr<const DiscBounds> dbounds = nullptr);
 
   /// Constructor from DetectorElementBase : Element proxy
@@ -96,9 +93,9 @@ class DiscSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transfrom applied after copying
   DiscSurface(const GeometryContext& gctx, const DiscSurface& other,
-              const Transform3D& transf);
+              const Transform3D& shift);
 
  public:
   ~DiscSurface() override = default;

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -34,18 +34,19 @@ class LineSurface : public Surface {
  protected:
   /// Constructor from Transform3D and bounds
   ///
-  /// @param htrans The transform that positions the surface in the global frame
+  /// @param transform The transform that positions the surface in the global
+  /// frame
   /// @param radius The straw radius
   /// @param halez The half length in z
-  LineSurface(std::shared_ptr<const Transform3D> htrans, double radius,
-              double halez);
+  LineSurface(const Transform3D& transform, double radius, double halez);
 
   /// Constructor from Transform3D and a shared bounds object
   ///
-  /// @param htrans The transform that positions the surface in the global frame
+  /// @param transform The transform that positions the surface in the global
+  /// frame
   /// @param lbounds The bounds describing the straw dimensions, can be
   /// optionally nullptr
-  LineSurface(std::shared_ptr<const Transform3D> htrans,
+  LineSurface(const Transform3D& transform,
               std::shared_ptr<const LineBounds> lbounds = nullptr);
 
   /// Constructor from DetectorElementBase : Element proxy
@@ -64,9 +65,9 @@ class LineSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transform applied after copying
   LineSurface(const GeometryContext& gctx, const LineSurface& other,
-              const Transform3D& transf);
+              const Transform3D& shift);
 
  public:
   ~LineSurface() override = default;

--- a/Core/include/Acts/Surfaces/PerigeeSurface.hpp
+++ b/Core/include/Acts/Surfaces/PerigeeSurface.hpp
@@ -32,8 +32,8 @@ class PerigeeSurface : public LineSurface {
 
   /// Constructor with a Transform - needed for tilt
   ///
-  /// @param tTransform is the transform for position and tilting
-  PerigeeSurface(std::shared_ptr<const Transform3D> tTransform);
+  /// @param transform is the transform for position and tilting
+  PerigeeSurface(const Transform3D& transform);
 
   /// Copy constructor
   ///
@@ -44,9 +44,9 @@ class PerigeeSurface : public LineSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transfrom applied after copying
   PerigeeSurface(const GeometryContext& gctx, const PerigeeSurface& other,
-                 const Transform3D& transf);
+                 const Transform3D& shift);
 
  public:
   /// Destructor - defaulted

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -36,9 +36,6 @@ class PlaneSurface : public Surface {
   friend Surface;
 
  protected:
-  /// Default Constructor - needed for persistency
-  PlaneSurface();
-
   /// Copy Constructor
   ///
   /// @param psf is the source surface for the copy
@@ -70,11 +67,12 @@ class PlaneSurface : public Surface {
   ///
   /// @param htrans transform in 3D that positions this surface
   /// @param pbounds bounds object to describe the actual surface area
-  PlaneSurface(std::shared_ptr<const Transform3D> htrans,
+  PlaneSurface(const Transform3D& htrans,
                std::shared_ptr<const PlanarBounds> pbounds = nullptr);
 
  public:
   ~PlaneSurface() override = default;
+  PlaneSurface() = delete;
 
   /// Assignment operator
   ///

--- a/Core/include/Acts/Surfaces/StrawSurface.hpp
+++ b/Core/include/Acts/Surfaces/StrawSurface.hpp
@@ -31,20 +31,19 @@ class StrawSurface : public LineSurface {
  protected:
   /// Constructor from Transform3D and bounds
   ///
-  /// @param htrans is the transform that positions the surface in the global
+  /// @param transform the transform that positions the straw in the global
   /// frame
   /// @param radius is the straw radius
   /// @param halez is the half length in z
-  StrawSurface(std::shared_ptr<const Transform3D> htrans, double radius,
-               double halez);
+  StrawSurface(const Transform3D& transform, double radius, double halez);
 
   /// Constructor from Transform3D and a shared bounds object
   ///
-  /// @param htrans is the transform that positions the surface in the global
+  /// @param transform the transform that positions the straw in the global
   /// frame
   /// @param lbounds are the bounds describing the straw dimensions, can be
   /// optionally nullptr
-  StrawSurface(std::shared_ptr<const Transform3D> htrans,
+  StrawSurface(const Transform3D& transform,
                std::shared_ptr<const LineBounds> lbounds = nullptr);
 
   /// Constructor from DetectorElementBase : Element proxy
@@ -64,9 +63,9 @@ class StrawSurface : public LineSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other is the source cone surface
-  /// @param transf is the additional transfrom applied after copying
+  /// @param shift is the additional transfrom applied after copying
   StrawSurface(const GeometryContext& gctx, const StrawSurface& other,
-               const Transform3D& transf);
+               const Transform3D& shift);
 
  public:
   ~StrawSurface() override = default;

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -94,7 +94,7 @@ class Surface : public virtual GeometryObject,
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param other Source surface for copy
-  /// @param shift Additional transform applied after copying from the source
+  /// @param shift Additional transform applied as: shift * transform
   Surface(const GeometryContext& gctx, const Surface& other,
           const Transform3D& shift);
 

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -70,9 +70,9 @@ class Surface : public virtual GeometryObject,
  protected:
   /// Constructor with Transform3D as a shared object
   ///
-  /// @param tform Transform3D positions the surface in 3D global space
+  /// @param transform Transform3D positions the surface in 3D global space
   /// @note also acts as default constructor
-  Surface(std::shared_ptr<const Transform3D> tform = nullptr);
+  Surface(const Transform3D& transform = Transform3D::Identity());
 
   /// Copy constructor
   ///
@@ -475,7 +475,7 @@ class Surface : public virtual GeometryObject,
  protected:
   /// Transform3D definition that positions
   /// (translation, rotation) the surface in global space
-  std::shared_ptr<const Transform3D> m_transform;
+  Transform3D m_transform = Transform3D::Identity();
 
   /// Pointer to the a DetectorElementBase
   const DetectorElementBase* m_associatedDetElement{nullptr};

--- a/Core/include/Acts/Surfaces/SurfaceArray.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceArray.hpp
@@ -438,7 +438,7 @@ class SurfaceArray {
   /// @param transform Optional additional transform for this SurfaceArray
   SurfaceArray(std::unique_ptr<ISurfaceGridLookup> gridLookup,
                std::vector<std::shared_ptr<const Surface>> surfaces,
-               std::shared_ptr<const Transform3D> transform = nullptr);
+               const Transform3D& transform = s_idTransform);
 
   /// @brief Constructor which takes concrete type SurfaceGridLookup
   /// @param gridLookup The grid storage. Is static casted to ISurfaceGridLookup
@@ -520,7 +520,7 @@ class SurfaceArray {
   ///       or overflow bin or out of range in any axis.
   bool isValidBin(size_t bin) const { return p_gridLookup->isValidBin(bin); }
 
-  const Transform3D& transform() const { return *m_transform; }
+  const Transform3D& transform() const { return m_transform; }
 
   /// @brief The binning values described by this surface grid lookup
   /// They are in order of the axes
@@ -543,7 +543,7 @@ class SurfaceArray {
   SurfaceVector m_surfacesRawPointers;
   // this is only used to keep info on transform applied
   // by l2g and g2l
-  std::shared_ptr<const Transform3D> m_transform;
+  Transform3D m_transform;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -19,13 +19,10 @@ inline Vector3D Surface::normal(const GeometryContext& gctx,
 
 inline const Transform3D& Surface::transform(
     const GeometryContext& gctx) const {
-  if (m_transform != nullptr) {
-    return (*(m_transform.get()));
-  }
   if (m_associatedDetElement != nullptr) {
     return m_associatedDetElement->transform(gctx);
   }
-  return s_idTransform;
+  return m_transform;
 }
 
 inline bool Surface::insideBounds(const Vector2D& lposition,

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -70,8 +70,7 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   thePlane.matrix().block(0, 3, 3, 1) = vtxPos;
 
   std::shared_ptr<PlaneSurface> planeSurface =
-      Surface::makeShared<PlaneSurface>(
-          std::make_shared<Transform3D>(thePlane));
+      Surface::makeShared<PlaneSurface>(thePlane);
 
   // Create propagator options
   auto logger = getDefaultLogger("IPEstProp", Logging::INFO);

--- a/Core/src/Geometry/AbstractVolume.cpp
+++ b/Core/src/Geometry/AbstractVolume.cpp
@@ -16,13 +16,10 @@
 #include <utility>
 
 Acts::AbstractVolume::AbstractVolume(
-    std::shared_ptr<const Transform3D> htrans,
-    std::shared_ptr<const VolumeBounds> volbounds)
-    : Volume(std::move(htrans), std::move(volbounds)) {
+    const Transform3D& transform, std::shared_ptr<const VolumeBounds> volbounds)
+    : Volume(transform, std::move(volbounds)) {
   createBoundarySurfaces();
 }
-
-Acts::AbstractVolume::~AbstractVolume() = default;
 
 const std::vector<Acts::BoundarySurfacePtr>&
 Acts::AbstractVolume::boundarySurfaces() const {
@@ -33,8 +30,7 @@ void Acts::AbstractVolume::createBoundarySurfaces() {
   using Boundary = BoundarySurfaceT<AbstractVolume>;
 
   // Transform Surfaces To BoundarySurfaces
-  auto orientedSurfaces =
-      Volume::volumeBounds().orientedSurfaces(m_transform.get());
+  auto orientedSurfaces = Volume::volumeBounds().orientedSurfaces(m_transform);
 
   m_boundarySurfaces.reserve(orientedSurfaces.size());
   for (auto& osf : orientedSurfaces) {

--- a/Core/src/Geometry/ConeLayer.cpp
+++ b/Core/src/Geometry/ConeLayer.cpp
@@ -13,13 +13,13 @@
 
 #include <utility>
 
-Acts::ConeLayer::ConeLayer(std::shared_ptr<const Transform3D> transform,
+Acts::ConeLayer::ConeLayer(const Transform3D& transform,
                            std::shared_ptr<const ConeBounds> cbounds,
                            std::unique_ptr<SurfaceArray> surfaceArray,
                            double thickness,
                            std::unique_ptr<ApproachDescriptor> ade,
                            LayerType laytyp)
-    : ConeSurface(std::move(transform), std::move(cbounds)),
+    : ConeSurface(transform, std::move(cbounds)),
       Layer(std::move(surfaceArray), thickness, std::move(ade), laytyp) {}
 
 const Acts::ConeSurface& Acts::ConeLayer::surfaceRepresentation() const {

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -85,56 +85,49 @@ Acts::ConeVolumeBounds::ConeVolumeBounds(double cylinderR, double alpha,
 }
 
 Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
-    const Transform3D* transformPtr) const {
-  // The transform - apply when given
-  Transform3D transform =
-      (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
-
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
   oSurfaces.reserve(6);
 
   // Create an inner Cone
   if (m_innerConeBounds != nullptr) {
-    auto innerConeTrans = std::make_shared<Transform3D>(
-        transform * Translation3D(0., 0., -get(eInnerOffsetZ)));
+    auto innerConeTrans =
+        transform * Translation3D(0., 0., -get(eInnerOffsetZ));
     auto innerCone =
         Surface::makeShared<ConeSurface>(innerConeTrans, m_innerConeBounds);
     oSurfaces.push_back(OrientedSurface(std::move(innerCone), forward));
   } else if (m_innerCylinderBounds != nullptr) {
     // Or alternatively the inner Cylinder
-    auto innerCylinderTrans = std::make_shared<Transform3D>(transform);
-    auto innerCylinder = Surface::makeShared<CylinderSurface>(
-        innerCylinderTrans, m_innerCylinderBounds);
+    auto innerCylinder =
+        Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(OrientedSurface(std::move(innerCylinder), forward));
   }
 
   // Create an outer Cone
   if (m_outerConeBounds != nullptr) {
-    auto outerConeTrans = std::make_shared<Transform3D>(
-        transform * Translation3D(0., 0., -get(eOuterOffsetZ)));
+    auto outerConeTrans =
+        transform * Translation3D(0., 0., -get(eOuterOffsetZ));
     auto outerCone =
         Surface::makeShared<ConeSurface>(outerConeTrans, m_outerConeBounds);
     oSurfaces.push_back(OrientedSurface(std::move(outerCone), backward));
   } else if (m_outerCylinderBounds != nullptr) {
     // or alternatively an outer Cylinder
-    auto outerCylinderTrans = std::make_shared<Transform3D>(transform);
-    auto outerCylinder = Surface::makeShared<CylinderSurface>(
-        outerCylinderTrans, m_outerCylinderBounds);
+    auto outerCylinder =
+        Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
     oSurfaces.push_back(OrientedSurface(std::move(outerCylinder), backward));
   }
 
   // Set a disc at Zmin
   if (m_negativeDiscBounds != nullptr) {
-    auto negativeDiscTrans = std::make_shared<Transform3D>(
-        transform * Translation3D(0., 0., -get(eHalfLengthZ)));
+    auto negativeDiscTrans =
+        transform * Translation3D(0., 0., -get(eHalfLengthZ));
     auto negativeDisc = Surface::makeShared<DiscSurface>(negativeDiscTrans,
                                                          m_negativeDiscBounds);
     oSurfaces.push_back(OrientedSurface(std::move(negativeDisc), forward));
   }
 
   // Set a disc at Zmax
-  auto positiveDiscTrans = std::make_shared<Transform3D>(
-      transform * Translation3D(0., 0., get(eHalfLengthZ)));
+  auto positiveDiscTrans = transform * Translation3D(0., 0., get(eHalfLengthZ));
   auto positiveDisc =
       Surface::makeShared<DiscSurface>(positiveDiscTrans, m_positiveDiscBounds);
   oSurfaces.push_back(OrientedSurface(std::move(positiveDisc), backward));
@@ -148,9 +141,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     Transform3D negSectorRelTrans{sectorRotation};
     negSectorRelTrans.prerotate(
         AngleAxis3D(get(eAveragePhi) - get(eHalfPhiSector), Vector3D::UnitZ()));
-    auto negSectorAbsTrans =
-        std::make_shared<Transform3D>(transform * negSectorRelTrans);
-
+    auto negSectorAbsTrans = transform * negSectorRelTrans;
     auto negSectorPlane =
         Surface::makeShared<PlaneSurface>(negSectorAbsTrans, m_sectorBounds);
     oSurfaces.push_back(OrientedSurface(std::move(negSectorPlane), forward));
@@ -158,9 +149,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     Transform3D posSectorRelTrans{sectorRotation};
     posSectorRelTrans.prerotate(
         AngleAxis3D(get(eAveragePhi) + get(eHalfPhiSector), Vector3D::UnitZ()));
-    auto posSectorAbsTrans =
-        std::make_shared<Transform3D>(transform * posSectorRelTrans);
-
+    auto posSectorAbsTrans = transform * posSectorRelTrans;
     auto posSectorPlane =
         Surface::makeShared<PlaneSurface>(posSectorAbsTrans, m_sectorBounds);
 

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -42,50 +42,38 @@ Acts::CuboidVolumeBounds& Acts::CuboidVolumeBounds::operator=(
 }
 
 Acts::OrientedSurfaces Acts::CuboidVolumeBounds::orientedSurfaces(
-    const Transform3D* transformPtr) const {
-  // The transform - apply when given
-  Transform3D transform =
-      (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
-
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
   oSurfaces.reserve(6);
   // Face surfaces xy -------------------------------------
   //   (1) - at negative local z
   auto sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., 0., -get(eHalfLengthZ))),
-      m_xyBounds);
+      transform * Translation3D(0., 0., -get(eHalfLengthZ)), m_xyBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (2) - at positive local z
   sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., 0., get(eHalfLengthZ))),
-      m_xyBounds);
+      transform * Translation3D(0., 0., get(eHalfLengthZ)), m_xyBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
   // Face surfaces yz -------------------------------------
   //   (3) - at negative local x
   sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(-get(eHalfLengthX), 0., 0.) * s_planeYZ),
+      transform * Translation3D(-get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (4) - at positive local x
   sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(get(eHalfLengthX), 0., 0.) * s_planeYZ),
+      transform * Translation3D(get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
   // Face surfaces zx -------------------------------------
   //   (5) - at negative local y
   sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX),
+      transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (6) - at positive local y
   sf = Surface::makeShared<PlaneSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., get(eHalfLengthY), 0.) * s_planeZX),
+      transform * Translation3D(0., get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
 

--- a/Core/src/Geometry/CuboidVolumeBuilder.cpp
+++ b/Core/src/Geometry/CuboidVolumeBuilder.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -39,11 +39,9 @@ Acts::CuboidVolumeBuilder::buildSurface(
   if (cfg.detElementConstructor) {
     surface = Surface::makeShared<PlaneSurface>(
         cfg.rBounds,
-        *(cfg.detElementConstructor(std::make_shared<const Transform3D>(trafo),
-                                    cfg.rBounds, cfg.thickness)));
+        *(cfg.detElementConstructor(trafo, cfg.rBounds, cfg.thickness)));
   } else {
-    surface = Surface::makeShared<PlaneSurface>(
-        std::make_shared<const Transform3D>(trafo), cfg.rBounds);
+    surface = Surface::makeShared<PlaneSurface>(trafo, cfg.rBounds);
   }
   surface->assignSurfaceMaterial(cfg.surMat);
   return surface;
@@ -63,10 +61,8 @@ std::shared_ptr<const Acts::Layer> Acts::CuboidVolumeBuilder::buildLayer(
   LayerCreator::Config lCfg;
   lCfg.surfaceArrayCreator = std::make_shared<const SurfaceArrayCreator>();
   LayerCreator layerCreator(lCfg);
-
   return layerCreator.planeLayer(gctx, {cfg.surface}, cfg.binsY, cfg.binsZ,
-                                 BinningValue::binX, std::nullopt,
-                                 std::make_shared<const Transform3D>(trafo));
+                                 BinningValue::binX, std::nullopt, trafo);
 }
 
 std::pair<double, double> Acts::CuboidVolumeBuilder::binningRange(
@@ -151,14 +147,14 @@ std::shared_ptr<Acts::TrackingVolume> Acts::CuboidVolumeBuilder::buildVolume(
   std::shared_ptr<TrackingVolume> trackVolume;
   if (layVec.empty()) {
     // Build TrackingVolume
-    trackVolume = TrackingVolume::create(
-        std::make_shared<const Transform3D>(trafo), bounds, cfg.volumeMaterial,
-        nullptr, nullptr, cfg.trackingVolumes, cfg.name);
+    trackVolume =
+        TrackingVolume::create(trafo, bounds, cfg.volumeMaterial, nullptr,
+                               nullptr, cfg.trackingVolumes, cfg.name);
   } else {
     // Build TrackingVolume
-    trackVolume = TrackingVolume::create(
-        std::make_shared<const Transform3D>(trafo), bounds, cfg.volumeMaterial,
-        std::move(layArr), nullptr, cfg.trackingVolumes, cfg.name);
+    trackVolume = TrackingVolume::create(trafo, bounds, cfg.volumeMaterial,
+                                         std::move(layArr), nullptr,
+                                         cfg.trackingVolumes, cfg.name);
   }
   return trackVolume;
 }
@@ -216,8 +212,8 @@ Acts::MutableTrackingVolumePtr Acts::CuboidVolumeBuilder::trackingVolume(
       new BinnedArrayXD<TrackingVolumePtr>(tapVec, std::move(bu)));
 
   // Create world volume
-  MutableTrackingVolumePtr mtvp(TrackingVolume::create(
-      std::make_shared<const Transform3D>(trafo), volume, trVolArr, "World"));
+  MutableTrackingVolumePtr mtvp(
+      TrackingVolume::create(trafo, volume, trVolArr, "World"));
 
   return mtvp;
 }

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -45,16 +45,8 @@ bool Acts::CutoutCylinderVolumeBounds::inside(const Acts::Vector3D& gpos,
 }
 
 Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
-    const Transform3D* transform) const {
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
-
-  // Transform copy
-  std::shared_ptr<const Transform3D> trf;
-  if (transform != nullptr) {
-    trf = std::make_shared<const Transform3D>(*transform);
-  } else {
-    trf = std::make_shared<const Transform3D>(Transform3D::Identity());
-  }
 
   if (get(eMinR) == 0.) {
     oSurfaces.resize(6);  // exactly six surfaces (no choke inner cover)
@@ -63,12 +55,13 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   }
 
   // Outer cylinder envelope
-  auto outer = Surface::makeShared<CylinderSurface>(trf, m_outerCylinderBounds);
+  auto outer =
+      Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.at(tubeOuterCover) = OrientedSurface(std::move(outer), backward);
 
   // Inner (cutout) cylinder envelope
   auto cutoutInner =
-      Surface::makeShared<CylinderSurface>(trf, m_cutoutCylinderBounds);
+      Surface::makeShared<CylinderSurface>(transform, m_cutoutCylinderBounds);
   oSurfaces.at(tubeInnerCover) =
       OrientedSurface(std::move(cutoutInner), forward);
 
@@ -77,44 +70,41 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   double zChoke = get(eHalfLengthZcutout) + hlChoke;
 
   if (m_innerCylinderBounds != nullptr) {
-    auto posChokeTrf = std::make_shared<const Transform3D>(
-        *trf * Translation3D(Vector3D(0, 0, zChoke)));
+    auto posChokeTrf = transform * Translation3D(Vector3D(0, 0, zChoke));
     auto posInner = Surface::makeShared<CylinderSurface>(posChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index7) = OrientedSurface(std::move(posInner), forward);
 
-    auto negChokeTrf = std::make_shared<const Transform3D>(
-        *trf * Translation3D(Vector3D(0, 0, -zChoke)));
+    auto negChokeTrf = transform * Translation3D(Vector3D(0, 0, -zChoke));
     auto negInner = Surface::makeShared<CylinderSurface>(negChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index6) = OrientedSurface(std::move(negInner), forward);
   }
 
   // Two Outer disks
-  auto posOutDiscTrf = std::make_shared<const Transform3D>(
-      *trf * Translation3D(Vector3D(0, 0, get(eHalfLengthZ))));
+  auto posOutDiscTrf =
+      transform * Translation3D(Vector3D(0, 0, get(eHalfLengthZ)));
   auto posOutDisc =
       Surface::makeShared<DiscSurface>(posOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(positiveFaceXY) =
       OrientedSurface(std::move(posOutDisc), backward);
 
-  auto negOutDiscTrf = std::make_shared<const Transform3D>(
-      *trf * Translation3D(Vector3D(0, 0, -get(eHalfLengthZ))));
-
+  auto negOutDiscTrf =
+      transform * Translation3D(Vector3D(0, 0, -get(eHalfLengthZ)));
   auto negOutDisc =
       Surface::makeShared<DiscSurface>(negOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(negativeFaceXY) =
       OrientedSurface(std::move(negOutDisc), forward);
 
   // Two Inner disks
-  auto posInDiscTrf = std::make_shared<const Transform3D>(
-      *trf * Translation3D(Vector3D(0, 0, get(eHalfLengthZcutout))));
+  auto posInDiscTrf =
+      transform * Translation3D(Vector3D(0, 0, get(eHalfLengthZcutout)));
   auto posInDisc =
       Surface::makeShared<DiscSurface>(posInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index5) = OrientedSurface(std::move(posInDisc), forward);
 
-  auto negInDiscTrf = std::make_shared<const Transform3D>(
-      *trf * Translation3D(Vector3D(0, 0, -get(eHalfLengthZcutout))));
+  auto negInDiscTrf =
+      transform * Translation3D(Vector3D(0, 0, -get(eHalfLengthZcutout)));
   auto negInDisc =
       Surface::makeShared<DiscSurface>(negInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index4) = OrientedSurface(std::move(negInDisc), backward);

--- a/Core/src/Geometry/CylinderLayer.cpp
+++ b/Core/src/Geometry/CylinderLayer.cpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// CylinderLayer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #include "Acts/Geometry/CylinderLayer.hpp"
 
@@ -23,7 +19,7 @@
 using Acts::VectorHelpers::phi;
 
 Acts::CylinderLayer::CylinderLayer(
-    const std::shared_ptr<const Transform3D>& transform,
+    const Transform3D& transform,
     const std::shared_ptr<const CylinderBounds>& cBounds,
     std::unique_ptr<SurfaceArray> surfaceArray, double thickness,
     std::unique_ptr<ApproachDescriptor> ades, LayerType laytyp)

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// CylinderVolumeBounds.cpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 
@@ -56,57 +52,48 @@ Acts::CylinderVolumeBounds::CylinderVolumeBounds(
 }
 
 Acts::OrientedSurfaces Acts::CylinderVolumeBounds::orientedSurfaces(
-    const Transform3D* transformPtr) const {
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
   oSurfaces.reserve(6);
 
-  // Set the transform
-  Transform3D transform =
-      (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
-  auto trfShared = std::make_shared<Transform3D>(transform);
-
   // [0] Bottom Disc (negative z)
   auto dSurface = Surface::makeShared<DiscSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., 0., -get(eHalfLengthZ))),
-      m_discBounds);
+      transform * Translation3D(0., 0., -get(eHalfLengthZ)), m_discBounds);
   oSurfaces.push_back(OrientedSurface(std::move(dSurface), forward));
   // [1] Top Disc (positive z)
   dSurface = Surface::makeShared<DiscSurface>(
-      std::make_shared<const Transform3D>(
-          transform * Translation3D(0., 0., get(eHalfLengthZ))),
-      m_discBounds);
+      transform * Translation3D(0., 0., get(eHalfLengthZ)), m_discBounds);
   oSurfaces.push_back(OrientedSurface(std::move(dSurface), backward));
 
   // [2] Outer Cylinder
   auto cSurface =
-      Surface::makeShared<CylinderSurface>(trfShared, m_outerCylinderBounds);
+      Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.push_back(OrientedSurface(std::move(cSurface), backward));
 
   // [3] Inner Cylinder (optional)
   if (m_innerCylinderBounds != nullptr) {
     cSurface =
-        Surface::makeShared<CylinderSurface>(trfShared, m_innerCylinderBounds);
+        Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(OrientedSurface(std::move(cSurface), forward));
   }
 
   // [4] & [5] - Sectoral planes (optional)
   if (m_sectorPlaneBounds != nullptr) {
     // sectorPlane 1 (negative phi)
-    const Transform3D* sp1Transform = new Transform3D(
+    const Transform3D sp1Transform = Transform3D(
         transform * AngleAxis3D(-get(eHalfPhiSector), Vector3D(0., 0., 1.)) *
         Translation3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.) *
         AngleAxis3D(M_PI / 2, Vector3D(1., 0., 0.)));
-    auto pSurface = Surface::makeShared<PlaneSurface>(
-        std::shared_ptr<const Transform3D>(sp1Transform), m_sectorPlaneBounds);
+    auto pSurface =
+        Surface::makeShared<PlaneSurface>(sp1Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(OrientedSurface(std::move(pSurface), forward));
     // sectorPlane 2 (positive phi)
-    const Transform3D* sp2Transform = new Transform3D(
+    const Transform3D sp2Transform = Transform3D(
         transform * AngleAxis3D(get(eHalfPhiSector), Vector3D(0., 0., 1.)) *
         Translation3D(0.5 * (get(eMinR) + get(eMaxR)), 0., 0.) *
         AngleAxis3D(-M_PI / 2, Vector3D(1., 0., 0.)));
-    pSurface = Surface::makeShared<PlaneSurface>(
-        std::shared_ptr<const Transform3D>(sp2Transform), m_sectorPlaneBounds);
+    pSurface =
+        Surface::makeShared<PlaneSurface>(sp2Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(OrientedSurface(std::move(pSurface), backward));
   }
   return oSurfaces;

--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// CylinderVolumeBuilder.cpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #include "Acts/Geometry/CylinderVolumeBuilder.hpp"
 

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -51,9 +51,8 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
     const GeometryContext& gctx, const LayerVector& layers,
     std::shared_ptr<const IVolumeMaterial> volumeMaterial,
     std::shared_ptr<const VolumeBounds> volumeBounds,
-    MutableTrackingVolumeVector mtvVector,
-    std::shared_ptr<const Transform3D> transform, const std::string& volumeName,
-    BinningType bType) const {
+    MutableTrackingVolumeVector mtvVector, const Transform3D& transform,
+    const std::string& volumeName, BinningType bType) const {
   // the final one to build / sensitive Volume / Bounds
   MutableTrackingVolumePtr tVolume = nullptr;
   // the layer array
@@ -61,9 +60,12 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
 
   // Cases are:
   // (1) volumeBounds && transform   : use both information
-  // (2) volumeBounds && !transform  : centered around 0, but with given bounds
-  // (3) !volumeBounds && transform  : estimate size from layers, use transform
-  // (4) !volumeBounds && !transform : estimate size & translation from layers
+  // (2) volumeBounds && transform==identity  : centered around 0, but with
+  // given bounds (3) !volumeBounds && transform  : estimate size from layers,
+  // use transform (4) !volumeBounds && transform==identity : estimate size &
+  // translation from layers
+  bool idTrf = transform.isApprox(s_idTransform);
+
   const CylinderVolumeBounds* cylinderBounds = nullptr;
   // this is the implementation of CylinderVolumeHelper
   if (volumeBounds) {
@@ -100,11 +102,11 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
     }
     // get the zMin/Max
     double zMin =
-        (transform ? transform->translation().z() : 0.) +
+        (not idTrf ? transform.translation().z() : 0.) +
         (cylinderBounds != nullptr
              ? -cylinderBounds->get(CylinderVolumeBounds::eHalfLengthZ)
              : 0.);
-    double zMax = (transform ? transform->translation().z() : 0.) +
+    double zMax = (not idTrf ? transform.translation().z() : 0.) +
                   (cylinderBounds != nullptr
                        ? cylinderBounds->get(CylinderVolumeBounds::eHalfLengthZ)
                        : 0.);
@@ -179,10 +181,7 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
   cBounds = new CylinderVolumeBounds(rMin, rMax, halflengthZ);
 
   // transform
-  std::shared_ptr<const Transform3D> transform =
-      (zPosition != 0) ? std::make_shared<const Transform3D>(
-                             Translation3D(0., 0., zPosition))
-                       : nullptr;
+  const Transform3D transform = Transform3D(Translation3D(0., 0., zPosition));
   // call to the creation method with Bounds & Translation3D
   return createTrackingVolume(gctx, layers, volumeMaterial,
                               VolumeBoundsPtr(cBounds), mtvVector, transform,
@@ -363,10 +362,8 @@ Acts::CylinderVolumeHelper::createContainerTrackingVolume(
   // Estimate the z - position
   double zPos = 0.5 * (zMin + zMax);
   // Create the transform from the stuff known so far
-  std::shared_ptr<const Transform3D> topVolumeTransform =
-      (std::abs(zPos) > 0.1)
-          ? std::make_shared<const Transform3D>(Translation3D(0., 0., zPos))
-          : nullptr;
+  const Transform3D topVolumeTransform =
+      Transform3D(Translation3D(0., 0., zPos));
   // Create the bounds from the information gathered so far
   CylinderVolumeBounds* topVolumeBounds =
       new CylinderVolumeBounds(rMin, rMax, 0.5 * std::abs(zMax - zMin));
@@ -411,9 +408,9 @@ Acts::CylinderVolumeHelper::createContainerTrackingVolume(
 bool Acts::CylinderVolumeHelper::estimateAndCheckDimension(
     const GeometryContext& gctx, const LayerVector& layers,
     const CylinderVolumeBounds*& cylinderVolumeBounds,
-    std::shared_ptr<const Transform3D>& transform, double& rMinClean,
-    double& rMaxClean, double& zMinClean, double& zMaxClean,
-    BinningValue& bValue, BinningType /*unused*/) const {
+    const Transform3D& transform, double& rMinClean, double& rMaxClean,
+    double& zMinClean, double& zMaxClean, BinningValue& bValue,
+    BinningType /*unused*/) const {
   // some verbose output
 
   ACTS_VERBOSE("Parsing the " << layers.size()
@@ -495,19 +492,21 @@ bool Acts::CylinderVolumeHelper::estimateAndCheckDimension(
 
   bool concentric = (zEstFromLayerEnv * zEstFromLayerEnv < 0.001);
 
+  bool idTrf = transform.isApprox(s_idTransform);
+
+  Transform3D vtransform = s_idTransform;
   // no CylinderBounds and Translation given - make it
-  if ((cylinderVolumeBounds == nullptr) && !transform) {
+  if ((cylinderVolumeBounds == nullptr) && idTrf) {
     // create the CylinderBounds from parsed layer inputs
     cylinderVolumeBounds =
         new CylinderVolumeBounds(layerRmin, layerRmax, halflengthFromLayer);
     // and the transform
-    transform = concentric ? std::make_shared<const Transform3D>(
-                                 Translation3D(0., 0., zEstFromLayerEnv))
-                           : nullptr;
-  } else if ((cylinderVolumeBounds != nullptr) && !transform && !concentric) {
-    transform = std::make_shared<const Transform3D>(
-        Translation3D(0., 0., zEstFromLayerEnv));
-  } else if (transform && (cylinderVolumeBounds == nullptr)) {
+    vtransform = concentric
+                     ? Transform3D(Translation3D(0., 0., zEstFromLayerEnv))
+                     : s_idTransform;
+  } else if ((cylinderVolumeBounds != nullptr) && idTrf && !concentric) {
+    vtransform = Transform3D(Translation3D(0., 0., zEstFromLayerEnv));
+  } else if (not idTrf && (cylinderVolumeBounds == nullptr)) {
     // create the CylinderBounds from parsed layer inputs
     cylinderVolumeBounds =
         new CylinderVolumeBounds(layerRmin, layerRmax, halflengthFromLayer);
@@ -517,7 +516,7 @@ bool Acts::CylinderVolumeHelper::estimateAndCheckDimension(
                << layerRmin << " / " << layerRmax << " / " << layerZmin << " / "
                << layerZmax);
 
-  double zFromTransform = transform ? transform->translation().z() : 0.;
+  double zFromTransform = not idTrf ? transform.translation().z() : 0.;
   ACTS_VERBOSE(
       "    -> while created bounds are (rMin/rMax/zMin/zMax) = "
       << cylinderVolumeBounds->get(CylinderVolumeBounds::eMinR) << " / "
@@ -800,12 +799,11 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
         nullptr;
 
     // the transform of the new boundary surface
-    std::shared_ptr<const Transform3D> transform = nullptr;
+    Transform3D transform = s_idTransform;
     if (std::abs(zMin + zMax) > 0.1) {
       // it's not a concentric cylinder, so create a transform
-      auto pTransform = std::make_shared<const Transform3D>(
-          Translation3D(Vector3D(0., 0., 0.5 * (zMin + zMax))));
-      transform = pTransform;
+      transform =
+          Transform3D(Translation3D(Vector3D(0., 0., 0.5 * (zMin + zMax))));
     }
     // 2 cases: r-Binning and zBinning
     if (faceOne == cylinderCover || faceOne == tubeOuterCover) {
@@ -831,8 +829,7 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
           &tvolOne->volumeBounds());
       double zPos = tvolOne->center().z();
       double zHL = cylVolBounds->get(CylinderVolumeBounds::eHalfLengthZ);
-      transform =
-          std::make_shared<const Transform3D>(Translation3D(0, 0, zPos + zHL));
+      transform = Transform3D(Translation3D(0, 0, zPos + zHL));
       // this puts the surface on the positive z side of the cyl vol bounds
       // iteration is from neg to pos, so it should always be in between.
 
@@ -936,10 +933,7 @@ Acts::CylinderVolumeHelper::createCylinderLayer(double z, double r,
   ACTS_VERBOSE("Creating a CylinderLayer at position " << z << " and radius "
                                                        << r);
   // positioning
-  std::shared_ptr<const Transform3D> transform =
-      (std::abs(z) > 0.1)
-          ? std::make_shared<const Transform3D>(Translation3D(0., 0., z))
-          : nullptr;
+  const Transform3D transform(Translation3D(0., 0., z));
 
   // z-binning
   BinUtility layerBinUtility(binsZ, z - halflengthZ, z + halflengthZ, open,
@@ -975,10 +969,7 @@ std::shared_ptr<const Acts::Layer> Acts::CylinderVolumeHelper::createDiscLayer(
                                                    << rMin << " / " << rMax);
 
   // positioning
-  std::shared_ptr<const Transform3D> transform =
-      (std::abs(z) > 0.1)
-          ? std::make_shared<const Transform3D>(Translation3D(0., 0., z))
-          : nullptr;
+  const Transform3D transform(Translation3D(0., 0., z));
 
   // R is the primary binning for the material
   BinUtility materialBinUtility(binsR, rMin, rMax, open, binR);

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -59,11 +59,13 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
   std::unique_ptr<const LayerArray> layerArray = nullptr;
 
   // Cases are:
-  // (1) volumeBounds && transform   : use both information
-  // (2) volumeBounds && transform==identity  : centered around 0, but with
-  // given bounds (3) !volumeBounds && transform  : estimate size from layers,
-  // use transform (4) !volumeBounds && transform==identity : estimate size &
-  // translation from layers
+  // (1) volumeBounds && transform : use both information
+  // (2) volumeBounds && transform==identity : centered around 0, but with
+  //     given bounds 
+  // (3) !volumeBounds && transform : estimate size from layers,
+  //     use transform 
+  // (4) !volumeBounds && transform==identity : estimate size &
+  //     translation from layers
   bool idTrf = transform.isApprox(s_idTransform);
 
   const CylinderVolumeBounds* cylinderBounds = nullptr;

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -61,9 +61,9 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
   // Cases are:
   // (1) volumeBounds && transform : use both information
   // (2) volumeBounds && transform==identity : centered around 0, but with
-  //     given bounds
+  //     given bounds 
   // (3) !volumeBounds && transform : estimate size from layers,
-  //     use transform
+  //     use transform 
   // (4) !volumeBounds && transform==identity : estimate size &
   //     translation from layers
   bool idTrf = transform.isApprox(s_idTransform);

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -61,9 +61,9 @@ Acts::CylinderVolumeHelper::createTrackingVolume(
   // Cases are:
   // (1) volumeBounds && transform : use both information
   // (2) volumeBounds && transform==identity : centered around 0, but with
-  //     given bounds 
+  //     given bounds
   // (3) !volumeBounds && transform : estimate size from layers,
-  //     use transform 
+  //     use transform
   // (4) !volumeBounds && transform==identity : estimate size &
   //     translation from layers
   bool idTrf = transform.isApprox(s_idTransform);

--- a/Core/src/Geometry/DiscLayer.cpp
+++ b/Core/src/Geometry/DiscLayer.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// DiscLayer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/DiscLayer.hpp"
 
 #include "Acts/Geometry/AbstractVolume.hpp"
@@ -25,7 +21,7 @@
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
-Acts::DiscLayer::DiscLayer(const std::shared_ptr<const Transform3D>& transform,
+Acts::DiscLayer::DiscLayer(const Transform3D& transform,
                            const std::shared_ptr<const DiscBounds>& dbounds,
                            std::unique_ptr<SurfaceArray> surfaceArray,
                            double thickness,

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -56,7 +56,7 @@ bool Acts::GenericCuboidVolumeBounds::inside(const Acts::Vector3D& gpos,
 }
 
 Acts::OrientedSurfaces Acts::GenericCuboidVolumeBounds::orientedSurfaces(
-    const Transform3D* transform) const {
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
 
   // approximate cog of the volume
@@ -100,13 +100,8 @@ Acts::OrientedSurfaces Acts::GenericCuboidVolumeBounds::orientedSurfaces(
                                     {d_l.x(), d_l.y()}});
 
     auto polyBounds = std::make_shared<const ConvexPolygonBounds<4>>(vertices);
-
-    auto srfTrf = std::make_shared<Transform3D>(vol2srf.inverse());
-    if (transform != nullptr) {
-      *srfTrf = (*transform) * (*srfTrf);
-    }
-
-    auto srf = Surface::makeShared<PlaneSurface>(std::move(srfTrf), polyBounds);
+    auto srfTrf = transform * vol2srf.inverse();
+    auto srf = Surface::makeShared<PlaneSurface>(srfTrf, polyBounds);
 
     oSurfaces.push_back(OrientedSurface(std::move(srf), nDir));
   };

--- a/Core/src/Geometry/LayerArrayCreator.cpp
+++ b/Core/src/Geometry/LayerArrayCreator.cpp
@@ -224,16 +224,11 @@ std::shared_ptr<Acts::Surface> Acts::LayerArrayCreator::createNavigationSurface(
         dynamic_cast<const CylinderBounds*>(&(layerSurface.bounds()));
     double navigationR = cBounds->get(CylinderBounds::eR) + offset;
     double halflengthZ = cBounds->get(CylinderBounds::eHalfLengthZ);
-    // create the new layer surface
-    std::shared_ptr<const Transform3D> navTrasform =
-        (!layerSurface.transform(gctx).isApprox(s_idTransform))
-            ? std::make_shared<const Transform3D>(layerSurface.transform(gctx))
-            : nullptr;
     // new navigation layer
     auto cylinderBounds =
         std::make_shared<CylinderBounds>(navigationR, halflengthZ);
-    navigationSurface =
-        Surface::makeShared<CylinderSurface>(navTrasform, cylinderBounds);
+    navigationSurface = Surface::makeShared<CylinderSurface>(
+        layerSurface.transform(gctx), cylinderBounds);
   } else {
     ACTS_WARNING("Not implemented.");
   }

--- a/Core/src/Geometry/PassiveLayerBuilder.cpp
+++ b/Core/src/Geometry/PassiveLayerBuilder.cpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// PassiveLayerBuilder.cpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #include "Acts/Geometry/PassiveLayerBuilder.hpp"
 
@@ -70,12 +66,11 @@ const Acts::LayerVector Acts::PassiveLayerBuilder::endcapLayers(
           std::make_shared<const RadialBounds>(m_cfg.posnegLayerRmin.at(ipnl),
                                                m_cfg.posnegLayerRmax.at(ipnl));
       // create the layer transforms
-      const Transform3D* eTransform = new Transform3D(
+      const Transform3D eTransform(
           Translation3D(0., 0., side * m_cfg.posnegLayerPositionZ.at(ipnl)));
       // create the layers
       MutableLayerPtr eLayer = DiscLayer::create(
-          std::shared_ptr<const Transform3D>(eTransform), dBounds, nullptr,
-          m_cfg.posnegLayerThickness.at(ipnl));
+          eTransform, dBounds, nullptr, m_cfg.posnegLayerThickness.at(ipnl));
 
       // assign the material to the layer surface
       std::shared_ptr<const ISurfaceMaterial> material = nullptr;
@@ -114,7 +109,7 @@ const Acts::LayerVector Acts::PassiveLayerBuilder::centralLayers(
           m_cfg.centralLayerRadii[icl], m_cfg.centralLayerHalflengthZ.at(icl));
       // create the layer
       MutableLayerPtr cLayer = CylinderLayer::create(
-          nullptr, cBounds, nullptr, m_cfg.centralLayerThickness.at(icl));
+          s_idTransform, cBounds, nullptr, m_cfg.centralLayerThickness.at(icl));
       // assign the material to the layer surface
       std::shared_ptr<const ISurfaceMaterial> material = nullptr;
       // create the material from jobOptions

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// PlaneLayer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 // Geometry module
 #include "Acts/Geometry/PlaneLayer.hpp"
 
@@ -19,13 +15,13 @@
 
 #include <utility>
 
-Acts::PlaneLayer::PlaneLayer(std::shared_ptr<const Transform3D> transform,
+Acts::PlaneLayer::PlaneLayer(const Transform3D& transform,
                              std::shared_ptr<const PlanarBounds>& pbounds,
                              std::unique_ptr<SurfaceArray> surfaceArray,
                              double thickness,
                              std::unique_ptr<ApproachDescriptor> ades,
                              LayerType laytyp)
-    : PlaneSurface(std::move(transform), pbounds),
+    : PlaneSurface(transform, pbounds),
       Layer(std::move(surfaceArray), thickness, std::move(ades), laytyp) {
   // @todo create representing volume
   // register the layer to the surface
@@ -61,19 +57,17 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   const Vector3D& lCenter = PlaneSurface::center(GeometryContext());
   const Vector3D& lVector = Surface::normal(GeometryContext(), lCenter);
   // create new surfaces
-  const Transform3D* apnTransform = new Transform3D(
+  const Transform3D apnTransform = Transform3D(
       Translation3D(lCenter - 0.5 * Layer::m_layerThickness * lVector) *
       lRotation);
-  const Transform3D* appTransform = new Transform3D(
+  const Transform3D appTransform = Transform3D(
       Translation3D(lCenter + 0.5 * Layer::m_layerThickness * lVector) *
       lRotation);
   // create the new surfaces
   aSurfaces.push_back(Surface::makeShared<Acts::PlaneSurface>(
-      std::shared_ptr<const Transform3D>(apnTransform),
-      PlaneSurface::m_bounds));
+      apnTransform, PlaneSurface::m_bounds));
   aSurfaces.push_back(Surface::makeShared<Acts::PlaneSurface>(
-      std::shared_ptr<const Transform3D>(appTransform),
-      PlaneSurface::m_bounds));
+      appTransform, PlaneSurface::m_bounds));
   // set the layer and make TrackingGeometry
   for (auto& sfPtr : aSurfaces) {
     auto mutableSf = const_cast<Surface*>(sfPtr.get());

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -31,7 +31,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsPhi,
     size_t binsZ, std::optional<ProtoLayer> protoLayerOpt,
-    const std::shared_ptr<const Transform3D>& transformOpt) const {
+    const Transform3D& transform) const {
   std::vector<const Surface*> surfacesRaw = unpack_shared_vector(surfaces);
   // Check if we have proto layer, else build it
   ProtoLayer protoLayer =
@@ -42,20 +42,18 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
   ACTS_VERBOSE(" -- with phi x z  = " << binsPhi << " x " << binsZ << " = "
                                       << binsPhi * binsZ << " bins.");
 
-  Transform3D transform =
-      transformOpt != nullptr ? *transformOpt : Transform3D::Identity();
-
+  Transform3D ftransform = transform;
   ProtoAxis pAxisPhi = createEquidistantAxis(gctx, surfacesRaw, binPhi,
-                                             protoLayer, transform, binsPhi);
+                                             protoLayer, ftransform, binsPhi);
   ProtoAxis pAxisZ = createEquidistantAxis(gctx, surfacesRaw, binZ, protoLayer,
-                                           transform, binsZ);
+                                           ftransform, binsZ);
 
   double R = protoLayer.medium(binR, true);
 
-  Transform3D itransform = transform.inverse();
+  Transform3D itransform = ftransform.inverse();
   // Transform lambda captures the transform matrix
-  auto globalToLocal = [transform](const Vector3D& pos) {
-    Vector3D loc = transform * pos;
+  auto globalToLocal = [ftransform](const Vector3D& pos) {
+    Vector3D loc = ftransform * pos;
     return Vector2D(phi(loc), loc.z());
   };
   auto localToGlobal = [itransform, R](const Vector2D& loc) {
@@ -71,9 +69,8 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
 
-  return std::make_unique<SurfaceArray>(
-      std::move(sl), std::move(surfaces),
-      std::make_shared<const Transform3D>(transform));
+  return std::make_unique<SurfaceArray>(std::move(sl), std::move(surfaces),
+                                        ftransform);
 }
 
 std::unique_ptr<Acts::SurfaceArray>
@@ -81,37 +78,38 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, BinningType bTypePhi,
     BinningType bTypeZ, std::optional<ProtoLayer> protoLayerOpt,
-    const std::shared_ptr<const Transform3D>& transformOpt) const {
+    const Transform3D& transform) const {
   std::vector<const Surface*> surfacesRaw = unpack_shared_vector(surfaces);
   // check if we have proto layer, else build it
   ProtoLayer protoLayer =
       protoLayerOpt ? *protoLayerOpt : ProtoLayer(gctx, surfacesRaw);
 
   double R = protoLayer.medium(binR, true);
-  Transform3D transform =
-      transformOpt != nullptr ? *transformOpt : Transform3D::Identity();
 
   ProtoAxis pAxisPhi;
   ProtoAxis pAxisZ;
 
+  Transform3D ftransform = transform;
+
   if (bTypePhi == equidistant) {
     pAxisPhi = createEquidistantAxis(gctx, surfacesRaw, binPhi, protoLayer,
-                                     transform, 0);
+                                     ftransform, 0);
   } else {
     pAxisPhi =
-        createVariableAxis(gctx, surfacesRaw, binPhi, protoLayer, transform);
+        createVariableAxis(gctx, surfacesRaw, binPhi, protoLayer, ftransform);
   }
 
   if (bTypeZ == equidistant) {
     pAxisZ =
-        createEquidistantAxis(gctx, surfacesRaw, binZ, protoLayer, transform);
+        createEquidistantAxis(gctx, surfacesRaw, binZ, protoLayer, ftransform);
   } else {
-    pAxisZ = createVariableAxis(gctx, surfacesRaw, binZ, protoLayer, transform);
+    pAxisZ =
+        createVariableAxis(gctx, surfacesRaw, binZ, protoLayer, ftransform);
   }
 
-  Transform3D itransform = transform.inverse();
-  auto globalToLocal = [transform](const Vector3D& pos) {
-    Vector3D loc = transform * pos;
+  Transform3D itransform = ftransform.inverse();
+  auto globalToLocal = [ftransform](const Vector3D& pos) {
+    Vector3D loc = ftransform * pos;
     return Vector2D(phi(loc), loc.z());
   };
   auto localToGlobal = [itransform, R](const Vector2D& loc) {
@@ -137,9 +135,8 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
   ACTS_VERBOSE(" -- with phi x z  = " << bins0 << " x " << bins1 << " = "
                                       << bins0 * bins1 << " bins.");
 
-  return std::make_unique<SurfaceArray>(
-      std::move(sl), std::move(surfaces),
-      std::make_shared<const Transform3D>(transform));
+  return std::make_unique<SurfaceArray>(std::move(sl), std::move(surfaces),
+                                        ftransform);
 }
 
 std::unique_ptr<Acts::SurfaceArray>
@@ -147,7 +144,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, size_t binsR,
     size_t binsPhi, std::optional<ProtoLayer> protoLayerOpt,
-    const std::shared_ptr<const Transform3D>& transformOpt) const {
+    const Transform3D& transform) const {
   std::vector<const Surface*> surfacesRaw = unpack_shared_vector(surfaces);
   // check if we have proto layer, else build it
   ProtoLayer protoLayer =
@@ -155,21 +152,19 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
 
   ACTS_VERBOSE("Creating a SurfaceArray on a disc");
 
-  Transform3D transform =
-      transformOpt != nullptr ? *transformOpt : Transform3D::Identity();
-
+  Transform3D ftransform = transform;
   ProtoAxis pAxisR = createEquidistantAxis(gctx, surfacesRaw, binR, protoLayer,
-                                           transform, binsR);
+                                           ftransform, binsR);
   ProtoAxis pAxisPhi = createEquidistantAxis(gctx, surfacesRaw, binPhi,
-                                             protoLayer, transform, binsPhi);
+                                             protoLayer, ftransform, binsPhi);
 
   double Z = protoLayer.medium(binZ, true);
   ACTS_VERBOSE("- z-position of disk estimated as " << Z);
 
   Transform3D itransform = transform.inverse();
   // transform lambda captures the transform matrix
-  auto globalToLocal = [transform](const Vector3D& pos) {
-    Vector3D loc = transform * pos;
+  auto globalToLocal = [ftransform](const Vector3D& pos) {
+    Vector3D loc = ftransform * pos;
     return Vector2D(perp(loc), phi(loc));
   };
   auto localToGlobal = [itransform, Z](const Vector2D& loc) {
@@ -193,9 +188,8 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
 
-  return std::make_unique<SurfaceArray>(
-      std::move(sl), std::move(surfaces),
-      std::make_shared<const Transform3D>(transform));
+  return std::make_unique<SurfaceArray>(std::move(sl), std::move(surfaces),
+                                        ftransform);
 }
 
 std::unique_ptr<Acts::SurfaceArray>
@@ -203,7 +197,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, BinningType bTypeR,
     BinningType bTypePhi, std::optional<ProtoLayer> protoLayerOpt,
-    const std::shared_ptr<const Transform3D>& transformOpt) const {
+    const Transform3D& transform) const {
   std::vector<const Surface*> surfacesRaw = unpack_shared_vector(surfaces);
   // check if we have proto layer, else build it
   ProtoLayer protoLayer =
@@ -211,17 +205,17 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
 
   ACTS_VERBOSE("Creating a SurfaceArray on a disc");
 
-  Transform3D transform =
-      transformOpt != nullptr ? *transformOpt : Transform3D::Identity();
-
   ProtoAxis pAxisPhi;
   ProtoAxis pAxisR;
 
+  Transform3D ftransform = transform;
+
   if (bTypeR == equidistant) {
     pAxisR =
-        createEquidistantAxis(gctx, surfacesRaw, binR, protoLayer, transform);
+        createEquidistantAxis(gctx, surfacesRaw, binR, protoLayer, ftransform);
   } else {
-    pAxisR = createVariableAxis(gctx, surfacesRaw, binR, protoLayer, transform);
+    pAxisR =
+        createVariableAxis(gctx, surfacesRaw, binR, protoLayer, ftransform);
   }
 
   // if we have more than one R ring, we need to figure out
@@ -257,26 +251,26 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
     size_t nBinsPhi =
         (*std::min_element(nPhiModules.begin(), nPhiModules.end()));
     pAxisPhi = createEquidistantAxis(gctx, surfacesRaw, binPhi, protoLayer,
-                                     transform, nBinsPhi);
+                                     ftransform, nBinsPhi);
 
   } else {
     // use regular determination
     if (bTypePhi == equidistant) {
       pAxisPhi = createEquidistantAxis(gctx, surfacesRaw, binPhi, protoLayer,
-                                       transform, 0);
+                                       ftransform, 0);
     } else {
       pAxisPhi =
-          createVariableAxis(gctx, surfacesRaw, binPhi, protoLayer, transform);
+          createVariableAxis(gctx, surfacesRaw, binPhi, protoLayer, ftransform);
     }
   }
 
   double Z = protoLayer.medium(binZ, true);
   ACTS_VERBOSE("- z-position of disk estimated as " << Z);
 
-  Transform3D itransform = transform.inverse();
+  Transform3D itransform = ftransform.inverse();
   // transform lambda captures the transform matrix
-  auto globalToLocal = [transform](const Vector3D& pos) {
-    Vector3D loc = transform * pos;
+  auto globalToLocal = [ftransform](const Vector3D& pos) {
+    Vector3D loc = ftransform * pos;
     return Vector2D(perp(loc), phi(loc));
   };
   auto localToGlobal = [itransform, Z](const Vector2D& loc) {
@@ -301,9 +295,8 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
 
-  return std::make_unique<SurfaceArray>(
-      std::move(sl), std::move(surfaces),
-      std::make_shared<const Transform3D>(transform));
+  return std::make_unique<SurfaceArray>(std::move(sl), std::move(surfaces),
+                                        ftransform);
 }
 
 /// SurfaceArrayCreator interface method - create an array on a plane
@@ -312,7 +305,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
     const GeometryContext& gctx,
     std::vector<std::shared_ptr<const Surface>> surfaces, size_t bins1,
     size_t bins2, BinningValue bValue, std::optional<ProtoLayer> protoLayerOpt,
-    const std::shared_ptr<const Transform3D>& transformOpt) const {
+    const Transform3D& transform) const {
   std::vector<const Surface*> surfacesRaw = unpack_shared_vector(surfaces);
   // check if we have proto layer, else build it
   ProtoLayer protoLayer =
@@ -322,14 +315,11 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
   ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
   ACTS_VERBOSE(" -- with " << bins1 << " x " << bins2 << " = " << bins1 * bins2
                            << " bins.");
-  // Transformation
-  Transform3D transform =
-      transformOpt != nullptr ? *transformOpt : Transform3D::Identity();
-
+  Transform3D ftransform = transform;
   Transform3D itransform = transform.inverse();
   // transform lambda captures the transform matrix
-  auto globalToLocal = [transform](const Vector3D& pos) {
-    Vector3D loc = transform * pos;
+  auto globalToLocal = [ftransform](const Vector3D& pos) {
+    Vector3D loc = ftransform * pos;
     return Vector2D(loc.x(), loc.y());
   };
   auto localToGlobal = [itransform](const Vector2D& loc) {
@@ -342,9 +332,9 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
   switch (bValue) {
     case BinningValue::binX: {
       ProtoAxis pAxis1 = createEquidistantAxis(gctx, surfacesRaw, binY,
-                                               protoLayer, transform, bins1);
+                                               protoLayer, ftransform, bins1);
       ProtoAxis pAxis2 = createEquidistantAxis(gctx, surfacesRaw, binZ,
-                                               protoLayer, transform, bins2);
+                                               protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<detail::AxisBoundaryType::Bound,
                                    detail::AxisBoundaryType::Bound>(
           globalToLocal, localToGlobal, pAxis1, pAxis2);
@@ -352,9 +342,9 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
     }
     case BinningValue::binY: {
       ProtoAxis pAxis1 = createEquidistantAxis(gctx, surfacesRaw, binX,
-                                               protoLayer, transform, bins1);
+                                               protoLayer, ftransform, bins1);
       ProtoAxis pAxis2 = createEquidistantAxis(gctx, surfacesRaw, binZ,
-                                               protoLayer, transform, bins2);
+                                               protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<detail::AxisBoundaryType::Bound,
                                    detail::AxisBoundaryType::Bound>(
           globalToLocal, localToGlobal, pAxis1, pAxis2);
@@ -362,9 +352,9 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
     }
     case BinningValue::binZ: {
       ProtoAxis pAxis1 = createEquidistantAxis(gctx, surfacesRaw, binX,
-                                               protoLayer, transform, bins1);
+                                               protoLayer, ftransform, bins1);
       ProtoAxis pAxis2 = createEquidistantAxis(gctx, surfacesRaw, binY,
-                                               protoLayer, transform, bins2);
+                                               protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<detail::AxisBoundaryType::Bound,
                                    detail::AxisBoundaryType::Bound>(
           globalToLocal, localToGlobal, pAxis1, pAxis2);
@@ -381,9 +371,8 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
 
-  return std::make_unique<SurfaceArray>(
-      std::move(sl), std::move(surfaces),
-      std::make_shared<const Transform3D>(transform));
+  return std::make_unique<SurfaceArray>(std::move(sl), std::move(surfaces),
+                                        ftransform);
   //!< @todo implement - take from ATLAS complex TRT builder
 }
 

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -18,19 +18,11 @@
 #include <functional>
 #include <utility>
 
-Acts::TrackingVolume::TrackingVolume()
-    : Volume(),
-      m_volumeMaterial(nullptr),
-      m_boundarySurfaces(),
-      m_confinedLayers(nullptr),
-      m_confinedVolumes(nullptr),
-      m_name("undefined") {}
-
 Acts::TrackingVolume::TrackingVolume(
-    std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volbounds,
+    const Transform3D& transform, VolumeBoundsPtr volbounds,
     const std::shared_ptr<const TrackingVolumeArray>& containedVolumeArray,
     const std::string& volumeName)
-    : Volume(std::move(htrans), std::move(volbounds)),
+    : Volume(transform, std::move(volbounds)),
       m_volumeMaterial(nullptr),
       m_boundarySurfaces(),
       m_confinedLayers(nullptr),
@@ -42,13 +34,13 @@ Acts::TrackingVolume::TrackingVolume(
 
 // constructor for arguments
 Acts::TrackingVolume::TrackingVolume(
-    std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volumeBounds,
+    const Transform3D& transform, VolumeBoundsPtr volumeBounds,
     std::shared_ptr<const IVolumeMaterial> volumeMaterial,
     std::unique_ptr<const LayerArray> staticLayerArray,
     std::shared_ptr<const TrackingVolumeArray> containedVolumeArray,
     MutableTrackingVolumeVector denseVolumeVector,
     const std::string& volumeName)
-    : Volume(std::move(htrans), std::move(volumeBounds)),
+    : Volume(transform, std::move(volumeBounds)),
       m_volumeMaterial(std::move(volumeMaterial)),
       m_confinedLayers(std::move(staticLayerArray)),
       m_confinedVolumes(std::move(containedVolumeArray)),
@@ -61,13 +53,13 @@ Acts::TrackingVolume::TrackingVolume(
 
 // constructor for arguments
 Acts::TrackingVolume::TrackingVolume(
-    std::shared_ptr<const Transform3D> htrans, VolumeBoundsPtr volbounds,
+    const Transform3D& transform, VolumeBoundsPtr volbounds,
     std::vector<std::unique_ptr<Volume::BoundingBox>> boxStore,
     std::vector<std::unique_ptr<const Volume>> descendants,
     const Volume::BoundingBox* top,
     std::shared_ptr<const IVolumeMaterial> volumeMaterial,
     const std::string& volumeName)
-    : Volume(std::move(htrans), std::move(volbounds)),
+    : Volume(transform, std::move(volbounds)),
       m_volumeMaterial(std::move(volumeMaterial)),
       m_name(volumeName),
       m_descendantVolumes(std::move(descendants)),
@@ -153,8 +145,7 @@ void Acts::TrackingVolume::createBoundarySurfaces() {
   using Boundary = BoundarySurfaceT<TrackingVolume>;
 
   // Transform Surfaces To BoundarySurfaces
-  auto orientedSurfaces =
-      Volume::volumeBounds().orientedSurfaces(m_transform.get());
+  auto orientedSurfaces = Volume::volumeBounds().orientedSurfaces(m_transform);
 
   m_boundarySurfaces.reserve(orientedSurfaces.size());
   for (auto& osf : orientedSurfaces) {

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -50,10 +50,7 @@ Acts::TrapezoidVolumeBounds::TrapezoidVolumeBounds(double minhalex,
 }
 
 Acts::OrientedSurfaces Acts::TrapezoidVolumeBounds::orientedSurfaces(
-    const Transform3D* transformPtr) const {
-  Transform3D transform =
-      (transformPtr == nullptr) ? Transform3D::Identity() : (*transformPtr);
-
+    const Transform3D& transform) const {
   OrientedSurfaces oSurfaces;
   oSurfaces.reserve(6);
 
@@ -65,14 +62,12 @@ Acts::OrientedSurfaces Acts::TrapezoidVolumeBounds::orientedSurfaces(
   Vector3D trapezoidCenter(transform.translation());
 
   //   (1) - At negative local z
-  auto nzTransform = std::make_shared<Transform3D>(
-      transform * Translation3D(0., 0., -get(eHalfLengthZ)));
+  auto nzTransform = transform * Translation3D(0., 0., -get(eHalfLengthZ));
   auto sf =
       Surface::makeShared<PlaneSurface>(nzTransform, m_faceXYTrapezoidBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (2) - At positive local z
-  auto pzTransform = std::make_shared<Transform3D>(
-      transform * Translation3D(0., 0., get(eHalfLengthZ)));
+  auto pzTransform = transform * Translation3D(0., 0., get(eHalfLengthZ));
   sf = Surface::makeShared<PlaneSurface>(pzTransform, m_faceXYTrapezoidBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
 
@@ -83,32 +78,32 @@ Acts::OrientedSurfaces Acts::TrapezoidVolumeBounds::orientedSurfaces(
   // Face surfaces yz
   // (3) - At point B, attached to beta opening angle
   Vector3D fbPosition(-get(eHalfLengthXnegY) + neghOffset, 0., 0.);
-  auto fbTransform = std::make_shared<Transform3D>(
+  auto fbTransform =
       transform * Translation3D(fbPosition) *
-      AngleAxis3D(-0.5 * M_PI + get(eBeta), Vector3D(0., 0., 1.)) * s_planeYZ);
+      AngleAxis3D(-0.5 * M_PI + get(eBeta), Vector3D(0., 0., 1.)) * s_planeYZ;
   sf =
       Surface::makeShared<PlaneSurface>(fbTransform, m_faceBetaRectangleBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
 
   // (4) - At point A, attached to alpha opening angle
   Vector3D faPosition(get(eHalfLengthXnegY) + poshOffset, 0., 0.);
-  auto faTransform = std::make_shared<Transform3D>(
+  auto faTransform =
       transform * Translation3D(faPosition) *
-      AngleAxis3D(-0.5 * M_PI + get(eAlpha), Vector3D(0., 0., 1.)) * s_planeYZ);
+      AngleAxis3D(-0.5 * M_PI + get(eAlpha), Vector3D(0., 0., 1.)) * s_planeYZ;
   sf = Surface::makeShared<PlaneSurface>(faTransform,
                                          m_faceAlphaRectangleBounds);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));
 
   // Face surfaces zx
   //   (5) - At negative local y
-  auto nxTransform = std::make_shared<Transform3D>(
-      transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX);
+  auto nxTransform =
+      transform * Translation3D(0., -get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(nxTransform,
                                          m_faceZXRectangleBoundsBottom);
   oSurfaces.push_back(OrientedSurface(std::move(sf), forward));
   //   (6) - At positive local y
-  auto pxTransform = std::make_shared<Transform3D>(
-      transform * Translation3D(topShift, get(eHalfLengthY), 0.) * s_planeZX);
+  auto pxTransform =
+      transform * Translation3D(topShift, get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(pxTransform,
                                          m_faceZXRectangleBoundsTop);
   oSurfaces.push_back(OrientedSurface(std::move(sf), backward));

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -1,14 +1,10 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-///////////////////////////////////////////////////////////////////
-// Volume.cpp, Acts project
-///////////////////////////////////////////////////////////////////
 
 #include "Acts/Geometry/Volume.hpp"
 
@@ -20,48 +16,24 @@
 
 using namespace Acts::UnitLiterals;
 
-Acts::Volume::Volume()
-    : GeometryObject(),
-      m_transform(nullptr),
-      m_center(s_origin),
-      m_volumeBounds(nullptr),
-      m_orientedBoundingBox(BoundingBox(this, {0, 0, 0}, {0, 0, 0})) {}
-
-Acts::Volume::Volume(const std::shared_ptr<const Transform3D>& htrans,
+Acts::Volume::Volume(const Transform3D& transform,
                      std::shared_ptr<const VolumeBounds> volbounds)
     : GeometryObject(),
-      m_transform(htrans),
-      m_itransform(m_transform ? m_transform->inverse()
-                               : Transform3D::Identity()),
-      m_center(s_origin),
+      m_transform(transform),
+      m_itransform(m_transform.inverse()),
+      m_center(m_transform.translation()),
       m_volumeBounds(std::move(volbounds)),
       m_orientedBoundingBox(m_volumeBounds->boundingBox(
-          nullptr, {0.05_mm, 0.05_mm, 0.05_mm}, this)) {
-  if (htrans) {
-    m_center = htrans->translation();
-  }
-}
+          nullptr, {0.05_mm, 0.05_mm, 0.05_mm}, this)) {}
 
-Acts::Volume::Volume(const Volume& vol, const Transform3D* shift)
+Acts::Volume::Volume(const Volume& vol, const Transform3D& shift)
     : GeometryObject(),
-      m_transform(vol.m_transform),
-      m_itransform(m_transform ? m_transform->inverse()
-                               : Transform3D::Identity()),
-      m_center(s_origin),
+      m_transform(shift * vol.m_transform),
+      m_itransform(m_transform.inverse()),
+      m_center(m_transform.translation()),
       m_volumeBounds(vol.m_volumeBounds),
       m_orientedBoundingBox(m_volumeBounds->boundingBox(
-          nullptr, {0.05_mm, 0.05_mm, 0.05_mm}, this)) {
-  // apply the shift if it exists
-  if (shift != nullptr) {
-    m_transform = std::make_shared<const Transform3D>(transform() * (*shift));
-    // reset inverse
-    m_itransform = m_transform->inverse();
-  }
-  // now set the center
-  m_center = transform().translation();
-}
-
-Acts::Volume::~Volume() = default;
+          nullptr, {0.05_mm, 0.05_mm, 0.05_mm}, this)) {}
 
 Acts::Vector3D Acts::Volume::binningPosition(const GeometryContext& /*gctx*/,
                                              Acts::BinningValue bValue) const {
@@ -86,9 +58,6 @@ Acts::Volume& Acts::Volume::operator=(const Acts::Volume& vol) {
 }
 
 bool Acts::Volume::inside(const Acts::Vector3D& gpos, double tol) const {
-  if (!m_transform) {
-    return (volumeBounds()).inside(gpos, tol);
-  }
   Acts::Vector3D posInVolFrame((transform().inverse()) * gpos);
   return (volumeBounds()).inside(posInVolFrame, tol);
 }
@@ -100,7 +69,7 @@ std::ostream& Acts::operator<<(std::ostream& sl, const Acts::Volume& vol) {
 
 Acts::Volume::BoundingBox Acts::Volume::boundingBox(
     const Vector3D& envelope) const {
-  return m_volumeBounds->boundingBox(m_transform.get(), envelope, this);
+  return m_volumeBounds->boundingBox(&m_transform, envelope, this);
 }
 
 const Acts::Volume::BoundingBox& Acts::Volume::orientedBoundingBox() const {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -25,28 +25,25 @@ Acts::ConeSurface::ConeSurface(const ConeSurface& other)
 
 Acts::ConeSurface::ConeSurface(const GeometryContext& gctx,
                                const ConeSurface& other,
-                               const Transform3D& transf)
-    : GeometryObject(),
-      Surface(gctx, other, transf),
-      m_bounds(other.m_bounds) {}
+                               const Transform3D& shift)
+    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
 
-Acts::ConeSurface::ConeSurface(std::shared_ptr<const Transform3D> htrans,
-                               double alpha, bool symmetric)
+Acts::ConeSurface::ConeSurface(const Transform3D& transform, double alpha,
+                               bool symmetric)
     : GeometryObject(),
-      Surface(std::move(htrans)),
+      Surface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, symmetric)) {}
 
-Acts::ConeSurface::ConeSurface(std::shared_ptr<const Transform3D> htrans,
-                               double alpha, double zmin, double zmax,
-                               double halfPhi)
+Acts::ConeSurface::ConeSurface(const Transform3D& transform, double alpha,
+                               double zmin, double zmax, double halfPhi)
     : GeometryObject(),
-      Surface(std::move(htrans)),
+      Surface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, zmin, zmax, halfPhi)) {
 }
 
-Acts::ConeSurface::ConeSurface(std::shared_ptr<const Transform3D> htrans,
+Acts::ConeSurface::ConeSurface(const Transform3D& transform,
                                const std::shared_ptr<const ConeBounds>& cbounds)
-    : GeometryObject(), Surface(std::move(htrans)), m_bounds(cbounds) {
+    : GeometryObject(), Surface(transform), m_bounds(cbounds) {
   throw_assert(cbounds, "ConeBounds must not be nullptr");
 }
 
@@ -115,8 +112,7 @@ Acts::Vector3D Acts::ConeSurface::localToGlobal(
 Acts::Result<Acts::Vector2D> Acts::ConeSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& /*unused*/) const {
-  Vector3D loc3Dframe =
-      m_transform ? (transform(gctx).inverse() * position) : position;
+  Vector3D loc3Dframe = transform(gctx).inverse() * position;
   double r = loc3Dframe.z() * bounds().tanAlpha();
   if (std::abs(perp(loc3Dframe) - r) > s_onSurfaceTolerance) {
     return Result<Vector2D>::failure(SurfaceError::GlobalPositionNotOnSurface);
@@ -129,16 +125,13 @@ double Acts::ConeSurface::pathCorrection(const GeometryContext& gctx,
                                          const Vector3D& position,
                                          const Vector3D& direction) const {
   // (cos phi cos alpha, sin phi cos alpha, sgn z sin alpha)
-  Vector3D posLocal =
-      m_transform ? transform(gctx).inverse() * position : position;
+  Vector3D posLocal = transform(gctx).inverse() * position;
   double phi = VectorHelpers::phi(posLocal);
   double sgn = posLocal.z() > 0. ? -1. : +1.;
   double cosAlpha = std::cos(bounds().get(ConeBounds::eAlpha));
   double sinAlpha = std::sin(bounds().get(ConeBounds::eAlpha));
   Vector3D normalC(cos(phi) * cosAlpha, sin(phi) * cosAlpha, sgn * sinAlpha);
-  if (m_transform) {
-    normalC = transform(gctx) * normalC;
-  }
+  normalC = transform(gctx) * normalC;
   // Back to the global frame
   double cAlpha = normalC.dot(direction);
   return std::abs(1. / cAlpha);
@@ -158,19 +151,15 @@ Acts::Vector3D Acts::ConeSurface::normal(
   double sinAlpha = std::sin(bounds().get(ConeBounds::eAlpha));
   Vector3D localNormal(cos(phi) * cosAlpha, sin(phi) * cosAlpha,
                        sgn * sinAlpha);
-  return m_transform ? Vector3D(transform(gctx).linear() * localNormal)
-                     : localNormal;
+  return Vector3D(transform(gctx).linear() * localNormal);
 }
 
 Acts::Vector3D Acts::ConeSurface::normal(const GeometryContext& gctx,
                                          const Acts::Vector3D& position) const {
   // get it into the cylinder frame if needed
   // @todo respect opening angle
-  Vector3D pos3D = position;
-  if (m_transform || (m_associatedDetElement != nullptr)) {
-    pos3D = transform(gctx).inverse() * position;
-    pos3D.z() = 0;
-  }
+  Vector3D pos3D = transform(gctx).inverse() * position;
+  pos3D.z() = 0;
   return pos3D.normalized();
 }
 

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -25,15 +25,13 @@ Acts::CylinderSurface::CylinderSurface(const CylinderSurface& other)
 
 Acts::CylinderSurface::CylinderSurface(const GeometryContext& gctx,
                                        const CylinderSurface& other,
-                                       const Transform3D& transf)
-    : GeometryObject(),
-      Surface(gctx, other, transf),
-      m_bounds(other.m_bounds) {}
+                                       const Transform3D& shift)
+    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
 
-Acts::CylinderSurface::CylinderSurface(
-    std::shared_ptr<const Transform3D> htrans, double radius, double halfz,
-    double halfphi, double avphi)
-    : Surface(std::move(htrans)),
+Acts::CylinderSurface::CylinderSurface(const Transform3D& transform,
+                                       double radius, double halfz,
+                                       double halfphi, double avphi)
+    : Surface(transform),
       m_bounds(std::make_shared<const CylinderBounds>(radius, halfz, halfphi,
                                                       avphi)) {}
 
@@ -46,9 +44,9 @@ Acts::CylinderSurface::CylinderSurface(
 }
 
 Acts::CylinderSurface::CylinderSurface(
-    std::shared_ptr<const Transform3D> htrans,
+    const Transform3D& transform,
     const std::shared_ptr<const CylinderBounds>& cbounds)
-    : Surface(std::move(htrans)), m_bounds(cbounds) {
+    : Surface(transform), m_bounds(cbounds) {
   throw_assert(cbounds, "CylinderBounds must not be nullptr");
 }
 

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -28,30 +28,26 @@ Acts::DiscSurface::DiscSurface(const DiscSurface& other)
 
 Acts::DiscSurface::DiscSurface(const GeometryContext& gctx,
                                const DiscSurface& other,
-                               const Transform3D& transf)
-    : GeometryObject(),
-      Surface(gctx, other, transf),
-      m_bounds(other.m_bounds) {}
+                               const Transform3D& shift)
+    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
 
-Acts::DiscSurface::DiscSurface(std::shared_ptr<const Transform3D> htrans,
-                               double rmin, double rmax, double hphisec)
+Acts::DiscSurface::DiscSurface(const Transform3D& transform, double rmin,
+                               double rmax, double hphisec)
     : GeometryObject(),
-      Surface(std::move(htrans)),
+      Surface(std::move(transform)),
       m_bounds(std::make_shared<const RadialBounds>(rmin, rmax, hphisec)) {}
 
-Acts::DiscSurface::DiscSurface(std::shared_ptr<const Transform3D> htrans,
-                               double minhalfx, double maxhalfx, double maxR,
-                               double minR, double avephi, double stereo)
+Acts::DiscSurface::DiscSurface(const Transform3D& transform, double minhalfx,
+                               double maxhalfx, double maxR, double minR,
+                               double avephi, double stereo)
     : GeometryObject(),
-      Surface(std::move(htrans)),
+      Surface(transform),
       m_bounds(std::make_shared<const DiscTrapezoidBounds>(
           minhalfx, maxhalfx, maxR, minR, avephi, stereo)) {}
 
-Acts::DiscSurface::DiscSurface(std::shared_ptr<const Transform3D> htrans,
+Acts::DiscSurface::DiscSurface(const Transform3D& transform,
                                std::shared_ptr<const DiscBounds> dbounds)
-    : GeometryObject(),
-      Surface(std::move(htrans)),
-      m_bounds(std::move(dbounds)) {}
+    : GeometryObject(), Surface(transform), m_bounds(std::move(dbounds)) {}
 
 Acts::DiscSurface::DiscSurface(const std::shared_ptr<const DiscBounds>& dbounds,
                                const DetectorElementBase& detelement)

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -12,17 +12,15 @@
 #include <cmath>
 #include <utility>
 
-Acts::LineSurface::LineSurface(std::shared_ptr<const Transform3D> htrans,
-                               double radius, double halez)
+Acts::LineSurface::LineSurface(const Transform3D& transform, double radius,
+                               double halez)
     : GeometryObject(),
-      Surface(std::move(htrans)),
+      Surface(transform),
       m_bounds(std::make_shared<const LineBounds>(radius, halez)) {}
 
-Acts::LineSurface::LineSurface(std::shared_ptr<const Transform3D> htrans,
+Acts::LineSurface::LineSurface(const Transform3D& transform,
                                std::shared_ptr<const LineBounds> lbounds)
-    : GeometryObject(),
-      Surface(std::move(htrans)),
-      m_bounds(std::move(lbounds)) {}
+    : GeometryObject(), Surface(transform), m_bounds(std::move(lbounds)) {}
 
 Acts::LineSurface::LineSurface(const std::shared_ptr<const LineBounds>& lbounds,
                                const DetectorElementBase& detelement)
@@ -35,10 +33,8 @@ Acts::LineSurface::LineSurface(const LineSurface& other)
 
 Acts::LineSurface::LineSurface(const GeometryContext& gctx,
                                const LineSurface& other,
-                               const Transform3D& transf)
-    : GeometryObject(),
-      Surface(gctx, other, transf),
-      m_bounds(other.m_bounds) {}
+                               const Transform3D& shift)
+    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
 
 Acts::LineSurface& Acts::LineSurface::operator=(const LineSurface& other) {
   if (this != &other) {

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -13,8 +13,8 @@
 #include <utility>
 
 Acts::PerigeeSurface::PerigeeSurface(const Vector3D& gp)
-    : LineSurface(Transform3D(Translation3D(gp.x(), gp.y(), gp.z())),
-                  nullptr) {}
+    : LineSurface(Transform3D(Translation3D(gp.x(), gp.y(), gp.z())), nullptr) {
+}
 
 Acts::PerigeeSurface::PerigeeSurface(const Transform3D& transform)
     : GeometryObject(), LineSurface(transform) {}

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 
 Acts::PerigeeSurface::PerigeeSurface(const Vector3D& gp)
-    : LineSurface(Translation3D(gp.x(), gp.y(), gp.z()) * s_idTransform,
+    : LineSurface(Transform3D(Translation3D(gp.x(), gp.y(), gp.z())),
                   nullptr) {}
 
 Acts::PerigeeSurface::PerigeeSurface(const Transform3D& transform)

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -13,22 +13,19 @@
 #include <utility>
 
 Acts::PerigeeSurface::PerigeeSurface(const Vector3D& gp)
-    : LineSurface(nullptr, nullptr) {
-  Surface::m_transform = std::make_shared<const Transform3D>(
-      Translation3D(gp.x(), gp.y(), gp.z()));
-}
+    : LineSurface(Translation3D(gp.x(), gp.y(), gp.z()) * s_idTransform,
+                  nullptr) {}
 
-Acts::PerigeeSurface::PerigeeSurface(
-    std::shared_ptr<const Transform3D> tTransform)
-    : GeometryObject(), LineSurface(std::move(tTransform)) {}
+Acts::PerigeeSurface::PerigeeSurface(const Transform3D& transform)
+    : GeometryObject(), LineSurface(transform) {}
 
 Acts::PerigeeSurface::PerigeeSurface(const PerigeeSurface& other)
     : GeometryObject(), LineSurface(other) {}
 
 Acts::PerigeeSurface::PerigeeSurface(const GeometryContext& gctx,
                                      const PerigeeSurface& other,
-                                     const Transform3D& transf)
-    : GeometryObject(), LineSurface(gctx, other, transf) {}
+                                     const Transform3D& shift)
+    : GeometryObject(), LineSurface(gctx, other, shift) {}
 
 Acts::PerigeeSurface& Acts::PerigeeSurface::operator=(
     const PerigeeSurface& other) {

--- a/Core/src/Surfaces/StrawSurface.cpp
+++ b/Core/src/Surfaces/StrawSurface.cpp
@@ -17,13 +17,13 @@
 #include <iostream>
 #include <utility>
 
-Acts::StrawSurface::StrawSurface(std::shared_ptr<const Transform3D> htrans,
-                                 double radius, double halez)
-    : GeometryObject(), LineSurface(std::move(htrans), radius, halez) {}
+Acts::StrawSurface::StrawSurface(const Transform3D& transform, double radius,
+                                 double halez)
+    : GeometryObject(), LineSurface(transform, radius, halez) {}
 
-Acts::StrawSurface::StrawSurface(std::shared_ptr<const Transform3D> htrans,
+Acts::StrawSurface::StrawSurface(const Transform3D& transform,
                                  std::shared_ptr<const LineBounds> lbounds)
-    : GeometryObject(), LineSurface(std::move(htrans), std::move(lbounds)) {}
+    : GeometryObject(), LineSurface(transform, std::move(lbounds)) {}
 
 Acts::StrawSurface::StrawSurface(
     const std::shared_ptr<const LineBounds>& lbounds,
@@ -35,8 +35,8 @@ Acts::StrawSurface::StrawSurface(const Acts::StrawSurface& other)
 
 Acts::StrawSurface::StrawSurface(const GeometryContext& gctx,
                                  const StrawSurface& other,
-                                 const Transform3D& transf)
-    : GeometryObject(), LineSurface(gctx, other, transf) {}
+                                 const Transform3D& shift)
+    : GeometryObject(), LineSurface(gctx, other, shift) {}
 
 Acts::StrawSurface& Acts::StrawSurface::operator=(const StrawSurface& other) {
   if (this != &other) {

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -14,13 +14,11 @@
 #include <iostream>
 #include <utility>
 
-Acts::Surface::Surface(std::shared_ptr<const Transform3D> tform)
-    : GeometryObject(), m_transform(std::move(tform)) {}
+Acts::Surface::Surface(const Transform3D& transform)
+    : GeometryObject(), m_transform(transform) {}
 
 Acts::Surface::Surface(const DetectorElementBase& detelement)
-    : GeometryObject(),
-      m_transform(nullptr),
-      m_associatedDetElement(&detelement) {}
+    : GeometryObject(), m_associatedDetElement(&detelement) {}
 
 Acts::Surface::Surface(const Surface& other)
     : GeometryObject(other),
@@ -31,8 +29,7 @@ Acts::Surface::Surface(const Surface& other)
 Acts::Surface::Surface(const GeometryContext& gctx, const Surface& other,
                        const Transform3D& shift)
     : GeometryObject(),
-      m_transform(std::make_shared<const Transform3D>(
-          Transform3D(shift * other.transform(gctx)))),
+      m_transform(Transform3D(shift * other.transform(gctx))),
       m_associatedLayer(nullptr),
       m_surfaceMaterial(other.m_surfaceMaterial) {}
 
@@ -170,10 +167,8 @@ bool Acts::Surface::operator==(const Surface& other) const {
     return false;
   }
   // (e) compare transform values
-  if (m_transform != nullptr && other.m_transform != nullptr) {
-    if (!m_transform->isApprox(*other.m_transform, 1e-9)) {
-      return false;
-    }
+  if (!m_transform.isApprox(other.m_transform, 1e-9)) {
+    return false;
   }
   // (f) compare material
   if (m_surfaceMaterial != other.m_surfaceMaterial) {

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -29,7 +29,7 @@ Acts::Surface::Surface(const Surface& other)
 Acts::Surface::Surface(const GeometryContext& gctx, const Surface& other,
                        const Transform3D& shift)
     : GeometryObject(),
-      m_transform(Transform3D(shift * other.transform(gctx))),
+      m_transform(shift * other.transform(gctx)),
       m_associatedLayer(nullptr),
       m_surfaceMaterial(other.m_surfaceMaterial) {}
 

--- a/Core/src/Surfaces/SurfaceArray.cpp
+++ b/Core/src/Surfaces/SurfaceArray.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,11 +20,11 @@ Acts::SurfaceArray::ISurfaceGridLookup::~ISurfaceGridLookup() = default;
 Acts::SurfaceArray::SurfaceArray(
     std::unique_ptr<ISurfaceGridLookup> gridLookup,
     std::vector<std::shared_ptr<const Surface>> surfaces,
-    std::shared_ptr<const Transform3D> transform)
+    const Transform3D& transform)
     : p_gridLookup(std::move(gridLookup)),
       m_surfaces(std::move(surfaces)),
       m_surfacesRawPointers(unpack_shared_vector(m_surfaces)),
-      m_transform(std::move(transform)) {}
+      m_transform(transform) {}
 
 Acts::SurfaceArray::SurfaceArray(std::shared_ptr<const Surface> srf)
     : p_gridLookup(

--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -277,9 +277,9 @@ void Acts::GeometryView3D::drawSegmentBase(IVisualization3D& helper,
 
   // Line - draw a line
   if (thickness > 0.) {
-    auto ltransform = std::make_shared<Transform3D>(Transform3D::Identity());
-    ltransform->prerotate(lrotation);
-    ltransform->pretranslate(lcenter);
+    auto ltransform = Transform3D::Identity();
+    ltransform.prerotate(lrotation);
+    ltransform.pretranslate(lcenter);
 
     auto lbounds = std::make_shared<CylinderBounds>(thickness, hlength);
     auto line = Surface::makeShared<CylinderSurface>(ltransform, lbounds);
@@ -297,27 +297,27 @@ void Acts::GeometryView3D::drawSegmentBase(IVisualization3D& helper,
     auto plateBounds = std::make_shared<RadialBounds>(thickness, awith);
 
     if (arrows > 0) {
-      auto aetransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aetransform->prerotate(lrotation);
-      aetransform->pretranslate(end);
+      auto aetransform = Transform3D::Identity();
+      aetransform.prerotate(lrotation);
+      aetransform.pretranslate(end);
       // Arrow cone
       auto coneBounds = std::make_shared<ConeBounds>(alpha, -alength, 0.);
       auto cone = Surface::makeShared<ConeSurface>(aetransform, coneBounds);
       drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
                   viewConfig);
       // Arrow end plate
-      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aptransform->prerotate(lrotation);
-      aptransform->pretranslate(Vector3D(end - alength * direction));
+      auto aptransform = Transform3D::Identity();
+      aptransform.prerotate(lrotation);
+      aptransform.pretranslate(Vector3D(end - alength * direction));
 
       auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
       drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),
                   viewConfig);
     }
     if (arrows < 0 or arrows == 2) {
-      auto astransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      astransform->prerotate(lrotation);
-      astransform->pretranslate(start);
+      auto astransform = Transform3D::Identity();
+      astransform.prerotate(lrotation);
+      astransform.pretranslate(start);
 
       // Arrow cone
       auto coneBounds = std::make_shared<ConeBounds>(alpha, 0., alength);
@@ -325,9 +325,9 @@ void Acts::GeometryView3D::drawSegmentBase(IVisualization3D& helper,
       drawSurface(helper, *cone, GeometryContext(), Transform3D::Identity(),
                   viewConfig);
       // Arrow end plate
-      auto aptransform = std::make_shared<Transform3D>(Transform3D::Identity());
-      aptransform->prerotate(lrotation);
-      aptransform->pretranslate(Vector3D(start + alength * direction));
+      auto aptransform = Transform3D::Identity();
+      aptransform.prerotate(lrotation);
+      aptransform.pretranslate(Vector3D(start + alength * direction));
 
       auto plate = Surface::makeShared<DiscSurface>(aptransform, plateBounds);
       drawSurface(helper, *plate, GeometryContext(), Transform3D::Identity(),

--- a/Examples/Detectors/EmptyDetector/src/EmptyDetector.cpp
+++ b/Examples/Detectors/EmptyDetector/src/EmptyDetector.cpp
@@ -36,8 +36,8 @@ auto EmptyDetector::finalize(
   auto cvBounds = std::make_shared<Acts::CylinderVolumeBounds>(0.0, r, hz);
 
   // Create the world volume
-  auto worldVolume =
-      Acts::TrackingVolume::create(nullptr, cvBounds, nullptr, "EmptyCylinder");
+  auto worldVolume = Acts::TrackingVolume::create(
+      Acts::Transform3D::Identity(), cvBounds, nullptr, "EmptyCylinder");
 
   // Create the tracking geometry
   auto tgGeometry =

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerBuilder.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerBuilder.hpp
@@ -160,8 +160,7 @@ class DD4hepLayerBuilder : public ILayerBuilder {
   // Private helper function to convert the TGeo transformation matrix into
   // an Acts transformation matrix
   // @param tGeoTrans TGeo transformation matrix which should be converted
-  std::shared_ptr<const Acts::Transform3D> convertTransform(
-      const TGeoMatrix* tGeoTrans) const;
+  Acts::Transform3D convertTransform(const TGeoMatrix* tGeoTrans) const;
 };
 
 inline const std::string& DD4hepLayerBuilder::identification() const {

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepVolumeBuilder.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepVolumeBuilder.hpp
@@ -90,8 +90,7 @@ class DD4hepVolumeBuilder : public IConfinedTrackingVolumeBuilder {
   ///
   /// @param [in] tGeoTrans Transformation of the DD4hep DetElement
   /// @return Pointer to the corresponding Acts transformation
-  std::shared_ptr<const Acts::Transform3D> convertTransform(
-      const TGeoMatrix* tGeoTrans) const;
+  Acts::Transform3D convertTransform(const TGeoMatrix* tGeoTrans) const;
 };
 
 inline const std::string& DD4hepVolumeBuilder::identification() const {

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -93,12 +93,12 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
         double rMin = tube->GetRmin() * UnitConstants::cm;
         double rMax = tube->GetRmax() * UnitConstants::cm;
         double zMin =
-            (transform->translation() -
-             transform->rotation().col(2) * tube->GetDz() * UnitConstants::cm)
+            (transform.translation() -
+             transform.rotation().col(2) * tube->GetDz() * UnitConstants::cm)
                 .z();
         double zMax =
-            (transform->translation() +
-             transform->rotation().col(2) * tube->GetDz() * UnitConstants::cm)
+            (transform.translation() +
+             transform.rotation().col(2) * tube->GetDz() * UnitConstants::cm)
                 .z();
         if (zMin > zMax) {
           std::swap(zMin, zMax);
@@ -323,18 +323,16 @@ Acts::DD4hepLayerBuilder::createSensitiveSurface(
   return dd4hepDetElement->surface().getSharedPtr();
 }
 
-std::shared_ptr<const Acts::Transform3D>
-Acts::DD4hepLayerBuilder::convertTransform(const TGeoMatrix* tGeoTrans) const {
+Acts::Transform3D Acts::DD4hepLayerBuilder::convertTransform(
+    const TGeoMatrix* tGeoTrans) const {
   // get the placement and orientation in respect to its mother
   const Double_t* rotation = tGeoTrans->GetRotationMatrix();
   const Double_t* translation = tGeoTrans->GetTranslation();
-  auto transform =
-      std::make_shared<const Transform3D>(TGeoPrimitivesHelper::makeTransform(
-          Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
-          Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
-          Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
-          Acts::Vector3D(translation[0] * UnitConstants::cm,
-                         translation[1] * UnitConstants::cm,
-                         translation[2] * UnitConstants::cm)));
-  return (transform);
+  return TGeoPrimitivesHelper::makeTransform(
+      Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
+      Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
+      Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
+      Acts::Vector3D(translation[0] * UnitConstants::cm,
+                     translation[1] * UnitConstants::cm,
+                     translation[2] * UnitConstants::cm));
 }

--- a/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
@@ -82,18 +82,15 @@ Acts::DD4hepVolumeBuilder::centralVolumes() const {
   return volumes;
 }
 
-std::shared_ptr<const Acts::Transform3D>
-Acts::DD4hepVolumeBuilder::convertTransform(const TGeoMatrix* tGeoTrans) const {
+Acts::Transform3D Acts::DD4hepVolumeBuilder::convertTransform(
+    const TGeoMatrix* tGeoTrans) const {
   // Get the placement and orientation in respect to its mother
   const Double_t* rotation = tGeoTrans->GetRotationMatrix();
   const Double_t* translation = tGeoTrans->GetTranslation();
-  auto transform =
-      std::make_shared<const Transform3D>(TGeoPrimitivesHelper::makeTransform(
-          Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
-          Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
-          Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
-          Acts::Vector3D(translation[0] * UnitConstants::cm,
-                         translation[1] * UnitConstants::cm,
-                         translation[2] * UnitConstants::cm)));
-  return (transform);
+  return TGeoPrimitivesHelper::makeTransform(
+      Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
+      Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
+      Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
+      Acts::Vector3D(translation[0] * units::_cm, translation[1] * units::_cm,
+                     translation[2] * units::_cm));
 }

--- a/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
@@ -91,6 +91,6 @@ Acts::Transform3D Acts::DD4hepVolumeBuilder::convertTransform(
       Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
       Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
       Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
-      Acts::Vector3D(translation[0] * units::_cm, translation[1] * units::_cm,
-                     translation[2] * units::_cm));
+      Acts::Vector3D(translation[0] * UnitConstants::cm, translation[1] * UnitConstants::cm,
+                     translation[2] * UnitConstants::cm));
 }

--- a/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
@@ -91,6 +91,7 @@ Acts::Transform3D Acts::DD4hepVolumeBuilder::convertTransform(
       Acts::Vector3D(rotation[0], rotation[3], rotation[6]),
       Acts::Vector3D(rotation[1], rotation[4], rotation[7]),
       Acts::Vector3D(rotation[2], rotation[5], rotation[8]),
-      Acts::Vector3D(translation[0] * UnitConstants::cm, translation[1] * UnitConstants::cm,
+      Acts::Vector3D(translation[0] * UnitConstants::cm,
+                     translation[1] * UnitConstants::cm,
                      translation[2] * UnitConstants::cm));
 }

--- a/Plugins/Digitization/src/CartesianSegmentation.cpp
+++ b/Plugins/Digitization/src/CartesianSegmentation.cpp
@@ -61,21 +61,19 @@ void Acts::CartesianSegmentation::createSegmentationSurfaces(
   std::shared_ptr<const PlanarBounds> moduleBounds(
       new RectangleBounds(m_activeBounds->boundingBox()));
   // - they are separated by half a thickness in z
-  auto mutableReadoutPlaneTransform =
-      std::make_shared<Transform3D>(Transform3D::Identity());
-  auto mutableCounterPlaneTransform =
-      std::make_shared<Transform3D>(Transform3D::Identity());
+  auto readoutPlaneTransform = Transform3D::Identity();
+  auto counterPlaneTransform = Transform3D::Identity();
   // readout and counter readout bounds, the bounds of the readout plane are
   // like the active ones
   std::shared_ptr<const PlanarBounds> readoutPlaneBounds = moduleBounds;
   std::shared_ptr<const PlanarBounds> counterPlaneBounds(nullptr);
   // the transform of the readout plane is always centric
-  (*mutableReadoutPlaneTransform).translation() =
+  readoutPlaneTransform.translation() =
       Vector3D(0., 0., readoutDirection * halfThickness);
   // no lorentz angle and everything is straight-forward
   if (lorentzAngle == 0.) {
     counterPlaneBounds = moduleBounds;
-    (*mutableCounterPlaneTransform).translation() =
+    counterPlaneTransform.translation() =
         Vector3D(0., 0., -readoutDirection * halfThickness);
   } else {
     // lorentz reduced Bounds
@@ -88,14 +86,9 @@ void Acts::CartesianSegmentation::createSegmentationSurfaces(
     // now we shift the counter plane in position - this depends on lorentz
     // angle
     double counterPlaneShift = -readoutDirection * lorentzPlaneShiftX;
-    (*mutableCounterPlaneTransform).translation() =
+    counterPlaneTransform.translation() =
         Vector3D(counterPlaneShift, 0., -readoutDirection * halfThickness);
   }
-  // - finalize the transforms
-  auto readoutPlaneTransform =
-      std::const_pointer_cast<const Transform3D>(mutableReadoutPlaneTransform);
-  auto counterPlaneTransform =
-      std::const_pointer_cast<const Transform3D>(mutableCounterPlaneTransform);
   // - build the readout & counter readout surfaces
   boundarySurfaces.push_back(Surface::makeShared<PlaneSurface>(
       readoutPlaneTransform, readoutPlaneBounds));
@@ -162,8 +155,8 @@ void Acts::CartesianSegmentation::createSegmentationSurfaces(
       const RotationMatrix3D& boundaryXRotation =
           boundaryStraight ? xBinRotationMatrix : lorentzPlaneRotationMatrix;
       // build the rotation from it
-      auto boundaryXTransform = std::make_shared<const Transform3D>(
-          Translation3D(boundaryXPosition) * boundaryXRotation);
+      auto boundaryXTransform =
+          Transform3D(Translation3D(boundaryXPosition) * boundaryXRotation);
       // the correct bounds for this
       std::shared_ptr<const PlanarBounds> boundaryXBounds =
           boundaryStraight ? xBinBounds : lorentzPlaneBounds;
@@ -175,7 +168,7 @@ void Acts::CartesianSegmentation::createSegmentationSurfaces(
       // shift by the lorentz angle
       Vector3D lorentzPlanePosition(
           cPosX - readoutDirection * lorentzPlaneShiftX, 0., 0.);
-      auto lorentzPlaneTransform = std::make_shared<const Transform3D>(
+      auto lorentzPlaneTransform = Transform3D(
           Translation3D(lorentzPlanePosition) * lorentzPlaneRotationMatrix);
       // lorentz plane surfaces
       segmentationSurfacesX.push_back(Surface::makeShared<PlaneSurface>(
@@ -205,8 +198,8 @@ void Acts::CartesianSegmentation::createSegmentationSurfaces(
         -m_activeBounds->boundingBox().halfLengthY() + ibiny * pitchY;
     Vector3D binSurfaceCenter(0., binPosY, 0.);
     // the binning transform
-    auto binTransform = std::make_shared<const Transform3D>(
-        Translation3D(binSurfaceCenter) * yBinRotationMatrix);
+    auto binTransform =
+        Transform3D(Translation3D(binSurfaceCenter) * yBinRotationMatrix);
     // these are the boundaries
     if (ibiny == 0 || ibiny == m_binUtility->bins(1)) {
       boundarySurfaces.push_back(

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
@@ -94,11 +94,7 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
   /// Pointer to TGeoNode (not owned)
   const TGeoNode* m_detElement{nullptr};
   /// Transformation of the detector element
-  std::shared_ptr<const Acts::Transform3D> m_transform{nullptr};
-  /// Center position of the detector element
-  std::shared_ptr<const Vector3D> m_center{nullptr};
-  /// Normal vector to the detector element
-  std::shared_ptr<const Vector3D> m_normal{nullptr};
+  Transform3D m_transform = Transform3D::Identity();
   /// Identifier of the detector element
   Identifier m_identifier;
   /// Boundaries of the detector element
@@ -115,7 +111,7 @@ inline Identifier TGeoDetectorElement::identifier() const {
 
 inline const Transform3D& TGeoDetectorElement::transform(
     const GeometryContext& /*gctx*/) const {
-  return (*m_transform);
+  return m_transform;
 }
 
 inline const Surface& TGeoDetectorElement::surface() const {

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
@@ -35,8 +35,8 @@ struct TGeoSurfaceConverter {
   /// @param scalor The unit scalor between TGeo and Acts
   ///
   /// @return tuple of DiscBounds, Trasnform, thickness
-  static std::tuple<std::shared_ptr<const CylinderBounds>,
-                    std::shared_ptr<const Transform3D>, double>
+  static std::tuple<std::shared_ptr<const CylinderBounds>, const Transform3D,
+                    double>
   cylinderComponents(const TGeoShape& tgShape, const Double_t* rotation,
                      const Double_t* translation, const std::string& axes,
                      double scalor = 10.) noexcept(false);
@@ -50,8 +50,8 @@ struct TGeoSurfaceConverter {
   /// @param scalor The unit scalor between TGeo and Acts
   ///
   /// @return tuple of DiscBounds, Trasnform, thickness
-  static std::tuple<std::shared_ptr<const DiscBounds>,
-                    std::shared_ptr<const Transform3D>, double>
+  static std::tuple<std::shared_ptr<const DiscBounds>, const Transform3D,
+                    double>
   discComponents(const TGeoShape& tgShape, const Double_t* rotation,
                  const Double_t* translation, const std::string& axes,
                  double scalor = 10.) noexcept(false);
@@ -65,8 +65,8 @@ struct TGeoSurfaceConverter {
   /// @param scalor The unit scalor between TGeo and Acts
   ///
   /// @return tuple of PlanarBounds, Trasnform, thickness
-  static std::tuple<std::shared_ptr<const PlanarBounds>,
-                    std::shared_ptr<const Transform3D>, double>
+  static std::tuple<std::shared_ptr<const PlanarBounds>, const Transform3D,
+                    double>
   planeComponents(const TGeoShape& tgShape, const Double_t* rotation,
                   const Double_t* translation, const std::string& axes,
                   double scalor = 10.) noexcept(false);

--- a/Plugins/TGeo/src/TGeoSurfaceConverter.cpp
+++ b/Plugins/TGeo/src/TGeoSurfaceConverter.cpp
@@ -40,15 +40,15 @@
 #include "TGeoTrd2.h"
 #include "TGeoTube.h"
 
-std::tuple<std::shared_ptr<const Acts::CylinderBounds>,
-           std::shared_ptr<const Acts::Transform3D>, double>
+std::tuple<std::shared_ptr<const Acts::CylinderBounds>, const Acts::Transform3D,
+           double>
 Acts::TGeoSurfaceConverter::cylinderComponents(const TGeoShape& tgShape,
                                                const Double_t* rotation,
                                                const Double_t* translation,
                                                const std::string& axes,
                                                double scalor) noexcept(false) {
   std::shared_ptr<const CylinderBounds> bounds = nullptr;
-  std::shared_ptr<const Transform3D> transform = nullptr;
+  Transform3D transform = Transform3D::Identity();
   double thickness = 0.;
 
   // Check if it's a tube (segment)
@@ -81,9 +81,7 @@ Acts::TGeoSurfaceConverter::cylinderComponents(const TGeoShape& tgShape,
     double medR = 0.5 * (minR + maxR);
     double halfZ = tube->GetDz() * scalor;
     if (halfZ > deltaR) {
-      transform = std::make_shared<const Transform3D>(
-          TGeoPrimitivesHelper::makeTransform(ax, ay, az, t));
-
+      transform = TGeoPrimitivesHelper::makeTransform(ax, ay, az, t);
       double halfPhi = M_PI;
       double avgPhi = 0.;
       // Check if it's a segment
@@ -107,8 +105,8 @@ Acts::TGeoSurfaceConverter::cylinderComponents(const TGeoShape& tgShape,
   return {bounds, transform, thickness};
 }
 
-std::tuple<std::shared_ptr<const Acts::DiscBounds>,
-           std::shared_ptr<const Acts::Transform3D>, double>
+std::tuple<std::shared_ptr<const Acts::DiscBounds>, const Acts::Transform3D,
+           double>
 Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
                                            const Double_t* rotation,
                                            const Double_t* translation,
@@ -116,7 +114,7 @@ Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
                                            double scalor) noexcept(false) {
   using Line2D = Eigen::Hyperplane<double, 2>;
   std::shared_ptr<const DiscBounds> bounds = nullptr;
-  std::shared_ptr<const Transform3D> transform = nullptr;
+  Transform3D transform = Transform3D::Identity();
 
   double thickness = 0.;
   // Special test for composite shape of silicon
@@ -136,8 +134,7 @@ Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
     Vector3D ay(rotation[1], rotation[4], rotation[7]);
     Vector3D az(rotation[2], rotation[5], rotation[8]);
 
-    transform = std::make_shared<const Transform3D>(
-        TGeoPrimitivesHelper::makeTransform(ax, ay, az, t));
+    transform = TGeoPrimitivesHelper::makeTransform(ax, ay, az, t);
 
     auto interNode = dynamic_cast<TGeoIntersection*>(compShape->GetBoolNode());
     if (interNode != nullptr) {
@@ -192,8 +189,7 @@ Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
           const Vector2D originShift = -ix;
 
           // Update transform by prepending the origin shift translation
-          transform = std::make_shared<const Transform3D>((*transform) *
-                                                          originTranslation);
+          transform = transform * originTranslation;
           // Transform phi line point to new origin and get phi
           double phi1 =
               VectorHelpers::phi(boundLines[0].second - boundLines[0].first);
@@ -233,9 +229,7 @@ Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
       Vector3D ax = xs * Vector3D(rotation[0], rotation[3], rotation[6]);
       Vector3D ay = ys * Vector3D(rotation[1], rotation[4], rotation[7]);
       Vector3D az = ax.cross(ay);
-
-      transform = std::make_shared<const Transform3D>(
-          TGeoPrimitivesHelper::makeTransform(ax, ay, az, t));
+      transform = TGeoPrimitivesHelper::makeTransform(ax, ay, az, t);
 
       double minR = tube->GetRmin() * scalor;
       double maxR = tube->GetRmax() * scalor;
@@ -263,8 +257,8 @@ Acts::TGeoSurfaceConverter::discComponents(const TGeoShape& tgShape,
   return {bounds, transform, thickness};
 }
 
-std::tuple<std::shared_ptr<const Acts::PlanarBounds>,
-           std::shared_ptr<const Acts::Transform3D>, double>
+std::tuple<std::shared_ptr<const Acts::PlanarBounds>, const Acts::Transform3D,
+           double>
 Acts::TGeoSurfaceConverter::planeComponents(const TGeoShape& tgShape,
                                             const Double_t* rotation,
                                             const Double_t* translation,
@@ -442,8 +436,7 @@ Acts::TGeoSurfaceConverter::planeComponents(const TGeoShape& tgShape,
 
   // Create the normal vector & the transfrom
   auto cz = cx.cross(cy);
-  auto transform = std::make_shared<const Transform3D>(
-      TGeoPrimitivesHelper::makeTransform(cx, cy, cz, t));
+  auto transform = TGeoPrimitivesHelper::makeTransform(cx, cy, cz, t);
 
   return {bounds, transform, thickness};
 }

--- a/Tests/Benchmarks/SurfaceIntersectionBenchmark.cpp
+++ b/Tests/Benchmarks/SurfaceIntersectionBenchmark.cpp
@@ -49,22 +49,18 @@ Transform3D at = Transform3D::Identity() * Translation3D(0_m, 0_m, 10_m) *
 
 // Define the Plane surface
 auto rb = std::make_shared<RectangleBounds>(1_m, 1_m);
-auto aPlane = Surface::makeShared<PlaneSurface>(
-    std::make_shared<Transform3D>(at), std::move(rb));
+auto aPlane = Surface::makeShared<PlaneSurface>(at, std::move(rb));
 
 // Define the Disc surface
 auto db = std::make_shared<RadialBounds>(0.2_m, 1.2_m);
-auto aDisc = Surface::makeShared<DiscSurface>(std::make_shared<Transform3D>(at),
-                                              std::move(db));
+auto aDisc = Surface::makeShared<DiscSurface>(at, std::move(db));
 
 // Define a Cylinder surface
 auto cb = std::make_shared<CylinderBounds>(10_m, 100_m);
-auto aCylinder = Surface::makeShared<CylinderSurface>(
-    std::make_shared<Transform3D>(at), std::move(cb));
+auto aCylinder = Surface::makeShared<CylinderSurface>(at, std::move(cb));
 
 // Define a Straw surface
-auto aStraw = Surface::makeShared<StrawSurface>(
-    std::make_shared<Transform3D>(at), 50_cm, 2_m);
+auto aStraw = Surface::makeShared<StrawSurface>(at, 50_cm, 2_m);
 
 // The orgin of our attempts for plane, disc and cylinder
 Vector3D origin(0., 0., 0.);

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CubicTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CubicTrackingGeometry.hpp
@@ -83,8 +83,7 @@ struct CubicTrackingGeometry {
       trafo.translation() = translations[i];
       // Create the detector element
       auto detElement = std::make_unique<const DetectorElementStub>(
-          std::make_shared<const Transform3D>(trafo), rBounds, 1._um,
-          surfaceMaterial);
+          trafo, rBounds, 1._um, surfaceMaterial);
       // And remember the surface
       surfaces[i] = detElement->surface().getSharedPtr();
       // Add it to the event store
@@ -99,8 +98,8 @@ struct CubicTrackingGeometry {
 
       std::unique_ptr<SurfaceArray> surArray(new SurfaceArray(surfaces[i]));
 
-      layers[i] = PlaneLayer::create(std::make_shared<const Transform3D>(trafo),
-                                     rBounds, std::move(surArray), 1._mm);
+      layers[i] =
+          PlaneLayer::create(trafo, rBounds, std::move(surArray), 1._mm);
 
       auto mutableSurface = const_cast<Surface*>(surfaces[i].get());
       mutableSurface->associateLayer(*layers[i]);
@@ -124,9 +123,9 @@ struct CubicTrackingGeometry {
         geoContext, layVec, -2_m - 1._mm, -1._m + 1._mm, BinningType::arbitrary,
         BinningValue::binX));
 
-    auto trackVolume1 = TrackingVolume::create(
-        std::make_shared<const Transform3D>(trafoVol1), boundsVol, nullptr,
-        std::move(layArr1), nullptr, {}, "Volume 1");
+    auto trackVolume1 =
+        TrackingVolume::create(trafoVol1, boundsVol, nullptr,
+                               std::move(layArr1), nullptr, {}, "Volume 1");
 
     // Build volume for surfaces with positive x-values
     Transform3D trafoVol2(Transform3D::Identity());
@@ -139,9 +138,9 @@ struct CubicTrackingGeometry {
         layArrCreator.layerArray(geoContext, layVec, 1._m - 2._mm, 2._m + 2._mm,
                                  BinningType::arbitrary, BinningValue::binX));
 
-    auto trackVolume2 = TrackingVolume::create(
-        std::make_shared<const Transform3D>(trafoVol2), boundsVol, nullptr,
-        std::move(layArr2), nullptr, {}, "Volume 2");
+    auto trackVolume2 =
+        TrackingVolume::create(trafoVol2, boundsVol, nullptr,
+                               std::move(layArr2), nullptr, {}, "Volume 2");
 
     // Glue volumes
     trackVolume2->glueTrackingVolume(
@@ -173,8 +172,7 @@ struct CubicTrackingGeometry {
         new BinnedArrayXD<TrackingVolumePtr>(tapVec, std::move(bu)));
 
     MutableTrackingVolumePtr mtvpWorld(
-        TrackingVolume::create(std::make_shared<const Transform3D>(trafoWorld),
-                               worldVol, trVolArr, "World"));
+        TrackingVolume::create(trafoWorld, worldVol, trVolArr, "World"));
 
     // Build and return tracking geometry
     return std::shared_ptr<TrackingGeometry>(

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
@@ -96,13 +96,11 @@ struct CylindricalTrackingGeometry {
     for (int im = 0; im < nPhi; ++im) {
       // Get the moduleTransform
       double phi = -M_PI + im * phiStep;
-      std::shared_ptr<Transform3D> mModuleTransform =
-          std::make_shared<Transform3D>(
-              Translation3D(ringRadius * std::cos(phi),
-                            ringRadius * std::sin(phi),
-                            ringZ + (im % 2) * zStagger) *
-              AngleAxis3D(phi - 0.5 * M_PI, Vector3D::UnitZ()) *
-              AngleAxis3D(moduleTilt, Vector3D::UnitY()));
+      auto mModuleTransform = Transform3D(
+          Translation3D(ringRadius * std::cos(phi), ringRadius * std::sin(phi),
+                        ringZ + (im % 2) * zStagger) *
+          AngleAxis3D(phi - 0.5 * M_PI, Vector3D::UnitZ()) *
+          AngleAxis3D(moduleTilt, Vector3D::UnitY()));
 
       // Create the detector element
       auto detElement = std::make_unique<const DetectorElementStub>(
@@ -168,9 +166,8 @@ struct CylindricalTrackingGeometry {
       moduleRotation.col(1) = moduleLocalY;
       moduleRotation.col(2) = moduleLocalZ;
       // Get the moduleTransform
-      std::shared_ptr<Transform3D> mModuleTransform =
-          std::make_shared<Transform3D>(Translation3D(mCenter) *
-                                        moduleRotation);
+      auto mModuleTransform =
+          Transform3D(Translation3D(mCenter) * moduleRotation);
       // Create the detector element
       auto detElement = std::make_unique<const DetectorElementStub>(
           mModuleTransform, mBounds, moduleThickness, moduleMaterialPtr);
@@ -327,9 +324,9 @@ struct CylindricalTrackingGeometry {
     auto pVolumeBounds =
         std::make_shared<const CylinderVolumeBounds>(25., 300., 1100.);
     // create the Tracking volume
-    auto pVolume = TrackingVolume::create(nullptr, pVolumeBounds, nullptr,
-                                          std::move(pLayerArray), nullptr, {},
-                                          "Pixel::Barrel");
+    auto pVolume = TrackingVolume::create(
+        Transform3D::Identity(), pVolumeBounds, nullptr, std::move(pLayerArray),
+        nullptr, {}, "Pixel::Barrel");
 
     // The combined volume
     auto detectorVolume = cylinderVolumeHelper->createContainerTrackingVolume(

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DetectorElementStub.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DetectorElementStub.hpp
@@ -35,7 +35,7 @@ class DetectorElementStub : public DetectorElementBase {
  public:
   DetectorElementStub() : DetectorElementBase() {}
 
-  DetectorElementStub(std::shared_ptr<const Transform3D> transform)
+  DetectorElementStub(const Transform3D& transform)
       : DetectorElementBase(), m_elementTransform(std::move(transform)) {}
 
   /// Constructor for single sided detector element
@@ -46,11 +46,11 @@ class DetectorElementStub : public DetectorElementBase {
   /// @param thickness is the module thickness
   /// @param material is the (optional) Surface material associated to it
   DetectorElementStub(
-      std::shared_ptr<const Transform3D> transform,
-      std::shared_ptr<const PlanarBounds> pBounds, double thickness,
+      const Transform3D& transform, std::shared_ptr<const PlanarBounds> pBounds,
+      double thickness,
       std::shared_ptr<const ISurfaceMaterial> material = nullptr)
       : DetectorElementBase(),
-        m_elementTransform(std::move(transform)),
+        m_elementTransform(transform),
         m_elementThickness(thickness) {
     auto mutableSurface = Surface::makeShared<PlaneSurface>(pBounds, *this);
     mutableSurface->assignSurfaceMaterial(material);
@@ -65,11 +65,11 @@ class DetectorElementStub : public DetectorElementBase {
   /// @param thickness is the module thickness
   /// @param material is the (optional) Surface material associated to it
   DetectorElementStub(
-      std::shared_ptr<const Transform3D> transform,
-      std::shared_ptr<const LineBounds> lBounds, double thickness,
+      const Transform3D& transform, std::shared_ptr<const LineBounds> lBounds,
+      double thickness,
       std::shared_ptr<const ISurfaceMaterial> material = nullptr)
       : DetectorElementBase(),
-        m_elementTransform(std::move(transform)),
+        m_elementTransform(transform),
         m_elementThickness(thickness) {
     auto mutableSurface = Surface::makeShared<LineSurfaceStub>(lBounds, *this);
     mutableSurface->assignSurfaceMaterial(material);
@@ -95,7 +95,7 @@ class DetectorElementStub : public DetectorElementBase {
 
  private:
   /// the transform for positioning in 3D space
-  std::shared_ptr<const Transform3D> m_elementTransform;
+  Transform3D m_elementTransform;
   /// the surface represented by it
   std::shared_ptr<const Surface> m_elementSurface{nullptr};
   /// the element thickness
@@ -104,7 +104,7 @@ class DetectorElementStub : public DetectorElementBase {
 
 inline const Transform3D& DetectorElementStub::transform(
     const GeometryContext& /*gctx*/) const {
-  return *m_elementTransform;
+  return m_elementTransform;
 }
 
 inline const Surface& DetectorElementStub::surface() const {

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
@@ -19,12 +19,11 @@ class LineSurfaceStub : public LineSurface {
  public:
   LineSurfaceStub() = delete;
   //
-  LineSurfaceStub(std::shared_ptr<const Transform3D> htrans, double radius,
-                  double halfz)
+  LineSurfaceStub(const Transform3D& htrans, double radius, double halfz)
       : GeometryObject(), LineSurface(htrans, radius, halfz) { /* nop */
   }
   //
-  LineSurfaceStub(std::shared_ptr<const Transform3D> htrans,
+  LineSurfaceStub(const Transform3D& htrans,
                   std::shared_ptr<const LineBounds> lbounds = nullptr)
       : GeometryObject(), LineSurface(htrans, lbounds) { /*nop */
   }

--- a/Tests/IntegrationTests/PropagationTests.hpp
+++ b/Tests/IntegrationTests/PropagationTests.hpp
@@ -165,7 +165,7 @@ inline void checkCovarianceConsistency(
 
 /// Construct the transformation from the curvilinear to the global coordinates.
 template <typename charge_t>
-inline std::shared_ptr<Acts::Transform3D> makeCurvilinearTransform(
+inline Acts::Transform3D makeCurvilinearTransform(
     const Acts::SingleBoundTrackParameters<charge_t>& params,
     const Acts::GeometryContext& geoCtx) {
   Acts::Vector3D unitW = params.momentum().normalized();
@@ -178,7 +178,7 @@ inline std::shared_ptr<Acts::Transform3D> makeCurvilinearTransform(
   Acts::Translation3D offset(params.position(geoCtx));
   Acts::Transform3D toGlobal = offset * rotation;
 
-  return std::make_shared<Acts::Transform3D>(toGlobal);
+  return toGlobal;
 }
 
 /// Construct a z-cylinder centered at zero with the track on its surface.
@@ -187,12 +187,10 @@ struct ZCylinderSurfaceBuilder {
   std::shared_ptr<Acts::CylinderSurface> operator()(
       const Acts::SingleBoundTrackParameters<charge_t>& params,
       const Acts::GeometryContext& geoCtx) {
-    auto transform =
-        std::make_shared<Acts::Transform3D>(Acts::Transform3D::Identity());
     auto radius = params.position(geoCtx).template head<2>().norm();
     auto halfz = std::numeric_limits<double>::max();
     return Acts::Surface::makeShared<Acts::CylinderSurface>(
-        std::move(transform), radius, halfz);
+        Acts::Transform3D::Identity(), radius, halfz);
   }
 };
 
@@ -213,10 +211,10 @@ struct DiscSurfaceBuilder {
     Acts::Vector3D localOffset = Acts::Vector3D::Zero();
     localOffset[Acts::ePos0] = 1_cm;
     localOffset[Acts::ePos1] = -1_cm;
-    Acts::Vector3D globalOriginDelta = cl->linear() * localOffset;
-    cl->pretranslate(globalOriginDelta);
+    Acts::Vector3D globalOriginDelta = cl.linear() * localOffset;
+    cl.pretranslate(globalOriginDelta);
 
-    return Acts::Surface::makeShared<Acts::DiscSurface>(std::move(cl));
+    return Acts::Surface::makeShared<Acts::DiscSurface>(cl);
   }
 };
 
@@ -238,8 +236,7 @@ struct ZStrawSurfaceBuilder {
       const Acts::SingleBoundTrackParameters<charge_t>& params,
       const Acts::GeometryContext& geoCtx) {
     return Acts::Surface::makeShared<Acts::StrawSurface>(
-        std::make_shared<Acts::Transform3D>(
-            Acts::Translation3D(params.position(geoCtx))));
+        Acts::Transform3D(Acts::Translation3D(params.position(geoCtx))));
   }
 };
 

--- a/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
@@ -119,23 +119,19 @@ void runTest(std::shared_ptr<const Surface> surface, double l0, double l1,
   }
 }
 
-std::shared_ptr<Transform3D> makeTransformIdentity() {
-  return std::make_shared<Transform3D>(Transform3D::Identity());
-}
-
 // different surfaces
 // parameters must be chosen such that all possible local positions (as defined
 // in the datasets header) represent valid points on the surface.
 const auto cones = bdata::make({
-    Surface::makeShared<ConeSurface>(makeTransformIdentity(),
+    Surface::makeShared<ConeSurface>(Transform3D::Identity(),
                                      0.5 /* opening angle */),
 });
 const auto cylinders = bdata::make({
-    Surface::makeShared<CylinderSurface>(makeTransformIdentity(),
+    Surface::makeShared<CylinderSurface>(Transform3D::Identity(),
                                          10.0 /* radius */, 100 /* half z */),
 });
 const auto discs = bdata::make({
-    Surface::makeShared<DiscSurface>(makeTransformIdentity(),
+    Surface::makeShared<DiscSurface>(Transform3D::Identity(),
                                      0 /* radius min */, 100 /* radius max */),
 });
 const auto perigees = bdata::make({
@@ -147,7 +143,7 @@ const auto planes = bdata::make({
     Surface::makeShared<PlaneSurface>(Vector3D(3, -4, 5), Vector3D::UnitZ()),
 });
 const auto straws = bdata::make({
-    Surface::makeShared<StrawSurface>(makeTransformIdentity(), 2.0 /* radius */,
+    Surface::makeShared<StrawSurface>(Transform3D::Identity(), 2.0 /* radius */,
                                       200.0 /* half z */),
 });
 

--- a/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
@@ -27,9 +27,10 @@ using FittableMeasurement = FittableMeasurement<SourceLink>;
 BOOST_AUTO_TEST_CASE(getSurface_test) {
   auto cylinderBounds = std::make_shared<CylinderBounds>(3, 10);
 
-  auto cylinder = Surface::makeShared<CylinderSurface>(nullptr, cylinderBounds);
-  auto cylinder2 =
-      Surface::makeShared<CylinderSurface>(nullptr, cylinderBounds);
+  auto cylinder = Surface::makeShared<CylinderSurface>(Transform3D::Identity(),
+                                                       cylinderBounds);
+  auto cylinder2 = Surface::makeShared<CylinderSurface>(Transform3D::Identity(),
+                                                        cylinderBounds);
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
@@ -47,7 +48,8 @@ BOOST_AUTO_TEST_CASE(getSurface_test) {
 }
 
 BOOST_AUTO_TEST_CASE(getSize_test) {
-  auto cylinder = Surface::makeShared<CylinderSurface>(nullptr, 3, 10);
+  auto cylinder =
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 3, 10);
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
@@ -68,7 +70,8 @@ BOOST_AUTO_TEST_CASE(getSize_test) {
 }
 
 BOOST_AUTO_TEST_CASE(MinimalSourceLinkTest) {
-  auto cylinder = Surface::makeShared<CylinderSurface>(nullptr, 3, 10);
+  auto cylinder =
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 3, 10);
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;

--- a/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
@@ -26,7 +26,8 @@ using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 /// @brief Unit test for creation of Measurement object
 ///
 BOOST_AUTO_TEST_CASE(measurement_initialization) {
-  auto cylinder = Surface::makeShared<CylinderSurface>(nullptr, 3, 10);
+  auto cylinder =
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 3, 10);
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;

--- a/Tests/UnitTests/Core/EventData/TrackParametersTestData.hpp
+++ b/Tests/UnitTests/Core/EventData/TrackParametersTestData.hpp
@@ -28,8 +28,7 @@ using namespace Acts;
 // inputs, i.e. no angles or strictly positive radii.
 const auto surfaces = bdata::make(std::vector<std::shared_ptr<const Surface>>{
     Surface::makeShared<CylinderSurface>(
-        std::make_shared<Transform3D>(Transform3D::Identity()), 10 /* radius */,
-        100 /* half-length z */),
+        Transform3D::Identity(), 10 /* radius */, 100 /* half-length z */),
     // TODO perigee roundtrip local->global->local does not seem to work
     // Surface::makeShared<PerigeeSurface>(Vector3D(0, 0, -1.5)),
     Surface::makeShared<PlaneSurface>(Vector3D::Zero(), Vector3D::UnitX()),

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -34,7 +34,8 @@ GeometryContext tgContext = GeometryContext();
 
 BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   // Make dummy measurement
-  auto cylinder = Surface::makeShared<CylinderSurface>(nullptr, 3, 10);
+  auto cylinder =
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 3, 10);
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;

--- a/Tests/UnitTests/Core/Geometry/BVHDataTestCase.hpp
+++ b/Tests/UnitTests/Core/Geometry/BVHDataTestCase.hpp
@@ -39,7 +39,7 @@ gridBoxFactory(size_t n = NBOXES, double hl = 1000, size_t octd = 5) {
       for (size_t k = 0; k <= n; k++) {
         Vector3D pos(min + i * step, min + j * step, min + k * step);
 
-        auto trf = std::make_shared<Transform3D>(Translation3D(pos));
+        auto trf = Transform3D(Translation3D(pos));
         auto vol = std::make_unique<AbstractVolume>(trf, vbds);
 
         volumes.push_back(std::move(vol));
@@ -61,13 +61,12 @@ gridBoxFactory(size_t n = NBOXES, double hl = 1000, size_t octd = 5) {
   }
 
   // box like overall shape
-  auto tvTrf = std::make_shared<Transform3D>(Transform3D::Identity());
   auto tvBounds =
       std::make_shared<CuboidVolumeBounds>(hl * 1.1, hl * 1.1, hl * 1.1);
 
-  auto tv =
-      TrackingVolume::create(tvTrf, tvBounds, std::move(boxStore),
-                             std::move(volumes), top, nullptr, "TheVolume");
+  auto tv = TrackingVolume::create(Transform3D::Identity(), tvBounds,
+                                   std::move(boxStore), std::move(volumes), top,
+                                   nullptr, "TheVolume");
 
   auto tg = std::make_shared<TrackingGeometry>(tv);
 

--- a/Tests/UnitTests/Core/Geometry/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Geometry/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unittest(AlignmentContext AlignmentContextTests.cpp)
 add_unittest(ConeVolumeBounds ConeVolumeBoundsTests.cpp)
+add_unittest(ConeLayer ConeLayerTests.cpp)
 add_unittest(CuboidVolumeBounds CuboidVolumeBoundsTests.cpp)
 add_unittest(CuboidVolumeBuilder CuboidVolumeBuilderTests.cpp)
 add_unittest(CutoutCylinderVolumeBounds CutoutCylinderVolumeBoundsTests.cpp)

--- a/Tests/UnitTests/Core/Geometry/ConeLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeLayerTests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(ConeLayerConstruction) {
   // minimally need a Transform3D and a PlanarBounds object (e.g.
   // ConeBounds) to construct
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   double alpha(M_PI / 8.0);
   const bool symmetric(false);
   auto pCone = std::make_shared<const ConeBounds>(alpha, symmetric);
@@ -46,10 +46,9 @@ BOOST_AUTO_TEST_CASE(ConeLayerConstruction) {
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
   /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
   const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds),
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds)};
   const double thickness(1.0);
   auto pConeLayerFromSurfaces = ConeLayer::create(pTransform, pCone, nullptr);
   BOOST_CHECK_EQUAL(pConeLayerFromSurfaces->layerType(), LayerType::active);
@@ -69,27 +68,6 @@ BOOST_AUTO_TEST_CASE(ConeLayerConstruction) {
   auto pConeLayerWithLayerType = ConeLayer::create(
       pTransform, pCone, nullptr, thickness, std::move(ad), LayerType::passive);
   BOOST_CHECK_EQUAL(pConeLayerWithLayerType->layerType(), LayerType::passive);
-}
-
-/// Unit test for testing Layer properties
-BOOST_AUTO_TEST_CASE(ConeLayerProperties /*, *utf::expected_failures(1)*/) {
-  Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  double alpha(M_PI / 8.0);
-  const bool symmetric(false);
-  // bounds object, rectangle type
-  auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
-  /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
-  auto pCone = std::make_shared<const ConeBounds>(alpha, symmetric);
-  const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
-  // const double        thickness(1.0);
-  auto pConeLayerFromSurfaces = ConeLayer::create(pTransform, pCone, nullptr);
-  // auto planeSurface = pConeLayer->surfaceRepresentation();
-  BOOST_CHECK_EQUAL(pConeLayerFromSurfaces->surfaceRepresentation().name(),
-                    std::string("Acts::ConeSurface"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(ConeVolumeBoundsSurfaceOrientation) {
 
   ConeVolumeBounds hcone(10_mm, 0.45, 80_mm, 50_mm, 0., M_PI);
 
-  auto cvbOrientedSurfaces = hcone.orientedSurfaces(nullptr);
+  auto cvbOrientedSurfaces = hcone.orientedSurfaces(Transform3D::Identity());
   BOOST_CHECK_EQUAL(cvbOrientedSurfaces.size(), 4);
 
   auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeProperties) {
 
 BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
   CuboidVolumeBounds box(5, 8, 7);
-  auto cvbOrientedSurfaces = box.orientedSurfaces(nullptr);
+  auto cvbOrientedSurfaces = box.orientedSurfaces(Transform3D::Identity());
 
   BOOST_CHECK_EQUAL(cvbOrientedSurfaces.size(), 6);
 

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBuilderTests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeBuilderTest) {
     cfg.thickness = 1_um;
 
     cfg.detElementConstructor =
-        [](std::shared_ptr<const Transform3D> trans,
+        [](const Transform3D& trans,
            std::shared_ptr<const RectangleBounds> bounds, double thickness) {
           return new DetectorElementStub(trans, bounds, thickness);
         };

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeBoundsBoundingBox) {
   CHECK_CLOSE_ABS(box.min(), Vector3D(-15, -15, -30), 1e-6);
   CHECK_CLOSE_ABS(box.max(), Vector3D(15, 15, 30), 1e-6);
 
-  auto ccvbSurfaces = ccvb.orientedSurfaces(nullptr);
+  auto ccvbSurfaces = ccvb.orientedSurfaces(Transform3D::Identity());
 }
 
 BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
 
   CutoutCylinderVolumeBounds ccvb(5, 10, 15, 30, 25);
 
-  auto ccvbOrientedSurfaces = ccvb.orientedSurfaces(nullptr);
+  auto ccvbOrientedSurfaces = ccvb.orientedSurfaces(Transform3D::Identity());
   BOOST_CHECK_EQUAL(ccvbOrientedSurfaces.size(), 8);
 
   auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/CylinderLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderLayerTests.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(CylinderLayerConstruction) {
   // minimally need a Transform3D and a PlanarBounds object (e.g.
   // CylinderBounds) to construct
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   double radius(0.5), halfz(10.);
   auto pCylinder = std::make_shared<const CylinderBounds>(radius, halfz);
   auto pCylinderLayer =
@@ -50,11 +50,10 @@ BOOST_AUTO_TEST_CASE(CylinderLayerConstruction) {
   // next level: need an array of Surfaces;
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
-  /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
+  /// Construction
   const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds),
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds)};
   const double thickness(1.0);
   auto pCylinderLayerFromSurfaces =
       CylinderLayer::create(pTransform, pCylinder, nullptr, thickness);
@@ -83,7 +82,7 @@ BOOST_AUTO_TEST_CASE(CylinderLayerConstruction) {
 /// Unit test for testing Layer properties
 BOOST_AUTO_TEST_CASE(CylinderLayerProperties /*, *utf::expected_failures(1)*/) {
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   double radius(0.5), halfz(10.);
   auto pCylinder = std::make_shared<const CylinderBounds>(radius, halfz);
   auto pCylinderLayer =

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -166,14 +166,12 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
   double halfz = 3.;
   CylinderVolumeBounds cylBounds(rmin, rmax, halfz);
   // create the transformation matrix
-  auto mutableTransformPtr = std::make_shared<Transform3D>(Translation3D(pos));
-  (*mutableTransformPtr) *= rotZ;
-  (*mutableTransformPtr) *= rotY;
-  (*mutableTransformPtr) *= rotX;
-  auto transformPtr =
-      std::const_pointer_cast<const Transform3D>(mutableTransformPtr);
+  auto transform = Transform3D(Translation3D(pos));
+  transform *= rotZ;
+  transform *= rotY;
+  transform *= rotX;
   // get the boundary surfaces
-  auto boundarySurfaces = cylBounds.orientedSurfaces(transformPtr.get());
+  auto boundarySurfaces = cylBounds.orientedSurfaces(transform);
   // Test
 
   // check if difference is halfZ - sign and direction independent
@@ -184,13 +182,13 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
       (pos - boundarySurfaces.at(1).first->center(tgContext)).norm(),
       cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
   // transform to local
-  double posDiscPosZ = (transformPtr->inverse() *
-                        boundarySurfaces.at(1).first->center(tgContext))
-                           .z();
-  double centerPosZ = (transformPtr->inverse() * pos).z();
-  double negDiscPosZ = (transformPtr->inverse() *
-                        boundarySurfaces.at(0).first->center(tgContext))
-                           .z();
+  double posDiscPosZ =
+      (transform.inverse() * boundarySurfaces.at(1).first->center(tgContext))
+          .z();
+  double centerPosZ = (transform.inverse() * pos).z();
+  double negDiscPosZ =
+      (transform.inverse() * boundarySurfaces.at(0).first->center(tgContext))
+          .z();
   // check if center of disc boundaries lies in the middle in z
   BOOST_CHECK_LT(centerPosZ, posDiscPosZ);
   BOOST_CHECK_GT(centerPosZ, negDiscPosZ);
@@ -206,13 +204,13 @@ BOOST_DATA_TEST_CASE(CylinderVolumeBoundsOrientedSurfaces,
   // positive disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transformPtr->rotation().col(2).dot(boundarySurfaces.at(1).first->normal(
+      transform.rotation().col(2).dot(boundarySurfaces.at(1).first->normal(
           tgContext, Acts::Vector2D(0., 0.))),
       1., 1e-12);
   // negative disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transformPtr->rotation().col(2).dot(boundarySurfaces.at(0).first->normal(
+      transform.rotation().col(2).dot(boundarySurfaces.at(0).first->normal(
           tgContext, Acts::Vector2D(0., 0.))),
       1., 1e-12);
   // test in r
@@ -273,7 +271,7 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeOrientedBoundaries) {
 
   CylinderVolumeBounds cvb(5, 10, 20);
 
-  auto cvbOrientedSurfaces = cvb.orientedSurfaces(nullptr);
+  auto cvbOrientedSurfaces = cvb.orientedSurfaces(Transform3D::Identity());
   BOOST_CHECK_EQUAL(cvbOrientedSurfaces.size(), 4);
 
   auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/DiscLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/DiscLayerTests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(DiscLayerConstruction) {
   // minimally need a Transform3D and a PlanarBounds object (e.g.
   // RadialBounds) to construct
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   const double minRad(5.), maxRad(10.);  // 20 x 10 disc
   auto pDisc = std::make_shared<const RadialBounds>(minRad, maxRad);
   auto pDiscLayer = DiscLayer::create(pTransform, pDisc, nullptr, 1.);
@@ -50,11 +50,10 @@ BOOST_AUTO_TEST_CASE(DiscLayerConstruction) {
   // next level: need an array of Surfaces;
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
-  /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
+  /// Construction
   const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds),
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds)};
   const double thickness(1.0);
   auto pDiscLayerFromSurfaces =
       DiscLayer::create(pTransform, pDisc, nullptr, 1.);
@@ -80,7 +79,7 @@ BOOST_AUTO_TEST_CASE(DiscLayerConstruction) {
 /// Unit test for testing Layer properties
 BOOST_AUTO_TEST_CASE(DiscLayerProperties /*, *utf::expected_failures(1)*/) {
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   const double minRad(5.), maxRad(10.);  // 20 x 10 disc
   auto pDisc = std::make_shared<const RadialBounds>(minRad, maxRad);
   auto pDiscLayer = DiscLayer::create(pTransform, pDisc, nullptr, 1.);

--- a/Tests/UnitTests/Core/Geometry/GenericApproachDescriptorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericApproachDescriptorTests.cpp
@@ -89,8 +89,8 @@ BOOST_AUTO_TEST_CASE(GenericApproachNoOverstepping) {
   Vector3D direction{0., 1., 0.};
   BoundaryCheck bcheck{true};
 
-  auto conCyl = Surface::makeShared<CylinderSurface>(
-      std::make_shared<Transform3D>(Transform3D::Identity()), 10., 20.);
+  auto conCyl =
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 10., 20.);
 
   std::vector<std::shared_ptr<const Surface>> approachSurface = {conCyl};
 

--- a/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
     return false;
   };
 
-  auto surfaces = cubo.orientedSurfaces(nullptr);
+  auto surfaces = cubo.orientedSurfaces(Transform3D::Identity());
   for (const auto& srf : surfaces) {
     auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
                {0, 1, 1}}};
   cubo = GenericCuboidVolumeBounds(vertices);
 
-  surfaces = cubo.orientedSurfaces(nullptr);
+  surfaces = cubo.orientedSurfaces(Transform3D::Identity());
   for (const auto& srf : surfaces) {
     auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
   trf = Translation3D(Vector3D(0, 8, -5)) *
         AngleAxis3D(M_PI / 3., Vector3D(1, -3, 9).normalized());
 
-  surfaces = cubo.orientedSurfaces(&trf);
+  surfaces = cubo.orientedSurfaces(trf);
   for (const auto& srf : surfaces) {
     auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
     for (const auto& vtx : pbounds->vertices()) {
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(GenericCuboidVolumeBoundarySurfaces) {
 
   GenericCuboidVolumeBounds cubo(vertices);
 
-  auto gcvbOrientedSurfaces = cubo.orientedSurfaces(nullptr);
+  auto gcvbOrientedSurfaces = cubo.orientedSurfaces(Transform3D::Identity());
   BOOST_CHECK_EQUAL(gcvbOrientedSurfaces.size(), 6);
 
   for (auto& os : gcvbOrientedSurfaces) {

--- a/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
@@ -129,10 +129,8 @@ struct LayerCreatorFixture {
       trans.translate(Vector3D(r, 0, z));
 
       auto bounds = std::make_shared<const RectangleBounds>(2, 1);
-
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<PlaneSurface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -159,10 +157,8 @@ struct LayerCreatorFixture {
       trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3D(0, 1, 0)));
 
       auto bounds = std::make_shared<const RectangleBounds>(w, h);
-
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<PlaneSurface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -207,18 +203,14 @@ struct LayerCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3D(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-
-        auto transAptr = std::make_shared<const Transform3D>(trans);
-
         std::shared_ptr<PlaneSurface> srfA =
-            Surface::makeShared<PlaneSurface>(transAptr, bounds);
+            Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3D nrm = srfA->normal(tgContext);
         Transform3D transB = trans;
         transB.pretranslate(nrm * 0.1);
-        auto transBptr = std::make_shared<const Transform3D>(transB);
         std::shared_ptr<PlaneSurface> srfB =
-            Surface::makeShared<PlaneSurface>(transBptr, bounds);
+            Surface::makeShared<PlaneSurface>(transB, bounds);
 
         pairs.push_back(std::make_pair(srfA.get(), srfB.get()));
 

--- a/Tests/UnitTests/Core/Geometry/LayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerTests.cpp
@@ -59,11 +59,10 @@ BOOST_AUTO_TEST_CASE(LayerProperties, *utf::expected_failures(1)) {
   // Make a dummy layer to play with
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
-  /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
+  /// Constructor
   const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds),
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds)};
   std::unique_ptr<ApproachDescriptor> ad(
       new GenericApproachDescriptor(aSurfaces));
   auto adPtr = ad.get();

--- a/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(PlaneLayerConstruction) {
   // minimally need a Transform3D and a PlanarBounds object (e.g.
   // RectangleBounds) to construct
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   const double halfX(10.), halfY(5.);  // 20 x 10 rectangle
   auto pRectangle = std::make_shared<const RectangleBounds>(halfX, halfY);
   auto pPlaneLayer = PlaneLayer::create(pTransform, pRectangle);
@@ -46,10 +46,9 @@ BOOST_AUTO_TEST_CASE(PlaneLayerConstruction) {
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(1., 1.);
   /// Constructor with transform pointer
-  std::shared_ptr<const Transform3D> pNullTransform{};
   const std::vector<std::shared_ptr<const Surface>> aSurfaces{
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds),
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)};
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds),
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rBounds)};
   const double thickness(1.0);
   SurfaceArrayCreator sac;
   size_t binsX(2), binsY(4);
@@ -81,7 +80,7 @@ BOOST_AUTO_TEST_CASE(PlaneLayerConstruction) {
 /// Unit test for testing Layer properties
 BOOST_AUTO_TEST_CASE(PlaneLayerProperties /*, *utf::expected_failures(1)*/) {
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   const double halfX(10.), halfY(5.);  // 20 x 10 rectangle
   auto pRectangle = std::make_shared<const RectangleBounds>(halfX, halfY);
   auto pPlaneLayer = PlaneLayer::create(pTransform, pRectangle);

--- a/Tests/UnitTests/Core/Geometry/ProtoLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ProtoLayerTests.cpp
@@ -46,23 +46,19 @@ BOOST_AUTO_TEST_CASE(ProtoLayerTests) {
   auto createProtoLayer = [&](const Transform3D& trf,
                               bool shared = false) -> ProtoLayer {
     auto atNegX = Surface::makeShared<PlaneSurface>(
-        std::make_shared<Transform3D>(
-            trf * Translation3D(Vector3D(-3., 0., 0.)) * planeYZ),
+        Transform3D(trf * Translation3D(Vector3D(-3., 0., 0.)) * planeYZ),
         recBounds);
 
     auto atPosX = Surface::makeShared<PlaneSurface>(
-        std::make_shared<Transform3D>(
-            trf * Translation3D(Vector3D(3., 0., 0.)) * planeYZ),
+        Transform3D(trf * Translation3D(Vector3D(3., 0., 0.)) * planeYZ),
         recBounds);
 
     auto atNegY = Surface::makeShared<PlaneSurface>(
-        std::make_shared<Transform3D>(
-            trf * Translation3D(Vector3D(0., -3, 0.)) * planeZX),
+        Transform3D(trf * Translation3D(Vector3D(0., -3, 0.)) * planeZX),
         recBounds);
 
     auto atPosY = Surface::makeShared<PlaneSurface>(
-        std::make_shared<Transform3D>(
-            trf * Translation3D(Vector3D(0., 3., 0.)) * planeZX),
+        Transform3D(trf * Translation3D(Vector3D(0., 3., 0.)) * planeZX),
         recBounds);
 
     std::vector<std::shared_ptr<const Surface>> sharedSurfaces = {
@@ -91,8 +87,8 @@ BOOST_AUTO_TEST_CASE(ProtoLayerTests) {
   auto rB = std::make_shared<RectangleBounds>(30., 60.);
 
   // Create the detector element
-  auto addSurface = Surface::makeShared<PlaneSurface>(
-      std::make_shared<Transform3D>(Transform3D::Identity()), rB);
+  auto addSurface =
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), rB);
 
   pLayerSf.add(tgContext, *addSurface.get());
   // CHECK That if you now have 5 surfaces

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -93,9 +93,8 @@ struct SurfaceArrayCreatorFixture {
 
       auto bounds = std::make_shared<const RectangleBounds>(w, h);
 
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -124,10 +123,8 @@ struct SurfaceArrayCreatorFixture {
       trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3D(0, 1, 0)));
 
       auto bounds = std::make_shared<const RectangleBounds>(w, h);
-
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -152,9 +149,8 @@ struct SurfaceArrayCreatorFixture {
 
       auto bounds = std::make_shared<const RectangleBounds>(2, 1.5);
 
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -199,18 +195,14 @@ struct SurfaceArrayCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3D(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-
-        auto transAptr = std::make_shared<const Transform3D>(trans);
-
         std::shared_ptr<Surface> srfA =
-            Surface::makeShared<PlaneSurface>(transAptr, bounds);
+            Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3D nrm = srfA->normal(tgContext);
         Transform3D transB = trans;
         transB.pretranslate(nrm * 0.1);
-        auto transBptr = std::make_shared<const Transform3D>(transB);
         std::shared_ptr<Surface> srfB =
-            Surface::makeShared<PlaneSurface>(transBptr, bounds);
+            Surface::makeShared<PlaneSurface>(transB, bounds);
 
         pairs.push_back(std::make_pair(srfA.get(), srfB.get()));
 

--- a/Tests/UnitTests/Core/Geometry/SurfaceBinningMatcherTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceBinningMatcherTests.cpp
@@ -25,7 +25,7 @@ namespace Test {
 GeometryContext tgContext = GeometryContext();
 
 BOOST_AUTO_TEST_CASE(PlaneSurfaceMatcher) {
-  auto identity = std::make_shared<Transform3D>(Transform3D::Identity());
+  auto identity = Transform3D::Identity();
 
   double rMin = 5.;
   double rMax = 10.;

--- a/Tests/UnitTests/Core/Geometry/TrackingVolumeCreation.hpp
+++ b/Tests/UnitTests/Core/Geometry/TrackingVolumeCreation.hpp
@@ -28,12 +28,10 @@ TrackingVolumePtr constructCylinderVolume(
   ///  the surface transforms
   auto sfnPosition =
       Vector3D(0., 0., -3 * surfaceHalfLengthZ - surfaceZoverlap);
-  auto sfnTransform =
-      std::make_shared<const Transform3D>(Translation3D(sfnPosition));
-  auto sfcTransform = nullptr;
+  auto sfnTransform = Transform3D(Translation3D(sfnPosition));
+  auto sfcTransform = Transform3D::Identity();
   auto sfpPosition = Vector3D(0., 0., 3 * surfaceHalfLengthZ - surfaceZoverlap);
-  auto sfpTransform =
-      std::make_shared<const Transform3D>(Translation3D(sfpPosition));
+  auto sfpTransform = Transform3D(Translation3D(sfpPosition));
   ///  the surfaces
   auto sfnBounds = std::make_shared<CylinderBounds>(
       surfaceR - 0.5 * surfaceRstagger, surfaceHalfLengthZ);
@@ -70,7 +68,8 @@ TrackingVolumePtr constructCylinderVolume(
 
   ///  now create the Layer
   auto layer0bounds = std::make_shared<const CylinderBounds>(surfaceR, bUmax);
-  auto layer0 = CylinderLayer::create(nullptr, layer0bounds, std::move(bArray),
+  auto layer0 = CylinderLayer::create(Transform3D::Identity(), layer0bounds,
+                                      std::move(bArray),
                                       surfaceRstagger + 2 * layerEnvelope);
   std::unique_ptr<const LayerArray> layerArray =
       std::make_unique<const BinnedArrayXD<LayerPtr>>(layer0);
@@ -79,8 +78,9 @@ TrackingVolumePtr constructCylinderVolume(
   auto volumeBounds = std::make_shared<const CylinderVolumeBounds>(
       innerVolumeR, outerVolumeR, bUmax + volumeEnvelope);
 
-  TrackingVolumePtr volume = TrackingVolume::create(
-      nullptr, volumeBounds, nullptr, std::move(layerArray), nullptr, {}, name);
+  TrackingVolumePtr volume =
+      TrackingVolume::create(Transform3D::Identity(), volumeBounds, nullptr,
+                             std::move(layerArray), nullptr, {}, name);
   ///  return the volume
   return volume;
 }
@@ -106,7 +106,8 @@ MutableTrackingVolumePtr constructContainerVolume(const GeometryContext& gctx,
       std::make_shared<const BinnedArrayXD<TrackingVolumePtr>>(
           volumes, std::move(vUtility));
   ///  create the container volume
-  auto hVolume = TrackingVolume::create(nullptr, hVolumeBounds, vArray, name);
+  auto hVolume = TrackingVolume::create(Transform3D::Identity(), hVolumeBounds,
+                                        vArray, name);
   // return the container
   return hVolume;
 }

--- a/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(bounding_box_creation) {
 BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
   TrapezoidVolumeBounds tvb(5, 10, 8, 4);
 
-  auto tvbOrientedSurfaces = tvb.orientedSurfaces(nullptr);
+  auto tvbOrientedSurfaces = tvb.orientedSurfaces(Transform3D::Identity());
   BOOST_CHECK_EQUAL(tvbOrientedSurfaces.size(), 6);
 
   auto geoCtx = GeometryContext();

--- a/Tests/UnitTests/Core/Geometry/VolumeTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/VolumeTests.cpp
@@ -46,8 +46,7 @@ BOOST_AUTO_TEST_CASE(VolumeTest) {
   CuboidVolumeBounds bounds(4_mm, 5_mm, 6_mm);
 
   // Build and test the volume
-  Volume volume(std::make_shared<const Transform3D>(transform),
-                std::make_shared<const CuboidVolumeBounds>(bounds));
+  Volume volume(transform, std::make_shared<const CuboidVolumeBounds>(bounds));
   BOOST_CHECK_EQUAL(volume.transform().matrix(), transform.matrix());
   CHECK_CLOSE_ABS(volume.itransform().matrix(), transform.inverse().matrix(),
                   eps);
@@ -59,7 +58,7 @@ BOOST_AUTO_TEST_CASE(VolumeTest) {
   Transform3D shift(Transform3D::Identity());
   Vector3D shiftTranslation{-4_mm, -5_mm, -6_mm};
   shift.translation() = shiftTranslation;
-  Volume volumeShift(volume, &shift);
+  Volume volumeShift(volume, shift);
   BOOST_CHECK_EQUAL(volumeShift.center(),
                     (volume.transform() * shift).translation());
   BOOST_CHECK_EQUAL(volumeShift.transform().rotation(),

--- a/Tests/UnitTests/Core/Geometry/VolumeTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/VolumeTests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(VolumeTest) {
   shift.translation() = shiftTranslation;
   Volume volumeShift(volume, shift);
   BOOST_CHECK_EQUAL(volumeShift.center(),
-                    (volume.transform() * shift).translation());
+                    (shift * volume.transform()).translation());
   BOOST_CHECK_EQUAL(volumeShift.transform().rotation(),
                     volume.transform().rotation());
 

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -394,8 +394,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
   charge = 1.;
   cov = 8.5 * Covariance::Identity();
   Transform3D trafo = Transform3D::Identity();
-  auto disc = Surface::makeShared<DiscSurface>(
-      std::make_shared<const Transform3D>(trafo));
+  auto disc = Surface::makeShared<DiscSurface>(trafo);
   BoundParameters boundDisc(geoCtx, cov, pos, mom, charge, time, disc);
 
   // Reset the state and test
@@ -413,8 +412,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
   time = 7.5;
   charge = 1.;
   cov = 8.5 * Covariance::Identity();
-  auto perigee = Surface::makeShared<PerigeeSurface>(
-      std::make_shared<const Transform3D>(trafo));
+  auto perigee = Surface::makeShared<PerigeeSurface>(trafo);
   BoundParameters boundPerigee(geoCtx, cov, pos, mom, charge, time, perigee);
 
   // Reset the state and test
@@ -433,8 +431,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
   time = 7.5;
   charge = 1.;
   cov = 8.5 * Covariance::Identity();
-  auto straw = Surface::makeShared<StrawSurface>(
-      std::make_shared<const Transform3D>(trafo));
+  auto straw = Surface::makeShared<StrawSurface>(trafo);
   BoundParameters boundStraw(geoCtx, cov, pos, mom, charge, time, straw);
 
   // Reset the state and test

--- a/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
@@ -46,15 +46,14 @@ MagneticFieldContext mfContext = MagneticFieldContext();
 /// @param nnomal The nominal normal direction
 /// @param angleT Rotation around the norminal normal
 /// @param angleU Roation around the original U axis
-std::shared_ptr<Transform3D> createCylindricTransform(const Vector3D& nposition,
-                                                      double angleX,
-                                                      double angleY) {
+Transform3D createCylindricTransform(const Vector3D& nposition, double angleX,
+                                     double angleY) {
   Transform3D ctransform;
   ctransform.setIdentity();
   ctransform.pretranslate(nposition);
   ctransform.prerotate(AngleAxis3D(angleX, Vector3D::UnitX()));
   ctransform.prerotate(AngleAxis3D(angleY, Vector3D::UnitY()));
-  return std::make_shared<Transform3D>(ctransform);
+  return ctransform;
 }
 
 /// Helper method to create a transform for a plane
@@ -64,10 +63,9 @@ std::shared_ptr<Transform3D> createCylindricTransform(const Vector3D& nposition,
 /// @param nnomal The nominal normal direction
 /// @param angleT Rotation around the norminal normal
 /// @param angleU Roation around the original U axis
-std::shared_ptr<Transform3D> createPlanarTransform(const Vector3D& nposition,
-                                                   const Vector3D& nnormal,
-                                                   double angleT,
-                                                   double angleU) {
+Transform3D createPlanarTransform(const Vector3D& nposition,
+                                  const Vector3D& nnormal, double angleT,
+                                  double angleU) {
   // the rotation of the destination surface
   Vector3D T = nnormal.normalized();
   Vector3D U = std::abs(T.dot(Vector3D::UnitZ())) < 0.99
@@ -85,7 +83,7 @@ std::shared_ptr<Transform3D> createPlanarTransform(const Vector3D& nposition,
   ctransform.prerotate(AngleAxis3D(angleT, T));
   ctransform.prerotate(AngleAxis3D(angleU, U));
   //
-  return std::make_shared<Transform3D>(ctransform);
+  return ctransform;
 }
 
 /// Helper method : convert into Acts matrix

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -119,9 +119,11 @@ EigenStepperType estepper(bField);
 EigenPropagatorType epropagator(std::move(estepper));
 
 auto mCylinder = std::make_shared<CylinderBounds>(10_mm, 1000_mm);
-auto mSurface = Surface::makeShared<CylinderSurface>(nullptr, mCylinder);
+auto mSurface =
+    Surface::makeShared<CylinderSurface>(Transform3D::Identity(), mCylinder);
 auto cCylinder = std::make_shared<CylinderBounds>(150_mm, 1000_mm);
-auto cSurface = Surface::makeShared<CylinderSurface>(nullptr, cCylinder);
+auto cSurface =
+    Surface::makeShared<CylinderSurface>(Transform3D::Identity(), cCylinder);
 
 const int ntests = 5;
 

--- a/Tests/UnitTests/Core/Propagator/VolumeMaterialInteractionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/VolumeMaterialInteractionTests.cpp
@@ -61,8 +61,7 @@ struct Stepper {
 
 BOOST_AUTO_TEST_CASE(volume_material_interaction_test) {
   // Create a Tracking Volume
-  auto htrans =
-      std::make_shared<const Transform3D>(Translation3D{-10., -10., 0.});
+  auto htrans = Transform3D(Translation3D{-10., -10., 0.});
   auto bound = std::make_shared<const CuboidVolumeBounds>(1_m, 1_m, 1_m);
   auto mat = makeSilicon();
   auto volMat = std::make_shared<const HomogeneousVolumeMaterial>(mat);

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(ConeSurfaces)
 BOOST_AUTO_TEST_CASE(ConeSurfaceConstruction) {
   // ConeSurface default constructor is deleted
   //
-  /// Constructor with transform alpha and symmetry
+  /// Constructor with transform, alpha and symmetry
   /// indicator
   double alpha{M_PI / 8.}, halfPhiSector{M_PI / 16.}, zMin{1.0}, zMax{10.};
   bool symmetric(false);

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -34,17 +34,16 @@ BOOST_AUTO_TEST_SUITE(ConeSurfaces)
 BOOST_AUTO_TEST_CASE(ConeSurfaceConstruction) {
   // ConeSurface default constructor is deleted
   //
-  /// Constructor with transform pointer, null or valid, alpha and symmetry
+  /// Constructor with transform alpha and symmetry
   /// indicator
   double alpha{M_PI / 8.}, halfPhiSector{M_PI / 16.}, zMin{1.0}, zMax{10.};
   bool symmetric(false);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  std::shared_ptr<const Transform3D> pNullTransform{};
-  BOOST_CHECK_EQUAL(
-      Surface::makeShared<ConeSurface>(pNullTransform, alpha, symmetric)
-          ->type(),
-      Surface::Cone);
+  auto pTransform = Transform3D(translation);
+  BOOST_CHECK_EQUAL(Surface::makeShared<ConeSurface>(Transform3D::Identity(),
+                                                     alpha, symmetric)
+                        ->type(),
+                    Surface::Cone);
   BOOST_CHECK_EQUAL(
       Surface::makeShared<ConeSurface>(pTransform, alpha, symmetric)->type(),
       Surface::Cone);
@@ -74,13 +73,13 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceConstruction) {
   //
   /// Copied and transformed
   auto copiedTransformedConeSurface = Surface::makeShared<ConeSurface>(
-      tgContext, *coneSurfaceObject, *pTransform);
+      tgContext, *coneSurfaceObject, pTransform);
   BOOST_CHECK_EQUAL(copiedTransformedConeSurface->type(), Surface::Cone);
 
   /// Construct with nullptr bounds
-  BOOST_CHECK_THROW(
-      auto nullBounds = Surface::makeShared<ConeSurface>(nullptr, nullptr),
-      AssertionFailureException);
+  BOOST_CHECK_THROW(auto nullBounds = Surface::makeShared<ConeSurface>(
+                        Transform3D::Identity(), nullptr),
+                    AssertionFailureException);
 }
 //
 /// Unit test for testing ConeSurface properties
@@ -89,7 +88,7 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceProperties) {
   double alpha{M_PI / 8.} /*,halfPhiSector{M_PI/16.}, zMin{1.0}, zMax{10.}*/;
   bool symmetric(false);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto coneSurfaceObject =
       Surface::makeShared<ConeSurface>(pTransform, alpha, symmetric);
   //
@@ -185,7 +184,7 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceEqualityOperators) {
   double alpha{M_PI / 8.} /*, halfPhiSector{M_PI/16.}, zMin{1.0}, zMax{10.}*/;
   bool symmetric(false);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto coneSurfaceObject =
       Surface::makeShared<ConeSurface>(pTransform, alpha, symmetric);
   //
@@ -199,7 +198,7 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceEqualityOperators) {
       "Create and then assign a ConeSurface object to the existing one");
   /// Test assignment
   auto assignedConeSurface =
-      Surface::makeShared<ConeSurface>(nullptr, 0.1, true);
+      Surface::makeShared<ConeSurface>(Transform3D::Identity(), 0.1, true);
   *assignedConeSurface = *coneSurfaceObject;
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedConeSurface == *coneSurfaceObject);
@@ -211,7 +210,7 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceExtent) {
   Translation3D translation{0., 0., 0.};
 
   // Testing a Full cone
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto pConeBounds = std::make_shared<const ConeBounds>(alpha, zMin, zMax);
   auto pCone = Surface::makeShared<ConeSurface>(pTransform, pConeBounds);
   auto pConeExtent = pCone->polyhedronRepresentation(tgContext, 1).extent();
@@ -244,11 +243,11 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceAlignment) {
   double alpha{M_PI / 8.};
   bool symmetric(false);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto coneSurfaceObject =
       Surface::makeShared<ConeSurface>(pTransform, alpha, symmetric);
 
-  const auto& rotation = pTransform->rotation();
+  const auto& rotation = pTransform.rotation();
   // The local frame z axis
   const Vector3D localZAxis = rotation.col(2);
   // Check the local z axis is aligned to global z axis

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -34,15 +34,10 @@ BOOST_AUTO_TEST_SUITE(CylinderSurfaces)
 BOOST_AUTO_TEST_CASE(CylinderSurfaceConstruction) {
   // CylinderSurface default constructor is deleted
   //
-  /// Constructor with transform pointer, null or valid, radius and halfZ
+  /// Constructor with transform, radius and halfZ
   double radius(1.0), halfZ(10.), halfPhiSector(M_PI / 8.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  std::shared_ptr<const Transform3D> pNullTransform{};
-  BOOST_CHECK_EQUAL(
-      Surface::makeShared<CylinderSurface>(pNullTransform, radius, halfZ)
-          ->type(),
-      Surface::Cylinder);
+  auto pTransform = Transform3D(translation);
   BOOST_CHECK_EQUAL(
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ)->type(),
       Surface::Cylinder);
@@ -70,14 +65,14 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceConstruction) {
   //
   /// Copied and transformed
   auto copiedTransformedCylinderSurface = Surface::makeShared<CylinderSurface>(
-      testContext, *cylinderSurfaceObject, *pTransform);
+      testContext, *cylinderSurfaceObject, pTransform);
   BOOST_CHECK_EQUAL(copiedTransformedCylinderSurface->type(),
                     Surface::Cylinder);
 
   /// Construct with nullptr bounds
-  BOOST_CHECK_THROW(
-      auto nullBounds = Surface::makeShared<CylinderSurface>(nullptr, nullptr),
-      AssertionFailureException);
+  BOOST_CHECK_THROW(auto nullBounds = Surface::makeShared<CylinderSurface>(
+                        Transform3D::Identity(), nullptr),
+                    AssertionFailureException);
 }
 //
 /// Unit test for testing CylinderSurface properties
@@ -85,7 +80,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
   /// Test clone method
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto cylinderSurfaceObject =
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ);
   //
@@ -212,7 +207,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
 BOOST_AUTO_TEST_CASE(CylinderSurfaceEqualityOperators) {
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto cylinderSurfaceObject =
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ);
   //
@@ -226,7 +221,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceEqualityOperators) {
       "Create and then assign a CylinderSurface object to the existing one");
   /// Test assignment
   auto assignedCylinderSurface =
-      Surface::makeShared<CylinderSurface>(nullptr, 6.6, 5.4);
+      Surface::makeShared<CylinderSurface>(Transform3D::Identity(), 6.6, 5.4);
   *assignedCylinderSurface = *cylinderSurfaceObject;
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedCylinderSurface == *cylinderSurfaceObject);
@@ -237,7 +232,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceExtent) {
   // Some radius and half length
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 0., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto cylinderSurface =
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ);
   // The Extent, let's measure it
@@ -258,11 +253,11 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceExtent) {
 BOOST_AUTO_TEST_CASE(CylinderSurfaceAlignment) {
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto cylinderSurfaceObject =
       Surface::makeShared<CylinderSurface>(pTransform, radius, halfZ);
 
-  const auto& rotation = pTransform->rotation();
+  const auto& rotation = pTransform.rotation();
   // The local frame z axis
   const Vector3D localZAxis = rotation.col(2);
   // Check the local z axis is aligned to global z axis

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -37,16 +37,13 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceConstruction) {
   // scaffolding...
   double rMin(1.0), rMax(5.0), halfPhiSector(M_PI / 8.);
   //
-  /// Test DiscSurface fully specified constructor but no transform
-  BOOST_CHECK_NO_THROW(
-      Surface::makeShared<DiscSurface>(nullptr, rMin, rMax, halfPhiSector));
-  //
   /// Test DiscSurface constructor with default halfPhiSector
-  BOOST_CHECK_NO_THROW(Surface::makeShared<DiscSurface>(nullptr, rMin, rMax));
+  BOOST_CHECK_NO_THROW(
+      Surface::makeShared<DiscSurface>(Transform3D::Identity(), rMin, rMax));
   //
   /// Test DiscSurface constructor with a transform specified
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   BOOST_CHECK_NO_THROW(
       Surface::makeShared<DiscSurface>(pTransform, rMin, rMax, halfPhiSector));
   //
@@ -62,7 +59,7 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceConstruction) {
   //
   /// Copied and transformed DiscSurface
   BOOST_CHECK_NO_THROW(Surface::makeShared<DiscSurface>(
-      tgContext, *anotherDiscSurface, *pTransform));
+      tgContext, *anotherDiscSurface, pTransform));
 
   /// Construct with nullptr bounds
   DetectorElementStub detElem;
@@ -74,10 +71,9 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceConstruction) {
 /// Unit tests of all named methods
 BOOST_AUTO_TEST_CASE(DiscSurfaceProperties, *utf::expected_failures(2)) {
   Vector3D origin3D{0, 0, 0};
-  std::shared_ptr<const Transform3D> pTransform;  // nullptr
   double rMin(1.0), rMax(5.0), halfPhiSector(M_PI / 8.);
-  auto discSurfaceObject =
-      Surface::makeShared<DiscSurface>(pTransform, rMin, rMax, halfPhiSector);
+  auto discSurfaceObject = Surface::makeShared<DiscSurface>(
+      Transform3D::Identity(), rMin, rMax, halfPhiSector);
   //
   /// Test type
   BOOST_CHECK_EQUAL(discSurfaceObject->type(), Surface::Disc);
@@ -207,11 +203,11 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceProperties, *utf::expected_failures(2)) {
 /// Unit test for testing DiscSurface assignment and equality
 BOOST_AUTO_TEST_CASE(DiscSurfaceAssignment) {
   Vector3D origin3D{0, 0, 0};
-  std::shared_ptr<const Transform3D> pTransform;  // nullptr
   double rMin(1.0), rMax(5.0), halfPhiSector(M_PI / 8.);
-  auto discSurfaceObject =
-      Surface::makeShared<DiscSurface>(pTransform, rMin, rMax, halfPhiSector);
-  auto assignedDisc = Surface::makeShared<DiscSurface>(nullptr, 2.2, 4.4, 0.07);
+  auto discSurfaceObject = Surface::makeShared<DiscSurface>(
+      Transform3D::Identity(), rMin, rMax, halfPhiSector);
+  auto assignedDisc =
+      Surface::makeShared<DiscSurface>(Transform3D::Identity(), 2.2, 4.4, 0.07);
   //
   BOOST_CHECK_NO_THROW(*assignedDisc = *discSurfaceObject);
   BOOST_CHECK((*assignedDisc) == (*discSurfaceObject));
@@ -221,7 +217,8 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAssignment) {
 BOOST_AUTO_TEST_CASE(DiscSurfaceExtent) {
   double rMin(1.0), rMax(5.0);
 
-  auto pDisc = Surface::makeShared<DiscSurface>(nullptr, 0., rMax);
+  auto pDisc =
+      Surface::makeShared<DiscSurface>(Transform3D::Identity(), 0., rMax);
   auto pDiscExtent = pDisc->polyhedronRepresentation(tgContext, 1).extent();
 
   CHECK_CLOSE_ABS(0., pDiscExtent.min(binZ), s_onSurfaceTolerance);
@@ -235,7 +232,8 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceExtent) {
   CHECK_CLOSE_ABS(-M_PI, pDiscExtent.min(binPhi), s_onSurfaceTolerance);
   CHECK_CLOSE_ABS(M_PI, pDiscExtent.max(binPhi), s_onSurfaceTolerance);
 
-  auto pRing = Surface::makeShared<DiscSurface>(nullptr, rMin, rMax);
+  auto pRing =
+      Surface::makeShared<DiscSurface>(Transform3D::Identity(), rMin, rMax);
   auto pRingExtent = pRing->polyhedronRepresentation(tgContext, 1).extent();
 
   CHECK_CLOSE_ABS(0., pRingExtent.min(binZ), s_onSurfaceTolerance);
@@ -252,12 +250,11 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceExtent) {
 BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
   Translation3D translation{0., 1., 2.};
   Transform3D transform(translation);
-  auto pTransform = std::make_shared<const Transform3D>(translation);
   double rMin(1.0), rMax(5.0), halfPhiSector(M_PI / 8.);
   auto discSurfaceObject =
-      Surface::makeShared<DiscSurface>(pTransform, rMin, rMax, halfPhiSector);
+      Surface::makeShared<DiscSurface>(transform, rMin, rMax, halfPhiSector);
 
-  const auto& rotation = pTransform->rotation();
+  const auto& rotation = transform.rotation();
   // The local frame z axis
   const Vector3D localZAxis = rotation.col(2);
   // Check the local z axis is aligned to global z axis

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(LineSurface_Constructors_test) {
   // ctor with translation, radius, halfz
   Translation3D translation{0., 1., 2.};
   Transform3D transform(translation);
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   const double radius{2.0}, halfz{20.};
   BOOST_CHECK(LineSurfaceStub(pTransform, radius, halfz).constructedOk());
   // ctor with nullptr for LineBounds
@@ -72,15 +72,14 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   // binningPosition()
   Translation3D translation{0., 1., 2.};
   Transform3D transform(translation);
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  LineSurfaceStub line(pTransform, 2.0, 20.);
+  LineSurfaceStub line(transform, 2.0, 20.);
   Vector3D referencePosition{0., 1., 2.};
   CHECK_CLOSE_ABS(referencePosition, line.binningPosition(tgContext, binX),
                   1e-6);
   //
   // bounds()
   auto pLineBounds = std::make_shared<const LineBounds>(2., 10.0);
-  LineSurfaceStub boundedLine(pTransform, pLineBounds);
+  LineSurfaceStub boundedLine(transform, pLineBounds);
   const LineBounds& bounds =
       dynamic_cast<const LineBounds&>(boundedLine.bounds());
   BOOST_CHECK_EQUAL(bounds, LineBounds(2., 10.0));
@@ -150,9 +149,8 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
 BOOST_AUTO_TEST_CASE(LineSurface_assignment_test) {
   Translation3D translation{0., 1., 2.};
   Transform3D transform(translation);
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  LineSurfaceStub originalLine(pTransform, 2.0, 20.);
-  LineSurfaceStub assignedLine(pTransform, 1.0, 1.0);
+  LineSurfaceStub originalLine(transform, 2.0, 20.);
+  LineSurfaceStub assignedLine(transform, 1.0, 1.0);
   BOOST_CHECK(assignedLine != originalLine);  // operator != from base
   assignedLine = originalLine;
   BOOST_CHECK(assignedLine == originalLine);  // operator == from base
@@ -162,10 +160,9 @@ BOOST_AUTO_TEST_CASE(LineSurface_assignment_test) {
 BOOST_AUTO_TEST_CASE(LineSurfaceAlignment) {
   Translation3D translation{0., 1., 2.};
   Transform3D transform(translation);
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  LineSurfaceStub line(pTransform, 2.0, 20.);
+  LineSurfaceStub line(transform, 2.0, 20.);
 
-  const auto& rotation = pTransform->rotation();
+  const auto& rotation = transform.rotation();
   // The local frame z axis
   const Vector3D localZAxis = rotation.col(2);
   // Check the local z axis is aligned to global z axis

--- a/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
@@ -41,12 +41,9 @@ BOOST_AUTO_TEST_CASE(PerigeeSurfaceConstruction) {
   BOOST_CHECK_EQUAL(Surface::makeShared<PerigeeSurface>(unitXYZ)->type(),
                     Surface::Perigee);
   //
-  /// Constructor with transform pointer, null or valid
+  /// Constructor with transform
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  std::shared_ptr<const Transform3D> pNullTransform{};
-  BOOST_CHECK_EQUAL(Surface::makeShared<PerigeeSurface>(pNullTransform)->type(),
-                    Surface::Perigee);
+  auto pTransform = Transform3D(translation);
   BOOST_CHECK_EQUAL(Surface::makeShared<PerigeeSurface>(pTransform)->type(),
                     Surface::Perigee);
   //
@@ -58,7 +55,7 @@ BOOST_AUTO_TEST_CASE(PerigeeSurfaceConstruction) {
   //
   /// Copied and transformed
   auto copiedTransformedPerigeeSurface = Surface::makeShared<PerigeeSurface>(
-      tgContext, *perigeeSurfaceObject, *pTransform);
+      tgContext, *perigeeSurfaceObject, pTransform);
   BOOST_CHECK_EQUAL(copiedTransformedPerigeeSurface->type(), Surface::Perigee);
 }
 //

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -35,15 +35,9 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceConstruction) {
   // PlaneSurface default constructor is deleted
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(3., 4.);
-  /// Constructor with transform pointer, null or valid, alpha and symmetry
-  /// indicator
+  /// Constructor with transform and bounds
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  std::shared_ptr<const Transform3D> pNullTransform{};
-  // constructor with nullptr transform
-  BOOST_CHECK_EQUAL(
-      Surface::makeShared<PlaneSurface>(pNullTransform, rBounds)->type(),
-      Surface::Plane);
+  auto pTransform = Transform3D(translation);
   // constructor with transform
   BOOST_CHECK_EQUAL(
       Surface::makeShared<PlaneSurface>(pTransform, rBounds)->type(),
@@ -58,7 +52,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceConstruction) {
   //
   /// Copied and transformed
   auto copiedTransformedPlaneSurface = Surface::makeShared<PlaneSurface>(
-      tgContext, *planeSurfaceObject, *pTransform);
+      tgContext, *planeSurfaceObject, pTransform);
   BOOST_CHECK_EQUAL(copiedTransformedPlaneSurface->type(), Surface::Plane);
 
   /// Construct with nullptr bounds
@@ -74,12 +68,12 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
   auto rBounds = std::make_shared<const RectangleBounds>(3., 4.);
   /// Test clone method
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto planeSurfaceObject =
       Surface::makeShared<PlaneSurface>(pTransform, rBounds);
   // Is it in the right place?
   Translation3D translation2{0., 2., 4.};
-  auto pTransform2 = std::make_shared<const Transform3D>(translation2);
+  auto pTransform2 = Transform3D(translation2);
   auto planeSurfaceObject2 =
       Surface::makeShared<PlaneSurface>(pTransform2, rBounds);
   /// Test type (redundant)
@@ -177,7 +171,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceEqualityOperators) {
   // rectangle bounds
   auto rBounds = std::make_shared<const RectangleBounds>(3., 4.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto planeSurfaceObject =
       Surface::makeShared<PlaneSurface>(pTransform, rBounds);
   auto planeSurfaceObject2 =
@@ -190,7 +184,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceEqualityOperators) {
       "Create and then assign a PlaneSurface object to the existing one");
   /// Test assignment
   auto assignedPlaneSurface =
-      Surface::makeShared<PlaneSurface>(nullptr, nullptr);
+      Surface::makeShared<PlaneSurface>(Transform3D::Identity(), nullptr);
   *assignedPlaneSurface = *planeSurfaceObject;
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedPlaneSurface == *planeSurfaceObject);
@@ -209,9 +203,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceExtent) {
   auto rBounds = std::make_shared<RectangleBounds>(rHx, rHy);
 
   auto plane = Surface::makeShared<PlaneSurface>(
-      std::make_shared<Transform3D>(Translation3D(Vector3D(0., yPs, 0.)) *
-                                    planeZX),
-      rBounds);
+      Transform3D(Translation3D(Vector3D(0., yPs, 0.)) * planeZX), rBounds);
 
   auto planeExtent = plane->polyhedronRepresentation(tgContext, 1).extent();
 
@@ -228,9 +220,8 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceExtent) {
   // Now rotate
   double alpha = 0.123;
   auto planeRot = Surface::makeShared<PlaneSurface>(
-      std::make_shared<Transform3D>(Translation3D(Vector3D(0., yPs, 0.)) *
-                                    AngleAxis3D(alpha, Vector3D(0., 0., 1.)) *
-                                    planeZX),
+      Transform3D(Translation3D(Vector3D(0., yPs, 0.)) *
+                  AngleAxis3D(alpha, Vector3D(0., 0., 1.)) * planeZX),
       rBounds);
 
   auto planeExtentRot =
@@ -255,10 +246,10 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   auto rBounds = std::make_shared<const RectangleBounds>(3., 4.);
   /// Test clone method
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto planeSurfaceObject =
       Surface::makeShared<PlaneSurface>(pTransform, rBounds);
-  const auto& rotation = pTransform->rotation();
+  const auto& rotation = pTransform.rotation();
   // The local frame z axis
   const Vector3D localZAxis = rotation.col(2);
   // Check the local z axis is aligned to global z axis

--- a/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
@@ -34,13 +34,13 @@ BOOST_AUTO_TEST_SUITE(StrawSurfaces)
 BOOST_AUTO_TEST_CASE(StrawSurfaceConstruction) {
   // StrawSurface default constructor is deleted
   //
-  /// Constructor with transform pointer, null or valid, radius and halfZ
+  /// Constructor with transform, radius and halfZ
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
-  std::shared_ptr<const Transform3D> pNullTransform{};
+  auto pTransform = Transform3D(translation);
   BOOST_CHECK_EQUAL(
-      Surface::makeShared<StrawSurface>(pNullTransform, radius, halfZ)->type(),
+      Surface::makeShared<StrawSurface>(Transform3D::Identity(), radius, halfZ)
+          ->type(),
       Surface::Straw);
   BOOST_CHECK_EQUAL(
       Surface::makeShared<StrawSurface>(pTransform, radius, halfZ)->type(),
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(StrawSurfaceConstruction) {
   //
   /// Copied and transformed
   auto copiedTransformedStrawSurface = Surface::makeShared<StrawSurface>(
-      tgContext, *strawSurfaceObject, *pTransform);
+      tgContext, *strawSurfaceObject, pTransform);
   BOOST_CHECK_EQUAL(copiedTransformedStrawSurface->type(), Surface::Straw);
 }
 //
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(StrawSurfaceProperties) {
   /// Test clone method
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto strawSurfaceObject =
       Surface::makeShared<StrawSurface>(pTransform, radius, halfZ);
   //
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(StrawSurfaceProperties) {
 BOOST_AUTO_TEST_CASE(EqualityOperators) {
   double radius(1.0), halfZ(10.);
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto strawSurfaceObject =
       Surface::makeShared<StrawSurface>(pTransform, radius, halfZ);
   //
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(EqualityOperators) {
       "Create and then assign a StrawSurface object to the existing one");
   /// Test assignment
   auto assignedStrawSurface =
-      Surface::makeShared<StrawSurface>(nullptr, 6.6, 33.33);
+      Surface::makeShared<StrawSurface>(Transform3D::Identity(), 6.6, 33.33);
   *assignedStrawSurface = *strawSurfaceObject;
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedStrawSurface == *strawSurfaceObject);

--- a/Tests/UnitTests/Core/Surfaces/SurfaceArrayTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceArrayTests.cpp
@@ -61,10 +61,8 @@ struct SurfaceArrayFixture {
       trans.translate(Vector3D(r, 0, z));
 
       auto bounds = std::make_shared<const RectangleBounds>(2, 1);
-
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<const Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -91,10 +89,8 @@ struct SurfaceArrayFixture {
       trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3D(0, 1, 0)));
 
       auto bounds = std::make_shared<const RectangleBounds>(w, h);
-
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<const Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -119,9 +115,8 @@ struct SurfaceArrayFixture {
 
       auto bounds = std::make_shared<const RectangleBounds>(2, 1.5);
 
-      auto transptr = std::make_shared<const Transform3D>(trans);
       std::shared_ptr<const Surface> srf =
-          Surface::makeShared<PlaneSurface>(transptr, bounds);
+          Surface::makeShared<PlaneSurface>(trans, bounds);
 
       res.push_back(srf);
       m_surfaces.push_back(
@@ -244,8 +239,7 @@ BOOST_FIXTURE_TEST_CASE(SurfaceArray_create, SurfaceArrayFixture) {
 BOOST_AUTO_TEST_CASE(SurfaceArray_singleElement) {
   double w = 3, h = 4;
   auto bounds = std::make_shared<const RectangleBounds>(w, h);
-  auto transptr = std::make_shared<const Transform3D>(Transform3D::Identity());
-  auto srf = Surface::makeShared<PlaneSurface>(transptr, bounds);
+  auto srf = Surface::makeShared<PlaneSurface>(Transform3D::Identity(), bounds);
 
   SurfaceArray sa(srf);
 

--- a/Tests/UnitTests/Core/Surfaces/SurfaceIntersectionTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceIntersectionTests.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE(CylinderIntersectionTests) {
 
   auto testCylinderIntersection = [&](const Transform3D& transform) -> void {
     // A cylinder created alinged with a provided transform
-    auto aCylinder = Surface::makeShared<CylinderSurface>(
-        std::make_shared<Transform3D>(transform), radius, halfZ);
+    auto aCylinder =
+        Surface::makeShared<CylinderSurface>(transform, radius, halfZ);
 
     // Linear transform
     auto lTransform = transform.linear();
@@ -172,8 +172,7 @@ BOOST_AUTO_TEST_CASE(ConeIntersectionTest) {
 
   auto testConeIntersection = [&](const Transform3D& transform) -> void {
     // A cone suface ready to use
-    auto aCone = Surface::makeShared<ConeSurface>(
-        std::make_shared<Transform3D>(transform), alpha, true);
+    auto aCone = Surface::makeShared<ConeSurface>(transform, alpha, true);
 
     // Linear transform
     auto lTransform = transform.linear();
@@ -229,8 +228,7 @@ BOOST_AUTO_TEST_CASE(PlanarIntersectionTest) {
   auto testPlanarIntersection = [&](const Transform3D& transform) -> void {
     // A Plane created with a specific transform
     auto aPlane = Surface::makeShared<PlaneSurface>(
-        std::make_shared<Transform3D>(transform),
-        std::make_shared<RectangleBounds>(halfX, halfY));
+        transform, std::make_shared<RectangleBounds>(halfX, halfY));
 
     /// Forward interseciton test
     Vector3D before = transform * Vector3D(-50_cm, -1_m, -1_m);
@@ -323,8 +321,7 @@ BOOST_AUTO_TEST_CASE(LineIntersectionTest) {
 
   auto testLineAppraoch = [&](const Transform3D& transform) -> void {
     // A Plane created with a specific transform
-    auto aLine = Surface::makeShared<StrawSurface>(
-        std::make_shared<Transform3D>(transform), radius, halfZ);
+    auto aLine = Surface::makeShared<StrawSurface>(transform, radius, halfZ);
 
     /// Forward interseciton test
     Vector3D before = transform * Vector3D(-50_cm, -1_m, -1_m);

--- a/Tests/UnitTests/Core/Surfaces/SurfaceLocalToGlobalRoundtripTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceLocalToGlobalRoundtripTests.cpp
@@ -61,10 +61,6 @@ void runTest(const Surface& surface, double l0, double l1, double phi,
   CHECK_CLOSE_OR_SMALL(lpResult.value()[ePos1], l1, eps, eps);
 }
 
-std::shared_ptr<Transform3D> makeTransformIdentity() {
-  return std::make_shared<Transform3D>(Transform3D::Identity());
-}
-
 // test datasets
 
 // local positions
@@ -81,15 +77,15 @@ const auto thetas = bdata::make({0.0, M_PI}) + thetasNoForwardBackward;
 // parameters must be chosen such that all possible local positions (as defined
 // in the datasets above) represent valid points on the surface.
 const auto cones = bdata::make({
-    Surface::makeShared<ConeSurface>(makeTransformIdentity(),
+    Surface::makeShared<ConeSurface>(Transform3D::Identity(),
                                      0.5 /* opening angle */),
 });
 const auto cylinders = bdata::make({
-    Surface::makeShared<CylinderSurface>(makeTransformIdentity(),
+    Surface::makeShared<CylinderSurface>(Transform3D::Identity(),
                                          10.0 /* radius */, 100 /* half z */),
 });
 const auto discs = bdata::make({
-    Surface::makeShared<DiscSurface>(makeTransformIdentity(),
+    Surface::makeShared<DiscSurface>(Transform3D::Identity(),
                                      0 /* radius min */, 100 /* radius max */),
 });
 const auto perigees = bdata::make({
@@ -101,7 +97,7 @@ const auto planes = bdata::make({
     Surface::makeShared<PlaneSurface>(Vector3D(3, -4, 5), Vector3D::UnitZ()),
 });
 const auto straws = bdata::make({
-    Surface::makeShared<StrawSurface>(makeTransformIdentity(), 2.0 /* radius */,
+    Surface::makeShared<StrawSurface>(Transform3D::Identity(), 2.0 /* radius */,
                                       200.0 /* half z */),
 });
 

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -18,7 +18,7 @@ namespace Acts {
 /// Surface derived class stub
 class SurfaceStub : public Surface {
  public:
-  SurfaceStub(std::shared_ptr<const Transform3D> htrans = nullptr)
+  SurfaceStub(const Transform3D& htrans = Transform3D::Identity())
       : GeometryObject(), Surface(htrans) {}
   SurfaceStub(const GeometryContext& gctx, const SurfaceStub& sf,
               const Transform3D& transf)

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(SurfaceConstruction) {
   BOOST_CHECK_EQUAL(Surface::Other,
                     SurfaceStub(tgContext, original, transform).type());
   // need some cruft to make the next one work
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   std::shared_ptr<const Acts::PlanarBounds> p =
       std::make_shared<const RectangleBounds>(5., 10.);
   DetectorElementStub detElement{pTransform, p, 0.2, nullptr};
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties, *utf::expected_failures(1)) {
       std::make_shared<const RectangleBounds>(5., 10.);
   Vector3D reference{0., 1., 2.};
   Translation3D translation{0., 1., 2.};
-  auto pTransform = std::make_shared<const Transform3D>(translation);
+  auto pTransform = Transform3D(translation);
   auto pLayer = PlaneLayer::create(pTransform, pPlanarBound);
   auto pMaterial =
       std::make_shared<const HomogeneousSurfaceMaterial>(makePercentSlab());
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties, *utf::expected_failures(1)) {
   BOOST_CHECK_EQUAL(surface.surfaceMaterial(),
                     pNewMaterial.get());  // passes ??
   //
-  CHECK_CLOSE_OR_SMALL(surface.transform(tgContext), *pTransform, 1e-6, 1e-9);
+  CHECK_CLOSE_OR_SMALL(surface.transform(tgContext), pTransform, 1e-6, 1e-9);
   // type() is pure virtual
 }
 
@@ -136,8 +136,8 @@ BOOST_AUTO_TEST_CASE(EqualityOperators) {
   Vector3D reference{0., 1., 2.};
   Translation3D translation1{0., 1., 2.};
   Translation3D translation2{1., 1., 2.};
-  auto pTransform1 = std::make_shared<const Transform3D>(translation1);
-  auto pTransform2 = std::make_shared<const Transform3D>(translation2);
+  auto pTransform1 = Transform3D(translation1);
+  auto pTransform2 = Transform3D(translation2);
   // build a planeSurface to be compared
   auto planeSurface =
       Surface::makeShared<PlaneSurface>(pTransform1, pPlanarBound);

--- a/Tests/UnitTests/Core/Utilities/BoundingBoxTest.cpp
+++ b/Tests/UnitTests/Core/Utilities/BoundingBoxTest.cpp
@@ -383,16 +383,16 @@ BOOST_AUTO_TEST_CASE(ray_obb_intersect) {
                {1.8, 1, 1},
                {0, 1, 1}}};
   auto cubo = std::make_shared<GenericCuboidVolumeBounds>(vertices);
-  auto trf = std::make_shared<Transform3D>();
-  *trf = Translation3D(Vector3D(0, 8, -5)) *
-         AngleAxis3D(M_PI / 3., Vector3D(1, -3, 9).normalized());
+  auto trf =
+      Transform3D(Translation3D(Vector3D(0, 8, -5)) *
+                  AngleAxis3D(M_PI / 3., Vector3D(1, -3, 9).normalized()));
 
   AbstractVolume vol(trf, cubo);
 
   PlyVisualization3D<double> ply;
 
   Transform3D trl = Transform3D::Identity();
-  trl.translation() = trf->translation();
+  trl.translation() = trf.translation();
 
   cubo->draw(ply);
 
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(ray_obb_intersect) {
   Vector3D centroid(0., 0., 0.);
 
   for (const auto& vtx_ : vertices) {
-    Vector3D vtx = *trf * vtx_;
+    Vector3D vtx = trf * vtx_;
     centroid += vtx;
   }
 
@@ -414,12 +414,12 @@ BOOST_AUTO_TEST_CASE(ray_obb_intersect) {
 
   // shoot rays to the corner points of the cuboid
   for (const auto& vtx_ : vertices) {
-    Vector3D vtx = *trf * vtx_;
+    Vector3D vtx = trf * vtx_;
 
     // this ray goes straight to the actual vertex, this should
     // definitely intersect the OBB
     Ray ray(origin, (vtx - origin).normalized());
-    ray = ray.transformed(trf->inverse());
+    ray = ray.transformed(trf.inverse());
     BOOST_CHECK(obb.intersect(ray));
     ray.draw(ply, (vtx - origin).norm());
 
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE(ray_obb_intersect) {
     // this should definitely NOT intersect the OBB
     vtx += (vtx - centroid);
     ray = Ray(origin, (vtx - origin).normalized());
-    ray = ray.transformed(trf->inverse());
+    ray = ray.transformed(trf.inverse());
     BOOST_CHECK(!obb.intersect(ray));
     ray.draw(ply, (vtx - origin).norm());
   }

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -64,7 +64,7 @@ static inline std::string testBoundParameters(IVisualization3D& helper) {
   ViewConfig scolor({235, 198, 52});
 
   auto gctx = GeometryContext();
-  auto identity = std::make_shared<Transform3D>(Transform3D::Identity());
+  auto identity = Transform3D::Identity();
 
   // rectangle and plane
   auto rectangle = std::make_shared<RectangleBounds>(15., 15.);
@@ -151,7 +151,7 @@ static inline std::string testMultiTrajectory(IVisualization3D& helper) {
     // The thickness to construct the associated detector element
     sConf.thickness = 1._um;
     sConf.detElementConstructor =
-        [](std::shared_ptr<const Transform3D> trans,
+        [](const Transform3D& trans,
            std::shared_ptr<const RectangleBounds> bounds, double thickness) {
           return new Test::DetectorElementStub(trans, bounds, thickness);
         };

--- a/Tests/UnitTests/Core/Visualization/PrimitivesView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/PrimitivesView3DBase.hpp
@@ -27,7 +27,7 @@ namespace Acts {
 namespace PrimitivesView3DTest {
 
 // Test on a plane
-auto identity = std::make_shared<Transform3D>(Transform3D::Identity());
+auto identity = Transform3D::Identity();
 auto rectangle = std::make_shared<RectangleBounds>(10., 10.);
 auto plane = Surface::makeShared<PlaneSurface>(identity, rectangle);
 

--- a/Tests/UnitTests/Core/Visualization/SurfaceView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/SurfaceView3DBase.hpp
@@ -46,7 +46,7 @@ namespace SurfaceView3DTest {
 static inline std::string run(IVisualization3D& helper, bool triangulate,
                               const std::string& tag) {
   auto gctx = GeometryContext();
-  auto identity = std::make_shared<Transform3D>(Transform3D::Identity());
+  auto identity = Transform3D::Identity();
   std::stringstream cStream;
 
   double halfPhiSector = M_PI / 4.;

--- a/Tests/UnitTests/Core/Visualization/VolumeView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/VolumeView3DBase.hpp
@@ -36,7 +36,7 @@ namespace VolumeView3DTest {
 static inline std::string run(IVisualization3D& helper, bool triangulate,
                               const std::string& tag) {
   auto gctx = GeometryContext();
-  auto identity = std::make_shared<Transform3D>(Transform3D::Identity());
+  auto identity = Transform3D::Identity();
   std::stringstream cStream;
 
   double halfPhiSector = M_PI / 4.;

--- a/Tests/UnitTests/Plugins/Digitization/DoubleHitSpacePointBuilderTests.cpp
+++ b/Tests/UnitTests/Plugins/Digitization/DoubleHitSpacePointBuilderTests.cpp
@@ -70,7 +70,7 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
 
   // Build Digitization
   const DigitizationModule digMod(segmentation, 1., 1., 0.);
-  DetectorElementStub detElem(std::make_shared<const Transform3D>(t3d));
+  DetectorElementStub detElem(t3d);
   auto pSur = Surface::makeShared<PlaneSurface>(recBounds, detElem);
   ActsSymMatrixD<3> cov;
   cov << 0., 0., 0., 0., 0., 0., 0., 0., 0.;
@@ -96,7 +96,7 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   Transform3D t3d2(Transform3D::Identity() * rotationNeg);
   t3d2.translation() = Vector3D(0., 0., 10.005_m);
 
-  DetectorElementStub detElem2(std::make_shared<const Transform3D>(t3d2));
+  DetectorElementStub detElem2(t3d2);
 
   auto pSur2 = Surface::makeShared<PlaneSurface>(recBounds, detElem2);
 
@@ -131,7 +131,7 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   Transform3D t3d3(Transform3D::Identity() * rotationNeg);
   t3d3.translation() = Vector3D(0., 0., 10.005_m);
 
-  DetectorElementStub detElem3(std::make_shared<const Transform3D>(t3d3));
+  DetectorElementStub detElem3(t3d3);
   auto pSur3 = Surface::makeShared<PlaneSurface>(recBounds, detElem3);
 
   PlanarModuleCluster* pmc3 =

--- a/Tests/UnitTests/Plugins/Digitization/SingleHitSpacePointBuilderTests.cpp
+++ b/Tests/UnitTests/Plugins/Digitization/SingleHitSpacePointBuilderTests.cpp
@@ -69,7 +69,7 @@ BOOST_DATA_TEST_CASE(SingleHitSpacePointBuilder_basic, bdata::xrange(1),
 
   // Build Digitization
   const DigitizationModule digMod(segmentation, 1., 1., 0.);
-  DetectorElementStub detElem(std::make_shared<const Transform3D>(t3d));
+  DetectorElementStub detElem(t3d);
   auto pSur = Surface::makeShared<PlaneSurface>(recBounds, detElem);
   ActsSymMatrixD<3> cov;
   cov << 0., 0., 0., 0., 0., 0., 0., 0., 0.;


### PR DESCRIPTION
This PR changes the memory model and consistently the construction of Surface/Layer/Volumes to by-value storage and construction from const reference.

Sits on top of #399 (merged)  and #405 (merged).

Fixes #408 