### PR TITLE
refactor: BinUtility: Move Transform3D to storage by value

### DIFF
--- a/Core/include/Acts/Utilities/BinAdjustment.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustment.hpp
@@ -33,10 +33,8 @@ namespace Acts {
 BinUtility adjustBinUtility(const BinUtility& bu, const RadialBounds& rBounds,
                             const Transform3D& transform) {
   // Default constructor
-  BinUtility uBinUtil;
-  if (!transform.isApprox(Transform3D::Identity())) {
-    uBinUtil = BinUtility(std::make_shared<const Transform3D>(transform));
-  }
+  BinUtility uBinUtil(transform);
+
   // The parameters from the cylinder bounds
   double minR = rBounds.get(RadialBounds::eMinR);
   double maxR = rBounds.get(RadialBounds::eMaxR);
@@ -83,10 +81,8 @@ BinUtility adjustBinUtility(const BinUtility& bu, const RadialBounds& rBounds,
 BinUtility adjustBinUtility(const BinUtility& bu, const CylinderBounds& cBounds,
                             const Transform3D& transform) {
   // Default constructor
-  BinUtility uBinUtil;
-  if (!transform.isApprox(Transform3D::Identity())) {
-    uBinUtil = BinUtility(std::make_shared<const Transform3D>(transform));
-  }
+  BinUtility uBinUtil(transform);
+
   // The parameters from the cylinder bounds
   double cR = cBounds.get(CylinderBounds::eR);
   double cHz = cBounds.get(CylinderBounds::eHalfLengthZ);
@@ -94,7 +90,7 @@ BinUtility adjustBinUtility(const BinUtility& bu, const CylinderBounds& cBounds,
   double halfPhi = cBounds.get(CylinderBounds::eHalfPhiSector);
   double minPhi = avgPhi - halfPhi;
   double maxPhi = avgPhi + halfPhi;
-  ;
+
   // Retrieve the binning data
   const std::vector<BinningData>& bData = bu.binningData();
   // Loop over the binning data and adjust the dimensions

--- a/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
@@ -34,10 +34,7 @@ BinUtility adjustBinUtility(const BinUtility& bu,
                             const CylinderVolumeBounds& cBounds,
                             const Transform3D& transform) {
   // Default constructor
-  BinUtility uBinUtil;
-  if (!transform.isApprox(Transform3D::Identity())) {
-    uBinUtil = BinUtility(std::make_shared<const Transform3D>(transform));
-  }
+  BinUtility uBinUtil(transform);
   // The parameters from the cylinder bounds
   double minR = cBounds.get(CylinderVolumeBounds::eMinR);
   double maxR = cBounds.get(CylinderVolumeBounds::eMaxR);
@@ -91,10 +88,7 @@ BinUtility adjustBinUtility(const BinUtility& bu,
                             const CutoutCylinderVolumeBounds& cBounds,
                             const Transform3D& transform) {
   // Default constructor
-  BinUtility uBinUtil;
-  if (!transform.isApprox(Transform3D::Identity())) {
-    uBinUtil = BinUtility(std::make_shared<const Transform3D>(transform));
-  }
+  BinUtility uBinUtil(transform);
   // The parameters from the cutout cylinder bounds
   double minR = cBounds.get(CutoutCylinderVolumeBounds::eMinR);
   double maxR = cBounds.get(CutoutCylinderVolumeBounds::eMaxR);
@@ -148,10 +142,7 @@ BinUtility adjustBinUtility(const BinUtility& bu,
                             const CuboidVolumeBounds& cBounds,
                             const Transform3D& transform) {
   // Default constructor
-  BinUtility uBinUtil;
-  if (!transform.isApprox(Transform3D::Identity())) {
-    uBinUtil = BinUtility(std::make_shared<const Transform3D>(transform));
-  }
+  BinUtility uBinUtil(transform);
   // The parameters from the cylinder bounds
   double minX = -cBounds.get(CuboidVolumeBounds::eHalfLengthX);
   double maxX = cBounds.get(CuboidVolumeBounds::eHalfLengthX);

--- a/Core/src/Material/MaterialGridHelper.cpp
+++ b/Core/src/Material/MaterialGridHelper.cpp
@@ -151,13 +151,7 @@ Acts::Grid2D Acts::createGrid2D(
       globalToLocalFromBin(bu[0].binvalue);
   std::function<double(Acts::Vector3D)> coord2 =
       globalToLocalFromBin(bu[1].binvalue);
-  Transform3D transfo;
-  if (bins.transform() != nullptr) {
-    transfo = bins.transform()->inverse();
-  } else {
-    transfo = Transform3D::Identity();
-  }
-
+  Transform3D transfo = bins.transform().inverse();
   transfoGlobalToLocal = [coord1, coord2,
                           transfo](Acts::Vector3D pos) -> Acts::Vector2D {
     pos = transfo * pos;
@@ -208,12 +202,8 @@ Acts::Grid3D Acts::createGrid3D(
       globalToLocalFromBin(bu[1].binvalue);
   std::function<double(Acts::Vector3D)> coord3 =
       globalToLocalFromBin(bu[2].binvalue);
-  Transform3D transfo;
-  if (bins.transform() != nullptr) {
-    transfo = bins.transform()->inverse();
-  } else {
-    transfo = Transform3D::Identity();
-  }
+  Transform3D transfo = bins.transform().inverse();
+
   transfoGlobalToLocal = [coord1, coord2, coord3,
                           transfo](Acts::Vector3D pos) -> Acts::Vector3D {
     pos = transfo * pos;

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -728,12 +728,14 @@ json Acts::JsonGeometryConverter::surfaceMaterialToJson(
     }
     std::vector<double> transfo;
     Acts::Transform3D transfo_matrix = bUtility->transform();
-    for (int i = 0; i < 4; i++) {
-      for (int j = 0; j < 4; j++) {
-        transfo.push_back(transfo_matrix(j, i));
+    if (not transfo_matrix.isApprox(Acts::Transform3D::Identity())) {
+      for (int i = 0; i < 4; i++) {
+        for (int j = 0; j < 4; j++) {
+          transfo.push_back(transfo_matrix(j, i));
+        }
       }
+      smj[m_cfg.transfokeys] = transfo;
     }
-    smj[m_cfg.transfokeys] = transfo;
   }
   return smj;
 }

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -373,8 +373,7 @@ Acts::JsonGeometryConverter::jsonToSurfaceMaterial(const json& material) {
   Acts::BinUtility bUtility;
   for (auto& [key, value] : material.items()) {
     if (key == m_cfg.transfokeys and not value.empty()) {
-      bUtility = Acts::BinUtility(
-          std::make_shared<const Transform3D>(jsonToTransform(value)));
+      bUtility = Acts::BinUtility(jsonToTransform(value));
       break;
     }
   }
@@ -413,8 +412,7 @@ const Acts::IVolumeMaterial* Acts::JsonGeometryConverter::jsonToVolumeMaterial(
   Acts::BinUtility bUtility;
   for (auto& [key, value] : material.items()) {
     if (key == m_cfg.transfokeys and not value.empty()) {
-      bUtility = Acts::BinUtility(
-          std::make_shared<const Transform3D>(jsonToTransform(value)));
+      bUtility = Acts::BinUtility(jsonToTransform(value));
       break;
     }
   }
@@ -728,16 +726,14 @@ json Acts::JsonGeometryConverter::surfaceMaterialToJson(
       }
       smj[binkeys[ibin]] = binj;
     }
-    if (bUtility->transform() != nullptr) {
-      std::vector<double> transfo;
-      Acts::Transform3D transfo_matrix = *(bUtility->transform().get());
-      for (int i = 0; i < 4; i++) {
-        for (int j = 0; j < 4; j++) {
-          transfo.push_back(transfo_matrix(j, i));
-        }
+    std::vector<double> transfo;
+    Acts::Transform3D transfo_matrix = bUtility->transform();
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 4; j++) {
+        transfo.push_back(transfo_matrix(j, i));
       }
-      smj[m_cfg.transfokeys] = transfo;
     }
+    smj[m_cfg.transfokeys] = transfo;
   }
   return smj;
 }
@@ -840,16 +836,14 @@ json Acts::JsonGeometryConverter::volumeMaterialToJson(
       }
       smj[binkeys[ibin]] = binj;
     }
-    if (bUtility->transform() != nullptr) {
-      std::vector<double> transfo;
-      Acts::Transform3D transfo_matrix = *(bUtility->transform().get());
-      for (int i = 0; i < 4; i++) {
-        for (int j = 0; j < 4; j++) {
-          transfo.push_back(transfo_matrix(j, i));
-        }
+    std::vector<double> transfo;
+    Acts::Transform3D transfo_matrix = bUtility->transform();
+    for (int i = 0; i < 4; i++) {
+      for (int j = 0; j < 4; j++) {
+        transfo.push_back(transfo_matrix(j, i));
       }
-      smj[m_cfg.transfokeys] = transfo;
     }
+    smj[m_cfg.transfokeys] = transfo;
   }
   return smj;
 }

--- a/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(BinUtility_transform) {
   noTranform += phiUtil;
   noTranform += zUtil;
 
-  BinUtility withTranform(std::make_shared<const Transform3D>(transform_LtoG));
+  BinUtility withTranform(transform_LtoG);
   withTranform += rUtil;
   withTranform += phiUtil;
   withTranform += zUtil;


### PR DESCRIPTION
This is the last PR to change Transform3D storage to be done by value.

Is independent from #411, and closes #412.

No measurable change in timing is observed by omitting the check if a transforms exists and only then multiply by the transform.

BREAKING CHANGE: the interface of the constructor and retrieval of the Transform3D for the `BinUtility` class