### PR TITLE
fix: Add error message for StepCountLimitReached

### DIFF
--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -71,7 +71,7 @@ auto Acts::Propagator<S, N>::propagate_impl(propagator_state_t& state) const
   if (!terminatedNormally) {
     state.navigation.navigationBreak = true;
     ACTS_ERROR("Propagation reached the step count limit of "
-               << state.options.maxSteps << "(did " << result.steps
+               << state.options.maxSteps << " (did " << result.steps
                << " steps)");
     return PropagatorError::StepCountLimitReached;
   }

--- a/Core/include/Acts/Propagator/PropagatorError.hpp
+++ b/Core/include/Acts/Propagator/PropagatorError.hpp
@@ -33,6 +33,8 @@ class PropagatorErrorCategory : public std::error_category {
         return "Propagation failed";
       case PropagatorError::WrongDirection:
         return "Propagation occurred in the wrong direction";
+      case PropagatorError::StepCountLimitReached:
+        return "Propagation reached the configured maximum number of steps";
       default:
         return "unknown";
     }


### PR DESCRIPTION
This was `unknown` before, because I had forgotton to add it in the switch statement. Also fixes a missing space in a related error printout.