### PR TITLE
refactor!: shorten parameter enum and related type names

### DIFF
--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -104,7 +104,7 @@ class Measurement {
   Measurement(std::shared_ptr<const RefObject> referenceObject,
               const source_link_t& source, CovarianceMatrix cov,
               typename std::enable_if<sizeof...(Tail) + 1 == sizeof...(params),
-                                      ParValue_t>::type head,
+                                      BoundScalar>::type head,
               Tail... values)
       : m_oParameters(std::move(cov), head, values...),
         m_pReferenceObject(std::move(referenceObject)),
@@ -201,7 +201,7 @@ class Measurement {
   ///
   /// @return value of the stored parameter
   template <parameter_indices_t parameter>
-  ParValue_t get() const {
+  BoundScalar get() const {
     return m_oParameters.template getParameter<parameter>();
   }
 
@@ -229,7 +229,7 @@ class Measurement {
   ///
   /// @return uncertainty \f$\sigma \ge 0\f$ for given parameter
   template <parameter_indices_t parameter>
-  ParValue_t uncertainty() const {
+  BoundScalar uncertainty() const {
     return m_oParameters.template getUncertainty<parameter>();
   }
 

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -31,11 +31,11 @@ namespace detail {
 template <typename T>
 struct ReferenceObject {};
 template <>
-struct ReferenceObject<BoundParametersIndices> {
+struct ReferenceObject<BoundIndices> {
   using type = Surface;
 };
 template <>
-struct ReferenceObject<FreeParametersIndices> {
+struct ReferenceObject<FreeIndices> {
   using type = Volume;
 };
 }  // namespace detail
@@ -353,24 +353,24 @@ class Measurement {
  */
 template <typename source_link_t>
 struct fittable_measurement_helper {
-  template <BoundParametersIndices... pars>
+  template <BoundIndices... pars>
   struct meas_factory {
-    using type = Measurement<source_link_t, BoundParametersIndices, pars...>;
+    using type = Measurement<source_link_t, BoundIndices, pars...>;
   };
 
   using type =
-      typename detail::type_generator_t<BoundParametersIndices, meas_factory>;
+      typename detail::type_generator_t<BoundIndices, meas_factory>;
 };
 
 template <typename source_link_t>
 struct fittable_volume_measurement_helper {
-  template <FreeParametersIndices... pars>
+  template <FreeIndices... pars>
   struct meas_factory {
-    using type = Measurement<source_link_t, FreeParametersIndices, pars...>;
+    using type = Measurement<source_link_t, FreeIndices, pars...>;
   };
 
   using type =
-      typename detail::type_generator_t<FreeParametersIndices, meas_factory>;
+      typename detail::type_generator_t<FreeIndices, meas_factory>;
 };
 
 /**

--- a/Core/include/Acts/EventData/Measurement.hpp
+++ b/Core/include/Acts/EventData/Measurement.hpp
@@ -358,8 +358,7 @@ struct fittable_measurement_helper {
     using type = Measurement<source_link_t, BoundIndices, pars...>;
   };
 
-  using type =
-      typename detail::type_generator_t<BoundIndices, meas_factory>;
+  using type = typename detail::type_generator_t<BoundIndices, meas_factory>;
 };
 
 template <typename source_link_t>
@@ -369,8 +368,7 @@ struct fittable_volume_measurement_helper {
     using type = Measurement<source_link_t, FreeIndices, pars...>;
   };
 
-  using type =
-      typename detail::type_generator_t<FreeIndices, meas_factory>;
+  using type = typename detail::type_generator_t<FreeIndices, meas_factory>;
 };
 
 /**

--- a/Core/include/Acts/EventData/MeasurementHelpers.hpp
+++ b/Core/include/Acts/EventData/MeasurementHelpers.hpp
@@ -91,8 +91,8 @@ struct visit_measurement_callable {
 /// @param lambda The lambda to call with the statically sized subsets
 template <typename L, typename A, typename B>
 auto visit_measurement(A&& param, B&& cov, size_t dim, L&& lambda) {
-  return template_switch<detail::visit_measurement_callable, 1,
-                         eBoundSize>(dim, param, cov, lambda);
+  return template_switch<detail::visit_measurement_callable, 1, eBoundSize>(
+      dim, param, cov, lambda);
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/MeasurementHelpers.hpp
+++ b/Core/include/Acts/EventData/MeasurementHelpers.hpp
@@ -92,7 +92,7 @@ struct visit_measurement_callable {
 template <typename L, typename A, typename B>
 auto visit_measurement(A&& param, B&& cov, size_t dim, L&& lambda) {
   return template_switch<detail::visit_measurement_callable, 1,
-                         eBoundParametersSize>(dim, param, cov, lambda);
+                         eBoundSize>(dim, param, cov, lambda);
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -446,7 +446,7 @@ class TrackStateProxy {
   /// @tparam params The parameter tags of the measurement
   /// @param meas The measurement object to set
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
-            ParID_t... params>
+            BoundIndices... params>
   void setCalibrated(const Acts::Measurement<SourceLink, BoundIndices,
                                              params...>& meas) {
     IndexData& dataref = data();
@@ -488,7 +488,7 @@ class TrackStateProxy {
   /// @tparam params The parameter tags of the measurement
   /// @param meas The measurement object to set
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
-            ParID_t... params>
+            BoundIndices... params>
   void resetCalibrated(
       const Acts::Measurement<SourceLink, BoundIndices, params...>&
           meas) {

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -141,9 +141,9 @@ class TrackStateProxy {
  public:
   using SourceLink = source_link_t;
   using Parameters =
-      typename Types<eBoundParametersSize, ReadOnly>::CoefficientsMap;
+      typename Types<eBoundSize, ReadOnly>::CoefficientsMap;
   using Covariance =
-      typename Types<eBoundParametersSize, ReadOnly>::CovarianceMap;
+      typename Types<eBoundSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
 
@@ -153,10 +153,10 @@ class TrackStateProxy {
   // vector, but that's required for 1xN projection matrices below.
   constexpr static auto ProjectorFlags = Eigen::RowMajor | Eigen::AutoAlign;
   using Projector = Eigen::Matrix<typename Covariance::Scalar, M,
-                                  eBoundParametersSize, ProjectorFlags>;
+                                  eBoundSize, ProjectorFlags>;
   using EffectiveProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
-                    ProjectorFlags, M, eBoundParametersSize>;
+                    ProjectorFlags, M, eBoundSize>;
 
   /// Index within the trajectory.
   /// @return the index
@@ -357,7 +357,7 @@ class TrackStateProxy {
     assert(dataref.iprojector != IndexData::kInvalid);
 
     static_assert(rows <= M, "Given projector has too many rows");
-    static_assert(cols <= eBoundParametersSize,
+    static_assert(cols <= eBoundSize,
                   "Given projector has too many columns");
 
     // set up full size projector with only zeros
@@ -447,11 +447,11 @@ class TrackStateProxy {
   /// @param meas The measurement object to set
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
             ParID_t... params>
-  void setCalibrated(const Acts::Measurement<SourceLink, BoundParametersIndices,
+  void setCalibrated(const Acts::Measurement<SourceLink, BoundIndices,
                                              params...>& meas) {
     IndexData& dataref = data();
     constexpr size_t measdim =
-        Acts::Measurement<SourceLink, BoundParametersIndices,
+        Acts::Measurement<SourceLink, BoundIndices,
                           params...>::size();
 
     dataref.measdim = measdim;
@@ -490,7 +490,7 @@ class TrackStateProxy {
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
             ParID_t... params>
   void resetCalibrated(
-      const Acts::Measurement<SourceLink, BoundParametersIndices, params...>&
+      const Acts::Measurement<SourceLink, BoundIndices, params...>&
           meas) {
     IndexData& dataref = data();
     auto& traj = *m_traj;
@@ -606,7 +606,7 @@ template <typename source_link_t>
 class MultiTrajectory {
  public:
   enum {
-    MeasurementSizeMax = eBoundParametersSize,
+    MeasurementSizeMax = eBoundSize,
   };
   using SourceLink = source_link_t;
   using ConstTrackStateProxy =
@@ -615,7 +615,7 @@ class MultiTrajectory {
       detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, false>;
 
   using ProjectorBitset =
-      std::bitset<eBoundParametersSize * MeasurementSizeMax>;
+      std::bitset<eBoundSize * MeasurementSizeMax>;
 
   /// Create an empty trajectory.
   MultiTrajectory() = default;
@@ -661,11 +661,11 @@ class MultiTrajectory {
  private:
   /// index to map track states to the corresponding
   std::vector<detail_lt::IndexData> m_index;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCoefficients m_params;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_cov;
+  typename detail_lt::Types<eBoundSize>::StorageCoefficients m_params;
+  typename detail_lt::Types<eBoundSize>::StorageCovariance m_cov;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCoefficients m_meas;
   typename detail_lt::Types<MeasurementSizeMax>::StorageCovariance m_measCov;
-  typename detail_lt::Types<eBoundParametersSize>::StorageCovariance m_jac;
+  typename detail_lt::Types<eBoundSize>::StorageCovariance m_jac;
   std::vector<SourceLink> m_sourceLinks;
   std::vector<ProjectorBitset> m_projectors;
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -140,10 +140,8 @@ template <typename source_link_t, size_t M, bool ReadOnly = true>
 class TrackStateProxy {
  public:
   using SourceLink = source_link_t;
-  using Parameters =
-      typename Types<eBoundSize, ReadOnly>::CoefficientsMap;
-  using Covariance =
-      typename Types<eBoundSize, ReadOnly>::CovarianceMap;
+  using Parameters = typename Types<eBoundSize, ReadOnly>::CoefficientsMap;
+  using Covariance = typename Types<eBoundSize, ReadOnly>::CovarianceMap;
   using Measurement = typename Types<M, ReadOnly>::CoefficientsMap;
   using MeasurementCovariance = typename Types<M, ReadOnly>::CovarianceMap;
 
@@ -152,8 +150,8 @@ class TrackStateProxy {
   // @TODO: Does not copy flags, because this fails: can't have col major row
   // vector, but that's required for 1xN projection matrices below.
   constexpr static auto ProjectorFlags = Eigen::RowMajor | Eigen::AutoAlign;
-  using Projector = Eigen::Matrix<typename Covariance::Scalar, M,
-                                  eBoundSize, ProjectorFlags>;
+  using Projector =
+      Eigen::Matrix<typename Covariance::Scalar, M, eBoundSize, ProjectorFlags>;
   using EffectiveProjector =
       Eigen::Matrix<typename Projector::Scalar, Eigen::Dynamic, Eigen::Dynamic,
                     ProjectorFlags, M, eBoundSize>;
@@ -357,8 +355,7 @@ class TrackStateProxy {
     assert(dataref.iprojector != IndexData::kInvalid);
 
     static_assert(rows <= M, "Given projector has too many rows");
-    static_assert(cols <= eBoundSize,
-                  "Given projector has too many columns");
+    static_assert(cols <= eBoundSize, "Given projector has too many columns");
 
     // set up full size projector with only zeros
     typename TrackStateProxy::Projector fullProjector =
@@ -447,12 +444,11 @@ class TrackStateProxy {
   /// @param meas The measurement object to set
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
             BoundIndices... params>
-  void setCalibrated(const Acts::Measurement<SourceLink, BoundIndices,
-                                             params...>& meas) {
+  void setCalibrated(
+      const Acts::Measurement<SourceLink, BoundIndices, params...>& meas) {
     IndexData& dataref = data();
     constexpr size_t measdim =
-        Acts::Measurement<SourceLink, BoundIndices,
-                          params...>::size();
+        Acts::Measurement<SourceLink, BoundIndices, params...>::size();
 
     dataref.measdim = measdim;
 
@@ -490,8 +486,7 @@ class TrackStateProxy {
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>,
             BoundIndices... params>
   void resetCalibrated(
-      const Acts::Measurement<SourceLink, BoundIndices, params...>&
-          meas) {
+      const Acts::Measurement<SourceLink, BoundIndices, params...>& meas) {
     IndexData& dataref = data();
     auto& traj = *m_traj;
     // force reallocate, whether currently invalid or shared index
@@ -614,8 +609,7 @@ class MultiTrajectory {
   using TrackStateProxy =
       detail_lt::TrackStateProxy<SourceLink, MeasurementSizeMax, false>;
 
-  using ProjectorBitset =
-      std::bitset<eBoundSize * MeasurementSizeMax>;
+  using ProjectorBitset = std::bitset<eBoundSize * MeasurementSizeMax>;
 
   /// Create an empty trajectory.
   MultiTrajectory() = default;

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -29,10 +29,8 @@
 namespace Acts {
 /// @cond
 // forward type declaration for full parameter set
-using FullParameterSet =
-    typename detail::full_parset<BoundIndices>::type;
-using FullFreeParameterSet =
-    typename detail::full_parset<FreeIndices>::type;
+using FullParameterSet = typename detail::full_parset<BoundIndices>::type;
+using FullFreeParameterSet = typename detail::full_parset<FreeIndices>::type;
 /// @endcond
 
 /**

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -30,9 +30,9 @@ namespace Acts {
 /// @cond
 // forward type declaration for full parameter set
 using FullParameterSet =
-    typename detail::full_parset<BoundParametersIndices>::type;
+    typename detail::full_parset<BoundIndices>::type;
 using FullFreeParameterSet =
-    typename detail::full_parset<FreeParametersIndices>::type;
+    typename detail::full_parset<FreeIndices>::type;
 /// @endcond
 
 /**

--- a/Core/include/Acts/EventData/ParameterSet.hpp
+++ b/Core/include/Acts/EventData/ParameterSet.hpp
@@ -47,7 +47,7 @@ using FullFreeParameterSet =
  * integral type used to identify different parameters. This could for example
  * be an @c enum, @c short, or <tt>unsigned int</tt>. This @c typedef must be
  * convertible to an <tt>unsigned int</tt>
- *  -# It must contain a <tt>typedef #ParValue_t</tt> specifying the type of
+ *  -# It must contain a <tt>typedef #BoundScalar</tt> specifying the type of
  * the parameter values. This could for
  *     instance be @c double, or @c float.
  *  -# It must contain a definition of an integral constant named @c N which is
@@ -108,11 +108,11 @@ class ParameterSet {
   // public typedefs
   /// matrix type for projecting full parameter vector onto local parameter
   /// space
-  using Projection = ActsMatrix<ParValue_t, kNumberOfParameters, kSizeMax>;
+  using Projection = ActsMatrix<BoundScalar, kNumberOfParameters, kSizeMax>;
   /// vector type for stored parameters
-  using ParameterVector = ActsVector<ParValue_t, kNumberOfParameters>;
+  using ParameterVector = ActsVector<BoundScalar, kNumberOfParameters>;
   /// type of covariance matrix
-  using CovarianceMatrix = ActsSymMatrix<ParValue_t, kNumberOfParameters>;
+  using CovarianceMatrix = ActsSymMatrix<BoundScalar, kNumberOfParameters>;
 
   /**
    * @brief initialize values of stored parameters and their covariance matrix
@@ -127,7 +127,7 @@ class ParameterSet {
   template <typename... Tail>
   ParameterSet(
       std::optional<CovarianceMatrix> cov,
-      std::enable_if_t<sizeof...(Tail) + 1 == kNumberOfParameters, ParValue_t>
+      std::enable_if_t<sizeof...(Tail) + 1 == kNumberOfParameters, BoundScalar>
           head,
       Tail... values)
       : m_vValues(kNumberOfParameters) {
@@ -258,7 +258,7 @@ class ParameterSet {
    * @return value of the stored parameter
    */
   template <parameter_indices_t parameter>
-  ParValue_t getParameter() const {
+  BoundScalar getParameter() const {
     return m_vValues(getIndex<parameter>());
   }
 
@@ -280,7 +280,7 @@ class ParameterSet {
    * @return previously stored value of this parameter
    */
   template <parameter_indices_t parameter>
-  void setParameter(ParValue_t value) {
+  void setParameter(BoundScalar value) {
     m_vValues(getIndex<parameter>()) =
         ParameterTypeFor<parameter_indices_t, parameter>::type::getValue(value);
   }
@@ -341,7 +341,7 @@ class ParameterSet {
    *         covariance matrix is set
    */
   template <parameter_indices_t parameter>
-  ParValue_t getUncertainty() const {
+  BoundScalar getUncertainty() const {
     if (m_optCovariance) {
       size_t index = getIndex<parameter>();
       return sqrt((*m_optCovariance)(index, index));
@@ -556,7 +556,7 @@ class ParameterSet {
    * @return constant matrix with @c #kNumberOfParameters rows and @c
    * #kSizeMax columns
    */
-  static const ActsMatrix<ParValue_t, kNumberOfParameters, kSizeMax>
+  static const ActsMatrix<BoundScalar, kNumberOfParameters, kSizeMax>
   projector() {
     return sProjector;
   }

--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -33,7 +33,7 @@ namespace Acts {
 template <class charge_policy_t>
 class SingleBoundTrackParameters {
  public:
-  using Scalar = BoundParametersScalar;
+  using Scalar = BoundScalar;
   using ParametersVector = BoundVector;
   using CovarianceMatrix = BoundSymMatrix;
 
@@ -128,7 +128,7 @@ class SingleBoundTrackParameters {
   /// Access a single parameter value indentified by its index.
   ///
   /// @tparam kIndex Track parameter index
-  template <BoundParametersIndices kIndex>
+  template <BoundIndices kIndex>
   Scalar get() const {
     return m_paramSet.template getParameter<kIndex>();
   }
@@ -137,7 +137,7 @@ class SingleBoundTrackParameters {
   /// @tparam kIndex Track parameter index
   /// @retval zero if the track parameters have no associated covariance
   /// @retval parameter standard deviation if the covariance is available
-  template <BoundParametersIndices kIndex>
+  template <BoundIndices kIndex>
   Scalar uncertainty() const {
     return m_paramSet.getUncertainty<kIndex>();
   }

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -28,7 +28,7 @@ class SingleCurvilinearTrackParameters
   using Base = SingleBoundTrackParameters<charge_policy_t>;
 
  public:
-  using Scalar = BoundParametersScalar;
+  using Scalar = BoundScalar;
   using ParametersVector = BoundVector;
   using CovarianceMatrix = BoundSymMatrix;
 

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -36,7 +36,7 @@ class SingleFreeTrackParameters {
                 "'Acts::NeutralPolicy");
 
  public:
-  using Scalar = FreeParametersScalar;
+  using Scalar = FreeScalar;
   using ParametersVector = FreeVector;
   using CovarianceMatrix = FreeSymMatrix;
 
@@ -76,7 +76,7 @@ class SingleFreeTrackParameters {
   /// @tparam kIndex Identifier of the parameter index which will be retrieved
   ///
   /// @return Value of the requested parameter
-  template <FreeParametersIndices kIndex>
+  template <FreeIndices kIndex>
   Scalar get() const {
     return m_oParameters.template getParameter<kIndex>();
   }
@@ -86,7 +86,7 @@ class SingleFreeTrackParameters {
   /// @tparam kIndex Identifier of the uncertainty index which will be retrieved
   ///
   /// @return Value of the requested parameter uncertainty
-  template <FreeParametersIndices kIndex>
+  template <FreeIndices kIndex>
   Scalar uncertainty() const {
     return m_oParameters.template getUncertainty<kIndex>();
   }
@@ -163,7 +163,7 @@ class SingleFreeTrackParameters {
   ///
   /// @note The context is not used here but makes the API consistent with
   /// @c SingleCurvilinearTrackParameters and @c SingleBoundTrackParameters
-  template <FreeParametersIndices kIndex>
+  template <FreeIndices kIndex>
   void set(const GeometryContext& /*gctx*/, Scalar newValue) {
     m_oParameters.setParameter<kIndex>(newValue);
   }

--- a/Core/include/Acts/EventData/detail/residual_calculator.hpp
+++ b/Core/include/Acts/EventData/detail/residual_calculator.hpp
@@ -35,7 +35,7 @@ struct residual_calculator_impl;
 
 template <typename parameter_indices_t, parameter_indices_t... params>
 struct residual_calculator {
-  using ParVector_t = ActsVector<ParValue_t, sizeof...(params)>;
+  using ParVector_t = ActsVector<BoundScalar, sizeof...(params)>;
 
   static ParVector_t result(const ParVector_t& test, const ParVector_t& ref) {
     ParVector_t result;

--- a/Core/include/Acts/EventData/detail/value_corrector.hpp
+++ b/Core/include/Acts/EventData/detail/value_corrector.hpp
@@ -29,23 +29,23 @@ namespace detail {
 ///
 /// @post All values in the argument `parVector` are within the valid
 ///       parameter range.
-template <ParID_t... params>
+template <BoundIndices... params>
 struct value_corrector;
 
 /// @cond
-template <typename R, ParID_t... params>
+template <typename R, BoundIndices... params>
 struct value_corrector_impl;
 
-template <ParID_t... params>
+template <BoundIndices... params>
 struct value_corrector {
-  using ParVector_t = ActsVector<ParValue_t, sizeof...(params)>;
+  using ParVector_t = ActsVector<BoundScalar, sizeof...(params)>;
 
   static void result(ParVector_t& values) {
     value_corrector_impl<ParVector_t, params...>::calculate(values, 0);
   }
 };
 
-template <typename R, ParID_t first, ParID_t... others>
+template <typename R, BoundIndices first, BoundIndices... others>
 struct value_corrector_impl<R, first, others...> {
   static void calculate(R& values, unsigned int pos) {
     using parameter_type = BoundParameterType<first>;
@@ -56,7 +56,7 @@ struct value_corrector_impl<R, first, others...> {
   }
 };
 
-template <typename R, ParID_t last>
+template <typename R, BoundIndices last>
 struct value_corrector_impl<R, last> {
   static void calculate(R& values, unsigned int pos) {
     using parameter_type = BoundParameterType<last>;

--- a/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/Fitter/GainMatrixUpdater.hpp
@@ -85,13 +85,13 @@ class GainMatrixUpdater {
           ACTS_VERBOSE("Calibrated measurement covariance:\n"
                        << calibrated_covariance);
 
-          const ActsMatrixD<measdim, eBoundParametersSize> H =
+          const ActsMatrixD<measdim, eBoundSize> H =
               trackState.projector()
-                  .template topLeftCorner<measdim, eBoundParametersSize>();
+                  .template topLeftCorner<measdim, eBoundSize>();
 
           ACTS_VERBOSE("Measurement projector H:\n" << H);
 
-          const ActsMatrixD<eBoundParametersSize, measdim> K =
+          const ActsMatrixD<eBoundSize, measdim> K =
               predicted_covariance * H.transpose() *
               (H * predicted_covariance * H.transpose() + calibrated_covariance)
                   .inverse();

--- a/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
+++ b/Core/include/Acts/Fitter/detail/KalmanGlobalCovariance.hpp
@@ -33,8 +33,7 @@ namespace detail {
 /// @return The global track parameters covariance matrix and the starting
 /// row/column for smoothed states
 template <typename source_link_t, typename parameters_t = BoundParameters>
-std::pair<ActsMatrixX<BoundScalar>,
-          std::unordered_map<size_t, size_t>>
+std::pair<ActsMatrixX<BoundScalar>, std::unordered_map<size_t, size_t>>
 globalTrackParametersCovariance(
     const Acts::MultiTrajectory<source_link_t>& multiTraj,
     const size_t& entryIndex) {
@@ -57,9 +56,8 @@ globalTrackParametersCovariance(
 
   // Set the size of global track parameters covariance for all smoothed states
   ActsMatrixX<BoundScalar> fullGlobalTrackParamsCov =
-      ActsMatrixX<BoundScalar>::Zero(
-          nSmoothedStates * eBoundSize,
-          nSmoothedStates * eBoundSize);
+      ActsMatrixX<BoundScalar>::Zero(nSmoothedStates * eBoundSize,
+                                     nSmoothedStates * eBoundSize);
   // The index of state within the trajectory and the starting row/column for
   // this state in the global covariance matrix
   std::unordered_map<size_t, size_t> stateRowIndices;
@@ -68,11 +66,11 @@ globalTrackParametersCovariance(
   size_t nProcessed = 0;
   auto prev_ts = multiTraj.getTrackState(lastSmoothedIndex);
   multiTraj.visitBackwards(lastSmoothedIndex, [&](const auto& ts) {
-    const size_t iRow = fullGlobalTrackParamsCov.rows() -
-                        eBoundSize * (nProcessed + 1);
+    const size_t iRow =
+        fullGlobalTrackParamsCov.rows() - eBoundSize * (nProcessed + 1);
     // Fill the covariance of this state
-    fullGlobalTrackParamsCov.block<eBoundSize, eBoundSize>(
-        iRow, iRow) = ts.smoothedCovariance();
+    fullGlobalTrackParamsCov.block<eBoundSize, eBoundSize>(iRow, iRow) =
+        ts.smoothedCovariance();
     // Fill the correlation between this state (indexed by i-1) and
     // beforehand smoothed states (indexed by j): C^n_{i-1, j}= G_{i-1} *
     // C^n_{i, j} for i <= j
@@ -84,15 +82,12 @@ globalTrackParametersCovariance(
       for (size_t iProcessed = 1; iProcessed <= nProcessed; iProcessed++) {
         const size_t iCol = iRow + eBoundSize * iProcessed;
         CovMatrix prev_correlation =
-            fullGlobalTrackParamsCov
-                .block<eBoundSize, eBoundSize>(
-                    iRow + eBoundSize, iCol);
+            fullGlobalTrackParamsCov.block<eBoundSize, eBoundSize>(
+                iRow + eBoundSize, iCol);
         CovMatrix correlation = G * prev_correlation;
-        fullGlobalTrackParamsCov
-            .block<eBoundSize, eBoundSize>(iRow, iCol) =
+        fullGlobalTrackParamsCov.block<eBoundSize, eBoundSize>(iRow, iCol) =
             correlation;
-        fullGlobalTrackParamsCov
-            .block<eBoundSize, eBoundSize>(iCol, iRow) =
+        fullGlobalTrackParamsCov.block<eBoundSize, eBoundSize>(iCol, iRow) =
             correlation.transpose();
       }
     }

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -108,7 +108,7 @@ class AtlasStepper {
       if (pars.covariance()) {
         // copy the covariance matrix
         covariance =
-            new ActsSymMatrixD<eBoundParametersSize>(*pars.covariance());
+            new ActsSymMatrixD<eBoundSize>(*pars.covariance());
         covTransport = true;
         useJacobian = true;
         const auto transform = pars.referenceSurface().referenceFrame(
@@ -268,11 +268,11 @@ class AtlasStepper {
     /// Cache: P[56] - P[59]
 
     // result
-    double parameters[eBoundParametersSize] = {0., 0., 0., 0., 0., 0.};
+    double parameters[eBoundSize] = {0., 0., 0., 0., 0., 0.};
     const Covariance* covariance;
     Covariance cov = Covariance::Zero();
     bool covTransport = false;
-    double jacobian[eBoundParametersSize * eBoundParametersSize];
+    double jacobian[eBoundSize * eBoundSize];
 
     // accummulated path length cache
     double pathAccumulated = 0.;
@@ -643,7 +643,7 @@ class AtlasStepper {
 
     // prepare the jacobian if we have a covariance
     // copy the covariance matrix
-    state.covariance = new ActsSymMatrixD<eBoundParametersSize>(covariance);
+    state.covariance = new ActsSymMatrixD<eBoundSize>(covariance);
     state.covTransport = true;
     state.useJacobian = true;
 
@@ -815,7 +815,7 @@ class AtlasStepper {
     state.jacobian[34] = P[43];  // dT/dCM
     state.jacobian[35] = P[51];  // dT/dT
 
-    Eigen::Map<Eigen::Matrix<double, eBoundParametersSize, eBoundParametersSize,
+    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize,
                              Eigen::RowMajor>>
         J(state.jacobian);
     state.cov = J * (*state.covariance) * J.transpose();
@@ -1073,7 +1073,7 @@ class AtlasStepper {
     state.jacobian[34] = state.pVector[43];  // dT/dCM
     state.jacobian[35] = state.pVector[51];  // dT/dT
 
-    Eigen::Map<Eigen::Matrix<double, eBoundParametersSize, eBoundParametersSize,
+    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize,
                              Eigen::RowMajor>>
         J(state.jacobian);
     state.cov = J * (*state.covariance) * J.transpose();

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -107,8 +107,7 @@ class AtlasStepper {
       // prepare the jacobian if we have a covariance
       if (pars.covariance()) {
         // copy the covariance matrix
-        covariance =
-            new ActsSymMatrixD<eBoundSize>(*pars.covariance());
+        covariance = new ActsSymMatrixD<eBoundSize>(*pars.covariance());
         covTransport = true;
         useJacobian = true;
         const auto transform = pars.referenceSurface().referenceFrame(
@@ -815,8 +814,7 @@ class AtlasStepper {
     state.jacobian[34] = P[43];  // dT/dCM
     state.jacobian[35] = P[51];  // dT/dT
 
-    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize,
-                             Eigen::RowMajor>>
+    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize, Eigen::RowMajor>>
         J(state.jacobian);
     state.cov = J * (*state.covariance) * J.transpose();
   }
@@ -1073,8 +1071,7 @@ class AtlasStepper {
     state.jacobian[34] = state.pVector[43];  // dT/dCM
     state.jacobian[35] = state.pVector[51];  // dT/dT
 
-    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize,
-                             Eigen::RowMajor>>
+    Eigen::Map<Eigen::Matrix<double, eBoundSize, eBoundSize, Eigen::RowMajor>>
         J(state.jacobian);
     state.cov = J * (*state.covariance) * J.transpose();
   }

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -146,8 +146,7 @@ class RiddersPropagator {
   ///
   /// @return Propagated covariance matrix
   const Covariance calculateCovariance(
-      const std::array<std::vector<BoundVector>, eBoundSize>&
-          derivatives,
+      const std::array<std::vector<BoundVector>, eBoundSize>& derivatives,
       const Covariance& startCov, const std::vector<double>& deviations) const;
 
   /// @brief This function fits a linear function through the final state

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -146,7 +146,7 @@ class RiddersPropagator {
   ///
   /// @return Propagated covariance matrix
   const Covariance calculateCovariance(
-      const std::array<std::vector<BoundVector>, eBoundParametersSize>&
+      const std::array<std::vector<BoundVector>, eBoundSize>&
           derivatives,
       const Covariance& startCov, const std::vector<double>& deviations) const;
 

--- a/Core/include/Acts/Propagator/RiddersPropagator.ipp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.ipp
@@ -199,8 +199,8 @@ Acts::RiddersPropagator<propagator_t>::wiggleDimension(
 
 template <typename propagator_t>
 auto Acts::RiddersPropagator<propagator_t>::calculateCovariance(
-    const std::array<std::vector<Acts::BoundVector>,
-                     Acts::eBoundSize>& derivatives,
+    const std::array<std::vector<Acts::BoundVector>, Acts::eBoundSize>&
+        derivatives,
     const Acts::BoundSymMatrix& startCov,
     const std::vector<double>& deviations) const -> const Covariance {
   Jacobian jacobian;

--- a/Core/include/Acts/Propagator/RiddersPropagator.ipp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.ipp
@@ -37,10 +37,10 @@ auto Acts::RiddersPropagator<propagator_t>::propagate(
   opts.pathLimit *= 2.;
 
   // Derivations of each parameter around the nominal parameters
-  std::array<std::vector<BoundVector>, eBoundParametersSize> derivatives;
+  std::array<std::vector<BoundVector>, eBoundSize> derivatives;
 
   // Wiggle each dimension individually
-  for (unsigned int i = 0; i < eBoundParametersSize; i++) {
+  for (unsigned int i = 0; i < eBoundSize; i++) {
     derivatives[i] =
         wiggleDimension(opts, start, i, surface, nominalParameters, deviations);
   }
@@ -97,10 +97,10 @@ auto Acts::RiddersPropagator<propagator_t>::propagate(
   opts.pathLimit *= 2.;
 
   // Derivations of each parameter around the nominal parameters
-  std::array<std::vector<BoundVector>, eBoundParametersSize> derivatives;
+  std::array<std::vector<BoundVector>, eBoundSize> derivatives;
 
   // Wiggle each dimension individually
-  for (unsigned int i = 0; i < eBoundParametersSize; i++) {
+  for (unsigned int i = 0; i < eBoundSize; i++) {
     derivatives[i] =
         wiggleDimension(opts, start, i, target, nominalParameters, deviations);
   }
@@ -200,7 +200,7 @@ Acts::RiddersPropagator<propagator_t>::wiggleDimension(
 template <typename propagator_t>
 auto Acts::RiddersPropagator<propagator_t>::calculateCovariance(
     const std::array<std::vector<Acts::BoundVector>,
-                     Acts::eBoundParametersSize>& derivatives,
+                     Acts::eBoundSize>& derivatives,
     const Acts::BoundSymMatrix& startCov,
     const std::vector<double>& deviations) const -> const Covariance {
   Jacobian jacobian;

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -196,18 +196,15 @@ inline const BoundRowVector LineSurface::derivativeFactors(
   const BoundRowVector s_vec =
       norm_vec * jacobian.topLeftCorner<3, eBoundSize>();
   // calculate the d factors for the dependency on Tx
-  const BoundRowVector d_vec =
-      locz * jacobian.block<3, eBoundSize>(4, 0);
+  const BoundRowVector d_vec = locz * jacobian.block<3, eBoundSize>(4, 0);
   // normalisation of normal & longitudinal components
   double norm = 1. / (1. - long_c * long_c);
   // create a matrix representation
-  ActsMatrixD<3, eBoundSize> long_mat =
-      ActsMatrixD<3, eBoundSize>::Zero();
+  ActsMatrixD<3, eBoundSize> long_mat = ActsMatrixD<3, eBoundSize>::Zero();
   long_mat.colwise() += locz.transpose();
   // build the combined normal & longitudinal components
-  return (norm *
-          (s_vec - pc * (long_mat * d_vec.asDiagonal() -
-                         jacobian.block<3, eBoundSize>(4, 0))));
+  return (norm * (s_vec - pc * (long_mat * d_vec.asDiagonal() -
+                                jacobian.block<3, eBoundSize>(4, 0))));
 }
 
 inline const AlignmentRowVector LineSurface::alignmentToPathDerivative(

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -194,20 +194,20 @@ inline const BoundRowVector LineSurface::derivativeFactors(
   ActsRowVectorD<3> norm_vec = direction.transpose() - long_c * locz;
   // calculate the s factors for the dependency on X
   const BoundRowVector s_vec =
-      norm_vec * jacobian.topLeftCorner<3, eBoundParametersSize>();
+      norm_vec * jacobian.topLeftCorner<3, eBoundSize>();
   // calculate the d factors for the dependency on Tx
   const BoundRowVector d_vec =
-      locz * jacobian.block<3, eBoundParametersSize>(4, 0);
+      locz * jacobian.block<3, eBoundSize>(4, 0);
   // normalisation of normal & longitudinal components
   double norm = 1. / (1. - long_c * long_c);
   // create a matrix representation
-  ActsMatrixD<3, eBoundParametersSize> long_mat =
-      ActsMatrixD<3, eBoundParametersSize>::Zero();
+  ActsMatrixD<3, eBoundSize> long_mat =
+      ActsMatrixD<3, eBoundSize>::Zero();
   long_mat.colwise() += locz.transpose();
   // build the combined normal & longitudinal components
   return (norm *
           (s_vec - pc * (long_mat * d_vec.asDiagonal() -
-                         jacobian.block<3, eBoundParametersSize>(4, 0))));
+                         jacobian.block<3, eBoundSize>(4, 0))));
 }
 
 inline const AlignmentRowVector LineSurface::alignmentToPathDerivative(

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -114,7 +114,7 @@ inline const BoundRowVector Surface::derivativeFactors(
   ActsRowVectorD<3> norm_vec = rft.template block<1, 3>(2, 0);
   norm_vec /= (norm_vec * direction);
   // calculate the s factors
-  return (norm_vec * jacobian.topLeftCorner<3, eBoundParametersSize>());
+  return (norm_vec * jacobian.topLeftCorner<3, eBoundSize>());
 }
 
 inline const DetectorElementBase* Surface::associatedDetectorElement() const {

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -48,6 +48,6 @@ using AlingmentMatrix =
 using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentParametersScalar, 3, eAlignmentParametersSize>;
 using AlignmentToBoundMatrix =
-    ActsMatrix<BoundParametersScalar, eBoundParametersSize,
+    ActsMatrix<BoundScalar, eBoundSize,
                eAlignmentParametersSize>;
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -48,6 +48,5 @@ using AlingmentMatrix =
 using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentParametersScalar, 3, eAlignmentParametersSize>;
 using AlignmentToBoundMatrix =
-    ActsMatrix<BoundScalar, eBoundSize,
-               eAlignmentParametersSize>;
+    ActsMatrix<BoundScalar, eBoundSize, eAlignmentParametersSize>;
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/ParameterDefinitions.hpp
+++ b/Core/include/Acts/Utilities/ParameterDefinitions.hpp
@@ -36,7 +36,7 @@ namespace Acts {
 /// This must be a regular `enum` and not a scoped `enum class` to allow
 /// implicit conversion to an integer. The enum value are thus visible directly
 /// in `namespace Acts` and are prefixed to avoid naming collisions.
-enum BoundParametersIndices : unsigned int {
+enum BoundIndices : unsigned int {
   // Local position on the reference surface.
   // This is intentionally named different from the position components in
   // the other data vectors, to clarify that this is defined on a surface
@@ -54,7 +54,7 @@ enum BoundParametersIndices : unsigned int {
   eBoundQOverP = 4,
   eBoundTime = 5,
   // Last uninitialized value contains the total number of components
-  eBoundParametersSize,
+  eBoundSize,
   // The following aliases without prefix exist for historical reasons
   // Generic spatial coordinates on the local surface
   eLOC_0 = eBoundLoc0,
@@ -79,7 +79,7 @@ enum BoundParametersIndices : unsigned int {
 };
 
 /// Underlying fundamental scalar type for bound track parameters.
-using BoundParametersScalar = double;
+using BoundScalar = double;
 
 /// Components of a free track parameters vector.
 ///
@@ -87,7 +87,7 @@ using BoundParametersScalar = double;
 /// This must be a regular `enum` and not a scoped `enum class` to allow
 /// implicit conversion to an integer. The enum value are thus visible directly
 /// in `namespace Acts` and are prefixed to avoid naming collisions.
-enum FreeParametersIndices : unsigned int {
+enum FreeIndices : unsigned int {
   // Spatial position
   // The spatial position components must be stored as one continous block.
   eFreePos0 = 0u,
@@ -101,14 +101,14 @@ enum FreeParametersIndices : unsigned int {
   eFreeDir1 = eFreeDir0 + 1u,
   eFreeDir2 = eFreeDir0 + 2u,
   // Global inverse-momentum-like parameter, i.e. q/p or 1/p
-  // See BoundParametersIndices for further information
+  // See BoundIndices for further information
   eFreeQOverP = 7u,
   // Last uninitialized value contains the total number of components
-  eFreeParametersSize,
+  eFreeSize,
 };
 
 /// Underlying fundamental scalar type for free track parameters.
-using FreeParametersScalar = double;
+using FreeScalar = double;
 
 }  // namespace Acts
 #endif
@@ -116,24 +116,24 @@ using FreeParametersScalar = double;
 namespace Acts {
 
 // Ensure bound track parameters definition is valid.
-static_assert(std::is_enum_v<BoundParametersIndices>,
-              "'BoundParametersIndices' must be an enum type");
-static_assert(std::is_convertible_v<BoundParametersIndices, size_t>,
-              "'BoundParametersIndices' must be convertible to size_t");
-static_assert(2 <= BoundParametersIndices::eBoundParametersSize,
+static_assert(std::is_enum_v<BoundIndices>,
+              "'BoundIndices' must be an enum type");
+static_assert(std::is_convertible_v<BoundIndices, size_t>,
+              "'BoundIndices' must be convertible to size_t");
+static_assert(2 <= BoundIndices::eBoundSize,
               "Bound track parameters must have at least two components");
-static_assert(std::is_floating_point_v<BoundParametersScalar>,
-              "'BoundParametersScalar' must be a floating point type");
+static_assert(std::is_floating_point_v<BoundScalar>,
+              "'BoundScalar' must be a floating point type");
 
 // Ensure free track parameters definition is valid.
-static_assert(std::is_enum_v<FreeParametersIndices>,
-              "'FreeParametersIndices' must be an enum type");
-static_assert(std::is_convertible_v<FreeParametersIndices, size_t>,
-              "'FreeParametersIndices' must be convertible to size_t");
-static_assert(6 <= FreeParametersIndices::eFreeParametersSize,
+static_assert(std::is_enum_v<FreeIndices>,
+              "'FreeIndices' must be an enum type");
+static_assert(std::is_convertible_v<FreeIndices, size_t>,
+              "'FreeIndices' must be convertible to size_t");
+static_assert(6 <= FreeIndices::eFreeSize,
               "Free track parameters must have at least six components");
-static_assert(std::is_floating_point_v<FreeParametersScalar>,
-              "'FreeParametersScalar' must be a floating point type");
+static_assert(std::is_floating_point_v<FreeScalar>,
+              "'FreeScalar' must be a floating point type");
 
 // Ensure bound track parameter components/ indices are consistently defined.
 static_assert(eLOC_0 != eLOC_1, "Local parameters must be differents");
@@ -161,96 +161,98 @@ static_assert(eFreeDir1 == eFreeDir0 + 1u, "Direction must be continous");
 static_assert(eFreeDir2 == eFreeDir0 + 2u, "Direction must be continous");
 
 namespace detail {
-template <BoundParametersIndices>
+
+template <BoundIndices>
 struct BoundParameterTraits;
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundLoc0> {
+struct BoundParameterTraits<BoundIndices::eBoundLoc0> {
   using type = local_parameter;
 };
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundLoc1> {
+struct BoundParameterTraits<BoundIndices::eBoundLoc1> {
   using type = local_parameter;
 };
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundPhi> {
+struct BoundParameterTraits<BoundIndices::eBoundPhi> {
   static constexpr double pMin() { return -M_PI; }
   static constexpr double pMax() { return M_PI; }
   using type = cyclic_parameter<double, pMin, pMax>;
 };
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundTheta> {
+struct BoundParameterTraits<BoundIndices::eBoundTheta> {
   static constexpr double pMin() { return 0; }
   static constexpr double pMax() { return M_PI; }
   using type = bound_parameter<double, pMin, pMax>;
 };
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundQOverP> {
+struct BoundParameterTraits<BoundIndices::eBoundQOverP> {
   using type = unbound_parameter;
 };
 template <>
-struct BoundParameterTraits<BoundParametersIndices::eBoundTime> {
+struct BoundParameterTraits<BoundIndices::eBoundTime> {
   using type = unbound_parameter;
 };
 
-template <FreeParametersIndices>
+template <FreeIndices>
 struct FreeParameterTraits;
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreePos0> {
+struct FreeParameterTraits<FreeIndices::eFreePos0> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreePos1> {
+struct FreeParameterTraits<FreeIndices::eFreePos1> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreePos2> {
+struct FreeParameterTraits<FreeIndices::eFreePos2> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreeTime> {
+struct FreeParameterTraits<FreeIndices::eFreeTime> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreeDir0> {
+struct FreeParameterTraits<FreeIndices::eFreeDir0> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreeDir1> {
+struct FreeParameterTraits<FreeIndices::eFreeDir1> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreeDir2> {
+struct FreeParameterTraits<FreeIndices::eFreeDir2> {
   using type = unbound_parameter;
 };
 template <>
-struct FreeParameterTraits<FreeParametersIndices::eFreeQOverP> {
+struct FreeParameterTraits<FreeIndices::eFreeQOverP> {
   using type = unbound_parameter;
 };
 
-template <typename parameter_indices_t>
+template <typename indices_t>
 struct ParametersSize;
 template <>
-struct ParametersSize<BoundParametersIndices> {
+struct ParametersSize<BoundIndices> {
   static constexpr unsigned int size =
-      static_cast<unsigned int>(BoundParametersIndices::eBoundParametersSize);
+      static_cast<unsigned int>(BoundIndices::eBoundSize);
 };
 template <>
-struct ParametersSize<FreeParametersIndices> {
+struct ParametersSize<FreeIndices> {
   static constexpr unsigned int size =
-      static_cast<unsigned int>(FreeParametersIndices::eFreeParametersSize);
+      static_cast<unsigned int>(FreeIndices::eFreeSize);
 };
+
 }  // namespace detail
 
 /// Single bound track parameter type for value constrains.
 ///
 /// The singular name is not a typo since this describes individual components.
-template <BoundParametersIndices kIndex>
+template <BoundIndices kIndex>
 using BoundParameterType = typename detail::BoundParameterTraits<kIndex>::type;
 
 /// Single free track parameter type for value constrains.
 ///
 /// The singular name is not a typo since this describes individual components.
-template <FreeParametersIndices kIndex>
+template <FreeIndices kIndex>
 using FreeParameterType = typename detail::FreeParameterTraits<kIndex>::type;
 
 /// Access the (Bound/Free)ParameterType through common struct
@@ -260,15 +262,15 @@ using FreeParameterType = typename detail::FreeParameterTraits<kIndex>::type;
 template <typename T, T I>
 struct ParameterTypeFor {};
 
-/// Access for @c BoundParametersIndices
-template <BoundParametersIndices I>
-struct ParameterTypeFor<BoundParametersIndices, I> {
+/// Access for @c BoundIndices
+template <BoundIndices I>
+struct ParameterTypeFor<BoundIndices, I> {
   using type = BoundParameterType<I>;
 };
 
-/// Access for @c FreeParametersIndices
-template <FreeParametersIndices I>
-struct ParameterTypeFor<FreeParametersIndices, I> {
+/// Access for @c FreeIndices
+template <FreeIndices I>
+struct ParameterTypeFor<FreeIndices, I> {
   using type = FreeParameterType<I>;
 };
 
@@ -277,47 +279,40 @@ struct ParameterTypeFor<FreeParametersIndices, I> {
 
 // Matrix and vector types related to bound track parameters.
 
-using BoundVector = ActsVector<BoundParametersScalar, eBoundParametersSize>;
-using BoundRowVector =
-    ActsRowVector<BoundParametersScalar, eBoundParametersSize>;
-using BoundMatrix = ActsMatrix<BoundParametersScalar, eBoundParametersSize,
-                               eBoundParametersSize>;
-using BoundSymMatrix =
-    ActsSymMatrix<BoundParametersScalar, eBoundParametersSize>;
+using BoundVector = ActsVector<BoundScalar, eBoundSize>;
+using BoundRowVector = ActsRowVector<BoundScalar, eBoundSize>;
+using BoundMatrix = ActsMatrix<BoundScalar, eBoundSize, eBoundSize>;
+using BoundSymMatrix = ActsSymMatrix<BoundScalar, eBoundSize>;
 
-using LocalCartesianToBoundLocalMatrix =
-    ActsMatrix<BoundParametersScalar, 2, 3>;
+using LocalCartesianToBoundLocalMatrix = ActsMatrix<BoundScalar, 2, 3>;
 
 // Matrix and vector types related to free track parameters.
 
-using FreeVector = ActsVector<FreeParametersScalar, eFreeParametersSize>;
-using FreeRowVector = ActsRowVector<FreeParametersScalar, eFreeParametersSize>;
-using FreeMatrix =
-    ActsMatrix<FreeParametersScalar, eFreeParametersSize, eFreeParametersSize>;
-using FreeSymMatrix = ActsSymMatrix<FreeParametersScalar, eFreeParametersSize>;
+using FreeVector = ActsVector<FreeScalar, eFreeSize>;
+using FreeRowVector = ActsRowVector<FreeScalar, eFreeSize>;
+using FreeMatrix = ActsMatrix<FreeScalar, eFreeSize, eFreeSize>;
+using FreeSymMatrix = ActsSymMatrix<FreeScalar, eFreeSize>;
 
 // Mapping to bound track parameters.
 //
 // Assumes that matrices represent maps from another space into the space of
-// bound track parameters. Thus, the bound parameters scalar type is sufficient
+// bound track parameters. Thus, the bound scalar type is sufficient
 // to retain accuracy.
 
-using FreeToBoundMatrix = ActsMatrix<BoundParametersScalar,
-                                     eBoundParametersSize, eFreeParametersSize>;
+using FreeToBoundMatrix = ActsMatrix<BoundScalar, eBoundSize, eFreeSize>;
 
 // Mapping to free track parameters.
 //
 // Assumes that matrices represent maps from another space into the space of
-// free track parameters. Thus, the free parameters scalar type is sufficient
+// free track parameters. Thus, the free scalar type is sufficient
 // to retain accuracy.
 
-using BoundToFreeMatrix =
-    ActsMatrix<FreeParametersScalar, eFreeParametersSize, eBoundParametersSize>;
+using BoundToFreeMatrix = ActsMatrix<FreeScalar, eFreeSize, eBoundSize>;
 
 // For backward compatibility. New code must use the more explicit
-// `BoundParameters{Indices,Scalar,Traits}...` types.
-using ParDef = BoundParametersIndices;
-using ParID_t = BoundParametersIndices;
-using ParValue_t = BoundParametersScalar;
+// `Bound{Indices,Scalar,Traits}...` types.
+using ParDef = BoundIndices;
+using ParID_t = BoundIndices;
+using ParValue_t = BoundScalar;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/ParameterDefinitions.hpp
+++ b/Core/include/Acts/Utilities/ParameterDefinitions.hpp
@@ -309,10 +309,4 @@ using FreeToBoundMatrix = ActsMatrix<BoundScalar, eBoundSize, eFreeSize>;
 
 using BoundToFreeMatrix = ActsMatrix<FreeScalar, eFreeSize, eBoundSize>;
 
-// For backward compatibility. New code must use the more explicit
-// `Bound{Indices,Scalar,Traits}...` types.
-using ParDef = BoundIndices;
-using ParID_t = BoundIndices;
-using ParValue_t = BoundScalar;
-
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -19,8 +19,7 @@ namespace {
 /// @brief Struct to cache track-specific matrix operations in Billoir fitter
 template <typename input_track_t>
 struct BilloirTrack {
-  using Jacobian = Acts::ActsMatrix<Acts::BoundScalar,
-                                    Acts::eBoundSize, 4>;
+  using Jacobian = Acts::ActsMatrix<Acts::BoundScalar, Acts::eBoundSize, 4>;
 
   BilloirTrack(const input_track_t* params, Acts::LinearizedTrack lTrack)
       : originalTrack(params), linTrack(std::move(lTrack)) {}
@@ -30,13 +29,13 @@ struct BilloirTrack {
   const input_track_t* originalTrack;
   Acts::LinearizedTrack linTrack;
   double chi2;
-  Jacobian DiMat;                                          // position jacobian
+  Jacobian DiMat;                                // position jacobian
   Acts::ActsMatrixD<Acts::eBoundSize, 3> EiMat;  // momentum jacobian
-  Acts::ActsSymMatrixD<3> CiMat;   //  = EtWmat * Emat (see below)
-  Acts::ActsMatrixD<4, 3> BiMat;   //  = DiMat^T * Wi * EiMat
-  Acts::ActsSymMatrixD<3> CiInv;   //  = (EiMat^T * Wi * EiMat)^-1
-  Acts::Vector3D UiVec;            //  = EiMat^T * Wi * dqi
-  Acts::ActsMatrixD<4, 3> BCiMat;  //  = BiMat * Ci^-1
+  Acts::ActsSymMatrixD<3> CiMat;                 //  = EtWmat * Emat (see below)
+  Acts::ActsMatrixD<4, 3> BiMat;                 //  = DiMat^T * Wi * EiMat
+  Acts::ActsSymMatrixD<3> CiInv;                 //  = (EiMat^T * Wi * EiMat)^-1
+  Acts::Vector3D UiVec;                          //  = EiMat^T * Wi * dqi
+  Acts::ActsMatrixD<4, 3> BCiMat;                //  = BiMat * Ci^-1
   Acts::BoundVector deltaQ;
 };
 

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -19,8 +19,8 @@ namespace {
 /// @brief Struct to cache track-specific matrix operations in Billoir fitter
 template <typename input_track_t>
 struct BilloirTrack {
-  using Jacobian = Acts::ActsMatrix<Acts::BoundParametersScalar,
-                                    Acts::eBoundParametersSize, 4>;
+  using Jacobian = Acts::ActsMatrix<Acts::BoundScalar,
+                                    Acts::eBoundSize, 4>;
 
   BilloirTrack(const input_track_t* params, Acts::LinearizedTrack lTrack)
       : originalTrack(params), linTrack(std::move(lTrack)) {}
@@ -31,7 +31,7 @@ struct BilloirTrack {
   Acts::LinearizedTrack linTrack;
   double chi2;
   Jacobian DiMat;                                          // position jacobian
-  Acts::ActsMatrixD<Acts::eBoundParametersSize, 3> EiMat;  // momentum jacobian
+  Acts::ActsMatrixD<Acts::eBoundSize, 3> EiMat;  // momentum jacobian
   Acts::ActsSymMatrixD<3> CiMat;   //  = EtWmat * Emat (see below)
   Acts::ActsMatrixD<4, 3> BiMat;   //  = DiMat^T * Wi * EiMat
   Acts::ActsSymMatrixD<3> CiInv;   //  = (EiMat^T * Wi * EiMat)^-1
@@ -134,15 +134,15 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
             qOverP - fQOvP, 0;
 
         // position jacobian (D matrix)
-        ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> Dmat;
+        ActsMatrix<BoundScalar, eBoundSize, 4> Dmat;
         Dmat = linTrack.positionJacobian;
 
         // momentum jacobian (E matrix)
-        ActsMatrixD<eBoundParametersSize, 3> Emat;
+        ActsMatrixD<eBoundSize, 3> Emat;
         Emat = linTrack.momentumJacobian;
         // cache some matrix multiplications
-        ActsMatrixD<4, eBoundParametersSize> DtWmat;
-        ActsMatrixD<3, eBoundParametersSize> EtWmat;
+        ActsMatrixD<4, eBoundSize> DtWmat;
+        ActsMatrixD<3, eBoundSize> EtWmat;
         BoundSymMatrix Wi = linTrack.weightAtPCA;
 
         DtWmat = Dmat.transpose() * Wi;
@@ -228,7 +228,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
       // calculate 5x5 covdelta_P matrix
       // d(d0,z0,phi,theta,qOverP, t)/d(x,y,z,phi,theta,qOverP,
       // t)-transformation matrix
-      ActsMatrixD<eBoundParametersSize, 7> transMat;
+      ActsMatrixD<eBoundSize, 7> transMat;
       transMat.setZero();
       transMat(0, 0) = bTrack.DiMat(0, 0);
       transMat(0, 1) = bTrack.DiMat(0, 1);

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -105,9 +105,9 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     for (const input_track_t* trackContainer : paramVector) {
       const auto& trackParams = extractParameters(*trackContainer);
       if (nIter == 0) {
-        double phi = trackParams.parameters()[ParID_t::ePHI];
-        double theta = trackParams.parameters()[ParID_t::eTHETA];
-        double qop = trackParams.parameters()[ParID_t::eQOP];
+        double phi = trackParams.parameters()[BoundIndices::ePHI];
+        double theta = trackParams.parameters()[BoundIndices::eTHETA];
+        double qop = trackParams.parameters()[BoundIndices::eQOP];
         trackMomenta.push_back(Vector3D(phi, theta, qop));
       }
 
@@ -117,11 +117,11 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
       if (result.ok()) {
         const auto& linTrack = *result;
         const auto& parametersAtPCA = linTrack.parametersAtPCA;
-        double d0 = parametersAtPCA[ParID_t::eLOC_D0];
-        double z0 = parametersAtPCA[ParID_t::eLOC_Z0];
-        double phi = parametersAtPCA[ParID_t::ePHI];
-        double theta = parametersAtPCA[ParID_t::eTHETA];
-        double qOverP = parametersAtPCA[ParID_t::eQOP];
+        double d0 = parametersAtPCA[BoundIndices::eLOC_D0];
+        double z0 = parametersAtPCA[BoundIndices::eLOC_Z0];
+        double phi = parametersAtPCA[BoundIndices::ePHI];
+        double theta = parametersAtPCA[BoundIndices::eTHETA];
+        double qOverP = parametersAtPCA[BoundIndices::eQOP];
 
         // calculate f(V_0,p_0)  f_d0 = f_z0 = 0
         double fPhi = trackMomenta[iTrack][0];

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -73,13 +73,13 @@ void Acts::GaussianTrackDensity<input_track_t>::addTracks(
   for (auto trk : trackList) {
     const BoundParameters& boundParams = extractParameters(*trk);
     // Get required track parameters
-    const double d0 = boundParams.parameters()[ParID_t::eLOC_D0];
-    const double z0 = boundParams.parameters()[ParID_t::eLOC_Z0];
+    const double d0 = boundParams.parameters()[BoundIndices::eLOC_D0];
+    const double z0 = boundParams.parameters()[BoundIndices::eLOC_Z0];
     // Get track covariance
     const auto perigeeCov = *(boundParams.covariance());
-    const double covDD = perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_D0);
-    const double covZZ = perigeeCov(ParID_t::eLOC_Z0, ParID_t::eLOC_Z0);
-    const double covDZ = perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_Z0);
+    const double covDD = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0);
+    const double covZZ = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
+    const double covDZ = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_Z0);
     const double covDeterminant = (perigeeCov.block<2, 2>(0, 0)).determinant();
 
     // Do track selection based on track cov matrix and m_cfg.d0SignificanceCut

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -77,9 +77,12 @@ void Acts::GaussianTrackDensity<input_track_t>::addTracks(
     const double z0 = boundParams.parameters()[BoundIndices::eLOC_Z0];
     // Get track covariance
     const auto perigeeCov = *(boundParams.covariance());
-    const double covDD = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0);
-    const double covZZ = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
-    const double covDZ = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_Z0);
+    const double covDD =
+        perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0);
+    const double covZZ =
+        perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
+    const double covDZ =
+        perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_Z0);
     const double covDeterminant = (perigeeCov.block<2, 2>(0, 0)).determinant();
 
     // Do track selection based on track cov matrix and m_cfg.d0SignificanceCut

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -105,13 +105,13 @@ template <int mainGridSize, int trkGridSize, typename vfitter_t>
 auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::
     doesPassTrackSelection(const BoundParameters& trk) const -> bool {
   // Get required track parameters
-  const double d0 = trk.parameters()[ParID_t::eLOC_D0];
-  const double z0 = trk.parameters()[ParID_t::eLOC_Z0];
+  const double d0 = trk.parameters()[BoundIndices::eLOC_D0];
+  const double z0 = trk.parameters()[BoundIndices::eLOC_Z0];
   // Get track covariance
   const auto perigeeCov = *(trk.covariance());
-  const double covDD = perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_D0);
-  const double covZZ = perigeeCov(ParID_t::eLOC_Z0, ParID_t::eLOC_Z0);
-  const double covDZ = perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_Z0);
+  const double covDD = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0);
+  const double covZZ = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
+  const double covDZ = perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_Z0);
   const double covDeterminant = covDD * covZZ - covDZ * covDZ;
 
   // Do track selection based on track cov matrix and d0SignificanceCut

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -116,7 +116,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   predParamsAtPCA[5] = 0.;
 
   // Fill position jacobian (D_k matrix), Eq. 5.36 in Ref(1)
-  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> positionJacobian;
+  ActsMatrix<BoundScalar, eBoundSize, 4> positionJacobian;
   positionJacobian.setZero();
   // First row
   positionJacobian(0, 0) = -sgnH * X / S;
@@ -138,7 +138,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   positionJacobian(5, 3) = 1;
 
   // Fill momentum jacobian (E_k matrix), Eq. 5.37 in Ref(1)
-  ActsMatrixD<eBoundParametersSize, 3> momentumJacobian;
+  ActsMatrixD<eBoundSize, 3> momentumJacobian;
   momentumJacobian.setZero();
 
   double R = X * cosPhiV + Y * sinPhiV;

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -56,17 +56,17 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   }
 
   // phiV and functions
-  double phiV = paramsAtPCA(ParID_t::ePHI);
+  double phiV = paramsAtPCA(BoundIndices::ePHI);
   double sinPhiV = std::sin(phiV);
   double cosPhiV = std::cos(phiV);
 
   // theta and functions
-  double th = paramsAtPCA(ParID_t::eTHETA);
+  double th = paramsAtPCA(BoundIndices::eTHETA);
   const double sinTh = std::sin(th);
   const double tanTh = std::tan(th);
 
   // q over p
-  double qOvP = paramsAtPCA(ParID_t::eQOP);
+  double qOvP = paramsAtPCA(BoundIndices::eQOP);
   double sgnH = (qOvP < 0.) ? -1 : 1;
 
   Vector3D momentumAtPCA(phiV, th, qOvP);

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -297,8 +297,9 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   newIPandSigma.IPd0 = d0;
   double d0_PVcontrib = d0JacXY.transpose() * (vrtXYCov * d0JacXY);
   if (d0_PVcontrib >= 0) {
-    newIPandSigma.sigmad0 = std::sqrt(
-        d0_PVcontrib + perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0));
+    newIPandSigma.sigmad0 =
+        std::sqrt(d0_PVcontrib +
+                  perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0));
     newIPandSigma.PVsigmad0 = std::sqrt(d0_PVcontrib);
   } else {
     newIPandSigma.sigmad0 =
@@ -307,10 +308,14 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   }
 
   SymMatrix2D covPerigeeZ0Theta;
-  covPerigeeZ0Theta(0, 0) = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
-  covPerigeeZ0Theta(0, 1) = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eTHETA);
-  covPerigeeZ0Theta(1, 0) = perigeeCov(BoundIndices::eTHETA, BoundIndices::eLOC_Z0);
-  covPerigeeZ0Theta(1, 1) = perigeeCov(BoundIndices::eTHETA, BoundIndices::eTHETA);
+  covPerigeeZ0Theta(0, 0) =
+      perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
+  covPerigeeZ0Theta(0, 1) =
+      perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eTHETA);
+  covPerigeeZ0Theta(1, 0) =
+      perigeeCov(BoundIndices::eTHETA, BoundIndices::eLOC_Z0);
+  covPerigeeZ0Theta(1, 1) =
+      perigeeCov(BoundIndices::eTHETA, BoundIndices::eTHETA);
 
   double vtxZZCov = vtx.covariance()(eZ, eZ);
 
@@ -324,8 +329,8 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
 
     newIPandSigma.PVsigmaz0SinTheta = std::sqrt(sinTheta * vtxZZCov * sinTheta);
     newIPandSigma.IPz0 = z0;
-    newIPandSigma.sigmaz0 =
-        std::sqrt(vtxZZCov + perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0));
+    newIPandSigma.sigmaz0 = std::sqrt(
+        vtxZZCov + perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0));
     newIPandSigma.PVsigmaz0 = std::sqrt(vtxZZCov);
   } else {
     // Remove contribution from PV

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -195,11 +195,11 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
                            Vector3D& momDir, State& state) const {
   Vector3D trkSurfaceCenter = trkParams.referenceSurface().center(gctx);
 
-  double d0 = trkParams.parameters()[ParID_t::eLOC_D0];
-  double z0 = trkParams.parameters()[ParID_t::eLOC_Z0];
-  double phi = trkParams.parameters()[ParID_t::ePHI];
-  double theta = trkParams.parameters()[ParID_t::eTHETA];
-  double qOvP = trkParams.parameters()[ParID_t::eQOP];
+  double d0 = trkParams.parameters()[BoundIndices::eLOC_D0];
+  double z0 = trkParams.parameters()[BoundIndices::eLOC_Z0];
+  double phi = trkParams.parameters()[BoundIndices::ePHI];
+  double theta = trkParams.parameters()[BoundIndices::eTHETA];
+  double qOvP = trkParams.parameters()[BoundIndices::eQOP];
 
   double sinTheta = std::sin(theta);
 
@@ -275,10 +275,10 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
 
   const auto& propRes = *result;
   const auto& params = propRes.endParameters->parameters();
-  const double d0 = params[ParID_t::eLOC_D0];
-  const double z0 = params[ParID_t::eLOC_Z0];
-  const double phi = params[ParID_t::ePHI];
-  const double theta = params[ParID_t::eTHETA];
+  const double d0 = params[BoundIndices::eLOC_D0];
+  const double z0 = params[BoundIndices::eLOC_Z0];
+  const double phi = params[BoundIndices::ePHI];
+  const double theta = params[BoundIndices::eTHETA];
 
   const double sinPhi = std::sin(phi);
   const double sinTheta = std::sin(theta);
@@ -298,19 +298,19 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   double d0_PVcontrib = d0JacXY.transpose() * (vrtXYCov * d0JacXY);
   if (d0_PVcontrib >= 0) {
     newIPandSigma.sigmad0 = std::sqrt(
-        d0_PVcontrib + perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_D0));
+        d0_PVcontrib + perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0));
     newIPandSigma.PVsigmad0 = std::sqrt(d0_PVcontrib);
   } else {
     newIPandSigma.sigmad0 =
-        std::sqrt(perigeeCov(ParID_t::eLOC_D0, ParID_t::eLOC_D0));
+        std::sqrt(perigeeCov(BoundIndices::eLOC_D0, BoundIndices::eLOC_D0));
     newIPandSigma.PVsigmad0 = 0;
   }
 
   SymMatrix2D covPerigeeZ0Theta;
-  covPerigeeZ0Theta(0, 0) = perigeeCov(ParID_t::eLOC_Z0, ParID_t::eLOC_Z0);
-  covPerigeeZ0Theta(0, 1) = perigeeCov(ParID_t::eLOC_Z0, ParID_t::eTHETA);
-  covPerigeeZ0Theta(1, 0) = perigeeCov(ParID_t::eTHETA, ParID_t::eLOC_Z0);
-  covPerigeeZ0Theta(1, 1) = perigeeCov(ParID_t::eTHETA, ParID_t::eTHETA);
+  covPerigeeZ0Theta(0, 0) = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0);
+  covPerigeeZ0Theta(0, 1) = perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eTHETA);
+  covPerigeeZ0Theta(1, 0) = perigeeCov(BoundIndices::eTHETA, BoundIndices::eLOC_Z0);
+  covPerigeeZ0Theta(1, 1) = perigeeCov(BoundIndices::eTHETA, BoundIndices::eTHETA);
 
   double vtxZZCov = vtx.covariance()(eZ, eZ);
 
@@ -325,7 +325,7 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     newIPandSigma.PVsigmaz0SinTheta = std::sqrt(sinTheta * vtxZZCov * sinTheta);
     newIPandSigma.IPz0 = z0;
     newIPandSigma.sigmaz0 =
-        std::sqrt(vtxZZCov + perigeeCov(ParID_t::eLOC_Z0, ParID_t::eLOC_Z0));
+        std::sqrt(vtxZZCov + perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0));
     newIPandSigma.PVsigmaz0 = std::sqrt(vtxZZCov);
   } else {
     // Remove contribution from PV
@@ -337,7 +337,7 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
 
     newIPandSigma.IPz0 = z0;
     newIPandSigma.sigmaz0 =
-        std::sqrt(perigeeCov(ParID_t::eLOC_Z0, ParID_t::eLOC_Z0));
+        std::sqrt(perigeeCov(BoundIndices::eLOC_Z0, BoundIndices::eLOC_Z0));
     newIPandSigma.PVsigmaz0 = 0;
   }
 

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -49,9 +49,9 @@ void Acts::KalmanVertexTrackUpdater::update(TrackAtVertex<input_track_t>& track,
   auto correctedPhiTheta =
       Acts::detail::ensureThetaBounds(newTrkMomentum(0), newTrkMomentum(1));
 
-  newTrkParams(ParID_t::ePHI) = correctedPhiTheta.first;     // phi
-  newTrkParams(ParID_t::eTHETA) = correctedPhiTheta.second;  // theta
-  newTrkParams(ParID_t::eQOP) = newTrkMomentum(2);           // qOverP
+  newTrkParams(BoundIndices::ePHI) = correctedPhiTheta.first;     // phi
+  newTrkParams(BoundIndices::eTHETA) = correctedPhiTheta.second;  // theta
+  newTrkParams(BoundIndices::eQOP) = newTrkMomentum(2);           // qOverP
 
   // Vertex covariance and weight matrices
   const ActsSymMatrixD<3> vtxCov =

--- a/Core/include/Acts/Vertexing/LinearizedTrack.hpp
+++ b/Core/include/Acts/Vertexing/LinearizedTrack.hpp
@@ -48,9 +48,9 @@ struct LinearizedTrack {
                   const BoundSymMatrix& parCovarianceAtPCA,
                   const BoundSymMatrix& parWeightAtPCA,
                   const Vector4D& linPoint,
-                  const ActsMatrix<BoundParametersScalar, eBoundParametersSize,
+                  const ActsMatrix<BoundScalar, eBoundSize,
                                    4>& posJacobian,
-                  const ActsMatrixD<eBoundParametersSize, 3>& momJacobian,
+                  const ActsMatrixD<eBoundSize, 3>& momJacobian,
                   const Vector4D& position, const Vector3D& momentum,
                   const BoundVector& constTerm)
       : parametersAtPCA(paramsAtPCA),
@@ -67,10 +67,10 @@ struct LinearizedTrack {
   BoundSymMatrix covarianceAtPCA{BoundSymMatrix::Zero()};
   BoundSymMatrix weightAtPCA{BoundSymMatrix::Zero()};
   Vector4D linearizationPoint{Vector4D::Zero()};
-  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> positionJacobian{
-      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero()};
-  ActsMatrixD<eBoundParametersSize, 3> momentumJacobian{
-      ActsMatrixD<eBoundParametersSize, 3>::Zero()};
+  ActsMatrix<BoundScalar, eBoundSize, 4> positionJacobian{
+      ActsMatrix<BoundScalar, eBoundSize, 4>::Zero()};
+  ActsMatrixD<eBoundSize, 3> momentumJacobian{
+      ActsMatrixD<eBoundSize, 3>::Zero()};
   Vector4D positionAtPCA{Vector4D::Zero()};
   Vector3D momentumAtPCA{Vector3D::Zero()};
   BoundVector constantTerm{BoundVector::Zero()};

--- a/Core/include/Acts/Vertexing/LinearizedTrack.hpp
+++ b/Core/include/Acts/Vertexing/LinearizedTrack.hpp
@@ -48,8 +48,7 @@ struct LinearizedTrack {
                   const BoundSymMatrix& parCovarianceAtPCA,
                   const BoundSymMatrix& parWeightAtPCA,
                   const Vector4D& linPoint,
-                  const ActsMatrix<BoundScalar, eBoundSize,
-                                   4>& posJacobian,
+                  const ActsMatrix<BoundScalar, eBoundSize, 4>& posJacobian,
                   const ActsMatrixD<eBoundSize, 3>& momJacobian,
                   const Vector4D& position, const Vector3D& momentum,
                   const BoundVector& constTerm)

--- a/Core/include/Acts/Vertexing/Vertex.hpp
+++ b/Core/include/Acts/Vertexing/Vertex.hpp
@@ -55,7 +55,7 @@ class Vertex {
   Vector3D position() const;
 
   /// @return Returns time
-  ParValue_t time() const;
+  BoundScalar time() const;
 
   /// @return Returns 4-position
   const Vector4D& fullPosition() const;
@@ -76,7 +76,7 @@ class Vertex {
   ///
   /// @param position Vertex position
   /// @param time The time
-  void setPosition(const Vector3D& position, ParValue_t time = 0);
+  void setPosition(const Vector3D& position, BoundScalar time = 0);
 
   /// @brief Set position and time
   ///
@@ -86,7 +86,7 @@ class Vertex {
   /// @brief Sets time
   ///
   /// @param time The time
-  void setTime(ParValue_t time);
+  void setTime(BoundScalar time);
 
   /// @brief Sets 3x3 covariance
   ///

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -42,7 +42,7 @@ Acts::Vector3D Acts::Vertex<input_track_t>::position() const {
 }
 
 template <typename input_track_t>
-Acts::ParValue_t Acts::Vertex<input_track_t>::time() const {
+Acts::BoundScalar Acts::Vertex<input_track_t>::time() const {
   return m_position[eTime];
 }
 
@@ -74,7 +74,7 @@ std::pair<double, double> Acts::Vertex<input_track_t>::fitQuality() const {
 
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setPosition(const Vector3D& position,
-                                              ParValue_t time) {
+                                              BoundScalar time) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
   m_position[ePos2] = position[ePos2];
@@ -88,7 +88,7 @@ void Acts::Vertex<input_track_t>::setFullPosition(
 }
 
 template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setTime(ParValue_t time) {
+void Acts::Vertex<input_track_t>::setTime(BoundScalar time) {
   m_position[eTime] = time;
 }
 

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
@@ -70,8 +70,8 @@ auto Acts::ZScanVertexFinder<vfitter_t>::find(
 
     // apply pT weighting as/if configured
     if (!m_cfg.disableAllWeights && (m_cfg.usePt || m_cfg.useLogPt)) {
-      double Pt = std::abs(1. / params.parameters()[ParID_t::eQOP]) *
-                  std::sin(params.parameters()[ParID_t::eTHETA]);
+      double Pt = std::abs(1. / params.parameters()[BoundIndices::eQOP]) *
+                  std::sin(params.parameters()[BoundIndices::eTHETA]);
       if (m_cfg.usePt) {
         z0AndWeight.second *= std::pow(Pt, m_cfg.expPt);
       } else {

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -126,8 +126,7 @@ const FreeToBoundMatrix surfaceDerivative(
   // Transport the covariance
   const ActsRowVectorD<3> normVec(direction);
   const BoundRowVector sfactors =
-      normVec *
-      jacobianLocalToGlobal.template topLeftCorner<3, eBoundSize>();
+      normVec * jacobianLocalToGlobal.template topLeftCorner<3, eBoundSize>();
   jacobianLocalToGlobal -= derivatives * sfactors;
   // Since the jacobian to local needs to calculated for the bound parameters
   // here, it is convenient to do the same here

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -127,7 +127,7 @@ const FreeToBoundMatrix surfaceDerivative(
   const ActsRowVectorD<3> normVec(direction);
   const BoundRowVector sfactors =
       normVec *
-      jacobianLocalToGlobal.template topLeftCorner<3, eBoundParametersSize>();
+      jacobianLocalToGlobal.template topLeftCorner<3, eBoundSize>();
   jacobianLocalToGlobal -= derivatives * sfactors;
   // Since the jacobian to local needs to calculated for the bound parameters
   // here, it is convenient to do the same here

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -98,12 +98,12 @@ const Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   // jacToLocal*derivatives*alignToPath
   alignToBound.block<2, eAlignmentParametersSize>(eLOC_0, eAlignmentCenter0) =
       loc3DToLocBound * alignToLoc3D +
-      jacToLocal.block<2, eFreeParametersSize>(eLOC_0, eFreePos0) *
+      jacToLocal.block<2, eFreeSize>(eLOC_0, eFreePos0) *
           derivatives * alignToPath;
   // -> For bound track parameters ePHI, eTHETA, eQOP, eT, it's
   // jacToLocal*derivatives*alignToPath
   alignToBound.block<4, eAlignmentParametersSize>(ePHI, eAlignmentCenter0) =
-      jacToLocal.block<4, eFreeParametersSize>(ePHI, eFreePos0) * derivatives *
+      jacToLocal.block<4, eFreeSize>(ePHI, eFreePos0) * derivatives *
       alignToPath;
 
   return alignToBound;

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -98,8 +98,8 @@ const Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   // jacToLocal*derivatives*alignToPath
   alignToBound.block<2, eAlignmentParametersSize>(eLOC_0, eAlignmentCenter0) =
       loc3DToLocBound * alignToLoc3D +
-      jacToLocal.block<2, eFreeSize>(eLOC_0, eFreePos0) *
-          derivatives * alignToPath;
+      jacToLocal.block<2, eFreeSize>(eLOC_0, eFreePos0) * derivatives *
+          alignToPath;
   // -> For bound track parameters ePHI, eTHETA, eQOP, eT, it's
   // jacToLocal*derivatives*alignToPath
   alignToBound.block<4, eAlignmentParametersSize>(ePHI, eAlignmentCenter0) =

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -134,60 +134,60 @@ readPropagationConfig(const vmap_t& vm, propagator_t propagator) {
     /// Set the covariance transport to true
     pAlgConfig.covarianceTransport = true;
     /// Set the covariance matrix
-    pAlgConfig.covariances(Acts::ParDef::eLOC_D0, Acts::ParDef::eLOC_D0) =
+    pAlgConfig.covariances(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eLOC_D0) =
         pAlgConfig.d0Sigma * pAlgConfig.d0Sigma;
-    pAlgConfig.covariances(Acts::ParDef::eLOC_Z0, Acts::ParDef::eLOC_Z0) =
+    pAlgConfig.covariances(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eLOC_Z0) =
         pAlgConfig.z0Sigma * pAlgConfig.z0Sigma;
-    pAlgConfig.covariances(Acts::ParDef::ePHI, Acts::ParDef::ePHI) =
+    pAlgConfig.covariances(Acts::BoundIndices::ePHI, Acts::BoundIndices::ePHI) =
         pAlgConfig.phiSigma * pAlgConfig.phiSigma;
-    pAlgConfig.covariances(Acts::ParDef::eTHETA, Acts::ParDef::eTHETA) =
+    pAlgConfig.covariances(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eTHETA) =
         pAlgConfig.thetaSigma * pAlgConfig.thetaSigma;
-    pAlgConfig.covariances(Acts::ParDef::eQOP, Acts::ParDef::eQOP) =
+    pAlgConfig.covariances(Acts::BoundIndices::eQOP, Acts::BoundIndices::eQOP) =
         pAlgConfig.qpSigma * pAlgConfig.qpSigma;
-    pAlgConfig.covariances(Acts::ParDef::eT, Acts::ParDef::eT) =
+    pAlgConfig.covariances(Acts::BoundIndices::eT, Acts::BoundIndices::eT) =
         pAlgConfig.tSigma * pAlgConfig.tSigma;
 
     // Read if the offdiagonal parameters have been read
     auto readOffd = vm["prop-corr-offd"].template as<read_range>();
     // Only if they are properly defined, assign
     if (readOffd.size() == 15) {
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::eLOC_Z0) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eLOC_Z0) =
           readOffd[0];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::ePHI) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::ePHI) =
           readOffd[1];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::eTHETA) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eTHETA) =
           readOffd[2];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::eQOP) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eQOP) =
           readOffd[3];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::eT) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eT) =
           readOffd[4];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_Z0, Acts::ParDef::ePHI) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::ePHI) =
           readOffd[5];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_Z0, Acts::ParDef::eTHETA) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eTHETA) =
           readOffd[6];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_Z0, Acts::ParDef::eQOP) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eQOP) =
           readOffd[7];
-      pAlgConfig.correlations(Acts::ParDef::eLOC_Z0, Acts::ParDef::eT) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eT) =
           readOffd[8];
-      pAlgConfig.correlations(Acts::ParDef::ePHI, Acts::ParDef::eTHETA) =
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eTHETA) =
           readOffd[9];
-      pAlgConfig.correlations(Acts::ParDef::ePHI, Acts::ParDef::eQOP) =
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eQOP) =
           readOffd[10];
-      pAlgConfig.correlations(Acts::ParDef::ePHI, Acts::ParDef::eT) =
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eT) =
           readOffd[11];
-      pAlgConfig.correlations(Acts::ParDef::eTHETA, Acts::ParDef::eQOP) =
+      pAlgConfig.correlations(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eQOP) =
           readOffd[12];
-      pAlgConfig.correlations(Acts::ParDef::eTHETA, Acts::ParDef::eT) =
+      pAlgConfig.correlations(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eT) =
           readOffd[13];
-      pAlgConfig.correlations(Acts::ParDef::eQOP, Acts::ParDef::eT) =
+      pAlgConfig.correlations(Acts::BoundIndices::eQOP, Acts::BoundIndices::eT) =
           readOffd[14];
     } else {
       /// Some pre-defined values (non-trivial helical correlations)
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::ePHI) = -0.8;
-      pAlgConfig.correlations(Acts::ParDef::eLOC_D0, Acts::ParDef::eQOP) = -0.3;
-      pAlgConfig.correlations(Acts::ParDef::eLOC_Z0, Acts::ParDef::eTHETA) =
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::ePHI) = -0.8;
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eQOP) = -0.3;
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eTHETA) =
           -0.8;
-      pAlgConfig.correlations(Acts::ParDef::ePHI, Acts::ParDef::eQOP) = 0.4;
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eQOP) = 0.4;
     }
   }
 

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -134,13 +134,16 @@ readPropagationConfig(const vmap_t& vm, propagator_t propagator) {
     /// Set the covariance transport to true
     pAlgConfig.covarianceTransport = true;
     /// Set the covariance matrix
-    pAlgConfig.covariances(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eLOC_D0) =
+    pAlgConfig.covariances(Acts::BoundIndices::eLOC_D0,
+                           Acts::BoundIndices::eLOC_D0) =
         pAlgConfig.d0Sigma * pAlgConfig.d0Sigma;
-    pAlgConfig.covariances(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eLOC_Z0) =
+    pAlgConfig.covariances(Acts::BoundIndices::eLOC_Z0,
+                           Acts::BoundIndices::eLOC_Z0) =
         pAlgConfig.z0Sigma * pAlgConfig.z0Sigma;
     pAlgConfig.covariances(Acts::BoundIndices::ePHI, Acts::BoundIndices::ePHI) =
         pAlgConfig.phiSigma * pAlgConfig.phiSigma;
-    pAlgConfig.covariances(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eTHETA) =
+    pAlgConfig.covariances(Acts::BoundIndices::eTHETA,
+                           Acts::BoundIndices::eTHETA) =
         pAlgConfig.thetaSigma * pAlgConfig.thetaSigma;
     pAlgConfig.covariances(Acts::BoundIndices::eQOP, Acts::BoundIndices::eQOP) =
         pAlgConfig.qpSigma * pAlgConfig.qpSigma;
@@ -151,43 +154,46 @@ readPropagationConfig(const vmap_t& vm, propagator_t propagator) {
     auto readOffd = vm["prop-corr-offd"].template as<read_range>();
     // Only if they are properly defined, assign
     if (readOffd.size() == 15) {
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eLOC_Z0) =
-          readOffd[0];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::ePHI) =
-          readOffd[1];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eTHETA) =
-          readOffd[2];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eQOP) =
-          readOffd[3];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eT) =
-          readOffd[4];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::ePHI) =
-          readOffd[5];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eTHETA) =
-          readOffd[6];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eQOP) =
-          readOffd[7];
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eT) =
-          readOffd[8];
-      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eTHETA) =
-          readOffd[9];
-      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eQOP) =
-          readOffd[10];
-      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eT) =
-          readOffd[11];
-      pAlgConfig.correlations(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eQOP) =
-          readOffd[12];
-      pAlgConfig.correlations(Acts::BoundIndices::eTHETA, Acts::BoundIndices::eT) =
-          readOffd[13];
-      pAlgConfig.correlations(Acts::BoundIndices::eQOP, Acts::BoundIndices::eT) =
-          readOffd[14];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::eLOC_Z0) = readOffd[0];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::ePHI) = readOffd[1];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::eTHETA) = readOffd[2];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::eQOP) = readOffd[3];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::eT) = readOffd[4];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0,
+                              Acts::BoundIndices::ePHI) = readOffd[5];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0,
+                              Acts::BoundIndices::eTHETA) = readOffd[6];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0,
+                              Acts::BoundIndices::eQOP) = readOffd[7];
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0,
+                              Acts::BoundIndices::eT) = readOffd[8];
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI,
+                              Acts::BoundIndices::eTHETA) = readOffd[9];
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI,
+                              Acts::BoundIndices::eQOP) = readOffd[10];
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI,
+                              Acts::BoundIndices::eT) = readOffd[11];
+      pAlgConfig.correlations(Acts::BoundIndices::eTHETA,
+                              Acts::BoundIndices::eQOP) = readOffd[12];
+      pAlgConfig.correlations(Acts::BoundIndices::eTHETA,
+                              Acts::BoundIndices::eT) = readOffd[13];
+      pAlgConfig.correlations(Acts::BoundIndices::eQOP,
+                              Acts::BoundIndices::eT) = readOffd[14];
     } else {
       /// Some pre-defined values (non-trivial helical correlations)
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::ePHI) = -0.8;
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0, Acts::BoundIndices::eQOP) = -0.3;
-      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0, Acts::BoundIndices::eTHETA) =
-          -0.8;
-      pAlgConfig.correlations(Acts::BoundIndices::ePHI, Acts::BoundIndices::eQOP) = 0.4;
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::ePHI) = -0.8;
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_D0,
+                              Acts::BoundIndices::eQOP) = -0.3;
+      pAlgConfig.correlations(Acts::BoundIndices::eLOC_Z0,
+                              Acts::BoundIndices::eTHETA) = -0.8;
+      pAlgConfig.correlations(Acts::BoundIndices::ePHI,
+                              Acts::BoundIndices::eQOP) = 0.4;
     }
   }
 

--- a/Examples/Framework/include/ActsExamples/EventData/SimSourceLink.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimSourceLink.hpp
@@ -48,12 +48,12 @@ class SimSourceLink {
     if (m_dim == 0) {
       throw std::runtime_error("Cannot create dim 0 measurement");
     } else if (m_dim == 1) {
-      return Acts::Measurement<SimSourceLink, Acts::BoundParametersIndices,
+      return Acts::Measurement<SimSourceLink, Acts::BoundIndices,
                                Acts::eBoundLoc0>{
           m_surface->getSharedPtr(), *this, m_cov.topLeftCorner<1, 1>(),
           m_values[0]};
     } else if (m_dim == 2) {
-      return Acts::Measurement<SimSourceLink, Acts::BoundParametersIndices,
+      return Acts::Measurement<SimSourceLink, Acts::BoundIndices,
                                Acts::eBoundLoc0, Acts::eBoundLoc1>{
           m_surface->getSharedPtr(), *this, m_cov.topLeftCorner<2, 2>(),
           m_values[0], m_values[1]};

--- a/Examples/Framework/src/Validation/ResPlotTool.cpp
+++ b/Examples/Framework/src/Validation/ResPlotTool.cpp
@@ -156,18 +156,18 @@ void ActsExamples::ResPlotTool::fill(
   auto lpResult = pSurface->globalToLocal(gctx, truthParticle.position(),
                                           truthParticle.unitDirection());
   if (lpResult.ok()) {
-    truthParameter[Acts::ParDef::eLOC_D0] =
-        lpResult.value()[Acts::ParDef::eLOC_D0];
-    truthParameter[Acts::ParDef::eLOC_Z0] =
-        lpResult.value()[Acts::ParDef::eLOC_Z0];
+    truthParameter[Acts::BoundIndices::eLOC_D0] =
+        lpResult.value()[Acts::BoundIndices::eLOC_D0];
+    truthParameter[Acts::BoundIndices::eLOC_Z0] =
+        lpResult.value()[Acts::BoundIndices::eLOC_Z0];
   } else {
     ACTS_ERROR("Global to local transformation did not succeed.");
   }
-  truthParameter[Acts::ParDef::ePHI] = phi(truthParticle.unitDirection());
-  truthParameter[Acts::ParDef::eTHETA] = theta(truthParticle.unitDirection());
-  truthParameter[Acts::ParDef::eQOP] =
+  truthParameter[Acts::BoundIndices::ePHI] = phi(truthParticle.unitDirection());
+  truthParameter[Acts::BoundIndices::eTHETA] = theta(truthParticle.unitDirection());
+  truthParameter[Acts::BoundIndices::eQOP] =
       truthParticle.charge() / truthParticle.absMomentum();
-  truthParameter[Acts::ParDef::eT] = truthParticle.time();
+  truthParameter[Acts::BoundIndices::eT] = truthParticle.time();
 
   // get the truth eta and pT
   const auto truthEta = eta(truthParticle.unitDirection());

--- a/Examples/Framework/src/Validation/ResPlotTool.cpp
+++ b/Examples/Framework/src/Validation/ResPlotTool.cpp
@@ -22,7 +22,7 @@ void ActsExamples::ResPlotTool::book(
   PlotHelpers::Binning bPull = m_cfg.varBinning.at("Pull");
 
   ACTS_DEBUG("Initialize the histograms for residual and pull plots");
-  for (unsigned int parID = 0; parID < Acts::eBoundParametersSize; parID++) {
+  for (unsigned int parID = 0; parID < Acts::eBoundSize; parID++) {
     std::string parName = m_cfg.paramNames.at(parID);
 
     std::string parResidual = "Residual_" + parName;
@@ -91,7 +91,7 @@ void ActsExamples::ResPlotTool::book(
 
 void ActsExamples::ResPlotTool::clear(ResPlotCache& resPlotCache) const {
   ACTS_DEBUG("Delete the hists.");
-  for (unsigned int parID = 0; parID < Acts::eBoundParametersSize; parID++) {
+  for (unsigned int parID = 0; parID < Acts::eBoundSize; parID++) {
     std::string parName = m_cfg.paramNames.at(parID);
     delete resPlotCache.res.at(parName);
     delete resPlotCache.res_vs_eta.at(parName);
@@ -113,7 +113,7 @@ void ActsExamples::ResPlotTool::clear(ResPlotCache& resPlotCache) const {
 void ActsExamples::ResPlotTool::write(
     const ResPlotTool::ResPlotCache& resPlotCache) const {
   ACTS_DEBUG("Write the hists to output file.");
-  for (unsigned int parID = 0; parID < Acts::eBoundParametersSize; parID++) {
+  for (unsigned int parID = 0; parID < Acts::eBoundSize; parID++) {
     std::string parName = m_cfg.paramNames.at(parID);
     resPlotCache.res.at(parName)->Write();
     resPlotCache.res_vs_eta.at(parName)->Write();
@@ -174,7 +174,7 @@ void ActsExamples::ResPlotTool::fill(
   const auto truthPt = truthParticle.transverseMomentum();
 
   // fill the histograms for residual and pull
-  for (unsigned int parID = 0; parID < Acts::eBoundParametersSize; parID++) {
+  for (unsigned int parID = 0; parID < Acts::eBoundSize; parID++) {
     std::string parName = m_cfg.paramNames.at(parID);
     float residual = trackParameter[parID] - truthParameter[parID];
     PlotHelpers::fillHisto(resPlotCache.res.at(parName), residual);
@@ -203,7 +203,7 @@ void ActsExamples::ResPlotTool::refinement(
     ResPlotTool::ResPlotCache& resPlotCache) const {
   PlotHelpers::Binning bEta = m_cfg.varBinning.at("Eta");
   PlotHelpers::Binning bPt = m_cfg.varBinning.at("Pt");
-  for (unsigned int parID = 0; parID < Acts::eBoundParametersSize; parID++) {
+  for (unsigned int parID = 0; parID < Acts::eBoundSize; parID++) {
     std::string parName = m_cfg.paramNames.at(parID);
     // refine the plots vs eta
     for (int j = 1; j <= bEta.nBins; j++) {

--- a/Examples/Framework/src/Validation/ResPlotTool.cpp
+++ b/Examples/Framework/src/Validation/ResPlotTool.cpp
@@ -164,7 +164,8 @@ void ActsExamples::ResPlotTool::fill(
     ACTS_ERROR("Global to local transformation did not succeed.");
   }
   truthParameter[Acts::BoundIndices::ePHI] = phi(truthParticle.unitDirection());
-  truthParameter[Acts::BoundIndices::eTHETA] = theta(truthParticle.unitDirection());
+  truthParameter[Acts::BoundIndices::eTHETA] =
+      theta(truthParticle.unitDirection());
   truthParameter[Acts::BoundIndices::eQOP] =
       truthParticle.charge() / truthParticle.absMomentum();
   truthParameter[Acts::BoundIndices::eT] = truthParticle.time();

--- a/Examples/Io/Root/src/RootPlanarClusterWriter.cpp
+++ b/Examples/Io/Root/src/RootPlanarClusterWriter.cpp
@@ -113,8 +113,8 @@ ActsExamples::ProcessCode ActsExamples::RootPlanarClusterWriter::writeT(
     const Acts::PlanarModuleCluster& cluster = entry.second;
     // local cluster information: position, @todo coveraiance
     auto parameters = cluster.parameters();
-    Acts::Vector2D local(parameters[Acts::ParDef::eLOC_0],
-                         parameters[Acts::ParDef::eLOC_1]);
+    Acts::Vector2D local(parameters[Acts::BoundIndices::eLOC_0],
+                         parameters[Acts::BoundIndices::eLOC_1]);
 
     /// prepare for calculating the
     Acts::Vector3D mom(1, 1, 1);

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -28,7 +28,7 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 using Acts::VectorHelpers::theta;
 using Measurement =
-    Acts::Measurement<ActsExamples::SimSourceLink, Acts::BoundParametersIndices,
+    Acts::Measurement<ActsExamples::SimSourceLink, Acts::BoundIndices,
                       Acts::eBoundLoc0, Acts::eBoundLoc1>;
 
 ActsExamples::RootTrajectoryWriter::RootTrajectoryWriter(

--- a/Examples/Io/Root/src/RootVertexAndTracksWriter.cpp
+++ b/Examples/Io/Root/src/RootVertexAndTracksWriter.cpp
@@ -197,12 +197,12 @@ ActsExamples::ProcessCode ActsExamples::RootVertexAndTracksWriter::writeT(
 
     for (auto& track : vertexAndTracks.tracks) {
       // Collect the track information
-      m_d0.push_back(track.parameters()[Acts::ParDef::eLOC_D0]);
-      m_z0.push_back(track.parameters()[Acts::ParDef::eLOC_Z0]);
-      m_phi.push_back(track.parameters()[Acts::ParDef::ePHI]);
-      m_theta.push_back(track.parameters()[Acts::ParDef::eTHETA]);
-      m_qp.push_back(track.parameters()[Acts::ParDef::eQOP]);
-      m_time.push_back(track.parameters()[Acts::ParDef::eT]);
+      m_d0.push_back(track.parameters()[Acts::BoundIndices::eLOC_D0]);
+      m_z0.push_back(track.parameters()[Acts::BoundIndices::eLOC_Z0]);
+      m_phi.push_back(track.parameters()[Acts::BoundIndices::ePHI]);
+      m_theta.push_back(track.parameters()[Acts::BoundIndices::eTHETA]);
+      m_qp.push_back(track.parameters()[Acts::BoundIndices::eQOP]);
+      m_time.push_back(track.parameters()[Acts::BoundIndices::eT]);
       // Current vertex index as vertex ID
       m_vtxID.push_back(m_vx.size() - 1);
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
@@ -26,11 +26,11 @@ using Identifier = Acts::MinimalSourceLink;
 namespace Acts {
 
 template <BoundIndices... params>
-using Measurement_t =
-    Measurement<Identifier, BoundIndices, params...>;
+using Measurement_t = Measurement<Identifier, BoundIndices, params...>;
 
 class PlanarModuleCluster
-    : public Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT> {
+    : public Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1,
+                           BoundIndices::eT> {
  public:
   /// Constructor from DigitizationCells
   ///
@@ -46,9 +46,10 @@ class PlanarModuleCluster
                       double loc0, double loc1, double t,
                       std::vector<DigitizationCell> dCells,
                       const DigitizationModule* dModule = nullptr)
-      : Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT>(
-            std::move(mSurface), identifier,  // original measurement
-            std::move(cov), loc0, loc1, t),
+      : Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1,
+                      BoundIndices::eT>(std::move(mSurface),
+                                        identifier,  // original measurement
+                                        std::move(cov), loc0, loc1, t),
         m_digitizationCells(std::move(dCells)),
         m_digitizationModule(dModule) {}
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
@@ -25,12 +25,12 @@ using Identifier = Acts::MinimalSourceLink;
 
 namespace Acts {
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using Measurement_t =
     Measurement<Identifier, BoundIndices, params...>;
 
 class PlanarModuleCluster
-    : public Measurement_t<ParDef::eLOC_0, ParDef::eLOC_1, ParDef::eT> {
+    : public Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT> {
  public:
   /// Constructor from DigitizationCells
   ///
@@ -46,7 +46,7 @@ class PlanarModuleCluster
                       double loc0, double loc1, double t,
                       std::vector<DigitizationCell> dCells,
                       const DigitizationModule* dModule = nullptr)
-      : Measurement_t<ParDef::eLOC_0, ParDef::eLOC_1, ParDef::eT>(
+      : Measurement_t<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT>(
             std::move(mSurface), identifier,  // original measurement
             std::move(cov), loc0, loc1, t),
         m_digitizationCells(std::move(dCells)),

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
@@ -27,7 +27,7 @@ namespace Acts {
 
 template <ParID_t... params>
 using Measurement_t =
-    Measurement<Identifier, BoundParametersIndices, params...>;
+    Measurement<Identifier, BoundIndices, params...>;
 
 class PlanarModuleCluster
     : public Measurement_t<ParDef::eLOC_0, ParDef::eLOC_1, ParDef::eT> {

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/DoubleHitSpacePointBuilder.ipp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/DoubleHitSpacePointBuilder.ipp
@@ -318,7 +318,8 @@ Acts::Vector2D Acts::SpacePointBuilder<Acts::SpacePoint<Cluster>>::localCoords(
     const Cluster& cluster) const {
   // Local position information
   auto par = cluster.parameters();
-  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0], par[Acts::BoundIndices::eLOC_1]);
+  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0],
+                       par[Acts::BoundIndices::eLOC_1]);
   return local;
 }
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/DoubleHitSpacePointBuilder.ipp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/DoubleHitSpacePointBuilder.ipp
@@ -318,7 +318,7 @@ Acts::Vector2D Acts::SpacePointBuilder<Acts::SpacePoint<Cluster>>::localCoords(
     const Cluster& cluster) const {
   // Local position information
   auto par = cluster.parameters();
-  Acts::Vector2D local(par[Acts::ParDef::eLOC_0], par[Acts::ParDef::eLOC_1]);
+  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0], par[Acts::BoundIndices::eLOC_1]);
   return local;
 }
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/SingleHitSpacePointBuilder.ipp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/SingleHitSpacePointBuilder.ipp
@@ -11,7 +11,8 @@ Acts::Vector2D Acts::SpacePointBuilder<Acts::SpacePoint<Cluster>>::localCoords(
     const Cluster& cluster) const {
   // Local position information
   auto par = cluster.parameters();
-  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0], par[Acts::BoundIndices::eLOC_1]);
+  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0],
+                       par[Acts::BoundIndices::eLOC_1]);
   return local;
 }
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/SingleHitSpacePointBuilder.ipp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/detail/SingleHitSpacePointBuilder.ipp
@@ -11,7 +11,7 @@ Acts::Vector2D Acts::SpacePointBuilder<Acts::SpacePoint<Cluster>>::localCoords(
     const Cluster& cluster) const {
   // Local position information
   auto par = cluster.parameters();
-  Acts::Vector2D local(par[Acts::ParDef::eLOC_0], par[Acts::ParDef::eLOC_1]);
+  Acts::Vector2D local(par[Acts::BoundIndices::eLOC_0], par[Acts::BoundIndices::eLOC_1]);
   return local;
 }
 

--- a/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
@@ -30,7 +30,7 @@ using namespace Acts;
 using namespace Acts::UnitLiterals;
 
 static constexpr auto eps =
-    8 * std::numeric_limits<BoundParametersScalar>::epsilon();
+    8 * std::numeric_limits<BoundScalar>::epsilon();
 static const GeometryContext geoCtx;
 
 template <typename charge_t>

--- a/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
@@ -29,8 +29,7 @@ namespace bdata = boost::unit_test::data;
 using namespace Acts;
 using namespace Acts::UnitLiterals;
 
-static constexpr auto eps =
-    8 * std::numeric_limits<BoundScalar>::epsilon();
+static constexpr auto eps = 8 * std::numeric_limits<BoundScalar>::epsilon();
 static const GeometryContext geoCtx;
 
 template <typename charge_t>

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -20,8 +20,7 @@
 
 using namespace Acts;
 
-static constexpr auto eps =
-    8 * std::numeric_limits<BoundScalar>::epsilon();
+static constexpr auto eps = 8 * std::numeric_limits<BoundScalar>::epsilon();
 
 BOOST_AUTO_TEST_SUITE(CurvilinearTrackParameters)
 

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -21,7 +21,7 @@
 using namespace Acts;
 
 static constexpr auto eps =
-    8 * std::numeric_limits<BoundParametersScalar>::epsilon();
+    8 * std::numeric_limits<BoundScalar>::epsilon();
 
 BOOST_AUTO_TEST_SUITE(CurvilinearTrackParameters)
 

--- a/Tests/UnitTests/Core/EventData/FittableTypeTests.cpp
+++ b/Tests/UnitTests/Core/EventData/FittableTypeTests.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(variant_bound_measurement_generation_test) {
   }
 }
 
-using freePar_t = FreeParametersIndices;
+using freePar_t = FreeIndices;
 
 template <freePar_t... pars>
 struct meas_factory2 {

--- a/Tests/UnitTests/Core/EventData/FittableTypeTests.cpp
+++ b/Tests/UnitTests/Core/EventData/FittableTypeTests.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(index_combination_generation_test) {
   }
 }  // namespace Acts
 
-using par_t = ParID_t;
+using par_t = BoundIndices;
 using Source = MinimalSourceLink;
 
 template <par_t... pars>

--- a/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
@@ -21,8 +21,7 @@ GeometryContext tgContext = GeometryContext();
 using SourceLink = MinimalSourceLink;
 
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 using FittableMeasurement = FittableMeasurement<SourceLink>;
 
 BOOST_AUTO_TEST_CASE(getSurface_test) {
@@ -34,8 +33,8 @@ BOOST_AUTO_TEST_CASE(getSurface_test) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
-                                                    std::move(cov), -0.1, 0.45);
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(
+      cylinder, {}, std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
 
@@ -52,16 +51,16 @@ BOOST_AUTO_TEST_CASE(getSize_test) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
-                                                    std::move(cov), -0.1, 0.45);
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(
+      cylinder, {}, std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
   BOOST_CHECK_EQUAL(MeasurementHelpers::getSize(fm), 2u);
 
   ActsSymMatrixD<3> cov3;
   cov.setRandom();
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT> m2(
-      cylinder, {}, std::move(cov3), -0.1, 0.45, 42);
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT>
+      m2(cylinder, {}, std::move(cov3), -0.1, 0.45, 42);
   fm = m2;
 
   BOOST_CHECK_EQUAL(MeasurementHelpers::getSize(fm), 3u);
@@ -72,8 +71,8 @@ BOOST_AUTO_TEST_CASE(MinimalSourceLinkTest) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
-                                                    std::move(cov), -0.1, 0.45);
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(
+      cylinder, {}, std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
   MinimalSourceLink msl{&fm};

--- a/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
@@ -20,7 +20,7 @@ GeometryContext tgContext = GeometryContext();
 
 using SourceLink = MinimalSourceLink;
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 using FittableMeasurement = FittableMeasurement<SourceLink>;
@@ -34,14 +34,14 @@ BOOST_AUTO_TEST_CASE(getSurface_test) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {},
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
                                                     std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
 
   BOOST_CHECK_EQUAL(MeasurementHelpers::getSurface(fm), cylinder.get());
 
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m2(
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m2(
       cylinder2, {}, std::move(cov), -0.1, 0.45);
   fm = m2;
   BOOST_CHECK_EQUAL(MeasurementHelpers::getSurface(fm), cylinder2.get());
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(getSize_test) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {},
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
                                                     std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(getSize_test) {
 
   ActsSymMatrixD<3> cov3;
   cov.setRandom();
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1, ParDef::eT> m2(
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1, BoundIndices::eT> m2(
       cylinder, {}, std::move(cov3), -0.1, 0.45, 42);
   fm = m2;
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(MinimalSourceLinkTest) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {},
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {},
                                                     std::move(cov), -0.1, 0.45);
 
   FittableMeasurement fm = m;
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(MinimalSourceLinkTest) {
   MinimalSourceLink msl2{&fm};
   BOOST_CHECK_EQUAL(msl, msl2);
 
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m2(
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m2(
       cylinder, {}, std::move(cov), -0.1, 0.45);
   FittableMeasurement fm2 = m2;
   MinimalSourceLink msl3{&fm2};

--- a/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementHelpersTests.cpp
@@ -22,7 +22,7 @@ using SourceLink = MinimalSourceLink;
 
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 using FittableMeasurement = FittableMeasurement<SourceLink>;
 
 BOOST_AUTO_TEST_CASE(getSurface_test) {

--- a/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
@@ -21,8 +21,7 @@ namespace Test {
 using SourceLink = MinimalSourceLink;
 
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief Unit test for creation of Measurement object
 ///
@@ -31,11 +30,11 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {}, cov, -0.1,
-                                                    0.45);
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(
+      cylinder, {}, cov, -0.1, 0.45);
 
-  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m_vec(cylinder, {}, cov,
-                                                        {-0.1, 0.45});
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m_vec(
+      cylinder, {}, cov, {-0.1, 0.45});
 
   std::default_random_engine generator(42);
 
@@ -65,8 +64,8 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
   // The parameters should be identical though
   BOOST_CHECK_EQUAL(mc.parameters(), mcAssigned.parameters());
 
-  std::vector<MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>> caMeasurements{
-      std::move(mcCopy), std::move(mcAssigned)};
+  std::vector<MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>>
+      caMeasurements{std::move(mcCopy), std::move(mcAssigned)};
 
   auto plane = Surface::makeShared<PlaneSurface>(Vector3D(0., 0., 0.),
                                                  Vector3D(1., 0., 0.));

--- a/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
@@ -22,7 +22,7 @@ using SourceLink = MinimalSourceLink;
 
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief Unit test for creation of Measurement object
 ///

--- a/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MeasurementTests.cpp
@@ -20,7 +20,7 @@ namespace Test {
 
 using SourceLink = MinimalSourceLink;
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 
@@ -31,10 +31,10 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
 
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m(cylinder, {}, cov, -0.1,
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m(cylinder, {}, cov, -0.1,
                                                     0.45);
 
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> m_vec(cylinder, {}, cov,
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> m_vec(cylinder, {}, cov,
                                                         {-0.1, 0.45});
 
   std::default_random_engine generator(42);
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
   // Create a measurement on a cylinder
   SymMatrix2D covc;
   covc << 0.04, 0, 0, 0.1;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> mc(
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> mc(
       cylinder, {}, std::move(covc), -0.1, 0.45);
 
   // Check the copy constructor
@@ -65,18 +65,18 @@ BOOST_AUTO_TEST_CASE(measurement_initialization) {
   // The parameters should be identical though
   BOOST_CHECK_EQUAL(mc.parameters(), mcAssigned.parameters());
 
-  std::vector<MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1>> caMeasurements{
+  std::vector<MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>> caMeasurements{
       std::move(mcCopy), std::move(mcAssigned)};
 
   auto plane = Surface::makeShared<PlaneSurface>(Vector3D(0., 0., 0.),
                                                  Vector3D(1., 0., 0.));
   ActsSymMatrixD<1> covp;
   covp << 0.01;
-  MeasurementType<ParDef::eLOC_0> mp(plane, {}, std::move(covp), 0.1);
+  MeasurementType<BoundIndices::eLOC_0> mp(plane, {}, std::move(covp), 0.1);
 
   SymMatrix2D covpp;
   covpp << 0.01, 0., 0., 0.02;
-  MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1> mpp(
+  MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1> mpp(
       plane, {}, std::move(covpp), 0.1, 0.2);
 
   std::vector<FittableMeasurement<SourceLink>> measurements{

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -44,11 +44,10 @@ using CovMat_t = BoundParameters::CovarianceMatrix;
 
 struct TestTrackState {
   SourceLink sourceLink;
-  std::optional<Measurement<SourceLink, BoundIndices, eBoundLoc0,
-                            eBoundLoc1, eBoundQOverP>>
+  std::optional<Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1,
+                            eBoundQOverP>>
       meas3d;
-  std::optional<
-      Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1>>
+  std::optional<Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1>>
       meas2d;
   std::optional<BoundParameters> predicted;
   std::optional<BoundParameters> filtered;
@@ -83,8 +82,7 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
     Vector3D mPar;
     mPar.setRandom();
-    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1,
-                eBoundQOverP>
+    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1, eBoundQOverP>
         meas{plane, {}, mCov, mPar[0], mPar[1], mPar[2]};
 
     fm = std::make_unique<FittableMeasurement<SourceLink>>(meas);
@@ -111,8 +109,8 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
     Vector2D mPar;
     mPar.setRandom();
-    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1>
-        meas{plane, {}, mCov, mPar[0], mPar[1]};
+    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1> meas{
+        plane, {}, mCov, mPar[0], mPar[1]};
 
     fm = std::make_unique<FittableMeasurement<SourceLink>>(meas);
 
@@ -599,8 +597,7 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
   BOOST_CHECK_EQUAL(pc.meas3d->sourceLink(), ts.uncalibrated());
 
   // full projector, should be exactly equal
-  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
-              eBoundSize>
+  ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax, eBoundSize>
       fullProj;
   fullProj.setZero();
   fullProj.topLeftCorner(pc.meas3d->size(), eBoundSize) =

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -44,11 +44,11 @@ using CovMat_t = BoundParameters::CovarianceMatrix;
 
 struct TestTrackState {
   SourceLink sourceLink;
-  std::optional<Measurement<SourceLink, BoundParametersIndices, eBoundLoc0,
+  std::optional<Measurement<SourceLink, BoundIndices, eBoundLoc0,
                             eBoundLoc1, eBoundQOverP>>
       meas3d;
   std::optional<
-      Measurement<SourceLink, BoundParametersIndices, eBoundLoc0, eBoundLoc1>>
+      Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1>>
       meas2d;
   std::optional<BoundParameters> predicted;
   std::optional<BoundParameters> filtered;
@@ -83,7 +83,7 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
     Vector3D mPar;
     mPar.setRandom();
-    Measurement<SourceLink, BoundParametersIndices, eBoundLoc0, eBoundLoc1,
+    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1,
                 eBoundQOverP>
         meas{plane, {}, mCov, mPar[0], mPar[1], mPar[2]};
 
@@ -111,7 +111,7 @@ auto fillTrackState(track_state_t& ts, TrackStatePropMask mask,
 
     Vector2D mPar;
     mPar.setRandom();
-    Measurement<SourceLink, BoundParametersIndices, eBoundLoc0, eBoundLoc1>
+    Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1>
         meas{plane, {}, mCov, mPar[0], mPar[1]};
 
     fm = std::make_unique<FittableMeasurement<SourceLink>>(meas);
@@ -521,7 +521,7 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mCov.setRandom();
   Vector2D mPar;
   mPar.setRandom();
-  Measurement<SourceLink, BoundParametersIndices, eBoundLoc0, eBoundLoc1> m2{
+  Measurement<SourceLink, BoundIndices, eBoundLoc0, eBoundLoc1> m2{
       pc.meas3d->referenceObject().getSharedPtr(), {}, mCov, mPar[0], mPar[1]};
 
   ts.setCalibrated(m2);
@@ -542,9 +542,9 @@ BOOST_AUTO_TEST_CASE(trackstate_reassignment) {
   mCovFull.topLeftCorner(2, 2) = mCov;
   BOOST_CHECK_EQUAL(ts.calibratedCovariance(), mCovFull);
 
-  ActsMatrixD<maxmeasdim, eBoundParametersSize> projFull;
+  ActsMatrixD<maxmeasdim, eBoundSize> projFull;
   projFull.setZero();
-  projFull.topLeftCorner(m2.size(), eBoundParametersSize) = m2.projector();
+  projFull.topLeftCorner(m2.size(), eBoundSize) = m2.projector();
   BOOST_CHECK_EQUAL(ts.projector(), projFull);
 }
 
@@ -600,10 +600,10 @@ BOOST_AUTO_TEST_CASE(storage_consistency) {
 
   // full projector, should be exactly equal
   ActsMatrixD<MultiTrajectory<SourceLink>::MeasurementSizeMax,
-              eBoundParametersSize>
+              eBoundSize>
       fullProj;
   fullProj.setZero();
-  fullProj.topLeftCorner(pc.meas3d->size(), eBoundParametersSize) =
+  fullProj.topLeftCorner(pc.meas3d->size(), eBoundSize) =
       pc.meas3d->projector();
   BOOST_CHECK_EQUAL(ts.projector(), fullProj);
 

--- a/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
+++ b/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
@@ -57,9 +57,9 @@ void check_residuals_for_bound_parameters() {
   dTheta << (theta_1 - theta_2);
 
   // both parameters inside bounds, difference is positive
-  ParameterSet<BoundParametersIndices, eBoundTheta> bound1(std::nullopt,
+  ParameterSet<BoundIndices, eBoundTheta> bound1(std::nullopt,
                                                            theta_1);
-  ParameterSet<BoundParametersIndices, eBoundTheta> bound2(std::nullopt,
+  ParameterSet<BoundIndices, eBoundTheta> bound2(std::nullopt,
                                                            theta_2);
   CHECK_CLOSE_REL(bound1.residual(bound2), dTheta, tol);
 
@@ -121,8 +121,8 @@ void check_residuals_for_cyclic_parameters() {
   ActsVectorD<1> dPhi;
   dPhi << (phi_1 - phi_2);
 
-  ParameterSet<BoundParametersIndices, eBoundPhi> cyclic1(std::nullopt, phi_1);
-  ParameterSet<BoundParametersIndices, eBoundPhi> cyclic2(std::nullopt, phi_2);
+  ParameterSet<BoundIndices, eBoundPhi> cyclic1(std::nullopt, phi_1);
+  ParameterSet<BoundIndices, eBoundPhi> cyclic2(std::nullopt, phi_2);
 
   // no boundary crossing, difference is positive
   CHECK_CLOSE_REL(cyclic1.residual(cyclic2), dPhi, tol);
@@ -330,11 +330,11 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   ActsVectorD<1> vec1D;
   vec1D << 0.1;
 
-  ParameterSet<BoundParametersIndices, eBoundLoc0> parSet_with_cov1D_real(cov1D,
+  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_real(cov1D,
                                                                           0.1);
 
   // This line does not compile
-  ParameterSet<BoundParametersIndices, eBoundLoc0> parSet_with_cov1D_vec1D(
+  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_vec1D(
       cov1D, vec1D);
 
   // Two-dimensional constructions
@@ -344,15 +344,15 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   ActsVectorD<2> vec2D;
   vec2D << 0.1, 0.3;
 
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>
       parSet_with_cov2D_real(cov2D, 0.1, 0.3);
 
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>
       parSet_with_cov2D_vec2D(cov2D, vec2D);
 
   // check template parameter based information
   BOOST_CHECK(
-      (ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1>::size() ==
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>::size() ==
        2));
 
   // covariance matrix
@@ -367,13 +367,13 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   Vector3D parValues(loc0, loc1, phi);
 
   // parameter set with covariance matrix, and three parameters as pack
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       parSet_with_cov(cov, loc0, loc1, phi);
 
   // parameter set with covariance matrix, and a vector
   ActsVectorD<3> vec;
   vec << loc0, loc1, phi;
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       parSet_with_cov_vec(cov, vec);
 
   // check number and type of stored parameters
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   BOOST_CHECK(parSet_with_cov.getUncertainty<eBoundPhi>() == sqrt(cov(2, 2)));
 
   // same parameter set without covariance matrix
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       parSet_without_cov(std::nullopt, parValues);
 
   BOOST_CHECK(!parSet_without_cov.getCovariance());
@@ -451,25 +451,25 @@ BOOST_AUTO_TEST_CASE(parset_copy_assignment_tests) {
   Vector3D firstParValues(loc0, loc1, phi);
 
   // parameter set with covariance matrix
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> first(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> first(
       cov, loc0, loc1, phi);
 
   // check copy constructor
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> copy(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> copy(
       first);
   BOOST_CHECK(first == copy);
 
   // check move constructor
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> moved(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> moved(
       std::move(copy));
   BOOST_CHECK(first == moved);
 
   // check assignment operator
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       assigned = moved;
   BOOST_CHECK(assigned == moved);
 
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> other(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> other(
       std::nullopt, 0, 1.7, -0.15);
   BOOST_CHECK(assigned != other);
   assigned = other;
@@ -478,18 +478,18 @@ BOOST_AUTO_TEST_CASE(parset_copy_assignment_tests) {
   // check move assignment
   BOOST_CHECK(first != assigned);
   first =
-      ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>(
+      ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>(
           assigned);
   BOOST_CHECK(first == assigned);
 
   // check swap method
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> lhs(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> lhs(
       cov, loc0, loc1, phi);
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> rhs(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> rhs(
       std::nullopt, 2 * loc0, 2 * loc1, 2 * phi);
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       lhs_copy = lhs;
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       rhs_copy = rhs;
 
   BOOST_CHECK(lhs != rhs && lhs == lhs_copy && rhs == rhs_copy);
@@ -515,9 +515,9 @@ BOOST_AUTO_TEST_CASE(parset_comparison_tests) {
                             // failed tests due to angle range corrections
 
   // parameter set with covariance matrix
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> first(
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> first(
       cov, loc0, loc1, phi);
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
       second(std::nullopt, 2 * loc0, 2 * loc1, 2 * phi);
 
   // check self comparison
@@ -570,36 +570,36 @@ BOOST_AUTO_TEST_CASE(parset_comparison_tests) {
  */
 BOOST_AUTO_TEST_CASE(parset_projection_tests) {
   // clang-format off
-  ActsMatrixD<1, eBoundParametersSize> phi_proj;
+  ActsMatrixD<1, eBoundSize> phi_proj;
   phi_proj << 0, 0, 1, 0, 0, 0;
 
-  ActsMatrixD<2, eBoundParametersSize> loc0_qop_proj;
+  ActsMatrixD<2, eBoundSize> loc0_qop_proj;
   loc0_qop_proj << 1, 0, 0, 0, 0, 0, 
                    0, 0, 0, 0, 1, 0;
 
-  ActsMatrixD<2, eBoundParametersSize> loc1_theta_proj;
+  ActsMatrixD<2, eBoundSize> loc1_theta_proj;
   loc1_theta_proj << 0, 1, 0, 0, 0, 0, 
                      0, 0, 0, 1, 0, 0;
 
-  ActsMatrixD<3, eBoundParametersSize> loc0_loc1_phi_proj;
+  ActsMatrixD<3, eBoundSize> loc0_loc1_phi_proj;
   loc0_loc1_phi_proj << 1, 0, 0, 0, 0, 0, 
                         0, 1, 0, 0, 0, 0, 
                         0, 0, 1, 0, 0, 0;
 
-  ActsMatrixD<4, eBoundParametersSize> loc0_phi_theta_qop_proj;
+  ActsMatrixD<4, eBoundSize> loc0_phi_theta_qop_proj;
   loc0_phi_theta_qop_proj << 1, 0, 0, 0, 0, 0, 
                              0, 0, 1, 0, 0, 0, 
                              0, 0, 0, 1, 0, 0, 
                              0, 0, 0, 0, 1, 0;
 
-  ActsMatrixD<5, eBoundParametersSize> loc0_loc1_phi_theta_qop_proj;
+  ActsMatrixD<5, eBoundSize> loc0_loc1_phi_theta_qop_proj;
   loc0_loc1_phi_theta_qop_proj << 1, 0, 0, 0, 0, 0, 
                                   0, 1, 0, 0, 0, 0, 
                                   0, 0, 1, 0, 0, 0, 
                                   0, 0, 0, 1, 0, 0, 
                                   0, 0, 0, 0, 1, 0;
 
-  ActsMatrixD<eBoundParametersSize, eBoundParametersSize>
+  ActsMatrixD<eBoundSize, eBoundSize>
       loc0_loc1_phi_theta_qop_t_proj;
   loc0_loc1_phi_theta_qop_t_proj << 1, 0, 0, 0, 0, 0, 
                                     0, 1, 0, 0, 0, 0, 
@@ -609,23 +609,23 @@ BOOST_AUTO_TEST_CASE(parset_projection_tests) {
                                     0, 0, 0, 0, 0, 1;
   // clang-format on
 
-  BOOST_CHECK((ParameterSet<BoundParametersIndices, eBoundPhi>::projector() ==
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundPhi>::projector() ==
                phi_proj));
-  BOOST_CHECK((ParameterSet<BoundParametersIndices, eBoundLoc0,
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0,
                             eBoundQOverP>::projector() == loc0_qop_proj));
-  BOOST_CHECK((ParameterSet<BoundParametersIndices, eBoundLoc1,
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc1,
                             eBoundTheta>::projector() == loc1_theta_proj));
-  BOOST_CHECK((ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1,
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1,
                             eBoundPhi>::projector() == loc0_loc1_phi_proj));
   BOOST_CHECK(
-      (ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundPhi, eBoundTheta,
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta,
                     eBoundQOverP>::projector() == loc0_phi_theta_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
                     eBoundTheta, eBoundQOverP>::projector() ==
        loc0_loc1_phi_theta_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
                     eBoundTheta, eBoundQOverP, eT>::projector() ==
        loc0_loc1_phi_theta_qop_t_proj));
 }
@@ -646,14 +646,14 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   const double large_number = 12443534120;
   const double small_number = -924342675;
   const double normal_number = 1.234;
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundLoc1, eBoundQOverP>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundQOverP>
       unbound(std::nullopt, small_number, large_number, normal_number);
   BOOST_CHECK(unbound.getParameter<eBoundLoc0>() == small_number);
   BOOST_CHECK(unbound.getParameter<eBoundLoc1>() == large_number);
   BOOST_CHECK(unbound.getParameter<eBoundQOverP>() == normal_number);
 
   // check bound parameter type
-  ParameterSet<BoundParametersIndices, eBoundTheta> bound(std::nullopt,
+  ParameterSet<BoundIndices, eBoundTheta> bound(std::nullopt,
                                                           small_number);
   BOOST_CHECK((bound.getParameter<eBoundTheta>() ==
                BoundParameterType<eBoundTheta>::min));
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   BOOST_CHECK((bound.getParameter<eBoundTheta>() == normal_number));
 
   // check cyclic parameter type
-  ParameterSet<BoundParametersIndices, eBoundPhi> cyclic(std::nullopt,
+  ParameterSet<BoundIndices, eBoundPhi> cyclic(std::nullopt,
                                                          small_number);
   // calculate expected results
   const double min = BoundParameterType<eBoundPhi>::min;
@@ -707,9 +707,9 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   const double delta_theta = second_theta - first_theta;
   Vector3D residuals(delta_loc0, delta_phi, delta_theta);
 
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
       first(std::nullopt, first_loc0, first_phi, first_theta);
-  ParameterSet<BoundParametersIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
       second(std::nullopt, second_loc0, second_phi, second_theta);
   CHECK_CLOSE_REL(residuals, second.residual(first), 1e-6);
 
@@ -724,7 +724,7 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
 }
 
 template <ParID_t... params>
-using ParSet = ParameterSet<BoundParametersIndices, params...>;
+using ParSet = ParameterSet<BoundIndices, params...>;
 
 /**
  * @brief Unit test for index-/type-based access of coordinates
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE(parset_parID_mapping) {
 BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   // check template parameter based information
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1>::size() == 2));
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1>::size() == 2));
 
   // covariance matrix
   ActsSymMatrixD<3> cov;
@@ -815,7 +815,7 @@ BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   Vector3D parValues(x, y, z);
 
   // parameter set with covariance matrix
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
       parSet_with_cov(cov, x, y, z);
 
   // check number and type of stored parameters
@@ -843,7 +843,7 @@ BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   BOOST_CHECK(parSet_with_cov.getUncertainty<eFreePos2>() == sqrt(cov(2, 2)));
 
   // same parameter set without covariance matrix
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
       parSet_without_cov(std::nullopt, parValues);
 
   BOOST_CHECK(!parSet_without_cov.getCovariance());
@@ -894,25 +894,25 @@ BOOST_AUTO_TEST_CASE(free_parset_copy_assignment_tests) {
   Vector3D firstParValues(x, y, z);
 
   // parameter set with covariance matrix
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> first(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(
       cov, x, y, z);
 
   // check copy constructor
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> copy(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> copy(
       first);
   BOOST_CHECK(first == copy);
 
   // check move constructor
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> moved(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> moved(
       std::move(copy));
   BOOST_CHECK(first == moved);
 
   // check assignment operator
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
       assigned = moved;
   BOOST_CHECK(assigned == moved);
 
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> other(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> other(
       std::nullopt, 0, 1.7, -0.15);
   BOOST_CHECK(assigned != other);
   assigned = other;
@@ -920,18 +920,18 @@ BOOST_AUTO_TEST_CASE(free_parset_copy_assignment_tests) {
 
   // check move assignment
   BOOST_CHECK(first != assigned);
-  first = ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>(
+  first = ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>(
       assigned);
   BOOST_CHECK(first == assigned);
 
   // check swap method
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> lhs(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> lhs(
       cov, x, y, z);
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> rhs(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> rhs(
       std::nullopt, 2 * x, 2 * y, 2 * z);
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
       lhs_copy = lhs;
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
       rhs_copy = rhs;
 
   BOOST_CHECK(lhs != rhs && lhs == lhs_copy && rhs == rhs_copy);
@@ -956,9 +956,9 @@ BOOST_AUTO_TEST_CASE(free_parset_comparison_tests) {
   double z = 0.3;
 
   // parameter set with covariance matrix
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> first(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(
       cov, x, y, z);
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> second(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> second(
       std::nullopt, 2 * x, 2 * y, 2 * z);
 
   // check self comparison
@@ -1011,36 +1011,36 @@ BOOST_AUTO_TEST_CASE(free_parset_comparison_tests) {
  */
 BOOST_AUTO_TEST_CASE(free_parset_projection_tests) {
   // clang-format off
-  ActsMatrixD<1, eFreeParametersSize> z_proj;
+  ActsMatrixD<1, eFreeSize> z_proj;
   z_proj << 0, 0, 1, 0, 0, 0, 0, 0;
 
-  ActsMatrixD<2, eFreeParametersSize> x_qop_proj;
+  ActsMatrixD<2, eFreeSize> x_qop_proj;
   x_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                 0, 0, 0, 0, 0, 0, 0, 1;
 
-  ActsMatrixD<2, eFreeParametersSize> y_tz_proj;
+  ActsMatrixD<2, eFreeSize> y_tz_proj;
   y_tz_proj << 0, 1, 0, 0, 0, 0, 0, 0, 
                0, 0, 0, 0, 0, 0, 1, 0;
 
-  ActsMatrixD<3, eFreeParametersSize> x_y_z_proj;
+  ActsMatrixD<3, eFreeSize> x_y_z_proj;
   x_y_z_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                 0, 1, 0, 0, 0, 0, 0, 0, 
                 0, 0, 1, 0, 0, 0, 0, 0;
 
-  ActsMatrixD<4, eFreeParametersSize> x_z_tz_qop_proj;
+  ActsMatrixD<4, eFreeSize> x_z_tz_qop_proj;
   x_z_tz_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                      0, 0, 1, 0, 0, 0, 0, 0, 
                      0, 0, 0, 0, 0, 0, 1, 0, 
                      0, 0, 0, 0, 0, 0, 0, 1;
 
-  ActsMatrixD<5, eFreeParametersSize> x_y_z_tz_qop_proj;
+  ActsMatrixD<5, eFreeSize> x_y_z_tz_qop_proj;
   x_y_z_tz_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                        0, 1, 0, 0, 0, 0, 0, 0, 
                        0, 0, 1, 0, 0, 0, 0, 0, 
                        0, 0, 0, 0, 0, 0, 1, 0, 
                        0, 0, 0, 0, 0, 0, 0, 1;
 
-  ActsMatrixD<6, eFreeParametersSize> x_y_z_t_tz_qop_proj;
+  ActsMatrixD<6, eFreeSize> x_y_z_t_tz_qop_proj;
   x_y_z_t_tz_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                          0, 1, 0, 0, 0, 0, 0, 0, 
                          0, 0, 1, 0, 0, 0, 0, 0, 
@@ -1048,7 +1048,7 @@ BOOST_AUTO_TEST_CASE(free_parset_projection_tests) {
                          0, 0, 0, 0, 0, 0, 1, 0, 
                          0, 0, 0, 0, 0, 0, 0, 1;
 
-  ActsMatrixD<7, eFreeParametersSize> x_y_z_t_ty_tz_qop_proj;
+  ActsMatrixD<7, eFreeSize> x_y_z_t_ty_tz_qop_proj;
   x_y_z_t_ty_tz_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                             0, 1, 0, 0, 0, 0, 0, 0, 
                             0, 0, 1, 0, 0, 0, 0, 0, 
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(free_parset_projection_tests) {
                             0, 0, 0, 0, 0, 0, 1, 0, 
                             0, 0, 0, 0, 0, 0, 0, 1;
 
-  ActsMatrixD<eFreeParametersSize, eFreeParametersSize>
+  ActsMatrixD<eFreeSize, eFreeSize>
       x_y_z_t_tx_ty_tz_qop_proj;
   x_y_z_t_tx_ty_tz_qop_proj << 1, 0, 0, 0, 0, 0, 0, 0, 
                                0, 1, 0, 0, 0, 0, 0, 0,
@@ -1070,30 +1070,30 @@ BOOST_AUTO_TEST_CASE(free_parset_projection_tests) {
   // clang-format on
 
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos2>::projector() == z_proj));
-  BOOST_CHECK((ParameterSet<FreeParametersIndices, eFreePos0,
+      (ParameterSet<FreeIndices, eFreePos2>::projector() == z_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0,
                             eFreeQOverP>::projector() == x_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos1, eFreeDir2>::projector() ==
+      (ParameterSet<FreeIndices, eFreePos1, eFreeDir2>::projector() ==
        y_tz_proj));
-  BOOST_CHECK((ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1,
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreePos1,
                             eFreePos2>::projector() == x_y_z_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos0, eFreePos2, eFreeDir2,
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos2, eFreeDir2,
                     eFreeQOverP>::projector() == x_z_tz_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2,
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
                     eFreeDir2, eFreeQOverP>::projector() == x_y_z_tz_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2,
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
                     eFreeTime, eFreeDir2, eFreeQOverP>::projector() ==
        x_y_z_t_tz_qop_proj));
   BOOST_CHECK((
-      ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2,
+      ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
                    eFreeTime, eFreeDir1, eFreeDir2, eFreeQOverP>::projector() ==
       x_y_z_t_ty_tz_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2,
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
                     eFreeTime, eFreeDir0, eFreeDir1, eFreeDir2,
                     eFreeQOverP>::projector() == x_y_z_t_tx_ty_tz_qop_proj));
 }
@@ -1113,7 +1113,7 @@ BOOST_AUTO_TEST_CASE(free_parset_residual_tests) {
   const double large_number = 12443534120;
   const double small_number = -924342675;
   const double normal_number = 0.1234;
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreeQOverP>
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreeQOverP>
       unbound(std::nullopt, small_number, large_number, normal_number);
   BOOST_CHECK(unbound.getParameter<eFreePos0>() == small_number);
   BOOST_CHECK(unbound.getParameter<eFreePos1>() == large_number);
@@ -1135,9 +1135,9 @@ BOOST_AUTO_TEST_CASE(free_parset_residual_tests) {
   const double delta_z = second_z - first_z;
   Vector3D residuals(delta_x, delta_y, delta_z);
 
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> first(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(
       std::nullopt, first_x, first_y, first_z);
-  ParameterSet<FreeParametersIndices, eFreePos0, eFreePos1, eFreePos2> second(
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> second(
       std::nullopt, second_x, second_y, second_z);
   CHECK_CLOSE_REL(residuals, second.residual(first), 1e-6);
 
@@ -1145,8 +1145,8 @@ BOOST_AUTO_TEST_CASE(free_parset_residual_tests) {
   free_random_residual_tests();
 }
 
-template <FreeParametersIndices... params>
-using FreeParSet = ParameterSet<FreeParametersIndices, params...>;
+template <FreeIndices... params>
+using FreeParSet = ParameterSet<FreeIndices, params...>;
 
 /**
  * @brief Unit test for index-/type-based access of coordinates
@@ -1245,7 +1245,7 @@ BOOST_AUTO_TEST_CASE(free_parset_parID_mapping) {
 
   // consistency of types
   BOOST_CHECK(
-      (std::is_same<std::remove_cv<decltype(at_index<FreeParametersIndices, 0,
+      (std::is_same<std::remove_cv<decltype(at_index<FreeIndices, 0,
                                                      eFreePos0>::value)>::type,
                     decltype(eFreePos0)>::value));
   BOOST_CHECK((std::is_same<decltype(FullSet::getParID<0>()),

--- a/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
+++ b/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   random_residual_tests();
 }
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using ParSet = ParameterSet<BoundIndices, params...>;
 
 /**
@@ -780,7 +780,7 @@ BOOST_AUTO_TEST_CASE(parset_parID_mapping) {
 
   // consistency of types
   BOOST_CHECK((std::is_same<std::remove_cv<decltype(
-                                at_index<ParID_t, 0, eBoundLoc0>::value)>::type,
+                                at_index<BoundIndices, 0, eBoundLoc0>::value)>::type,
                             decltype(eBoundLoc0)>::value));
   BOOST_CHECK((std::is_same<decltype(FullSet::getParID<0>()),
                             decltype(eBoundLoc0)>::value));

--- a/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
+++ b/Tests/UnitTests/Core/EventData/ParameterSetTests.cpp
@@ -57,10 +57,8 @@ void check_residuals_for_bound_parameters() {
   dTheta << (theta_1 - theta_2);
 
   // both parameters inside bounds, difference is positive
-  ParameterSet<BoundIndices, eBoundTheta> bound1(std::nullopt,
-                                                           theta_1);
-  ParameterSet<BoundIndices, eBoundTheta> bound2(std::nullopt,
-                                                           theta_2);
+  ParameterSet<BoundIndices, eBoundTheta> bound1(std::nullopt, theta_1);
+  ParameterSet<BoundIndices, eBoundTheta> bound2(std::nullopt, theta_2);
   CHECK_CLOSE_REL(bound1.residual(bound2), dTheta, tol);
 
   // both parameters inside bound, difference negative
@@ -330,12 +328,10 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   ActsVectorD<1> vec1D;
   vec1D << 0.1;
 
-  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_real(cov1D,
-                                                                          0.1);
+  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_real(cov1D, 0.1);
 
   // This line does not compile
-  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_vec1D(
-      cov1D, vec1D);
+  ParameterSet<BoundIndices, eBoundLoc0> parSet_with_cov1D_vec1D(cov1D, vec1D);
 
   // Two-dimensional constructions
   ActsSymMatrixD<2> cov2D;
@@ -344,16 +340,15 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   ActsVectorD<2> vec2D;
   vec2D << 0.1, 0.3;
 
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>
-      parSet_with_cov2D_real(cov2D, 0.1, 0.3);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1> parSet_with_cov2D_real(
+      cov2D, 0.1, 0.3);
 
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>
-      parSet_with_cov2D_vec2D(cov2D, vec2D);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1> parSet_with_cov2D_vec2D(
+      cov2D, vec2D);
 
   // check template parameter based information
   BOOST_CHECK(
-      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>::size() ==
-       2));
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1>::size() == 2));
 
   // covariance matrix
   ActsSymMatrixD<3> cov;
@@ -367,8 +362,8 @@ BOOST_AUTO_TEST_CASE(parset_consistency_tests) {
   Vector3D parValues(loc0, loc1, phi);
 
   // parameter set with covariance matrix, and three parameters as pack
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
-      parSet_with_cov(cov, loc0, loc1, phi);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> parSet_with_cov(
+      cov, loc0, loc1, phi);
 
   // parameter set with covariance matrix, and a vector
   ActsVectorD<3> vec;
@@ -455,8 +450,7 @@ BOOST_AUTO_TEST_CASE(parset_copy_assignment_tests) {
       cov, loc0, loc1, phi);
 
   // check copy constructor
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> copy(
-      first);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> copy(first);
   BOOST_CHECK(first == copy);
 
   // check move constructor
@@ -465,8 +459,8 @@ BOOST_AUTO_TEST_CASE(parset_copy_assignment_tests) {
   BOOST_CHECK(first == moved);
 
   // check assignment operator
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
-      assigned = moved;
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> assigned =
+      moved;
   BOOST_CHECK(assigned == moved);
 
   ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> other(
@@ -478,19 +472,16 @@ BOOST_AUTO_TEST_CASE(parset_copy_assignment_tests) {
   // check move assignment
   BOOST_CHECK(first != assigned);
   first =
-      ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>(
-          assigned);
+      ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>(assigned);
   BOOST_CHECK(first == assigned);
 
   // check swap method
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> lhs(
-      cov, loc0, loc1, phi);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> lhs(cov, loc0,
+                                                                    loc1, phi);
   ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> rhs(
       std::nullopt, 2 * loc0, 2 * loc1, 2 * phi);
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
-      lhs_copy = lhs;
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
-      rhs_copy = rhs;
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> lhs_copy = lhs;
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> rhs_copy = rhs;
 
   BOOST_CHECK(lhs != rhs && lhs == lhs_copy && rhs == rhs_copy);
   using std::swap;
@@ -517,8 +508,8 @@ BOOST_AUTO_TEST_CASE(parset_comparison_tests) {
   // parameter set with covariance matrix
   ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> first(
       cov, loc0, loc1, phi);
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi>
-      second(std::nullopt, 2 * loc0, 2 * loc1, 2 * phi);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi> second(
+      std::nullopt, 2 * loc0, 2 * loc1, 2 * phi);
 
   // check self comparison
   BOOST_CHECK(first == first);
@@ -609,25 +600,24 @@ BOOST_AUTO_TEST_CASE(parset_projection_tests) {
                                     0, 0, 0, 0, 0, 1;
   // clang-format on
 
-  BOOST_CHECK((ParameterSet<BoundIndices, eBoundPhi>::projector() ==
-               phi_proj));
-  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0,
-                            eBoundQOverP>::projector() == loc0_qop_proj));
-  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc1,
-                            eBoundTheta>::projector() == loc1_theta_proj));
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundPhi>::projector() == phi_proj));
+  BOOST_CHECK(
+      (ParameterSet<BoundIndices, eBoundLoc0, eBoundQOverP>::projector() ==
+       loc0_qop_proj));
+  BOOST_CHECK(
+      (ParameterSet<BoundIndices, eBoundLoc1, eBoundTheta>::projector() ==
+       loc1_theta_proj));
   BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1,
                             eBoundPhi>::projector() == loc0_loc1_phi_proj));
   BOOST_CHECK(
       (ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta,
                     eBoundQOverP>::projector() == loc0_phi_theta_qop_proj));
-  BOOST_CHECK(
-      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
-                    eBoundTheta, eBoundQOverP>::projector() ==
-       loc0_loc1_phi_theta_qop_proj));
-  BOOST_CHECK(
-      (ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
-                    eBoundTheta, eBoundQOverP, eT>::projector() ==
-       loc0_loc1_phi_theta_qop_t_proj));
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
+                            eBoundTheta, eBoundQOverP>::projector() ==
+               loc0_loc1_phi_theta_qop_proj));
+  BOOST_CHECK((ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundPhi,
+                            eBoundTheta, eBoundQOverP, eT>::projector() ==
+               loc0_loc1_phi_theta_qop_t_proj));
 }
 
 /**
@@ -646,15 +636,14 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   const double large_number = 12443534120;
   const double small_number = -924342675;
   const double normal_number = 1.234;
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundQOverP>
-      unbound(std::nullopt, small_number, large_number, normal_number);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundLoc1, eBoundQOverP> unbound(
+      std::nullopt, small_number, large_number, normal_number);
   BOOST_CHECK(unbound.getParameter<eBoundLoc0>() == small_number);
   BOOST_CHECK(unbound.getParameter<eBoundLoc1>() == large_number);
   BOOST_CHECK(unbound.getParameter<eBoundQOverP>() == normal_number);
 
   // check bound parameter type
-  ParameterSet<BoundIndices, eBoundTheta> bound(std::nullopt,
-                                                          small_number);
+  ParameterSet<BoundIndices, eBoundTheta> bound(std::nullopt, small_number);
   BOOST_CHECK((bound.getParameter<eBoundTheta>() ==
                BoundParameterType<eBoundTheta>::min));
   bound.setParameter<eBoundTheta>(large_number);
@@ -664,8 +653,7 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   BOOST_CHECK((bound.getParameter<eBoundTheta>() == normal_number));
 
   // check cyclic parameter type
-  ParameterSet<BoundIndices, eBoundPhi> cyclic(std::nullopt,
-                                                         small_number);
+  ParameterSet<BoundIndices, eBoundPhi> cyclic(std::nullopt, small_number);
   // calculate expected results
   const double min = BoundParameterType<eBoundPhi>::min;
   const double max = BoundParameterType<eBoundPhi>::max;
@@ -707,10 +695,10 @@ BOOST_AUTO_TEST_CASE(parset_residual_tests) {
   const double delta_theta = second_theta - first_theta;
   Vector3D residuals(delta_loc0, delta_phi, delta_theta);
 
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
-      first(std::nullopt, first_loc0, first_phi, first_theta);
-  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta>
-      second(std::nullopt, second_loc0, second_phi, second_theta);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta> first(
+      std::nullopt, first_loc0, first_phi, first_theta);
+  ParameterSet<BoundIndices, eBoundLoc0, eBoundPhi, eBoundTheta> second(
+      std::nullopt, second_loc0, second_phi, second_theta);
   CHECK_CLOSE_REL(residuals, second.residual(first), 1e-6);
 
   // some more checks for bound variables
@@ -779,9 +767,10 @@ BOOST_AUTO_TEST_CASE(parset_parID_mapping) {
   BOOST_CHECK((FullSet::getParID<FullSet::getIndex<eT>()>() == eT));
 
   // consistency of types
-  BOOST_CHECK((std::is_same<std::remove_cv<decltype(
-                                at_index<BoundIndices, 0, eBoundLoc0>::value)>::type,
-                            decltype(eBoundLoc0)>::value));
+  BOOST_CHECK(
+      (std::is_same<std::remove_cv<decltype(
+                        at_index<BoundIndices, 0, eBoundLoc0>::value)>::type,
+                    decltype(eBoundLoc0)>::value));
   BOOST_CHECK((std::is_same<decltype(FullSet::getParID<0>()),
                             decltype(eBoundLoc0)>::value));
 }
@@ -801,8 +790,7 @@ BOOST_AUTO_TEST_CASE(parset_parID_mapping) {
  */
 BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   // check template parameter based information
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos0, eFreePos1>::size() == 2));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreePos1>::size() == 2));
 
   // covariance matrix
   ActsSymMatrixD<3> cov;
@@ -815,8 +803,8 @@ BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   Vector3D parValues(x, y, z);
 
   // parameter set with covariance matrix
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
-      parSet_with_cov(cov, x, y, z);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> parSet_with_cov(
+      cov, x, y, z);
 
   // check number and type of stored parameters
   BOOST_CHECK(parSet_with_cov.size() == 3);
@@ -843,8 +831,8 @@ BOOST_AUTO_TEST_CASE(free_parset_consistency_tests) {
   BOOST_CHECK(parSet_with_cov.getUncertainty<eFreePos2>() == sqrt(cov(2, 2)));
 
   // same parameter set without covariance matrix
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
-      parSet_without_cov(std::nullopt, parValues);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> parSet_without_cov(
+      std::nullopt, parValues);
 
   BOOST_CHECK(!parSet_without_cov.getCovariance());
   BOOST_CHECK(parSet_without_cov.getUncertainty<eFreePos0>() < 0);
@@ -894,12 +882,11 @@ BOOST_AUTO_TEST_CASE(free_parset_copy_assignment_tests) {
   Vector3D firstParValues(x, y, z);
 
   // parameter set with covariance matrix
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(
-      cov, x, y, z);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(cov, x, y,
+                                                                   z);
 
   // check copy constructor
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> copy(
-      first);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> copy(first);
   BOOST_CHECK(first == copy);
 
   // check move constructor
@@ -908,8 +895,7 @@ BOOST_AUTO_TEST_CASE(free_parset_copy_assignment_tests) {
   BOOST_CHECK(first == moved);
 
   // check assignment operator
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
-      assigned = moved;
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> assigned = moved;
   BOOST_CHECK(assigned == moved);
 
   ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> other(
@@ -920,19 +906,15 @@ BOOST_AUTO_TEST_CASE(free_parset_copy_assignment_tests) {
 
   // check move assignment
   BOOST_CHECK(first != assigned);
-  first = ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>(
-      assigned);
+  first = ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>(assigned);
   BOOST_CHECK(first == assigned);
 
   // check swap method
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> lhs(
-      cov, x, y, z);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> lhs(cov, x, y, z);
   ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> rhs(
       std::nullopt, 2 * x, 2 * y, 2 * z);
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
-      lhs_copy = lhs;
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>
-      rhs_copy = rhs;
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> lhs_copy = lhs;
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> rhs_copy = rhs;
 
   BOOST_CHECK(lhs != rhs && lhs == lhs_copy && rhs == rhs_copy);
   using std::swap;
@@ -956,8 +938,8 @@ BOOST_AUTO_TEST_CASE(free_parset_comparison_tests) {
   double z = 0.3;
 
   // parameter set with covariance matrix
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(
-      cov, x, y, z);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> first(cov, x, y,
+                                                                   z);
   ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2> second(
       std::nullopt, 2 * x, 2 * y, 2 * z);
 
@@ -1069,33 +1051,30 @@ BOOST_AUTO_TEST_CASE(free_parset_projection_tests) {
                                0, 0, 0, 0, 0, 0, 0, 1;
   // clang-format on
 
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos2>::projector() == z_proj));
-  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0,
-                            eFreeQOverP>::projector() == x_qop_proj));
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos1, eFreeDir2>::projector() ==
-       y_tz_proj));
-  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreePos1,
-                            eFreePos2>::projector() == x_y_z_proj));
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos0, eFreePos2, eFreeDir2,
-                    eFreeQOverP>::projector() == x_z_tz_qop_proj));
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
-                    eFreeDir2, eFreeQOverP>::projector() == x_y_z_tz_qop_proj));
-  BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
-                    eFreeTime, eFreeDir2, eFreeQOverP>::projector() ==
-       x_y_z_t_tz_qop_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos2>::projector() == z_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreeQOverP>::projector() ==
+               x_qop_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos1, eFreeDir2>::projector() ==
+               y_tz_proj));
   BOOST_CHECK((
-      ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
-                   eFreeTime, eFreeDir1, eFreeDir2, eFreeQOverP>::projector() ==
-      x_y_z_t_ty_tz_qop_proj));
+      ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2>::projector() ==
+      x_y_z_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreePos2, eFreeDir2,
+                            eFreeQOverP>::projector() == x_z_tz_qop_proj));
   BOOST_CHECK(
-      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
-                    eFreeTime, eFreeDir0, eFreeDir1, eFreeDir2,
-                    eFreeQOverP>::projector() == x_y_z_t_tx_ty_tz_qop_proj));
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2, eFreeDir2,
+                    eFreeQOverP>::projector() == x_y_z_tz_qop_proj));
+  BOOST_CHECK((ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2,
+                            eFreeTime, eFreeDir2, eFreeQOverP>::projector() ==
+               x_y_z_t_tz_qop_proj));
+  BOOST_CHECK(
+      (ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2, eFreeTime,
+                    eFreeDir1, eFreeDir2, eFreeQOverP>::projector() ==
+       x_y_z_t_ty_tz_qop_proj));
+  BOOST_CHECK((
+      ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreePos2, eFreeTime,
+                   eFreeDir0, eFreeDir1, eFreeDir2, eFreeQOverP>::projector() ==
+      x_y_z_t_tx_ty_tz_qop_proj));
 }
 
 /**
@@ -1113,8 +1092,8 @@ BOOST_AUTO_TEST_CASE(free_parset_residual_tests) {
   const double large_number = 12443534120;
   const double small_number = -924342675;
   const double normal_number = 0.1234;
-  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreeQOverP>
-      unbound(std::nullopt, small_number, large_number, normal_number);
+  ParameterSet<FreeIndices, eFreePos0, eFreePos1, eFreeQOverP> unbound(
+      std::nullopt, small_number, large_number, normal_number);
   BOOST_CHECK(unbound.getParameter<eFreePos0>() == small_number);
   BOOST_CHECK(unbound.getParameter<eFreePos1>() == large_number);
   BOOST_CHECK(unbound.getParameter<eFreeQOverP>() == normal_number);
@@ -1245,8 +1224,8 @@ BOOST_AUTO_TEST_CASE(free_parset_parID_mapping) {
 
   // consistency of types
   BOOST_CHECK(
-      (std::is_same<std::remove_cv<decltype(at_index<FreeIndices, 0,
-                                                     eFreePos0>::value)>::type,
+      (std::is_same<std::remove_cv<decltype(
+                        at_index<FreeIndices, 0, eFreePos0>::value)>::type,
                     decltype(eFreePos0)>::value));
   BOOST_CHECK((std::is_same<decltype(FullSet::getParID<0>()),
                             decltype(eFreePos0)>::value));

--- a/Tests/UnitTests/Core/EventData/ParametersTestHelper.hpp
+++ b/Tests/UnitTests/Core/EventData/ParametersTestHelper.hpp
@@ -20,7 +20,7 @@ namespace Test {
 template <typename Parameter>
 void consistencyCheck(const Parameter& pars, const Vector3D& position,
                       const Vector3D& momentum, double charge, double time,
-                      std::array<double, eBoundParametersSize> values) {
+                      std::array<double, eBoundSize> values) {
   // check parameter vector
   CHECK_CLOSE_ABS(pars.parameters()[eLOC_0], values[0], s_onSurfaceTolerance);
   CHECK_CLOSE_ABS(pars.parameters()[eLOC_1], values[1], s_onSurfaceTolerance);

--- a/Tests/UnitTests/Core/EventData/TransformBoundToFreeTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TransformBoundToFreeTests.cpp
@@ -21,7 +21,7 @@ using namespace Acts;
 using namespace Acts::UnitLiterals;
 
 namespace {
-constexpr auto eps = std::numeric_limits<FreeParametersScalar>::epsilon();
+constexpr auto eps = std::numeric_limits<FreeScalar>::epsilon();
 }
 
 BOOST_AUTO_TEST_SUITE(TransformBoundToFree)

--- a/Tests/UnitTests/Core/EventData/TransformFreeToBoundTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TransformFreeToBoundTests.cpp
@@ -21,7 +21,7 @@ using namespace Acts;
 using namespace Acts::UnitLiterals;
 
 namespace {
-constexpr auto eps = std::numeric_limits<BoundParametersScalar>::epsilon();
+constexpr auto eps = std::numeric_limits<BoundScalar>::epsilon();
 }
 
 BOOST_AUTO_TEST_SUITE(TransformFreeToBound)

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -27,7 +27,7 @@ using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -26,8 +26,7 @@ using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();

--- a/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixSmootherTests.cpp
@@ -25,7 +25,7 @@ namespace Test {
 using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 
@@ -44,17 +44,17 @@ BOOST_AUTO_TEST_CASE(gain_matrix_smoother) {
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
   FittableMeasurement<SourceLink> meas1(
-      MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1>(
+      MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>(
           plane1, {}, std::move(cov), -0.1, 0.45));
 
   cov << 0.04, 0, 0, 0.1;
   FittableMeasurement<SourceLink> meas2(
-      MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1>(
+      MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>(
           plane2, {}, std::move(cov), -0.2, 0.35));
 
   cov << 0.04, 0, 0, 0.1;
   FittableMeasurement<SourceLink> meas3(
-      MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1>(
+      MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>(
           plane3, {}, std::move(cov), -0.05, 0.25));
 
   MultiTrajectory<SourceLink> traj;

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -27,8 +27,7 @@ using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -28,7 +28,7 @@ using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();

--- a/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/GainMatrixUpdaterTests.cpp
@@ -26,7 +26,7 @@ namespace Test {
 using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 using SourceLink = MinimalSourceLink;
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(gain_matrix_updater) {
   SymMatrix2D cov;
   cov << 0.04, 0, 0, 0.1;
   FittableMeasurement<SourceLink> meas(
-      MeasurementType<ParDef::eLOC_0, ParDef::eLOC_1>(
+      MeasurementType<BoundIndices::eLOC_0, BoundIndices::eLOC_1>(
           cylinder, {}, std::move(cov), -0.1, 0.45));
 
   // Make dummy track parameter

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -68,7 +68,7 @@ CalibrationContext calContext = CalibrationContext();
 
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief This struct creates FittableMeasurements on the
 /// detector surfaces, according to the given smearing xxparameters
@@ -255,9 +255,9 @@ struct MinimalOutlierFinder {
           using par_t = ActsVectorD<measdim>;
 
           // Take the projector (measurement mapping function)
-          const ActsMatrixD<measdim, eBoundParametersSize> H =
+          const ActsMatrixD<measdim, eBoundSize> H =
               state.projector()
-                  .template topLeftCorner<measdim, eBoundParametersSize>();
+                  .template topLeftCorner<measdim, eBoundSize>();
 
           // Calculate the residual
           const par_t residual = calibrated - H * predicted;
@@ -416,7 +416,7 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
   // Check the size of the global track parameters size
   BOOST_CHECK_EQUAL(stateRowIndices.size(), 6);
   BOOST_CHECK_EQUAL(stateRowIndices.at(fittedTrack.trackTip), 30);
-  BOOST_CHECK_EQUAL(trackParamsCov.rows(), 6 * eBoundParametersSize);
+  BOOST_CHECK_EQUAL(trackParamsCov.rows(), 6 * eBoundSize);
 
   // Make sure it is deterministic
   fitRes = kFitter.fit(sourcelinks, rStart, kfOptions);
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(kalman_fitter_zero_field) {
   BOOST_CHECK_EQUAL(holeTrackStateRowIndices.size(), 6);
   BOOST_CHECK_EQUAL(holeTrackStateRowIndices.at(fittedWithHoleTrack.trackTip),
                     30);
-  BOOST_CHECK_EQUAL(holeTrackTrackParamsCov.rows(), 6 * eBoundParametersSize);
+  BOOST_CHECK_EQUAL(holeTrackTrackParamsCov.rows(), 6 * eBoundSize);
 
   // Count one hole
   BOOST_CHECK_EQUAL(fittedWithHoleTrack.missedActiveSurfaces.size(), 1u);

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -67,8 +67,7 @@ MagneticFieldContext mfContext = MagneticFieldContext();
 CalibrationContext calContext = CalibrationContext();
 
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief This struct creates FittableMeasurements on the
 /// detector surfaces, according to the given smearing xxparameters
@@ -256,8 +255,7 @@ struct MinimalOutlierFinder {
 
           // Take the projector (measurement mapping function)
           const ActsMatrixD<measdim, eBoundSize> H =
-              state.projector()
-                  .template topLeftCorner<measdim, eBoundSize>();
+              state.projector().template topLeftCorner<measdim, eBoundSize>();
 
           // Calculate the residual
           const par_t residual = calibrated - H * predicted;

--- a/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/Fitter/KalmanFitterTests.cpp
@@ -50,7 +50,7 @@ using SourceLink = MinimalSourceLink;
 using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
 
-using Resolution = std::pair<ParID_t, double>;
+using Resolution = std::pair<BoundIndices, double>;
 using ElementResolution = std::vector<Resolution>;
 using VolumeResolution = std::map<GeometryID::Value, ElementResolution>;
 using DetectorResolution = std::map<GeometryID::Value, VolumeResolution>;
@@ -66,7 +66,7 @@ GeometryContext tgContext = GeometryContext();
 MagneticFieldContext mfContext = MagneticFieldContext();
 CalibrationContext calContext = CalibrationContext();
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 

--- a/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
@@ -108,9 +108,9 @@ std::shared_ptr<Transform3D> createPlanarTransform(const Vector3D& nposition,
 BoundToFreeMatrix convertToMatrix(const std::array<double, 60> P) {
   // initialize to zero
   BoundToFreeMatrix jMatrix = BoundToFreeMatrix::Zero();
-  for (size_t j = 0; j < eBoundParametersSize; ++j) {
-    for (size_t i = 0; i < eFreeParametersSize; ++i) {
-      size_t ijc = eFreeParametersSize + j * eFreeParametersSize + i;
+  for (size_t j = 0; j < eBoundSize; ++j) {
+    for (size_t i = 0; i < eFreeSize; ++i) {
+      size_t ijc = eFreeSize + j * eFreeSize + i;
       jMatrix(i, j) = P[ijc];
     }
   }

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -88,7 +88,7 @@ CalibrationContext calContext = CalibrationContext();
 
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief This struct creates FittableMeasurements on the
 /// detector surfaces, according to the given smearing xxparameters

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -70,7 +70,7 @@ GeometryID makeId(int volume = 0, int layer = 0, int sensitive = 0) {
 using SourceLink = ExtendedMinimalSourceLink;
 using Jacobian = BoundMatrix;
 using Covariance = BoundSymMatrix;
-using Resolution = std::pair<ParID_t, double>;
+using Resolution = std::pair<BoundIndices, double>;
 using ElementResolution = std::vector<Resolution>;
 using VolumeResolution = std::map<GeometryID::Value, ElementResolution>;
 using DetectorResolution = std::map<GeometryID::Value, VolumeResolution>;
@@ -86,7 +86,7 @@ GeometryContext tgContext = GeometryContext();
 MagneticFieldContext mfContext = MagneticFieldContext();
 CalibrationContext calContext = CalibrationContext();
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 

--- a/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinder/CombinatorialKalmanFilterTests.cpp
@@ -87,8 +87,7 @@ MagneticFieldContext mfContext = MagneticFieldContext();
 CalibrationContext calContext = CalibrationContext();
 
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 /// @brief This struct creates FittableMeasurements on the
 /// detector surfaces, according to the given smearing xxparameters

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -155,15 +155,15 @@ BOOST_AUTO_TEST_CASE(impactpoint_estimator_params_distance_test) {
     const auto& trackIP3dParams = trackAtIP3d.parameters();
 
     // d0 and z0 should have changed
-    BOOST_CHECK_NE(myTrackParams[ParID_t::eLOC_D0],
-                   trackIP3dParams[ParID_t::eLOC_D0]);
-    BOOST_CHECK_NE(myTrackParams[ParID_t::eLOC_Z0],
-                   trackIP3dParams[ParID_t::eLOC_Z0]);
+    BOOST_CHECK_NE(myTrackParams[BoundIndices::eLOC_D0],
+                   trackIP3dParams[BoundIndices::eLOC_D0]);
+    BOOST_CHECK_NE(myTrackParams[BoundIndices::eLOC_Z0],
+                   trackIP3dParams[BoundIndices::eLOC_Z0]);
     // Theta along helix and q/p shoud remain the same
-    CHECK_CLOSE_REL(myTrackParams[ParID_t::eTHETA],
-                    trackIP3dParams[ParID_t::eTHETA], 1e-5);
-    CHECK_CLOSE_REL(myTrackParams[ParID_t::eQOP],
-                    trackIP3dParams[ParID_t::eQOP], 1e-5);
+    CHECK_CLOSE_REL(myTrackParams[BoundIndices::eTHETA],
+                    trackIP3dParams[BoundIndices::eTHETA], 1e-5);
+    CHECK_CLOSE_REL(myTrackParams[BoundIndices::eQOP],
+                    trackIP3dParams[BoundIndices::eQOP], 1e-5);
 
     if (debugMode) {
       std::cout << std::setprecision(10) << "Old track parameters: \n"

--- a/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
@@ -129,10 +129,10 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
   Vector4D vecSPZero = Vector4D::Zero();
-  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> matBound2SPZero =
-      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero();
-  ActsMatrixD<eBoundParametersSize, 3> matBound2MomZero =
-      ActsMatrixD<eBoundParametersSize, 3>::Zero();
+  ActsMatrix<BoundScalar, eBoundSize, 4> matBound2SPZero =
+      ActsMatrix<BoundScalar, eBoundSize, 4>::Zero();
+  ActsMatrixD<eBoundSize, 3> matBound2MomZero =
+      ActsMatrixD<eBoundSize, 3>::Zero();
 
   for (const BoundParameters& parameters : tracks) {
     LinearizedTrack linTrack =
@@ -221,10 +221,10 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_straightline_test) {
   BoundVector vecBoundZero = BoundVector::Zero();
   BoundSymMatrix matBoundZero = BoundSymMatrix::Zero();
   Vector4D vecSPZero = Vector4D::Zero();
-  ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4> matBound2SPZero =
-      ActsMatrix<BoundParametersScalar, eBoundParametersSize, 4>::Zero();
-  ActsMatrixD<eBoundParametersSize, 3> matBound2MomZero =
-      ActsMatrixD<eBoundParametersSize, 3>::Zero();
+  ActsMatrix<BoundScalar, eBoundSize, 4> matBound2SPZero =
+      ActsMatrix<BoundScalar, eBoundSize, 4>::Zero();
+  ActsMatrixD<eBoundSize, 3> matBound2MomZero =
+      ActsMatrixD<eBoundSize, 3>::Zero();
 
   for (const BoundParameters& parameters : tracks) {
     LinearizedTrack linTrack =

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -45,7 +45,7 @@ namespace EventDataView3DTest {
 using SourceLink = MinimalSourceLink;
 using Covariance = BoundSymMatrix;
 
-template <ParID_t... params>
+template <BoundIndices... params>
 using MeasurementType =
     Measurement<SourceLink, BoundIndices, params...>;
 

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -47,7 +47,7 @@ using Covariance = BoundSymMatrix;
 
 template <ParID_t... params>
 using MeasurementType =
-    Measurement<SourceLink, BoundParametersIndices, params...>;
+    Measurement<SourceLink, BoundIndices, params...>;
 
 std::normal_distribution<double> gauss(0., 1.);
 std::default_random_engine generator(42);

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -46,8 +46,7 @@ using SourceLink = MinimalSourceLink;
 using Covariance = BoundSymMatrix;
 
 template <BoundIndices... params>
-using MeasurementType =
-    Measurement<SourceLink, BoundIndices, params...>;
+using MeasurementType = Measurement<SourceLink, BoundIndices, params...>;
 
 std::normal_distribution<double> gauss(0., 1.);
 std::default_random_engine generator(42);

--- a/docs/core/eventdata.md
+++ b/docs/core/eventdata.md
@@ -24,7 +24,7 @@ namespace detail {
    */
   struct coordinate_transformation
   {
-    typedef ActsVector<ParValue_t, Acts::NGlobalPars> ParVector_t;
+    typedef ActsVector<BoundScalar, Acts::NGlobalPars> ParVector_t;
 
     static Vector3D
     parameters2globalPosition(const ParVector_t& pars, const Surface& s)
@@ -67,7 +67,7 @@ The default parametrization is chosen to be the ATLAS parameterisation:
 
 ```cpp
 namespace Acts {
-enum ParDef : unsigned int {
+enum BoundIndices : unsigned int {
   eLOC_0    = 0,  ///< first coordinate in local surface frame
   eLOC_1    = 1,  ///< second coordinate in local surface frame
   eLOC_R    = eLOC_0,
@@ -139,7 +139,7 @@ Measurements in a detector can be one to many-dimensional (covering the full
 range up to the full track parametrization).
 
 ```cpp
-template <typename Identifier, ParID_t... params>
+template <typename Identifier, BoundIndices... params>
 class Measurement
 {
   // check type conditions


### PR DESCRIPTION
This renames the following types
```
BoundParametersIndices -> BoundIndices
BoundParametersScalar -> BoundScalar
eBoundParametersSize -> eBoundSize
FreeParametersIndices -> FreeIndices
FreeParametersScalar -> FreeScalar
eFreeParametersSize -> eFreeSize
```
and replace the following previously deprecated typedefs with the correct types
```
ParDef -> BoundIndices
ParID_t -> BoundIndices
ParValue_t -> BoundScalar
```

Fixes #137 and fixes #407.
