### PR TITLE
fix!: Move TrackStatePropMask to Acts namespace

### DIFF
--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -11,6 +11,8 @@
 #include <limits>
 #include <type_traits>
 
+namespace Acts {
+
 /// Collection of bit masks to enable steering which components of a track state
 /// should be initialized, and which should be left invalid.
 /// These mask values can be combined using binary operators, so
@@ -80,4 +82,6 @@ constexpr TrackStatePropMask& operator^=(TrackStatePropMask& lhs,
       static_cast<std::underlying_type<TrackStatePropMask>::type>(lhs) ^
       static_cast<std::underlying_type<TrackStatePropMask>::type>(rhs));
   return lhs;
+}
+
 }

--- a/Core/include/Acts/EventData/TrackStatePropMask.hpp
+++ b/Core/include/Acts/EventData/TrackStatePropMask.hpp
@@ -84,4 +84,4 @@ constexpr TrackStatePropMask& operator^=(TrackStatePropMask& lhs,
   return lhs;
 }
 
-}
+}  // namespace Acts

--- a/Core/include/Acts/Geometry/GeometryObject.hpp
+++ b/Core/include/Acts/Geometry/GeometryObject.hpp
@@ -17,8 +17,6 @@
 
 namespace Acts {
 
-/// @class GeometryObject
-///
 /// Base class to provide GeometryID interface:
 /// - simple set and get
 ///

--- a/Core/include/Acts/Geometry/GeometryObjectSorter.hpp
+++ b/Core/include/Acts/Geometry/GeometryObjectSorter.hpp
@@ -20,8 +20,6 @@
 
 namespace Acts {
 
-// @class ObjectSorterT
-///
 template <class T>
 class ObjectSorterT : public std::binary_function<T, T, bool> {
  public:
@@ -81,8 +79,6 @@ class ObjectSorterT : public std::binary_function<T, T, bool> {
   BinningValue m_binningValue;  ///< the binning value
 };
 
-/// @class DistanceSorterT
-///
 /// This will check on absolute distance
 template <class T>
 class DistanceSorterT : public std::binary_function<T, T, bool> {
@@ -164,8 +160,6 @@ class DistanceSorterT : public std::binary_function<T, T, bool> {
   double m_refEta;
 };
 
-/// @class GeometryObjectSorter
-///
 template <class T>
 class GeometryObjectSorterT : public std::binary_function<T, T, bool> {
  public:

--- a/Core/include/Acts/Geometry/TrackingGeometryBuilder.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometryBuilder.hpp
@@ -24,8 +24,6 @@ namespace Acts {
 class TrackingGeometry;
 class IMaterialDecorator;
 
-/// @class GeometryBuilder
-///
 /// The Acts::TrackingGeometry Builder for volumes that wrap around another
 ///
 /// It retrieves an array of ITrackingVolumeBuilder tools that are configured

--- a/Core/include/Acts/Seeding/BinnedSPGroup.hpp
+++ b/Core/include/Acts/Seeding/BinnedSPGroup.hpp
@@ -19,7 +19,7 @@
 
 namespace Acts {
 
-///@class NeighborhooodIterator Iterates over the elements of all bins given
+/// Iterates over the elements of all bins given
 /// by the indices parameter in the given SpacePointGrid.
 /// Fullfills the forward iterator.
 template <typename external_spacepoint_t>

--- a/Core/include/Acts/Seeding/SeedFilter.hpp
+++ b/Core/include/Acts/Seeding/SeedFilter.hpp
@@ -20,7 +20,7 @@
 
 namespace Acts {
 
-/// @class Filter seeds at various stages with the currently
+/// Filter seeds at various stages with the currently
 /// available information.
 template <typename external_spacepoint_t>
 class SeedFilter {

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -20,8 +20,6 @@
 #include <type_traits>
 
 namespace Acts {
-/// @class AdaptiveMultiVertexFinder
-///
 /// @brief Implements an iterative vertex finder
 ///
 ////////////////////////////////////////////////////////////

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -50,7 +50,6 @@ class ImpactPointEstimator {
     typename BField_t::Cache fieldCache;
   };
 
-  /// @struct Configuration struct
   struct Config {
     /// @brief Config constructor if magnetic field is present
     ///


### PR DESCRIPTION
Also fixes some instances of classes being reported outside the Acts namespace due to weird doc comments.

Fixes #426

BREAKING CHANGE: `TrackStatePropeMask` moves to `Acts::TrackStatePropMask`