### PR TITLE
fix: fixing rmin/rmax ordering in DiscSurface

### DIFF
--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -63,12 +63,12 @@ class DiscSurface : public Surface {
   /// @param transform is transform that places the disc in the global 3D space
   /// @param minhalfx The half length in x at minimal r
   /// @param maxhalfx The half length in x at maximal r
-  /// @param maxR The inner radius of the disc surface
   /// @param minR The outer radius of the disc surface
+  /// @param maxR The inner radius of the disc surface
   /// @param avephi The position in phi (default is 0.)
   /// @param stereo The optional stereo angle
   DiscSurface(const Transform3D& transform, double minhalfx, double maxhalfx,
-              double maxR, double minR, double avephi = 0., double stereo = 0.);
+              double minR, double maxR, double avephi = 0., double stereo = 0.);
 
   /// Constructor for Discs from Transform3D and shared DiscBounds
   ///

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -38,12 +38,12 @@ Acts::DiscSurface::DiscSurface(const Transform3D& transform, double rmin,
       m_bounds(std::make_shared<const RadialBounds>(rmin, rmax, hphisec)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3D& transform, double minhalfx,
-                               double maxhalfx, double maxR, double minR,
+                               double maxhalfx, double minR, double maxR,
                                double avephi, double stereo)
     : GeometryObject(),
       Surface(transform),
       m_bounds(std::make_shared<const DiscTrapezoidBounds>(
-          minhalfx, maxhalfx, maxR, minR, avephi, stereo)) {}
+          minhalfx, maxhalfx, minR, maxR, avephi, stereo)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3D& transform,
                                std::shared_ptr<const DiscBounds> dbounds)


### PR DESCRIPTION
Closes #442 which revealed a bug actually.

The `DiscSurface` would construct `DiscTrapezoidBounds` with the wrong order of arguments.