### PR TITLE
refactor: Bugfix Volume material mapper

### DIFF
--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -203,7 +203,7 @@ void Acts::VolumeMaterialMapper::createExtraHits(
     // adjust the thickness of the last extrapolated step
     properties.scaleThickness(remainder / properties.thickness());
     extraRemainderPositions.push_back(position + volumeStep * direction);
-    matPoint.push_back(std::pair(properties, extraPosition));
+    matPoint.push_back(std::pair(properties, extraRemainderPositions));
   }
 }
 


### PR DESCRIPTION
I made a small mistake in the last PR leading to material being ignore if not thick enough. 
This PR fixes it.