### PR TITLE
ci: Use containers from the Github registry and unify CI jobs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu2004:v3
+    container: ghcr.io/acts-project/ubuntu2004:v5
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -46,10 +46,9 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./build/coverage/cov.xml
-
   build_performance:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu2004:v2
+    container: ghcr.io/acts-project/ubuntu2004:v5
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,27 +11,98 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
 
 jobs:
-  ubuntu2004:
+  linux:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu2004:v4
+    container: ghcr.io/acts-project/${{ matrix.image }}:v5
+    strategy:
+      matrix:
+        image:
+          - centos7-lcg95apython3
+          - centos7-lcg96
+          - ubuntu2004
+    env:
+      SETUP: true
+      INSTALL_DIR: ${{ github.workspace }}/install
     steps:
       - uses: actions/checkout@v2
+      - name: Define setup script
+        if: contains(matrix.image, 'lcg')
+        run: echo "::set-env name=SETUP::source /opt/lcg_view/setup.sh"
+      - name: Configure
+        # use manual mkdir+cd. CMake on LCG95 does not like -B ... -S ...
+        run: >
+          ${SETUP} &&
+          mkdir build && cd build &&
+          cmake ..
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+          -DACTS_BUILD_EVERYTHING=on
+      - name: Build
+        run: ${SETUP} && cmake --build build -- 
+      - name: Unit tests
+        run: ${SETUP} && cmake --build build -- test
+      - name: Integration tests
+        run: ${SETUP} && cmake --build build -- integrationtests
+      - name: Install
+        run: ${SETUP} && cmake --build build -- install
+      - name: Downstream configure
+        run: >
+          ${SETUP} &&
+          mkdir build-downstream && cd build-downstream &&
+          cmake ../Tests/DownstreamProject
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
+      - name: Downstream build
+        run: ${SETUP} && cmake --build build-downstream --
+      - name: Downstream run
+        run: ${SETUP} && ./build-downstream/bin/ShowActsVersion
+  macos:
+    runs-on: macos-10.15
+    env:
+      INSTALL_DIR: ${{ github.workspace }}/install
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: >
+          brew install cmake eigen ninja
+          && sudo mkdir /usr/local/acts
+          && sudo chown $USER /usr/local/acts
+          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
         run: >
           cmake -B build -S .
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+          -DCMAKE_PREFIX_PATH=/usr/local/acts
           -DACTS_BUILD_EVERYTHING=on
       - name: Build
-        run: cmake --build build --
+        run: cmake --build build  --
       - name: Unit tests
         run: cmake --build build -- test
       - name: Integration tests
         run: cmake --build build -- integrationtests
+      - name: Install
+        run: cmake --build build -- install
+      - name: Downstream configure
+        run: >
+          cmake -B build-downstream -S Tests/DownstreamProject
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_PREFIX_PATH="${INSTALL_DIR};/usr/local/acts"
+      - name: Downstream build
+        run: cmake --build build-downstream --
+      - name: Downstream run
+        run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu1804_cuda:v4
+    container: ghcr.io/acts-project/ubuntu1804_cuda:v5
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -45,65 +116,9 @@ jobs:
           -DACTS_BUILD_UNITTESTS=ON
       - name: Build
         run: cmake --build build --
-  macos:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: src
-      - name: Install dependencies
-        run: >
-          brew install cmake eigen ninja
-          && sudo mkdir /usr/local/acts
-          && sudo chown $USER /usr/local/acts
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
-      - name: Configure
-        run: >
-          cmake -B build -S src
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_PREFIX_PATH=/usr/local/acts
-          -DACTS_BUILD_EVERYTHING=on
-      - name: Build
-        run: cmake --build build  --
-      - name: Unit tests
-        run: cmake --build build -- test
-      - name: Integration tests
-        run: cmake --build build -- integrationtests
-  lcg:
-    runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/${{ matrix.os }}-lcg${{ matrix.lcg }}:v4
-    strategy:
-      matrix:
-        os:
-          - centos7
-        lcg:
-          - 95apython3
-          - 96
-    env:
-      SETUP: /opt/lcg_view/setup.sh
-    steps:
-      - uses: actions/checkout@v1
-      - name: Configure
-        run: >
-          source ${SETUP}
-          && mkdir build
-          && cd build
-          && cmake ..
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DACTS_BUILD_EVERYTHING=on
-      - name: Build
-        run: source ${SETUP} && cmake --build build --
-      - name: Unit tests
-        run: source ${SETUP} && cmake --build build -- test
-      - name: Integration tests
-        run: source ${SETUP} && cmake --build build -- integrationtests
   docs:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu2004:v4
+    container: ghcr.io/acts-project/ubuntu2004:v5
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -118,32 +133,3 @@ jobs:
         with:
           name: acts-docs
           path: docs/_build/html/
-  downstream:
-    runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/ubuntu2004:v4
-    steps:
-      - uses: actions/checkout@v2
-      - name: Configure Acts
-        run: >
-          cmake -B build-acts -S .
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-acts
-          -DACTS_BUILD_JSON_PLUGIN=on
-          -DACTS_BUILD_FATRAS=on
-      - name: Build Acts
-        run: cmake --build build-acts --
-      - name: Install Acts
-        run: cmake --build build-acts -- install
-      - name: Configure Downstream
-        run: >
-          cmake -B build-downstream -S Tests/DownstreamProject
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install-acts
-      - name: Build Downstream
-        run: cmake --build build-downstream --
-      - name: Run Downstream
-        run: ./build-downstream/bin/ShowActsVersion

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -47,6 +47,10 @@ jobs:
         run: ${SETUP} && cmake --build build -- integrationtests
       - name: Install
         run: ${SETUP} && cmake --build build -- install
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-${{ matrix.image }}
+          path: ${{ env.INSTALL_DIR }}
       - name: Downstream configure
         run: >
           ${SETUP} &&
@@ -89,6 +93,10 @@ jobs:
         run: cmake --build build -- integrationtests
       - name: Install
         run: cmake --build build -- install
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-macos
+          path: ${{ env.INSTALL_DIR }}
       - name: Downstream configure
         run: >
           cmake -B build-downstream -S Tests/DownstreamProject

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: gitlab-registry.cern.ch/acts/machines/format8:v3
+    container: ghcr.io/acts-project/format8:v5
     steps:
       - uses: actions/checkout@v2
       - name: Check
@@ -37,7 +37,6 @@ jobs:
       - name: Check
         run: >
           CI/check_include_guards.py . --fail-global --exclude "*thirdparty/*"
-
   boost_test_macro:
     runs-on: ubuntu-latest
     steps:

--- a/Tests/DownstreamProject/CMakeLists.txt
+++ b/Tests/DownstreamProject/CMakeLists.txt
@@ -4,8 +4,8 @@ project(ActsDownstreamProject)
 
 find_package(
   Acts CONFIG REQUIRED
-  COMPONENTS Core Fatras
-  OPTIONAL_COMPONENTS DD4hepPlugin JsonPlugin)
+  COMPONENTS Core Fatras PluginJson PluginTGeo
+  OPTIONAL_COMPONENTS PluginDD4hep)
 
 # place artifacts in GNU-like paths, e.g. binaries in `<build_dir>/bin`
 include(GNUInstallDirs)

--- a/Tests/DownstreamProject/CMakeLists.txt
+++ b/Tests/DownstreamProject/CMakeLists.txt
@@ -2,15 +2,35 @@ cmake_minimum_required(VERSION 3.11)
 
 project(ActsDownstreamProject)
 
+# find all optional components that are build with ACTS_BUILD_EVERYTHING=on
 find_package(
   Acts CONFIG REQUIRED
-  COMPONENTS Core Fatras PluginJson PluginTGeo
-  OPTIONAL_COMPONENTS PluginDD4hep)
+  COMPONENTS
+    Core
+    Fatras
+    PluginDD4hep
+    PluginDigitization
+    PluginIdentification
+    PluginJson
+    PluginLegacy
+    PluginTGeo)
 
 # place artifacts in GNU-like paths, e.g. binaries in `<build_dir>/bin`
 include(GNUInstallDirs)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 
+# link with all optional components even when they are not really used
+# to check e.g. for possible linker issues
 add_executable(ShowActsVersion ShowActsVersion.cpp)
-target_link_libraries(ShowActsVersion PRIVATE ActsCore ActsFatras)
+target_link_libraries(
+  ShowActsVersion
+  PRIVATE
+    ActsCore
+    ActsFatras
+    ActsPluginDD4hep
+    ActsPluginDigitization
+    ActsPluginIdentification
+    ActsPluginJson
+    ActsPluginLegacy
+    ActsPluginTGeo)

--- a/cmake/ActsConfig.cmake.in
+++ b/cmake/ActsConfig.cmake.in
@@ -24,7 +24,7 @@ endif()
 
 # check that requested components are available
 foreach(_component ${Acts_FIND_COMPONENTS})
-  # check if this component is available 
+  # check if this component is available
   if(NOT _component IN_LIST Acts_COMPONENTS)
     if (${Acts_FIND_REQUIRED_${_component}})
       # not supported, but required -> fail
@@ -51,15 +51,15 @@ include(CMakeFindDependencyMacro)
 set(Boost_NO_BOOST_CMAKE ON)
 find_dependency(Boost @Boost_VERSION_STRING@ MODULE EXACT)
 find_dependency(Eigen3 @Eigen3_VERSION@ CONFIG EXACT)
-if(DD4hepPlugin IN_LIST Acts_COMPONENTS)
+if(PluginDD4hep IN_LIST Acts_COMPONENTS)
   find_dependency(DD4hep @DD4hep_VERSION@ CONFIG EXACT)
 endif()
-if(JsonPlugin IN_LIST Acts_COMPONENTS)
+if(PluginJson IN_LIST Acts_COMPONENTS)
   # if nlohmann::json is compiled as part of the Acts build
   # then the version is undefined; can not search for exac match
   find_dependency(nlohmann_json @nlohman_json_VERSION@ CONFIG)
 endif()
-if(TGeoPlugin IN_LIST Acts_COMPONENTS)
+if(PluginTGeo IN_LIST Acts_COMPONENTS)
   find_dependency(ROOT @ROOT_VERSION@ CONFIG EXACT)
 endif()
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -114,12 +114,12 @@ A set of container images is available through the [Acts container
 registry][acts_containers]. The following containers are used as part of the
 continous integration setup and come with all dependencies pre-installed.
 
--   `ubuntu2004`: based on Ubuntu 20.04 with manual installation of HEP-specific
-    software
 -   `centos7-lcg95apython3`: based on CentOS 7 with HEP-specific software from
     LCG release 95apython3
 -   `centos7-lcg96`: based on CentOS 7 with HEP-specific software from LCG
     release 96
+-   `ubuntu2004`: based on Ubuntu 20.04 with manual installation of HEP-specific
+    software
 
 To use these locally, you first need to pull the relevant images from the
 registry. Stable versions are tagged as `vX` where `X` is the version number.
@@ -127,17 +127,12 @@ The latest version is also tagged as `master`. The following command downloads
 the latest `ubuntu2004` image:
 
 ```console
-$ docker pull gitlab-registry.cern.ch/acts/machines/ubuntu2004:master
+$ docker pull ghcr.io/acts-project/ubuntu2004:master
 ```
 
 This should print the image id as part of the output. You can also find out the
 image id by running `docker images` to list all your locally available container
-images. If you encounter authorization issues, you might need to login to the
-registry first via
-
-```console
-$ docker login gitlab-registry.cern.ch
-```
+images.
 
 Now, you need to start a shell within the container to run the build. Assuming
 that `<source>` is the path to your source checkout on your host machine, the
@@ -161,7 +156,7 @@ container $ cmake -B build -S /acts -DACTS_BUILD_FATRAS=on
 container $ cmake --build build
 ```
 
-[acts_containers]: https://gitlab.cern.ch/acts/machines/container_registry
+[acts_containers]: https://github.com/orgs/acts-project/packages?ecosystem=container
 
 ### On your local machine
 


### PR DESCRIPTION
Use container images from the public Github container registry in the CI builds. This removes one of the last dependencies on CERN infrastructure as the images were previously taken from the CERN Gitlab registry.

Some of the build jobs are unified to reduce variability between builds. The separated downstream build has been removed. An extended downstream test build is now part of the regular build jobs so that all build configurations are tested consistently.

Includes some fixes for errors in the installed CMake config.