### PR TITLE
build: Make it easier to build the SYCL plugin correctly

### DIFF
--- a/cmake/FindSYCL.cmake
+++ b/cmake/FindSYCL.cmake
@@ -109,15 +109,9 @@ if( SYCL_builtin_FOUND )
    endif()
    # Look for object files holding SYCL device code, which would be needed for
    # the final binaries.
-   if( MSVC )
-      set( _defaultSupportLib "msvc" )
-   else()
-      set( _defaultSupportLib "glibc" )
-   endif()
-   set( SYCL_SEARCH_SUPPORT_LIBRARIES "${_defaultSupportLib};cmath" CACHE STRING
-      "List of support libraries / object files to look for" )
+   set( SYCL_SEARCH_SUPPORT_LIBRARIES "" CACHE STRING
+      "List of support libraries / object files to look for and link" )
    mark_as_advanced( SYCL_SEARCH_SUPPORT_LIBRARIES )
-   unset( _defaultSupportLib )
    get_filename_component( _compilerDir "${CMAKE_CXX_COMPILER}" DIRECTORY )
    set( SYCL_SUPPORT_LIBRARIES )
    foreach( _supportLib ${SYCL_SEARCH_SUPPORT_LIBRARIES} )


### PR DESCRIPTION
This removes the automatic linking of the "SYCL object files" of the oneAPI compiler by default. They were necessary when using the OpenCL backend, with a previous version of the SYCL plugin. But they are no longer needed. And they are actually outright harmful when using the CUDA backend of the oneAPI compiler. (As @cgleggett very rightfully complained about it.)

With this update, with the latest version of Intel's compiler that I have available, unfortunately it's still not possible to build a single binary for both OpenCL and CUDA backends. But at least separate builds can successfully made like:

```
[bash][Elrond]:build > cmake -DCMAKE_BUILD_TYPE=Release -DACTS_BUILD_PLUGIN_SYCL=TRUE -DACTS_BUILD_UNITTESTS=TRUE ../acts/
-- The CXX compiler identification is Clang 12.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Boost: /data/software/boost/1.73.0/x86_64-ubuntu1804-gcc8-opt/include (found suitable version "1.73.0", minimum required is "1.69") found components: filesystem program_options unit_test_framework 
-- Checking if /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ is SYCL capable...
-- Checking if /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ is SYCL capable... success
-- Checking for available SYCL target(s)...
--   - Found target: spir64-unknown-unknown-sycldevice
-- Checking for available SYCL target(s)... done
-- Enable component 'Core' in 'Core'
-- Disable component 'PluginCuda' in 'Plugins/Cuda'
-- Disable component 'PluginDigitization' in 'Plugins/Digitization'
-- Disable component 'PluginIdentification' in 'Plugins/Identification'
-- Disable component 'PluginJson' in 'Plugins/Json'
-- Disable component 'PluginLegacy' in 'Plugins/Legacy'
-- Enable component 'PluginSycl' in 'Plugins/Sycl'
-- Disable component 'PluginTGeo' in 'Plugins/TGeo'
-- Disable component 'PluginDD4hep' in 'Plugins/DD4hep'
-- Disable component 'Fatras' in 'Fatras'
-- Ignore 'Examples' subdirectory
-- Ignore 'Tests/Benchmarks' subdirectory
-- Ignore 'Tests/IntegrationTests' subdirectory
-- Ignore 'Tests/UnitTests/Benchmarks' subdirectory
-- Ignore 'Tests/UnitTests/Fatras' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Digitization' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Json' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Cuda' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/TGeo' subdirectory
-- Ignore 'docs' subdirectory
-- Configuring done
-- Generating done
-- Build files have been written to: /data/projects/acts-sycl/build
[bash][Elrond]:build >
```

and:

```
bash][Elrond]:build > cmake -DCMAKE_BUILD_TYPE=Release -DACTS_BUILD_PLUGIN_SYCL=TRUE -DACTS_BUILD_UNITTESTS=TRUE -DSYCL_POSSIBLE_TARGETS="nvptx64-nvidia-cuda-sycldevice" ../acts/
-- The CXX compiler identification is Clang 12.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Boost: /data/software/boost/1.73.0/x86_64-ubuntu1804-gcc8-opt/include (found suitable version "1.73.0", minimum required is "1.69") found components: filesystem program_options unit_test_framework 
-- Checking if /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ is SYCL capable...
-- Checking if /data/software/intel/clang/12.0.0-2020-09-04/x86_64-ubuntu1804-gcc8-opt/bin/clang++ is SYCL capable... success
-- Checking for available SYCL target(s)...
--   - Found target: nvptx64-nvidia-cuda-sycldevice
-- Checking for available SYCL target(s)... done
-- Enable component 'Core' in 'Core'
-- Disable component 'PluginCuda' in 'Plugins/Cuda'
-- Disable component 'PluginDigitization' in 'Plugins/Digitization'
-- Disable component 'PluginIdentification' in 'Plugins/Identification'
-- Disable component 'PluginJson' in 'Plugins/Json'
-- Disable component 'PluginLegacy' in 'Plugins/Legacy'
-- Enable component 'PluginSycl' in 'Plugins/Sycl'
-- Disable component 'PluginTGeo' in 'Plugins/TGeo'
-- Disable component 'PluginDD4hep' in 'Plugins/DD4hep'
-- Disable component 'Fatras' in 'Fatras'
-- Ignore 'Examples' subdirectory
-- Ignore 'Tests/Benchmarks' subdirectory
-- Ignore 'Tests/IntegrationTests' subdirectory
-- Ignore 'Tests/UnitTests/Benchmarks' subdirectory
-- Ignore 'Tests/UnitTests/Fatras' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Digitization' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Json' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/Cuda' subdirectory
-- Ignore 'Tests/UnitTests/Plugins/TGeo' subdirectory
-- Ignore 'docs' subdirectory
-- Configuring done
-- Generating done
-- Build files have been written to: /data/projects/acts-sycl/build
[bash][Elrond]:build >
```

And then you can run the test with:

```
[bash][Elrond]:build > SYCL_BE=PI_OPENCL ./bin/ActsUnitTestSeedfinderSycl -f /data/projects/acts/atlas_seeds/pu100/evt1.txt -m
Running on: Intel(R) Gen9 HD Graphics NEO
read 186463 SP from file /data/projects/acts/atlas_seeds/pu100/evt1.txt
Preparation time: 0.453999
Analyzed 260 groups for CPU
Analyzed 260 groups for SYCL

------------------------- Time Metric -------------------------
             Device:        CPU       SYCL  Speedup/ Agreement
           Time (s):   3.153386   2.535762            1.243566
        Seeds found:      68832      68832           99.994186
---------------------------------------------------------------

[bash][Elrond]:build >
```

and:

```
[bash][Elrond]:build > SYCL_BE=PI_CUDA ./bin/ActsUnitTestSeedfinderSycl -f /data/projects/acts/atlas_seeds/pu100/evt1.txt -m
Running on: GeForce GTX 960
read 186463 SP from file /data/projects/acts/atlas_seeds/pu100/evt1.txt
Preparation time: 0.485126
Analyzed 260 groups for CPU
Analyzed 260 groups for SYCL

------------------------- Time Metric -------------------------
             Device:        CPU       SYCL  Speedup/ Agreement
           Time (s):   3.167867   2.225112            1.423689
        Seeds found:      68832      68832           99.992737
---------------------------------------------------------------

[bash][Elrond]:build >
```

Also pinging @czangela.