### PR TITLE
build: FindSYCL.cmake Improvement, master branch (2020.09.22.)

### DIFF
--- a/cmake/FindSYCL.cmake
+++ b/cmake/FindSYCL.cmake
@@ -51,6 +51,7 @@ cmake_minimum_required( VERSION 3.13 )
 include( CheckIncludeFileCXX )
 include( CheckCXXSourceCompiles )
 include( CMakeParseArguments )
+include( FindPackageHandleStandardArgs )
 set( CMAKE_REQUIRED_QUIET TRUE )
 
 # Greet the user.
@@ -185,3 +186,7 @@ else()
       set( SYCL_FOUND FALSE )
    endif()
 endif()
+
+# Handle the standard find_package(...) arguments explicitly.
+find_package_handle_standard_args( SYCL
+   REQUIRED_VARS CMAKE_CXX_COMPILER SYCL_FOUND )


### PR DESCRIPTION
As @cgleggett made us aware with @czangela, the code was not handling it gracefully enough if one would ask for the build of the SYCL plugin while not having a SYCL capable compiler set up.

Previously I thought that just setting `SYCL_FOUND` to `FALSE` would be enough for `find_package(SYCL REQUIRED)` to fail. But apparently not... So now the code explicitly makes use of CMake's built-in function for handling such arguments passed to `find_package(...)`.