### PR TITLE
fix: address std::any issue with clang

### DIFF
--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"


### PR DESCRIPTION
This fixes the clang compatibility issue that we see with `std::reference_wrapper<std::any>`, as from #343

Issue found when compiling with dpcpp/clang++ w/ the SYCL plugin.
