### PR TITLE
refactor: Better print output

### DIFF
--- a/Core/include/Acts/Utilities/MultiIndex.hpp
+++ b/Core/include/Acts/Utilities/MultiIndex.hpp
@@ -138,10 +138,12 @@ class MultiIndex {
   }
   friend inline std::ostream& operator<<(std::ostream& os, MultiIndex idx) {
     // one level is always defined
+    os << '(';
     os << idx.level(0u);
     for (std::size_t lvl = 1; lvl < NumLevels; ++lvl) {
       os << '|' << idx.level(lvl);
     }
+    os << ')';
     return os;
   }
 };

--- a/Core/src/EventData/PrintParameters.cpp
+++ b/Core/src/EventData/PrintParameters.cpp
@@ -10,49 +10,140 @@
 
 #include "Acts/Surfaces/Surface.hpp"
 
+#include <array>
+#include <iomanip>
 #include <ostream>
+
+namespace {
+
+constexpr std::array<std::size_t, 8> kMonotonic = {
+    0, 1, 2, 3, 4, 5, 6, 7,
+};
+
+constexpr std::array<const char*, Acts::eBoundSize> makeBoundNames() {
+  std::array<const char*, Acts::eBoundSize> names = {nullptr};
+  // must be set by index since the order is user-configurable
+  names[Acts::eBoundLoc0] = "l0:";
+  names[Acts::eBoundLoc1] = "l1:";
+  names[Acts::eBoundTime] = "time:";
+  names[Acts::eBoundPhi] = "phi:";
+  names[Acts::eBoundTheta] = "theta:";
+  names[Acts::eBoundQOverP] = "q/p:";
+  return names;
+}
+
+constexpr std::array<const char*, Acts::eFreeSize> makeFreeNames() {
+  std::array<const char*, Acts::eFreeSize> names = {nullptr};
+  // must be set by index since the order is user-configurable
+  names[Acts::eFreePos0] = "pos0:";
+  names[Acts::eFreePos1] = "pos1:";
+  names[Acts::eFreePos2] = "pos2:";
+  names[Acts::eFreeTime] = "time:";
+  names[Acts::eFreeDir0] = "dir0:";
+  names[Acts::eFreeDir1] = "dir1:";
+  names[Acts::eFreeDir2] = "dir2:";
+  names[Acts::eFreeQOverP] = "q/p:";
+  return names;
+}
+
+constexpr std::size_t kNamesMaxSize = 6;
+
+/// Print parameters and associated covariance.
+///
+/// The output format format is
+///
+///     name0: value0 +- stddev0  corr00
+///     name1: value1 +- stddev1  corr10 corr11
+///     name2: value2 +- stddev2  corr20 corr21 corr22
+///     ...
+///
+template <typename indices_container_t, typename names_container_t,
+          typename parameters_t, typename covariance_t>
+void printParametersCovariance(std::ostream& os,
+                               const indices_container_t& indices,
+                               const names_container_t& names,
+                               const Eigen::MatrixBase<parameters_t>& params,
+                               const Eigen::MatrixBase<covariance_t>* cov) {
+  EIGEN_STATIC_ASSERT_VECTOR_ONLY(parameters_t);
+
+  // save stream formatting state
+  auto flags = os.flags();
+  auto precision = os.precision();
+
+  // compute the standard deviations
+  typename parameters_t::PlainObject stddev;
+  if (cov) {
+    stddev = cov->diagonal().cwiseSqrt();
+  }
+
+  for (Eigen::Index i = 0; i < params.size(); ++i) {
+    // no newline after the last line. e.g. the log macros automatically add a
+    // newline and having a finishing newline would lead to empty lines.
+    if (0 < i) {
+      os << '\n';
+    }
+
+    // show name
+    os << std::setw(kNamesMaxSize) << std::left << names[indices[i]];
+    // show value
+    os << " ";
+    os << std::defaultfloat << std::setprecision(4);
+    os << std::setw(10) << std::right << params[i];
+
+    if (cov) {
+      // show standard deviation
+      os << " +- ";
+      os << std::setw(10) << std::left << stddev[i];
+      // show lower-triangular part of the correlation matrix
+      os << " ";
+      os << std::fixed << std::setprecision(3);
+      for (Eigen::Index j = 0; j <= i; ++j) {
+        auto corr = (*cov)(i, j) / (stddev[i] * stddev[j]);
+        os << " " << std::setw(6) << std::right << corr;
+      }
+    }
+  }
+
+  // restore previous stream formatting state
+  os.flags(flags);
+  os.precision(precision);
+}
+
+/// Print parameters only.
+template <typename indices_container_t, typename names_container_t,
+          typename parameters_t>
+void printParameters(std::ostream& os, const indices_container_t& indices,
+                     const names_container_t& names,
+                     const Eigen::MatrixBase<parameters_t>& params) {
+  EIGEN_STATIC_ASSERT_VECTOR_ONLY(parameters_t);
+
+  const Eigen::Matrix<typename parameters_t::Scalar,
+                      parameters_t::SizeAtCompileTime,
+                      parameters_t::SizeAtCompileTime>* cov = nullptr;
+  printParametersCovariance(os, indices, names, params, cov);
+}
+
+}  // namespace
 
 void Acts::detail::printBoundParameters(std::ostream& os,
                                         const Acts::Surface& surface,
                                         const Acts::BoundVector& params,
                                         const Acts::BoundSymMatrix* cov) {
-  // Set stream output format
-  auto oldPrecision = os.precision(7);
-  auto oldFlags = os.setf(std::ios::fixed);
-
-  os << "BoundTrackParameters:\n";
-  os << "  parameters: " << params.transpose() << '\n';
   if (cov) {
-    os << "  covariance:\n";
-    os << *cov << '\n';
+    printParametersCovariance(os, kMonotonic, makeBoundNames(), params, cov);
   } else {
-    os << "  no covariance stored\n";
+    printParameters(os, kMonotonic, makeBoundNames(), params);
   }
-  os << "  on surface: " << surface.geometryId() << ' ' << surface.name()
-     << '\n';
-
-  // Reset stream format
-  os.setf(oldFlags);
-  os.precision(oldPrecision);
+  os << "\non surface " << surface.geometryId() << " of type "
+     << surface.name();
 }
 
 void Acts::detail::printFreeParameters(std::ostream& os,
                                        const Acts::FreeVector& params,
                                        const Acts::FreeMatrix* cov) {
-  // Set stream output format
-  auto oldPrecision = os.precision(7);
-  auto oldFlags = os.setf(std::ios::fixed);
-
-  os << "FreeTrackParameters:\n";
-  os << "  parameters: " << params.transpose() << '\n';
   if (cov) {
-    os << "  covariance:\n";
-    os << *cov << '\n';
+    printParametersCovariance(os, kMonotonic, makeFreeNames(), params, cov);
   } else {
-    os << "  no covariance stored\n";
+    printParameters(os, kMonotonic, makeFreeNames(), params);
   }
-
-  // Reset stream format
-  os.setf(oldFlags);
-  os.precision(oldPrecision);
 }

--- a/Core/src/EventData/PrintParameters.cpp
+++ b/Core/src/EventData/PrintParameters.cpp
@@ -23,8 +23,8 @@ constexpr std::array<std::size_t, 8> kMonotonic = {
 constexpr std::array<const char*, Acts::eBoundSize> makeBoundNames() {
   std::array<const char*, Acts::eBoundSize> names = {nullptr};
   // must be set by index since the order is user-configurable
-  names[Acts::eBoundLoc0] = "l0:";
-  names[Acts::eBoundLoc1] = "l1:";
+  names[Acts::eBoundLoc0] = "loc0:";
+  names[Acts::eBoundLoc1] = "loc1:";
   names[Acts::eBoundTime] = "time:";
   names[Acts::eBoundPhi] = "phi:";
   names[Acts::eBoundTheta] = "theta:";

--- a/Core/src/Geometry/GeometryIdentifier.cpp
+++ b/Core/src/Geometry/GeometryIdentifier.cpp
@@ -19,7 +19,7 @@ std::ostream& Acts::operator<<(std::ostream& os, Acts::GeometryIdentifier id) {
   }
 
   static const char* const names[] = {
-      "volume=", "boundary=", "layer=", "approach=", "sensitive=",
+      "vol=", "bnd=", "lay=", "apr=", "sen=",
   };
   const GeometryIdentifier::Value levels[] = {
       id.volume(), id.boundary(), id.layer(), id.approach(), id.sensitive(),

--- a/Core/src/Geometry/GeometryIdentifier.cpp
+++ b/Core/src/Geometry/GeometryIdentifier.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,10 +12,30 @@
 #include <ostream>
 
 std::ostream& Acts::operator<<(std::ostream& os, Acts::GeometryIdentifier id) {
-  os << "[ " << std::setw(3) << id.volume();
-  os << " | " << std::setw(3) << id.boundary();
-  os << " | " << std::setw(3) << id.layer();
-  os << " | " << std::setw(3) << id.approach();
-  os << " | " << std::setw(4) << id.sensitive() << " ]";
+  // zero represents an invalid/undefined identifier
+  if (not id.value()) {
+    os << "(undefined)";
+    return os;
+  }
+
+  static const char* const names[] = {
+      "volume=", "boundary=", "layer=", "approach=", "sensitive=",
+  };
+  const GeometryIdentifier::Value levels[] = {
+      id.volume(), id.boundary(), id.layer(), id.approach(), id.sensitive(),
+  };
+
+  os << '(';
+  bool writeSeparator = false;
+  for (auto i = 0u; i < 5u; ++i) {
+    if (levels[i]) {
+      if (writeSeparator) {
+        os << '|';
+      }
+      os << names[i] << levels[i];
+      writeSeparator = true;
+    }
+  }
+  os << ')';
   return os;
 }

--- a/Core/src/Material/Material.cpp
+++ b/Core/src/Material/Material.cpp
@@ -99,11 +99,11 @@ std::ostream& Acts::operator<<(std::ostream& os, const Material& material) {
   if (!material) {
     os << "vacuum";
   } else {
-    os << "X0=" << material.X0();
-    os << "|L0=" << material.L0();
-    os << "|Ar=" << material.Ar();
-    os << "|Z=" << material.Z();
-    os << "|MolarRho=" << material.molarDensity();
+    os << "x0=" << material.X0();
+    os << "|l0=" << material.L0();
+    os << "|ar=" << material.Ar();
+    os << "|z=" << material.Z();
+    os << "|molar_rho=" << material.molarDensity();
   }
   return os;
 }

--- a/Fatras/src/Particle.cpp
+++ b/Fatras/src/Particle.cpp
@@ -15,10 +15,11 @@ ActsFatras::Particle::Particle(Barcode particleId, Acts::PdgParticle pdg)
 
 std::ostream& ActsFatras::operator<<(std::ostream& os,
                                      const ActsFatras::Particle& particle) {
+  // print compact format that only contains the identify information but not
+  // the potentially changing kinematics
   os << "particle_id=" << particle.particleId();
-  os << " process=" << particle.process();
-  os << " pdg=" << particle.pdg();
-  os << " q=" << particle.charge();
-  os << " m=" << particle.mass();
+  os << "|pdg=" << particle.pdg();
+  os << "|q=" << particle.charge();
+  os << "|m=" << particle.mass();
   return os;
 }

--- a/Fatras/src/ParticleData.cpp
+++ b/Fatras/src/ParticleData.cpp
@@ -63,9 +63,10 @@ std::string_view ActsFatras::findName(Acts::PdgParticle pdg) {
 
 std::ostream& Acts::operator<<(std::ostream& os, Acts::PdgParticle pdg) {
   const auto name = ActsFatras::findName(pdg);
-  os << static_cast<int32_t>(pdg);
   if (not name.empty()) {
-    os << '|' << name;
+    os << name;
+  } else {
+    os << static_cast<int32_t>(pdg);
   }
   return os;
 }

--- a/Tests/Data/material-map.json
+++ b/Tests/Data/material-map.json
@@ -1,11 +1,11 @@
 {
     "volumes": {
         "2": {
-            "Geoid": "[   2 |   0 |   2 |   0 |    0 ]",
+            "Geoid": "(vol=2|lay=2)",
             "Name": "",
             "layers": {
                 "2": {
-                    "Geoid": "[   2 |   0 |   2 |   0 |    0 ]",
+                    "Geoid": "(vol=2|lay=2)",
                     "representing": {
                         "bin0": [
                             "binR",
@@ -45,7 +45,7 @@
                     }
                 },
                 "4": {
-                    "Geoid": "[   2 |   0 |   4 |   0 |    0 ]",
+                    "Geoid": "(vol=2|lay=4)",
                     "representing": {
                         "bin0": [
                             "binR",


### PR DESCRIPTION
These are cleanups and fixes to various print outputs as preparation for upcoming event data changes.

Track parameters are now printed by name with the covariance decomposed into standard deviations and correlations. The new output looks like this:

```
loc0:           0 +- 0.03         1.000
loc1:           0 +- 0.008092     0.000  1.000
phi:        2.645 +- 0.01745      0.000  0.000  1.000
theta:      2.864 +- 0.01745      0.000  0.000  0.000  1.000
q/p:     -0.06783 +- 6.778e-05    0.000  0.000  0.000  0.000  1.000
time:       -2041 +- 1499         0.000  0.000  0.000  0.000  0.000  1.000
on surface (vol=X|lay=Y|sen=Z) of type Acts::PlaneSurface
```

The `GeometryIdentifier` use names to identify its components as follows
```
(undefined) # if all components are zero
(vol=4|lay=3|sen=3) # only non-zero components are shown
```
and the similar `MultiIndex` use a similar format output without zero-suppression
```
(1|0|123|125|42)
```

**Note:** This changes the output of the JSON material map writers; the affected properties are for information only and not used when reading back a material map.