### PR TITLE
feat: add tolerance parameter to globalToLocal functions

### DIFF
--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -150,6 +150,8 @@ class ConeSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
   /// @param momentum is the global momentum (ignored in this operation)
+  /// @param tolerance optional tolerance within which a point is considered
+  /// valid on surface
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -152,9 +152,10 @@ class ConeSurface : public Surface {
   /// @param momentum is the global momentum (ignored in this operation)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                 const Vector3D& position,
-                                 const Vector3D& momentum) const final;
+  Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -158,6 +158,8 @@ class CylinderSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
   /// @param momentum is the global momentum (ignored in this operation)
+  /// @param tolerance optional tolerance within which a point is considered
+  /// valid on surface
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -160,9 +160,10 @@ class CylinderSurface : public Surface {
   /// @param momentum is the global momentum (ignored in this operation)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                 const Vector3D& position,
-                                 const Vector3D& momentum) const final;
+  Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -155,9 +155,10 @@ class DiscSurface : public Surface {
   /// @param momentum global 3D momentum representation (optionally ignored)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                 const Vector3D& position,
-                                 const Vector3D& momentum) const final;
+  Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const final;
 
   /// Special method for DiscSurface : local<->local transformations polar <->
   /// cartesian

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -153,6 +153,8 @@ class DiscSurface : public Surface {
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
   /// @param momentum global 3D momentum representation (optionally ignored)
+  /// @param tolerance optional tolerance within which a point is considered
+  /// valid on surface
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -193,6 +193,7 @@ class LineSurface : public Surface {
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
   /// @param momentum global 3D momentum representation (optionally ignored)
+  /// @param unused tolerance
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -193,7 +193,7 @@ class LineSurface : public Surface {
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
   /// @param momentum global 3D momentum representation (optionally ignored)
-  /// @param unused tolerance
+  /// @param tolerance (unused)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -195,9 +195,10 @@ class LineSurface : public Surface {
   /// @param momentum global 3D momentum representation (optionally ignored)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                 const Vector3D& position,
-                                 const Vector3D& momentum) const final;
+  Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const final;
 
   /// @brief Straight line intersection schema
   ///

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -131,9 +131,10 @@ class PlaneSurface : public Surface {
   /// method symmetry)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                 const Vector3D& position,
-                                 const Vector3D& momentum) const override;
+  Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const override;
 
   /// Method that calculates the correction due to incident angle
   ///

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -127,8 +127,9 @@ class PlaneSurface : public Surface {
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
   /// @param momentum global 3D momentum representation (optionally ignored)
-  /// @param lposition local 2D position to be filled (given by reference for
   /// method symmetry)
+  /// @param tolerance optional tolerance within which a point is considered
+  /// valid on surface
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -295,9 +295,10 @@ class Surface : public virtual GeometryObject,
   /// @param momentum global 3D momentum representation (optionally ignored)
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
-  virtual Result<Vector2D> globalToLocal(const GeometryContext& gctx,
-                                         const Vector3D& position,
-                                         const Vector3D& momentum) const = 0;
+  virtual Result<Vector2D> globalToLocal(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& momentum,
+      double tolerance = s_onSurfaceTolerance) const = 0;
 
   /// Return mehtod for the reference frame
   /// This is the frame in which the covariance matrix is defined (specialized

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -293,6 +293,8 @@ class Surface : public virtual GeometryObject,
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
   /// @param momentum global 3D momentum representation (optionally ignored)
+  /// @param tolerance optional tolerance within which a point is considered
+  /// valid on surface
   ///
   /// @return a Result<Vector2D> which can be !ok() if the operation fails
   virtual Result<Vector2D> globalToLocal(

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -21,9 +21,10 @@ inline Vector3D LineSurface::localToGlobal(const GeometryContext& gctx,
                   lposition[eBoundLoc0] * radiusAxisGlobal.normalized());
 }
 
-inline Result<Vector2D> LineSurface::globalToLocal(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& momentum) const {
+inline Result<Vector2D> LineSurface::globalToLocal(const GeometryContext& gctx,
+                                                   const Vector3D& position,
+                                                   const Vector3D& momentum,
+                                                   double /*tolerance*/) const {
   using VectorHelpers::perp;
 
   const auto& sTransform = transform(gctx);

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -111,14 +111,14 @@ Acts::Vector3D Acts::ConeSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2D> Acts::ConeSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& /*unused*/) const {
+    const Vector3D& /*unused*/, double tolerance) const {
   Vector3D loc3Dframe = transform(gctx).inverse() * position;
   double r = loc3Dframe.z() * bounds().tanAlpha();
-  if (std::abs(perp(loc3Dframe) - r) > s_onSurfaceTolerance) {
+  if (std::abs(perp(loc3Dframe) - r) > tolerance) {
     return Result<Vector2D>::failure(SurfaceError::GlobalPositionNotOnSurface);
   }
-  return Result<Vector2D>::success(
-      {r * atan2(loc3Dframe.y(), loc3Dframe.x()), loc3Dframe.z()});
+  return Result<Acts::Vector2D>::success(
+      Vector2D(r * atan2(loc3Dframe.y(), loc3Dframe.x()), loc3Dframe.z()));
 }
 
 double Acts::ConeSurface::pathCorrection(const GeometryContext& gctx,

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -111,9 +111,13 @@ Acts::Vector3D Acts::CylinderSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2D> Acts::CylinderSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& /*unused*/) const {
-  // @todo check if s_onSurfaceTolerance would do here
-  double inttol = bounds().get(CylinderBounds::eR) * 0.0001;
+    const Vector3D& /*unused*/, double tolerance) const {
+  double inttol = tolerance;
+  if (tolerance == s_onSurfaceTolerance) {
+    // transform default value!
+    // @TODO: check if s_onSurfaceTolerance would do here
+    inttol = bounds().get(CylinderBounds::eR) * 0.0001;
+  }
   if (inttol < 0.01) {
     inttol = 0.01;
   }

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -80,11 +80,10 @@ Acts::Vector3D Acts::DiscSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2D> Acts::DiscSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& /*gmom*/) const {
+    const Vector3D& /*gmom*/, double tolerance) const {
   // transport it to the globalframe
   Vector3D loc3Dframe = (transform(gctx).inverse()) * position;
-  if (loc3Dframe.z() * loc3Dframe.z() >
-      s_onSurfaceTolerance * s_onSurfaceTolerance) {
+  if (loc3Dframe.z() * loc3Dframe.z() > tolerance * tolerance) {
     return Result<Vector2D>::failure(SurfaceError::GlobalPositionNotOnSurface);
   }
   return Result<Acts::Vector2D>::success({perp(loc3Dframe), phi(loc3Dframe)});

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -82,10 +82,9 @@ Acts::Vector3D Acts::PlaneSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2D> Acts::PlaneSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& /*unused*/) const {
+    const Vector3D& /*unused*/, double tolerance) const {
   Vector3D loc3Dframe = transform(gctx).inverse() * position;
-  if (loc3Dframe.z() * loc3Dframe.z() >
-      s_onSurfaceTolerance * s_onSurfaceTolerance) {
+  if (loc3Dframe.z() * loc3Dframe.z() > tolerance * tolerance) {
     return Result<Vector2D>::failure(SurfaceError::GlobalPositionNotOnSurface);
   }
   return Result<Vector2D>::success({loc3Dframe.x(), loc3Dframe.y()});

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -122,6 +122,20 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
 
   CHECK_CLOSE_REL(localPosition, expectedLocalPosition, 1e-2);
 
+  Vector3D globalPositionOff =
+      globalPosition +
+      planeSurfaceObject->normal(tgContext, localPosition) * 0.1;
+
+  BOOST_CHECK(
+      planeSurfaceObject->globalToLocal(tgContext, globalPositionOff, momentum)
+          .error());
+  BOOST_CHECK(planeSurfaceObject
+                  ->globalToLocal(tgContext, globalPositionOff, momentum, 0.05)
+                  .error());
+  BOOST_CHECK(planeSurfaceObject
+                  ->globalToLocal(tgContext, globalPositionOff, momentum, 0.2)
+                  .ok());
+
   /// Test isOnSurface
   Vector3D offSurface{0, 1, -2.};
   BOOST_CHECK(planeSurfaceObject->isOnSurface(tgContext, globalPosition,

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -61,7 +61,8 @@ class SurfaceStub : public Surface {
   /// Global to local transformation
   Result<Vector2D> globalToLocal(const GeometryContext& /*cxt*/,
                                  const Vector3D& /*gpos*/,
-                                 const Vector3D& /*gmom*/) const final {
+                                 const Vector3D& /*gmom*/,
+                                 double /*tolerance*/) const final {
     return Result<Vector2D>::success(Vector2D{20., 20.});
   }
 


### PR DESCRIPTION
As brought up on Mattermost and #493, the static tolerance in the `globalToLocal` functions might not be desirable.
This PR adds an additional argument that sets the tolerance. It is defaulted to `s_onSurfaceTolerance`, which was hardcoded before. This should be backwards compatible.

/cc @osbornjd