### PR TITLE
refactor(examples): Smear particle in the perigee frame

### DIFF
--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
@@ -9,6 +9,7 @@
 #include "ActsExamples/TruthTracking/ParticleSmearing.hpp"
 
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/EventData/Track.hpp"
@@ -40,64 +41,64 @@ ActsExamples::ProcessCode ActsExamples::ParticleSmearing::execute(
   auto rng = m_cfg.randomNumbers->spawnGenerator(ctx);
   std::normal_distribution<double> stdNormal(0.0, 1.0);
 
-  for (const auto& particle : particles) {
-    const auto phi = Acts::VectorHelpers::phi(particle.unitDirection());
-    const auto theta = Acts::VectorHelpers::theta(particle.unitDirection());
-    const auto pt = particle.transverseMomentum();
-    const auto p = particle.absMomentum();
+  for (auto&& [vtxId, vtxParticles] : groupBySecondaryVertex(particles)) {
+    // a group contains at least one particle by construction. assume that all
+    // particles within the group originate from the same position and use it to
+    // as the refernce position for the perigee frame.
+    auto perigee = Acts::Surface::makeShared<Acts::PerigeeSurface>(
+        vtxParticles.begin()->position());
 
-    // compute momentum-dependent resolutions
-    const auto sigmaD0 =
-        m_cfg.sigmaD0 +
-        m_cfg.sigmaD0PtA * std::exp(-1.0 * std::abs(m_cfg.sigmaD0PtB) * pt);
-    const auto sigmaZ0 =
-        m_cfg.sigmaZ0 +
-        m_cfg.sigmaZ0PtA * std::exp(-1.0 * std::abs(m_cfg.sigmaZ0PtB) * pt);
-    const auto sigmaP = m_cfg.sigmaPRel * p;
-    // var(q/p) = (d(1/p)/dp)² * var(p) = (-1/p²)² * var(p)
-    const auto sigmaQOverP = sigmaP / (p * p);
-    // shortcuts for other resolutions
-    const auto sigmaT0 = m_cfg.sigmaT0;
-    const auto sigmaPhi = m_cfg.sigmaPhi;
-    const auto sigmaTheta = m_cfg.sigmaTheta;
-    // converstion from perigee d0,z0 to curvilinear u,v
-    // d0 and u differ only by a sign
-    const auto sigmaU = sigmaD0;
-    // project from z0 to the second axes orthogonal to the track direction
-    const auto sigmaV = sigmaZ0 * std::sin(theta);
+    for (const auto& particle : vtxParticles) {
+      const auto time = particle.time();
+      const auto phi = Acts::VectorHelpers::phi(particle.unitDirection());
+      const auto theta = Acts::VectorHelpers::theta(particle.unitDirection());
+      const auto pt = particle.transverseMomentum();
+      const auto p = particle.absMomentum();
+      const auto q = particle.charge();
 
-    // draw random noise
-    const auto deltaD0 = sigmaD0 * stdNormal(rng);
-    const auto deltaZ0 = sigmaZ0 * stdNormal(rng);
-    const auto deltaT0 = sigmaT0 * stdNormal(rng);
-    const auto deltaPhi = sigmaPhi * stdNormal(rng);
-    const auto deltaTheta = sigmaTheta * stdNormal(rng);
-    const auto deltaP = sigmaP * stdNormal(rng);
+      // compute momentum-dependent resolutions
+      const double sigmaD0 =
+          m_cfg.sigmaD0 +
+          m_cfg.sigmaD0PtA * std::exp(-1.0 * std::abs(m_cfg.sigmaD0PtB) * pt);
+      const double sigmaZ0 =
+          m_cfg.sigmaZ0 +
+          m_cfg.sigmaZ0PtA * std::exp(-1.0 * std::abs(m_cfg.sigmaZ0PtB) * pt);
+      const double sigmaP = m_cfg.sigmaPRel * p;
+      // var(q/p) = (d(1/p)/dp)² * var(p) = (-1/p²)² * var(p)
+      const double sigmaQOverP = sigmaP / (p * p);
+      // shortcuts for other resolutions
+      const double sigmaT0 = m_cfg.sigmaT0;
+      const double sigmaPhi = m_cfg.sigmaPhi;
+      const double sigmaTheta = m_cfg.sigmaTheta;
 
-    // smear the position/time
-    Acts::Vector4D pos4 = particle.position4();
-    pos4[Acts::ePos0] += deltaD0 * std::sin(phi);
-    pos4[Acts::ePos1] += deltaD0 * -std::cos(phi);
-    pos4[Acts::ePos2] += deltaZ0;
-    pos4[Acts::eTime] += deltaT0;
-    // smear direction angles phi,theta ensuring correct bounds
-    const auto [newPhi, newTheta] =
-        Acts::detail::ensureThetaBounds(phi + deltaPhi, theta + deltaTheta);
-    // compute smeared absolute momentum vector
-    const auto newP = p + deltaP;
+      Acts::BoundVector params = Acts::BoundVector::Zero();
+      // smear the position/time
+      params[Acts::eBoundLoc0] = sigmaD0 * stdNormal(rng);
+      params[Acts::eBoundLoc1] = sigmaZ0 * stdNormal(rng);
+      params[Acts::eBoundTime] = time + sigmaT0 * stdNormal(rng);
+      // smear direction angles phi,theta ensuring correct bounds
+      const double deltaPhi = sigmaPhi * stdNormal(rng);
+      const double deltaTheta = sigmaTheta * stdNormal(rng);
+      const auto [newPhi, newTheta] =
+          Acts::detail::ensureThetaBounds(phi + deltaPhi, theta + deltaTheta);
+      params[Acts::eBoundPhi] = newPhi;
+      params[Acts::eBoundTheta] = newTheta;
+      // compute smeared absolute momentum vector
+      const double newP = std::max(0.0, p + sigmaP * stdNormal(rng));
+      params[Acts::eBoundQOverP] = (q != 0) ? (q / newP) : (1 / newP);
 
-    // build the track covariance matrix using the smearing sigmas
-    Acts::BoundSymMatrix cov = Acts::BoundSymMatrix::Zero();
-    cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = sigmaU * sigmaU;
-    cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = sigmaV * sigmaV;
-    cov(Acts::eBoundTime, Acts::eBoundTime) = sigmaT0 * sigmaT0;
-    cov(Acts::eBoundPhi, Acts::eBoundPhi) = sigmaPhi * sigmaPhi;
-    cov(Acts::eBoundTheta, Acts::eBoundTheta) = sigmaTheta * sigmaTheta;
-    cov(Acts::eBoundQOverP, Acts::eBoundQOverP) = sigmaQOverP * sigmaQOverP;
+      // build the track covariance matrix using the smearing sigmas
+      Acts::BoundSymMatrix cov = Acts::BoundSymMatrix::Zero();
+      cov(Acts::eBoundLoc0, Acts::eBoundLoc0) = sigmaD0 * sigmaD0;
+      cov(Acts::eBoundLoc1, Acts::eBoundLoc1) = sigmaZ0 * sigmaZ0;
+      cov(Acts::eBoundTime, Acts::eBoundTime) = sigmaT0 * sigmaT0;
+      cov(Acts::eBoundPhi, Acts::eBoundPhi) = sigmaPhi * sigmaPhi;
+      cov(Acts::eBoundTheta, Acts::eBoundTheta) = sigmaTheta * sigmaTheta;
+      cov(Acts::eBoundQOverP, Acts::eBoundQOverP) = sigmaQOverP * sigmaQOverP;
 
-    parameters.emplace_back(pos4, newPhi, newTheta, newP, particle.charge(),
-                            cov);
-  };
+      parameters.emplace_back(perigee, params, q, cov);
+    }
+  }
 
   ctx.eventStore.add(m_cfg.outputTrackParameters, std::move(parameters));
   return ProcessCode::SUCCESS;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
@@ -19,9 +19,10 @@ namespace ActsExamples {
 
 /// Create track states by smearing truth particle information.
 ///
-/// A curvilinear track state is constructed at the vertex position for
-/// each input particle. They are stored in the same order as the input
-/// particles.
+/// Particles are smeared in the perigee frame anchored at their true vertex
+/// position. The `d0` and `z0` parameters are always defined within that
+/// perigee frame and not globally. The generated bound parameters are stored in
+/// the same order as the input particles.
 class ParticleSmearing final : public BareAlgorithm {
  public:
   struct Config {

--- a/Examples/Framework/include/ActsExamples/EventData/Track.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/Track.hpp
@@ -21,7 +21,7 @@
 namespace ActsExamples {
 
 /// (Reconstructed) track parameters e.g. close to the vertex.
-using TrackParameters = Acts::CurvilinearTrackParameters;
+using TrackParameters = Acts::BoundTrackParameters;
 /// Container of reconstructed track states for multiple tracks.
 using TrackParametersContainer = std::vector<TrackParameters>;
 


### PR DESCRIPTION
Change the `ParticleSmearing` to actually smear in the perigee frame with a common perigee surface for all particles originating from the same vertex instead of smearing each particle in its own curvilinear frame with projected uncertainties.

To do so, the default track parameters in the framework are changed to bound parameters. With the recent changes of the Core EDM this is no possible since curvilinear parameters are just bound parameters and can be store within.