### PR TITLE
refactor!: split fit/alignment derivatives calculation

### DIFF
--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -199,10 +199,10 @@ class ConeSurface : public Surface {
   /// Return properly formatted class name for screen output
   std::string name() const override;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
-  /// global 3D Cartesian coordinates and its rotation represented with
-  /// extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. alignment parameters of the surface (i.e.
+  /// local frame origin in global 3D Cartesian coordinates and its rotation
+  /// represented with extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -205,20 +205,12 @@ class ConeSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
-  /// its rotation
   /// @param position The position of the paramters in global
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-      const RotationMatrix3D& rotToLocalYAxis,
-      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -199,9 +199,10 @@ class ConeSurface : public Surface {
   /// Return properly formatted class name for screen output
   std::string name() const override;
 
-  /// Calculate the derivative of path length w.r.t. alignment parameters of the
-  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
-  /// its rotation represented with extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
+  /// global 3D Cartesian coordinates and its rotation represented with
+  /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -205,13 +205,11 @@ class ConeSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const final;
+      const GeometryContext& gctx, const FreeVector& parameters) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -199,6 +199,27 @@ class ConeSurface : public Surface {
   /// Return properly formatted class name for screen output
   std::string name() const override;
 
+  /// Calculate the derivative of path length w.r.t. alignment parameters of the
+  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
+  /// its rotation represented with extrinsic Euler angles)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
+  /// its rotation
+  /// @param position The position of the paramters in global
+  /// @param direction The direction of the track
+  ///
+  /// @return Derivative of path length w.r.t. the alignment parameters
+  AlignmentRowVector alignmentToPathDerivative(
+      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+      const RotationMatrix3D& rotToLocalYAxis,
+      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const Vector3D& direction) const final;
+
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -206,10 +206,10 @@ class CylinderSurface : public Surface {
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       size_t lseg) const override;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
-  /// global 3D Cartesian coordinates and its rotation represented with
-  /// extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. alignment parameters of the surface (i.e.
+  /// local frame origin in global 3D Cartesian coordinates and its rotation
+  /// represented with extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -212,13 +212,11 @@ class CylinderSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const final;
+      const GeometryContext& gctx, const FreeVector& parameters) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -212,20 +212,12 @@ class CylinderSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
-  /// its rotation
   /// @param position The position of the paramters in global
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-      const RotationMatrix3D& rotToLocalYAxis,
-      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -206,9 +206,10 @@ class CylinderSurface : public Surface {
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       size_t lseg) const override;
 
-  /// Calculate the derivative of path length w.r.t. alignment parameters of the
-  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
-  /// its rotation represented with extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
+  /// global 3D Cartesian coordinates and its rotation represented with
+  /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -206,6 +206,27 @@ class CylinderSurface : public Surface {
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       size_t lseg) const override;
 
+  /// Calculate the derivative of path length w.r.t. alignment parameters of the
+  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
+  /// its rotation represented with extrinsic Euler angles)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
+  /// its rotation
+  /// @param position The position of the paramters in global
+  /// @param direction The direction of the track
+  ///
+  /// @return Derivative of path length w.r.t. the alignment parameters
+  AlignmentRowVector alignmentToPathDerivative(
+      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+      const RotationMatrix3D& rotToLocalYAxis,
+      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const Vector3D& direction) const final;
+
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -233,12 +233,10 @@ class DiscSurface : public Surface {
   /// @param jacobian The jacobian to be initialized
   /// @param position The global position of the parameters
   /// @param direction The direction at of the parameters
-  ///
-  /// @return the transposed reference frame (avoids recalculation)
-  RotationMatrix3D initJacobianToLocal(const GeometryContext& gctx,
-                                       FreeToBoundMatrix& jacobian,
-                                       const Vector3D& position,
-                                       const Vector3D& direction) const final;
+  void initJacobianToLocal(const GeometryContext& gctx,
+                           FreeToBoundMatrix& jacobian,
+                           const Vector3D& position,
+                           const Vector3D& direction) const final;
 
   /// Path correction due to incident of the track
   ///

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -132,21 +132,17 @@ class LineSurface : public Surface {
                             const Vector3D& position, const Vector3D& direction,
                             const BoundVector& pars) const final;
 
-  /// Calculate the form factors for the derivatives
-  /// the calculation is identical for all surfaces where the
-  /// reference frame does not depend on the direction
+  /// Calculate the derivative of path length at the geometry contraint w.r.t.
+  /// free parameter.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the position of the paramters in global
   /// @param direction is the direction of the track
-  /// @param rft is the transposed reference frame (avoids recalculation)
-  /// @param jacobian is the transport jacobian
   ///
   /// @return a five-dim vector
-  BoundRowVector derivativeFactors(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction, const RotationMatrix3D& rft,
-      const BoundToFreeMatrix& jacobian) const final;
+  FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
+                                     const Vector3D& position,
+                                     const Vector3D& direction) const final;
 
   /// Local to global transformation
   /// for line surfaces the momentum is used in order to interpret the drift

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -258,20 +258,12 @@ class LineSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
-  /// its rotation
   /// @param position The position of the paramters in global
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-      const RotationMatrix3D& rotToLocalYAxis,
-      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -258,13 +258,11 @@ class LineSurface : public Surface {
   /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const final;
+      const GeometryContext& gctx, const FreeVector& parameters) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -133,16 +133,14 @@ class LineSurface : public Surface {
                             const BoundVector& pars) const final;
 
   /// Calculate the derivative of path length at the geometry constraint or
-  /// point-of-closest-approach w.r.t. free parameter.
+  /// point-of-closest-approach w.r.t. free parameters
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters
-  /// @param rft is the transposed reference frame (avoids recalculation)
   ///
   /// @return Derivative of path length w.r.t. free parameters
   FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
-                                     const FreeVector& parameters,
-                                     const RotationMatrix3D& rft) const final;
+                                     const FreeVector& parameters) const final;
 
   /// Local to global transformation
   /// for line surfaces the momentum is used in order to interpret the drift

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -136,14 +136,12 @@ class LineSurface : public Surface {
   /// w.r.t. free parameter.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the position of the paramters in global
-  /// @param direction is the direction of the track
+  /// @param parameters is the free parameters
   /// @param rft is the transposed reference frame (avoids recalculation)
   ///
   /// @return a free vector
   FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
-                                     const Vector3D& position,
-                                     const Vector3D& direction,
+                                     const FreeVector& parameters,
                                      const RotationMatrix3D& rft) const final;
 
   /// Local to global transformation

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -132,8 +132,8 @@ class LineSurface : public Surface {
                             const Vector3D& position, const Vector3D& direction,
                             const BoundVector& pars) const final;
 
-  /// Calculate the derivative of path length at the geometry contraint w.r.t.
-  /// free parameter.
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. free parameter.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the position of the paramters in global
@@ -254,9 +254,10 @@ class LineSurface : public Surface {
   /// Return properly formatted class name for screen output */
   std::string name() const override;
 
-  /// Calculate the derivative of path length w.r.t. alignment parameters of the
-  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
-  /// its rotation represented with extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
+  /// global 3D Cartesian coordinates and its rotation represented with
+  /// extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -132,14 +132,14 @@ class LineSurface : public Surface {
                             const Vector3D& position, const Vector3D& direction,
                             const BoundVector& pars) const final;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. free parameter.
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. free parameter.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters
   /// @param rft is the transposed reference frame (avoids recalculation)
   ///
-  /// @return a free vector
+  /// @return Derivative of path length w.r.t. free parameters
   FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
                                      const FreeVector& parameters,
                                      const RotationMatrix3D& rft) const final;
@@ -252,10 +252,10 @@ class LineSurface : public Surface {
   /// Return properly formatted class name for screen output */
   std::string name() const override;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
-  /// global 3D Cartesian coordinates and its rotation represented with
-  /// extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. alignment parameters of the surface (i.e.
+  /// local frame origin in global 3D Cartesian coordinates and its rotation
+  /// represented with extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -259,6 +259,10 @@ class LineSurface : public Surface {
   /// its rotation represented with extrinsic Euler angles)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
+  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
+  /// its rotation
   /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
   /// its rotation
   /// @param position The position of the paramters in global
@@ -266,8 +270,10 @@ class LineSurface : public Surface {
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
-      const Vector3D& position, const Vector3D& direction) const final;
+      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+      const RotationMatrix3D& rotToLocalYAxis,
+      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const Vector3D& direction) const final;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -138,11 +138,13 @@ class LineSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the position of the paramters in global
   /// @param direction is the direction of the track
+  /// @param rft is the transposed reference frame (avoids recalculation)
   ///
-  /// @return a five-dim vector
+  /// @return a free vector
   FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
                                      const Vector3D& position,
-                                     const Vector3D& direction) const final;
+                                     const Vector3D& direction,
+                                     const RotationMatrix3D& rft) const final;
 
   /// Local to global transformation
   /// for line surfaces the momentum is used in order to interpret the drift

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -357,8 +357,8 @@ class Surface : public virtual GeometryObject,
                                                const Vector3D& position,
                                                const Vector3D& direction) const;
 
-  /// Calculate the form factors for the derivatives
-  /// the calculation is identical for all surfaces where the
+  /// Calculate the derivative of path length at the geometry contraint w.r.t.
+  /// free parameter. The calculation is identical for all surfaces where the
   /// reference frame does not depend on the direction
   ///
   ///
@@ -369,14 +369,11 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the position of the paramters in global
   /// @param direction is the direction of the track
-  /// @param rft is the transposed reference frame (avoids recalculation)
-  /// @param jacobian is the transport jacobian
   ///
   /// @return a five-dim vector
-  virtual BoundRowVector derivativeFactors(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction, const RotationMatrix3D& rft,
-      const BoundToFreeMatrix& jacobian) const;
+  virtual FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
+                                             const Vector3D& position,
+                                             const Vector3D& direction) const;
 
   /// Calucation of the path correction for incident
   ///

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -466,9 +466,7 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return Derivative of bound local w.r.t. alignment parameters
   AlignmentToBoundLocalMatrix alignmentToLocalDerivativeWithoutCorrection(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-      const RotationMatrix3D& rotToLocalYAxis,
-      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const;
 
   /// Calculate the derivative of path length at the geometry constraint or POCA
@@ -481,20 +479,12 @@ class Surface : public virtual GeometryObject,
   /// ConeSurface
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
-  /// its rotation
   /// @param position The position of the paramters in global
   /// @param direction The direction of the track
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   virtual AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-      const RotationMatrix3D& rotToLocalYAxis,
-      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const GeometryContext& gctx, const Vector3D& position,
       const Vector3D& direction) const;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -366,14 +366,12 @@ class Surface : public virtual GeometryObject,
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the position of the paramters in global
-  /// @param direction is the direction of the track
+  /// @param parameters is the free parameters
   /// @param rft is the transposed reference frame (avoids recalculation)
   ///
   /// @return a free vector
   virtual FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
-                                             const Vector3D& position,
-                                             const Vector3D& direction,
+                                             const FreeVector& parameters,
                                              const RotationMatrix3D& rft) const;
 
   /// Calucation of the path correction for incident

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -357,9 +357,10 @@ class Surface : public virtual GeometryObject,
                                                const Vector3D& position,
                                                const Vector3D& direction) const;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. free parameter. The calculation is identical for all surfaces where
-  /// the reference frame does not depend on the direction
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. free parameter. The calculation is
+  /// identical for all surfaces where the reference frame does not depend on
+  /// the direction
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
@@ -369,7 +370,7 @@ class Surface : public virtual GeometryObject,
   /// @param parameters is the free parameters
   /// @param rft is the transposed reference frame (avoids recalculation)
   ///
-  /// @return a free vector
+  /// @return Derivative of path length w.r.t. free parameters
   virtual FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
                                              const FreeVector& parameters,
                                              const RotationMatrix3D& rft) const;
@@ -432,18 +433,19 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   /// change of alignment parameters
   /// @param parameters is the free parameters
-  /// @param derivatives is the derivative of free parameters w.r.t. path length
+  /// @param pathDerivative is the derivative of free parameters w.r.t. path
+  /// length
   ///
-  /// @return Derivative of bound local position w.r.t. local frame
+  /// @return Derivative of bound track parameters w.r.t. local frame
   /// alignment parameters
   AlignmentToBoundMatrix alignmentToBoundDerivative(
       const GeometryContext& gctx, const FreeVector& parameters,
-      const FreeVector& derivatives) const;
+      const FreeVector& pathDerivative) const;
 
-  /// Calculate the derivative of bound local w.r.t.
-  /// alignment parameters of the surface (i.e. origin in global 3D Cartesian
-  /// coordinates and its rotation represented with extrinsic Euler angles)
-  /// without any path correction
+  /// Calculate the derivative of bound track parameters w.r.t.
+  /// alignment parameters of its reference surface (i.e. origin in global 3D
+  /// Cartesian coordinates and its rotation represented with extrinsic Euler
+  /// angles) without any path correction
   ///
   /// @note This function should be used together with alignment to path
   /// derivative to get the full alignment to bound derivatives
@@ -451,14 +453,15 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters
   ///
-  /// @return Derivative of bound local w.r.t. alignment parameters
-  AlignmentToBoundLocalMatrix alignmentToLocalDerivativeWithoutCorrection(
+  /// @return Derivative of bound track parameters w.r.t. local frame alignment
+  /// parameters without path correction
+  AlignmentToBoundMatrix alignmentToBoundDerivativeWithoutCorrection(
       const GeometryContext& gctx, const FreeVector& parameters) const;
 
-  /// Calculate the derivative of path length at the geometry constraint or POCA
-  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
-  /// global 3D Cartesian coordinates and its rotation represented with
-  /// extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or
+  /// point-of-closest-approach w.r.t. alignment parameters of the surface (i.e.
+  /// local frame origin in global 3D Cartesian coordinates and its rotation
+  /// represented with extrinsic Euler angles)
   ///
   /// @note Re-implementation is needed for surface whose intersection with
   /// track is not its local xy plane, e.g. LineSurface, CylinderSurface and

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -438,22 +438,6 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const FreeVector& parameters,
       const FreeVector& pathDerivative) const;
 
-  /// Calculate the derivative of bound track parameters w.r.t.
-  /// alignment parameters of its reference surface (i.e. origin in global 3D
-  /// Cartesian coordinates and its rotation represented with extrinsic Euler
-  /// angles) without any path correction
-  ///
-  /// @note This function should be used together with alignment to path
-  /// derivative to get the full alignment to bound derivatives
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param parameters is the free parameters
-  ///
-  /// @return Derivative of bound track parameters w.r.t. local frame alignment
-  /// parameters without path correction
-  AlignmentToBoundMatrix alignmentToBoundDerivativeWithoutCorrection(
-      const GeometryContext& gctx, const FreeVector& parameters) const;
-
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. alignment parameters of the surface (i.e.
   /// local frame origin in global 3D Cartesian coordinates and its rotation
@@ -499,6 +483,23 @@ class Surface : public virtual GeometryObject,
 
   /// Possibility to attach a material descrption
   std::shared_ptr<const ISurfaceMaterial> m_surfaceMaterial;
+
+ private:
+  /// Calculate the derivative of bound track parameters w.r.t.
+  /// alignment parameters of its reference surface (i.e. origin in global 3D
+  /// Cartesian coordinates and its rotation represented with extrinsic Euler
+  /// angles) without any path correction
+  ///
+  /// @note This function should be used together with alignment to path
+  /// derivative to get the full alignment to bound derivatives
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param parameters is the free parameters
+  ///
+  /// @return Derivative of bound track parameters w.r.t. local frame alignment
+  /// parameters without path correction
+  AlignmentToBoundMatrix alignmentToBoundDerivativeWithoutCorrection(
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 };
 
 #include "Acts/Surfaces/detail/Surface.ipp"

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -361,7 +361,6 @@ class Surface : public virtual GeometryObject,
   /// free parameter. The calculation is identical for all surfaces where the
   /// reference frame does not depend on the direction
   ///
-  ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
@@ -369,11 +368,13 @@ class Surface : public virtual GeometryObject,
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the position of the paramters in global
   /// @param direction is the direction of the track
+  /// @param rft is the transposed reference frame (avoids recalculation)
   ///
-  /// @return a five-dim vector
+  /// @return a free vector
   virtual FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
                                              const Vector3D& position,
-                                             const Vector3D& direction) const;
+                                             const Vector3D& direction,
+                                             const RotationMatrix3D& rft) const;
 
   /// Calucation of the path correction for incident
   ///

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -426,23 +426,27 @@ class Surface : public virtual GeometryObject,
   virtual Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                               size_t lseg) const = 0;
 
-  /// The derivative of bound track parameters w.r.t. alignment
+  /// The derivative of bound local (eBoundLoc0, eBoundLoc1) w.r.t. alignment
   /// parameters of its reference surface (i.e. local frame origin in
   /// global 3D Cartesian coordinates and its rotation represented with
   /// extrinsic Euler angles)
   ///
+  /// @note Here, only the derivatives of bound local are calculated is
+  /// because other bound parameters (eBoundPhi, eBoundTheta, eBoundQOverP,
+  /// eBoundTime) are not changing with the alignment parameters assuming a
+  /// linerized track model with limited mis-alignment. Also, the residual used
+  /// to the calculate the chi2 are only relevant to the bound local
+  ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param derivatives Path length derivatives of the free, nominal
-  /// parameters to help evaluate change of free track parameters caused by
   /// change of alignment parameters
   /// @param position The position of the paramters in global
   /// @param direction The direction of the track
   ///
-  /// @return Derivative of bound track parameters w.r.t. local frame
+  /// @return Derivative of bound local position w.r.t. local frame
   /// alignment parameters
-  AlignmentToBoundMatrix alignmentToBoundDerivative(
-      const GeometryContext& gctx, const FreeVector& derivatives,
-      const Vector3D& position, const Vector3D& direction) const;
+  AlignmentToBoundLocalMatrix alignmentToLocalDerivative(
+      const GeometryContext& gctx, const Vector3D& position,
+      const Vector3D& direction) const;
 
   /// Calculate the derivative of bound local w.r.t.
   /// alignment parameters of the surface (i.e. origin in global 3D Cartesian
@@ -450,11 +454,7 @@ class Surface : public virtual GeometryObject,
   /// without any path correction
   ///
   /// @note This function should be used together with alignment to path
-  /// derivative to get the full alignment to bound derivative. Here, only the
-  /// derivatives of bound local (eBoundLoc0, eBoundLoc1) are calculated is
-  /// because other bound parameters (eBoundPhi, eBoundTheta, eBoundQOverP,
-  /// eBoundTime) are not relevant to the alignment parameters when the path
-  /// correction is not considered.
+  /// derivative to get the full alignment to bound local derivative.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
@@ -467,7 +467,7 @@ class Surface : public virtual GeometryObject,
   /// @param direction The direction of the track
   ///
   /// @return Derivative of bound local w.r.t. alignment parameters
-  AlignmentToBoundLocalMatrix alignmentToBoundLocalDerivativeWithoutCorrection(
+  AlignmentToBoundLocalMatrix alignmentToLocalDerivativeWithoutCorrection(
       const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
       const RotationMatrix3D& rotToLocalYAxis,
       const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -350,15 +350,13 @@ class Surface : public virtual GeometryObject,
   /// @param position is the global position of the parameters
   /// @param direction is the direction at of the parameters
   /// @param gctx The current geometry context object, e.g. alignment
-  ///
-  /// @return the transposed reference frame (avoids recalculation)
-  virtual RotationMatrix3D initJacobianToLocal(const GeometryContext& gctx,
-                                               FreeToBoundMatrix& jacobian,
-                                               const Vector3D& position,
-                                               const Vector3D& direction) const;
+  virtual void initJacobianToLocal(const GeometryContext& gctx,
+                                   FreeToBoundMatrix& jacobian,
+                                   const Vector3D& position,
+                                   const Vector3D& direction) const;
 
   /// Calculate the derivative of path length at the geometry constraint or
-  /// point-of-closest-approach w.r.t. free parameter. The calculation is
+  /// point-of-closest-approach w.r.t. free parameters. The calculation is
   /// identical for all surfaces where the reference frame does not depend on
   /// the direction
   ///
@@ -368,12 +366,10 @@ class Surface : public virtual GeometryObject,
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters
-  /// @param rft is the transposed reference frame (avoids recalculation)
   ///
   /// @return Derivative of path length w.r.t. free parameters
-  virtual FreeRowVector freeToPathDerivative(const GeometryContext& gctx,
-                                             const FreeVector& parameters,
-                                             const RotationMatrix3D& rft) const;
+  virtual FreeRowVector freeToPathDerivative(
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 
   /// Calucation of the path correction for incident
   ///

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -452,6 +452,10 @@ class Surface : public virtual GeometryObject,
   /// not its local xy plane, e.g. LineSurface, CylinderSurface and ConeSurface
   ///
   /// @param gctx The current geometry context object, e.g. alignment
+  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
+  /// its rotation
   /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
   /// its rotation
   /// @param position The position of the paramters in global
@@ -459,8 +463,10 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   virtual AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
-      const Vector3D& position, const Vector3D& direction) const;
+      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+      const RotationMatrix3D& rotToLocalYAxis,
+      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const Vector3D& direction) const;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -357,9 +357,9 @@ class Surface : public virtual GeometryObject,
                                                const Vector3D& position,
                                                const Vector3D& direction) const;
 
-  /// Calculate the derivative of path length at the geometry contraint w.r.t.
-  /// free parameter. The calculation is identical for all surfaces where the
-  /// reference frame does not depend on the direction
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. free parameter. The calculation is identical for all surfaces where
+  /// the reference frame does not depend on the direction
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
@@ -473,9 +473,10 @@ class Surface : public virtual GeometryObject,
       const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
       const Vector3D& direction) const;
 
-  /// Calculate the derivative of path length w.r.t. alignment parameters of the
-  /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
-  /// its rotation represented with extrinsic Euler angles)
+  /// Calculate the derivative of path length at the geometry constraint or POCA
+  /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
+  /// global 3D Cartesian coordinates and its rotation represented with
+  /// extrinsic Euler angles)
   ///
   /// @note Re-implementation is needed for surface whose intersection with
   /// track is not its local xy plane, e.g. LineSurface, CylinderSurface and

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -424,25 +424,21 @@ class Surface : public virtual GeometryObject,
   virtual Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                               size_t lseg) const = 0;
 
-  /// The derivative of bound local (eBoundLoc0, eBoundLoc1) w.r.t. alignment
+  /// The derivative of bound track parameters w.r.t. alignment
   /// parameters of its reference surface (i.e. local frame origin in
   /// global 3D Cartesian coordinates and its rotation represented with
   /// extrinsic Euler angles)
   ///
-  /// @note Here, only the derivatives of bound local are calculated is
-  /// because other bound parameters (eBoundPhi, eBoundTheta, eBoundQOverP,
-  /// eBoundTime) are not changing with the alignment parameters assuming a
-  /// linerized track model with limited mis-alignment. Also, the residual used
-  /// to the calculate the chi2 are only relevant to the bound local
-  ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// change of alignment parameters
   /// @param parameters is the free parameters
+  /// @param derivatives is the derivative of free parameters w.r.t. path length
   ///
   /// @return Derivative of bound local position w.r.t. local frame
   /// alignment parameters
-  AlignmentToBoundLocalMatrix alignmentToLocalDerivative(
-      const GeometryContext& gctx, const FreeVector& parameters) const;
+  AlignmentToBoundMatrix alignmentToBoundDerivative(
+      const GeometryContext& gctx, const FreeVector& parameters,
+      const FreeVector& derivatives) const;
 
   /// Calculate the derivative of bound local w.r.t.
   /// alignment parameters of the surface (i.e. origin in global 3D Cartesian
@@ -450,7 +446,7 @@ class Surface : public virtual GeometryObject,
   /// without any path correction
   ///
   /// @note This function should be used together with alignment to path
-  /// derivative to get the full alignment to bound local derivative.
+  /// derivative to get the full alignment to bound derivatives
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -437,14 +437,12 @@ class Surface : public virtual GeometryObject,
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// change of alignment parameters
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of bound local position w.r.t. local frame
   /// alignment parameters
   AlignmentToBoundLocalMatrix alignmentToLocalDerivative(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const;
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 
   /// Calculate the derivative of bound local w.r.t.
   /// alignment parameters of the surface (i.e. origin in global 3D Cartesian
@@ -455,19 +453,11 @@ class Surface : public virtual GeometryObject,
   /// derivative to get the full alignment to bound local derivative.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
-  /// its rotation
-  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
-  /// its rotation
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of bound local w.r.t. alignment parameters
   AlignmentToBoundLocalMatrix alignmentToLocalDerivativeWithoutCorrection(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const;
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 
   /// Calculate the derivative of path length at the geometry constraint or POCA
   /// w.r.t. alignment parameters of the surface (i.e. local frame origin in
@@ -479,13 +469,11 @@ class Surface : public virtual GeometryObject,
   /// ConeSurface
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position of the paramters in global
-  /// @param direction The direction of the track
+  /// @param parameters is the free parameters
   ///
   /// @return Derivative of path length w.r.t. the alignment parameters
   virtual AlignmentRowVector alignmentToPathDerivative(
-      const GeometryContext& gctx, const Vector3D& position,
-      const Vector3D& direction) const;
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 
   /// Calculate the derivative of bound track parameters local position w.r.t.
   /// position in local 3D Cartesian coordinates

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -444,12 +444,42 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const FreeVector& derivatives,
       const Vector3D& position, const Vector3D& direction) const;
 
+  /// Calculate the derivative of bound local w.r.t.
+  /// alignment parameters of the surface (i.e. origin in global 3D Cartesian
+  /// coordinates and its rotation represented with extrinsic Euler angles)
+  /// without any path correction
+  ///
+  /// @note This function should be used together with alignment to path
+  /// derivative to get the full alignment to bound derivative. Here, only the
+  /// derivatives of bound local (eBoundLoc0, eBoundLoc1) are calculated is
+  /// because other bound parameters (eBoundPhi, eBoundTheta, eBoundQOverP,
+  /// eBoundTime) are not relevant to the alignment parameters when the path
+  /// correction is not considered.
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalYAxis The derivative of local frame y axis vector w.r.t.
+  /// its rotation
+  /// @param rotToLocalZAxis The derivative of local frame z axis vector w.r.t.
+  /// its rotation
+  /// @param position The position of the paramters in global
+  /// @param direction The direction of the track
+  ///
+  /// @return Derivative of bound local w.r.t. alignment parameters
+  AlignmentToBoundLocalMatrix alignmentToBoundLocalDerivativeWithoutCorrection(
+      const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+      const RotationMatrix3D& rotToLocalYAxis,
+      const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+      const Vector3D& direction) const;
+
   /// Calculate the derivative of path length w.r.t. alignment parameters of the
   /// surface (i.e. local frame origin in global 3D Cartesian coordinates and
   /// its rotation represented with extrinsic Euler angles)
   ///
-  /// Re-implementation is needed for surface whose intersection with track is
-  /// not its local xy plane, e.g. LineSurface, CylinderSurface and ConeSurface
+  /// @note Re-implementation is needed for surface whose intersection with
+  /// track is not its local xy plane, e.g. LineSurface, CylinderSurface and
+  /// ConeSurface
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param rotToLocalXAxis The derivative of local frame x axis vector w.r.t.

--- a/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
@@ -88,9 +88,7 @@ inline SurfaceIntersection ConeSurface::intersect(
 }
 
 inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-    const RotationMatrix3D& rotToLocalYAxis,
-    const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+    const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& direction) const {
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
@@ -124,6 +122,9 @@ inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
           (dx * localPos.x() + dy * localPos.y() -
            dz * localPos.z() * tanAlpha2) *
           dz * dirRowVec;
+  // Calculate the derivative of local frame axes w.r.t its rotation
+  const auto [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
+      detail::rotationToLocalAxesDerivative(rotation);
   // Initialize the derivative of propagation path w.r.t. local frame
   // translation (origin) and rotation
   AlignmentRowVector alignToPath = AlignmentRowVector::Zero();

--- a/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
@@ -88,8 +88,11 @@ inline SurfaceIntersection ConeSurface::intersect(
 }
 
 inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global position
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();

--- a/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
@@ -94,14 +94,14 @@ inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
-  const ActsRowVector<double, 3> pcRowVec =
+  const ActsRowVector<AlignmentScalar, 3> pcRowVec =
       (position - center(gctx)).transpose();
   // The rotation
   const auto& rotation = transform(gctx).rotation();
   // The local frame x/y/z axis
-  const Vector3D localXAxis = rotation.block<3, 1>(0, 0);
-  const Vector3D localYAxis = rotation.block<3, 1>(0, 1);
-  const Vector3D localZAxis = rotation.block<3, 1>(0, 2);
+  const Vector3D localXAxis = rotation.col(0);
+  const Vector3D localYAxis = rotation.col(1);
+  const Vector3D localZAxis = rotation.col(2);
   // The local coordinates
   const Vector3D localPos = rotation.transpose() * position;
   const double dx = direction.dot(localXAxis);
@@ -111,15 +111,15 @@ inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
   const double tanAlpha2 = bounds().tanAlpha() * bounds().tanAlpha();
   const double norm = 1. / (1. - dz * dz * (1 + tanAlpha2));
   // The direction transpose
-  const ActsRowVector<double, 3> dirRowVec = direction.transpose();
+  const ActsRowVector<AlignmentScalar, 3> dirRowVec = direction.transpose();
   // The derivative of path w.r.t. the local axes
   // @note The following calculations assume that the intersection of the track
   // with the cone always satisfy: localPos.z()*tanAlpha =perp(localPos)
-  const ActsRowVector<double, 3> localXAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localXAxisToPath =
       -2.0 * norm * (dx * pcRowVec + localPos.x() * dirRowVec);
-  const ActsRowVector<double, 3> localYAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localYAxisToPath =
       -2.0 * norm * (dy * pcRowVec + localPos.y() * dirRowVec);
-  const ActsRowVector<double, 3> localZAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localZAxisToPath =
       2.0 * norm * tanAlpha2 * (dz * pcRowVec + localPos.z() * dirRowVec) -
       4.0 * norm * norm * (1 + tanAlpha2) *
           (dx * localPos.x() + dy * localPos.y() -

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -113,8 +113,11 @@ inline SurfaceIntersection CylinderSurface::intersect(
 }
 
 inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global position
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -119,14 +119,14 @@ inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
-  const ActsRowVector<double, 3> pcRowVec =
+  const ActsRowVector<AlignmentScalar, 3> pcRowVec =
       (position - center(gctx)).transpose();
   // The rotation
   const auto& rotation = transform(gctx).rotation();
   // The local frame x/y/z axis
-  const Vector3D localXAxis = rotation.block<3, 1>(0, 0);
-  const Vector3D localYAxis = rotation.block<3, 1>(0, 1);
-  const Vector3D localZAxis = rotation.block<3, 1>(0, 2);
+  const Vector3D localXAxis = rotation.col(0);
+  const Vector3D localYAxis = rotation.col(1);
+  const Vector3D localZAxis = rotation.col(2);
   // The local coordinates
   const Vector3D localPos = rotation.transpose() * position;
   const double dx = direction.dot(localXAxis);
@@ -135,15 +135,15 @@ inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
   // The normalization factor
   const double norm = 1. / (1. - dz * dz);
   // The direction transpose
-  const ActsRowVector<double, 3> dirRowVec = direction.transpose();
+  const ActsRowVector<AlignmentScalar, 3> dirRowVec = direction.transpose();
   // The derivative of path w.r.t. the local axes
   // @note The following calculations assume that the intersection of the track
   // with the cylinder always satisfy: perp(localPos) = R
-  const ActsRowVector<double, 3> localXAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localXAxisToPath =
       -2.0 * norm * (dx * pcRowVec + localPos.x() * dirRowVec);
-  const ActsRowVector<double, 3> localYAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localYAxisToPath =
       -2.0 * norm * (dy * pcRowVec + localPos.y() * dirRowVec);
-  const ActsRowVector<double, 3> localZAxisToPath =
+  const ActsRowVector<AlignmentScalar, 3> localZAxisToPath =
       -4.0 * norm * norm * (dx * localPos.x() + dy * localPos.y()) * dz *
       dirRowVec;
   // Calculate the derivative of local frame axes w.r.t its rotation

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -113,9 +113,7 @@ inline SurfaceIntersection CylinderSurface::intersect(
 }
 
 inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
-    const RotationMatrix3D& rotToLocalYAxis,
-    const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+    const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& direction) const {
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
@@ -145,6 +143,9 @@ inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
   const ActsRowVector<double, 3> localZAxisToPath =
       -4.0 * norm * norm * (dx * localPos.x() + dy * localPos.y()) * dz *
       dirRowVec;
+  // Calculate the derivative of local frame axes w.r.t its rotation
+  const auto [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
+      detail::rotationToLocalAxesDerivative(rotation);
   // Initialize the derivative of propagation path w.r.t. local frame
   // translation (origin) and rotation
   AlignmentRowVector alignToPath = AlignmentRowVector::Zero();

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -112,6 +112,51 @@ inline SurfaceIntersection CylinderSurface::intersect(
   return cIntersection;
 }
 
+inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
+    const GeometryContext& gctx, const RotationMatrix3D& rotToLocalXAxis,
+    const RotationMatrix3D& rotToLocalYAxis,
+    const RotationMatrix3D& rotToLocalZAxis, const Vector3D& position,
+    const Vector3D& direction) const {
+  // The vector between position and center
+  const ActsRowVector<double, 3> pcRowVec =
+      (position - center(gctx)).transpose();
+  // The rotation
+  const auto& rotation = transform(gctx).rotation();
+  // The local frame x/y/z axis
+  const Vector3D localXAxis = rotation.block<3, 1>(0, 0);
+  const Vector3D localYAxis = rotation.block<3, 1>(0, 1);
+  const Vector3D localZAxis = rotation.block<3, 1>(0, 2);
+  // The local coordinates
+  const Vector3D localPos = rotation.transpose() * position;
+  const double dx = direction.dot(localXAxis);
+  const double dy = direction.dot(localYAxis);
+  const double dz = direction.dot(localZAxis);
+  // The normalization factor
+  const double norm = 1. / (1. - dz * dz);
+  // The direction transpose
+  const ActsRowVector<double, 3> dirRowVec = direction.transpose();
+  // The derivative of path w.r.t. the local axes
+  // @note The following calculations assume that the intersection of the track
+  // with the cylinder always satisfy: perp(localPos) = R
+  const ActsRowVector<double, 3> localXAxisToPath =
+      -2.0 * norm * (dx * pcRowVec + localPos.x() * dirRowVec);
+  const ActsRowVector<double, 3> localYAxisToPath =
+      -2.0 * norm * (dy * pcRowVec + localPos.y() * dirRowVec);
+  const ActsRowVector<double, 3> localZAxisToPath =
+      -4.0 * norm * norm * (dx * localPos.x() + dy * localPos.y()) * dz *
+      dirRowVec;
+  // Initialize the derivative of propagation path w.r.t. local frame
+  // translation (origin) and rotation
+  AlignmentRowVector alignToPath = AlignmentRowVector::Zero();
+  alignToPath.segment<3>(eAlignmentCenter0) =
+      2.0 * norm * (dx * localXAxis.transpose() + dy * localYAxis.transpose());
+  alignToPath.segment<3>(eAlignmentRotation0) =
+      localXAxisToPath * rotToLocalXAxis + localYAxisToPath * rotToLocalYAxis +
+      localZAxisToPath * rotToLocalZAxis;
+
+  return alignToPath;
+}
+
 inline LocalCartesianToBoundLocalMatrix
 CylinderSurface::localCartesianToBoundLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position) const {

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -65,9 +65,10 @@ inline void DiscSurface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian(7, eBoundQOverP) = 1;
 }
 
-inline RotationMatrix3D DiscSurface::initJacobianToLocal(
-    const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
-    const Vector3D& position, const Vector3D& direction) const {
+inline void DiscSurface::initJacobianToLocal(const GeometryContext& gctx,
+                                             FreeToBoundMatrix& jacobian,
+                                             const Vector3D& position,
+                                             const Vector3D& direction) const {
   using VectorHelpers::perp;
   using VectorHelpers::phi;
   // Optimized trigonometry on the propagation direction
@@ -103,8 +104,6 @@ inline RotationMatrix3D DiscSurface::initJacobianToLocal(
   jacobian(eBoundTheta, 5) = sinPhi * cosTheta;
   jacobian(eBoundTheta, 6) = -sinTheta;
   jacobian(eBoundQOverP, 7) = 1;
-  // return the transposed reference frame
-  return rframeT;
 }
 
 inline SurfaceIntersection DiscSurface::intersect(

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -185,25 +185,22 @@ inline void LineSurface::initJacobianToGlobal(const GeometryContext& gctx,
 
 inline FreeRowVector LineSurface::freeToPathDerivative(
     const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const Vector3D& direction, const RotationMatrix3D& rft) const {
   // The vector between position and center
-  const ActsRowVector<double, 3> pcRowVec =
-      (position - center(gctx)).transpose();
-  // The local frame z axis
-  const Vector3D localZAxis = transform(gctx).matrix().block<3, 1>(0, 2);
+  const ActsRowVector<double, 3> pc = (position - center(gctx)).transpose();
+  // The longitudinal component vector (along local z axis)
+  ActsRowVectorD<3> locZ = rft.block<1, 3>(1, 0);
+  // Cosine of angle between momentum direction and local z axis
+  const double dz = locZ * direction;
+  const double norm = 1. / (1. - dz * dz);
   // The local z coordinate
-  const double localZ = pcRowVec * localZAxis;
-  // Cosine of angle between momentum direction and local frame z axis
-  const double dirZ = localZAxis.dot(direction);
-  const double norm = 1. / (1. - dirZ * dirZ);
+  const double pz = locZ.dot(pc);
   // Initialize the derivative of propagation path w.r.t. free parameter
   FreeRowVector freeToPath = FreeRowVector::Zero();
   // The derivative of path w.r.t. position
-  freeToPath.segment<3>(eFreePos0) =
-      norm * (dirZ * localZAxis.transpose() - direction.transpose());
+  freeToPath.segment<3>(eFreePos0) = norm * (dz * locZ - direction.transpose());
   // The derivative of path w.r.t. direction
-  freeToPath.segment<3>(eFreeDir0) =
-      norm * (localZ * localZAxis.transpose() - pcRowVec);
+  freeToPath.segment<3>(eFreeDir0) = norm * (pz * locZ - pc);
 
   return freeToPath;
 }

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -183,8 +183,12 @@ inline void LineSurface::initJacobianToGlobal(const GeometryContext& gctx,
 }
 
 inline FreeRowVector LineSurface::freeToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction, const RotationMatrix3D& rft) const {
+    const GeometryContext& gctx, const FreeVector& parameters,
+    const RotationMatrix3D& rft) const {
+  // The global posiiton
+  const auto position = parameters.segment<3>(eFreePos0);
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -190,7 +190,7 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
-  const ActsRowVector<double, 3> pcRowVec =
+  const ActsRowVector<AlignmentScalar, 3> pcRowVec =
       (position - center(gctx)).transpose();
   // The longitudinal component vector (along local z axis)
   ActsRowVectorD<3> locZ = rft.block<1, 3>(1, 0);
@@ -216,12 +216,12 @@ inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
-  const ActsRowVector<double, 3> pcRowVec =
+  const ActsRowVector<AlignmentScalar, 3> pcRowVec =
       (position - center(gctx)).transpose();
   // The rotation
   const auto& rotation = transform(gctx).rotation();
   // The local frame z axis
-  const Vector3D localZAxis = rotation.block<3, 1>(0, 2);
+  const Vector3D localZAxis = rotation.col(2);
   // The local z coordinate
   const double pz = pcRowVec * localZAxis;
   // Cosine of angle between momentum direction and local frame z axis

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -186,7 +186,7 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters,
     const RotationMatrix3D& rft) const {
   // The global posiiton
-  const auto position = parameters.segment<3>(eFreePos0);
+  const auto position = parameters.head<3>();
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
@@ -210,8 +210,11 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
 }
 
 inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global posiiton
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -24,22 +24,21 @@ inline Vector3D LineSurface::localToGlobal(const GeometryContext& gctx,
 inline Result<Vector2D> LineSurface::globalToLocal(const GeometryContext& gctx,
                                                    const Vector3D& position,
                                                    const Vector3D& momentum,
-                                                   double /*tolerance*/) const {
-  using VectorHelpers::perp;
-
+                                                   double tolerance) const {
   const auto& sTransform = transform(gctx);
   const auto& tMatrix = sTransform.matrix();
-  Vector3D lineDirection(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
-  // Bring the global position into the local frame
-  Vector3D loc3Dframe = sTransform.inverse() * position;
-  // construct localPosition with sign*perp(candidate) and z.()
-  Vector2D lposition(perp(loc3Dframe), loc3Dframe.z());
   Vector3D sCenter(tMatrix(0, 3), tMatrix(1, 3), tMatrix(2, 3));
-  Vector3D decVec(position - sCenter);
-  // assign the right sign
-  double sign = ((lineDirection.cross(momentum)).dot(decVec) < 0.) ? -1. : 1.;
-  lposition[eBoundLoc0] *= sign;
-  return Result<Vector2D>::success(lposition);
+  // The vector from center to position
+  Vector3D pcVec = position - sCenter;
+  // The measurement reference frame
+  RotationMatrix3D rframe = referenceFrame(gctx, position, momentum);
+  // The position coordinates in the measurement reference frame
+  Vector3D rframePos = rframe.transpose() * pcVec;
+  // Check if the position is on the track POCA
+  if (rframePos.z() * rframePos.z() > tolerance * tolerance) {
+    return Result<Vector2D>::failure(SurfaceError::GlobalPositionNotOnSurface);
+  }
+  return Result<Vector2D>::success({rframePos.x(), rframePos.y()});
 }
 
 inline std::string LineSurface::name() const {

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -210,20 +210,23 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
 }
 
 inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const RotationMatrix3D& /*unused*/,
-    const RotationMatrix3D& /*unused*/, const RotationMatrix3D& rotToLocalZAxis,
-    const Vector3D& position, const Vector3D& direction) const {
+    const GeometryContext& gctx, const Vector3D& position,
+    const Vector3D& direction) const {
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();
+  // The rotation
+  const auto& rotation = transform(gctx).rotation();
   // The local frame z axis
-  const Vector3D localZAxis = transform(gctx).matrix().block<3, 1>(0, 2);
+  const Vector3D localZAxis = rotation.block<3, 1>(0, 2);
   // The local z coordinate
   const double pz = pcRowVec * localZAxis;
-
   // Cosine of angle between momentum direction and local frame z axis
   const double dz = localZAxis.dot(direction);
   const double norm = 1. / (1. - dz * dz);
+  // Calculate the derivative of local frame axes w.r.t its rotation
+  const auto [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
+      detail::rotationToLocalAxesDerivative(rotation);
   // Initialize the derivative of propagation path w.r.t. local frame
   // translation (origin) and rotation
   AlignmentRowVector alignToPath = AlignmentRowVector::Zero();

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -205,7 +205,8 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
 }
 
 inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
+    const GeometryContext& gctx, const RotationMatrix3D& /*unused*/,
+    const RotationMatrix3D& /*unused*/, const RotationMatrix3D& rotToLocalZAxis,
     const Vector3D& position, const Vector3D& direction) const {
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -103,15 +103,17 @@ inline RotationMatrix3D Surface::initJacobianToLocal(
   return rframeT;
 }
 
-inline BoundRowVector Surface::derivativeFactors(
-    const GeometryContext& /*unused*/, const Vector3D& /*unused*/,
-    const Vector3D& direction, const RotationMatrix3D& rft,
-    const BoundToFreeMatrix& jacobian) const {
-  // Create the normal and scale it with the projection onto the direction
-  ActsRowVectorD<3> norm_vec = rft.template block<1, 3>(2, 0);
-  norm_vec /= (norm_vec * direction);
-  // calculate the s factors
-  return (norm_vec * jacobian.topLeftCorner<3, eBoundSize>());
+inline FreeRowVector Surface::freeToPathDerivative(
+    const GeometryContext& gctx, const Vector3D& /*unused*/,
+    const Vector3D& direction) const {
+  // The local frame z axis
+  const Vector3D localZAxis = transform(gctx).matrix().block<3, 1>(0, 2);
+  // The normalization factor
+  const double norm = -1.0 / (localZAxis.dot(direction));
+  FreeRowVector freeToPath = FreeRowVector::Zero();
+  freeToPath.head<3>() = norm * localZAxis.transpose();
+
+  return freeToPath;
 }
 
 inline const DetectorElementBase* Surface::associatedDetectorElement() const {

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -104,14 +104,14 @@ inline RotationMatrix3D Surface::initJacobianToLocal(
 }
 
 inline FreeRowVector Surface::freeToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& /*unused*/,
-    const Vector3D& direction) const {
-  // The local frame z axis
-  const Vector3D localZAxis = transform(gctx).matrix().block<3, 1>(0, 2);
-  // The normalization factor
-  const double norm = -1.0 / (localZAxis.dot(direction));
+    const GeometryContext& /*unused*/, const Vector3D& /*unused*/,
+    const Vector3D& direction, const RotationMatrix3D& rft) const {
+  // Create the normal and scale it with the projection onto the direction
+  ActsRowVectorD<3> norm_vec = rft.template block<1, 3>(2, 0);
+  norm_vec /= (norm_vec * direction);
+
   FreeRowVector freeToPath = FreeRowVector::Zero();
-  freeToPath.head<3>() = norm * localZAxis.transpose();
+  freeToPath.head<3>() = -1.0 * norm_vec;
 
   return freeToPath;
 }

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -104,8 +104,10 @@ inline RotationMatrix3D Surface::initJacobianToLocal(
 }
 
 inline FreeRowVector Surface::freeToPathDerivative(
-    const GeometryContext& /*unused*/, const Vector3D& /*unused*/,
-    const Vector3D& direction, const RotationMatrix3D& rft) const {
+    const GeometryContext& /*unused*/, const FreeVector& parameters,
+    const RotationMatrix3D& rft) const {
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // Create the normal and scale it with the projection onto the direction
   ActsRowVectorD<3> norm_vec = rft.template block<1, 3>(2, 0);
   norm_vec /= (norm_vec * direction);

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -72,9 +72,10 @@ inline void Surface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian(7, eBoundQOverP) = 1;
 }
 
-inline RotationMatrix3D Surface::initJacobianToLocal(
-    const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
-    const Vector3D& position, const Vector3D& direction) const {
+inline void Surface::initJacobianToLocal(const GeometryContext& gctx,
+                                         FreeToBoundMatrix& jacobian,
+                                         const Vector3D& position,
+                                         const Vector3D& direction) const {
   // Optimized trigonometry on the propagation direction
   const double x = direction(0);  // == cos(phi) * sin(theta)
   const double y = direction(1);  // == sin(phi) * sin(theta)
@@ -99,22 +100,23 @@ inline RotationMatrix3D Surface::initJacobianToLocal(
   jacobian(eBoundTheta, 5) = sinPhi * cosTheta;
   jacobian(eBoundTheta, 6) = -sinTheta;
   jacobian(eBoundQOverP, 7) = 1;
-  // return the frame where this happened
-  return rframeT;
 }
 
 inline FreeRowVector Surface::freeToPathDerivative(
-    const GeometryContext& /*unused*/, const FreeVector& parameters,
-    const RotationMatrix3D& rft) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global position
+  const auto position = parameters.head<3>();
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
-  // Create the normal and scale it with the projection onto the direction
-  ActsRowVectorD<3> norm_vec = rft.template block<1, 3>(2, 0);
-  norm_vec /= (norm_vec * direction);
-
+  // The measurement frame of the surface
+  const RotationMatrix3D rframe = referenceFrame(gctx, position, direction);
+  // The measurement frame z axis
+  const Vector3D refZAxis = rframe.col(2);
+  // Cosine of angle between momentum direction and measurement frame z axis
+  const double dz = refZAxis.dot(direction);
+  // Initialize the derivative
   FreeRowVector freeToPath = FreeRowVector::Zero();
-  freeToPath.head<3>() = -1.0 * norm_vec;
-
+  freeToPath.head<3>() = -1.0 * refZAxis.transpose() / dz;
   return freeToPath;
 }
 

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -43,5 +43,6 @@ using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentScalar, 3, eAlignmentSize>;
 using AlignmentToBoundMatrix =
     ActsMatrix<BoundScalar, eBoundSize, eAlignmentSize>;
+using AlignmentToBoundLocalMatrix = ActsMatrix<BoundScalar, 2, eAlignmentSize>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -41,8 +41,6 @@ using AlingmentMatrix =
     ActsMatrix<AlignmentScalar, eAlignmentSize, eAlignmentSize>;
 using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentScalar, 3, eAlignmentSize>;
-using AlignmentToBoundMatrix =
-    ActsMatrix<BoundScalar, eBoundSize, eAlignmentSize>;
 using AlignmentToBoundLocalMatrix = ActsMatrix<BoundScalar, 2, eAlignmentSize>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -41,6 +41,8 @@ using AlingmentMatrix =
     ActsMatrix<AlignmentScalar, eAlignmentSize, eAlignmentSize>;
 using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentScalar, 3, eAlignmentSize>;
+using AlignmentToBoundMatrix =
+    ActsMatrix<BoundScalar, eBoundSize, eAlignmentSize>;
 using AlignmentToBoundLocalMatrix = ActsMatrix<BoundScalar, 2, eAlignmentSize>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
+++ b/Core/include/Acts/Utilities/AlignmentDefinitions.hpp
@@ -43,6 +43,5 @@ using AlignmentToLocalCartesianMatrix =
     ActsMatrix<AlignmentScalar, 3, eAlignmentSize>;
 using AlignmentToBoundMatrix =
     ActsMatrix<BoundScalar, eBoundSize, eAlignmentSize>;
-using AlignmentToBoundLocalMatrix = ActsMatrix<BoundScalar, 2, eAlignmentSize>;
 
 }  // namespace Acts

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -94,14 +94,14 @@ FreeToBoundMatrix surfaceDerivative(
   // Initialize the transport final frame jacobian
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
   // Initalize the jacobian to local, returns the transposed ref frame
-  auto rframeT = surface.initJacobianToLocal(geoContext, jacToLocal,
-                                             parameters.segment<3>(eFreePos0),
-                                             parameters.segment<3>(eFreeDir0));
+  surface.initJacobianToLocal(geoContext, jacToLocal,
+                              parameters.segment<3>(eFreePos0),
+                              parameters.segment<3>(eFreeDir0));
   // Calculate the form factors for the derivatives
-  const BoundRowVector sVec = surface.derivativeFactors(
-      geoContext, parameters.segment<3>(eFreePos0),
-      parameters.segment<3>(eFreeDir0), rframeT, jacobianLocalToGlobal);
-  jacobianLocalToGlobal -= derivatives * sVec;
+  const FreeRowVector freeToPath =
+      surface.freeToPathDerivative(geoContext, parameters.segment<3>(eFreePos0),
+                                   parameters.segment<3>(eFreeDir0));
+  jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Return the jacobian to local
   return jacToLocal;
 }

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -93,13 +93,13 @@ FreeToBoundMatrix surfaceDerivative(
     const FreeVector& derivatives, const Surface& surface) {
   // Initialize the transport final frame jacobian
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
-  // Initalize the jacobian to local, returns the transposed ref frame
-  auto rframeT = surface.initJacobianToLocal(geoContext, jacToLocal,
-                                             parameters.segment<3>(eFreePos0),
-                                             parameters.segment<3>(eFreeDir0));
+  // Initalize the jacobian to local
+  surface.initJacobianToLocal(geoContext, jacToLocal,
+                              parameters.segment<3>(eFreePos0),
+                              parameters.segment<3>(eFreeDir0));
   // Calculate the form factors for the derivatives
   const FreeRowVector freeToPath =
-      surface.freeToPathDerivative(geoContext, parameters, rframeT);
+      surface.freeToPathDerivative(geoContext, parameters);
   jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Return the jacobian to local
   return jacToLocal;

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -99,8 +99,7 @@ FreeToBoundMatrix surfaceDerivative(
                                              parameters.segment<3>(eFreeDir0));
   // Calculate the form factors for the derivatives
   const FreeRowVector freeToPath =
-      surface.freeToPathDerivative(geoContext, parameters.segment<3>(eFreePos0),
-                                   parameters.segment<3>(eFreeDir0), rframeT);
+      surface.freeToPathDerivative(geoContext, parameters, rframeT);
   jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Return the jacobian to local
   return jacToLocal;

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -94,13 +94,13 @@ FreeToBoundMatrix surfaceDerivative(
   // Initialize the transport final frame jacobian
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
   // Initalize the jacobian to local, returns the transposed ref frame
-  surface.initJacobianToLocal(geoContext, jacToLocal,
-                              parameters.segment<3>(eFreePos0),
-                              parameters.segment<3>(eFreeDir0));
+  auto rframeT = surface.initJacobianToLocal(geoContext, jacToLocal,
+                                             parameters.segment<3>(eFreePos0),
+                                             parameters.segment<3>(eFreeDir0));
   // Calculate the form factors for the derivatives
   const FreeRowVector freeToPath =
       surface.freeToPathDerivative(geoContext, parameters.segment<3>(eFreePos0),
-                                   parameters.segment<3>(eFreeDir0));
+                                   parameters.segment<3>(eFreeDir0), rframeT);
   jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Return the jacobian to local
   return jacToLocal;

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -83,7 +83,8 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
       localCartesianToBoundLocalDerivative(gctx, position);
   // 4) Calculate the derivative of path length w.r.t. alignment parameters
   const auto& alignToPath =
-      alignmentToPathDerivative(gctx, rotToLocalZAxis, position, direction);
+      alignmentToPathDerivative(gctx, rotToLocalXAxis, rotToLocalYAxis,
+                                rotToLocalZAxis, position, direction);
   // 5) Calculate the jacobian from free parameters to bound parameters
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
   initJacobianToLocal(gctx, jacToLocal, position, direction);
@@ -93,6 +94,9 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   // -> For bound track parameters eBoundLoc0, eBoundLoc1, it's
   // loc3DToLocBound*alignToLoc3D +
   // jacToLocal*derivatives*alignToPath
+  // @note For line surface, the alignment to bound local without path
+  // correction cannot be decomposed into the alignment->loca3D and
+  // local3D->localBond. Thus, reimplementation is needed.
   alignToBound.block<2, eAlignmentSize>(eBoundLoc0, eAlignmentCenter0) =
       loc3DToLocBound * alignToLoc3D +
       jacToLocal.block<2, eFreeSize>(eBoundLoc0, eFreePos0) * derivatives *
@@ -107,7 +111,8 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
 }
 
 Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const RotationMatrix3D& rotToLocalZAxis,
+    const GeometryContext& gctx, const RotationMatrix3D& /*unused*/,
+    const RotationMatrix3D& /*unused*/, const RotationMatrix3D& rotToLocalZAxis,
     const Vector3D& position, const Vector3D& direction) const {
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -50,8 +50,6 @@ bool Acts::Surface::isOnSurface(const GeometryContext& gctx,
 Acts::AlignmentToBoundLocalMatrix Acts::Surface::alignmentToLocalDerivative(
     const GeometryContext& gctx, const Vector3D& position,
     const Vector3D& direction) const {
-  // The local frame rotation
-  const auto& rotation = transform(gctx).rotation();
   // 1) Calculate the derivative of bound parameter local position w.r.t.
   // alignment parameters without path length correction
   const auto alignToLocalWithoutCorrection =

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -136,13 +136,13 @@ Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
   const Vector3D localZAxis = rotation.col(2);
 
   // Cosine of angle between momentum direction and local frame z axis
-  const double dirZ = localZAxis.dot(direction);
+  const double dz = localZAxis.dot(direction);
   // Initialize the derivative of propagation path w.r.t. local frame
   // translation (origin) and rotation
   AlignmentRowVector alignToPath = AlignmentRowVector::Zero();
-  alignToPath.segment<3>(eAlignmentCenter0) = localZAxis.transpose() / dirZ;
+  alignToPath.segment<3>(eAlignmentCenter0) = localZAxis.transpose() / dz;
   alignToPath.segment<3>(eAlignmentRotation0) =
-      -pcRowVec * rotToLocalZAxis / dirZ;
+      -pcRowVec * rotToLocalZAxis / dz;
 
   return alignToPath;
 }

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -48,14 +48,17 @@ bool Acts::Surface::isOnSurface(const GeometryContext& gctx,
 }
 
 Acts::AlignmentToBoundLocalMatrix Acts::Surface::alignmentToLocalDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global posiiton
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // 1) Calculate the derivative of bound parameter local position w.r.t.
   // alignment parameters without path length correction
   const auto alignToLocalWithoutCorrection =
-      alignmentToLocalDerivativeWithoutCorrection(gctx, position, direction);
+      alignmentToLocalDerivativeWithoutCorrection(gctx, parameters);
   // 2) Calculate the derivative of path length w.r.t. alignment parameters
-  const auto alignToPath = alignmentToPathDerivative(gctx, position, direction);
+  const auto alignToPath = alignmentToPathDerivative(gctx, parameters);
   // 3) Calculate the jacobian from free parameters to bound parameters
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
   initJacobianToLocal(gctx, jacToLocal, position, direction);
@@ -70,8 +73,9 @@ Acts::AlignmentToBoundLocalMatrix Acts::Surface::alignmentToLocalDerivative(
 
 Acts::AlignmentToBoundLocalMatrix
 Acts::Surface::alignmentToLocalDerivativeWithoutCorrection(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& /*unused*/) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global posiiton
+  const auto position = parameters.segment<3>(eFreePos0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();
@@ -106,8 +110,11 @@ Acts::Surface::alignmentToLocalDerivativeWithoutCorrection(
 }
 
 Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
-    const GeometryContext& gctx, const Vector3D& position,
-    const Vector3D& direction) const {
+    const GeometryContext& gctx, const FreeVector& parameters) const {
+  // The global posiiton
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
   const ActsRowVector<double, 3> pcRowVec =
       (position - center(gctx)).transpose();

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -265,9 +265,9 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
   Vector3D momentum{0, 0, 1};
   Vector3D direction = momentum.normalized();
   // Construct a free parameters
-  FreeVector parameters;
-  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
-      direction.x(), direction.y(), direction.z(), 1;
+  FreeVector parameters = FreeVector::Zero();
+  parameters.head<3>() = globalPosition;
+  parameters.segment<3>(eFreeDir0) = direction;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -265,16 +265,10 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
   Vector3D momentum{0, 0, 1};
   Vector3D direction = momentum.normalized();
 
-  // Call the function to calculate the derivative of local frame axes w.r.t its
-  // rotation
-  const auto& [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
-      detail::rotationToLocalAxesDerivative(rotation);
-
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      discSurfaceObject->alignmentToPathDerivative(
-          tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
-          globalPosition, direction);
+      discSurfaceObject->alignmentToPathDerivative(tgContext, globalPosition,
+                                                   direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 3, 0, 0;

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -272,8 +272,9 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      discSurfaceObject->alignmentToPathDerivative(tgContext, rotToLocalZAxis,
-                                                   globalPosition, direction);
+      discSurfaceObject->alignmentToPathDerivative(
+          tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
+          globalPosition, direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 3, 0, 0;

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -260,15 +260,18 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
   // Check the local z axis is aligned to global z axis
   CHECK_CLOSE_ABS(localZAxis, Vector3D(0., 0., 1.), 1e-15);
 
-  /// Define the track (global) position and direction
+  // Define the track (global) position and direction
   Vector3D globalPosition{0, 4, 2};
   Vector3D momentum{0, 0, 1};
   Vector3D direction = momentum.normalized();
+  // Construct a free parameters
+  FreeVector parameters;
+  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
+      direction.x(), direction.y(), direction.z(), 1;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      discSurfaceObject->alignmentToPathDerivative(tgContext, globalPosition,
-                                                   direction);
+      discSurfaceObject->alignmentToPathDerivative(tgContext, parameters);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 3, 0, 0;

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -173,15 +173,9 @@ BOOST_AUTO_TEST_CASE(LineSurfaceAlignment) {
   Vector3D momentum{-1, 1, 1};
   Vector3D direction = momentum.normalized();
 
-  // Call the function to calculate the derivative of local frame axes w.r.t its
-  // rotation
-  const auto& [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
-      detail::rotationToLocalAxesDerivative(rotation);
-
   // (a) Test the derivative of path length w.r.t. alignment parameters
-  const AlignmentRowVector& alignToPath = line.alignmentToPathDerivative(
-      tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
-      globalPosition, direction);
+  const AlignmentRowVector& alignToPath =
+      line.alignmentToPathDerivative(tgContext, globalPosition, direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   const double value = std::sqrt(3) / 2;

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -180,7 +180,8 @@ BOOST_AUTO_TEST_CASE(LineSurfaceAlignment) {
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath = line.alignmentToPathDerivative(
-      tgContext, rotToLocalZAxis, globalPosition, direction);
+      tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
+      globalPosition, direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   const double value = std::sqrt(3) / 2;

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -168,14 +168,18 @@ BOOST_AUTO_TEST_CASE(LineSurfaceAlignment) {
   // Check the local z axis is aligned to global z axis
   CHECK_CLOSE_ABS(localZAxis, Vector3D(0., 0., 1.), 1e-15);
 
-  /// Define the track (global) position and direction
+  // Define the track (global) position and direction
   Vector3D globalPosition{1, 2, 4};
   Vector3D momentum{-1, 1, 1};
   Vector3D direction = momentum.normalized();
+  // Construct a free parameters
+  FreeVector parameters;
+  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
+      direction.x(), direction.y(), direction.z(), 1;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      line.alignmentToPathDerivative(tgContext, globalPosition, direction);
+      line.alignmentToPathDerivative(tgContext, parameters);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   const double value = std::sqrt(3) / 2;

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -173,9 +173,9 @@ BOOST_AUTO_TEST_CASE(LineSurfaceAlignment) {
   Vector3D momentum{-1, 1, 1};
   Vector3D direction = momentum.normalized();
   // Construct a free parameters
-  FreeVector parameters;
-  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
-      direction.x(), direction.y(), direction.z(), 1;
+  FreeVector parameters = FreeVector::Zero();
+  parameters.head<3>() = globalPosition;
+  parameters.segment<3>(eFreeDir0) = direction;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -284,8 +284,9 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      planeSurfaceObject->alignmentToPathDerivative(tgContext, rotToLocalZAxis,
-                                                    globalPosition, direction);
+      planeSurfaceObject->alignmentToPathDerivative(
+          tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
+          globalPosition, direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 2, -1, 0;

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -304,13 +304,11 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
 
   // (c) Test the derivative of bound parameters (only test loc0, loc1 here)
   // w.r.t. alignment parameters
-  FreeVector derivatives = FreeVector::Zero();
-  derivatives.segment<3>(0) = momentum;
-  const AlignmentToBoundMatrix& alignToBound =
-      planeSurfaceObject->alignmentToBoundDerivative(tgContext, derivatives,
-                                                     globalPosition, direction);
-  const AlignmentRowVector& alignToloc0 = alignToBound.block<1, 6>(0, 0);
-  const AlignmentRowVector& alignToloc1 = alignToBound.block<1, 6>(1, 0);
+  const AlignmentToBoundLocalMatrix& alignToLocal =
+      planeSurfaceObject->alignmentToLocalDerivative(tgContext, globalPosition,
+                                                     direction);
+  const AlignmentRowVector& alignToloc0 = alignToLocal.block<1, 6>(0, 0);
+  const AlignmentRowVector& alignToloc1 = alignToLocal.block<1, 6>(1, 0);
   // The expected results
   AlignmentRowVector expAlignToloc0;
   expAlignToloc0 << -1, 0, 0, 0, 0, 2;

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -277,16 +277,10 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   Vector3D globalPosition =
       planeSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
 
-  // Call the function to calculate the derivative of local frame axes w.r.t its
-  // rotation
-  const auto& [rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis] =
-      detail::rotationToLocalAxesDerivative(rotation);
-
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      planeSurfaceObject->alignmentToPathDerivative(
-          tgContext, rotToLocalXAxis, rotToLocalYAxis, rotToLocalZAxis,
-          globalPosition, direction);
+      planeSurfaceObject->alignmentToPathDerivative(tgContext, globalPosition,
+                                                    direction);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 2, -1, 0;

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -306,8 +306,10 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   const AlignmentToBoundMatrix& alignToBound =
       planeSurfaceObject->alignmentToBoundDerivative(tgContext, parameters,
                                                      derivatives);
-  const AlignmentRowVector alignToloc0 = alignToBound.block<1, 6>(0, 0);
-  const AlignmentRowVector alignToloc1 = alignToBound.block<1, 6>(1, 0);
+  const AlignmentRowVector alignToloc0 =
+      alignToBound.block<1, 6>(eBoundLoc0, eAlignmentCenter0);
+  const AlignmentRowVector alignToloc1 =
+      alignToBound.block<1, 6>(eBoundLoc1, eAlignmentCenter0);
   // The expected results
   AlignmentRowVector expAlignToloc0;
   expAlignToloc0 << -1, 0, 0, 0, 0, 2;

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -277,9 +277,9 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   Vector3D globalPosition =
       planeSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
   // Construct a free parameters
-  FreeVector parameters;
-  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
-      direction.x(), direction.y(), direction.z(), 1;
+  FreeVector parameters = FreeVector::Zero();
+  parameters.head<3>() = globalPosition;
+  parameters.segment<3>(eFreeDir0) = direction;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -258,7 +258,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceExtent) {
 BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   // bounds object, rectangle type
   auto rBounds = std::make_shared<const RectangleBounds>(3., 4.);
-  /// Test clone method
+  // Test clone method
   Translation3D translation{0., 1., 2.};
   auto pTransform = Transform3D(translation);
   auto planeSurfaceObject =
@@ -269,18 +269,21 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   // Check the local z axis is aligned to global z axis
   CHECK_CLOSE_ABS(localZAxis, Vector3D(0., 0., 1.), 1e-15);
 
-  /// Define the track (local) position and direction
+  // Define the track (local) position and direction
   Vector2D localPosition{1, 2};
   Vector3D momentum{0, 0, 1};
   Vector3D direction = momentum.normalized();
-  /// Get the global position
+  // Get the global position
   Vector3D globalPosition =
       planeSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
+  // Construct a free parameters
+  FreeVector parameters;
+  parameters << globalPosition.x(), globalPosition.y(), globalPosition.z(), 0,
+      direction.x(), direction.y(), direction.z(), 1;
 
   // (a) Test the derivative of path length w.r.t. alignment parameters
   const AlignmentRowVector& alignToPath =
-      planeSurfaceObject->alignmentToPathDerivative(tgContext, globalPosition,
-                                                    direction);
+      planeSurfaceObject->alignmentToPathDerivative(tgContext, parameters);
   // The expected results
   AlignmentRowVector expAlignToPath = AlignmentRowVector::Zero();
   expAlignToPath << 0, 0, 1, 2, -1, 0;
@@ -299,8 +302,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   // (c) Test the derivative of bound parameters (only test loc0, loc1 here)
   // w.r.t. alignment parameters
   const AlignmentToBoundLocalMatrix& alignToLocal =
-      planeSurfaceObject->alignmentToLocalDerivative(tgContext, globalPosition,
-                                                     direction);
+      planeSurfaceObject->alignmentToLocalDerivative(tgContext, parameters);
   const AlignmentRowVector& alignToloc0 = alignToLocal.block<1, 6>(0, 0);
   const AlignmentRowVector& alignToloc1 = alignToLocal.block<1, 6>(1, 0);
   // The expected results

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -301,10 +301,13 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
 
   // (c) Test the derivative of bound parameters (only test loc0, loc1 here)
   // w.r.t. alignment parameters
-  const AlignmentToBoundLocalMatrix& alignToLocal =
-      planeSurfaceObject->alignmentToLocalDerivative(tgContext, parameters);
-  const AlignmentRowVector& alignToloc0 = alignToLocal.block<1, 6>(0, 0);
-  const AlignmentRowVector& alignToloc1 = alignToLocal.block<1, 6>(1, 0);
+  FreeVector derivatives = FreeVector::Zero();
+  derivatives.head<3>() = direction;
+  const AlignmentToBoundMatrix& alignToBound =
+      planeSurfaceObject->alignmentToBoundDerivative(tgContext, parameters,
+                                                     derivatives);
+  const AlignmentRowVector alignToloc0 = alignToBound.block<1, 6>(0, 0);
+  const AlignmentRowVector alignToloc1 = alignToBound.block<1, 6>(1, 0);
   // The expected results
   AlignmentRowVector expAlignToloc0;
   expAlignToloc0 << -1, 0, 0, 0, 0, 2;


### PR DESCRIPTION
BREAKING CHANGE: This PR refactors the interfaces for calculating the Jacobian/derivatives between bound parameters/alignment parameters and free parameters. There are four types of functions involved for those calculations:
1. The free parameters transportation function
2. The transforms between free parameters and bound parameters (In principle, the transforms could be further split into the free parameters <=> local cartesian coordinates, and local cartesian coordinates <=> bound parameters)
3. The geometry constraint for the intersection or the POCA

This PR changes/fixes the relevant functions to explicitly calculate the derivatives of the above 2 and 3. This could allow validation of those calculations by comparing the results with those from Autodiff.