### PR TITLE
fix: Fix FPE overflow issue

### DIFF
--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -48,7 +48,7 @@ struct ConstrainedStep {
     }
     // The check the current value and set it if appropriate
     double cValue = values[type];
-    values[type] = cValue * cValue < value * value ? cValue : value;
+    values[type] = std::abs(cValue) < std::abs(value) ? cValue : value;
   }
 
   /// release a certain constraint value

--- a/Core/include/Acts/Propagator/detail/LoopProtection.hpp
+++ b/Core/include/Acts/Propagator/detail/LoopProtection.hpp
@@ -42,7 +42,7 @@ struct LoopProtection {
             state.options.abortList.template get<path_arborter_t>();
         double loopLimit = state.options.loopFraction * helixPath;
         double pathLimit = pathAborter.internalLimit;
-        if (loopLimit * loopLimit < pathLimit * pathLimit) {
+        if (std::abs(loopLimit) < std::abs(pathLimit)) {
           pathAborter.internalLimit = loopLimit;
 
           ACTS_VERBOSE("Path aborter limit set to "

--- a/Core/include/Acts/Utilities/AnnealingUtility.hpp
+++ b/Core/include/Acts/Utilities/AnnealingUtility.hpp
@@ -32,12 +32,7 @@ class AnnealingUtility {
     // Config constructor with default temperature list: {64.,16.,4.,2.,1.5,1.}
     Config(const std::vector<double>& temperatures = {64., 16., 4., 2., 1.5,
                                                       1.})
-        : setOfTemperatures(temperatures) {
-      // Set Gaussian cut-off terms for each temperature
-      for (double temp : temperatures) {
-        gaussCutTempVec.push_back(std::exp(-cutOff / (2. * temp)));
-      }
-    }
+        : setOfTemperatures(temperatures) {}
 
     // Insensitivity of calculated weight at cutoff
     double cutOff{9.};
@@ -45,14 +40,15 @@ class AnnealingUtility {
     // Set of temperatures, annealing starts at setOfTemperatures[0]
     // and anneals towards setOfTemperatures[last]
     std::vector<double> setOfTemperatures;
-
-    // For each temperature, a Gaussian term with the chi2 cut-off value
-    // is calculated and stored here
-    std::vector<double> gaussCutTempVec;
   };
 
   /// Constructor
-  AnnealingUtility(const Config& cfg = Config()) : m_cfg(cfg) {}
+  AnnealingUtility(const Config& cfg = Config()) : m_cfg(cfg) {
+    // Set Gaussian cut-off terms for each temperature
+    for (double temp : cfg.setOfTemperatures) {
+      m_gaussCutTempVec.push_back(std::exp(-cfg.cutOff / (2. * temp)));
+    }
+  }
 
   /// Does the actual annealing step
   void anneal(State& state) const;
@@ -78,5 +74,9 @@ class AnnealingUtility {
  private:
   /// Configuration object
   Config m_cfg;
+
+  // For each temperature, a Gaussian term with the chi2 cut-off value
+  // is calculated and stored here
+  std::vector<double> m_gaussCutTempVec;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/AnnealingUtility.hpp
+++ b/Core/include/Acts/Utilities/AnnealingUtility.hpp
@@ -32,7 +32,12 @@ class AnnealingUtility {
     // Config constructor with default temperature list: {64.,16.,4.,2.,1.5,1.}
     Config(const std::vector<double>& temperatures = {64., 16., 4., 2., 1.5,
                                                       1.})
-        : setOfTemperatures(temperatures) {}
+        : setOfTemperatures(temperatures) {
+      // Set Gaussian cut-off terms for each temperature
+      for (double temp : temperatures) {
+        gaussCutTempVec.push_back(std::exp(-cutOff / (2. * temp)));
+      }
+    }
 
     // Insensitivity of calculated weight at cutoff
     double cutOff{9.};
@@ -40,6 +45,10 @@ class AnnealingUtility {
     // Set of temperatures, annealing starts at setOfTemperatures[0]
     // and anneals towards setOfTemperatures[last]
     std::vector<double> setOfTemperatures;
+
+    // For each temperature, a Gaussian term with the chi2 cut-off value
+    // is calculated and stored here
+    std::vector<double> gaussCutTempVec;
   };
 
   /// Constructor

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -53,7 +53,7 @@ Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
                       maxDensity, maxSecondDerivative);
   }
 
-  return std::make_pair(maxPosition,
+  return maxSecondDerivative == 0. ? std::make_pair(0.,0.) : std::make_pair(maxPosition,
                         std::sqrt(-(maxDensity / maxSecondDerivative)));
 }
 

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -53,8 +53,10 @@ Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
                       maxDensity, maxSecondDerivative);
   }
 
-  return maxSecondDerivative == 0. ? std::make_pair(0.,0.) : std::make_pair(maxPosition,
-                        std::sqrt(-(maxDensity / maxSecondDerivative)));
+  return maxSecondDerivative == 0.
+             ? std::make_pair(0., 0.)
+             : std::make_pair(maxPosition,
+                              std::sqrt(-(maxDensity / maxSecondDerivative)));
 }
 
 template <typename input_track_t>

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -53,7 +53,7 @@ Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
                       maxDensity, maxSecondDerivative);
   }
 
-  return maxSecondDerivative == 0.
+  return (maxSecondDerivative == 0.)
              ? std::make_pair(0., 0.)
              : std::make_pair(maxPosition,
                               std::sqrt(-(maxDensity / maxSecondDerivative)));

--- a/Core/src/Utilities/AnnealingUtility.cpp
+++ b/Core/src/Utilities/AnnealingUtility.cpp
@@ -15,7 +15,7 @@
 /// @param invTemp Denominator 1/(2 * temperature)
 ///
 /// @return exp(-chi2 * invTemp)
-static double gaussFunc(double chi2, double invTemp) {
+static double computeAnnealingWeight(double chi2, double invTemp) {
   return std::exp(-chi2 * invTemp);
 }
 
@@ -33,12 +33,12 @@ double Acts::AnnealingUtility::getWeight(
   // Calculate 1/denominator in exp function already here
   const double currentInvTemp = 1. / (2. * m_cfg.setOfTemperatures[idx]);
 
-  double num = gaussFunc(chi2, currentInvTemp);
+  double num = computeAnnealingWeight(chi2, currentInvTemp);
 
-  double denom = m_cfg.gaussCutTempVec[idx];
+  double denom = m_gaussCutTempVec[idx];
 
   for (double val : allChi2) {
-    denom += gaussFunc(val, currentInvTemp);
+    denom += computeAnnealingWeight(val, currentInvTemp);
   }
 
   return num / denom;
@@ -49,5 +49,6 @@ double Acts::AnnealingUtility::getWeight(State& state, double chi2) const {
   const double currentInvTemp =
       1. / (2 * m_cfg.setOfTemperatures[state.currentTemperatureIndex]);
 
-  return 1. / (1. + gaussFunc(m_cfg.cutOff - chi2, currentInvTemp));
+  return 1. /
+         (1. + computeAnnealingWeight(m_cfg.cutOff - chi2, currentInvTemp));
 }


### PR DESCRIPTION
This PR fixes the FPE overflow issues that we've seen in running the AMVF on q221 and q431 jobs in Athena:

- We've first seen this issue in the propagator loop protection. The issue here was a square of ```pathLimit``` while 
```cpp
pathLimit = std::numeric_limits<double>::max();
```
- Same thing as above happened in the ```ConstrainedStep```.
-  A divide-by-zero protection was added to ```GaussianTrackDensity```.
- [This line in the annealing tool](https://github.com/acts-project/acts/blob/af17d414b9b4365e441101a8fbd636a37822151a/Core/src/Utilities/AnnealingUtility.cpp#L36) also threw an FPE for very large ```chi2``` values, since the denominator in the weight calculation will become extremely large. I've redone the math (+validated its correctness numerically) such that the ```chi2``` now enters the Gaussian in such a way that the numerator gets close to 0 (as opposed to the denominator becoming extremely large), hence avoiding FPE.

With these fixes, no such issues were seen anymore in running q221 and q431:

q221:
```bash
FPEAuditor                                           INFO FPE summary for this job
FPEAuditor                                           INFO  FPE OVERFLOWs  : 0
FPEAuditor                                           INFO  FPE INVALIDs   : 0
FPEAuditor                                           INFO  FPE DIVBYZEROs : 0
```
q431:
```bash
FPEAuditor                                           INFO FPE summary for this job
FPEAuditor                                           INFO  FPE OVERFLOWs  : 0
FPEAuditor                                           INFO  FPE INVALIDs   : 0
FPEAuditor                                           INFO  FPE DIVBYZEROs : 0
```

/cc @asalzburger
