### PR TITLE
refactor(plugin/digitization): Add Digitization-specific SourceLink (EDM rework part 2a/4)

### DIFF
--- a/Examples/Algorithms/Digitization/src/PlanarSteppingAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/PlanarSteppingAlgorithm.cpp
@@ -151,8 +151,9 @@ ActsExamples::ProcessCode ActsExamples::PlanarSteppingAlgorithm::execute(
 
       // create the planar cluster
       Acts::PlanarModuleCluster pCluster(
-          dg.surface->getSharedPtr(), Identifier(identifier_type(idx), {idx}),
-          std::move(cov), localX, localY, hit.time(), std::move(usedCells));
+          dg.surface->getSharedPtr(),
+          Acts::DigitizationSourceLink(*dg.surface, {idx}), std::move(cov),
+          localX, localY, hit.time(), std::move(usedCells));
 
       // insert into the cluster container. since the input data is already
       // sorted by geoId, we should always be able to add at the end.

--- a/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
+++ b/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
@@ -264,7 +264,7 @@ ActsExamples::ProcessCode ActsExamples::CsvPlanarClusterReader::read(
     // create the planar cluster
     Acts::PlanarModuleCluster cluster(
         surface.getSharedPtr(),
-        Identifier(identifier_type(geoId.value()), std::move(simHitIndices)),
+        Acts::DigitizationSourceLink(surface, std::move(simHitIndices)),
         std::move(cov), local[0], local[1], time, std::move(digitizationCells));
 
     // due to the previous sorting of the raw hit data by geometry id, new

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationCell.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationCell.hpp
@@ -1,22 +1,19 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
-#include "Acts/Utilities/Definitions.hpp"
 
-#include <iostream>
+#include "Acts/Utilities/Definitions.hpp"
 
 namespace Acts {
 
 /// @brief pair of ints for definition of a cell
 struct DigitizationCell {
-  virtual ~DigitizationCell() = default;
-
   // identification and data
   size_t channel0 = 0;
   size_t channel1 = 1;
@@ -39,6 +36,7 @@ struct DigitizationCell {
       data += dc.data;
     }
   }
+
   /// the deposited energy
   /// @param analogueReadout flag indicating if we have analgue readout
   /// @note this function is needed because possible derived classes may
@@ -89,4 +87,5 @@ struct DigitizationStep {
         stepReadoutProjected(projectedPosition),
         stepCellCenter(cellPosition) {}
 };
+
 }  // namespace Acts

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationCell.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationCell.hpp
@@ -13,11 +13,12 @@
 namespace Acts {
 
 /// @brief pair of ints for definition of a cell
-struct DigitizationCell {
+struct DigitizationCell final {
   // identification and data
   size_t channel0 = 0;
   size_t channel1 = 1;
   float data = 0.;
+
   // connstruct them
   DigitizationCell(size_t ch0, size_t ch1, float d = 0.)
       : channel0(ch0), channel1(ch1), data(d) {}
@@ -31,7 +32,7 @@ struct DigitizationCell {
   /// calculate the energy deposit differently. Furthermore this allows to apply
   /// an energy cut, because the energy deposit can also be stored for digital
   /// readout.
-  virtual void addCell(const DigitizationCell& dc, bool analogueReadout) {
+  void addCell(const DigitizationCell& dc, bool analogueReadout) {
     if (analogueReadout) {
       data += dc.data;
     }
@@ -43,11 +44,11 @@ struct DigitizationCell {
   /// calculate the energy deposit differently. Furthermore this allows to apply
   /// an energy cut, because the energy deposit can also be stored for digital
   /// readout.
-  virtual double depositedEnergy() const { return data; }
+  double depositedEnergy() const { return data; }
 };
 
 /// @brief DigitizationStep for further handling
-struct DigitizationStep {
+struct DigitizationStep final {
   double stepLength{0.};   /// this is the path length within the cell
   double driftLength{0.};  /// this is the path length of the setp center to the
                            /// readout surface

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationSourceLink.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/DigitizationSourceLink.hpp
@@ -1,0 +1,64 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+
+#include <cassert>
+#include <vector>
+
+namespace Acts {
+
+class Surface;
+
+/// Source link to connect digitization clusters back to truth information.
+class DigitizationSourceLink final {
+ public:
+  /// Constructor from geometry identifier and truth indices.
+  ///
+  /// @param surface is the representing surface
+  /// @param indices are the truth indices
+  DigitizationSourceLink(const Surface& surface,
+                         std::vector<std::size_t> indices = {})
+      : m_surface(&surface), m_indices(std::move(indices)) {}
+
+  /// Construct and invalid source link. Must be default constructible to
+  /// satisfy SourceLinkConcept.
+  DigitizationSourceLink() = default;
+  DigitizationSourceLink(const DigitizationSourceLink&) = default;
+  DigitizationSourceLink(DigitizationSourceLink&&) = default;
+  DigitizationSourceLink& operator=(const DigitizationSourceLink&) = default;
+  DigitizationSourceLink& operator=(DigitizationSourceLink&&) = default;
+
+  /// Access the reference surface.
+  const Surface& referenceSurface() const {
+    assert(m_surface and "Invalid Surface pointer in DigitizationSourceLink");
+    return *m_surface;
+  }
+  /// Access all associated truth indices.
+  const std::vector<std::size_t>& indices() const { return m_indices; }
+
+ private:
+  /// The stored surface. Use pointer to make the object copyable.
+  const Surface* m_surface = nullptr;
+  /// Associated truth indices.
+  std::vector<std::size_t> m_indices;
+};
+
+inline bool operator==(const DigitizationSourceLink& lhs,
+                       const DigitizationSourceLink& rhs) {
+  return (lhs.referenceSurface() == rhs.referenceSurface()) and
+         (lhs.indices() == rhs.indices());
+}
+inline bool operator!=(const DigitizationSourceLink& lhs,
+                       const DigitizationSourceLink& rhs) {
+  return not(lhs == rhs);
+}
+
+}  // namespace Acts

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleCluster.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,48 +9,35 @@
 #pragma once
 
 #include "Acts/EventData/Measurement.hpp"
-#include "Acts/EventData/MeasurementHelpers.hpp"
-
-/// Set the identifier PLUGIN
-#ifdef ACTS_CORE_IDENTIFIER_PLUGIN
-#include ACTS_CORE_IDENTIFIER_PLUGIN
-#else
-using Identifier = Acts::MinimalSourceLink;
-#endif
-
 #include "Acts/Plugins/Digitization/DigitizationCell.hpp"
 #include "Acts/Plugins/Digitization/DigitizationModule.hpp"
-#include "Acts/Utilities/Logger.hpp"
-#include "Acts/Utilities/ParameterDefinitions.hpp"
+#include "Acts/Plugins/Digitization/DigitizationSourceLink.hpp"
 
 namespace Acts {
 
-template <BoundIndices... params>
-using Measurement_t = Measurement<Identifier, BoundIndices, params...>;
-
 class PlanarModuleCluster
-    : public Measurement_t<BoundIndices::eBoundLoc0, BoundIndices::eBoundLoc1,
-                           BoundIndices::eBoundTime> {
+    : public Measurement<DigitizationSourceLink, BoundIndices, eBoundLoc0,
+                         eBoundLoc1, eBoundTime> {
+  using Base = Measurement<DigitizationSourceLink, BoundIndices, eBoundLoc0,
+                           eBoundLoc1, eBoundTime>;
+
  public:
   /// Constructor from DigitizationCells
   ///
   /// @param [in] mSurface is the module surface
-  /// @param [in] cIdentifier is the channel identifier of the local position
+  /// @param [in] sourceLink is the link to the truth information
   /// @param [in] cov is the covariance matrix
   /// @param [in] loc0 is the local position in the first coordinate
   /// @param [in] loc1 is the local position in the second coordinate
   /// @param [in] t Timestamp of the cluster
   /// @param [in] dCells is the vector of digitization cells
   PlanarModuleCluster(std::shared_ptr<const Surface> mSurface,
-                      const Identifier& identifier, ActsSymMatrixD<3> cov,
+                      DigitizationSourceLink sourceLink, ActsSymMatrixD<3> cov,
                       double loc0, double loc1, double t,
                       std::vector<DigitizationCell> dCells,
                       const DigitizationModule* dModule = nullptr)
-      : Measurement_t<BoundIndices::eBoundLoc0, BoundIndices::eBoundLoc1,
-                      BoundIndices::eBoundTime>(
-            std::move(mSurface),
-            identifier,  // original measurement
-            std::move(cov), loc0, loc1, t),
+      : Base(std::move(mSurface), std::move(sourceLink), std::move(cov), loc0,
+             loc1, t),
         m_digitizationCells(std::move(dCells)),
         m_digitizationModule(dModule) {}
 
@@ -78,4 +65,5 @@ inline const DigitizationModule* PlanarModuleCluster::digitizationModule()
     const {
   return m_digitizationModule;
 }
+
 }  // namespace Acts

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleStepper.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/PlanarModuleStepper.hpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Plugins/Digitization/DigitizationCell.hpp"
 #include "Acts/Utilities/Definitions.hpp"

--- a/Tests/UnitTests/Plugins/Digitization/DoubleHitSpacePointBuilderTests.cpp
+++ b/Tests/UnitTests/Plugins/Digitization/DoubleHitSpacePointBuilderTests.cpp
@@ -36,8 +36,7 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   std::cout << "Create first hit" << std::endl;
 
   // Build Bounds
-  std::shared_ptr<const RectangleBounds> recBounds(
-      new RectangleBounds(35_um, 25_mm));
+  auto recBounds = std::make_shared<RectangleBounds>(35_um, 25_mm);
 
   // Build binning and segmentation
   std::vector<float> boundariesX, boundariesY;
@@ -52,8 +51,7 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   std::shared_ptr<BinUtility> buY(new BinUtility(binDataY));
   (*buX) += (*buY);
 
-  std::shared_ptr<const Segmentation> segmentation(
-      new CartesianSegmentation(buX, recBounds));
+  auto segmentation = std::make_shared<CartesianSegmentation>(buX, recBounds);
 
   // Build translation
 
@@ -77,9 +75,9 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   Vector2D local = {0.1, -0.1};
 
   // Build PlanarModuleCluster
-  PlanarModuleCluster* pmc =
-      new PlanarModuleCluster(pSur, {}, cov, local[0], local[1], 0.,
-                              {DigitizationCell(0, 0, 1.)}, &digMod);
+  PlanarModuleCluster pmc(pSur, DigitizationSourceLink(*pSur, {}), cov,
+                          local[0], local[1], 0., {DigitizationCell(0, 0, 1.)},
+                          &digMod);
 
   std::cout << "Create second hit" << std::endl;
 
@@ -100,9 +98,9 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
 
   auto pSur2 = Surface::makeShared<PlaneSurface>(recBounds, detElem2);
 
-  PlanarModuleCluster* pmc2 =
-      new PlanarModuleCluster(pSur2, {}, cov, local[0], local[1], 0.,
-                              {DigitizationCell(0, 0, 1.)}, &digMod);
+  PlanarModuleCluster pmc2(pSur2, DigitizationSourceLink(*pSur, {}), cov,
+                           local[0], local[1], 0., {DigitizationCell(0, 0, 1.)},
+                           &digMod);
 
   std::cout << "Store both hits" << std::endl;
 
@@ -113,11 +111,11 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
 
   // Combine two PlanarModuleClusters
   SpacePointBuilder<SpacePoint<PlanarModuleCluster>> dhsp(dhsp_cfg);
-  dhsp.makeClusterPairs(tgContext, {pmc}, {pmc2}, clusterPairs);
+  dhsp.makeClusterPairs(tgContext, {&pmc}, {&pmc2}, clusterPairs);
 
   BOOST_CHECK_EQUAL(clusterPairs.size(), 1u);
-  BOOST_CHECK_EQUAL(*(clusterPairs[0].first), *pmc);
-  BOOST_CHECK_EQUAL(*(clusterPairs[0].second), *pmc2);
+  BOOST_CHECK_EQUAL(clusterPairs[0].first, &pmc);
+  BOOST_CHECK_EQUAL(clusterPairs[0].second, &pmc2);
 
   std::cout << "Calculate space point" << std::endl;
 
@@ -134,14 +132,14 @@ BOOST_DATA_TEST_CASE(DoubleHitsSpacePointBuilder_basic, bdata::xrange(1),
   DetectorElementStub detElem3(t3d3);
   auto pSur3 = Surface::makeShared<PlaneSurface>(recBounds, detElem3);
 
-  PlanarModuleCluster* pmc3 =
-      new PlanarModuleCluster(pSur3, {}, cov, local[0], local[1], 0.,
-                              {DigitizationCell(0, 0, 1.)}, &digMod);
+  PlanarModuleCluster pmc3(pSur3, DigitizationSourceLink(*pSur, {}), cov,
+                           local[0], local[1], 0., {DigitizationCell(0, 0, 1.)},
+                           &digMod);
 
   std::cout << "Try to store hits" << std::endl;
 
   // Combine points
-  dhsp.makeClusterPairs(tgContext, {pmc}, {pmc3}, clusterPairs);
+  dhsp.makeClusterPairs(tgContext, {&pmc}, {&pmc3}, clusterPairs);
 
   // Test for rejecting unconnected hits
   BOOST_CHECK_EQUAL(resultSP.size(), 1u);


### PR DESCRIPTION
Remove the dependency of the digitization plugin on the generic `Identifier` and the `IdentificationPlugin`. Introduce a custom `DigitizationSourceLink` instead, that fulfills the `SourceLinkConcept` and contains all the necessary information.