### PR TITLE
feat(examples): Add/use a concrete Index type for containers. (EDM rework part 2b/4)

### DIFF
--- a/Examples/Algorithms/Printers/ActsExamples/Printers/HitsPrinter.cpp
+++ b/Examples/Algorithms/Printers/ActsExamples/Printers/HitsPrinter.cpp
@@ -11,7 +11,7 @@
 #include "Acts/Plugins/Digitization/PlanarModuleCluster.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Utilities/Range.hpp"

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.cpp
@@ -9,7 +9,7 @@
 #include "ActsExamples/TruthTracking/TruthSeedSelector.hpp"
 
 #include "Acts/Utilities/Helpers.hpp"
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Utilities/Range.hpp"

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.cpp
@@ -8,7 +8,7 @@
 
 #include "ActsExamples/TruthTracking/TruthTrackFinder.hpp"
 
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"

--- a/Examples/Framework/include/ActsExamples/EventData/ProtoTrack.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/ProtoTrack.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,13 +8,14 @@
 
 #pragma once
 
-#include <cstddef>
+#include "ActsExamples/EventData/Index.hpp"
+
 #include <vector>
 
 namespace ActsExamples {
 
 /// A proto track is a collection of hits identified by their indices.
-using ProtoTrack = std::vector<size_t>;
+using ProtoTrack = std::vector<Index>;
 /// Container of proto tracks. Each proto track is identified by its index.
 using ProtoTrackContainer = std::vector<ProtoTrack>;
 

--- a/Examples/Framework/include/ActsExamples/EventData/ProtoVertex.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/ProtoVertex.hpp
@@ -8,13 +8,14 @@
 
 #pragma once
 
-#include <cstdint>
+#include "ActsExamples/EventData/Index.hpp"
+
 #include <vector>
 
 namespace ActsExamples {
 
 /// A proto vertex is a collection of tracks identified by their indices.
-using ProtoVertex = std::vector<uint32_t>;
+using ProtoVertex = std::vector<Index>;
 /// Container of proto vertices. Each proto vertex is identified by its index.
 using ProtoVertexContainer = std::vector<ProtoVertex>;
 

--- a/Examples/Framework/include/ActsExamples/Validation/ProtoTrackClassification.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/ProtoTrackClassification.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
 

--- a/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
+++ b/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
@@ -12,7 +12,7 @@
 #include "Acts/Plugins/Identification/IdentifiedDetectorElement.hpp"
 #include "Acts/Utilities/Units.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/SimIdentifier.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.cpp
@@ -10,7 +10,7 @@
 
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Units.hpp"
-#include "ActsExamples/EventData/IndexContainers.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
 #include "ActsExamples/Utilities/Range.hpp"


### PR DESCRIPTION
Add a `Index` typeded to be used to identify indices into edm containers. The `IndexMultimap<...>` container is updated to always use this type as its key instead of being templated on it.