### PR TITLE
fix: Only write boundary surface associated to curent volume

### DIFF
--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -556,7 +556,7 @@ void Acts::JsonGeometryConverter::convertToRep(
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
       geo_id_value bid = boundaryID.boundary();
       // Ignore if the volumeID is not correct (i.e. shared boundary)
-      if (boundaryID.volume() == vid){
+      if (boundaryID.volume() == vid) {
         volRep.boundaries[bid] = bssfRep.surfaceMaterial();
         volRep.boundarySurfaces[bid] = &bssfRep;
       }
@@ -565,7 +565,7 @@ void Acts::JsonGeometryConverter::convertToRep(
       // configuration
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
       geo_id_value bid = boundaryID.boundary();
-      if (boundaryID.volume() == vid){
+      if (boundaryID.volume() == vid) {
         Acts::BinUtility bUtility = DefaultBin(bssfRep);
         Acts::ISurfaceMaterial* bMaterial =
             new Acts::ProtoSurfaceMaterial(bUtility);

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -548,28 +548,33 @@ void Acts::JsonGeometryConverter::convertToRep(
       }
     }
   }
+  std::cout << "vol id : " << tVolume.geometryId() << std::endl;
   // Let's finally check the boundaries
   for (auto& bsurf : tVolume.boundarySurfaces()) {
     // the surface representation
     auto& bssfRep = bsurf->surfaceRepresentation();
+    std::cout << "bnd id : " << bssfRep.geometryId() << std::endl;
     if (bssfRep.surfaceMaterial() != nullptr) {
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
       geo_id_value bid = boundaryID.boundary();
       // Ignore if the volumeID is not correct (i.e. shared boundary)
-      // if (boundaryID.value(Acts::GeometryIdentifier::volume_mask) == vid){
-      volRep.boundaries[bid] = bssfRep.surfaceMaterial();
-      volRep.boundarySurfaces[bid] = &bssfRep;
-      // }
+      if (boundaryID.volume() == vid){
+        volRep.boundaries[bid] = bssfRep.surfaceMaterial();
+        volRep.boundarySurfaces[bid] = &bssfRep;
+      }
     } else if (m_cfg.processnonmaterial == true) {
       // if no material suface exist add a default one for the mapping
       // configuration
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
       geo_id_value bid = boundaryID.boundary();
-      Acts::BinUtility bUtility = DefaultBin(bssfRep);
-      Acts::ISurfaceMaterial* bMaterial =
-          new Acts::ProtoSurfaceMaterial(bUtility);
-      volRep.boundaries[bid] = bMaterial;
-      volRep.boundarySurfaces[bid] = &bssfRep;
+      if (boundaryID.volume() == vid){
+        Acts::BinUtility bUtility = DefaultBin(bssfRep);
+        Acts::ISurfaceMaterial* bMaterial =
+            new Acts::ProtoSurfaceMaterial(bUtility);
+        volRep.boundaries[bid] = bMaterial;
+        volRep.boundarySurfaces[bid] = &bssfRep;
+        std::cout << "bip :" << std::endl;
+      }
     }
   }
   // Write if it's good

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -548,12 +548,10 @@ void Acts::JsonGeometryConverter::convertToRep(
       }
     }
   }
-  std::cout << "vol id : " << tVolume.geometryId() << std::endl;
   // Let's finally check the boundaries
   for (auto& bsurf : tVolume.boundarySurfaces()) {
     // the surface representation
     auto& bssfRep = bsurf->surfaceRepresentation();
-    std::cout << "bnd id : " << bssfRep.geometryId() << std::endl;
     if (bssfRep.surfaceMaterial() != nullptr) {
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
       geo_id_value bid = boundaryID.boundary();
@@ -573,7 +571,6 @@ void Acts::JsonGeometryConverter::convertToRep(
             new Acts::ProtoSurfaceMaterial(bUtility);
         volRep.boundaries[bid] = bMaterial;
         volRep.boundarySurfaces[bid] = &bssfRep;
-        std::cout << "bip :" << std::endl;
       }
     }
   }


### PR DESCRIPTION
In the json converter, for a give volume, only write the boundary surface associated to said volume. If all boundary are written they could over-right each other of multiple boundary have the same boundary id.
