### PR TITLE
refactor(examples): HepMCWriter and Reader as algorithm

### DIFF
--- a/Examples/Io/HepMC3/CMakeLists.txt
+++ b/Examples/Io/HepMC3/CMakeLists.txt
@@ -1,13 +1,17 @@
 add_library(
   ActsExamplesIoHepMC3 SHARED
   src/HepMC3Event.cpp
+  src/HepMC3Options.cpp
   src/HepMC3Particle.cpp
   src/HepMC3Reader.cpp
   src/HepMC3Vertex.cpp
   src/HepMC3Writer.cpp)
 target_include_directories(
   ActsExamplesIoHepMC3
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> ${HEPMC3_INCLUDE_DIR})
+  SYSTEM PUBLIC ${HEPMC3_INCLUDE_DIR})
+target_include_directories(
+  ActsExamplesIoHepMC3
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(
   ActsExamplesIoHepMC3
   PUBLIC ActsCore ActsExamplesFramework ${HEPMC3_LIBRARIES} HepPID)

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
@@ -31,40 +31,40 @@ struct HepMC3Event {
   /// @note The allowed units are MeV and Gev
   /// @param event event in HepMC data type
   /// @param momentumUnit new unit of momentum
-  void momentumUnit(std::shared_ptr<HepMC3::GenEvent> event,
+  void momentumUnit(HepMC3::GenEvent& event,
                     const double momentumUnit);
 
   /// @brief Sets new units for lengths
   /// @note The allowed units are mm and cm
   /// @param event event in HepMC data type
   /// @param lengthUnit new unit of length
-  void lengthUnit(std::shared_ptr<HepMC3::GenEvent> event,
+  void lengthUnit(HepMC3::GenEvent& event,
                   const double lengthUnit);
 
   /// @brief Shifts the positioning of an event in space and time
   /// @param event event in HepMC data type
   /// @param deltaPos relative spatial shift that will be applied
   /// @param deltaTime relative time shift that will be applied
-  void shiftPositionBy(std::shared_ptr<HepMC3::GenEvent> event,
+  void shiftPositionBy(HepMC3::GenEvent& event,
                        const Acts::Vector3D& deltaPos, const double deltaTime);
 
   /// @brief Shifts the positioning of an event to a paint in space and time
   /// @param event event in HepMC data type
   /// @param pos new position of the event
   /// @param time new time of the event
-  void shiftPositionTo(std::shared_ptr<HepMC3::GenEvent> event,
+  void shiftPositionTo(HepMC3::GenEvent& event,
                        const Acts::Vector3D& pos, const double time);
 
   /// @brief Shifts the positioning of an event to a paint in space
   /// @param event event in HepMC data type
   /// @param pos new position of the event
-  void shiftPositionTo(std::shared_ptr<HepMC3::GenEvent> event,
+  void shiftPositionTo(HepMC3::GenEvent& event,
                        const Acts::Vector3D& pos);
 
   /// @brief Shifts the positioning of an event to a paint in time
   /// @param event event in HepMC data type
   /// @param time new time of the event
-  void shiftPositionTo(std::shared_ptr<HepMC3::GenEvent> event,
+  void shiftPositionTo(HepMC3::GenEvent& event,
                        const double time);
 
   ///
@@ -74,14 +74,14 @@ struct HepMC3Event {
   /// @brief Adds a new particle
   /// @param event event in HepMC data type
   /// @param particle new particle that will be added
-  void addParticle(std::shared_ptr<HepMC3::GenEvent> event,
+  void addParticle(HepMC3::GenEvent& event,
                    std::shared_ptr<SimParticle> particle);
 
   /// @brief Adds a new vertex
   /// @param event event in HepMC data type
   /// @param vertex new vertex that will be added
   /// @note The statuses are not represented in Acts and therefore set to 0
-  void addVertex(std::shared_ptr<HepMC3::GenEvent> event,
+  void addVertex(HepMC3::GenEvent& event,
                  const std::shared_ptr<SimVertex> vertex);
   ///
   /// Remover
@@ -90,7 +90,7 @@ struct HepMC3Event {
   /// @brief Removes a particle from the record
   /// @param event event in HepMC data type
   /// @param particle particle that will be removed
-  void removeParticle(std::shared_ptr<HepMC3::GenEvent> event,
+  void removeParticle(HepMC3::GenEvent& event,
                       const std::shared_ptr<SimParticle>& particle);
 
   /// @brief Removes a vertex from the record
@@ -98,7 +98,7 @@ struct HepMC3Event {
   /// HepMC3Event::compareVertices())
   /// @param event event in HepMC data type
   /// @param vertex vertex that will be removed
-  void removeVertex(std::shared_ptr<HepMC3::GenEvent> event,
+  void removeVertex(HepMC3::GenEvent& event,
                     const std::shared_ptr<SimVertex>& vertex);
 
   ///
@@ -108,46 +108,46 @@ struct HepMC3Event {
   /// @brief Getter of the unit of momentum used
   /// @param event event in HepMC data type
   /// @return unit of momentum
-  double momentumUnit(const std::shared_ptr<HepMC3::GenEvent> event);
+  double momentumUnit(const HepMC3::GenEvent& event);
 
   /// @brief Getter of the unit of length used
   /// @param event event in HepMC data type
   /// @return unit of length
-  double lengthUnit(const std::shared_ptr<HepMC3::GenEvent> event);
+  double lengthUnit(const HepMC3::GenEvent& event);
 
   /// @brief Getter of the position of the event
   /// @param event event in HepMC data type
   /// @return vector to the location of the event
-  Acts::Vector3D eventPos(const std::shared_ptr<HepMC3::GenEvent> event);
+  Acts::Vector3D eventPos(const HepMC3::GenEvent& event);
 
   /// @brief Getter of the time of the event
   /// @param event event in HepMC data type
   /// @return time of the event
-  double eventTime(const std::shared_ptr<HepMC3::GenEvent> event);
+  double eventTime(const HepMC3::GenEvent& event);
 
   /// @brief Get list of particles
   /// @param event event in HepMC data type
   /// @return List of particles
   std::vector<std::unique_ptr<SimParticle>> particles(
-      const std::shared_ptr<HepMC3::GenEvent> event);
+      const HepMC3::GenEvent& event);
 
   /// @brief Get list of vertices
   /// @param event event in HepMC data type
   /// @return List of vertices
   std::vector<std::unique_ptr<SimVertex>> vertices(
-      const std::shared_ptr<HepMC3::GenEvent> event);
+      const HepMC3::GenEvent& event);
 
   /// @brief Get beam particles
   /// @param event event in HepMC data type
   /// @return List of beam particles
   std::vector<std::unique_ptr<SimParticle>> beams(
-      const std::shared_ptr<HepMC3::GenEvent> event);
+      const HepMC3::GenEvent& event);
 
   /// @brief Get final state particles
   /// @param event event in HepMC data type
   /// @return List of final state particles
   std::vector<std::unique_ptr<SimParticle>> finalState(
-      const std::shared_ptr<HepMC3::GenEvent> event);
+      const HepMC3::GenEvent& event);
 
  private:
   /// @brief Converts an SimParticle into HepMC3::GenParticle

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
@@ -31,41 +31,37 @@ struct HepMC3Event {
   /// @note The allowed units are MeV and Gev
   /// @param event event in HepMC data type
   /// @param momentumUnit new unit of momentum
-  void momentumUnit(HepMC3::GenEvent& event,
-                    const double momentumUnit);
+  void momentumUnit(HepMC3::GenEvent& event, const double momentumUnit);
 
   /// @brief Sets new units for lengths
   /// @note The allowed units are mm and cm
   /// @param event event in HepMC data type
   /// @param lengthUnit new unit of length
-  void lengthUnit(HepMC3::GenEvent& event,
-                  const double lengthUnit);
+  void lengthUnit(HepMC3::GenEvent& event, const double lengthUnit);
 
   /// @brief Shifts the positioning of an event in space and time
   /// @param event event in HepMC data type
   /// @param deltaPos relative spatial shift that will be applied
   /// @param deltaTime relative time shift that will be applied
-  void shiftPositionBy(HepMC3::GenEvent& event,
-                       const Acts::Vector3D& deltaPos, const double deltaTime);
+  void shiftPositionBy(HepMC3::GenEvent& event, const Acts::Vector3D& deltaPos,
+                       const double deltaTime);
 
   /// @brief Shifts the positioning of an event to a paint in space and time
   /// @param event event in HepMC data type
   /// @param pos new position of the event
   /// @param time new time of the event
-  void shiftPositionTo(HepMC3::GenEvent& event,
-                       const Acts::Vector3D& pos, const double time);
+  void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos,
+                       const double time);
 
   /// @brief Shifts the positioning of an event to a paint in space
   /// @param event event in HepMC data type
   /// @param pos new position of the event
-  void shiftPositionTo(HepMC3::GenEvent& event,
-                       const Acts::Vector3D& pos);
+  void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos);
 
   /// @brief Shifts the positioning of an event to a paint in time
   /// @param event event in HepMC data type
   /// @param time new time of the event
-  void shiftPositionTo(HepMC3::GenEvent& event,
-                       const double time);
+  void shiftPositionTo(HepMC3::GenEvent& event, const double time);
 
   ///
   /// Adder

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Options.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Options.hpp
@@ -1,0 +1,44 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsExamples/Utilities/OptionsFwd.hpp"
+
+#include "HepMC3Reader.hpp"
+#include "HepMC3Writer.hpp"
+
+namespace ActsExamples {
+
+namespace Options {
+
+/// @brief HepMC3 specific writer options
+///
+/// @param desc The option description forward
+void addHepMC3WriterOptions(Description& desc);
+
+/// Read the HepMC3 writer options and @return a HepMC3WriterAscii::Config
+///
+/// @param variables is the parameter map for the options
+///
+/// @returns a Config object for the HepMC3WriterAscii
+HepMC3AsciiWriter::Config readHepMC3WriterOptions(const Variables& variables);
+
+/// @brief HepMC3 specific reader options
+///
+/// @param desc The option description forward
+void addHepMC3ReaderOptions(Description& desc);
+
+/// Read the HepMC3 reader options and @return a HepMC3ReaderAscii::Config
+///
+/// @param variables is the parameter map for the options
+///
+/// @returns a Config object for the HepMC3ReaderAscii
+HepMC3AsciiReader::Config readHepMC3ReaderOptions(const Variables& variables);
+}  // namespace Options
+}  // namespace ActsExamples

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Options.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Options.hpp
@@ -17,7 +17,7 @@ namespace ActsExamples {
 
 namespace Options {
 
-/// @brief HepMC3 specific writer options
+/// Add HepMC3 specific writer options.
 ///
 /// @param desc The option description forward
 void addHepMC3WriterOptions(Description& desc);
@@ -29,7 +29,7 @@ void addHepMC3WriterOptions(Description& desc);
 /// @returns a Config object for the HepMC3WriterAscii
 HepMC3AsciiWriter::Config readHepMC3WriterOptions(const Variables& variables);
 
-/// @brief HepMC3 specific reader options
+/// Add HepMC3 specific reader options.
 ///
 /// @param desc The option description forward
 void addHepMC3ReaderOptions(Description& desc);

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,14 +8,24 @@
 
 #pragma once
 
+#include "ActsExamples/Framework/IReader.hpp"
+#include <Acts/Utilities/Logger.hpp>
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/ReaderAscii.h>
 
 namespace ActsExamples {
 
 /// HepMC3 event reader.
-struct HepMC3ReaderAscii {
- public:
+struct HepMC3ReaderAscii : public IReader {
+  struct Config {
+    // The input directory
+    std::string inputDir = "";
+    // The stem of input file names
+    std::string inputStemFileName = "";
+    // The output collection
+    std::string outputCollection = "";
+  };
+
   /// @brief Reads an event from file
   /// @param reader reader of run files
   /// @param event storage of the read event
@@ -27,5 +37,29 @@ struct HepMC3ReaderAscii {
   /// @param reader reader of run files
   /// @return boolean status indicator
   bool status(HepMC3::ReaderAscii& reader);
+
+  /// Construct the particle reader.
+  ///
+  /// @param [in] cfg The configuration object
+  /// @param [in] lvl The logging level
+  HepMC3ReaderAscii(const Config& cfg, Acts::Logging::Level lvl);
+
+  std::string name() const final override;
+
+  /// Return the available events range.
+  std::pair<size_t, size_t> availableEvents() const final override;
+
+  /// Read out data from the input stream.
+  ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+ private:
+  /// The configuration of this writer
+  Config m_cfg;
+  /// Number of events
+  std::pair<size_t, size_t> m_eventsRange;
+  /// The logger
+  std::unique_ptr<const Acts::Logger> m_logger;
+
+  const Acts::Logger& logger() const { return *m_logger; }
 };
 }  // namespace ActsExamples

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "ActsExamples/Framework/IReader.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/Framework/IReader.hpp"
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/ReaderAscii.h>
 
@@ -17,7 +17,7 @@ namespace ActsExamples {
 
 /// HepMC3 event reader.
 class HepMC3AsciiReader final : public IReader {
-public:
+ public:
   struct Config {
     // The input directory
     std::string inputDir;
@@ -31,8 +31,7 @@ public:
   /// @param reader reader of run files
   /// @param event storage of the read event
   /// @return boolean indicator if the reading was successful
-  bool readEvent(HepMC3::ReaderAscii& reader,
-                 HepMC3::GenEvent& event);
+  bool readEvent(HepMC3::ReaderAscii& reader, HepMC3::GenEvent& event);
 
   /// @brief Reports the status of the reader
   /// @param reader reader of run files

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
@@ -9,21 +9,22 @@
 #pragma once
 
 #include "ActsExamples/Framework/IReader.hpp"
-#include <Acts/Utilities/Logger.hpp>
+#include "Acts/Utilities/Logger.hpp"
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/ReaderAscii.h>
 
 namespace ActsExamples {
 
 /// HepMC3 event reader.
-struct HepMC3ReaderAscii : public IReader {
+class HepMC3AsciiReader final : public IReader {
+public:
   struct Config {
     // The input directory
-    std::string inputDir = "";
+    std::string inputDir;
     // The stem of input file names
-    std::string inputStemFileName = "";
+    std::string inputStem;
     // The output collection
-    std::string outputCollection = "";
+    std::string outputEvents;
   };
 
   /// @brief Reads an event from file
@@ -31,7 +32,7 @@ struct HepMC3ReaderAscii : public IReader {
   /// @param event storage of the read event
   /// @return boolean indicator if the reading was successful
   bool readEvent(HepMC3::ReaderAscii& reader,
-                 std::shared_ptr<HepMC3::GenEvent> event);
+                 HepMC3::GenEvent& event);
 
   /// @brief Reports the status of the reader
   /// @param reader reader of run files
@@ -42,7 +43,7 @@ struct HepMC3ReaderAscii : public IReader {
   ///
   /// @param [in] cfg The configuration object
   /// @param [in] lvl The logging level
-  HepMC3ReaderAscii(const Config& cfg, Acts::Logging::Level lvl);
+  HepMC3AsciiReader(const Config& cfg, Acts::Logging::Level lvl);
 
   std::string name() const final override;
 

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,26 +8,44 @@
 
 #pragma once
 
-#include <HepMC3/GenEvent.h>
+#include "ActsExamples/Framework/WriterT.hpp"
+#include "ActsExamples/Utilities/OptionsFwd.hpp"
+#include <string>
+#include <HepMC/GenEvent.h>
 #include <HepMC3/WriterAscii.h>
 
 namespace ActsExamples {
 
 /// HepMC3 event writer.
-struct HepMC3WriterAscii {
- public:
-  /// @brief Writes an event to file
-  /// @param writer writer of run files
-  /// @param event storage of the event
-  /// @return boolean indicator if the writing was successful
-  /// @note HepMC3 does not state a success or failure. The returned argument is
-  /// always true.
-  bool writeEvent(HepMC3::WriterAscii& writer,
-                  std::shared_ptr<HepMC3::GenEvent> event);
+struct HepMC3WriterAscii final
+    : public WriterT<std::vector<std::shared_ptr<HepMC3::GenEvent>>> {
+  struct Config {
+    // The output directory
+    std::string outputDir = "";
+    // The stem of output file names
+    std::string outputStemFileName = "";
+    // The input collection
+    std::string inputCollection = "";
+  };
 
-  /// @brief Reports the status of the writer
-  /// @param writer writer of run files
-  /// @return boolean status indicator
-  bool status(HepMC3::WriterAscii& writer);
+  /// @brief Constructor
+  ///
+  /// @param [in] cfg Config of the writer
+  /// @param [in] lvl The level of the logger
+  HepMC3WriterAscii(const Config&& cfg, Acts::Logging::Level lvl);
+
+  /// @brief Writing method
+  ///
+  /// @param [in] ctx The context of this algorithm
+  /// @param [in] events The recorded HepMC3 events
+  ///
+  /// @return Code describing whether the writing was successful
+  ProcessCode writeT(const ActsExamples::AlgorithmContext& ctx,
+                     const std::vector<std::shared_ptr<HepMC3::GenEvent>>&
+                         events) final override;
+
+ private:
+  /// The configuration of this writer
+  Config m_cfg;
 };
 }  // namespace ActsExamples

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -28,13 +28,13 @@ class HepMC3AsciiWriter final : public WriterT<std::vector<HepMC3::GenEvent>> {
     std::string inputEvents;
   };
 
-  /// @brief Constructor
+  /// Construct the writer.
   ///
   /// @param [in] cfg Config of the writer
   /// @param [in] lvl The level of the logger
   HepMC3AsciiWriter(const Config&& cfg, Acts::Logging::Level lvl);
 
-  /// @brief Writing method
+  /// Writing events to file.
   ///
   /// @param [in] ctx The context of this algorithm
   /// @param [in] events The recorded HepMC3 events

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -17,22 +17,23 @@
 namespace ActsExamples {
 
 /// HepMC3 event writer.
-struct HepMC3WriterAscii final
-    : public WriterT<std::vector<std::shared_ptr<HepMC3::GenEvent>>> {
+class HepMC3AsciiWriter final
+    : public WriterT<std::vector<HepMC3::GenEvent>> {
+public:
   struct Config {
     // The output directory
-    std::string outputDir = "";
+    std::string outputDir;
     // The stem of output file names
-    std::string outputStemFileName = "";
+    std::string outputStem;
     // The input collection
-    std::string inputCollection = "";
+    std::string inputEvents;
   };
 
   /// @brief Constructor
   ///
   /// @param [in] cfg Config of the writer
   /// @param [in] lvl The level of the logger
-  HepMC3WriterAscii(const Config&& cfg, Acts::Logging::Level lvl);
+  HepMC3AsciiWriter(const Config&& cfg, Acts::Logging::Level lvl);
 
   /// @brief Writing method
   ///
@@ -41,7 +42,7 @@ struct HepMC3WriterAscii final
   ///
   /// @return Code describing whether the writing was successful
   ProcessCode writeT(const ActsExamples::AlgorithmContext& ctx,
-                     const std::vector<std::shared_ptr<HepMC3::GenEvent>>&
+                     const std::vector<HepMC3::GenEvent>&
                          events) final override;
 
  private:

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -17,9 +17,8 @@
 namespace ActsExamples {
 
 /// HepMC3 event writer.
-class HepMC3AsciiWriter final
-    : public WriterT<std::vector<HepMC3::GenEvent>> {
-public:
+class HepMC3AsciiWriter final : public WriterT<std::vector<HepMC3::GenEvent>> {
+ public:
   struct Config {
     // The output directory
     std::string outputDir;
@@ -41,9 +40,9 @@ public:
   /// @param [in] events The recorded HepMC3 events
   ///
   /// @return Code describing whether the writing was successful
-  ProcessCode writeT(const ActsExamples::AlgorithmContext& ctx,
-                     const std::vector<HepMC3::GenEvent>&
-                         events) final override;
+  ProcessCode writeT(
+      const ActsExamples::AlgorithmContext& ctx,
+      const std::vector<HepMC3::GenEvent>& events) final override;
 
  private:
   /// The configuration of this writer

--- a/Examples/Io/HepMC3/src/HepMC3Event.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Event.cpp
@@ -15,8 +15,8 @@
 /// Setter
 ///
 
-void ActsExamples::HepMC3Event::momentumUnit(
-    HepMC3::GenEvent& event, const double momentumUnit) {
+void ActsExamples::HepMC3Event::momentumUnit(HepMC3::GenEvent& event,
+                                             const double momentumUnit) {
   // Check, if the momentum unit fits Acts::UnitConstants::MeV or _GeV
   HepMC3::Units::MomentumUnit mom;
   if (momentumUnit == Acts::UnitConstants::MeV)
@@ -33,8 +33,8 @@ void ActsExamples::HepMC3Event::momentumUnit(
   event.set_units(mom, event.length_unit());
 }
 
-void ActsExamples::HepMC3Event::lengthUnit(
-    HepMC3::GenEvent& event, const double lengthUnit) {
+void ActsExamples::HepMC3Event::lengthUnit(HepMC3::GenEvent& event,
+                                           const double lengthUnit) {
   // Check, if the length unit fits Acts::UnitConstants::mm or _cm
   HepMC3::Units::LengthUnit len;
   if (lengthUnit == Acts::UnitConstants::mm)
@@ -52,32 +52,32 @@ void ActsExamples::HepMC3Event::lengthUnit(
   event.set_units(event.momentum_unit(), len);
 }
 
-void ActsExamples::HepMC3Event::shiftPositionBy(
-    HepMC3::GenEvent& event, const Acts::Vector3D& deltaPos,
-    const double deltaTime) {
+void ActsExamples::HepMC3Event::shiftPositionBy(HepMC3::GenEvent& event,
+                                                const Acts::Vector3D& deltaPos,
+                                                const double deltaTime) {
   // Create HepMC3::FourVector from position and time for shift
   const HepMC3::FourVector vec(deltaPos(0), deltaPos(1), deltaPos(2),
                                deltaTime);
   event.shift_position_by(vec);
 }
 
-void ActsExamples::HepMC3Event::shiftPositionTo(
-    HepMC3::GenEvent& event, const Acts::Vector3D& pos,
-    const double time) {
+void ActsExamples::HepMC3Event::shiftPositionTo(HepMC3::GenEvent& event,
+                                                const Acts::Vector3D& pos,
+                                                const double time) {
   // Create HepMC3::FourVector from position and time for the new position
   const HepMC3::FourVector vec(pos(0), pos(1), pos(2), time);
   event.shift_position_to(vec);
 }
 
-void ActsExamples::HepMC3Event::shiftPositionTo(
-    HepMC3::GenEvent& event, const Acts::Vector3D& pos) {
+void ActsExamples::HepMC3Event::shiftPositionTo(HepMC3::GenEvent& event,
+                                                const Acts::Vector3D& pos) {
   // Create HepMC3::FourVector from position and time for the new position
   const HepMC3::FourVector vec(pos(0), pos(1), pos(2), event.event_pos().t());
   event.shift_position_to(vec);
 }
 
-void ActsExamples::HepMC3Event::shiftPositionTo(
-    HepMC3::GenEvent& event, const double time) {
+void ActsExamples::HepMC3Event::shiftPositionTo(HepMC3::GenEvent& event,
+                                                const double time) {
   // Create HepMC3::FourVector from position and time for the new position
   const HepMC3::FourVector vec(event.event_pos().x(), event.event_pos().y(),
                                event.event_pos().z(), time);
@@ -101,8 +101,7 @@ HepMC3::GenParticlePtr ActsExamples::HepMC3Event::actsParticleToGen(
 }
 
 void ActsExamples::HepMC3Event::addParticle(
-    HepMC3::GenEvent& event,
-    std::shared_ptr<SimParticle> particle) {
+    HepMC3::GenEvent& event, std::shared_ptr<SimParticle> particle) {
   // Add new particle
   event.add_particle(actsParticleToGen(particle));
 }
@@ -132,8 +131,7 @@ HepMC3::GenVertexPtr ActsExamples::HepMC3Event::createGenVertex(
 }
 
 void ActsExamples::HepMC3Event::addVertex(
-    HepMC3::GenEvent& event,
-    const std::shared_ptr<SimVertex> vertex) {
+    HepMC3::GenEvent& event, const std::shared_ptr<SimVertex> vertex) {
   // Add new vertex
   event.add_vertex(createGenVertex(vertex));
 }
@@ -143,8 +141,7 @@ void ActsExamples::HepMC3Event::addVertex(
 ///
 
 void ActsExamples::HepMC3Event::removeParticle(
-    HepMC3::GenEvent& event,
-    const std::shared_ptr<SimParticle>& particle) {
+    HepMC3::GenEvent& event, const std::shared_ptr<SimParticle>& particle) {
   const std::vector<HepMC3::GenParticlePtr> genParticles = event.particles();
   const auto id = particle->particleId();
   // Search HepMC3::GenParticle with the same id as the Acts particle
@@ -179,8 +176,7 @@ bool ActsExamples::HepMC3Event::compareVertices(
 }
 
 void ActsExamples::HepMC3Event::removeVertex(
-    HepMC3::GenEvent& event,
-    const std::shared_ptr<SimVertex>& vertex) {
+    HepMC3::GenEvent& event, const std::shared_ptr<SimVertex>& vertex) {
   const std::vector<HepMC3::GenVertexPtr> genVertices = event.vertices();
   // Walk over every recorded vertex
   for (auto& genVertex : genVertices)
@@ -195,16 +191,14 @@ void ActsExamples::HepMC3Event::removeVertex(
 /// Getter
 ///
 
-double ActsExamples::HepMC3Event::momentumUnit(
-    const HepMC3::GenEvent& event) {
+double ActsExamples::HepMC3Event::momentumUnit(const HepMC3::GenEvent& event) {
   // HepMC allows only MEV and GEV. This allows an easy identification.
   return (event.momentum_unit() == HepMC3::Units::MomentumUnit::MEV
               ? Acts::UnitConstants::MeV
               : Acts::UnitConstants::GeV);
 }
 
-double ActsExamples::HepMC3Event::lengthUnit(
-    const HepMC3::GenEvent& event) {
+double ActsExamples::HepMC3Event::lengthUnit(const HepMC3::GenEvent& event) {
   // HepMC allows only MM and CM. This allows an easy identification.
   return (event.length_unit() == HepMC3::Units::LengthUnit::MM
               ? Acts::UnitConstants::mm
@@ -221,17 +215,16 @@ Acts::Vector3D ActsExamples::HepMC3Event::eventPos(
   return vec;
 }
 
-double ActsExamples::HepMC3Event::eventTime(
-    const HepMC3::GenEvent& event) {
+double ActsExamples::HepMC3Event::eventTime(const HepMC3::GenEvent& event) {
   // Extract the time from HepMC3::FourVector
   return event.event_pos().t();
 }
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
-ActsExamples::HepMC3Event::particles(
-    const HepMC3::GenEvent& event) {
+ActsExamples::HepMC3Event::particles(const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimParticle>> actsParticles;
-  const std::vector<HepMC3::ConstGenParticlePtr> genParticles = event.particles();
+  const std::vector<HepMC3::ConstGenParticlePtr> genParticles =
+      event.particles();
 
   HepMC3Particle simPart;
 
@@ -244,8 +237,7 @@ ActsExamples::HepMC3Event::particles(
 }
 
 std::vector<std::unique_ptr<ActsExamples::SimVertex>>
-ActsExamples::HepMC3Event::vertices(
-    const HepMC3::GenEvent& event) {
+ActsExamples::HepMC3Event::vertices(const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimVertex>> actsVertices;
   const std::vector<HepMC3::ConstGenVertexPtr> genVertices = event.vertices();
 
@@ -260,8 +252,7 @@ ActsExamples::HepMC3Event::vertices(
 }
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
-ActsExamples::HepMC3Event::beams(
-    const HepMC3::GenEvent& event) {
+ActsExamples::HepMC3Event::beams(const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimParticle>> actsBeams;
   const std::vector<HepMC3::ConstGenParticlePtr> genBeams = event.beams();
 
@@ -275,8 +266,7 @@ ActsExamples::HepMC3Event::beams(
 }
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
-ActsExamples::HepMC3Event::finalState(
-    const HepMC3::GenEvent& event) {
+ActsExamples::HepMC3Event::finalState(const HepMC3::GenEvent& event) {
   std::vector<HepMC3::ConstGenParticlePtr> particles = event.particles();
   std::vector<std::unique_ptr<SimParticle>> fState;
 

--- a/Examples/Io/HepMC3/src/HepMC3Event.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Event.cpp
@@ -16,7 +16,7 @@
 ///
 
 void ActsExamples::HepMC3Event::momentumUnit(
-    std::shared_ptr<HepMC3::GenEvent> event, const double momentumUnit) {
+    HepMC3::GenEvent& event, const double momentumUnit) {
   // Check, if the momentum unit fits Acts::UnitConstants::MeV or _GeV
   HepMC3::Units::MomentumUnit mom;
   if (momentumUnit == Acts::UnitConstants::MeV)
@@ -30,11 +30,11 @@ void ActsExamples::HepMC3Event::momentumUnit(
     mom = HepMC3::Units::MomentumUnit::GEV;
   }
   // Set units
-  event->set_units(mom, event->length_unit());
+  event.set_units(mom, event.length_unit());
 }
 
 void ActsExamples::HepMC3Event::lengthUnit(
-    std::shared_ptr<HepMC3::GenEvent> event, const double lengthUnit) {
+    HepMC3::GenEvent& event, const double lengthUnit) {
   // Check, if the length unit fits Acts::UnitConstants::mm or _cm
   HepMC3::Units::LengthUnit len;
   if (lengthUnit == Acts::UnitConstants::mm)
@@ -49,39 +49,39 @@ void ActsExamples::HepMC3Event::lengthUnit(
   }
 
   // Set units
-  event->set_units(event->momentum_unit(), len);
+  event.set_units(event.momentum_unit(), len);
 }
 
 void ActsExamples::HepMC3Event::shiftPositionBy(
-    std::shared_ptr<HepMC3::GenEvent> event, const Acts::Vector3D& deltaPos,
+    HepMC3::GenEvent& event, const Acts::Vector3D& deltaPos,
     const double deltaTime) {
   // Create HepMC3::FourVector from position and time for shift
   const HepMC3::FourVector vec(deltaPos(0), deltaPos(1), deltaPos(2),
                                deltaTime);
-  event->shift_position_by(vec);
+  event.shift_position_by(vec);
 }
 
 void ActsExamples::HepMC3Event::shiftPositionTo(
-    std::shared_ptr<HepMC3::GenEvent> event, const Acts::Vector3D& pos,
+    HepMC3::GenEvent& event, const Acts::Vector3D& pos,
     const double time) {
   // Create HepMC3::FourVector from position and time for the new position
   const HepMC3::FourVector vec(pos(0), pos(1), pos(2), time);
-  event->shift_position_to(vec);
+  event.shift_position_to(vec);
 }
 
 void ActsExamples::HepMC3Event::shiftPositionTo(
-    std::shared_ptr<HepMC3::GenEvent> event, const Acts::Vector3D& pos) {
+    HepMC3::GenEvent& event, const Acts::Vector3D& pos) {
   // Create HepMC3::FourVector from position and time for the new position
-  const HepMC3::FourVector vec(pos(0), pos(1), pos(2), event->event_pos().t());
-  event->shift_position_to(vec);
+  const HepMC3::FourVector vec(pos(0), pos(1), pos(2), event.event_pos().t());
+  event.shift_position_to(vec);
 }
 
 void ActsExamples::HepMC3Event::shiftPositionTo(
-    std::shared_ptr<HepMC3::GenEvent> event, const double time) {
+    HepMC3::GenEvent& event, const double time) {
   // Create HepMC3::FourVector from position and time for the new position
-  const HepMC3::FourVector vec(event->event_pos().x(), event->event_pos().y(),
-                               event->event_pos().z(), time);
-  event->shift_position_to(vec);
+  const HepMC3::FourVector vec(event.event_pos().x(), event.event_pos().y(),
+                               event.event_pos().z(), time);
+  event.shift_position_to(vec);
 }
 
 ///
@@ -101,10 +101,10 @@ HepMC3::GenParticlePtr ActsExamples::HepMC3Event::actsParticleToGen(
 }
 
 void ActsExamples::HepMC3Event::addParticle(
-    std::shared_ptr<HepMC3::GenEvent> event,
+    HepMC3::GenEvent& event,
     std::shared_ptr<SimParticle> particle) {
   // Add new particle
-  event->add_particle(actsParticleToGen(particle));
+  event.add_particle(actsParticleToGen(particle));
 }
 
 HepMC3::GenVertexPtr ActsExamples::HepMC3Event::createGenVertex(
@@ -132,10 +132,10 @@ HepMC3::GenVertexPtr ActsExamples::HepMC3Event::createGenVertex(
 }
 
 void ActsExamples::HepMC3Event::addVertex(
-    std::shared_ptr<HepMC3::GenEvent> event,
+    HepMC3::GenEvent& event,
     const std::shared_ptr<SimVertex> vertex) {
   // Add new vertex
-  event->add_vertex(createGenVertex(vertex));
+  event.add_vertex(createGenVertex(vertex));
 }
 
 ///
@@ -143,15 +143,15 @@ void ActsExamples::HepMC3Event::addVertex(
 ///
 
 void ActsExamples::HepMC3Event::removeParticle(
-    std::shared_ptr<HepMC3::GenEvent> event,
+    HepMC3::GenEvent& event,
     const std::shared_ptr<SimParticle>& particle) {
-  const std::vector<HepMC3::GenParticlePtr> genParticles = event->particles();
+  const std::vector<HepMC3::GenParticlePtr> genParticles = event.particles();
   const auto id = particle->particleId();
   // Search HepMC3::GenParticle with the same id as the Acts particle
   for (auto& genParticle : genParticles) {
     if (genParticle->id() == id) {
       // Remove particle if found
-      event->remove_particle(genParticle);
+      event.remove_particle(genParticle);
       break;
     }
   }
@@ -179,14 +179,14 @@ bool ActsExamples::HepMC3Event::compareVertices(
 }
 
 void ActsExamples::HepMC3Event::removeVertex(
-    std::shared_ptr<HepMC3::GenEvent> event,
+    HepMC3::GenEvent& event,
     const std::shared_ptr<SimVertex>& vertex) {
-  const std::vector<HepMC3::GenVertexPtr> genVertices = event->vertices();
+  const std::vector<HepMC3::GenVertexPtr> genVertices = event.vertices();
   // Walk over every recorded vertex
   for (auto& genVertex : genVertices)
     if (compareVertices(vertex, genVertex)) {
       // Remove vertex if it matches actsVertex
-      event->remove_vertex(genVertex);
+      event.remove_vertex(genVertex);
       break;
     }
 }
@@ -196,42 +196,42 @@ void ActsExamples::HepMC3Event::removeVertex(
 ///
 
 double ActsExamples::HepMC3Event::momentumUnit(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   // HepMC allows only MEV and GEV. This allows an easy identification.
-  return (event->momentum_unit() == HepMC3::Units::MomentumUnit::MEV
+  return (event.momentum_unit() == HepMC3::Units::MomentumUnit::MEV
               ? Acts::UnitConstants::MeV
               : Acts::UnitConstants::GeV);
 }
 
 double ActsExamples::HepMC3Event::lengthUnit(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   // HepMC allows only MM and CM. This allows an easy identification.
-  return (event->length_unit() == HepMC3::Units::LengthUnit::MM
+  return (event.length_unit() == HepMC3::Units::LengthUnit::MM
               ? Acts::UnitConstants::mm
               : Acts::UnitConstants::cm);
 }
 
 Acts::Vector3D ActsExamples::HepMC3Event::eventPos(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   // Extract the position from HepMC3::FourVector
   Acts::Vector3D vec;
-  vec(0) = event->event_pos().x();
-  vec(1) = event->event_pos().y();
-  vec(2) = event->event_pos().z();
+  vec(0) = event.event_pos().x();
+  vec(1) = event.event_pos().y();
+  vec(2) = event.event_pos().z();
   return vec;
 }
 
 double ActsExamples::HepMC3Event::eventTime(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   // Extract the time from HepMC3::FourVector
-  return event->event_pos().t();
+  return event.event_pos().t();
 }
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
 ActsExamples::HepMC3Event::particles(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimParticle>> actsParticles;
-  const std::vector<HepMC3::GenParticlePtr> genParticles = event->particles();
+  const std::vector<HepMC3::ConstGenParticlePtr> genParticles = event.particles();
 
   HepMC3Particle simPart;
 
@@ -245,9 +245,9 @@ ActsExamples::HepMC3Event::particles(
 
 std::vector<std::unique_ptr<ActsExamples::SimVertex>>
 ActsExamples::HepMC3Event::vertices(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimVertex>> actsVertices;
-  const std::vector<HepMC3::GenVertexPtr> genVertices = event->vertices();
+  const std::vector<HepMC3::ConstGenVertexPtr> genVertices = event.vertices();
 
   HepMC3Vertex simVert;
 
@@ -261,9 +261,9 @@ ActsExamples::HepMC3Event::vertices(
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
 ActsExamples::HepMC3Event::beams(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
+    const HepMC3::GenEvent& event) {
   std::vector<std::unique_ptr<SimParticle>> actsBeams;
-  const std::vector<HepMC3::GenParticlePtr> genBeams = event->beams();
+  const std::vector<HepMC3::ConstGenParticlePtr> genBeams = event.beams();
 
   HepMC3Particle simPart;
 
@@ -276,8 +276,8 @@ ActsExamples::HepMC3Event::beams(
 
 std::vector<std::unique_ptr<ActsExamples::SimParticle>>
 ActsExamples::HepMC3Event::finalState(
-    const std::shared_ptr<HepMC3::GenEvent> event) {
-  std::vector<HepMC3::GenParticlePtr> particles = event->particles();
+    const HepMC3::GenEvent& event) {
+  std::vector<HepMC3::ConstGenParticlePtr> particles = event.particles();
   std::vector<std::unique_ptr<SimParticle>> fState;
 
   HepMC3Particle simPart;

--- a/Examples/Io/HepMC3/src/HepMC3Options.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Options.cpp
@@ -32,8 +32,7 @@ ActsExamples::Options::readHepMC3WriterOptions(
   ActsExamples::HepMC3AsciiWriter::Config writerConfig;
   writerConfig.outputDir =
       variables["hepmc3-output-directory"].as<std::string>();
-  writerConfig.outputStem =
-      variables["hepmc3-stem"].as<std::string>();
+  writerConfig.outputStem = variables["hepmc3-stem"].as<std::string>();
 
   return writerConfig;
 }
@@ -55,8 +54,7 @@ ActsExamples::Options::readHepMC3ReaderOptions(
     const ActsExamples::Options::Variables& variables) {
   ActsExamples::HepMC3AsciiReader::Config readerConfig;
   readerConfig.inputDir = variables["hepmc3-input-directory"].as<std::string>();
-  readerConfig.inputStem =
-      variables["hepmc3-stem"].as<std::string>();
+  readerConfig.inputStem = variables["hepmc3-stem"].as<std::string>();
 
   return readerConfig;
 }

--- a/Examples/Io/HepMC3/src/HepMC3Options.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Options.cpp
@@ -20,8 +20,6 @@ void ActsExamples::Options::addHepMC3WriterOptions(
 
   auto opt = desc.add_options();
 
-  opt("hepmc3-output-directory", value<std::string>()->default_value(""),
-      "The output directory");
   opt("hepmc3-stem", value<std::string>()->default_value("events"),
       "The stem of file names of the output");
 }
@@ -31,7 +29,7 @@ ActsExamples::Options::readHepMC3WriterOptions(
     const ActsExamples::Options::Variables& variables) {
   ActsExamples::HepMC3AsciiWriter::Config writerConfig;
   writerConfig.outputDir =
-      variables["hepmc3-output-directory"].as<std::string>();
+      variables["output-dir"].as<std::string>();
   writerConfig.outputStem = variables["hepmc3-stem"].as<std::string>();
 
   return writerConfig;
@@ -43,8 +41,6 @@ void ActsExamples::Options::addHepMC3ReaderOptions(
 
   auto opt = desc.add_options();
 
-  opt("hepmc3-input-directory", value<std::string>()->default_value(""),
-      "The input directory");
   opt("hepmc3-stem", value<std::string>()->default_value("events"),
       "The stem of file names of the input");
 }
@@ -53,7 +49,7 @@ ActsExamples::HepMC3AsciiReader::Config
 ActsExamples::Options::readHepMC3ReaderOptions(
     const ActsExamples::Options::Variables& variables) {
   ActsExamples::HepMC3AsciiReader::Config readerConfig;
-  readerConfig.inputDir = variables["hepmc3-input-directory"].as<std::string>();
+  readerConfig.inputDir = variables["input-dir"].as<std::string>();
   readerConfig.inputStem = variables["hepmc3-stem"].as<std::string>();
 
   return readerConfig;

--- a/Examples/Io/HepMC3/src/HepMC3Options.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Options.cpp
@@ -1,0 +1,62 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/HepMC3/HepMC3Options.hpp"
+
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include <string>
+
+#include <boost/program_options.hpp>
+
+void ActsExamples::Options::addHepMC3WriterOptions(
+    ActsExamples::Options::Description& desc) {
+  using boost::program_options::value;
+
+  auto opt = desc.add_options();
+
+  opt("hepmc3-output-directory", value<std::string>()->default_value(""),
+      "The output directory");
+  opt("hepmc3-stem", value<std::string>()->default_value("events"),
+      "The stem of file names of the output");
+}
+
+ActsExamples::HepMC3AsciiWriter::Config
+ActsExamples::Options::readHepMC3WriterOptions(
+    const ActsExamples::Options::Variables& variables) {
+  ActsExamples::HepMC3AsciiWriter::Config writerConfig;
+  writerConfig.outputDir =
+      variables["hepmc3-output-directory"].as<std::string>();
+  writerConfig.outputStem =
+      variables["hepmc3-stem"].as<std::string>();
+
+  return writerConfig;
+}
+
+void ActsExamples::Options::addHepMC3ReaderOptions(
+    ActsExamples::Options::Description& desc) {
+  using boost::program_options::value;
+
+  auto opt = desc.add_options();
+
+  opt("hepmc3-input-directory", value<std::string>()->default_value(""),
+      "The input directory");
+  opt("hepmc3-stem", value<std::string>()->default_value("events"),
+      "The stem of file names of the input");
+}
+
+ActsExamples::HepMC3AsciiReader::Config
+ActsExamples::Options::readHepMC3ReaderOptions(
+    const ActsExamples::Options::Variables& variables) {
+  ActsExamples::HepMC3AsciiReader::Config readerConfig;
+  readerConfig.inputDir = variables["hepmc3-input-directory"].as<std::string>();
+  readerConfig.inputStem =
+      variables["hepmc3-stem"].as<std::string>();
+
+  return readerConfig;
+}

--- a/Examples/Io/HepMC3/src/HepMC3Options.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Options.cpp
@@ -28,8 +28,7 @@ ActsExamples::HepMC3AsciiWriter::Config
 ActsExamples::Options::readHepMC3WriterOptions(
     const ActsExamples::Options::Variables& variables) {
   ActsExamples::HepMC3AsciiWriter::Config writerConfig;
-  writerConfig.outputDir =
-      variables["output-dir"].as<std::string>();
+  writerConfig.outputDir = variables["output-dir"].as<std::string>();
   writerConfig.outputStem = variables["hepmc3-stem"].as<std::string>();
 
   return writerConfig;

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -1,12 +1,15 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
+#include <HepMC3/Units.h>
 
 bool ActsExamples::HepMC3ReaderAscii::readEvent(
     HepMC3::ReaderAscii& reader, std::shared_ptr<HepMC3::GenEvent> event) {
@@ -16,4 +19,48 @@ bool ActsExamples::HepMC3ReaderAscii::readEvent(
 
 bool ActsExamples::HepMC3ReaderAscii::status(HepMC3::ReaderAscii& reader) {
   return !reader.failed();
+}
+
+ActsExamples::HepMC3ReaderAscii::HepMC3ReaderAscii(
+    const ActsExamples::HepMC3ReaderAscii::Config& cfg,
+    Acts::Logging::Level lvl)
+    : m_cfg(cfg),
+      m_eventsRange(determineEventFilesRange(
+          cfg.inputDir, cfg.inputStemFileName + ".hepmc3")),
+      m_logger(Acts::getDefaultLogger("HepMC3ReaderAscii", lvl)) {
+  if (m_cfg.inputStemFileName.empty()) {
+    throw std::invalid_argument("Missing input filename stem");
+  }
+  if (m_cfg.outputCollection.empty()) {
+    throw std::invalid_argument("Missing output collection");
+  }
+}
+
+std::string ActsExamples::HepMC3ReaderAscii::HepMC3ReaderAscii::name() const {
+  return "HepMC3ReaderAscii";
+}
+
+std::pair<size_t, size_t> ActsExamples::HepMC3ReaderAscii::availableEvents()
+    const {
+  return m_eventsRange;
+}
+
+ActsExamples::ProcessCode ActsExamples::HepMC3ReaderAscii::read(
+    const ActsExamples::AlgorithmContext& ctx) {
+  std::vector<std::shared_ptr<HepMC3::GenEvent>> events;
+  HepMC3::GenEvent event(HepMC3::Units::GEV, HepMC3::Units::MM);
+
+  auto path = perEventFilepath(m_cfg.inputDir, m_cfg.inputStemFileName + ".csv",
+                               ctx.eventNumber);
+  HepMC3::ReaderAscii reader(path);
+
+  while (reader.read_event(event)) {
+    events.push_back(std::make_shared<HepMC3::GenEvent>(event));
+    event.clear();
+  }
+
+  ctx.eventStore.add(m_cfg.outputCollection, std::move(events));
+
+  return reader.failed() ? ActsExamples::ProcessCode::ABORT
+                         : ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -11,8 +11,8 @@
 #include "ActsExamples/Utilities/Paths.hpp"
 #include <HepMC3/Units.h>
 
-bool ActsExamples::HepMC3AsciiReader::readEvent(
-    HepMC3::ReaderAscii& reader, HepMC3::GenEvent& event) {
+bool ActsExamples::HepMC3AsciiReader::readEvent(HepMC3::ReaderAscii& reader,
+                                                HepMC3::GenEvent& event) {
   // Read event and store it
   return reader.read_event(event);
 }
@@ -25,8 +25,8 @@ ActsExamples::HepMC3AsciiReader::HepMC3AsciiReader(
     const ActsExamples::HepMC3AsciiReader::Config& cfg,
     Acts::Logging::Level lvl)
     : m_cfg(cfg),
-      m_eventsRange(determineEventFilesRange(
-          cfg.inputDir, cfg.inputStem + ".hepmc3")),
+      m_eventsRange(
+          determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".hepmc3")),
       m_logger(Acts::getDefaultLogger("HepMC3AsciiReader", lvl)) {
   if (m_cfg.inputStem.empty()) {
     throw std::invalid_argument("Missing input filename stem");
@@ -52,7 +52,7 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiReader::read(
 
   auto path = perEventFilepath(m_cfg.inputDir, m_cfg.inputStem + ".hepmc3",
                                ctx.eventNumber);
-                               
+
   ACTS_DEBUG("Attempting to write event to " << path);
   HepMC3::ReaderAscii reader(path);
 
@@ -61,9 +61,9 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiReader::read(
     event.clear();
   }
 
-  if(reader.failed())
-	return ActsExamples::ProcessCode::ABORT;
-  
+  if (reader.failed())
+    return ActsExamples::ProcessCode::ABORT;
+
   ctx.eventStore.add(m_cfg.outputEvents, std::move(events));
 
   return ActsExamples::ProcessCode::SUCCESS;

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -19,19 +19,18 @@ ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config&& cfg,
 ActsExamples::ProcessCode ActsExamples::HepMC3AsciiWriter::writeT(
     const ActsExamples::AlgorithmContext& ctx,
     const std::vector<HepMC3::GenEvent>& events) {
-  auto path = perEventFilepath(
-      m_cfg.outputDir, m_cfg.outputStem + ".hepmc3", ctx.eventNumber);
-  
+  auto path = perEventFilepath(m_cfg.outputDir, m_cfg.outputStem + ".hepmc3",
+                               ctx.eventNumber);
+
   ACTS_DEBUG("Attempting to write event to " << path);
   HepMC3::WriterAscii writer(path);
 
-  for (const auto& event : events)
-  {
+  for (const auto& event : events) {
     writer.write_event(event);
-	if(writer.failed())
-		return ActsExamples::ProcessCode::ABORT;
+    if (writer.failed())
+      return ActsExamples::ProcessCode::ABORT;
   }
-  
+
   writer.close();
   return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -1,20 +1,33 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
 
-bool ActsExamples::HepMC3WriterAscii::writeEvent(
-    HepMC3::WriterAscii& writer, std::shared_ptr<HepMC3::GenEvent> event) {
-  // Write event from storage
-  writer.write_event(*event);
-  return true;
+ActsExamples::HepMC3WriterAscii::HepMC3WriterAscii(const Config&& cfg,
+                                                   Acts::Logging::Level lvl)
+    : WriterT(cfg.inputCollection, "HepMC3EventWriter", lvl), m_cfg(cfg) {
+  if (m_cfg.outputStemFileName.empty())
+    throw std::invalid_argument("Missing output stem file name");
 }
 
-bool ActsExamples::HepMC3WriterAscii::status(HepMC3::WriterAscii& writer) {
-  return writer.failed();
+ActsExamples::ProcessCode ActsExamples::HepMC3WriterAscii::writeT(
+    const ActsExamples::AlgorithmContext& ctx,
+    const std::vector<std::shared_ptr<HepMC3::GenEvent>>& events) {
+  auto path = perEventFilepath(
+      m_cfg.outputDir, m_cfg.outputStemFileName + ".hepmc3", ctx.eventNumber);
+  std::cout << "Path: " << path << std::endl;
+  HepMC3::WriterAscii writer(path);
+
+  for (const auto& event : events)
+    writer.write_event(*event);
+
+  writer.close();
+  return writer.failed() ? ActsExamples::ProcessCode::ABORT
+                         : ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -9,25 +9,29 @@
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
 
-ActsExamples::HepMC3WriterAscii::HepMC3WriterAscii(const Config&& cfg,
+ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config&& cfg,
                                                    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputCollection, "HepMC3EventWriter", lvl), m_cfg(cfg) {
-  if (m_cfg.outputStemFileName.empty())
+    : WriterT(cfg.inputEvents, "HepMC3EventWriter", lvl), m_cfg(cfg) {
+  if (m_cfg.outputStem.empty())
     throw std::invalid_argument("Missing output stem file name");
 }
 
-ActsExamples::ProcessCode ActsExamples::HepMC3WriterAscii::writeT(
+ActsExamples::ProcessCode ActsExamples::HepMC3AsciiWriter::writeT(
     const ActsExamples::AlgorithmContext& ctx,
-    const std::vector<std::shared_ptr<HepMC3::GenEvent>>& events) {
+    const std::vector<HepMC3::GenEvent>& events) {
   auto path = perEventFilepath(
-      m_cfg.outputDir, m_cfg.outputStemFileName + ".hepmc3", ctx.eventNumber);
-  std::cout << "Path: " << path << std::endl;
+      m_cfg.outputDir, m_cfg.outputStem + ".hepmc3", ctx.eventNumber);
+  
+  ACTS_DEBUG("Attempting to write event to " << path);
   HepMC3::WriterAscii writer(path);
 
   for (const auto& event : events)
-    writer.write_event(*event);
-
+  {
+    writer.write_event(event);
+	if(writer.failed())
+		return ActsExamples::ProcessCode::ABORT;
+  }
+  
   writer.close();
-  return writer.failed() ? ActsExamples::ProcessCode::ABORT
-                         : ActsExamples::ProcessCode::SUCCESS;
+  return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Run/HepMC3/CMakeLists.txt
+++ b/Examples/Run/HepMC3/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(
 target_link_libraries(
   ActsExampleHepMC3
   PRIVATE
-    ActsCore
+    ActsCore ActsExamplesCommon
     ActsExamplesFramework ActsExamplesIoHepMC3
     Boost::program_options)
 

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -8,10 +8,10 @@
 
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/EventData/SimVertex.hpp"
-#include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Event.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Options.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
 
 #include <fstream>
 

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
 
   // Create the reader
   auto hepMC3ReaderConfig = ActsExamples::Options::readHepMC3ReaderOptions(vm);
-  ActsExamples::HepMC3ReaderAscii simReader(hepMC3ReaderConfig, logLevel);
+  ActsExamples::HepMC3AsciiReader simReader(hepMC3ReaderConfig, logLevel);
 
   std::cout << "Preparing reader " << std::flush;
   HepMC3::ReaderAscii reader("test.hepmc3");
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     std::cout << "failed" << std::endl;
   }
 
-  std::shared_ptr<HepMC3::GenEvent> genevt(new HepMC3::GenEvent());
+  HepMC3::GenEvent genevt;
 
   std::cout << "Reading event " << std::flush;
   if (simReader.readEvent(reader, genevt)) {

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,19 +8,35 @@
 
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/EventData/SimVertex.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Event.hpp"
+#include "ActsExamples/Io/HepMC3/HepMC3Options.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
 
 #include <fstream>
 
-#include "HepMC3/ReaderAscii.h"
-#include "HepPID/ParticleName.hh"
+#include <HepMC3/GenEvent.h>
+#include <HepMC3/ReaderAscii.h>
+#include <HepPID/ParticleName.hh>
 
 ///
 /// Straight forward example of reading a HepMC3 file.
 ///
-int main(int /*argc*/, char** /*argv*/) {
-  ActsExamples::HepMC3ReaderAscii simReader;
+int main(int argc, char** argv) {
+  // Declare the supported program options.
+  // Setup and parse options
+  auto desc = ActsExamples::Options::makeDefaultOptions();
+  ActsExamples::Options::addHepMC3ReaderOptions(desc);
+  auto vm = ActsExamples::Options::parse(desc, argc, argv);
+  if (vm.empty()) {
+    return EXIT_FAILURE;
+  }
+
+  auto logLevel = ActsExamples::Options::readLogLevel(vm);
+
+  // Create the reader
+  auto hepMC3ReaderConfig = ActsExamples::Options::readHepMC3ReaderOptions(vm);
+  ActsExamples::HepMC3ReaderAscii simReader(hepMC3ReaderConfig, logLevel);
 
   std::cout << "Preparing reader " << std::flush;
   HepMC3::ReaderAscii reader("test.hepmc3");


### PR DESCRIPTION
This PR modifies the `HepMCWriter` and `HepMCReader` such that they can be used as algorithms in the `Sequencer`. 