### PR TITLE
chore(core): include-what-you-use Geometry (2/X)

### DIFF
--- a/Core/include/Acts/Geometry/AbstractVolume.hpp
+++ b/Core/include/Acts/Geometry/AbstractVolume.hpp
@@ -7,10 +7,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace Acts {

--- a/Core/include/Acts/Geometry/ConeLayer.hpp
+++ b/Core/include/Acts/Geometry/ConeLayer.hpp
@@ -7,16 +7,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
+#include "Acts/Geometry/ApproachDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
+#include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Surfaces/ConeSurface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <algorithm>
+#include <memory>
 
 namespace Acts {
-
-class ConeBounds;
-class ApproachDescriptor;
 
 /// @class ConeLayer
 ///

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -13,16 +13,18 @@
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
-#include <cmath>
+#include <array>
+#include <iomanip>
+#include <memory>
+#include <ostream>
+#include <vector>
 
 namespace Acts {
 
-class Surface;
 class CylinderBounds;
 class ConeBounds;
 class RadialBounds;
 class PlanarBounds;
-class Volume;
 
 /// @class ConeVolumeBounds
 ///

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -15,14 +15,15 @@
 
 #include <array>
 #include <cmath>
-#include <exception>
+#include <iomanip>
+#include <iosfwd>
+#include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace Acts {
 
 class RectangleBounds;
-class Volume;
-class Surface;
 
 /// @class CuboidVolumeBounds
 ///

--- a/Core/include/Acts/Geometry/CuboidVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBuilder.hpp
@@ -14,7 +14,10 @@
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <functional>
+#include <iosfwd>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace Acts {
@@ -26,6 +29,7 @@ class ISurfaceMaterial;
 class IVolumeMaterial;
 class DetectorElementBase;
 class PlaneSurface;
+class Layer;
 
 /// @brief This class builds a box detector with a configurable amount of
 /// surfaces in it. The idea is to allow a quick configuration of a detector for

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -8,19 +8,17 @@
 
 #pragma once
 
-#include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/Polyhedron.hpp"
+#include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <array>
-#include <exception>
+#include <iosfwd>
+#include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace Acts {
-
-class IVisualization3D;
 
 class CylinderBounds;
 class DiscBounds;

--- a/Core/include/Acts/Geometry/CylinderLayer.hpp
+++ b/Core/include/Acts/Geometry/CylinderLayer.hpp
@@ -8,19 +8,17 @@
 
 #pragma once
 
-#include "Acts/Geometry/CylinderVolumeBounds.hpp"
-#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/ApproachDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <algorithm>
+#include <memory>
 
 namespace Acts {
-
-class CylinderBounds;
-class ApproachDescriptor;
 
 /// @class CylinderLayer
 ///

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -8,26 +8,25 @@
 
 #pragma once
 
-#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <array>
 #include <cmath>
-#include <exception>
-#include <vector>
+#include <iomanip>
+#include <iosfwd>
+#include <memory>
+#include <stdexcept>
 
 namespace Acts {
 
-class Surface;
 class CylinderBounds;
 class RadialBounds;
 class PlanarBounds;
-class IVisualization3D;
 
 /// @class CylinderVolumeBounds
 ///

--- a/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
@@ -9,24 +9,27 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/IConfinedTrackingVolumeBuilder.hpp"
-#include "Acts/Geometry/ILayerBuilder.hpp"
 #include "Acts/Geometry/ITrackingVolumeBuilder.hpp"
 #include "Acts/Geometry/ITrackingVolumeHelper.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Units.hpp"
 
+#include <algorithm>
 #include <array>
 #include <limits>
+#include <memory>
+#include <ostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace Acts {
 
-class TrackingVolume;
-class VolumeBounds;
 class IVolumeMaterial;
 class ISurfaceMaterial;
+class ILayerBuilder;
+class IConfinedTrackingVolumeBuilder;
 
 /// @enum WrappingCondition
 enum WrappingCondition {

--- a/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeHelper.hpp
@@ -10,11 +10,12 @@
 
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/ILayerArrayCreator.hpp"
-#include "Acts/Geometry/ITrackingVolumeArrayCreator.hpp"
 #include "Acts/Geometry/ITrackingVolumeHelper.hpp"
+#include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,6 +27,8 @@ class TrackingVolume;
 class VolumeBounds;
 class CylinderVolumeBounds;
 class IVolumeMaterial;
+class ILayerArrayCreator;
+class ITrackingVolumeArrayCreator;
 
 /// @class CylinderVolumeHelper
 ///
@@ -57,7 +60,6 @@ class CylinderVolumeHelper : public ITrackingVolumeHelper {
                        std::unique_ptr<const Logger> logger = getDefaultLogger(
                            "CylinderVolumeHelper", Logging::INFO));
 
-  /// Destructor
   ~CylinderVolumeHelper() override = default;
 
   /// Create a TrackingVolume* from a set of layers and (optional) parameters

--- a/Core/include/Acts/Geometry/DiscLayer.hpp
+++ b/Core/include/Acts/Geometry/DiscLayer.hpp
@@ -8,17 +8,17 @@
 
 #pragma once
 
-#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/ApproachDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
-#include <algorithm>
+#include <memory>
 
 namespace Acts {
 
 class DiscBounds;
-class ApproachDescriptor;
 
 /// @class DiscLayer
 ///

--- a/Core/include/Acts/Geometry/Extent.hpp
+++ b/Core/include/Acts/Geometry/Extent.hpp
@@ -12,7 +12,10 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <iosfwd>
+#include <limits>
 #include <utility>
 #include <vector>
 

--- a/Core/include/Acts/Geometry/GenericApproachDescriptor.hpp
+++ b/Core/include/Acts/Geometry/GenericApproachDescriptor.hpp
@@ -9,14 +9,19 @@
 #pragma once
 
 #include "Acts/Geometry/ApproachDescriptor.hpp"
-#include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/BoundaryCheck.hpp"
+#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 
-#include <algorithm>
+#include <memory>
+#include <vector>
 
 namespace Acts {
+
+class Layer;
+class Surface;
 
 /// @class GenericApproachDescriptor
 ///

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <array>

--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <iosfwd>
+#include <utility>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <iosfwd>
 #include <utility>
 

--- a/Core/include/Acts/Geometry/GlueVolumesDescriptor.hpp
+++ b/Core/include/Acts/Geometry/GlueVolumesDescriptor.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <vector>

--- a/Core/include/Acts/Geometry/Layer.hpp
+++ b/Core/include/Acts/Geometry/Layer.hpp
@@ -13,14 +13,16 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Geometry/GeometryObject.hpp"
-#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Material/IMaterialDecorator.hpp"
+#include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 
-#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Acts {
 
@@ -31,6 +33,7 @@ class Volume;
 class VolumeBounds;
 class TrackingVolume;
 class ApproachDescriptor;
+class IMaterialDecorator;
 
 // Simple surface intersection
 using SurfaceIntersection = ObjectIntersection<Surface>;

--- a/Core/include/Acts/Geometry/LayerArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/LayerArrayCreator.hpp
@@ -10,10 +10,7 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/ILayerArrayCreator.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
-
-#include <algorithm>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/LayerCreator.hpp
+++ b/Core/include/Acts/Geometry/LayerCreator.hpp
@@ -10,12 +10,16 @@
 
 #include "Acts/Geometry/ApproachDescriptor.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/SurfaceArrayCreator.hpp"
-#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Geometry/GeometryStatics.hpp"
+#include "Acts/Geometry/ProtoLayer.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include <memory>
 #include <optional>
+#include <vector>
 
 namespace Acts {
 
@@ -23,7 +27,9 @@ namespace Test {
 struct LayerCreatorFixture;
 }
 class Surface;
+class SurfaceArrayCreator;
 class Layer;
+
 using MutableLayerPtr = std::shared_ptr<Layer>;
 
 /// @class LayerCreator

--- a/Core/include/Acts/Geometry/NavigationLayer.hpp
+++ b/Core/include/Acts/Geometry/NavigationLayer.hpp
@@ -11,13 +11,14 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/Layer.hpp"
-#include "Acts/Utilities/BinnedArray.hpp"
+#include "Acts/Surfaces/BoundaryCheck.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
-namespace Acts {
+#include <memory>
 
-class Surface;
-class BinUtility;
+namespace Acts {
 
 /// @class NavigationLayer
 ///

--- a/Core/include/Acts/Geometry/PassiveLayerBuilder.hpp
+++ b/Core/include/Acts/Geometry/PassiveLayerBuilder.hpp
@@ -10,11 +10,15 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/ILayerBuilder.hpp"
-#include "Acts/Geometry/Layer.hpp"
-#include "Acts/Material/MaterialSlab.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace Acts {
+
+class ISurfaceMaterial;
 
 /// @class PassiveLayerBuilder
 ///

--- a/Core/include/Acts/Geometry/PlaneLayer.hpp
+++ b/Core/include/Acts/Geometry/PlaneLayer.hpp
@@ -7,15 +7,18 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
+#include "Acts/Geometry/ApproachDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
-#include <algorithm>
+#include <memory>
 
 namespace Acts {
 
-class ApproachDescriptor;
+class PlanarBounds;
 
 /// @class PlaneLayer
 ///

--- a/Core/include/Acts/Geometry/Polyhedron.hpp
+++ b/Core/include/Acts/Geometry/Polyhedron.hpp
@@ -9,12 +9,8 @@
 #pragma once
 
 #include "Acts/Geometry/Extent.hpp"
-#include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/Helpers.hpp"
 
-#include <array>
-#include <limits>
 #include <vector>
 
 namespace Acts {

--- a/Core/include/Acts/Geometry/ProtoLayer.hpp
+++ b/Core/include/Acts/Geometry/ProtoLayer.hpp
@@ -11,9 +11,11 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 
 #include <iostream>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/ProtoLayerHelper.hpp
+++ b/Core/include/Acts/Geometry/ProtoLayerHelper.hpp
@@ -11,11 +11,15 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/ProtoLayer.hpp"
 #include "Acts/Utilities/BinningType.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
-#include "Acts/Utilities/Units.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace Acts {
+
+class Surface;
 
 /// @class ProtoLayerHelper
 ///

--- a/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
@@ -9,15 +9,24 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/ProtoLayer.hpp"
-#include "Acts/Surfaces/PlanarBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Units.hpp"
+#include "Acts/Utilities/detail/AxisFwd.hpp"
 
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
 #include <optional>
+#include <tuple>
+#include <vector>
 
 namespace Acts {
 namespace Test {

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -9,12 +9,13 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <functional>
-#include <iosfwd>
-#include <unordered_map>
 #include <memory>
+#include <string>
+#include <unordered_map>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -9,13 +9,12 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <functional>
-#include <memory>
-#include <string>
+#include <iosfwd>
 #include <unordered_map>
+#include <memory>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/TrackingGeometryBuilder.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometryBuilder.hpp
@@ -10,9 +10,7 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/ITrackingGeometryBuilder.hpp"
-#include "Acts/Geometry/ITrackingVolumeBuilder.hpp"
 #include "Acts/Geometry/ITrackingVolumeHelper.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
 #include <functional>
@@ -21,14 +19,14 @@
 
 namespace Acts {
 
+class TrackingVolume;
 class TrackingGeometry;
 class IMaterialDecorator;
 
 /// The Acts::TrackingGeometry Builder for volumes that wrap around another
 ///
-/// It retrieves an array of ITrackingVolumeBuilder tools that are configured
-/// to be built in sequence, where the output of one volume builder is provided
-/// to the next volume volume builder and accordingly
+/// It retrieves an array of std::functions that build the TrackingGeometry
+/// sequentially in order, with the following options:
 /// - contained (e.g. a final insertion of a beam pipe of longer extend)
 /// - wrapped (e.g. an outer detector wrapping an inner one)
 /// - attached (e.g. a neighbor detector attaching to the previous one)

--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "Acts/Geometry/AbstractVolume.hpp"
+#include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
@@ -20,17 +22,26 @@
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Frustum.hpp"
+#include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Ray.hpp"
 
 #include <functional>
-#include <string>
+#include <iosfwd>
 #include <unordered_map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace Acts {
 
 class GlueVolumesDescriptor;
 class VolumeBounds;
+class IMaterialDecorator;
+class ISurfaceMaterial;
+class IVolumeMaterial;
+class Surface;
+class TrackingVolume;
 
 template <typename object_t>
 struct NavigationOptions;

--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "Acts/Geometry/AbstractVolume.hpp"
-#include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
@@ -22,26 +20,17 @@
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Frustum.hpp"
-#include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Ray.hpp"
 
 #include <functional>
-#include <iosfwd>
-#include <unordered_map>
-#include <memory>
 #include <string>
-#include <vector>
+#include <unordered_map>
 
 namespace Acts {
 
 class GlueVolumesDescriptor;
 class VolumeBounds;
-class IMaterialDecorator;
-class ISurfaceMaterial;
-class IVolumeMaterial;
-class Surface;
-class TrackingVolume;
 
 template <typename object_t>
 struct NavigationOptions;

--- a/Core/include/Acts/Geometry/TrackingVolumeArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolumeArrayCreator.hpp
@@ -10,16 +10,14 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/ITrackingVolumeArrayCreator.hpp"
-#include "Acts/Utilities/BinnedArray.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
-#include <algorithm>
+#include <memory>
+#include <utility>
 
 namespace Acts {
-
-class Layer;
-class TrackingVolume;
 
 using TrackingVolumeOrderPosition = std::pair<TrackingVolumePtr, Vector3D>;
 

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -10,15 +10,17 @@
 
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <array>
+#include <iomanip>
+#include <iosfwd>
+#include <memory>
+#include <stdexcept>
 #include <vector>
 
 namespace Acts {
 
-class Surface;
 class RectangleBounds;
 class TrapezoidBounds;
 

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -10,10 +10,11 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryObject.hpp"
-#include "Acts/Geometry/GeometryStatics.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
+#include <iosfwd>
 #include <memory>
 
 namespace Acts {

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -7,19 +7,20 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Utilities/BinningType.hpp"
-#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
-#include <iomanip>
+#include <cmath>
 #include <iostream>
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace Acts {
 
 class Surface;
-class Volume;
 
 class VolumeBounds;
 using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;

--- a/Core/include/Acts/Geometry/detail/Layer.ipp
+++ b/Core/include/Acts/Geometry/detail/Layer.ipp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <limits>
+#include <map>
 
 namespace Acts {
 

--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -7,18 +7,20 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
+
 #include "Acts/Utilities/BinningData.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <array>
+#include <cstddef>
 #include <iostream>
 #include <memory>
 #include <vector>
 
 namespace Acts {
 
-///  @class BinUtility
+/// @class BinUtility
 ///
 /// The BinUtility class that translated global and local position into a bins
 /// of a BinnedArray, most performant is equidistant binning without a

--- a/Core/src/Geometry/AbstractVolume.cpp
+++ b/Core/src/Geometry/AbstractVolume.cpp
@@ -12,7 +12,6 @@
 #include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
-#include <iostream>
 #include <utility>
 
 Acts::AbstractVolume::AbstractVolume(

--- a/Core/src/Geometry/CMakeLists.txt
+++ b/Core/src/Geometry/CMakeLists.txt
@@ -2,7 +2,6 @@ target_sources_local(
   ActsCore
   PRIVATE
     AbstractVolume.cpp
-    BinUtility.cpp
     ConeLayer.cpp
     ConeVolumeBounds.cpp
     CuboidVolumeBounds.cpp

--- a/Core/src/Geometry/ConeLayer.cpp
+++ b/Core/src/Geometry/ConeLayer.cpp
@@ -8,10 +8,7 @@
 
 #include "Acts/Geometry/ConeLayer.hpp"
 
-#include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-
-#include <utility>
 
 Acts::ConeLayer::ConeLayer(const Transform3D& transform,
                            std::shared_ptr<const ConeBounds> cbounds,

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -8,6 +8,7 @@
 
 #include "Acts/Geometry/ConeVolumeBounds.hpp"
 
+#include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Surfaces/ConeSurface.hpp"
 #include "Acts/Surfaces/ConvexPolygonBounds.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
@@ -15,12 +16,15 @@
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
-#include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+#include "Acts/Utilities/detail/periodic.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <stdexcept>
 
 Acts::ConeVolumeBounds::ConeVolumeBounds(double innerAlpha, double innerOffsetZ,
                                          double outerAlpha, double outerOffsetZ,

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -13,7 +13,6 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
 
-#include <cmath>
 #include <iostream>
 
 Acts::CuboidVolumeBounds::CuboidVolumeBounds(double halex, double haley,

--- a/Core/src/Geometry/CuboidVolumeBuilder.cpp
+++ b/Core/src/Geometry/CuboidVolumeBuilder.cpp
@@ -8,11 +8,13 @@
 
 #include "Acts/Geometry/CuboidVolumeBuilder.hpp"
 
+#include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/LayerArrayCreator.hpp"
 #include "Acts/Geometry/LayerCreator.hpp"
 #include "Acts/Geometry/PlaneLayer.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/detail/DefaultDetectorElementBase.hpp"
@@ -20,10 +22,18 @@
 #include "Acts/Material/MaterialSlab.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 #include "Acts/Utilities/BinnedArrayXD.hpp"
+#include "Acts/Utilities/BinningData.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/Units.hpp"
+
+#include <limits>
+#include <optional>
 
 std::shared_ptr<const Acts::PlaneSurface>
 Acts::CuboidVolumeBuilder::buildSurface(

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -15,11 +15,13 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
-#include "Acts/Visualization/IVisualization3D.hpp"
 
 #include <memory>
+#include <ostream>
 #include <vector>
 
 bool Acts::CutoutCylinderVolumeBounds::inside(const Acts::Vector3D& gpos,

--- a/Core/src/Geometry/CylinderLayer.cpp
+++ b/Core/src/Geometry/CylinderLayer.cpp
@@ -10,11 +10,14 @@
 
 #include "Acts/Geometry/AbstractVolume.hpp"
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
+#include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
-#include "Acts/Surfaces/CylinderBounds.hpp"
-#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <vector>
 
 using Acts::VectorHelpers::phi;
 

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -14,8 +14,8 @@
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
-#include "Acts/Visualization/IVisualization3D.hpp"
 
 #include <cmath>
 #include <iostream>

--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -8,18 +8,29 @@
 
 #include "Acts/Geometry/CylinderVolumeBuilder.hpp"
 
+#include "Acts/Geometry/AbstractVolume.hpp"
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/CylinderLayer.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
-#include "Acts/Geometry/DiscLayer.hpp"
+#include "Acts/Geometry/IConfinedTrackingVolumeBuilder.hpp"
+#include "Acts/Geometry/ILayerBuilder.hpp"
 #include "Acts/Geometry/ITrackingVolumeHelper.hpp"
+#include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <algorithm>
+#include <iosfwd>
+#include <iterator>
 #include <vector>
+#include <math.h>
 
 Acts::CylinderVolumeBuilder::CylinderVolumeBuilder(
     const Acts::CylinderVolumeBuilder::Config& cvbConfig,

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -8,22 +8,30 @@
 
 #include "Acts/Geometry/CylinderVolumeHelper.hpp"
 
-#include "Acts/Geometry/AbstractVolume.hpp"
 #include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/CylinderLayer.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/DiscLayer.hpp"
+#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/GlueVolumesDescriptor.hpp"
 #include "Acts/Geometry/ILayerArrayCreator.hpp"
 #include "Acts/Geometry/ITrackingVolumeArrayCreator.hpp"
+#include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
-#include "Acts/Material/BinnedSurfaceMaterial.hpp"
-#include "Acts/Material/Material.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Material/ISurfaceMaterial.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
+#include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Utilities/BinnedArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
+#include <algorithm>
 #include <cmath>
 
 Acts::CylinderVolumeHelper::CylinderVolumeHelper(

--- a/Core/src/Geometry/DiscLayer.cpp
+++ b/Core/src/Geometry/DiscLayer.cpp
@@ -10,13 +10,16 @@
 
 #include "Acts/Geometry/AbstractVolume.hpp"
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
+#include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
-#include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
-#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <vector>
 
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;

--- a/Core/src/Geometry/Extent.cpp
+++ b/Core/src/Geometry/Extent.cpp
@@ -8,6 +8,7 @@
 
 #include "Acts/Geometry/Extent.hpp"
 
+#include <iomanip>
 #include <ostream>
 
 std::ostream& Acts::Extent::toStream(std::ostream& sl) const {

--- a/Core/src/Geometry/GenericApproachDescriptor.cpp
+++ b/Core/src/Geometry/GenericApproachDescriptor.cpp
@@ -11,6 +11,8 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 
+#include <algorithm>
+
 void Acts::GenericApproachDescriptor::registerLayer(const Layer& lay) {
   // go through the surfaces
   for (auto& sf : m_surfaceCache) {

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -12,12 +12,17 @@
 #include "Acts/Surfaces/ConvexPolygonBounds.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/ThrowAssert.hpp"
 #include "Acts/Visualization/IVisualization3D.hpp"
 
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
 #include <ostream>
+#include <stdexcept>
 
 Acts::GenericCuboidVolumeBounds::GenericCuboidVolumeBounds(
     const std::array<Acts::Vector3D, 8>& vertices) noexcept(false)

--- a/Core/src/Geometry/GeometryIdentifier.cpp
+++ b/Core/src/Geometry/GeometryIdentifier.cpp
@@ -8,7 +8,6 @@
 
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 
-#include <iomanip>
 #include <ostream>
 
 std::ostream& Acts::operator<<(std::ostream& os, Acts::GeometryIdentifier id) {

--- a/Core/src/Geometry/GlueVolumesDescriptor.cpp
+++ b/Core/src/Geometry/GlueVolumesDescriptor.cpp
@@ -6,14 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// GlueVolumesDescriptor.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/GlueVolumesDescriptor.hpp"
 
 #include "Acts/Geometry/TrackingVolume.hpp"
 
+#include <ostream>
 #include <utility>
 
 Acts::GlueVolumesDescriptor::GlueVolumesDescriptor(

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -6,13 +6,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// Layer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
-// Geometry module
 #include "Acts/Geometry/Layer.hpp"
 
+#include "Acts/Material/IMaterialDecorator.hpp"
 #include "Acts/Material/ISurfaceMaterial.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinUtility.hpp"

--- a/Core/src/Geometry/LayerArrayCreator.cpp
+++ b/Core/src/Geometry/LayerArrayCreator.cpp
@@ -6,28 +6,27 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// LayerArrayCreator.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/LayerArrayCreator.hpp"
 
 #include "Acts/Geometry/GeometryObjectSorter.hpp"
-#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/NavigationLayer.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
-#include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
-#include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
-#include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinnedArrayXD.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
+#include <algorithm>
 #include <cmath>
+#include <memory>
+#include <utility>
+#include <vector>
 
 std::unique_ptr<const Acts::LayerArray> Acts::LayerArrayCreator::layerArray(
     const GeometryContext& gctx, const LayerVector& layersInput, double min,

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -10,17 +10,22 @@
 
 #include "Acts/Geometry/CylinderLayer.hpp"
 #include "Acts/Geometry/DiscLayer.hpp"
+#include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/PlaneLayer.hpp"
 #include "Acts/Geometry/ProtoLayer.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/PlanarBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/Units.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 
-#include <cmath>
+#include <algorithm>
+#include <iterator>
 #include <set>
+#include <utility>
 
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;

--- a/Core/src/Geometry/NavigationLayer.cpp
+++ b/Core/src/Geometry/NavigationLayer.cpp
@@ -6,13 +6,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// NavigationLayer.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/NavigationLayer.hpp"
 
-#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 
 Acts::NavigationLayer::NavigationLayer(
     std::shared_ptr<const Surface> surfaceRepresentation, double thickness)

--- a/Core/src/Geometry/PassiveLayerBuilder.cpp
+++ b/Core/src/Geometry/PassiveLayerBuilder.cpp
@@ -10,10 +10,12 @@
 
 #include "Acts/Geometry/CylinderLayer.hpp"
 #include "Acts/Geometry/DiscLayer.hpp"
-#include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
-#include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Geometry/GeometryStatics.hpp"
+#include "Acts/Geometry/Layer.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 Acts::PassiveLayerBuilder::PassiveLayerBuilder(

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -6,14 +6,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Geometry module
 #include "Acts/Geometry/PlaneLayer.hpp"
 
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/Helpers.hpp"
 
-#include <utility>
+#include <vector>
 
 Acts::PlaneLayer::PlaneLayer(const Transform3D& transform,
                              std::shared_ptr<const PlanarBounds>& pbounds,

--- a/Core/src/Geometry/Polyhedron.cpp
+++ b/Core/src/Geometry/Polyhedron.cpp
@@ -12,6 +12,9 @@
 #include "Acts/Utilities/BinningType.hpp"
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
+#include <utility>
 
 void Acts::Polyhedron::merge(const Acts::Polyhedron& other) {
   size_t cvert = vertices.size();

--- a/Core/src/Geometry/ProtoLayer.cpp
+++ b/Core/src/Geometry/ProtoLayer.cpp
@@ -8,13 +8,11 @@
 
 #include "Acts/Geometry/ProtoLayer.hpp"
 
+#include "Acts/Geometry/DetectorElementBase.hpp"
 #include "Acts/Geometry/Polyhedron.hpp"
-#include "Acts/Surfaces/AnnulusBounds.hpp"
-#include "Acts/Surfaces/CylinderBounds.hpp"
-#include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
-#include <algorithm>
 #include <cmath>
 
 using Acts::VectorHelpers::perp;

--- a/Core/src/Geometry/ProtoLayerHelper.cpp
+++ b/Core/src/Geometry/ProtoLayerHelper.cpp
@@ -9,6 +9,10 @@
 #include "Acts/Geometry/ProtoLayerHelper.hpp"
 
 #include "Acts/Geometry/Extent.hpp"
+#include "Acts/Geometry/Polyhedron.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+
+#include <iosfwd>
 
 std::vector<Acts::ProtoLayer> Acts::ProtoLayerHelper::protoLayers(
     const GeometryContext& gctx, const std::vector<const Surface*>& surfaces,

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -11,13 +11,13 @@
 #include "Acts/Surfaces/PlanarBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
-#include "Acts/Utilities/BinUtility.hpp"
-#include "Acts/Utilities/BinnedArrayXD.hpp"
+#include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
+#include "Acts/Utilities/IAxis.hpp"
 #include "Acts/Utilities/Units.hpp"
-#include "Acts/Utilities/detail/Axis.hpp"
+#include "Acts/Utilities/detail/grid_helper.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -8,7 +8,6 @@
 
 #include "Acts/Geometry/TrackingGeometry.hpp"
 
-#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -8,6 +8,7 @@
 
 #include "Acts/Geometry/TrackingGeometry.hpp"
 
+#include "Acts/Geometry/GeometryStatics.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"

--- a/Core/src/Geometry/TrackingGeometryBuilder.cpp
+++ b/Core/src/Geometry/TrackingGeometryBuilder.cpp
@@ -6,15 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrackingGeometryBuilder.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/TrackingGeometryBuilder.hpp"
 
-#include "Acts/Geometry/CylinderVolumeBounds.hpp"
-#include "Acts/Geometry/ITrackingVolumeBuilder.hpp"
-#include "Acts/Geometry/ITrackingVolumeHelper.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -8,14 +8,24 @@
 
 #include "Acts/Geometry/TrackingVolume.hpp"
 
+#include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Geometry/GlueVolumesDescriptor.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Material/IMaterialDecorator.hpp"
+#include "Acts/Material/IVolumeMaterial.hpp"
 #include "Acts/Material/ProtoVolumeMaterial.hpp"
 #include "Acts/Propagator/Navigator.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Frustum.hpp"
+#include "Acts/Utilities/Ray.hpp"
 
+#include <algorithm>
+#include <array>
 #include <functional>
+#include <string>
 #include <utility>
 
 Acts::TrackingVolume::TrackingVolume(

--- a/Core/src/Geometry/TrackingVolumeArrayCreator.cpp
+++ b/Core/src/Geometry/TrackingVolumeArrayCreator.cpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// TrackingVolumeArrayCreator.cpp, Acts project
-///////////////////////////////////////////////////////////////////
-
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
 
 #include "Acts/Geometry/GeometryObjectSorter.hpp"
@@ -18,6 +14,9 @@
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinnedArrayXD.hpp"
 #include "Acts/Utilities/Definitions.hpp"
+
+#include <algorithm>
+#include <vector>
 
 std::shared_ptr<const Acts::TrackingVolumeArray>
 Acts::TrackingVolumeArrayCreator::trackingVolumeArray(

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -8,9 +8,10 @@
 
 #include "Acts/Geometry/TrapezoidVolumeBounds.hpp"
 
-#include "Acts/Geometry/GeometryStatics.hpp"
+#include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
 

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -12,7 +12,6 @@
 #include "Acts/Utilities/Units.hpp"
 
 #include <iostream>
-#include <utility>
 
 using namespace Acts::UnitLiterals;
 

--- a/Core/src/Utilities/BinUtility.cpp
+++ b/Core/src/Utilities/BinUtility.cpp
@@ -10,7 +10,6 @@
 
 #include <iostream>
 
-/**Overload of << operator for std::ostream for debug output*/
 std::ostream& Acts::operator<<(std::ostream& sl, const BinUtility& bgen) {
   return bgen.toStream(sl);
 }

--- a/Core/src/Utilities/CMakeLists.txt
+++ b/Core/src/Utilities/CMakeLists.txt
@@ -2,5 +2,6 @@ target_sources_local(
   ActsCore
   PRIVATE
     AnnealingUtility.cpp
+    BinUtility.cpp
     Logger.cpp
 )

--- a/Tests/UnitTests/Core/Geometry/SimpleGeometryTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SimpleGeometryTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/LayerArrayCreator.hpp"
 #include "Acts/Geometry/LayerCreator.hpp"
 #include "Acts/Geometry/PassiveLayerBuilder.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingGeometryBuilder.hpp"
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"

--- a/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Geometry/LayerArrayCreator.hpp"
 #include "Acts/Geometry/LayerCreator.hpp"
 #include "Acts/Geometry/PassiveLayerBuilder.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"


### PR DESCRIPTION
This PR is the second in a series of cleaning the include statements based on `include-what-you-use`.

It sits on top of #526.

This also moves the `BinUtility` into the right folder.