### PR TITLE
feat csv simhit writer/reader

### DIFF
--- a/Core/include/Acts/Surfaces/detail/IntersectionHelper2D.hpp
+++ b/Core/include/Acts/Surfaces/detail/IntersectionHelper2D.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <utility>
-
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Intersection.hpp"
+
+#include <utility>
 
 namespace Acts {
 namespace detail {

--- a/Core/include/Acts/Utilities/BinAdjustment.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustment.hpp
@@ -16,8 +16,6 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
-
-#include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <stdexcept>

--- a/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
@@ -16,7 +16,6 @@
 #include "Acts/Geometry/CutoutCylinderVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/Volume.hpp"
-
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 

--- a/Core/include/Acts/Utilities/MultiIndex.hpp
+++ b/Core/include/Acts/Utilities/MultiIndex.hpp
@@ -152,8 +152,8 @@ class MultiIndex {
 namespace std {
 template <typename Storage, std::size_t... BitsPerLevel>
 struct hash<Acts::MultiIndex<Storage, BitsPerLevel...>> {
-  auto operator()(Acts::MultiIndex<Storage, BitsPerLevel...> idx) const
-      noexcept {
+  auto operator()(
+      Acts::MultiIndex<Storage, BitsPerLevel...> idx) const noexcept {
     return std::hash<Storage>()(idx.value());
   }
 };

--- a/Core/include/Acts/Utilities/MultiIndex.hpp
+++ b/Core/include/Acts/Utilities/MultiIndex.hpp
@@ -152,8 +152,8 @@ class MultiIndex {
 namespace std {
 template <typename Storage, std::size_t... BitsPerLevel>
 struct hash<Acts::MultiIndex<Storage, BitsPerLevel...>> {
-  auto operator()(
-      Acts::MultiIndex<Storage, BitsPerLevel...> idx) const noexcept {
+  auto operator()(Acts::MultiIndex<Storage, BitsPerLevel...> idx) const
+      noexcept {
     return std::hash<Storage>()(idx.value());
   }
 };

--- a/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
+++ b/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
@@ -23,7 +23,7 @@ namespace hana = boost::hana;
 struct result_type_extractor {
   // Checks whether the type even has a result type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::result_type>{});
+      [](auto t) -> hana::type<typename decltype(t)::type::result_type> {});
   // meta function to extract the result type
   template <typename T>
   using extractor_impl = typename T::result_type;
@@ -38,7 +38,7 @@ struct result_type_extractor {
 struct action_type_extractor {
   // Checks if aborter even has action type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::action_type>{});
+      [](auto t) -> hana::type<typename decltype(t)::type::action_type> {});
   // meta function to extract the action type
   template <typename T>
   using extractor_impl = typename T::action_type;

--- a/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
+++ b/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
@@ -23,7 +23,7 @@ namespace hana = boost::hana;
 struct result_type_extractor {
   // Checks whether the type even has a result type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::result_type> {});
+      [](auto t) -> hana::type<typename decltype(t)::type::result_type>{});
   // meta function to extract the result type
   template <typename T>
   using extractor_impl = typename T::result_type;
@@ -38,7 +38,7 @@ struct result_type_extractor {
 struct action_type_extractor {
   // Checks if aborter even has action type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::action_type> {});
+      [](auto t) -> hana::type<typename decltype(t)::type::action_type>{});
   // meta function to extract the action type
   template <typename T>
   using extractor_impl = typename T::action_type;

--- a/Core/src/EventData/MeasurementHelpers.cpp
+++ b/Core/src/EventData/MeasurementHelpers.cpp
@@ -18,6 +18,6 @@ const Acts::Surface& Acts::MinimalSourceLink::referenceSurface() const {
 }
 
 const Acts::FittableMeasurement<Acts::MinimalSourceLink>&
-Acts::MinimalSourceLink::operator*() const {
+    Acts::MinimalSourceLink::operator*() const {
   return *meas;
 }

--- a/Core/src/EventData/MeasurementHelpers.cpp
+++ b/Core/src/EventData/MeasurementHelpers.cpp
@@ -18,6 +18,6 @@ const Acts::Surface& Acts::MinimalSourceLink::referenceSurface() const {
 }
 
 const Acts::FittableMeasurement<Acts::MinimalSourceLink>&
-    Acts::MinimalSourceLink::operator*() const {
+Acts::MinimalSourceLink::operator*() const {
   return *meas;
 }

--- a/Core/src/Surfaces/IntersectionHelper2D.cpp
+++ b/Core/src/Surfaces/IntersectionHelper2D.cpp
@@ -6,12 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
+
+#include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
+
 #include <cmath>
 #include <iostream>
 #include <tuple>
-
-#include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
-#include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
 
 Acts::Intersection2D Acts::detail::IntersectionHelper2D::intersectSegment(
     const Vector2D& s0, const Vector2D& s1, const Vector2D& origin,

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/LineSurface.hpp"
 
 #include "Acts/Utilities/ThrowAssert.hpp"
+
 #include <cmath>
 #include <utility>
 

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Utilities/Result.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsFatras/Digitization/DigitizationError.hpp"
+
 #include <climits>
 #include <cmath>
 #include <exception>

--- a/Examples/Algorithms/Geant4/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4/src/EventAction.cpp
@@ -8,12 +8,13 @@
 
 #include "EventAction.hpp"
 
+#include "ActsExamples/Geant4/PrimaryGeneratorAction.hpp"
+
 #include <stdexcept>
 
 #include <G4Event.hh>
 #include <G4RunManager.hh>
 
-#include "ActsExamples/Geant4/PrimaryGeneratorAction.hpp"
 #include "SteppingAction.hpp"
 
 using namespace ActsExamples;

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -27,8 +27,8 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
                                    std::numeric_limits<double>::max())) {}
 
-ActsExamples::SimParticleContainer ActsExamples::ParametricParticleGenerator::
-operator()(RandomEngine& rng) const {
+ActsExamples::SimParticleContainer
+ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
   using UniformIndex = std::uniform_int_distribution<unsigned int>;
   using UniformReal = std::uniform_real_distribution<double>;
 

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -27,8 +27,8 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
                                    std::numeric_limits<double>::max())) {}
 
-ActsExamples::SimParticleContainer
-ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
+ActsExamples::SimParticleContainer ActsExamples::ParametricParticleGenerator::
+operator()(RandomEngine& rng) const {
   using UniformIndex = std::uniform_int_distribution<unsigned int>;
   using UniformReal = std::uniform_real_distribution<double>;
 

--- a/Examples/Algorithms/Printers/ActsExamples/Printers/TrackParametersPrinter.cpp
+++ b/Examples/Algorithms/Printers/ActsExamples/Printers/TrackParametersPrinter.cpp
@@ -6,12 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "TrackParametersPrinter.hpp"
+
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
-
-#include "TrackParametersPrinter.hpp"
 
 ActsExamples::TrackParametersPrinter::TrackParametersPrinter(
     const Config& cfg, Acts::Logging::Level lvl)

--- a/Examples/Io/Csv/CMakeLists.txt
+++ b/Examples/Io/Csv/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
   src/CsvParticleWriter.cpp
   src/CsvPlanarClusterReader.cpp
   src/CsvPlanarClusterWriter.cpp
+  src/CsvSimHitReader.cpp
+  src/CsvSimHitWriter.cpp
   src/CsvTrackingGeometryWriter.cpp)
 target_include_directories(
   ActsExamplesIoCsv

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
@@ -1,0 +1,71 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#pragma once
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/Framework/IReader.hpp"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace Acts {
+class Surface;
+}
+
+namespace ActsExamples {
+
+/// Read in a simhit collection in comma-separated-value format.
+///
+/// This reads one files per event in the configured input directory. By default
+/// it reads file in the current working directory. Files are assumed to be
+/// named using the following schema
+///
+///     event000000001-<stem>.csv
+///     event000000002-<stem>.csv
+///
+/// and each line in the file corresponds to one hit/cluster.
+class CsvSimHitReader final : public IReader {
+ public:
+  struct Config {
+    /// Where to read input files from.
+    std::string inputDir;
+    /// Input filename stem.
+    std::string inputStem;
+    /// Output simulated (truth) hits collection.
+    std::string outputSimulatedHits;
+    /// Tracking geometry required to access global-to-local transforms.
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
+  };
+
+  /// Construct the simhit reader.
+  ///
+  /// @params cfg is the configuration object
+  /// @params lvl is the logging level
+  CsvSimHitReader(const Config& cfg, Acts::Logging::Level lvl);
+
+  std::string name() const final override;
+
+  /// Return the available events range.
+  std::pair<size_t, size_t> availableEvents() const final override;
+
+  /// Read out data from the input stream.
+  ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+ private:
+  Config m_cfg;
+  //std::unordered_map<Acts::GeometryIdentifier, const Acts::Surface*> m_surfaces;
+  std::pair<size_t, size_t> m_eventsRange;
+  std::unique_ptr<const Acts::Logger> m_logger;
+
+  const Acts::Logger& logger() const { return *m_logger; }
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryIdentifier.hpp"
-#include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/IReader.hpp"
 
@@ -25,13 +24,13 @@ namespace ActsExamples {
 /// Read in a simhit collection in comma-separated-value format.
 ///
 /// This reads one files per event in the configured input directory. By default
-/// it reads file in the current working directory. Files are assumed to be
+/// it reads files in the current working directory. Files are assumed to be
 /// named using the following schema
 ///
 ///     event000000001-<stem>.csv
 ///     event000000002-<stem>.csv
 ///
-/// and each line in the file corresponds to one hit/cluster.
+/// and each line in the file corresponds to one simhit.
 class CsvSimHitReader final : public IReader {
  public:
   struct Config {
@@ -41,8 +40,6 @@ class CsvSimHitReader final : public IReader {
     std::string inputStem;
     /// Output simulated (truth) hits collection.
     std::string outputSimulatedHits;
-    /// Tracking geometry required to access global-to-local transforms.
-    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
   };
 
   /// Construct the simhit reader.
@@ -61,7 +58,6 @@ class CsvSimHitReader final : public IReader {
 
  private:
   Config m_cfg;
-  //std::unordered_map<Acts::GeometryIdentifier, const Acts::Surface*> m_surfaces;
   std::pair<size_t, size_t> m_eventsRange;
   std::unique_ptr<const Acts::Logger> m_logger;
 

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "Acts/Plugins/Digitization/PlanarModuleCluster.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/Framework/WriterT.hpp"
 
@@ -30,7 +30,7 @@ namespace ActsExamples {
 ///     ...
 ///
 /// and each line in the file corresponds to one simhit.
-class CsvSimHitWriter final : public WriterT<SimHitContainer>> {
+class CsvSimHitWriter final : public WriterT<SimHitContainer> {
  public:
   struct Config {
     /// Which simulated (truth) hits collection to use.

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
@@ -1,0 +1,64 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017-2018 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Plugins/Digitization/PlanarModuleCluster.hpp"
+#include "ActsExamples/EventData/GeometryContainers.hpp"
+#include "ActsExamples/Framework/WriterT.hpp"
+
+#include <limits>
+#include <string>
+
+namespace ActsExamples {
+
+/// Write out a simhit collection before detector digitization in comma-
+/// separated-value format.
+///
+/// This writes one file per event containing information about the
+/// global space points, momenta (before and after interaction )and hit index
+/// into the configured output directory. By default it writes to the
+/// current working directory. Files are named using the following schema
+///
+///     event000000001-<stem>.csv
+///     event000000002-<stem>.csv
+///     ...
+///
+/// and each line in the file corresponds to one simhit.
+class CsvSimHitWriter final : public WriterT<SimHitContainer>> {
+ public:
+  struct Config {
+    /// Which simulated (truth) hits collection to use.
+    std::string inputSimulatedHits;
+    /// Where to place output files
+    std::string outputDir;
+    /// Output filename stem.
+    std::string outputStem;
+    /// Number of decimal digits for floating point precision in output.
+    size_t outputPrecision = std::numeric_limits<float>::max_digits10;
+  };
+
+  /// Construct the cluster writer.
+  ///
+  /// @params cfg is the configuration object
+  /// @params lvl is the logging level
+  CsvSimHitWriter(const Config& cfg, Acts::Logging::Level lvl);
+
+ protected:
+  /// Type-specific write implementation.
+  ///
+  /// @param[in] ctx is the algorithm context
+  /// @param[in] simHits are the simhits to be written
+  ProcessCode writeT(const AlgorithmContext& ctx,
+                     const SimHitContainer& simHits) final override;
+
+ private:
+  Config m_cfg;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/Framework/WriterT.hpp"
 
 #include <limits>
@@ -21,7 +21,7 @@ namespace ActsExamples {
 /// separated-value format.
 ///
 /// This writes one file per event containing information about the
-/// global space points, momenta (before and after interaction )and hit index
+/// global space points, momenta (before and after interaction) and hit index
 /// into the configured output directory. By default it writes to the
 /// current working directory. Files are named using the following schema
 ///

--- a/Examples/Io/Csv/src/CsvSimHitReader.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitReader.cpp
@@ -23,7 +23,8 @@ ActsExamples::CsvSimHitReader::CsvSimHitReader(
     : m_cfg(cfg)
       // TODO check that all files (hits,cells,truth) exists
       ,
-      m_eventsRange(determineEventFilesRange(cfg.inputDir, "hits.csv")),
+      m_eventsRange(
+          determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".csv")),
       m_logger(Acts::getDefaultLogger("CsvSimHitReader", lvl)) {
   if (m_cfg.inputStem.empty()) {
     throw std::invalid_argument("Missing input filename stem");

--- a/Examples/Io/Csv/src/CsvSimHitReader.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitReader.cpp
@@ -60,35 +60,35 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitReader::read(
   };
   dfe::NamedTupleCsvReader<SimHitData> reader(path, optionalColumns);
 
-  std::vector<ActsFatras::Hit> unordered;
+  SimHitContainer::sequence_type unordered;
   SimHitData data;
 
   while (reader.read(data)) {
-    const auto geometryId  = Acts::GeometryIdentifier(simhit.geometry_id);
+    const auto geometryId  = Acts::GeometryIdentifier(data.geometry_id);
     // TODO validate geo id consistency
-    const auto particleId  = ActsFatras::Barcode(simhit.particle_id);
+    const auto particleId  = ActsFatras::Barcode(data.particle_id);
 
     ActsFatras::Hit::Vector4 pos4{
-      simhit.tx * Acts::UnitConstants::mm,
-      simhit.ty * Acts::UnitConstants::mm,
-      simhit.tz * Acts::UnitConstants::mm,
-      simhit.tt * Acts::UnitConstants::ns,
+      data.tx * Acts::UnitConstants::mm,
+      data.ty * Acts::UnitConstants::mm,
+      data.tz * Acts::UnitConstants::mm,
+      data.tt * Acts::UnitConstants::ns,
     };
     ActsFatras::Hit::Vector4 mom4{
-      simhit.tpx * Acts::UnitConstants::GeV,
-      simhit.tpy * Acts::UnitConstants::GeV,
-      simhit.tpz * Acts::UnitConstants::GeV,
-      simhit.te  * Acts::UnitConstants::GeV,
+      data.tpx * Acts::UnitConstants::GeV,
+      data.tpy * Acts::UnitConstants::GeV,
+      data.tpz * Acts::UnitConstants::GeV,
+      data.te  * Acts::UnitConstants::GeV,
     };
     ActsFatras::Hit::Vector4 delta4{
-      simhit.deltapx * Acts::UnitConstants::GeV,
-      simhit.deltapy * Acts::UnitConstants::GeV,
-      simhit.deltapz * Acts::UnitConstants::GeV,
-      simhit.deltae  * Acts::UnitConstants::GeV,
+      data.deltapx * Acts::UnitConstants::GeV,
+      data.deltapy * Acts::UnitConstants::GeV,
+      data.deltapz * Acts::UnitConstants::GeV,
+      data.deltae  * Acts::UnitConstants::GeV,
     };
 
     ActsFatras::Hit hit(geometryId, particleId, pos4, mom4, mom4 + delta4,
-                        simhit.index());
+                        data.index);
     unordered.push_back(std::move(hit));
   }
 

--- a/Examples/Io/Csv/src/CsvSimHitReader.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitReader.cpp
@@ -18,11 +18,9 @@
 #include "TrackMlData.hpp"
 
 ActsExamples::CsvSimHitReader::CsvSimHitReader(
-    const ActsExamples::CsvSimHitReader::Config& cfg,
-    Acts::Logging::Level lvl)
-    : m_cfg(cfg)
+    const ActsExamples::CsvSimHitReader::Config& cfg, Acts::Logging::Level lvl)
+    : m_cfg(cfg),
       // TODO check that all files (hits,cells,truth) exists
-      ,
       m_eventsRange(
           determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".csv")),
       m_logger(Acts::getDefaultLogger("CsvSimHitReader", lvl)) {
@@ -34,24 +32,17 @@ ActsExamples::CsvSimHitReader::CsvSimHitReader(
   }
 }
 
-std::string ActsExamples::CsvSimHitReader::CsvSimHitReader::name()
-    const {
+std::string ActsExamples::CsvSimHitReader::CsvSimHitReader::name() const {
   return "CsvSimHitReader";
 }
 
-std::pair<size_t, size_t>
-ActsExamples::CsvSimHitReader::availableEvents() const {
+std::pair<size_t, size_t> ActsExamples::CsvSimHitReader::availableEvents()
+    const {
   return m_eventsRange;
 }
 
-
 ActsExamples::ProcessCode ActsExamples::CsvSimHitReader::read(
     const ActsExamples::AlgorithmContext& ctx) {
-  // geometry_id in the files is not required to be neither continuous nor
-  // monotonic. internally, we want continous indices within [0,#geoObj)
-  // to simplify data handling. to be able to perform this mapping we first
-  // read all data into memory before converting to the internal event data
-  // types.
   auto path = perEventFilepath(m_cfg.inputDir, m_cfg.inputStem + ".csv",
                                ctx.eventNumber);
   // define all optional columns
@@ -65,27 +56,27 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitReader::read(
   SimHitData data;
 
   while (reader.read(data)) {
-    const auto geometryId  = Acts::GeometryIdentifier(data.geometry_id);
+    const auto geometryId = Acts::GeometryIdentifier(data.geometry_id);
     // TODO validate geo id consistency
-    const auto particleId  = ActsFatras::Barcode(data.particle_id);
+    const auto particleId = ActsFatras::Barcode(data.particle_id);
 
     ActsFatras::Hit::Vector4 pos4{
-      data.tx * Acts::UnitConstants::mm,
-      data.ty * Acts::UnitConstants::mm,
-      data.tz * Acts::UnitConstants::mm,
-      data.tt * Acts::UnitConstants::ns,
+        data.tx * Acts::UnitConstants::mm,
+        data.ty * Acts::UnitConstants::mm,
+        data.tz * Acts::UnitConstants::mm,
+        data.tt * Acts::UnitConstants::ns,
     };
     ActsFatras::Hit::Vector4 mom4{
-      data.tpx * Acts::UnitConstants::GeV,
-      data.tpy * Acts::UnitConstants::GeV,
-      data.tpz * Acts::UnitConstants::GeV,
-      data.te  * Acts::UnitConstants::GeV,
+        data.tpx * Acts::UnitConstants::GeV,
+        data.tpy * Acts::UnitConstants::GeV,
+        data.tpz * Acts::UnitConstants::GeV,
+        data.te * Acts::UnitConstants::GeV,
     };
     ActsFatras::Hit::Vector4 delta4{
-      data.deltapx * Acts::UnitConstants::GeV,
-      data.deltapy * Acts::UnitConstants::GeV,
-      data.deltapz * Acts::UnitConstants::GeV,
-      data.deltae  * Acts::UnitConstants::GeV,
+        data.deltapx * Acts::UnitConstants::GeV,
+        data.deltapy * Acts::UnitConstants::GeV,
+        data.deltapz * Acts::UnitConstants::GeV,
+        data.deltae * Acts::UnitConstants::GeV,
     };
 
     ActsFatras::Hit hit(geometryId, particleId, pos4, mom4, mom4 + delta4,
@@ -93,7 +84,7 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitReader::read(
     unordered.push_back(std::move(hit));
   }
 
-  // write the ordered data to the EventStore
+  // write the ordered data to the EventStore (according to geometry_id).
   SimHitContainer simHits;
   simHits.adopt_sequence(std::move(unordered));
   ctx.eventStore.add(m_cfg.outputSimulatedHits, std::move(simHits));

--- a/Examples/Io/Csv/src/CsvSimHitReader.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitReader.cpp
@@ -1,0 +1,101 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+
+#include "Acts/Utilities/Units.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
+
+#include <dfe/dfe_io_dsv.hpp>
+
+#include "TrackMlData.hpp"
+
+ActsExamples::CsvSimHitReader::CsvSimHitReader(
+    const ActsExamples::CsvSimHitReader::Config& cfg,
+    Acts::Logging::Level lvl)
+    : m_cfg(cfg)
+      // TODO check that all files (hits,cells,truth) exists
+      ,
+      m_eventsRange(determineEventFilesRange(cfg.inputDir, "hits.csv")),
+      m_logger(Acts::getDefaultLogger("CsvSimHitReader", lvl)) {
+  if (m_cfg.inputStem.empty()) {
+    throw std::invalid_argument("Missing input filename stem");
+  }
+  if (m_cfg.outputSimulatedHits.empty()) {
+    throw std::invalid_argument("Missing simulated hits output collection");
+  }
+}
+
+std::string ActsExamples::CsvSimHitReader::CsvSimHitReader::name()
+    const {
+  return "CsvSimHitReader";
+}
+
+std::pair<size_t, size_t>
+ActsExamples::CsvSimHitReader::availableEvents() const {
+  return m_eventsRange;
+}
+
+
+ActsExamples::ProcessCode ActsExamples::CsvSimHitReader::read(
+    const ActsExamples::AlgorithmContext& ctx) {
+  // geometry_id in the files is not required to be neither continuous nor
+  // monotonic. internally, we want continous indices within [0,#geoObj)
+  // to simplify data handling. to be able to perform this mapping we first
+  // read all data into memory before converting to the internal event data
+  // types.
+  auto path = perEventFilepath(m_cfg.inputDir, m_cfg.inputStem + ".csv",
+                               ctx.eventNumber);
+  // define all optional columns
+  std::vector<std::string> optionalColumns = {
+      "geometry_id", "tt",      "te",     "deltapx",
+      "deltapy",     "deltapz", "deltae", "index",
+  };
+  dfe::NamedTupleCsvReader<SimHitData> reader(path, optionalColumns);
+
+  std::vector<ActsFatras::Hit> unordered;
+  SimHitData data;
+
+  while (reader.read(data)) {
+    const auto geometryId  = Acts::GeometryIdentifier(simhit.geometry_id);
+    // TODO validate geo id consistency
+    const auto particleId  = ActsFatras::Barcode(simhit.particle_id);
+
+    ActsFatras::Hit::Vector4 pos4{
+      simhit.tx * Acts::UnitConstants::mm,
+      simhit.ty * Acts::UnitConstants::mm,
+      simhit.tz * Acts::UnitConstants::mm,
+      simhit.tt * Acts::UnitConstants::ns,
+    };
+    ActsFatras::Hit::Vector4 mom4{
+      simhit.tpx * Acts::UnitConstants::GeV,
+      simhit.tpy * Acts::UnitConstants::GeV,
+      simhit.tpz * Acts::UnitConstants::GeV,
+      simhit.te  * Acts::UnitConstants::GeV,
+    };
+    ActsFatras::Hit::Vector4 delta4{
+      simhit.deltapx * Acts::UnitConstants::GeV,
+      simhit.deltapy * Acts::UnitConstants::GeV,
+      simhit.deltapz * Acts::UnitConstants::GeV,
+      simhit.deltae  * Acts::UnitConstants::GeV,
+    };
+
+    ActsFatras::Hit hit(geometryId, particleId, pos4, mom4, mom4 + delta4,
+                        simhit.index());
+    unordered.push_back(std::move(hit));
+  }
+
+  // write the ordered data to the EventStore
+  SimHitContainer simHits;
+  simHits.adopt_sequence(std::move(unordered));
+  ctx.eventStore.add(m_cfg.outputSimulatedHits, std::move(simHits));
+
+  return ActsExamples::ProcessCode::SUCCESS;
+}

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -1,0 +1,77 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Csv/CsvSimHitWriter.hpp"
+
+#include "Acts/Utilities/Units.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
+
+#include <stdexcept>
+
+#include <dfe/dfe_io_dsv.hpp>
+
+#include "TrackMlData.hpp"
+
+ActsExamples::CsvSimHitWriter::CsvSimHitWriter(
+    const ActsExamples::CsvSimHitWriter::Config& cfg,
+    Acts::Logging::Level lvl)
+    : WriterT(cfg.inputSimulatedHits, "CsvSimHitWriter", lvl), m_cfg(cfg) {
+    // inputSimHits is already checked by base constructor
+    if (m_cfg.outputStem.empty()) {
+        throw std::invalid_argument("Missing ouput filename stem");
+    }
+}
+
+ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
+    const AlgorithmContext& ctx,
+    const ActsExamples::SimHitContainer& simHits) {
+  // open per-event file for all simhit components
+  std::string pathSimHit = perEventFilepath(
+                   m_cfg.outputDir, m_cfg.outputStem + ".csv", ctx.eventNumber);
+
+  dfe::NamedTupleCsvWriter<SimHitData> writerSimHit(pathSimHit,
+                                                     m_cfg.outputPrecision);
+
+  // TrackMlData struct
+  SimHitData simhit;
+  // Write data from internal impl. to output-side struct
+  for (const auto& simHit : simHits) {
+    Acts::GeometryIdentifier geoId       = simHit.geometryId();
+    // local simhit information in global coord.
+    const Acts::Vector4D& globalPos4     = simHit.position4()
+    const Acts::Vector4& momentum4Before = simhit.momentum4Before();
+
+    simhit.geometry_id = geoId.value();
+    simhit.particle_id = simHit.particleId().value();
+    // hit position
+    simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
+    simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
+    simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
+    simhit.tt = globalPos4.time() / Acts::UnitConstants::ns;
+    // particle four-momentum before interaction
+    simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
+    simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
+    simhit.tpz = momentum4Before.z() / Acts::UnitConstants::GeV;
+    simhit.te  = momentum4Before.w() / Acts::UnitConstants::GeV;
+    // particle four-momentum change due to interaction
+    const auto delta4 = simHit.momentum4After() - momentum4Before;
+    simhit.deltapx = delta4.x() / Acts::UnitConstants::GeV;
+    simhit.deltapy = delta4.y() / Acts::UnitConstants::GeV;
+    simhit.deltapz = delta4.z() / Acts::UnitConstants::GeV;
+    simhit.deltae  = delta4.w() / Acts::UnitConstants::GeV;
+    // TODO write hit index along the particle trajectory
+    simhit.index = simHit.index();
+    writerSimHit.append(simhit);
+    } // end simHit loop
+
+  }
+
+  return ActsExamples::ProcessCode::SUCCESS;
+}

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -32,44 +32,44 @@ ActsExamples::CsvSimHitWriter::CsvSimHitWriter(
 ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
     const AlgorithmContext& ctx,
     const ActsExamples::SimHitContainer& simHits) {
-  // open per-event file for all simhit components
-  std::string pathSimHit = perEventFilepath(
+    // open per-event file for all simhit components
+    std::string pathSimHit = perEventFilepath(
                    m_cfg.outputDir, m_cfg.outputStem + ".csv", ctx.eventNumber);
 
-  dfe::NamedTupleCsvWriter<SimHitData> writerSimHit(pathSimHit,
+    dfe::NamedTupleCsvWriter<SimHitData> writerSimHit(pathSimHit,
                                                      m_cfg.outputPrecision);
 
-  // TrackMlData struct
-  SimHitData simhit;
-  // Write data from internal impl. to output-side struct
-  for (const auto& simHit : simHits) {
-    Acts::GeometryIdentifier geoId        = simHit.geometryId();
-    // local simhit information in global coord.
-    const Acts::Vector4D& globalPos4      = simHit.position4();
-    const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
+    // TrackMlData struct
+    SimHitData simhit;
+    // Write data from internal impl. to output-side struct
+    for (const auto& simHit : simHits) {
+        Acts::GeometryIdentifier geoId        = simHit.geometryId();
+        // local simhit information in global coord.
+        const Acts::Vector4D& globalPos4      = simHit.position4();
+        const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
 
-    simhit.geometry_id = geoId.value();
-    simhit.particle_id = simHit.particleId().value();
-    // hit position
-    simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
-    simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
-    simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
-    simhit.tt = globalPos4.w() / Acts::UnitConstants::ns;
-    // particle four-momentum before interaction
-    simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
-    simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
-    simhit.tpz = momentum4Before.z() / Acts::UnitConstants::GeV;
-    simhit.te  = momentum4Before.w() / Acts::UnitConstants::GeV;
-    // particle four-momentum change due to interaction
-    const auto delta4 = simHit.momentum4After() - momentum4Before;
-    simhit.deltapx = delta4.x() / Acts::UnitConstants::GeV;
-    simhit.deltapy = delta4.y() / Acts::UnitConstants::GeV;
-    simhit.deltapz = delta4.z() / Acts::UnitConstants::GeV;
-    simhit.deltae  = delta4.w() / Acts::UnitConstants::GeV;
-    // TODO write hit index along the particle trajectory
-    simhit.index = simHit.index();
-    writerSimHit.append(simhit);
+        simhit.geometry_id = geoId.value();
+        simhit.particle_id = simHit.particleId().value();
+        // hit position
+        simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
+        simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
+        simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
+        simhit.tt = globalPos4.w() / Acts::UnitConstants::ns;
+        // particle four-momentum before interaction
+        simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
+        simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
+        simhit.tpz = momentum4Before.z() / Acts::UnitConstants::GeV;
+        simhit.te  = momentum4Before.w() / Acts::UnitConstants::GeV;
+        // particle four-momentum change due to interaction
+        const auto delta4 = simHit.momentum4After() - momentum4Before;
+        simhit.deltapx = delta4.x() / Acts::UnitConstants::GeV;
+        simhit.deltapy = delta4.y() / Acts::UnitConstants::GeV;
+        simhit.deltapz = delta4.z() / Acts::UnitConstants::GeV;
+        simhit.deltae  = delta4.w() / Acts::UnitConstants::GeV;
+        // TODO write hit index along the particle trajectory
+        simhit.index = simHit.index();
+        writerSimHit.append(simhit);
     } // end simHit loop
 
-  return ActsExamples::ProcessCode::SUCCESS;
+    return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -20,56 +20,54 @@
 #include "TrackMlData.hpp"
 
 ActsExamples::CsvSimHitWriter::CsvSimHitWriter(
-    const ActsExamples::CsvSimHitWriter::Config& cfg,
-    Acts::Logging::Level lvl)
+    const ActsExamples::CsvSimHitWriter::Config& cfg, Acts::Logging::Level lvl)
     : WriterT(cfg.inputSimulatedHits, "CsvSimHitWriter", lvl), m_cfg(cfg) {
-    // inputSimHits is already checked by base constructor
-    if (m_cfg.outputStem.empty()) {
-        throw std::invalid_argument("Missing ouput filename stem");
-    }
+  // inputSimHits is already checked by base constructor
+  if (m_cfg.outputStem.empty()) {
+    throw std::invalid_argument("Missing ouput filename stem");
+  }
 }
 
 ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
-    const AlgorithmContext& ctx,
-    const ActsExamples::SimHitContainer& simHits) {
-    // open per-event file for all simhit components
-    std::string pathSimHit = perEventFilepath(
-                   m_cfg.outputDir, m_cfg.outputStem + ".csv", ctx.eventNumber);
+    const AlgorithmContext& ctx, const ActsExamples::SimHitContainer& simHits) {
+  // open per-event file for all simhit components
+  std::string pathSimHit = perEventFilepath(
+      m_cfg.outputDir, m_cfg.outputStem + ".csv", ctx.eventNumber);
 
-    dfe::NamedTupleCsvWriter<SimHitData> writerSimHit(pathSimHit,
-                                                     m_cfg.outputPrecision);
+  dfe::NamedTupleCsvWriter<SimHitData> writerSimHit(pathSimHit,
+                                                    m_cfg.outputPrecision);
 
-    // TrackMlData struct
-    SimHitData simhit;
-    // Write data from internal impl. to output-side struct
-    for (const auto& simHit : simHits) {
-        Acts::GeometryIdentifier geoId        = simHit.geometryId();
-        // local simhit information in global coord.
-        const Acts::Vector4D& globalPos4      = simHit.position4();
-        const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
+  // TrackMlData struct
+  SimHitData simhit;
+  // Write data from internal impl. to output-side struct
+  for (const auto& simHit : simHits) {
+    Acts::GeometryIdentifier geoId = simHit.geometryId();
+    // local simhit information in global coord.
+    const Acts::Vector4D& globalPos4 = simHit.position4();
+    const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
 
-        simhit.geometry_id = geoId.value();
-        simhit.particle_id = simHit.particleId().value();
-        // hit position
-        simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
-        simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
-        simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
-        simhit.tt = globalPos4.w() / Acts::UnitConstants::ns;
-        // particle four-momentum before interaction
-        simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
-        simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
-        simhit.tpz = momentum4Before.z() / Acts::UnitConstants::GeV;
-        simhit.te  = momentum4Before.w() / Acts::UnitConstants::GeV;
-        // particle four-momentum change due to interaction
-        const auto delta4 = simHit.momentum4After() - momentum4Before;
-        simhit.deltapx = delta4.x() / Acts::UnitConstants::GeV;
-        simhit.deltapy = delta4.y() / Acts::UnitConstants::GeV;
-        simhit.deltapz = delta4.z() / Acts::UnitConstants::GeV;
-        simhit.deltae  = delta4.w() / Acts::UnitConstants::GeV;
-        // TODO write hit index along the particle trajectory
-        simhit.index = simHit.index();
-        writerSimHit.append(simhit);
-    } // end simHit loop
+    simhit.geometry_id = geoId.value();
+    simhit.particle_id = simHit.particleId().value();
+    // hit position
+    simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
+    simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
+    simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
+    simhit.tt = globalPos4.w() / Acts::UnitConstants::ns;
+    // particle four-momentum before interaction
+    simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
+    simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
+    simhit.tpz = momentum4Before.z() / Acts::UnitConstants::GeV;
+    simhit.te = momentum4Before.w() / Acts::UnitConstants::GeV;
+    // particle four-momentum change due to interaction
+    const auto delta4 = simHit.momentum4After() - momentum4Before;
+    simhit.deltapx = delta4.x() / Acts::UnitConstants::GeV;
+    simhit.deltapy = delta4.y() / Acts::UnitConstants::GeV;
+    simhit.deltapz = delta4.z() / Acts::UnitConstants::GeV;
+    simhit.deltae = delta4.w() / Acts::UnitConstants::GeV;
+    // TODO write hit index along the particle trajectory
+    simhit.index = simHit.index();
+    writerSimHit.append(simhit);
+  }  // end simHit loop
 
-    return ActsExamples::ProcessCode::SUCCESS;
+  return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -43,10 +43,10 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
   SimHitData simhit;
   // Write data from internal impl. to output-side struct
   for (const auto& simHit : simHits) {
-    Acts::GeometryIdentifier geoId       = simHit.geometryId();
+    Acts::GeometryIdentifier geoId        = simHit.geometryId();
     // local simhit information in global coord.
-    const Acts::Vector4D& globalPos4     = simHit.position4()
-    const Acts::Vector4& momentum4Before = simhit.momentum4Before();
+    const Acts::Vector4D& globalPos4      = simHit.position4();
+    const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
 
     simhit.geometry_id = geoId.value();
     simhit.particle_id = simHit.particleId().value();
@@ -54,7 +54,7 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
     simhit.tx = globalPos4.x() / Acts::UnitConstants::mm;
     simhit.ty = globalPos4.y() / Acts::UnitConstants::mm;
     simhit.tz = globalPos4.z() / Acts::UnitConstants::mm;
-    simhit.tt = globalPos4.time() / Acts::UnitConstants::ns;
+    simhit.tt = globalPos4.w() / Acts::UnitConstants::ns;
     // particle four-momentum before interaction
     simhit.tpx = momentum4Before.x() / Acts::UnitConstants::GeV;
     simhit.tpy = momentum4Before.y() / Acts::UnitConstants::GeV;
@@ -70,8 +70,6 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
     simhit.index = simHit.index();
     writerSimHit.append(simhit);
     } // end simHit loop
-
-  }
 
   return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Csv/src/TrackMlData.hpp
+++ b/Examples/Io/Csv/src/TrackMlData.hpp
@@ -63,8 +63,8 @@ struct SimHitData {
   // Hit index along the trajectory. Not available in the TrackML datasets.
   int32_t index = -1;
 
-  DFE_NAMEDTUPLE(SimHitData, particle_id, geometry_id, tx, ty, tz, tt,
-                 tpx, tpy, tpz, te, deltapx, deltapy, deltapz, deltae, index);
+  DFE_NAMEDTUPLE(SimHitData, particle_id, geometry_id, tx, ty, tz, tt, tpx, tpy,
+                 tpz, te, deltapx, deltapy, deltapz, deltae, index);
 };
 
 struct TruthHitData {

--- a/Examples/Io/Csv/src/TrackMlData.hpp
+++ b/Examples/Io/Csv/src/TrackMlData.hpp
@@ -39,6 +39,34 @@ struct ParticleData {
                  vt, px, py, pz, m, q);
 };
 
+// Write out simhits before digitization (no hi_id associated)
+struct SimHitData {
+  /// Hit surface identifier. Not available in the TrackML datasets.
+  uint64_t geometry_id = 0u;
+  /// Event-unique particle identifier of the generating particle.
+  uint64_t particle_id;
+  /// True global hit position components in mm.
+  float tx, ty, tz;
+  // True global hit time in ns. Not available in the TrackML datasets.
+  float tt = 0.0f;
+  /// True particle momentum in GeV before interaction.
+  float tpx, tpy, tpz;
+  /// True particle energy in GeV before interaction.
+  /// Not available in the TrackML datasets.
+  float te = 0.0f;
+  /// True four-momentum change in GeV due to interaction.
+  /// Not available in the TrackML datasets.
+  float deltapx = 0.0f;
+  float deltapy = 0.0f;
+  float deltapz = 0.0f;
+  float deltae = 0.0f;
+  // Hit index along the trajectory. Not available in the TrackML datasets.
+  int32_t index = -1;
+
+  DFE_NAMEDTUPLE(SimHitData, particle_id, geometry_id, tx, ty, tz, tt,
+                 tpx, tpy, tpz, te, deltapx, deltapy, deltapz, deltae, index);
+};
+
 struct TruthHitData {
   /// Event-unique hit identifier. As defined for the simulated hit below and
   /// used to link back to it; same value can appear multiple times here due to

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/IReader.hpp"
+
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/ReaderAscii.h>
 

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -10,7 +10,9 @@
 
 #include "ActsExamples/Framework/WriterT.hpp"
 #include "ActsExamples/Utilities/OptionsFwd.hpp"
+
 #include <string>
+
 #include <HepMC/GenEvent.h>
 #include <HepMC3/WriterAscii.h>
 

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -7,8 +7,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
+
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
+
 #include <HepMC3/Units.h>
 
 bool ActsExamples::HepMC3AsciiReader::readEvent(HepMC3::ReaderAscii& reader,

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
+
 #include "ActsExamples/Utilities/Paths.hpp"
 
 ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config&& cfg,

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootDigitizationWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootDigitizationWriter.hpp
@@ -18,10 +18,10 @@
 #include <Acts/Utilities/Helpers.hpp>
 #include <Acts/Utilities/ParameterDefinitions.hpp>
 
-#include <TTree.h>
-
 #include <memory>
 #include <mutex>
+
+#include <TTree.h>
 
 class TFile;
 class TTree;

--- a/Examples/Io/Root/src/RootDigitizationWriter.cpp
+++ b/Examples/Io/Root/src/RootDigitizationWriter.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/Root/RootDigitizationWriter.hpp"
+
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/SimIdentifier.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -15,7 +15,6 @@
 #include "Acts/EventData/detail/TransformationBoundToFree.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Units.hpp"
-
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
 

--- a/Examples/Run/Fatras/CMakeLists.txt
+++ b/Examples/Run/Fatras/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(
 target_link_libraries(
   ActsExampleFatrasGeneric
   PRIVATE ActsExamplesFatrasCommon ActsExamplesDetectorGeneric)
-
+  
 # Generic detector with IOV based alignment
 add_executable(
   ActsExampleFatrasAligned

--- a/Examples/Run/Fatras/Common/FatrasSimulation.cpp
+++ b/Examples/Run/Fatras/Common/FatrasSimulation.cpp
@@ -23,6 +23,8 @@
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Io/Csv/CsvParticleWriter.hpp"
+#include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSimHitWriter.hpp"
 #include "ActsExamples/Io/Root/RootParticleWriter.hpp"
 #include "ActsExamples/Io/Root/RootSimHitWriter.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
@@ -152,6 +154,36 @@ void setupSimulationAlgorithms(
     writeInitial.outputStem = fatras.outputParticlesInitial;
     sequencer.addWriter(std::make_shared<ActsExamples::CsvParticleWriter>(
         writeInitial, logLevel));
+
+    //--------------------------------------------------------------------------
+    // SimHit rw test
+    //--------------------------------------------------------------------------
+
+    // write simulated hits collection
+    ActsExamples::CsvSimHitWriter::Config writeSimHits;
+    writeSimHits.inputSimulatedHits = fatras.outputHits;
+    writeSimHits.outputDir = outputDir;
+    writeSimHits.outputStem = "sim" + fatras.outputHits;
+    sequencer.addWriter(std::make_shared<ActsExamples::CsvSimHitWriter>(
+        writeSimHits, logLevel));
+
+    // read simulated hits collection
+    ActsExamples::CsvSimHitReader::Config readSimHits;
+    readSimHits.inputDir = outputDir;
+    readSimHits.inputStem = "sim" + fatras.outputHits;
+    readSimHits.outputSimulatedHits = "sim" + fatras.outputHits + "_readTest";
+    sequencer.addReader(std::make_shared<ActsExamples::CsvSimHitReader>(
+        readSimHits, logLevel));
+
+    // write simulated hits collection that was read in to disk again
+    ActsExamples::CsvSimHitWriter::Config writeSimHits_readTest;
+    writeSimHits_readTest.inputSimulatedHits = "sim" + fatras.outputHits + "_readTest";
+    writeSimHits_readTest.outputDir = outputDir;
+    writeSimHits_readTest.outputStem = "sim" + fatras.outputHits + "_readTest";
+    sequencer.addWriter(std::make_shared<ActsExamples::CsvSimHitWriter>(
+        writeSimHits_readTest, logLevel));
+
+    //--------------------------------------------------------------------------
 
     // write final simulated particles
     ActsExamples::CsvParticleWriter::Config writeFinal;

--- a/Examples/Run/Fatras/Common/FatrasSimulation.cpp
+++ b/Examples/Run/Fatras/Common/FatrasSimulation.cpp
@@ -156,7 +156,7 @@ void setupSimulationAlgorithms(
         writeInitial, logLevel));
 
     //--------------------------------------------------------------------------
-    // SimHit rw test
+    // SimHit write test
     //--------------------------------------------------------------------------
 
     // write simulated hits collection
@@ -166,24 +166,6 @@ void setupSimulationAlgorithms(
     writeSimHits.outputStem = "sim" + fatras.outputHits;
     sequencer.addWriter(std::make_shared<ActsExamples::CsvSimHitWriter>(
         writeSimHits, logLevel));
-
-    // read simulated hits collection
-    ActsExamples::CsvSimHitReader::Config readSimHits;
-    readSimHits.inputDir = outputDir;
-    readSimHits.inputStem = "sim" + fatras.outputHits;
-    readSimHits.outputSimulatedHits = "sim" + fatras.outputHits + "_readTest";
-    sequencer.addReader(std::make_shared<ActsExamples::CsvSimHitReader>(
-        readSimHits, logLevel));
-
-    // write simulated hits collection that was read in to disk again
-    ActsExamples::CsvSimHitWriter::Config writeSimHits_readTest;
-    writeSimHits_readTest.inputSimulatedHits = "sim" + fatras.outputHits + "_readTest";
-    writeSimHits_readTest.outputDir = outputDir;
-    writeSimHits_readTest.outputStem = "sim" + fatras.outputHits + "_readTest";
-    sequencer.addWriter(std::make_shared<ActsExamples::CsvSimHitWriter>(
-        writeSimHits_readTest, logLevel));
-
-    //--------------------------------------------------------------------------
 
     // write final simulated particles
     ActsExamples::CsvParticleWriter::Config writeFinal;

--- a/Examples/Run/Geant4/DD4hep/DD4hepGeantinoRecording.cpp
+++ b/Examples/Run/Geant4/DD4hep/DD4hepGeantinoRecording.cpp
@@ -10,9 +10,10 @@
 #include "ActsExamples/DD4hepDetector/DD4hepGeometryService.hpp"
 #include "ActsExamples/Geant4DD4hep/DD4hepDetectorConstruction.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
-#include "../GeantinoRecordingBase.hpp"
 
 #include <boost/program_options.hpp>
+
+#include "../GeantinoRecordingBase.hpp"
 
 using namespace ActsExamples;
 

--- a/Examples/Run/Geant4/GdmlGeantinoRecording.cpp
+++ b/Examples/Run/Geant4/GdmlGeantinoRecording.cpp
@@ -6,10 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <boost/program_options.hpp>
-
 #include "ActsExamples/Geant4/GdmlDetectorConstruction.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
+
+#include <boost/program_options.hpp>
+
 #include "GeantinoRecordingBase.hpp"
 
 using namespace ActsExamples;

--- a/Examples/Run/Geant4/GeantinoRecordingBase.hpp
+++ b/Examples/Run/Geant4/GeantinoRecordingBase.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
-
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Geant4/Geant4Options.hpp"
@@ -18,6 +16,9 @@
 #include "ActsExamples/Io/Root/RootSimHitWriter.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
+
+#include <boost/program_options.hpp>
+
 #include "G4VUserDetectorConstruction.hh"
 
 using namespace ActsExamples;

--- a/Fatras/include/ActsFatras/Digitization/detail/ParametersSmearer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/detail/ParametersSmearer.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include <utility>
-
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/ParameterDefinitions.hpp"
 #include "Acts/Utilities/Result.hpp"
+
+#include <utility>
 
 namespace ActsFatras {
 

--- a/Fatras/src/DigitizationError.cpp
+++ b/Fatras/src/DigitizationError.cpp
@@ -8,8 +8,8 @@
 
 #include "ActsFatras/Digitization/DigitizationError.hpp"
 
-const char* ActsFatras::detail::DigitizationErrorCategory::name()
-    const noexcept {
+const char* ActsFatras::detail::DigitizationErrorCategory::name() const
+    noexcept {
   return "DigitizationError";
 }
 

--- a/Fatras/src/DigitizationError.cpp
+++ b/Fatras/src/DigitizationError.cpp
@@ -8,8 +8,8 @@
 
 #include "ActsFatras/Digitization/DigitizationError.hpp"
 
-const char* ActsFatras::detail::DigitizationErrorCategory::name() const
-    noexcept {
+const char* ActsFatras::detail::DigitizationErrorCategory::name()
+    const noexcept {
   return "DigitizationError";
 }
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Kernels.cuh
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Kernels.cuh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <cuda_runtime.h>
 
 typedef struct {

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaMatrix.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaMatrix.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuMatrix.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaScalar.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaScalar.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuScalar.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaUtils.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaUtils.cu
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaVector.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaVector.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuVector.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmMatrix.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmMatrix.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuMatrix.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmScalar.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmScalar.cu
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/src/Seeding/Kernels.cu
+++ b/Plugins/Cuda/src/Seeding/Kernels.cu
@@ -8,7 +8,9 @@
 
 #include "Acts/Plugins/Cuda/Cuda.hpp"
 #include "Acts/Plugins/Cuda/Seeding/Kernels.cuh"
+
 #include <iostream>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 

--- a/Plugins/Cuda/src/Seeding2/CountDublets.cu
+++ b/Plugins/Cuda/src/Seeding2/CountDublets.cu
@@ -9,6 +9,7 @@
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Seeding2/Details/CountDublets.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 
 // CUDA include(s).

--- a/Plugins/Cuda/src/Seeding2/FindDublets.cu
+++ b/Plugins/Cuda/src/Seeding2/FindDublets.cu
@@ -9,6 +9,7 @@
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Seeding2/Details/FindDublets.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 #include "../Utilities/MatrixMacros.hpp"
 

--- a/Plugins/Cuda/src/Seeding2/FindTriplets.cu
+++ b/Plugins/Cuda/src/Seeding2/FindTriplets.cu
@@ -11,6 +11,7 @@
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/TripletFilterConfig.hpp"
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 #include "../Utilities/MatrixMacros.hpp"
 

--- a/Plugins/Cuda/src/Utilities/Arrays.cu
+++ b/Plugins/Cuda/src/Utilities/Arrays.cu
@@ -10,6 +10,7 @@
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
 #include "Acts/Plugins/Cuda/Utilities/Arrays.hpp"
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "ErrorCheck.cuh"
 #include "StreamHandlers.cuh"
 

--- a/Plugins/Cuda/src/Utilities/Info.cu
+++ b/Plugins/Cuda/src/Utilities/Info.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/Info.hpp"
+
 #include "ErrorCheck.cuh"
 
 // System include(s).

--- a/Plugins/Cuda/src/Utilities/MemoryManager.cu
+++ b/Plugins/Cuda/src/Utilities/MemoryManager.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "ErrorCheck.cuh"
 
 // CUDA include(s).

--- a/Plugins/Cuda/src/Utilities/StreamWrapper.cu
+++ b/Plugins/Cuda/src/Utilities/StreamWrapper.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/StreamWrapper.hpp"
+
 #include "ErrorCheck.cuh"
 #include "StreamHandlers.cuh"
 

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Utilities/Definitions.hpp"
 
 #include <memory>
+
 #include "RtypesCore.h"
 
 class TGeoShape;

--- a/Tests/Benchmarks/RayFrustumBenchmark.cpp
+++ b/Tests/Benchmarks/RayFrustumBenchmark.cpp
@@ -6,14 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <algorithm>
-#include <chrono>
-#include <functional>
-#include <iostream>
-#include <map>
-#include <random>
-#include <vector>
-
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Tests/CommonHelpers/BenchmarkTools.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
@@ -21,6 +13,14 @@
 #include "Acts/Utilities/Frustum.hpp"
 #include "Acts/Utilities/Ray.hpp"
 #include "Acts/Utilities/Units.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <random>
+#include <vector>
 
 using namespace Acts;
 

--- a/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+
 #include "LayerStub.hpp"
 
 using boost::test_tools::output_test_stream;

--- a/Tests/UnitTests/Core/Utilities/BinAdjustmentTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinAdjustmentTests.cpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
-
 #include "Acts/Utilities/BinAdjustment.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/Definitions.hpp"

--- a/Tests/UnitTests/Core/Utilities/BinAdjustmentVolumeTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinAdjustmentVolumeTests.cpp
@@ -11,7 +11,6 @@
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CutoutCylinderVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
-
 #include "Acts/Utilities/BinAdjustmentVolume.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/Definitions.hpp"

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
+
 #include <boost/test/unit_test.hpp>
 
-#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"

--- a/Tests/UnitTests/Plugins/Cuda/Utilities/CudaMostSimplifiedTests.cu
+++ b/Tests/UnitTests/Plugins/Cuda/Utilities/CudaMostSimplifiedTests.cu
@@ -7,7 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/unit_test.hpp>
+
 #include "Acts/Plugins/Cuda/Cuda.hpp"
+
 #include <Eigen/Dense>
 #include <cuda_profiler_api.h>
 

--- a/Tests/UnitTests/Plugins/Cuda/Utilities/CudaTests.cu
+++ b/Tests/UnitTests/Plugins/Cuda/Utilities/CudaTests.cu
@@ -7,7 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/unit_test.hpp>
+
 #include "Acts/Plugins/Cuda/Cuda.hpp"
+
 #include <Eigen/Dense>
 #include <cuda_profiler_api.h>
 


### PR DESCRIPTION
Add a dedicated simhit csv reader/writer pair in the examples, so as to be able to write out simhits before digitization and independent of clusters. In conjunction with that, add a simhit data structure in the TrackMlData to avoid setting the hit id, which becomes available only after digitization. The simhit writer was integrated in the Fatras Simulation Example for testing.
