### PR TITLE
refactor!: Simplify interface for jacobian between local and global parameters

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -96,7 +96,13 @@ class EigenStepper {
         // set the covariance transport flag to true and copy
         covTransport = true;
         cov = BoundSymMatrix(*par.covariance());
-        surface.initJacobianToGlobal(gctx, jacToGlobal, pos, dir,
+        // Construct a free parameters vector
+        FreeVector freeParams = FreeVector::Zero();
+        freeParams.head<3>() = pos;
+        freeParams(eFreeTime) = t;
+        freeParams.segment<3>(eFreeDir0) = dir;
+        freeParams(eFreeQOverP) = q / p;
+        surface.initJacobianToGlobal(gctx, jacToGlobal, freeParams,
                                      par.parameters());
       }
     }

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -102,8 +102,8 @@ class EigenStepper {
         freeParams(eFreeTime) = t;
         freeParams.segment<3>(eFreeDir0) = dir;
         freeParams(eFreeQOverP) = q / p;
-        surface.initJacobianToGlobal(gctx, jacToGlobal, freeParams,
-                                     par.parameters());
+        jacToGlobal =
+            surface.jacobianLocalToGlobal(gctx, freeParams, par.parameters());
       }
     }
 
@@ -186,8 +186,8 @@ class EigenStepper {
   ///
   /// @param [in, out] state State of the stepper
   /// @param [in] boundParams Parameters in bound parametrisation
-  /// @param [in] freeParams Parameters in free parametrisation
   /// @param [in] cov Covariance matrix
+  /// @param [in] surface The reference surface of the bound parameters
   /// @param [in] navDir Navigation direction
   /// @param [in] stepSize Step size
   void resetState(

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -96,14 +96,7 @@ class EigenStepper {
         // set the covariance transport flag to true and copy
         covTransport = true;
         cov = BoundSymMatrix(*par.covariance());
-        // Construct a free parameters vector
-        FreeVector freeParams = FreeVector::Zero();
-        freeParams.head<3>() = pos;
-        freeParams(eFreeTime) = t;
-        freeParams.segment<3>(eFreeDir0) = dir;
-        freeParams(eFreeQOverP) = q / p;
-        jacToGlobal =
-            surface.jacobianLocalToGlobal(gctx, freeParams, par.parameters());
+        jacToGlobal = surface.jacobianLocalToGlobal(gctx, par.parameters());
       }
     }
 

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -31,7 +31,7 @@ void Acts::EigenStepper<B, E, A>::resetState(State& state,
 
   // Reinitialize the stepping jacobian
   state.jacToGlobal =
-      surface.jacobianLocalToGlobal(state.geoContext, freeParams, boundParams);
+      surface.jacobianLocalToGlobal(state.geoContext, boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -20,11 +20,11 @@ void Acts::EigenStepper<B, E, A>::resetState(State& state,
                                              const Surface& surface,
                                              const NavigationDirection navDir,
                                              const double stepSize) const {
-  // Transform from bound to free parameters
-  const FreeVector freeParams = detail::transformBoundToFreeParameters(
-      surface, state.geoContext, boundParams);
   // Update the stepping state
-  update(state, freeParams, cov);
+  update(state,
+         detail::transformBoundToFreeParameters(surface, state.geoContext,
+                                                boundParams),
+         cov);
   state.navDir = navDir;
   state.stepSize = ConstrainedStep(stepSize);
   state.pathAccumulated = 0.;

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -30,8 +30,8 @@ void Acts::EigenStepper<B, E, A>::resetState(State& state,
   state.pathAccumulated = 0.;
 
   // Reinitialize the stepping jacobian
-  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, freeParams,
-                               boundParams);
+  state.jacToGlobal =
+      surface.jacobianLocalToGlobal(state.geoContext, freeParams, boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -20,18 +20,18 @@ void Acts::EigenStepper<B, E, A>::resetState(State& state,
                                              const Surface& surface,
                                              const NavigationDirection navDir,
                                              const double stepSize) const {
+  // Transform from bound to free parameters
+  const FreeVector freeParams = detail::transformBoundToFreeParameters(
+      surface, state.geoContext, boundParams);
   // Update the stepping state
-  update(state,
-         detail::transformBoundToFreeParameters(surface, state.geoContext,
-                                                boundParams),
-         cov);
+  update(state, freeParams, cov);
   state.navDir = navDir;
   state.stepSize = ConstrainedStep(stepSize);
   state.pathAccumulated = 0.;
 
   // Reinitialize the stepping jacobian
-  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal,
-                               position(state), direction(state), boundParams);
+  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, freeParams,
+                               boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -78,7 +78,13 @@ class StraightLineStepper {
         // set the covariance transport flag to true and copy
         covTransport = true;
         cov = BoundSymMatrix(*par.covariance());
-        surface.initJacobianToGlobal(gctx, jacToGlobal, pos, dir,
+        // Construct a free parameters vector
+        FreeVector freeParams = FreeVector::Zero();
+        freeParams.head<3>() = pos;
+        freeParams(eFreeTime) = t;
+        freeParams.segment<3>(eFreeDir0) = dir;
+        freeParams(eFreeQOverP) = q / p;
+        surface.initJacobianToGlobal(gctx, jacToGlobal, freeParams,
                                      par.parameters());
       }
     }

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -78,14 +78,7 @@ class StraightLineStepper {
         // set the covariance transport flag to true and copy
         covTransport = true;
         cov = BoundSymMatrix(*par.covariance());
-        // Construct a free parameters vector
-        FreeVector freeParams = FreeVector::Zero();
-        freeParams.head<3>() = pos;
-        freeParams(eFreeTime) = t;
-        freeParams.segment<3>(eFreeDir0) = dir;
-        freeParams(eFreeQOverP) = q / p;
-        jacToGlobal =
-            surface.jacobianLocalToGlobal(gctx, freeParams, par.parameters());
+        jacToGlobal = surface.jacobianLocalToGlobal(gctx, par.parameters());
       }
     }
 

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -84,8 +84,8 @@ class StraightLineStepper {
         freeParams(eFreeTime) = t;
         freeParams.segment<3>(eFreeDir0) = dir;
         freeParams(eFreeQOverP) = q / p;
-        surface.initJacobianToGlobal(gctx, jacToGlobal, freeParams,
-                                     par.parameters());
+        jacToGlobal =
+            surface.jacobianLocalToGlobal(gctx, freeParams, par.parameters());
       }
     }
 

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -39,7 +39,7 @@ namespace detail {
 /// @param [in, out] transportJacobian Global jacobian since the last reset
 /// @param [in, out] derivatives Path length derivatives of the free, nominal
 /// parameters
-/// @param [in, out] jacobianLocalToGlobal Projection jacobian of the last bound
+/// @param [in, out] jacToGlobal Projection jacobian of the last bound
 /// parametrisation to free parameters
 /// @param [in] parameters Free, nominal parametrisation
 /// @param [in] covTransport Decision whether the covariance transport should be
@@ -55,7 +55,7 @@ std::tuple<BoundTrackParameters, BoundMatrix, double> boundState(
     std::reference_wrapper<const GeometryContext> geoContext,
     BoundSymMatrix& covarianceMatrix, BoundMatrix& jacobian,
     FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacobianLocalToGlobal, const FreeVector& parameters,
+    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
     bool covTransport, double accumulatedPath, const Surface& surface);
 
 /// Create and return a curvilinear state at the current position
@@ -67,7 +67,7 @@ std::tuple<BoundTrackParameters, BoundMatrix, double> boundState(
 /// @param [in, out] transportJacobian Global jacobian since the last reset
 /// @param [in, out] derivatives Path length derivatives of the free, nominal
 /// parameters
-/// @param [in, out] jacobianLocalToGlobal Projection jacobian of the last bound
+/// @param [in, out] jacToGlobal Projection jacobian of the last bound
 /// parametrisation to free parameters
 /// @param [in] parameters Free, nominal parametrisation
 /// @param [in] covTransport Decision whether the covariance transport should be
@@ -81,7 +81,7 @@ std::tuple<BoundTrackParameters, BoundMatrix, double> boundState(
 std::tuple<CurvilinearTrackParameters, BoundMatrix, double> curvilinearState(
     BoundSymMatrix& covarianceMatrix, BoundMatrix& jacobian,
     FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacobianLocalToGlobal, const FreeVector& parameters,
+    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
     bool covTransport, double accumulatedPath);
 
 /// @brief Method for on-demand transport of the covariance to a new frame at
@@ -93,7 +93,7 @@ std::tuple<CurvilinearTrackParameters, BoundMatrix, double> curvilinearState(
 /// @param [in, out] transportJacobian Global jacobian since the last reset
 /// @param [in, out] derivatives Path length derivatives of the free, nominal
 /// parameters
-/// @param [in, out] jacobianLocalToGlobal Projection jacobian of the last bound
+/// @param [in, out] jacToGlobal Projection jacobian of the last bound
 /// parametrisation to free parameters
 /// @param [in] parameters Free, nominal parametrisation
 /// @param [in] surface is the surface to which the covariance is
@@ -103,7 +103,7 @@ void covarianceTransport(
     std::reference_wrapper<const GeometryContext> geoContext,
     BoundSymMatrix& covarianceMatrix, BoundMatrix& jacobian,
     FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacobianLocalToGlobal, const FreeVector& parameters,
+    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
     const Surface& surface);
 
 /// @brief Method for on-demand transport of the covariance to a new frame at
@@ -114,13 +114,13 @@ void covarianceTransport(
 /// @param [in, out] transportJacobian Global jacobian since the last reset
 /// @param [in, out] derivatives Path length derivatives of the free, nominal
 /// parameters
-/// @param [in, out] jacobianLocalToGlobal Projection jacobian of the last bound
+/// @param [in, out] jacToGlobal Projection jacobian of the last bound
 /// parametrisation to free parameters
 /// @param [in] direction Normalised direction vector
 void covarianceTransport(BoundSymMatrix& covarianceMatrix,
                          BoundMatrix& jacobian, FreeMatrix& transportJacobian,
                          FreeVector& derivatives,
-                         BoundToFreeMatrix& jacobianLocalToGlobal,
+                         BoundToFreeMatrix& jacToGlobal,
                          const Vector3D& direction);
 }  // namespace detail
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -208,19 +208,17 @@ class DiscSurface : public Surface {
                                   const Vector3D& position,
                                   double tol = 0.) const;
 
-  /// Initialize the jacobian from local to global
-  /// the surface knows best, hence the calculation is done here.
-  /// The jacobian is assumed to be initialised, so only the
-  /// relevant entries are filled
+  /// Calculate the jacobian from local to global which the surface knows best,
+  /// hence the calculation is done here
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian The jacobian to be initialized
   /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
-  void initJacobianToGlobal(const GeometryContext& gctx,
-                            BoundToFreeMatrix& jacobian,
-                            const FreeVector& freeParams,
-                            const BoundVector& boundParams) const final;
+  ///
+  /// @return Jacobian from local to global
+  BoundToFreeMatrix jacobianLocalToGlobal(
+      const GeometryContext& gctx, const FreeVector& freeParams,
+      const BoundVector& boundParams) const final;
 
   /// Calculate the jacobian from global to local which the surface knows best,
   /// hence the calculation is done here

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -212,13 +212,11 @@ class DiscSurface : public Surface {
   /// hence the calculation is done here
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
   ///
   /// @return Jacobian from local to global
   BoundToFreeMatrix jacobianLocalToGlobal(
-      const GeometryContext& gctx, const FreeVector& freeParams,
-      const BoundVector& boundParams) const final;
+      const GeometryContext& gctx, const BoundVector& boundParams) const final;
 
   /// Calculate the jacobian from global to local which the surface knows best,
   /// hence the calculation is done here

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -215,14 +215,12 @@ class DiscSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param jacobian The jacobian to be initialized
-  /// @param position The global position of the parameters
-  /// @param direction The direction at of the parameters
-  ///
-  /// @param pars The paranmeters vector
+  /// @param freeParams is the free parameters vector
+  /// @param boundParams is the bound parameters vector
   void initJacobianToGlobal(const GeometryContext& gctx,
                             BoundToFreeMatrix& jacobian,
-                            const Vector3D& position, const Vector3D& direction,
-                            const BoundVector& pars) const final;
+                            const FreeVector& freeParams,
+                            const BoundVector& boundParams) const final;
 
   /// Initialize the jacobian from global to local
   /// the surface knows best, hence the calculation is done here.
@@ -230,13 +228,11 @@ class DiscSurface : public Surface {
   /// relevant entries are filled
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian The jacobian to be initialized
-  /// @param position The global position of the parameters
-  /// @param direction The direction at of the parameters
+  /// @param jacobian is the jacobian to be initialized
+  /// @param parameters is the free parameters
   void initJacobianToLocal(const GeometryContext& gctx,
                            FreeToBoundMatrix& jacobian,
-                           const Vector3D& position,
-                           const Vector3D& direction) const final;
+                           const FreeVector& parameters) const final;
 
   /// Path correction due to incident of the track
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -222,17 +222,15 @@ class DiscSurface : public Surface {
                             const FreeVector& freeParams,
                             const BoundVector& boundParams) const final;
 
-  /// Initialize the jacobian from global to local
-  /// the surface knows best, hence the calculation is done here.
-  /// The jacobian is assumed to be initialised, so only the
-  /// relevant entries are filled
+  /// Calculate the jacobian from global to local which the surface knows best,
+  /// hence the calculation is done here
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian is the jacobian to be initialized
   /// @param parameters is the free parameters
-  void initJacobianToLocal(const GeometryContext& gctx,
-                           FreeToBoundMatrix& jacobian,
-                           const FreeVector& parameters) const final;
+  ///
+  /// @return Jacobian from global to local
+  FreeToBoundMatrix jacobianGlobalToLocal(
+      const GeometryContext& gctx, const FreeVector& parameters) const final;
 
   /// Path correction due to incident of the track
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -209,7 +209,7 @@ class DiscSurface : public Surface {
                                   double tol = 0.) const;
 
   /// Calculate the jacobian from local to global which the surface knows best,
-  /// hence the calculation is done here
+  /// hence the calculation is done here.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param boundParams is the bound parameters vector
@@ -219,7 +219,7 @@ class DiscSurface : public Surface {
       const GeometryContext& gctx, const BoundVector& boundParams) const final;
 
   /// Calculate the jacobian from global to local which the surface knows best,
-  /// hence the calculation is done here
+  /// hence the calculation is done here.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param parameters is the free parameters
@@ -308,5 +308,4 @@ class DiscSurface : public Surface {
 };
 
 #include "Acts/Surfaces/detail/DiscSurface.ipp"
-
 }  // end of namespace Acts

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -123,14 +123,12 @@ class LineSurface : public Surface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param jacobian is the jacobian to be initialized
-  /// @param position is the global position of the parameters
-  /// @param direction is the direction at of the parameters
-  ///
-  /// @param pars is the paranmeters vector
+  /// @param freeParams is the free parameters vector
+  /// @param boundParams is the bound parameters vector
   void initJacobianToGlobal(const GeometryContext& gctx,
                             BoundToFreeMatrix& jacobian,
-                            const Vector3D& position, const Vector3D& direction,
-                            const BoundVector& pars) const final;
+                            const FreeVector& freeParams,
+                            const BoundVector& boundParams) const final;
 
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. free parameters

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -117,7 +117,7 @@ class LineSurface : public Surface {
                                   const Vector3D& momentum) const final;
 
   /// Calculate the jacobian from local to global which the surface knows best,
-  /// hence the calculation is done here
+  /// hence the calculation is done here.
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param boundParams is the bound parameters vector

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -120,13 +120,11 @@ class LineSurface : public Surface {
   /// hence the calculation is done here
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
   ///
   /// @return Jacobian from local to global
   BoundToFreeMatrix jacobianLocalToGlobal(
-      const GeometryContext& gctx, const FreeVector& freeParams,
-      const BoundVector& boundParams) const final;
+      const GeometryContext& gctx, const BoundVector& boundParams) const final;
 
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. free parameters

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -116,19 +116,17 @@ class LineSurface : public Surface {
                                   const Vector3D& position,
                                   const Vector3D& momentum) const final;
 
-  /// Initialize the jacobian from local to global
-  /// the surface knows best, hence the calculation is done here.
-  /// The jacobian is assumed to be initialised, so only the
-  /// relevant entries are filled
+  /// Calculate the jacobian from local to global which the surface knows best,
+  /// hence the calculation is done here
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian is the jacobian to be initialized
   /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
-  void initJacobianToGlobal(const GeometryContext& gctx,
-                            BoundToFreeMatrix& jacobian,
-                            const FreeVector& freeParams,
-                            const BoundVector& boundParams) const final;
+  ///
+  /// @return Jacobian from local to global
+  BoundToFreeMatrix jacobianLocalToGlobal(
+      const GeometryContext& gctx, const FreeVector& freeParams,
+      const BoundVector& boundParams) const final;
 
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. free parameters

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -317,23 +317,21 @@ class Surface : public virtual GeometryObject,
                                                 const Vector3D& position,
                                                 const Vector3D& momentum) const;
 
-  /// Initialize the jacobian from local to global
-  /// the surface knows best, hence the calculation is done here.
-  /// The jacobian is assumed to be initialised, so only the
-  /// relevant entries are filled
+  /// Calculate the jacobian from local to global which the surface knows best,
+  /// hence the calculation is done here
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian is the jacobian to be initialized
   /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
-  virtual void initJacobianToGlobal(const GeometryContext& gctx,
-                                    BoundToFreeMatrix& jacobian,
-                                    const FreeVector& freeParams,
-                                    const BoundVector& boundParams) const;
+  ///
+  /// @return Jacobian from local to global
+  virtual BoundToFreeMatrix jacobianLocalToGlobal(
+      const GeometryContext& gctx, const FreeVector& freeParams,
+      const BoundVector& boundParams) const;
 
   /// Calculate the jacobian from global to local which the surface knows best,
   /// hence the calculation is done here

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -335,21 +335,19 @@ class Surface : public virtual GeometryObject,
                                     const FreeVector& freeParams,
                                     const BoundVector& boundParams) const;
 
-  /// Initialize the jacobian from global to local
-  /// the surface knows best, hence the calculation is done here.
-  /// The jacobian is assumed to be initialised, so only the
-  /// relevant entries are filled
+  /// Calculate the jacobian from global to local which the surface knows best,
+  /// hence the calculation is done here
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param jacobian is the jacobian to be initialized
   /// @param parameters is the free parameters
-  virtual void initJacobianToLocal(const GeometryContext& gctx,
-                                   FreeToBoundMatrix& jacobian,
-                                   const FreeVector& parameters) const;
+  ///
+  /// @return Jacobian from global to local
+  virtual FreeToBoundMatrix jacobianGlobalToLocal(
+      const GeometryContext& gctx, const FreeVector& parameters) const;
 
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. free parameters. The calculation is

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -23,7 +23,6 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
-#include "Acts/Utilities/UnitVectors.hpp"
 
 #include <memory>
 
@@ -319,7 +318,13 @@ class Surface : public virtual GeometryObject,
                                                 const Vector3D& momentum) const;
 
   /// Calculate the jacobian from local to global which the surface knows best,
-  /// hence the calculation is done here
+  /// hence the calculation is done here.
+  ///
+  /// @note In priciple, the input could also be a free parameters
+  /// vector as it could be transformed to a bound parameters. But the transform
+  /// might fail in case the parameters is not on surface. To avoid the check
+  /// inside this function, it takes directly the bound parameters as input
+  /// (then the check might be done where this function is called).
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
@@ -333,7 +338,10 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const BoundVector& boundParams) const;
 
   /// Calculate the jacobian from global to local which the surface knows best,
-  /// hence the calculation is done here
+  /// hence the calculation is done here.
+  ///
+  /// @note It assumes the input free parameters is on surface, hence no
+  /// onSurface check is done inside this function.
   ///
   /// @todo this mixes track parameterisation and geometry
   /// should move to :
@@ -493,6 +501,5 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const FreeVector& parameters) const;
 };
 
-#include "Acts/Surfaces/detail/Surface.ipp"
-
 }  // namespace Acts
+#include "Acts/Surfaces/detail/Surface.ipp"

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -24,6 +24,7 @@
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
+
 #include <memory>
 
 namespace Acts {

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -328,14 +328,12 @@ class Surface : public virtual GeometryObject,
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param jacobian is the jacobian to be initialized
-  /// @param position is the global position of the parameters
-  /// @param direction is the direction at of the parameters
-  /// @param pars is the parameter vector
+  /// @param freeParams is the free parameters vector
+  /// @param boundParams is the bound parameters vector
   virtual void initJacobianToGlobal(const GeometryContext& gctx,
                                     BoundToFreeMatrix& jacobian,
-                                    const Vector3D& position,
-                                    const Vector3D& direction,
-                                    const BoundVector& pars) const;
+                                    const FreeVector& freeParams,
+                                    const BoundVector& boundParams) const;
 
   /// Initialize the jacobian from global to local
   /// the surface knows best, hence the calculation is done here.
@@ -346,14 +344,12 @@ class Surface : public virtual GeometryObject,
   /// should move to :
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
   ///
-  /// @param jacobian is the jacobian to be initialized
-  /// @param position is the global position of the parameters
-  /// @param direction is the direction at of the parameters
   /// @param gctx The current geometry context object, e.g. alignment
+  /// @param jacobian is the jacobian to be initialized
+  /// @param parameters is the free parameters
   virtual void initJacobianToLocal(const GeometryContext& gctx,
                                    FreeToBoundMatrix& jacobian,
-                                   const Vector3D& position,
-                                   const Vector3D& direction) const;
+                                   const FreeVector& parameters) const;
 
   /// Calculate the derivative of path length at the geometry constraint or
   /// point-of-closest-approach w.r.t. free parameters. The calculation is

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -23,7 +23,7 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
-
+#include "Acts/Utilities/UnitVectors.hpp"
 #include <memory>
 
 namespace Acts {
@@ -325,13 +325,11 @@ class Surface : public virtual GeometryObject,
   /// "Acts/EventData/detail/coordinate_transformations.hpp"
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param freeParams is the free parameters vector
   /// @param boundParams is the bound parameters vector
   ///
   /// @return Jacobian from local to global
   virtual BoundToFreeMatrix jacobianLocalToGlobal(
-      const GeometryContext& gctx, const FreeVector& freeParams,
-      const BoundVector& boundParams) const;
+      const GeometryContext& gctx, const BoundVector& boundParams) const;
 
   /// Calculate the jacobian from global to local which the surface knows best,
   /// hence the calculation is done here

--- a/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/ConeSurface.ipp
@@ -90,7 +90,7 @@ inline SurfaceIntersection ConeSurface::intersect(
 inline AlignmentRowVector ConeSurface::alignmentToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global position
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center

--- a/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/CylinderSurface.ipp
@@ -115,7 +115,7 @@ inline SurfaceIntersection CylinderSurface::intersect(
 inline AlignmentRowVector CylinderSurface::alignmentToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global position
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -19,11 +19,13 @@ inline Vector2D DiscSurface::localCartesianToPolar(
                   atan2(lcart[eBoundLoc1], lcart[eBoundLoc0]));
 }
 
-inline void DiscSurface::initJacobianToGlobal(const GeometryContext& gctx,
-                                              BoundToFreeMatrix& jacobian,
-                                              const Vector3D& position,
-                                              const Vector3D& direction,
-                                              const BoundVector& pars) const {
+inline void DiscSurface::initJacobianToGlobal(
+    const GeometryContext& gctx, BoundToFreeMatrix& jacobian,
+    const FreeVector& freeParams, const BoundVector& boundParams) const {
+  // The global position
+  const auto position = freeParams.head<3>();
+  // The direction
+  const auto direction = freeParams.segment<3>(eFreeDir0);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.
@@ -44,8 +46,8 @@ inline void DiscSurface::initJacobianToGlobal(const GeometryContext& gctx,
   const auto rframe = referenceFrame(gctx, position, direction);
 
   // special polar coordinates for the Disc
-  double lrad = pars[eBoundLoc0];
-  double lphi = pars[eBoundLoc1];
+  double lrad = boundParams[eBoundLoc0];
+  double lphi = boundParams[eBoundLoc1];
   double lcos_phi = cos(lphi);
   double lsin_phi = sin(lphi);
   // the local error components - rotated from reference frame
@@ -65,12 +67,15 @@ inline void DiscSurface::initJacobianToGlobal(const GeometryContext& gctx,
   jacobian(7, eBoundQOverP) = 1;
 }
 
-inline void DiscSurface::initJacobianToLocal(const GeometryContext& gctx,
-                                             FreeToBoundMatrix& jacobian,
-                                             const Vector3D& position,
-                                             const Vector3D& direction) const {
+inline void DiscSurface::initJacobianToLocal(
+    const GeometryContext& gctx, FreeToBoundMatrix& jacobian,
+    const FreeVector& parameters) const {
   using VectorHelpers::perp;
   using VectorHelpers::phi;
+  // The global position
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // Optimized trigonometry on the propagation direction
   const double x = direction(0);  // == cos(phi) * sin(theta)
   const double y = direction(1);  // == sin(phi) * sin(theta)

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -20,12 +20,14 @@ inline Vector2D DiscSurface::localCartesianToPolar(
 }
 
 inline BoundToFreeMatrix DiscSurface::jacobianLocalToGlobal(
-    const GeometryContext& gctx, const FreeVector& freeParams,
-    const BoundVector& boundParams) const {
-  // The global position
-  const auto position = freeParams.head<3>();
-  // The direction
-  const auto direction = freeParams.segment<3>(eFreeDir0);
+    const GeometryContext& gctx, const BoundVector& boundParams) const {
+  // convert angles to global unit direction vector
+  const Vector3D direction = makeDirectionUnitFromPhiTheta(
+      boundParams[eBoundPhi], boundParams[eBoundTheta]);
+
+  // convert local position to global position vector
+  const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
+  const Vector3D position = localToGlobal(gctx, local, direction);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline Acts::Vector2D DiscSurface::localPolarToCartesian(
+inline Vector2D DiscSurface::localPolarToCartesian(
     const Vector2D& lpolar) const {
   return Vector2D(lpolar[eBoundLoc0] * cos(lpolar[eBoundLoc1]),
                   lpolar[eBoundLoc0] * sin(lpolar[eBoundLoc1]));

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -25,7 +25,7 @@ inline BoundToFreeMatrix DiscSurface::jacobianLocalToGlobal(
   FreeVector freeParams =
       detail::transformBoundToFreeParameters(*this, gctx, boundParams);
   // The global position
-  const Vector3D position = freeParams.head<3>();
+  const Vector3D position = freeParams.segment<3>(eFreePos0);
   // The direction
   const Vector3D direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
@@ -65,7 +65,7 @@ inline FreeToBoundMatrix DiscSurface::jacobianGlobalToLocal(
   using VectorHelpers::perp;
   using VectorHelpers::phi;
   // The global position
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // Optimized trigonometry on the propagation direction

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline Vector2D DiscSurface::localPolarToCartesian(
+inline Acts::Vector2D DiscSurface::localPolarToCartesian(
     const Vector2D& lpolar) const {
   return Vector2D(lpolar[eBoundLoc0] * cos(lpolar[eBoundLoc1]),
                   lpolar[eBoundLoc0] * sin(lpolar[eBoundLoc1]));
@@ -21,12 +21,13 @@ inline Vector2D DiscSurface::localCartesianToPolar(
 
 inline BoundToFreeMatrix DiscSurface::jacobianLocalToGlobal(
     const GeometryContext& gctx, const BoundVector& boundParams) const {
-  // Convert angles to global unit direction vector
-  const Vector3D direction = makeDirectionUnitFromPhiTheta(
-      boundParams[eBoundPhi], boundParams[eBoundTheta]);
-  // Convert local position to global position vector
-  const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
-  const Vector3D position = localToGlobal(gctx, local, direction);
+  // Transform from bound to free parameters
+  FreeVector freeParams =
+      detail::transformBoundToFreeParameters(*this, gctx, boundParams);
+  // The global position
+  const Vector3D position = freeParams.head<3>();
+  // The direction
+  const Vector3D direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
   const double cos_theta = std::cos(boundParams[eBoundTheta]);
   const double sin_theta = std::sin(boundParams[eBoundTheta]);

--- a/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/DiscSurface.ipp
@@ -21,29 +21,17 @@ inline Vector2D DiscSurface::localCartesianToPolar(
 
 inline BoundToFreeMatrix DiscSurface::jacobianLocalToGlobal(
     const GeometryContext& gctx, const BoundVector& boundParams) const {
-  // convert angles to global unit direction vector
+  // Convert angles to global unit direction vector
   const Vector3D direction = makeDirectionUnitFromPhiTheta(
       boundParams[eBoundPhi], boundParams[eBoundTheta]);
-
-  // convert local position to global position vector
+  // Convert local position to global position vector
   const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
   const Vector3D position = localToGlobal(gctx, local, direction);
-  // The trigonometry required to convert the direction to spherical
-  // coordinates and then compute the sines and cosines again can be
-  // surprisingly expensive from a performance point of view.
-  //
-  // Here, we can avoid it because the direction is by definition a unit
-  // vector, with the following coordinate conversions...
-  const double x = direction(0);  // == cos(phi) * sin(theta)
-  const double y = direction(1);  // == sin(phi) * sin(theta)
-  const double z = direction(2);  // == cos(theta)
-
-  // ...which we can invert to directly get the sines and cosines:
-  const double cos_theta = z;
-  const double sin_theta = sqrt(x * x + y * y);
-  const double inv_sin_theta = 1. / sin_theta;
-  const double cos_phi = x * inv_sin_theta;
-  const double sin_phi = y * inv_sin_theta;
+  // Get the sines and cosines directly
+  const double cos_theta = std::cos(boundParams[eBoundTheta]);
+  const double sin_theta = std::sin(boundParams[eBoundTheta]);
+  const double cos_phi = std::cos(boundParams[eBoundPhi]);
+  const double sin_phi = std::sin(boundParams[eBoundPhi]);
   // special polar coordinates for the Disc
   double lrad = boundParams[eBoundLoc0];
   double lphi = boundParams[eBoundLoc1];

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -131,12 +131,13 @@ inline SurfaceIntersection LineSurface::intersect(
 }
 
 inline BoundToFreeMatrix LineSurface::jacobianLocalToGlobal(
-    const GeometryContext& gctx, const FreeVector& freeParams,
-    const BoundVector& boundParams) const {
-  // The global position
-  const auto position = freeParams.head<3>();
-  // The direction
-  const auto direction = freeParams.segment<3>(eFreeDir0);
+    const GeometryContext& gctx, const BoundVector& boundParams) const {
+  // convert angles to global unit direction vector
+  const Vector3D direction = makeDirectionUnitFromPhiTheta(
+      boundParams[eBoundPhi], boundParams[eBoundTheta]);
+  // convert local position to global position vector
+  const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
+  const Vector3D position = localToGlobal(gctx, local, direction);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -132,12 +132,13 @@ inline SurfaceIntersection LineSurface::intersect(
 
 inline BoundToFreeMatrix LineSurface::jacobianLocalToGlobal(
     const GeometryContext& gctx, const BoundVector& boundParams) const {
-  // Convert angles to global unit direction vector
-  const Vector3D direction = makeDirectionUnitFromPhiTheta(
-      boundParams[eBoundPhi], boundParams[eBoundTheta]);
-  // Convert local position to global position vector
-  const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
-  const Vector3D position = localToGlobal(gctx, local, direction);
+  // Transform from bound to free parameters
+  FreeVector freeParams =
+      detail::transformBoundToFreeParameters(*this, gctx, boundParams);
+  // The global position
+  const Vector3D position = freeParams.head<3>();
+  // The direction
+  const Vector3D direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
   const double cos_theta = std::cos(boundParams[eBoundTheta]);
   const double sin_theta = std::sin(boundParams[eBoundTheta]);

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -130,11 +130,13 @@ inline SurfaceIntersection LineSurface::intersect(
           this};
 }
 
-inline void LineSurface::initJacobianToGlobal(const GeometryContext& gctx,
-                                              BoundToFreeMatrix& jacobian,
-                                              const Vector3D& position,
-                                              const Vector3D& direction,
-                                              const BoundVector& pars) const {
+inline void LineSurface::initJacobianToGlobal(
+    const GeometryContext& gctx, BoundToFreeMatrix& jacobian,
+    const FreeVector& freeParams, const BoundVector& boundParams) const {
+  // The global position
+  const auto position = freeParams.head<3>();
+  // The direction
+  const auto direction = freeParams.segment<3>(eFreeDir0);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.
@@ -178,8 +180,9 @@ inline void LineSurface::initJacobianToGlobal(const GeometryContext& gctx,
   dDThetaY -=
       rframe.block<3, 1>(0, 0) * (rframe.block<3, 1>(0, 0).dot(dDThetaY));
   // set the jacobian components for global d/ phi/Theta
-  jacobian.block<3, 1>(0, eBoundPhi) = dDPhiY * pars[eBoundLoc0] * ipdn;
-  jacobian.block<3, 1>(0, eBoundTheta) = dDThetaY * pars[eBoundLoc0] * ipdn;
+  jacobian.block<3, 1>(0, eBoundPhi) = dDPhiY * boundParams[eBoundLoc0] * ipdn;
+  jacobian.block<3, 1>(0, eBoundTheta) =
+      dDThetaY * boundParams[eBoundLoc0] * ipdn;
 }
 
 inline FreeRowVector LineSurface::freeToPathDerivative(

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -132,28 +132,17 @@ inline SurfaceIntersection LineSurface::intersect(
 
 inline BoundToFreeMatrix LineSurface::jacobianLocalToGlobal(
     const GeometryContext& gctx, const BoundVector& boundParams) const {
-  // convert angles to global unit direction vector
+  // Convert angles to global unit direction vector
   const Vector3D direction = makeDirectionUnitFromPhiTheta(
       boundParams[eBoundPhi], boundParams[eBoundTheta]);
-  // convert local position to global position vector
+  // Convert local position to global position vector
   const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
   const Vector3D position = localToGlobal(gctx, local, direction);
-  // The trigonometry required to convert the direction to spherical
-  // coordinates and then compute the sines and cosines again can be
-  // surprisingly expensive from a performance point of view.
-  //
-  // Here, we can avoid it because the direction is by definition a unit
-  // vector, with the following coordinate conversions...
-  const double x = direction(0);  // == cos(phi) * sin(theta)
-  const double y = direction(1);  // == sin(phi) * sin(theta)
-  const double z = direction(2);  // == cos(theta)
-
-  // ...which we can invert to directly get the sines and cosines:
-  const double cos_theta = z;
-  const double sin_theta = sqrt(x * x + y * y);
-  const double inv_sin_theta = 1. / sin_theta;
-  const double cos_phi = x * inv_sin_theta;
-  const double sin_phi = y * inv_sin_theta;
+  // Get the sines and cosines directly
+  const double cos_theta = std::cos(boundParams[eBoundTheta]);
+  const double sin_theta = std::sin(boundParams[eBoundTheta]);
+  const double cos_phi = std::cos(boundParams[eBoundPhi]);
+  const double sin_phi = std::sin(boundParams[eBoundPhi]);
   // retrieve the reference frame
   const auto rframe = referenceFrame(gctx, position, direction);
   // Initialize the jacobian from local to global

--- a/Core/include/Acts/Surfaces/detail/LineSurface.ipp
+++ b/Core/include/Acts/Surfaces/detail/LineSurface.ipp
@@ -136,7 +136,7 @@ inline BoundToFreeMatrix LineSurface::jacobianLocalToGlobal(
   FreeVector freeParams =
       detail::transformBoundToFreeParameters(*this, gctx, boundParams);
   // The global position
-  const Vector3D position = freeParams.head<3>();
+  const Vector3D position = freeParams.segment<3>(eFreePos0);
   // The direction
   const Vector3D direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
@@ -183,7 +183,7 @@ inline BoundToFreeMatrix LineSurface::jacobianLocalToGlobal(
 inline FreeRowVector LineSurface::freeToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global posiiton
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center
@@ -213,7 +213,7 @@ inline FreeRowVector LineSurface::freeToPathDerivative(
 inline AlignmentRowVector LineSurface::alignmentToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global posiiton
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -36,11 +36,13 @@ inline RotationMatrix3D Surface::referenceFrame(
   return transform(gctx).matrix().block<3, 3>(0, 0);
 }
 
-inline void Surface::initJacobianToGlobal(const GeometryContext& gctx,
-                                          BoundToFreeMatrix& jacobian,
-                                          const Vector3D& position,
-                                          const Vector3D& direction,
-                                          const BoundVector& /*pars*/) const {
+inline void Surface::initJacobianToGlobal(
+    const GeometryContext& gctx, BoundToFreeMatrix& jacobian,
+    const FreeVector& freeParams, const BoundVector& /*boundParams*/) const {
+  // The global position
+  const auto position = freeParams.head<3>();
+  // The direction
+  const auto direction = freeParams.segment<3>(eFreeDir0);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.
@@ -74,8 +76,11 @@ inline void Surface::initJacobianToGlobal(const GeometryContext& gctx,
 
 inline void Surface::initJacobianToLocal(const GeometryContext& gctx,
                                          FreeToBoundMatrix& jacobian,
-                                         const Vector3D& position,
-                                         const Vector3D& direction) const {
+                                         const FreeVector& parameters) const {
+  // The global position
+  const auto position = parameters.head<3>();
+  // The direction
+  const auto direction = parameters.segment<3>(eFreeDir0);
   // Optimized trigonometry on the propagation direction
   const double x = direction(0);  // == cos(phi) * sin(theta)
   const double y = direction(1);  // == sin(phi) * sin(theta)

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -37,12 +37,14 @@ inline RotationMatrix3D Surface::referenceFrame(
 }
 
 inline BoundToFreeMatrix Surface::jacobianLocalToGlobal(
-    const GeometryContext& gctx, const FreeVector& freeParams,
-    const BoundVector& /*boundParams*/) const {
-  // The global position
-  const auto position = freeParams.head<3>();
-  // The direction
-  const auto direction = freeParams.segment<3>(eFreeDir0);
+    const GeometryContext& gctx, const BoundVector& boundParams) const {
+  // convert angles to global unit direction vector
+  const Vector3D direction = makeDirectionUnitFromPhiTheta(
+      boundParams[eBoundPhi], boundParams[eBoundTheta]);
+
+  // convert local position to global position vector
+  const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
+  const Vector3D position = localToGlobal(gctx, local, direction);
   // The trigonometry required to convert the direction to spherical
   // coordinates and then compute the sines and cosines again can be
   // surprisingly expensive from a performance point of view.

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -44,7 +44,7 @@ inline Acts::BoundToFreeMatrix Acts::Surface::jacobianLocalToGlobal(
   FreeVector freeParams =
       detail::transformBoundToFreeParameters(*this, gctx, boundParams);
   // The global position
-  const Vector3D position = freeParams.head<3>();
+  const Vector3D position = freeParams.segment<3>(eFreePos0);
   // The direction
   const Vector3D direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
@@ -73,7 +73,7 @@ inline Acts::BoundToFreeMatrix Acts::Surface::jacobianLocalToGlobal(
 inline Acts::FreeToBoundMatrix Acts::Surface::jacobianGlobalToLocal(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global position
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // Optimized trigonometry on the propagation direction
@@ -108,7 +108,7 @@ inline Acts::FreeToBoundMatrix Acts::Surface::jacobianGlobalToLocal(
 inline Acts::FreeRowVector Acts::Surface::freeToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global position
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The measurement frame of the surface
@@ -119,7 +119,7 @@ inline Acts::FreeRowVector Acts::Surface::freeToPathDerivative(
   const double dz = refZAxis.dot(direction);
   // Initialize the derivative
   FreeRowVector freeToPath = FreeRowVector::Zero();
-  freeToPath.head<3>() = -1.0 * refZAxis.transpose() / dz;
+  freeToPath.segment<3>(eFreePos0) = -1.0 * refZAxis.transpose() / dz;
   return freeToPath;
 }
 

--- a/Core/include/Acts/Surfaces/detail/Surface.ipp
+++ b/Core/include/Acts/Surfaces/detail/Surface.ipp
@@ -38,29 +38,17 @@ inline RotationMatrix3D Surface::referenceFrame(
 
 inline BoundToFreeMatrix Surface::jacobianLocalToGlobal(
     const GeometryContext& gctx, const BoundVector& boundParams) const {
-  // convert angles to global unit direction vector
+  // Convert angles to global unit direction vector
   const Vector3D direction = makeDirectionUnitFromPhiTheta(
       boundParams[eBoundPhi], boundParams[eBoundTheta]);
-
-  // convert local position to global position vector
+  // Convert local position to global position vector
   const Vector2D local(boundParams[eBoundLoc0], boundParams[eBoundLoc1]);
   const Vector3D position = localToGlobal(gctx, local, direction);
-  // The trigonometry required to convert the direction to spherical
-  // coordinates and then compute the sines and cosines again can be
-  // surprisingly expensive from a performance point of view.
-  //
-  // Here, we can avoid it because the direction is by definition a unit
-  // vector, with the following coordinate conversions...
-  const double x = direction(0);  // == cos(phi) * sin(theta)
-  const double y = direction(1);  // == sin(phi) * sin(theta)
-  const double z = direction(2);  // == cos(theta)
-
-  // ...which we can invert to directly get the sines and cosines:
-  const double cos_theta = z;
-  const double sin_theta = sqrt(x * x + y * y);
-  const double inv_sin_theta = 1. / sin_theta;
-  const double cos_phi = x * inv_sin_theta;
-  const double sin_phi = y * inv_sin_theta;
+  // Get the sines and cosines directly
+  const double cos_theta = std::cos(boundParams[eBoundTheta]);
+  const double sin_theta = std::sin(boundParams[eBoundTheta]);
+  const double cos_phi = std::cos(boundParams[eBoundPhi]);
+  const double sin_phi = std::sin(boundParams[eBoundPhi]);
   // retrieve the reference frame
   const auto rframe = referenceFrame(gctx, position, direction);
   // Initialize the jacobian from local to global

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -104,7 +104,7 @@ void StraightLineStepper::resetState(State& state,
 
   // Reinitialize the stepping jacobian
   state.jacToGlobal =
-      surface.jacobianLocalToGlobal(state.geoContext, freeParams, boundParams);
+      surface.jacobianLocalToGlobal(state.geoContext, boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -103,8 +103,8 @@ void StraightLineStepper::resetState(State& state,
   state.pathAccumulated = 0.;
 
   // Reinitialize the stepping jacobian
-  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, freeParams,
-                               boundParams);
+  state.jacToGlobal =
+      surface.jacobianLocalToGlobal(state.geoContext, freeParams, boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -93,18 +93,18 @@ void StraightLineStepper::resetState(State& state,
                                      const Surface& surface,
                                      const NavigationDirection navDir,
                                      const double stepSize) const {
+  // Transform from bound to free parameters
+  const FreeVector freeParams = detail::transformBoundToFreeParameters(
+      surface, state.geoContext, boundParams);
   // Update the stepping state
-  update(state,
-         detail::transformBoundToFreeParameters(surface, state.geoContext,
-                                                boundParams),
-         cov);
+  update(state, freeParams, cov);
   state.navDir = navDir;
   state.stepSize = ConstrainedStep(stepSize);
   state.pathAccumulated = 0.;
 
   // Reinitialize the stepping jacobian
-  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal,
-                               position(state), direction(state), boundParams);
+  surface.initJacobianToGlobal(state.geoContext, state.jacToGlobal, freeParams,
+                               boundParams);
   state.jacobian = BoundMatrix::Identity();
   state.jacTransport = FreeMatrix::Identity();
   state.derivative = FreeVector::Zero();

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -93,11 +93,11 @@ void StraightLineStepper::resetState(State& state,
                                      const Surface& surface,
                                      const NavigationDirection navDir,
                                      const double stepSize) const {
-  // Transform from bound to free parameters
-  const FreeVector freeParams = detail::transformBoundToFreeParameters(
-      surface, state.geoContext, boundParams);
   // Update the stepping state
-  update(state, freeParams, cov);
+  update(state,
+         detail::transformBoundToFreeParameters(surface, state.geoContext,
+                                                ￼ boundParams),
+         cov);
   state.navDir = navDir;
   state.stepSize = ConstrainedStep(stepSize);
   state.pathAccumulated = 0.;

--- a/Core/src/Propagator/StraightLineStepper.cpp
+++ b/Core/src/Propagator/StraightLineStepper.cpp
@@ -96,7 +96,7 @@ void StraightLineStepper::resetState(State& state,
   // Update the stepping state
   update(state,
          detail::transformBoundToFreeParameters(surface, state.geoContext,
-                                                ￼ boundParams),
+                                                boundParams),
          cov);
   state.navDir = navDir;
   state.stepSize = ConstrainedStep(stepSize);

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -97,9 +97,11 @@ FreeToBoundMatrix surfaceDerivative(
   surface.initJacobianToLocal(geoContext, jacToLocal,
                               parameters.segment<3>(eFreePos0),
                               parameters.segment<3>(eFreeDir0));
-  // Calculate the form factors for the derivatives
+  // Calculate the derivative of path length at the the bound parameters
+  // reference surface or the point-of-closest approach w.r.t. free parameters
   const FreeRowVector freeToPath =
       surface.freeToPathDerivative(geoContext, parameters);
+  // Correction to the local to global jacobian
   jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Return the jacobian to local
   return jacToLocal;
@@ -125,11 +127,12 @@ FreeToBoundMatrix surfaceDerivative(
 const FreeToBoundMatrix surfaceDerivative(
     const Vector3D& direction, BoundToFreeMatrix& jacobianLocalToGlobal,
     const FreeVector& derivatives) {
-  // Transport the covariance
-  const ActsRowVectorD<3> normVec(direction);
-  const BoundRowVector sfactors =
-      normVec * jacobianLocalToGlobal.template topLeftCorner<3, eBoundSize>();
-  jacobianLocalToGlobal -= derivatives * sfactors;
+  // Calculate the derivative of path length at the the curvilinear parameters
+  // reference surface w.r.t. free parameters
+  FreeRowVector freeToPath = FreeRowVector::Zero();
+  freeToPath.head<3>() = -1.0 * direction;
+  // Correction to the local to global jacobian
+  jacobianLocalToGlobal += derivatives * freeToPath * jacobianLocalToGlobal;
   // Since the jacobian to local needs to calculated for the bound parameters
   // here, it is convenient to do the same here
   return freeToCurvilinearJacobian(direction);

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -141,7 +141,7 @@ void jacobianLocalToLocal(const Vector3D& direction,
   // Calculate the derivative of path length at the the curvilinear surface
   // w.r.t. free parameters
   FreeRowVector freeToPath = FreeRowVector::Zero();
-  freeToPath.head<3>() = -1.0 * direction;
+  freeToPath.segment<3>(eFreePos0) = -1.0 * direction;
   // Calculate the jacobian from global to local at the curvilinear surface
   FreeToBoundMatrix jacToLocal = freeToCurvilinearJacobian(direction);
   // Calculate the full jocobian from the local parameters at the start surface

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -256,8 +256,8 @@ BoundState boundState(std::reference_wrapper<const GeometryContext> geoContext,
     // Then reinitialize the transportJacobian, derivatives and the
     // jacToGlobal
     covarianceTransport(geoContext, covarianceMatrix, jacobian,
-                        transportJacobian, derivatives, jacToGlobal,
-                        parameters, surface);
+                        transportJacobian, derivatives, jacToGlobal, parameters,
+                        surface);
   }
   if (covarianceMatrix != BoundSymMatrix::Zero()) {
     cov = covarianceMatrix;

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -101,14 +101,13 @@ void localToLocalJacobian(
   // point-of-closest approach w.r.t. free parameters
   const FreeRowVector freeToPath =
       surface.freeToPathDerivative(geoContext, parameters);
-  // Initalize the jacobian from global to local at the final surface
-  FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
   // Calculate the jacobian from global to local at the final surface
-  surface.initJacobianToLocal(geoContext, jacToLocal, parameters);
+  FreeToBoundMatrix jacToLocal =
+      surface.jacobianGlobalToLocal(geoContext, parameters);
   // Calculate the full jocobian from the local parameters at the start surface
   // to local parameters at the final surface
   // @note jac(locA->locB) = jac(gloB->locB)*(1+
-  // pathCorrectionFactor(gloB))*transportJac(gloA->gloB) *jac(locA->gloA)
+  // pathCorrectionFactor(gloB))*jacTransport(gloA->gloB) *jac(locA->gloA)
   jacFull = jacToLocal * (FreeMatrix::Identity() + derivatives * freeToPath) *
             transportJacobian * jacobianLocalToGlobal;
 }
@@ -148,7 +147,7 @@ void localToLocalJacobian(const Vector3D& direction,
   // Calculate the full jocobian from the local parameters at the start surface
   // to curvilinear parameters
   // @note jac(locA->locB) = jac(gloB->locB)*(1+
-  // pathCorrectionFactor(gloB))*transportJac(gloA->gloB) *jac(locA->gloA)
+  // pathCorrectionFactor(gloB))*jacTransport(gloA->gloB) *jac(locA->gloA)
   jacFull = jacToLocal * (FreeMatrix::Identity() + derivatives * freeToPath) *
             transportJacobian * jacobianLocalToGlobal;
 }

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -74,7 +74,7 @@ FreeToBoundMatrix freeToCurvilinearJacobian(const Vector3D& direction) {
 /// @brief This function calculates the full jacobian from local parameters at
 /// the start surface to bound parameters at the final surface
 ///
-// @note Modifications of the jacobian related to the
+/// @note Modifications of the jacobian related to the
 /// projection onto a surface is considered. Since a variation of the start
 /// parameters within a given uncertainty would lead to a variation of the end
 /// parameters, these need to be propagated onto the target surface. This an
@@ -186,7 +186,7 @@ void reinitializeJacobians(
     ACTS_FATAL(
         "Inconsistency in global to local transformation during propagation.")
   }
-  // Transform from free to bound parameters 
+  // Transform from free to bound parameters
   BoundVector boundParams =
       detail::transformFreeToBoundParameters(freeParams, surface, geoContext);
   // Reset the jacobian from local to global

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -186,7 +186,7 @@ void reinitializeJacobians(
     ACTS_FATAL(
         "Inconsistency in global to local transformation during propagation.")
   }
-  // Construct a bound parameters
+  // Transform from free to bound parameters 
   BoundVector boundParams =
       detail::transformFreeToBoundParameters(freeParams, surface, geoContext);
   // Reset the jacobian from local to global

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -193,7 +193,7 @@ void reinitializeJacobians(
       theta(direction), freeParams[eFreeQOverP], freeParams[eFreeTime];
   // Reset the jacobian from local to global
   jacobianLocalToGlobal =
-      surface.jacobianLocalToGlobal(geoContext, freeParams, boundParams);
+      surface.jacobianLocalToGlobal(geoContext, boundParams);
 }
 
 /// @brief This function reinitialises the state members required for the

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -186,7 +186,6 @@ void reinitializeJacobians(
     ACTS_FATAL(
         "Inconsistency in global to local transformation during propagation.")
   }
-  auto loc = lpResult.value();
   // Construct a bound parameters
   BoundVector boundParams =
       detail::transformFreeToBoundParameters(freeParams, surface, geoContext);

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Propagator/detail/CovarianceEngine.hpp"
 
 #include "Acts/EventData/detail/TransformationBoundToFree.hpp"
+#include "Acts/EventData/detail/TransformationFreeToBound.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 
@@ -187,9 +188,8 @@ void reinitializeJacobians(
   }
   auto loc = lpResult.value();
   // Construct a bound parameters
-  BoundVector boundParams;
-  boundParams << loc[eBoundLoc0], loc[eBoundLoc1], phi(direction),
-      theta(direction), freeParams[eFreeQOverP], freeParams[eFreeTime];
+  BoundVector boundParams =
+      detail::transformFreeToBoundParameters(freeParams, surface, geoContext);
   // Reset the jacobian from local to global
   jacToGlobal = surface.jacobianLocalToGlobal(geoContext, boundParams);
 }

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -50,10 +50,6 @@ bool Acts::Surface::isOnSurface(const GeometryContext& gctx,
 Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
     const GeometryContext& gctx, const FreeVector& parameters,
     const FreeVector& pathDerivative) const {
-  // The global posiiton
-  const auto position = parameters.head<3>();
-  // The direction
-  const auto direction = parameters.segment<3>(eFreeDir0);
   // 1) Calculate the derivative of bound parameter local position w.r.t.
   // alignment parameters without path length correction
   const auto alignToBoundWithoutCorrection =
@@ -62,7 +58,7 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   const auto alignToPath = alignmentToPathDerivative(gctx, parameters);
   // 3) Calculate the jacobian from free parameters to bound parameters
   FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
-  initJacobianToLocal(gctx, jacToLocal, position, direction);
+  initJacobianToLocal(gctx, jacToLocal, parameters);
   // 4) The derivative of bound parameters w.r.t. alignment
   // parameters is alignToBoundWithoutCorrection +
   // jacToLocal*pathDerivative*alignToPath

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -57,13 +57,12 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   // 2) Calculate the derivative of path length w.r.t. alignment parameters
   const auto alignToPath = alignmentToPathDerivative(gctx, parameters);
   // 3) Calculate the jacobian from free parameters to bound parameters
-  FreeToBoundMatrix jacGlobalToLocal = jacobianGlobalToLocal(gctx, parameters);
+  FreeToBoundMatrix jacToLocal = jacobianGlobalToLocal(gctx, parameters);
   // 4) The derivative of bound parameters w.r.t. alignment
   // parameters is alignToBoundWithoutCorrection +
   // jacToLocal*pathDerivative*alignToPath
   AlignmentToBoundMatrix alignToBound =
-      alignToBoundWithoutCorrection +
-      jacGlobalToLocal * pathDerivative * alignToPath;
+      alignToBoundWithoutCorrection + jacToLocal * pathDerivative * alignToPath;
 
   return alignToBound;
 }

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -112,7 +112,7 @@ Acts::Surface::alignmentToBoundDerivativeWithoutCorrection(
 Acts::AlignmentRowVector Acts::Surface::alignmentToPathDerivative(
     const GeometryContext& gctx, const FreeVector& parameters) const {
   // The global posiiton
-  const auto position = parameters.head<3>();
+  const auto position = parameters.segment<3>(eFreePos0);
   // The direction
   const auto direction = parameters.segment<3>(eFreeDir0);
   // The vector between position and center

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -57,13 +57,13 @@ Acts::AlignmentToBoundMatrix Acts::Surface::alignmentToBoundDerivative(
   // 2) Calculate the derivative of path length w.r.t. alignment parameters
   const auto alignToPath = alignmentToPathDerivative(gctx, parameters);
   // 3) Calculate the jacobian from free parameters to bound parameters
-  FreeToBoundMatrix jacToLocal = FreeToBoundMatrix::Zero();
-  initJacobianToLocal(gctx, jacToLocal, parameters);
+  FreeToBoundMatrix jacGlobalToLocal = jacobianGlobalToLocal(gctx, parameters);
   // 4) The derivative of bound parameters w.r.t. alignment
   // parameters is alignToBoundWithoutCorrection +
   // jacToLocal*pathDerivative*alignToPath
   AlignmentToBoundMatrix alignToBound =
-      alignToBoundWithoutCorrection + jacToLocal * pathDerivative * alignToPath;
+      alignToBoundWithoutCorrection +
+      jacGlobalToLocal * pathDerivative * alignToPath;
 
   return alignToBound;
 }


### PR DESCRIPTION
BREAKING CHANGE: This PR simplifies the calculation within the `covarianceTransport` by changing the `surfaceDerivative` method to `localToLocalJacobian` which packs up the calculation for the full jacobian from local parameters at start surface to local parameters at the final surface. Among the `localToLocalJacobian` input parameters, only the `jacFull` is updated. Reinitializations of other jacobians are done separately within the `covarianceTransport`. In this way, how different jacobians are updated with each `covarianceTransport` is more clear.

This PR also packs the global `position` and `direction` to a `FreeVector` as the input parameter of `initJacobianToLocal` and `initJacobianToGlobal`. This could make the interfaces for jacobian/derivative calculation more consistent.