### PR TITLE
fix(examples): Missing digitization output collections

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -29,10 +29,10 @@ ActsExamples::CKFPerformanceWriter::CKFPerformanceWriter(
       m_duplicationPlotTool(m_cfg.duplicationPlotToolConfig, lvl),
       m_trackSummaryPlotTool(m_cfg.trackSummaryPlotToolConfig, lvl) {
   // trajectories collection name is already checked by base ctor
-  if (cfg.inputParticles.empty()) {
+  if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing particles input collection");
   }
-  if (cfg.inputMeasurementParticlesMap.empty()) {
+  if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
   if (m_cfg.outputFilename.empty()) {

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -32,10 +32,10 @@ ActsExamples::TrackFitterPerformanceWriter::TrackFitterPerformanceWriter(
 
 {
   // trajectories collection name is already checked by base ctor
-  if (cfg.inputParticles.empty()) {
+  if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing particles input collection");
   }
-  if (cfg.inputMeasurementParticlesMap.empty()) {
+  if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
   if (m_cfg.outputFilename.empty()) {

--- a/Examples/Io/Root/src/RootTrajectoryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryWriter.cpp
@@ -41,7 +41,7 @@ ActsExamples::RootTrajectoryWriter::RootTrajectoryWriter(
       m_cfg(cfg),
       m_outputFile(cfg.rootFile) {
   // trajectories collection name is already checked by base ctor
-  if (cfg.inputParticles.empty()) {
+  if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing particles input collection");
   }
   if (m_cfg.inputSimHits.empty()) {
@@ -50,14 +50,14 @@ ActsExamples::RootTrajectoryWriter::RootTrajectoryWriter(
   if (m_cfg.inputMeasurements.empty()) {
     throw std::invalid_argument("Missing measurements input collection");
   }
-  if (cfg.inputMeasurementParticlesMap.empty()) {
+  if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
-  if (cfg.inputMeasurementSimHitsMap.empty()) {
+  if (m_cfg.inputMeasurementSimHitsMap.empty()) {
     throw std::invalid_argument(
         "Missing hit-simulated-hits map input collection");
   }
-  if (cfg.outputFilename.empty()) {
+  if (m_cfg.outputFilename.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
   if (m_cfg.outputTreename.empty()) {

--- a/Examples/Run/Fatras/Common/FatrasDigitization.cpp
+++ b/Examples/Run/Fatras/Common/FatrasDigitization.cpp
@@ -41,6 +41,9 @@ void setupDigitization(
     SmearingAlgorithm::Config smearCfg = Options::readSmearingConfig(vars);
     smearCfg.inputSimHits = kFatrasCollectionHits;
     smearCfg.outputMeasurements = "measurements";
+    smearCfg.outputSourceLinks = "sourcelinks";
+    smearCfg.outputMeasurementParticlesMap = "measurement_particles_map";
+    smearCfg.outputMeasurementSimHitsMap = "measurement_simhits_map";
     smearCfg.trackingGeometry = trackingGeometry;
     smearCfg.randomNumbers = randomNumbers;
     sequencer.addAlgorithm(
@@ -64,6 +67,10 @@ void setupDigitization(
     PlanarSteppingAlgorithm::Config digi;
     digi.inputSimHits = "hits";
     digi.outputClusters = "clusters";
+    digi.outputMeasurements = "measurements";
+    digi.outputSourceLinks = "sourcelinks";
+    digi.outputMeasurementParticlesMap = "measurement_particles_map";
+    digi.outputMeasurementSimHitsMap = "measurement_simhits_map";
     digi.planarModuleStepper = std::make_shared<Acts::PlanarModuleStepper>(
         Acts::getDefaultLogger("PlanarModuleStepper", logLevel));
     digi.randomNumbers = randomNumbers;


### PR DESCRIPTION
As a follow-up to #511, this PR adds those missing output collections in the `FatrasDigitization.cpp` and fixes some input collections in a few Root/Performance writers.