### PR TITLE
refactor: HepMC3 converter as namespace instead of struct

### DIFF
--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
@@ -21,156 +21,123 @@
 namespace ActsExamples {
 
 /// Helper struct to convert HepMC3 event to the internal format.
-struct HepMC3Event {
- public:
-  ///
-  /// Setter
-  ///
+namespace HepMC3Event {
+///
+/// Setter
+///
 
-  /// @brief Sets new units for momentums
-  /// @note The allowed units are MeV and Gev
-  /// @param event event in HepMC data type
-  /// @param momentumUnit new unit of momentum
-  void momentumUnit(HepMC3::GenEvent& event, const double momentumUnit);
+/// @brief Sets new units for momentums
+/// @note The allowed units are MeV and Gev
+/// @param event event in HepMC data type
+/// @param momentumUnit new unit of momentum
+void momentumUnit(HepMC3::GenEvent& event, const double momentumUnit);
 
-  /// @brief Sets new units for lengths
-  /// @note The allowed units are mm and cm
-  /// @param event event in HepMC data type
-  /// @param lengthUnit new unit of length
-  void lengthUnit(HepMC3::GenEvent& event, const double lengthUnit);
+/// @brief Sets new units for lengths
+/// @note The allowed units are mm and cm
+/// @param event event in HepMC data type
+/// @param lengthUnit new unit of length
+void lengthUnit(HepMC3::GenEvent& event, const double lengthUnit);
 
-  /// @brief Shifts the positioning of an event in space and time
-  /// @param event event in HepMC data type
-  /// @param deltaPos relative spatial shift that will be applied
-  /// @param deltaTime relative time shift that will be applied
-  void shiftPositionBy(HepMC3::GenEvent& event, const Acts::Vector3D& deltaPos,
-                       const double deltaTime);
+/// @brief Shifts the positioning of an event in space and time
+/// @param event event in HepMC data type
+/// @param deltaPos relative spatial shift that will be applied
+/// @param deltaTime relative time shift that will be applied
+void shiftPositionBy(HepMC3::GenEvent& event, const Acts::Vector3D& deltaPos,
+                     const double deltaTime);
 
-  /// @brief Shifts the positioning of an event to a paint in space and time
-  /// @param event event in HepMC data type
-  /// @param pos new position of the event
-  /// @param time new time of the event
-  void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos,
-                       const double time);
+/// @brief Shifts the positioning of an event to a paint in space and time
+/// @param event event in HepMC data type
+/// @param pos new position of the event
+/// @param time new time of the event
+void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos,
+                     const double time);
 
-  /// @brief Shifts the positioning of an event to a paint in space
-  /// @param event event in HepMC data type
-  /// @param pos new position of the event
-  void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos);
+/// @brief Shifts the positioning of an event to a paint in space
+/// @param event event in HepMC data type
+/// @param pos new position of the event
+void shiftPositionTo(HepMC3::GenEvent& event, const Acts::Vector3D& pos);
 
-  /// @brief Shifts the positioning of an event to a paint in time
-  /// @param event event in HepMC data type
-  /// @param time new time of the event
-  void shiftPositionTo(HepMC3::GenEvent& event, const double time);
+/// @brief Shifts the positioning of an event to a paint in time
+/// @param event event in HepMC data type
+/// @param time new time of the event
+void shiftPositionTo(HepMC3::GenEvent& event, const double time);
 
-  ///
-  /// Adder
-  ///
+///
+/// Adder
+///
 
-  /// @brief Adds a new particle
-  /// @param event event in HepMC data type
-  /// @param particle new particle that will be added
-  void addParticle(HepMC3::GenEvent& event,
-                   std::shared_ptr<SimParticle> particle);
+/// @brief Adds a new particle
+/// @param event event in HepMC data type
+/// @param particle new particle that will be added
+void addParticle(HepMC3::GenEvent& event,
+                 std::shared_ptr<SimParticle> particle);
 
-  /// @brief Adds a new vertex
-  /// @param event event in HepMC data type
-  /// @param vertex new vertex that will be added
-  /// @note The statuses are not represented in Acts and therefore set to 0
-  void addVertex(HepMC3::GenEvent& event,
-                 const std::shared_ptr<SimVertex> vertex);
-  ///
-  /// Remover
-  ///
+/// @brief Adds a new vertex
+/// @param event event in HepMC data type
+/// @param vertex new vertex that will be added
+/// @note The statuses are not represented in Acts and therefore set to 0
+void addVertex(HepMC3::GenEvent& event,
+               const std::shared_ptr<SimVertex> vertex);
+///
+/// Remover
+///
 
-  /// @brief Removes a particle from the record
-  /// @param event event in HepMC data type
-  /// @param particle particle that will be removed
-  void removeParticle(HepMC3::GenEvent& event,
-                      const std::shared_ptr<SimParticle>& particle);
+/// @brief Removes a particle from the record
+/// @param event event in HepMC data type
+/// @param particle particle that will be removed
+void removeParticle(HepMC3::GenEvent& event,
+                    const std::shared_ptr<SimParticle>& particle);
 
-  /// @brief Removes a vertex from the record
-  /// @note The identification of the vertex is potentially unstable (c.f.
-  /// HepMC3Event::compareVertices())
-  /// @param event event in HepMC data type
-  /// @param vertex vertex that will be removed
-  void removeVertex(HepMC3::GenEvent& event,
-                    const std::shared_ptr<SimVertex>& vertex);
+/// @brief Removes a vertex from the record
+/// @note The identification of the vertex is potentially unstable (c.f.
+/// HepMC3Event::compareVertices())
+/// @param event event in HepMC data type
+/// @param vertex vertex that will be removed
+void removeVertex(HepMC3::GenEvent& event,
+                  const std::shared_ptr<SimVertex>& vertex);
 
-  ///
-  /// Getter
-  ///
+///
+/// Getter
+///
 
-  /// @brief Getter of the unit of momentum used
-  /// @param event event in HepMC data type
-  /// @return unit of momentum
-  double momentumUnit(const HepMC3::GenEvent& event);
+/// @brief Getter of the unit of momentum used
+/// @param event event in HepMC data type
+/// @return unit of momentum
+double momentumUnit(const HepMC3::GenEvent& event);
 
-  /// @brief Getter of the unit of length used
-  /// @param event event in HepMC data type
-  /// @return unit of length
-  double lengthUnit(const HepMC3::GenEvent& event);
+/// @brief Getter of the unit of length used
+/// @param event event in HepMC data type
+/// @return unit of length
+double lengthUnit(const HepMC3::GenEvent& event);
 
-  /// @brief Getter of the position of the event
-  /// @param event event in HepMC data type
-  /// @return vector to the location of the event
-  Acts::Vector3D eventPos(const HepMC3::GenEvent& event);
+/// @brief Getter of the position of the event
+/// @param event event in HepMC data type
+/// @return vector to the location of the event
+Acts::Vector3D eventPos(const HepMC3::GenEvent& event);
 
-  /// @brief Getter of the time of the event
-  /// @param event event in HepMC data type
-  /// @return time of the event
-  double eventTime(const HepMC3::GenEvent& event);
+/// @brief Getter of the time of the event
+/// @param event event in HepMC data type
+/// @return time of the event
+double eventTime(const HepMC3::GenEvent& event);
 
-  /// @brief Get list of particles
-  /// @param event event in HepMC data type
-  /// @return List of particles
-  std::vector<std::unique_ptr<SimParticle>> particles(
-      const HepMC3::GenEvent& event);
+/// @brief Get list of particles
+/// @param event event in HepMC data type
+/// @return List of particles
+std::vector<SimParticle> particles(const HepMC3::GenEvent& event);
 
-  /// @brief Get list of vertices
-  /// @param event event in HepMC data type
-  /// @return List of vertices
-  std::vector<std::unique_ptr<SimVertex>> vertices(
-      const HepMC3::GenEvent& event);
+/// @brief Get list of vertices
+/// @param event event in HepMC data type
+/// @return List of vertices
+std::vector<std::unique_ptr<SimVertex>> vertices(const HepMC3::GenEvent& event);
 
-  /// @brief Get beam particles
-  /// @param event event in HepMC data type
-  /// @return List of beam particles
-  std::vector<std::unique_ptr<SimParticle>> beams(
-      const HepMC3::GenEvent& event);
+/// @brief Get beam particles
+/// @param event event in HepMC data type
+/// @return List of beam particles
+std::vector<SimParticle> beams(const HepMC3::GenEvent& event);
 
-  /// @brief Get final state particles
-  /// @param event event in HepMC data type
-  /// @return List of final state particles
-  std::vector<std::unique_ptr<SimParticle>> finalState(
-      const HepMC3::GenEvent& event);
-
- private:
-  /// @brief Converts an SimParticle into HepMC3::GenParticle
-  /// @note The conversion ignores HepMC status codes
-  /// @param actsParticle Acts particle that will be converted
-  /// @return converted particle
-  HepMC3::GenParticlePtr actsParticleToGen(
-      std::shared_ptr<SimParticle> actsParticle);
-
-  /// @brief Converts an Acts vertex to a HepMC3::GenVertexPtr
-  /// @note The conversion ignores HepMC status codes
-  /// @param actsVertex Acts vertex that will be converted
-  /// @return Converted Acts vertex to HepMC3::GenVertexPtr
-  HepMC3::GenVertexPtr createGenVertex(
-      const std::shared_ptr<SimVertex>& actsVertex);
-
-  /// @brief Compares an Acts vertex with a HepMC3::GenVertex
-  /// @note An Acts vertex does not store a barcode. Therefore the content of
-  /// both vertices is compared. The position, time and number of incoming and
-  /// outgoing particles will be compared. Since a second vertex could exist in
-  /// the record with identical informations (although unlikely), this
-  /// comparison could lead to false positive results. On the other hand, a
-  /// numerical deviation of the parameters could lead to a false negative.
-  /// @param actsVertex Acts vertex
-  /// @param genVertex HepMC3::GenVertex
-  /// @return boolean result if both vertices are identical
-  bool compareVertices(const std::shared_ptr<SimVertex>& actsVertex,
-                       const HepMC3::GenVertexPtr& genVertex);
-};
+/// @brief Get final state particles
+/// @param event event in HepMC data type
+/// @return List of final state particles
+std::vector<SimParticle> finalState(const HepMC3::GenEvent& event);
+}  // namespace HepMC3Event
 }  // namespace ActsExamples

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Event.hpp
@@ -20,7 +20,7 @@
 
 namespace ActsExamples {
 
-/// Helper struct to convert HepMC3 event to the internal format.
+/// Helper functions to convert HepMC3 event to the internal format.
 namespace HepMC3Event {
 ///
 /// Setter

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Particle.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Particle.hpp
@@ -19,77 +19,74 @@
 namespace ActsExamples {
 
 /// Helper struct to convert HepMC3 particles to internal format.
-struct HepMC3Particle {
- public:
-  /// @brief Returns the particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return corresponding Acts particle
-  std::unique_ptr<SimParticle> particle(
-      const std::shared_ptr<HepMC3::GenParticle> particle);
+namespace HepMC3Particle {
+/// @brief Returns the particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return corresponding Acts particle
+SimParticle particle(HepMC3::ConstGenParticlePtr particle);
 
-  /// @brief Returns the id of the particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return id of the particle
-  int id(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the id of the particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return id of the particle
+int id(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the production vertex of the particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return production vertex of the particle
-  std::unique_ptr<SimVertex> productionVertex(
-      const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the production vertex of the particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return production vertex of the particle
+std::unique_ptr<SimVertex> productionVertex(
+    const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the end vertex of the particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return end vertex of the particle
-  std::unique_ptr<SimVertex> endVertex(
-      const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the end vertex of the particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return end vertex of the particle
+std::unique_ptr<SimVertex> endVertex(
+    const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the PDG code of a particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return PDG code of the particle
-  int pdgID(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the PDG code of a particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return PDG code of the particle
+int pdgID(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the momentum of a particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return momentum of the particle
-  Acts::Vector3D momentum(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the momentum of a particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return momentum of the particle
+Acts::Vector3D momentum(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the energy of a particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return energy of the particle
-  double energy(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the energy of a particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return energy of the particle
+double energy(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the mass of a particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return mass of the particle
-  double mass(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the mass of a particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return mass of the particle
+double mass(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Returns the charge of a particle translated into Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @return charge of the particle
-  double charge(const std::shared_ptr<HepMC3::GenParticle> particle);
+/// @brief Returns the charge of a particle translated into Acts
+/// @param particle HepMC3::GenParticle particle
+/// @return charge of the particle
+double charge(const std::shared_ptr<HepMC3::GenParticle> particle);
 
-  /// @brief Sets the PDG code of a particle translated from Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @param pid PDG code that will be set
-  void pdgID(std::shared_ptr<HepMC3::GenParticle> particle, const int pid);
+/// @brief Sets the PDG code of a particle translated from Acts
+/// @param particle HepMC3::GenParticle particle
+/// @param pid PDG code that will be set
+void pdgID(std::shared_ptr<HepMC3::GenParticle> particle, const int pid);
 
-  /// @brief Sets the momentum of a particle translated from Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @param mom momentum that will be set
-  void momentum(std::shared_ptr<HepMC3::GenParticle> particle,
-                const Acts::Vector3D& mom);
+/// @brief Sets the momentum of a particle translated from Acts
+/// @param particle HepMC3::GenParticle particle
+/// @param mom momentum that will be set
+void momentum(std::shared_ptr<HepMC3::GenParticle> particle,
+              const Acts::Vector3D& mom);
 
-  /// @brief Sets the energy of a particle translated from Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @param energy energy that will be set
-  void energy(std::shared_ptr<HepMC3::GenParticle> particle,
-              const double energy);
+/// @brief Sets the energy of a particle translated from Acts
+/// @param particle HepMC3::GenParticle particle
+/// @param energy energy that will be set
+void energy(std::shared_ptr<HepMC3::GenParticle> particle, const double energy);
 
-  /// @brief Sets the mass of a particle translated from Acts
-  /// @param particle HepMC3::GenParticle particle
-  /// @param mass mass that will be set
-  void mass(std::shared_ptr<HepMC3::GenParticle> particle, const double mass);
-};
+/// @brief Sets the mass of a particle translated from Acts
+/// @param particle HepMC3::GenParticle particle
+/// @param mass mass that will be set
+void mass(std::shared_ptr<HepMC3::GenParticle> particle, const double mass);
+}  // namespace HepMC3Particle
 
 }  // namespace ActsExamples

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Vertex.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Vertex.hpp
@@ -18,104 +18,79 @@
 namespace ActsExamples {
 
 /// Helper struct to convert HepMC3 vertex into the internal format.
-struct HepMC3Vertex {
- public:
-  /// @brief Returns a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return corresponding Acts vertex
-  std::unique_ptr<SimVertex> processVertex(
-      const std::shared_ptr<HepMC3::GenVertex> vertex);
+namespace HepMC3Vertex {
+/// @brief Returns a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return corresponding Acts vertex
+std::unique_ptr<SimVertex> processVertex(
+    const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns a boolean expression if a vertex is in an event translated
-  /// into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return boolean expression if the vertex is in an event
-  bool inEvent(const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns a boolean expression if a vertex is in an event translated
+/// into Acts
+/// @param vertex vertex in HepMC data type
+/// @return boolean expression if the vertex is in an event
+bool inEvent(const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return id of the vertex
-  int id(const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return id of the vertex
+int id(const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns the incoming particles of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return incoming particles of the vertex
-  std::vector<SimParticle> particlesIn(
-      const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns the incoming particles of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return incoming particles of the vertex
+std::vector<SimParticle> particlesIn(
+    const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns the outgoing particles of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return outgoing particles of the vertex
-  std::vector<SimParticle> particlesOut(
-      const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns the outgoing particles of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return outgoing particles of the vertex
+std::vector<SimParticle> particlesOut(
+    const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns the position of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return position of the vertex
-  Acts::Vector3D position(const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns the position of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return position of the vertex
+Acts::Vector3D position(const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Returns the time of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @return time of the vertex
-  double time(const std::shared_ptr<HepMC3::GenVertex> vertex);
+/// @brief Returns the time of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @return time of the vertex
+double time(const std::shared_ptr<HepMC3::GenVertex> vertex);
 
-  /// @brief Adds an incoming particle to a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param particle incoming particle that will be added
-  void addParticleIn(std::shared_ptr<HepMC3::GenVertex> vertex,
-                     std::shared_ptr<SimParticle> particle);
+/// @brief Adds an incoming particle to a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param particle incoming particle that will be added
+void addParticleIn(std::shared_ptr<HepMC3::GenVertex> vertex,
+                   std::shared_ptr<SimParticle> particle);
 
-  /// @brief Adds an outgoing particle to a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param particle outgoing particle that will be added
-  void addParticleOut(std::shared_ptr<HepMC3::GenVertex> vertex,
+/// @brief Adds an outgoing particle to a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param particle outgoing particle that will be added
+void addParticleOut(std::shared_ptr<HepMC3::GenVertex> vertex,
+                    std::shared_ptr<SimParticle> particle);
+
+/// @brief Removes an incoming particle from a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param particle incoming particle that will be removed
+void removeParticleIn(std::shared_ptr<HepMC3::GenVertex> vertex,
                       std::shared_ptr<SimParticle> particle);
 
-  /// @brief Removes an incoming particle from a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param particle incoming particle that will be removed
-  void removeParticleIn(std::shared_ptr<HepMC3::GenVertex> vertex,
-                        std::shared_ptr<SimParticle> particle);
+/// @brief Removes an outgoing particle from a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param particle outgoing particle that will be removed
+void removeParticleOut(std::shared_ptr<HepMC3::GenVertex> vertex,
+                       std::shared_ptr<SimParticle> particle);
 
-  /// @brief Removes an outgoing particle from a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param particle outgoing particle that will be removed
-  void removeParticleOut(std::shared_ptr<HepMC3::GenVertex> vertex,
-                         std::shared_ptr<SimParticle> particle);
+/// @brief Sets the position of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param pos new position of the vertex
+void position(const std::shared_ptr<HepMC3::GenVertex> vertex,
+              Acts::Vector3D pos);
 
-  /// @brief Sets the position of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param pos new position of the vertex
-  void position(const std::shared_ptr<HepMC3::GenVertex> vertex,
-                Acts::Vector3D pos);
-
-  /// @brief Sets the time of a vertex translated into Acts
-  /// @param vertex vertex in HepMC data type
-  /// @param time new time of the vertex
-  void time(const std::shared_ptr<HepMC3::GenVertex> vertex, double time);
-
- private:
-  /// @brief Converts HepMC3::GenParticle objects into Acts
-  /// @param genParticles list of HepMC3::GenParticle objects
-  /// @return converted list
-  std::vector<SimParticle> genParticlesToActs(
-      const std::vector<HepMC3::GenParticlePtr>& genParticles);
-
-  /// @brief Converts an SimParticle into HepMC3::GenParticle
-  /// @note The conversion ignores HepMC status codes
-  /// @param actsParticle Acts particle that will be converted
-  /// @return converted particle
-  HepMC3::GenParticlePtr actsParticleToGen(
-      std::shared_ptr<SimParticle> actsParticle);
-
-  /// @brief Finds a HepMC3::GenParticle from a list that matches an
-  /// SimParticle object
-  /// @param genParticles list of HepMC particles
-  /// @param actsParticle Acts particle
-  /// @return HepMC particle that matched with the Acts particle or nullptr if
-  /// no match was found
-  HepMC3::GenParticlePtr matchParticles(
-      const std::vector<HepMC3::GenParticlePtr>& genParticles,
-      std::shared_ptr<SimParticle> actsParticle);
-};
+/// @brief Sets the time of a vertex translated into Acts
+/// @param vertex vertex in HepMC data type
+/// @param time new time of the vertex
+void time(const std::shared_ptr<HepMC3::GenVertex> vertex, double time);
+}  // namespace HepMC3Vertex
 }  // namespace ActsExamples

--- a/Examples/Io/HepMC3/src/HepMC3Particle.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Particle.cpp
@@ -10,9 +10,8 @@
 
 #include "ActsExamples/Io/HepMC3/HepMC3Vertex.hpp"
 
-std::unique_ptr<ActsExamples::SimParticle>
-ActsExamples::HepMC3Particle::particle(
-    const std::shared_ptr<HepMC3::GenParticle> particle) {
+ActsExamples::SimParticle ActsExamples::HepMC3Particle::particle(
+    HepMC3::ConstGenParticlePtr particle) {
   // TODO this is probably not quite right
   ActsFatras::Barcode particleId;
   particleId.setParticle(particle->id());
@@ -21,7 +20,7 @@ ActsExamples::HepMC3Particle::particle(
   fw.setDirection(particle->momentum().x(), particle->momentum().y(),
                   particle->momentum().z());
   fw.setAbsMomentum(particle->momentum().p3mod());
-  return std::make_unique<SimParticle>(std::move(fw));
+  return fw;
 }
 
 int ActsExamples::HepMC3Particle::id(
@@ -32,11 +31,9 @@ int ActsExamples::HepMC3Particle::id(
 std::unique_ptr<ActsExamples::SimVertex>
 ActsExamples::HepMC3Particle::productionVertex(
     const std::shared_ptr<HepMC3::GenParticle> particle) {
-  HepMC3Vertex simVert;
-
   // Return the vertex if it exists
   if (particle->production_vertex())
-    return simVert.processVertex(
+    return HepMC3Vertex::processVertex(
         std::make_shared<HepMC3::GenVertex>(*particle->production_vertex()));
   else
     return nullptr;
@@ -45,11 +42,9 @@ ActsExamples::HepMC3Particle::productionVertex(
 std::unique_ptr<ActsExamples::SimVertex>
 ActsExamples::HepMC3Particle::endVertex(
     const std::shared_ptr<HepMC3::GenParticle> particle) {
-  HepMC3Vertex simVert;
-
   // Return the vertex if it exists
   if (particle->end_vertex())
-    return simVert.processVertex(
+    return HepMC3Vertex::processVertex(
         std::make_shared<HepMC3::GenVertex>(*(particle->end_vertex())));
   else
     return nullptr;

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -56,12 +56,14 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiReader::read(
   ACTS_DEBUG("Attempting to write event to " << path);
   HepMC3::ReaderAscii reader(path);
 
-  while (reader.read_event(event)) {
+  reader.read_event(event);
+  while (!reader.failed()) {
     events.push_back(std::move(event));
     event.clear();
+    reader.read_event(event);
   }
 
-  if (reader.failed())
+  if (events.empty())
     return ActsExamples::ProcessCode::ABORT;
 
   ctx.eventStore.add(m_cfg.outputEvents, std::move(events));

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -56,28 +56,29 @@ int main(int argc, char** argv) {
   }
   std::cout << std::endl;
 
+  using ActsExamples::HepMC3Event;
   std::cout << "Event data:" << std::endl;
   std::cout << "Units: ";
-  if (ActsExamples::HepMC3Event::momentumUnit(genevt) ==
+  if (momentumUnit(genevt) ==
       Acts::UnitConstants::GeV)
     std::cout << "[GEV], ";
-  else if (ActsExamples::HepMC3Event::momentumUnit(genevt) ==
+  else if (momentumUnit(genevt) ==
            Acts::UnitConstants::MeV)
     std::cout << "[MeV], ";
-  if (ActsExamples::HepMC3Event::lengthUnit(genevt) == Acts::UnitConstants::mm)
+  if (lengthUnit(genevt) == Acts::UnitConstants::mm)
     std::cout << "[mm]" << std::endl;
-  else if (ActsExamples::HepMC3Event::lengthUnit(genevt) ==
+  else if (lengthUnit(genevt) ==
            Acts::UnitConstants::cm)
     std::cout << "[cm]" << std::endl;
-  Acts::Vector3D evtPos = ActsExamples::HepMC3Event::eventPos(genevt);
+  Acts::Vector3D evtPos = eventPos(genevt);
   std::cout << "Event position: " << evtPos(0) << ", " << evtPos(1) << ", "
             << evtPos(2) << std::endl;
-  std::cout << "Event time: " << ActsExamples::HepMC3Event::eventTime(genevt)
+  std::cout << "Event time: " << eventTime(genevt)
             << std::endl;
 
   std::cout << "Beam particles: ";
   std::vector<ActsExamples::SimParticle> beam =
-      ActsExamples::HepMC3Event::beams(genevt);
+      beams(genevt);
   if (beam.empty())
     std::cout << "none" << std::endl;
   else {
@@ -88,7 +89,7 @@ int main(int argc, char** argv) {
 
   std::cout << std::endl << "Vertices: ";
   std::vector<std::unique_ptr<ActsExamples::SimVertex>> vertices =
-      ActsExamples::HepMC3Event::vertices(genevt);
+      vertices(genevt);
   if (vertices.empty())
     std::cout << "none" << std::endl;
   else {
@@ -108,7 +109,7 @@ int main(int argc, char** argv) {
 
   std::cout << "Total particle record:" << std::endl;
   std::vector<ActsExamples::SimParticle> particles =
-      ActsExamples::HepMC3Event::particles(genevt);
+      particles(genevt);
   for (auto& particle : particles)
     std::cout << HepPID::particleName(particle.pdg())
               << "\tID:" << particle.particleId() << ", momentum: ("
@@ -118,7 +119,7 @@ int main(int argc, char** argv) {
 
   std::cout << std::endl << "Initial to final state: ";
   std::vector<ActsExamples::SimParticle> fState =
-      ActsExamples::HepMC3Event::finalState(genevt);
+      finalState(genevt);
   for (auto& pbeam : beam)
     std::cout << HepPID::particleName(pbeam.pdg()) << " ";
   std::cout << "-> ";

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -59,26 +59,21 @@ int main(int argc, char** argv) {
   using ActsExamples::HepMC3Event;
   std::cout << "Event data:" << std::endl;
   std::cout << "Units: ";
-  if (momentumUnit(genevt) ==
-      Acts::UnitConstants::GeV)
+  if (momentumUnit(genevt) == Acts::UnitConstants::GeV)
     std::cout << "[GEV], ";
-  else if (momentumUnit(genevt) ==
-           Acts::UnitConstants::MeV)
+  else if (momentumUnit(genevt) == Acts::UnitConstants::MeV)
     std::cout << "[MeV], ";
   if (lengthUnit(genevt) == Acts::UnitConstants::mm)
     std::cout << "[mm]" << std::endl;
-  else if (lengthUnit(genevt) ==
-           Acts::UnitConstants::cm)
+  else if (lengthUnit(genevt) == Acts::UnitConstants::cm)
     std::cout << "[cm]" << std::endl;
   Acts::Vector3D evtPos = eventPos(genevt);
   std::cout << "Event position: " << evtPos(0) << ", " << evtPos(1) << ", "
             << evtPos(2) << std::endl;
-  std::cout << "Event time: " << eventTime(genevt)
-            << std::endl;
+  std::cout << "Event time: " << eventTime(genevt) << std::endl;
 
   std::cout << "Beam particles: ";
-  std::vector<ActsExamples::SimParticle> beam =
-      beams(genevt);
+  std::vector<ActsExamples::SimParticle> beam = beams(genevt);
   if (beam.empty())
     std::cout << "none" << std::endl;
   else {
@@ -108,8 +103,7 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "Total particle record:" << std::endl;
-  std::vector<ActsExamples::SimParticle> particles =
-      particles(genevt);
+  std::vector<ActsExamples::SimParticle> particles = particles(genevt);
   for (auto& particle : particles)
     std::cout << HepPID::particleName(particle.pdg())
               << "\tID:" << particle.particleId() << ", momentum: ("
@@ -118,8 +112,7 @@ int main(int argc, char** argv) {
               << "), mass:  " << particle.mass() << std::endl;
 
   std::cout << std::endl << "Initial to final state: ";
-  std::vector<ActsExamples::SimParticle> fState =
-      finalState(genevt);
+  std::vector<ActsExamples::SimParticle> fState = finalState(genevt);
   for (auto& pbeam : beam)
     std::cout << HepPID::particleName(pbeam.pdg()) << " ";
   std::cout << "-> ";

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
 
   std::cout << std::endl << "Vertices: ";
   std::vector<std::unique_ptr<ActsExamples::SimVertex>> vertices =
-      vertices(genevt);
+      ActsExamples::HepMC3Event::vertices(genevt);
   if (vertices.empty())
     std::cout << "none" << std::endl;
   else {
@@ -103,7 +103,8 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "Total particle record:" << std::endl;
-  std::vector<ActsExamples::SimParticle> particles = particles(genevt);
+  std::vector<ActsExamples::SimParticle> particles = 
+      ActsExamples::HepMC3Event::particles(genevt);
   for (auto& particle : particles)
     std::cout << HepPID::particleName(particle.pdg())
               << "\tID:" << particle.particleId() << ", momentum: ("

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -56,37 +56,39 @@ int main(int argc, char** argv) {
   }
   std::cout << std::endl;
 
-  ActsExamples::HepMC3Event simEvent;
-
   std::cout << "Event data:" << std::endl;
   std::cout << "Units: ";
-  if (simEvent.momentumUnit(genevt) == Acts::UnitConstants::GeV)
+  if (ActsExamples::HepMC3Event::momentumUnit(genevt) ==
+      Acts::UnitConstants::GeV)
     std::cout << "[GEV], ";
-  else if (simEvent.momentumUnit(genevt) == Acts::UnitConstants::MeV)
+  else if (ActsExamples::HepMC3Event::momentumUnit(genevt) ==
+           Acts::UnitConstants::MeV)
     std::cout << "[MeV], ";
-  if (simEvent.lengthUnit(genevt) == Acts::UnitConstants::mm)
+  if (ActsExamples::HepMC3Event::lengthUnit(genevt) == Acts::UnitConstants::mm)
     std::cout << "[mm]" << std::endl;
-  else if (simEvent.lengthUnit(genevt) == Acts::UnitConstants::cm)
+  else if (ActsExamples::HepMC3Event::lengthUnit(genevt) ==
+           Acts::UnitConstants::cm)
     std::cout << "[cm]" << std::endl;
-  Acts::Vector3D evtPos = simEvent.eventPos(genevt);
+  Acts::Vector3D evtPos = ActsExamples::HepMC3Event::eventPos(genevt);
   std::cout << "Event position: " << evtPos(0) << ", " << evtPos(1) << ", "
             << evtPos(2) << std::endl;
-  std::cout << "Event time: " << simEvent.eventTime(genevt) << std::endl;
+  std::cout << "Event time: " << ActsExamples::HepMC3Event::eventTime(genevt)
+            << std::endl;
 
   std::cout << "Beam particles: ";
-  std::vector<std::unique_ptr<ActsExamples::SimParticle>> beam =
-      simEvent.beams(genevt);
+  std::vector<ActsExamples::SimParticle> beam =
+      ActsExamples::HepMC3Event::beams(genevt);
   if (beam.empty())
     std::cout << "none" << std::endl;
   else {
     for (auto& pbeam : beam)
-      std::cout << HepPID::particleName(pbeam->pdg()) << " ";
+      std::cout << HepPID::particleName(pbeam.pdg()) << " ";
     std::cout << std::endl;
   }
 
   std::cout << std::endl << "Vertices: ";
   std::vector<std::unique_ptr<ActsExamples::SimVertex>> vertices =
-      simEvent.vertices(genevt);
+      ActsExamples::HepMC3Event::vertices(genevt);
   if (vertices.empty())
     std::cout << "none" << std::endl;
   else {
@@ -105,22 +107,22 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "Total particle record:" << std::endl;
-  std::vector<std::unique_ptr<ActsExamples::SimParticle>> particles =
-      simEvent.particles(genevt);
+  std::vector<ActsExamples::SimParticle> particles =
+      ActsExamples::HepMC3Event::particles(genevt);
   for (auto& particle : particles)
-    std::cout << HepPID::particleName(particle->pdg())
-              << "\tID:" << particle->particleId() << ", momentum: ("
-              << particle->momentum4()(0) << ", " << particle->momentum4()(1)
-              << ", " << particle->momentum4()(2)
-              << "), mass:  " << particle->mass() << std::endl;
+    std::cout << HepPID::particleName(particle.pdg())
+              << "\tID:" << particle.particleId() << ", momentum: ("
+              << particle.momentum4()(0) << ", " << particle.momentum4()(1)
+              << ", " << particle.momentum4()(2)
+              << "), mass:  " << particle.mass() << std::endl;
 
   std::cout << std::endl << "Initial to final state: ";
-  std::vector<std::unique_ptr<ActsExamples::SimParticle>> fState =
-      simEvent.finalState(genevt);
+  std::vector<ActsExamples::SimParticle> fState =
+      ActsExamples::HepMC3Event::finalState(genevt);
   for (auto& pbeam : beam)
-    std::cout << HepPID::particleName(pbeam->pdg()) << " ";
+    std::cout << HepPID::particleName(pbeam.pdg()) << " ";
   std::cout << "-> ";
   for (auto& fs : fState)
-    std::cout << HepPID::particleName(fs->pdg()) << " ";
+    std::cout << HepPID::particleName(fs.pdg()) << " ";
   std::cout << std::endl;
 }

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
   }
   std::cout << std::endl;
 
-  using ActsExamples::HepMC3Event;
+  using namespace ActsExamples::HepMC3Event;
   std::cout << "Event data:" << std::endl;
   std::cout << "Units: ";
   if (momentumUnit(genevt) == Acts::UnitConstants::GeV)

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
   }
 
   std::cout << "Total particle record:" << std::endl;
-  std::vector<ActsExamples::SimParticle> particles = 
+  std::vector<ActsExamples::SimParticle> particles =
       ActsExamples::HepMC3Event::particles(genevt);
   for (auto& particle : particles)
     std::cout << HepPID::particleName(particle.pdg())


### PR DESCRIPTION
This PR changes the stateless HepMC3 converter structs to become namespaces instead.