### PR TITLE
refactor!: Implement track parameters without ParameterSet (EDM rework 4b/4)

### DIFF
--- a/Core/include/Acts/EventData/Charge.hpp
+++ b/Core/include/Acts/EventData/Charge.hpp
@@ -57,7 +57,7 @@ struct Neutral {
   /// This constructor is only provided to allow consistent construction.
   template <typename T>
   constexpr Neutral(T absQ) noexcept {
-    assert((absQ == 0.0f) and "Input charge must be zero");
+    assert((absQ == static_cast<T>(0)) and "Input charge must be zero");
     // suppress `unused variable` warning in non-debug builds
     (void)(absQ);
   }

--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -12,6 +12,7 @@
 #include "Acts/EventData/detail/TransformationFreeToBound.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
+#include "Acts/Utilities/detail/periodic.hpp"
 
 #include <cassert>
 #include <cmath>
@@ -60,6 +61,7 @@ class SingleBoundTrackParameters {
     assert((0 <= (params[eBoundQOverP] * q)) and
            "Inconsistent q/p and q signs");
     assert(m_surface);
+    normalizePhiTheta();
   }
 
   /// Construct from a parameters vector on the surface.
@@ -80,6 +82,7 @@ class SingleBoundTrackParameters {
         m_surface(std::move(surface)),
         m_chargeInterpreter(T()) {
     assert(m_surface);
+    normalizePhiTheta();
   }
 
   /// Construct from four-position, direction, absolute momentum, and charge.
@@ -104,6 +107,7 @@ class SingleBoundTrackParameters {
         m_chargeInterpreter(std::abs(q)) {
     assert((0 <= p) and "Absolute momentum must be positive");
     assert(m_surface);
+    // free-to-bound transform always return phi/theta within bounds
   }
 
   /// Construct from four-position, direction, and charge-over-momentum.
@@ -132,6 +136,7 @@ class SingleBoundTrackParameters {
         m_surface(std::move(surface)),
         m_chargeInterpreter(T()) {
     assert(m_surface);
+    // free-to-bound transform always return phi/theta within bounds
   }
 
   // this class does not have a custom default constructor and thus should not
@@ -225,6 +230,14 @@ class SingleBoundTrackParameters {
   std::shared_ptr<const Surface> m_surface;
   // TODO use [[no_unique_address]] once we switch to C++20
   charge_t m_chargeInterpreter;
+
+  /// Ensure phi and theta angles are within bounds.
+  void normalizePhiTheta() {
+    auto [phi, theta] =
+        detail::ensureThetaBounds(m_params[eBoundPhi], m_params[eBoundTheta]);
+    m_params[eBoundPhi] = phi;
+    m_params[eBoundTheta] = theta;
+  }
 
   /// Print information to the output stream.
   friend std::ostream& operator<<(std::ostream& os,

--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -226,18 +226,6 @@ class SingleBoundTrackParameters {
   // TODO use [[no_unique_address]] once we switch to C++20
   charge_t m_chargeInterpreter;
 
-  /// Compare two bound parameters for equality.
-  friend bool operator==(const SingleBoundTrackParameters& lhs,
-                         const SingleBoundTrackParameters& rhs) {
-    return (lhs.m_params == rhs.m_params) and (lhs.m_cov == rhs.m_cov) and
-           (lhs.m_surface == rhs.m_surface) and
-           (lhs.m_chargeInterpreter == rhs.m_chargeInterpreter);
-  }
-  /// Compare two bound parameters for inequality.
-  friend bool operator!=(const SingleBoundTrackParameters& lhs,
-                         const SingleBoundTrackParameters& rhs) {
-    return !(lhs == rhs);
-  }
   /// Print information to the output stream.
   friend std::ostream& operator<<(std::ostream& os,
                                   const SingleBoundTrackParameters& tp) {

--- a/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleCurvilinearTrackParameters.hpp
@@ -111,8 +111,17 @@ class SingleCurvilinearTrackParameters
                                                           theta, qOverP),
              std::move(cov)) {}
 
-  // this class does not have a custom default constructor and thus should not
-  // provide any custom default cstors, dstor, or assignment. see ISOCPP C.20.
+  /// Parameters are not default constructible due to the charge type.
+  SingleCurvilinearTrackParameters() = delete;
+  SingleCurvilinearTrackParameters(const SingleCurvilinearTrackParameters&) =
+      default;
+  SingleCurvilinearTrackParameters(SingleCurvilinearTrackParameters&&) =
+      default;
+  ~SingleCurvilinearTrackParameters() = default;
+  SingleCurvilinearTrackParameters& operator=(
+      const SingleCurvilinearTrackParameters&) = default;
+  SingleCurvilinearTrackParameters& operator=(
+      SingleCurvilinearTrackParameters&&) = default;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -63,7 +63,7 @@ class SingleFreeTrackParameters {
             std::enable_if_t<std::is_default_constructible_v<T>, int> = 0>
   SingleFreeTrackParameters(const ParametersVector& params,
                             std::optional<CovarianceMatrix> cov = std::nullopt)
-      : m_params(params), m_cov(std::move(cov)), m_chargeInterpreter(T()) {}
+      : m_params(params), m_cov(std::move(cov)) {}
 
   /// Construct from four-position, angles, absolute momentum, and charge.
   ///
@@ -107,9 +107,7 @@ class SingleFreeTrackParameters {
   SingleFreeTrackParameters(const Vector4D& pos4, Scalar phi, Scalar theta,
                             Scalar qOverP,
                             std::optional<CovarianceMatrix> cov = std::nullopt)
-      : m_params(FreeVector::Zero()),
-        m_cov(std::move(cov)),
-        m_chargeInterpreter(T()) {
+      : m_params(FreeVector::Zero()), m_cov(std::move(cov)) {
     auto dir = makeDirectionUnitFromPhiTheta(phi, theta);
     m_params[eFreePos0] = pos4[ePos0];
     m_params[eFreePos1] = pos4[ePos1];
@@ -121,8 +119,14 @@ class SingleFreeTrackParameters {
     m_params[eFreeQOverP] = qOverP;
   }
 
-  // this class does not have a custom default constructor and thus should not
-  // provide any custom default cstors, dstor, or assignment. see ISOCPP C.20.
+  /// Parameters are not default constructible due to the charge type.
+  SingleFreeTrackParameters() = delete;
+  SingleFreeTrackParameters(const SingleFreeTrackParameters&) = default;
+  SingleFreeTrackParameters(SingleFreeTrackParameters&&) = default;
+  ~SingleFreeTrackParameters() = default;
+  SingleFreeTrackParameters& operator=(const SingleFreeTrackParameters&) =
+      default;
+  SingleFreeTrackParameters& operator=(SingleFreeTrackParameters&&) = default;
 
   /// Parameters vector.
   const ParametersVector& parameters() const { return m_params; }

--- a/Core/include/Acts/EventData/TrackParametersConcept.hpp
+++ b/Core/include/Acts/EventData/TrackParametersConcept.hpp
@@ -12,6 +12,8 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/TypeTraits.hpp"
 
+#include <type_traits>
+
 namespace Acts {
 
 class Surface;
@@ -64,10 +66,10 @@ struct BoundTrackParametersConceptImpl {
 
   // check for required methods
   constexpr static bool hasMethodParameters =
-      identical_to<BoundVector, ReturnTypeParameters, const T>;
+      std::is_convertible_v<ReturnTypeParameters<T>, BoundVector>;
   constexpr static bool hasMethodCovariance =
-      identical_to<const std::optional<BoundSymMatrix>&, ReturnTypeCovariance,
-                   const T>;
+      std::is_convertible_v<ReturnTypeCovariance<T>,
+                            std::optional<BoundSymMatrix>>;
   constexpr static bool hasMethodFourPositionFromContext =
       identical_to<Vector4D, ReturnTypeFourPositionFromContext, const T>;
   constexpr static bool hasMethodPositionFromContext =
@@ -121,10 +123,10 @@ struct FreeTrackParametersConceptImpl {
 
   // check for required methods
   constexpr static bool hasMethodParameters =
-      identical_to<FreeVector, ReturnTypeParameters, const T>;
+      std::is_convertible_v<ReturnTypeParameters<T>, FreeVector>;
   constexpr static bool hasMethodCovariance =
-      identical_to<const std::optional<FreeSymMatrix>&, ReturnTypeCovariance,
-                   const T>;
+      std::is_convertible_v<ReturnTypeCovariance<T>,
+                            std::optional<FreeSymMatrix>>;
   constexpr static bool hasMethodFourPosition =
       identical_to<Vector4D, ReturnTypeFourPosition, const T>;
   constexpr static bool hasMethodPosition =


### PR DESCRIPTION
BREAKING CHANGE: Bound track parameters loose the `.getParameterSet()` accessor.

Implements all track parameters types without `ParameterSet` using the appropriate vector/matrix types directly. The track parameters concepts are updated such that the `.parameters()` and `.covariance()` return types only need to be convertible to the expected plain vector/matrix types.

These changes prepare for the eventual removal of the `ParameterSet` infrastructure as part of the EDM rework.

Contains changes from #553 and must be merged afterwards.
