### PR TITLE
feat: Digitization 3, add ChannelMerger

### DIFF
--- a/Core/include/Acts/Surfaces/AnnulusBounds.hpp
+++ b/Core/include/Acts/Surfaces/AnnulusBounds.hpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <exception>
+#include <iostream>
 #include <vector>
 
 namespace Acts {
@@ -135,8 +136,8 @@ class AnnulusBounds : public DiscBounds {
   /// @param lseg the number of segments used to approximate
   /// and eventually curved line
   ///
-  /// @note that the extremas are given, which may slightly alter the
-  /// number of segments returned
+  /// @note that that if @param lseg > 0, the extrema points are given,
+  ///  which may slightly alter the number of segments returned
   ///
   /// @return vector for vertices in 2D
   std::vector<Vector2D> vertices(unsigned int lseg) const;
@@ -154,7 +155,6 @@ class AnnulusBounds : public DiscBounds {
   Vector2D m_moduleOrigin;
   Vector2D m_shiftXY;  // == -m_moduleOrigin
   Vector2D m_shiftPC;
-  double m_phiAvg;
   Transform2D m_rotationStripPC;
   Transform2D m_translation;
 

--- a/Core/include/Acts/Surfaces/AnnulusBounds.hpp
+++ b/Core/include/Acts/Surfaces/AnnulusBounds.hpp
@@ -15,7 +15,6 @@
 
 #include <array>
 #include <exception>
-#include <iostream>
 #include <vector>
 
 namespace Acts {

--- a/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
@@ -128,6 +128,9 @@ class DiscTrapezoidBounds : public DiscBounds {
  private:
   std::array<double, eSize> m_values;
 
+  /// Dreived maximum y value
+  double m_ymax;
+
   /// Check the input values for consistency, will throw a logic_exception
   /// if consistency is not given
   void checkConsistency() noexcept(false);

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -103,10 +103,11 @@ std::vector<Acts::Vector2D> Acts::AnnulusBounds::vertices(
   // List of vertices counter-clockwise starting with left inner
   std::vector<Acts::Vector2D> rvertices;
 
-  double phiMinInner = VectorHelpers::phi(m_inLeftStripXY);
-  double phiMaxInner = VectorHelpers::phi(m_inRightStripXY);
-  double phiMinOuter = VectorHelpers::phi(m_outRightStripXY);
-  double phiMaxOuter = VectorHelpers::phi(m_outLeftStripXY);
+  // Shift them to get the module phi
+  double phiMinInner = VectorHelpers::phi(m_inLeftStripXY - m_moduleOrigin);
+  double phiMaxInner = VectorHelpers::phi(m_inRightStripXY - m_moduleOrigin);
+  double phiMinOuter = VectorHelpers::phi(m_outRightStripXY - m_moduleOrigin);
+  double phiMaxOuter = VectorHelpers::phi(m_outLeftStripXY - m_moduleOrigin);
 
   std::vector<double> phisInner =
       detail::VerticesHelper::phiSegments(phiMinInner, phiMaxInner);
@@ -127,6 +128,9 @@ std::vector<Acts::Vector2D> Acts::AnnulusBounds::vertices(
         rvertices, {get(eMaxR), get(eMaxR)}, phisOuter[iseg],
         phisOuter[iseg + 1], lseg, addon);
   }
+
+  std::for_each(rvertices.begin(), rvertices.end(),
+                [&](Acts::Vector2D& rv) { rv += m_moduleOrigin; });
 
   return rvertices;
 }

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -20,7 +20,6 @@ Acts::AnnulusBounds::AnnulusBounds(
     const std::array<double, eSize>& values) noexcept(false)
     : m_values(values), m_moduleOrigin({values[eOriginX], values[eOriginY]}) {
   checkConsistency();
-
   m_rotationStripPC =
       Eigen::Translation<double, 2>(Vector2D(0, -get(eAveragePhi)));
   m_translation = Eigen::Translation<double, 2>(m_moduleOrigin);
@@ -100,45 +99,47 @@ std::vector<Acts::Vector2D> Acts::AnnulusBounds::corners() const {
 
 std::vector<Acts::Vector2D> Acts::AnnulusBounds::vertices(
     unsigned int lseg) const {
-  // List of vertices counter-clockwise starting with left inner
-  std::vector<Acts::Vector2D> rvertices;
+  if (lseg > 0) {
+    // List of vertices counter-clockwise starting with left inner
+    std::vector<Acts::Vector2D> rvertices;
 
-  // Shift them to get the module phi
-  double phiMinInner = VectorHelpers::phi(m_inLeftStripXY - m_moduleOrigin);
-  double phiMaxInner = VectorHelpers::phi(m_inRightStripXY - m_moduleOrigin);
-  double phiMinOuter = VectorHelpers::phi(m_outRightStripXY - m_moduleOrigin);
-  double phiMaxOuter = VectorHelpers::phi(m_outLeftStripXY - m_moduleOrigin);
+    // Shift them to get the module phi
+    double phiMinInner = VectorHelpers::phi(m_inLeftStripXY - m_moduleOrigin);
+    double phiMaxInner = VectorHelpers::phi(m_inRightStripXY - m_moduleOrigin);
+    double phiMinOuter = VectorHelpers::phi(m_outRightStripXY - m_moduleOrigin);
+    double phiMaxOuter = VectorHelpers::phi(m_outLeftStripXY - m_moduleOrigin);
 
-  std::vector<double> phisInner =
-      detail::VerticesHelper::phiSegments(phiMinInner, phiMaxInner);
-  std::vector<double> phisOuter =
-      detail::VerticesHelper::phiSegments(phiMinOuter, phiMaxOuter);
+    std::vector<double> phisInner =
+        detail::VerticesHelper::phiSegments(phiMinInner, phiMaxInner);
+    std::vector<double> phisOuter =
+        detail::VerticesHelper::phiSegments(phiMinOuter, phiMaxOuter);
 
-  // Inner bow from phi_min -> phi_max
-  for (unsigned int iseg = 0; iseg < phisInner.size() - 1; ++iseg) {
-    int addon = (iseg == phisInner.size() - 2) ? 1 : 0;
-    detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
-        rvertices, {get(eMinR), get(eMinR)}, phisInner[iseg],
-        phisInner[iseg + 1], lseg, addon);
+    // Inner bow from phi_min -> phi_max
+    for (unsigned int iseg = 0; iseg < phisInner.size() - 1; ++iseg) {
+      int addon = (iseg == phisInner.size() - 2) ? 1 : 0;
+      detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
+          rvertices, {get(eMinR), get(eMinR)}, phisInner[iseg],
+          phisInner[iseg + 1], lseg, addon);
+    }
+    // Upper bow from phi_min -> phi_max
+    for (unsigned int iseg = 0; iseg < phisOuter.size() - 1; ++iseg) {
+      int addon = (iseg == phisOuter.size() - 2) ? 1 : 0;
+      detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
+          rvertices, {get(eMaxR), get(eMaxR)}, phisOuter[iseg],
+          phisOuter[iseg + 1], lseg, addon);
+    }
+    std::for_each(rvertices.begin(), rvertices.end(),
+                  [&](Acts::Vector2D& rv) { rv += m_moduleOrigin; });
+    return rvertices;
   }
-  // Upper bow from phi_min -> phi_max
-  for (unsigned int iseg = 0; iseg < phisOuter.size() - 1; ++iseg) {
-    int addon = (iseg == phisOuter.size() - 2) ? 1 : 0;
-    detail::VerticesHelper::createSegment<Vector2D, Transform2D>(
-        rvertices, {get(eMaxR), get(eMaxR)}, phisOuter[iseg],
-        phisOuter[iseg + 1], lseg, addon);
-  }
-
-  std::for_each(rvertices.begin(), rvertices.end(),
-                [&](Acts::Vector2D& rv) { rv += m_moduleOrigin; });
-
-  return rvertices;
+  return {m_inLeftStripXY, m_inRightStripXY, m_outRightStripXY,
+          m_outLeftStripXY};
 }
 
 bool Acts::AnnulusBounds::inside(const Vector2D& lposition, double tolR,
                                  double tolPhi) const {
   // locpo is PC in STRIP SYSTEM
-  // need to perform internal rotation induced by m_phiAvg
+  // need to perform internal rotation induced by average phi
   Vector2D locpo_rotated = m_rotationStripPC * lposition;
   double phiLoc = locpo_rotated[eBoundLoc1];
   double rLoc = locpo_rotated[eBoundLoc0];
@@ -192,7 +193,7 @@ bool Acts::AnnulusBounds::inside(const Vector2D& lposition,
     // via jacobian.
     // The following transforms into STRIP XY, does the shift into MODULE XY,
     // and then transforms into MODULE PC
-    double dphi = m_phiAvg;
+    double dphi = get(eAveragePhi);
     double phi_strip = locpo_rotated[eBoundLoc1];
     double r_strip = locpo_rotated[eBoundLoc0];
     double O_x = m_shiftXY[eBoundLoc0];
@@ -356,7 +357,7 @@ double Acts::AnnulusBounds::squaredNorm(
 }
 
 Acts::Vector2D Acts::AnnulusBounds::moduleOrigin() const {
-  return Eigen::Rotation2D<double>(m_phiAvg) * m_moduleOrigin;
+  return Eigen::Rotation2D<double>(get(eAveragePhi)) * m_moduleOrigin;
 }
 
 // Ostream operator overload
@@ -367,9 +368,7 @@ std::ostream& Acts::AnnulusBounds::toStream(std::ostream& sl) const {
   sl << "(" << get(eMinR) << ", " << get(eMaxR) << ", " << phiMin() << ", "
      << phiMax() << ")" << '\n';
   sl << " - shift xy = " << m_shiftXY.x() << ", " << m_shiftXY.y() << '\n';
-  ;
   sl << " - shift pc = " << m_shiftPC.x() << ", " << m_shiftPC.y() << '\n';
-  ;
   sl << std::setprecision(-1);
   return sl;
 }

--- a/Core/src/Surfaces/DiscTrapezoidBounds.cpp
+++ b/Core/src/Surfaces/DiscTrapezoidBounds.cpp
@@ -19,7 +19,7 @@ Acts::DiscTrapezoidBounds::DiscTrapezoidBounds(double halfXminR,
     : m_values({halfXminR, halfXmaxR, minR, maxR, avgPhi, stereo}) {
   checkConsistency();
   m_ymax = std::sqrt(get(eMaxR) * get(eMaxR) -
-                          get(eHalfLengthXmaxR) * get(eHalfLengthXmaxR));
+                     get(eHalfLengthXmaxR) * get(eHalfLengthXmaxR));
 }
 
 Acts::SurfaceBounds::BoundsType Acts::DiscTrapezoidBounds::type() const {
@@ -48,7 +48,6 @@ Acts::ActsMatrixD<2, 2> Acts::DiscTrapezoidBounds::jacobianToLocalCartesian(
 
 bool Acts::DiscTrapezoidBounds::inside(
     const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
-      
   Vector2D vertices[] = {{get(eHalfLengthXminR), get(eMinR)},
                          {get(eHalfLengthXmaxR), m_ymax},
                          {-get(eHalfLengthXmaxR), m_ymax},

--- a/Core/src/Surfaces/DiscTrapezoidBounds.cpp
+++ b/Core/src/Surfaces/DiscTrapezoidBounds.cpp
@@ -19,7 +19,7 @@ Acts::DiscTrapezoidBounds::DiscTrapezoidBounds(double halfXminR,
     : m_values({halfXminR, halfXmaxR, minR, maxR, avgPhi, stereo}) {
   checkConsistency();
   m_ymax = std::sqrt(get(eMaxR) * get(eMaxR) -
-                     get(eHalfLengthXmaxR) * get(eHalfLengthXmaxR));
+                          get(eHalfLengthXmaxR) * get(eHalfLengthXmaxR));
 }
 
 Acts::SurfaceBounds::BoundsType Acts::DiscTrapezoidBounds::type() const {
@@ -48,9 +48,14 @@ Acts::ActsMatrixD<2, 2> Acts::DiscTrapezoidBounds::jacobianToLocalCartesian(
 
 bool Acts::DiscTrapezoidBounds::inside(
     const Acts::Vector2D& lposition, const Acts::BoundaryCheck& bcheck) const {
+      
+  Vector2D vertices[] = {{get(eHalfLengthXminR), get(eMinR)},
+                         {get(eHalfLengthXmaxR), m_ymax},
+                         {-get(eHalfLengthXmaxR), m_ymax},
+                         {-get(eHalfLengthXminR), get(eMinR)}};
   auto jacobian = jacobianToLocalCartesian(lposition);
   return bcheck.transformed(jacobian).isInside(toLocalCartesian(lposition),
-                                               vertices(1));
+                                               vertices);
 }
 
 std::vector<Acts::Vector2D> Acts::DiscTrapezoidBounds::vertices(

--- a/Fatras/CMakeLists.txt
+++ b/Fatras/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(
   ActsFatras SHARED
-  src/Digitization/DigitizationError.cpp
   src/Digitization/Channelizer.cpp
+  src/Digitization/DigitizationError.cpp
+  src/Digitization/PlanarSurfaceMask.cpp
   src/EventData/Particle.cpp
   src/EventData/ProcessType.cpp
   src/Kernel/SimulatorError.cpp

--- a/Fatras/include/ActsFatras/Digitization/ChannelMerger.hpp
+++ b/Fatras/include/ActsFatras/Digitization/ChannelMerger.hpp
@@ -1,0 +1,73 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsFatras/Digitization/DigitizationData.hpp"
+#include <Acts/EventData/ParameterSet.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Surfaces/SurfaceError.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+
+#include <array>
+#include <utility>
+
+namespace ActsFatras {
+
+/// Channel combination to a resulting parameter set.
+///
+struct ChannelMerger {
+  /// Generic implementation of a channel merger, currently only additive
+  /// channel merging
+  ///
+  /// @tparam kParameters parameter pack describing the parameters to smear
+  ///
+  /// @param channels The channels from one cluster
+  ///
+  /// @return A cluster containing the parameter set and cluster size
+  template <typename signal_t, Acts::BoundIndices... kParameters>
+  const std::vector<Channel<signal_t, kParameters...>> merge(
+      const std::vector<Channel<signal_t, kParameters...>>& channels) const {
+    using StorageSequence = std::make_index_sequence<sizeof...(kParameters)>;
+    using Channel = Channel<signal_t, kParameters...>;
+    using ChannelKey = std::array<unsigned int, sizeof...(kParameters)>;
+
+    // Fill a channel map
+    std::map<ChannelKey, Channel> channelMap;
+    for (const auto& ch : channels) {
+      ChannelKey key;
+      extractKeys(ch, key, StorageSequence{});
+      auto chItr = channelMap.find(key);
+      if (chItr != channelMap.end()) {
+        chItr->second.value += ch.value;
+        chItr->second.links.insert(ch.links.begin(), ch.links.end());
+      } else {
+        channelMap.insert(std::pair<ChannelKey, Channel>(key, ch));
+      }
+    }
+    // Unroll the channels after merging
+    std::vector<Channel> mergedChannels;
+    mergedChannels.reserve(channelMap.size());
+    for (auto& [key, value] : channelMap) {
+      mergedChannels.push_back(value);
+    }
+    return mergedChannels;
+  }
+
+  /// Helper method to extract the map keys from the channels
+  ///
+  /// @tparam kStorage is the access sequence to the channel
+  template <typename channel_t, typename key_t, std::size_t... kStorage>
+  static void extractKeys(const channel_t& channel, key_t& key,
+                          std::index_sequence<kStorage...>) {
+    ((key[kStorage] = channel.cellId[kStorage].first), ...);
+  }
+};
+
+}  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Digitization/Channelizer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/Channelizer.hpp
@@ -24,10 +24,17 @@ namespace ActsFatras {
 /// onto the readout surface into channel segments.
 ///
 struct Channelizer {
+  /// Shorthand for a 2D segment
+  using Segment2D = std::array<Acts::Vector2D, 2>;
+  /// Shorthand for a 2D bin
+  using Bin2D = std::array<unsigned int, 2>;
+  /// shorthand for a 2D bin delta
+  using BinDelta2D = std::array<int, 2>;
+
   /// Nested struct for stepping from one channel to the next.
   struct ChannelStep {
     /// This is the delta to the last step in bins
-    std::array<int, 2> delta = {0, 0};
+    BinDelta2D delta = {0, 0};
     /// The intersection with the channel boundary
     Acts::Vector2D intersect;
     /// The patlength from the start
@@ -38,7 +45,7 @@ struct Channelizer {
     /// @param delta_ The bin delta for this step
     /// @param intersect_ The intersect with the channel boundary
     /// @param start The start of the surface segment, for path from origin
-    ChannelStep(std::array<int, 2> delta_, Acts::Vector2D intersect_,
+    ChannelStep(BinDelta2D delta_, Acts::Vector2D intersect_,
                 const Acts::Vector2D& start)
         : delta(delta_),
           intersect(intersect_),
@@ -56,10 +63,10 @@ struct Channelizer {
   /// Nested struct for representing channel steps.
   struct ChannelSegment {
     /// The bin of this segment
-    std::array<unsigned int, 2> bin = {0, 0};
+    Bin2D bin = {0, 0};
     /// The segment start, end points
-    std::array<Acts::Vector2D, 2> path2D;
-    // The clipped path length
+    Segment2D path2D;
+    /// The clipped path length
     double pathLength = 0.;
 
     /// Constructor with arguments
@@ -67,8 +74,7 @@ struct Channelizer {
     /// @param bin_ The bin corresponding to this step
     /// @param path2D_ The start/end 2D position of the segement
     /// @param pathLength_ The segment length for this bin
-    ChannelSegment(std::array<unsigned int, 2> bin_,
-                   std::array<Acts::Vector2D, 2> path2D_, double pathLength_)
+    ChannelSegment(Bin2D bin_, Segment2D path2D_, double pathLength_)
         : bin(std::move(bin_)),
           path2D(std::move(path2D_)),
           pathLength(pathLength_) {}
@@ -86,15 +92,13 @@ struct Channelizer {
   /// @param geoCtx The geometry context for the localToGlobal, etc.
   /// @param surface The surface for the channelizing
   /// @param segmentation The segmentation for the channelizing
-  /// @param start The surface segment start (cartesian coordinates)
-  /// @param end The surface segement end (cartesian coordinates)
+  /// @param segment The surface segment (cartesian coordinates)
   ///
   /// @return a vector of ChannelSegment objects
   std::vector<ChannelSegment> segments(const Acts::GeometryContext& geoCtx,
                                        const Acts::Surface& surface,
                                        const Acts::BinUtility& segmentation,
-                                       const Acts::Vector2D& start,
-                                       const Acts::Vector2D& end) const;
+                                       const Segment2D& segment) const;
 };
 
 }  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Digitization/DigitizationError.hpp
+++ b/Fatras/include/ActsFatras/Digitization/DigitizationError.hpp
@@ -16,7 +16,8 @@ namespace ActsFatras {
 enum class DigitizationError {
   SmearingOutOfRange,
   SmearingError,
-  NoSurfaceDefined
+  UndefinedSurface,
+  MaskingError
 };
 
 namespace detail {

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
@@ -29,7 +29,6 @@ struct PlanarSurfaceMask {
   ///
   /// @note Only PlaneSurface/DiscSurface are supported
   ///
-  /// @param geoCtx The geometry context
   /// @param surface The surface in question
   /// @param segment The track segment (on surface)
   ///
@@ -39,22 +38,29 @@ struct PlanarSurfaceMask {
 
   /// Apply the mask of a polygon
   ///
-  /// @param outise The outside point of the segment
+  /// @param outside The outside point of the segment
   /// @param inside The inside point of the segment
   /// @param vertices The vertices of the polygon
   ///
-  /// @return a result wrapping the new new outside position
+  /// @return a result wrapping the new outside position
   Acts::Result<Acts::Vector2D> polygonMask(
       const Acts::Vector2D& outside, const Acts::Vector2D& inside,
       const std::vector<Acts::Vector2D>& vertices) const;
 };
 
+/// A helper class for segments in polar coordinates.
 struct PolarSegment {
+  /// The clipped position
   Acts::Vector2D clipped;
+  /// The start position of the segment (cartesian)
   Acts::Vector2D start;
+  /// The end position of the segment (cartesian)
   Acts::Vector2D end;
+  /// Indicator if inisde or not
   bool inside = false;
 
+  /// Constructor from arguments.
+  /// Parameter definition see above.
   PolarSegment(Acts::Vector2D clipped_, const Acts::Vector2D& start_,
                const Acts::Vector2D& end_, bool inside_)
       : clipped(clipped_), start(start_), end(end_), inside(inside_) {}

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
@@ -1,0 +1,63 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Result.hpp"
+
+#include <array>
+
+namespace Acts {
+class Surface;
+}
+
+namespace ActsFatras {
+
+/// A brief struct that allows to apply a surface bound mask.
+struct PlanarSurfaceMask {
+  /// Shorthand for a 2-d segment;
+  using Segment2D = std::array<Acts::Vector2D, 2>;
+
+  /// Apply the mask on the segment
+  /// - If the semgent is full inside the surface, return unchanged
+  /// - Otherwise mask/clip the segment to fit into the bounds
+  ///
+  /// @note Only PlaneSurface/DiscSurface are supported
+  ///
+  /// @param geoCtx The geometry context
+  /// @param surface The surface in question
+  /// @param segment The track segment (on surface)
+  ///
+  /// @return a result wrapping a segment
+  Acts::Result<Segment2D> apply(const Acts::Surface& surface,
+                                const Segment2D& segment) const;
+
+  /// Apply the mask of a polygon
+  ///
+  /// @param outise The outside point of the segment
+  /// @param inside The inside point of the segment
+  /// @param vertices The vertices of the polygon
+  ///
+  /// @return a result wrapping the new new outside position
+  Acts::Result<Acts::Vector2D> polygonMask(
+      const Acts::Vector2D& outside, const Acts::Vector2D& inside,
+      const std::vector<Acts::Vector2D>& vertices) const;
+};
+
+struct PolarSegment {
+  Acts::Vector2D clipped;
+  Acts::Vector2D start;
+  Acts::Vector2D end;
+  bool inside = false;
+
+  PolarSegment(Acts::Vector2D clipped_, const Acts::Vector2D& start_,
+               const Acts::Vector2D& end_, bool inside_)
+      : clipped(clipped_), start(start_), end(end_), inside(inside_) {}
+};
+
+}  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Result.hpp"
 
@@ -14,7 +15,9 @@
 
 namespace Acts {
 class Surface;
-}
+class AnnulusBounds;
+class RadialBounds;
+}  // namespace Acts
 
 namespace ActsFatras {
 
@@ -38,32 +41,40 @@ struct PlanarSurfaceMask {
 
   /// Apply the mask of a polygon
   ///
-  /// @param outside The outside point of the segment
-  /// @param inside The inside point of the segment
   /// @param vertices The vertices of the polygon
+  /// @param segment The track segment (on surface)
+  /// @param firstInside The indicator if the first is inside
   ///
-  /// @return a result wrapping the new outside position
-  Acts::Result<Acts::Vector2D> polygonMask(
-      const Acts::Vector2D& outside, const Acts::Vector2D& inside,
-      const std::vector<Acts::Vector2D>& vertices) const;
-};
+  /// @return a result wrapping a segment
+  Acts::Result<Segment2D> polygonMask(
+      const std::vector<Acts::Vector2D>& vertices, const Segment2D& segment,
+      bool firstInside) const;
 
-/// A helper class for segments in polar coordinates.
-struct PolarSegment {
-  /// The clipped position
-  Acts::Vector2D clipped;
-  /// The start position of the segment (cartesian)
-  Acts::Vector2D start;
-  /// The end position of the segment (cartesian)
-  Acts::Vector2D end;
-  /// Indicator if inisde or not
-  bool inside = false;
+  /// Apply the mask of a Radial disk
+  ///
+  /// @param rBounds The radial disc for the masking
+  /// @param segment The track segment (on surface)
+  /// @param polarSegment The track segmetn (on surface, in polar)
+  /// @param firstInside The indicator if the first is inside
+  ///
+  /// @return a result wrapping a segment
+  Acts::Result<Segment2D> radialMask(const Acts::RadialBounds& rBounds,
+                                     const Segment2D& segment,
+                                     const Segment2D& polarSegment,
+                                     bool firstInside) const;
 
-  /// Constructor from arguments.
-  /// Parameter definition see above.
-  PolarSegment(Acts::Vector2D clipped_, const Acts::Vector2D& start_,
-               const Acts::Vector2D& end_, bool inside_)
-      : clipped(clipped_), start(start_), end(end_), inside(inside_) {}
+  /// Apply the mask of an annulus disk
+  ///
+  /// @param aBounds The annulus disc for the masking
+  /// @param segment The track segment (on surface)
+  /// @param firstInside The indicator if the first is inside
+  ///
+  /// @return a result wrapping a segment
+  Acts::Result<Segment2D> annulusMask(const Acts::AnnulusBounds& aBounds,
+                                      const Segment2D& segment,
+                                      bool firstInside) const;
+
+  Acts::detail::IntersectionHelper2D intersector;
 };
 
 }  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Digitization/UncorrelatedHitSmearer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/UncorrelatedHitSmearer.hpp
@@ -83,7 +83,7 @@ struct BoundParametersSmearer {
         detail::ParametersSmearer<Acts::BoundIndices, kParameters...>;
 
     if (sInput.surface == nullptr) {
-      return Result(ActsFatras::DigitizationError::NoSurfaceDefined);
+      return Result(ActsFatras::DigitizationError::UndefinedSurface);
     }
 
     const auto& hit = sInput.hit.get();

--- a/Fatras/src/Digitization/Channelizer.cpp
+++ b/Fatras/src/Digitization/Channelizer.cpp
@@ -16,19 +16,22 @@ std::vector<ActsFatras::Channelizer::ChannelSegment>
 ActsFatras::Channelizer::segments(const Acts::GeometryContext& geoCtx,
                                   const Acts::Surface& surface,
                                   const Acts::BinUtility& segmentation,
-                                  const Acts::Vector2D& start,
-                                  const Acts::Vector2D& end) const {
+                                  const Segment2D& segment) const {
   // Return if the segmentation is not two-dimensional
   // (strips need to have one bin along the strip)
   if (segmentation.dimensions() != 2) {
     return {};
   }
 
+  // Start and end point
+  const auto& start = segment[0];
+  const auto& end = segment[1];
+
   // Full path length - the full channel
   auto segment2d = (end - start);
   std::vector<ChannelStep> cSteps;
-  std::array<unsigned int, 2> bstart = {0, 0};
-  std::array<unsigned int, 2> bend = {0, 0};
+  Bin2D bstart = {0, 0};
+  Bin2D bend = {0, 0};
 
   if (surface.type() == Acts::Surface::SurfaceType::Plane) {
     // Get the segmentation and convert it to lines & arcs
@@ -135,8 +138,8 @@ ActsFatras::Channelizer::segments(const Acts::GeometryContext& geoCtx,
   std::vector<ChannelSegment> cSegments;
   cSegments.reserve(cSteps.size());
 
-  std::array<unsigned int, 2> currentBin = {bstart[0], bstart[1]};
-  std::array<int, 2> lastDelta = {0, 0};
+  Bin2D currentBin = {bstart[0], bstart[1]};
+  BinDelta2D lastDelta = {0, 0};
   Acts::Vector2D lastIntersect = start;
   double lastPath = 0.;
   for (auto& cStep : cSteps) {

--- a/Fatras/src/Digitization/DigitizationError.cpp
+++ b/Fatras/src/Digitization/DigitizationError.cpp
@@ -1,5 +1,4 @@
 // This file is part of the Acts project.
-// This file is part of the Acts project.
 //
 // Copyright (C) 2020 CERN for the benefit of the Acts project
 //

--- a/Fatras/src/Digitization/DigitizationError.cpp
+++ b/Fatras/src/Digitization/DigitizationError.cpp
@@ -20,8 +20,10 @@ std::string ActsFatras::detail::DigitizationErrorCategory::message(
       return "Digitization: smeared out of surface bounds.";
     case DigitizationError::SmearingError:
       return "Digitization: smearing error occured.";
-    case DigitizationError::NoSurfaceDefined:
+    case DigitizationError::UndefinedSurface:
       return "Digitization: no surface for bound measurement defined.";
+    case DigitizationError::MaskingError:
+      return "Digitization: surface maks could not be applied.";
     default:
       return "unknown";
   }

--- a/Fatras/src/Digitization/DigitizationError.cpp
+++ b/Fatras/src/Digitization/DigitizationError.cpp
@@ -1,4 +1,5 @@
 // This file is part of the Acts project.
+// This file is part of the Acts project.
 //
 // Copyright (C) 2020 CERN for the benefit of the Acts project
 //
@@ -23,7 +24,7 @@ std::string ActsFatras::detail::DigitizationErrorCategory::message(
     case DigitizationError::UndefinedSurface:
       return "Digitization: no surface for bound measurement defined.";
     case DigitizationError::MaskingError:
-      return "Digitization: surface maks could not be applied.";
+      return "Digitization: surface mask could not be applied.";
     default:
       return "unknown";
   }

--- a/Fatras/src/Digitization/DigitizationError.cpp
+++ b/Fatras/src/Digitization/DigitizationError.cpp
@@ -17,13 +17,13 @@ std::string ActsFatras::detail::DigitizationErrorCategory::message(
     int c) const {
   switch (static_cast<DigitizationError>(c)) {
     case DigitizationError::SmearingOutOfRange:
-      return "Digitization: smeared out of surface bounds.";
+      return "Smeared out of surface bounds.";
     case DigitizationError::SmearingError:
-      return "Digitization: smearing error occured.";
+      return "Smearing error occured.";
     case DigitizationError::UndefinedSurface:
-      return "Digitization: no surface for bound measurement defined.";
+      return "Surface undefined for this operation.";
     case DigitizationError::MaskingError:
-      return "Digitization: surface mask could not be applied.";
+      return "Surface mask could not be applied.";
     default:
       return "unknown";
   }

--- a/Fatras/src/Digitization/PlanarSurfaceMask.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceMask.cpp
@@ -150,14 +150,14 @@ ActsFatras::PlanarSurfaceMask::apply(const Acts::Surface& surface,
           [](const Acts::Vector2D& a, const Acts::Vector2D& b) {
             return (Acts::VectorHelpers::phi(a) < Acts::VectorHelpers::phi(b));
           });
-      Segment2D minEdge = {cartesianEdges[0], cartesianEdges[3]};
-      Segment2D maxEdge = {cartesianEdges[1], cartesianEdges[2]};
+      Segment2D minEdge = {cartesianEdges[0], cartesianEdges[2]};
+      Segment2D maxEdge = {cartesianEdges[1], cartesianEdges[3]};
       sectorEdges = {minEdge, maxEdge};
       std::pair<double, double> phisMinR = {
           Acts::VectorHelpers::phi(cartesianEdges[0]),
           Acts::VectorHelpers::phi(cartesianEdges[2])};
       std::pair<double, double> phisMaxR = {
-          Acts::VectorHelpers::phi(cartesianEdges[1]),
+          Acts::VectorHelpers::phi(cartesianEdges[2]),
           Acts::VectorHelpers::phi(cartesianEdges[3])};
       polarE = {phisMinR, phisMaxR};
     }

--- a/Fatras/src/Digitization/PlanarSurfaceMask.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceMask.cpp
@@ -1,0 +1,232 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/Digitization/PlanarSurfaceMask.hpp"
+
+#include "ActsFatras/Digitization/DigitizationError.hpp"
+#include <Acts/Surfaces/AnnulusBounds.hpp>
+#include <Acts/Surfaces/DiscTrapezoidBounds.hpp>
+#include <Acts/Surfaces/PlanarBounds.hpp>
+#include <Acts/Surfaces/RadialBounds.hpp>
+#include <Acts/Surfaces/Surface.hpp>
+#include <Acts/Surfaces/detail/IntersectionHelper2D.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+
+Acts::Result<std::array<Acts::Vector2D, 2>>
+ActsFatras::PlanarSurfaceMask::apply(const Acts::Surface& surface,
+                                     const Segment2D& segment) const {
+  auto surfaceType = surface.type();
+  Segment2D clipped(segment);
+
+  // Plane surface section -------------------
+  if (surfaceType == Acts::Surface::Plane or
+      surface.bounds().type() == Acts::SurfaceBounds::eDiscTrapezoid) {
+    Acts::Vector2D localStart =
+        (surfaceType == Acts::Surface::Plane)
+            ? segment[0]
+            : Acts::Vector2D(Acts::VectorHelpers::perp(segment[0]),
+                             Acts::VectorHelpers::phi(segment[0]));
+
+    Acts::Vector2D localEnd =
+        (surfaceType == Acts::Surface::Plane)
+            ? segment[1]
+            : Acts::Vector2D(Acts::VectorHelpers::perp(segment[1]),
+                             Acts::VectorHelpers::phi(segment[1]));
+
+    bool startInside = surface.bounds().inside(localStart, true);
+    bool endInside = surface.bounds().inside(localEnd, true);
+
+    if (startInside and endInside) {
+      return segment;
+    }
+
+    // It's either planar or disc trapezoid bounds
+    const Acts::PlanarBounds* planarBounds = nullptr;
+    const Acts::DiscTrapezoidBounds* dtbBounds = nullptr;
+    if (surfaceType == Acts::Surface::Plane) {
+      planarBounds =
+          static_cast<const Acts::PlanarBounds*>(&(surface.bounds()));
+      if (planarBounds->type() == Acts::SurfaceBounds::eEllipse) {
+        return DigitizationError::UndefinedSurface;
+      }
+    } else {
+      dtbBounds =
+          static_cast<const Acts::DiscTrapezoidBounds*>(&(surface.bounds()));
+    }
+    auto vertices = planarBounds != nullptr ? planarBounds->vertices(1)
+                                            : dtbBounds->vertices(1);
+    if (not startInside) {
+      auto maskedR = polygonMask(segment[0], segment[1], vertices);
+      if (maskedR.ok()) {
+        clipped[0] = maskedR.value();
+      } else {
+        return DigitizationError::MaskingError;
+      }
+    }
+    if (not endInside) {
+      auto maskedR = polygonMask(segment[1], segment[0], vertices);
+      if (maskedR.ok()) {
+        clipped[1] = maskedR.value();
+      } else {
+        return DigitizationError::MaskingError;
+      }
+    }
+    return clipped;
+
+    // Disc surface section --------------------
+  } else if (surfaceType == Acts::Surface::Disc) {
+    // Polar coordinates
+    Acts::Vector2D sPolar(Acts::VectorHelpers::perp(segment[0]),
+                          Acts::VectorHelpers::phi(segment[0]));
+    Acts::Vector2D ePolar(Acts::VectorHelpers::perp(segment[1]),
+                          Acts::VectorHelpers::phi(segment[1]));
+
+    bool startInside = surface.bounds().inside(sPolar, true);
+    bool endInside = surface.bounds().inside(ePolar, true);
+
+    if (startInside and endInside) {
+      return segment;
+    }
+
+    // DiscTrapezoidalBounds are already excluded
+    std::array<double, 2> radialE;
+    std::array<std::pair<double, double>, 2> polarE;
+    std::array<Segment2D, 2> sectorEdges;
+    if (surface.bounds().type() == Acts::SurfaceBounds::eDisc) {
+      auto rBounds =
+          static_cast<const Acts::RadialBounds*>(&(surface.bounds()));
+      double rMin = rBounds->get(Acts::RadialBounds::eMinR);
+      double rMax = rBounds->get(Acts::RadialBounds::eMaxR);
+      radialE = {rMin, rMax};
+      double hPhi = rBounds->get(Acts::RadialBounds::eHalfPhiSector);
+      double aPhi = rBounds->get(Acts::RadialBounds::eAveragePhi);
+      std::pair<double, double> phiMinMax = {aPhi - hPhi, aPhi + hPhi};
+      polarE = {phiMinMax, phiMinMax};
+      double cphiMin = std::cos(aPhi - hPhi);
+      double sphiMin = std::sin(aPhi - hPhi);
+      double cphiMax = std::cos(aPhi + hPhi);
+      double sphiMax = std::sin(aPhi + hPhi);
+      Segment2D minEdge = {Acts::Vector2D(rMin * cphiMin, rMin * sphiMin),
+                           Acts::Vector2D(rMax * cphiMin, rMax * sphiMin)};
+      Segment2D maxEdge = {Acts::Vector2D(rMin * cphiMax, rMin * sphiMax),
+                           Acts::Vector2D(rMax * cphiMax, rMax * sphiMax)};
+      sectorEdges = {minEdge, maxEdge};
+
+    } else if (surface.bounds().type() == Acts::SurfaceBounds::eAnnulus) {
+      auto aBounds =
+          static_cast<const Acts::AnnulusBounds*>(&(surface.bounds()));
+      double rMin = aBounds->rMin();
+      double rMax = aBounds->rMax();
+      radialE = {rMin, rMax};
+
+      auto polarEdges = aBounds->corners();
+      auto polarCenter = aBounds->moduleOrigin();
+
+      std::vector<Acts::Vector2D> cartesianEdges;
+      for (const auto& pe : polarEdges) {
+        double R = pe[Acts::eBoundLoc0];
+        double phi = pe[Acts::eBoundLoc1];
+        Acts::Vector2D ce(R * std::cos(phi) - polarCenter.x(),
+                          R * std::sin(phi) - polarCenter.y());
+        cartesianEdges.push_back(ce);
+      }
+      std::sort(cartesianEdges.begin(), cartesianEdges.end(),
+                [](const Acts::Vector2D& a, const Acts::Vector2D& b) {
+                  return (Acts::VectorHelpers::perp(a) <
+                          Acts::VectorHelpers::perp(b));
+                });
+      std::sort(
+          cartesianEdges.begin(), cartesianEdges.begin() + 1,
+          [](const Acts::Vector2D& a, const Acts::Vector2D& b) {
+            return (Acts::VectorHelpers::phi(a) < Acts::VectorHelpers::phi(b));
+          });
+      std::sort(
+          cartesianEdges.begin() + 2, cartesianEdges.begin() + 3,
+          [](const Acts::Vector2D& a, const Acts::Vector2D& b) {
+            return (Acts::VectorHelpers::phi(a) < Acts::VectorHelpers::phi(b));
+          });
+      Segment2D minEdge = {cartesianEdges[0], cartesianEdges[3]};
+      Segment2D maxEdge = {cartesianEdges[1], cartesianEdges[2]};
+      sectorEdges = {minEdge, maxEdge};
+      std::pair<double, double> phisMinR = {
+          Acts::VectorHelpers::phi(cartesianEdges[0]),
+          Acts::VectorHelpers::phi(cartesianEdges[2])};
+      std::pair<double, double> phisMaxR = {
+          Acts::VectorHelpers::phi(cartesianEdges[1]),
+          Acts::VectorHelpers::phi(cartesianEdges[3])};
+      polarE = {phisMinR, phisMaxR};
+    }
+
+    Acts::detail::IntersectionHelper2D intersector;
+
+    std::array<PolarSegment, 2> segEdges = {
+        PolarSegment(segment[0], segment[0], segment[1], startInside),
+        PolarSegment(segment[1], segment[1], segment[0], endInside)};
+
+    // Clip to radial bound
+    for (auto& se : segEdges) {
+      Acts::Intersection2D solution;
+      if (not se.inside) {
+        Acts::Vector2D sedir = (se.end - se.start).normalized();
+        for (const auto& sector : sectorEdges) {
+          auto tSolution = intersector.intersectSegment(sector[0], sector[1],
+                                                        se.start, sedir, true);
+          if (tSolution and tSolution.pathLength > 0. and
+              tSolution.pathLength < solution.pathLength) {
+            se.clipped = tSolution.position;
+            solution = tSolution;
+          }
+        }
+        size_t ir = 0;
+        // Check radial first
+        for (auto r : radialE) {
+          auto tSolution = intersector.intersectCircleSegment(
+              r, polarE[ir].first, polarE[ir].second, se.start, sedir);
+          if (tSolution and tSolution.pathLength > 0. and
+              tSolution.pathLength < solution.pathLength) {
+            se.clipped = tSolution.position;
+            solution = tSolution;
+          }
+          ++ir;
+        }
+        // No clipping happened
+        if (not solution) {
+          return DigitizationError::MaskingError;
+        }
+      }
+    }
+    clipped = {segEdges[0].clipped, segEdges[1].clipped};
+    return clipped;
+  }
+  return DigitizationError::UndefinedSurface;
+}
+
+Acts::Result<Acts::Vector2D> ActsFatras::PlanarSurfaceMask::polygonMask(
+    const Acts::Vector2D& outside, const Acts::Vector2D& inside,
+    const std::vector<Acts::Vector2D>& vertices) const {
+  Acts::Intersection2D solution;
+  Acts::detail::IntersectionHelper2D intersector;
+
+  for (size_t iv = 0; iv < vertices.size(); ++iv) {
+    const Acts::Vector2D& s0 = vertices[iv];
+    const Acts::Vector2D& s1 =
+        (iv + 1) < vertices.size() ? vertices[iv + 1] : vertices[0];
+
+    Acts::Vector2D lineSegment2D = (inside - outside).normalized();
+    auto intersection =
+        intersector.intersectSegment(s0, s1, outside, lineSegment2D, true);
+    if (intersection and intersection.pathLength < solution.pathLength) {
+      solution = intersection;
+    }
+  }
+
+  if (solution.status == Acts::Intersection2D::Status::reachable) {
+    return Acts::Result<Acts::Vector2D>::success(solution.position);
+  }
+  return Acts::Result<Acts::Vector2D>::failure(DigitizationError::MaskingError);
+}

--- a/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
@@ -25,9 +25,6 @@ BOOST_AUTO_TEST_SUITE(Surfaces)
 BOOST_AUTO_TEST_CASE(DiscTrapezoidBoundsConstruction) {
   double minHalfX(1.0), maxHalfX(5.0), rMin(2.0), rMax(6.0), averagePhi(0.0),
       stereo(0.1);
-  // test default construction
-  // DiscTrapezoidBounds defaultConstructedDiscTrapezoidBounds;  should be
-  // deleted
   //
   /// Test construction with dimensions and default stereo
   BOOST_CHECK_EQUAL(

--- a/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(DiscTrapezoidBoundsProperties) {
   /// Test distanceToBoundary
   Vector2D origin(0., 0.);
   Vector2D outside(30., 0.);
-  Vector2D inSurface(2., 0.0);
+  Vector2D inSurface(2.5, 0.0);
   //
   /// Test dump
   boost::test_tools::output_test_stream dumpOuput;

--- a/Tests/UnitTests/Fatras/Digitization/BoundRandomValues.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/BoundRandomValues.hpp
@@ -6,6 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#pragma once
+
+#include "Acts/Utilities/Definitions.hpp"
+
 #include <array>
 
 namespace ActsFatras {
@@ -25,7 +29,7 @@ struct RectangleRandom {
   /// generate a x/y position inside the Rectangle @return
   ///
   /// @note r0, r1 need to be within [0,1]
-  std::array<double, 2> operator()(double r0, double r1) const {
+  Acts::Vector2D operator()(double r0, double r1) const {
     return {(2 * r0 - 1) * xmax, (2 * r1 - 1) * ymax};
   }
 };
@@ -58,7 +62,7 @@ struct TrapezoidRandom {
   /// generate a x/y position inside the Trapezoid @return
   ///
   /// @note r0, r1 need to be within [0,1]
-  std::array<double, 2> operator()(double r0, double r1) const {
+  Acts::Vector2D operator()(double r0, double r1) const {
     double y = ymin + (ymax - ymin) * r1;
     double xmax = xminy + (xmaxy - xminy) / (ymax - ymin) * (y - ymin);
     double x = (2 * r0 - 1) * xmax;
@@ -86,7 +90,7 @@ struct DiscRandom {
   /// generate a x/y position inside the Disc @return
   ///
   /// @note r0, r1 need to be within [0,1]
-  std::array<double, 2> operator()(double r0, double r1) const {
+  Acts::Vector2D operator()(double r0, double r1) const {
     double r = rmin + (rmax - rmin) * r0;
     double phi = phimin + (phimax - phimin) * r1;
     return {r * std::cos(phi), r * std::sin(phi)};
@@ -123,7 +127,7 @@ struct AnnulusRandom {
   /// generate a x/y position inside Annulus shape and  @return
   ///
   /// @note r0, r1 need to be within [0,1]
-  std::array<double, 2> operator()(double r0, double r1) const {
+  Acts::Vector2D operator()(double r0, double r1) const {
     double r = rmin + (rmax - rmin) * r0;
     double phi = phimins + (phimaxs - phimins) * r1;
     return {r * std::cos(phi), r * std::sin(phi)};

--- a/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
+++ b/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(unittest_extra_libraries ActsFatras)
 
+add_unittest(FatrasChannelMerger ChannelMergerTests.cpp)
 add_unittest(FatrasChannelizer ChannelizerTests.cpp)
 add_unittest(FatrasPlanarSurfaceMask PlanarSurfaceMaskTests.cpp)
 add_unittest(FatrasUncorrelatedHitSmearer UncorrelatedHitSmearerTests.cpp)

--- a/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
+++ b/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(unittest_extra_libraries ActsFatras)
 
 add_unittest(FatrasChannelizer ChannelizerTests.cpp)
+add_unittest(FatrasPlanarSurfaceMask PlanarSurfaceMaskTests.cpp)
 add_unittest(FatrasUncorrelatedHitSmearer UncorrelatedHitSmearerTests.cpp)

--- a/Tests/UnitTests/Fatras/Digitization/ChannelMergerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/ChannelMergerTests.cpp
@@ -1,0 +1,96 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "ActsFatras/Digitization/ChannelMerger.hpp"
+#include "ActsFatras/Digitization/DigitizationError.hpp"
+
+#include <Acts/Tests/CommonHelpers/FloatComparisons.hpp>
+#include <Acts/Utilities/Definitions.hpp>
+#include <Acts/Utilities/Helpers.hpp>
+#include <Acts/Utilities/ParameterDefinitions.hpp>
+
+namespace ActsFatras {
+
+BOOST_AUTO_TEST_SUITE(Digitization)
+
+BOOST_AUTO_TEST_CASE(ChannelMerger1D) {
+  ChannelMerger cm;
+
+  // Some cells
+  Cell cell0(5, 10.5);
+  Cell cell1(6, 11.5);
+  Cell cell2(7, 12.5);
+
+  using Channel1D = Channel<double, Acts::eBoundLoc0>;
+
+  // Digital clustering test
+  std::vector<Channel1D> channels = {{{cell0}, 1., {5}},
+                                     {{cell1}, 1., {5}},
+                                     {{cell2}, 1., {5}},
+                                     {{cell0}, 0.5, {6}}};
+
+  BOOST_CHECK_EQUAL(channels.size(), 4u);
+  auto mergedChannels = cm.merge<double, Acts::eBoundLoc0>(channels);
+  BOOST_CHECK_EQUAL(mergedChannels.size(), 3u);
+
+  std::unordered_set<unsigned int> mergedLinks = {5, 6};
+  // Find the merged one and check the merged value
+  for (const auto& ch : mergedChannels) {
+    if (ch.cellId[0].first == 5) {
+      // Check if the channel value is merged
+      CHECK_CLOSE_ABS(ch.value, 1.5, Acts::s_epsilon);
+      // check if the channel links are merged
+      BOOST_CHECK_EQUAL(ch.links.size(), 2u);
+      BOOST_CHECK(ch.links == mergedLinks);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ChannelMerger2D) {
+  ChannelMerger cm;
+
+  // Some cells in 0 direction
+  Cell cell00(5, 10.5);
+  Cell cell01(6, 11.5);
+  Cell cell02(7, 12.5);
+
+  // Some cells in 1 direction
+  Cell cell10(10, 0.5);
+  Cell cell11(10, 0.5);
+  Cell cell12(11, 1.5);
+
+  using Channel2D = Channel<double, Acts::eBoundLoc0, Acts::eBoundLoc1>;
+
+  std::vector<Channel2D> channels = {{{cell00, cell10}, 1., {5}},
+                                     {{cell01, cell11}, 1., {5}},
+                                     {{cell02, cell12}, 1., {5}},
+                                     {{cell01, cell11}, 0.5, {6}}};
+
+  BOOST_CHECK_EQUAL(channels.size(), 4u);
+  auto mergedChannels =
+      cm.merge<double, Acts::eBoundLoc0, Acts::eBoundLoc1>(channels);
+  BOOST_CHECK_EQUAL(mergedChannels.size(), 3u);
+
+  std::unordered_set<unsigned int> mergedLinks = {5, 6};
+  // Find the merged one and check the merged value
+  for (const auto& ch : mergedChannels) {
+    if (ch.cellId[0].first == 6) {
+      // Check if the channel value is merged
+      CHECK_CLOSE_ABS(ch.value, 1.5, Acts::s_epsilon);
+      // check if the channel links are merged
+      BOOST_CHECK_EQUAL(ch.links.size(), 2u);
+      BOOST_CHECK(ch.links == mergedLinks);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsFatras

--- a/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
@@ -142,16 +142,17 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
       std::ofstream shape;
       std::ofstream grid;
 
+      const auto centerXY = surface->center(geoCtx).segment<2>(0);
       // 0 - write the shape
       shape.open("Channelizer" + name + "Borders.csv");
       if (surface->type() == Acts::Surface::Plane) {
         const auto* pBounds =
             static_cast<const Acts::PlanarBounds*>(&(surface->bounds()));
-        csvHelper.writePolygon(shape, pBounds->vertices(1));
+        csvHelper.writePolygon(shape, pBounds->vertices(1), -centerXY);
       } else if (surface->type() == Acts::Surface::Disc) {
         const auto* dBounds =
             static_cast<const Acts::DiscBounds*>(&(surface->bounds()));
-        csvHelper.writePolygon(shape, dBounds->vertices(72));
+        csvHelper.writePolygon(shape, dBounds->vertices(72), -centerXY);
       }
       // 1 - write the grid
       grid.open("Channelizer" + name + "Grid.csv");

--- a/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
@@ -141,7 +141,6 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
     if (index == 0) {
       std::ofstream shape;
       std::ofstream grid;
-
       const auto centerXY = surface->center(geoCtx).segment<2>(0);
       // 0 - write the shape
       shape.open("Channelizer" + name + "Borders.csv");

--- a/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
@@ -24,7 +24,8 @@
 #include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "ActsFatras/Digitization/Channelizer.hpp"
-#include "BoundRandomValues.hpp"
+#include "DigitizationCsvOutput.hpp"
+#include "PlanarSurfaceTestBeds.hpp"
 
 #include <array>
 #include <fstream>
@@ -53,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ChannelizerCartesian) {
   // Test: Normal hit into the surface
   Acts::Vector2D nPosition(0.37, 0.76);
   auto nSegments =
-      cl.segments(geoCtx, *planeSurface, pixelated, nPosition, nPosition);
+      cl.segments(geoCtx, *planeSurface, pixelated, {nPosition, nPosition});
   BOOST_CHECK(nSegments.size() == 1);
   BOOST_CHECK(nSegments[0].bin[0] == 13);
   BOOST_CHECK(nSegments[0].bin[1] == 17);
@@ -62,21 +63,21 @@ BOOST_AUTO_TEST_CASE(ChannelizerCartesian) {
   Acts::Vector2D ixPositionS(0.37, 0.76);
   Acts::Vector2D ixPositionE(0.02, 0.73);
   auto ixSegments =
-      cl.segments(geoCtx, *planeSurface, pixelated, ixPositionS, ixPositionE);
+      cl.segments(geoCtx, *planeSurface, pixelated, {ixPositionS, ixPositionE});
   BOOST_CHECK(ixSegments.size() == 4);
 
   // Test: Inclined hit into the surface - positive y direction
   Acts::Vector2D iyPositionS(0.37, 0.76);
   Acts::Vector2D iyPositionE(0.39, 0.91);
   auto iySegments =
-      cl.segments(geoCtx, *planeSurface, pixelated, iyPositionS, iyPositionE);
+      cl.segments(geoCtx, *planeSurface, pixelated, {iyPositionS, iyPositionE});
   BOOST_CHECK(iySegments.size() == 3);
 
   // Test: Inclined hit into the surface - x/y direction
   Acts::Vector2D ixyPositionS(-0.27, 0.76);
   Acts::Vector2D ixyPositionE(-0.02, -0.73);
-  auto ixySegments =
-      cl.segments(geoCtx, *planeSurface, pixelated, ixyPositionS, ixyPositionE);
+  auto ixySegments = cl.segments(geoCtx, *planeSurface, pixelated,
+                                 {ixyPositionS, ixyPositionE});
   BOOST_CHECK(ixySegments.size() == 18);
 }
 
@@ -97,7 +98,7 @@ BOOST_AUTO_TEST_CASE(ChannelizerPolarRadial) {
   // Test: Normal hit into the surface
   Acts::Vector2D nPosition(6.76, 0.5);
   auto nSegments =
-      cl.segments(geoCtx, *radialDisc, strips, nPosition, nPosition);
+      cl.segments(geoCtx, *radialDisc, strips, {nPosition, nPosition});
   BOOST_CHECK(nSegments.size() == 1);
   BOOST_CHECK(nSegments[0].bin[0] == 0);
   BOOST_CHECK(nSegments[0].bin[1] == 161);
@@ -106,17 +107,15 @@ BOOST_AUTO_TEST_CASE(ChannelizerPolarRadial) {
   Acts::Vector2D sPositionS(6.76, 0.5);
   Acts::Vector2D sPositionE(7.03, -0.3);
   auto sSegment =
-      cl.segments(geoCtx, *radialDisc, strips, sPositionS, sPositionE);
+      cl.segments(geoCtx, *radialDisc, strips, {sPositionS, sPositionE});
   BOOST_CHECK(sSegment.size() == 59);
 
   // Test: jump over R boundary, but stay in phi bin
   sPositionS = Acts::Vector2D(6.76, 0.);
   sPositionE = Acts::Vector2D(7.83, 0.);
-  sSegment = cl.segments(geoCtx, *radialDisc, strips, sPositionS, sPositionE);
+  sSegment = cl.segments(geoCtx, *radialDisc, strips, {sPositionS, sPositionE});
   BOOST_CHECK(sSegment.size() == 2);
 }
-
-std::vector<std::array<std::ofstream, 3>> out;
 
 /// Unit test for testing the Channelizer
 BOOST_DATA_TEST_CASE(RandomChannelizerTest,
@@ -127,75 +126,15 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
   Acts::GeometryContext geoCtx;
   Channelizer cl;
 
-  // Pixel test in Rectangle
-  auto rectangle = std::make_shared<Acts::RectangleBounds>(3., 6.5);
-  auto rSurface = Acts::Surface::makeShared<Acts::PlaneSurface>(
-      Acts::Transform3D::Identity(), rectangle);
-  Acts::BinUtility pixelated(15, -3., 3., Acts::open, Acts::binX);
-  pixelated += Acts::BinUtility(26, -6.5, 6.5, Acts::open, Acts::binY);
-  RectangleRandom rRandom(3., 6.5);
+  // Test beds with random numbers generated inside
+  PlanarSurfaceTestBeds pstd;
+  auto testBeds = pstd(1.);
 
-  // Cartesian strip test in Trapezoid
-  auto trapezoid = std::make_shared<Acts::TrapezoidBounds>(2., 3.5, 4.);
-  auto tSurface = Acts::Surface::makeShared<Acts::PlaneSurface>(
-      Acts::Transform3D::Identity(), trapezoid);
-  Acts::BinUtility stripsX(35, -3.5, 3.5, Acts::open, Acts::binX);
-  stripsX += Acts::BinUtility(1, -4., 4., Acts::open, Acts::binY);
-  TrapezoidRandom tRandom(2., 3.5, 4.);
-
-  // Phi strip test in DiscTrapezoid
-  double rmin = 2.;
-  double rmax = 7.5;
-  double xmin = 2.;
-  double xmax = 3.5;
-  double ymax = std::sqrt(rmax * rmax - xmax * xmax);
-  double alpha = std::max(atan2(xmin, rmin), atan2(xmax, ymax));
-
-  auto discTrapezoid =
-      std::make_shared<Acts::DiscTrapezoidBounds>(xmin, xmax, rmin, rmax);
-  auto dtSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-      Acts::Transform3D::Identity(), discTrapezoid);
-  Acts::BinUtility stripsPhi(1, 2., 7.5, Acts::open, Acts::binR);
-  stripsPhi += Acts::BinUtility(25, M_PI_2 - alpha, M_PI_2 + alpha, Acts::open,
-                                Acts::binPhi);
-  TrapezoidRandom dtRandom(xmin, xmax, rmin, ymax);
-
-  // Raidal disc test
-  auto discRadial =
-      std::make_shared<Acts::RadialBounds>(rmin, rmax, M_PI_4, M_PI_2);
-  auto dSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-      Acts::Transform3D::Identity(), discRadial);
-  Acts::BinUtility rphiseg(10, rmin, rmax, Acts::open, Acts::binR);
-  rphiseg += Acts::BinUtility(20, (M_PI_2 - M_PI_4), (M_PI_2 + M_PI_4),
-                              Acts::open, Acts::binPhi);
-  DiscRandom dRandom(rmin, rmax, M_PI_2 - M_PI_4, M_PI_2 + M_PI_4);
-
-  // Annulus disc test
-  Acts::Vector2D aorigin(0.05, -0.1);
-  double phimin = -0.25;
-  double phimax = 0.38;
-  auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, -0.25, 0.38,
-                                                       aorigin, M_PI_4);
-  auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-      Acts::Transform3D::Identity(), annulus);
-  Acts::BinUtility stripsPhiA(1, 0., 10., Acts::open, Acts::binR);
-  stripsPhiA += Acts::BinUtility(12, -0.25, 0.36, Acts::open, Acts::binPhi);
-  AnnulusRandom aRandom(rmin, rmax, phimin, phimax, aorigin.x(), aorigin.y());
-
-  using Randomizer = std::function<std::array<double, 2>(double, double)>;
-  using TestBed = std::tuple<std::string, const Acts::Surface*,
-                             Acts::BinUtility, Randomizer>;
-
-  std::vector<TestBed> testBeds = {
-      {"Rectangle", rSurface.get(), pixelated, rRandom},
-      {"Trapezoid", tSurface.get(), stripsX, tRandom},
-      {"DiscTrapezoid", dtSurface.get(), stripsPhi, dtRandom},
-      {"DiscRadial", dSurface.get(), rphiseg, dRandom},
-      {"Annulus", aSurface.get(), stripsPhiA, aRandom}};
+  DigitizationCsvOutput csvHelper;
 
   for (const auto& tb : testBeds) {
     const auto& name = std::get<0>(tb);
-    const auto* surface = std::get<1>(tb);
+    const auto* surface = (std::get<1>(tb)).get();
     const auto& segmentation = std::get<2>(tb);
     const auto& randomizer = std::get<3>(tb);
 
@@ -203,40 +142,16 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
       std::ofstream shape;
       std::ofstream grid;
 
-      // Helper method to write a line
-      auto writeLine = [](std::ostream& outf, const Acts::Vector2D& p0,
-                          const Acts::Vector2D& p1) -> void {
-        outf << "l," << p0.x() << "," << p0.y() << "," << p1.x() << ","
-             << p1.y() << "\n";
-      };
-
-      // Helper method to write an arc
-      auto writeArc = [&](std::ostream& outf, double r, double phiMin,
-                          double phiMax) -> void {
-        outf << "a," << r << "," << r << "," << phiMin << "," << phiMax << "\n";
-      };
-
-      // Helper method to write a polygon
-      auto writePolygon =
-          [&](std::ostream& outf,
-              const std::vector<Acts::Vector2D>& vertices) -> void {
-        auto nvertices = vertices.size();
-        for (unsigned long iv = 1; iv < nvertices; ++iv) {
-          writeLine(outf, vertices[iv - 1], vertices[iv]);
-        }
-        writeLine(outf, vertices[nvertices - 1], vertices[0]);
-      };
-
       // 0 - write the shape
       shape.open("Channelizer" + name + "Borders.csv");
       if (surface->type() == Acts::Surface::Plane) {
         const auto* pBounds =
             static_cast<const Acts::PlanarBounds*>(&(surface->bounds()));
-        writePolygon(shape, pBounds->vertices(1));
+        csvHelper.writePolygon(shape, pBounds->vertices(1));
       } else if (surface->type() == Acts::Surface::Disc) {
         const auto* dBounds =
             static_cast<const Acts::DiscBounds*>(&(surface->bounds()));
-        writePolygon(shape, dBounds->vertices(72));
+        csvHelper.writePolygon(shape, dBounds->vertices(72));
       }
       // 1 - write the grid
       grid.open("Channelizer" + name + "Grid.csv");
@@ -249,27 +164,27 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
         const auto& xboundaries = segmentation.binningData()[0].boundaries();
         const auto& yboundaries = segmentation.binningData()[1].boundaries();
         for (const auto xval : xboundaries) {
-          writeLine(grid, {xval, bymin}, {xval, bymax});
+          csvHelper.writeLine(grid, {xval, bymin}, {xval, bymax});
         }
         for (const auto yval : yboundaries) {
-          writeLine(grid, {bxmin, yval}, {bxmax, yval});
+          csvHelper.writeLine(grid, {bxmin, yval}, {bxmax, yval});
         }
       } else if (segmentation.binningData()[0].binvalue == Acts::binR and
                  segmentation.binningData()[1].binvalue == Acts::binPhi) {
-        double brmin = 0.;  // segmentation.binningData()[0].min;
+        double brmin = segmentation.binningData()[0].min;
         double brmax = segmentation.binningData()[0].max;
         double bphimin = segmentation.binningData()[1].min;
         double bphimax = segmentation.binningData()[1].max;
         const auto& rboundaries = segmentation.binningData()[0].boundaries();
         const auto& phiboundaries = segmentation.binningData()[1].boundaries();
         for (const auto r : rboundaries) {
-          writeArc(grid, r, bphimin, bphimax);
+          csvHelper.writeArc(grid, r, bphimin, bphimax);
         }
         for (const auto phi : phiboundaries) {
           double cphi = std::cos(phi);
           double sphi = std::sin(phi);
-          writeLine(grid, {brmin * cphi, brmin * sphi},
-                    {brmax * cphi, brmax * sphi});
+          csvHelper.writeLine(grid, {brmin * cphi, brmin * sphi},
+                              {brmax * cphi, brmax * sphi});
         }
       }
     }
@@ -286,12 +201,10 @@ BOOST_DATA_TEST_CASE(RandomChannelizerTest,
                  ".csv");
 
     /// Run the channelizer
-    auto cSegement = cl.segments(geoCtx, *surface, segmentation,
-                                 {start[0], start[1]}, {end[0], end[1]});
+    auto cSegement = cl.segments(geoCtx, *surface, segmentation, {start, end});
 
     for (const auto& cs : cSegement) {
-      segments << "l," << cs.path2D[0].x() << "," << cs.path2D[0].y() << ","
-               << cs.path2D[1].x() << "," << cs.path2D[1].y() << "\n";
+      csvHelper.writeLine(segments, cs.path2D[0], cs.path2D[1]);
     }
 
     segments.close();

--- a/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
@@ -43,12 +43,14 @@ struct DigitizationCsvOutput {
   /// @param outf The output stream
   /// @param vertices The vertices of the polygon
   void writePolygon(std::ostream& outf,
-                    const std::vector<Acts::Vector2D>& vertices) const {
+                    const std::vector<Acts::Vector2D>& vertices,
+                    const Acts::Vector2D& shift = Acts::Vector2D(0.,
+                                                                 0.)) const {
     auto nvertices = vertices.size();
     for (unsigned long iv = 1; iv < nvertices; ++iv) {
-      writeLine(outf, vertices[iv - 1], vertices[iv]);
+      writeLine(outf, vertices[iv - 1] + shift, vertices[iv] + shift);
     }
-    writeLine(outf, vertices[nvertices - 1], vertices[0]);
+    writeLine(outf, vertices[nvertices - 1] + shift, vertices[0] + shift);
   };
 };
 

--- a/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
@@ -1,0 +1,55 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Definitions.hpp"
+
+#include <fstream>
+
+namespace ActsFatras {
+
+/// Helper to write out Digitization tesbed into csv files.
+struct DigitizationCsvOutput {
+  /// Helper method to format the output of a line into csv
+  ///
+  /// @param outf The output stream
+  /// @param p0 The start point
+  /// @param p1 The end point
+  void writeLine(std::ostream& outf, const Acts::Vector2D& p0,
+                 const Acts::Vector2D& p1) const {
+    outf << "l," << p0.x() << "," << p0.y() << "," << p1.x() << "," << p1.y()
+         << "\n";
+  };
+
+  /// Helper method to write an arc into csv
+  ///
+  /// @param outf The output stream
+  /// @param r The radius of the arc
+  /// @param phiMin The minimum phi
+  /// @param phiMin The maximum phi phi
+  void writeArc(std::ostream& outf, double r, double phiMin,
+                double phiMax) const {
+    outf << "a," << r << "," << r << "," << phiMin << "," << phiMax << "\n";
+  };
+
+  /// Helper method to write a polygon
+  ///
+  /// @param outf The output stream
+  /// @param vertices The vertices of the polygon
+  void writePolygon(std::ostream& outf,
+                    const std::vector<Acts::Vector2D>& vertices) const {
+    auto nvertices = vertices.size();
+    for (unsigned long iv = 1; iv < nvertices; ++iv) {
+      writeLine(outf, vertices[iv - 1], vertices[iv]);
+    }
+    writeLine(outf, vertices[nvertices - 1], vertices[0]);
+  };
+};
+
+}  // namespace ActsFatras

--- a/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
@@ -32,7 +32,7 @@ struct DigitizationCsvOutput {
   /// @param outf The output stream
   /// @param r The radius of the arc
   /// @param phiMin The minimum phi
-  /// @param phiMin The maximum phi phi
+  /// @param phiMin The maximum phi
   void writeArc(std::ostream& outf, double r, double phiMin,
                 double phiMax) const {
     outf << "a," << r << "," << r << "," << phiMin << "," << phiMax << "\n";

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(DiscMaskRadialBounds) {
   CHECK_CLOSE_ABS(Acts::VectorHelpers::phi(clipped[0]), M_PI_4,
                   Acts::s_epsilon);
 
-  /// Case four: outside phi max
+  /// Case five: outside phi max
   segment = {Acts::Vector2D(0., 3.5), Acts::Vector2D(-8., 5.)};
   clipped = psm.apply(*discSurface, segment).value();
   CHECK_CLOSE_ABS(Acts::VectorHelpers::phi(clipped[1]), M_PI_2 + M_PI_4,

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
@@ -1,0 +1,197 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "ActsFatras/Digitization/PlanarSurfaceMask.hpp"
+
+#include "Acts/Surfaces/AnnulusBounds.hpp"
+#include "Acts/Surfaces/DiscSurface.hpp"
+#include "Acts/Surfaces/DiscTrapezoidBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/TrapezoidBounds.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "ActsFatras/Digitization/DigitizationError.hpp"
+#include "DigitizationCsvOutput.hpp"
+#include "PlanarSurfaceTestBeds.hpp"
+
+#include <array>
+#include <fstream>
+
+namespace bdata = boost::unit_test::data;
+
+namespace ActsFatras {
+
+std::vector<std::array<std::ofstream, 3>> out;
+
+BOOST_AUTO_TEST_SUITE(Digitization)
+
+BOOST_AUTO_TEST_CASE(PlaneMaskRectangleBounds) {
+  auto rectangleBounds = std::make_shared<Acts::RectangleBounds>(2., 3.5);
+  auto planeSurface = Acts::Surface::makeShared<Acts::PlaneSurface>(
+      Acts::Transform3D::Identity(), rectangleBounds);
+
+  ActsFatras::PlanarSurfaceMask psm;
+
+  /// Case one : one outside
+  std::array<Acts::Vector2D, 2> segment = {Acts::Vector2D(2.5, -4.5),
+                                           Acts::Vector2D(-1., -1.)};
+  auto clipped = psm.apply(*planeSurface, segment).value();
+
+  CHECK_CLOSE_ABS(clipped[1].x(), segment[1].x(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[1].y(), segment[1].y(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].x(), 1.5, Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].y(), -3.5, Acts::s_epsilon);
+
+  /// Case two : two outside
+  segment = {Acts::Vector2D(1., 4.), Acts::Vector2D(3., 2.)};
+  clipped = psm.apply(*planeSurface, segment).value();
+
+  CHECK_CLOSE_ABS(clipped[1].x(), 2., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[1].y(), 3., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].x(), 1.5, Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].y(), 3.5, Acts::s_epsilon);
+
+  /// Case two : both inside (most likely case, untouched)
+  segment = {Acts::Vector2D(-1., 0.5), Acts::Vector2D(0., 2.)};
+  clipped = psm.apply(*planeSurface, segment).value();
+
+  CHECK_CLOSE_ABS(clipped[0].x(), segment[0].x(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].y(), segment[0].y(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[1].x(), segment[1].x(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[1].y(), segment[1].y(), Acts::s_epsilon);
+}
+
+BOOST_AUTO_TEST_CASE(DiscMaskRadialBounds) {
+  auto discRadial =
+      std::make_shared<Acts::RadialBounds>(2., 7.5, M_PI_4, M_PI_2);
+  auto discSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
+      Acts::Transform3D::Identity(), discRadial);
+
+  ActsFatras::PlanarSurfaceMask psm;
+
+  /// Case one : one outside R min
+  std::array<Acts::Vector2D, 2> segment = {Acts::Vector2D(0.5, 1.8),
+                                           Acts::Vector2D(0.9, 6.)};
+  auto clipped = psm.apply(*discSurface, segment).value();
+
+  CHECK_CLOSE_ABS(clipped[1].x(), segment[1].x(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[1].y(), segment[1].y(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::perp(clipped[0]), 2.,
+                  5 * Acts::s_epsilon);
+
+  /// Case two : one outside R max
+  segment = {Acts::Vector2D(0.5, 2.8), Acts::Vector2D(0.9, 8.5)};
+  clipped = psm.apply(*discSurface, segment).value();
+
+  CHECK_CLOSE_ABS(clipped[0].x(), segment[0].x(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(clipped[0].y(), segment[0].y(), Acts::s_epsilon);
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::perp(clipped[1]), 7.5,
+                  5 * Acts::s_epsilon);
+
+  /// Case three : both outside R min / max
+  segment = {Acts::Vector2D(0.5, 1.8), Acts::Vector2D(0.9, 8.5)};
+  clipped = psm.apply(*discSurface, segment).value();
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::perp(clipped[0]), 2.,
+                  5 * Acts::s_epsilon);
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::perp(clipped[1]), 7.5,
+                  5 * Acts::s_epsilon);
+  /// Case four: outside phi min
+  segment = {Acts::Vector2D(2.8, 2.5), Acts::Vector2D(0., 3.5)};
+  clipped = psm.apply(*discSurface, segment).value();
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::phi(clipped[0]), M_PI_4,
+                  Acts::s_epsilon);
+
+  /// Case four: outside phi max
+  segment = {Acts::Vector2D(0., 3.5), Acts::Vector2D(-8., 5.)};
+  clipped = psm.apply(*discSurface, segment).value();
+  CHECK_CLOSE_ABS(Acts::VectorHelpers::phi(clipped[1]), M_PI_2 + M_PI_4,
+                  Acts::s_epsilon);
+}
+
+std::vector<std::array<std::ofstream, 3>> segmentOutput;
+
+int ntests = 100;
+
+/// Unit test for testing the Surface mask
+BOOST_DATA_TEST_CASE(RandomPlanarSurfaceMask,
+                     bdata::random(0., 1.) ^ bdata::random(0., 1.) ^
+                         bdata::random(0., 1.) ^ bdata::random(0., 1.) ^
+                         bdata::xrange(ntests),
+                     startR0, startR1, endR0, endR1, index) {
+  Acts::GeometryContext geoCtx;
+
+  ActsFatras::PlanarSurfaceMask psm;
+
+  // Test beds with random numbers generated inside
+  PlanarSurfaceTestBeds pstd;
+  // Smearing 10 percent outside
+  auto testBeds = pstd(1.1);
+
+  DigitizationCsvOutput csvHelper;
+
+  int itb = 0;
+  for (const auto& tb : testBeds) {
+    const auto& name = std::get<0>(tb);
+    const auto* surface = (std::get<1>(tb)).get();
+    const auto& randomizer = std::get<3>(tb);
+
+    if (index == 0) {
+      std::ofstream shape;
+
+      // 0 - write the shape
+      shape.open("PlanarSurfaceMask" + name + "Borders.csv");
+      if (surface->type() == Acts::Surface::Plane) {
+        const auto* pBounds =
+            static_cast<const Acts::PlanarBounds*>(&(surface->bounds()));
+        csvHelper.writePolygon(shape, pBounds->vertices(1));
+      } else if (surface->type() == Acts::Surface::Disc) {
+        const auto* dBounds =
+            static_cast<const Acts::DiscBounds*>(&(surface->bounds()));
+        csvHelper.writePolygon(shape, dBounds->vertices(72));
+      }
+
+      segmentOutput.push_back(std::array<std::ofstream, 3>());
+      segmentOutput[itb][0].open("PlanarSurfaceMask" + name + "Inside.csv");
+      segmentOutput[itb][1].open("PlanarSurfaceMask" + name + "Clipped.csv");
+      segmentOutput[itb][2].open("PlanarSurfaceMask" + name + "Outside.csv");
+    }
+
+    auto start = randomizer(startR0, startR1);
+    auto end = randomizer(endR0, endR1);
+
+    std::array<Acts::Vector2D, 2> segment = {start, end};
+    auto clippedTest = psm.apply(*surface, segment);
+    if (clippedTest.ok()) {
+      auto clipped = clippedTest.value();
+      if (segment == clipped) {
+        csvHelper.writeLine(segmentOutput[itb][0], start, end);
+      } else {
+        csvHelper.writeLine(segmentOutput[itb][1], clipped[0], clipped[1]);
+      }
+    } else {
+      csvHelper.writeLine(segmentOutput[itb][2], start, end);
+    }
+    ++itb;
+  }
+
+  // close the lines
+  if (itb == ntests - 1) {
+    segmentOutput[itb][0].close();
+    segmentOutput[itb][1].close();
+    segmentOutput[itb][2].close();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsFatras

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
@@ -118,23 +118,7 @@ BOOST_AUTO_TEST_CASE(DiscMaskRadialBounds) {
                   Acts::s_epsilon);
 }
 
-BOOST_AUTO_TEST_CASE(DiscAnnulusBounds) {
-  // Annulus disc test
-  Acts::Vector2D aorigin(0.1, -0.3);
-  double rmin = 2.5;
-  double rmax = 4.5;
-  double phimin = -0.25;
-  double phimax = 0.38;
-  auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, phimin,
-                                                       phimax, aorigin);
-  auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-      Acts::Transform3D::Identity() *
-          Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
-      annulus);
-}
-
 std::vector<std::array<std::ofstream, 3>> segmentOutput;
-
 int ntests = 100;
 
 /// Unit test for testing the Surface mask

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
@@ -118,6 +118,21 @@ BOOST_AUTO_TEST_CASE(DiscMaskRadialBounds) {
                   Acts::s_epsilon);
 }
 
+BOOST_AUTO_TEST_CASE(DiscAnnulusBounds) {
+  // Annulus disc test
+  Acts::Vector2D aorigin(0.1, -0.3);
+  double rmin = 2.5;
+  double rmax = 4.5;
+  double phimin = -0.25;
+  double phimax = 0.38;
+  auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, phimin,
+                                                       phimax, aorigin);
+  auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
+      Acts::Transform3D::Identity() *
+          Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
+      annulus);
+}
+
 std::vector<std::array<std::ofstream, 3>> segmentOutput;
 
 int ntests = 100;
@@ -147,17 +162,18 @@ BOOST_DATA_TEST_CASE(RandomPlanarSurfaceMask,
 
     if (index == 0) {
       std::ofstream shape;
+      const auto centerXY = surface->center(geoCtx).segment<2>(0);
 
       // 0 - write the shape
       shape.open("PlanarSurfaceMask" + name + "Borders.csv");
       if (surface->type() == Acts::Surface::Plane) {
         const auto* pBounds =
             static_cast<const Acts::PlanarBounds*>(&(surface->bounds()));
-        csvHelper.writePolygon(shape, pBounds->vertices(1));
+        csvHelper.writePolygon(shape, pBounds->vertices(1), -centerXY);
       } else if (surface->type() == Acts::Surface::Disc) {
         const auto* dBounds =
             static_cast<const Acts::DiscBounds*>(&(surface->bounds()));
-        csvHelper.writePolygon(shape, dBounds->vertices(72));
+        csvHelper.writePolygon(shape, dBounds->vertices(72), -centerXY);
       }
 
       segmentOutput.push_back(std::array<std::ofstream, 3>());

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
@@ -99,7 +99,7 @@ struct PlanarSurfaceTestBeds {
                        (M_PI_2 - M_PI_4) * irScale, (M_PI_2 + M_PI_4) * rScale);
 
     // Annulus disc test
-    Acts::Vector2D aorigin(0.05, -0.1);
+    Acts::Vector2D aorigin(0.05, -0.2);
     double phimin = -0.25;
     double phimax = 0.38;
     auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, -0.25,

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
@@ -99,16 +99,24 @@ struct PlanarSurfaceTestBeds {
                        (M_PI_2 - M_PI_4) * irScale, (M_PI_2 + M_PI_4) * rScale);
 
     // Annulus disc test
+    rmax = 4.5;
     Acts::Vector2D aorigin(0.1, -0.3);
     double phimin = -0.25;
     double phimax = 0.38;
     auto annulus = std::make_shared<Acts::AnnulusBounds>(
         rmin, rmax, phimin, phimax, aorigin, M_PI_4);
+    auto vertices = annulus->vertices(72);
+    std::for_each(vertices.begin(), vertices.end(), [&](Acts::Vector2D& v) {
+      double r = Acts::VectorHelpers::perp(v);
+      rmin = std::min(rmin, r);
+      rmax = std::max(rmax, r);
+    });
+
     auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
         Acts::Transform3D::Identity() *
             Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
         annulus);
-    Acts::BinUtility stripsPhiA(2, rmin, rmax, Acts::open, Acts::binR);
+    Acts::BinUtility stripsPhiA(1, rmin, rmax, Acts::open, Acts::binR);
     stripsPhiA +=
         Acts::BinUtility(12, phimin, phimax, Acts::open, Acts::binPhi);
     AnnulusRandom aRandom(rmin * irScale, rmax * rScale, phimin * rScale,

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
@@ -99,15 +99,18 @@ struct PlanarSurfaceTestBeds {
                        (M_PI_2 - M_PI_4) * irScale, (M_PI_2 + M_PI_4) * rScale);
 
     // Annulus disc test
-    Acts::Vector2D aorigin(0.05, -0.2);
+    Acts::Vector2D aorigin(0.1, -0.3);
     double phimin = -0.25;
     double phimax = 0.38;
-    auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, -0.25,
-                                                         0.38, aorigin, M_PI_4);
+    auto annulus = std::make_shared<Acts::AnnulusBounds>(
+        rmin, rmax, phimin, phimax, aorigin, M_PI_4);
     auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-        Acts::Transform3D::Identity(), annulus);
-    Acts::BinUtility stripsPhiA(1, 0., 10., Acts::open, Acts::binR);
-    stripsPhiA += Acts::BinUtility(12, -0.25, 0.36, Acts::open, Acts::binPhi);
+        Acts::Transform3D::Identity() *
+            Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
+        annulus);
+    Acts::BinUtility stripsPhiA(2, rmin, rmax, Acts::open, Acts::binR);
+    stripsPhiA +=
+        Acts::BinUtility(12, phimin, phimax, Acts::open, Acts::binPhi);
     AnnulusRandom aRandom(rmin * irScale, rmax * rScale, phimin * rScale,
                           phimax * rScale, aorigin.x(), aorigin.y());
 

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
@@ -99,12 +99,18 @@ struct PlanarSurfaceTestBeds {
                        (M_PI_2 - M_PI_4) * irScale, (M_PI_2 + M_PI_4) * rScale);
 
     // Annulus disc test
-    rmax = 4.5;
+    rmin = 2.5;
+    rmax = 5.5;
     Acts::Vector2D aorigin(0.1, -0.3);
     double phimin = -0.25;
     double phimax = 0.38;
-    auto annulus = std::make_shared<Acts::AnnulusBounds>(
-        rmin, rmax, phimin, phimax, aorigin, M_PI_4);
+    auto annulus = std::make_shared<Acts::AnnulusBounds>(rmin, rmax, phimin,
+                                                         phimax, aorigin);
+    auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
+        Acts::Transform3D::Identity() *
+            Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
+        annulus);
+
     auto vertices = annulus->vertices(72);
     std::for_each(vertices.begin(), vertices.end(), [&](Acts::Vector2D& v) {
       double r = Acts::VectorHelpers::perp(v);
@@ -112,10 +118,6 @@ struct PlanarSurfaceTestBeds {
       rmax = std::max(rmax, r);
     });
 
-    auto aSurface = Acts::Surface::makeShared<Acts::DiscSurface>(
-        Acts::Transform3D::Identity() *
-            Acts::Translation3D(-aorigin.x(), -aorigin.y(), 0.),
-        annulus);
     Acts::BinUtility stripsPhiA(1, rmin, rmax, Acts::open, Acts::binR);
     stripsPhiA +=
         Acts::BinUtility(12, phimin, phimax, Acts::open, Acts::binPhi);


### PR DESCRIPTION
This PR adds another (until now not possible) feature to the digitisation.
With this PR channels from different clusters can be merged, and the truth links will be restored by then.

It sits on top of #546 - so awaiting for that to be merged in.
