### PR TITLE
chore: Propagation 1, separate PropagatorOptions 

### DIFF
--- a/Core/include/Acts/Propagator/AbortList.hpp
+++ b/Core/include/Acts/Propagator/AbortList.hpp
@@ -45,28 +45,11 @@ struct AbortList : public detail::Extendable<aborters_t...> {
 
   using detail::Extendable<aborters_t...>::get;
 
-  /// Default constructor
   AbortList() = default;
-
-  /// Default copy constructor
-  ///
-  /// @param aborters The source action list
   AbortList(const AbortList<aborters_t...>& aborters) = default;
-
-  /// Default move constructor
-  ///
-  /// @param aborters The source action list
   AbortList(AbortList<aborters_t...>&& aborters) = default;
-
-  /// Default move assignment operator
-  ///
-  /// @param aborters The source action list
   AbortList<aborters_t...>& operator=(
       const AbortList<aborters_t...>& aborters) = default;
-
-  /// Default move assignment operator
-  ///
-  /// @param aborters The source action list
   AbortList<aborters_t...>& operator=(AbortList<aborters_t...>&& aborters) =
       default;
 
@@ -82,7 +65,7 @@ struct AbortList : public detail::Extendable<aborters_t...> {
   AbortList(std::tuple<aborters_t...>&& aborters)
       : detail::Extendable<aborters_t...>(std::move(aborters)) {}
 
-  /// Append new entries and return a new condition
+  /// Append new entries and return a new, extended abort list
   template <typename... appendices_t>
   AbortList<aborters_t..., appendices_t...> append(appendices_t... aps) const {
     auto catTuple =

--- a/Core/include/Acts/Propagator/ActionList.hpp
+++ b/Core/include/Acts/Propagator/ActionList.hpp
@@ -44,28 +44,11 @@ struct ActionList : public detail::Extendable<actors_t...> {
 
   using detail::Extendable<actors_t...>::get;
 
-  /// Default constructor
   ActionList() = default;
-
-  /// Default copy constructor
-  ///
-  /// @param actors The source action list
   ActionList(const ActionList<actors_t...>& actors) = default;
-
-  /// Default move constructor
-  ///
-  /// @param actors The source action list
   ActionList(ActionList<actors_t...>&& actors) = default;
-
-  /// Default move assignment operator
-  ///
-  /// @param actors The source action list
   ActionList<actors_t...>& operator=(const ActionList<actors_t...>& actors) =
       default;
-
-  /// Default move assignment operator
-  ///
-  /// @param actors The source action list
   ActionList<actors_t...>& operator=(ActionList<actors_t...>&& actors) =
       default;
 

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -131,7 +131,7 @@ class EigenStepper {
     FreeVector derivative = FreeVector::Zero();
 
     /// Covariance matrix (and indicator)
-    //// associated with the initial error on track parameters
+    /// associated with the initial error on track parameters
     bool covTransport = false;
     Covariance cov = Covariance::Zero();
 

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -17,6 +17,7 @@
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/AbortList.hpp"
 #include "Acts/Propagator/ActionList.hpp"
+#include "Acts/Propagator/PropagatorOptions.hpp"
 #include "Acts/Propagator/PropagatorError.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Propagator/StepperConcept.hpp"
@@ -57,138 +58,6 @@ struct PropagatorResult : private detail::Extendable<result_list...> {
 
   /// Signed distance over which the parameters were propagated
   double pathLength = 0.;
-};
-
-/// @brief Class holding the trivial options in propagator options
-///
-struct PropagatorPlainOptions {
-  /// Propagation direction
-  NavigationDirection direction = forward;
-
-  /// The |pdg| code for (eventual) material integration - pion default
-  int absPdgCode = 211;
-
-  /// The mass for the particle for (eventual) material integration
-  double mass = 139.57018 * UnitConstants::MeV;
-
-  /// Maximum number of steps for one propagate call
-  unsigned int maxSteps = 1000;
-
-  /// Maximum number of Runge-Kutta steps for the stepper step call
-  unsigned int maxRungeKuttaStepTrials = 10000;
-
-  /// Absolute maximum step size
-  double maxStepSize = std::numeric_limits<double>::max();
-
-  /// Absolute maximum path length
-  double pathLimit = std::numeric_limits<double>::max();
-
-  /// Required tolerance to reach target (surface, pathlength)
-  double targetTolerance = s_onSurfaceTolerance;
-
-  /// Loop protection step, it adapts the pathLimit
-  bool loopProtection = true;
-  double loopFraction = 0.5;  ///< Allowed loop fraction, 1 is a full loop
-
-  // Configurations for Stepper
-  /// Tolerance for the error of the integration
-  double tolerance = 1e-4;
-
-  /// Cut-off value for the step size
-  double stepSizeCutOff = 0.;
-};
-
-/// @brief Options for propagate() call
-///
-/// @tparam action_list_t List of action types called after each
-///    propagation step with the current propagation and stepper state
-///
-/// @tparam aborter_list_t List of abort conditions tested after each
-///    propagation step using the current propagation and stepper state
-///
-template <typename action_list_t = ActionList<>,
-          typename aborter_list_t = AbortList<>>
-struct PropagatorOptions : public PropagatorPlainOptions {
-  using action_list_type = action_list_t;
-  using aborter_list_type = aborter_list_t;
-
-  /// Delete default contructor
-  PropagatorOptions() = delete;
-
-  /// PropagatorOptions copy constructor
-  PropagatorOptions(
-      const PropagatorOptions<action_list_t, aborter_list_t>& po) = default;
-
-  /// PropagatorOptions with context
-  PropagatorOptions(std::reference_wrapper<const GeometryContext> gctx,
-                    std::reference_wrapper<const MagneticFieldContext> mctx,
-                    LoggerWrapper logger_)
-      : geoContext(gctx), magFieldContext(mctx), logger(logger_) {}
-
-  /// @brief Expand the Options with extended aborters
-  ///
-  /// @tparam extended_aborter_list_t Type of the new aborter list
-  ///
-  /// @param aborters The new aborter list to be used (internally)
-  template <typename extended_aborter_list_t>
-  PropagatorOptions<action_list_t, extended_aborter_list_t> extend(
-      extended_aborter_list_t aborters) const {
-    PropagatorOptions<action_list_t, extended_aborter_list_t> eoptions(
-        geoContext, magFieldContext, logger);
-    // Copy the options over
-    eoptions.direction = direction;
-    eoptions.absPdgCode = absPdgCode;
-    eoptions.mass = mass;
-    eoptions.maxSteps = maxSteps;
-    eoptions.maxRungeKuttaStepTrials = maxRungeKuttaStepTrials;
-    eoptions.maxStepSize = direction * std::abs(maxStepSize);
-    eoptions.targetTolerance = targetTolerance;
-    eoptions.pathLimit = direction * std::abs(pathLimit);
-    eoptions.loopProtection = loopProtection;
-    eoptions.loopFraction = loopFraction;
-
-    // Stepper options
-    eoptions.tolerance = tolerance;
-    eoptions.stepSizeCutOff = stepSizeCutOff;
-    // Action / abort list
-    eoptions.actionList = std::move(actionList);
-    eoptions.abortList = std::move(aborters);
-    // And return the options
-    return eoptions;
-  }
-
-  /// @brief Set the plain options
-  ///
-  /// @param pOptions The plain options
-  void setPlainOptions(const PropagatorPlainOptions& pOptions) {
-    // Copy the options over
-    direction = pOptions.direction;
-    absPdgCode = pOptions.absPdgCode;
-    mass = pOptions.mass;
-    maxSteps = pOptions.maxSteps;
-    maxRungeKuttaStepTrials = pOptions.maxRungeKuttaStepTrials;
-    maxStepSize = direction * std::abs(pOptions.maxStepSize);
-    targetTolerance = pOptions.targetTolerance;
-    pathLimit = direction * std::abs(pOptions.pathLimit);
-    loopProtection = pOptions.loopProtection;
-    loopFraction = pOptions.loopFraction;
-    tolerance = pOptions.tolerance;
-    stepSizeCutOff = pOptions.stepSizeCutOff;
-  }
-
-  /// List of actions
-  action_list_t actionList;
-
-  /// List of abort conditions
-  aborter_list_t abortList;
-
-  /// The context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-
-  /// The context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
-
-  LoggerWrapper logger;
 };
 
 /// @brief Propagator for particles (optionally in a magnetic field)

--- a/Core/include/Acts/Propagator/PropagatorOptions.hpp
+++ b/Core/include/Acts/Propagator/PropagatorOptions.hpp
@@ -1,0 +1,148 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/Units.hpp"
+
+#include <climits>
+
+namespace Acts {
+
+/// @brief Class holding the trivial options in propagator options
+///
+struct PropagatorPlainOptions {
+  /// Propagation direction
+  NavigationDirection direction = forward;
+
+  /// The |pdg| code for (eventual) material integration - pion default
+  int absPdgCode = 211;
+
+  /// The mass for the particle for (eventual) material integration
+  double mass = 139.57018 * UnitConstants::MeV;
+
+  /// Maximum number of steps for one propagate call
+  unsigned int maxSteps = 1000;
+
+  /// Maximum number of Runge-Kutta steps for the stepper step call
+  unsigned int maxRungeKuttaStepTrials = 10000;
+
+  /// Absolute maximum step size
+  double maxStepSize = std::numeric_limits<double>::max();
+
+  /// Absolute maximum path length
+  double pathLimit = std::numeric_limits<double>::max();
+
+  /// Required tolerance to reach target (surface, pathlength)
+  double targetTolerance = s_onSurfaceTolerance;
+
+  /// Loop protection step, it adapts the pathLimit
+  bool loopProtection = true;
+  double loopFraction = 0.5;  ///< Allowed loop fraction, 1 is a full loop
+
+  // Configurations for Stepper
+  /// Tolerance for the error of the integration
+  double tolerance = 1e-4;
+
+  /// Cut-off value for the step size
+  double stepSizeCutOff = 0.;
+};
+
+/// @brief Options for propagate() call
+///
+/// @tparam action_list_t List of action types called after each
+///    propagation step with the current propagation and stepper state
+///
+/// @tparam aborter_list_t List of abort conditions tested after each
+///    propagation step using the current propagation and stepper state
+///
+template <typename action_list_t = ActionList<>,
+          typename aborter_list_t = AbortList<>>
+struct PropagatorOptions : public PropagatorPlainOptions {
+  using action_list_type = action_list_t;
+  using aborter_list_type = aborter_list_t;
+
+  PropagatorOptions() = delete;
+  PropagatorOptions(
+      const PropagatorOptions<action_list_t, aborter_list_t>& po) = default;
+
+  /// PropagatorOptions with context
+  PropagatorOptions(std::reference_wrapper<const GeometryContext> gctx,
+                    std::reference_wrapper<const MagneticFieldContext> mctx,
+                    LoggerWrapper logger_)
+      : geoContext(gctx), magFieldContext(mctx), logger(logger_) {}
+
+  /// @brief Expand the Options with extended aborters
+  ///
+  /// @tparam extended_aborter_list_t Type of the new aborter list
+  ///
+  /// @param aborters The new aborter list to be used (internally)
+  template <typename extended_aborter_list_t>
+  PropagatorOptions<action_list_t, extended_aborter_list_t> extend(
+      extended_aborter_list_t aborters) const {
+    PropagatorOptions<action_list_t, extended_aborter_list_t> eoptions(
+        geoContext, magFieldContext, logger);
+    // Copy the options over
+    eoptions.direction = direction;
+    eoptions.absPdgCode = absPdgCode;
+    eoptions.mass = mass;
+    eoptions.maxSteps = maxSteps;
+    eoptions.maxRungeKuttaStepTrials = maxRungeKuttaStepTrials;
+    eoptions.maxStepSize = direction * std::abs(maxStepSize);
+    eoptions.targetTolerance = targetTolerance;
+    eoptions.pathLimit = direction * std::abs(pathLimit);
+    eoptions.loopProtection = loopProtection;
+    eoptions.loopFraction = loopFraction;
+
+    // Stepper options
+    eoptions.tolerance = tolerance;
+    eoptions.stepSizeCutOff = stepSizeCutOff;
+    // Action / abort list
+    eoptions.actionList = std::move(actionList);
+    eoptions.abortList = std::move(aborters);
+    // And return the options
+    return eoptions;
+  }
+
+  /// @brief Set the plain options
+  ///
+  /// @param pOptions The plain options
+  void setPlainOptions(const PropagatorPlainOptions& pOptions) {
+    // Copy the options over
+    direction = pOptions.direction;
+    absPdgCode = pOptions.absPdgCode;
+    mass = pOptions.mass;
+    maxSteps = pOptions.maxSteps;
+    maxRungeKuttaStepTrials = pOptions.maxRungeKuttaStepTrials;
+    maxStepSize = direction * std::abs(pOptions.maxStepSize);
+    targetTolerance = pOptions.targetTolerance;
+    pathLimit = direction * std::abs(pOptions.pathLimit);
+    loopProtection = pOptions.loopProtection;
+    loopFraction = pOptions.loopFraction;
+    tolerance = pOptions.tolerance;
+    stepSizeCutOff = pOptions.stepSizeCutOff;
+  }
+
+  /// List of actions
+  action_list_t actionList;
+
+  /// List of abort conditions
+  aborter_list_t abortList;
+
+  /// The context object for the geometry
+  std::reference_wrapper<const GeometryContext> geoContext;
+
+  /// The context object for the magnetic field
+  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
+
+  LoggerWrapper logger;
+};
+
+}  // namespace Acts


### PR DESCRIPTION
This PR simply splits out the `PropagatorOptions` into a new file and removes useless comments from `ActionList` and `AbortList`.