### PR TITLE
fix: AMVF track linearization and seed constraint fix for q431 test (backport)

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -243,7 +243,7 @@ class AdaptiveMultiVertexFinder {
   /// @param currentConstraint Vertex constraint
   /// @param seedVertex Seed vertex
   void setConstraintAfterSeeding(Vertex<InputTrack_t>& currentConstraint,
-                                 const Vertex<InputTrack_t>& seedVertex) const;
+                                 Vertex<InputTrack_t>& seedVertex) const;
 
   /// @brief Calculates the IP significance of a track to a given vertex
   ///

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -550,6 +550,13 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
   // Update fitter state with removed vertex candidate
   fitterState.removeVertexFromMultiMap(vtx);
 
+  for(auto entry : fitterState.tracksAtVerticesMap){
+    // Delete all linearized tracks for current (bad) vertex
+    if(entry.first.second == vtx){
+      entry.second.isLinearized = false;
+    }
+  }
+
   // Do the fit with removed vertex
   auto fitResult = m_cfg.vertexFitter.addVtxToFit(
       fitterState, vtx, m_cfg.linearizer, vertexingOptions);

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -552,7 +552,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
 
   for (auto& entry : fitterState.tracksAtVerticesMap) {
     // Delete all linearized tracks for current (bad) vertex
-    if (entry.first.second == vtx) {
+    if (entry.first.second == &vtx) {
       entry.second.isLinearized = false;
     }
   }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -550,9 +550,9 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
   // Update fitter state with removed vertex candidate
   fitterState.removeVertexFromMultiMap(vtx);
 
-  for(auto entry : fitterState.tracksAtVerticesMap){
+  for (auto entry : fitterState.tracksAtVerticesMap) {
     // Delete all linearized tracks for current (bad) vertex
-    if(entry.first.second == vtx){
+    if (entry.first.second == vtx) {
       entry.second.isLinearized = false;
     }
   }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -33,7 +33,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
   std::vector<const InputTrack_t*> removedSeedTracks;
   while (((m_cfg.addSingleTrackVertices && seedTracks.size() > 0) ||
           ((!m_cfg.addSingleTrackVertices) && seedTracks.size() > 1)) &&
-         iteration < m_cfg.maxIterations) {    
+         iteration < m_cfg.maxIterations) {
     // Tracks that are used for searching compatible tracks
     // near a vertex candidate
     std::vector<const InputTrack_t*> searchTracks;
@@ -53,7 +53,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
 
     Vertex<InputTrack_t>& vtxCandidate = *allVertices.back();
     allVerticesPtr.push_back(&vtxCandidate);
-            
+
     ACTS_DEBUG("Position of current vertex candidate after seeding: "
                << vtxCandidate.fullPosition());
     if (vtxCandidate.position().z() ==
@@ -165,18 +165,16 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::doSeeding(
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     setConstraintAfterSeeding(Vertex<InputTrack_t>& currentConstraint,
-                              Vertex<InputTrack_t>& seedVertex) const
-    -> void {
+                              Vertex<InputTrack_t>& seedVertex) const -> void {
   if (m_cfg.useBeamSpotConstraint) {
     if (currentConstraint.fullCovariance() == SymMatrix4D::Zero()) {
       ACTS_WARNING(
           "No constraint provided, but useBeamSpotConstraint set to true.");
     }
-    if (not m_cfg.useSeedConstraint) {      
+    if (not m_cfg.useSeedConstraint) {
       // Set seed vertex constraint to old constraint before seeding
       seedVertex.setFullCovariance(currentConstraint.fullCovariance());
-    }
-    else{      
+    } else {
       // Use the constraint provided by the seed finder
       currentConstraint.setFullPosition(seedVertex.fullPosition());
       currentConstraint.setFullCovariance(seedVertex.fullCovariance());
@@ -287,7 +285,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
       vtx.setFullPosition(Vector4D(0., 0., newZ, 0.));
 
       // Update vertex info for current vertex
-      fitterState.vtxInfoMap[&vtx] = VertexInfo<InputTrack_t>(currentConstraint, vtx.fullPosition());
+      fitterState.vtxInfoMap[&vtx] =
+          VertexInfo<InputTrack_t>(currentConstraint, vtx.fullPosition());
 
       // Try to add compatible track with adapted vertex position
       auto res = addCompatibleTracksToVertex(allTracks, vtx, fitterState,
@@ -297,7 +296,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
       }
 
       if (fitterState.vtxInfoMap[&vtx].trackLinks.empty()) {
-        ACTS_DEBUG( 
+        ACTS_DEBUG(
             "No tracks near seed were found, while at least one was "
             "expected. Break.");
         return Result<bool>::success(false);

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -550,7 +550,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
   // Update fitter state with removed vertex candidate
   fitterState.removeVertexFromMultiMap(vtx);
 
-  for (auto entry : fitterState.tracksAtVerticesMap) {
+  for (auto& entry : fitterState.tracksAtVerticesMap) {
     // Delete all linearized tracks for current (bad) vertex
     if (entry.first.second == vtx) {
       entry.second.isLinearized = false;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -33,7 +33,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
   std::vector<const InputTrack_t*> removedSeedTracks;
   while (((m_cfg.addSingleTrackVertices && seedTracks.size() > 0) ||
           ((!m_cfg.addSingleTrackVertices) && seedTracks.size() > 1)) &&
-         iteration < m_cfg.maxIterations) {
+         iteration < m_cfg.maxIterations) {    
     // Tracks that are used for searching compatible tracks
     // near a vertex candidate
     std::vector<const InputTrack_t*> searchTracks;
@@ -53,7 +53,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
 
     Vertex<InputTrack_t>& vtxCandidate = *allVertices.back();
     allVerticesPtr.push_back(&vtxCandidate);
-
+            
     ACTS_DEBUG("Position of current vertex candidate after seeding: "
                << vtxCandidate.fullPosition());
     if (vtxCandidate.position().z() ==
@@ -165,14 +165,19 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::doSeeding(
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     setConstraintAfterSeeding(Vertex<InputTrack_t>& currentConstraint,
-                              const Vertex<InputTrack_t>& seedVertex) const
+                              Vertex<InputTrack_t>& seedVertex) const
     -> void {
   if (m_cfg.useBeamSpotConstraint) {
     if (currentConstraint.fullCovariance() == SymMatrix4D::Zero()) {
       ACTS_WARNING(
           "No constraint provided, but useBeamSpotConstraint set to true.");
     }
-    if (m_cfg.useSeedConstraint) {
+    if (not m_cfg.useSeedConstraint) {      
+      // Set seed vertex constraint to old constraint before seeding
+      seedVertex.setFullCovariance(currentConstraint.fullCovariance());
+    }
+    else{      
+      // Use the constraint provided by the seed finder
       currentConstraint.setFullPosition(seedVertex.fullPosition());
       currentConstraint.setFullCovariance(seedVertex.fullCovariance());
     }
@@ -282,8 +287,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
       vtx.setFullPosition(Vector4D(0., 0., newZ, 0.));
 
       // Update vertex info for current vertex
-      fitterState.vtxInfoMap[&vtx] =
-          VertexInfo<InputTrack_t>(currentConstraint, vtx.fullPosition());
+      fitterState.vtxInfoMap[&vtx] = VertexInfo<InputTrack_t>(currentConstraint, vtx.fullPosition());
 
       // Try to add compatible track with adapted vertex position
       auto res = addCompatibleTracksToVertex(allTracks, vtx, fitterState,
@@ -293,7 +297,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
       }
 
       if (fitterState.vtxInfoMap[&vtx].trackLinks.empty()) {
-        ACTS_DEBUG(
+        ACTS_DEBUG( 
             "No tracks near seed were found, while at least one was "
             "expected. Break.");
         return Result<bool>::success(false);

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -102,7 +102,6 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
       m_cfg.annealingTool.anneal(state.annealingState);
     }
     isSmallShift = checkSmallShift(state);
-
     ++nIter;
   }
   // Multivertex fit is finished
@@ -262,7 +261,6 @@ Acts::Result<void> Acts::
         const VertexingOptions<input_track_t>& vertexingOptions) const {
   for (auto vtx : state.vertexCollection) {
     VertexInfo<input_track_t>& currentVtxInfo = state.vtxInfoMap[vtx];
-
     for (const auto& trk : currentVtxInfo.trackLinks) {
       auto& trkAtVtx = state.tracksAtVerticesMap.at(std::make_pair(trk, vtx));
 
@@ -293,7 +291,6 @@ Acts::Result<void> Acts::
         ACTS_VERBOSE("Track weight too low. Skip track.");
       }
     }  // End loop over tracks at vertex
-
     ACTS_VERBOSE("New vertex position: " << vtx->fullPosition());
   }  // End loop over vertex collection
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -274,8 +274,7 @@ Acts::Result<void> Acts::
 
       if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         // Check if linearization state exists or need to be relinearized
-        if (not trkAtVtx.isLinearized ||
-            state.vtxInfoMap[vtx].relinearize) {
+        if (not trkAtVtx.isLinearized || state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
               vertexingOptions.geoContext, vertexingOptions.magFieldContext,

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -274,8 +274,7 @@ Acts::Result<void> Acts::
 
       if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         // Check if linearization state exists or need to be relinearized
-        if (trkAtVtx.linearizedState.covarianceAtPCA ==
-                BoundSymMatrix::Zero() ||
+        if (not trkAtVtx.isLinearized ||
             state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
@@ -285,6 +284,7 @@ Acts::Result<void> Acts::
             return result.error();
           }
           trkAtVtx.linearizedState = *result;
+          trkAtVtx.isLinearized = true;
           state.vtxInfoMap[vtx].linPoint = state.vtxInfoMap[vtx].oldPosition;
         }
         // Update the vertex with the new track

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -45,7 +45,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   }
   BoundSymMatrix parCovarianceAtPCA = *(endParams->covariance());
 
-  if (endParams->covariance()->determinant() == 0) {
+  if (endParams->covariance()->determinant() <= 0) {
     // Use the original parameters
     paramsAtPCA = params.parameters();
     auto pos = endParams->position(gctx);

--- a/Core/include/Acts/Vertexing/TrackAtVertex.hpp
+++ b/Core/include/Acts/Vertexing/TrackAtVertex.hpp
@@ -79,6 +79,9 @@ struct TrackAtVertex {
 
   /// The linearized state of the track at vertex
   LinearizedTrack linearizedState;
+
+  /// Is already linearized
+  bool isLinearized = false;
 };
 
 }  // namespace Acts


### PR DESCRIPTION
These changes fix the issues we've seen when employing the ACTS AMVF on data in Athena, targeting an ACTS v1.2.1 bug fix release. Changes made:

- In case the algorithm finds a bad vertex and deletes it at some point again, I need to force it to relinearize the tracks in the next iteration since they were linearized with respect to the bad vertex.
- If the seed constraint is turned off, the old (e.g. beamspot) constraint will now be correctly applied.
- For consistency reasons with Athena, a negative determinant check in the track linearizer is added.

The corresponding master PR [can be found here](https://github.com/acts-project/acts/pull/550).

## Data: 
![validation_AllPrimaryVertices_vx_z](https://user-images.githubusercontent.com/62748548/98038503-889ff000-1e1d-11eb-83ed-cc8c7f8a0c17.png)
![validation_AllPrimaryVertices_vx_nTracks](https://user-images.githubusercontent.com/62748548/98038537-948bb200-1e1d-11eb-9c48-47034318172c.png)
![validation_AllPrimaryVertices_vx_err_z](https://user-images.githubusercontent.com/62748548/98038547-99506600-1e1d-11eb-8e40-593017a7a3bb.png)

## MC:

![validation_AllPrimaryVertices_vx_z](https://user-images.githubusercontent.com/62748548/98038619-b84ef800-1e1d-11eb-8799-4a94ce995062.png)
![validation_AllPrimaryVertices_vx_nTracks](https://user-images.githubusercontent.com/62748548/98038626-bb49e880-1e1d-11eb-9852-ce132fdac111.png)
![validation_AllPrimaryVertices_vx_err_z](https://user-images.githubusercontent.com/62748548/98038639-c00e9c80-1e1d-11eb-9b3b-5390421610ea.png)

