### PR TITLE
fix: Warning about unneeded ref in ranged for loop

### DIFF
--- a/Core/include/Acts/Surfaces/SurfaceArray.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceArray.hpp
@@ -308,7 +308,7 @@ class SurfaceArray {
         std::vector<const Surface*>& neighbors = m_neighborMap.at(i);
         neighbors.clear();
 
-        for (const auto& idx : neighborIdxs) {
+        for (const auto idx : neighborIdxs) {
           const std::vector<const Surface*>& binContent = m_grid.at(idx);
           std::copy(binContent.begin(), binContent.end(),
                     std::back_inserter(neighbors));


### PR DESCRIPTION
This is a backport of #556 with the HepMC3 changes removed
This showed up we believe after GitHub Actions bumped to AppleClang 12.