### PR TITLE
refactor: Clean up gain matrix smoother/updater

### DIFF
--- a/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
@@ -54,7 +54,7 @@ class GainMatrixSmoother {
     ACTS_VERBOSE("Start smoothing from previous track state at index: "
                  << prev_ts.previous());
 
-    // default error represents an invalid non-error state, no need for optional
+    // default-constructed error represents success, i.e. an invalid error code
     std::error_code error;
     trajectory.applyBackwards(prev_ts.previous(), [&prev_ts, &error,
                                                    &logger](auto ts) {

--- a/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,42 +9,34 @@
 #pragma once
 
 #include "Acts/EventData/MultiTrajectory.hpp"
-#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/detail/covariance_helper.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/TrackFitting/KalmanFitterError.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 
-#include <memory>
-
-#include <boost/range/adaptors.hpp>
-
 namespace Acts {
 
-/// @brief Kalman smoother implementation based on Gain matrix formalism
+/// Kalman trajectory smoother based on gain matrix formalism.
 ///
-/// @tparam parameters_t Type of the track parameters
-/// @tparam jacobian_t Type of the Jacobian
+/// This implements not a single smoothing step, but the full backwards
+/// smoothing procedure for a filtered, forward trajectory using the stored
+/// linearization.
 class GainMatrixSmoother {
  public:
-  /// Operater for Kalman smoothing
+  /// Run the Kalman smoothing for one trajectory.
   ///
   /// @tparam source_link_t The type of source link
-  ///
-  /// @param gctx The geometry context for the smoothing
-  /// @param trajectory The trajectory to be smoothed
-  /// @param entryIndex The index of state to start the smoothing
-  /// @param globalTrackParamsCovPtr The pointer to global track parameters
-  /// covariance matrix
-  ///
-  /// @return The smoothed track parameters at the first measurement state
+  /// @param[in] gctx The geometry context for the smoothing
+  /// @param[in,out] trajectory The trajectory to be smoothed
+  /// @param[in] entryIndex The index of state to start the smoothing
+  /// @param[in] logger Where to write logging information to
   template <typename source_link_t>
   Result<void> operator()(const GeometryContext& /* gctx */,
                           MultiTrajectory<source_link_t>& trajectory,
                           size_t entryIndex,
                           LoggerWrapper logger = getDummyLogger()) const {
     ACTS_VERBOSE("Invoked GainMatrixSmoother on entry index: " << entryIndex);
-    using namespace boost::adaptors;
 
     // For the last state: smoothed is filtered - also: switch to next
     ACTS_VERBOSE("Getting previous track state");
@@ -53,98 +45,92 @@ class GainMatrixSmoother {
     prev_ts.smoothed() = prev_ts.filtered();
     prev_ts.smoothedCovariance() = prev_ts.filteredCovariance();
 
-    // Smoothing gain matrix
-    BoundSymMatrix G;
-
     // make sure there is more than one track state
-    std::optional<std::error_code> error{std::nullopt};  // assume ok
     if (prev_ts.previous() == Acts::detail_lt::IndexData::kInvalid) {
       ACTS_VERBOSE("Only one track state given, smoothing terminates early");
-    } else {
-      ACTS_VERBOSE("Start smoothing from previous track state at index: "
-                   << prev_ts.previous());
-
-      trajectory.applyBackwards(prev_ts.previous(), [&prev_ts, &G, &error,
-                                                     &logger](auto ts) {
-        // should have filtered and predicted, this should also include the
-        // covariances.
-        assert(ts.hasFiltered());
-        assert(ts.hasPredicted());
-        assert(ts.hasJacobian());
-
-        // previous trackstate should have smoothed and predicted
-        assert(prev_ts.hasSmoothed());
-        assert(prev_ts.hasPredicted());
-
-        ACTS_VERBOSE("Calculate smoothing matrix:");
-        ACTS_VERBOSE("Filtered covariance:\n" << ts.filteredCovariance());
-        ACTS_VERBOSE("Jacobian:\n" << ts.jacobian());
-        ACTS_VERBOSE("Prev. predicted covariance\n"
-                     << prev_ts.predictedCovariance() << "\n, inverse: \n"
-                     << prev_ts.predictedCovariance().inverse());
-
-        // Gain smoothing matrix
-        // NB: The jacobian stored in a state is the jacobian from previous
-        // state to this state in forward propagation
-        G = ts.filteredCovariance() * prev_ts.jacobian().transpose() *
-            prev_ts.predictedCovariance().inverse();
-
-        if (G.hasNaN()) {
-          error = KalmanFitterError::SmoothFailed;  // set to error
-          return false;                             // abort execution
-        }
-
-        ACTS_VERBOSE("Gain smoothing matrix G:\n" << G);
-
-        ACTS_VERBOSE("Calculate smoothed parameters:");
-        ACTS_VERBOSE("Filtered parameters: " << ts.filtered().transpose());
-        ACTS_VERBOSE(
-            "Prev. smoothed parameters: " << prev_ts.smoothed().transpose());
-        ACTS_VERBOSE(
-            "Prev. predicted parameters: " << prev_ts.predicted().transpose());
-
-        // Calculate the smoothed parameters
-        ts.smoothed() =
-            ts.filtered() + G * (prev_ts.smoothed() - prev_ts.predicted());
-
-        ACTS_VERBOSE("Smoothed parameters are: " << ts.smoothed().transpose());
-
-        ACTS_VERBOSE("Calculate smoothed covariance:");
-        ACTS_VERBOSE("Prev. smoothed covariance:\n"
-                     << prev_ts.smoothedCovariance());
-
-        // And the smoothed covariance
-        ts.smoothedCovariance() =
-            ts.filteredCovariance() -
-            G * (prev_ts.predictedCovariance() - prev_ts.smoothedCovariance()) *
-                G.transpose();
-
-        // Check if the covariance matrix is semi-positive definite.
-        // If not, make one (could do more) attempt to replace it with the
-        // nearest semi-positive def matrix,
-        // but it could still be non semi-positive
-        BoundSymMatrix smoothedCov = ts.smoothedCovariance();
-        if (not detail::covariance_helper<BoundSymMatrix>::validate(
-                smoothedCov)) {
-          ACTS_DEBUG(
-              "Smoothed covariance is not positive definite. Could result in "
-              "negative covariance!");
-        }
-        // Reset smoothed covariance
-        ts.smoothedCovariance() = smoothedCov;
-        ACTS_VERBOSE("Smoothed covariance is: \n" << ts.smoothedCovariance());
-
-        prev_ts = ts;
-        return true;  // continue execution
-      });
-    }
-    if (error) {
-      // error is set, return result
-      return *error;
+      return Result<void>::success();
     }
 
-    // construct parameters from last track state
-    return Result<void>::success();
+    ACTS_VERBOSE("Start smoothing from previous track state at index: "
+                 << prev_ts.previous());
+
+    // default error represents an invalid non-error state, no need for optional
+    std::error_code error;
+    trajectory.applyBackwards(prev_ts.previous(), [&prev_ts, &error,
+                                                   &logger](auto ts) {
+      // should have filtered and predicted, this should also include the
+      // covariances.
+      assert(ts.hasFiltered());
+      assert(ts.hasPredicted());
+      assert(ts.hasJacobian());
+
+      // previous trackstate should have smoothed and predicted
+      assert(prev_ts.hasSmoothed());
+      assert(prev_ts.hasPredicted());
+
+      ACTS_VERBOSE("Calculate smoothing matrix:");
+      ACTS_VERBOSE("Filtered covariance:\n" << ts.filteredCovariance());
+      ACTS_VERBOSE("Jacobian:\n" << ts.jacobian());
+      ACTS_VERBOSE("Prev. predicted covariance\n"
+                   << prev_ts.predictedCovariance() << "\n, inverse: \n"
+                   << prev_ts.predictedCovariance().inverse());
+
+      // Gain smoothing matrix
+      // NB: The jacobian stored in a state is the jacobian from previous
+      // state to this state in forward propagation
+      BoundMatrix G = ts.filteredCovariance() * prev_ts.jacobian().transpose() *
+                      prev_ts.predictedCovariance().inverse();
+
+      if (G.hasNaN()) {
+        error = KalmanFitterError::SmoothFailed;  // set to error
+        return false;                             // abort execution
+      }
+
+      ACTS_VERBOSE("Gain smoothing matrix G:\n" << G);
+
+      ACTS_VERBOSE("Calculate smoothed parameters:");
+      ACTS_VERBOSE("Filtered parameters: " << ts.filtered().transpose());
+      ACTS_VERBOSE(
+          "Prev. smoothed parameters: " << prev_ts.smoothed().transpose());
+      ACTS_VERBOSE(
+          "Prev. predicted parameters: " << prev_ts.predicted().transpose());
+
+      // Calculate the smoothed parameters
+      ts.smoothed() =
+          ts.filtered() + G * (prev_ts.smoothed() - prev_ts.predicted());
+
+      ACTS_VERBOSE("Smoothed parameters are: " << ts.smoothed().transpose());
+      ACTS_VERBOSE("Calculate smoothed covariance:");
+      ACTS_VERBOSE("Prev. smoothed covariance:\n"
+                   << prev_ts.smoothedCovariance());
+
+      // And the smoothed covariance
+      ts.smoothedCovariance() =
+          ts.filteredCovariance() -
+          G * (prev_ts.predictedCovariance() - prev_ts.smoothedCovariance()) *
+              G.transpose();
+
+      // Check if the covariance matrix is semi-positive definite.
+      // If not, make one (could do more) attempt to replace it with the
+      // nearest semi-positive def matrix,
+      // but it could still be non semi-positive
+      BoundSymMatrix smoothedCov = ts.smoothedCovariance();
+      if (not detail::covariance_helper<BoundSymMatrix>::validate(
+              smoothedCov)) {
+        ACTS_DEBUG(
+            "Smoothed covariance is not positive definite. Could result in "
+            "negative covariance!");
+      }
+      // Reset smoothed covariance
+      ts.smoothedCovariance() = smoothedCov;
+      ACTS_VERBOSE("Smoothed covariance is: \n" << ts.smoothedCovariance());
+
+      prev_ts = ts;
+      return true;  // continue execution
+    });
+
+    return error ? Result<void>::failure(error) : Result<void>::success();
   }
 };
+
 }  // namespace Acts

--- a/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
@@ -59,7 +59,7 @@ class GainMatrixUpdater {
     auto filtered = trackState.filtered();
     auto filteredCovariance = trackState.filteredCovariance();
 
-    // default error represents an invalid non-error state, no need for optional
+    // default-constructed error represents success, i.e. an invalid error code
     std::error_code error;
     visit_measurement(
         trackState.calibrated(), trackState.calibratedCovariance(),

--- a/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
@@ -76,7 +76,7 @@ class GainMatrixUpdater {
           ACTS_VERBOSE("Calibrated measurement covariance:\n"
                        << calibratedCovariance);
 
-          ActsMatrix<Scalar, kMeasurementSize, eBoundSize> H =
+          const ActsMatrix<Scalar, kMeasurementSize, eBoundSize> H =
               trackState.projector()
                   .template topLeftCorner<kMeasurementSize, eBoundSize>();
 

--- a/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,44 +11,32 @@
 #include "Acts/EventData/Measurement.hpp"
 #include "Acts/EventData/MeasurementHelpers.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
-#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/TrackFitting/KalmanFitterError.hpp"
-#include "Acts/TrackFitting/detail/VoidKalmanComponents.hpp"
-#include "Acts/Utilities/Definitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 
-#include <memory>
-#include <variant>
-
 namespace Acts {
 
-/// @brief Update step of Kalman Filter using gain matrix formalism
+/// Kalman update step using the gain matrix formalism.
 class GainMatrixUpdater {
  public:
-  /// @brief Public call operator for the boost visitor pattern
+  /// Run the Kalman update step for a single trajectory state.
   ///
-  /// @tparam track_state_t Type of the track state for the update
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param trackState the measured track state
-  /// @param direction the navigation direction
-  ///
-  /// @return Bool indicating whether this update was 'successful'
-  /// @note Non-'successful' updates could be holes or outliers,
-  ///       which need to be treated differently in calling code.
-  template <typename track_state_t>
-  Result<void> operator()(const GeometryContext& /*gctx*/,
-                          track_state_t trackState,
-                          const NavigationDirection& direction = forward,
-                          LoggerWrapper logger = getDummyLogger()) const {
+  /// @tparam source_link_t The type of source link
+  /// @tparam kMeasurementSizeMax
+  /// @param[in] gctx The current geometry context object, e.g. alignment
+  /// @param[in,out] trackState The track state
+  /// @param[in] direction The navigation direction
+  /// @param[in] logger Where to write logging information to
+  template <typename source_link_t, size_t kMeasurementSizeMax>
+  Result<void> operator()(
+      const GeometryContext& /*gctx*/,
+      detail_lt::TrackStateProxy<source_link_t, kMeasurementSizeMax, false>&
+          trackState,
+      const NavigationDirection& direction = forward,
+      LoggerWrapper logger = getDummyLogger()) const {
     ACTS_VERBOSE("Invoked GainMatrixUpdater");
-    // let's make sure the types are consistent
-    using SourceLink = typename track_state_t::SourceLink;
-    using TrackStateProxy =
-        typename MultiTrajectory<SourceLink>::TrackStateProxy;
-    static_assert(std::is_same_v<track_state_t, TrackStateProxy>,
-                  "Given track state type is not a track state proxy");
 
     // we should definitely have an uncalibrated measurement here
     assert(trackState.hasUncalibrated());
@@ -61,39 +49,42 @@ class GainMatrixUpdater {
 
     // read-only handles. Types are eigen maps to backing storage
     const auto predicted = trackState.predicted();
-    const auto predicted_covariance = trackState.predictedCovariance();
+    const auto predictedCovariance = trackState.predictedCovariance();
 
     ACTS_VERBOSE("Predicted parameters: " << predicted.transpose());
-    ACTS_VERBOSE("Predicted covariance:\n" << predicted_covariance);
+    ACTS_VERBOSE("Predicted covariance:\n" << predictedCovariance);
 
     // read-write handles. Types are eigen maps into backing storage.
     // This writes directly into the trajectory storage
     auto filtered = trackState.filtered();
-    auto filtered_covariance = trackState.filteredCovariance();
+    auto filteredCovariance = trackState.filteredCovariance();
 
-    std::optional<std::error_code> error{std::nullopt};  // assume ok
+    // default error represents an invalid non-error state, no need for optional
+    std::error_code error;
     visit_measurement(
         trackState.calibrated(), trackState.calibratedCovariance(),
         trackState.calibratedSize(),
-        [&](const auto calibrated, const auto calibrated_covariance) {
-          constexpr size_t measdim = decltype(calibrated)::RowsAtCompileTime;
-          using cov_t = ActsSymMatrixD<measdim>;
-          using par_t = ActsVectorD<measdim>;
+        [&](const auto calibrated, const auto calibratedCovariance) {
+          constexpr size_t kMeasurementSize =
+              decltype(calibrated)::RowsAtCompileTime;
+          using Scalar = typename decltype(calibrated)::Scalar;
+          using ParametersVector = ActsVector<Scalar, kMeasurementSize>;
+          using CovarianceMatrix = ActsSymMatrix<Scalar, kMeasurementSize>;
 
-          ACTS_VERBOSE("Measurement dimension: " << measdim);
+          ACTS_VERBOSE("Measurement dimension: " << kMeasurementSize);
           ACTS_VERBOSE("Calibrated measurement: " << calibrated.transpose());
           ACTS_VERBOSE("Calibrated measurement covariance:\n"
-                       << calibrated_covariance);
+                       << calibratedCovariance);
 
-          const ActsMatrixD<measdim, eBoundSize> H =
+          const auto& H =
               trackState.projector()
-                  .template topLeftCorner<measdim, eBoundSize>();
+                  .template topLeftCorner<kMeasurementSize, eBoundSize>();
 
           ACTS_VERBOSE("Measurement projector H:\n" << H);
 
-          const ActsMatrixD<eBoundSize, measdim> K =
-              predicted_covariance * H.transpose() *
-              (H * predicted_covariance * H.transpose() + calibrated_covariance)
+          const ActsMatrix<Scalar, eBoundSize, kMeasurementSize> K =
+              predictedCovariance * H.transpose() *
+              (H * predictedCovariance * H.transpose() + calibratedCovariance)
                   .inverse();
 
           ACTS_VERBOSE("Gain Matrix K:\n" << K);
@@ -107,10 +98,10 @@ class GainMatrixUpdater {
           }
 
           filtered = predicted + K * (calibrated - H * predicted);
-          filtered_covariance =
-              (BoundSymMatrix::Identity() - K * H) * predicted_covariance;
+          filteredCovariance =
+              (BoundSymMatrix::Identity() - K * H) * predictedCovariance;
           ACTS_VERBOSE("Filtered parameters: " << filtered.transpose());
-          ACTS_VERBOSE("Filtered covariance:\n" << filtered_covariance);
+          ACTS_VERBOSE("Filtered covariance:\n" << filteredCovariance);
 
           // calculate filtered residual
           //
@@ -119,13 +110,14 @@ class GainMatrixUpdater {
           //        EventDataView unit tests. Revisit this once Measurement
           //        overhead problems (Acts issue #350) are sorted out.
           //
-          par_t residual;
+          ParametersVector residual;
           residual = calibrated - H * filtered;
           ACTS_VERBOSE("Residual: " << residual.transpose());
 
           trackState.chi2() =
               (residual.transpose() *
-               ((cov_t::Identity() - H * K) * calibrated_covariance).inverse() *
+               ((CovarianceMatrix::Identity() - H * K) * calibratedCovariance)
+                   .inverse() *
                residual)
                   .value();
 
@@ -133,13 +125,7 @@ class GainMatrixUpdater {
           return true;  // continue execution
         });
 
-    if (error) {
-      // error is set, return result
-      return *error;
-    }
-
-    // always succeed, no outlier logic yet
-    return Result<void>::success();
+    return error ? Result<void>::failure(error) : Result<void>::success();
   }
 };
 

--- a/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
@@ -76,7 +76,7 @@ class GainMatrixUpdater {
           ACTS_VERBOSE("Calibrated measurement covariance:\n"
                        << calibratedCovariance);
 
-          const auto& H =
+          ActsMatrix<Scalar, kMeasurementSize, eBoundSize> H =
               trackState.projector()
                   .template topLeftCorner<kMeasurementSize, eBoundSize>();
 


### PR DESCRIPTION
Includes the following changes:

- Removal of unused includes and adding of missing ones.
- Update of the documentation to match the code.
- Removal of unnecessary `std::optional` use.
- Apply naming guidelines.
- Reduce indenting by adding early exits where possible.