### PR TITLE
feat: simple speed improvement AtlasStepper

### DIFF
--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -1228,10 +1228,9 @@ class AtlasStepper {
       sA[2] = C6 * Sl;
 
       // Evaluate the time propagation
-      state.stepping.pVector[3] +=
-          h * std::hypot(1, state.options.mass / momentum(state.stepping));
-      state.stepping.pVector[59] =
-          std::hypot(1, state.options.mass / momentum(state.stepping));
+      double dtds = std::hypot(1, state.options.mass / momentum(state.stepping));
+      state.stepping.pVector[3] += h * dtds;
+      state.stepping.pVector[59] = dtds;
       state.stepping.field = f;
       state.stepping.newfield = false;
 
@@ -1239,8 +1238,7 @@ class AtlasStepper {
         double dtdl =
             h * state.options.mass * state.options.mass *
             charge(state.stepping) /
-            (momentum(state.stepping) *
-             std::hypot(1., state.options.mass / momentum(state.stepping)));
+            (momentum(state.stepping) * dtds);
         state.stepping.pVector[43] += dtdl;
 
         // Jacobian calculation

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -1228,17 +1228,17 @@ class AtlasStepper {
       sA[2] = C6 * Sl;
 
       // Evaluate the time propagation
-      double dtds = std::hypot(1, state.options.mass / momentum(state.stepping));
+      double dtds =
+          std::hypot(1, state.options.mass / momentum(state.stepping));
       state.stepping.pVector[3] += h * dtds;
       state.stepping.pVector[59] = dtds;
       state.stepping.field = f;
       state.stepping.newfield = false;
 
       if (Jac) {
-        double dtdl =
-            h * state.options.mass * state.options.mass *
-            charge(state.stepping) /
-            (momentum(state.stepping) * dtds);
+        double dtdl = h * state.options.mass * state.options.mass *
+                      charge(state.stepping) /
+                      (momentum(state.stepping) * dtds);
         state.stepping.pVector[43] += dtdl;
 
         // Jacobian calculation


### PR DESCRIPTION
This PR changes the triple-call to `std::hypot`, a clever compiler may fix that for you but it did reduce the call number in my tests. 