### PR TITLE
fix: Avoid Loopers in ActsExamples

### DIFF
--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -101,7 +101,7 @@ class PropagationAlgorithm : public BareAlgorithm {
     /// pt range
     std::pair<double, double> ptRange = {100_MeV, 100_GeV};
     /// looper protection
-    double ptLoopers = 300_MeV;
+    double ptLoopers = 500_MeV;
 
     /// Max step size steering
     double maxStepSize = 3_m;

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -86,17 +86,20 @@ PropagationOutput PropagationAlgorithm<propagator_t>::executeTest(
     options.maxStepSize = m_cfg.maxStepSize;
 
     // Propagate using the propagator
-    const auto& result =
-        m_cfg.propagator.propagate(startParameters, options).value();
-    auto steppingResults = result.template get<SteppingLogger::result_type>();
+    auto result = m_cfg.propagator.propagate(startParameters, options);
+    if (result.ok()) {
+      const auto& resultValue = result.value();
+      auto steppingResults =
+          resultValue.template get<SteppingLogger::result_type>();
 
-    // Set the stepping result
-    pOutput.first = std::move(steppingResults.steps);
-    // Also set the material recording result - if configured
-    if (m_cfg.recordMaterialInteractions) {
-      auto materialResult =
-          result.template get<MaterialInteractor::result_type>();
-      pOutput.second = std::move(materialResult);
+      // Set the stepping result
+      pOutput.first = std::move(steppingResults.steps);
+      // Also set the material recording result - if configured
+      if (m_cfg.recordMaterialInteractions) {
+        auto materialResult =
+            resultValue.template get<MaterialInteractor::result_type>();
+        pOutput.second = std::move(materialResult);
+      }
     }
   }
   return pOutput;

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -78,7 +78,7 @@ void addPropagationOptions(aopt_t& opt) {
       "Transverse momentum range for proprapolated tracks [in GeV].")(
       "prop-max-stepsize", po::value<double>()->default_value(3_m),
       "Maximum step size for the propagation [in mm].")(
-      "prop-pt-loopers", po::value<double>()->default_value(300_MeV),
+      "prop-pt-loopers", po::value<double>()->default_value(500_MeV),
       "Transverse momentum below which loops are being detected [in GeV].");
 }
 


### PR DESCRIPTION
The loop protection for the ActsExamples was set to a 0.3 GeV threshold, but this left the chance for some loopers to still exist.

This PR sets the default higher, but at the same time properly catches & checks the `Result` object of the `propagate(...)` call.

Addresses #581.