### PR TITLE
fix: Fix linearization point updates in AMVFitter

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -270,7 +270,7 @@ Acts::Result<void> Acts::
 
       if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         // Check if linearization state exists or need to be relinearized
-        if (not trkAtVtx.isLinearized){
+        if (not trkAtVtx.isLinearized) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
               vertexingOptions.geoContext, vertexingOptions.magFieldContext,
@@ -280,7 +280,7 @@ Acts::Result<void> Acts::
           }
           trkAtVtx.linearizedState = *result;
           trkAtVtx.isLinearized = true;
-        } else if(state.vtxInfoMap[vtx].relinearize) {
+        } else if (state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
               vertexingOptions.geoContext, vertexingOptions.magFieldContext,
@@ -291,7 +291,6 @@ Acts::Result<void> Acts::
           state.vtxInfoMap[vtx].linPoint = state.vtxInfoMap[vtx].oldPosition;
           trkAtVtx.linearizedState = *result;
           trkAtVtx.isLinearized = true;
-          
         }
         // Update the vertex with the new track
         KalmanVertexUpdater::updateVertexWithTrack<input_track_t>(*vtx,
@@ -346,7 +345,7 @@ void Acts::AdaptiveMultiVertexFitter<
   for (const auto vtx : state.vertexCollection) {
     for (const auto trk : state.vtxInfoMap[vtx].trackLinks) {
       auto& trkAtVtx = state.tracksAtVerticesMap.at(std::make_pair(trk, vtx));
-      if(trkAtVtx.trackWeight > m_cfg.minWeight){
+      if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         KalmanVertexTrackUpdater::update<input_track_t>(trkAtVtx, *vtx);
       }
     }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -52,7 +52,6 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
   while (nIter < m_cfg.maxIterations &&
          (!state.annealingState.equilibriumReached || !isSmallShift)) {
     // Initial loop over all vertices in state.vertexCollection
-
     for (auto currentVtx : state.vertexCollection) {
       VertexInfo<input_track_t>& currentVtxInfo = state.vtxInfoMap[currentVtx];
       currentVtxInfo.relinearize = false;
@@ -86,7 +85,6 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
       }
       double weight =
           1. / m_cfg.annealingTool.getWeight(state.annealingState, 1.);
-
       currentVtx->setFullCovariance(currentVtx->fullCovariance() * weight);
 
       // Set vertexCompatibility for all TrackAtVertex objects
@@ -272,7 +270,7 @@ Acts::Result<void> Acts::
 
       if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         // Check if linearization state exists or need to be relinearized
-        if (not trkAtVtx.isLinearized || state.vtxInfoMap[vtx].relinearize) {
+        if (not trkAtVtx.isLinearized){
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
               vertexingOptions.geoContext, vertexingOptions.magFieldContext,
@@ -282,7 +280,18 @@ Acts::Result<void> Acts::
           }
           trkAtVtx.linearizedState = *result;
           trkAtVtx.isLinearized = true;
+        } else if(state.vtxInfoMap[vtx].relinearize) {
+          auto result = linearizer.linearizeTrack(
+              m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
+              vertexingOptions.geoContext, vertexingOptions.magFieldContext,
+              state.linearizerState);
+          if (!result.ok()) {
+            return result.error();
+          }
           state.vtxInfoMap[vtx].linPoint = state.vtxInfoMap[vtx].oldPosition;
+          trkAtVtx.linearizedState = *result;
+          trkAtVtx.isLinearized = true;
+          
         }
         // Update the vertex with the new track
         KalmanVertexUpdater::updateVertexWithTrack<input_track_t>(*vtx,
@@ -336,8 +345,10 @@ void Acts::AdaptiveMultiVertexFitter<
     input_track_t, linearizer_t>::doVertexSmoothing(State& state) const {
   for (const auto vtx : state.vertexCollection) {
     for (const auto trk : state.vtxInfoMap[vtx].trackLinks) {
-      KalmanVertexTrackUpdater::update<input_track_t>(
-          state.tracksAtVerticesMap.at(std::make_pair(trk, vtx)), *vtx);
+      auto& trkAtVtx = state.tracksAtVerticesMap.at(std::make_pair(trk, vtx));
+      if(trkAtVtx.trackWeight > m_cfg.minWeight){
+        KalmanVertexTrackUpdater::update<input_track_t>(trkAtVtx, *vtx);
+      }
     }
   }
 }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -270,7 +270,7 @@ Acts::Result<void> Acts::
 
       if (trkAtVtx.trackWeight > m_cfg.minWeight) {
         // Check if linearization state exists or need to be relinearized
-        if (not trkAtVtx.isLinearized) {
+        if (not trkAtVtx.isLinearized || state.vtxInfoMap[vtx].relinearize) {
           auto result = linearizer.linearizeTrack(
               m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
               vertexingOptions.geoContext, vertexingOptions.magFieldContext,
@@ -278,17 +278,11 @@ Acts::Result<void> Acts::
           if (!result.ok()) {
             return result.error();
           }
-          trkAtVtx.linearizedState = *result;
-          trkAtVtx.isLinearized = true;
-        } else if (state.vtxInfoMap[vtx].relinearize) {
-          auto result = linearizer.linearizeTrack(
-              m_extractParameters(*trk), state.vtxInfoMap[vtx].oldPosition,
-              vertexingOptions.geoContext, vertexingOptions.magFieldContext,
-              state.linearizerState);
-          if (!result.ok()) {
-            return result.error();
+
+          if (trkAtVtx.isLinearized) {
+            state.vtxInfoMap[vtx].linPoint = state.vtxInfoMap[vtx].oldPosition;
           }
-          state.vtxInfoMap[vtx].linPoint = state.vtxInfoMap[vtx].oldPosition;
+
           trkAtVtx.linearizedState = *result;
           trkAtVtx.isLinearized = true;
         }

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -22,8 +22,6 @@ void Acts::KalmanVertexTrackUpdater::update(TrackAtVertex<input_track_t>& track,
   // Check if linearized state exists
   if (linTrack.covarianceAtPCA.determinant() == 0.) {
     // Track has no linearized state, returning w/o update
-    std::cout << "RETURNING WITHOUT UPDATE... track is linearized:" << track.isLinearized << std::endl;
-    std::cout << "old chi2/ndf: " << track.chi2Track << "," << track.ndf << std::endl;
     return;
   }
 
@@ -110,7 +108,6 @@ void Acts::KalmanVertexTrackUpdater::update(TrackAtVertex<input_track_t>& track,
   track.chi2Track = chi2;
   track.ndf = 2 * track.trackWeight;
 
-  std::cout << "chi2/ndf: " << track.chi2Track << "," << track.ndf << std::endl;
   return;
 }
 

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.ipp
@@ -22,6 +22,8 @@ void Acts::KalmanVertexTrackUpdater::update(TrackAtVertex<input_track_t>& track,
   // Check if linearized state exists
   if (linTrack.covarianceAtPCA.determinant() == 0.) {
     // Track has no linearized state, returning w/o update
+    std::cout << "RETURNING WITHOUT UPDATE... track is linearized:" << track.isLinearized << std::endl;
+    std::cout << "old chi2/ndf: " << track.chi2Track << "," << track.ndf << std::endl;
     return;
   }
 
@@ -108,6 +110,7 @@ void Acts::KalmanVertexTrackUpdater::update(TrackAtVertex<input_track_t>& track,
   track.chi2Track = chi2;
   track.ndf = 2 * track.trackWeight;
 
+  std::cout << "chi2/ndf: " << track.chi2Track << "," << track.ndf << std::endl;
   return;
 }
 


### PR DESCRIPTION
This PR fixes a last issue that was seen when running on data events in Athena, where the linearization point needs only to be updated in certain cases (i.e. not if the track is not linearized).
Also a small track weight cut is applied for the vertex smoothing.
Both changes have only a very small impact on the AMVF outcome, but are still needed for it to function properly.
