### PR TITLE
fix: Resolve compile errors of Autodiff Plugin caused by PR  #569

### DIFF
--- a/Plugins/Autodiff/include/Acts/Plugins/Autodiff/AutodiffExtensionWrapper.hpp
+++ b/Plugins/Autodiff/include/Acts/Plugins/Autodiff/AutodiffExtensionWrapper.hpp
@@ -71,8 +71,7 @@ struct AutodiffExtensionWrapper {
  private:
   // A fake stepper-state
   struct FakeStepperState {
-    AutodiffScalar t, p;
-    AutodiffVector3 pos, dir;
+    AutodiffFreeVector pars;
     AutodiffFreeVector derivative;
     double q;
     bool covTransport = false;
@@ -89,9 +88,15 @@ struct AutodiffExtensionWrapper {
   // A fake stepper
   struct FakeStepper {
     auto charge(const FakeStepperState& s) const { return s.q; }
-    auto momentum(const FakeStepperState& s) const { return s.p; }
-    auto direction(const FakeStepperState& s) const { return s.dir; }
-    auto position(const FakeStepperState& s) const { return s.pos; }
+    auto momentum(const FakeStepperState& s) const {
+      return s.q / s.pars(eFreeQOverP);
+    }
+    auto direction(const FakeStepperState& s) const {
+      return s.pars.template segment<3>(eFreeDir0);
+    }
+    auto position(const FakeStepperState& s) const {
+      return s.pars.template segment<3>(eFreePos0);
+    }
   };
 
   // Here the autodiff jacobian is computed
@@ -135,11 +140,7 @@ struct AutodiffExtensionWrapper {
     FakeStepper stepper;
 
     // Set dependent variables
-    state.stepping.pos = in.segment<3>(eFreePos0);
-    state.stepping.t = in(eFreeTime);
-    state.stepping.dir = in.segment<3>(eFreeDir0);
-    state.stepping.p =
-        (state.stepping.q != 0. ? state.stepping.q : 1.) / in(eFreeQOverP);
+    state.stepping.pars = in;
 
     std::array<AutodiffScalar, 4> kQoP;
     std::array<AutodiffVector3, 4> k;
@@ -172,11 +173,10 @@ struct AutodiffExtensionWrapper {
     out.segment<3>(eFreeDir0) = final_dir / final_dir.norm();
 
     // qop
-    out(eFreeQOverP) =
-        (state.stepping.q != 0. ? state.stepping.q : 1.) / state.stepping.p;
+    out(eFreeQOverP) = state.stepping.pars(eFreeQOverP);
 
     // time
-    out(eFreeTime) = state.stepping.t;
+    out(eFreeTime) = state.stepping.pars(eFreeTime);
 
     return out;
   }

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -31,8 +31,9 @@ following folders removed:
 
 ## autodiff
 
-A copy of [autodiff](https://github.com/autodiff/autodiff), v0.5.11.
-In the `CMakeLists.txt` the commands `add_subdirectory(tests)` and 
+A copy of [autodiff](https://github.com/autodiff/autodiff), v0.5.12 (however, the 
+version given in the `CMakeLists.txt` of autodiff has not been changed by the maintainers
+and is still v0.5.11). In the `CMakeLists.txt` the commands `add_subdirectory(tests)` and 
 `add_subdirectory(examples)` have been commented out. All folders/files have been 
 removed except the following ones:
 

--- a/thirdparty/autodiff/autodiff/common/meta.hpp
+++ b/thirdparty/autodiff/autodiff/common/meta.hpp
@@ -67,7 +67,7 @@ constexpr auto TupleHead(Tuple&& tuple)
 template<typename Tuple>
 constexpr auto TupleTail(Tuple&& tuple)
 {
-    auto g = [&](auto&& arg, auto&&... args) constexpr {
+    auto g = [&](auto&&, auto&&... args) constexpr {
         return std::forward_as_tuple(args...);
     };
     return std::apply(g, std::forward<Tuple>(tuple));

--- a/thirdparty/autodiff/autodiff/forward/forward.hpp
+++ b/thirdparty/autodiff/autodiff/forward/forward.hpp
@@ -1016,7 +1016,7 @@ template<typename R, enableif<isExpr<R>>...> constexpr auto abs(R&& r) -> AbsExp
 template<typename R, enableif<isExpr<R>>...> constexpr auto abs2(R&& r) { return std::forward<R>(r) * std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto conj(R&& r) { return std::forward<R>(r); }
 template<typename R, enableif<isExpr<R>>...> constexpr auto real(R&& r) { return std::forward<R>(r); }
-template<typename R, enableif<isExpr<R>>...> constexpr auto imag(R&& r) { return 0.0; }
+template<typename R, enableif<isExpr<R>>...> constexpr auto imag(R&&) { return 0.0; }
 template<typename R, enableif<isExpr<R>>...> constexpr auto erf(R&& r) -> ErfExpr<R> { return { r }; }
 
 //=====================================================================================================================
@@ -1744,9 +1744,8 @@ constexpr void apply(Dual<T, G>& self, SqrtOp)
 template<typename T, typename G>
 constexpr void apply(Dual<T, G>& self, AbsOp)
 {
-    const T aux = self.val;
+    self.grad *= self.val < T(0) ? G(-1) : (self.val > T(0) ? G(1) : G(0));
     self.val = abs(self.val);
-    self.grad *= aux / self.val;
 }
 
 template<typename T, typename G>

--- a/thirdparty/autodiff/autodiff/reverse/reverse.hpp
+++ b/thirdparty/autodiff/autodiff/reverse/reverse.hpp
@@ -834,13 +834,15 @@ struct AbsExpr : UnaryExpr<T>
     virtual void propagate(const T& wprime)
     {
         if(x->val < 0.0) x->propagate(-wprime);
-        else x->propagate(wprime);
+        else if (x->val > 0.0) x->propagate(wprime);
+        else x->propagate(T(0));
     }
 
     virtual void propagatex(const ExprPtr<T>& wprime)
     {
         if(x->val < 0.0) x->propagatex(-wprime);
-        else x->propagatex(wprime);
+        else if (x->val > 0.0) x->propagatex(wprime);
+        else x->propagate(T(0));
     }
 };
 
@@ -1004,7 +1006,7 @@ template<typename T> ExprPtr<T> abs(const ExprPtr<T>& x) { return std::make_shar
 template<typename T> ExprPtr<T> abs2(const ExprPtr<T>& x) { return x * x; }
 template<typename T> ExprPtr<T> conj(const ExprPtr<T>& x) { return x; }
 template<typename T> ExprPtr<T> real(const ExprPtr<T>& x) { return x; }
-template<typename T> ExprPtr<T> imag(const ExprPtr<T>& x) { return constant<T>(0.0); }
+template<typename T> ExprPtr<T> imag(const ExprPtr<T>&) { return constant<T>(0.0); }
 template<typename T> ExprPtr<T> erf(const ExprPtr<T>& x) { return std::make_shared<ErfExpr<T>>(erf(x->val), x); }
 
 //------------------------------------------------------------------------------
@@ -1237,7 +1239,7 @@ auto val(const ExprPtr<T>& x)
 /// Return the derivatives of a variable y with respect to all independent variables.
 template<typename T>
 [[deprecated("Use method `derivatives(y, wrt(a, b, c,...)` instead.")]]
-auto derivatives(const T& y)
+auto derivatives(const T&)
 {
     static_assert(!std::is_same_v<T,T>, "Method derivatives(const var&) has been deprecated. Use method derivatives(y, wrt(a, b, c,...) instead.");
 }
@@ -1245,7 +1247,7 @@ auto derivatives(const T& y)
 /// Return the derivatives of a variable y with respect to all independent variables.
 template<typename T>
 [[deprecated("Use method derivativesx(y, wrt(a, b, c,...) instead.")]]
-auto derivativesx(const T& y)
+auto derivativesx(const T&)
 {
     static_assert(!std::is_same_v<T,T>, "Method derivativesx(const var&) has been deprecated. Use method derivativesx(y, wrt(a, b, c,...) instead.");
 }


### PR DESCRIPTION
This PR updates the Autodiff-Plugin, since it is dependent on the internal data layout of the `StepperState`, which was changed in PR #569.

PS: I'm not sure how this works internally, but shouldn't such things be catched by the CI? Or does this not apply for Plugins?