### PR TITLE
feat: Interface for Fatras propagation termination by interaction

### DIFF
--- a/Examples/Run/Fatras/Common/FatrasSimulation.cpp
+++ b/Examples/Run/Fatras/Common/FatrasSimulation.cpp
@@ -34,6 +34,7 @@
 #include "ActsFatras/Kernel/PhysicsList.hpp"
 #include "ActsFatras/Kernel/Process.hpp"
 #include "ActsFatras/Kernel/Simulator.hpp"
+#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheBloch.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp"
 #include "ActsFatras/Physics/Scattering/Highland.hpp"
@@ -41,7 +42,6 @@
 #include "ActsFatras/Selectors/KinematicCasts.hpp"
 #include "ActsFatras/Selectors/SelectorHelpers.hpp"
 #include "ActsFatras/Selectors/SurfaceSelectors.hpp"
-#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 
 #include <boost/program_options.hpp>
 
@@ -112,7 +112,8 @@ void setupSimulationAlgorithms(
   using NeutralSelector =
       ActsFatras::CombineAnd<ActsFatras::NeutralSelector, MinP>;
   using NeutralSimulator = ActsFatras::ParticleSimulator<
-      NeutralPropagator, ActsFatras::PhysicsList<>, ActsFatras::NoSurface, ActsFatras::VoidPostPropagationInteractor>;
+      NeutralPropagator, ActsFatras::PhysicsList<>, ActsFatras::NoSurface,
+      ActsFatras::VoidPostPropagationInteractor>;
   // full simulator type for charged and neutrals
   using Simulator = ActsFatras::Simulator<ChargedSelector, ChargedSimulator,
                                           NeutralSelector, NeutralSimulator>;

--- a/Examples/Run/Fatras/Common/FatrasSimulation.cpp
+++ b/Examples/Run/Fatras/Common/FatrasSimulation.cpp
@@ -41,6 +41,7 @@
 #include "ActsFatras/Selectors/KinematicCasts.hpp"
 #include "ActsFatras/Selectors/SelectorHelpers.hpp"
 #include "ActsFatras/Selectors/SurfaceSelectors.hpp"
+#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 
 #include <boost/program_options.hpp>
 
@@ -106,12 +107,12 @@ void setupSimulationAlgorithms(
       ActsFatras::CombineAnd<ActsFatras::ChargedSelector, MinP>;
   using ChargedSimulator = ActsFatras::ParticleSimulator<
       ChargedPropagator, ActsFatras::ChargedElectroMagneticPhysicsList,
-      HitSurfaceSelector>;
+      HitSurfaceSelector, ActsFatras::VoidPostPropagationInteractor>;
   // neutral particles w/o physics and no hits
   using NeutralSelector =
       ActsFatras::CombineAnd<ActsFatras::NeutralSelector, MinP>;
   using NeutralSimulator = ActsFatras::ParticleSimulator<
-      NeutralPropagator, ActsFatras::PhysicsList<>, ActsFatras::NoSurface>;
+      NeutralPropagator, ActsFatras::PhysicsList<>, ActsFatras::NoSurface, ActsFatras::VoidPostPropagationInteractor>;
   // full simulator type for charged and neutrals
   using Simulator = ActsFatras::Simulator<ChargedSelector, ChargedSimulator,
                                           NeutralSelector, NeutralSimulator>;

--- a/Fatras/include/ActsFatras/Kernel/Simulator.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulator.hpp
@@ -37,9 +37,11 @@ namespace ActsFatras {
 /// @tparam propagator_t is the type of the underlying propagator
 /// @tparam physics_list_t is the type of the simulated physics list
 /// @tparam hit_surface_selector_t is the type that selects hit surfaces
-/// @tparam post_propagation_interactor_t Type that allows to stop the propagation and manipulate the result after the propagation
+/// @tparam post_propagation_interactor_t Type that allows to stop the
+/// propagation and manipulate the result after the propagation
 template <typename propagator_t, typename physics_list_t,
-          typename hit_surface_selector_t, typename post_propagation_interactor_t>
+          typename hit_surface_selector_t,
+          typename post_propagation_interactor_t>
 struct ParticleSimulator {
   /// How and within which geometry to propagate the particle.
   propagator_t propagator;
@@ -76,7 +78,8 @@ struct ParticleSimulator {
 
     // propagator-related additional types
     using Interactor =
-        detail::Interactor<generator_t, physics_list_t, hit_surface_selector_t, post_propagation_interactor_t>;
+        detail::Interactor<generator_t, physics_list_t, hit_surface_selector_t,
+                           post_propagation_interactor_t>;
     using InteractorResult = typename Interactor::result_type;
     using Actions = Acts::ActionList<Interactor>;
     using Abort = Acts::AbortList<typename Interactor::ParticleNotAlive,
@@ -94,7 +97,9 @@ struct ParticleSimulator {
     interactor.physics = physics;
     interactor.selectHitSurface = selectHitSurface;
     interactor.particle = particle;
-    auto& postPropagationInteractor = options.abortList.template get<typename Interactor::ParticleNotAlive>().postPropagationInteractor;
+    auto &postPropagationInteractor =
+        options.abortList.template get<typename Interactor::ParticleNotAlive>()
+            .postPropagationInteractor;
     postPropagationInteractor.setAbortConditions(generator, particle);
     // use AnyCharge to be able to handle neutral and charged parameters
     Acts::SingleCurvilinearTrackParameters<Acts::AnyCharge> start(
@@ -102,8 +107,8 @@ struct ParticleSimulator {
         particle.charge());
     auto result = propagator.propagate(start, options);
     if (result.ok()) {
-	  auto& interactorResult = result.value().template get<InteractorResult>();
-	  postPropagationInteractor(generator, interactorResult);
+      auto &interactorResult = result.value().template get<InteractorResult>();
+      postPropagationInteractor(generator, interactorResult);
       return interactorResult;
     } else {
       return result.error();

--- a/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
@@ -31,7 +31,8 @@ namespace detail {
 /// @tparam physics_list_t is a simulation physics lists
 /// @tparam hit_surface_selector_t is a selector of sensitive hit surfaces
 template <typename generator_t, typename physics_list_t,
-          typename hit_surface_selector_t, typename post_propagation_interactor_t>
+          typename hit_surface_selector_t,
+          typename post_propagation_interactor_t>
 struct Interactor {
   using result_type = SimulationResult;
 
@@ -43,11 +44,13 @@ struct Interactor {
     template <typename propagator_state_t, typename stepper_t>
     constexpr bool operator()(propagator_state_t &, const stepper_t &,
                               const result_type &result) const {
-	  return not result.isAlive || postPropagationInteractor(result.pathInX0, result.pathInL0, result.particle.time());
+      return not result.isAlive ||
+             postPropagationInteractor(result.pathInX0, result.pathInL0,
+                                       result.particle.time());
     }
-    
-      /// Action that only occurs if the propagation ends
-	post_propagation_interactor_t postPropagationInteractor;
+
+    /// Action that only occurs if the propagation ends
+    post_propagation_interactor_t postPropagationInteractor;
   };
 
   /// Random number generator used for the simulation.

--- a/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
@@ -31,7 +31,7 @@ namespace detail {
 /// @tparam physics_list_t is a simulation physics lists
 /// @tparam hit_surface_selector_t is a selector of sensitive hit surfaces
 template <typename generator_t, typename physics_list_t,
-          typename hit_surface_selector_t>
+          typename hit_surface_selector_t, typename post_propagation_interactor_t>
 struct Interactor {
   using result_type = SimulationResult;
 
@@ -43,8 +43,11 @@ struct Interactor {
     template <typename propagator_state_t, typename stepper_t>
     constexpr bool operator()(propagator_state_t &, const stepper_t &,
                               const result_type &result) const {
-      return not result.isAlive;
+	  return not result.isAlive || postPropagationInteractor(result.pathInX0, result.pathInL0, result.particle.time());
     }
+    
+      /// Action that only occurs if the propagation ends
+	post_propagation_interactor_t postPropagationInteractor;
   };
 
   /// Random number generator used for the simulation.

--- a/Fatras/include/ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp
@@ -8,29 +8,39 @@
 
 #pragma once
 
-#include "ActsFatras/Kernel/SimulationResult.hpp"
 #include "ActsFatras/EventData/Particle.hpp"
+#include "ActsFatras/Kernel/SimulationResult.hpp"
 
 namespace ActsFatras {
 
-/// Void class that allows simulating effects that e.g. destroy the particle. Since these types of effects will stop the simulation in any case there is no need to implement these in the physics list used by the @c Interactor.
-/// This class allows to abort the propagation based on conditions that are set based on the initial condition (i.e. the particle properties before the propagation). After the propagation is finished, this class can manipulate the resulting particles once more (i.e. by calculating a particle decay).
-/// @note Any conditions used in this class have no effect upon the @c Interactor.
+/// Void class that allows simulating effects that e.g. destroy the particle.
+/// Since these types of effects will stop the simulation in any case there is
+/// no need to implement these in the physics list used by the @c Interactor.
+/// This class allows to abort the propagation based on conditions that are set
+/// based on the initial condition (i.e. the particle properties before the
+/// propagation). After the propagation is finished, this class can manipulate
+/// the resulting particles once more (i.e. by calculating a particle decay).
+/// @note Any conditions used in this class have no effect upon the @c
+/// Interactor.
 struct VoidPostPropagationInteractor {
+  /// @brief Aborter condition used in the propagation. This method allows to
+  /// trigger its effect(s) if its conditions are fulfilled.
+  constexpr bool operator()(const Particle::Scalar /*x0*/,
+                            const Particle::Scalar /*l0*/,
+                            const Particle::Scalar /*time*/) const {
+    return false;
+  }
 
-	/// @brief Aborter condition used in the propagation. This method allows to trigger its effect(s) if its conditions are fulfilled.
-	constexpr bool operator()(const Particle::Scalar /*x0*/, const Particle::Scalar /*l0*/, const Particle::Scalar /*time*/) const {
-	  return false;
-	}
-		
-	/// @brief Configuration method. Allows to configure its aborting conditions based upon the initial state
-	template <typename generator_t>
-	void setAbortConditions(generator_t& /*generator*/, const Particle& /*particle*/) {
-	}
-	 
-	/// @brief The actual effect that is triggered after the propagation is finished.
-	template <typename generator_t>
-	void operator()(generator_t& /*generator*/, SimulationResult& /*result*/) const {
-	 }
+  /// @brief Configuration method. Allows to configure its aborting conditions
+  /// based upon the initial state
+  template <typename generator_t>
+  void setAbortConditions(generator_t& /*generator*/,
+                          const Particle& /*particle*/) {}
+
+  /// @brief The actual effect that is triggered after the propagation is
+  /// finished.
+  template <typename generator_t>
+  void operator()(generator_t& /*generator*/,
+                  SimulationResult& /*result*/) const {}
 };
-}
+}  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp
@@ -1,0 +1,36 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsFatras/Kernel/SimulationResult.hpp"
+#include "ActsFatras/EventData/Particle.hpp"
+
+namespace ActsFatras {
+
+/// Void class that allows simulating effects that e.g. destroy the particle. Since these types of effects will stop the simulation in any case there is no need to implement these in the physics list used by the @c Interactor.
+/// This class allows to abort the propagation based on conditions that are set based on the initial condition (i.e. the particle properties before the propagation). After the propagation is finished, this class can manipulate the resulting particles once more (i.e. by calculating a particle decay).
+/// @note Any conditions used in this class have no effect upon the @c Interactor.
+struct VoidPostPropagationInteractor {
+
+	/// @brief Aborter condition used in the propagation. This method allows to trigger its effect(s) if its conditions are fulfilled.
+	constexpr bool operator()(const Particle::Scalar /*x0*/, const Particle::Scalar /*l0*/, const Particle::Scalar /*time*/) const {
+	  return false;
+	}
+		
+	/// @brief Configuration method. Allows to configure its aborting conditions based upon the initial state
+	template <typename generator_t>
+	void setAbortConditions(generator_t& /*generator*/, const Particle& /*particle*/) {
+	}
+	 
+	/// @brief The actual effect that is triggered after the propagation is finished.
+	template <typename generator_t>
+	void operator()(generator_t& /*generator*/, SimulationResult& /*result*/) const {
+	 }
+};
+}

--- a/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
+++ b/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
@@ -23,6 +23,7 @@
 #include "ActsFatras/Selectors/ChargeSelectors.hpp"
 #include "ActsFatras/Selectors/SurfaceSelectors.hpp"
 #include "ActsFatras/Utilities/ParticleData.hpp"
+#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 
 #include <algorithm>
 #include <random>
@@ -71,12 +72,12 @@ using ChargedPhysicsList =
                             SplitEnergyLoss>;
 using ChargedSimulator =
     ActsFatras::ParticleSimulator<ChargedPropagator, ChargedPhysicsList,
-                                  ActsFatras::EverySurface>;
+                                  ActsFatras::EverySurface, ActsFatras::VoidPostPropagationInteractor>;
 // all neutral particles w/o physics and no hits
 using NeutralSelector = ActsFatras::NeutralSelector;
 using NeutralSimulator =
     ActsFatras::ParticleSimulator<NeutralPropagator, ActsFatras::PhysicsList<>,
-                                  ActsFatras::NoSurface>;
+                                  ActsFatras::NoSurface, ActsFatras::VoidPostPropagationInteractor>;
 // full simulator type for charged and neutrals
 using Simulator = ActsFatras::Simulator<ChargedSelector, ChargedSimulator,
                                         NeutralSelector, NeutralSimulator>;

--- a/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
+++ b/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
@@ -19,11 +19,11 @@
 #include "Acts/Utilities/UnitVectors.hpp"
 #include "ActsFatras/Kernel/PhysicsList.hpp"
 #include "ActsFatras/Kernel/Simulator.hpp"
+#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 #include "ActsFatras/Physics/StandardPhysicsLists.hpp"
 #include "ActsFatras/Selectors/ChargeSelectors.hpp"
 #include "ActsFatras/Selectors/SurfaceSelectors.hpp"
 #include "ActsFatras/Utilities/ParticleData.hpp"
-#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 
 #include <algorithm>
 #include <random>
@@ -72,12 +72,14 @@ using ChargedPhysicsList =
                             SplitEnergyLoss>;
 using ChargedSimulator =
     ActsFatras::ParticleSimulator<ChargedPropagator, ChargedPhysicsList,
-                                  ActsFatras::EverySurface, ActsFatras::VoidPostPropagationInteractor>;
+                                  ActsFatras::EverySurface,
+                                  ActsFatras::VoidPostPropagationInteractor>;
 // all neutral particles w/o physics and no hits
 using NeutralSelector = ActsFatras::NeutralSelector;
 using NeutralSimulator =
     ActsFatras::ParticleSimulator<NeutralPropagator, ActsFatras::PhysicsList<>,
-                                  ActsFatras::NoSurface, ActsFatras::VoidPostPropagationInteractor>;
+                                  ActsFatras::NoSurface,
+                                  ActsFatras::VoidPostPropagationInteractor>;
 // full simulator type for charged and neutrals
 using Simulator = ActsFatras::Simulator<ChargedSelector, ChargedSimulator,
                                         NeutralSelector, NeutralSimulator>;

--- a/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Tests/CommonHelpers/PredefinedMaterials.hpp"
 #include "ActsFatras/Kernel/detail/Interactor.hpp"
 #include "ActsFatras/Selectors/SurfaceSelectors.hpp"
+#include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
 
 #include <limits>
 #include <random>
@@ -79,7 +80,7 @@ struct Fixture {
   using Generator = std::ranlux48;
   using Interactor =
       typename ActsFatras::detail::Interactor<Generator, MockPhysicsList,
-                                              SurfaceSelector>;
+                                              SurfaceSelector, VoidPostPropagationInteractor>;
   using InteractorResult = typename Interactor::result_type;
 
   Generator generator;

--- a/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
@@ -14,8 +14,8 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Tests/CommonHelpers/PredefinedMaterials.hpp"
 #include "ActsFatras/Kernel/detail/Interactor.hpp"
-#include "ActsFatras/Selectors/SurfaceSelectors.hpp"
 #include "ActsFatras/Kernel/detail/VoidPostPropagationInteractor.hpp"
+#include "ActsFatras/Selectors/SurfaceSelectors.hpp"
 
 #include <limits>
 #include <random>
@@ -80,7 +80,8 @@ struct Fixture {
   using Generator = std::ranlux48;
   using Interactor =
       typename ActsFatras::detail::Interactor<Generator, MockPhysicsList,
-                                              SurfaceSelector, VoidPostPropagationInteractor>;
+                                              SurfaceSelector,
+                                              VoidPostPropagationInteractor>;
   using InteractorResult = typename Interactor::result_type;
 
   Generator generator;


### PR DESCRIPTION
The `ParticleSimulator` propagates a particle and applies via the `Interactor` several physics effects. The `Interactor` itself calls a list of effects after each step. The propagation terminates if the particle is not alive anymore. For some effects like decay, it is known that the propagation terminates after this effect is applied. Hence it is not required to call these effects inside the physics list of the `Interactor` after each step but call it once.
This PR provides a templated interface for such an effect. Therewith it is possible to extend the `Interactor` abort condition using traveled distances and the lifetime of the particle. The abort conditions itself can be evaluated once before the start of the propagation. After the termination of the propagation an additional call allows to apply the physics effect(s) upon the result.