### PR TITLE
fix: Geometry context in Json converter

### DIFF
--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -148,6 +148,7 @@ int processGeometry(int argc, char* argv[],
       jmConverterCfg.writeData = vm["mat-output-data"].template as<bool>();
       jmConverterCfg.processnonmaterial =
           vm["mat-output-allmaterial"].template as<bool>();
+      jmConverterCfg.context = context.geoContext;
       // The writer
       ActsExamples::JsonMaterialWriter jmwImpl(std::move(jmConverterCfg),
                                                materialFileName + ".json");

--- a/Examples/Run/Common/src/MaterialValidationBase.cpp
+++ b/Examples/Run/Common/src/MaterialValidationBase.cpp
@@ -155,6 +155,9 @@ int materialValidationExample(int argc, char* argv[],
   auto geometry = ActsExamples::Geometry::build(vm, detector);
   auto tGeometry = geometry.first;
   auto contextDecorators = geometry.second;
+  for (auto cdr : contextDecorators) {
+    sequencer.addContextDecorator(cdr);
+  }
 
   // Create the random number engine
   auto randomNumberSvcCfg = ActsExamples::Options::readRandomNumbersConfig(vm);

--- a/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
@@ -136,6 +136,8 @@ class JsonGeometryConverter {
     std::string surfacerangekey = "srange";
     /// The default logger
     std::shared_ptr<const Logger> logger;
+    /// Default geometry context to extract surface tranforms
+    GeometryContext context = GeometryContext();
     /// The name of the writer
     std::string name = "";
 

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -862,7 +862,7 @@ void Acts::JsonGeometryConverter::addSurfaceToJson(json& sjson,
 
   // Cast the surface bound to both disk and cylinder
   const Acts::SurfaceBounds& surfaceBounds = surface->bounds();
-  auto sTransform = surface->transform(GeometryContext());
+  auto sTransform = surface->transform(m_cfg.context);
 
   const Acts::RadialBounds* radialBounds =
       dynamic_cast<const Acts::RadialBounds*>(&surfaceBounds);


### PR DESCRIPTION
Added the geometry context as one of the config augment for the json geometry converter. The geometry and material mapping example have been updated to use the context. It don't think anything like a "nominal context" exist so for now the geometry context of event 0.

This resolve Issue #488.
