### PR TITLE
feat: Introduce Adaptive gaussian track density vertex seed finder

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -24,7 +24,7 @@ namespace Acts {
 /// Each single track is modelled as a 2(!)-dim Gaussian distribution grid
 /// in the d0-z0 plane, but only the overlap with the z-axis (i.e. a 1-dim
 /// density vector) needs to be calculated. All track contributions along the
-/// beam axis (main density grid) a superimposed and the z-value of the bin
+/// beam axis (main density grid) are superimposed and the z-value of the bin
 /// with the highest track density is returned as a vertex candidate.
 /// Unlike the GridDensityVertexFinder, this seeder implements an adaptive
 /// version where the density grid grows bigger with added tracks.

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -24,7 +24,7 @@ namespace Acts {
 /// Each single track is modelled as a 2-dim Gaussian distribution grid
 /// in the d0-z0 plane, but only the overlap with the z-axis (i.e. a 1-dim
 /// density vector) needs to be calculated. All track contributions along the
-/// beam axis (main density grid) are superimposed and the z-value of the bin
+/// beam axis (main density vector) are superimposed and the z-value of the bin
 /// with the highest track density is returned as a vertex candidate.
 /// Unlike the GridDensityVertexFinder, this seeder implements an adaptive
 /// version where the density grid grows bigger with added tracks.
@@ -74,7 +74,7 @@ class AdaptiveGridDensityVertexFinder {
   ///
   /// Only needed if cacheGridStateForTrackRemoval == true
   struct State {
-    // The main density grid
+    // The main density vector
     std::vector<float> mainGridDensity;
     // Vector holding corresponding z bin values
     std::vector<int> mainGridZValues;

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "Acts/EventData/TrackParameters.hpp"
-#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
@@ -81,7 +81,7 @@ class AdaptiveGridDensityVertexFinder {
 
     // Map to store z-bin and track grid (i.e. the density contribution of
     // a single track to the main grid) for every single track
-    std::map<const InputTrack_t*, std::pair<int, ActsVectorF<trkGridSize>>>
+    std::map<const InputTrack_t*, std::pair<int, ActsVector<float, trkGridSize>>>
         binAndTrackGridMap;
 
     // Map to store bool if track has passed track selection or not

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -26,6 +26,8 @@ namespace Acts {
 /// density vector) needs to be calculated. All track contributions along the
 /// beam axis (main density grid) a superimposed and the z-value of the bin
 /// with the highest track density is returned as a vertex candidate.
+/// Unlike the GridDensityVertexFinder, this seeder implements an adaptive
+/// version where the density grid grows bigger with added tracks.
 ///
 /// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
 /// a single track is modelled as a (trkGridSize x trkGridSize) grid
@@ -41,9 +43,9 @@ class AdaptiveGridDensityVertexFinder {
  public:
   /// @brief The Config struct
   struct Config {
-    ///@param zMinMax min and max z value of big z-axis grid
-    Config(float zMinMax = 100)
-        : gridDensity(typename GridDensity::Config(zMinMax)) {}
+    ///@param binSize Bin size of grid in mm
+    Config(float binSize = 0.1)
+        : gridDensity(typename GridDensity::Config(binSize)) {}
     ///@param gDensity The grid density
     Config(const GridDensity& gDensity) : gridDensity(gDensity) {}
 

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -1,0 +1,169 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Result.hpp"
+#include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
+#include "Acts/Vertexing/Vertex.hpp"
+#include "Acts/Vertexing/VertexingOptions.hpp"
+
+#include "DummyVertexFitter.hpp"
+
+namespace Acts {
+
+/// @class AdaptiveGridDensityVertexFinder
+/// @brief Vertex finder that makes use of a track density grid.
+/// Each single track is modelled as a 2(!)-dim Gaussian distribution grid
+/// in the d0-z0 plane, but only the overlap with the z-axis (i.e. a 1-dim
+/// density vector) needs to be calculated. All track contributions along the
+/// beam axis (main density grid) a superimposed and the z-value of the bin
+/// with the highest track density is returned as a vertex candidate.
+///
+/// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
+/// a single track is modelled as a (trkGridSize x trkGridSize) grid
+/// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
+template <int trkGridSize = 15,
+          typename vfitter_t = DummyVertexFitter<>>
+class AdaptiveGridDensityVertexFinder {
+  // Assert odd trkGridSize
+  static_assert(trkGridSize % 2);
+
+  using InputTrack_t = typename vfitter_t::InputTrack_t;
+  using GridDensity = AdaptiveGridTrackDensity<trkGridSize>;
+
+ public:
+  /// @brief The Config struct
+  struct Config {
+    ///@param zMinMax min and max z value of big z-axis grid
+    Config(float zMinMax = 100)
+        : gridDensity(typename GridDensity::Config(zMinMax)) {}
+    ///@param gDensity The grid density
+    Config(const GridDensity& gDensity) : gridDensity(gDensity) {}
+
+    // The grid density object
+    GridDensity gridDensity;
+
+    // Cache the main grid and the density contributions (trackGrid and z-bin)
+    // for every single track.
+    // This option enables the possibility to calculate the entire main grid
+    // only once in the first iteration. If tracks are removed from the track
+    // collection, the individual track density contributions to the main grid
+    // can just be removed without calculating the entire grid from scratch.
+    bool cacheGridStateForTrackRemoval = true;
+
+    // Maximum d0 impact parameter significance to use a track
+    double maxD0TrackSignificance = 3.5;
+    // Maximum z0 impact parameter significance to use a track
+    double maxZ0TrackSignificance = 12.;
+    // The actual corresponding cut values in the algorithm
+    double d0SignificanceCut = maxD0TrackSignificance * maxD0TrackSignificance;
+    double z0SignificanceCut = maxZ0TrackSignificance * maxZ0TrackSignificance;
+    bool estimateSeedWidth = false;
+  };
+
+  /// @brief The State struct
+  ///
+  /// Only needed if cacheGridStateForTrackRemoval == true
+  struct State {
+    // The main density grid
+    std::vector<float> mainGridDensity;
+    // Vector holding corresponding z bin values
+    std::vector<int> mainGridZValues;
+
+    // Map to store z-bin and track grid (i.e. the density contribution of
+    // a single track to the main grid) for every single track
+    std::map<const InputTrack_t*, std::pair<int, ActsVectorF<trkGridSize>>>
+        binAndTrackGridMap;
+
+    // Map to store bool if track has passed track selection or not
+    std::map<const InputTrack_t*, bool> trackSelectionMap;
+
+    // Store tracks that have been removed from track collection. These
+    // track will be removed from the main grid
+    std::vector<const InputTrack_t*> tracksToRemove;
+
+    bool isInitialized = false;
+  };
+
+  /// @brief Function that finds single vertex candidate
+  ///
+  /// @param trackVector Input track collection
+  /// @param vertexingOptions Vertexing options
+  /// @param state The state object to cache the density grid
+  /// and density contributions of each track, to be used
+  /// if cacheGridStateForTrackRemoval == true
+  ///
+  /// @return Vector of vertices, filled with a single
+  ///         vertex (for consistent interfaces)
+  Result<std::vector<Vertex<InputTrack_t>>> find(
+      const std::vector<const InputTrack_t*>& trackVector,
+      const VertexingOptions<InputTrack_t>& vertexingOptions,
+      State& state) const;
+
+  /// @brief Constructor used if InputTrack_t type == BoundTrackParameters
+  ///
+  /// @param cfg Configuration object
+  template <
+      typename T = InputTrack_t,
+      std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
+  AdaptiveGridDensityVertexFinder(const Config& cfg)
+      : m_cfg(cfg), m_extractParameters([](T params) { return params; }) {}
+
+  /// @brief Default constructor used if InputTrack_t type ==
+  /// BoundTrackParameters
+  template <
+      typename T = InputTrack_t,
+      std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
+  AdaptiveGridDensityVertexFinder()
+      : m_extractParameters([](T params) { return params; }) {}
+
+  /// @brief Constructor for user-defined InputTrack_t type =!
+  /// BoundTrackParameters
+  ///
+  /// @param cfg Configuration object
+  /// @param func Function extracting BoundTrackParameters from InputTrack_t
+  /// object
+  AdaptiveGridDensityVertexFinder(
+      const Config& cfg,
+      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      : m_cfg(cfg), m_extractParameters(func) {}
+
+  /// @brief Constructor for user-defined InputTrack_t type =!
+  /// BoundTrackParameters with default Config object
+  ///
+  /// @param func Function extracting BoundTrackParameters from InputTrack_t
+  /// object
+  AdaptiveGridDensityVertexFinder(
+      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      : m_extractParameters(func) {}
+
+ private:
+  /// @brief Checks if a track passes the selection criteria for seeding
+  ///
+  /// @param trk The track
+  ///
+  /// @return Bool track passes selection
+  bool doesPassTrackSelection(const BoundTrackParameters& trk) const;
+
+  // The configuration object
+  const Config m_cfg;
+
+  /// @brief Function to extract track parameters,
+  /// InputTrack_t objects are BoundTrackParameters by default, function to be
+  /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
+  ///
+  /// @param InputTrack_t object to extract track parameters from
+  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+};
+
+}  // namespace Acts
+
+#include "AdaptiveGridDensityVertexFinder.ipp"

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -21,7 +21,7 @@ namespace Acts {
 
 /// @class AdaptiveGridDensityVertexFinder
 /// @brief Vertex finder that makes use of a track density grid.
-/// Each single track is modelled as a 2(!)-dim Gaussian distribution grid
+/// Each single track is modelled as a 2-dim Gaussian distribution grid
 /// in the d0-z0 plane, but only the overlap with the z-axis (i.e. a 1-dim
 /// density vector) needs to be calculated. All track contributions along the
 /// beam axis (main density grid) are superimposed and the z-value of the bin

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -30,8 +30,7 @@ namespace Acts {
 /// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
 /// a single track is modelled as a (trkGridSize x trkGridSize) grid
 /// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
-template <int trkGridSize = 15,
-          typename vfitter_t = DummyVertexFitter<>>
+template <int trkGridSize = 15, typename vfitter_t = DummyVertexFitter<>>
 class AdaptiveGridDensityVertexFinder {
   // Assert odd trkGridSize
   static_assert(trkGridSize % 2);

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
@@ -81,7 +81,8 @@ class AdaptiveGridDensityVertexFinder {
 
     // Map to store z-bin and track grid (i.e. the density contribution of
     // a single track to the main grid) for every single track
-    std::map<const InputTrack_t*, std::pair<int, ActsVector<float, trkGridSize>>>
+    std::map<const InputTrack_t*,
+             std::pair<int, ActsVector<float, trkGridSize>>>
         binAndTrackGridMap;
 
     // Map to store bool if track has passed track selection or not

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -29,7 +29,7 @@ namespace Acts {
 /// Unlike the GridDensityVertexFinder, this seeder implements an adaptive
 /// version where the density grid grows bigger with added tracks.
 ///
-/// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
+/// @tparam trkGridSize The 2-dim grid size of a single track, i.e.
 /// a single track is modelled as a (trkGridSize x trkGridSize) grid
 /// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
 template <int trkGridSize = 15, typename vfitter_t = DummyVertexFitter<>>

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
@@ -24,7 +24,8 @@ auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::find(
       couldRemoveTracks = true;
       auto binAndTrackGrid = state.binAndTrackGridMap.at(trk);
       m_cfg.gridDensity.removeTrackGridFromMainGrid(
-          binAndTrackGrid.first, binAndTrackGrid.second, state.mainGridDensity, state.mainGridZValues);
+          binAndTrackGrid.first, binAndTrackGrid.second, state.mainGridDensity,
+          state.mainGridZValues);
     }
     if (not couldRemoveTracks) {
       // No tracks were removed anymore
@@ -47,8 +48,8 @@ auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::find(
         }
         continue;
       }
-      auto binAndTrackGrid =
-          m_cfg.gridDensity.addTrack(trkParams, state.mainGridDensity, state.mainGridZValues);
+      auto binAndTrackGrid = m_cfg.gridDensity.addTrack(
+          trkParams, state.mainGridDensity, state.mainGridZValues);
       // Cache track density contribution to main grid if enabled
       if (m_cfg.cacheGridStateForTrackRemoval) {
         state.binAndTrackGridMap[trk] = binAndTrackGrid;
@@ -63,7 +64,8 @@ auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::find(
   if (not state.mainGridDensity.empty()) {
     if (not m_cfg.estimateSeedWidth) {
       // Get z value of highest density bin
-      auto maxZres = m_cfg.gridDensity.getMaxZPosition(state.mainGridDensity, state.mainGridZValues);
+      auto maxZres = m_cfg.gridDensity.getMaxZPosition(state.mainGridDensity,
+                                                       state.mainGridZValues);
 
       if (!maxZres.ok()) {
         return maxZres.error();
@@ -71,7 +73,8 @@ auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::find(
       z = *maxZres;
     } else {
       // Get z value of highest density bin and width
-      auto maxZres = m_cfg.gridDensity.getMaxZPositionAndWidth(state.mainGridDensity, state.mainGridZValues);
+      auto maxZres = m_cfg.gridDensity.getMaxZPositionAndWidth(
+          state.mainGridDensity, state.mainGridZValues);
 
       if (!maxZres.ok()) {
         return maxZres.error();

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
@@ -127,7 +127,8 @@ auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::
     return false;
   }
 
-  // Calculate track density quantities
+  // Calculate track density quantities to check if track can easily
+  // be considered as 2-dim Gaussian distribution without causing problems
   double constantTerm =
       -(d0 * d0 * covZZ + z0 * z0 * covDD + 2. * d0 * z0 * covDZ) /
       (2. * covDeterminant);

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
@@ -1,0 +1,141 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+template <int trkGridSize, typename vfitter_t>
+auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::find(
+    const std::vector<const InputTrack_t*>& trackVector,
+    const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
+    -> Result<std::vector<Vertex<InputTrack_t>>> {
+  // Remove density contributions from tracks removed from track collection
+  if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&
+      !state.tracksToRemove.empty()) {
+    // Bool to check if removable tracks, that pass selection, still exist
+    bool couldRemoveTracks = false;
+    for (auto trk : state.tracksToRemove) {
+      if (not state.trackSelectionMap.at(trk)) {
+        // Track was never added to grid, so cannot remove it
+        continue;
+      }
+      couldRemoveTracks = true;
+      auto binAndTrackGrid = state.binAndTrackGridMap.at(trk);
+      m_cfg.gridDensity.removeTrackGridFromMainGrid(
+          binAndTrackGrid.first, binAndTrackGrid.second, state.mainGridDensity, state.mainGridZValues);
+    }
+    if (not couldRemoveTracks) {
+      // No tracks were removed anymore
+      // Return empty seed, i.e. vertex at constraint position
+      // (Note: Upstream finder should check for this break condition)
+      std::vector<Vertex<InputTrack_t>> seedVec{
+          vertexingOptions.vertexConstraint};
+      return seedVec;
+    }
+  } else {
+    state.mainGridDensity.clear();
+    state.mainGridZValues.clear();
+    // Fill with track densities
+    for (auto trk : trackVector) {
+      const BoundTrackParameters& trkParams = m_extractParameters(*trk);
+      // Take only tracks that fulfill selection criteria
+      if (not doesPassTrackSelection(trkParams)) {
+        if (m_cfg.cacheGridStateForTrackRemoval) {
+          state.trackSelectionMap[trk] = false;
+        }
+        continue;
+      }
+      auto binAndTrackGrid =
+          m_cfg.gridDensity.addTrack(trkParams, state.mainGridDensity, state.mainGridZValues);
+      // Cache track density contribution to main grid if enabled
+      if (m_cfg.cacheGridStateForTrackRemoval) {
+        state.binAndTrackGridMap[trk] = binAndTrackGrid;
+        state.trackSelectionMap[trk] = true;
+      }
+    }
+    state.isInitialized = true;
+  }
+
+  double z = 0;
+  double width = 0;
+  if (not state.mainGridDensity.empty()) {
+    if (not m_cfg.estimateSeedWidth) {
+      // Get z value of highest density bin
+      auto maxZres = m_cfg.gridDensity.getMaxZPosition(state.mainGridDensity, state.mainGridZValues);
+
+      if (!maxZres.ok()) {
+        return maxZres.error();
+      }
+      z = *maxZres;
+    } else {
+      // Get z value of highest density bin and width
+      auto maxZres = m_cfg.gridDensity.getMaxZPositionAndWidth(state.mainGridDensity, state.mainGridZValues);
+
+      if (!maxZres.ok()) {
+        return maxZres.error();
+      }
+      z = (*maxZres).first;
+      width = (*maxZres).second;
+    }
+  }
+
+  // Construct output vertex
+  Vector3D seedPos =
+      vertexingOptions.vertexConstraint.position() + Vector3D(0., 0., z);
+
+  Vertex<InputTrack_t> returnVertex = Vertex<InputTrack_t>(seedPos);
+
+  ActsSymMatrixD<4> seedCov =
+      vertexingOptions.vertexConstraint.fullCovariance();
+
+  if (width != 0.) {
+    // Use z-constraint from seed width
+    seedCov(2, 2) = width * width;
+  }
+
+  returnVertex.setFullCovariance(seedCov);
+
+  std::vector<Vertex<InputTrack_t>> seedVec{returnVertex};
+
+  return seedVec;
+}
+
+template <int trkGridSize, typename vfitter_t>
+auto Acts::AdaptiveGridDensityVertexFinder<trkGridSize, vfitter_t>::
+    doesPassTrackSelection(const BoundTrackParameters& trk) const -> bool {
+  // Get required track parameters
+  const double d0 = trk.parameters()[BoundIndices::eBoundLoc0];
+  const double z0 = trk.parameters()[BoundIndices::eBoundLoc1];
+  // Get track covariance
+  const auto perigeeCov = *(trk.covariance());
+  const double covDD =
+      perigeeCov(BoundIndices::eBoundLoc0, BoundIndices::eBoundLoc0);
+  const double covZZ =
+      perigeeCov(BoundIndices::eBoundLoc1, BoundIndices::eBoundLoc1);
+  const double covDZ =
+      perigeeCov(BoundIndices::eBoundLoc0, BoundIndices::eBoundLoc1);
+  const double covDeterminant = covDD * covZZ - covDZ * covDZ;
+
+  // Do track selection based on track cov matrix and d0SignificanceCut
+  if ((covDD <= 0) || (d0 * d0 / covDD > m_cfg.d0SignificanceCut) ||
+      (covZZ <= 0) || (covDeterminant <= 0)) {
+    return false;
+  }
+
+  // Calculate track density quantities
+  double constantTerm =
+      -(d0 * d0 * covZZ + z0 * z0 * covDD + 2. * d0 * z0 * covDZ) /
+      (2. * covDeterminant);
+  const double linearTerm = (d0 * covDZ + z0 * covDD) / covDeterminant;
+  const double quadraticTerm = -covDD / (2. * covDeterminant);
+  double discriminant =
+      linearTerm * linearTerm -
+      4. * quadraticTerm * (constantTerm + 2. * m_cfg.z0SignificanceCut);
+  if (discriminant < 0) {
+    return false;
+  }
+
+  return true;
+}

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -72,9 +72,9 @@ class AdaptiveGridTrackDensity {
   /// @return A pair storing information about the z-bin position
   /// the track was added (int) and the 1-dim density contribution
   /// of the track itself
-  std::pair<int, ActsVectorF<trkGridSize>> addTrack(const BoundTrackParameters& trk,
-                std::vector<float>& mainGridDensity,
-                std::vector<int>& mainGridZValues) const;
+  std::pair<int, ActsVectorF<trkGridSize>> addTrack(
+      const BoundTrackParameters& trk, std::vector<float>& mainGridDensity,
+      std::vector<int>& mainGridZValues) const;
 
   /// @brief Removes a track from the overall grid density
   ///
@@ -82,10 +82,10 @@ class AdaptiveGridTrackDensity {
   /// removed from
   /// @param trkGrid The 1-dim density contribution of the track
   /// @param mainGrid The main 1-dim density grid along the z-axis
-  void removeTrackGridFromMainGrid(int zBin,
-                                   const ActsVectorF<trkGridSize>& trkGrid,
-                                   std::vector<float>& mainGridDensity,
-                                   const std::vector<int>& mainGridZValues) const;
+  void removeTrackGridFromMainGrid(
+      int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+      std::vector<float>& mainGridDensity,
+      const std::vector<int>& mainGridZValues) const;
 
   // private:
   /// @brief Helper function that acutally adds the track to the

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -37,7 +37,7 @@ class AdaptiveGridTrackDensity {
   /// @struct Config The configuration struct
   struct Config {
     /// @param binSize_ The binSize in mm
-    Config(float binSize_) : binSize(binSize_) {}
+    Config(float binSize_ = 0.1) : binSize(binSize_) {}
 
     // Z size of one single bin in grid
     float binSize;  // mm

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -122,8 +122,8 @@ class AdaptiveGridTrackDensity {
                                            float distCtrD,
                                            float distCtrZ) const;
 
-  /// @brief Function that estimates the seed width based on the FWHM of
-  /// the maximum density peak
+  /// @brief Function that estimates the seed width based on the full width
+  /// at half maximum (FWHM) of the maximum density peak
   ///
   /// @param mainGridDensity The main 1-dim density grid along the z-axis
   /// @param mainGridZValues The corresponding z-bin values of the track

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -161,7 +161,7 @@ class AdaptiveGridTrackDensity {
   ///
   /// @return The sum
   double getDensitySum(const std::vector<float>& mainGridDensity,
-                       const std::vector<int>& mainGridZValues, int pos) const;
+                       const std::vector<int>& mainGridZValues,unsigned int pos) const;
 
   Config m_cfg;
 };

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -16,7 +16,7 @@ namespace Acts {
 /// @class AdaptiveGridTrackDensity
 /// @brief Implements a 1-dim density grid to be filled with
 /// track Gaussian distributions. Each single track is modelled
-/// as a 2(!)-dim Gaussian distribution grid in the d0-z0 plane,
+/// as a 2-dim Gaussian distribution grid in the d0-z0 plane,
 /// but only the overlap with the z-axis (i.e. a 1-dim density
 /// vector) needs to be calculated.
 /// The position of the highest track density (of either a single

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -72,7 +72,7 @@ class AdaptiveGridTrackDensity {
   /// @return A pair storing information about the z-bin position
   /// the track was added (int) and the 1-dim density contribution
   /// of the track itself
-  void addTrack(const BoundTrackParameters& trk,
+  std::pair<int, ActsVectorF<trkGridSize>> addTrack(const BoundTrackParameters& trk,
                 std::vector<float>& mainGridDensity,
                 std::vector<int>& mainGridZValues) const;
 
@@ -82,10 +82,10 @@ class AdaptiveGridTrackDensity {
   /// removed from
   /// @param trkGrid The 1-dim density contribution of the track
   /// @param mainGrid The main 1-dim density grid along the z-axis
-  // void removeTrackGridFromMainGrid(int zBin,
-  //                                  const ActsVectorF<trkGridSize>& trkGrid,
-  //                                  ActsVectorF<mainGridSize>& mainGrid)
-  //                                  const;
+  void removeTrackGridFromMainGrid(int zBin,
+                                   const ActsVectorF<trkGridSize>& trkGrid,
+                                   std::vector<float>& mainGridDensity,
+                                   const std::vector<int>& mainGridZValues) const;
 
   // private:
   /// @brief Helper function that acutally adds the track to the

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -161,7 +161,8 @@ class AdaptiveGridTrackDensity {
   ///
   /// @return The sum
   double getDensitySum(const std::vector<float>& mainGridDensity,
-                       const std::vector<int>& mainGridZValues,unsigned int pos) const;
+                       const std::vector<int>& mainGridZValues,
+                       unsigned int pos) const;
 
   Config m_cfg;
 };

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -7,8 +7,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
-#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Utilities/Result.hpp"
 
 namespace Acts {
@@ -118,9 +118,10 @@ class AdaptiveGridTrackDensity {
   /// bin center in the 2-dim grid
   /// @param distCtrZ The distance in z0 from the track position to its
   /// bin center in the 2-dim grid
-  ActsVector<float, trkGridSize> createTrackGrid(int offset, const SymMatrix2D& cov,
-                                           float distCtrD,
-                                           float distCtrZ) const;
+  ActsVector<float, trkGridSize> createTrackGrid(int offset,
+                                                 const SymMatrix2D& cov,
+                                                 float distCtrD,
+                                                 float distCtrZ) const;
 
   /// @brief Function that estimates the seed width based on the full width
   /// at half maximum (FWHM) of the maximum density peak

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -107,7 +107,7 @@ class AdaptiveGridTrackDensity {
       std::vector<float>& mainGridDensity,
       const std::vector<int>& mainGridZValues) const;
 
-  private:
+ private:
   /// @brief Function that creates a 1-dim track grid (i.e. a vector)
   /// with the correct density contribution of a track along the z-axis
   ///

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -1,0 +1,171 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Result.hpp"
+
+namespace Acts {
+
+template <int trkGridSize = 15>
+class AdaptiveGridTrackDensity {
+  // Assert odd trkGridSize
+  static_assert(trkGridSize % 2);
+
+ public:
+  /// @struct Config The configuration struct
+  struct Config {
+    /// @param zMinMax The minimum and maximum z-values (in mm) that
+    /// should be covered by the main 1-dim density grid along the z-axis
+    /// Note: This value together with 'mainGridSize' determines the
+    /// overall bin size to be used as seen below
+    Config(float binSize_) : binSize(binSize_) {}
+
+    // Z size of one single bin in grid
+    float binSize;  // mm
+
+    // Do NOT use just the z-bin with the highest
+    // track density, but instead check the (up to)
+    // first three density maxima (only those that have
+    // a maximum relative deviation of 'relativeDensityDev'
+    // from the main maximum) and take the z-bin of the
+    // maximum with the highest surrounding density sum
+    bool useHighestSumZPosition = false;
+
+    // The maximum relative density deviation from the main
+    // maximum to consider the second and third maximum for
+    // the highest-sum approach from above
+    float maxRelativeDensityDev = 0.01;
+  };
+
+  AdaptiveGridTrackDensity(const Config& cfg) : m_cfg(cfg) {}
+
+
+  /// @brief Returns the z position of maximum track density
+  ///
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  ///
+  /// @return The z position of maximum track density
+  Result<float>
+  getMaxZPosition(const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const;
+
+  /// @brief Returns the z position of maximum track density and
+  /// the estimated width
+  ///
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  ///
+  /// @return The z position of maximum track density and width
+  Result<std::pair<float, float>>
+    getMaxZPositionAndWidth(const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const;
+
+
+  
+  /// @brief Adds a single track to the overall grid density
+  ///
+  /// @param trk The track to be added
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  ///
+  /// @return A pair storing information about the z-bin position
+  /// the track was added (int) and the 1-dim density contribution
+  /// of the track itself
+  void addTrack(
+      const BoundTrackParameters& trk,
+      std::vector<float>& mainGridDensity,
+      std::vector<int>& mainGridZValues) const;
+
+  /// @brief Removes a track from the overall grid density
+  ///
+  /// @param zBin The center z-bin position the track needs to be
+  /// removed from
+  /// @param trkGrid The 1-dim density contribution of the track
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  // void removeTrackGridFromMainGrid(int zBin,
+  //                                  const ActsVectorF<trkGridSize>& trkGrid,
+  //                                  ActsVectorF<mainGridSize>& mainGrid) const;
+
+ //private:
+  /// @brief Helper function that acutally adds the track to the
+  /// main density grid
+  ///
+  /// @param zBin The center z-bin position the track
+  /// @param trkGrid The 1-dim density contribution of the track
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  // void addTrackGridToMainGrid(int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+  //                             ActsVectorF<mainGridSize>& mainGrid) const;
+
+  /// @brief Helper function that modifies the main density grid
+  /// (either adds or removes a track)
+  ///
+  /// @param zBin The center z-bin position the track
+  /// @param trkGrid The 1-dim density contribution of the track
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  /// @param modifyModeSign Sign that determines the mode of modification,
+  /// +1 for adding a track, -1 for removing a track
+  // void modifyMainGridWithTrackGrid(int zBin,
+  //                                  const ActsVectorF<trkGridSize>& trkGrid,
+  //                                  ActsVectorF<mainGridSize>& mainGrid,
+  //                                  int modifyModeSign) const;
+
+  /// @brief Function that creates a 1-dim track grid (i.e. a vector)
+  /// with the correct density contribution of a track along the z-axis
+  ///
+  /// @param offset Offset in d0 direction, to account for the 2-dim part
+  /// of the Gaussian track distribution
+  /// @param cov The track covariance matrix
+  /// @param distCtrD The distance in d0 from the track position to its
+  /// bin center in the 2-dim grid
+  /// @param distCtrZ The distance in z0 from the track position to its
+  /// bin center in the 2-dim grid
+  ActsVectorF<trkGridSize> createTrackGrid(int offset, const SymMatrix2D& cov,
+                                           float distCtrD,
+                                           float distCtrZ) const;
+
+  /// @brief Function that estimates the seed width based on the FWHM of
+  /// the maximum density peak
+  ///
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  /// @maxZ z-position of the maximum density value
+  ///
+  /// @return The width
+  Result<float>
+  estimateSeedWidth(
+    const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues, float maxZ) const;
+
+  /// @brief Helper to retrieve values according to a 2-dim normal distribution
+   float normal2D(float d, float z, const SymMatrix2D& cov) const;
+
+  /// @brief Checks the (up to) first three density maxima (only those that have
+  /// a maximum relative deviation of 'relativeDensityDev' from the main
+  /// maximum) and take the z-bin of the maximum with the highest surrounding
+  /// density
+  ///
+  /// @param mainGrid The main 1-dim density grid along the z-axis
+  ///
+  /// @return The z-bin position
+  // int getHighestSumZPosition(ActsVectorF<mainGridSize>& mainGrid) const;
+
+  /// @brief Calculates the density sum of a z-bin and its two neighboring bins
+  /// as needed for 'getHighestSumZPosition'
+  ///
+  /// @parem mainGrid The main 1-dim density grid along the z-axis
+  /// @param pos The center z-bin positon
+  ///
+  /// @return The sum
+  // double getDensitySum(const ActsVectorF<mainGridSize>& mainGrid,
+  //                      int pos) const;
+
+  Config m_cfg;
+};
+
+}  // namespace Acts
+
+#include "Acts/Vertexing/AdaptiveGridTrackDensity.ipp"

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -53,7 +53,7 @@ class AdaptiveGridTrackDensity {
   ///
   /// @return The z position of maximum track density
   Result<float>
-  getMaxZPosition(const std::vector<float>& mainGridDensity,
+  getMaxZPosition(std::vector<float>& mainGridDensity,
     const std::vector<int>& mainGridZValues) const;
 
   /// @brief Returns the z position of maximum track density and
@@ -63,7 +63,7 @@ class AdaptiveGridTrackDensity {
   ///
   /// @return The z position of maximum track density and width
   Result<std::pair<float, float>>
-    getMaxZPositionAndWidth(const std::vector<float>& mainGridDensity,
+    getMaxZPositionAndWidth(std::vector<float>& mainGridDensity,
     const std::vector<int>& mainGridZValues) const;
 
 
@@ -151,7 +151,8 @@ class AdaptiveGridTrackDensity {
   /// @param mainGrid The main 1-dim density grid along the z-axis
   ///
   /// @return The z-bin position
-  // int getHighestSumZPosition(ActsVectorF<mainGridSize>& mainGrid) const;
+  int getHighestSumZPosition(std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const;
 
   /// @brief Calculates the density sum of a z-bin and its two neighboring bins
   /// as needed for 'getHighestSumZPosition'
@@ -160,8 +161,9 @@ class AdaptiveGridTrackDensity {
   /// @param pos The center z-bin positon
   ///
   /// @return The sum
-  // double getDensitySum(const ActsVectorF<mainGridSize>& mainGrid,
-  //                      int pos) const;
+  double getDensitySum(
+    const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues, int pos) const;
 
   Config m_cfg;
 };

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -46,15 +46,13 @@ class AdaptiveGridTrackDensity {
 
   AdaptiveGridTrackDensity(const Config& cfg) : m_cfg(cfg) {}
 
-
   /// @brief Returns the z position of maximum track density
   ///
   /// @param mainGrid The main 1-dim density grid along the z-axis
   ///
   /// @return The z position of maximum track density
-  Result<float>
-  getMaxZPosition(std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues) const;
+  Result<float> getMaxZPosition(std::vector<float>& mainGridDensity,
+                                const std::vector<int>& mainGridZValues) const;
 
   /// @brief Returns the z position of maximum track density and
   /// the estimated width
@@ -62,12 +60,10 @@ class AdaptiveGridTrackDensity {
   /// @param mainGrid The main 1-dim density grid along the z-axis
   ///
   /// @return The z position of maximum track density and width
-  Result<std::pair<float, float>>
-    getMaxZPositionAndWidth(std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues) const;
+  Result<std::pair<float, float>> getMaxZPositionAndWidth(
+      std::vector<float>& mainGridDensity,
+      const std::vector<int>& mainGridZValues) const;
 
-
-  
   /// @brief Adds a single track to the overall grid density
   ///
   /// @param trk The track to be added
@@ -76,10 +72,9 @@ class AdaptiveGridTrackDensity {
   /// @return A pair storing information about the z-bin position
   /// the track was added (int) and the 1-dim density contribution
   /// of the track itself
-  void addTrack(
-      const BoundTrackParameters& trk,
-      std::vector<float>& mainGridDensity,
-      std::vector<int>& mainGridZValues) const;
+  void addTrack(const BoundTrackParameters& trk,
+                std::vector<float>& mainGridDensity,
+                std::vector<int>& mainGridZValues) const;
 
   /// @brief Removes a track from the overall grid density
   ///
@@ -89,16 +84,18 @@ class AdaptiveGridTrackDensity {
   /// @param mainGrid The main 1-dim density grid along the z-axis
   // void removeTrackGridFromMainGrid(int zBin,
   //                                  const ActsVectorF<trkGridSize>& trkGrid,
-  //                                  ActsVectorF<mainGridSize>& mainGrid) const;
+  //                                  ActsVectorF<mainGridSize>& mainGrid)
+  //                                  const;
 
- //private:
+  // private:
   /// @brief Helper function that acutally adds the track to the
   /// main density grid
   ///
   /// @param zBin The center z-bin position the track
   /// @param trkGrid The 1-dim density contribution of the track
   /// @param mainGrid The main 1-dim density grid along the z-axis
-  // void addTrackGridToMainGrid(int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+  // void addTrackGridToMainGrid(int zBin, const ActsVectorF<trkGridSize>&
+  // trkGrid,
   //                             ActsVectorF<mainGridSize>& mainGrid) const;
 
   /// @brief Helper function that modifies the main density grid
@@ -135,13 +132,12 @@ class AdaptiveGridTrackDensity {
   /// @maxZ z-position of the maximum density value
   ///
   /// @return The width
-  Result<float>
-  estimateSeedWidth(
-    const std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues, float maxZ) const;
+  Result<float> estimateSeedWidth(const std::vector<float>& mainGridDensity,
+                                  const std::vector<int>& mainGridZValues,
+                                  float maxZ) const;
 
   /// @brief Helper to retrieve values according to a 2-dim normal distribution
-   float normal2D(float d, float z, const SymMatrix2D& cov) const;
+  float normal2D(float d, float z, const SymMatrix2D& cov) const;
 
   /// @brief Checks the (up to) first three density maxima (only those that have
   /// a maximum relative deviation of 'relativeDensityDev' from the main
@@ -152,7 +148,7 @@ class AdaptiveGridTrackDensity {
   ///
   /// @return The z-bin position
   int getHighestSumZPosition(std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues) const;
+                             const std::vector<int>& mainGridZValues) const;
 
   /// @brief Calculates the density sum of a z-bin and its two neighboring bins
   /// as needed for 'getHighestSumZPosition'
@@ -161,9 +157,8 @@ class AdaptiveGridTrackDensity {
   /// @param pos The center z-bin positon
   ///
   /// @return The sum
-  double getDensitySum(
-    const std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues, int pos) const;
+  double getDensitySum(const std::vector<float>& mainGridDensity,
+                       const std::vector<int>& mainGridZValues, int pos) const;
 
   Config m_cfg;
 };

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 #include "Acts/EventData/TrackParameters.hpp"
-#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/Result.hpp"
 
 namespace Acts {
@@ -90,7 +90,7 @@ class AdaptiveGridTrackDensity {
   /// @return A pair storing information about the z-bin position
   /// the track was added (int) and the 1-dim density contribution
   /// of the track itself
-  std::pair<int, ActsVectorF<trkGridSize>> addTrack(
+  std::pair<int, ActsVector<float, trkGridSize>> addTrack(
       const BoundTrackParameters& trk, std::vector<float>& mainGridDensity,
       std::vector<int>& mainGridZValues) const;
 
@@ -103,7 +103,7 @@ class AdaptiveGridTrackDensity {
   /// @param mainGridZValues The corresponding z-bin values of the track
   /// densities along the z-axis
   void removeTrackGridFromMainGrid(
-      int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+      int zBin, const ActsVector<float, trkGridSize>& trkGrid,
       std::vector<float>& mainGridDensity,
       const std::vector<int>& mainGridZValues) const;
 
@@ -118,7 +118,7 @@ class AdaptiveGridTrackDensity {
   /// bin center in the 2-dim grid
   /// @param distCtrZ The distance in z0 from the track position to its
   /// bin center in the 2-dim grid
-  ActsVectorF<trkGridSize> createTrackGrid(int offset, const SymMatrix2D& cov,
+  ActsVector<float, trkGridSize> createTrackGrid(int offset, const SymMatrix2D& cov,
                                            float distCtrD,
                                            float distCtrZ) const;
 

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -25,7 +25,7 @@ namespace Acts {
 /// Unlike the GaussianGridTrackDensity, the overall density vector
 /// grows adaptively with the tracks densities being added to the grid.
 ///
-/// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
+/// @tparam trkGridSize The 2-dim grid size of a single track, i.e.
 /// a single track is modelled as a (trkGridSize x trkGridSize) grid
 /// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
 template <int trkGridSize = 15>

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -19,11 +19,8 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::getMaxZPosition(const std::vector<f
 
   int zbin = -1;
   if (!m_cfg.useHighestSumZPosition) {
-    
     int zGridPos = std::distance(mainGridDensity.begin(), std::max_element(mainGridDensity.begin(),mainGridDensity.end()));
-
     zbin = mainGridZValues[zGridPos];
-
   } else {
     // Get z position with highest density sum
     // of surrounding bins
@@ -57,7 +54,6 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::
   return returnPair;
 }
 
-
 template <int trkGridSize>
 void
 Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
@@ -73,15 +69,12 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
   // Calculate bin in z
   int zBin = int(z0 / m_cfg.binSize);
 
-  std::cout << "z0/zbin: " << z0 << "," << zBin << std::endl;
-
   // Calculate the positions of the bin centers
   float binCtrD = dOffset * m_cfg.binSize;
 
   int sign = (z0 > 0) ? +1 : -1;
   float binCtrZ = (zBin + sign * 0.5f) * m_cfg.binSize;
 
-  std::cout << "binCtrZ: " << binCtrZ << std::endl;
 
   // Calculate the distance between IP values and their
   // corresponding bin centers
@@ -102,22 +95,12 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
 
   int startEnd = int(trkGridSize - 1)/2;
 
-  std::cout << "current z values: " << std::endl;
   for(int i = 0; i < trkGridSize; i++){
-    std::cout << "zbins: " << int(zBin + (i-startEnd)) << std::endl;
     zBinValues.push_back(int(zBin + (i-startEnd)));
-  }
-
-  std::cout << "mainGridZValues before: " <<std::endl;
-
-  for(auto& bla : mainGridZValues){
-    std::cout << bla << std::endl;
   }
 
   for(int i = 0; i < trkGridSize; i++){
     int z = zBinValues[i];
-    
-    std::cout << "testing z value: " << z << std::endl;
 
     auto findIter = std::find(mainGridZValues.begin(), mainGridZValues.end(), z);
     //bool exists = std::binary_search(mainGridZValues.begin(), mainGridZValues.end(), z);
@@ -126,11 +109,9 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
     // results are always the same as if we're using bineary search here
     if(findIter != mainGridZValues.end()){
     // Z bin already exists
-      std::cout << "z exists..." << std::endl;
       mainGridDensity[std::distance(mainGridZValues.begin(), findIter)] += trackGrid[i];
     }
     else{
-      std::cout << "z did not exist..." << std::endl;
     // Create new z bin
       auto it = std::upper_bound( mainGridZValues.begin(), mainGridZValues.end(), z );
       mainGridDensity.insert(mainGridDensity.begin() + std::distance(mainGridZValues.begin(), it), trackGrid[i]);
@@ -170,11 +151,11 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
   int sign = (maxZ > 0) ? +1 : -1;
   int zMaxGridBin  = int(maxZ / m_cfg.binSize - sign * 0.5f);
 
-  std::cout << "seed width estimation... max z bin: " << zMaxGridBin << std::endl; 
 
   // Find location in mainGridZValues
   auto findIter = std::find(mainGridZValues.begin(), mainGridZValues.end(), zMaxGridBin);
   int zBin = std::distance(mainGridZValues.begin(), findIter);
+
 
   const float maxValue = mainGridDensity[zBin];
   float gridValue = mainGridDensity[zBin];
@@ -183,12 +164,14 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
   int rhmBin = zBin;
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continous z values
-    std::cout << "R:cont z values?: " << zMaxGridBin + (rhmBin - zBin) << "," << mainGridZValues[rhmBin] << std::endl;
     if( (zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin])
     {
       break;
     }
     rhmBin += 1;
+    if(rhmBin == mainGridDensity.size()){
+      break;
+    }
     gridValue = mainGridDensity[rhmBin];
   }
 
@@ -199,13 +182,15 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
   int lhmBin = zBin;
   gridValue = mainGridDensity[zBin];
   while (gridValue > maxValue / 2) {
-    std::cout << "L:cont z values?: " << zMaxGridBin + (rhmBin - zBin) << "," << mainGridZValues[rhmBin] << std::endl;
     // Check if we are still operating on continous z values
-    if( (zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin])
+    if( (zMaxGridBin + (lhmBin - zBin)) != mainGridZValues[lhmBin])
     {
       break;
     }
     lhmBin -= 1;
+    if(lhmBin < 0){
+      break;
+    }
     gridValue = mainGridDensity[lhmBin];
   }
 

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -17,16 +17,16 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::getMaxZPosition(std::vector<float>&
     return VertexingError::EmptyInput;
   }
 
-  int zbin = -1;
+  int zGridPos = -1;
   if (!m_cfg.useHighestSumZPosition) {
-    int zGridPos = std::distance(mainGridDensity.begin(), std::max_element(mainGridDensity.begin(),mainGridDensity.end()));
-    zbin = mainGridZValues[zGridPos];
+    zGridPos = std::distance(mainGridDensity.begin(), std::max_element(mainGridDensity.begin(),mainGridDensity.end()));
   } else {
     // Get z position with highest density sum
     // of surrounding bins
-    zbin = getHighestSumZPosition(mainGridDensity, mainGridZValues);
+    zGridPos = getHighestSumZPosition(mainGridDensity, mainGridZValues);
   }
 
+  int zbin = mainGridZValues[zGridPos];
   // Derive corresponding z value
   int sign = (zbin > 0) ? +1 : -1;
   return (zbin + sign * 0.5f) * m_cfg.binSize;
@@ -229,7 +229,6 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::
 
   // The global maximum
   int zGridPos = std::distance(mainGridDensity.begin(), std::max_element(mainGridDensity.begin(),mainGridDensity.end()));
-  //zbin = mainGridZValues[zGridPos];
 
   int zFirstMax = zGridPos;
   double firstDensity = mainGridDensity[zFirstMax];

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -82,7 +82,8 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
   float distCtrD = d0 - binCtrD;
   float distCtrZ = z0 - binCtrZ;
 
-  ActsVector<float, trkGridSize> trackGrid(ActsVector<float, trkGridSize>::Zero());
+  ActsVector<float, trkGridSize> trackGrid(
+      ActsVector<float, trkGridSize>::Zero());
 
   // Check if current track does affect grid density
   // in central bins at z-axis
@@ -149,7 +150,8 @@ Acts::ActsVector<float, trkGridSize>
 Acts::AdaptiveGridTrackDensity<trkGridSize>::createTrackGrid(
     int offset, const Acts::SymMatrix2D& cov, float distCtrD,
     float distCtrZ) const {
-  ActsVector<float, trkGridSize> trackGrid(ActsVector<float, trkGridSize>::Zero());
+  ActsVector<float, trkGridSize> trackGrid(
+      ActsVector<float, trkGridSize>::Zero());
 
   float i = (trkGridSize - 1) / 2 + offset;
   float d = (i - static_cast<float>(trkGridSize) / 2 + 0.5f) * m_cfg.binSize;

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -58,7 +58,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::getMaxZPositionAndWidth(
 }
 
 template <int trkGridSize>
-std::pair<int, Acts::ActsVectorF<trkGridSize>>
+std::pair<int, Acts::ActsVector<float, trkGridSize>>
 Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
     const Acts::BoundTrackParameters& trk, std::vector<float>& mainGridDensity,
     std::vector<int>& mainGridZValues) const {
@@ -82,7 +82,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
   float distCtrD = d0 - binCtrD;
   float distCtrZ = z0 - binCtrZ;
 
-  ActsVectorF<trkGridSize> trackGrid(ActsVectorF<trkGridSize>::Zero());
+  ActsVector<float, trkGridSize> trackGrid(ActsVector<float, trkGridSize>::Zero());
 
   // Check if current track does affect grid density
   // in central bins at z-axis
@@ -128,7 +128,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
 
 template <int trkGridSize>
 void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(
-    int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+    int zBin, const ActsVector<float, trkGridSize>& trkGrid,
     std::vector<float>& mainGridDensity,
     const std::vector<int>& mainGridZValues) const {
   // Find position of current z bin in mainGridZValues
@@ -145,11 +145,11 @@ void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(
 }
 
 template <int trkGridSize>
-Acts::ActsVectorF<trkGridSize>
+Acts::ActsVector<float, trkGridSize>
 Acts::AdaptiveGridTrackDensity<trkGridSize>::createTrackGrid(
     int offset, const Acts::SymMatrix2D& cov, float distCtrD,
     float distCtrZ) const {
-  ActsVectorF<trkGridSize> trackGrid(ActsVectorF<trkGridSize>::Zero());
+  ActsVector<float, trkGridSize> trackGrid(ActsVector<float, trkGridSize>::Zero());
 
   float i = (trkGridSize - 1) / 2 + offset;
   float d = (i - static_cast<float>(trkGridSize) / 2 + 0.5f) * m_cfg.binSize;

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -1,0 +1,237 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#include "Acts/Vertexing/VertexingError.hpp"
+
+#include <algorithm>
+
+template <int trkGridSize>
+Acts::Result<float>
+Acts::AdaptiveGridTrackDensity<trkGridSize>::getMaxZPosition(const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const {
+  if (mainGridDensity.empty() || mainGridZValues.empty()) {
+    return VertexingError::EmptyInput;
+  }
+
+  int zbin = -1;
+  if (!m_cfg.useHighestSumZPosition) {
+    
+    int zGridPos = std::distance(mainGridDensity.begin(), std::max_element(mainGridDensity.begin(),mainGridDensity.end()));
+
+    zbin = mainGridZValues[zGridPos];
+
+  } else {
+    // Get z position with highest density sum
+    // of surrounding bins
+    //zbin = getHighestSumZPosition(mainGrid);
+  }
+
+  // Derive corresponding z value
+  int sign = (zbin > 0) ? +1 : -1;
+  return (zbin + sign * 0.5f) * m_cfg.binSize;
+}
+
+template <int trkGridSize>
+Acts::Result<std::pair<float, float>>
+Acts::AdaptiveGridTrackDensity<trkGridSize>::
+    getMaxZPositionAndWidth(const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const {
+  // Get z maximum value
+  auto maxZRes = getMaxZPosition(mainGridDensity, mainGridZValues);
+  if (not maxZRes.ok()) {
+    return maxZRes.error();
+  }
+  float maxZ = *maxZRes;
+
+  // Get seed width estimate
+  auto widthRes = estimateSeedWidth(mainGridDensity, mainGridZValues,maxZ);
+  if (not widthRes.ok()) {
+    return widthRes.error();
+  }
+  float width = *widthRes;
+  std::pair<float, float> returnPair{maxZ, width};
+  return returnPair;
+}
+
+
+template <int trkGridSize>
+void
+Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
+    const Acts::BoundTrackParameters& trk,
+    std::vector<float>& mainGridDensity,
+    std::vector<int>& mainGridZValues) const {
+  SymMatrix2D cov = trk.covariance()->block<2, 2>(0, 0);
+  float d0 = trk.parameters()[0];
+  float z0 = trk.parameters()[1];
+
+  // Calculate offset in d direction to central bin at z-axis
+  int dOffset = std::floor(d0 / m_cfg.binSize - 0.5) + 1;
+  // Calculate bin in z
+  int zBin = int(z0 / m_cfg.binSize);
+
+  std::cout << "z0/zbin: " << z0 << "," << zBin << std::endl;
+
+  // Calculate the positions of the bin centers
+  float binCtrD = dOffset * m_cfg.binSize;
+
+  int sign = (z0 > 0) ? +1 : -1;
+  float binCtrZ = (zBin + sign * 0.5f) * m_cfg.binSize;
+
+  std::cout << "binCtrZ: " << binCtrZ << std::endl;
+
+  // Calculate the distance between IP values and their
+  // corresponding bin centers
+  float distCtrD = d0 - binCtrD;
+  float distCtrZ = z0 - binCtrZ;
+
+  // Check if current track does affect grid density
+  // in central bins at z-axis
+  if ((std::abs(dOffset) > trkGridSize - 1) / 2.) {
+    return;
+  }
+
+  // Create the track grid
+  ActsVectorF<trkGridSize> trackGrid =
+      createTrackGrid(dOffset, cov, distCtrD, distCtrZ);
+
+  std::vector<int> zBinValues;
+
+  int startEnd = int(trkGridSize - 1)/2;
+
+  std::cout << "current z values: " << std::endl;
+  for(int i = 0; i < trkGridSize; i++){
+    std::cout << "zbins: " << int(zBin + (i-startEnd)) << std::endl;
+    zBinValues.push_back(int(zBin + (i-startEnd)));
+  }
+
+  std::cout << "mainGridZValues before: " <<std::endl;
+
+  for(auto& bla : mainGridZValues){
+    std::cout << bla << std::endl;
+  }
+
+  for(int i = 0; i < trkGridSize; i++){
+    int z = zBinValues[i];
+    
+    std::cout << "testing z value: " << z << std::endl;
+
+    auto findIter = std::find(mainGridZValues.begin(), mainGridZValues.end(), z);
+    //bool exists = std::binary_search(mainGridZValues.begin(), mainGridZValues.end(), z);
+    // TODO: wanted to check if element exists with findIter != mainGridZValues.end()
+    // but if element is actually last element in list, caused problems maybe? Check if
+    // results are always the same as if we're using bineary search here
+    if(findIter != mainGridZValues.end()){
+    // Z bin already exists
+      std::cout << "z exists..." << std::endl;
+      mainGridDensity[std::distance(mainGridZValues.begin(), findIter)] += trackGrid[i];
+    }
+    else{
+      std::cout << "z did not exist..." << std::endl;
+    // Create new z bin
+      auto it = std::upper_bound( mainGridZValues.begin(), mainGridZValues.end(), z );
+      mainGridDensity.insert(mainGridDensity.begin() + std::distance(mainGridZValues.begin(), it), trackGrid[i]);
+      mainGridZValues.insert(it, z);
+    } 
+  }
+}
+
+// 
+template <int trkGridSize>
+Acts::ActsVectorF<trkGridSize>
+Acts::AdaptiveGridTrackDensity<trkGridSize>::createTrackGrid(
+    int offset, const Acts::SymMatrix2D& cov, float distCtrD,
+    float distCtrZ) const {
+  ActsVectorF<trkGridSize> trackGrid(ActsVectorF<trkGridSize>::Zero());
+
+  int i = (trkGridSize - 1) / 2 + offset;
+  float d = (i - static_cast<float>(trkGridSize) / 2 + 0.5f) * m_cfg.binSize;
+
+  // Loop over columns
+  for (int j = 0; j < trkGridSize; j++) {
+    float z = (j - static_cast<float>(trkGridSize) / 2 + 0.5f) * m_cfg.binSize;
+    trackGrid(j) = normal2D(d + distCtrD, z + distCtrZ, cov);
+  }
+  return trackGrid;
+}
+
+template <int trkGridSize>
+Acts::Result<float>
+Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
+    const std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues, float maxZ) const {
+  if (mainGridDensity.empty() || mainGridZValues.empty()) {
+    return VertexingError::EmptyInput;
+  }
+  // Get z bin of max density z value
+  int sign = (maxZ > 0) ? +1 : -1;
+  int zMaxGridBin  = int(maxZ / m_cfg.binSize - sign * 0.5f);
+
+  std::cout << "seed width estimation... max z bin: " << zMaxGridBin << std::endl; 
+
+  // Find location in mainGridZValues
+  auto findIter = std::find(mainGridZValues.begin(), mainGridZValues.end(), zMaxGridBin);
+  int zBin = std::distance(mainGridZValues.begin(), findIter);
+
+  const float maxValue = mainGridDensity[zBin];
+  float gridValue = mainGridDensity[zBin];
+
+  // Find right half-maximum bin
+  int rhmBin = zBin;
+  while (gridValue > maxValue / 2) {
+    // Check if we are still operating on continous z values
+    std::cout << "R:cont z values?: " << zMaxGridBin + (rhmBin - zBin) << "," << mainGridZValues[rhmBin] << std::endl;
+    if( (zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin])
+    {
+      break;
+    }
+    rhmBin += 1;
+    gridValue = mainGridDensity[rhmBin];
+  }
+
+  // Use linear approximation to find better z value for FWHM between bins
+  float deltaZ1 = (maxValue / 2 - mainGridDensity[rhmBin - 1]) *
+                  (m_cfg.binSize / (mainGridDensity[rhmBin - 1] - mainGridDensity[rhmBin]));
+  // Find left half-maximum bin
+  int lhmBin = zBin;
+  gridValue = mainGridDensity[zBin];
+  while (gridValue > maxValue / 2) {
+    std::cout << "L:cont z values?: " << zMaxGridBin + (rhmBin - zBin) << "," << mainGridZValues[rhmBin] << std::endl;
+    // Check if we are still operating on continous z values
+    if( (zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin])
+    {
+      break;
+    }
+    lhmBin -= 1;
+    gridValue = mainGridDensity[lhmBin];
+  }
+
+  // Use linear approximation to find better z value for FWHM between bins
+  float deltaZ2 = (maxValue / 2 - mainGridDensity[lhmBin + 1]) *
+                  (m_cfg.binSize / (mainGridDensity[rhmBin + 1] - mainGridDensity[rhmBin]));
+
+  // Approximate FWHM
+  float fwhm =
+      rhmBin * m_cfg.binSize - deltaZ1 - lhmBin * m_cfg.binSize - deltaZ2;
+
+  // FWHM = 2.355 * sigma
+  float width = fwhm / 2.355f;
+
+  return std::isnormal(width) ? width : 0.0f;
+}
+
+
+template <int trkGridSize>
+float Acts::AdaptiveGridTrackDensity<trkGridSize>::normal2D(
+    float d, float z, const Acts::SymMatrix2D& cov) const {
+  float det = cov.determinant();
+  float coef = 1 / (2 * M_PI * std::sqrt(det));
+  float expo =
+      -1 / (2 * det) *
+      (cov(1, 1) * d * d - d * z * (cov(0, 1) + cov(1, 0)) + cov(0, 0) * z * z);
+  return coef * std::exp(expo);
+}
+

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -177,20 +177,20 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
   // Find location in mainGridZValues
   auto findIter =
       std::find(mainGridZValues.begin(), mainGridZValues.end(), zMaxGridBin);
-  unsigned int zBin = std::distance(mainGridZValues.begin(), findIter);
+  int zBin = std::distance(mainGridZValues.begin(), findIter);
 
   const float maxValue = mainGridDensity[zBin];
   float gridValue = mainGridDensity[zBin];
 
   // Find right half-maximum bin
-  unsigned int rhmBin = zBin;
+  int rhmBin = zBin;
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continous z values
     if ((zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin]) {
       break;
     }
     rhmBin += 1;
-    if (rhmBin == mainGridDensity.size()) {
+    if (rhmBin == int(mainGridDensity.size())) {
       break;
     }
     gridValue = mainGridDensity[rhmBin];
@@ -201,7 +201,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
       (maxValue / 2 - mainGridDensity[rhmBin - 1]) *
       (m_cfg.binSize / (mainGridDensity[rhmBin - 1] - mainGridDensity[rhmBin]));
   // Find left half-maximum bin
-  unsigned int lhmBin = zBin;
+  int lhmBin = zBin;
   gridValue = mainGridDensity[zBin];
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continous z values

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -126,7 +126,6 @@ std::pair<int, Acts::ActsVectorF<trkGridSize>> Acts::AdaptiveGridTrackDensity<tr
   return {zBin, trackGrid};
 }
 
-
 template <int trkGridSize>
 void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(int zBin,
                                    const ActsVectorF<trkGridSize>& trkGrid,
@@ -142,11 +141,7 @@ void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(in
   // Go over trkGrid and remove it from mainDensityGrid
   int startEnd = int(trkGridSize - 1) / 2;
   for (int i = 0; i < trkGridSize; i++) {
-    std::cout << "\ncurrent i: " << i << std::endl;
-    std::cout << "old value in mainGrid: " << mainGridDensity[int(densityIdx + (i - startEnd))] << std::endl;
-    std::cout << "removing value...: " << trkGrid[i] << std::endl;
     mainGridDensity[int(densityIdx + (i - startEnd))] -= trkGrid[i];
-    std::cout << "new value in mainGrid: " << mainGridDensity[int(densityIdx + (i - startEnd))] << std::endl;
   }
 }
 

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -261,10 +261,10 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::
   mainGridDensity[zSecondMax] = secondDensity;
 
   // Return the z-bin position of the highest density sum
-  if (secondSum > firstSum || secondSum > thirdSum) {
+  if (secondSum > firstSum && secondSum > thirdSum) {
     return zSecondMax;
   }
-  if (thirdSum > secondSum || thirdSum > firstSum) {
+  if (thirdSum > secondSum && thirdSum > firstSum) {
     return zThirdMax;
   }
   return zFirstMax;

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -58,7 +58,8 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::getMaxZPositionAndWidth(
 }
 
 template <int trkGridSize>
-std::pair<int, Acts::ActsVectorF<trkGridSize>> Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
+std::pair<int, Acts::ActsVectorF<trkGridSize>>
+Acts::AdaptiveGridTrackDensity<trkGridSize>::addTrack(
     const Acts::BoundTrackParameters& trk, std::vector<float>& mainGridDensity,
     std::vector<int>& mainGridZValues) const {
   SymMatrix2D cov = trk.covariance()->block<2, 2>(0, 0);
@@ -90,8 +91,7 @@ std::pair<int, Acts::ActsVectorF<trkGridSize>> Acts::AdaptiveGridTrackDensity<tr
   }
 
   // Create the track grid
-  trackGrid =
-      createTrackGrid(dOffset, cov, distCtrD, distCtrZ);
+  trackGrid = createTrackGrid(dOffset, cov, distCtrD, distCtrZ);
 
   std::vector<int> zBinValues;
 
@@ -107,7 +107,7 @@ std::pair<int, Acts::ActsVectorF<trkGridSize>> Acts::AdaptiveGridTrackDensity<tr
     // Check if track density already exists at current z position
     auto findIter =
         std::find(mainGridZValues.begin(), mainGridZValues.end(), z);
-    
+
     if (findIter != mainGridZValues.end()) {
       // Z bin already exists
       mainGridDensity[std::distance(mainGridZValues.begin(), findIter)] +=
@@ -127,14 +127,13 @@ std::pair<int, Acts::ActsVectorF<trkGridSize>> Acts::AdaptiveGridTrackDensity<tr
 }
 
 template <int trkGridSize>
-void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(int zBin,
-                                   const ActsVectorF<trkGridSize>& trkGrid,
-                                   std::vector<float>& mainGridDensity,
-                                   const std::vector<int>& mainGridZValues) const {
-
+void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(
+    int zBin, const ActsVectorF<trkGridSize>& trkGrid,
+    std::vector<float>& mainGridDensity,
+    const std::vector<int>& mainGridZValues) const {
   // Find position of current z bin in mainGridZValues
   auto findIter =
-        std::find(mainGridZValues.begin(), mainGridZValues.end(), zBin);
+      std::find(mainGridZValues.begin(), mainGridZValues.end(), zBin);
   // Calculate corresponding index in mainGridDensity
   int densityIdx = std::distance(mainGridZValues.begin(), findIter);
 

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -151,7 +151,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::createTrackGrid(
     float distCtrZ) const {
   ActsVectorF<trkGridSize> trackGrid(ActsVectorF<trkGridSize>::Zero());
 
-  int i = (trkGridSize - 1) / 2 + offset;
+  float i = (trkGridSize - 1) / 2 + offset;
   float d = (i - static_cast<float>(trkGridSize) / 2 + 0.5f) * m_cfg.binSize;
 
   // Loop over columns

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -177,13 +177,13 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
   // Find location in mainGridZValues
   auto findIter =
       std::find(mainGridZValues.begin(), mainGridZValues.end(), zMaxGridBin);
-  int zBin = std::distance(mainGridZValues.begin(), findIter);
+  unsigned int zBin = std::distance(mainGridZValues.begin(), findIter);
 
   const float maxValue = mainGridDensity[zBin];
   float gridValue = mainGridDensity[zBin];
 
   // Find right half-maximum bin
-  int rhmBin = zBin;
+  unsigned int rhmBin = zBin;
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continous z values
     if ((zMaxGridBin + (rhmBin - zBin)) != mainGridZValues[rhmBin]) {
@@ -201,7 +201,7 @@ Acts::AdaptiveGridTrackDensity<trkGridSize>::estimateSeedWidth(
       (maxValue / 2 - mainGridDensity[rhmBin - 1]) *
       (m_cfg.binSize / (mainGridDensity[rhmBin - 1] - mainGridDensity[rhmBin]));
   // Find left half-maximum bin
-  int lhmBin = zBin;
+  unsigned int lhmBin = zBin;
   gridValue = mainGridDensity[zBin];
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continous z values
@@ -249,11 +249,11 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::getHighestSumZPosition(
   // one has the highest surrounding density sum (the two neighboring bins)
 
   // The global maximum
-  int zGridPos = std::distance(
+  unsigned int zGridPos = std::distance(
       mainGridDensity.begin(),
       std::max_element(mainGridDensity.begin(), mainGridDensity.end()));
 
-  int zFirstMax = zGridPos;
+  unsigned int zFirstMax = zGridPos;
   double firstDensity = mainGridDensity[zFirstMax];
   double firstSum = getDensitySum(mainGridDensity, mainGridZValues, zFirstMax);
 
@@ -262,7 +262,7 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::getHighestSumZPosition(
   zGridPos = std::distance(
       mainGridDensity.begin(),
       std::max_element(mainGridDensity.begin(), mainGridDensity.end()));
-  int zSecondMax = zGridPos;
+  unsigned int zSecondMax = zGridPos;
   double secondDensity = mainGridDensity[zSecondMax];
   double secondSum = 0;
   if (firstDensity - secondDensity <
@@ -275,7 +275,7 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::getHighestSumZPosition(
   zGridPos = std::distance(
       mainGridDensity.begin(),
       std::max_element(mainGridDensity.begin(), mainGridDensity.end()));
-  int zThirdMax = zGridPos;
+  unsigned int zThirdMax = zGridPos;
   double thirdDensity = mainGridDensity[zThirdMax];
   double thirdSum = 0;
   if (firstDensity - thirdDensity <
@@ -300,7 +300,7 @@ int Acts::AdaptiveGridTrackDensity<trkGridSize>::getHighestSumZPosition(
 template <int trkGridSize>
 double Acts::AdaptiveGridTrackDensity<trkGridSize>::getDensitySum(
     const std::vector<float>& mainGridDensity,
-    const std::vector<int>& mainGridZValues, int pos) const {
+    const std::vector<int>& mainGridZValues, unsigned int pos) const {
   double sum = mainGridDensity[pos];
   // Sum up only the density contributions from the
   // neighboring bins if they are still within bounds

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -138,7 +138,7 @@ void Acts::AdaptiveGridTrackDensity<trkGridSize>::removeTrackGridFromMainGrid(
   int densityIdx = std::distance(mainGridZValues.begin(), findIter);
 
   // Go over trkGrid and remove it from mainDensityGrid
-  int startEnd = int(trkGridSize - 1) / 2;
+  int startEnd = int((trkGridSize - 1) / 2);
   for (int i = 0; i < trkGridSize; i++) {
     mainGridDensity[int(densityIdx + (i - startEnd))] -= trkGrid[i];
   }

--- a/Core/include/Acts/Vertexing/GaussianGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianGridTrackDensity.ipp
@@ -256,10 +256,10 @@ int Acts::GaussianGridTrackDensity<mainGridSize, trkGridSize>::
   mainGrid[zSecondMax] = secondDensity;
 
   // Return the z-bin position of the highest density sum
-  if (secondSum > firstSum || secondSum > thirdSum) {
+  if (secondSum > firstSum && secondSum > thirdSum) {
     return zSecondMax;
   }
-  if (thirdSum > secondSum || thirdSum > firstSum) {
+  if (thirdSum > secondSum && thirdSum > firstSum) {
     return zThirdMax;
   }
   return zFirstMax;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -262,8 +262,8 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_removing_test) {
   BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize);
 
   // Calculate total density
-  float densitySum0 =0;
-  for (auto& d : mainGridDensity){
+  float densitySum0 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum0 += d;
   }
 
@@ -275,19 +275,20 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_removing_test) {
   BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize);
 
   // Calculate new total density
-  float densitySum1 =0;
-  for (auto& d : mainGridDensity){
+  float densitySum1 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum1 += d;
   }
 
   BOOST_CHECK(2 * densitySum0 == densitySum1);
 
   // Remove track 1
-  grid.removeTrackGridFromMainGrid(zBinAndTrack1.first, zBinAndTrack1.second, mainGridDensity, mainGridZValues);
- 
+  grid.removeTrackGridFromMainGrid(zBinAndTrack1.first, zBinAndTrack1.second,
+                                   mainGridDensity, mainGridZValues);
+
   // Calculate new total density
-  float densitySum2 =0;
-  for (auto& d : mainGridDensity){
+  float densitySum2 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum2 += d;
   }
 
@@ -300,19 +301,20 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_removing_test) {
   auto zBinAndTrack2 = grid.addTrack(params1, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
-  int nNonOverlappingBins = int(std::abs(z0Trk1 - z0Trk2)/binSize + 1);
+  int nNonOverlappingBins = int(std::abs(z0Trk1 - z0Trk2) / binSize + 1);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize + nNonOverlappingBins);
 
-  float densitySum3 =0;
-  for (auto& d : mainGridDensity){
+  float densitySum3 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum3 += d;
   }
 
   // Remove second track 1
-  grid.removeTrackGridFromMainGrid(zBinAndTrack0.first, zBinAndTrack0.second, mainGridDensity, mainGridZValues);
- 
-  float densitySum4 =0;
-  for (auto& d : mainGridDensity){
+  grid.removeTrackGridFromMainGrid(zBinAndTrack0.first, zBinAndTrack0.second,
+                                   mainGridDensity, mainGridZValues);
+
+  float densitySum4 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum4 += d;
   }
 
@@ -320,13 +322,14 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_removing_test) {
   CHECK_CLOSE_ABS(densitySum4, densitySum3 - densitySum0, 1e-5);
 
   // Remove last track again
-  grid.removeTrackGridFromMainGrid(zBinAndTrack2.first, zBinAndTrack2.second, mainGridDensity, mainGridZValues);
-  
+  grid.removeTrackGridFromMainGrid(zBinAndTrack2.first, zBinAndTrack2.second,
+                                   mainGridDensity, mainGridZValues);
+
   // Size should not have changed
   BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize + nNonOverlappingBins);
 
-  float densitySum5 =0;
-  for (auto& d : mainGridDensity){
+  float densitySum5 = 0;
+  for (auto& d : mainGridDensity) {
     densitySum5 += d;
   }
 

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -156,7 +156,71 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_max_z_and_width_test) {
   BOOST_CHECK(resWidth1.ok());
   BOOST_CHECK_EQUAL((*resWidth1).first, z0Trk2);
   BOOST_CHECK((*resWidth1).second > 0);
-  
+}
+
+BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
+
+  const int trkGridSize = 15;
+
+  double binSize = 0.1;  // mm
+
+  // Set up grid density with zMinMax
+  AdaptiveGridTrackDensity<trkGridSize>::Config cfg(binSize);
+  cfg.useHighestSumZPosition = true;
+
+  AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
+
+  // Create some test tracks
+  Covariance covMat;
+  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
+      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+
+  float z0Trk1 = 0.25;
+  float z0Trk2 = -10.95;
+  BoundVector paramVec1;
+  paramVec1 << 0.01, z0Trk1, 0, 0, 0, 0;
+  BoundVector paramVec2;
+  paramVec2 << 0.009, z0Trk2, 0, 0, 0, 0;
+
+  // Create perigee surface
+  std::shared_ptr<PerigeeSurface> perigeeSurface =
+      Surface::makeShared<PerigeeSurface>(Vector3D(0., 0., 0.));
+
+  BoundTrackParameters params1(perigeeSurface, paramVec1, covMat);
+  BoundTrackParameters params2(perigeeSurface, paramVec2, covMat);
+
+  // Start with empty grids
+  std::vector<float> mainGridDensity;
+  std::vector<int> mainGridZValues;
+
+  // Fill grid with track densities
+  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+
+  auto res1 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
+  BOOST_CHECK(res1.ok());
+  // Maximum should be at z0Trk1 position
+  BOOST_CHECK_EQUAL(*res1, z0Trk1);
+
+  // Add second track
+  grid.addTrack(params2, mainGridDensity, mainGridZValues);
+  auto res2 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
+  BOOST_CHECK(res2.ok());
+  // Trk 2 is closer to z-axis and should yield higher density values
+  // New maximum is therefore at z0Trk2
+  BOOST_CHECK_EQUAL(*res2, z0Trk2);
+
+  // Add small density values around the maximum of track 1
+  const float densityToAdd = 5e-4;
+  mainGridDensity[21] += densityToAdd;
+  mainGridDensity[23] += densityToAdd;
+
+  auto res3 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
+  BOOST_CHECK(res3.ok());
+  // Trk 2 still has the highest peak density value, however, the small
+  // added densities for track 1 around its maximum should now lead to
+  // a prediction at z0Trk1 again
+  BOOST_CHECK_EQUAL(*res3, z0Trk1);
+
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -35,9 +35,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
   AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
 
   // Create some test tracks
-  Covariance covMat;
-  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
-      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+  Covariance covMat(Covariance::Identity());
 
   BoundVector paramVec0;
   paramVec0 << 100.0, -0.45, 0, 0, 0, 0;
@@ -112,9 +110,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_max_z_and_width_test) {
   AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
 
   // Create some test tracks
-  Covariance covMat;
-  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
-      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+  Covariance covMat(Covariance::Identity());
 
   float z0Trk1 = 0.25;
   float z0Trk2 = -10.95;
@@ -169,9 +165,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
   AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
 
   // Create some test tracks
-  Covariance covMat;
-  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
-      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+  Covariance covMat(Covariance::Identity());
 
   float z0Trk1 = 0.25;
   float z0Trk2 = -10.95;
@@ -230,9 +224,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_removing_test) {
   AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
 
   // Create some test tracks
-  Covariance covMat;
-  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
-      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+  Covariance covMat(Covariance::Identity());
 
   // Define z0 values for test tracks
   float z0Trk1 = -0.45;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -68,34 +68,34 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
   std::vector<int> mainGridZValues;
 
   // Track is too far away from z axis and was not added
-  grid.addTrack(params0, mainGridDensity, mainGridZValues);
+  auto zBinAndTrack = grid.addTrack(params0, mainGridDensity, mainGridZValues);
   BOOST_CHECK(mainGridDensity.empty());
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Track should have been entirely added to both grids
-  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params1, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Track should have been entirely added to both grids
-  grid.addTrack(params2, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params2, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), 2 * trkGridSize);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Track 3 has overlap of 2 bins with track 1
-  grid.addTrack(params3, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params3, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), 3 * trkGridSize - 2);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Add first track again, should *not* introduce new z entries
-  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params1, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), 3 * trkGridSize - 2);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Add two more tracks and check if order is correct
-  grid.addTrack(params4, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params4, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
-  grid.addTrack(params5, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params5, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   BOOST_CHECK(
@@ -135,14 +135,14 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_max_z_and_width_test) {
   std::vector<int> mainGridZValues;
 
   // Fill grid with track densities
-  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  auto zBinAndTrack = grid.addTrack(params1, mainGridDensity, mainGridZValues);
   auto res1 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
   BOOST_CHECK(res1.ok());
   // Maximum should be at z0Trk1 position
   BOOST_CHECK_EQUAL(*res1, z0Trk1);
 
   // Add second track
-  grid.addTrack(params2, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params2, mainGridDensity, mainGridZValues);
   auto res2 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
   BOOST_CHECK(res2.ok());
   // Trk 2 is closer to z-axis and should yield higher density values
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
   std::vector<int> mainGridZValues;
 
   // Fill grid with track densities
-  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  auto zBinAndTrack = grid.addTrack(params1, mainGridDensity, mainGridZValues);
 
   auto res1 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
   BOOST_CHECK(res1.ok());
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
   BOOST_CHECK_EQUAL(*res1, z0Trk1);
 
   // Add second track
-  grid.addTrack(params2, mainGridDensity, mainGridZValues);
+  zBinAndTrack = grid.addTrack(params2, mainGridDensity, mainGridZValues);
   auto res2 = grid.getMaxZPosition(mainGridDensity, mainGridZValues);
   BOOST_CHECK(res2.ok());
   // Trk 2 is closer to z-axis and should yield higher density values

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -34,7 +34,9 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
   AdaptiveGridTrackDensity<trkGridSize>::Config cfg(binSize);
   AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
 
-  // Create some test tracks
+  // Create some test tracks in such a way that some tracks
+  //  e.g. overlap and that certain tracks need to be inserted
+  // between two other tracks
   Covariance covMat(Covariance::Identity());
 
   BoundVector paramVec0;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -26,7 +26,6 @@ namespace Test {
 using Covariance = BoundSymMatrix;
 
 BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
-
   const int trkGridSize = 15;
 
   double binSize = 0.1;  // mm
@@ -80,17 +79,17 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
 
   // Track should have been entirely added to both grids
   grid.addTrack(params2, mainGridDensity, mainGridZValues);
-  BOOST_CHECK_EQUAL(mainGridDensity.size(), 2*trkGridSize);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 2 * trkGridSize);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
-  
+
   // Track 3 has overlap of 2 bins with track 1
   grid.addTrack(params3, mainGridDensity, mainGridZValues);
-  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3*trkGridSize - 2);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3 * trkGridSize - 2);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Add first track again, should *not* introduce new z entries
   grid.addTrack(params1, mainGridDensity, mainGridZValues);
-  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3*trkGridSize - 2);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3 * trkGridSize - 2);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
 
   // Add two more tracks and check if order is correct
@@ -98,13 +97,12 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_track_adding_test) {
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
   grid.addTrack(params5, mainGridDensity, mainGridZValues);
   BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
- 
-  BOOST_CHECK(std::is_sorted(std::begin(mainGridZValues), std::end(mainGridZValues)));
 
+  BOOST_CHECK(
+      std::is_sorted(std::begin(mainGridZValues), std::end(mainGridZValues)));
 }
 
 BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_max_z_and_width_test) {
-
   const int trkGridSize = 15;
 
   double binSize = 0.1;  // mm
@@ -152,14 +150,14 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_max_z_and_width_test) {
   BOOST_CHECK_EQUAL(*res2, z0Trk2);
 
   // Get max position and width estimation
-  auto resWidth1 = grid.getMaxZPositionAndWidth(mainGridDensity, mainGridZValues);
+  auto resWidth1 =
+      grid.getMaxZPositionAndWidth(mainGridDensity, mainGridZValues);
   BOOST_CHECK(resWidth1.ok());
   BOOST_CHECK_EQUAL((*resWidth1).first, z0Trk2);
   BOOST_CHECK((*resWidth1).second > 0);
 }
 
 BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
-
   const int trkGridSize = 15;
 
   double binSize = 0.1;  // mm
@@ -220,7 +218,6 @@ BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_highest_density_sum_test) {
   // added densities for track 1 around its maximum should now lead to
   // a prediction at z0Trk1 again
   BOOST_CHECK_EQUAL(*res3, z0Trk1);
-
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -13,8 +13,6 @@
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
-#include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/Units.hpp"
 #include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
 
 namespace bdata = boost::unit_test::data;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveGridTrackDensityTests.cpp
@@ -1,0 +1,118 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/tools/output_test_stream.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Surfaces/PerigeeSurface.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Units.hpp"
+#include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
+
+namespace bdata = boost::unit_test::data;
+using namespace Acts::UnitLiterals;
+
+namespace Acts {
+namespace Test {
+
+using Covariance = BoundSymMatrix;
+
+// Create a test context
+GeometryContext geoContext = GeometryContext();
+
+BOOST_AUTO_TEST_CASE(adaptive_gaussian_grid_density_test) {
+
+  const int trkGridSize = 15;
+
+  double binSize = 0.1;  // mm
+
+  // Set up grid density with zMinMax
+  AdaptiveGridTrackDensity<trkGridSize>::Config cfg(binSize);
+  AdaptiveGridTrackDensity<trkGridSize> grid(cfg);
+
+  // Create some test tracks
+  Covariance covMat;
+  covMat << 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0,
+      0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+
+  BoundVector paramVec0;
+  paramVec0 << 100.0, -0.45, 0, 0, 0, 0;
+  BoundVector paramVec1;
+  paramVec1 << 0.01, -0.45, 0, 0, 0, 0;
+  BoundVector paramVec2;
+  paramVec2 << 0.01, 10.95, 0, 0, 0, 0;
+  BoundVector paramVec3;
+  paramVec3 << 0.01, 0.95, 0, 0, 0, 0;
+  BoundVector paramVec4;
+  paramVec4 << 0.01, -30.95, 0, 0, 0, 0;
+  BoundVector paramVec5;
+  paramVec5 << 0.01, -15.0, 0, 0, 0, 0;
+
+  // Create perigee surface
+  std::shared_ptr<PerigeeSurface> perigeeSurface =
+      Surface::makeShared<PerigeeSurface>(Vector3D(0., 0., 0.));
+
+  BoundTrackParameters params0(perigeeSurface, paramVec0, covMat);
+  BoundTrackParameters params1(perigeeSurface, paramVec1, covMat);
+  BoundTrackParameters params2(perigeeSurface, paramVec2, covMat);
+  BoundTrackParameters params3(perigeeSurface, paramVec3, covMat);
+  BoundTrackParameters params4(perigeeSurface, paramVec4, covMat);
+  BoundTrackParameters params5(perigeeSurface, paramVec5, covMat);
+
+  // Start with empty grids
+  std::vector<float> mainGridDensity;
+  std::vector<int> mainGridZValues;
+
+  // Track is too far away from z axis and was not added
+  grid.addTrack(params0, mainGridDensity, mainGridZValues);
+  BOOST_CHECK(mainGridDensity.empty());
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+
+  // Track should have been entirely added to both grids
+  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), trkGridSize);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+
+  // Track should have been entirely added to both grids
+  grid.addTrack(params2, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 2*trkGridSize);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+  
+  // Track 3 has overlap of 2 bins with track 1
+  grid.addTrack(params3, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3*trkGridSize - 2);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+
+  // Add first track again, should *not* introduce new z entries
+  grid.addTrack(params1, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), 3*trkGridSize - 2);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+
+  // Add two more tracks and check if order is correct
+  grid.addTrack(params4, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+  grid.addTrack(params5, mainGridDensity, mainGridZValues);
+  BOOST_CHECK_EQUAL(mainGridDensity.size(), mainGridZValues.size());
+ 
+  BOOST_CHECK(std::is_sorted(std::begin(mainGridZValues), std::end(mainGridZValues)));
+
+
+  // for(int i = 0; i < mainGridDensity.size(); i++){
+  //   std::cout << mainGridZValues[i] << ": " << mainGridDensity[i] << std::endl;
+  // }
+
+  //std::cout << mainGridZValues << std::endl;
+  // std::cout << mainGridDensity << std::endl;
+
+}
+
+}  // namespace Test
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -16,10 +16,12 @@
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Utilities/Definitions.hpp"
+#include "Acts/Utilities/Units.hpp"
+#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveMultiVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveMultiVertexFitter.hpp"
 #include "Acts/Vertexing/GridDensityVertexFinder.hpp"
-#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/HelicalTrackLinearizer.hpp"
 #include "Acts/Vertexing/ImpactPointEstimator.hpp"
 #include "Acts/Vertexing/TrackDensityVertexFinder.hpp"
@@ -483,13 +485,14 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   }
 }
 
-
 /// @brief AMVF test with adaptive grid seed finder
-BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_adaptive_grid_seed_finder_test) {
+BOOST_AUTO_TEST_CASE(
+    adaptive_multi_vertex_finder_adaptive_grid_seed_finder_test) {
   // Set debug mode
   bool debugMode = false;
   if (debugMode) {
-    std::cout << "Starting AMVF test with adaptive grid seed finder..." << std::endl;
+    std::cout << "Starting AMVF test with adaptive grid seed finder..."
+              << std::endl;
   }
   // Set up constant B-Field
   ConstantBField bField(Vector3D(0., 0., 2_T));
@@ -627,7 +630,6 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_adaptive_grid_seed_finder_test
     BOOST_CHECK_EQUAL(found, true);
   }
 }
-
 
 }  // namespace Test
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -19,6 +19,7 @@
 #include "Acts/Vertexing/AdaptiveMultiVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveMultiVertexFitter.hpp"
 #include "Acts/Vertexing/GridDensityVertexFinder.hpp"
+#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/HelicalTrackLinearizer.hpp"
 #include "Acts/Vertexing/ImpactPointEstimator.hpp"
 #include "Acts/Vertexing/TrackDensityVertexFinder.hpp"
@@ -481,6 +482,152 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
     BOOST_CHECK_EQUAL(found, true);
   }
 }
+
+
+/// @brief AMVF test with adaptive grid seed finder
+BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_adaptive_grid_seed_finder_test) {
+  // Set debug mode
+  bool debugMode = false;
+  if (debugMode) {
+    std::cout << "Starting AMVF test with adaptive grid seed finder..." << std::endl;
+  }
+  // Set up constant B-Field
+  ConstantBField bField(Vector3D(0., 0., 2_T));
+
+  // Set up EigenStepper
+  // EigenStepper<ConstantBField> stepper(bField);
+  EigenStepper<ConstantBField> stepper(bField);
+
+  // Set up propagator with void navigator
+  auto propagator = std::make_shared<Propagator>(stepper);
+
+  // IP Estimator
+  using IPEstimator = ImpactPointEstimator<BoundTrackParameters, Propagator>;
+
+  IPEstimator::Config ipEstCfg(bField, propagator);
+  IPEstimator ipEst(ipEstCfg);
+
+  std::vector<double> temperatures{8.0, 4.0, 2.0, 1.4142136, 1.2247449, 1.0};
+  AnnealingUtility::Config annealingConfig(temperatures);
+  AnnealingUtility annealingUtility(annealingConfig);
+
+  using Fitter = AdaptiveMultiVertexFitter<BoundTrackParameters, Linearizer>;
+
+  Fitter::Config fitterCfg(ipEst);
+
+  fitterCfg.annealingTool = annealingUtility;
+
+  // Linearizer for BoundTrackParameters type test
+  Linearizer::Config ltConfig(bField, propagator);
+  Linearizer linearizer(ltConfig);
+
+  // Test smoothing
+  fitterCfg.doSmoothing = true;
+
+  Fitter fitter(fitterCfg);
+
+  using SeedFinder = AdaptiveGridDensityVertexFinder<55>;
+  SeedFinder::Config seedFinderCfg(0.05);
+  seedFinderCfg.cacheGridStateForTrackRemoval = true;
+
+  SeedFinder seedFinder(seedFinderCfg);
+
+  using Finder = AdaptiveMultiVertexFinder<Fitter, SeedFinder>;
+
+  Finder::Config finderConfig(std::move(fitter), seedFinder, ipEst, linearizer);
+
+  Finder finder(finderConfig);
+  Finder::State state;
+
+  auto csvData = readTracksAndVertexCSV(toolString);
+  auto tracks = std::get<TracksData>(csvData);
+
+  if (debugMode) {
+    std::cout << "Number of tracks in event: " << tracks.size() << std::endl;
+    int maxCout = 10;
+    int count = 0;
+    for (const auto& trk : tracks) {
+      std::cout << count << ". track: " << std::endl;
+      std::cout << "params: " << trk << std::endl;
+      count++;
+      if (count == maxCout) {
+        break;
+      }
+    }
+  }
+
+  std::vector<const BoundTrackParameters*> tracksPtr;
+  for (const auto& trk : tracks) {
+    tracksPtr.push_back(&trk);
+  }
+
+  VertexingOptions<BoundTrackParameters> vertexingOptions(geoContext,
+                                                          magFieldContext);
+
+  vertexingOptions.vertexConstraint = std::get<BeamSpotData>(csvData);
+
+  auto t1 = std::chrono::system_clock::now();
+  auto findResult = finder.find(tracksPtr, vertexingOptions, state);
+  auto t2 = std::chrono::system_clock::now();
+
+  auto timediff =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+
+  if (!findResult.ok()) {
+    std::cout << findResult.error().message() << std::endl;
+  }
+
+  BOOST_CHECK(findResult.ok());
+
+  std::vector<Vertex<BoundTrackParameters>> allVertices = *findResult;
+
+  if (debugMode) {
+    std::cout << "Time needed: " << timediff << " ms." << std::endl;
+    std::cout << "Number of vertices reconstructed: " << allVertices.size()
+              << std::endl;
+
+    int count = 0;
+    for (const auto& vtx : allVertices) {
+      count++;
+      std::cout << count << ". Vertex at position: " << vtx.position()[0]
+                << ", " << vtx.position()[1] << ", " << vtx.position()[2]
+                << std::endl;
+      std::cout << count << ". Vertex with cov: " << vtx.covariance()
+                << std::endl;
+      std::cout << "\t with n tracks: " << vtx.tracks().size() << std::endl;
+    }
+  }
+  // Test expected outcomes from athena implementation
+  // Number of reconstructed vertices
+  auto verticesInfo = std::get<VerticesData>(csvData);
+  const int expNRecoVertices = verticesInfo.size();
+
+  BOOST_CHECK_EQUAL(allVertices.size(), expNRecoVertices);
+  std::vector<bool> vtxFound(expNRecoVertices, false);
+
+  for (auto vtx : allVertices) {
+    double vtxZ = vtx.position()[2];
+    double diffZ = 1e5;
+    int foundVtxIdx = -1;
+    for (int i = 0; i < expNRecoVertices; i++) {
+      if (not vtxFound[i]) {
+        if (std::abs(vtxZ - verticesInfo[i].position[2]) < diffZ) {
+          diffZ = std::abs(vtxZ - verticesInfo[i].position[2]);
+          foundVtxIdx = i;
+        }
+      }
+    }
+    if (diffZ < 0.5_mm) {
+      vtxFound[foundVtxIdx] = true;
+      CHECK_CLOSE_ABS(vtx.tracks().size(), verticesInfo[foundVtxIdx].nTracks,
+                      2);
+    }
+  }
+  for (bool found : vtxFound) {
+    BOOST_CHECK_EQUAL(found, true);
+  }
+}
+
 
 }  // namespace Test
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -16,8 +16,6 @@
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
-#include "Acts/Utilities/Definitions.hpp"
-#include "Acts/Utilities/Units.hpp"
 #include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveMultiVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveMultiVertexFitter.hpp"

--- a/Tests/UnitTests/Core/Vertexing/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Vertexing/CMakeLists.txt
@@ -10,3 +10,5 @@ add_unittest(ZScanVertexFinder ZScanVertexFinderTests.cpp)
 add_unittest(TrackDensityVertexFinder TrackDensityVertexFinderTests.cpp)
 add_unittest(GaussianGridTrackDensity GaussianGridTrackDensityTests.cpp)
 add_unittest(GridDensityVertexFinder GridDensityVertexFinderTests.cpp)
+add_unittest(AdaptiveGridTrackDensity AdaptiveGridTrackDensityTests.cpp)
+

--- a/Tests/UnitTests/Core/Vertexing/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Vertexing/CMakeLists.txt
@@ -11,4 +11,3 @@ add_unittest(TrackDensityVertexFinder TrackDensityVertexFinderTests.cpp)
 add_unittest(GaussianGridTrackDensity GaussianGridTrackDensityTests.cpp)
 add_unittest(GridDensityVertexFinder GridDensityVertexFinderTests.cpp)
 add_unittest(AdaptiveGridTrackDensity AdaptiveGridTrackDensityTests.cpp)
-

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -412,6 +412,9 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
       std::cout << "Estimated z-seed width 2: " << cov(eZ, eZ) << std::endl;
     }
   }
+
+  // Test for same seed width
+  CHECK_CLOSE_ABS(covZZ1, covZZ2, 1e-4);
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -19,6 +19,8 @@
 #include "Acts/Utilities/UnitVectors.hpp"
 #include "Acts/Vertexing/GaussianGridTrackDensity.hpp"
 #include "Acts/Vertexing/GridDensityVertexFinder.hpp"
+#include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
+#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 
 namespace bdata = boost::unit_test::data;
 using namespace Acts::UnitLiterals;
@@ -70,12 +72,22 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
   VertexingOptions<BoundTrackParameters> vertexingOptions(geoContext,
                                                           magFieldContext);
 
-  using Finder = GridDensityVertexFinder<mainGridSize, trkGridSize>;
-  Finder::Config cfg;
-  cfg.cacheGridStateForTrackRemoval = false;
-  Finder finder(cfg);
+  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
+  Finder1::Config cfg1;
+  cfg1.cacheGridStateForTrackRemoval = false;
+  Finder1 finder1(cfg1);
+  Finder1::State state1;
 
-  Finder::State state;
+  using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
+  // Use custom grid density here with same bin size as Finder1
+  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
+
+  using Finder2 = AdaptiveGridDensityVertexFinder<trkGridSize>;
+  Finder2::Config cfg2(adaptiveDensity);
+  cfg2.cacheGridStateForTrackRemoval = false;
+  Finder2 finder2(cfg2);
+  Finder2::State state2;
 
   int mySeed = 31415;
   std::mt19937 gen(mySeed);
@@ -112,19 +124,40 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
     trackPtrVec.push_back(&trk);
   }
 
-  auto res = finder.find(trackPtrVec, vertexingOptions, state);
-  if (!res.ok()) {
-    std::cout << res.error().message() << std::endl;
+  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  if (!res1.ok()) {
+    std::cout << res1.error().message() << std::endl;
   }
 
-  if (res.ok()) {
-    BOOST_CHECK(!(*res).empty());
-    Vector3D result = (*res).back().position();
-    if (debugMode) {
-      std::cout << "Vertex position result: " << result << std::endl;
-    }
-    CHECK_CLOSE_ABS(result[eZ], zVertexPos1, 1_mm);
+  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  if (!res2.ok()) {
+    std::cout << res2.error().message() << std::endl;
   }
+
+  double zResult1 = 0;
+  if (res1.ok()) {
+    BOOST_CHECK(!(*res1).empty());
+    Vector3D result1 = (*res1).back().position();
+    if (debugMode) {
+      std::cout << "Vertex position result 1: " << result1 << std::endl;
+    }
+    CHECK_CLOSE_ABS(result1[eZ], zVertexPos1, 1_mm);
+    zResult1 = result1[eZ];
+  }
+
+  double zResult2 = 0;
+  if (res2.ok()) {
+    BOOST_CHECK(!(*res2).empty());
+    Vector3D result2 = (*res2).back().position();
+    if (debugMode) {
+      std::cout << "Vertex position result 2: " << result2 << std::endl;
+    }
+    CHECK_CLOSE_ABS(result2[eZ], zVertexPos1, 1_mm);
+    zResult2 = result2[eZ];
+  }
+
+  // Both finders should give same results
+  BOOST_CHECK(zResult1 == zResult2);
 }
 
 BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
@@ -143,7 +176,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   VertexingOptions<BoundTrackParameters> vertexingOptions(geoContext,
                                                           magFieldContext);
 
-  using Finder = GridDensityVertexFinder<mainGridSize, trkGridSize>;
+  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
   using GridDensity = GaussianGridTrackDensity<mainGridSize, trkGridSize>;
 
   // Use custom grid density here
@@ -151,9 +184,20 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   densityConfig.useHighestSumZPosition = true;
   GridDensity density(densityConfig);
 
-  Finder::Config cfg(density);
+  Finder1::Config cfg(density);
   cfg.cacheGridStateForTrackRemoval = true;
-  Finder finder(cfg);
+  Finder1 finder1(cfg);
+
+  using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
+  // Use custom grid density here with same bin size as Finder1
+  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  adaptiveDensityConfig.useHighestSumZPosition = true;
+  AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
+
+  using Finder2 = AdaptiveGridDensityVertexFinder<trkGridSize>;
+  Finder2::Config cfg2(adaptiveDensity);
+  cfg2.cacheGridStateForTrackRemoval = true;
+  Finder2 finder2(cfg2);
 
   int mySeed = 31415;
   std::mt19937 gen(mySeed);
@@ -183,20 +227,41 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     trackPtrVec.push_back(&trk);
   }
 
-  Finder::State state;
+  Finder1::State state1;
+  Finder2::State state2;
 
-  auto res = finder.find(trackPtrVec, vertexingOptions, state);
-  if (!res.ok()) {
-    std::cout << res.error().message() << std::endl;
+  double zResult1 = 0;
+  double zResult2 = 0;
+
+  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  if (!res1.ok()) {
+    std::cout << res1.error().message() << std::endl;
   }
-  if (res.ok()) {
-    BOOST_CHECK(!(*res).empty());
-    Vector3D result = (*res).back().position();
+  if (res1.ok()) {
+    BOOST_CHECK(!(*res1).empty());
+    Vector3D result = (*res1).back().position();
     if (debugMode) {
-      std::cout << "Vertex position after first fill: " << result << std::endl;
+      std::cout << "Vertex position after first fill 1: " << result << std::endl;
     }
     CHECK_CLOSE_ABS(result[eZ], zVertexPos1, 1_mm);
+    zResult1 = result[eZ];
   }
+
+  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  if (!res2.ok()) {
+    std::cout << res2.error().message() << std::endl;
+  }
+  if (res2.ok()) {
+    BOOST_CHECK(!(*res2).empty());
+    Vector3D result = (*res2).back().position();
+    if (debugMode) {
+      std::cout << "Vertex position after first fill 2: " << result << std::endl;
+    }
+    CHECK_CLOSE_ABS(result[eZ], zVertexPos1, 1_mm);
+    zResult2 = result[eZ];
+  }
+
+  BOOST_CHECK(zResult1 == zResult2);
 
   int trkCount = 0;
   std::vector<const BoundTrackParameters*> removedTracks;
@@ -207,22 +272,42 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     trkCount++;
   }
 
-  state.tracksToRemove = removedTracks;
+  state1.tracksToRemove = removedTracks;
+  state2.tracksToRemove = removedTracks;
 
-  auto res2 = finder.find(trackPtrVec, vertexingOptions, state);
-  if (!res2.ok()) {
-    std::cout << res2.error().message() << std::endl;
+  auto res3 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  if (!res3.ok()) {
+    std::cout << res3.error().message() << std::endl;
   }
-  if (res2.ok()) {
-    BOOST_CHECK(!(*res2).empty());
-    Vector3D result = (*res2).back().position();
+  if (res3.ok()) {
+    BOOST_CHECK(!(*res3).empty());
+    Vector3D result = (*res3).back().position();
     if (debugMode) {
       std::cout
-          << "Vertex position after removing tracks near first density peak: "
+          << "Vertex position after removing tracks near first density peak 1: "
           << result << std::endl;
     }
     CHECK_CLOSE_ABS(result[eZ], zVertexPos2, 1_mm);
+    zResult1 = result[eZ];
   }
+
+   auto res4 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  if (!res4.ok()) {
+    std::cout << res4.error().message() << std::endl;
+  }
+  if (res4.ok()) {
+    BOOST_CHECK(!(*res4).empty());
+    Vector3D result = (*res4).back().position();
+    if (debugMode) {
+      std::cout
+          << "Vertex position after removing tracks near first density peak 2: "
+          << result << std::endl;
+    }
+    CHECK_CLOSE_ABS(result[eZ], zVertexPos2, 1_mm);
+    zResult2 = result[eZ];
+  }
+
+  BOOST_CHECK(zResult1 == zResult2);
 }
 
 ///
@@ -247,13 +332,24 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   constraintVtx.setCovariance(ActsSymMatrixD<3>::Identity());
   vertexingOptions.vertexConstraint = constraintVtx;
 
-  using Finder = GridDensityVertexFinder<mainGridSize, trkGridSize>;
-  Finder::Config cfg;
-  cfg.cacheGridStateForTrackRemoval = false;
-  cfg.estimateSeedWidth = true;
-  Finder finder(cfg);
+  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
+  Finder1::Config cfg1;
+  cfg1.cacheGridStateForTrackRemoval = false;
+  cfg1.estimateSeedWidth = true;
+  Finder1 finder1(cfg1);
+  Finder1::State state1;
 
-  Finder::State state;
+  using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
+  // Use custom grid density here with same bin size as Finder1
+  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
+
+  using Finder2 = AdaptiveGridDensityVertexFinder<trkGridSize>;
+  Finder2::Config cfg2(adaptiveDensity);
+  cfg2.cacheGridStateForTrackRemoval = false;
+  cfg2.estimateSeedWidth = true;
+  Finder2 finder2(cfg2);
+  Finder2::State state2;
 
   int mySeed = 31415;
   std::mt19937 gen(mySeed);
@@ -281,18 +377,39 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
     trackPtrVec.push_back(&trk);
   }
 
-  auto res = finder.find(trackPtrVec, vertexingOptions, state);
-  if (!res.ok()) {
-    std::cout << res.error().message() << std::endl;
+  // Test finder 1
+  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  if (!res1.ok()) {
+    std::cout << res1.error().message() << std::endl;
   }
 
-  if (res.ok()) {
-    BOOST_CHECK(!(*res).empty());
-    ActsSymMatrixD<3> cov = (*res).back().covariance();
+  double covZZ1 = 0;
+  if (res1.ok()) {
+    BOOST_CHECK(!(*res1).empty());
+    ActsSymMatrixD<3> cov = (*res1).back().covariance();
     BOOST_CHECK(constraintVtx.covariance() != cov);
     BOOST_CHECK(cov(eZ, eZ) != 0.);
+    covZZ1 = cov(eZ, eZ);
     if (debugMode) {
-      std::cout << "Estimated z-seed width: " << cov(eZ, eZ) << std::endl;
+      std::cout << "Estimated z-seed width 1: " << cov(eZ, eZ) << std::endl;
+    }
+  }
+
+  // Test finder 2
+  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  if (!res2.ok()) {
+    std::cout << res2.error().message() << std::endl;
+  }
+
+  double covZZ2 = 0;
+  if (res2.ok()) {
+    BOOST_CHECK(!(*res2).empty());
+    ActsSymMatrixD<3> cov = (*res2).back().covariance();
+    BOOST_CHECK(constraintVtx.covariance() != cov);
+    BOOST_CHECK(cov(eZ, eZ) != 0.);
+    covZZ2 = cov(eZ, eZ);
+    if (debugMode) {
+      std::cout << "Estimated z-seed width 2: " << cov(eZ, eZ) << std::endl;
     }
   }
 }

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -17,7 +17,6 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
-#include "Acts/Utilities/Units.hpp"
 #include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
 #include "Acts/Vertexing/GaussianGridTrackDensity.hpp"

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -17,10 +17,11 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
+#include "Acts/Utilities/Units.hpp"
+#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
+#include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
 #include "Acts/Vertexing/GaussianGridTrackDensity.hpp"
 #include "Acts/Vertexing/GridDensityVertexFinder.hpp"
-#include "Acts/Vertexing/AdaptiveGridTrackDensity.hpp"
-#include "Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp"
 
 namespace bdata = boost::unit_test::data;
 using namespace Acts::UnitLiterals;
@@ -80,7 +81,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
 
   using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
   // Use custom grid density here with same bin size as Finder1
-  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  AdapticeGridDensity::Config adaptiveDensityConfig(2. / 30. * 1_mm);
   AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
 
   using Finder2 = AdaptiveGridDensityVertexFinder<trkGridSize>;
@@ -190,7 +191,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
 
   using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
   // Use custom grid density here with same bin size as Finder1
-  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  AdapticeGridDensity::Config adaptiveDensityConfig(2. / 30. * 1_mm);
   adaptiveDensityConfig.useHighestSumZPosition = true;
   AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
 
@@ -241,7 +242,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     BOOST_CHECK(!(*res1).empty());
     Vector3D result = (*res1).back().position();
     if (debugMode) {
-      std::cout << "Vertex position after first fill 1: " << result << std::endl;
+      std::cout << "Vertex position after first fill 1: " << result
+                << std::endl;
     }
     CHECK_CLOSE_ABS(result[eZ], zVertexPos1, 1_mm);
     zResult1 = result[eZ];
@@ -255,7 +257,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     BOOST_CHECK(!(*res2).empty());
     Vector3D result = (*res2).back().position();
     if (debugMode) {
-      std::cout << "Vertex position after first fill 2: " << result << std::endl;
+      std::cout << "Vertex position after first fill 2: " << result
+                << std::endl;
     }
     CHECK_CLOSE_ABS(result[eZ], zVertexPos1, 1_mm);
     zResult2 = result[eZ];
@@ -291,7 +294,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     zResult1 = result[eZ];
   }
 
-   auto res4 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  auto res4 = finder2.find(trackPtrVec, vertexingOptions, state2);
   if (!res4.ok()) {
     std::cout << res4.error().message() << std::endl;
   }
@@ -341,7 +344,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
 
   using AdapticeGridDensity = AdaptiveGridTrackDensity<trkGridSize>;
   // Use custom grid density here with same bin size as Finder1
-  AdapticeGridDensity::Config adaptiveDensityConfig(2./30.*1_mm);
+  AdapticeGridDensity::Config adaptiveDensityConfig(2. / 30. * 1_mm);
   AdapticeGridDensity adaptiveDensity(adaptiveDensityConfig);
 
   using Finder2 = AdaptiveGridDensityVertexFinder<trkGridSize>;


### PR DESCRIPTION
This PR introduces a new vertex seed finder that is based on the existing Grid density seed finder, however, it's an adaptive version that allows the track density grid to grow bigger dynamically over time as new tracks are added to the seed finder.
This should consume much less memory as no e.g. 10.000-dim density vector is required (that is potentially quite empty) and the vector just grows over time.
Having three different versions of a Gaussian seed finder in place now, I will soon open an issue to check if we can potentially combine these seed finders to a single finder in the future, that just uses different track density implementations in the background (continuous density, grid density, adaptive grid density).