### PR TITLE
ci: CERN public website URL has changed

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -76,7 +76,7 @@ jobs:
           brew install cmake eigen ninja
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && curl -SL https://acts.web.cern.ch/ACTS/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
+          && curl -SL https://acts.web.cern.ch/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
         run: >
           cmake -B build -S .


### PR DESCRIPTION
We need to fetch dependencies from https://acts.web.cern.ch/ci/macOS/ rather than the old https://acts.web.cern.ch/ACTS/ci/macOS.
This PR changes the URL.

See #602 and #507 where we see the macOS CI failing.

/cc @asalzburger @irinaene