### PR TITLE
ci: fix macOS build failures due to DD4hep CMake

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -78,11 +78,15 @@ jobs:
           && sudo chown $USER /usr/local/acts
           && curl -SL https://acts.web.cern.ch/ci/macOS/deps.43e0201.tar.gz | tar -xzC /usr/local/acts
       - name: Configure
+        # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
+        # dd4hep CMake configuration that gets triggered on recent CMake
+        # versions such as the one installed via homebrew
         run: >
           cmake -B build -S .
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_STANDARD=17
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
           -DCMAKE_PREFIX_PATH=/usr/local/acts
           -DACTS_BUILD_EVERYTHING=on
@@ -104,6 +108,7 @@ jobs:
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_STANDARD=17
           -DCMAKE_PREFIX_PATH="${INSTALL_DIR};/usr/local/acts"
       - name: Downstream build
         run: cmake --build build-downstream --


### PR DESCRIPTION
Set `CMAKE_CXX_STANDARD=17` explicitely for the macOS CI build.

The DD4hep CMake configurations seems to be buggy (surprise). It seems to require that the `CMAKE_CXX_STANDARD` options is set to a definite value, but this only gets triggered on recent CMake versions. The current CMake version installed via homebrew seems to do just that.