### PR TITLE
refactor(Fatras): rename Particle position/momentum accessors

### DIFF
--- a/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
@@ -89,7 +89,7 @@ ActsExamples::ProcessCode ActsExamples::EventRecording::execute(
 
     // Set beam particle properties
     const Acts::Vector4D momentum4 =
-        part.momentum4() / Acts::UnitConstants::GeV;
+        part.fourMomentum() / Acts::UnitConstants::GeV;
     HepMC3::FourVector beamMom4(momentum4[0], momentum4[1], momentum4[2],
                                 momentum4[3]);
     auto beamParticle = event.particles()[0];

--- a/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
@@ -65,7 +65,7 @@ void ActsExamples::PrimaryGeneratorAction::prepareParticleGun(
   const auto pos = part.position() * convertLength;
   const auto dir = part.unitDirection();
   m_particleGun->SetParticlePosition({pos[0], pos[1], pos[2]});
-  m_particleGun->SetParticleMomentum(part.absMomentum() * convertEnergy);
+  m_particleGun->SetParticleMomentum(part.absoluteMomentum() * convertEnergy);
   m_particleGun->SetParticleMomentumDirection({dir[0], dir[1], dir[2]});
 }
 

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.cpp
@@ -64,7 +64,7 @@ ActsExamples::ProcessCode ActsExamples::EventGenerator::read(
         const auto pid = ActsFatras::Barcode(particle.particleId())
                              .setVertexPrimary(nPrimaryVertices);
         // move particle to the vertex
-        const auto pos4 = (vertexPosition + particle.position4()).eval();
+        const auto pos4 = (vertexPosition + particle.fourPosition()).eval();
         // `withParticleId` returns a copy because it changes the identity
         particle = particle.withParticleId(pid).setPosition4(pos4);
       };

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -27,8 +27,8 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
                                    std::numeric_limits<double>::max())) {}
 
-ActsExamples::SimParticleContainer ActsExamples::ParametricParticleGenerator::
-operator()(RandomEngine& rng) const {
+ActsExamples::SimParticleContainer
+ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
   using UniformIndex = std::uniform_int_distribution<unsigned int>;
   using UniformReal = std::uniform_real_distribution<double>;
 

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -27,8 +27,8 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
                                    std::numeric_limits<double>::max())) {}
 
-ActsExamples::SimParticleContainer
-ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
+ActsExamples::SimParticleContainer ActsExamples::ParametricParticleGenerator::
+operator()(RandomEngine& rng) const {
   using UniformIndex = std::uniform_int_distribution<unsigned int>;
   using UniformReal = std::uniform_real_distribution<double>;
 

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -74,7 +74,7 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
     // construct the particle;
     ActsFatras::Particle particle(pid, pdg, q, m_mass);
     particle.setDirection(dir);
-    particle.setAbsMomentum(p);
+    particle.setAbsoluteMomentum(p);
 
     // generated particle ids are already ordered and should end up at the end
     particles.insert(particles.end(), std::move(particle));

--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
@@ -119,7 +119,7 @@ ActsExamples::SimParticleContainer ActsExamples::Pythia8Generator::operator()(
     particle.setPosition4(pos4);
     // normalization/ units are not import for the direction
     particle.setDirection(genParticle.px(), genParticle.py(), genParticle.pz());
-    particle.setAbsMomentum(
+    particle.setAbsoluteMomentum(
         std::hypot(genParticle.px(), genParticle.py(), genParticle.pz()) *
         1_GeV);
 

--- a/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
+++ b/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
@@ -156,7 +156,7 @@ void filterAndSort(
          cit != interaction.after.cend();) {
       // Test whether a particle fulfills the conditions
       if (cit->pdg() < cfg.absPdgMin || cit->pdg() > cfg.absPdgMax ||
-          cit->absMomentum() < cfg.pMin) {
+          cit->absoluteMomentum() < cfg.pMin) {
         interaction.after.erase(cit);
       } else {
         cit++;
@@ -168,7 +168,7 @@ void filterAndSort(
   for (auto& interaction : interactions) {
     std::sort(interaction.after.begin(), interaction.after.end(),
               [](ActsExamples::SimParticle& a, ActsExamples::SimParticle& b) {
-                return a.absMomentum() > b.absMomentum();
+                return a.absoluteMomentum() > b.absoluteMomentum();
               });
   }
 }

--- a/Examples/Algorithms/Printers/ActsExamples/Printers/ParticlesPrinter.cpp
+++ b/Examples/Algorithms/Printers/ActsExamples/Printers/ParticlesPrinter.cpp
@@ -42,7 +42,8 @@ ActsExamples::ProcessCode ActsExamples::ParticlesPrinter::execute(
                                    << " mm");
     ACTS_INFO("    direction:    " << particle.unitDirection().transpose());
     ACTS_INFO("    time:         " << particle.time() / 1_ns << " ns");
-    ACTS_INFO("    |p|:          " << particle.absMomentum() / 1_GeV << " GeV");
+    ACTS_INFO("    |p|:          " << particle.absoluteMomentum() / 1_GeV
+                                   << " GeV");
   }
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
@@ -53,7 +53,7 @@ ActsExamples::ProcessCode ActsExamples::ParticleSmearing::execute(
       const auto phi = Acts::VectorHelpers::phi(particle.unitDirection());
       const auto theta = Acts::VectorHelpers::theta(particle.unitDirection());
       const auto pt = particle.transverseMomentum();
-      const auto p = particle.absMomentum();
+      const auto p = particle.absoluteMomentum();
       const auto q = particle.charge();
 
       // compute momentum-dependent resolutions

--- a/Examples/Framework/src/Validation/ResPlotTool.cpp
+++ b/Examples/Framework/src/Validation/ResPlotTool.cpp
@@ -168,7 +168,7 @@ void ActsExamples::ResPlotTool::fill(
   truthParameter[Acts::BoundIndices::eBoundTheta] =
       theta(truthParticle.unitDirection());
   truthParameter[Acts::BoundIndices::eBoundQOverP] =
-      truthParticle.charge() / truthParticle.absMomentum();
+      truthParticle.charge() / truthParticle.absoluteMomentum();
   truthParameter[Acts::BoundIndices::eBoundTime] = truthParticle.time();
 
   // get the truth eta and pT

--- a/Examples/Io/Csv/src/CsvParticleReader.cpp
+++ b/Examples/Io/Csv/src/CsvParticleReader.cpp
@@ -68,8 +68,8 @@ ActsExamples::ProcessCode ActsExamples::CsvParticleReader::read(
         data.vz * Acts::UnitConstants::mm, data.vt * Acts::UnitConstants::ns);
     // only used for direction; normalization/units do not matter
     particle.setDirection(data.px, data.py, data.pz);
-    particle.setAbsMomentum(std::hypot(data.px, data.py, data.pz) *
-                            Acts::UnitConstants::GeV);
+    particle.setAbsoluteMomentum(std::hypot(data.px, data.py, data.pz) *
+                                 Acts::UnitConstants::GeV);
     unordered.push_back(std::move(particle));
   }
 

--- a/Examples/Io/Csv/src/CsvParticleWriter.cpp
+++ b/Examples/Io/Csv/src/CsvParticleWriter.cpp
@@ -46,7 +46,7 @@ ActsExamples::ProcessCode ActsExamples::CsvParticleWriter::writeT(
     data.vy = particle.position().y() / Acts::UnitConstants::mm;
     data.vz = particle.position().z() / Acts::UnitConstants::mm;
     data.vt = particle.time() / Acts::UnitConstants::ns;
-    const auto p = particle.absMomentum() / Acts::UnitConstants::GeV;
+    const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
     data.px = p * particle.unitDirection().x();
     data.py = p * particle.unitDirection().y();
     data.pz = p * particle.unitDirection().z();

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -43,7 +43,7 @@ ActsExamples::ProcessCode ActsExamples::CsvSimHitWriter::writeT(
   // Write data from internal impl. to output-side struct
   for (const auto& simHit : simHits) {
     // local simhit information in global coord.
-    const Acts::Vector4D& globalPos4 = simHit.position4();
+    const Acts::Vector4D& globalPos4 = simHit.fourPosition();
     const Acts::Vector4D& momentum4Before = simHit.momentum4Before();
 
     simhit.geometry_id = simHit.geometryId().value();

--- a/Examples/Io/HepMC3/src/HepMC3Event.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Event.cpp
@@ -19,7 +19,7 @@ namespace {
 HepMC3::GenParticlePtr actsParticleToGen(
     std::shared_ptr<ActsExamples::SimParticle> actsParticle) {
   // Extract momentum and energy from Acts particle for HepMC3::FourVector
-  const auto mom4 = actsParticle->momentum4();
+  const auto mom4 = actsParticle->fourMomentum();
   const HepMC3::FourVector vec(mom4[0], mom4[1], mom4[2], mom4[3]);
   // Create HepMC3::GenParticle
   HepMC3::GenParticle genParticle(vec, actsParticle->pdg());

--- a/Examples/Io/HepMC3/src/HepMC3Particle.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Particle.cpp
@@ -19,7 +19,7 @@ ActsExamples::SimParticle ActsExamples::HepMC3Particle::particle(
                  HepPID::charge(particle->pid()), particle->generated_mass());
   fw.setDirection(particle->momentum().x(), particle->momentum().y(),
                   particle->momentum().z());
-  fw.setAbsMomentum(particle->momentum().p3mod());
+  fw.setAbsoluteMomentum(particle->momentum().p3mod());
   return fw;
 }
 

--- a/Examples/Io/HepMC3/src/HepMC3Vertex.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Vertex.cpp
@@ -31,7 +31,7 @@ std::vector<ActsExamples::SimParticle> genParticlesToActs(
 HepMC3::GenParticlePtr actsParticleToGen(
     std::shared_ptr<ActsExamples::SimParticle> actsParticle) {
   // Extract momentum and energy from Acts particle for HepMC3::FourVector
-  const auto mom = actsParticle->momentum4();
+  const auto mom = actsParticle->fourMomentum();
   const HepMC3::FourVector vec(mom[0], mom[1], mom[2], mom[3]);
   // Create HepMC3::GenParticle
   HepMC3::GenParticle genParticle(vec, actsParticle->pdg());

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.cpp
@@ -207,7 +207,7 @@ struct ActsExamples::TrackFinderPerformanceWriter::Impl {
         prtVy = particle.position().y() / Acts::UnitConstants::mm;
         prtVz = particle.position().z() / Acts::UnitConstants::mm;
         prtVt = particle.time() / Acts::UnitConstants::ns;
-        const auto p = particle.absMomentum() / Acts::UnitConstants::GeV;
+        const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
         prtPx = p * particle.unitDirection().x();
         prtPy = p * particle.unitDirection().y();
         prtPz = p * particle.unitDirection().z();

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -101,7 +101,7 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
     m_vz = particle.position4().z() / Acts::UnitConstants::mm;
     m_vt = particle.position4().w() / Acts::UnitConstants::ns;
     // momentum
-    const auto p = particle.absMomentum() / Acts::UnitConstants::GeV;
+    const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
     m_px = p * particle.unitDirection().x();
     m_py = p * particle.unitDirection().y();
     m_pz = p * particle.unitDirection().z();

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -96,10 +96,10 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
     m_particleType = particle.pdg();
     m_process = static_cast<decltype(m_process)>(particle.process());
     // position
-    m_vx = particle.position4().x() / Acts::UnitConstants::mm;
-    m_vy = particle.position4().y() / Acts::UnitConstants::mm;
-    m_vz = particle.position4().z() / Acts::UnitConstants::mm;
-    m_vt = particle.position4().w() / Acts::UnitConstants::ns;
+    m_vx = particle.fourPosition().x() / Acts::UnitConstants::mm;
+    m_vy = particle.fourPosition().y() / Acts::UnitConstants::mm;
+    m_vz = particle.fourPosition().z() / Acts::UnitConstants::mm;
+    m_vt = particle.fourPosition().w() / Acts::UnitConstants::ns;
     // momentum
     const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
     m_px = p * particle.unitDirection().x();

--- a/Examples/Io/Root/src/RootSimHitWriter.cpp
+++ b/Examples/Io/Root/src/RootSimHitWriter.cpp
@@ -94,10 +94,10 @@ ActsExamples::ProcessCode ActsExamples::RootSimHitWriter::writeT(
     m_particleId = hit.particleId().value();
     m_geometryId = hit.geometryId().value();
     // write hit position
-    m_tx = hit.position4().x() / Acts::UnitConstants::mm;
-    m_ty = hit.position4().y() / Acts::UnitConstants::mm;
-    m_tz = hit.position4().z() / Acts::UnitConstants::mm;
-    m_tt = hit.position4().w() / Acts::UnitConstants::ns;
+    m_tx = hit.fourPosition().x() / Acts::UnitConstants::mm;
+    m_ty = hit.fourPosition().y() / Acts::UnitConstants::mm;
+    m_tz = hit.fourPosition().z() / Acts::UnitConstants::mm;
+    m_tt = hit.fourPosition().w() / Acts::UnitConstants::ns;
     // write four-momentum before interaction
     m_tpx = hit.momentum4Before().x() / Acts::UnitConstants::GeV;
     m_tpy = hit.momentum4Before().y() / Acts::UnitConstants::GeV;

--- a/Examples/Io/Root/src/RootTrajectoryParametersWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersWriter.cpp
@@ -177,7 +177,7 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryParametersWriter::writeT(
           const auto& particle = *ip;
           ACTS_DEBUG("Find the truth particle with barcode = " << m_t_barcode);
           // Get the truth particle info at vertex
-          const auto p = particle.absMomentum();
+          const auto p = particle.absoluteMomentum();
           m_t_charge = particle.charge();
           m_t_time = particle.time();
           m_t_vx = particle.position().x();

--- a/Examples/Io/Root/src/detail/AverageSimHits.hpp
+++ b/Examples/Io/Root/src/detail/AverageSimHits.hpp
@@ -69,7 +69,7 @@ averageSimHits(const Acts::GeometryContext& gCtx, const Acts::Surface& surface,
     }
     // global position should already be at the intersection. no need to perform
     // an additional intersection call.
-    avgPos4 += simHit.position4();
+    avgPos4 += simHit.fourPosition();
     avgDir += simHit.unitDirection();
   }
 

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -108,9 +108,10 @@ int main(int argc, char** argv) {
   for (auto& particle : particles)
     std::cout << HepPID::particleName(particle.pdg())
               << "\tID:" << particle.particleId() << ", momentum: ("
-              << particle.momentum4()(0) << ", " << particle.momentum4()(1)
-              << ", " << particle.momentum4()(2)
-              << "), mass:  " << particle.mass() << std::endl;
+              << particle.fourMomentum()(0) << ", "
+              << particle.fourMomentum()(1) << ", "
+              << particle.fourMomentum()(2) << "), mass:  " << particle.mass()
+              << std::endl;
 
   std::cout << std::endl << "Initial to final state: ";
   std::vector<ActsExamples::SimParticle> fState = finalState(genevt);

--- a/Fatras/include/ActsFatras/EventData/Hit.hpp
+++ b/Fatras/include/ActsFatras/EventData/Hit.hpp
@@ -68,7 +68,7 @@ class Hit {
   constexpr int32_t index() const { return m_index; }
 
   /// Space-time position four-vector.
-  const Vector4& position4() const { return m_pos4; }
+  const Vector4& fourPosition() const { return m_pos4; }
   /// Three-position, i.e. spatial coordinates without the time.
   auto position() const { return m_pos4.segment<3>(Acts::ePos0); }
   /// Time coordinate.

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -100,7 +100,7 @@ class Particle {
     return *this;
   }
   /// Set the absolute momentum.
-  Particle &setAbsMomentum(Scalar absMomentum) {
+  Particle &setAbsoluteMomentum(Scalar absMomentum) {
     m_absMomentum = absMomentum;
     return *this;
   }
@@ -153,7 +153,7 @@ class Particle {
     return m_absMomentum * m_unitDirection.segment<2>(Acts::eMom0).norm();
   }
   /// Absolute momentum.
-  constexpr Scalar absMomentum() const { return m_absMomentum; }
+  constexpr Scalar absoluteMomentum() const { return m_absMomentum; }
   /// Total energy, i.e. norm of the four-momentum.
   Scalar energy() const { return std::hypot(m_mass, m_absMomentum); }
 

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -137,7 +137,7 @@ class Particle {
   /// Time coordinate.
   Scalar time() const { return m_position4[Acts::eTime]; }
   /// Energy-momentum four-vector.
-  Vector4 momentum4() const {
+  Vector4 fourMomentum() const {
     Vector4 mom4;
     // stored direction is always normalized
     mom4[Acts::eMom0] = m_absMomentum * m_unitDirection[Acts::ePos0];

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -131,7 +131,7 @@ class Particle {
   constexpr Scalar mass() const { return m_mass; }
 
   /// Space-time position four-vector.
-  constexpr const Vector4 &position4() const { return m_position4; }
+  constexpr const Vector4 &fourPosition() const { return m_position4; }
   /// Three-position, i.e. spatial coordinates without the time.
   auto position() const { return m_position4.segment<3>(Acts::ePos0); }
   /// Time coordinate.

--- a/Fatras/include/ActsFatras/Kernel/Simulator.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulator.hpp
@@ -95,7 +95,7 @@ struct ParticleSimulator {
     interactor.particle = particle;
     // use AnyCharge to be able to handle neutral and charged parameters
     Acts::SingleCurvilinearTrackParameters<Acts::AnyCharge> start(
-        particle.position4(), particle.unitDirection(),
+        particle.fourPosition(), particle.unitDirection(),
         particle.absoluteMomentum(), particle.charge());
     auto result = propagator.propagate(start, options);
     if (result.ok()) {

--- a/Fatras/include/ActsFatras/Kernel/Simulator.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulator.hpp
@@ -95,8 +95,8 @@ struct ParticleSimulator {
     interactor.particle = particle;
     // use AnyCharge to be able to handle neutral and charged parameters
     Acts::SingleCurvilinearTrackParameters<Acts::AnyCharge> start(
-        particle.position4(), particle.unitDirection(), particle.absMomentum(),
-        particle.charge());
+        particle.position4(), particle.unitDirection(),
+        particle.absoluteMomentum(), particle.charge());
     auto result = propagator.propagate(start, options);
     if (result.ok()) {
       return result.value().template get<InteractorResult>();

--- a/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
@@ -90,7 +90,7 @@ struct Interactor {
             .setPosition4(stepper.position(state.stepping),
                           stepper.time(state.stepping))
             .setDirection(stepper.direction(state.stepping))
-            .setAbsMomentum(stepper.momentum(state.stepping));
+            .setAbsoluteMomentum(stepper.momentum(state.stepping));
     // we want to keep the particle state before and after the interaction.
     // since the particle is modified in-place we need a copy.
     Particle after = before;
@@ -148,7 +148,7 @@ struct Interactor {
 
     // continue the propagation with the modified parameters
     stepper.update(state.stepping, after.position(), after.unitDirection(),
-                   after.absMomentum(), after.time());
+                   after.absoluteMomentum(), after.time());
   }
 
   /// Pure observer interface. Does not apply to the Fatras simulator.

--- a/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
@@ -142,7 +142,7 @@ struct Interactor {
       result.hits.emplace_back(
           surface.geometryId(), before.particleId(),
           // the interaction could potentially modify the particle position
-          Hit::Scalar(0.5) * (before.position4() + after.position4()),
+          Hit::Scalar(0.5) * (before.fourPosition() + after.fourPosition()),
           before.momentum4(), after.momentum4(), result.hits.size());
     }
 

--- a/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/Interactor.hpp
@@ -143,7 +143,7 @@ struct Interactor {
           surface.geometryId(), before.particleId(),
           // the interaction could potentially modify the particle position
           Hit::Scalar(0.5) * (before.fourPosition() + after.fourPosition()),
-          before.momentum4(), after.momentum4(), result.hits.size());
+          before.fourMomentum(), after.fourMomentum(), result.hits.size());
     }
 
     // continue the propagation with the modified parameters

--- a/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheBloch.hpp
+++ b/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheBloch.hpp
@@ -43,7 +43,7 @@ struct BetheBloch {
     // compute energy loss distribution parameters
     const auto pdg = particle.pdg();
     const auto m = particle.mass();
-    const auto qOverP = particle.charge() / particle.absMomentum();
+    const auto qOverP = particle.charge() / particle.absoluteMomentum();
     const auto q = particle.charge();
     // most probable value
     const auto energyLoss =

--- a/Fatras/include/ActsFatras/Physics/Scattering/GaussianMixture.hpp
+++ b/Fatras/include/ActsFatras/Physics/Scattering/GaussianMixture.hpp
@@ -44,7 +44,7 @@ struct GaussianMixture {
     /// Calculate the highland formula first
     double sigma = Acts::computeMultipleScatteringTheta0(
         slab, particle.pdg(), particle.mass(),
-        particle.charge() / particle.absMomentum(), particle.charge());
+        particle.charge() / particle.absoluteMomentum(), particle.charge());
     double sigma2 = sigma * sigma;
 
     // Gauss distribution, will be sampled with generator
@@ -56,7 +56,7 @@ struct GaussianMixture {
     // d_0'
     // beta² = (p/E)² = p²/(p² + m²) = 1/(1 + (m/p)²)
     // 1/beta² = 1 + (m/p)²
-    double mOverP = particle.mass() / particle.absMomentum();
+    double mOverP = particle.mass() / particle.absoluteMomentum();
     double beta2inv = 1 + mOverP * mOverP;
     double dprime = slab.thicknessInX0() * beta2inv;
     double log_dprime = std::log(dprime);
@@ -78,8 +78,8 @@ struct GaussianMixture {
 
     // G4 optimised / native double Gaussian model
     if (optGaussianMixtureG4) {
-      sigma2 =
-          225. * dprime / (particle.absMomentum() * particle.absMomentum());
+      sigma2 = 225. * dprime /
+               (particle.absoluteMomentum() * particle.absoluteMomentum());
     }
     // throw the random number core/tail
     if (uniformDist(generator) < epsilon) {

--- a/Fatras/include/ActsFatras/Physics/Scattering/GeneralMixture.hpp
+++ b/Fatras/include/ActsFatras/Physics/Scattering/GeneralMixture.hpp
@@ -55,7 +55,7 @@ struct GeneralMixture {
       //   beta² = (p/E)² = p²/(p² + m²) = 1/(1 + (m/p)²)
       // 1/beta² = 1 + (m/p)²
       //    beta = 1/sqrt(1 + (m/p)²)
-      double mOverP = particle.mass() / particle.absMomentum();
+      double mOverP = particle.mass() / particle.absoluteMomentum();
       double beta2Inv = 1 + mOverP * mOverP;
       double beta = 1 / std::sqrt(beta2Inv);
       double tInX0 = slab.thicknessInX0();
@@ -63,11 +63,11 @@ struct GeneralMixture {
       if (tob2 > 0.6 / std::pow(slab.material().Z(), 0.6)) {
         // Gaussian mixture or pure Gaussian
         if (tob2 > 10) {
-          scattering_params = getGaussian(beta, particle.absMomentum(), tInX0,
-                                          genMixtureScalor);
+          scattering_params = getGaussian(beta, particle.absoluteMomentum(),
+                                          tInX0, genMixtureScalor);
         } else {
           scattering_params =
-              getGaussmix(beta, particle.absMomentum(), tInX0,
+              getGaussmix(beta, particle.absoluteMomentum(), tInX0,
                           slab.material().Z(), genMixtureScalor);
         }
         // Simulate
@@ -75,7 +75,7 @@ struct GeneralMixture {
       } else {
         // Semigaussian mixture - get parameters
         auto scattering_params_sg =
-            getSemigauss(beta, particle.absMomentum(), tInX0,
+            getSemigauss(beta, particle.absoluteMomentum(), tInX0,
                          slab.material().Z(), genMixtureScalor);
         // Simulate
         theta = semigauss(generator, scattering_params_sg);
@@ -85,7 +85,7 @@ struct GeneralMixture {
       // return projection factor times sigma times gauss random
       const auto theta0 = Acts::computeMultipleScatteringTheta0(
           slab, particle.pdg(), particle.mass(),
-          particle.charge() / particle.absMomentum(), particle.charge());
+          particle.charge() / particle.absoluteMomentum(), particle.charge());
       theta = std::normal_distribution<double>(0.0, theta0)(generator);
     }
     // scale from planar to 3d angle

--- a/Fatras/include/ActsFatras/Physics/Scattering/Highland.hpp
+++ b/Fatras/include/ActsFatras/Physics/Scattering/Highland.hpp
@@ -35,7 +35,7 @@ struct Highland {
     // compute the planar scattering angle
     const auto theta0 = Acts::computeMultipleScatteringTheta0(
         slab, particle.pdg(), particle.mass(),
-        particle.charge() / particle.absMomentum(), particle.charge());
+        particle.charge() / particle.absoluteMomentum(), particle.charge());
     // draw from the normal distribution representing the 3d angle distribution
     return std::normal_distribution<double>(0.0, M_SQRT2 * theta0)(generator);
   }

--- a/Fatras/include/ActsFatras/Selectors/KinematicCasts.hpp
+++ b/Fatras/include/ActsFatras/Selectors/KinematicCasts.hpp
@@ -56,15 +56,16 @@ struct AbsEta {
 struct Pt {
   double operator()(const Particle& particle) const {
     // particle direction is always normalized, i.e. dt²+dz²=1 w/ dt²=dx²+dy²
-    return particle.absMomentum() * std::hypot(particle.unitDirection().x(),
-                                               particle.unitDirection().y());
+    return particle.absoluteMomentum() *
+           std::hypot(particle.unitDirection().x(),
+                      particle.unitDirection().y());
   }
 };
 
 /// Retrieve the absolute momentum.
 struct P {
   double operator()(const Particle& particle) const {
-    return particle.absMomentum();
+    return particle.absoluteMomentum();
   }
 };
 

--- a/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
+++ b/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
@@ -39,11 +39,12 @@ struct SplitEnergyLoss {
   bool operator()(generator_t&, const Acts::MaterialSlab&,
                   ActsFatras::Particle& particle,
                   std::vector<ActsFatras::Particle>& generated) const {
-    const auto p = particle.absMomentum();
+    const auto p = particle.absoluteMomentum();
     if (splitMomentumMin < p) {
-      particle.setAbsMomentum(0.5 * p);
+      particle.setAbsoluteMomentum(0.5 * p);
       const auto pid = particle.particleId().makeDescendant();
-      generated.push_back(particle.withParticleId(pid).setAbsMomentum(0.5 * p));
+      generated.push_back(
+          particle.withParticleId(pid).setAbsoluteMomentum(0.5 * p));
     }
     // never break
     return false;
@@ -182,7 +183,7 @@ BOOST_DATA_TEST_CASE(FatrasSimulation, dataset, pdg, phi, eta, p,
     const auto particle =
         ActsFatras::Particle(pid, pdg)
             .setDirection(Acts::makeDirectionUnitFromPhiEta(phi, eta))
-            .setAbsMomentum(p);
+            .setAbsoluteMomentum(p);
     input.push_back(std::move(particle));
   }
   BOOST_TEST_INFO(input.front());

--- a/Tests/UnitTests/Fatras/EventData/HitTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/HitTests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(WithoutInteraction) {
   BOOST_CHECK_EQUAL(h.geometryId(), gid);
   BOOST_CHECK_EQUAL(h.particleId(), pid);
   BOOST_CHECK_EQUAL(h.index(), 12u);
-  CHECK_CLOSE_REL(h.position4(), p4, eps);
+  CHECK_CLOSE_REL(h.fourPosition(), p4, eps);
   CHECK_CLOSE_REL(h.position(), Hit::Vector3(1, 2, 3), eps);
   CHECK_CLOSE_REL(h.time(), 4, eps);
   CHECK_CLOSE_REL(h.momentum4Before(), m4, eps);
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(WithEnergyLoss) {
   BOOST_CHECK_EQUAL(h.geometryId(), gid);
   BOOST_CHECK_EQUAL(h.particleId(), pid);
   BOOST_CHECK_EQUAL(h.index(), 13u);
-  CHECK_CLOSE_REL(h.position4(), p4, eps);
+  CHECK_CLOSE_REL(h.fourPosition(), p4, eps);
   CHECK_CLOSE_REL(h.position(), Hit::Vector3(1, 2, 3), eps);
   CHECK_CLOSE_REL(h.time(), 4, eps);
   CHECK_CLOSE_OR_SMALL(h.momentum4Before(), m40, eps, eps);
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(WithScattering) {
   BOOST_CHECK_EQUAL(h.geometryId(), gid);
   BOOST_CHECK_EQUAL(h.particleId(), pid);
   BOOST_CHECK_EQUAL(h.index(), 42u);
-  CHECK_CLOSE_REL(h.position4(), p4, eps);
+  CHECK_CLOSE_REL(h.fourPosition(), p4, eps);
   CHECK_CLOSE_REL(h.position(), Hit::Vector3(1, 2, 3), eps);
   CHECK_CLOSE_REL(h.time(), 4, eps);
   CHECK_CLOSE_OR_SMALL(h.momentum4Before(), m40, eps, eps);
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(WithEverything) {
   BOOST_CHECK_EQUAL(h.geometryId(), gid);
   BOOST_CHECK_EQUAL(h.particleId(), pid);
   BOOST_CHECK_EQUAL(h.index(), 1u);
-  CHECK_CLOSE_REL(h.position4(), p4, eps);
+  CHECK_CLOSE_REL(h.fourPosition(), p4, eps);
   CHECK_CLOSE_REL(h.position(), Hit::Vector3(1, 2, 3), eps);
   CHECK_CLOSE_REL(h.time(), 4, eps);
   CHECK_CLOSE_OR_SMALL(h.momentum4Before(), m40, eps, eps);

--- a/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(Construct) {
   // particle direction is undefined, but must be normalized
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), Particle::Scalar(0));
-  BOOST_CHECK_EQUAL(particle.absMomentum(), Particle::Scalar(0));
+  BOOST_CHECK_EQUAL(particle.absoluteMomentum(), Particle::Scalar(0));
   // particle is created at rest and thus not alive
   BOOST_CHECK(not particle);
 }
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
   const auto pid = Barcode().setVertexPrimary(1).setParticle(42);
   auto particle = Particle(pid, PdgParticle::eProton, 1_GeV, 1_e)
                       .setDirection(Particle::Vector3::UnitX())
-                      .setAbsMomentum(2_GeV);
+                      .setAbsoluteMomentum(2_GeV);
 
   BOOST_CHECK_EQUAL(particle.mass(), 1_GeV);
   // check that the particle has some input energy
@@ -60,14 +60,14 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
   BOOST_CHECK_EQUAL(particle.momentum4().z(), 0_GeV);
   BOOST_CHECK_EQUAL(particle.momentum4().w(), std::hypot(1_GeV, 2_GeV));
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), 2_GeV);
-  BOOST_CHECK_EQUAL(particle.absMomentum(), 2_GeV);
+  BOOST_CHECK_EQUAL(particle.absoluteMomentum(), 2_GeV);
   BOOST_CHECK_EQUAL(particle.energy(), std::hypot(1_GeV, 2_GeV));
   // particle direction must be normalized
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // loose some energy
   particle.correctEnergy(-100_MeV);
   BOOST_CHECK_LT(particle.transverseMomentum(), 2_GeV);
-  BOOST_CHECK_LT(particle.absMomentum(), 2_GeV);
+  BOOST_CHECK_LT(particle.absoluteMomentum(), 2_GeV);
   BOOST_CHECK_EQUAL(particle.energy(),
                     Particle::Scalar(std::hypot(1_GeV, 2_GeV) - 100_MeV));
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
@@ -76,13 +76,13 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
   // loose a lot of energy
   particle.correctEnergy(-3_GeV);
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), Particle::Scalar(0));
-  BOOST_CHECK_EQUAL(particle.absMomentum(), Particle::Scalar(0));
+  BOOST_CHECK_EQUAL(particle.absoluteMomentum(), Particle::Scalar(0));
   BOOST_CHECK_EQUAL(particle.energy(), particle.mass());
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // lossing even more energy does nothing
   particle.correctEnergy(-10_GeV);
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), Particle::Scalar(0));
-  BOOST_CHECK_EQUAL(particle.absMomentum(), Particle::Scalar(0));
+  BOOST_CHECK_EQUAL(particle.absoluteMomentum(), Particle::Scalar(0));
   BOOST_CHECK_EQUAL(particle.energy(), particle.mass());
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // particle is not alive anymore

--- a/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
@@ -55,10 +55,10 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
 
   BOOST_CHECK_EQUAL(particle.mass(), 1_GeV);
   // check that the particle has some input energy
-  BOOST_CHECK_EQUAL(particle.momentum4().x(), 2_GeV);
-  BOOST_CHECK_EQUAL(particle.momentum4().y(), 0_GeV);
-  BOOST_CHECK_EQUAL(particle.momentum4().z(), 0_GeV);
-  BOOST_CHECK_EQUAL(particle.momentum4().w(), std::hypot(1_GeV, 2_GeV));
+  BOOST_CHECK_EQUAL(particle.fourMomentum().x(), 2_GeV);
+  BOOST_CHECK_EQUAL(particle.fourMomentum().y(), 0_GeV);
+  BOOST_CHECK_EQUAL(particle.fourMomentum().z(), 0_GeV);
+  BOOST_CHECK_EQUAL(particle.fourMomentum().w(), std::hypot(1_GeV, 2_GeV));
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), 2_GeV);
   BOOST_CHECK_EQUAL(particle.absoluteMomentum(), 2_GeV);
   BOOST_CHECK_EQUAL(particle.energy(), std::hypot(1_GeV, 2_GeV));

--- a/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
@@ -32,13 +32,13 @@ BOOST_AUTO_TEST_CASE(Construct) {
   BOOST_CHECK_EQUAL(particle.particleId(), pid);
   BOOST_CHECK_EQUAL(particle.pdg(), PdgParticle::eProton);
   // particle is at rest at the origin
-  BOOST_CHECK_EQUAL(particle.position4(), Particle::Vector4::Zero());
+  BOOST_CHECK_EQUAL(particle.fourPosition(), Particle::Vector4::Zero());
   BOOST_CHECK_EQUAL(particle.position(), Particle::Vector3::Zero());
   BOOST_CHECK_EQUAL(particle.time(), Particle::Scalar(0));
-  BOOST_CHECK_EQUAL(particle.position4().x(), particle.position().x());
-  BOOST_CHECK_EQUAL(particle.position4().y(), particle.position().y());
-  BOOST_CHECK_EQUAL(particle.position4().z(), particle.position().z());
-  BOOST_CHECK_EQUAL(particle.position4().w(), particle.time());
+  BOOST_CHECK_EQUAL(particle.fourPosition().x(), particle.position().x());
+  BOOST_CHECK_EQUAL(particle.fourPosition().y(), particle.position().y());
+  BOOST_CHECK_EQUAL(particle.fourPosition().z(), particle.position().z());
+  BOOST_CHECK_EQUAL(particle.fourPosition().w(), particle.time());
   // particle direction is undefined, but must be normalized
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), Particle::Scalar(0));

--- a/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/InteractorTests.cpp
@@ -97,7 +97,7 @@ struct Fixture {
                  Acts::PdgParticle::eProton, 0, 1)
             .setPosition4(1, 2, 3, 4)
             .setDirection(1, 0, 0)
-            .setAbsMomentum(100);
+            .setAbsoluteMomentum(100);
     interactor.generator = &generator;
     interactor.physics.energyLoss = energyLoss;
     interactor.particle = particle;
@@ -105,7 +105,7 @@ struct Fixture {
     state.stepping.position = particle.position();
     state.stepping.time = particle.time();
     state.stepping.direction = particle.unitDirection();
-    state.stepping.momentum = particle.absMomentum();
+    state.stepping.momentum = particle.absoluteMomentum();
   }
 };
 

--- a/Tests/UnitTests/Fatras/Kernel/ProcessTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/ProcessTests.cpp
@@ -30,10 +30,10 @@ struct MakeChildren {
                                                  ActsFatras::Particle &) const {
     // create daughter particles
     return {
-        Particle().setAbsMomentum(1_GeV),
-        Particle().setAbsMomentum(2_GeV),
-        Particle().setAbsMomentum(3_GeV),
-        Particle().setAbsMomentum(4_GeV),
+        Particle().setAbsoluteMomentum(1_GeV),
+        Particle().setAbsoluteMomentum(2_GeV),
+        Particle().setAbsoluteMomentum(3_GeV),
+        Particle().setAbsoluteMomentum(4_GeV),
     };
   }
 };
@@ -43,14 +43,14 @@ struct HighP {
   double minP = 10_GeV;
 
   bool operator()(const ActsFatras::Particle &particle) const {
-    return (minP <= particle.absMomentum());
+    return (minP <= particle.absoluteMomentum());
   }
 };
 
 struct Fixture {
   std::default_random_engine generator;
   Acts::MaterialSlab slab{Acts::Test::makeBeryllium(), 1_mm};
-  Particle parent = Particle().setAbsMomentum(10_GeV);
+  Particle parent = Particle().setAbsoluteMomentum(10_GeV);
   std::vector<Particle> children;
 };
 }  // namespace
@@ -72,15 +72,15 @@ BOOST_AUTO_TEST_CASE(WithInputSelector) {
   process.selectInput.minP = 10_GeV;
 
   // above threshold should not abort
-  f.parent.setAbsMomentum(20_GeV);
+  f.parent.setAbsoluteMomentum(20_GeV);
   BOOST_CHECK(not process(f.generator, f.slab, f.parent, f.children));
   BOOST_CHECK_EQUAL(f.children.size(), 4u);
   // on threshold should still not abort
-  f.parent.setAbsMomentum(10_GeV);
+  f.parent.setAbsoluteMomentum(10_GeV);
   BOOST_CHECK(not process(f.generator, f.slab, f.parent, f.children));
   BOOST_CHECK_EQUAL(f.children.size(), 8u);
   // below threshold should abort and not run the process at all
-  f.parent.setAbsMomentum(2_GeV);
+  f.parent.setAbsoluteMomentum(2_GeV);
   BOOST_CHECK(not process(f.generator, f.slab, f.parent, f.children));
   // process did not run -> no new children
   BOOST_CHECK_EQUAL(f.children.size(), 8u);
@@ -92,15 +92,15 @@ BOOST_AUTO_TEST_CASE(WithOutputSelector) {
   process.selectOutputParticle.minP = 10_GeV;
 
   // above threshold should not abort
-  f.parent.setAbsMomentum(20_GeV);
+  f.parent.setAbsoluteMomentum(20_GeV);
   BOOST_CHECK(not process(f.generator, f.slab, f.parent, f.children));
   BOOST_CHECK_EQUAL(f.children.size(), 4u);
   // on threshold should still not abort
-  f.parent.setAbsMomentum(10_GeV);
+  f.parent.setAbsoluteMomentum(10_GeV);
   BOOST_CHECK(not process(f.generator, f.slab, f.parent, f.children));
   BOOST_CHECK_EQUAL(f.children.size(), 8u);
   // below threshold should abort but only after running the process
-  f.parent.setAbsMomentum(2_GeV);
+  f.parent.setAbsoluteMomentum(2_GeV);
   BOOST_CHECK(process(f.generator, f.slab, f.parent, f.children));
   // process did still run -> new children
   BOOST_CHECK_EQUAL(f.children.size(), 12u);

--- a/Tests/UnitTests/Fatras/Physics/Dataset.hpp
+++ b/Tests/UnitTests/Fatras/Physics/Dataset.hpp
@@ -50,7 +50,7 @@ inline ActsFatras::Particle makeParticle(Acts::PdgParticle pdg, double phi,
       .setPosition4(0, 0, 0, 0)
       .setDirection(std::cos(lambda) * std::cos(phi),
                     std::cos(lambda) * std::sin(phi), std::sin(lambda))
-      .setAbsMomentum(p);
+      .setAbsoluteMomentum(p);
 }
 
 }  // namespace Dataset

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -32,7 +32,7 @@ BOOST_DATA_TEST_CASE(BetheBloch, Dataset::parameters, pdg, phi, lambda, p,
   ActsFatras::BetheBloch process;
   const auto outgoing = process(gen, Acts::Test::makeUnitSlab(), after);
   // energy loss changes momentum and energy
-  BOOST_CHECK_LT(after.absMomentum(), before.absMomentum());
+  BOOST_CHECK_LT(after.absoluteMomentum(), before.absoluteMomentum());
   BOOST_CHECK_LT(after.energy(), before.energy());
   // energy loss creates no new particles
   BOOST_CHECK(outgoing.empty());
@@ -47,7 +47,7 @@ BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
   ActsFatras::BetheHeitler process;
   const auto outgoing = process(gen, Acts::Test::makeUnitSlab(), after);
   // energy loss changes momentum and energy
-  BOOST_CHECK_LT(after.absMomentum(), before.absMomentum());
+  BOOST_CHECK_LT(after.absoluteMomentum(), before.absoluteMomentum());
   BOOST_CHECK_LT(after.energy(), before.energy());
   // energy loss creates no new particles
   BOOST_CHECK(outgoing.empty());

--- a/Tests/UnitTests/Fatras/Physics/ScatteringTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/ScatteringTests.cpp
@@ -34,7 +34,7 @@ void test(const Scattering& scattering, uint32_t seed,
 
   const auto outgoing = scattering(gen, Acts::Test::makePercentSlab(), after);
   // scattering leaves absolute energy/momentum unchanged
-  CHECK_CLOSE_REL(after.absMomentum(), before.absMomentum(), eps);
+  CHECK_CLOSE_REL(after.absoluteMomentum(), before.absoluteMomentum(), eps);
   CHECK_CLOSE_REL(after.energy(), before.energy(), eps);
   // scattering has changed the direction
   BOOST_CHECK_LT(before.unitDirection().dot(after.unitDirection()), 1);

--- a/Tests/UnitTests/Fatras/Selectors/Dataset.hpp
+++ b/Tests/UnitTests/Fatras/Selectors/Dataset.hpp
@@ -21,7 +21,7 @@ ActsFatras::Particle makeParticle(Acts::PdgParticle pdg, double z, double eta) {
   return ActsFatras::Particle(id, pdg)
       .setPosition4(0.0, 0.0, z, 0.0)
       .setDirection(1.0 / std::cosh(eta), 0.0, std::tanh(eta))
-      .setAbsMomentum(1.5_GeV);
+      .setAbsoluteMomentum(1.5_GeV);
 }
 
 const auto centralElectron =


### PR DESCRIPTION
This renames some Fatras particle properties accessors as follows
```cpp
particle.fourPosition();
particle.fourMomentum();
particle.absoluteMomentum();
```
to match the naming of equivalent track parameters accessors in the core.

Closes #448.