### PR TITLE
ci: Use clang-format 10

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format8:v5
+    container: ghcr.io/acts-project/format10:v5
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/CI/check_format_local
+++ b/CI/check_format_local
@@ -17,5 +17,5 @@ docker run --rm -ti \
        -v ${WD}:/work_dir:rw \
        --user "${USER_ID}:${GROUP_ID}" \
        -w "/work_dir" \
-       gitlab-registry.cern.ch/acts/machines/format8:master \
+       ghcr.io/acts-project/format10:v5 \
        CI/check_format .

--- a/Core/include/Acts/MagneticField/SharedBField.hpp
+++ b/Core/include/Acts/MagneticField/SharedBField.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <memory>
 
 namespace Acts {

--- a/Core/include/Acts/Material/Material.hpp
+++ b/Core/include/Acts/Material/Material.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <iosfwd>
 #include <limits>
 

--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Common.hpp"
+
 #include <algorithm>
 #include <array>
 #include <iomanip>

--- a/Core/include/Acts/Seeding/InternalSpacePoint.hpp
+++ b/Core/include/Acts/Seeding/InternalSpacePoint.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <array>
 #include <cmath>
 #include <limits>

--- a/Core/include/Acts/Surfaces/detail/AlignmentHelper.hpp
+++ b/Core/include/Acts/Surfaces/detail/AlignmentHelper.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <utility>
 #include <vector>
 

--- a/Core/include/Acts/Surfaces/detail/IntersectionHelper2D.hpp
+++ b/Core/include/Acts/Surfaces/detail/IntersectionHelper2D.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <array>
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/Intersection.hpp"
+
+#include <array>
 
 namespace Acts {
 namespace detail {

--- a/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
+++ b/Core/include/Acts/Surfaces/detail/VerticesHelper.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Common.hpp"
+
 #include <utility>
 #include <vector>
 

--- a/Core/include/Acts/Utilities/AnnealingUtility.hpp
+++ b/Core/include/Acts/Utilities/AnnealingUtility.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <vector>
 
 namespace Acts {

--- a/Core/include/Acts/Utilities/BinAdjustment.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustment.hpp
@@ -12,12 +12,10 @@
 
 #pragma once
 
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
-#include "Acts/Utilities/BinUtility.hpp"
-
-#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 
 #include <stdexcept>

--- a/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
+++ b/Core/include/Acts/Utilities/BinAdjustmentVolume.hpp
@@ -12,12 +12,11 @@
 
 #pragma once
 
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CutoutCylinderVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/Volume.hpp"
-
-#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 
 #include <stdexcept>

--- a/Core/include/Acts/Utilities/Intersection.hpp
+++ b/Core/include/Acts/Utilities/Intersection.hpp
@@ -11,9 +11,9 @@
 ///////////////////////////////////////////////////////////////////
 
 #pragma once
-#include <limits>
-
 #include "Acts/Definitions/Algebra.hpp"
+
+#include <limits>
 namespace Acts {
 
 ///  @struct Intersection

--- a/Core/include/Acts/Utilities/MultiIndex.hpp
+++ b/Core/include/Acts/Utilities/MultiIndex.hpp
@@ -152,8 +152,8 @@ class MultiIndex {
 namespace std {
 template <typename Storage, std::size_t... BitsPerLevel>
 struct hash<Acts::MultiIndex<Storage, BitsPerLevel...>> {
-  auto operator()(Acts::MultiIndex<Storage, BitsPerLevel...> idx) const
-      noexcept {
+  auto operator()(
+      Acts::MultiIndex<Storage, BitsPerLevel...> idx) const noexcept {
     return std::hash<Storage>()(idx.value());
   }
 };

--- a/Core/include/Acts/Utilities/UnitVectors.hpp
+++ b/Core/include/Acts/Utilities/UnitVectors.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <cmath>
 #include <limits>
 #include <utility>

--- a/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
+++ b/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
@@ -23,7 +23,7 @@ namespace hana = boost::hana;
 struct result_type_extractor {
   // Checks whether the type even has a result type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::result_type>{});
+      [](auto t) -> hana::type<typename decltype(t)::type::result_type> {});
   // meta function to extract the result type
   template <typename T>
   using extractor_impl = typename T::result_type;
@@ -38,7 +38,7 @@ struct result_type_extractor {
 struct action_type_extractor {
   // Checks if aborter even has action type
   static constexpr auto predicate = hana::is_valid(
-      [](auto t) -> hana::type<typename decltype(t)::type::action_type>{});
+      [](auto t) -> hana::type<typename decltype(t)::type::action_type> {});
   // meta function to extract the action type
   template <typename T>
   using extractor_impl = typename T::action_type;

--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -30,6 +30,7 @@
 #include <iosfwd>
 #include <iterator>
 #include <vector>
+
 #include <math.h>
 
 Acts::CylinderVolumeBuilder::CylinderVolumeBuilder(

--- a/Core/src/MagneticField/SolenoidBField.cpp
+++ b/Core/src/MagneticField/SolenoidBField.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Utilities/Helpers.hpp"
 
 #include <algorithm>
+
 #include <boost/exception/exception.hpp>
 #include <boost/math/special_functions/ellint_1.hpp>
 #include <boost/math/special_functions/ellint_2.hpp>

--- a/Core/src/Surfaces/IntersectionHelper2D.cpp
+++ b/Core/src/Surfaces/IntersectionHelper2D.cpp
@@ -6,13 +6,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
+
+#include "Acts/Utilities/Helpers.hpp"
+#include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
+
 #include <cmath>
 #include <iostream>
 #include <tuple>
-
-#include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
-#include "Acts/Utilities/Helpers.hpp"
-#include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
 
 Acts::Intersection2D Acts::detail::IntersectionHelper2D::intersectSegment(
     const Vector2D& s0, const Vector2D& s1, const Vector2D& origin,

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/LineSurface.hpp"
 
 #include "Acts/Utilities/ThrowAssert.hpp"
+
 #include <cmath>
 #include <utility>
 

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Utilities/Result.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsFatras/Digitization/DigitizationError.hpp"
+
 #include <climits>
 #include <cmath>
 #include <exception>

--- a/Examples/Algorithms/Geant4/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4/src/EventAction.cpp
@@ -8,12 +8,13 @@
 
 #include "EventAction.hpp"
 
+#include "ActsExamples/Geant4/PrimaryGeneratorAction.hpp"
+
 #include <stdexcept>
 
 #include <G4Event.hh>
 #include <G4RunManager.hh>
 
-#include "ActsExamples/Geant4/PrimaryGeneratorAction.hpp"
 #include "SteppingAction.hpp"
 
 using namespace ActsExamples;

--- a/Examples/Algorithms/Geant4HepMC/include/ActsExamples/Geant4HepMC/EventRecording.hpp
+++ b/Examples/Algorithms/Geant4HepMC/include/ActsExamples/Geant4HepMC/EventRecording.hpp
@@ -8,14 +8,15 @@
 
 #pragma once
 
-#include <memory>
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Propagator/MaterialInteractor.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
+
+#include <memory>
 #include <mutex>
+
 #include <G4VUserDetectorConstruction.hh>
 #include <HepMC3/GenEvent.h>
 

--- a/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
@@ -7,9 +7,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "EventAction.hpp"
+
 #include <stdexcept>
+
 #include <G4Event.hh>
 #include <G4RunManager.hh>
+
 #include "SteppingAction.hpp"
 
 namespace {

--- a/Examples/Algorithms/Geant4HepMC/src/EventAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventAction.hpp
@@ -11,10 +11,10 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <G4UserEventAction.hh>
-#include <globals.hh>
 
+#include <G4UserEventAction.hh>
 #include <HepMC3/GenEvent.h>
+#include <globals.hh>
 
 namespace ActsExamples {
 

--- a/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
@@ -7,19 +7,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Geant4HepMC/EventRecording.hpp"
+
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Geant4/GdmlDetectorConstruction.hpp"
+
 #include <iostream>
 #include <stdexcept>
+
 #include <FTFP_BERT.hh>
+#include <HepMC3/GenParticle.h>
+
 #include "EventAction.hpp"
 #include "G4RunManager.hh"
 #include "PrimaryGeneratorAction.hpp"
 #include "RunAction.hpp"
 #include "SteppingAction.hpp"
-
-#include <HepMC3/GenParticle.h>
 
 ActsExamples::EventRecording::~EventRecording() {
   m_runManager = nullptr;

--- a/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
@@ -7,8 +7,11 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "PrimaryGeneratorAction.hpp"
+
 #include "Acts/Definitions/Units.hpp"
+
 #include <stdexcept>
+
 #include <G4Event.hh>
 #include <G4ParticleDefinition.hh>
 #include <G4ParticleGun.hh>

--- a/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.hpp
@@ -9,7 +9,9 @@
 #pragma once
 
 #include "ActsExamples/EventData/SimParticle.hpp"
+
 #include <memory>
+
 #include <G4ParticleTable.hh>
 #include <G4SystemOfUnits.hh>
 #include <G4ThreeVector.hh>

--- a/Examples/Algorithms/Geant4HepMC/src/SteppingAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/SteppingAction.cpp
@@ -7,14 +7,16 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "SteppingAction.hpp"
+
 #include <stdexcept>
+
 #include <G4RunManager.hh>
 #include <G4Step.hh>
 #include <G4VProcess.hh>
-#include "EventAction.hpp"
-
 #include <HepMC3/Attribute.h>
 #include <HepMC3/Units.h>
+
+#include "EventAction.hpp"
 
 ActsExamples::SteppingAction* ActsExamples::SteppingAction::s_instance =
     nullptr;

--- a/Examples/Algorithms/Geant4HepMC/src/SteppingAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/SteppingAction.hpp
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <vector>
-#include <G4UserSteppingAction.hh>
-#include <globals.hh>
 
+#include <G4UserSteppingAction.hh>
 #include <HepMC3/GenParticle.h>
 #include <HepMC3/GenVertex.h>
+#include <globals.hh>
 
 namespace ActsExamples {
 

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -27,8 +27,8 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
                                    std::numeric_limits<double>::max())) {}
 
-ActsExamples::SimParticleContainer ActsExamples::ParametricParticleGenerator::
-operator()(RandomEngine& rng) const {
+ActsExamples::SimParticleContainer
+ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
   using UniformIndex = std::uniform_int_distribution<unsigned int>;
   using UniformReal = std::uniform_real_distribution<double>;
 

--- a/Examples/Algorithms/HepMC/include/ActsExamples/HepMC/HepMCProcessExtractor.hpp
+++ b/Examples/Algorithms/HepMC/include/ActsExamples/HepMC/HepMCProcessExtractor.hpp
@@ -8,14 +8,14 @@
 
 #pragma once
 
-#include <memory>
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
+
+#include <memory>
 
 class G4RunManager;
 

--- a/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
+++ b/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
@@ -7,8 +7,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/HepMC/HepMCProcessExtractor.hpp"
+
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Particle.hpp"
+
 #include <stdexcept>
 
 #include <HepMC3/GenEvent.h>

--- a/Examples/Algorithms/Printers/ActsExamples/Printers/TrackParametersPrinter.cpp
+++ b/Examples/Algorithms/Printers/ActsExamples/Printers/TrackParametersPrinter.cpp
@@ -6,12 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "TrackParametersPrinter.hpp"
+
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
-
-#include "TrackParametersPrinter.hpp"
 
 ActsExamples::TrackParametersPrinter::TrackParametersPrinter(
     const Config& cfg, Acts::Logging::Level lvl)

--- a/Examples/Algorithms/Seeding/include/ActsExamples/Seeding/SeedingAlgorithm.hpp
+++ b/Examples/Algorithms/Seeding/include/ActsExamples/Seeding/SeedingAlgorithm.hpp
@@ -17,6 +17,7 @@
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimSpacePoint.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
+
 #include <memory>
 #include <set>
 #include <string>

--- a/Examples/Algorithms/Seeding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/Seeding/src/SeedingAlgorithm.cpp
@@ -8,6 +8,7 @@
 
 #include "ActsExamples/Seeding/SeedingAlgorithm.hpp"
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/DetectorElementBase.hpp"
 #include "Acts/Seeding/BinFinder.hpp"
@@ -16,14 +17,13 @@
 #include "Acts/Seeding/InternalSpacePoint.hpp"
 #include "Acts/Seeding/Seed.hpp"
 #include "Acts/Seeding/SeedFilter.hpp"
-
-#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/EventData/SimVertex.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
+
 #include <iostream>
 #include <stdexcept>
 

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Reader.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/IReader.hpp"
+
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/ReaderAscii.h>
 

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -10,7 +10,9 @@
 
 #include "ActsExamples/Framework/WriterT.hpp"
 #include "ActsExamples/Utilities/OptionsFwd.hpp"
+
 #include <string>
+
 #include <HepMC3/GenEvent.h>
 #include <HepMC3/WriterAscii.h>
 

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -7,8 +7,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
+
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
+
 #include <HepMC3/Units.h>
 
 bool ActsExamples::HepMC3AsciiReader::readEvent(HepMC3::ReaderAscii& reader,

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
+
 #include "ActsExamples/Utilities/Paths.hpp"
 
 ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config&& cfg,

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "SeedingPerformanceWriter.hpp"
+
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
@@ -15,6 +16,7 @@
 #include <numeric>
 #include <set>
 #include <stdexcept>
+
 #include <TFile.h>
 
 using HitParticlesMap = ActsExamples::IndexMultimap<ActsFatras::Barcode>;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootDigitizationWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootDigitizationWriter.hpp
@@ -20,8 +20,6 @@
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/Framework/WriterT.hpp"
 
-#include <TTree.h>
-
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/Examples/Run/Geant4/DD4hep/DD4hepGeantinoRecording.cpp
+++ b/Examples/Run/Geant4/DD4hep/DD4hepGeantinoRecording.cpp
@@ -10,9 +10,10 @@
 #include "ActsExamples/DD4hepDetector/DD4hepGeometryService.hpp"
 #include "ActsExamples/Geant4DD4hep/DD4hepDetectorConstruction.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
-#include "../GeantinoRecordingBase.hpp"
 
 #include <boost/program_options.hpp>
+
+#include "../GeantinoRecordingBase.hpp"
 
 using namespace ActsExamples;
 

--- a/Examples/Run/Geant4/GdmlGeantinoRecording.cpp
+++ b/Examples/Run/Geant4/GdmlGeantinoRecording.cpp
@@ -6,10 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <boost/program_options.hpp>
-
 #include "ActsExamples/Geant4/GdmlDetectorConstruction.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
+
+#include <boost/program_options.hpp>
+
 #include "GeantinoRecordingBase.hpp"
 
 using namespace ActsExamples;

--- a/Examples/Run/Geant4/GeantinoRecordingBase.hpp
+++ b/Examples/Run/Geant4/GeantinoRecordingBase.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <boost/program_options.hpp>
-
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Geant4/Geant4Options.hpp"
@@ -18,6 +16,9 @@
 #include "ActsExamples/Io/Root/RootSimHitWriter.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
+
+#include <boost/program_options.hpp>
+
 #include "G4VUserDetectorConstruction.hh"
 
 using namespace ActsExamples;

--- a/Examples/Run/Geant4/HepMC/EventRecordingExample.cpp
+++ b/Examples/Run/Geant4/HepMC/EventRecordingExample.cpp
@@ -20,8 +20,10 @@
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
+
 #include <fstream>
 #include <string>
+
 #include <boost/program_options.hpp>
 
 int main(int argc, char* argv[]) {

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -31,6 +31,7 @@
 #include <Acts/Definitions/Units.hpp>
 
 #include <memory>
+
 #include <boost/filesystem.hpp>
 
 using namespace Acts::UnitLiterals;

--- a/Fatras/include/ActsFatras/Digitization/Channelizer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/Channelizer.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+
 #include <array>
 #include <vector>
 

--- a/Fatras/include/ActsFatras/Digitization/detail/ParametersSmearer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/detail/ParametersSmearer.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include <utility>
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Utilities/Result.hpp"
+
+#include <utility>
 
 namespace ActsFatras {
 

--- a/Fatras/src/Digitization/Channelizer.cpp
+++ b/Fatras/src/Digitization/Channelizer.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "ActsFatras/Digitization/Channelizer.hpp"
+
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/detail/IntersectionHelper2D.hpp"
 #include "Acts/Utilities/BinUtility.hpp"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Kernels.cuh
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Kernels.cuh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <cuda_runtime.h>
 
 typedef struct {

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaMatrix.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaMatrix.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuMatrix.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaScalar.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaScalar.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuScalar.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaUtils.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaUtils.cu
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <iostream>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaVector.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/CudaVector.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuVector.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmMatrix.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmMatrix.cu
@@ -9,8 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Cuda/Utilities/CpuMatrix.hpp"
+
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmScalar.cu
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Utilities/UsmScalar.cu
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <memory>
+
 #include "CudaUtils.cu"
 #include "cuda.h"
 #include "cuda_runtime.h"

--- a/Plugins/Cuda/src/Seeding/Kernels.cu
+++ b/Plugins/Cuda/src/Seeding/Kernels.cu
@@ -8,7 +8,9 @@
 
 #include "Acts/Plugins/Cuda/Cuda.hpp"
 #include "Acts/Plugins/Cuda/Seeding/Kernels.cuh"
+
 #include <iostream>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
 

--- a/Plugins/Cuda/src/Seeding2/CountDublets.cu
+++ b/Plugins/Cuda/src/Seeding2/CountDublets.cu
@@ -9,6 +9,7 @@
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Seeding2/Details/CountDublets.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 
 // CUDA include(s).

--- a/Plugins/Cuda/src/Seeding2/FindDublets.cu
+++ b/Plugins/Cuda/src/Seeding2/FindDublets.cu
@@ -9,6 +9,7 @@
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Seeding2/Details/FindDublets.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 #include "../Utilities/MatrixMacros.hpp"
 

--- a/Plugins/Cuda/src/Seeding2/FindTriplets.cu
+++ b/Plugins/Cuda/src/Seeding2/FindTriplets.cu
@@ -11,6 +11,7 @@
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
 #include "Acts/Plugins/Cuda/Seeding2/TripletFilterConfig.hpp"
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "../Utilities/ErrorCheck.cuh"
 #include "../Utilities/MatrixMacros.hpp"
 

--- a/Plugins/Cuda/src/Utilities/Arrays.cu
+++ b/Plugins/Cuda/src/Utilities/Arrays.cu
@@ -10,6 +10,7 @@
 #include "Acts/Plugins/Cuda/Seeding2/Details/Types.hpp"
 #include "Acts/Plugins/Cuda/Utilities/Arrays.hpp"
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "ErrorCheck.cuh"
 #include "StreamHandlers.cuh"
 

--- a/Plugins/Cuda/src/Utilities/Info.cu
+++ b/Plugins/Cuda/src/Utilities/Info.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/Info.hpp"
+
 #include "ErrorCheck.cuh"
 
 // System include(s).

--- a/Plugins/Cuda/src/Utilities/MemoryManager.cu
+++ b/Plugins/Cuda/src/Utilities/MemoryManager.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/MemoryManager.hpp"
+
 #include "ErrorCheck.cuh"
 
 // CUDA include(s).

--- a/Plugins/Cuda/src/Utilities/StreamWrapper.cu
+++ b/Plugins/Cuda/src/Utilities/StreamWrapper.cu
@@ -8,6 +8,7 @@
 
 // CUDA plugin include(s).
 #include "Acts/Plugins/Cuda/Utilities/StreamWrapper.hpp"
+
 #include "ErrorCheck.cuh"
 #include "StreamHandlers.cuh"
 

--- a/Plugins/Digitization/include/Acts/Plugins/Digitization/SpacePointBuilder.hpp
+++ b/Plugins/Digitization/include/Acts/Plugins/Digitization/SpacePointBuilder.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <vector>
 
 namespace Acts {

--- a/Plugins/Onnx/include/Acts/Plugins/Onnx/MLTrackClassifier.hpp
+++ b/Plugins/Onnx/include/Acts/Plugins/Onnx/MLTrackClassifier.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <vector>
-
 #include "Acts/Plugins/Onnx/OnnxRuntimeBase.hpp"
+
+#include <vector>
 
 namespace Acts {
 

--- a/Plugins/Onnx/include/Acts/Plugins/Onnx/OnnxRuntimeBase.hpp
+++ b/Plugins/Onnx/include/Acts/Plugins/Onnx/OnnxRuntimeBase.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <vector>
+
 #include <core/session/onnxruntime_cxx_api.h>
 
 namespace Acts {

--- a/Plugins/Onnx/src/MLTrackClassifier.cpp
+++ b/Plugins/Onnx/src/MLTrackClassifier.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Plugins/Onnx/MLTrackClassifier.hpp"
+
 #include <cassert>
 #include <stdexcept>
-
-#include "Acts/Plugins/Onnx/MLTrackClassifier.hpp"
 
 // prediction function
 Acts::MLTrackClassifier::TrackLabels Acts::MLTrackClassifier::predictTrackLabel(

--- a/Plugins/Onnx/src/OnnxRuntimeBase.cpp
+++ b/Plugins/Onnx/src/OnnxRuntimeBase.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Plugins/Onnx/OnnxRuntimeBase.hpp"
+
 #include <cassert>
 #include <stdexcept>
-
-#include "Acts/Plugins/Onnx/OnnxRuntimeBase.hpp"
 
 // parametrized constructor
 Acts::OnnxRuntimeBase::OnnxRuntimeBase(Ort::Env& env, const char* modelPath) {

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoPrimitivesHelper.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoPrimitivesHelper.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <string>
 #include <vector>
 

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoSurfaceConverter.hpp
@@ -9,7 +9,9 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <memory>
+
 #include "RtypesCore.h"
 
 class TGeoShape;

--- a/Tests/Benchmarks/RayFrustumBenchmark.cpp
+++ b/Tests/Benchmarks/RayFrustumBenchmark.cpp
@@ -6,14 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <algorithm>
-#include <chrono>
-#include <functional>
-#include <iostream>
-#include <map>
-#include <random>
-#include <vector>
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
@@ -21,6 +13,14 @@
 #include "Acts/Utilities/BoundingBox.hpp"
 #include "Acts/Utilities/Frustum.hpp"
 #include "Acts/Utilities/Ray.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <random>
+#include <vector>
 
 using namespace Acts;
 

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/FloatComparisons.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/FloatComparisons.hpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <algorithm>
 #include <limits>
 

--- a/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+
 #include "LayerStub.hpp"
 
 using boost::test_tools::output_test_stream;

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -144,7 +144,7 @@ struct PropagatorState {
     }
 
     BoundState boundState(State& state, const Surface& surface, bool /*unused*/
-                          ) const {
+    ) const {
       BoundTrackParameters parameters(surface.getSharedPtr(), tgContext,
                                       state.pos4, state.dir, state.p, state.q);
       BoundState bState{std::move(parameters), Jacobian::Identity(),
@@ -153,7 +153,7 @@ struct PropagatorState {
     }
 
     CurvilinearState curvilinearState(State& state, bool /*unused*/
-                                      ) const {
+    ) const {
       CurvilinearTrackParameters parameters(state.pos4, state.dir, state.p,
                                             state.q);
       // Create the bound state

--- a/Tests/UnitTests/Core/Utilities/BinAdjustmentTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinAdjustmentTests.cpp
@@ -8,10 +8,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
-
-#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/BinAdjustment.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 

--- a/Tests/UnitTests/Core/Utilities/BinAdjustmentVolumeTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinAdjustmentVolumeTests.cpp
@@ -8,11 +8,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CutoutCylinderVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
-
-#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/BinAdjustmentVolume.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 

--- a/Tests/UnitTests/Core/Visualization/PrimitivesView3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/PrimitivesView3DTests.cpp
@@ -10,6 +10,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <fstream>
 #include <iostream>
 #include <sstream>

--- a/Tests/UnitTests/Fatras/Digitization/BoundRandomValues.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/BoundRandomValues.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <array>
 
 namespace ActsFatras {

--- a/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/ChannelizerTests.cpp
@@ -24,13 +24,14 @@
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "ActsFatras/Digitization/Channelizer.hpp"
-#include "DigitizationCsvOutput.hpp"
-#include "PlanarSurfaceTestBeds.hpp"
 
 #include <array>
 #include <fstream>
 #include <functional>
 #include <vector>
+
+#include "DigitizationCsvOutput.hpp"
+#include "PlanarSurfaceTestBeds.hpp"
 
 namespace bdata = boost::unit_test::data;
 

--- a/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/DigitizationCsvOutput.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <fstream>
 
 namespace ActsFatras {

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceMaskTests.cpp
@@ -9,8 +9,6 @@
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include "ActsFatras/Digitization/PlanarSurfaceMask.hpp"
-
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/AnnulusBounds.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
@@ -21,11 +19,13 @@
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "ActsFatras/Digitization/DigitizationError.hpp"
-#include "DigitizationCsvOutput.hpp"
-#include "PlanarSurfaceTestBeds.hpp"
+#include "ActsFatras/Digitization/PlanarSurfaceMask.hpp"
 
 #include <array>
 #include <fstream>
+
+#include "DigitizationCsvOutput.hpp"
+#include "PlanarSurfaceTestBeds.hpp"
 
 namespace bdata = boost::unit_test::data;
 

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceTestBeds.hpp
@@ -20,11 +20,12 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningType.hpp"
-#include "BoundRandomValues.hpp"
 
 #include <array>
 #include <tuple>
 #include <vector>
+
+#include "BoundRandomValues.hpp"
 
 namespace ActsFatras {
 

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
+
 #include <boost/test/unit_test.hpp>
 
-#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"

--- a/Tests/UnitTests/Plugins/Cuda/Utilities/CudaMostSimplifiedTests.cu
+++ b/Tests/UnitTests/Plugins/Cuda/Utilities/CudaMostSimplifiedTests.cu
@@ -7,7 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/unit_test.hpp>
+
 #include "Acts/Plugins/Cuda/Cuda.hpp"
+
 #include <Eigen/Dense>
 #include <cuda_profiler_api.h>
 

--- a/Tests/UnitTests/Plugins/Cuda/Utilities/CudaTests.cu
+++ b/Tests/UnitTests/Plugins/Cuda/Utilities/CudaTests.cu
@@ -7,7 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/unit_test.hpp>
+
 #include "Acts/Plugins/Cuda/Cuda.hpp"
+
 #include <Eigen/Dense>
 #include <cuda_profiler_api.h>
 


### PR DESCRIPTION
Update clang-format to version 10 in the CI checks and related scripts and apply the resulting format changes.

This was discussed and decided already a while ago in one of the developers meetings, but we never got around to implement it. This PR finally fixes that.