### PR TITLE
ci: Use LCG 97 and 98 for CI builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,12 +13,12 @@ env:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:v5
+    container: ghcr.io/acts-project/${{ matrix.image }}:v6
     strategy:
       matrix:
         image:
-          - centos7-lcg95apython3
-          - centos7-lcg96
+          - centos7-lcg97apython3-gcc9
+          - centos7-lcg98python3-gcc10
           - ubuntu2004
     env:
       SETUP: true
@@ -116,7 +116,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:v5
+    container: ghcr.io/acts-project/ubuntu1804_cuda:v6
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -132,7 +132,7 @@ jobs:
         run: cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v5
+    container: ghcr.io/acts-project/ubuntu2004:v6
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/CI/check_format_local
+++ b/CI/check_format_local
@@ -17,5 +17,5 @@ docker run --rm -ti \
        -v ${WD}:/work_dir:rw \
        --user "${USER_ID}:${GROUP_ID}" \
        -w "/work_dir" \
-       ghcr.io/acts-project/format10:v5 \
+       ghcr.io/acts-project/format10:v6 \
        CI/check_format .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ if(ACTS_BUILD_DOCS)
 endif()
 
 if(ACTS_CUSTOM_SCALARTYPE)
-    message(STATUS "Building Acts with custom scalar type: "${ACTS_CUSTOM_SCALARTYPE} )
+    message(STATUS "Building Acts with custom scalar type: ${ACTS_CUSTOM_SCALARTYPE}")
 endif()
 
 # core library, core plugins, and other components

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,13 @@ if(ACTS_BUILD_EXAMPLES)
   # standalone components. for simplicity always request all possible
   # required components.
   find_package(ROOT ${_root_version} CONFIG REQUIRED COMPONENTS Core Geom GenVector Hist Tree TreePlayer)
-  find_package(TBB REQUIRED)
+  # newer DD4hep version require TBB and search interally for TBB in
+  # config-only mode. to avoid missmatches we explicitely search using
+  # config-only mode first to be sure that we find the same version.
+  find_package(TBB CONFIG)
+  if(NOT TBB_FOUND)
+    find_package(TBB MODULE REQUIRED)
+  endif()
   add_subdirectory(thirdparty/dfelibs)
 endif()
 if(ACTS_BUILD_EXAMPLES_DD4HEP AND ACTS_BUILD_EXAMPLES_GEANT4)

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.ipp
@@ -306,7 +306,7 @@ double Acts::AdaptiveGridTrackDensity<trkGridSize>::getDensitySum(
   double sum = mainGridDensity[pos];
   // Sum up only the density contributions from the
   // neighboring bins if they are still within bounds
-  if (pos - 1 >= 0) {
+  if (0 < pos) {
     // Check if we are still operating on continous z values
     if (mainGridZValues[pos] - mainGridZValues[pos - 1] == 1) {
       sum += mainGridDensity[pos - 1];

--- a/Examples/Framework/CMakeLists.txt
+++ b/Examples/Framework/CMakeLists.txt
@@ -16,12 +16,11 @@ add_library(
 )
 target_include_directories(
   ActsExamplesFramework
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE ${TBB_INCLUDE_DIRS})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(
   ActsExamplesFramework
   PUBLIC ActsCore ActsFatras Boost::boost ROOT::Core ROOT::Hist
-  PRIVATE ${TBB_LIBRARIES} dfelibs Boost::filesystem)
+  PRIVATE Boost::filesystem dfelibs TBB::tbb)
 target_compile_definitions(
   ActsExamplesFramework
   PRIVATE BOOST_FILESYSTEM_NO_DEPRECATED)

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -1,292 +1,424 @@
-# Module for locating Intel's Threading Building Blocks (TBB).
+# - Find ThreadingBuildingBlocks include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(TBB
+#    [REQUIRED]             # Fail with error if TBB is not found
+#    )                      #
+# Once done, this will define
 #
-# Customizable variables:
-#   TBB_ROOT_DIR
-#     Specifies TBB's root directory.
+#  TBB_FOUND - system has TBB
+#  TBB_INCLUDE_DIRS - the TBB include directories
+#  TBB_LIBRARIES - TBB libraries to be lined, doesn't include malloc or
+#                  malloc proxy
+#  TBB::tbb - imported target for the TBB library
 #
-# Read-only variables:
-#   TBB_FOUND
-#     Indicates whether the library has been found.
+#  TBB_VERSION_MAJOR - Major Product Version Number
+#  TBB_VERSION_MINOR - Minor Product Version Number
+#  TBB_INTERFACE_VERSION - Engineering Focused Version Number
+#  TBB_COMPATIBLE_INTERFACE_VERSION - The oldest major interface version
+#                                     still supported. This uses the engineering
+#                                     focused interface version numbers.
 #
-#   TBB_INCLUDE_DIRS
-#      Specifies TBB's include directory.
+#  TBB_MALLOC_FOUND - system has TBB malloc library
+#  TBB_MALLOC_INCLUDE_DIRS - the TBB malloc include directories
+#  TBB_MALLOC_LIBRARIES - The TBB malloc libraries to be lined
+#  TBB::malloc - imported target for the TBB malloc library
 #
-#   TBB_LIBRARIES
-#     Specifies TBB libraries that should be passed to target_link_libararies.
-#
-#   TBB_<COMPONENT>_LIBRARIES
-#     Specifies the libraries of a specific <COMPONENT>.
-#
-#   TBB_<COMPONENT>_FOUND
-#     Indicates whether the specified <COMPONENT> was found.
+#  TBB_MALLOC_PROXY_FOUND - system has TBB malloc proxy library
+#  TBB_MALLOC_PROXY_INCLUDE_DIRS = the TBB malloc proxy include directories
+#  TBB_MALLOC_PROXY_LIBRARIES - The TBB malloc proxy libraries to be lined
+#  TBB::malloc_proxy - imported target for the TBB malloc proxy library
 #
 #
-# Copyright (c) 2012 Sergiu Dotenco
+# This module reads hints about search locations from variables:
+#  ENV TBB_ARCH_PLATFORM - for eg. set it to "mic" for Xeon Phi builds
+#  ENV TBB_ROOT or just TBB_ROOT - root directory of tbb installation
+#  ENV TBB_BUILD_PREFIX - specifies the build prefix for user built tbb
+#                         libraries. Should be specified with ENV TBB_ROOT
+#                         and optionally...
+#  ENV TBB_BUILD_DIR - if build directory is different than ${TBB_ROOT}/build
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
+# Modified by Robert Maynard from the original OGRE source
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTTBBLAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+#-------------------------------------------------------------------
+# This file is part of the CMake build system for OGRE
+#     (Object-oriented Graphics Rendering Engine)
+# For the latest info, see http://www.ogre3d.org/
+#
+# The contents of this file are placed in the public domain. Feel
+# free to make use of it in any way you like.
+#-------------------------------------------------------------------
+#
+#=============================================================================
+# Copyright 2010-2012 Kitware, Inc.
+# Copyright 2012      Rolf Eike Beer <eike@sf-mail.de>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
 
-INCLUDE (FindPackageHandleStandardArgs)
 
-IF (CMAKE_VERSION VERSION_GREATER 2.8.7)
-  SET (_TBB_CHECK_COMPONENTS FALSE)
-ELSE (CMAKE_VERSION VERSION_GREATER 2.8.7)
-  SET (_TBB_CHECK_COMPONENTS TRUE)
-ENDIF (CMAKE_VERSION VERSION_GREATER 2.8.7)
+#=============================================================================
+#  FindTBB helper functions and macros
+#
 
-FIND_PATH (TBB_ROOT_DIR
-  NAMES include/tbb/tbb.h
-  PATHS ENV TBBROOT
-        ENV TBB40_INSTALL_DIR
-        ENV TBB30_INSTALL_DIR
-        ENV TBB22_INSTALL_DIR
-        ENV TBB21_INSTALL_DIR
-        ENV TBB_ROOT_DIR
-  DOC "TBB root directory")
+#====================================================
+# Fix the library path in case it is a linker script
+#====================================================
+function(tbb_extract_real_library library real_library)
+  if(NOT UNIX OR NOT EXISTS ${library})
+    set(${real_library} "${library}" PARENT_SCOPE)
+    return()
+  endif()
 
-FIND_PATH (TBB_INCLUDE_DIR
-  NAMES tbb/tbb.h
-  HINTS ${TBB_ROOT_DIR}
-  PATH_SUFFIXES "include" "../include"
-  DOC "TBB include directory" NO_DEFAULT_PATH) #Allow default tbb makefile layout
+  #Read in the first 4 bytes and see if they are the ELF magic number
+  set(_elf_magic "7f454c46")
+  file(READ ${library} _hex_data OFFSET 0 LIMIT 4 HEX)
+  if(_hex_data STREQUAL _elf_magic)
+    #we have opened a elf binary so this is what
+    #we should link to
+    set(${real_library} "${library}" PARENT_SCOPE)
+    return()
+  endif()
 
-FIND_PATH (TBB_INCLUDE_DIR
-  NAMES tbb/tbb.h
-  HINTS ${TBB_ROOT_DIR}
-  PATH_SUFFIXES include
-  DOC "TBB include directory" )
+  file(READ ${library} _data OFFSET 0 LIMIT 1024)
+  if("${_data}" MATCHES "INPUT \\(([^(]+)\\)")
+    #extract out the .so name from REGEX MATCH command
+    set(_proper_so_name "${CMAKE_MATCH_1}")
 
-IF (MSVC11)
-  SET (_TBB_COMPILER vc11)
-ELSEIF (MSVC10)
-  SET (_TBB_COMPILER vc10)
-ELSEIF (MSVC90)
-  SET (_TBB_COMPILER vc9)
-ELSEIF (MSVC80)
-  SET (_TBB_COMPILER vc8)
-ELSEIF (WIN32)
-  SET (_TBB_COMPILER vc_mt)
-ENDIF (MSVC11)
+    #construct path to the real .so which is presumed to be in the same directory
+    #as the input file
+    get_filename_component(_so_dir "${library}" DIRECTORY)
+    set(${real_library} "${_so_dir}/${_proper_so_name}" PARENT_SCOPE)
+  else()
+    #unable to determine what this library is so just hope everything works
+    #and pass it unmodified.
+    set(${real_library} "${library}" PARENT_SCOPE)
+  endif()
+endfunction()
 
-IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
-  SET (_TBB_POSSIBLE_LIB_SUFFIXES lib/intel64/${_TBB_COMPILER})
-  SET (_TBB_POSSIBLE_BIN_SUFFIXES bin/intel64/${_TBB_COMPILER})
-ELSE (CMAKE_SIZEOF_VOID_P EQUAL 8)
-  SET (_TBB_POSSIBLE_LIB_SUFFIXES lib/ia32/${_TBB_COMPILER})
-  SET (_TBB_POSSIBLE_BIN_SUFFIXES bin/ia32/${_TBB_COMPILER})
-ENDIF (CMAKE_SIZEOF_VOID_P EQUAL 8)
+#===============================================
+# Do the final processing for the package find.
+#===============================================
+macro(findpkg_finish PREFIX TARGET_NAME)
+  if (${PREFIX}_INCLUDE_DIR AND ${PREFIX}_LIBRARY)
+    set(${PREFIX}_FOUND TRUE)
+    set (${PREFIX}_INCLUDE_DIRS ${${PREFIX}_INCLUDE_DIR})
+    set (${PREFIX}_LIBRARIES ${${PREFIX}_LIBRARY})
+  else ()
+    if (${PREFIX}_FIND_REQUIRED AND NOT ${PREFIX}_FIND_QUIETLY)
+      message(FATAL_ERROR "Required library ${PREFIX} not found.")
+    endif ()
+  endif ()
 
-LIST (APPEND _TBB_POSSIBLE_LIB_SUFFIXES lib/$ENV{TBB_ARCH_PLATFORM})
+  if (NOT TARGET "TBB::${TARGET_NAME}")
+    if (${PREFIX}_LIBRARY_RELEASE)
+      tbb_extract_real_library(${${PREFIX}_LIBRARY_RELEASE} real_release)
+    endif ()
+    if (${PREFIX}_LIBRARY_DEBUG)
+      tbb_extract_real_library(${${PREFIX}_LIBRARY_DEBUG} real_debug)
+    endif ()
+    add_library(TBB::${TARGET_NAME} UNKNOWN IMPORTED)
+    set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${${PREFIX}_INCLUDE_DIR}")
+    if (${PREFIX}_LIBRARY_DEBUG AND ${PREFIX}_LIBRARY_RELEASE)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_release}"
+        IMPORTED_LOCATION_DEBUG "${real_debug}"
+        IMPORTED_LOCATION_RELEASE "${real_release}")
+    elseif (${PREFIX}_LIBRARY_RELEASE)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_release}")
+    elseif (${PREFIX}_LIBRARY_DEBUG)
+      set_target_properties(TBB::${TARGET_NAME} PROPERTIES
+        IMPORTED_LOCATION "${real_debug}")
+    endif ()
+  endif ()
 
-FIND_LIBRARY (TBB_LIBRARY_RELEASE
-  NAMES tbb
-  HINTS ${TBB_ROOT_DIR}
-  PATH_SUFFIXES ${_TBB_POSSIBLE_LIB_SUFFIXES}
-  DOC "TBB release library")
+  #mark the following variables as internal variables
+  mark_as_advanced(${PREFIX}_INCLUDE_DIR
+                   ${PREFIX}_LIBRARY
+                   ${PREFIX}_LIBRARY_DEBUG
+                   ${PREFIX}_LIBRARY_RELEASE)
+endmacro()
 
-FIND_LIBRARY (TBB_LIBRARY_DEBUG
-  NAMES tbb_debug
-  HINTS ${TBB_ROOT_DIR}
-  PATH_SUFFIXES ${_TBB_POSSIBLE_LIB_SUFFIXES}
-  DOC "TBB debug library")
+#===============================================
+# Generate debug names from given release names
+#===============================================
+macro(get_debug_names PREFIX)
+  foreach(i ${${PREFIX}})
+    set(${PREFIX}_DEBUG ${${PREFIX}_DEBUG} ${i}d ${i}D ${i}_d ${i}_D ${i}_debug ${i})
+  endforeach()
+endmacro()
 
-IF (TBB_LIBRARY_RELEASE AND TBB_LIBRARY_DEBUG)
-  IF (NOT TBB_LIBRARY)
-    SET (TBB_LIBRARY optimized ${TBB_LIBRARY_RELEASE} debug ${TBB_LIBRARY_DEBUG}
-      CACHE DOC "TBB library" FORCE)
-  ENDIF (NOT TBB_LIBRARY)
-ELSEIF (TBB_LIBRARY_RELEASE)
-  IF (NOT TBB_LIBRARY)
-    SET (TBB_LIBRARY ${TBB_LIBRARY_RELEASE} CACHE DOC "TBB library" FORCE)
-  ENDIF (NOT TBB_LIBRARY)
-ENDIF (TBB_LIBRARY_RELEASE AND TBB_LIBRARY_DEBUG)
+#===============================================
+# See if we have env vars to help us find tbb
+#===============================================
+macro(getenv_path VAR)
+   set(ENV_${VAR} $ENV{${VAR}})
+   # replace won't work if var is blank
+   if (ENV_${VAR})
+     string( REGEX REPLACE "\\\\" "/" ENV_${VAR} ${ENV_${VAR}} )
+   endif ()
+endmacro()
 
-IF (TBB_LIBRARY_DEBUG)
-  LIST (APPEND _TBB_ALL_LIBS ${TBB_LIBRARY_DEBUG})
-ENDIF (TBB_LIBRARY_DEBUG)
+#===============================================
+# Couple a set of release AND debug libraries
+#===============================================
+macro(make_library_set PREFIX)
+  if (${PREFIX}_RELEASE AND ${PREFIX}_DEBUG)
+    set(${PREFIX} optimized ${${PREFIX}_RELEASE} debug ${${PREFIX}_DEBUG})
+  elseif (${PREFIX}_RELEASE)
+    set(${PREFIX} ${${PREFIX}_RELEASE})
+  elseif (${PREFIX}_DEBUG)
+    set(${PREFIX} ${${PREFIX}_DEBUG})
+  endif ()
+endmacro()
 
-IF (TBB_LIBRARY_RELEASE)
-  LIST (APPEND _TBB_ALL_LIBS ${TBB_LIBRARY_RELEASE})
-ENDIF (TBB_LIBRARY_RELEASE)
 
-FOREACH (_TBB_COMPONENT ${TBB_FIND_COMPONENTS})
-  STRING (TOUPPER ${_TBB_COMPONENT} _TBB_COMPONENT_UPPER)
-  SET (_TBB_LIBRARY_BASE TBB_${_TBB_COMPONENT_UPPER}_LIBRARY)
+#=============================================================================
+#  Now to actually find TBB
+#
 
-  IF (${_TBB_COMPONENT} STREQUAL preview)
-    SET (_TBB_LIBRARY_NAME tbb_${_TBB_COMPONENT})
-  ELSE (${_TBB_COMPONENT} STREQUAL preview)
-    SET (_TBB_LIBRARY_NAME tbb${_TBB_COMPONENT})
-  ENDIF (${_TBB_COMPONENT} STREQUAL preview)
+# Get path, convert backslashes as ${ENV_${var}}
+getenv_path(TBB_ROOT)
 
-  FIND_LIBRARY (${_TBB_LIBRARY_BASE}_RELEASE
-    NAMES ${_TBB_LIBRARY_NAME}
-    HINTS ${TBB_ROOT_DIR}
-    PATH_SUFFIXES ${_TBB_POSSIBLE_LIB_SUFFIXES}
-    DOC "TBB ${_TBB_COMPONENT} release library")
+# initialize search paths
+set(TBB_PREFIX_PATH ${TBB_ROOT} ${ENV_TBB_ROOT})
+set(TBB_INC_SEARCH_PATH "")
+set(TBB_LIB_SEARCH_PATH "")
 
-  FIND_LIBRARY (${_TBB_LIBRARY_BASE}_DEBUG
-    NAMES ${_TBB_LIBRARY_NAME}_debug
-    HINTS ${TBB_ROOT_DIR}
-    PATH_SUFFIXES ${_TBB_POSSIBLE_LIB_SUFFIXES}
-    DOC "TBB ${_TBB_COMPONENT} debug library")
 
-  MARK_AS_ADVANCED (${_TBB_LIBRARY_BASE} ${_TBB_LIBRARY_BASE}_DEBUG)
+# If user built from sources
+set(TBB_BUILD_PREFIX $ENV{TBB_BUILD_PREFIX})
+if (TBB_BUILD_PREFIX AND ENV_TBB_ROOT)
+  getenv_path(TBB_BUILD_DIR)
+  if (NOT ENV_TBB_BUILD_DIR)
+    set(ENV_TBB_BUILD_DIR ${ENV_TBB_ROOT}/build)
+  endif ()
 
-  SET (TBB_${_TBB_COMPONENT_UPPER}_FOUND TRUE)
+  # include directory under ${ENV_TBB_ROOT}/include
+  list(APPEND TBB_LIB_SEARCH_PATH
+    ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_release
+    ${ENV_TBB_BUILD_DIR}/${TBB_BUILD_PREFIX}_debug)
+endif ()
 
-  IF (${_TBB_LIBRARY_BASE}_DEBUG AND ${_TBB_LIBRARY_BASE}_RELEASE)
-    SET (${_TBB_LIBRARY_BASE}
-      debug ${${_TBB_LIBRARY_BASE}_DEBUG}
-      optimized ${${_TBB_LIBRARY_BASE}_RELEASE} CACHE DOC
-      "TBB ${_TBB_COMPONENT} library")
-  ELSEIF (${_TBB_LIBRARY_BASE}_DEBUG)
-    SET (${_TBB_LIBRARY_BASE} ${${_TBB_LIBRARY_BASE}_DEBUG})
-  ELSEIF (${_TBB_LIBRARY_BASE}_RELEASE)
-    SET (${_TBB_LIBRARY_BASE} ${${_TBB_LIBRARY_BASE}_RELEASE}
-      CACHE DOC "TBB ${_TBB_COMPONENT} library")
-  ELSE (${_TBB_LIBRARY_BASE}_DEBUG AND ${_TBB_LIBRARY_BASE}_RELEASE)
-    # Component missing: record it for a later report
-    LIST (APPEND _TBB_MISSING_COMPONENTS ${_TBB_COMPONENT})
-    SET (TBB_${_TBB_COMPONENT_UPPER}_FOUND FALSE)
-  ENDIF (${_TBB_LIBRARY_BASE}_DEBUG AND ${_TBB_LIBRARY_BASE}_RELEASE)
 
-  IF (${_TBB_LIBRARY_BASE}_DEBUG)
-    LIST (APPEND _TBB_ALL_LIBS ${${_TBB_LIBRARY_BASE}_DEBUG})
-  ENDIF (${_TBB_LIBRARY_BASE}_DEBUG)
+# For Windows, let's assume that the user might be using the precompiled
+# TBB packages from the main website. These use a rather awkward directory
+# structure (at least for automatically finding the right files) depending
+# on platform and compiler, but we'll do our best to accommodate it.
+# Not adding the same effort for the precompiled linux builds, though. Those
+# have different versions for CC compiler versions and linux kernels which
+# will never adequately match the user's setup, so there is no feasible way
+# to detect the "best" version to use. The user will have to manually
+# select the right files. (Chances are the distributions are shipping their
+# custom version of tbb, anyway, so the problem is probably nonexistent.)
+if (WIN32 AND MSVC)
+  set(COMPILER_PREFIX "vc7.1")
+  if (MSVC_VERSION EQUAL 1400)
+    set(COMPILER_PREFIX "vc8")
+  elseif(MSVC_VERSION EQUAL 1500)
+    set(COMPILER_PREFIX "vc9")
+  elseif(MSVC_VERSION EQUAL 1600)
+    set(COMPILER_PREFIX "vc10")
+  elseif(MSVC_VERSION EQUAL 1700)
+    set(COMPILER_PREFIX "vc11")
+  elseif(MSVC_VERSION EQUAL 1800)
+    set(COMPILER_PREFIX "vc12")
+  elseif(MSVC_VERSION GREATER_EQUAL 1900)
+    set(COMPILER_PREFIX "vc14")
+  endif ()
 
-  IF (${_TBB_LIBRARY_BASE}_RELEASE)
-    LIST (APPEND _TBB_ALL_LIBS ${${_TBB_LIBRARY_BASE}_RELEASE})
-  ENDIF (${_TBB_LIBRARY_BASE}_RELEASE)
+  # for each prefix path, add ia32/64\${COMPILER_PREFIX}\lib to the lib search path
+  foreach (dir IN LISTS TBB_PREFIX_PATH)
+    if (CMAKE_CL_64)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia64/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia64/${COMPILER_PREFIX})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${COMPILER_PREFIX})
+    else ()
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${COMPILER_PREFIX}/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${COMPILER_PREFIX})
+    endif ()
+  endforeach ()
+endif ()
 
-  SET (TBB_${_TBB_COMPONENT}_FOUND ${TBB_${_TBB_COMPONENT_UPPER}_FOUND})
+# For OS X binary distribution, choose libc++ based libraries for Mavericks (10.9)
+# and above and AppleClang
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+    NOT CMAKE_SYSTEM_VERSION VERSION_LESS 13.0)
+  set (USE_LIBCXX OFF)
+  cmake_policy(GET CMP0025 POLICY_VAR)
 
-  IF (${_TBB_LIBRARY_BASE})
-    # setup the TBB_<COMPONENT>_LIBRARIES variable
-    SET (TBB_${_TBB_COMPONENT_UPPER}_LIBRARIES ${${_TBB_LIBRARY_BASE}})
-    LIST (APPEND TBB_LIBRARIES ${${_TBB_LIBRARY_BASE}})
-  ELSE (${_TBB_LIBRARY_BASE})
-    LIST (APPEND _TBB_MISSING_LIBRARIES ${_TBB_LIBRARY_BASE})
-  ENDIF (${_TBB_LIBRARY_BASE})
-ENDFOREACH (_TBB_COMPONENT ${TBB_FIND_COMPONENTS})
+  if (POLICY_VAR STREQUAL "NEW")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+      set (USE_LIBCXX ON)
+    endif ()
+  else ()
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+      set (USE_LIBCXX ON)
+    endif ()
+  endif ()
 
-LIST (APPEND TBB_LIBRARIES ${TBB_LIBRARY})
-SET (TBB_INCLUDE_DIRS ${TBB_INCLUDE_DIR})
+  if (USE_LIBCXX)
+    foreach (dir IN LISTS TBB_PREFIX_PATH)
+      list (APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/libc++ ${dir}/libc++/lib)
+    endforeach ()
+  endif ()
+endif ()
 
-IF (DEFINED _TBB_MISSING_COMPONENTS AND _TBB_CHECK_COMPONENTS)
-  IF (NOT TBB_FIND_QUIETLY)
-    MESSAGE (STATUS "One or more TBB components were not found:")
-    # Display missing components indented, each on a separate line
-    FOREACH (_TBB_MISSING_COMPONENT ${_TBB_MISSING_COMPONENTS})
-      MESSAGE (STATUS "  " ${_TBB_MISSING_COMPONENT})
-    ENDFOREACH (_TBB_MISSING_COMPONENT ${_TBB_MISSING_COMPONENTS})
-  ENDIF (NOT TBB_FIND_QUIETLY)
-ENDIF (DEFINED _TBB_MISSING_COMPONENTS AND _TBB_CHECK_COMPONENTS)
+# check compiler ABI
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(COMPILER_PREFIX)
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+    list(APPEND COMPILER_PREFIX "gcc4.8")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+    list(APPEND COMPILER_PREFIX "gcc4.7")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)
+    list(APPEND COMPILER_PREFIX "gcc4.4")
+  endif()
+  list(APPEND COMPILER_PREFIX "gcc4.1")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(COMPILER_PREFIX)
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0) # Complete guess
+    list(APPEND COMPILER_PREFIX "gcc4.8")
+  endif()
+  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.6)
+    list(APPEND COMPILER_PREFIX "gcc4.7")
+  endif()
+  list(APPEND COMPILER_PREFIX "gcc4.4")
+else() # Assume compatibility with 4.4 for other compilers
+  list(APPEND COMPILER_PREFIX "gcc4.4")
+endif ()
 
-# Determine library's version
+# if platform architecture is explicitly specified
+set(TBB_ARCH_PLATFORM $ENV{TBB_ARCH_PLATFORM})
+if (TBB_ARCH_PLATFORM)
+  foreach (dir IN LISTS TBB_PREFIX_PATH)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/${TBB_ARCH_PLATFORM}/lib)
+    list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/${TBB_ARCH_PLATFORM})
+  endforeach ()
+endif ()
 
-SET (_TBB_VERSION_HEADER ${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h)
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+  foreach (prefix IN LISTS COMPILER_PREFIX)
+    if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/intel64/${prefix})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/intel64/${prefix}/lib)
+    else ()
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib/ia32/${prefix})
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/lib)
+      list(APPEND TBB_LIB_SEARCH_PATH ${dir}/ia32/${prefix}/lib)
+    endif ()
+  endforeach()
+endforeach ()
 
-IF (EXISTS ${_TBB_VERSION_HEADER})
-  FILE (READ ${_TBB_VERSION_HEADER} _TBB_VERSION_CONTENTS)
+# add general search paths
+foreach (dir IN LISTS TBB_PREFIX_PATH)
+  list(APPEND TBB_LIB_SEARCH_PATH ${dir}/lib ${dir}/Lib ${dir}/lib/tbb
+    ${dir}/Libs)
+  list(APPEND TBB_INC_SEARCH_PATH ${dir}/include ${dir}/Include
+    ${dir}/include/tbb)
+endforeach ()
 
-  STRING (REGEX REPLACE ".*#define TBB_VERSION_MAJOR[ \t]+([0-9]+).*" "\\1"
-    TBB_VERSION_MAJOR "${_TBB_VERSION_CONTENTS}")
-  STRING (REGEX REPLACE ".*#define TBB_VERSION_MINOR[ \t]+([0-9]+).*" "\\1"
-    TBB_VERSION_MINOR "${_TBB_VERSION_CONTENTS}")
+set(TBB_LIBRARY_NAMES tbb)
+get_debug_names(TBB_LIBRARY_NAMES)
 
-  SET (TBB_VERSION ${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR})
-  SET (TBB_VERSION_COMPONENTS 2)
-ENDIF (EXISTS ${_TBB_VERSION_HEADER})
 
-IF (WIN32)
-  FIND_PROGRAM (LIB_EXECUTABLE NAMES lib
-    HINTS "$ENV{VS110COMNTOOLS}/../../VC/bin"
-          "$ENV{VS100COMNTOOLS}/../../VC/bin"
-          "$ENV{VS90COMNTOOLS}/../../VC/bin"
-          "$ENV{VS71COMNTOOLS}/../../VC/bin"
-          "$ENV{VS80COMNTOOLS}/../../VC/bin"
-    DOC "Library manager")
+find_path(TBB_INCLUDE_DIR
+          NAMES tbb/tbb.h
+          PATHS ${TBB_INC_SEARCH_PATH})
 
-  MARK_AS_ADVANCED (LIB_EXECUTABLE)
-ENDIF (WIN32)
+find_library(TBB_LIBRARY_RELEASE
+             NAMES ${TBB_LIBRARY_NAMES}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_LIBRARY_DEBUG
+             NAMES ${TBB_LIBRARY_NAMES_DEBUG}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_LIBRARY)
 
-MACRO (GET_LIB_REQUISITES LIB REQUISITES)
-  IF (LIB_EXECUTABLE)
-    GET_FILENAME_COMPONENT (_LIB_PATH ${LIB_EXECUTABLE} PATH)
+findpkg_finish(TBB tbb)
 
-    IF (MSVC)
-      # Do not redirect the output
-      UNSET (ENV{VS_UNICODE_OUTPUT})
-    ENDIF (MSVC)
+#if we haven't found TBB no point on going any further
+if (NOT TBB_FOUND)
+  return()
+endif ()
 
-    EXECUTE_PROCESS (COMMAND ${LIB_EXECUTABLE} /nologo /list ${LIB}
-      WORKING_DIRECTORY ${_LIB_PATH}/../../Common7/IDE
-      OUTPUT_VARIABLE _LIB_OUTPUT ERROR_QUIET)
+#=============================================================================
+# Look for TBB's malloc package
+set(TBB_MALLOC_LIBRARY_NAMES tbbmalloc)
+get_debug_names(TBB_MALLOC_LIBRARY_NAMES)
 
-    STRING (REPLACE "\n" ";" "${REQUISITES}" "${_LIB_OUTPUT}")
-    LIST (REMOVE_DUPLICATES ${REQUISITES})
-  ENDIF (LIB_EXECUTABLE)
-ENDMACRO (GET_LIB_REQUISITES)
+find_path(TBB_MALLOC_INCLUDE_DIR
+          NAMES tbb/tbb.h
+          PATHS ${TBB_INC_SEARCH_PATH})
 
-IF (_TBB_ALL_LIBS)
-  # collect lib requisites using the lib tool
-  FOREACH (_TBB_COMPONENT ${_TBB_ALL_LIBS})
-    GET_LIB_REQUISITES (${_TBB_COMPONENT} _TBB_REQUISITES)
-  ENDFOREACH (_TBB_COMPONENT)
-ENDIF (_TBB_ALL_LIBS)
+find_library(TBB_MALLOC_LIBRARY_RELEASE
+             NAMES ${TBB_MALLOC_LIBRARY_NAMES}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_LIBRARY_DEBUG
+             NAMES ${TBB_MALLOC_LIBRARY_NAMES_DEBUG}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_LIBRARY)
 
-IF (NOT TBB_BINARY_DIR)
-  SET (_TBB_UPDATE_BINARY_DIR TRUE)
-ELSE (NOT TBB_BINARY_DIR)
-  SET (_TBB_UPDATE_BINARY_DIR FALSE)
-ENDIF (NOT TBB_BINARY_DIR)
+findpkg_finish(TBB_MALLOC tbbmalloc)
 
-SET (_TBB_BINARY_DIR_HINTS ${_TBB_POSSIBLE_BIN_SUFFIXES})
+#=============================================================================
+# Look for TBB's malloc proxy package
+set(TBB_MALLOC_PROXY_LIBRARY_NAMES tbbmalloc_proxy)
+get_debug_names(TBB_MALLOC_PROXY_LIBRARY_NAMES)
 
-IF (_TBB_REQUISITES)
-  FIND_FILE (TBB_BINARY_DIR NAMES ${_TBB_REQUISITES}
-    HINTS ${TBB_ROOT_DIR}
-    PATH_SUFFIXES ${_TBB_BINARY_DIR_HINTS} NO_DEFAULT_PATH)
-ENDIF (_TBB_REQUISITES)
+find_path(TBB_MALLOC_PROXY_INCLUDE_DIR
+          NAMES tbb/tbbmalloc_proxy.h
+          PATHS ${TBB_INC_SEARCH_PATH})
 
-IF (TBB_BINARY_DIR AND _TBB_UPDATE_BINARY_DIR)
-  SET (_TBB_BINARY_DIR ${TBB_BINARY_DIR})
-  UNSET (TBB_BINARY_DIR CACHE)
+find_library(TBB_MALLOC_PROXY_LIBRARY_RELEASE
+             NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+find_library(TBB_MALLOC_PROXY_LIBRARY_DEBUG
+             NAMES ${TBB_MALLOC_PROXY_LIBRARY_NAMES_DEBUG}
+             PATHS ${TBB_LIB_SEARCH_PATH})
+make_library_set(TBB_MALLOC_PROXY_LIBRARY)
 
-  IF (_TBB_BINARY_DIR)
-    GET_FILENAME_COMPONENT (TBB_BINARY_DIR ${_TBB_BINARY_DIR} PATH)
-  ENDIF (_TBB_BINARY_DIR)
-ENDIF (TBB_BINARY_DIR AND _TBB_UPDATE_BINARY_DIR)
+findpkg_finish(TBB_MALLOC_PROXY tbbmalloc_proxy)
 
-SET (TBB_BINARY_DIR ${TBB_BINARY_DIR} CACHE PATH "TBB binary directory")
 
-MARK_AS_ADVANCED (TBB_INCLUDE_DIR TBB_LIBRARY TBB_LIBRARY_RELEASE
-  TBB_LIBRARY_DEBUG TBB_BINARY_DIR)
+#=============================================================================
+#parse all the version numbers from tbb
+if(NOT TBB_VERSION)
 
-IF (NOT _TBB_CHECK_COMPONENTS)
- SET (_TBB_FPHSA_ADDITIONAL_ARGS HANDLE_COMPONENTS)
-ENDIF (NOT _TBB_CHECK_COMPONENTS)
+ #only read the start of the file
+ file(STRINGS
+      "${TBB_INCLUDE_DIR}/tbb/tbb_stddef.h"
+      TBB_VERSION_CONTENTS
+      REGEX "VERSION")
 
-IF (CMAKE_VERSION VERSION_GREATER 2.8.2)
-  LIST (APPEND _TBB_FPHSA_ADDITIONAL_ARGS VERSION_VAR TBB_VERSION)
-ENDIF (CMAKE_VERSION VERSION_GREATER 2.8.2)
+  string(REGEX REPLACE
+    ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
+    TBB_VERSION_MAJOR "${TBB_VERSION_CONTENTS}")
 
-FIND_PACKAGE_HANDLE_STANDARD_ARGS (TBB REQUIRED_VARS TBB_ROOT_DIR
-  TBB_INCLUDE_DIR TBB_LIBRARY ${_TBB_MISSING_LIBRARIES}
-  ${_TBB_FPHSA_ADDITIONAL_ARGS})
+  string(REGEX REPLACE
+    ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
+    TBB_VERSION_MINOR "${TBB_VERSION_CONTENTS}")
+
+  string(REGEX REPLACE
+        ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
+        TBB_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+
+  string(REGEX REPLACE
+        ".*#define TBB_COMPATIBLE_INTERFACE_VERSION ([0-9]+).*" "\\1"
+        TBB_COMPATIBLE_INTERFACE_VERSION "${TBB_VERSION_CONTENTS}")
+
+endif()


### PR DESCRIPTION
Replace the LCG 95apython3 and 96 CI builds with new ones based on LCG 97apython3 and LCG 98python3 container images. That also means that all CI builds should have a recent Python 3 version available (because, you know, its 2020). According to [lcginfo](http://lcginfo.cern.ch/) there already exists an patch release LCG 98apython3 but that one does not seem to be available as RPMs and can not be used in our self-contained container images yet.

The DD4hep version provided by LCG 98 now requires TBB. The DD4hep CMake configuration seems to use a config-only `find_package(TBB CONFIG)` call internally. To avoid library missmatches TBB is searched for twice, once in config-only mode and once in module-only. This should ensure that consistent versions are found. The `FindTBB` CMake module is updated to a newer version from the [VTK project](https://github.com/Kitware/VTK/blob/master/CMake/FindTBB.cmake) that provides CMake targets compatible with the ones provided by the TBB CMake config.

Can only be merged after acts-project/machines#25 has been merged and a new container tag has been created.