### PR TITLE
fix: Iterative Vertex Finder algorithm updated for seed vertex at z = 0

### DIFF
--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -30,6 +30,11 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     // retrieve the seed vertex as the last element in
     // the seed vertexCollection
     Vertex<InputTrack_t>& seedVertex = *seedRes;
+
+    if(seedVertex.fullPosition()[eZ] == 0){ 
+      break;
+    }
+
     /// End seeding
     /// Now take only tracks compatible with current seed
     // Tracks used for the fit in this iteration

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -31,7 +31,10 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     // the seed vertexCollection
     Vertex<InputTrack_t>& seedVertex = *seedRes;
 
-    if(seedVertex.fullPosition()[eZ] == 0){ 
+    if(seedVertex.fullPosition()[eZ] == 
+       vertexingOptions.vertexConstraint.position().z()){
+      ACTS_DEBUG(
+          "No seed found anymore. Break and stop primary vertex finding."); 
       break;
     }
 

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -31,10 +31,10 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     // the seed vertexCollection
     Vertex<InputTrack_t>& seedVertex = *seedRes;
 
-    if(seedVertex.fullPosition()[eZ] == 
-       vertexingOptions.vertexConstraint.position().z()){
+    if (seedVertex.fullPosition()[eZ] ==
+        vertexingOptions.vertexConstraint.position().z()) {
       ACTS_DEBUG(
-          "No seed found anymore. Break and stop primary vertex finding."); 
+          "No seed found anymore. Break and stop primary vertex finding.");
       break;
     }
 


### PR DESCRIPTION
Hi @baschlag and @asalzburger, Sorry I accidentally closed the last pull request while making some changes. Creating this new request. @baschlag, yes the addition of this break statement is the only change that I have done in ACTS code. The matrix inversion that I talked about earlier was in Athena. 

Please comment!