### PR TITLE
ci: Re-enable CUDA plugin in the CUDA CI job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -126,7 +126,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=/usr/bin/g++-8
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
-          -DACTS_BUILD_CUDA_PLUGIN=ON
+          -DACTS_BUILD_PLUGIN_CUDA=ON
           -DACTS_BUILD_UNITTESTS=ON
       - name: Build
         run: cmake --build build --


### PR DESCRIPTION
This got accidentally disabled when the plugin option names where changed.