### PR TITLE
ci: Bump Image versions to v9

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  CONTAINER_VERSION: v9
 
 # NOTE this only builds core unittests to reduce the output size. if we
 #      found a way to have Github actions not fail regularly with this job
@@ -18,7 +19,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v8
+    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -48,7 +49,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v8
+    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
-  CONTAINER_VERSION: v9
 
 # NOTE this only builds core unittests to reduce the output size. if we
 #      found a way to have Github actions not fail regularly with this job
@@ -19,7 +18,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/ubuntu2004:v9
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -49,7 +48,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/ubuntu2004:v9
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -49,7 +49,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -49,7 +49,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,12 +9,11 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
-  CONTAINER_VERSION: v9
 
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/${{ matrix.image }}:v9
     strategy:
       matrix:
         image:
@@ -117,7 +116,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/ubuntu1804_cuda:v9
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -133,7 +132,7 @@ jobs:
         run: cmake --build build --
   sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_oneapi:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/ubuntu2004_oneapi:v9
     defaults:
       run:
         shell: bash
@@ -155,7 +154,7 @@ jobs:
           && cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/ubuntu2004:v9
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,11 +9,12 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  CONTAINER_VERSION: v9
 
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:v8
+    container: ghcr.io/acts-project/${{ matrix.image }}:$CONTAINER_VERSION
     strategy:
       matrix:
         image:
@@ -116,7 +117,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:v8
+    container: ghcr.io/acts-project/ubuntu1804_cuda:$CONTAINER_VERSION
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -132,7 +133,7 @@ jobs:
         run: cmake --build build --
   sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_oneapi:v9
+    container: ghcr.io/acts-project/ubuntu2004_oneapi:$CONTAINER_VERSION
     defaults:
       run:
         shell: bash
@@ -154,7 +155,7 @@ jobs:
           && cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v8
+    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/${{ matrix.image }}:${{ env['CONTAINER_VERSION'] }}
     strategy:
       matrix:
         image:
@@ -117,7 +117,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/ubuntu1804_cuda:${{ env['CONTAINER_VERSION'] }}
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -133,7 +133,7 @@ jobs:
         run: cmake --build build --
   sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_oneapi:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/ubuntu2004_oneapi:${{ env['CONTAINER_VERSION'] }}
     defaults:
       run:
         shell: bash
@@ -155,7 +155,7 @@ jobs:
           && cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/ubuntu2004:${{ env['CONTAINER_VERSION'] }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/${{ matrix.image }}:${{ env.CONTAINER_VERSION }}
     strategy:
       matrix:
         image:
@@ -117,7 +117,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/ubuntu1804_cuda:${{ env.CONTAINER_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -133,7 +133,7 @@ jobs:
         run: cmake --build build --
   sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_oneapi:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/ubuntu2004_oneapi:${{ env.CONTAINER_VERSION }}
     defaults:
       run:
         shell: bash
@@ -155,7 +155,7 @@ jobs:
           && cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/ubuntu2004:${{ env.CONTAINER_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,13 +7,10 @@ on:
       - master
       - 'release/**'
 
-env:
-  CONTAINER_VERSION: v9
-
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:${{ env['CONTAINER_VERSION'] }}
+    container: ghcr.io/acts-project/format10:v9
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:${{ env.CONTAINER_VERSION }}
+    container: ghcr.io/acts-project/format10:${{ env['CONTAINER_VERSION'] }}
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,10 +7,13 @@ on:
       - master
       - 'release/**'
 
+env:
+  CONTAINER_VERSION: v9
+
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:v8
+    container: ghcr.io/acts-project/format10:$CONTAINER_VERSION
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:$CONTAINER_VERSION
+    container: ghcr.io/acts-project/format10:${{ env.CONTAINER_VERSION }}
     steps:
       - uses: actions/checkout@v2
       - name: Check


### PR DESCRIPTION
Closes #642

@msmk0 I checked, but it appears it's not possible to use env vars in the expression for the container URL. So I guess we'll have to stick to hard-coding the version.