### PR TITLE
fix: make generic examples work again

### DIFF
--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -144,7 +144,7 @@ int processGeometry(int argc, char* argv[],
       jmConverterCfg.processDenseVolumes =
           vm["mat-output-dense-volumes"].template as<bool>();
       jmConverterCfg.writeData = vm["mat-output-data"].template as<bool>();
-      jmConverterCfg.processnonmaterial =
+      jmConverterCfg.processNonMaterial =
           vm["mat-output-allmaterial"].template as<bool>();
       jmConverterCfg.context = context.geoContext;
       // The writer

--- a/Examples/Run/Fatras/Common/FatrasDigitization.cpp
+++ b/Examples/Run/Fatras/Common/FatrasDigitization.cpp
@@ -37,7 +37,7 @@ void setupDigitization(
   auto logLevel = Options::readLogLevel(vars);
   auto outputDir = vars["output-dir"].template as<std::string>();
 
-  if (vars["digi-smearing"].as<bool>()) {
+  if (vars["digi-smear"].as<bool>()) {
     SmearingAlgorithm::Config smearCfg = Options::readSmearingConfig(vars);
     smearCfg.inputSimHits = kFatrasCollectionHits;
     smearCfg.outputMeasurements = "measurements";

--- a/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
@@ -97,7 +97,7 @@ class JsonGeometryConverter {
     /// The volume identification string
     std::string volkey = "volumes";
     /// The name identification
-    std::string namekey = "Name";
+    std::string namekey = "name";
     /// The boundary surface string
     std::string boukey = "boundaries";
     /// The layer identification string
@@ -117,7 +117,7 @@ class JsonGeometryConverter {
     /// The bin2 key
     std::string bin2key = "bin2";
     /// The local to global tranfo key
-    std::string transfokeys = "tranformation";
+    std::string transfokeys = "transformation";
     /// The type key -> proto, else
     std::string typekey = "type";
     /// The data key
@@ -154,7 +154,7 @@ class JsonGeometryConverter {
     /// Steering to handle volume data
     bool processDenseVolumes = false;
     /// Add proto material to all surfaces
-    bool processnonmaterial = false;
+    bool processNonMaterial = false;
     /// Write out data
     bool writeData = true;
 

--- a/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
@@ -87,7 +87,7 @@ class JsonGeometryConverter {
   };
 
   /// @class Config
-  /// Configuration of the Reader
+  /// Configuration of the Converter
   class Config {
    public:
     /// The geometry version
@@ -110,13 +110,13 @@ class JsonGeometryConverter {
     std::string senkey = "sensitive";
     /// The representing idntification string
     std::string repkey = "representing";
-    /// The bin keys
+    /// The bin0 key
     std::string bin0key = "bin0";
     /// The bin1 key
     std::string bin1key = "bin1";
     /// The bin2 key
     std::string bin2key = "bin2";
-    /// The local to global tranfo key
+    /// The local to global transformation key
     std::string transfokeys = "transformation";
     /// The type key -> proto, else
     std::string typekey = "type";
@@ -126,7 +126,7 @@ class JsonGeometryConverter {
     std::string geometryidkey = "Geoid";
     /// The surface geoid key
     std::string surfacegeometryidkey = "SGeoid";
-    /// The mapping key, add surface to map if true
+    /// The mapping key, add surface to mapping procedure if true
     std::string mapkey = "mapMaterial";
     /// The surface type key
     std::string surfacetypekey = "stype";

--- a/Plugins/Json/src/JsonGeometryConverter.cpp
+++ b/Plugins/Json/src/JsonGeometryConverter.cpp
@@ -528,7 +528,7 @@ void Acts::JsonGeometryConverter::convertToRep(
   // Write the material if there's one
   if (tVolume.volumeMaterial() != nullptr) {
     volRep.material = tVolume.volumeMaterial();
-  } else if (m_cfg.processnonmaterial == true) {
+  } else if (m_cfg.processNonMaterial == true) {
     Acts::BinUtility bUtility = DefaultBin(tVolume);
     Acts::IVolumeMaterial* bMaterial = new Acts::ProtoVolumeMaterial(bUtility);
     volRep.material = bMaterial;
@@ -560,7 +560,7 @@ void Acts::JsonGeometryConverter::convertToRep(
         volRep.boundaries[bid] = bssfRep.surfaceMaterial();
         volRep.boundarySurfaces[bid] = &bssfRep;
       }
-    } else if (m_cfg.processnonmaterial == true) {
+    } else if (m_cfg.processNonMaterial == true) {
       // if no material suface exist add a default one for the mapping
       // configuration
       Acts::GeometryIdentifier boundaryID = bssfRep.geometryId();
@@ -595,7 +595,7 @@ Acts::JsonGeometryConverter::LayerRep Acts::JsonGeometryConverter::convertToRep(
         geo_id_value sid = sensitiveID.sensitive();
         layRep.sensitives.insert({sid, ssf->surfaceMaterial()});
         layRep.sensitiveSurfaces.insert({sid, ssf});
-      } else if (m_cfg.processnonmaterial == true) {
+      } else if (m_cfg.processNonMaterial == true) {
         // if no material suface exist add a default one for the mapping
         // configuration
         Acts::GeometryIdentifier sensitiveID = ssf->geometryId();
@@ -613,7 +613,7 @@ Acts::JsonGeometryConverter::LayerRep Acts::JsonGeometryConverter::convertToRep(
     if (tLayer.surfaceRepresentation().surfaceMaterial() != nullptr) {
       layRep.representing = tLayer.surfaceRepresentation().surfaceMaterial();
       layRep.representingSurface = &tLayer.surfaceRepresentation();
-    } else if (m_cfg.processnonmaterial == true) {
+    } else if (m_cfg.processNonMaterial == true) {
       // if no material suface exist add a default one for the mapping
       // configuration
       Acts::BinUtility rUtility = DefaultBin(tLayer.surfaceRepresentation());
@@ -632,7 +632,7 @@ Acts::JsonGeometryConverter::LayerRep Acts::JsonGeometryConverter::convertToRep(
         geo_id_value aid = approachID.approach();
         layRep.approaches.insert({aid, asf->surfaceMaterial()});
         layRep.approacheSurfaces.insert({aid, asf});
-      } else if (m_cfg.processnonmaterial == true) {
+      } else if (m_cfg.processNonMaterial == true) {
         // if no material suface exist add a default one for the mapping
         // configuration
         Acts::GeometryIdentifier approachID = asf->geometryId();

--- a/Tests/Data/material-map.json
+++ b/Tests/Data/material-map.json
@@ -2,7 +2,7 @@
     "volumes": {
         "2": {
             "Geoid": "vol=2|lay=2",
-            "Name": "",
+            "name": "",
             "layers": {
                 "2": {
                     "Geoid": "vol=2|lay=2",


### PR DESCRIPTION
This PR has two small fixes:

- in Core, it fixes a spelling mistake and naming mash-up (@Corentin-Allaire)
- in Examples, it fixes the GenericFatrasExample as it was broken due to the Options change (@msmk0)
 