### PR TITLE
feat: introduce geometric digitization 2d

### DIFF
--- a/Examples/Algorithms/Digitization/CMakeLists.txt
+++ b/Examples/Algorithms/Digitization/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(
   ActsExamplesDigitization
   PRIVATE
     ActsCore ActsPluginDigitization ActsPluginIdentification
+    ActsFatras
     ActsExamplesFramework
     Boost::program_options)
 

--- a/Examples/Algorithms/Digitization/CMakeLists.txt
+++ b/Examples/Algorithms/Digitization/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   ActsExamplesDigitization SHARED
   src/PlanarSteppingAlgorithm.cpp
   src/HitSmearing.cpp
+  src/DigitizationAlgorithm.cpp
   src/SmearingAlgorithm.cpp
   src/DigitizationOptions.cpp)
 target_include_directories(

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
@@ -10,8 +10,12 @@
 
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Geometry/GeometryHierarchyMap.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
+#include "ActsFatras/Digitization/Channelizer.hpp"
+#include "ActsFatras/Digitization/PlanarSurfaceDrift.hpp"
+#include "ActsFatras/Digitization/PlanarSurfaceMask.hpp"
 
 #include <memory>
 #include <string>
@@ -44,7 +48,7 @@ class DigitizationAlgorithm final : public BareAlgorithm {
     /// Random numbers tool.
     std::shared_ptr<const RandomNumbers> randomNumbers = nullptr;
     /// The smearers per GeometryIdentifier
-    // Acts::GeometryHierarchyMap<SmearerConfig> smearers;
+    Acts::GeometryHierarchyMap<Acts::BinUtility> segmentations;
   };
 
   /// Construct the smearing algorithm.
@@ -61,6 +65,9 @@ class DigitizationAlgorithm final : public BareAlgorithm {
 
  private:
   Config m_cfg;
+  ActsFatras::Channelizer m_channelizer;
+  ActsFatras::PlanarSurfaceDrift m_planarDrift;
+  ActsFatras::PlanarSurfaceMask m_planarMask;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
@@ -1,0 +1,68 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/Geometry/GeometryHierarchyMap.hpp"
+#include "ActsExamples/Framework/BareAlgorithm.hpp"
+#include "ActsExamples/Framework/RandomNumbers.hpp"
+
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace Acts {
+class Surface;
+class TrackingGeometry;
+}  // namespace Acts
+
+namespace ActsExamples {
+
+/// Algorithm that turns simulated hits into measurements by truth smearing.
+class DigitizationAlgorithm final : public BareAlgorithm {
+ public:
+
+  struct Config {
+    /// Input collection of simulated hits.
+    std::string inputSimHits;
+    /// Output source links collection.
+    std::string outputSourceLinks;
+    /// Output measurements collection.
+    std::string outputMeasurements;
+    /// Output collection to map measured hits to contributing particles.
+    std::string outputMeasurementParticlesMap;
+    /// Output collection to map measured hits to simulated hits.
+    std::string outputMeasurementSimHitsMap;
+    /// Tracking geometry required to access global-to-local transforms.
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry = nullptr;
+    /// Random numbers tool.
+    std::shared_ptr<const RandomNumbers> randomNumbers = nullptr;
+    /// The smearers per GeometryIdentifier
+    // Acts::GeometryHierarchyMap<SmearerConfig> smearers;
+  };
+
+  /// Construct the smearing algorithm.
+  ///
+  /// @param cfg is the algorithm configuration
+  /// @param lvl is the logging level
+  DigitizationAlgorithm(Config cfg, Acts::Logging::Level lvl);
+
+  /// Build measurement from simulation hits at input.
+  ///
+  /// @param ctx is the algorithm context with event information
+  /// @return a process code indication success or failure
+  ProcessCode execute(const AlgorithmContext& ctx) const final override;
+
+ private:
+
+  Config m_cfg;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
@@ -28,7 +28,6 @@ namespace ActsExamples {
 /// Algorithm that turns simulated hits into measurements by truth smearing.
 class DigitizationAlgorithm final : public BareAlgorithm {
  public:
-
   struct Config {
     /// Input collection of simulated hits.
     std::string inputSimHits;
@@ -61,7 +60,6 @@ class DigitizationAlgorithm final : public BareAlgorithm {
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
 
  private:
-
   Config m_cfg;
 };
 

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationOptions.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationOptions.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
 #include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
 #include "ActsExamples/Utilities/OptionsFwd.hpp"
 
@@ -23,6 +24,12 @@ void addDigitizationOptions(Description& desc);
 ///
 /// @param variables The variables to read from
 SmearingAlgorithm::Config readSmearingConfig(const Variables& variables);
+
+/// Read DigitizationAlgorithm Config from the options.
+///
+/// @param variables The variables to read from
+DigitizationAlgorithm::Config readDigitizationConfig(
+    const Variables& variables);
 
 }  // namespace Options
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -74,10 +74,10 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
     // otherwise clang on macos complains that it is unable to capture the local
     // binding in the lambda used for visiting the smearer below.
     Acts::GeometryIdentifier moduleGeoId = simHitsGroup.first;
-   
+
     const Acts::Surface* surfacePtr =
         m_cfg.trackingGeometry->findSurface(moduleGeoId);
-   
+
     if (not surfacePtr) {
       // this is either an invalid geometry id or a misconfigured smearer
       // setup; both cases can not be handled and should be fatal.
@@ -85,9 +85,8 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
                                            << " for configured smearer");
       return ProcessCode::ABORT;
     }
-
   }
-  
+
   ctx.eventStore.add(m_cfg.outputSourceLinks, std::move(sourceLinks));
   ctx.eventStore.add(m_cfg.outputMeasurements, std::move(measurements));
   ctx.eventStore.add(m_cfg.outputMeasurementParticlesMap,

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -1,0 +1,98 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
+
+#include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "ActsExamples/EventData/GeometryContainers.hpp"
+#include "ActsExamples/EventData/IndexSourceLink.hpp"
+#include "ActsExamples/EventData/Measurement.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsFatras/Digitization/UncorrelatedHitSmearer.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <type_traits>
+
+ActsExamples::DigitizationAlgorithm::DigitizationAlgorithm(
+    ActsExamples::DigitizationAlgorithm::Config cfg, Acts::Logging::Level lvl)
+    : ActsExamples::BareAlgorithm("DigitizationAlgorithm", lvl),
+      m_cfg(std::move(cfg)) {
+  if (m_cfg.inputSimHits.empty()) {
+    throw std::invalid_argument("Missing simulated hits input collection");
+  }
+  if (m_cfg.outputMeasurements.empty()) {
+    throw std::invalid_argument("Missing measurements output collection");
+  }
+  if (m_cfg.outputSourceLinks.empty()) {
+    throw std::invalid_argument("Missing source links output collection");
+  }
+  if (m_cfg.outputMeasurementParticlesMap.empty()) {
+    throw std::invalid_argument(
+        "Missing hit-to-particles map output collection");
+  }
+  if (m_cfg.outputMeasurementSimHitsMap.empty()) {
+    throw std::invalid_argument(
+        "Missing hit-to-simulated-hits map output collection");
+  }
+  if (not m_cfg.trackingGeometry) {
+    throw std::invalid_argument("Missing tracking geometry");
+  }
+  if (not m_cfg.randomNumbers) {
+    throw std::invalid_argument("Missing random numbers tool");
+  }
+}
+
+ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
+    const AlgorithmContext& ctx) const {
+  // retrieve input
+  const auto& simHits = ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimHits);
+
+  // prepare output containers
+  IndexSourceLinkContainer sourceLinks;
+  MeasurementContainer measurements;
+  IndexMultimap<ActsFatras::Barcode> hitParticlesMap;
+  IndexMultimap<Index> hitSimHitsMap;
+  sourceLinks.reserve(simHits.size());
+  measurements.reserve(simHits.size());
+  hitParticlesMap.reserve(simHits.size());
+  hitSimHitsMap.reserve(simHits.size());
+
+  // setup random number generator
+  auto rng = m_cfg.randomNumbers->spawnGenerator(ctx);
+
+  for (auto simHitsGroup : groupByModule(simHits)) {
+    // manual pair unpacking instead of using
+    //   auto [moduleGeoId, moduleSimHits] : ...
+    // otherwise clang on macos complains that it is unable to capture the local
+    // binding in the lambda used for visiting the smearer below.
+    Acts::GeometryIdentifier moduleGeoId = simHitsGroup.first;
+   
+    const Acts::Surface* surfacePtr =
+        m_cfg.trackingGeometry->findSurface(moduleGeoId);
+   
+    if (not surfacePtr) {
+      // this is either an invalid geometry id or a misconfigured smearer
+      // setup; both cases can not be handled and should be fatal.
+      ACTS_ERROR("Could not find surface " << moduleGeoId
+                                           << " for configured smearer");
+      return ProcessCode::ABORT;
+    }
+
+  }
+  
+  ctx.eventStore.add(m_cfg.outputSourceLinks, std::move(sourceLinks));
+  ctx.eventStore.add(m_cfg.outputMeasurements, std::move(measurements));
+  ctx.eventStore.add(m_cfg.outputMeasurementParticlesMap,
+                     std::move(hitParticlesMap));
+  ctx.eventStore.add(m_cfg.outputMeasurementSimHitsMap,
+                     std::move(hitSimHitsMap));
+  return ProcessCode::SUCCESS;
+}

--- a/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
@@ -23,6 +23,12 @@ void ActsExamples::Options::addDigitizationOptions(Description& desc) {
   using boost::program_options::bool_switch;
   using boost::program_options::value;
 
+  // digitization can be done using a smearing approach or a geometric approach
+  //
+  // --digi-smear on  # swtiches the smearing on
+  // --digi-geo2d on  # switches the geometric clustering in 2d on 
+  // --digi-geo3d on  # switches the geometric clustering in 3d on (legacy)
+  //
   // each volume configuration is one logical block
   //
   //   --digi-smear-volume-id=8
@@ -44,8 +50,10 @@ void ActsExamples::Options::addDigitizationOptions(Description& desc) {
   opt("digi-config-file", value<std::string>(),
       "Configuration (.json) file for digitization description, overwrites "
       "options input on command line.");
-  opt("digi-geometric-3d", bool_switch(),
-      "Geometric: Switching geometric digitisation in 3D on");
+  opt("digi-geo3d", bool_switch(),
+      "Geometric: Switching geometric digitization in 2D on");
+  opt("digi-geo2d", bool_switch(),
+      "Geometric: Switching geometric digitization in 3D on");
   opt("digi-smear", bool_switch(), "Smearing: Switching hit smearing on");
   opt("digi-smear-volume", value<std::vector<int>>(),
       "Smearing Input: sensitive volume identifiers.");

--- a/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
@@ -26,7 +26,7 @@ void ActsExamples::Options::addDigitizationOptions(Description& desc) {
   // digitization can be done using a smearing approach or a geometric approach
   //
   // --digi-smear on  # swtiches the smearing on
-  // --digi-geo2d on  # switches the geometric clustering in 2d on 
+  // --digi-geo2d on  # switches the geometric clustering in 2d on
   // --digi-geo3d on  # switches the geometric clustering in 3d on (legacy)
   //
   // each volume configuration is one logical block

--- a/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationOptions.cpp
@@ -29,20 +29,29 @@ void ActsExamples::Options::addDigitizationOptions(Description& desc) {
   // --digi-geo2d on  # switches the geometric clustering in 2d on
   // --digi-geo3d on  # switches the geometric clustering in 3d on (legacy)
   //
-  // each volume configuration is one logical block
+  // geometric 2d configuration
+  //   each volume configuration is one logical block
+  //   --digi-volume-id=8
+  //   --digi-indices=0:1 # loc0, loc1
+  //   --digi-geo2d-pitches=0.05:0.05
   //
-  //   --digi-smear-volume-id=8
-  //   --digi-smear-indices=0:1:5 # loc0, loc1, and time
+  //  which can be repeated as often as needed
+  //
+  // smearing configuration:
+  //   each volume configuration is one logical block
+  //
+  //   --digi-volume-id=8
+  //   --digi-indices=0:1:5 # loc0, loc1, and time
   //   --digi-smear-types=0:0:3   # loc{0,1} uses gaussian, time uses uniform
   //   # parameter 0: loc0 gaussian width
   //   # parameter 1: loc1 gaussian width
   //   # parameter 2-4: time pitch,min,max
   //   --digi-smear-parameters=10:20:2.5:-25:25
   //
-  // which can be repeated as often as needed
+  //   which can be repeated as often as needed
   //
-  //   --digi-smear-volume-id=11
-  //   --digi-smear-indices=1       # loc1
+  //   --digi-volume-id=11
+  //   --digi-indices=1       # loc1
   //   --digi-smear-types=0         # loc1 uses gaussian
   //   --digi-smear-parameters=12.5 # loc1 gaussian width
   //
@@ -51,14 +60,14 @@ void ActsExamples::Options::addDigitizationOptions(Description& desc) {
       "Configuration (.json) file for digitization description, overwrites "
       "options input on command line.");
   opt("digi-geo3d", bool_switch(),
-      "Geometric: Switching geometric digitization in 2D on");
+      "Geometric: Switching geometric digitization in 3D on (legacy).");
+  opt("digi-volume", value<std::vector<int>>(),
+      "Common Input: sensitive volume identifiers.");
+  opt("digi-indices", value<std::vector<VariableIntegers>>(),
+      "Common Input: smear parameter indices for this volume.");
   opt("digi-geo2d", bool_switch(),
-      "Geometric: Switching geometric digitization in 3D on");
+      "Geometric: Switching geometric digitization in 2D on.");
   opt("digi-smear", bool_switch(), "Smearing: Switching hit smearing on");
-  opt("digi-smear-volume", value<std::vector<int>>(),
-      "Smearing Input: sensitive volume identifiers.");
-  opt("digi-smear-indices", value<std::vector<VariableIntegers>>(),
-      "Smearing Input: smear parameter indices for this volume.");
   opt("digi-smear-types", value<std::vector<VariableIntegers>>(),
       "Smearing Input: smear function types as 0 (gauss), 1 (truncated gauss), "
       "2 (clipped gauss), 3 (uniform), 4 (digital).");
@@ -122,20 +131,19 @@ ActsExamples::Options::readSmearingConfig(const Variables& variables) {
   // smearers configuration. this will be caught later on during the algorithm
   // construction.
 
-  auto volumes = variables["digi-smear-volume"].as<std::vector<int>>();
+  auto volumes = variables["digi-volume"].as<std::vector<int>>();
   if (volumes.empty()) {
     // no configured volumes are not considered an error at this stage
     return smearCfg;
   }
 
-  auto indices =
-      variables["digi-smear-indices"].as<std::vector<VariableIntegers>>();
+  auto indices = variables["digi-indices"].as<std::vector<VariableIntegers>>();
   auto types =
       variables["digi-smear-types"].as<std::vector<VariableIntegers>>();
   auto parameters =
       variables["digi-smear-parameters"].as<std::vector<VariableReals>>();
   if (indices.size() != volumes.size()) {
-    ACTS_ERROR("Inconsistent digi-smear-indices options. Expected "
+    ACTS_ERROR("Inconsistent digi-indices options. Expected "
                << volumes.size() << ", but received " << indices.size());
     return smearCfg;
   }
@@ -210,4 +218,14 @@ ActsExamples::Options::readSmearingConfig(const Variables& variables) {
           std::move(smearersInput));
 
   return smearCfg;
+}
+
+ActsExamples::DigitizationAlgorithm::Config
+ActsExamples::Options::readDigitizationConfig(const Variables& variables) {
+  ACTS_LOCAL_LOGGER(
+      Acts::getDefaultLogger("DigitizationOptions", Acts::Logging::INFO));
+
+  DigitizationAlgorithm::Config digiCfg;
+
+  return digiCfg;
 }

--- a/Examples/Run/Fatras/Common/FatrasDigitization.cpp
+++ b/Examples/Run/Fatras/Common/FatrasDigitization.cpp
@@ -67,6 +67,18 @@ void setupDigitization(
     }
 
   } else if (vars["digi-geo2d"].as<bool>()) {
+    DigitizationAlgorithm::Config digiCfg =
+        Options::readDigitizationConfig(vars);
+    digiCfg.inputSimHits = kFatrasCollectionHits;
+    digiCfg.outputMeasurements = "measurements";
+    digiCfg.outputSourceLinks = "sourcelinks";
+    digiCfg.outputMeasurementParticlesMap = "measurement_particles_map";
+    digiCfg.outputMeasurementSimHitsMap = "measurement_simhits_map";
+    digiCfg.trackingGeometry = trackingGeometry;
+    digiCfg.randomNumbers = randomNumbers;
+    sequencer.addAlgorithm(
+        std::make_shared<DigitizationAlgorithm>(digiCfg, logLevel));
+
   } else if (vars["digi-geo3d"].as<bool>()) {
     // Configure the digitizer
     PlanarSteppingAlgorithm::Config digi;

--- a/Examples/Run/Fatras/Common/FatrasDigitization.cpp
+++ b/Examples/Run/Fatras/Common/FatrasDigitization.cpp
@@ -7,9 +7,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Plugins/Digitization/PlanarModuleStepper.hpp"
+#include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
 #include "ActsExamples/Digitization/DigitizationOptions.hpp"
 #include "ActsExamples/Digitization/PlanarSteppingAlgorithm.hpp"
-#include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
 #include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
@@ -66,9 +66,7 @@ void setupDigitization(
           std::make_shared<RootDigitizationWriter>(smearWriterRoot, logLevel));
     }
 
-  } else if (vars["digi-geo2d"].as<bool>()) { 
-
-
+  } else if (vars["digi-geo2d"].as<bool>()) {
   } else if (vars["digi-geo3d"].as<bool>()) {
     // Configure the digitizer
     PlanarSteppingAlgorithm::Config digi;

--- a/Examples/Run/Fatras/Common/FatrasDigitization.cpp
+++ b/Examples/Run/Fatras/Common/FatrasDigitization.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Plugins/Digitization/PlanarModuleStepper.hpp"
 #include "ActsExamples/Digitization/DigitizationOptions.hpp"
 #include "ActsExamples/Digitization/PlanarSteppingAlgorithm.hpp"
+#include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
 #include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
@@ -65,7 +66,10 @@ void setupDigitization(
           std::make_shared<RootDigitizationWriter>(smearWriterRoot, logLevel));
     }
 
-  } else if (vars["digi-geometric-3d"].as<bool>()) {
+  } else if (vars["digi-geo2d"].as<bool>()) { 
+
+
+  } else if (vars["digi-geo3d"].as<bool>()) {
     // Configure the digitizer
     PlanarSteppingAlgorithm::Config digi;
     digi.inputSimHits = "hits";

--- a/Examples/Scripts/CKF_timing_vs_mu.sh
+++ b/Examples/Scripts/CKF_timing_vs_mu.sh
@@ -87,7 +87,7 @@ for mu in 0 50 100 150 200 250 300 ; do
     eval ${gen}
 
     # Run sim
-    sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} --select-pt-gev '0.1:' --select-eta '-3:3' --fatras-pmin-gev 0.1 --remove-neutral 1 --digi-geometric-3d --input-dir=data/gen/ttbar_e${numEvents}_mu${mu} --output-csv=1 --output-dir=data/sim_${detector}/ttbar_e${numEvents}_mu${mu}"  
+    sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} --select-pt-gev '0.1:' --select-eta '-3:3' --fatras-pmin-gev 0.1 --remove-neutral 1 --digi-geo3d --input-dir=data/gen/ttbar_e${numEvents}_mu${mu} --output-csv=1 --output-dir=data/sim_${detector}/ttbar_e${numEvents}_mu${mu}"  
     echo ${sim}
     eval ${sim}
 

--- a/Examples/Scripts/KF_timing.sh
+++ b/Examples/Scripts/KF_timing.sh
@@ -97,7 +97,7 @@ jobID=0
          eta=$(echo "${etaBin}*0.5 + 0.25"|bc) 
 
          # Run sim
-         sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} -n ${numEvents} --gen-nparticles ${numTracksPerEvent} --gen-p-gev ${pt}:${pt} --gen-eta ${etaLow}:${etaUp} --digi-geometric-3d --output-csv=1 --output-dir=data/sim_${detector}/e${numEvents}_t${numTracksPerEvent}_eta${eta}_pt${pt}"  
+         sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} -n ${numEvents} --gen-nparticles ${numTracksPerEvent} --gen-p-gev ${pt}:${pt} --gen-eta ${etaLow}:${etaUp} --digi-geo3d --output-csv=1 --output-dir=data/sim_${detector}/e${numEvents}_t${numTracksPerEvent}_eta${eta}_pt${pt}"  
          echo "Run sim with '${sim}'"
          eval ${sim}
        

--- a/Fatras/CMakeLists.txt
+++ b/Fatras/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   ActsFatras SHARED
   src/Digitization/Channelizer.cpp
   src/Digitization/DigitizationError.cpp
+  src/Digitization/PlanarSurfaceDrift.cpp
   src/Digitization/PlanarSurfaceMask.cpp
   src/EventData/Particle.cpp
   src/EventData/ProcessType.cpp

--- a/Fatras/include/ActsFatras/Digitization/ChannelMerger.hpp
+++ b/Fatras/include/ActsFatras/Digitization/ChannelMerger.hpp
@@ -14,7 +14,9 @@
 #include "ActsFatras/Digitization/DigitizationData.hpp"
 
 #include <array>
+#include <map>
 #include <utility>
+#include <vector>
 
 namespace ActsFatras {
 

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
@@ -1,0 +1,49 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceError.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <functional>
+
+namespace ActsFatras {
+
+/// The PlanarSurfaceDrift takes an intersection in the nominal surface and
+/// projects the ends into the readout surface, which can be at : -1, 0, 1
+///
+/// A Lorentz drift angle can be applied, such as a small smearing to it
+struct PlanarSurfaceDrift {
+  /// Shorthand for a 2D segment
+  using Segment2D = std::array<Acts::Vector2, 2>;
+
+  /// Drift the full 3D segment onto a surface 2D readout plane
+  ///
+  /// @param gctx The current Geometry context
+  /// @param surface The nominal intersection surface
+  /// @param depletion The emulated module/depletion thickness
+  /// @param pos The position in global coordinates
+  /// @param dir The direciton in global coordinates
+  /// @param driftDir The drift direction in local (surface) coordinates
+  ///        @note a drift direction of (0,0,0) is drift to central plane
+  ///              any other a drift direction with driftDir.z() != 0.
+  ///              will result on a readout on either + 0.5*depletion
+  ///              or -0.5*depletion
+  ///
+  /// @return a Segment on the readout surface @note without masking
+  Segment2D toReadout(const Acts::GeometryContext& gctx,
+                      const Acts::Surface& surface, double depletion,
+                      const Acts::Vector3& pos, const Acts::Vector3& dir,
+                      const Acts::Vector3& driftdir) const;
+};
+
+}  // namespace ActsFatras

--- a/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
@@ -1,0 +1,49 @@
+
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/Digitization/PlanarSurfaceDrift.hpp"
+
+ActsFatras::PlanarSurfaceDrift::Segment2D
+ActsFatras::PlanarSurfaceDrift::toReadout(const Acts::GeometryContext& gctx,
+                                          const Acts::Surface& surface,
+                                          double depletion,
+                                          const Acts::Vector3& pos,
+                                          const Acts::Vector3& dir,
+                                          const Acts::Vector3& driftDir) const {
+  // Transform the hit & direction into the local surface frame
+  const auto& invTransform = surface.transform(gctx).inverse();
+  Acts::Vector2 pos2Local = (invTransform * pos).segment<2>(0);
+  Acts::Vector3 seg3Local = invTransform.linear() * dir;
+  // Scale unit direction to the actual segemnt in the (depletion) zone
+  seg3Local *= depletion / std::cos(Acts::VectorHelpers::theta(seg3Local));
+  // Calulate local entry/exit before drift
+  Acts::Vector2 entry = pos2Local - 0.5 * seg3Local.segment<2>(0);
+  Acts::Vector2 exit = pos2Local + 0.5 * seg3Local.segment<2>(0);
+  // Actually apply a drift
+  // - dirftDir is assumed in local coordinates
+  if (not driftDir.isApprox(Acts::Vector3(0., 0., 0.)) and
+      not driftDir.isApprox(Acts::Vector3(0., 0., 1.)) and
+      not driftDir.isApprox(Acts::Vector3(0., 0., -1.))) {
+    // Apply the scaled drift
+    auto applyDrift = [&](Acts::Vector2& local) {
+      auto scaledDriftDir =
+          driftDir * depletion / std::cos(Acts::VectorHelpers::theta(driftDir));
+      local += scaledDriftDir.segment<2>(0);
+    };
+
+    if (driftDir.z() > 0.) {
+      applyDrift(entry);
+    }
+    if (driftDir.z() < 0.) {
+      applyDrift(exit);
+    }
+  }
+
+  return {entry, exit};
+}

--- a/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
@@ -116,11 +116,7 @@ class JsonGeometryConverter {
     std::string bin1key = "bin1";
     /// The bin2 key
     std::string bin2key = "bin2";
-<<<<<<< HEAD
     /// The local to global transformation key
-=======
-    /// The local to global tranfo key
->>>>>>> 3a8c2740b... make generic examples work again
     std::string transfokeys = "transformation";
     /// The type key -> proto, else
     std::string typekey = "type";

--- a/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/JsonGeometryConverter.hpp
@@ -116,7 +116,11 @@ class JsonGeometryConverter {
     std::string bin1key = "bin1";
     /// The bin2 key
     std::string bin2key = "bin2";
+<<<<<<< HEAD
     /// The local to global transformation key
+=======
+    /// The local to global tranfo key
+>>>>>>> 3a8c2740b... make generic examples work again
     std::string transfokeys = "transformation";
     /// The type key -> proto, else
     std::string typekey = "type";

--- a/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
+++ b/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
@@ -2,5 +2,6 @@ set(unittest_extra_libraries ActsFatras)
 
 add_unittest(FatrasChannelMerger ChannelMergerTests.cpp)
 add_unittest(FatrasChannelizer ChannelizerTests.cpp)
+add_unittest(FatrasPlanarSurfaceDrift PlanarSurfaceDriftTests.cpp)
 add_unittest(FatrasPlanarSurfaceMask PlanarSurfaceMaskTests.cpp)
 add_unittest(FatrasUncorrelatedHitSmearer UncorrelatedHitSmearerTests.cpp)

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
@@ -1,0 +1,114 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "ActsFatras/Digitization/DigitizationError.hpp"
+#include "ActsFatras/Digitization/PlanarSurfaceDrift.hpp"
+
+namespace bdata = boost::unit_test::data;
+
+namespace ActsFatras {
+
+BOOST_AUTO_TEST_SUITE(Digitization)
+
+BOOST_AUTO_TEST_CASE(PlanarSurfaceDrift) {
+  Acts::GeometryContext geoCtx;
+
+  ActsFatras::PlanarSurfaceDrift psd;
+
+  Acts::Vector3 cPosition = Acts::Vector3(10., 50., 12.);
+  Acts::Vector3 cNormal = Acts::Vector3(1., 1., 1.).normalized();
+
+  auto planeSurface =
+      Acts::Surface::makeShared<Acts::PlaneSurface>(cPosition, cNormal);
+
+  double depletion = 0.250;
+
+  // Nominal intersection
+  Acts::Vector3 noDrift(0., 0., 0.);
+  Acts::Vector3 holeDrift = Acts::Vector3(0.5, 0., 1.).normalized();
+  Acts::Vector3 chargeDrift = Acts::Vector3(0.5, 0., -1.).normalized();
+
+  // Intersect surface at normal direction and no drift
+  //
+  // -> resulting segment must have entry & exit at (0,0) local coordinates
+  auto noDriftSegment = psd.toReadout(geoCtx, *planeSurface, depletion,
+                                      cPosition, cNormal, noDrift);
+
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].x(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].y(), 0., Acts::s_epsilon);
+
+  Acts::Vector3 particleDir = Acts::Vector3(2., 1., 1.).normalized();
+
+  // Intersect surface at particleDirection != normal and no drift
+  //
+  // -> local segment must be symmetric around (0,0)
+  noDriftSegment = psd.toReadout(geoCtx, *planeSurface, depletion, cPosition,
+                                 particleDir, noDrift);
+
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), -noDriftSegment[1].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), -noDriftSegment[1].y(),
+                  Acts::s_epsilon);
+
+  // Intersect surface at particleDirection != normal and a drift somewhat along
+  // the normal and x
+  //
+  // -> local segment must not be symmetric around (0,0)
+  // -> segment exit at pos local z remains unchanged
+  // -> segment entry at neg local z changes in x, remains unchaged in y
+  auto driftedSegment = psd.toReadout(geoCtx, *planeSurface, depletion,
+                                      cPosition, particleDir, holeDrift);
+
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - driftedSegment[1].x()) >
+              Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].y() - driftedSegment[1].y()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].x(), driftedSegment[1].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].y(), driftedSegment[1].y(),
+                  Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - noDriftSegment[0].x()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(driftedSegment[0].y(), noDriftSegment[0].y(),
+                  Acts::s_epsilon);
+
+  // Intersect surface at particleDirection != normal and a drift somewhat
+  // opposite the normal and y
+  //
+  // -> local segment must not be symmetric around (0,0)
+  // -> segment entry at neg local z remains unchanged
+  // -> segment exit at pos local z changes in x, remains unchaged in y
+  driftedSegment = psd.toReadout(geoCtx, *planeSurface, depletion, cPosition,
+                                 particleDir, chargeDrift);
+
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - driftedSegment[1].x()) >
+              Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].y() - driftedSegment[1].y()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), driftedSegment[0].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), driftedSegment[0].y(),
+                  Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[1].x() - noDriftSegment[1].x()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(driftedSegment[1].y(), noDriftSegment[1].y(),
+                  Acts::s_epsilon);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsFatras

--- a/docs/howto/run_fatras.rst
+++ b/docs/howto/run_fatras.rst
@@ -107,7 +107,7 @@ muons in a reasonable kinematic range are generated.
        --output-csv=1 \
        --events=100 \
        --bf-value=0 0 2 \
-       --digi-geometric-3d
+       --digi-geo3d
 
 For each event, the following files will be created
 
@@ -139,6 +139,6 @@ particles.
        --select-pt=0.5: \
        --remove-neutral \
        --bf-value=0 0 2 \
-       --digi-geometric-3d
+       --digi-geo3d
 
 The output file structure will be the same as discussed above.


### PR DESCRIPTION
This PR finally adds the 2D digitization to the Examples.

It introduces the last final Digitization struct in Fatras `PlanarSurfaceDrift` which projects an intersected 3D segment onto a readout plane using a drift direction.

It also adds an example algorithm in `Examples/Algorithm` that performs this geometric digitisation.