### PR TITLE
feat: introduce surface drift 

### DIFF
--- a/Fatras/CMakeLists.txt
+++ b/Fatras/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   src/Digitization/Channelizer.cpp
   src/Digitization/DigitizationError.cpp
   src/Digitization/PlanarSurfaceMask.cpp
+  src/Digitization/PlanarSurfaceDrift.cpp
   src/EventData/Particle.cpp
   src/EventData/ProcessType.cpp
   src/Kernel/SimulatorError.cpp

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
@@ -1,0 +1,49 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceError.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <functional>
+
+namespace ActsFatras {
+
+/// The PlanarSurfaceDrift takes an intersection in the nominal surface and
+/// projects the ends into the readout surface, which can be at : -1, 0, 1
+///
+/// A Lorentz drift angle can be applied, such as a small smearing to it
+struct PlanarSurfaceDrift {
+  /// Shorthand for a 2D segment
+  using Segment2D = std::array<Acts::Vector2, 2>;
+
+  /// Drift the full 3D segment onto a surface 2D readout plane
+  ///
+  /// @param gctx The current Geometry context
+  /// @param surface The nominal intersection surface
+  /// @param depletion The emulated module/depletion thickness
+  /// @param pos The position in global coordinates
+  /// @param dir The direciton in global coordinates
+  /// @param driftDir The drift direction in local (surface) coordinates
+  ///        @note a drift direction of (0,0,0) is drift to central plane
+  ///              any other a drift direction with driftDir.z() != 0.
+  ///              will result on a readout on either + 0.5*depletion
+  ///              or -0.5*depletion
+  ///
+  /// @return a Segment on the readout surface @note without masking
+  Segment2D toReadout(const Acts::GeometryContext& gctx,
+                      const Acts::Surface& surface, double depletion,
+                      const Acts::Vector3& pos, const Acts::Vector3& dir,
+                      const Acts::Vector3& driftdir) const;
+};
+
+}  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
@@ -21,7 +21,8 @@ namespace ActsFatras {
 /// The PlanarSurfaceDrift takes an intersection in the nominal surface and
 /// projects the ends into the readout surface, which can be at : -1, 0, 1
 ///
-/// A Lorentz drift angle can be applied, such as a small smearing to it
+/// A Lorentz drift angle can be applied.
+///
 struct PlanarSurfaceDrift {
   /// Shorthand for a 2D segment
   using Segment2D = std::array<Acts::Vector2, 2>;
@@ -30,7 +31,7 @@ struct PlanarSurfaceDrift {
   ///
   /// @param gctx The current Geometry context
   /// @param surface The nominal intersection surface
-  /// @param depletion The emulated module/depletion thickness
+  /// @param thickness The emulated module/depletion thickness
   /// @param pos The position in global coordinates
   /// @param dir The direciton in global coordinates
   /// @param driftDir The drift direction in local (surface) coordinates
@@ -41,7 +42,7 @@ struct PlanarSurfaceDrift {
   ///
   /// @return a Segment on the readout surface @note without masking
   Segment2D toReadout(const Acts::GeometryContext& gctx,
-                      const Acts::Surface& surface, double depletion,
+                      const Acts::Surface& surface, double thickness,
                       const Acts::Vector3& pos, const Acts::Vector3& dir,
                       const Acts::Vector3& driftdir) const;
 };

--- a/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
@@ -1,0 +1,49 @@
+
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/Digitization/PlanarSurfaceDrift.hpp"
+
+ActsFatras::PlanarSurfaceDrift::Segment2D
+ActsFatras::PlanarSurfaceDrift::toReadout(const Acts::GeometryContext& gctx,
+                                          const Acts::Surface& surface,
+                                          double depletion,
+                                          const Acts::Vector3& pos,
+                                          const Acts::Vector3& dir,
+                                          const Acts::Vector3& driftDir) const {
+  // Transform the hit & direction into the local surface frame
+  const auto& invTransform = surface.transform(gctx).inverse();
+  Acts::Vector2 pos2Local = (invTransform * pos).segment<2>(0);
+  Acts::Vector3 seg3Local = invTransform.linear() * dir;
+  // Scale unit direction to the actual segemnt in the (depletion) zone
+  seg3Local *= depletion / std::cos(Acts::VectorHelpers::theta(seg3Local));
+  // Calulate local entry/exit before drift
+  Acts::Vector2 entry = pos2Local - 0.5 * seg3Local.segment<2>(0);
+  Acts::Vector2 exit = pos2Local + 0.5 * seg3Local.segment<2>(0);
+  // Actually apply a drift
+  // - dirftDir is assumed in local coordinates
+  if (not driftDir.isApprox(Acts::Vector3(0., 0., 0.)) and
+      not driftDir.isApprox(Acts::Vector3(0., 0., 1.)) and
+      not driftDir.isApprox(Acts::Vector3(0., 0., -1.))) {
+    // Apply the scaled drift
+    auto applyDrift = [&](Acts::Vector2& local) {
+      auto scaledDriftDir =
+          driftDir * depletion / std::cos(Acts::VectorHelpers::theta(driftDir));
+      local += scaledDriftDir.segment<2>(0);
+    };
+
+    if (driftDir.z() > 0.) {
+      applyDrift(entry);
+    }
+    if (driftDir.z() < 0.) {
+      applyDrift(exit);
+    }
+  }
+
+  return {entry, exit};
+}

--- a/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
@@ -1,7 +1,6 @@
-
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
@@ -11,7 +11,7 @@
 ActsFatras::PlanarSurfaceDrift::Segment2D
 ActsFatras::PlanarSurfaceDrift::toReadout(const Acts::GeometryContext& gctx,
                                           const Acts::Surface& surface,
-                                          double depletion,
+                                          double thickness,
                                           const Acts::Vector3& pos,
                                           const Acts::Vector3& dir,
                                           const Acts::Vector3& driftDir) const {
@@ -19,20 +19,18 @@ ActsFatras::PlanarSurfaceDrift::toReadout(const Acts::GeometryContext& gctx,
   const auto& invTransform = surface.transform(gctx).inverse();
   Acts::Vector2 pos2Local = (invTransform * pos).segment<2>(0);
   Acts::Vector3 seg3Local = invTransform.linear() * dir;
-  // Scale unit direction to the actual segemnt in the (depletion) zone
-  seg3Local *= depletion / std::cos(Acts::VectorHelpers::theta(seg3Local));
+  // Scale unit direction to the actual segment in the (depletion/drift) zone
+  seg3Local *= thickness / std::cos(Acts::VectorHelpers::theta(seg3Local));
   // Calulate local entry/exit before drift
   Acts::Vector2 entry = pos2Local - 0.5 * seg3Local.segment<2>(0);
   Acts::Vector2 exit = pos2Local + 0.5 * seg3Local.segment<2>(0);
   // Actually apply a drift
   // - dirftDir is assumed in local coordinates
-  if (not driftDir.isApprox(Acts::Vector3(0., 0., 0.)) and
-      not driftDir.isApprox(Acts::Vector3(0., 0., 1.)) and
-      not driftDir.isApprox(Acts::Vector3(0., 0., -1.))) {
+  if (not driftDir.segment<2>(0).isApprox(Acts::Vector2(0., 0.))) {
     // Apply the scaled drift
     auto applyDrift = [&](Acts::Vector2& local) {
       auto scaledDriftDir =
-          driftDir * depletion / std::cos(Acts::VectorHelpers::theta(driftDir));
+          driftDir * thickness / std::cos(Acts::VectorHelpers::theta(driftDir));
       local += scaledDriftDir.segment<2>(0);
     };
 

--- a/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
+++ b/Tests/UnitTests/Fatras/Digitization/CMakeLists.txt
@@ -2,5 +2,6 @@ set(unittest_extra_libraries ActsFatras)
 
 add_unittest(FatrasChannelMerger ChannelMergerTests.cpp)
 add_unittest(FatrasChannelizer ChannelizerTests.cpp)
+add_unittest(FatrasPlanarSurfaceDrift PlanarSurfaceDriftTests.cpp)
 add_unittest(FatrasPlanarSurfaceMask PlanarSurfaceMaskTests.cpp)
 add_unittest(FatrasUncorrelatedHitSmearer UncorrelatedHitSmearerTests.cpp)

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
@@ -1,0 +1,114 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "ActsFatras/Digitization/DigitizationError.hpp"
+#include "ActsFatras/Digitization/PlanarSurfaceDrift.hpp"
+
+namespace bdata = boost::unit_test::data;
+
+namespace ActsFatras {
+
+BOOST_AUTO_TEST_SUITE(Digitization)
+
+BOOST_AUTO_TEST_CASE(PlanarSurfaceDrift) {
+  Acts::GeometryContext geoCtx;
+
+  ActsFatras::PlanarSurfaceDrift psd;
+
+  Acts::Vector3 cPosition = Acts::Vector3(10., 50., 12.);
+  Acts::Vector3 cNormal = Acts::Vector3(1., 1., 1.).normalized();
+
+  auto planeSurface =
+      Acts::Surface::makeShared<Acts::PlaneSurface>(cPosition, cNormal);
+
+  double depletion = 0.250;
+
+  // Nominal intersection
+  Acts::Vector3 noDrift(0., 0., 0.);
+  Acts::Vector3 holeDrift = Acts::Vector3(0.5, 0., 1.).normalized();
+  Acts::Vector3 chargeDrift = Acts::Vector3(0.5, 0., -1.).normalized();
+
+  // Intersect surface at normal direction and no drift
+  //
+  // -> resulting segment must have entry & exit at (0,0) local coordinates
+  auto noDriftSegment = psd.toReadout(geoCtx, *planeSurface, depletion,
+                                      cPosition, cNormal, noDrift);
+
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].x(), 0., Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].y(), 0., Acts::s_epsilon);
+
+  Acts::Vector3 particleDir = Acts::Vector3(2., 1., 1.).normalized();
+
+  // Intersect surface at particleDirection != normal and no drift
+  //
+  // -> local segment must be symmetric around (0,0)
+  noDriftSegment = psd.toReadout(geoCtx, *planeSurface, depletion, cPosition,
+                                 particleDir, noDrift);
+
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), -noDriftSegment[1].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), -noDriftSegment[1].y(),
+                  Acts::s_epsilon);
+
+  // Intersect surface at particleDirection != normal and a drift somewhat along
+  // the normal and x
+  //
+  // -> local segment must not be symmetric around (0,0)
+  // -> segment exit at pos local z remains unchanged
+  // -> segment entry at neg local z changes in x, remains unchaged in y
+  auto driftedSegment = psd.toReadout(geoCtx, *planeSurface, depletion,
+                                      cPosition, particleDir, holeDrift);
+
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - driftedSegment[1].x()) >
+              Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].y() - driftedSegment[1].y()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].x(), driftedSegment[1].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[1].y(), driftedSegment[1].y(),
+                  Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - noDriftSegment[0].x()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(driftedSegment[0].y(), noDriftSegment[0].y(),
+                  Acts::s_epsilon);
+
+  // Intersect surface at particleDirection != normal and a drift somewhat
+  // opposite the normal and y
+  //
+  // -> local segment must not be symmetric around (0,0)
+  // -> segment entry at neg local z remains unchanged
+  // -> segment exit at pos local z changes in x, remains unchaged in y
+  driftedSegment = psd.toReadout(geoCtx, *planeSurface, depletion, cPosition,
+                                 particleDir, chargeDrift);
+
+  BOOST_CHECK(std::abs(driftedSegment[0].x() - driftedSegment[1].x()) >
+              Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[0].y() - driftedSegment[1].y()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].x(), driftedSegment[0].x(),
+                  Acts::s_epsilon);
+  CHECK_CLOSE_ABS(noDriftSegment[0].y(), driftedSegment[0].y(),
+                  Acts::s_epsilon);
+  BOOST_CHECK(std::abs(driftedSegment[1].x() - noDriftSegment[1].x()) >
+              Acts::s_epsilon);
+  CHECK_CLOSE_ABS(driftedSegment[1].y(), noDriftSegment[1].y(),
+                  Acts::s_epsilon);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsFatras

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
@@ -23,7 +23,6 @@ namespace ActsFatras {
 BOOST_AUTO_TEST_SUITE(Digitization)
 
 BOOST_AUTO_TEST_CASE(PlanarSurfaceDrift) {
-    
   Acts::GeometryContext geoCtx;
 
   ActsFatras::PlanarSurfaceDrift psd;

--- a/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/PlanarSurfaceDriftTests.cpp
@@ -23,6 +23,7 @@ namespace ActsFatras {
 BOOST_AUTO_TEST_SUITE(Digitization)
 
 BOOST_AUTO_TEST_CASE(PlanarSurfaceDrift) {
+    
   Acts::GeometryContext geoCtx;
 
   ActsFatras::PlanarSurfaceDrift psd;


### PR DESCRIPTION
This PR splits out the addition of the surface merger to the `Fatras/Digitzation` module. 

The `PlanarSurfaceDrift` struct allows to project an intersection segment to a readout surface,
it is tested in a new `UnitTest`.