### PR TITLE
feat: streamline json plugin

### DIFF
--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -127,7 +127,7 @@ class BinUtility {
   /// Virtual Destructor
   ~BinUtility() = default;
 
-  /// return the binning data vector
+  /// Return the binning data vector
   const std::vector<BinningData>& binningData() const { return m_binningData; }
 
   /// Return the total number of bins

--- a/Core/include/Acts/Utilities/BinningData.hpp
+++ b/Core/include/Acts/Utilities/BinningData.hpp
@@ -114,7 +114,7 @@ class BinningData {
     checkSubStructure();
   }
 
-  /// Constructor for equidistant binning
+  /// Constructor for non-equidistant binning
   ///
   /// @param bOption is the binning option : open / closed
   /// @param bValue is the binning value : binX, binY, etc.
@@ -212,6 +212,9 @@ class BinningData {
     }
     return (*this);
   }
+
+  /// Default constructor - needed for persistency streaming
+  BinningData() = default;
 
   /// Destructor
   ~BinningData() = default;

--- a/Core/include/Acts/Utilities/BinningData.hpp
+++ b/Core/include/Acts/Utilities/BinningData.hpp
@@ -6,9 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// BinUtility.h, Acts project
-///////////////////////////////////////////////////////////////////
 #pragma once
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/BinningType.hpp"
@@ -213,10 +210,7 @@ class BinningData {
     return (*this);
   }
 
-  /// Default constructor - needed for persistency streaming
   BinningData() = default;
-
-  /// Destructor
   ~BinningData() = default;
 
   /// Return the number of bins - including sub bins

--- a/Plugins/Json/CMakeLists.txt
+++ b/Plugins/Json/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   ActsPluginJson SHARED
   src/JsonGeometryConverter.cpp
+  src/AlgebraJsonConverter.cpp
   src/UtilitiesJsonConverter.cpp)
 target_include_directories(
   ActsPluginJson

--- a/Plugins/Json/CMakeLists.txt
+++ b/Plugins/Json/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   ActsPluginJson SHARED
-  src/JsonGeometryConverter.cpp)
+  src/JsonGeometryConverter.cpp
+  src/UtilitiesJsonConverter.cpp)
 target_include_directories(
   ActsPluginJson
   PUBLIC

--- a/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
@@ -12,7 +12,7 @@
 
 #include <nlohmann/json.hpp>
 
-// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// Custom Json encoder/decoders. Naming is mandated by nlohman::json and thus
 // can not match our naming guidelines.
 
 void to_json(nlohmann::json& j, const Acts::Transform3& t);

--- a/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
@@ -14,7 +14,10 @@
 
 // Custom Json encoder/decoders. Naming is mandated by nlohman::json and thus
 // can not match our naming guidelines.
+namespace Acts {
 
 void to_json(nlohmann::json& j, const Acts::Transform3& t);
 
 void from_json(const nlohmann::json& j, Acts::Transform3& t);
+
+}  // namespace Acts

--- a/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
@@ -16,8 +16,8 @@
 // can not match our naming guidelines.
 namespace Acts {
 
-void to_json(nlohmann::json& j, const Acts::Transform3& t);
+void to_json(nlohmann::json& j, const Transform3& t);
 
-void from_json(const nlohmann::json& j, Acts::Transform3& t);
+void from_json(const nlohmann::json& j, Transform3& t);
 
 }  // namespace Acts

--- a/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/AlgebraJsonConverter.hpp
@@ -1,0 +1,20 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+
+#include <nlohmann/json.hpp>
+
+// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// can not match our naming guidelines.
+
+void to_json(nlohmann::json& j, const Acts::Transform3& t);
+
+void from_json(const nlohmann::json& j, Acts::Transform3& t);

--- a/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
@@ -13,7 +13,7 @@
 
 #include <nlohmann/json.hpp>
 
-// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// Custom Json encoder/decoders. Naming is mandated by nlohman::json and thus
 // can not match our naming guidelines.
 
 void to_json(nlohmann::json& j, const Acts::BinningData& bd);

--- a/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
@@ -18,12 +18,12 @@
 
 namespace Acts {
 
-void to_json(nlohmann::json& j, const Acts::BinningData& bd);
+void to_json(nlohmann::json& j, const BinningData& bd);
 
-void from_json(const nlohmann::json& j, Acts::BinningData& bd);
+void from_json(const nlohmann::json& j, BinningData& bd);
 
-void to_json(nlohmann::json& j, const Acts::BinUtility& bu);
+void to_json(nlohmann::json& j, const BinUtility& bu);
 
-void from_json(const nlohmann::json& j, Acts::BinUtility& bu);
+void from_json(const nlohmann::json& j, BinUtility& bu);
 
 }  // namespace Acts

--- a/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
@@ -1,0 +1,25 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Utilities/BinningData.hpp"
+
+#include <nlohmann/json.hpp>
+
+// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// can not match our naming guidelines.
+
+void toJson(nlohmann::json& j, const Acts::BinningData& bd);
+
+void from_json(const nlohmann::json& j, Acts::BinningData& bd);
+
+void to_json(nlohmann::json& j, const Acts::BinUtility& bu);
+
+void from_json(const nlohmann::json& j, Acts::BinUtility& bu);

--- a/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
@@ -16,6 +16,8 @@
 // Custom Json encoder/decoders. Naming is mandated by nlohman::json and thus
 // can not match our naming guidelines.
 
+namespace Acts {
+
 void to_json(nlohmann::json& j, const Acts::BinningData& bd);
 
 void from_json(const nlohmann::json& j, Acts::BinningData& bd);
@@ -23,3 +25,5 @@ void from_json(const nlohmann::json& j, Acts::BinningData& bd);
 void to_json(nlohmann::json& j, const Acts::BinUtility& bu);
 
 void from_json(const nlohmann::json& j, Acts::BinUtility& bu);
+
+}  // namespace Acts

--- a/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/UtilitiesJsonConverter.hpp
@@ -16,7 +16,7 @@
 // Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
 // can not match our naming guidelines.
 
-void toJson(nlohmann::json& j, const Acts::BinningData& bd);
+void to_json(nlohmann::json& j, const Acts::BinningData& bd);
 
 void from_json(const nlohmann::json& j, Acts::BinningData& bd);
 

--- a/Plugins/Json/src/AlgebraJsonConverter.cpp
+++ b/Plugins/Json/src/AlgebraJsonConverter.cpp
@@ -1,0 +1,49 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
+
+// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// can not match our naming guidelines.
+
+void to_json(nlohmann::json& j, const Acts::Transform3& r) {
+  auto translation = r.translation();
+  if (translation != Acts::Vector3(0., 0., 0)) {
+    std::array<Acts::ActsScalar, 3> tdata = {translation.x(), translation.y(),
+                                             translation.z()};
+    j["translation"] = tdata;
+  } else {
+    j["translation"] = nlohmann::json();
+  }
+
+  auto rotation = r.rotation();
+  if (rotation != Acts::RotationMatrix3::Identity()) {
+    std::array<Acts::ActsScalar, 9> rdata = {
+        rotation(0, 0), rotation(0, 1), rotation(0, 2),
+        rotation(1, 0), rotation(1, 1), rotation(1, 2),
+        rotation(2, 0), rotation(2, 1), rotation(2, 2)};
+    j["rotation"] = rdata;
+  } else {
+    j["rotation"] = nlohmann::json();
+  }
+}
+
+void from_json(const nlohmann::json& j, Acts::Transform3& t) {
+  t = Acts::Transform3::Identity();
+  if (j.find("translation") != j.end() and not j["translation"].empty()) {
+    std::array<Acts::ActsScalar, 3> tdata = j["translation"];
+    t.pretranslate(Acts::Vector3(tdata[0], tdata[1], tdata[2]));
+  }
+  if (j.find("rotation") != j.end() and not j["rotation"].empty()) {
+    std::array<Acts::ActsScalar, 9> rdata = j["rotation"];
+    Acts::RotationMatrix3 rot;
+    rot << rdata[0], rdata[1], rdata[2], rdata[3], rdata[4], rdata[5], rdata[6],
+        rdata[7], rdata[8];
+    t.prerotate(rot);
+  }
+}

--- a/Plugins/Json/src/AlgebraJsonConverter.cpp
+++ b/Plugins/Json/src/AlgebraJsonConverter.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
+#include "Acts/Plugins/Json/AlgebraJsonConverter.hpp"
 
 void Acts::to_json(nlohmann::json& j, const Acts::Transform3& r) {
   auto translation = r.translation();

--- a/Plugins/Json/src/AlgebraJsonConverter.cpp
+++ b/Plugins/Json/src/AlgebraJsonConverter.cpp
@@ -8,9 +8,6 @@
 
 #include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
 
-// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
-// can not match our naming guidelines.
-
 void to_json(nlohmann::json& j, const Acts::Transform3& r) {
   auto translation = r.translation();
   if (translation != Acts::Vector3(0., 0., 0)) {

--- a/Plugins/Json/src/AlgebraJsonConverter.cpp
+++ b/Plugins/Json/src/AlgebraJsonConverter.cpp
@@ -8,7 +8,7 @@
 
 #include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
 
-void to_json(nlohmann::json& j, const Acts::Transform3& r) {
+void Acts::to_json(nlohmann::json& j, const Acts::Transform3& r) {
   auto translation = r.translation();
   if (translation != Acts::Vector3(0., 0., 0)) {
     std::array<Acts::ActsScalar, 3> tdata = {translation.x(), translation.y(),
@@ -30,7 +30,7 @@ void to_json(nlohmann::json& j, const Acts::Transform3& r) {
   }
 }
 
-void from_json(const nlohmann::json& j, Acts::Transform3& t) {
+void Acts::from_json(const nlohmann::json& j, Acts::Transform3& t) {
   t = Acts::Transform3::Identity();
   if (j.find("translation") != j.end() and not j["translation"].empty()) {
     std::array<Acts::ActsScalar, 3> tdata = j["translation"];

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -10,7 +10,7 @@
 
 #include "Acts/Plugins/Json/AlgebraJsonConverter.hpp"
 
-void to_json(nlohmann::json& j, const Acts::BinningData& bd) {
+void Acts::to_json(nlohmann::json& j, const Acts::BinningData& bd) {
   // Common to all bin utilities
   j["min"] = bd.min;
   j["max"] = bd.max;
@@ -40,7 +40,7 @@ void to_json(nlohmann::json& j, const Acts::BinningData& bd) {
   j["bins"] = bins;
 }
 
-void from_json(const nlohmann::json& j, Acts::BinningData& bd) {
+void Acts::from_json(const nlohmann::json& j, Acts::BinningData& bd) {
   // Common to all bin utilities
   float min = j["min"];
   float max = j["max"];
@@ -74,7 +74,7 @@ void from_json(const nlohmann::json& j, Acts::BinningData& bd) {
   }
 }
 
-void to_json(nlohmann::json& j, const Acts::BinUtility& bu) {
+void Acts::to_json(nlohmann::json& j, const Acts::BinUtility& bu) {
   nlohmann::json jbindata;
   for (const auto& bdata : bu.binningData()) {
     nlohmann::json jdata;

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -89,7 +89,7 @@ void Acts::to_json(nlohmann::json& j, const Acts::BinUtility& bu) {
   }
 }
 
-void from_json(const nlohmann::json& j, Acts::BinUtility& bu) {
+void Acts::from_json(const nlohmann::json& j, Acts::BinUtility& bu) {
   bu = Acts::BinUtility();
   if (j.find("transform") != j.end() and not j["transform"].empty()) {
     Acts::Transform3 trf;

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -1,12 +1,12 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Json/JsonUtilitiesConverter.hpp"
+#include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
 
 // Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
 // can not match our naming guidelines.

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -1,0 +1,92 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Plugins/Json/JsonUtilitiesConverter.hpp"
+
+// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
+// can not match our naming guidelines.
+
+void to_json(nlohmann::json& j, const Acts::BinningData& bd) {
+  // Common to all bin utilities
+  j["min"] = bd.min;
+  j["max"] = bd.max;
+  j["option"] = (bd.option == Acts::open ? "open" : "closed");
+  j["value"] = Acts::binningValueNames[bd.binvalue];
+  int bins = bd.bins();
+  // Write sub bin data if present
+  if (bd.subBinningData != nullptr) {
+    nlohmann::json subjson;
+    to_json(subjson, *bd.subBinningData);
+    j["subdata"] = subjson;
+    j["subadditive"] = bd.subBinningAdditive;
+    // this modifies the bins as bins() returns total number in general
+    if (bd.subBinningAdditive){
+      bins -= static_cast<int>(subjson["bins"]) + 1;
+    } else {
+      bins /= static_cast<int>(subjson["bins"]);
+    }
+  }
+  // Now distinguish between equidistant / arbitrary
+  if (bd.type == Acts::equidistant) {
+    j["type"] = "equidistant";
+  } else if (bd.type == Acts::arbitrary) {
+    j["type"] = "arbitrary";
+    j["boundaries"] = bd.boundaries();
+  }
+  j["bins"] = bins;
+}
+
+void from_json(const nlohmann::json& j, Acts::BinningData& bd) {
+  // Common to all bin utilities
+  float min = j["min"];
+  float max = j["max"];
+  int bins = j["bins"];
+  std::string valueName = j["value"];
+  auto valueIter = std::find(Acts::binningValueNames.begin(),
+                             Acts::binningValueNames.end(), valueName);
+  Acts::BinningValue bValue = static_cast<Acts::BinningValue>(
+      valueIter - Acts::binningValueNames.begin());
+  if (bins == 1) {
+    bd = Acts::BinningData(bValue, min, max);
+    return;
+  }
+  Acts::BinningOption bOption =
+      (j["option"] == "open") ? Acts::open : Acts::closed;
+  Acts::BinningType bType =
+      (j["type"] == "equidistant") ? Acts::equidistant : Acts::arbitrary;
+
+  std::unique_ptr<Acts::BinningData> subBinning = nullptr;
+  bool subBinningAdditive = false;
+  if (j.find("subdata") != j.end()) {
+    subBinningAdditive = j["subadditive"];
+  }
+
+  if (bType == Acts::equidistant) {
+    bd = Acts::BinningData(bOption, bValue, bins, min, max,
+                           std::move(subBinning), subBinningAdditive);
+  } else {
+    std::vector<float> boundaries = j["boundaries"];
+    bd = Acts::BinningData(bOption, bValue, boundaries, std::move(subBinning));
+  }
+}
+
+void to_json(nlohmann::json& j, const Acts::BinUtility& bu) {
+  for (const auto& bdata : bu.binningData()) {
+    nlohmann::json jdata;
+    to_json(jdata, bdata);
+    j.push_back(jdata);
+  }
+}
+
+void from_json(const nlohmann::json& j, Acts::BinUtility& bu) {
+  for (const auto& jdata : j) {
+    Acts::BinningData bd;
+    from_json(jdata, bd);
+    bu += Acts::BinUtility(bd);
+  }
+}

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -10,9 +10,6 @@
 
 #include "Acts/Plugins/Json/AlgebraJsonConverter.hpp"
 
-// Custom Json encoder/decoders. Maming is mandated by nlohman::json and thus
-// can not match our naming guidelines.
-
 void to_json(nlohmann::json& j, const Acts::BinningData& bd) {
   // Common to all bin utilities
   j["min"] = bd.min;

--- a/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
@@ -1,0 +1,90 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Plugins/Json/AlgebraJsonConverter.hpp"
+#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
+
+#include <fstream>
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+
+BOOST_AUTO_TEST_SUITE(AlgebraJsonConverter)
+
+BOOST_AUTO_TEST_CASE(TransformRoundTripTests) {
+  Acts::Transform3 reference = Acts::Transform3::Identity();
+
+  std::ofstream out;
+
+  // Test the identity transform
+  nlohmann::json identityOut;
+  to_json(identityOut, reference);
+  out.open("Transform3_Identity.json");
+  out << identityOut.dump(2);
+  out.close();
+
+  auto in = std::ifstream("Transform3_Identity.json",
+                          std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json identityIn;
+  in >> identityIn;
+  in.close();
+
+  Acts::Transform3 test;
+  from_json(identityIn, test);
+
+  BOOST_CHECK(test.isApprox(reference));
+
+  // Test a pure translation transform
+  reference.pretranslate(Acts::Vector3(1., 2., 3.));
+
+  nlohmann::json translationOut;
+  to_json(translationOut, reference);
+  out.open("Transform3_Translation.json");
+  out << translationOut.dump(2);
+  out.close();
+
+  in = std::ifstream("Transform3_Translation.json",
+                     std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json translationIn;
+  in >> translationIn;
+  in.close();
+
+  test = Acts::Transform3::Identity();
+  from_json(translationIn, test);
+
+  BOOST_CHECK(test.isApprox(reference));
+
+  // Test a full transform
+  reference = Eigen::AngleAxis(0.12334, Acts::Vector3(1., 2., 3).normalized());
+  reference.pretranslate(Acts::Vector3(1., 2., 3.));
+
+  nlohmann::json fullOut;
+  to_json(fullOut, reference);
+  out.open("Transform3_Full.json");
+  out << fullOut.dump(2);
+  out.close();
+
+  in = std::ifstream("Transform3_Full.json",
+                     std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json fullIn;
+  in >> fullIn;
+  in.close();
+
+  test = Acts::Transform3::Identity();
+  from_json(fullIn, test);
+
+  BOOST_CHECK(test.isApprox(reference));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
@@ -17,10 +17,12 @@
 
 #include <nlohmann/json.hpp>
 
+using namespace Acts;
+
 BOOST_AUTO_TEST_SUITE(AlgebraJsonConverter)
 
 BOOST_AUTO_TEST_CASE(TransformRoundTripTests) {
-  Acts::Transform3 reference = Acts::Transform3::Identity();
+  Transform3 reference = Transform3::Identity();
 
   std::ofstream out;
 
@@ -38,13 +40,13 @@ BOOST_AUTO_TEST_CASE(TransformRoundTripTests) {
   in >> identityIn;
   in.close();
 
-  Acts::Transform3 test;
+  Transform3 test;
   from_json(identityIn, test);
 
   BOOST_CHECK(test.isApprox(reference));
 
   // Test a pure translation transform
-  reference.pretranslate(Acts::Vector3(1., 2., 3.));
+  reference.pretranslate(Vector3(1., 2., 3.));
 
   nlohmann::json translationOut;
   to_json(translationOut, reference);
@@ -59,14 +61,14 @@ BOOST_AUTO_TEST_CASE(TransformRoundTripTests) {
   in >> translationIn;
   in.close();
 
-  test = Acts::Transform3::Identity();
+  test = Transform3::Identity();
   from_json(translationIn, test);
 
   BOOST_CHECK(test.isApprox(reference));
 
   // Test a full transform
-  reference = Eigen::AngleAxis(0.12334, Acts::Vector3(1., 2., 3).normalized());
-  reference.pretranslate(Acts::Vector3(1., 2., 3.));
+  reference = Eigen::AngleAxis(0.12334, Vector3(1., 2., 3).normalized());
+  reference.pretranslate(Vector3(1., 2., 3.));
 
   nlohmann::json fullOut;
   to_json(fullOut, reference);
@@ -81,7 +83,7 @@ BOOST_AUTO_TEST_CASE(TransformRoundTripTests) {
   in >> fullIn;
   in.close();
 
-  test = Acts::Transform3::Identity();
+  test = Transform3::Identity();
   from_json(fullIn, test);
 
   BOOST_CHECK(test.isApprox(reference));

--- a/Tests/UnitTests/Plugins/Json/CMakeLists.txt
+++ b/Tests/UnitTests/Plugins/Json/CMakeLists.txt
@@ -2,4 +2,5 @@ set(unittest_extra_libraries ActsPluginJson)
 
 add_unittest(GeometryHierarchyMapJsonConverter GeometryHierarchyMapJsonConverterTests.cpp)
 add_unittest(MaterialMapJsonConverter MaterialMapJsonConverterTests.cpp)
+add_unittest(AlgebraJsonConverter AlgebraJsonConverterTests.cpp)
 add_unittest(UtilitiesJsonConverter UtilitiesJsonConverterTests.cpp)

--- a/Tests/UnitTests/Plugins/Json/CMakeLists.txt
+++ b/Tests/UnitTests/Plugins/Json/CMakeLists.txt
@@ -2,3 +2,4 @@ set(unittest_extra_libraries ActsPluginJson)
 
 add_unittest(GeometryHierarchyMapJsonConverter GeometryHierarchyMapJsonConverterTests.cpp)
 add_unittest(MaterialMapJsonConverter MaterialMapJsonConverterTests.cpp)
+add_unittest(UtilitiesJsonConverter UtilitiesJsonConverterTests.cpp)

--- a/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
@@ -19,6 +19,8 @@
 
 #include <nlohmann/json.hpp>
 
+using namespace Acts;
+
 BOOST_AUTO_TEST_SUITE(UtilitiesJsonConverter)
 
 namespace {
@@ -29,8 +31,7 @@ namespace {
 /// @param tolerance a tolerance parameter
 ///
 /// @return a boolean
-bool isEqual(const Acts::BinningData& ba, const Acts::BinningData& bb,
-             float tolerance) {
+bool isEqual(const BinningData& ba, const BinningData& bb, float tolerance) {
   bool equalBool = (ba.type == bb.type) and (ba.option == bb.option) and
                    (ba.binvalue == bb.binvalue) and (ba.zdim == bb.zdim) and
                    (ba.subBinningAdditive == bb.subBinningAdditive);
@@ -64,8 +65,7 @@ bool isEqual(const Acts::BinningData& ba, const Acts::BinningData& bb,
 /// @param tolerance a tolerance parameter
 ///
 /// @return a bollean if equal
-bool isEqual(const Acts::BinUtility& ba, const Acts::BinUtility& bb,
-             float tolerance) {
+bool isEqual(const BinUtility& ba, const BinUtility& bb, float tolerance) {
   bool equal = (ba.binningData().size() == bb.binningData().size());
   if (equal) {
     for (size_t ib = 0; ib < ba.binningData().size(); ++ib) {
@@ -78,7 +78,7 @@ bool isEqual(const Acts::BinUtility& ba, const Acts::BinUtility& bb,
 }  // namespace
 
 BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
-  Acts::BinUtility reference(2, 0., 4., Acts::open, Acts::binR);
+  BinUtility reference(2, 0., 4., open, binR);
 
   std::ofstream out;
 
@@ -96,13 +96,13 @@ BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
   in >> joneDimIn;
   in.close();
 
-  Acts::BinUtility test;
+  BinUtility test;
   from_json(joneDimIn, test);
 
   BOOST_CHECK(isEqual(reference, test, 0.0001));
 
   // Increase to two dimensions
-  reference += Acts::BinUtility(10., -M_PI, M_PI, Acts::closed, Acts::binPhi);
+  reference += BinUtility(10., -M_PI, M_PI, closed, binPhi);
   nlohmann::json jtwoDimOut;
   to_json(jtwoDimOut, reference);
   out.open("BinUtility_2D.json");
@@ -116,14 +116,14 @@ BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
   in >> jtwoDimIn;
   in.close();
 
-  test = Acts::BinUtility();
+  test = BinUtility();
   from_json(jtwoDimIn, test);
 
   BOOST_CHECK(isEqual(reference, test, 0.0001));
 
   // Increase to three dimensions
   std::vector<float> boundaries = {-4., -1.5, 0., 10.};
-  reference += Acts::BinUtility(boundaries, Acts::open, Acts::binZ);
+  reference += BinUtility(boundaries, open, binZ);
   nlohmann::json jthreeDimOut;
   to_json(jthreeDimOut, reference);
   out.open("BinUtility_3D.json");
@@ -137,19 +137,19 @@ BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
   in >> jthreeDimIn;
   in.close();
 
-  test = Acts::BinUtility();
+  test = BinUtility();
   from_json(jthreeDimIn, test);
 
   BOOST_CHECK(isEqual(reference, test, 0.0001));
 
   // One with transform
-  Acts::Transform3 t;
-  t = Eigen::AngleAxis(0.12334, Acts::Vector3(1., 2., 3).normalized());
-  t.pretranslate(Acts::Vector3(1., 2., 3.));
+  Transform3 t;
+  t = Eigen::AngleAxis(0.12334, Vector3(1., 2., 3).normalized());
+  t.pretranslate(Vector3(1., 2., 3.));
 
   auto bData = reference.binningData()[0];
 
-  reference = Acts::BinUtility(bData, t);
+  reference = BinUtility(bData, t);
 
   nlohmann::json jtransformOut;
   to_json(jtransformOut, reference);
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
   in >> jtransformIn;
   in.close();
 
-  test = Acts::BinUtility();
+  test = BinUtility();
   from_json(jtransformIn, test);
 
   BOOST_CHECK(isEqual(reference, test, 0.0001));

--- a/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
@@ -1,0 +1,65 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
+#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <iostream>
+
+BOOST_AUTO_TEST_SUITE(UtilitiesJsonConverter)
+
+BOOST_AUTO_TEST_CASE(BinUtilityRoundTripTests) {
+
+  Acts::BinUtility reference(Acts::binR, 0, 4);
+
+  std::ofstream out;
+
+
+  // Test in in one dimension
+  nlohmann::json joneDimOut;
+  to_json(joneDimOut, reference);
+  out.open("oneDim.json");
+  out << joneDimOut.dump(2);
+  out.close();
+
+  auto in = std::ifstream("oneDim.json", std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json joneDimIn;
+  in >> joneDimIn;
+  in.close();
+
+  Acts::BinUtility test;
+  from_json(joneDimIn, test);
+
+  // Increase to two dimensions
+  reference += Acts::BinUtility(10., -M_PI, M_PI, Acts::closed, Acts::binPhi);
+  nlohmann::json jtwoDimOut;
+  to_json(jtwoDimOut, reference);
+  out.open("twoDim.json");
+  out << jtwoDimOut.dump(2);
+  out.close();
+
+  in = std::ifstream("twoDim.json", std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json jtwoDimIn;
+  in >> jtwoDimIn;
+  in.close();
+  
+  test = Acts::BinUtility();
+  from_json(jtwoDimIn, test);
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR introduces the first modules of the updated `Json` converters that use the `nlohmann::json::to_json/from_json`  interface.

