### PR TITLE
feat: optimise BinningData, remove dead code

### DIFF
--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -167,35 +167,6 @@ class BinUtility {
     return bEval;
   }
 
-  /// Bin neighbour range
-  /// this method calls the increment/decreement methods
-  /// the bin itself is also contained, so if not an edge-case
-  /// this would be
-  ///  | n | c | p |
-  ///
-  /// @param position is the position for the neighbour Range test
-  /// @param ba is the binning accessor
-  ///
-  /// @return a vector of neighbour sizes
-  std::vector<size_t> neighbourRange(const Vector3& position,
-                                     size_t ba = 0) const {
-    if (ba >= m_binningData.size()) {
-      return {0};
-    }
-    std::vector<size_t> neighbourRange;
-    size_t cbin = bin(position, ba);
-    size_t pbin = cbin;
-    size_t nbin = cbin;
-    if (m_binningData[ba].decrement(pbin)) {
-      neighbourRange.push_back(pbin);
-    }
-    neighbourRange.push_back(cbin);
-    if (m_binningData[ba].increment(nbin) && nbin != pbin) {
-      neighbourRange.push_back(nbin);
-    }
-    return neighbourRange;
-  }
-
   /// Return the oder direction for fast interlinking
   ///
   /// @param position is the global position for the next search

--- a/Core/include/Acts/Utilities/BinnedArray.hpp
+++ b/Core/include/Acts/Utilities/BinnedArray.hpp
@@ -72,17 +72,6 @@ class BinnedArray {
     return object(position, bins);
   }
 
-  /// Returns the object found through global position search
-  /// and their neighbor objects
-  ///
-  /// @todo check if this needs connectivity directive
-  ///
-  /// @param bin is the binning
-  ///
-  /// @return a vector of unique objects
-  virtual std::vector<T> objectCluster(
-      const std::array<size_t, 3>& bin) const = 0;
-
   /// Return all unqiue object
   /// @note this is the accessor to the
   /// @return the vector of all array objects

--- a/Core/include/Acts/Utilities/BinnedArrayXD.hpp
+++ b/Core/include/Acts/Utilities/BinnedArrayXD.hpp
@@ -182,52 +182,6 @@ class BinnedArrayXD : public BinnedArray<T> {
     return m_objectGrid;
   }
 
-  /// Returns the object according to the bin triple
-  /// and their neighbour objects (if different)
-  ///
-  /// @param binTriple is the binning
-  ///
-  /// @return a vector of unique objects
-  std::vector<T> objectCluster(
-      const std::array<size_t, 3>& binTriple) const override {
-    // prepare the return vector
-    std::vector<T> rvector;
-    // reference bin object to be excluded
-    T bObject = m_objectGrid[binTriple[2]][binTriple[1]][binTriple[0]];
-    // get the dimensions first
-    size_t bdim = m_binUtility->dimensions();
-    // avoiding code duplication
-    std::vector<size_t> zerorange = {0};
-    // 2D bin
-    std::vector<size_t> bin2values =
-        (bdim > 2) ? m_binUtility->binningData()[2].neighbourRange(binTriple[2])
-                   : zerorange;
-    // 1D bin
-    std::vector<size_t> bin1values =
-        (bdim > 1) ? m_binUtility->binningData()[1].neighbourRange(binTriple[1])
-                   : zerorange;
-    // 0D bin
-    std::vector<size_t> bin0values =
-        m_binUtility->binningData()[0].neighbourRange(binTriple[0]);
-
-    // do the loop
-    for (auto b2 : bin2values) {
-      for (auto b1 : bin1values) {
-        for (auto b0 : bin0values) {
-          // get the object
-          T object = m_objectGrid[b2][b1][b0];
-          if (object && object != bObject &&
-              std::find(rvector.begin(), rvector.end(), object) ==
-                  rvector.end()) {
-            rvector.push_back(object);
-          }
-        }
-      }
-    }
-    // return the ones you found
-    return rvector;
-  }
-
   /// Return the BinUtility
   /// @return plain pointer to the bin utility of this array
   const BinUtility* binUtility() const final { return (m_binUtility.get()); }

--- a/Core/include/Acts/Utilities/BinningData.hpp
+++ b/Core/include/Acts/Utilities/BinningData.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
 #include <memory>
@@ -142,8 +143,7 @@ class BinningData {
     min = m_boundaries[0];
     max = m_boundaries[m_boundaries.size() - 1];
     // set to equidistant search
-    m_functionPtr =
-        m_bins < 50 ? &searchInVectorWithBoundary : &binarySearchWithBoundary;
+    m_functionPtr = &searchInVectorWithBoundary;
     // the binning data has sub structure - multiplicative
     checkSubStructure();
   }
@@ -176,8 +176,7 @@ class BinningData {
     if (type == equidistant) {
       m_functionPtr = &searchEquidistantWithBoundary;
     } else {
-      m_functionPtr =
-          m_bins < 50 ? &searchInVectorWithBoundary : &binarySearchWithBoundary;
+      m_functionPtr = &searchInVectorWithBoundary;
     }
   }
 
@@ -206,8 +205,7 @@ class BinningData {
       if (type == equidistant) {
         m_functionPtr = &searchEquidistantWithBoundary;
       } else {
-        m_functionPtr = m_bins < 50 ? &searchInVectorWithBoundary
-                                    : &binarySearchWithBoundary;
+        m_functionPtr = &searchInVectorWithBoundary;
       }
     }
     return (*this);
@@ -218,26 +216,6 @@ class BinningData {
 
   /// Return the number of bins - including sub bins
   size_t bins() const { return m_totalBins; }
-
-  /// Decrement the bin
-  /// - boolean indicates if decrement actually worked
-  ///
-  /// @param bin is the bin to be decremented
-  bool decrement(size_t& bin) const {
-    size_t sbin = bin;
-    bin = bin > 0 ? bin - 1 : (option == open ? bin : m_bins - 1);
-    return (sbin != bin);
-  }
-
-  /// Increment the bin
-  /// - boolean indicates if decrement actually worked
-  ///
-  /// @param bin the bin to be incremented
-  bool increment(size_t& bin) const {
-    size_t sbin = bin;
-    bin = bin + 1 < m_bins ? bin + 1 : (option == open ? bin : 0);
-    return (sbin != bin);
-  }
 
   /// Return the boundaries  - including sub boundaries
   /// @return vector of floats indicating the boundary values
@@ -429,29 +407,6 @@ class BinningData {
     return 0.5 * (bmin + bmax);
   }
 
-  /// access to lower/higher bins
-  ///
-  /// takes a bin entry and returns the lower/higher bound
-  /// respecting open/closed
-  /// @return low/high bounds
-  std::vector<size_t> neighbourRange(size_t bin) const {
-    size_t low = bin;
-    size_t high = bin;
-    // decrement and increment
-    bool dsucc = decrement(low);
-    bool isucc = increment(high);
-    // both worked -> triple range
-    if (dsucc && isucc) {
-      return {low, bin, high};
-    }
-    // one worked -> double range
-    if (dsucc || isucc) {
-      return {low, high};
-    }
-    // none worked -> single bin
-    return {bin};
-  }
-
  private:
   size_t m_bins;                    ///< number of bins
   std::vector<float> m_boundaries;  ///< vector of holding the bin boundaries
@@ -533,8 +488,7 @@ class BinningData {
                       : ((bData.option == open) ? (bData.m_bins - 1) : 0));
   }
 
-  // Linear search in arbitrary vector
-  // - superior in O(10) searches
+  // Search in arbitrary boundary
   static size_t searchInVectorWithBoundary(float value,
                                            const BinningData& bData) {
     // lower boundary
@@ -545,45 +499,11 @@ class BinningData {
     if (value >= bData.max) {
       return (bData.option == closed) ? 0 : (bData.m_bins - 1);
     }
-    // search
-    auto vIter = bData.m_boundaries.begin();
-    size_t bin = 0;
-    for (; vIter != bData.m_boundaries.end(); ++vIter, ++bin) {
-      if ((*vIter) > value) {
-        break;
-      }
-    }
-    return (bin - 1);
-  }
 
-  // A binary search with in an arbitrary vector
-  //    - faster than vector search for O(50) objects
-  static size_t binarySearchWithBoundary(float value,
-                                         const BinningData& bData) {
-    // Binary search in an array of n values to locate value
-    if (value <= bData.m_boundaries[0]) {
-      return (bData.option == closed) ? (bData.m_bins - 1) : 0;
-    }
-    size_t nabove, nbelow, middle;
-    // overflow
-    nabove = bData.m_boundaries.size();
-    if (value >= bData.max) {
-      return (bData.option == closed) ? 0 : nabove - 2;
-    }
-    // binary search
-    nbelow = 0;
-    while (nabove - nbelow > 1) {
-      middle = (nabove + nbelow) / 2;
-      if (value == bData.m_boundaries[middle - 1]) {
-        return middle - 1;
-      }
-      if (value < bData.m_boundaries[middle - 1]) {
-        nabove = middle;
-      } else {
-        nbelow = middle;
-      }
-    }
-    return nbelow - 1;
+    auto lb = std::lower_bound(bData.m_boundaries.begin(),
+                               bData.m_boundaries.end(), value);
+    return static_cast<size_t>(std::distance(bData.m_boundaries.begin(), lb) -
+                               1);
   }
 };
 }  // namespace Acts

--- a/Tests/Benchmarks/BinUtilityBenchmark.cpp
+++ b/Tests/Benchmarks/BinUtilityBenchmark.cpp
@@ -1,0 +1,147 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Tests/CommonHelpers/BenchmarkTools.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Utilities/Logger.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include <boost/program_options.hpp>
+
+namespace po = boost::program_options;
+using namespace Acts;
+
+int main(int argc, char* argv[]) {
+  unsigned int lvl = Acts::Logging::INFO;
+  unsigned int toys = 1;
+
+  try {
+    po::options_description desc("Allowed options");
+    // clang-format off
+  desc.add_options()
+      ("help", "produce help message")
+      ("toys",po::value<unsigned int>(&toys)->default_value(100000000),"number searches to be done")
+      ("verbose",po::value<unsigned int>(&lvl)->default_value(Acts::Logging::INFO),"logging level");
+    // clang-format on
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help") != 0u) {
+      std::cout << desc << std::endl;
+      return 0;
+    }
+  } catch (std::exception& e) {
+    std::cerr << "error: " << e.what() << std::endl;
+    return 1;
+  }
+
+  ACTS_LOCAL_LOGGER(getDefaultLogger("BinUtility", Acts::Logging::Level(lvl)));
+
+  std::vector<float> fewBins;
+  fewBins.reserve(6);
+  for (unsigned int ib = 0; ib < 6; ++ib) {
+    fewBins.push_back(ib * 6. / 5.);
+  }
+  Acts::BinUtility small(fewBins, Acts::open, Acts::binX);
+
+  std::vector<float> mediumBins;
+  mediumBins.reserve(21);
+  for (unsigned int ib = 0; ib < 21; ++ib) {
+    mediumBins.push_back(ib * 6. / 20.);
+  }
+  Acts::BinUtility medium(mediumBins, Acts::open, Acts::binX);
+
+  std::vector<float> manyBins;
+  manyBins.reserve(101);
+  for (unsigned int ib = 0; ib < 101; ++ib) {
+    manyBins.push_back(ib * 6. / 100.);
+  }
+
+  Acts::BinUtility many(manyBins, Acts::open, Acts::binX);
+
+  Acts::Vector3 low = Acts::Vector3(1.5, 0., 0.);
+  Acts::Vector3 high = Acts::Vector3(4.5, 0., 0.);
+
+  size_t st = 0;
+  size_t gt = 0;
+  size_t num_iters = 0;
+  const auto bin_utility_benchmark_small = Acts::Test::microBenchmark(
+      [&] {
+        auto bin = num_iters % 2 ? small.bin(low) : small.bin(high);
+        if (bin < 3) {
+          ++st;
+        } else {
+          ++gt;
+        }
+        ++num_iters;
+      },
+      1, toys);
+
+  ACTS_INFO("Execution stats small: " << bin_utility_benchmark_small);
+  ACTS_INFO("Fraction is: " << st << " vs. " << gt);
+
+  st = 0;
+  gt = 0;
+  num_iters = 0;
+  const auto bin_utility_benchmark_medium = Acts::Test::microBenchmark(
+      [&] {
+        auto bin = num_iters % 2 ? medium.bin(low) : medium.bin(high);
+        if (bin < 10) {
+          ++st;
+        } else {
+          ++gt;
+        }
+        ++num_iters;
+      },
+      1, toys);
+
+  ACTS_INFO("Execution stats medium: " << bin_utility_benchmark_medium);
+  ACTS_INFO("Fraction is: " << st << " vs. " << gt);
+
+  st = 0;
+  gt = 0;
+  num_iters = 0;
+  const auto bin_utility_benchmark_many = Acts::Test::microBenchmark(
+      [&] {
+        auto bin = num_iters % 2 ? many.bin(low) : many.bin(high);
+        if (bin < 49) {
+          ++st;
+        } else {
+          ++gt;
+        }
+        ++num_iters;
+      },
+      1, toys);
+
+  ACTS_INFO("Execution stats many: " << bin_utility_benchmark_many);
+  ACTS_INFO("Fraction is: " << st << " vs. " << gt);
+
+  Acts::BinUtility equidistant(100, 0., 6., Acts::open, Acts::binX);
+  st = 0;
+  gt = 0;
+  num_iters = 0;
+  const auto bin_utility_benchmark_eq = Acts::Test::microBenchmark(
+      [&] {
+        auto bin = num_iters % 2 ? equidistant.bin(low) : equidistant.bin(high);
+        if (bin < 49) {
+          ++st;
+        } else {
+          ++gt;
+        }
+        ++num_iters;
+      },
+      1, toys);
+
+  ACTS_INFO("Execution stats equidistant: " << bin_utility_benchmark_eq);
+  ACTS_INFO("Fraction is: " << st << " vs. " << gt);
+
+  return 0;
+}

--- a/Tests/Benchmarks/CMakeLists.txt
+++ b/Tests/Benchmarks/CMakeLists.txt
@@ -22,6 +22,7 @@ endmacro()
 
 add_benchmark(AtlasStepper AtlasStepperBenchmark.cpp)
 add_benchmark(BoundaryCheck BoundaryCheckBenchmark.cpp)
+add_benchmark(BinUtility BinUtilityBenchmark.cpp)
 add_benchmark(EigenStepper EigenStepperBenchmark.cpp)
 add_benchmark(SolenoidField SolenoidFieldBenchmark.cpp)
 add_benchmark(SurfaceIntersection SurfaceIntersectionBenchmark.cpp)

--- a/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
@@ -58,44 +58,32 @@ BOOST_AUTO_TEST_CASE(BinUtility_equidistant_binning) {
   BOOST_CHECK_EQUAL(xyzTriple[0], 1u);
   BOOST_CHECK_EQUAL(xyzTriple[1], 2u);
   BOOST_CHECK_EQUAL(xyzTriple[2], 3u);
-
-  // Full range
-  std::vector<size_t> xRangeCheck0 = {0, 1, 2};
-  std::vector<size_t> xyRangeCheck1 = {1, 2, 3};
-  std::vector<size_t> xyzRangeCheck2 = {2, 3, 4};
-
-  auto xNrange0 = xUtil_eq.neighbourRange(xyzPosition, 0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(xNrange0.begin(), xNrange0.end(),
-                                xRangeCheck0.begin(), xRangeCheck0.end());
-
-  auto xNrange1 = xUtil_eq.neighbourRange(xyzPosition, 1);
-  BOOST_CHECK_EQUAL(xNrange1.size(), 1u);
-  BOOST_CHECK_EQUAL(xNrange1[0], 0u);
-
-  auto xNrange2 = xUtil_eq.neighbourRange(xyzPosition, 2);
-  BOOST_CHECK_EQUAL(xNrange2.size(), 1u);
-  BOOST_CHECK_EQUAL(xNrange2[0], 0u);
-
-  auto xyNrange1 = xyUtil_eq.neighbourRange(xyzPosition, 1);
-  BOOST_CHECK_EQUAL_COLLECTIONS(xyNrange1.begin(), xyNrange1.end(),
-                                xyRangeCheck1.begin(), xyRangeCheck1.end());
-
-  auto xyzNrange2 = xyzUtil_eq.neighbourRange(xyzPosition, 2);
-  BOOST_CHECK_EQUAL_COLLECTIONS(xyzNrange2.begin(), xyzNrange2.end(),
-                                xyzRangeCheck2.begin(), xyzRangeCheck2.end());
-
-  // Partial range
-  std::vector<size_t> xEdgeCheck = {0, 1};
-  auto xEdgeRange = xUtil_eq.neighbourRange(edgePosition, 0);
-  BOOST_CHECK_EQUAL_COLLECTIONS(xEdgeRange.begin(), xEdgeRange.end(),
-                                xEdgeCheck.begin(), xEdgeCheck.end());
 }
+
+// OPEN - equidistant binning tests
+BOOST_AUTO_TEST_CASE(BinUtility_arbitrary_binning) {
+  std::vector<float> bvalues = {-5., 0., 1., 1.1, 8.};
+  BinUtility xUtil(bvalues, Acts::open, Acts::binX);
+
+  // Underflow
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(-6., 0., 0.)), 0u);
+  // Bin 0
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(-4., 0., 0.)), 0u);
+  // Bin 1
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(0.5, 0., 0.)), 1u);
+  // Bin 2
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(1.05, 0., 0.)), 2u);
+  // Bin 3
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(4., 0., 0.)), 3u);
+  // Overflow
+  BOOST_CHECK_EQUAL(xUtil.bin(Vector3(9., 0., 0.)), 3u);
+}
+
 // OPEN - local to global transform test
 BOOST_AUTO_TEST_CASE(BinUtility_transform) {
   Transform3 transform_LtoG = Transform3::Identity();
   transform_LtoG = transform_LtoG * Translation3(0., 0., -50);
   transform_LtoG = transform_LtoG * AngleAxis3(M_PI / 4, Vector3(0, 0, 1));
-  ;
 
   Transform3 transform_GtoL = transform_LtoG.inverse();
 

--- a/Tests/UnitTests/Core/Utilities/BinningDataTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinningDataTests.cpp
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(BinningData_bins) {
   // | 0 | 1 | 2 | 3 | 4 | 10 |
   BOOST_CHECK_EQUAL(xData_arb.searchGlobal(xyzPosition), size_t(0));
   BOOST_CHECK_EQUAL(xData_arb.search(6.), size_t(4));
-  BOOST_CHECK_EQUAL(xData_arb_binary.searchGlobal(xyzPosition), size_t(1));
+  BOOST_CHECK_EQUAL(xData_arb_binary.searchGlobal(xyzPosition), size_t(0));
   BOOST_CHECK_EQUAL(xData_arb_binary.search(50.), (nBins_binary - 1));
   // | 0 | 1 | 1.5 | 2 |  3 | 4 | 5 |
   BOOST_CHECK_EQUAL(xData_add.searchGlobal(xyzPosition), size_t(0));
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(BinningData_bins) {
   BOOST_CHECK_EQUAL(yData_eq.searchLocal(xyPosition), size_t(1));
   BOOST_CHECK_EQUAL(zData_eq.searchLocal(rphizPosition), size_t(2));
   BOOST_CHECK_EQUAL(xData_arb.searchLocal(xyPosition), size_t(0));
-  BOOST_CHECK_EQUAL(xData_arb_binary.searchLocal(xyPosition), size_t(1));
+  BOOST_CHECK_EQUAL(xData_arb_binary.searchLocal(xyPosition), size_t(0));
 
   // r/phi/rphiData
   BOOST_CHECK_EQUAL(rData_eq.searchGlobal(xyzPosition), size_t(1));
@@ -276,29 +276,6 @@ BOOST_AUTO_TEST_CASE(BinningData_open_close) {
                     xData_arb_binary.bins());
   BOOST_CHECK_EQUAL(yData_arb.searchGlobal(xyzPositionOutside), size_t(0));
 
-  // increment an open bin
-  // - for equidistant
-  size_t bin = 9;
-  xData_eq.increment(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(9));
-  bin = 0;
-  xData_eq.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-  // - for arbitrary
-  bin = 5;
-  xData_arb.increment(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(5));
-  bin = 0;
-  xData_arb.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-
-  bin = nBins_binary;
-  xData_arb_binary.increment(bin);
-  BOOST_CHECK_EQUAL(bin, nBins_binary);
-  bin = 0;
-  xData_arb_binary.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-
   // closed values
   BOOST_CHECK_EQUAL(phiData_eq.search(-4.), size_t(4));
   BOOST_CHECK_EQUAL(phiData_eq.search(4.), size_t(0));
@@ -306,27 +283,6 @@ BOOST_AUTO_TEST_CASE(BinningData_open_close) {
   BOOST_CHECK_EQUAL(phiData_arb.search(4.), size_t(0));
   BOOST_CHECK_EQUAL(phiData_arb_binary.search(-4.), (nBins_binary - 1));
   BOOST_CHECK_EQUAL(phiData_arb_binary.search(4.), size_t(0));
-
-  bin = 4;
-  phiData_eq.increment(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-  bin = 0;
-  phiData_eq.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(4));
-
-  bin = 4;
-  phiData_arb.increment(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-  bin = 0;
-  phiData_arb.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(4));
-
-  bin = nBins_binary;
-  phiData_arb_binary.increment(bin);
-  BOOST_CHECK_EQUAL(bin, size_t(0));
-  bin = 0;
-  phiData_arb_binary.decrement(bin);
-  BOOST_CHECK_EQUAL(bin, (nBins_binary - 1));
 }
 
 // test boundaries


### PR DESCRIPTION
This PR cleans the `BinUtility` and  `BinningData` objects:
- removes dead code
- removes hand-written search in vector in favour of `std::lower_bound`

It adds/removes relevant `UnitTests` and adds a new benchmark test, the benchmark before the changes shows:
```shell
16:36:17    BinUtility     INFO      Execution stats small: 1000 runs of 1 iteration(s), 0.0ms total, 0.0430+/-0.0001µs per run, 43.000+/-0.058ns per iteration
16:36:17    BinUtility     INFO      Fraction is: 21968011 vs. 21968011
16:36:19    BinUtility     INFO      Execution stats medium: 1000 runs of 1 iteration(s), 0.1ms total, 0.0510+/-0.0003µs per run, 51.000+/-0.346ns per iteration
16:36:19    BinUtility     INFO      Fraction is: 19641811 vs. 19641811
16:36:21    BinUtility     INFO      Execution stats many: 1000 runs of 1 iteration(s), 0.1ms total, 0.0780+/-0.0002µs per run, 78.000+/-0.173ns per iteration
16:36:21    BinUtility     INFO      Fraction is: 12780128 vs. 12780128
16:36:23    BinUtility     INFO      Execution stats many (lower_bounds): 1000 runs of 1 iteration(s), 0.0ms total, 0.0420+/-0.0001µs per run, 42.000+/-0.086ns per iteration
16:36:23    BinUtility     INFO      Fraction is: 23670634 vs. 23670634
```

to the new implementation:
```shell
17:25:25    BinUtility     INFO      Execution stats small: 1000 runs of 1 iteration(s), 0.0ms total, 0.0450+/-0.0001µs per run, 45.000+/-0.115ns per iteration
17:25:25    BinUtility     INFO      Fraction is: 21444179 vs. 21444179
17:25:27    BinUtility     INFO      Execution stats medium: 1000 runs of 1 iteration(s), 0.0ms total, 0.0460+/-0.0001µs per run, 46.000+/-0.115ns per iteration
17:25:27    BinUtility     INFO      Fraction is: 21030434 vs. 21030434
17:25:29    BinUtility     INFO      Execution stats many: 1000 runs of 1 iteration(s), 0.0ms total, 0.0480+/-0.0001µs per run, 48.000+/-0.115ns per iteration
17:25:29    BinUtility     INFO      Fraction is: 20028335 vs. 20028335
17:25:31    BinUtility     INFO      Execution stats equidistant: 1000 runs of 1 iteration(s), 0.0ms total, 0.0450+/-0.0001µs per run, 45.000+/-0.058ns per iteration
17:25:31    BinUtility     INFO      Fraction is: 20992746 vs. 20992746
```
The new implementation is faster in all bin scenarios.

Eventually, the `BinUtility` should go in favour of `Grid` usage, the removal of dead code is a first step towards this.
