### PR TITLE
feat: introduce Json converter for SurfaceBounds

### DIFF
--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -33,16 +33,16 @@ class SurfaceBounds {
     eCylinder = 1,
     eDiamond = 2,
     eDisc = 3,
-    eEllipse = 5,
-    eLine = 6,
-    eRectangle = 7,
-    eTrapezoid = 8,
-    eTriangle = 9,
-    eDiscTrapezoid = 10,
-    eConvexPolygon = 11,
-    eAnnulus = 12,
-    eBoundless = 13,
-    eOther = 14
+    eEllipse = 4,
+    eLine = 5,
+    eRectangle = 6,
+    eTrapezoid = 7,
+    eTriangle = 8,
+    eDiscTrapezoid = 9,
+    eConvexPolygon = 10,
+    eAnnulus = 11,
+    eBoundless = 12,
+    eOther = 13
   };
 
   virtual ~SurfaceBounds() = default;

--- a/Plugins/Json/CMakeLists.txt
+++ b/Plugins/Json/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   ActsPluginJson SHARED
   src/JsonGeometryConverter.cpp
   src/AlgebraJsonConverter.cpp
+  src/SurfaceBoundsJsonConverter.cpp
   src/UtilitiesJsonConverter.cpp)
 target_include_directories(
   ActsPluginJson

--- a/Plugins/Json/include/Acts/Plugins/Json/SurfaceBoundsJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/SurfaceBoundsJsonConverter.hpp
@@ -1,0 +1,48 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Surfaces/SurfaceBounds.hpp"
+
+#include <array>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+// Custom Json encoder/decoders. Naming is mandated by nlohman::json and thus
+// can not match our naming guidelines.
+namespace Acts {
+
+static std::vector<std::string> boundTypes = {
+    "ConeBounds",          "CylinderBounds",      "DiamondBounds",
+    "DiscBounds",          "EllipseBounds",       "LineBounds",
+    "RectangleBounds",     "TrapezoidBounds",     "TriangleBounds",
+    "DiscTrapezoidBounds", "ConvexPolygonBounds", "AnnulusBounds",
+    "OtherBounds"};
+
+void to_json(nlohmann::json& j, const SurfaceBounds& bounds);
+
+/// Converstion to surfaceBounds from json
+///
+/// The type is given as a template argument in order to be able
+/// to construct the correct fitting types for surfaces.
+///
+/// @param j the read-in json object
+///
+/// @return a shared_ptr to a surface object for type polymorphism
+template <typename bounds_t>
+std::shared_ptr<const bounds_t> surfaceBoundsFromJson(const nlohmann::json& j) {
+  const size_t kValues = bounds_t::BoundValues::eSize;
+  std::array<ActsScalar, kValues> bValues;
+  std::vector<ActsScalar> bVector = j["values"];
+  std::copy_n(bVector.begin(), kValues, bValues.begin());
+  return std::make_shared<const bounds_t>(bValues);
+}
+
+}  // namespace Acts

--- a/Plugins/Json/src/SurfaceBoundsJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceBoundsJsonConverter.cpp
@@ -1,0 +1,14 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Plugins/Json/SurfaceBoundsJsonConverter.hpp"
+
+void Acts::to_json(nlohmann::json& j, const Acts::SurfaceBounds& bounds) {
+  j["type"] = boundTypes[bounds.type()];
+  j["values"] = bounds.values();
+}

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -77,9 +77,7 @@ void Acts::from_json(const nlohmann::json& j, Acts::BinningData& bd) {
 void Acts::to_json(nlohmann::json& j, const Acts::BinUtility& bu) {
   nlohmann::json jbindata;
   for (const auto& bdata : bu.binningData()) {
-    nlohmann::json jdata;
-    to_json(jdata, bdata);
-    jbindata.push_back(jdata);
+    jbindata.push_back(nlohmann::json(bdata));
   }
   j["binningdata"] = jbindata;
   if (not bu.transform().isApprox(Acts::Transform3::Identity())) {

--- a/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/AlgebraJsonConverterTests.cpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Plugins/Json/AlgebraJsonConverter.hpp"
-#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
 
 #include <fstream>
 #include <iostream>

--- a/Tests/UnitTests/Plugins/Json/CMakeLists.txt
+++ b/Tests/UnitTests/Plugins/Json/CMakeLists.txt
@@ -4,3 +4,4 @@ add_unittest(GeometryHierarchyMapJsonConverter GeometryHierarchyMapJsonConverter
 add_unittest(MaterialMapJsonConverter MaterialMapJsonConverterTests.cpp)
 add_unittest(AlgebraJsonConverter AlgebraJsonConverterTests.cpp)
 add_unittest(UtilitiesJsonConverter UtilitiesJsonConverterTests.cpp)
+add_unittest(SurfaceBoundsJsonConverter SurfaceBoundsJsonConverterTests.cpp)

--- a/Tests/UnitTests/Plugins/Json/SurfaceBoundsJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/SurfaceBoundsJsonConverterTests.cpp
@@ -1,0 +1,51 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Plugins/Json/SurfaceBoundsJsonConverter.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
+
+#include <fstream>
+#include <iostream>
+
+#include <nlohmann/json.hpp>
+
+using namespace Acts;
+
+BOOST_AUTO_TEST_SUITE(SurfaceBoundsJsonConverter)
+
+BOOST_AUTO_TEST_CASE(SurfaceBoundsRoundTripTests) {
+  std::ofstream out;
+
+  // As all SurfaceBounds have the same streaming API only a one is
+  // tested here, all others are tests are identical
+
+  auto rectangeRef = std::make_shared<const RectangleBounds>(4., 6.);
+  // Test a rectangle
+  nlohmann::json rectangleOut;
+  to_json(rectangleOut, *rectangeRef);
+  out.open("RectangleBounds.json");
+  out << rectangleOut.dump(2);
+  out.close();
+
+  auto in = std::ifstream("RectangleBounds.json",
+                          std::ifstream::in | std::ifstream::binary);
+  BOOST_CHECK(in.good());
+  nlohmann::json rectangleIn;
+  in >> rectangleIn;
+  in.close();
+
+  auto rectangleTest = surfaceBoundsFromJson<RectangleBounds>(rectangleIn);
+
+  BOOST_CHECK(rectangeRef->values() == rectangleTest->values());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/UtilitiesJsonConverterTests.cpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
-#include "Acts/Tests/CommonHelpers/DataDirectory.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningData.hpp"
 


### PR DESCRIPTION
This PR includes the next `Json` converter, this time for `SurfaceBounds`.

All `SurfaceBounds` have a `values()` streaming method (providing a `std::vector`) and a constructor by providing a `std::array`. Hence, only one converter is needed, however, the type has to be given explicitely, no automated conversion is possible, as the `Surface` objects never swallow `SurfaceBounds` directly but a class extension of the appropriate type.

UnitTest for one is attached, no need to call the same functions on all inherited objects.