### PR TITLE
docs: Lock down breathe to 4.26.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ sphinx>=2.0
 sphinx_rtd_theme>=0.4
 sphinx_markdown_tables
 recommonmark
-breathe>=4.13
+breathe==4.26.0
 exhale
 m2r


### PR DESCRIPTION
Attempt to fix the doc build by locking down breathe to `4.26.0`.