### PR TITLE
fix: Boost warnings due to deprecations

### DIFF
--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include <boost/program_options.hpp>
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 
 /// The main executable
 ///
@@ -45,7 +45,7 @@ void accessStepWise(field_t& bField, field_context_t& bFieldContext,
   typename field_t::Cache bCache(bFieldContext);
   // boost display
   size_t totalSteps = events * theta_steps * phi_steps * access_steps;
-  boost::progress_display show_progress(totalSteps);
+  boost::timer::progress_display show_progress(totalSteps);
   // the event loop
   // loop over the events - @todo move to parallel for
   for (size_t ievt = 0; ievt < events; ++ievt) {
@@ -93,7 +93,7 @@ void accessRandom(field_t& bField, field_context_t& bFieldContext,
 
   // initialize the field cache
   typename field_t::Cache bCache(bFieldContext);
-  boost::progress_display show_progress(totalSteps);
+  boost::timer::progress_display show_progress(totalSteps);
 
   // the event loop
   // loop over the events - @todo move to parallel for

--- a/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
@@ -9,7 +9,7 @@
 /// @file MagneticFieldInterfaceConsistencyTests.cpp
 
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
@@ -9,7 +9,7 @@
 // clang-format off
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/output_test_stream.hpp>
+#include <boost/test/tools/output_test_stream.hpp>
 // clang-format on
 
 #include <limits>


### PR DESCRIPTION
This fixes some changed / moved / deprecated boost
headers. Functionality stays the same
