### PR TITLE
fix: PayloadDecorator doesn't always populate the context

### DIFF
--- a/Examples/Detectors/ContextualDetector/src/PayloadDecorator.cpp
+++ b/Examples/Detectors/ContextualDetector/src/PayloadDecorator.cpp
@@ -27,17 +27,16 @@ ActsExamples::ProcessCode ActsExamples::Contextual::PayloadDecorator::decorate(
   std::vector<Acts::Transform3> aStore = m_nominalStore;
 
   ACTS_VERBOSE("New IOV detected, emulate new alignment");
-  if (context.eventNumber % m_cfg.iovSize) {
-    for (auto& tf : aStore) {
-      tf *= Acts::AngleAxis3(m_cfg.rotationStep * context.eventNumber,
-                             Acts::Vector3::UnitY());
-    }
-    // This creates a full payload context, i.e. the nominal store
-    PayloadDetectorElement::ContextType alignableGeoContext;
-    alignableGeoContext.alignmentStore = std::move(aStore);
-    context.geoContext =
-        std::make_any<PayloadDetectorElement::ContextType>(alignableGeoContext);
+  for (auto& tf : aStore) {
+    tf *= Acts::AngleAxis3(
+        m_cfg.rotationStep * (context.eventNumber / m_cfg.iovSize),
+        Acts::Vector3::UnitY());
   }
+  // This creates a full payload context, i.e. the nominal store
+  PayloadDetectorElement::ContextType alignableGeoContext;
+  alignableGeoContext.alignmentStore = std::move(aStore);
+  context.geoContext =
+      std::make_any<PayloadDetectorElement::ContextType>(alignableGeoContext);
   return ProcessCode::SUCCESS;
 }
 


### PR DESCRIPTION
The payload decorator was set up to ONLY populate the context at IOV boundaries. This leads to any cast exceptions. This PR changes this to populate the context always, and adds an assertion.

@asalzburger: How to I verify that the alignment in the context is correct? Do I just look at the prop steps or is there an automated way?
