### PR TITLE
feat!: Use strong types for context objects

### DIFF
--- a/Core/include/Acts/Geometry/GeometryContext.hpp
+++ b/Core/include/Acts/Geometry/GeometryContext.hpp
@@ -13,7 +13,7 @@
 #include ACTS_CORE_GEOMETRYCONTEXT_PLUGIN
 #else
 
-#include <any>
+#include "Acts/Utilities/detail/ContextType.hpp"
 
 namespace Acts {
 
@@ -23,7 +23,7 @@ namespace Acts {
 /// It is propagated through the code to allow for event/thread
 /// dependent geometry changes
 
-using GeometryContext = std::any;
+using GeometryContext = ContextType;
 
 }  // namespace Acts
 

--- a/Core/include/Acts/MagneticField/ConstantBField.hpp
+++ b/Core/include/Acts/MagneticField/ConstantBField.hpp
@@ -21,7 +21,7 @@ class ConstantBField final {
  public:
   struct Cache {
     /// @brief constructor with context
-    Cache(std::reference_wrapper<const MagneticFieldContext> /*mcfg*/) {}
+    Cache(const MagneticFieldContext& /*mcfg*/) {}
   };
 
   /// Construct constant magnetic field from field vector.

--- a/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
+++ b/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
@@ -252,7 +252,7 @@ class InterpolatedBFieldMap final {
     /// @brief Constructor with magnetic field context
     ///
     /// @param mcfg the magnetic field context
-    Cache(std::reference_wrapper<const MagneticFieldContext> /*mcfg*/) {}
+    Cache(const MagneticFieldContext& /*mcfg*/) {}
 
     std::optional<typename Mapper_t::FieldCell> fieldCell;
     bool initialized = false;

--- a/Core/include/Acts/MagneticField/MagneticFieldContext.hpp
+++ b/Core/include/Acts/MagneticField/MagneticFieldContext.hpp
@@ -13,7 +13,7 @@
 #include ACTS_CORE_MAGFIELDCONTEXT_PLUGIN
 #else
 
-#include <any>
+#include "Acts/Utilities/detail/ContextType.hpp"
 
 namespace Acts {
 
@@ -23,7 +23,7 @@ namespace Acts {
 /// It is propagated through the code to allow for event/thread
 /// dependent magnetic field changes
 
-using MagneticFieldContext = std::any;
+using MagneticFieldContext = ContextType;
 
 }  // namespace Acts
 

--- a/Core/include/Acts/MagneticField/NullBField.hpp
+++ b/Core/include/Acts/MagneticField/NullBField.hpp
@@ -18,7 +18,7 @@ class NullBField final {
  public:
   struct Cache {
     /// @brief constructor with context
-    Cache(std::reference_wrapper<const MagneticFieldContext> /*mcfg*/) {}
+    Cache(const MagneticFieldContext& /*mcfg*/) {}
   };
 
   /// @brief Default constructor

--- a/Core/include/Acts/MagneticField/SolenoidBField.hpp
+++ b/Core/include/Acts/MagneticField/SolenoidBField.hpp
@@ -70,7 +70,7 @@ class SolenoidBField {
     /// @brief Constructor with magnetic field context
     ///
     /// @param mcfg the magnetic field context
-    Cache(std::reference_wrapper<const MagneticFieldContext> /*mcfg*/) {}
+    Cache(const MagneticFieldContext& /*mcfg*/) {}
   };
 
   /// Config struct for the SolenoidBfield.

--- a/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
+++ b/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
@@ -97,8 +97,7 @@ class SurfaceMaterialMapper {
   /// Nested State struct which is used for the mapping prococess
   struct State {
     /// Constructor of the Sate with contexts
-    State(std::reference_wrapper<const GeometryContext> gctx,
-          std::reference_wrapper<const MagneticFieldContext> mctx)
+    State(const GeometryContext& gctx, const MagneticFieldContext& mctx)
         : geoContext(gctx), magFieldContext(mctx) {}
 
     /// The accumulated material per geometry ID

--- a/Core/include/Acts/Material/VolumeMaterialMapper.hpp
+++ b/Core/include/Acts/Material/VolumeMaterialMapper.hpp
@@ -81,8 +81,7 @@ class VolumeMaterialMapper {
   /// Nested State struct which is used for the mapping prococess
   struct State {
     /// Constructor of the Sate with contexts
-    State(std::reference_wrapper<const GeometryContext> gctx,
-          std::reference_wrapper<const MagneticFieldContext> mctx)
+    State(const GeometryContext& gctx, const MagneticFieldContext& mctx)
         : geoContext(gctx), magFieldContext(mctx) {}
 
     /// The recorded material per geometry ID

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -59,8 +59,7 @@ class AtlasStepper {
     /// @param[in] ssize the steps size limitation
     /// @param [in] stolerance is the stepping tolerance
     template <typename Parameters>
-    State(std::reference_wrapper<const GeometryContext> gctx,
-          std::reference_wrapper<const MagneticFieldContext> mctx,
+    State(const GeometryContext& gctx, const MagneticFieldContext& mctx,
           const Parameters& pars, NavigationDirection ndir = forward,
           double ssize = std::numeric_limits<double>::max(),
           double stolerance = s_onSurfaceTolerance)

--- a/Core/include/Acts/Propagator/DenseEnvironmentExtension.hpp
+++ b/Core/include/Acts/Propagator/DenseEnvironmentExtension.hpp
@@ -33,10 +33,9 @@ struct DenseStepperPropagatorOptions
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param mctx The current magnetic fielc context object
-  DenseStepperPropagatorOptions(
-      std::reference_wrapper<const GeometryContext> gctx,
-      std::reference_wrapper<const MagneticFieldContext> mctx,
-      LoggerWrapper logger_)
+  DenseStepperPropagatorOptions(const GeometryContext& gctx,
+                                const MagneticFieldContext& mctx,
+                                LoggerWrapper logger_)
       : PropagatorOptions<action_list_t, aborter_list_t>(gctx, mctx, logger_) {}
 
   /// Toggle between mean and mode evaluation of energy loss

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -75,8 +75,8 @@ class EigenStepper {
     ///
     /// @note the covariance matrix is copied when needed
     template <typename charge_t>
-    explicit State(std::reference_wrapper<const GeometryContext> gctx,
-                   std::reference_wrapper<const MagneticFieldContext> mctx,
+    explicit State(const GeometryContext& gctx,
+                   const MagneticFieldContext& mctx,
                    const SingleBoundTrackParameters<charge_t>& par,
                    NavigationDirection ndir = forward,
                    double ssize = std::numeric_limits<double>::max(),

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -86,7 +86,7 @@ void Acts::EigenStepper<B, E, A>::covarianceTransport(State& state) const {
 template <typename B, typename E, typename A>
 void Acts::EigenStepper<B, E, A>::covarianceTransport(
     State& state, const Surface& surface) const {
-  detail::covarianceTransport(state.geoContext, state.cov, state.jacobian,
+  detail::covarianceTransport(state.geoContext.get(), state.cov, state.jacobian,
                               state.jacTransport, state.derivative,
                               state.jacToGlobal, state.pars, surface);
 }

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -120,9 +120,8 @@ struct PropagatorOptions : public PropagatorPlainOptions {
       const PropagatorOptions<action_list_t, aborter_list_t>& po) = default;
 
   /// PropagatorOptions with context
-  PropagatorOptions(std::reference_wrapper<const GeometryContext> gctx,
-                    std::reference_wrapper<const MagneticFieldContext> mctx,
-                    LoggerWrapper logger_)
+  PropagatorOptions(const GeometryContext& gctx,
+                    const MagneticFieldContext& mctx, LoggerWrapper logger_)
       : geoContext(gctx), magFieldContext(mctx), logger(logger_) {}
 
   /// @brief Expand the Options with extended aborters

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -59,8 +59,8 @@ class StraightLineStepper {
     ///
     /// @note the covariance matrix is copied when needed
     template <typename charge_t>
-    explicit State(std::reference_wrapper<const GeometryContext> gctx,
-                   std::reference_wrapper<const MagneticFieldContext> /*mctx*/,
+    explicit State(const GeometryContext& gctx,
+                   const MagneticFieldContext& /*mctx*/,
                    const SingleBoundTrackParameters<charge_t>& par,
                    NavigationDirection ndir = forward,
                    double ssize = std::numeric_limits<double>::max(),

--- a/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
+++ b/Core/include/Acts/Propagator/detail/CovarianceEngine.hpp
@@ -52,11 +52,11 @@ namespace detail {
 ///   - the stepwise jacobian towards it (from last bound)
 ///   - and the path length (from start - for ordering)
 std::tuple<BoundTrackParameters, BoundMatrix, double> boundState(
-    std::reference_wrapper<const GeometryContext> geoContext,
-    BoundSymMatrix& covarianceMatrix, BoundMatrix& jacobian,
-    FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
-    bool covTransport, double accumulatedPath, const Surface& surface);
+    const GeometryContext& geoContext, BoundSymMatrix& covarianceMatrix,
+    BoundMatrix& jacobian, FreeMatrix& transportJacobian,
+    FreeVector& derivatives, BoundToFreeMatrix& jacToGlobal,
+    const FreeVector& parameters, bool covTransport, double accumulatedPath,
+    const Surface& surface);
 
 /// Create and return a curvilinear state at the current position
 ///
@@ -99,12 +99,12 @@ std::tuple<CurvilinearTrackParameters, BoundMatrix, double> curvilinearState(
 /// @param [in] surface is the surface to which the covariance is
 ///        forwarded to
 /// @note No check is done if the position is actually on the surface
-void covarianceTransport(
-    std::reference_wrapper<const GeometryContext> geoContext,
-    BoundSymMatrix& covarianceMatrix, BoundMatrix& jacobian,
-    FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
-    const Surface& surface);
+void covarianceTransport(const GeometryContext& geoContext,
+                         BoundSymMatrix& covarianceMatrix,
+                         BoundMatrix& jacobian, FreeMatrix& transportJacobian,
+                         FreeVector& derivatives,
+                         BoundToFreeMatrix& jacToGlobal,
+                         const FreeVector& parameters, const Surface& surface);
 
 /// @brief Method for on-demand transport of the covariance to a new frame at
 /// current position in parameter space

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -83,8 +83,7 @@ struct CombinatorialKalmanFilterOptions {
   /// @param eLoss Whether to include energy loss
   /// @param rSmoothing Whether to run smoothing to get fitted parameter
   CombinatorialKalmanFilterOptions(
-      std::reference_wrapper<const GeometryContext> gctx,
-      std::reference_wrapper<const MagneticFieldContext> mctx,
+      const GeometryContext& gctx, const MagneticFieldContext& mctx,
       std::reference_wrapper<const CalibrationContext> cctx,
       Calibrator calibrator_, MeasurementSelector measurementSelector_,
       LoggerWrapper logger_, const PropagatorPlainOptions& pOptions,
@@ -749,8 +748,7 @@ class CombinatorialKalmanFilter {
         const TrackStatePropMask& stateMask, const BoundState& boundState,
         const source_link_t& sourcelink,
         const BoundVariantMeasurement<source_link_t>& measurement,
-        bool isOutlier, result_type& result,
-        std::reference_wrapper<const GeometryContext> geoContext,
+        bool isOutlier, result_type& result, const GeometryContext& geoContext,
         const size_t& prevTip, const TipState& prevTipState,
         size_t neighborTip = SIZE_MAX, size_t sharedTip = SIZE_MAX,
         LoggerWrapper logger = getDummyLogger()) const {

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -63,8 +63,8 @@ struct KalmanFitterOptions {
   /// @param eLoss Whether to include energy loss
   /// @param rFiltering Whether to run filtering in reversed direction as
   /// smoothing
-  KalmanFitterOptions(std::reference_wrapper<const GeometryContext> gctx,
-                      std::reference_wrapper<const MagneticFieldContext> mctx,
+  KalmanFitterOptions(const GeometryContext& gctx,
+                      const MagneticFieldContext& mctx,
                       std::reference_wrapper<const CalibrationContext> cctx,
                       Calibrator calibrator_, OutlierFinder outlierFinder_,
                       LoggerWrapper logger_,

--- a/Core/include/Acts/Utilities/detail/ContextType.hpp
+++ b/Core/include/Acts/Utilities/detail/ContextType.hpp
@@ -13,9 +13,9 @@
 namespace Acts {
 
 /// Strong type wrapper around std::any. This has all the flexibility of
-/// std::any, but it does not auto construct from anything. You have to call the
-/// make static factory manually with the target type, to populate the internal
-/// std::any. You can then access and modify the any as desired.
+/// std::any, but it does not convert-construct from anything. You have to call
+/// one of the explicit constructors manually to populate
+/// the internal std::any. You can then access and modify the any as desired.
 ///
 /// @note This is used for the context types, and should probably not used
 /// outside of this use-case.
@@ -25,45 +25,39 @@ class ContextType {
   ///
   ContextType() {}
 
-  /// Static factory method from arguments.
+  /// Move construct a new Context Type object from anything. Must be explicit.
   ///
-  /// @tparam T The underlying type to construct
-  /// @tparam Args Types of construction arguments
-  /// @param args Values of construction arguments
-  /// @return ContextType The constructed context instance
-  //   template <typename T, typename... Args>
-  //   static ContextType make(Args&&... args) {
-  //     ContextType ctx;
-  //     ctx.m_data.emplace<T>(std::forward<Args>(args)...);
-  //     return ctx;
-  //   }
-
-  //   template <typename T>
-  //   static ContextType make(T&& value) {
-  //     ContextType ctx;
-  //     ctx.m_data = value;
-  //     return ctx;
-  //   }
-
-  //   template <typename T>
-  //   static ContextType make(const T& value) {
-  //     ContextType ctx;
-  //     ctx.m_data = value;
-  //     return ctx;
-  //   }
-
+  /// @tparam T The type of the value to construct from
+  /// @param value The value to construct from
   template <typename T>
   explicit ContextType(T&& value) : m_data{std::move(value)} {}
 
+  /// Copy construct a new Context Type object from anything. Must be explicit.
+  ///
+  /// @tparam T The type of the value to construct from
+  /// @param value The value to construct from
+  template <typename T>
+  explicit ContextType(const T& value) : m_data{value} {}
+
+  /// Move assignment of anything to this object is allowed.
+  ///
+  /// @tparam T The type of the value to assign
+  /// @param value The value to assign
+  /// @return ContextType&
   template <typename T>
   ContextType& operator=(T&& value) {
     m_data = std::move(value);
     return *this;
   }
 
+  /// Copy assignment of anything to this object is allowed.
+  ///
+  /// @tparam T The type of the value to assign
+  /// @param value The value to assign
+  /// @return ContextType&
   template <typename T>
   ContextType& operator=(const T& value) {
-    m_data = std::move(value);
+    m_data = value;
     return *this;
   }
 

--- a/Core/include/Acts/Utilities/detail/ContextType.hpp
+++ b/Core/include/Acts/Utilities/detail/ContextType.hpp
@@ -1,0 +1,84 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <any>
+
+namespace Acts {
+
+/// Strong type wrapper around std::any. This has all the flexibility of
+/// std::any, but it does not auto construct from anything. You have to call the
+/// make static factory manually with the target type, to populate the internal
+/// std::any. You can then access and modify the any as desired.
+///
+/// @note This is used for the context types, and should probably not used
+/// outside of this use-case.
+class ContextType {
+ public:
+  /// Default constructor, does nothing
+  ///
+  ContextType() {}
+
+  /// Static factory method from arguments.
+  ///
+  /// @tparam T The underlying type to construct
+  /// @tparam Args Types of construction arguments
+  /// @param args Values of construction arguments
+  /// @return ContextType The constructed context instance
+  //   template <typename T, typename... Args>
+  //   static ContextType make(Args&&... args) {
+  //     ContextType ctx;
+  //     ctx.m_data.emplace<T>(std::forward<Args>(args)...);
+  //     return ctx;
+  //   }
+
+  //   template <typename T>
+  //   static ContextType make(T&& value) {
+  //     ContextType ctx;
+  //     ctx.m_data = value;
+  //     return ctx;
+  //   }
+
+  //   template <typename T>
+  //   static ContextType make(const T& value) {
+  //     ContextType ctx;
+  //     ctx.m_data = value;
+  //     return ctx;
+  //   }
+
+  template <typename T>
+  explicit ContextType(T&& value) : m_data{std::move(value)} {}
+
+  template <typename T>
+  ContextType& operator=(T&& value) {
+    m_data = std::move(value);
+    return *this;
+  }
+
+  template <typename T>
+  ContextType& operator=(const T& value) {
+    m_data = std::move(value);
+    return *this;
+  }
+
+  /// Mutable access to the contained any storage
+  ///
+  /// @return std::any&
+  std::any& any() { return m_data; }
+
+  /// Immutable access to the ocntained any storage
+  ///
+  /// @return const std::any&
+  const std::any& any() const { return m_data; }
+
+ private:
+  std::any m_data;
+};
+
+}  // namespace Acts

--- a/Core/include/Acts/Utilities/detail/ContextType.hpp
+++ b/Core/include/Acts/Utilities/detail/ContextType.hpp
@@ -61,15 +61,23 @@ class ContextType {
     return *this;
   }
 
-  /// Mutable access to the contained any storage
+  /// Retrieve a reference to the contained type
   ///
-  /// @return std::any&
-  std::any& any() { return m_data; }
+  /// @tparam T The type to attempt to retrieve the value as
+  /// @return Reference to the contained value
+  template <typename T>
+  std::decay_t<T>& get() {
+    return std::any_cast<std::decay_t<T>&>(m_data);
+  }
 
-  /// Immutable access to the ocntained any storage
+  /// Retrieve a reference to the contained type
   ///
-  /// @return const std::any&
-  const std::any& any() const { return m_data; }
+  /// @tparam T The type to attempt to retrieve the value as
+  /// @return Reference to the contained value
+  template <typename T>
+  const std::decay_t<T>& get() const {
+    return std::any_cast<const std::decay_t<T>&>(m_data);
+  }
 
  private:
   std::any m_data;

--- a/Core/include/Acts/Vertexing/VertexingOptions.hpp
+++ b/Core/include/Acts/Vertexing/VertexingOptions.hpp
@@ -30,8 +30,7 @@ struct VertexingOptions {
   /// @param mctx The magnetic context for this fit
   /// @param vconstr The pointing contraint to a vertex
   VertexingOptions(
-      std::reference_wrapper<const GeometryContext> gctx,
-      std::reference_wrapper<const MagneticFieldContext> mctx,
+      const GeometryContext& gctx, const MagneticFieldContext& mctx,
       const Vertex<input_track_t>& vconstr = Vertex<input_track_t>())
       : geoContext(gctx), magFieldContext(mctx), vertexConstraint(vconstr) {}
 

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -92,11 +92,12 @@ FreeToBoundMatrix freeToCurvilinearJacobian(const Vector3& direction) {
 /// parameters at the final surface
 /// @param [in] surface The final surface onto which the projection should be
 /// performed
-void jacobianLocalToLocal(
-    std::reference_wrapper<const GeometryContext> geoContext,
-    const FreeVector& parameters, const BoundToFreeMatrix& jacToGlobal,
-    const FreeMatrix& transportJacobian, const FreeVector& derivatives,
-    Jacobian& jacFull, const Surface& surface) {
+void jacobianLocalToLocal(const GeometryContext& geoContext,
+                          const FreeVector& parameters,
+                          const BoundToFreeMatrix& jacToGlobal,
+                          const FreeMatrix& transportJacobian,
+                          const FreeVector& derivatives, Jacobian& jacFull,
+                          const Surface& surface) {
   // Calculate the derivative of path length at the final surface or the
   // point-of-closest approach w.r.t. free parameters
   const FreeToPathMatrix freeToPath =
@@ -164,11 +165,12 @@ void jacobianLocalToLocal(const Vector3& direction,
 /// parametrisation to free parameters
 /// @param [in] freeParams Free, nominal parametrisation
 /// @param [in] surface The reference surface of the local parametrisation
-void reinitializeJacobians(
-    std::reference_wrapper<const GeometryContext> geoContext,
-    FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacToGlobal, const FreeVector& freeParams,
-    const Surface& surface) {
+void reinitializeJacobians(const GeometryContext& geoContext,
+                           FreeMatrix& transportJacobian,
+                           FreeVector& derivatives,
+                           BoundToFreeMatrix& jacToGlobal,
+                           const FreeVector& freeParams,
+                           const Surface& surface) {
   using VectorHelpers::phi;
   using VectorHelpers::theta;
 
@@ -240,7 +242,7 @@ void reinitializeJacobians(FreeMatrix& transportJacobian,
 
 namespace detail {
 
-BoundState boundState(std::reference_wrapper<const GeometryContext> geoContext,
+BoundState boundState(const GeometryContext& geoContext,
                       Covariance& covarianceMatrix, Jacobian& jacobian,
                       FreeMatrix& transportJacobian, FreeVector& derivatives,
                       BoundToFreeMatrix& jacToGlobal,
@@ -329,12 +331,11 @@ void covarianceTransport(Covariance& covarianceMatrix, Jacobian& jacobian,
   reinitializeJacobians(transportJacobian, derivatives, jacToGlobal, direction);
 }
 
-void covarianceTransport(
-    std::reference_wrapper<const GeometryContext> geoContext,
-    Covariance& covarianceMatrix, Jacobian& jacobian,
-    FreeMatrix& transportJacobian, FreeVector& derivatives,
-    BoundToFreeMatrix& jacToGlobal, const FreeVector& parameters,
-    const Surface& surface) {
+void covarianceTransport(const GeometryContext& geoContext,
+                         Covariance& covarianceMatrix, Jacobian& jacobian,
+                         FreeMatrix& transportJacobian, FreeVector& derivatives,
+                         BoundToFreeMatrix& jacToGlobal,
+                         const FreeVector& parameters, const Surface& surface) {
   // Calculate the full jacobian from local parameters at the start surface to
   // current bound parameters
   jacobianLocalToLocal(geoContext, parameters, jacToGlobal, transportJacobian,

--- a/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignedDetectorElement.hpp
+++ b/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignedDetectorElement.hpp
@@ -84,7 +84,7 @@ inline const Acts::Transform3& AlignedDetectorElement::transform(
   // Check if a different transform than the nominal exists
   if (m_alignedTransforms.size()) {
     // cast into the right context object
-    auto alignContext = std::any_cast<ContextType>(gctx.any());
+    auto alignContext = gctx.get<ContextType>();
     return (*m_alignedTransforms[alignContext.iov].get());
   }
   // Return the standard transform if not found

--- a/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignedDetectorElement.hpp
+++ b/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignedDetectorElement.hpp
@@ -84,7 +84,7 @@ inline const Acts::Transform3& AlignedDetectorElement::transform(
   // Check if a different transform than the nominal exists
   if (m_alignedTransforms.size()) {
     // cast into the right context object
-    auto alignContext = std::any_cast<ContextType>(gctx);
+    auto alignContext = std::any_cast<ContextType>(gctx.any());
     return (*m_alignedTransforms[alignContext.iov].get());
   }
   // Return the standard transform if not found

--- a/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/PayloadDetectorElement.hpp
+++ b/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/PayloadDetectorElement.hpp
@@ -67,7 +67,7 @@ class PayloadDetectorElement : public Generic::GenericDetectorElement {
 inline const Acts::Transform3& PayloadDetectorElement::transform(
     const Acts::GeometryContext& gctx) const {
   // cast into the right context object
-  auto alignContext = std::any_cast<ContextType>(gctx);
+  auto alignContext = std::any_cast<ContextType>(gctx.any());
   identifier_type idValue = identifier_type(identifier());
 
   // check if we have the right alignment parameter in hand

--- a/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/PayloadDetectorElement.hpp
+++ b/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/PayloadDetectorElement.hpp
@@ -67,7 +67,7 @@ class PayloadDetectorElement : public Generic::GenericDetectorElement {
 inline const Acts::Transform3& PayloadDetectorElement::transform(
     const Acts::GeometryContext& gctx) const {
   // cast into the right context object
-  auto alignContext = std::any_cast<ContextType>(gctx.any());
+  auto alignContext = gctx.get<ContextType>();
   identifier_type idValue = identifier_type(identifier());
 
   // check if we have the right alignment parameter in hand

--- a/Examples/Detectors/ContextualDetector/src/AlignmentDecorator.cpp
+++ b/Examples/Detectors/ContextualDetector/src/AlignmentDecorator.cpp
@@ -90,8 +90,7 @@ ActsExamples::Contextual::AlignmentDecorator::decorate(
   }
   // Set the geometry context
   AlignedDetectorElement::ContextType alignedContext{iov};
-  context.geoContext =
-      std::make_any<AlignedDetectorElement::ContextType>(alignedContext);
+  context.geoContext = alignedContext;
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Detectors/ContextualDetector/src/PayloadDecorator.cpp
+++ b/Examples/Detectors/ContextualDetector/src/PayloadDecorator.cpp
@@ -47,7 +47,7 @@ void ActsExamples::Contextual::PayloadDecorator::parseGeometry(
   size_t nTransforms = 0;
   tGeometry.visitSurfaces([&nTransforms](const auto*) { ++nTransforms; });
 
-  PayloadDetectorElement::ContextType nominalCtx;
+  Acts::GeometryContext nominalCtx{PayloadDetectorElement::ContextType{}};
 
   // Collect the surfacas into the nominal store
   std::vector<Acts::Transform3> aStore(nTransforms,

--- a/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/BuildGenericDetector.hpp
+++ b/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/BuildGenericDetector.hpp
@@ -99,7 +99,7 @@ std::vector<std::vector<Acts::Vector3>> modulePositionsDisc(
 /// return a unique vector to the tracking geometry
 template <typename detector_element_t>
 std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
-    const typename detector_element_t::ContextType& gctx,
+    const typename detector_element_t::ContextType& gctxIn,
     std::vector<std::vector<std::shared_ptr<detector_element_t>>>&
         detectorStore,
     size_t level,
@@ -112,6 +112,9 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
 
   using ProtoLayerCreator = ProtoLayerCreatorT<detector_element_t>;
   using LayerBuilder = LayerBuilderT<detector_element_t>;
+
+  //   auto gctx = Acts::GeometryContext::make(gctxIn);
+  Acts::GeometryContext gctx{gctxIn};
 
   // configure surface array creator
   Acts::SurfaceArrayCreator::Config sacConfig;

--- a/Examples/Detectors/MagneticField/include/ActsExamples/Plugins/BField/ScalableBField.hpp
+++ b/Examples/Detectors/MagneticField/include/ActsExamples/Plugins/BField/ScalableBField.hpp
@@ -32,8 +32,8 @@ class ScalableBField final {
     double scalor = 1.;
 
     /// @brief constructor with context
-    Cache(const Acts::MagneticFieldContext& mcfg) {
-      scalor = std::any_cast<const ScalableBFieldContext>(mcfg).scalor;
+    Cache(const Acts::MagneticFieldContext& mctx) {
+      scalor = std::any_cast<const ScalableBFieldContext>(mctx.any()).scalor;
     }
   };
 

--- a/Examples/Detectors/MagneticField/include/ActsExamples/Plugins/BField/ScalableBField.hpp
+++ b/Examples/Detectors/MagneticField/include/ActsExamples/Plugins/BField/ScalableBField.hpp
@@ -33,7 +33,7 @@ class ScalableBField final {
 
     /// @brief constructor with context
     Cache(const Acts::MagneticFieldContext& mctx) {
-      scalor = std::any_cast<const ScalableBFieldContext>(mctx.any()).scalor;
+      scalor = mctx.get<const ScalableBFieldContext>().scalor;
     }
   };
 

--- a/Examples/Detectors/MagneticField/src/BFieldScalor.cpp
+++ b/Examples/Detectors/MagneticField/src/BFieldScalor.cpp
@@ -21,7 +21,8 @@ ActsExamples::ProcessCode ActsExamples::BField::BFieldScalor::decorate(
     AlgorithmContext& context) {
   ScalableBFieldContext bFieldContext{
       std::pow(m_cfg.scalor, context.eventNumber)};
-  context.magFieldContext = std::make_any<ScalableBFieldContext>(bFieldContext);
+  context.magFieldContext = bFieldContext;
+  //   Acts::MagneticFieldContext::make<ScalableBFieldContext>(bFieldContext);
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Detectors/MagneticField/src/BFieldScalor.cpp
+++ b/Examples/Detectors/MagneticField/src/BFieldScalor.cpp
@@ -22,7 +22,6 @@ ActsExamples::ProcessCode ActsExamples::BField::BFieldScalor::decorate(
   ScalableBFieldContext bFieldContext{
       std::pow(m_cfg.scalor, context.eventNumber)};
   context.magFieldContext = bFieldContext;
-  //   Acts::MagneticFieldContext::make<ScalableBFieldContext>(bFieldContext);
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
+++ b/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
@@ -104,7 +104,7 @@ inline const Acts::Transform3& TelescopeDetectorElement::transform(
   // Check if a different transform than the nominal exists
   if (m_alignedTransforms.size()) {
     // cast into the right context object
-    auto alignContext = std::any_cast<ContextType>(gctx);
+    auto alignContext = std::any_cast<ContextType>(gctx.any());
     return (*m_alignedTransforms[alignContext.iov].get());
   }
   // Return the standard transform if not found

--- a/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
+++ b/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
@@ -104,7 +104,7 @@ inline const Acts::Transform3& TelescopeDetectorElement::transform(
   // Check if a different transform than the nominal exists
   if (m_alignedTransforms.size()) {
     // cast into the right context object
-    auto alignContext = std::any_cast<ContextType>(gctx.any());
+    auto alignContext = gctx.get<ContextType>();
     return (*m_alignedTransforms[alignContext.iov].get());
   }
   // Return the standard transform if not found

--- a/Examples/Detectors/TelescopeDetector/src/BuildTelescopeDetector.cpp
+++ b/Examples/Detectors/TelescopeDetector/src/BuildTelescopeDetector.cpp
@@ -110,8 +110,9 @@ ActsExamples::Telescope::buildDetector(
     layVec.push_back(layers[i]);
   }
   // Create the layer array
+  Acts::GeometryContext genGctx{gctx};
   std::unique_ptr<const Acts::LayerArray> layArr(layArrCreator.layerArray(
-      gctx, layVec, positions.front() - 2._mm, positions.back() + 2._mm,
+      genGctx, layVec, positions.front() - 2._mm, positions.back() + 2._mm,
       Acts::BinningType::arbitrary, binValue));
 
   // Build the tracking volume

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CubicTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CubicTrackingGeometry.hpp
@@ -39,8 +39,7 @@ struct CubicTrackingGeometry {
   /// Default constructor for the Cubit tracking geometry
   ///
   /// @param gctx the geometry context for this geometry at building time
-  CubicTrackingGeometry(std::reference_wrapper<const GeometryContext> gctx)
-      : geoContext(gctx) {
+  CubicTrackingGeometry(const GeometryContext& gctx) : geoContext(gctx) {
     using namespace UnitLiterals;
 
     // Construct the rotation

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
@@ -45,9 +45,7 @@ struct CylindricalTrackingGeometry {
   std::reference_wrapper<const GeometryContext> geoContext;
 
   /// Only allowed constructor with reference wrapper
-  CylindricalTrackingGeometry(
-      std::reference_wrapper<const GeometryContext> gctx)
-      : geoContext(gctx) {}
+  CylindricalTrackingGeometry(const GeometryContext& gctx) : geoContext(gctx) {}
 
   using DetectorStore = std::vector<std::unique_ptr<const DetectorElementStub>>;
 

--- a/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
@@ -94,7 +94,7 @@ class AlignableDetectorElement : public DetectorElementBase {
 
 inline const Transform3& AlignableDetectorElement::transform(
     const GeometryContext& gctx) const {
-  auto alignContext = std::any_cast<AlignmentContext>(gctx.any());
+  auto alignContext = gctx.get<AlignmentContext>();
   if (alignContext.alignmentStore != nullptr and
       alignContext.alignmentIndex < 2) {
     return (*(alignContext.alignmentStore))[alignContext.alignmentIndex];

--- a/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
@@ -94,7 +94,7 @@ class AlignableDetectorElement : public DetectorElementBase {
 
 inline const Transform3& AlignableDetectorElement::transform(
     const GeometryContext& gctx) const {
-  auto alignContext = std::any_cast<AlignmentContext>(gctx);
+  auto alignContext = std::any_cast<AlignmentContext>(gctx.any());
   if (alignContext.alignmentStore != nullptr and
       alignContext.alignmentIndex < 2) {
     return (*(alignContext.alignmentStore))[alignContext.alignmentIndex];
@@ -149,9 +149,9 @@ BOOST_AUTO_TEST_CASE(AlignmentContextTests) {
   const auto& alignedSurface = alignedElement.surface();
 
   // The alignment centexts
-  AlignmentContext defaultContext{};
-  AlignmentContext negativeContext(alignmentStore, 0);
-  AlignmentContext positiveContext(alignmentStore, 1);
+  GeometryContext defaultContext{AlignmentContext{}};
+  GeometryContext negativeContext{AlignmentContext{alignmentStore, 0}};
+  GeometryContext positiveContext{AlignmentContext{alignmentStore, 1}};
 
   // Test the transforms
   BOOST_CHECK(alignedSurface.transform(defaultContext)


### PR DESCRIPTION
Move away from using a raw typedef to std::any. Doing that has certain drawbacks: std::any can be convert constructed from anything. This causes problems when constructing anything that only accepts a context any. GCC9 even has recursion trouble in the type_traits infrastructure leading to compile time failures.

Moving to wrappers can alleviate this. They only have an explicit constructor, meaning that they are not autoconstructed by conversion. This is a little bit more cumbersome to use, but much more robust I believe.

Performance should not be affected.

Previously, to break the problems of converting constructors with a single `std::any` argument, we resorted to `std::reference_wrapper<std::any>`, which only resolved it to some degree. This PR also removes this workaround. `std::reference_wrapper<const {Geometry,MagneticField}Context>` is still retained when used to store a context reference as a member, as for example in the stepper state. 

BREAKING CHANGE: The public interface of the geometry and magnetic context type change. Before, they were raw `std::any`s, now they are of type `Acts::ContextType`. Construction needs to be explicit, and the contained `std::any` can be accessed via the `Acts::ContextType::get()` methods. `std::any_cast` to unpack the concrete context value is still supported, but needs to retrieve the internal `std::any` first. **NOTE**: If you forget to call `.any()` on the context object, `std::any_cast` will compile, but will throw `std::bad_any_cast` at runtime.
