### PR TITLE
ci: Do not run automatic homebrew cleanup on install

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 jobs:
   linux:


### PR DESCRIPTION
Currently, the macOS CI job spends a considerable amount of time cleanup
up the homebrew install, which is pointless because it's erased at the
end of the job anyway. Adding an environment variable, this can be
disabled.
