### PR TITLE
fix: Fix confusion between shadowed variables in the AtlasStepperTests

### DIFF
--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -398,10 +398,10 @@ BOOST_AUTO_TEST_CASE(Reset) {
   // Reset using different surface shapes
   // 1) Disc surface
   // Setting some parameters
-  newPos << 1.5, -2.5, 0.;
+  newPos << 0.5, -1.5, 0.;
   newAbsMom *= 1.23;
-  newTime = 7.5;
-  newCharge = 1.;
+  newTime = 8.4;
+  newCharge = -1.;
   newCov = 10.9 * Covariance::Identity();
   Transform3 trafo = Transform3::Identity();
   auto disc = Surface::makeShared<DiscSurface>(trafo);
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
   newPos << 1.5, -2.5, 3.5;
   newAbsMom *= 0.45;
   newTime = 2.3;
-  newCharge = -1.;
+  newCharge = 1.;
   newCov = 8.7 * Covariance::Identity();
   auto perigee = Surface::makeShared<PerigeeSurface>(trafo);
   BoundTrackParameters boundPerigee(perigee, geoCtx,

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -316,13 +316,13 @@ BOOST_AUTO_TEST_CASE(Reset) {
   stepper.step(state);
 
   // Construct the parameters
-  Vector3 pos(1.5, -2.5, 3.5);
-  Vector3 mom(4.5, -5.5, 6.5);
-  double time = 7.5;
-  double charge = 1.;
-  BoundSymMatrix cov = 8.5 * Covariance::Identity();
-  CurvilinearTrackParameters cp(makeVector4(pos, time), unitDir, absMom, charge,
-                                cov);
+  Vector3 newPos(1.5, -2.5, 3.5);
+  auto newAbsMom = 4.2 * absMom;
+  double newTime = 7.5;
+  double newCharge = 1.;
+  BoundSymMatrix newCov = 8.5 * Covariance::Identity();
+  CurvilinearTrackParameters cp(makeVector4(newPos, newTime), unitDir,
+                                newAbsMom, newCharge, newCov);
   FreeVector freeParams = detail::transformBoundToFreeParameters(
       cp.referenceSurface(), geoCtx, cp.parameters());
   NavigationDirection ndir = forward;
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
                      cp.referenceSurface(), ndir, stepSize);
   // Test all components
   BOOST_CHECK(stateCopy.covTransport);
-  BOOST_CHECK_EQUAL(*stateCopy.covariance, cov);
+  BOOST_CHECK_EQUAL(*stateCopy.covariance, newCov);
   BOOST_CHECK_EQUAL(stepper.position(stateCopy),
                     freeParams.template segment<3>(eFreePos0));
   BOOST_CHECK_EQUAL(stepper.direction(stateCopy),
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
                      cp.referenceSurface(), ndir);
   // Test all components
   BOOST_CHECK(stateCopy.covTransport);
-  BOOST_CHECK_EQUAL(*stateCopy.covariance, cov);
+  BOOST_CHECK_EQUAL(*stateCopy.covariance, newCov);
   BOOST_CHECK_EQUAL(stepper.position(stateCopy),
                     freeParams.template segment<3>(eFreePos0));
   BOOST_CHECK_EQUAL(stepper.direction(stateCopy),
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
                      cp.referenceSurface());
   // Test all components
   BOOST_CHECK(stateCopy.covTransport);
-  BOOST_CHECK_EQUAL(*stateCopy.covariance, cov);
+  BOOST_CHECK_EQUAL(*stateCopy.covariance, newCov);
   BOOST_CHECK_EQUAL(stepper.position(stateCopy),
                     freeParams.template segment<3>(eFreePos0));
   BOOST_CHECK_EQUAL(stepper.direction(stateCopy),
@@ -398,14 +398,15 @@ BOOST_AUTO_TEST_CASE(Reset) {
   // Reset using different surface shapes
   // 1) Disc surface
   // Setting some parameters
-  pos << 1.5, -2.5, 0.;
-  mom << 4.5, -5.5, 6.5;
-  time = 7.5;
-  charge = 1.;
-  cov = 8.5 * Covariance::Identity();
+  newPos << 1.5, -2.5, 0.;
+  newAbsMom *= 1.23;
+  newTime = 7.5;
+  newCharge = 1.;
+  newCov = 10.9 * Covariance::Identity();
   Transform3 trafo = Transform3::Identity();
   auto disc = Surface::makeShared<DiscSurface>(trafo);
-  BoundTrackParameters boundDisc(disc, geoCtx, pos4, unitDir, absMom, charge);
+  BoundTrackParameters boundDisc(disc, geoCtx, makeVector4(newPos, newTime),
+                                 unitDir, newAbsMom, newCharge, newCov);
 
   // Reset the state and test
   Stepper::State stateDisc = state.stepping;
@@ -417,14 +418,15 @@ BOOST_AUTO_TEST_CASE(Reset) {
 
   // 2) Perigee surface
   // Setting some parameters
-  pos << 1.5, -2.5, 3.5;
-  mom << 4.5, -5.5, 6.5;
-  time = 7.5;
-  charge = 1.;
-  cov = 8.5 * Covariance::Identity();
+  newPos << 1.5, -2.5, 3.5;
+  newAbsMom *= 0.45;
+  newTime = 2.3;
+  newCharge = -1.;
+  newCov = 8.7 * Covariance::Identity();
   auto perigee = Surface::makeShared<PerigeeSurface>(trafo);
-  BoundTrackParameters boundPerigee(perigee, geoCtx, pos4, unitDir, absMom,
-                                    charge);
+  BoundTrackParameters boundPerigee(perigee, geoCtx,
+                                    makeVector4(newPos, newTime), unitDir,
+                                    newAbsMom, newCharge, newCov);
 
   // Reset the state and test
   Stepper::State statePerigee = state.stepping;
@@ -436,14 +438,10 @@ BOOST_AUTO_TEST_CASE(Reset) {
   CHECK_NE_COLLECTIONS(statePerigee.pVector, stateDisc.pVector);
 
   // 3) Straw surface
-  // Setting some parameters
-  pos << 1.5, -2.5, 3.5;
-  mom << 4.5, -5.5, 6.5;
-  time = 7.5;
-  charge = 1.;
-  cov = 8.5 * Covariance::Identity();
+  // Use the same parameters as for previous Perigee surface
   auto straw = Surface::makeShared<StrawSurface>(trafo);
-  BoundTrackParameters boundStraw(straw, geoCtx, pos4, unitDir, absMom, charge);
+  BoundTrackParameters boundStraw(straw, geoCtx, makeVector4(newPos, newTime),
+                                  unitDir, newAbsMom, newCharge, newCov);
 
   // Reset the state and test
   Stepper::State stateStraw = state.stepping;


### PR DESCRIPTION
Last September, #443 accidentally introduced a nonsensical operation in the AtlasStepperTests during a refactoring (compute bound parameters with a position which is not on the surface of interest). This happened because @msmk0 was understandably misled by a set of local and global variables with identical names and unrelated contents, with the local variables shadowing the global ones.

This nonsensical operation was not caught by the unit tests because passing an invalid position to the BoundParameters constructors only leads to the emission of a FATAL log, and not to any stronger error reporting like throwing an exception (returning a Result would not be possible here as this happens inside of a class constructor).

However, the FATAL log was caught by #687, so in the interest of enabling #688, here's my fix. To reduce the odds of future problems, I switched this sub-test the same variable naming convention as the rest of the AtlasStepperTests (newXyz for the local override to the xyz global variable) and also made the test inputs just a little bit more diverse, removing redundant input setting when it is actually desired that two tests use the same input.