### PR TITLE
fix: use of ordered_json

### DIFF
--- a/Plugins/Json/include/Acts/Plugins/Json/MaterialMapJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/MaterialMapJsonConverter.hpp
@@ -91,13 +91,14 @@ class MaterialMapJsonConverter {
   /// Convert a DetectorMaterialMaps to json
   ///
   /// @param maps The material map collection
-  nlohmann::json materialMapsToJson(const DetectorMaterialMaps& maps);
+  nlohmann::ordered_json materialMapsToJson(const DetectorMaterialMaps& maps);
 
   /// Convert a tracking geometry to json.
   /// Can be used to initialise the material mapping process.
   ///
   /// @param tGeometry is the tracking geometry
-  nlohmann::json trackingGeometryToJson(const TrackingGeometry& tGeometry);
+  nlohmann::ordered_json trackingGeometryToJson(
+      const TrackingGeometry& tGeometry);
 
   /// Go through a volume to find subvolume, layers and surfaces.
   /// Store volumes and surfaces in two vector used to initialised the geometry

--- a/Plugins/Json/src/MaterialMapJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialMapJsonConverter.cpp
@@ -173,7 +173,7 @@ Acts::MaterialMapJsonConverter::MaterialMapJsonConverter(
 
 /// Convert method
 ///
-nlohmann::json Acts::MaterialMapJsonConverter::materialMapsToJson(
+nlohmann::ordered_json Acts::MaterialMapJsonConverter::materialMapsToJson(
     const DetectorMaterialMaps& maps) {
   VolumeMaterialMap volumeMap = maps.second;
   std::vector<std::pair<GeometryIdentifier, const IVolumeMaterial*>>
@@ -183,7 +183,7 @@ nlohmann::json Acts::MaterialMapJsonConverter::materialMapsToJson(
   }
   GeometryHierarchyMap<const IVolumeMaterial*> HierarchyVolumeMap(
       mapVolumeInit);
-  nlohmann::json materialVolume =
+  nlohmann::ordered_json materialVolume =
       m_volumeMaterialConverter.toJson(HierarchyVolumeMap);
   SurfaceMaterialMap surfaceMap = maps.first;
   std::vector<std::pair<GeometryIdentifier, const ISurfaceMaterial*>>
@@ -193,7 +193,7 @@ nlohmann::json Acts::MaterialMapJsonConverter::materialMapsToJson(
   }
   GeometryHierarchyMap<const ISurfaceMaterial*> HierarchySurfaceMap(
       mapSurfaceInit);
-  nlohmann::json materialSurface =
+  nlohmann::ordered_json materialSurface =
       m_surfaceMaterialConverter.toJson(HierarchySurfaceMap);
   nlohmann::ordered_json materialMap;
   materialMap["Volumes"] = materialVolume;
@@ -230,7 +230,7 @@ Acts::MaterialMapJsonConverter::jsonToMaterialMaps(
   return maps;
 }
 
-nlohmann::json Acts::MaterialMapJsonConverter::trackingGeometryToJson(
+nlohmann::ordered_json Acts::MaterialMapJsonConverter::trackingGeometryToJson(
     const Acts::TrackingGeometry& tGeometry) {
   std::vector<std::pair<GeometryIdentifier, Acts::TrackingVolumeAndMaterial>>
       volumeHierarchy;
@@ -240,10 +240,12 @@ nlohmann::json Acts::MaterialMapJsonConverter::trackingGeometryToJson(
                      tGeometry.highestTrackingVolume());
   GeometryHierarchyMap<Acts::TrackingVolumeAndMaterial> HierarchyVolumeMap(
       volumeHierarchy);
-  nlohmann::json jsonVolumes = m_volumeConverter.toJson(HierarchyVolumeMap);
+  nlohmann::ordered_json jsonVolumes =
+      m_volumeConverter.toJson(HierarchyVolumeMap);
   GeometryHierarchyMap<Acts::SurfaceAndMaterial> HierarchySurfaceMap(
       surfaceHierarchy);
-  nlohmann::json jsonSurfaces = m_surfaceConverter.toJson(HierarchySurfaceMap);
+  nlohmann::ordered_json jsonSurfaces =
+      m_surfaceConverter.toJson(HierarchySurfaceMap);
   nlohmann::ordered_json hierarchyMap;
   hierarchyMap["Volumes"] = jsonVolumes;
   hierarchyMap["Surfaces"] = jsonSurfaces;

--- a/Tests/UnitTests/Plugins/Json/MaterialMapJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/MaterialMapJsonConverterTests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(RoundtripFromFile) {
   Acts::MaterialMapJsonConverter::Config converterCfg;
   Acts::MaterialMapJsonConverter converter(converterCfg);
   auto materialMap = converter.jsonToMaterialMaps(refJson);
-  auto encodedJson = converter.materialMapsToJson(materialMap);
+  nlohmann::json encodedJson = converter.materialMapsToJson(materialMap);
 
   // verify identical encoded JSON values
   BOOST_CHECK_EQUAL(refJson, encodedJson);


### PR DESCRIPTION
When the material map and tracking geometry where written to file they were not using ordered_json due to an oversight (the ordered_json had been converted to json before being written). This fix this issue so that the key appear in proper order in the files.
