### PR TITLE
fix: Bethe-Heitler photon emission

### DIFF
--- a/Fatras/CMakeLists.txt
+++ b/Fatras/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   src/EventData/ProcessType.cpp
   src/Kernel/SimulatorError.cpp
   src/Physics/StandardPhysicsLists.cpp
+  src/Physics/EnergyLoss/BetheHeitler.cpp
   src/Utilities/LandauDistribution.cpp
   src/Utilities/ParticleData.cpp)
 target_compile_features(

--- a/Fatras/include/ActsFatras/EventData/ProcessType.hpp
+++ b/Fatras/include/ActsFatras/EventData/ProcessType.hpp
@@ -20,6 +20,7 @@ enum class ProcessType : uint32_t {
   eUndefined = 0,
   eDecay = 1,
   ePhotonConversion = 2,
+  eBremsstrahlung = 3,
 };
 
 std::ostream &operator<<(std::ostream &os, ProcessType processType);

--- a/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
+++ b/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Material/MaterialSlab.hpp"
 #include "ActsFatras/EventData/Particle.hpp"
+#include "Acts/Utilities/UnitVectors.hpp"
 
 #include <array>
 #include <random>
@@ -22,8 +23,56 @@ namespace ActsFatras {
 /// "A Gaussian-mixture approximation of the Bethe–Heitler model of electron
 /// energy loss by bremsstrahlung" R. Frühwirth
 struct BetheHeitler {
+	using Scalar = Particle::Scalar;
+  using Vector3 = Particle::Vector3;
+  
   /// A scaling factor to
   double scaleFactor = 1.;
+
+ // Simplified angle evaluation
+  bool uniformHertzDipoleAngle = false;
+  
+// electron in original state, energy loss sampled
+Particle bremPhoton(const Particle &particle, Scalar gammaE, Scalar rndPsi, Scalar rndTheta1, Scalar rndTheta2, Scalar rndTheta3) const
+{
+  // ------------------------------------------------------
+  // simple approach
+  // (a) simulate theta uniform within the opening angle of the relativistic Hertz dipole
+  //      theta_max = 1/gamma
+  // (b)Following the Geant4 approximation from L. Urban -> encapsulate that later
+  //      the azimutal angle
+    
+  Scalar psi    =  2. * M_PI * rndPsi;
+    
+  // the start of the equation
+  Scalar theta = 0.;
+  if (uniformHertzDipoleAngle) {
+    // the simplest simulation
+    theta = particle.mass() / particle.energy() * rndTheta1;  
+  } else {
+    // -----> 
+    theta = particle.mass() / particle.energy();
+    // follow 
+    constexpr Scalar a = 0.625; // 5/8
+    Scalar u =  -log(rndTheta2 * rndTheta3) / a;
+    theta *= (rndTheta1 < 0.25 ) ? u : u / 3.; // 9./(9.+27) = 0.25
+  }
+  
+  Vector3 particleDirection = particle.unitDirection();
+  Vector3 photonDirection = particleDirection;
+  
+  // construct the combined rotation to the scattered direction
+  Acts::RotationMatrix3 rotation(
+      // rotation of the scattering deflector axis relative to the reference
+      Acts::AngleAxis3(psi, particleDirection) *
+      // rotation by the scattering angle around the deflector axis
+      Acts::AngleAxis3(theta, Acts::makeCurvilinearUnitU(particleDirection)));
+  photonDirection.applyOnTheLeft(rotation);
+     
+     Particle photon(particle.particleId().makeDescendant(0), Acts::PdgParticle::eGamma);
+     photon.setProcess(ActsFatras::ProcessType::eBremsstrahlung).setPosition4(particle.fourPosition()).setDirection(photonDirection).setAbsoluteMomentum(gammaE);
+  return photon;
+} 
 
   /// Simulate energy loss and update the particle parameters.
   ///
@@ -45,16 +94,16 @@ struct BetheHeitler {
     const auto z = std::exp(-u);
     const auto sampledEnergyLoss =
         std::abs(scaleFactor * particle.energy() * (z - 1.));
-    const Particle::Scalar momentum = particle.absoluteMomentum();
-	
-    // apply the energy loss
-    particle.correctEnergy(-sampledEnergyLoss);
 
-	// Build the produced photon
-    Particle photon(particle.particleId().makeDescendant(0), Acts::PdgParticle::eGamma);
-    photon.setProcess(ProcessType::eBremsstrahlung).setPosition4(particle.fourPosition())
-		.setDirection(particle.unitDirection()).setAbsoluteMomentum(std::min(sampledEnergyLoss, momentum));
+std::uniform_real_distribution<Scalar> uDist(0., 1.);
+// Build the produced photon
+Particle photon = bremPhoton(particle, sampledEnergyLoss,uDist(generator), uDist(generator), uDist(generator), uDist(generator));
+  // Recoil input momentum
+  particle.setDirection(particle.unitDirection() * particle.absoluteMomentum() - photon.energy() * photon.unitDirection());
 	
+	    // apply the energy loss
+    particle.correctEnergy(-sampledEnergyLoss);
+    
     return {photon};
   }
 };

--- a/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
+++ b/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,7 +13,7 @@
 
 #include <array>
 #include <random>
-
+#include <iostream>
 namespace ActsFatras {
 
 /// Simulate electron energy loss using the Bethe-Heitler description.
@@ -30,13 +30,13 @@ struct BetheHeitler {
   /// @param[in]     generator is the random number generator
   /// @param[in]     slab      defines the passed material
   /// @param[in,out] particle  is the particle being updated
-  /// @return Empty secondaries containers.
+  /// @return Produced photon.
   ///
   /// @tparam generator_t is a RandomNumberEngine
   template <typename generator_t>
-  std::array<Particle, 0> operator()(generator_t &generator,
+  std::array<Particle, 1> operator()(generator_t &generator,
                                      const Acts::MaterialSlab &slab,
-                                     Particle &particle) const {
+                                     Particle &particle) const {    
     // Take a random gamma-distributed value - depending on t/X0
     std::gamma_distribution<double> gDist(slab.thicknessInX0() / std::log(2.0),
                                           1.0);
@@ -45,12 +45,17 @@ struct BetheHeitler {
     const auto z = std::exp(-u);
     const auto sampledEnergyLoss =
         std::abs(scaleFactor * particle.energy() * (z - 1.));
-
+    const Particle::Scalar momentum = particle.absoluteMomentum();
+	
     // apply the energy loss
     particle.correctEnergy(-sampledEnergyLoss);
 
-    // TODO return the lost energy as a photon
-    return {};
+	// Build the produced photon
+    Particle photon(particle.particleId().makeDescendant(0), Acts::PdgParticle::eGamma);
+    photon.setProcess(ProcessType::eBremsstrahlung).setPosition4(particle.fourPosition())
+		.setDirection(particle.unitDirection()).setAbsoluteMomentum(std::min(sampledEnergyLoss, momentum));
+	
+    return {photon};
   }
 };
 

--- a/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
+++ b/Fatras/include/ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp
@@ -13,8 +13,8 @@
 #include "ActsFatras/EventData/Particle.hpp"
 
 #include <array>
-#include <iostream>
 #include <random>
+
 namespace ActsFatras {
 
 /// Simulate electron energy loss using the Bethe-Heitler description.
@@ -32,54 +32,17 @@ struct BetheHeitler {
   // Simplified angle evaluation
   bool uniformHertzDipoleAngle = false;
 
-  // electron in original state, energy loss sampled
+  /// Simulate the photon emission
+  ///
+  /// @param [in] particle The unmodified electron
+  /// @param [in] gammaE Energy of the photon
+  /// @param [in] rndPsi Random number for the azimuthal angle
+  /// @param [in] rndTheta1 Random number for the polar angle
+  /// @param [in] rndTheta2 Random number for the polar angle
+  /// @param [in] rndTheta3 Random number for the polar angle
   Particle bremPhoton(const Particle &particle, Scalar gammaE, Scalar rndPsi,
                       Scalar rndTheta1, Scalar rndTheta2,
-                      Scalar rndTheta3) const {
-    // ------------------------------------------------------
-    // simple approach
-    // (a) simulate theta uniform within the opening angle of the relativistic
-    // Hertz dipole
-    //      theta_max = 1/gamma
-    // (b)Following the Geant4 approximation from L. Urban -> encapsulate that
-    // later
-    //      the azimutal angle
-
-    Scalar psi = 2. * M_PI * rndPsi;
-
-    // the start of the equation
-    Scalar theta = 0.;
-    if (uniformHertzDipoleAngle) {
-      // the simplest simulation
-      theta = particle.mass() / particle.energy() * rndTheta1;
-    } else {
-      // ----->
-      theta = particle.mass() / particle.energy();
-      // follow
-      constexpr Scalar a = 0.625;  // 5/8
-      Scalar u = -log(rndTheta2 * rndTheta3) / a;
-      theta *= (rndTheta1 < 0.25) ? u : u / 3.;  // 9./(9.+27) = 0.25
-    }
-
-    Vector3 particleDirection = particle.unitDirection();
-    Vector3 photonDirection = particleDirection;
-
-    // construct the combined rotation to the scattered direction
-    Acts::RotationMatrix3 rotation(
-        // rotation of the scattering deflector axis relative to the reference
-        Acts::AngleAxis3(psi, particleDirection) *
-        // rotation by the scattering angle around the deflector axis
-        Acts::AngleAxis3(theta, Acts::makeCurvilinearUnitU(particleDirection)));
-    photonDirection.applyOnTheLeft(rotation);
-
-    Particle photon(particle.particleId().makeDescendant(0),
-                    Acts::PdgParticle::eGamma);
-    photon.setProcess(ActsFatras::ProcessType::eBremsstrahlung)
-        .setPosition4(particle.fourPosition())
-        .setDirection(photonDirection)
-        .setAbsoluteMomentum(gammaE);
-    return photon;
-  }
+                      Scalar rndTheta3) const;
 
   /// Simulate energy loss and update the particle parameters.
   ///

--- a/Fatras/src/Physics/EnergyLoss/BetheHeitler.cpp
+++ b/Fatras/src/Physics/EnergyLoss/BetheHeitler.cpp
@@ -8,50 +8,50 @@
 
 #include "ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp"
 
-  ActsFatras::Particle ActsFatras::BetheHeitler::bremPhoton(const Particle &particle, Scalar gammaE, Scalar rndPsi,
-                      Scalar rndTheta1, Scalar rndTheta2,
-                      Scalar rndTheta3) const {
-    // ------------------------------------------------------
-    // simple approach
-    // (a) simulate theta uniform within the opening angle of the relativistic
-    // Hertz dipole
-    //      theta_max = 1/gamma
-    // (b)Following the Geant4 approximation from L. Urban -> encapsulate that
-    // later
-    //      the azimutal angle
+ActsFatras::Particle ActsFatras::BetheHeitler::bremPhoton(
+    const Particle &particle, Scalar gammaE, Scalar rndPsi, Scalar rndTheta1,
+    Scalar rndTheta2, Scalar rndTheta3) const {
+  // ------------------------------------------------------
+  // simple approach
+  // (a) simulate theta uniform within the opening angle of the relativistic
+  // Hertz dipole
+  //      theta_max = 1/gamma
+  // (b)Following the Geant4 approximation from L. Urban -> encapsulate that
+  // later
+  //      the azimutal angle
 
-    Scalar psi = 2. * M_PI * rndPsi;
+  Scalar psi = 2. * M_PI * rndPsi;
 
-    // the start of the equation
-    Scalar theta = 0.;
-    if (uniformHertzDipoleAngle) {
-      // the simplest simulation
-      theta = particle.mass() / particle.energy() * rndTheta1;
-    } else {
-      // ----->
-      theta = particle.mass() / particle.energy();
-      // follow
-      constexpr Scalar a = 0.625;  // 5/8
-      Scalar u = -log(rndTheta2 * rndTheta3) / a;
-      theta *= (rndTheta1 < 0.25) ? u : u / 3.;  // 9./(9.+27) = 0.25
-    }
-
-    Vector3 particleDirection = particle.unitDirection();
-    Vector3 photonDirection = particleDirection;
-
-    // construct the combined rotation to the scattered direction
-    Acts::RotationMatrix3 rotation(
-        // rotation of the scattering deflector axis relative to the reference
-        Acts::AngleAxis3(psi, particleDirection) *
-        // rotation by the scattering angle around the deflector axis
-        Acts::AngleAxis3(theta, Acts::makeCurvilinearUnitU(particleDirection)));
-    photonDirection.applyOnTheLeft(rotation);
-
-    Particle photon(particle.particleId().makeDescendant(0),
-                    Acts::PdgParticle::eGamma);
-    photon.setProcess(ActsFatras::ProcessType::eBremsstrahlung)
-        .setPosition4(particle.fourPosition())
-        .setDirection(photonDirection)
-        .setAbsoluteMomentum(gammaE);
-    return photon;
+  // the start of the equation
+  Scalar theta = 0.;
+  if (uniformHertzDipoleAngle) {
+    // the simplest simulation
+    theta = particle.mass() / particle.energy() * rndTheta1;
+  } else {
+    // ----->
+    theta = particle.mass() / particle.energy();
+    // follow
+    constexpr Scalar a = 0.625;  // 5/8
+    Scalar u = -log(rndTheta2 * rndTheta3) / a;
+    theta *= (rndTheta1 < 0.25) ? u : u / 3.;  // 9./(9.+27) = 0.25
   }
+
+  Vector3 particleDirection = particle.unitDirection();
+  Vector3 photonDirection = particleDirection;
+
+  // construct the combined rotation to the scattered direction
+  Acts::RotationMatrix3 rotation(
+      // rotation of the scattering deflector axis relative to the reference
+      Acts::AngleAxis3(psi, particleDirection) *
+      // rotation by the scattering angle around the deflector axis
+      Acts::AngleAxis3(theta, Acts::makeCurvilinearUnitU(particleDirection)));
+  photonDirection.applyOnTheLeft(rotation);
+
+  Particle photon(particle.particleId().makeDescendant(0),
+                  Acts::PdgParticle::eGamma);
+  photon.setProcess(ActsFatras::ProcessType::eBremsstrahlung)
+      .setPosition4(particle.fourPosition())
+      .setDirection(photonDirection)
+      .setAbsoluteMomentum(gammaE);
+  return photon;
+}

--- a/Fatras/src/Physics/EnergyLoss/BetheHeitler.cpp
+++ b/Fatras/src/Physics/EnergyLoss/BetheHeitler.cpp
@@ -1,0 +1,57 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp"
+
+  ActsFatras::Particle ActsFatras::BetheHeitler::bremPhoton(const Particle &particle, Scalar gammaE, Scalar rndPsi,
+                      Scalar rndTheta1, Scalar rndTheta2,
+                      Scalar rndTheta3) const {
+    // ------------------------------------------------------
+    // simple approach
+    // (a) simulate theta uniform within the opening angle of the relativistic
+    // Hertz dipole
+    //      theta_max = 1/gamma
+    // (b)Following the Geant4 approximation from L. Urban -> encapsulate that
+    // later
+    //      the azimutal angle
+
+    Scalar psi = 2. * M_PI * rndPsi;
+
+    // the start of the equation
+    Scalar theta = 0.;
+    if (uniformHertzDipoleAngle) {
+      // the simplest simulation
+      theta = particle.mass() / particle.energy() * rndTheta1;
+    } else {
+      // ----->
+      theta = particle.mass() / particle.energy();
+      // follow
+      constexpr Scalar a = 0.625;  // 5/8
+      Scalar u = -log(rndTheta2 * rndTheta3) / a;
+      theta *= (rndTheta1 < 0.25) ? u : u / 3.;  // 9./(9.+27) = 0.25
+    }
+
+    Vector3 particleDirection = particle.unitDirection();
+    Vector3 photonDirection = particleDirection;
+
+    // construct the combined rotation to the scattered direction
+    Acts::RotationMatrix3 rotation(
+        // rotation of the scattering deflector axis relative to the reference
+        Acts::AngleAxis3(psi, particleDirection) *
+        // rotation by the scattering angle around the deflector axis
+        Acts::AngleAxis3(theta, Acts::makeCurvilinearUnitU(particleDirection)));
+    photonDirection.applyOnTheLeft(rotation);
+
+    Particle photon(particle.particleId().makeDescendant(0),
+                    Acts::PdgParticle::eGamma);
+    photon.setProcess(ActsFatras::ProcessType::eBremsstrahlung)
+        .setPosition4(particle.fourPosition())
+        .setDirection(photonDirection)
+        .setAbsoluteMomentum(gammaE);
+    return photon;
+  }

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2018-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,6 +14,7 @@
 #include "ActsFatras/EventData/Particle.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheBloch.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 
 #include <random>
 
@@ -40,8 +41,9 @@ BOOST_DATA_TEST_CASE(BetheBloch, Dataset::parameters, pdg, phi, lambda, p,
 
 BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
                      seed) {
+  (void) pdg;
   Generator gen(seed);
-  ActsFatras::Particle before = Dataset::makeParticle(pdg, phi, lambda, p);
+  ActsFatras::Particle before = Dataset::makeParticle(Acts::PdgParticle::eElectron, phi, lambda, p);
   ActsFatras::Particle after = before;
 
   ActsFatras::BetheHeitler process;
@@ -50,7 +52,19 @@ BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
   BOOST_CHECK_LT(after.absoluteMomentum(), before.absoluteMomentum());
   BOOST_CHECK_LT(after.energy(), before.energy());
   // energy loss creates no new particles
-  BOOST_CHECK(outgoing.empty());
+  BOOST_CHECK_EQUAL(outgoing.size(), 1);
+  BOOST_CHECK_GT(outgoing[0].absoluteMomentum(), 0.);
+  
+  // Get the four momenta
+  	Acts::Vector4 p0 = before.fourMomentum();
+  	Acts::Vector4 p1 = after.fourMomentum();
+  	Acts::Vector4 k = outgoing[0].fourMomentum();
+  
+  // Test for similar invariant masses
+  	Acts::Vector4 sum = p1 + k;
+  	double s = sum(Acts::eEnergy) * sum(Acts::eEnergy) - sum.template segment<3>(Acts::eMom0).norm() * sum.template segment<3>(Acts::eMom0).norm();
+  	double s0 = p0(Acts::eEnergy) * p0(Acts::eEnergy) - p0.template segment<3>(Acts::eMom0).norm() * p0.template segment<3>(Acts::eMom0).norm();
+  	CHECK_CLOSE_OR_SMALL(s, s0, 1e-2, 1e-2);
 }
-
+	
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -39,9 +39,8 @@ BOOST_DATA_TEST_CASE(BetheBloch, Dataset::parameters, pdg, phi, lambda, p,
   BOOST_CHECK(outgoing.empty());
 }
 
-BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
-                     seed) {
-  (void)pdg;
+BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::momentumPhi * Dataset::momentumLambda * Dataset::momentumAbs ^ Dataset::rngSeed, phi, lambda, p, seed) {
+
   Generator gen(seed);
   ActsFatras::Particle before =
       Dataset::makeParticle(Acts::PdgParticle::eElectron, phi, lambda, p);

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -10,11 +10,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Tests/CommonHelpers/PredefinedMaterials.hpp"
 #include "ActsFatras/EventData/Particle.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheBloch.hpp"
 #include "ActsFatras/Physics/EnergyLoss/BetheHeitler.hpp"
-#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 
 #include <random>
 
@@ -41,9 +41,10 @@ BOOST_DATA_TEST_CASE(BetheBloch, Dataset::parameters, pdg, phi, lambda, p,
 
 BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
                      seed) {
-  (void) pdg;
+  (void)pdg;
   Generator gen(seed);
-  ActsFatras::Particle before = Dataset::makeParticle(Acts::PdgParticle::eElectron, phi, lambda, p);
+  ActsFatras::Particle before =
+      Dataset::makeParticle(Acts::PdgParticle::eElectron, phi, lambda, p);
   ActsFatras::Particle after = before;
 
   ActsFatras::BetheHeitler process;
@@ -56,17 +57,21 @@ BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
   BOOST_CHECK_GT(outgoing[0].absoluteMomentum(), 0.);
   BOOST_CHECK_EQUAL(outgoing[0].pathInX0(), 0.);
   BOOST_CHECK_EQUAL(outgoing[0].pathInL0(), 0.);
-  
+
   // Get the four momenta
-  	Acts::Vector4 p0 = before.fourMomentum();
-  	Acts::Vector4 p1 = after.fourMomentum();
-  	Acts::Vector4 k = outgoing[0].fourMomentum();
-  
+  Acts::Vector4 p0 = before.fourMomentum();
+  Acts::Vector4 p1 = after.fourMomentum();
+  Acts::Vector4 k = outgoing[0].fourMomentum();
+
   // Test for similar invariant masses
-  	Acts::Vector4 sum = p1 + k;
-  	double s = sum(Acts::eEnergy) * sum(Acts::eEnergy) - sum.template segment<3>(Acts::eMom0).norm() * sum.template segment<3>(Acts::eMom0).norm();
-  	double s0 = p0(Acts::eEnergy) * p0(Acts::eEnergy) - p0.template segment<3>(Acts::eMom0).norm() * p0.template segment<3>(Acts::eMom0).norm();
-  	CHECK_CLOSE_OR_SMALL(s, s0, 1e-2, 1e-2);
+  Acts::Vector4 sum = p1 + k;
+  double s = sum(Acts::eEnergy) * sum(Acts::eEnergy) -
+             sum.template segment<3>(Acts::eMom0).norm() *
+                 sum.template segment<3>(Acts::eMom0).norm();
+  double s0 = p0(Acts::eEnergy) * p0(Acts::eEnergy) -
+              p0.template segment<3>(Acts::eMom0).norm() *
+                  p0.template segment<3>(Acts::eMom0).norm();
+  CHECK_CLOSE_OR_SMALL(s, s0, 1e-2, 1e-2);
 }
-	
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -54,6 +54,8 @@ BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::parameters, pdg, phi, lambda, p,
   // energy loss creates no new particles
   BOOST_CHECK_EQUAL(outgoing.size(), 1);
   BOOST_CHECK_GT(outgoing[0].absoluteMomentum(), 0.);
+  BOOST_CHECK_EQUAL(outgoing[0].pathInX0(), 0.);
+  BOOST_CHECK_EQUAL(outgoing[0].pathInL0(), 0.);
   
   // Get the four momenta
   	Acts::Vector4 p0 = before.fourMomentum();

--- a/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
+++ b/Tests/UnitTests/Fatras/Physics/EnergyLossTests.cpp
@@ -39,8 +39,11 @@ BOOST_DATA_TEST_CASE(BetheBloch, Dataset::parameters, pdg, phi, lambda, p,
   BOOST_CHECK(outgoing.empty());
 }
 
-BOOST_DATA_TEST_CASE(BetheHeitler, Dataset::momentumPhi * Dataset::momentumLambda * Dataset::momentumAbs ^ Dataset::rngSeed, phi, lambda, p, seed) {
-
+BOOST_DATA_TEST_CASE(
+    BetheHeitler,
+    Dataset::momentumPhi* Dataset::momentumLambda* Dataset::momentumAbs ^
+        Dataset::rngSeed,
+    phi, lambda, p, seed) {
   Generator gen(seed);
   ActsFatras::Particle before =
       Dataset::makeParticle(Acts::PdgParticle::eElectron, phi, lambda, p);


### PR DESCRIPTION
The current implementation of the Bethe-Heitler process just reduces the particles energy. This PR adds the corresponding emission of a photon and adapts the angle of the radiating particle accordingly.