### PR TITLE
ci: Run geometry and Geantino examples as in the material mapping tutorial

### DIFF
--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -9,11 +9,14 @@ NUM_EVENTS=100
 SRC_DIR=`pwd`
 BUILD_DIR=`pwd`/build
 DD4HEP_INPUT="--dd4hep-input file:${SRC_DIR}/Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml"
+timed_run() {
+    echo ""
+    echo "=== Running $* ==="
+    echo ""
+    time ${BUILD_DIR}/bin/$*
+}
 run_example() {
-    echo ""
-    echo "=== Running $* -n ${NUM_EVENTS} ==="
-    echo ""
-    time ${BUILD_DIR}/bin/$* -n ${NUM_EVENTS}
+    timed_run $* -n ${NUM_EVENTS}
 }
 
 # Data for Geant4-based examples
@@ -36,18 +39,28 @@ export G4PARTICLEXSDATA=$G4_DATA_DIR/G4PARTICLESXS
 # Run hello world example
 run_example ActsExampleHelloWorld
 
-# Run geometry examples for all geometries
+# Run geometry examples for all geometries, in the configuration suggested by
+# the material mapping tutorial
 #
 # We must try to avoid running examples for all geometries because
 # that results in a combinatorial explosion of CI running time. But
-# these examples are fast enough.
+# these particular examples are fast enough.
 #
-run_example ActsExampleGeometryAligned
-run_example ActsExampleGeometryDD4hep ${DD4HEP_INPUT}
-run_example ActsExampleGeometryEmpty
-run_example ActsExampleGeometryGeneric
-run_example ActsExampleGeometryPayload
-run_example ActsExampleGeometryTelescope
+run_geometry_example() {
+    timed_run ActsExampleGeometry$* \
+                  -n1 \
+                  -j1 \
+                  --mat-output-file geometry-map-$1 \
+                  --output-json true \
+                  --mat-output-allmaterial true \
+                  --mat-output-sensitive false
+}
+run_geometry_example Aligned
+run_geometry_example DD4hep ${DD4HEP_INPUT}
+run_geometry_example Empty
+run_geometry_example Generic
+run_geometry_example Payload
+run_geometry_example Telescope
 # TODO: Add TGeo geometry example (needs an input file + knowhow)
 
 # Run propagation examples for all geometries

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -82,7 +82,8 @@ run_example ActsExamplePropagationPayload
 run_example ActsExampleParticleGun
 run_example ActsExamplePythia8
 
-# Run Geantino recording example
+# Run Geantino recording example, as in the material mapping tutorial (but with
+# 10x less events to keep CI running times reasonable)
 #
 # FIXME: Currently only works in single-threaded mode, even though it
 #        should theoretically be thread-safe as Geant4 usage is
@@ -90,7 +91,11 @@ run_example ActsExamplePythia8
 #        thread-unsafe Geant4 code is accidentally run outside of the
 #        mutex-protected region of the code. See issue #207 .
 #
-run_example ActsExampleGeantinoRecordingDD4hep ${DD4HEP_INPUT} -j1
+timed_run ActsExampleGeantinoRecordingDD4hep \
+              -j1 \
+              ${DD4HEP_INPUT} \
+              --output-root \
+              -n1000
 # TODO: Add GDML version (needs an input file + knowhow)
 
 # Run material validation example (generic-only, see above)

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -95,7 +95,6 @@ run_geantino_example() {
     timed_run ActsExampleGeantinoRecording$* \
                   -n1000 \
                   -j1 \
-                  ${DD4HEP_INPUT} \
                   --g4-material-tracks=geant4-material-tracks-$1 \
                   --output-root
 }

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -44,7 +44,7 @@ run_example ActsExampleHelloWorld
 #
 # We must try to avoid running examples for all geometries because
 # that results in a combinatorial explosion of CI running time. But
-# these particular examples are fast enough.
+# these examples are fast enough.
 #
 run_geometry_example() {
     timed_run ActsExampleGeometry$* \

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -91,11 +91,15 @@ run_example ActsExamplePythia8
 #        thread-unsafe Geant4 code is accidentally run outside of the
 #        mutex-protected region of the code. See issue #207 .
 #
-timed_run ActsExampleGeantinoRecordingDD4hep \
-              -j1 \
-              ${DD4HEP_INPUT} \
-              --output-root \
-              -n1000
+run_geantino_example() {
+    timed_run ActsExampleGeantinoRecording$* \
+                  -n1000 \
+                  -j1 \
+                  ${DD4HEP_INPUT} \
+                  --g4-material-tracks=geant4-material-tracks-$1 \
+                  --output-root
+}
+run_geantino_example DD4hep ${DD4HEP_INPUT}
 # TODO: Add GDML version (needs an input file + knowhow)
 
 # Run material validation example (generic-only, see above)

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -51,7 +51,7 @@ run_geometry_example() {
                   -n1 \
                   -j1 \
                   --mat-output-file geometry-map-$1 \
-                  --output-json true \
+                  --output-json \
                   --mat-output-allmaterial true \
                   --mat-output-sensitive false
 }

--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -53,7 +53,7 @@ run_geometry_example() {
                   --mat-output-file geometry-map-$1 \
                   --output-json \
                   --mat-output-allmaterial true \
-                  --mat-output-sensitive false
+                  --mat-output-sensitives false
 }
 run_geometry_example Aligned
 run_geometry_example DD4hep ${DD4HEP_INPUT}

--- a/docs/howto/run_material_mapping.rst
+++ b/docs/howto/run_material_mapping.rst
@@ -15,7 +15,7 @@ First we will need to extract the list of all the surfaces and volumes in our de
 
 .. code-block:: console
 
-  ./../build/bin/ActsExampleGeometryDD4hep -n1 -j1 --mat-output-file geometry-map  --dd4hep-input ../Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml --output-json true --mat-output-allmaterial true --mat-output-sensitive false
+  ./../build/bin/ActsExampleGeometryDD4hep -n1 -j1 --mat-output-file geometry-map  --dd4hep-input ../Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml --output-json true --mat-output-allmaterial true --mat-output-sensitives false
 
 This algorithm is useful to obtain a visualisation of your detector using the different types of output available (``output-obj`` gives ``.obj`` with a 3D representation of the different subdetectors, for example). Here, we use ``output-json`` to obtain a map of all the surfaces and volumes in the detector with a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``), ``mat-output-allmaterial`` ensure that a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``) is associated to all the surfaces (or volumes), enforcing all of them to be written.
 Four types of surfaces exist:


### PR DESCRIPTION
While full material mapping CI will wait for #733 to be fixed, starting to follow the material mapping tutorial in search for new example configurations already gave me some ideas for the geometry examples and the Geantino example.

**EDIT:** Oh, and while spending too much time looking at the examples' help strings, I also found a typo in the option for controlling material output for sensitive surfaces: it is "--mat-output-sensitive**s**", and not "--mat-output-sensitive".
**EDIT:** Synchronized Geantino example configuration too.