### PR TITLE
refactor: Use pointer for (C)KF inputMeasurements

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -249,7 +249,7 @@ class CombinatorialKalmanFilter {
     const Surface* targetSurface = nullptr;
 
     /// Allows retrieving measurements for a surface
-    std::unordered_map<GeometryIdentifier, std::vector<source_link_t>>
+    const std::unordered_map<GeometryIdentifier, std::vector<source_link_t>>*
         inputMeasurements;
 
     /// Whether to consider multiple scattering.
@@ -506,8 +506,8 @@ class CombinatorialKalmanFilter {
       size_t nBranchesOnSurface = 0;
 
       // Try to find the surface in the measurement surfaces
-      auto sourcelink_it = inputMeasurements.find(surface->geometryId());
-      if (sourcelink_it != inputMeasurements.end()) {
+      auto sourcelink_it = inputMeasurements->find(surface->geometryId());
+      if (sourcelink_it != inputMeasurements->end()) {
         // Screen output message
         ACTS_VERBOSE("Measurement surface " << surface->geometryId()
                                             << " detected.");
@@ -1219,7 +1219,7 @@ class CombinatorialKalmanFilter {
     // Catch the actor and set the measurements
     auto& combKalmanActor =
         propOptions.actionList.template get<CombinatorialKalmanFilterActor>();
-    combKalmanActor.inputMeasurements = std::move(inputMeasurements);
+    combKalmanActor.inputMeasurements = &inputMeasurements;
     combKalmanActor.targetSurface = tfOptions.referenceSurface;
     combKalmanActor.multipleScattering = tfOptions.multipleScattering;
     combKalmanActor.energyLoss = tfOptions.energyLoss;

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -231,7 +231,8 @@ class KalmanFitter {
     const Surface* targetSurface = nullptr;
 
     /// Allows retrieving measurements for a surface
-    std::map<GeometryIdentifier, source_link_t> inputMeasurements;
+    const std::map<GeometryIdentifier, source_link_t>* inputMeasurements =
+        nullptr;
 
     /// Whether to consider multiple scattering.
     bool multipleScattering = true;
@@ -265,8 +266,8 @@ class KalmanFitter {
       // We will try to hit those surface by ignoring boundary checks.
       if constexpr (not isDirectNavigator) {
         if (result.processedStates == 0) {
-          for (auto measurementIt = inputMeasurements.begin();
-               measurementIt != inputMeasurements.end(); measurementIt++) {
+          for (auto measurementIt = inputMeasurements->begin();
+               measurementIt != inputMeasurements->end(); measurementIt++) {
             state.navigation.externalSurfaces.insert(
                 std::pair<uint64_t, GeometryIdentifier>(
                     measurementIt->first.layer(), measurementIt->first));
@@ -331,7 +332,7 @@ class KalmanFitter {
       // reset navigation&stepping before run reversed filtering or
       // proceed to run smoothing
       if (not result.smoothed and not result.reversed) {
-        if (result.measurementStates == inputMeasurements.size() or
+        if (result.measurementStates == inputMeasurements->size() or
             (result.measurementStates > 0 and
              state.navigation.navigationBreak)) {
           // Remove the missing surfaces that occur after the last measurement
@@ -495,8 +496,8 @@ class KalmanFitter {
                         const stepper_t& stepper, result_type& result) const {
       const auto& logger = state.options.logger;
       // Try to find the surface in the measurement surfaces
-      auto sourcelink_it = inputMeasurements.find(surface->geometryId());
-      if (sourcelink_it != inputMeasurements.end()) {
+      auto sourcelink_it = inputMeasurements->find(surface->geometryId());
+      if (sourcelink_it != inputMeasurements->end()) {
         // Screen output message
         ACTS_VERBOSE("Measurement surface " << surface->geometryId()
                                             << " detected.");
@@ -687,8 +688,8 @@ class KalmanFitter {
                                 result_type& result) const {
       const auto& logger = state.options.logger;
       // Try to find the surface in the measurement surfaces
-      auto sourcelink_it = inputMeasurements.find(surface->geometryId());
-      if (sourcelink_it != inputMeasurements.end()) {
+      auto sourcelink_it = inputMeasurements->find(surface->geometryId());
+      if (sourcelink_it != inputMeasurements->end()) {
         // Screen output message
         ACTS_VERBOSE("Measurement surface "
                      << surface->geometryId()
@@ -1087,7 +1088,7 @@ class KalmanFitter {
 
     // Catch the actor and set the measurements
     auto& kalmanActor = kalmanOptions.actionList.template get<KalmanActor>();
-    kalmanActor.inputMeasurements = std::move(inputMeasurements);
+    kalmanActor.inputMeasurements = &inputMeasurements;
     kalmanActor.targetSurface = kfOptions.referenceSurface;
     kalmanActor.multipleScattering = kfOptions.multipleScattering;
     kalmanActor.energyLoss = kfOptions.energyLoss;
@@ -1181,7 +1182,7 @@ class KalmanFitter {
 
     // Catch the actor and set the measurements
     auto& kalmanActor = kalmanOptions.actionList.template get<KalmanActor>();
-    kalmanActor.inputMeasurements = std::move(inputMeasurements);
+    kalmanActor.inputMeasurements = &inputMeasurements;
     kalmanActor.targetSurface = kfOptions.referenceSurface;
     kalmanActor.multipleScattering = kfOptions.multipleScattering;
     kalmanActor.energyLoss = kfOptions.energyLoss;


### PR DESCRIPTION
This PR changes the `inputMeasurements` in (C)KF actor to use pointer. This could save the data copy time vastly. 
