### PR TITLE
feat: Switching SteppingLogger to sterile when no output requested

### DIFF
--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -71,7 +71,7 @@ class PropagationAlgorithm : public BareAlgorithm {
 
     /// proapgation mode
     int mode = 0;
-    /// Switch the logger to sterila
+    /// Switch the logger to sterile
     bool sterileLogger = false;
     /// debug output
     bool debugOutput = false;

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -71,6 +71,8 @@ class PropagationAlgorithm : public BareAlgorithm {
 
     /// proapgation mode
     int mode = 0;
+    /// Switch the logger to sterila
+    bool sterileLogger = false;
     /// debug output
     bool debugOutput = false;
     /// Modify the behavior of the material interaction: energy loss

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -88,7 +88,6 @@ PropagationOutput PropagationAlgorithm<propagator_t>::executeTest(
     // Set a maximum step size
     options.maxStepSize = m_cfg.maxStepSize;
 
-
     // Propagate using the propagator
     auto result = m_cfg.propagator.propagate(startParameters, options);
     if (result.ok()) {

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -83,7 +83,7 @@ PropagationOutput PropagationAlgorithm<propagator_t>::executeTest(
     mInteractor.recordInteractions = m_cfg.recordMaterialInteractions;
 
     // Switch the logger to sterile, e.g. for timing checks
-    auto sLogger = options.actionList.get<SteppingLogger>();
+    auto& sLogger = options.actionList.get<SteppingLogger>();
     sLogger.sterile = m_cfg.sterileLogger;
     // Set a maximum step size
     options.maxStepSize = m_cfg.maxStepSize;

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -82,8 +82,12 @@ PropagationOutput PropagationAlgorithm<propagator_t>::executeTest(
     mInteractor.energyLoss = m_cfg.energyLoss;
     mInteractor.recordInteractions = m_cfg.recordMaterialInteractions;
 
+    // Switch the logger to sterile, e.g. for timing checks
+    auto sLogger = options.actionList.get<SteppingLogger>();
+    sLogger.sterile = m_cfg.sterileLogger;
     // Set a maximum step size
     options.maxStepSize = m_cfg.maxStepSize;
+
 
     // Propagate using the propagator
     auto result = m_cfg.propagator.propagate(startParameters, options);


### PR DESCRIPTION
This PR switches the SteppingLogger to `sterile` when no persistent output is requested in the `PropgationExample`. This aides the time measurement of the propagation, as otherwise the `getSharedPtr(...)` within the logger is a signficant factor.
