### PR TITLE
fix: NuclearInteractionParametrisationWriter fixes

### DIFF
--- a/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
+++ b/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
@@ -344,7 +344,6 @@ ActsExamples::RootNuclearInteractionParametersWriter::
 
 ActsExamples::ProcessCode
 ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
-  std::cout << "End Run called" << std::endl;
   namespace Parametrisation = detail::NuclearInteractionParametrisation;
   if (m_eventFractionCollection.empty())
     return ProcessCode::ABORT;
@@ -456,7 +455,6 @@ ActsExamples::ProcessCode
 ActsExamples::RootNuclearInteractionParametersWriter::writeT(
     const AlgorithmContext& /*ctx*/,
     const ExtractedSimulationProcessContainer& event) {
-  std::cout << "writeT called" << std::endl;
   // Convert the tuple to use additional categorisation variables
   std::vector<detail::NuclearInteractionParametrisation::EventFraction>
       eventFractions;

--- a/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
+++ b/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
@@ -344,7 +344,7 @@ ActsExamples::RootNuclearInteractionParametersWriter::
 
 ActsExamples::ProcessCode
 ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
-std::cout << "End Run called" << std::endl;
+  std::cout << "End Run called" << std::endl;
   namespace Parametrisation = detail::NuclearInteractionParametrisation;
   if (m_eventFractionCollection.empty())
     return ProcessCode::ABORT;
@@ -367,7 +367,7 @@ std::cout << "End Run called" << std::endl;
       std::to_string(m_eventFractionCollection[0].initialMomentum).c_str());
   gDirectory->mkdir("soft");
   gDirectory->mkdir("hard");
-  
+
   // Write the nuclear interaction probability
   ACTS_DEBUG("Starting parametrisation of nuclear interaction probability");
   const auto nuclearInteractionProbability =
@@ -438,14 +438,14 @@ std::cout << "End Run called" << std::endl;
   const auto multProbHard = buildMap(multiplicity.second);
   gDirectory->WriteObject(&multProbHard.first, "MultiplicityBinBorders");
   gDirectory->WriteObject(&multProbHard.second, "MultiplicityBinContents");
-  
+
   for (unsigned int i = 1; i <= m_cfg.multiplicityMax; i++) {
     ACTS_DEBUG("Starting parametrisation of final state kinematics for hard " +
                std::to_string(i) + " particle(s) final state");
     recordKinematicParametrisation(m_eventFractionCollection, false, i, m_cfg);
     ACTS_DEBUG("Parametrisation of final state kinematics for hard " +
                std::to_string(i) + " particle(s) final state finished");
-  }  
+  }
   gDirectory->cd();
   tf->Write();
   tf->Close();
@@ -456,7 +456,7 @@ ActsExamples::ProcessCode
 ActsExamples::RootNuclearInteractionParametersWriter::writeT(
     const AlgorithmContext& /*ctx*/,
     const ExtractedSimulationProcessContainer& event) {
-std::cout << "writeT called" << std::endl;
+  std::cout << "writeT called" << std::endl;
   // Convert the tuple to use additional categorisation variables
   std::vector<detail::NuclearInteractionParametrisation::EventFraction>
       eventFractions;

--- a/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
+++ b/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
@@ -93,8 +93,8 @@ Parametrisation buildMomentumParameters(const EventCollection& events,
                                         unsigned int nBins) {
   // Strip off data
   auto momenta = prepareMomenta(events, multiplicity, soft);
-  if(momenta.empty())
-	return Parametrisation();
+  if (momenta.empty())
+    return Parametrisation();
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(momenta, nBins);
@@ -220,8 +220,8 @@ Parametrisation buildInvariantMassParameters(const EventCollection& events,
                                              bool soft, unsigned int nBins) {
   // Strip off data
   auto invariantMasses = prepareInvariantMasses(events, multiplicity, soft);
-  if(invariantMasses.empty())
-	return Parametrisation();
+  if (invariantMasses.empty())
+    return Parametrisation();
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(invariantMasses, nBins);
@@ -255,33 +255,30 @@ cumulativePDGprobability(const EventCollection& events) {
 
   // Build a cumulative distribution
   for (const auto& element : counter) {
-	  float sum = 0;
-	auto prevIt = counter[element.first].begin();
+    float sum = 0;
+    auto prevIt = counter[element.first].begin();
     for (auto it1 = counter[element.first].begin();
          it1 != counter[element.first].end(); it1++) {
-		float binEntry = 0;
-		if(it1 == counter[element.first].begin())
-		{
-			binEntry = it1->second;
-			prevIt = it1;
-		}
-		else
-		{
-			binEntry = it1->second - prevIt->second;
-			prevIt = it1;
-		}
+      float binEntry = 0;
+      if (it1 == counter[element.first].begin()) {
+        binEntry = it1->second;
+        prevIt = it1;
+      } else {
+        binEntry = it1->second - prevIt->second;
+        prevIt = it1;
+      }
       // Add content to next bins
       for (auto it2 = std::next(it1, 1); it2 != counter[element.first].end();
            it2++) {
-		it2->second += binEntry;
-		sum = it2->second;
+        it2->second += binEntry;
+        sum = it2->second;
       }
     }
-          // Normalise the entry
+    // Normalise the entry
     for (auto it1 = counter[element.first].begin();
          it1 != counter[element.first].end(); it1++) {
-			 it1->second /= sum;
-		 }
+      it1->second /= sum;
+    }
   }
   return counter;
 }
@@ -305,10 +302,12 @@ cumulativeMultiplicityProbability(const EventCollection& events,
   }
 
   // Build and fill the histograms
-  TH1F* softHisto = new TH1F("", "", std::min(maxSoft, multiplicityMax) + 1 - minSoft,
-                             minSoft, std::min(maxSoft, multiplicityMax) + 1);
-  TH1F* hardHisto = new TH1F("", "", std::min(maxHard, multiplicityMax) + 1 - minHard,
-                             minHard, std::min(maxHard, multiplicityMax) + 1);
+  TH1F* softHisto =
+      new TH1F("", "", std::min(maxSoft, multiplicityMax) + 1 - minSoft,
+               minSoft, std::min(maxSoft, multiplicityMax) + 1);
+  TH1F* hardHisto =
+      new TH1F("", "", std::min(maxHard, multiplicityMax) + 1 - minHard,
+               minHard, std::min(maxHard, multiplicityMax) + 1);
   for (const EventFraction& event : events) {
     if (event.multiplicity <= multiplicityMax) {
       if (event.soft)

--- a/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
+++ b/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
@@ -79,7 +79,6 @@ std::pair<Vector, Matrix> calculateMeanAndCovariance(
 EigenspaceComponents calculateEigenspace(const Vector& mean,
                                          const Matrix& covariance) {
   // Calculate eigenvalues and eigenvectors
-  //~ Eigen::EigenSolver<Matrix<multiplicity_t>> es(covariance);
   Eigen::EigenSolver<Matrix> es(covariance);
   Vector eigenvalues = es.eigenvalues().real();
   Matrix eigenvectors = es.eigenvectors().real();
@@ -94,6 +93,8 @@ Parametrisation buildMomentumParameters(const EventCollection& events,
                                         unsigned int nBins) {
   // Strip off data
   auto momenta = prepareMomenta(events, multiplicity, soft);
+  if(momenta.empty())
+	return Parametrisation();
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(momenta, nBins);
@@ -101,7 +102,7 @@ Parametrisation buildMomentumParameters(const EventCollection& events,
   // Build normal distribution
   auto momentaGaussian = convertEventToGaussian(histos, momenta);
   auto meanAndCovariance =
-      calculateMeanAndCovariance(multiplicity, momentaGaussian);
+      calculateMeanAndCovariance(multiplicity + 1, momentaGaussian);
   // Calculate the transformation into the eigenspace of the covariance matrix
   EigenspaceComponents eigenspaceElements =
       calculateEigenspace(meanAndCovariance.first, meanAndCovariance.second);
@@ -121,7 +122,7 @@ EventProperties prepareMomenta(const EventCollection& events,
       const float initialMomentum = event.initialParticle.absoluteMomentum();
       float sum = 0.;
       std::vector<float> momenta;
-      momenta.reserve(multiplicity);
+      momenta.reserve(multiplicity + 1);
       // Fill the vector with the scaled momenta
       for (const ActsExamples::SimParticle& p : event.finalParticles) {
         sum += p.absoluteMomentum();
@@ -219,6 +220,8 @@ Parametrisation buildInvariantMassParameters(const EventCollection& events,
                                              bool soft, unsigned int nBins) {
   // Strip off data
   auto invariantMasses = prepareInvariantMasses(events, multiplicity, soft);
+  if(invariantMasses.empty())
+	return Parametrisation();
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(invariantMasses, nBins);
@@ -238,33 +241,47 @@ Parametrisation buildInvariantMassParameters(const EventCollection& events,
 std::unordered_map<int, std::unordered_map<int, float>>
 cumulativePDGprobability(const EventCollection& events) {
   std::unordered_map<int, std::unordered_map<int, float>> counter;
-  std::unordered_map<int, float> totalSum;
 
   // Count how many and which particles were created by which particle
   for (const EventFraction& event : events) {
     if (!event.soft) {
       counter[event.initialParticle.pdg()][event.finalParticles[0].pdg()]++;
-      totalSum[event.initialParticle.pdg()]++;
     }
     for (unsigned int i = 1; i < event.multiplicity; i++) {
       counter[event.finalParticles[i - 1].pdg()]
              [event.finalParticles[i].pdg()]++;
-      totalSum[event.finalParticles[i - 1].pdg()]++;
     }
   }
 
   // Build a cumulative distribution
   for (const auto& element : counter) {
+	  float sum = 0;
+	auto prevIt = counter[element.first].begin();
     for (auto it1 = counter[element.first].begin();
          it1 != counter[element.first].end(); it1++) {
+		float binEntry = 0;
+		if(it1 == counter[element.first].begin())
+		{
+			binEntry = it1->second;
+			prevIt = it1;
+		}
+		else
+		{
+			binEntry = it1->second - prevIt->second;
+			prevIt = it1;
+		}
       // Add content to next bins
       for (auto it2 = std::next(it1, 1); it2 != counter[element.first].end();
            it2++) {
-        it2->second += it1->second;
+		it2->second += binEntry;
+		sum = it2->second;
       }
-      // Normalise the entry
-      it1->second /= totalSum[element.first];
     }
+          // Normalise the entry
+    for (auto it1 = counter[element.first].begin();
+         it1 != counter[element.first].end(); it1++) {
+			 it1->second /= sum;
+		 }
   }
   return counter;
 }
@@ -288,10 +305,10 @@ cumulativeMultiplicityProbability(const EventCollection& events,
   }
 
   // Build and fill the histograms
-  TH1F* softHisto = new TH1F("", "", std::min(maxSoft, multiplicityMax) + 1,
-                             minSoft, std::min(maxSoft, multiplicityMax));
-  TH1F* hardHisto = new TH1F("", "", std::max(maxHard, multiplicityMax) + 1,
-                             minHard, std::min(maxHard, multiplicityMax));
+  TH1F* softHisto = new TH1F("", "", std::min(maxSoft, multiplicityMax) + 1 - minSoft,
+                             minSoft, std::min(maxSoft, multiplicityMax) + 1);
+  TH1F* hardHisto = new TH1F("", "", std::min(maxHard, multiplicityMax) + 1 - minHard,
+                             minHard, std::min(maxHard, multiplicityMax) + 1);
   for (const EventFraction& event : events) {
     if (event.multiplicity <= multiplicityMax) {
       if (event.soft)


### PR DESCRIPTION
This PR fixes the construction of the parametrisation by fixing the indices and the construction of a CDF.
Occasionally the writing of the parametrisation was not performed. This PR fixes this issue.