### PR TITLE
perf: EigenStepper step size adjustment

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -158,10 +158,7 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
-if(error_estimate <= state.options.tolerance && state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
-{
-	std::cout << "Error: " << error_estimate << " " << state.options.tolerance << " | " << h << std::endl;
-}
+
     return (error_estimate <= state.options.tolerance);
   };
 
@@ -170,14 +167,9 @@ if(error_estimate <= state.options.tolerance && state.stepping.stepSize.currentT
   // Select and adjust the appropriate Runge-Kutta step size as given
   // ATL-SOFT-PUB-2009-001
   while (!tryRungeKuttaStep(state.stepping.stepSize)) {
-if(state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
-std::cout << "StepSize adjustment: " << stepSizeScaling << " | " << error_estimate << " | " << std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(error_estimate)),
-                                         0.25)),
-                 4.) << std::endl;
     stepSizeScaling =
         std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(error_estimate)),
+                                          std::abs(2. * error_estimate)),
                                          0.25)),
                  4.);
 
@@ -234,13 +226,6 @@ std::cout << "StepSize adjustment: " << stepSizeScaling << " | " << error_estima
   state.stepping.pathAccumulated += h;
   if(state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
   {
-	  std::cout << "Final scaling: " << state.stepping.stepSize << " " << std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(error_estimate)),
-                                         0.25)),
-                 4.) << " -> " << state.stepping.stepSize * std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(error_estimate)),
-                                         0.25)),
-                 4.) << std::endl;
     state.stepping.stepSize = state.stepping.stepSize * std::min(std::max(0.25, std::pow((state.options.tolerance /
                                           std::abs(error_estimate)),
                                          0.25)),

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -224,9 +224,11 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
     state.stepping.derivative.template segment<3>(4) = sd.k4;
   }
   state.stepping.pathAccumulated += h;
-  if(state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
-  {
-    state.stepping.stepSize = state.stepping.stepSize * std::min(std::max(0.25, std::pow((state.options.tolerance /
+  if (state.stepping.stepSize.currentType() ==
+      ConstrainedStep::Type::accuracy) {
+    state.stepping.stepSize =
+        state.stepping.stepSize *
+        std::min(std::max(0.25, std::pow((state.options.tolerance /
                                           std::abs(error_estimate)),
                                          0.25)),
                  4.);

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -158,6 +158,10 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
+if(error_estimate <= state.options.tolerance && state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
+{
+	std::cout << "Error: " << error_estimate << " " << state.options.tolerance << " | " << h << std::endl;
+}
     return (error_estimate <= state.options.tolerance);
   };
 
@@ -166,9 +170,14 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   // Select and adjust the appropriate Runge-Kutta step size as given
   // ATL-SOFT-PUB-2009-001
   while (!tryRungeKuttaStep(state.stepping.stepSize)) {
+if(state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
+std::cout << "StepSize adjustment: " << stepSizeScaling << " | " << error_estimate << " | " << std::min(std::max(0.25, std::pow((state.options.tolerance /
+                                          std::abs(error_estimate)),
+                                         0.25)),
+                 4.) << std::endl;
     stepSizeScaling =
         std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(2. * error_estimate)),
+                                          std::abs(error_estimate)),
                                          0.25)),
                  4.);
 
@@ -223,5 +232,19 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
     state.stepping.derivative.template segment<3>(4) = sd.k4;
   }
   state.stepping.pathAccumulated += h;
+  if(state.stepping.stepSize.currentType() == ConstrainedStep::Type::accuracy)
+  {
+	  std::cout << "Final scaling: " << state.stepping.stepSize << " " << std::min(std::max(0.25, std::pow((state.options.tolerance /
+                                          std::abs(error_estimate)),
+                                         0.25)),
+                 4.) << " -> " << state.stepping.stepSize * std::min(std::max(0.25, std::pow((state.options.tolerance /
+                                          std::abs(error_estimate)),
+                                         0.25)),
+                 4.) << std::endl;
+    state.stepping.stepSize = state.stepping.stepSize * std::min(std::max(0.25, std::pow((state.options.tolerance /
+                                          std::abs(error_estimate)),
+                                         0.25)),
+                 4.);
+  }
   return h;
 }

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -260,8 +260,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   PropState ps(std::move(esState));
 
   ps.stepping.covTransport = false;
-  double h = es.step(ps).value();
-  BOOST_CHECK_EQUAL(ps.stepping.stepSize, h);
+  es.step(ps).value();
   CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, eps);
   BOOST_CHECK_NE(es.position(ps.stepping).norm(), newPos.norm());
   BOOST_CHECK_NE(es.direction(ps.stepping), newMom.normalized());
@@ -271,8 +270,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   BOOST_CHECK_EQUAL(ps.stepping.jacTransport, FreeMatrix::Identity());
 
   ps.stepping.covTransport = true;
-  double h2 = es.step(ps).value();
-  BOOST_CHECK_EQUAL(h2, h);
+  es.step(ps).value();
   CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, eps);
   BOOST_CHECK_NE(es.position(ps.stepping).norm(), newPos.norm());
   BOOST_CHECK_NE(es.direction(ps.stepping), newMom.normalized());


### PR DESCRIPTION
The `EigenStepper` will either keep the step size or reduce it. This depends on the error of the numerical integration. A step accepted if the error is below the tolerance. Calculating the next step size according to ATL-SOFT-PUB-2009-001 Eqs. (6) and (7), the next step size can be estimated to be larger or equal to the accepted one. Therewith the next step could be larger (potentially) reducing the required amount of steps.

The changes were tested using the ATLAS magnetic field, the GenericDetector, 100k events with 100 events per p_T configuration. It was found that this additional scaling leads to step size adjustments (due to energy loss & magnetic field fluctuations). Without the transport of covariance matrices the propagation tend to take longer than the current implementation. Below the timings with covariance transport are shown:

Current Implementation:

identifier | time_total_s | time_perevent_s
Algorithm:PropagationAlgorithm | 26.52 | 0.0002652
Writer:RootPropagationStepsWriter | 22.54 | 0.0002254
Writer:RootPropagationStepsWriter:endRun | 0.1285 | 1.285E-06

This PR:

identifier | time_total_s | time_perevent_s
Algorithm:PropagationAlgorithm | 14.82 | 0.0001482
Writer:RootPropagationStepsWriter | 21.62 | 0.0002162
Writer:RootPropagationStepsWriter:endRun | 0.9658 | 9.658E-06

