### PR TITLE
refactor: Average the atomic number in log

### DIFF
--- a/Core/src/Material/AverageMaterials.cpp
+++ b/Core/src/Material/AverageMaterials.cpp
@@ -95,7 +95,7 @@ Acts::MaterialSlab Acts::detail::combineSlabs(const MaterialSlab& slab1,
   double thicknessWeight1 = slab1.thickness() / thickness;
   double thicknessWeight2 = slab2.thickness() / thickness;
   float z;
-  if (mat1.Z() != 0 && mat2.Z()) {
+  if (mat1.Z() != 0 && mat2.Z() != 0) {
     z = exp(thicknessWeight1 * log(mat1.Z()) +
             thicknessWeight2 * log(mat2.Z()));
   } else {


### PR DESCRIPTION
Up until now the averaging of the material property (Ar and Z) were done using the number of mol per unit of surface of the materials. For Z this will lead to an incorrect computation of the energy loss which is proportional to `ln(Z)*thickness`.

This PR modify the way the value of Z is averaged (averaging the value of ln(Z) instead).

I do not know of any other use for Z than the computation of the mean excitation energy (and none are present in the acts files) but if there is another use for the value of Z then maybe we shouldn't change the way this is averaged (or change it differently).