### PR TITLE
fix: change Alignment store to map in Examples

### DIFF
--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -175,7 +175,7 @@ ProcessCode PropagationAlgorithm<propagator_t>::execute(
       sMomentum = startParameters.momentum();
       pOutput = executeTest(context, startParameters);
     } else {
-      // execute the test for neeutral particles
+      // execute the test for neutral particles
       Acts::NeutralBoundTrackParameters neutralParameters(
           surface, std::move(pars), std::move(cov));
       sPosition = neutralParameters.position(context.geoContext);

--- a/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignmentDecorator.hpp
+++ b/Examples/Detectors/ContextualDetector/include/ActsExamples/ContextualDetector/AlignmentDecorator.hpp
@@ -85,7 +85,7 @@ class AlignmentDecorator : public IContextDecorator {
   std::unique_ptr<const Acts::Logger> m_logger;  ///!< the logging instance
   std::string m_name = "AlignmentDecorator";
 
-  ///< protect multiple alignments to be loaded at once
+  ///< Protect multiple alignments to be loaded at once
   std::mutex m_alignmentMutex;
   std::vector<bool> m_iovStatus;
   std::vector<bool> m_flushStatus;

--- a/Examples/Detectors/ContextualDetector/src/AlignmentDecorator.cpp
+++ b/Examples/Detectors/ContextualDetector/src/AlignmentDecorator.cpp
@@ -11,6 +11,7 @@
 #include <Acts/Geometry/TrackingGeometry.hpp>
 
 #include <random>
+#include <thread>
 
 ActsExamples::Contextual::AlignmentDecorator::AlignmentDecorator(
     const ActsExamples::Contextual::AlignmentDecorator::Config& cfg,
@@ -25,6 +26,10 @@ ActsExamples::Contextual::AlignmentDecorator::decorate(
 
   // In which iov batch are we?
   unsigned int iov = context.eventNumber / m_cfg.iovSize;
+
+  ACTS_VERBOSE("IOV handling in thread " << std::this_thread::get_id() << ".");
+  ACTS_VERBOSE("IOV resolved to " << iov << " - from event "
+                                  << context.eventNumber << ".");
 
   if (m_cfg.randomNumberSvc != nullptr) {
     // Detect if we have a new alignment range


### PR DESCRIPTION
This PR changes the demonstrator for the AlignmentDetector to a map in order not to overwrite accidentally prior IOV transforms.

Obviously this is not the most performant contextual data approach on the client side.