### PR TITLE
feat: csv surface grid writer

### DIFF
--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
@@ -44,6 +44,8 @@ class CsvTrackingGeometryWriter : public IWriter {
     bool writeSensitive = true;
     /// Write boundary surfaces
     bool writeBoundary = false;
+    /// Write the grid information
+    bool writeGrid = true;
     /// Whether to write the per-event file.
     bool writePerEvent = false;
   };

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
@@ -44,8 +44,8 @@ class CsvTrackingGeometryWriter : public IWriter {
     bool writeSensitive = true;
     /// Write boundary surfaces
     bool writeBoundary = false;
-    /// Write the grid information
-    bool writeGrid = true;
+    /// Write the surface grid information
+    bool writeSurfaceGrid = true;
     /// Whether to write the per-event file.
     bool writePerEvent = false;
   };

--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -181,4 +181,22 @@ struct SurfaceData {
                  bound_param5, bound_param6);
 };
 
+struct SurfaceGrid {
+  /// Surface identifier. Not available in the TrackML datasets.
+  uint64_t geometry_id;
+  /// Partially decoded surface identifier components.
+  uint32_t volume_id, layer_id;
+  /// The number of bins in loc 0 / 1
+  int type_loc0 = -1;
+  int nbins_loc0 = -1;
+  float min_loc0, max_loc0;
+  int type_loc1 = -1;
+  int nbins_loc1 = -1;
+  float min_loc1, max_loc1;
+
+  DFE_NAMEDTUPLE(SurfaceGrid, geometry_id, volume_id, layer_id, type_loc0,
+                 nbins_loc0, min_loc0, max_loc0, type_loc1, nbins_loc1,
+                 min_loc1, max_loc1);
+};
+
 }  // namespace ActsExamples

--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -181,11 +181,11 @@ struct SurfaceData {
                  bound_param5, bound_param6);
 };
 
-struct SurfaceGrid {
+struct SurfaceGridData {
   /// Surface identifier. Not available in the TrackML datasets.
   uint64_t geometry_id;
   /// Partially decoded surface identifier components.
-  uint32_t volume_id, layer_id;
+  uint32_t volume_id, layer_id, surface_id;
   /// The number of bins in loc 0 / 1
   int type_loc0 = -1;
   int nbins_loc0 = -1;
@@ -194,9 +194,10 @@ struct SurfaceGrid {
   int nbins_loc1 = -1;
   float min_loc1, max_loc1;
 
-  DFE_NAMEDTUPLE(SurfaceGrid, geometry_id, volume_id, layer_id, type_loc0,
+  DFE_NAMEDTUPLE(SurfaceGridData, geometry_id, volume_id, layer_id, surface_id, type_loc0,
                  nbins_loc0, min_loc0, max_loc0, type_loc1, nbins_loc1,
                  min_loc1, max_loc1);
 };
+
 
 }  // namespace ActsExamples

--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -194,10 +194,9 @@ struct SurfaceGridData {
   int nbins_loc1 = -1;
   float min_loc1, max_loc1;
 
-  DFE_NAMEDTUPLE(SurfaceGridData, geometry_id, volume_id, layer_id, surface_id, type_loc0,
-                 nbins_loc0, min_loc0, max_loc0, type_loc1, nbins_loc1,
-                 min_loc1, max_loc1);
+  DFE_NAMEDTUPLE(SurfaceGridData, geometry_id, volume_id, layer_id, surface_id,
+                 type_loc0, nbins_loc0, min_loc0, max_loc0, type_loc1,
+                 nbins_loc1, min_loc1, max_loc1);
 };
-
 
 }  // namespace ActsExamples

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -204,6 +204,7 @@ ProcessCode CsvTrackingGeometryWriter::endRun() {
       joinPaths(m_cfg.outputDir, "surface-grids.csv"), m_cfg.outputPrecision);
 
   writeVolume(sfWriter, sfGridWriter, *m_world, m_cfg.writeSensitive,
-              m_cfg.writeSensitive, m_cfg.writeSurfaceGrid, Acts::GeometryContext());
+              m_cfg.writeSensitive, m_cfg.writeSurfaceGrid,
+              Acts::GeometryContext());
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -50,6 +50,7 @@ std::string CsvTrackingGeometryWriter::name() const {
 namespace {
 
 using SurfaceWriter = dfe::NamedTupleCsvWriter<SurfaceData>;
+using SurfaceGridWriter = dfe::NamedTupleCsvWriter<SurfaceGrid>;
 using BoundarySurface = Acts::BoundarySurfaceT<Acts::TrackingVolume>;
 
 /// Write a single surface.
@@ -98,11 +99,11 @@ void fillSurfaceData(SurfaceData& data, const Acts::Surface& surface,
 }
 
 /// Write a single surface.
-void writeSurface(SurfaceWriter& writer, const Acts::Surface& surface,
+void writeSurface(SurfaceWriter& sfWriter, const Acts::Surface& surface,
                   const Acts::GeometryContext& geoCtx) {
   SurfaceData data;
   fillSurfaceData(data, surface, geoCtx);
-  writer.append(data);
+  sfWriter.append(data);
 }
 
 /// Write a single surface.
@@ -115,8 +116,9 @@ void writeBoundarySurface(SurfaceWriter& writer,
 }
 
 /// Write all child surfaces and descend into confined volumes.
-void writeVolume(SurfaceWriter& writer, const Acts::TrackingVolume& volume,
-                 bool writeSensitive, bool writeBoundary,
+void writeVolume(SurfaceWriter& sfWriter, SurfaceGridWriter& sfGridWriter,
+                 const Acts::TrackingVolume& volume, bool writeSensitive,
+                 bool writeBoundary, bool writeGrid,
                  const Acts::GeometryContext& geoCtx) {
   // process all layers that are directly stored within this volume
   if (volume.confinedLayers()) {
@@ -126,10 +128,38 @@ void writeVolume(SurfaceWriter& writer, const Acts::TrackingVolume& volume,
         continue;
       }
       // check for sensitive surfaces
-      if (layer->surfaceArray() and writeSensitive) {
-        for (auto surface : layer->surfaceArray()->surfaces()) {
-          if (surface) {
-            writeSurface(writer, *surface, geoCtx);
+      if (layer->surfaceArray()) {
+        auto sfArray = layer->surfaceArray();
+
+        if (writeGrid) {
+          SurfaceGrid sfGrid;
+          sfGrid.geometry_id = layer->geometryId().value();
+          sfGrid.volume_id = layer->geometryId().volume();
+          sfGrid.layer_id = layer->geometryId().layer();
+
+          // Draw the grid itself
+          auto binning = sfArray->binningValues();
+          auto axes = sfArray->getAxes();
+          if (not binning.empty() and binning.size() == 2 and
+              axes.size() == 2) {
+            auto loc0Values = axes[0]->getBinEdges();
+            sfGrid.nbins_loc0 = loc0Values.size();
+            sfGrid.min_loc0 = loc0Values[0];
+            sfGrid.max_loc0 = loc0Values[loc0Values.size() - 1];
+            auto loc1Values = axes[1]->getBinEdges();
+            sfGrid.nbins_loc1 = loc1Values.size();
+            sfGrid.min_loc1 = loc1Values[0];
+            sfGrid.max_loc1 = loc1Values[loc1Values.size() - 1];
+          }
+
+          sfGridWriter.append(sfGrid);
+        }
+
+        if (writeSensitive) {
+          for (auto surface : sfArray->surfaces()) {
+            if (surface) {
+              writeSurface(sfWriter, *surface, geoCtx);
+            }
           }
         }
       }
@@ -137,15 +167,15 @@ void writeVolume(SurfaceWriter& writer, const Acts::TrackingVolume& volume,
     // This is a navigation volume, write the boundaries
     if (writeBoundary) {
       for (auto bsurface : volume.boundarySurfaces()) {
-        writeBoundarySurface(writer, *bsurface, geoCtx);
+        writeBoundarySurface(sfWriter, *bsurface, geoCtx);
       }
     }
   }
   // step down into hierarchy to process all child volumnes
   if (volume.confinedVolumes()) {
     for (auto confined : volume.confinedVolumes()->arrayObjects()) {
-      writeVolume(writer, *confined.get(), writeSensitive, writeBoundary,
-                  geoCtx);
+      writeVolume(sfWriter, sfGridWriter, *confined.get(), writeSensitive,
+                  writeBoundary, writeGrid, geoCtx);
     }
   }
 }
@@ -155,18 +185,25 @@ ProcessCode CsvTrackingGeometryWriter::write(const AlgorithmContext& ctx) {
   if (not m_cfg.writePerEvent) {
     return ProcessCode::SUCCESS;
   }
-  SurfaceWriter writer(
+  SurfaceWriter sfWriter(
       perEventFilepath(m_cfg.outputDir, "detectors.csv", ctx.eventNumber),
       m_cfg.outputPrecision);
-  writeVolume(writer, *m_world, m_cfg.writeSensitive, m_cfg.writeSensitive,
-              ctx.geoContext);
+  SurfaceGridWriter sfGridWriter(
+      perEventFilepath(m_cfg.outputDir, "surface-grids.csv", ctx.eventNumber),
+      m_cfg.outputPrecision);
+
+  writeVolume(sfWriter, sfGridWriter, *m_world, m_cfg.writeSensitive,
+              m_cfg.writeSensitive, m_cfg.writeGrid, ctx.geoContext);
   return ProcessCode::SUCCESS;
 }
 
 ProcessCode CsvTrackingGeometryWriter::endRun() {
-  SurfaceWriter writer(joinPaths(m_cfg.outputDir, "detectors.csv"),
-                       m_cfg.outputPrecision);
-  writeVolume(writer, *m_world, m_cfg.writeSensitive, m_cfg.writeSensitive,
-              Acts::GeometryContext());
+  SurfaceWriter sfWriter(joinPaths(m_cfg.outputDir, "detectors.csv"),
+                         m_cfg.outputPrecision);
+  SurfaceGridWriter sfGridWriter(
+      joinPaths(m_cfg.outputDir, "surface-grids.csv"), m_cfg.outputPrecision);
+
+  writeVolume(sfWriter, sfGridWriter, *m_world, m_cfg.writeSensitive,
+              m_cfg.writeSensitive, m_cfg.writeGrid, Acts::GeometryContext());
   return ProcessCode::SUCCESS;
 }


### PR DESCRIPTION
This PR adds a new CVS writer component to be able to write out the Detector surfaces for navigation inspection.

![itk_vol_10_lay_28](https://user-images.githubusercontent.com/26623879/112989225-f8b06900-9164-11eb-9fe4-e3eeeaf4ce0e.png)
