### PR TITLE
refactor: remove constexpr from charge method

### DIFF
--- a/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleBoundTrackParameters.hpp
@@ -218,7 +218,7 @@ class SingleBoundTrackParameters {
   Vector3 momentum() const { return absoluteMomentum() * unitDirection(); }
 
   /// Particle electric charge.
-  constexpr Scalar charge() const {
+  Scalar charge() const {
     return m_chargeInterpreter.extractCharge(get<eBoundQOverP>());
   }
 

--- a/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/SingleFreeTrackParameters.hpp
@@ -180,7 +180,7 @@ class SingleFreeTrackParameters {
   Vector3 momentum() const { return absoluteMomentum() * unitDirection(); }
 
   /// Particle electric charge.
-  constexpr Scalar charge() const {
+  Scalar charge() const {
     return m_chargeInterpreter.extractCharge(get<eFreeQOverP>());
   }
 


### PR DESCRIPTION
In order to make compilers happier, and enable compilation for GPUs via hipSYCL, the `charge()` method of SingleBountTrackParameters and SingleFreeTrackParameters should not be marked constexpr, as the called method `get()` is not constexpr.

see https://github.com/acts-project/acts/issues/757


