### PR TITLE
fix: reco selection criteria

### DIFF
--- a/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
+++ b/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
@@ -239,7 +239,6 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
   // The projection of the top space point on the transverse plane of the new
   // frame
   ActsScalar rn = local2.x() * local2.x() + local2.y() * local2.y();
-
   // The (1/tanTheta) of momentum in the new frame,
   ActsScalar invTanTheta =
       local2.z() * std::sqrt(1. / rn) / (1. + rho * rho * rn);

--- a/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
+++ b/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
@@ -239,6 +239,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
   // The projection of the top space point on the transverse plane of the new
   // frame
   ActsScalar rn = local2.x() * local2.x() + local2.y() * local2.y();
+
   // The (1/tanTheta) of momentum in the new frame,
   ActsScalar invTanTheta =
       local2.z() * std::sqrt(1. / rn) / (1. + rho * rho * rn);
@@ -295,6 +296,13 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
     params[eBoundTime] = spGlobalPositions[0].norm() / v;
   }
 
+  if (params.hasNaN()) {
+    ACTS_ERROR(
+        "The NaN value exists at the estimated track parameters from seed with"
+        << "\nbottom sp: " << spGlobalPositions[0] << "\nmiddle sp: "
+        << spGlobalPositions[1] << "\ntop sp: " << spGlobalPositions[2]);
+    return std::nullopt;
+  }
   return params;
 }
 

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
@@ -74,9 +74,9 @@ class TrackParamsEstimationAlgorithm final : public BareAlgorithm {
     /// Constant term of the loc1 resolution.
     double sigmaLoc1 = 100 * Acts::UnitConstants::um;
     /// Phi angular resolution.
-    double sigmaPhi = 0.005 * Acts::UnitConstants::degree;
+    double sigmaPhi = 0.02 * Acts::UnitConstants::degree;
     /// Theta angular resolution.
-    double sigmaTheta = 0.001 * Acts::UnitConstants::degree;
+    double sigmaTheta = 0.02 * Acts::UnitConstants::degree;
     /// q/p resolution.
     double sigmaQOverP = 0.1 / Acts::UnitConstants::GeV;
     /// Time resolution.

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -101,8 +101,13 @@ ActsExamples::TrackParamsEstimationAlgorithm::createSeeds(
                 return std::hypot(lhs->r(), lhs->z()) <
                        std::hypot(rhs->r(), rhs->z());
               });
-    // Loop over the found space points to find seeds with simple selection
+
+    // Loop over the found space points to find the seed with maxium deltaR
+    // betweent the bottom and top space point
     // @todo add the check of deltaZ
+    bool seedFound = false;
+    std::array<size_t, 3> bestSPIndices;
+    double maxDeltaR = std::numeric_limits<double>::min();
     for (size_t ib = 0; ib < spacePointsOnTrack.size() - 2; ++ib) {
       for (size_t im = ib + 1; im < spacePointsOnTrack.size() - 1; ++im) {
         for (size_t it = im + 1; it < spacePointsOnTrack.size(); ++it) {
@@ -112,12 +117,21 @@ ActsExamples::TrackParamsEstimationAlgorithm::createSeeds(
                                      spacePointsOnTrack[im]->r());
           if (bmDeltaR >= m_cfg.deltaRMin and bmDeltaR <= m_cfg.deltaRMax and
               mtDeltaR >= m_cfg.deltaRMin and mtDeltaR <= m_cfg.deltaRMax) {
-            seeds.emplace_back(*spacePointsOnTrack[ib], *spacePointsOnTrack[im],
-                               *spacePointsOnTrack[it],
-                               spacePointsOnTrack[im]->z());
+            if ((bmDeltaR + mtDeltaR) > maxDeltaR) {
+              maxDeltaR = bmDeltaR + mtDeltaR;
+              bestSPIndices = {ib, im, it};
+              seedFound = true;
+            }
           }
         }
       }
+    }
+
+    if (seedFound) {
+      seeds.emplace_back(*spacePointsOnTrack[bestSPIndices[0]],
+                         *spacePointsOnTrack[bestSPIndices[1]],
+                         *spacePointsOnTrack[bestSPIndices[2]],
+                         spacePointsOnTrack[bestSPIndices[1]]->z());
     }
   }
   return seeds;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -82,6 +82,7 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
   using HitParticlesMap = IndexMultimap<ActsFatras::Barcode>;
   // The number of majority particle hits and fitted track parameters
   using RecoTrackInfo = std::pair<size_t, Acts::BoundTrackParameters>;
+  using Acts::VectorHelpers::perp;
 
   // Read truth input collections
   const auto& particles =
@@ -133,6 +134,12 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
         continue;
       }
       const auto& fittedParameters = traj.trackParameters(trackTip);
+      // Requirement on the pT of the track
+      const auto& momentum = fittedParameters.momentum();
+      const auto pT = perp(momentum);
+      if (pT < m_cfg.ptMin) {
+        continue;
+      }
       // Fill the trajectory summary info
       m_trackSummaryPlotTool.fill(m_trackSummaryPlotCache, fittedParameters,
                                   trajState.nStates, trajState.nMeasurements,
@@ -211,6 +218,9 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
   // Loop over all truth particle seeds for efficiency plots and reco details.
   // These are filled w.r.t. truth particle seed info
   for (const auto& particle : particles) {
+    if (particle.transverseMomentum() < m_cfg.ptMin) {
+      continue;
+    }
     auto particleId = particle.particleId();
     // Investigate the truth-matched tracks
     size_t nMatchedTracks = 0;

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -217,8 +217,8 @@ int runRecCKFTracks(int argc, char* argv[],
     paramsEstimationCfg.deltaRMin = 10._mm;
     paramsEstimationCfg.sigmaLoc0 = 25._um;
     paramsEstimationCfg.sigmaLoc1 = 100._um;
-    paramsEstimationCfg.sigmaPhi = 0.005_degree;
-    paramsEstimationCfg.sigmaTheta = 0.001_degree;
+    paramsEstimationCfg.sigmaPhi = 0.02_degree;
+    paramsEstimationCfg.sigmaTheta = 0.02_degree;
     paramsEstimationCfg.sigmaQOverP = 0.1 / 1._GeV;
     paramsEstimationCfg.sigmaT0 = 1400._s;
     sequencer.addAlgorithm(std::make_shared<TrackParamsEstimationAlgorithm>(

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -214,6 +214,7 @@ int runRecCKFTracks(int argc, char* argv[],
     paramsEstimationCfg.magneticField = magneticField;
     paramsEstimationCfg.bFieldMin = 0.1_T;
     paramsEstimationCfg.deltaRMax = 100._mm;
+    paramsEstimationCfg.deltaRMin = 10._mm;
     paramsEstimationCfg.sigmaLoc0 = 25._um;
     paramsEstimationCfg.sigmaLoc1 = 100._um;
     paramsEstimationCfg.sigmaPhi = 0.005_degree;
@@ -280,8 +281,8 @@ int runRecCKFTracks(int argc, char* argv[],
   perfWriterCfg.inputTrajectories = trackFindingCfg.outputTrajectories;
   perfWriterCfg.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  // The bottom seed on a pixel detector 'eats' one or two measurements?
-  perfWriterCfg.nMeasurementsMin = particleSelectorCfg.nHitsMin - 2;
+  // The bottom seed could be the first, second or third hits on the truth track
+  perfWriterCfg.nMeasurementsMin = particleSelectorCfg.nHitsMin - 3;
   perfWriterCfg.outputDir = outputDir;
 #ifdef ACTS_PLUGIN_ONNX
   // Onnx plugin related options

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -120,7 +120,7 @@ int runRecCKFTracks(int argc, char* argv[],
   particleSelectorCfg.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
   particleSelectorCfg.outputParticles = "particles_selected";
-  particleSelectorCfg.ptMin = 1_GeV;
+  particleSelectorCfg.ptMin = 500_MeV;
   particleSelectorCfg.nHitsMin = 9;
   sequencer.addAlgorithm(
       std::make_shared<TruthSeedSelector>(particleSelectorCfg, logLevel));
@@ -283,6 +283,7 @@ int runRecCKFTracks(int argc, char* argv[],
       digiCfg.outputMeasurementParticlesMap;
   // The bottom seed could be the first, second or third hits on the truth track
   perfWriterCfg.nMeasurementsMin = particleSelectorCfg.nHitsMin - 3;
+  perfWriterCfg.ptMin = 1_GeV;
   perfWriterCfg.outputDir = outputDir;
 #ifdef ACTS_PLUGIN_ONNX
   // Onnx plugin related options

--- a/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
@@ -97,6 +97,8 @@ int runRecTruthTracks(int argc, char* argv[],
   particleSelectorCfg.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
   particleSelectorCfg.outputParticles = "particles_selected";
+  particleSelectorCfg.nHitsMin = 9;
+  particleSelectorCfg.ptMin = 500._MeV;
   sequencer.addAlgorithm(
       std::make_shared<TruthSeedSelector>(particleSelectorCfg, logLevel));
 


### PR DESCRIPTION
This PR fixes a few selections during the reconstruction and performance writing, including the truth seed selection (selecting the truth seed with maximum deltaR between bottom and top space point), truth particle selection and reconstructed tracks selection.