### PR TITLE
feat: allow custom boundary check for sensitive surfaces

### DIFF
--- a/Core/include/Acts/Geometry/detail/Layer.ipp
+++ b/Core/include/Acts/Geometry/detail/Layer.ipp
@@ -143,7 +143,7 @@ std::vector<SurfaceIntersection> Layer::compatibleSurfaces(
     if (!acceptSurface(sf, sensitive)) {
       return;
     }
-    bool boundaryCheck = options.boundaryCheck;
+    BoundaryCheck boundaryCheck = options.boundaryCheck;
     if (std::find(options.externalSurfaces.begin(),
                   options.externalSurfaces.end(),
                   sf.geometryId()) != options.externalSurfaces.end()) {

--- a/Core/include/Acts/Propagator/DenseEnvironmentExtension.hpp
+++ b/Core/include/Acts/Propagator/DenseEnvironmentExtension.hpp
@@ -67,6 +67,7 @@ struct DenseStepperPropagatorOptions
     eoptions.pathLimit = this->pathLimit;
     eoptions.loopProtection = this->loopProtection;
     eoptions.loopFraction = this->loopFraction;
+    eoptions.boundaryCheck = this->boundaryCheck;
 
     // Stepper options
     eoptions.tolerance = this->tolerance;

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -41,6 +41,7 @@ struct NavigationOptions {
   NavigationDirection navDir = forward;
 
   /// The boundary check directive
+  /// - this is for contained surfaces only
   BoundaryCheck boundaryCheck = true;
 
   // How to resolve the geometry
@@ -81,7 +82,7 @@ struct NavigationOptions {
                     bool resolvep = false, const object_t* sobject = nullptr,
                     const object_t* eobject = nullptr)
       : navDir(ndir),
-        boundaryCheck(std::move(bcheck)),
+        boundaryCheck(bcheck),
         resolveSensitive(resolves),
         resolveMaterial(resolvem),
         resolvePassive(resolvep),
@@ -286,8 +287,9 @@ class Navigator {
       state.navigation.navigationStage = Stage::surfaceTarget;
       ACTS_VERBOSE(volInfo(state) << "Staying focussed on surface.");
       // Try finding status of layer
+      // - force boundary check to true
     } else if (status(state, stepper, state.navigation.navLayers,
-                      state.navigation.navLayerIter)) {
+                      state.navigation.navLayerIter, true)) {
       ACTS_VERBOSE(volInfo(state) << "Status: in layer handling.");
       if (state.navigation.currentSurface != nullptr) {
         ACTS_VERBOSE(volInfo(state) << "On layer: update layer information.");
@@ -302,8 +304,9 @@ class Navigator {
         ACTS_VERBOSE(volInfo(state) << "Staying focussed on layer.");
       }
       // Try finding status of boundaries
+      // - force boundary check to true
     } else if (status(state, stepper, state.navigation.navBoundaries,
-                      state.navigation.navBoundaryIter)) {
+                      state.navigation.navBoundaryIter, true)) {
       ACTS_VERBOSE(volInfo(state) << "Status: in boundary handling.");
 
       // Are we on the boundary - then overwrite the stage
@@ -509,13 +512,15 @@ class Navigator {
   /// @param [in] stepper Stepper in use
   /// @param [in] navSurfaces is the navigation status objects
   /// @param [in] navIter test surface fore the status test
+  /// @param [in] requireInside force boundary checking (for portals, layers)
   ///
   /// @return boolean return triggers exit to stepper
   template <typename propagator_state_t, typename stepper_t,
             typename navigation_surfaces_t, typename navigation_iter_t>
   bool status(propagator_state_t& state, const stepper_t& stepper,
               navigation_surfaces_t& navSurfaces,
-              const navigation_iter_t& navIter) const {
+              const navigation_iter_t& navIter,
+              bool requireInside = false) const {
     const auto& logger = state.options.logger;
 
     // No surfaces, status check will be done on layer
@@ -524,11 +529,16 @@ class Navigator {
     }
     // Take the current surface
     auto surface = navIter->representation;
-    // Check if we are at a surface
+    // Check if we are at a surface with the adequate boundary check
+    BoundaryCheck boundaryCheck = true;
+    if (not requireInside) {
+      boundaryCheck = state.options.boundaryCheck;
+    }
+
     // If we are on the surface pointed at by the iterator, we can make
     // it the current one to pass it to the other actors
     auto surfaceStatus =
-        stepper.updateSurfaceStatus(state.stepping, *surface, true);
+        stepper.updateSurfaceStatus(state.stepping, *surface, boundaryCheck);
     if (surfaceStatus == Intersection3D::Status::onSurface) {
       ACTS_VERBOSE(volInfo(state)
                    << "Status Surface successfully hit, storing it.");
@@ -611,15 +621,26 @@ class Navigator {
       // Screen output which surface you are on
       ACTS_VERBOSE(volInfo(state) << "Next surface candidate will be "
                                   << surface->geometryId());
-      // Estimate the surface status
-      bool boundaryCheck = true;
+
+      // Estimate the boundary surface check:
+      // - for external: use false (required to try them at akk costs)
+      // - for passive surfaces (material): use true
+      // - for sensitive surfaces (on search): use the configured version
+      BoundaryCheck boundaryCheck = state.options.boundaryCheck;
+      bool isExternal = false;
       for (auto it = externalSurfaceRange.first;
            it != externalSurfaceRange.second; it++) {
         if (surface->geometryId() == it->second) {
           boundaryCheck = false;
+          isExternal = true;
           break;
         }
       }
+      // Overwrite if it is not a sensitive surface
+      if (not isExternal and surface->geometryId().sensitive() == 0) {
+        boundaryCheck = true;
+      }
+
       auto surfaceStatus =
           stepper.updateSurfaceStatus(state.stepping, *surface, boundaryCheck);
       if (surfaceStatus == Intersection3D::Status::reachable) {
@@ -691,6 +712,7 @@ class Navigator {
       // check if current volume has BVH, or layers
       if (state.navigation.currentVolume->hasBoundingVolumeHierarchy()) {
         // has hierarchy, use that, skip layer resolution
+        // - boundary check is forced to be true
         NavigationOptions<Surface> navOpts(
             state.stepping.navDir, true, resolveSensitive, resolveMaterial,
             resolvePassive, nullptr, state.navigation.targetSurface);
@@ -868,7 +890,8 @@ class Navigator {
 
     // Helper function to find boundaries
     auto findBoundaries = [&]() -> bool {
-      // The navigation options
+      // The navigation options for boundaries
+      // - boundary check is forced true
       NavigationOptions<Surface> navOpts(state.stepping.navDir, true);
       navOpts.pathLimit =
           state.stepping.stepSize.value(ConstrainedStep::aborter);
@@ -1053,10 +1076,12 @@ class Navigator {
     // are we on the start layer
     bool onStart = (navLayer == state.navigation.startLayer);
     auto startSurface = onStart ? state.navigation.startSurface : layerSurface;
-    // Use navigation parameters and NavigationOptions
+    // Use navigation parameters and NavigationOptions on layer:
+    // - use boundary check directive from propagation options
     NavigationOptions<Surface> navOpts(
-        state.stepping.navDir, true, resolveSensitive, resolveMaterial,
-        resolvePassive, startSurface, state.navigation.targetSurface);
+        state.stepping.navDir, state.options.boundaryCheck, resolveSensitive,
+        resolveMaterial, resolvePassive, startSurface,
+        state.navigation.targetSurface);
 
     std::vector<GeometryIdentifier> externalSurfaces;
     if (!state.navigation.externalSurfaces.empty()) {
@@ -1135,6 +1160,7 @@ class Navigator {
             : nullptr;
     // Create the navigation options
     // - and get the compatible layers, start layer will be excluded
+    // - boundary check is forced to be true
     NavigationOptions<Layer> navOpts(state.stepping.navDir, true,
                                      resolveSensitive, resolveMaterial,
                                      resolvePassive, startLayer, nullptr);

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -86,6 +86,9 @@ struct PropagatorPlainOptions {
   /// Required tolerance to reach target (surface, pathlength)
   double targetTolerance = s_onSurfaceTolerance;
 
+  /// BoundaryCheck for search options of sensitives
+  BoundaryCheck boundaryCheck = true;
+
   /// Loop protection step, it adapts the pathLimit
   bool loopProtection = true;
   double loopFraction = 0.5;  ///< Allowed loop fraction, 1 is a full loop
@@ -134,6 +137,7 @@ struct PropagatorOptions : public PropagatorPlainOptions {
       extended_aborter_list_t aborters) const {
     PropagatorOptions<action_list_t, extended_aborter_list_t> eoptions(
         geoContext, magFieldContext, logger);
+
     // Copy the options over
     eoptions.direction = direction;
     eoptions.absPdgCode = absPdgCode;
@@ -145,6 +149,7 @@ struct PropagatorOptions : public PropagatorPlainOptions {
     eoptions.pathLimit = direction * std::abs(pathLimit);
     eoptions.loopProtection = loopProtection;
     eoptions.loopFraction = loopFraction;
+    eoptions.boundaryCheck = boundaryCheck;
 
     // Stepper options
     eoptions.tolerance = tolerance;
@@ -171,6 +176,7 @@ struct PropagatorOptions : public PropagatorPlainOptions {
     pathLimit = direction * std::abs(pOptions.pathLimit);
     loopProtection = pOptions.loopProtection;
     loopFraction = pOptions.loopFraction;
+    boundaryCheck = pOptions.boundaryCheck;
     tolerance = pOptions.tolerance;
     stepSizeCutOff = pOptions.stepSizeCutOff;
   }

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -73,6 +73,7 @@ auto Acts::Propagator<S, N>::propagate_impl(propagator_state_t& state) const
     ACTS_ERROR("Propagation reached the step count limit of "
                << state.options.maxSteps << " (did " << result.steps
                << " steps)");
+    ACTS_ERROR("Last step size was = " << state.stepping.stepSize.toString());
     return PropagatorError::StepCountLimitReached;
   }
 

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -104,6 +104,8 @@ class PropagationAlgorithm : public BareAlgorithm {
     std::pair<double, double> ptRange = {100_MeV, 100_GeV};
     /// looper protection
     double ptLoopers = 500_MeV;
+    /// Search tolerance
+    double searchTolerance = 0_mm;
 
     /// Max step size steering
     double maxStepSize = 3_m;

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.ipp
@@ -6,7 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <Acts/Utilities/Helpers.hpp>
+#include "Acts/Surfaces/BoundaryCheck.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 
 #include <random>
 
@@ -71,6 +72,11 @@ PropagationOutput PropagationAlgorithm<propagator_t>::executeTest(
     PropagatorOptions options(context.geoContext, context.magFieldContext,
                               Acts::LoggerWrapper{logger()});
     options.pathLimit = pathLength;
+    options.boundaryCheck = true;
+    if (m_cfg.searchTolerance > 0.) {
+      options.boundaryCheck = Acts::BoundaryCheck(
+          true, true, m_cfg.searchTolerance, m_cfg.searchTolerance);
+    }
 
     // Activate loop protection at some pt value
     options.loopProtection =

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -82,7 +82,9 @@ void addPropagationOptions(aopt_t& opt) {
       "prop-max-stepsize", po::value<double>()->default_value(3_m),
       "Maximum step size for the propagation [in mm].")(
       "prop-pt-loopers", po::value<double>()->default_value(500_MeV),
-      "Transverse momentum below which loops are being detected [in GeV].");
+      "Transverse momentum below which loops are being detected [in GeV].")(
+      "prop-search-tolerance", po::value<double>()->default_value(0_mm),
+      "Tolerance within sensitive surfaces are searched for [in mm].");
 }
 
 /// Read the pgropagator options and return a Config file
@@ -125,6 +127,8 @@ readPropagationConfig(const vmap_t& vm, propagator_t propagator) {
   pAlgConfig.etaRange = {ietar[0], ietar[1]};
   pAlgConfig.ptRange = {iptr[0] * 1_GeV, iptr[1] * 1_GeV};
   pAlgConfig.ptLoopers = vm["prop-pt-loopers"].template as<double>() * 1_GeV;
+  pAlgConfig.searchTolerance =
+      vm["prop-search-tolerance"].template as<double>() * 1_mm;
   pAlgConfig.maxStepSize = vm["prop-max-stepsize"].template as<double>() * 1_mm;
 
   pAlgConfig.propagationStepCollection =

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootPropagationStepsWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootPropagationStepsWriter.hpp
@@ -75,6 +75,8 @@ class RootPropagationStepsWriter
   std::vector<int> m_layerID;      ///< layer identifier if
   std::vector<int> m_approachID;   ///< surface identifier
   std::vector<int> m_sensitiveID;  ///< surface identifier
+  std::vector<float> m_l0;         ///< local0 of the step, 0 if not defined
+  std::vector<float> m_l1;         ///< local1 of the step, 0 if not defined
   std::vector<float> m_x;          ///< global x
   std::vector<float> m_y;          ///< global y
   std::vector<float> m_z;          ///< global z

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -200,6 +200,8 @@ struct PropagatorState {
     size_t debugMsgWidth = 50;
 
     LoggerWrapper logger{getDummyLogger()};
+
+    BoundaryCheck boundaryCheck = true;
   };
 
   /// Navigation cache: the start surface


### PR DESCRIPTION
This PR allows to set a custom `BoundaryCheck` for sensitive surfaces via the `PropagatorOptions`.

An Example how to do this is shown in the `Examples/PropagationAlgorithm` .

Below is a image of a search with forced boundary check to module boundary, and an extended one by `2 mm`.

![Screenshot 2021-04-07 at 15 48 08](https://user-images.githubusercontent.com/26623879/113890061-20867900-97c4-11eb-8997-247114408799.png)
