### PR TITLE
feat:  material mapping fixes odd

### DIFF
--- a/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
+++ b/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
@@ -39,6 +39,8 @@ class TrackingGeometry;
 /// @brief selector for finding surface
 struct MaterialSurface {
   bool operator()(const Surface& sf) const {
+    std::cout << " - checking for SurfaceMaterial " << sf.surfaceMaterial()
+              << std::endl;
     return (sf.surfaceMaterial() != nullptr);
   }
 };

--- a/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
+++ b/Core/include/Acts/Material/SurfaceMaterialMapper.hpp
@@ -39,8 +39,6 @@ class TrackingGeometry;
 /// @brief selector for finding surface
 struct MaterialSurface {
   bool operator()(const Surface& sf) const {
-    std::cout << " - checking for SurfaceMaterial " << sf.surfaceMaterial()
-              << std::endl;
     return (sf.surfaceMaterial() != nullptr);
   }
 };

--- a/Core/include/Acts/Propagator/detail/PointwiseMaterialInteraction.hpp
+++ b/Core/include/Acts/Propagator/detail/PointwiseMaterialInteraction.hpp
@@ -43,7 +43,7 @@ struct PointwiseMaterialInteraction {
   /// The effective, passed material properties including the path correction.
   MaterialSlab slab;
   /// The path correction factor due to non-zero incidence on the surface.
-  double pathCorrection;
+  double pathCorrection = 0.;
   /// Expected phi variance due to the interactions.
   double variancePhi = 0.;
   /// Expected theta variance due to the interactions.

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -392,6 +392,9 @@ void Acts::TrackingVolume::closeGeometry(
     // now assign to the boundary surface
     auto& mutableBSurface = *(const_cast<Surface*>(&bSurface));
     mutableBSurface.assignGeometryId(boundaryID);
+    // Assigne material
+    std::cout << "[ TrackingGeometry ] Assign material to : "
+              << mutableBSurface.geometryId() << std::endl;
     // assign the material if you have a decorator
     if (materialDecorator != nullptr) {
       materialDecorator->decorate(mutableBSurface);

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -392,10 +392,7 @@ void Acts::TrackingVolume::closeGeometry(
     // now assign to the boundary surface
     auto& mutableBSurface = *(const_cast<Surface*>(&bSurface));
     mutableBSurface.assignGeometryId(boundaryID);
-    // Assigne material
-    std::cout << "[ TrackingGeometry ] Assign material to : "
-              << mutableBSurface.geometryId() << std::endl;
-    // assign the material if you have a decorator
+    // Assigne material if you have a decorator
     if (materialDecorator != nullptr) {
       materialDecorator->decorate(mutableBSurface);
     }

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -208,7 +208,7 @@ void Acts::SurfaceMaterialMapper::mapMaterialTrack(
       ActionList<MaterialSurfaceCollector, MaterialVolumeCollector>;
   using AbortList = AbortList<EndOfWorldReached>;
 
-  auto propLogger = getDefaultLogger("SufMatMapProp", Logging::INFO);
+  auto propLogger = getDefaultLogger("SurfMatMapProp", Logging::INFO);
   PropagatorOptions<ActionList, AbortList> options(
       mState.geoContext, mState.magFieldContext, LoggerWrapper{*propLogger});
 

--- a/Examples/Algorithms/Geant4/src/SteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/SteppingAction.cpp
@@ -89,6 +89,7 @@ void SteppingAction::UserSteppingAction(const G4Step* step) {
     mInteraction.direction = Acts::Vector3(rawDir.x(), rawDir.y(), rawDir.z());
     mInteraction.direction.normalized();
     mInteraction.materialSlab = slab;
+    mInteraction.pathCorrection = (step->GetStepLength() / CLHEP::mm);
     m_materialSteps.push_back(mInteraction);
 
     //   // Get the track associated to the step

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -50,7 +50,13 @@ void addPropagationOptions(aopt_t& opt) {
       po::value<std::string>()->default_value("propagation-material"),
       "Propagation material collection.")(
       "prop-ntests", po::value<size_t>()->default_value(1000),
-      "Number of tests performed.")(
+      "Number of tests performed.")("prop-resolve-material",
+                                    po::value<bool>()->default_value(true),
+                                    "Resolve all smaterial surfaces.")(
+      "prop-resolve-passive", po::value<bool>()->default_value(false),
+      "Resolve all passive surfaces.")("prop-resolve-sensitive",
+                                       po::value<bool>()->default_value(true),
+                                       "Resolve all sensitive surfaces.")(
       "prop-d0-sigma", po::value<double>()->default_value(15_um),
       "Sigma of the transverse impact parameter [in mm].")(
       "prop-z0-sigma", po::value<double>()->default_value(55_mm),

--- a/Examples/Detectors/DD4hepDetector/src/TestTracker/ZPlanarTracker_geo.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/TestTracker/ZPlanarTracker_geo.cpp
@@ -81,7 +81,7 @@ static Ref_t create_element(Detector& lcdd, xml_h e, SensitiveDetector sens) {
     // add Extension for translation to ACTS TrackingGeometry
     Acts::ActsExtension* detlayer = new Acts::ActsExtension("zyx");
     detlayer->addValue(10. * Acts::UnitConstants::mm, "r_min", "envelope");
-    detlayer->addValue(10. * Acts::UnitConstants::mm, "r_mx", "envelope");
+    detlayer->addValue(10. * Acts::UnitConstants::mm, "r_max", "envelope");
     detlayer->addValue(10. * Acts::UnitConstants::mm, "z_min", "envelope");
     detlayer->addValue(10. * Acts::UnitConstants::mm, "z_max", "envelope");
     detlayer->addType("sensitive plane", "layer");

--- a/Examples/Detectors/DD4hepDetector/src/TestTracker/ZPlanarTracker_geo.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/TestTracker/ZPlanarTracker_geo.cpp
@@ -80,8 +80,10 @@ static Ref_t create_element(Detector& lcdd, xml_h e, SensitiveDetector sens) {
 
     // add Extension for translation to ACTS TrackingGeometry
     Acts::ActsExtension* detlayer = new Acts::ActsExtension("zyx");
-    detlayer->addValue(10. * Acts::UnitConstants::mm, "r", "envelope");
-    detlayer->addValue(10. * Acts::UnitConstants::mm, "z", "envelope");
+    detlayer->addValue(10. * Acts::UnitConstants::mm, "r_min", "envelope");
+    detlayer->addValue(10. * Acts::UnitConstants::mm, "r_mx", "envelope");
+    detlayer->addValue(10. * Acts::UnitConstants::mm, "z_min", "envelope");
+    detlayer->addValue(10. * Acts::UnitConstants::mm, "z_max", "envelope");
     detlayer->addType("sensitive plane", "layer");
     layerDE.addExtension<Acts::ActsExtension>(detlayer);
 

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialWriter.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-///////////////////////////////////////////////////////////////////
-// RootMaterialWriter.h
-///////////////////////////////////////////////////////////////////
-
 #pragma once
 
 #include "ActsExamples/Framework/ProcessCode.hpp"

--- a/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
@@ -198,19 +198,22 @@ ActsExamples::ProcessCode ActsExamples::RootMaterialTrackWriter::writeT(
 
     // an now loop over the material
     for (auto& mint : mtrack.second.materialInteractions) {
+      auto direction = mint.direction.normalized();
+
       // The material step position information
       m_step_x.push_back(mint.position.x());
       m_step_y.push_back(mint.position.y());
       m_step_z.push_back(mint.position.z());
-      m_step_dx.push_back(mint.direction.x());
-      m_step_dy.push_back(mint.direction.y());
-      m_step_dz.push_back(mint.direction.z());
+      m_step_dx.push_back(direction.x());
+      m_step_dy.push_back(direction.y());
+      m_step_dz.push_back(direction.z());
 
       if (m_cfg.prePostStep) {
         Acts::Vector3 prePos =
-            mint.position - 0.5 * mint.pathCorrection * mint.direction;
+            mint.position - 0.5 * mint.pathCorrection * direction;
         Acts::Vector3 posPos =
-            mint.position + 0.5 * mint.pathCorrection * mint.direction;
+            mint.position + 0.5 * mint.pathCorrection * direction;
+
         m_step_sx.push_back(prePos.x());
         m_step_sy.push_back(prePos.y());
         m_step_sz.push_back(prePos.z());

--- a/Examples/Run/Common/src/MaterialMappingBase.cpp
+++ b/Examples/Run/Common/src/MaterialMappingBase.cpp
@@ -118,6 +118,9 @@ int materialMappingExample(int argc, char* argv[],
   if (mapSurface) {
     // Get a Navigator
     Acts::Navigator navigator(tGeometry);
+    navigator.resolveSensitive = true;
+    navigator.resolveMaterial = true;
+    navigator.resolvePassive = true;
     // Make stepper and propagator
     SlStepper stepper;
     Propagator propagator(std::move(stepper), std::move(navigator));

--- a/Examples/Run/Common/src/PropagationExampleBase.cpp
+++ b/Examples/Run/Common/src/PropagationExampleBase.cpp
@@ -6,7 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/MagneticField/SharedBField.hpp"
+#include "Acts/Propagator/AtlasStepper.hpp"
+#include "Acts/Propagator/EigenStepper.hpp"
+#include "Acts/Propagator/Navigator.hpp"
+#include "Acts/Propagator/Propagator.hpp"
+#include "Acts/Propagator/StraightLineStepper.hpp"
 #include "ActsExamples/Detector/IBaseDetector.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
@@ -18,12 +24,6 @@
 #include "ActsExamples/Propagation/PropagationAlgorithm.hpp"
 #include "ActsExamples/Propagation/PropagationOptions.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
-#include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/Propagator/AtlasStepper.hpp>
-#include <Acts/Propagator/EigenStepper.hpp>
-#include <Acts/Propagator/Navigator.hpp>
-#include <Acts/Propagator/Propagator.hpp>
-#include <Acts/Propagator/StraightLineStepper.hpp>
 
 #include <memory>
 
@@ -81,6 +81,11 @@ int propagationExample(int argc, char* argv[],
     using Stepper = std::decay_t<decltype(stepper)>;
     using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
     Acts::Navigator navigator(tGeometry);
+    navigator.resolveMaterial = vm["prop-resolve-material"].template as<bool>();
+    navigator.resolvePassive = vm["prop-resolve-passive"].template as<bool>();
+    navigator.resolveSensitive =
+        vm["prop-resolve-sensitive"].template as<bool>();
+
     Propagator propagator(std::move(stepper), std::move(navigator));
 
     // Read the propagation config and create the algorithms

--- a/Examples/Scripts/propagation_timing.sh
+++ b/Examples/Scripts/propagation_timing.sh
@@ -31,7 +31,7 @@ for pt in 0.1 0.5 1.0 2.0 5.0 10.0 100.0 ; do
   for stepper in {0..2} ; do
     
     # Compute the name of the example executable
-    executable="ActsExample$1Example -n$2  ${magfield} --prop-ntests $3 -j $4 --prop-pt-range ${pt} ${pt} --prop-stepper ${stepper} --output-root true"
+    executable="ActsExamplePropagation$1 -n$2  ${magfield} --prop-ntests $3 -j $4 --prop-pt-range ${pt} ${pt} --prop-stepper ${stepper} --output-root"
 
     echo "${jobID}, ${stepper}, ${pt}" >> ${output_file}
     eval ${executable}

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -77,13 +77,15 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
           detElement.placement().ptr()->GetVolume()->GetShape();
       // create the proto layer
       ProtoLayer pl(gctx, layerSurfaces);
-      if (detExtension->hasValue("r", "envelope") &&
-          detExtension->hasValue("z", "envelope")) {
+      if (detExtension->hasValue("r_min", "envelope") &&
+          detExtension->hasValue("r_max", "envelope") &&
+          detExtension->hasValue("z_min", "envelope") &&
+          detExtension->hasValue("z_max", "envelope")) {
         // set the values of the proto layer in case enevelopes are handed over
-        pl.envelope[Acts::binR] = {detExtension->getValue("r", "envelope"),
-                                   detExtension->getValue("r", "envelope")};
-        pl.envelope[Acts::binZ] = {detExtension->getValue("z", "envelope"),
-                                   detExtension->getValue("z", "envelope")};
+        pl.envelope[Acts::binR] = {detExtension->getValue("r_min", "envelope"),
+                                   detExtension->getValue("r_max", "envelope")};
+        pl.envelope[Acts::binZ] = {detExtension->getValue("z_min", "envelope"),
+                                   detExtension->getValue("z_max", "envelope")};
       } else if (geoShape != nullptr) {
         TGeoTubeSeg* tube = dynamic_cast<TGeoTubeSeg*>(geoShape);
         if (tube == nullptr) {
@@ -199,13 +201,16 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::centralLayers(
           detElement.placement().ptr()->GetVolume()->GetShape();
       // create the proto layer
       ProtoLayer pl(gctx, layerSurfaces);
-      if (detExtension->hasValue("r", "envelope") &&
-          detExtension->hasValue("z", "envelope")) {
+
+      if (detExtension->hasValue("r_min", "envelope") &&
+          detExtension->hasValue("r_max", "envelope") &&
+          detExtension->hasValue("z_min", "envelope") &&
+          detExtension->hasValue("z_max", "envelope")) {
         // set the values of the proto layer in case enevelopes are handed over
-        pl.envelope[Acts::binR] = {detExtension->getValue("r", "envelope"),
-                                   detExtension->getValue("r", "envelope")};
-        pl.envelope[Acts::binZ] = {detExtension->getValue("z", "envelope"),
-                                   detExtension->getValue("z", "envelope")};
+        pl.envelope[Acts::binR] = {detExtension->getValue("r_min", "envelope"),
+                                   detExtension->getValue("r_max", "envelope")};
+        pl.envelope[Acts::binZ] = {detExtension->getValue("z_min", "envelope"),
+                                   detExtension->getValue("z_max", "envelope")};
       } else if (geoShape != nullptr) {
         TGeoTubeSeg* tube = dynamic_cast<TGeoTubeSeg*>(geoShape);
         if (tube == nullptr)

--- a/Plugins/Json/src/MaterialMapJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialMapJsonConverter.cpp
@@ -181,20 +181,20 @@ nlohmann::ordered_json Acts::MaterialMapJsonConverter::materialMapsToJson(
   for (auto it = volumeMap.begin(); it != volumeMap.end(); it++) {
     mapVolumeInit.push_back({it->first, it->second.get()});
   }
-  GeometryHierarchyMap<const IVolumeMaterial*> HierarchyVolumeMap(
+  GeometryHierarchyMap<const IVolumeMaterial*> hierarchyVolumeMap(
       mapVolumeInit);
   nlohmann::ordered_json materialVolume =
-      m_volumeMaterialConverter.toJson(HierarchyVolumeMap);
+      m_volumeMaterialConverter.toJson(hierarchyVolumeMap);
   SurfaceMaterialMap surfaceMap = maps.first;
   std::vector<std::pair<GeometryIdentifier, const ISurfaceMaterial*>>
       mapSurfaceInit;
   for (auto it = surfaceMap.begin(); it != surfaceMap.end(); it++) {
     mapSurfaceInit.push_back({it->first, it->second.get()});
   }
-  GeometryHierarchyMap<const ISurfaceMaterial*> HierarchySurfaceMap(
+  GeometryHierarchyMap<const ISurfaceMaterial*> hierarchySurfaceMap(
       mapSurfaceInit);
   nlohmann::ordered_json materialSurface =
-      m_surfaceMaterialConverter.toJson(HierarchySurfaceMap);
+      m_surfaceMaterialConverter.toJson(hierarchySurfaceMap);
   nlohmann::ordered_json materialMap;
   materialMap["Volumes"] = materialVolume;
   materialMap["Surfaces"] = materialSurface;
@@ -205,22 +205,22 @@ Acts::MaterialMapJsonConverter::DetectorMaterialMaps
 Acts::MaterialMapJsonConverter::jsonToMaterialMaps(
     const nlohmann::json& materialmap) {
   nlohmann::json materialVolume = materialmap["Volumes"];
-  GeometryHierarchyMap<const IVolumeMaterial*> HierarchyVolumeMap =
+  GeometryHierarchyMap<const IVolumeMaterial*> hierarchyVolumeMap =
       m_volumeMaterialConverter.fromJson(materialVolume);
   VolumeMaterialMap volumeMap;
-  for (size_t i = 0; i < HierarchyVolumeMap.size(); i++) {
+  for (size_t i = 0; i < hierarchyVolumeMap.size(); i++) {
     std::shared_ptr<const IVolumeMaterial> volumePointer(
-        HierarchyVolumeMap.valueAt(i));
-    volumeMap.insert({HierarchyVolumeMap.idAt(i), std::move(volumePointer)});
+        hierarchyVolumeMap.valueAt(i));
+    volumeMap.insert({hierarchyVolumeMap.idAt(i), std::move(volumePointer)});
   }
   nlohmann::json materialSurface = materialmap["Surfaces"];
-  GeometryHierarchyMap<const ISurfaceMaterial*> HierarchySurfaceMap =
+  GeometryHierarchyMap<const ISurfaceMaterial*> hierarchySurfaceMap =
       m_surfaceMaterialConverter.fromJson(materialSurface);
   SurfaceMaterialMap surfaceMap;
-  for (size_t i = 0; i < HierarchySurfaceMap.size(); i++) {
+  for (size_t i = 0; i < hierarchySurfaceMap.size(); i++) {
     std::shared_ptr<const ISurfaceMaterial> surfacePointer(
-        HierarchySurfaceMap.valueAt(i));
-    surfaceMap.insert({HierarchySurfaceMap.idAt(i), std::move(surfacePointer)});
+        hierarchySurfaceMap.valueAt(i));
+    surfaceMap.insert({hierarchySurfaceMap.idAt(i), std::move(surfacePointer)});
   }
 
   Acts::MaterialMapJsonConverter::DetectorMaterialMaps maps = {surfaceMap,
@@ -238,14 +238,14 @@ nlohmann::ordered_json Acts::MaterialMapJsonConverter::trackingGeometryToJson(
       surfaceHierarchy;
   convertToHierarchy(volumeHierarchy, surfaceHierarchy,
                      tGeometry.highestTrackingVolume());
-  GeometryHierarchyMap<Acts::TrackingVolumeAndMaterial> HierarchyVolumeMap(
+  GeometryHierarchyMap<Acts::TrackingVolumeAndMaterial> hierarchyVolumeMap(
       volumeHierarchy);
   nlohmann::ordered_json jsonVolumes =
-      m_volumeConverter.toJson(HierarchyVolumeMap);
-  GeometryHierarchyMap<Acts::SurfaceAndMaterial> HierarchySurfaceMap(
+      m_volumeConverter.toJson(hierarchyVolumeMap);
+  GeometryHierarchyMap<Acts::SurfaceAndMaterial> hierarchySurfaceMap(
       surfaceHierarchy);
   nlohmann::ordered_json jsonSurfaces =
-      m_surfaceConverter.toJson(HierarchySurfaceMap);
+      m_surfaceConverter.toJson(hierarchySurfaceMap);
   nlohmann::ordered_json hierarchyMap;
   hierarchyMap["Volumes"] = jsonVolumes;
   hierarchyMap["Surfaces"] = jsonSurfaces;
@@ -332,6 +332,6 @@ void Acts::MaterialMapJsonConverter::convertToHierarchy(
             {bssfRep.geometryId(),
              defaultSurfaceMaterial(bssfRep.getSharedPtr())});
       }
-    }
+    } 
   }
 }

--- a/Plugins/Json/src/MaterialMapJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialMapJsonConverter.cpp
@@ -332,6 +332,6 @@ void Acts::MaterialMapJsonConverter::convertToHierarchy(
             {bssfRep.geometryId(),
              defaultSurfaceMaterial(bssfRep.getSharedPtr())});
       }
-    } 
+    }
   }
 }

--- a/thirdparty/OpenDataDetector/factory/ODDPixelBarrel_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDPixelBarrel_geo.cpp
@@ -213,13 +213,17 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Place the layer with appropriate Acts::Extension
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
+    layerExtension->addType("sensitive cylinder", "layer");
+    layerExtension->addValue(1., "r_min", "envelope");
+    layerExtension->addValue(5., "r_max", "envelope");   
+    layerExtension->addValue(5., "z_min", "envelope");
+    layerExtension->addValue(5., "z_max", "envelope");     
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {
       xml_comp_t x_layer_material = lmat;
       xmlToProtoSurfaceMaterial(x_layer_material, *layerExtension,
                                 "layer_material");
     }
-    layerExtension->addType("sensitive cylinder", "layer");
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
 
     PlacedVolume placedLayer = barrelVolume.placeVolume(layerVolume);

--- a/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
@@ -166,6 +166,10 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive disk", "layer");
+    layerExtension->addValue(10., "r_min", "envelope");
+    layerExtension->addValue(10., "r_max", "envelope");   
+    layerExtension->addValue(10., "z_min", "envelope");
+    layerExtension->addValue(10., "z_max", "envelope");        
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {

--- a/thirdparty/OpenDataDetector/factory/ODDStripBarrel_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDStripBarrel_geo.cpp
@@ -162,6 +162,10 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive cylinder", "layer");
+    layerExtension->addValue(10., "r_min", "envelope");
+    layerExtension->addValue(25., "r_max", "envelope");   
+    layerExtension->addValue(10., "z_min", "envelope");
+    layerExtension->addValue(10., "z_max", "envelope");     
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {

--- a/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
@@ -166,7 +166,12 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
     layerExtension->addType("sensitive disk", "layer");
+    layerExtension->addValue(25, "r_min", "envelope");
+    layerExtension->addValue(10, "r_max", "envelope");
+    layerExtension->addValue(10, "z_min", "envelope");
+    layerExtension->addValue(10, "z_max", "envelope");
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
+
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {
       xml_comp_t x_layer_material = lmat;


### PR DESCRIPTION
This PR fixes a few things in the material mapping and DD4Hep description:
 * ODD has now by-hand-envelopes (fixes navigation issues), copy and repo is updated
 * Pre/Post step of material user action was wrongly calculated 
 * Naming convention is fixed in `HierachySurface...` and `HierarchyVolume...`
 
Still an issue of not being able to map onto the last boundary surfaces:

![ODD_tX0_preliminary](https://user-images.githubusercontent.com/26623879/114686638-486d6380-9d13-11eb-8708-664b384d5e7c.png)

![ODD_g4_acts_material_position](https://user-images.githubusercontent.com/26623879/114686590-3d1a3800-9d13-11eb-9815-1da16bab32b4.png)
