### PR TITLE
fix: added sgnH to maxRho in HelicalTrackLinearizer.

### DIFF
--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -77,7 +77,7 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   double rho;
   // Curvature is infinite w/o b field
   if (Bz == 0. || std::abs(qOvP) < m_cfg.minQoP) {
-    rho = m_cfg.maxRho;
+    rho = sgnH * m_cfg.maxRho;
   } else {
     rho = sinTh * (1. / qOvP) / Bz;
   }


### PR DESCRIPTION
I replaced  maxRho with sgnH*maxRho (case of B=0, straight tracks) in the HelicalTrackLinearizer, since generally the curvature is signed.

In my case (vertex fitting with straight tracks), the missing sign of maxRho resulted into negative diagonal covariance matrix entries of the vertex fit for negatively charged particles. 
