### PR TITLE
fix: division by 0 in SpacePointGrid

### DIFF
--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -20,7 +20,8 @@ Acts::SpacePointGridCreator::createGrid(
     phiBins = 100;
   } else {
     // calculate circle intersections of helix and max detector radius
-    float minHelixRadius = config.minPt / (300. * std::abs(config.bFieldInZ));  // in mm
+    float minHelixRadius =
+        config.minPt / (300. * std::abs(config.bFieldInZ));  // in mm
     float maxR2 = config.rMax * config.rMax;
     float xOuter = maxR2 / (2 * minHelixRadius);
     float yOuter = std::sqrt(maxR2 - xOuter * xOuter);

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -53,7 +53,7 @@ Acts::SpacePointGridCreator::createGrid(
   int zBins;
   // for pseudorapidity == 0, create 100 phi-bins
   if (zBinSize <= 0) {
-    zBins = 100
+    zBins = 100;
   } else {
     zBins = std::floor((config.zMax - config.zMin) / zBinSize);
   }

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -16,7 +16,8 @@ Acts::SpacePointGridCreator::createGrid(
     const Acts::SpacePointGridConfig& config) {
   int phiBins;
   // for no (or bogus) magnetic field, create 100 phi-bins
-  if (config.bFieldInZ <= 0) {
+  config.bFieldInZ = std::abs(config.bFieldInZ);
+  if (config.bFieldInZ == 0) {
     phiBins = 100;
   } else {
     // calculate circle intersections of helix and max detector radius
@@ -52,10 +53,11 @@ Acts::SpacePointGridCreator::createGrid(
   float zBinSize = config.cotThetaMax * config.deltaRMax;
   int zBins;
   // for pseudorapidity == 0, create 100 phi-bins
-  if (zBinSize <= 0) {
+  if (zBinSize == 0) {
     zBins = 100;
   } else {
     zBins = std::floor((config.zMax - config.zMin) / zBinSize);
+    zBins = zBins < 1 ? 1 : zBins;
   }
   detail::Axis<detail::AxisType::Equidistant, detail::AxisBoundaryType::Bound>
       zAxis(config.zMin, config.zMax, zBins);

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -14,27 +14,33 @@ template <typename SpacePoint>
 std::unique_ptr<Acts::SpacePointGrid<SpacePoint>>
 Acts::SpacePointGridCreator::createGrid(
     const Acts::SpacePointGridConfig& config) {
-  // calculate circle intersections of helix and max detector radius
-  float minHelixRadius = config.minPt / (300. * config.bFieldInZ);  // in mm
-  float maxR2 = config.rMax * config.rMax;
-  float xOuter = maxR2 / (2 * minHelixRadius);
-  float yOuter = std::sqrt(maxR2 - xOuter * xOuter);
-  float outerAngle = std::atan(xOuter / yOuter);
-  // intersection of helix and max detector radius minus maximum R distance from
-  // middle SP to top SP
-  float innerAngle = 0;
-  if (config.rMax > config.deltaRMax) {
-    float innerCircleR2 =
-        (config.rMax - config.deltaRMax) * (config.rMax - config.deltaRMax);
-    float xInner = innerCircleR2 / (2 * minHelixRadius);
-    float yInner = std::sqrt(innerCircleR2 - xInner * xInner);
-    innerAngle = std::atan(xInner / yInner);
-  }
+  int phiBins;
+  // for no (or bogus) magnetic field, create 100 phi-bins
+  if (config.bFieldInZ <= 0){
+      phiBins = 100;
+  } else {
+    // calculate circle intersections of helix and max detector radius
+    float minHelixRadius = config.minPt / (300. * config.bFieldInZ);  // in mm
+    float maxR2 = config.rMax * config.rMax;
+    float xOuter = maxR2 / (2 * minHelixRadius);
+    float yOuter = std::sqrt(maxR2 - xOuter * xOuter);
+    float outerAngle = std::atan(xOuter / yOuter);
+    // intersection of helix and max detector radius minus maximum R distance from
+    // middle SP to top SP
+    float innerAngle = 0;
+    if (config.rMax > config.deltaRMax) {
+      float innerCircleR2 =
+          (config.rMax - config.deltaRMax) * (config.rMax - config.deltaRMax);
+      float xInner = innerCircleR2 / (2 * minHelixRadius);
+      float yInner = std::sqrt(innerCircleR2 - xInner * xInner);
+      innerAngle = std::atan(xInner / yInner);
+    }
 
-  // FIXME: phibin size must include max impact parameters
-  // divide 2pi by angle delta to get number of phi-bins
-  // size is always 2pi even for regions of interest
-  int phiBins = std::floor(2 * M_PI / (outerAngle - innerAngle));
+    // FIXME: phibin size must include max impact parameters
+    // divide 2pi by angle delta to get number of phi-bins
+    // size is always 2pi even for regions of interest
+    phiBins = std::floor(2 * M_PI / (outerAngle - innerAngle));
+  }
   Acts::detail::Axis<detail::AxisType::Equidistant,
                      detail::AxisBoundaryType::Closed>
       phiAxis(-M_PI, M_PI, phiBins);
@@ -44,7 +50,13 @@ Acts::SpacePointGridCreator::createGrid(
   // seeds
   // FIXME: zBinSize must include scattering
   float zBinSize = config.cotThetaMax * config.deltaRMax;
-  int zBins = std::floor((config.zMax - config.zMin) / zBinSize);
+  int zBins;
+  // for pseudorapidity == 0, create 100 phi-bins
+  if (zBinSize <= 0){
+    zBins = 100
+  } else {
+    zBins = std::floor((config.zMax - config.zMin) / zBinSize);
+  }
   detail::Axis<detail::AxisType::Equidistant, detail::AxisBoundaryType::Bound>
       zAxis(config.zMin, config.zMax, zBins);
   return std::make_unique<Acts::SpacePointGrid<SpacePoint>>(

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -15,13 +15,12 @@ std::unique_ptr<Acts::SpacePointGrid<SpacePoint>>
 Acts::SpacePointGridCreator::createGrid(
     const Acts::SpacePointGridConfig& config) {
   int phiBins;
-  // for no (or bogus) magnetic field, create 100 phi-bins
-  config.bFieldInZ = std::abs(config.bFieldInZ);
+  // for no magnetic field, create 100 phi-bins
   if (config.bFieldInZ == 0) {
     phiBins = 100;
   } else {
     // calculate circle intersections of helix and max detector radius
-    float minHelixRadius = config.minPt / (300. * config.bFieldInZ);  // in mm
+    float minHelixRadius = config.minPt / (300. * std::abs(config.bFieldInZ));  // in mm
     float maxR2 = config.rMax * config.rMax;
     float xOuter = maxR2 / (2 * minHelixRadius);
     float yOuter = std::sqrt(maxR2 - xOuter * xOuter);

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2018 CERN for the benefit of the Acts project
+// Copyright (C) 2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,8 @@ Acts::SpacePointGridCreator::createGrid(
     const Acts::SpacePointGridConfig& config) {
   int phiBins;
   // for no (or bogus) magnetic field, create 100 phi-bins
-  if (config.bFieldInZ <= 0){
-      phiBins = 100;
+  if (config.bFieldInZ <= 0) {
+    phiBins = 100;
   } else {
     // calculate circle intersections of helix and max detector radius
     float minHelixRadius = config.minPt / (300. * config.bFieldInZ);  // in mm
@@ -25,8 +25,8 @@ Acts::SpacePointGridCreator::createGrid(
     float xOuter = maxR2 / (2 * minHelixRadius);
     float yOuter = std::sqrt(maxR2 - xOuter * xOuter);
     float outerAngle = std::atan(xOuter / yOuter);
-    // intersection of helix and max detector radius minus maximum R distance from
-    // middle SP to top SP
+    // intersection of helix and max detector radius minus maximum R distance
+    // from middle SP to top SP
     float innerAngle = 0;
     if (config.rMax > config.deltaRMax) {
       float innerCircleR2 =
@@ -52,7 +52,7 @@ Acts::SpacePointGridCreator::createGrid(
   float zBinSize = config.cotThetaMax * config.deltaRMax;
   int zBins;
   // for pseudorapidity == 0, create 100 phi-bins
-  if (zBinSize <= 0){
+  if (zBinSize <= 0) {
     zBins = 100
   } else {
     zBins = std::floor((config.zMax - config.zMin) / zBinSize);


### PR DESCRIPTION
For no magnetic field or pseudorapidity == 0, the SpacePointGrid now creates 100 phi bins respectively 100 z bins instead of crashing
