### PR TITLE
feat: enable option for transverse momentum in Examples

### DIFF
--- a/CI/run_examples.sh
+++ b/CI/run_examples.sh
@@ -84,7 +84,7 @@ run_example ActsExampleParticleGun \
                 --output-csv \
                 --gen-phi-degree=0:90 \
                 --gen-eta=-2:2 \
-                --gen-p-gev=1:5 \
+                --gen-mom-gev=1:5 \
                 --gen-pdg=13 \
                 --gen-randomize-charge \
                 --gen-nparticles=4

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -63,7 +63,7 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
     const double phi = phiDist(rng);
     const double cosTheta = cosThetaDist(rng);
     const double sinTheta = std::sqrt(1 - cosTheta * cosTheta);
-    const double p = pDist(rng);
+    double p = pDist(rng);
 
     // we already have sin/cos theta. they can be used directly to
     Acts::Vector3 dir;
@@ -74,6 +74,7 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) const {
     // construct the particle;
     ActsFatras::Particle particle(pid, pdg, q, m_mass);
     particle.setDirection(dir);
+    p *= m_cfg.pTransverse ? 1. / sinTheta : 1.;
     particle.setAbsoluteMomentum(p);
 
     // generated particle ids are already ordered and should end up at the end

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
@@ -27,18 +27,20 @@ namespace ActsExamples {
 class ParametricParticleGenerator {
  public:
   struct Config {
-    // Low, high (exclusive) for the transverse direction angle.
+    /// Low, high (exclusive) for the transverse direction angle.
     double phiMin = -M_PI;
     double phiMax = M_PI;
-    // Low, high (inclusive) for  the longitudinal direction angle.
-    //
-    // This intentionally uses theta instead of eta so it can represent the
-    // full direction space with finite values.
+    /// Low, high (inclusive) for  the longitudinal direction angle.
+    ///
+    /// This intentionally uses theta instead of eta so it can represent the
+    /// full direction space with finite values.
     double thetaMin = 0.0;
     double thetaMax = M_PI;
-    // Low, high (exclusive) for absolute momentum.
+    /// Low, high (exclusive) for absolute/transverse momentum.
     double pMin = 1 * Acts::UnitConstants::GeV;
     double pMax = 10 * Acts::UnitConstants::GeV;
+    /// Indicate if the momentum referse to transverse momentum
+    bool pTransverse = false;
     /// (Absolute) PDG particle number to identify the particle type.
     Acts::PdgParticle pdg = Acts::PdgParticle::eMuon;
     /// Randomize the charge and flip the PDG particle number sign accordingly.

--- a/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
@@ -33,9 +33,11 @@ void ActsExamples::Options::addParticleGunOptions(Description& desc) {
   opt("gen-eta",
       value<Interval>()->value_name("MIN:MAX")->default_value({-4.0, 4.0}),
       "Pseudo-rapidity generation range");
-  opt("gen-p-gev",
+  opt("gen-mom-gev",
       value<Interval>()->value_name("MIN:MAX")->default_value({1.0, 10.0}),
-      "Absolute momentum generation range in GeV");
+      "Absolute (or transverse) momentum generation range in GeV");
+  opt("gen-mom-transverse", bool_switch(),
+      "Momentum referse to transverse momentum");
   opt("gen-pdg", value<int32_t>()->default_value(Acts::PdgParticle::eMuon),
       "PDG number of the particle, will be adjusted for charge flip.");
   opt("gen-randomize-charge", bool_switch(),
@@ -71,7 +73,8 @@ ActsExamples::Options::readParticleGunOptions(const Variables& vars) {
   getRange("gen-eta", 1.0, etaMin, etaMax);
   pgCfg.thetaMin = 2 * std::atan(std::exp(-etaMin));
   pgCfg.thetaMax = 2 * std::atan(std::exp(-etaMax));
-  getRange("gen-p-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);
+  getRange("gen-mom-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);
+  pgCfg.pTransverse = vars["gen-mom-transverse"].template as<bool>();
   pgCfg.pdg =
       static_cast<Acts::PdgParticle>(vars["gen-pdg"].template as<int32_t>());
   pgCfg.randomizeCharge = vars["gen-randomize-charge"].template as<bool>();

--- a/Examples/Scripts/KF_timing.sh
+++ b/Examples/Scripts/KF_timing.sh
@@ -97,7 +97,7 @@ jobID=0
          eta=$(echo "${etaBin}*0.5 + 0.25"|bc) 
 
          # Run sim
-         sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} -n ${numEvents} --gen-nparticles ${numTracksPerEvent} --gen-p-gev ${pt}:${pt} --gen-eta ${etaLow}:${etaUp} --output-csv=1 --output-dir=data/sim_${detector}/e${numEvents}_t${numTracksPerEvent}_eta${eta}_pt${pt}"
+         sim="${exe_dir}/ActsExampleFatras${detector} ${dd4hep_input} ${bField} -n ${numEvents} --gen-nparticles ${numTracksPerEvent} --gen-mom-gev ${pt}:${pt} --gen-eta ${etaLow}:${etaUp} --output-csv=1 --output-dir=data/sim_${detector}/e${numEvents}_t${numTracksPerEvent}_eta${eta}_pt${pt}"
          echo "Run sim with '${sim}'"
          eval ${sim}
        

--- a/docs/howto/run_fatras.rst
+++ b/docs/howto/run_fatras.rst
@@ -40,7 +40,7 @@ directory.
        --output-csv \
        --gen-phi-degree=0:90 \
        --gen-eta=-2:2 \
-       --gen-p-gev=1:5 \
+       --gen-mom-gev=1:5 \
        --gen-pdg=13 \
        --gen-randomize-charge \
        --gen-nparticles=4


### PR DESCRIPTION
This PR is super minimal and enables to generate constant PT particles for validation.

Validation screenshot below:

![Screenshot 2021-04-27 at 10 42 03](https://user-images.githubusercontent.com/26623879/116212941-a3587f00-a745-11eb-8056-d28a64c580dd.png)
