### PR TITLE
feat: adding DD4hep digitization, fix measurement writer, add variance in o…

### DIFF
--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
@@ -85,6 +85,7 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
 
     /// Reconstruction information
     float recBound[Acts::eBoundSize];
+    float varBound[Acts::eBoundSize];
 
     /// Cluster information comprised of
     /// nch :  number of channels
@@ -146,6 +147,7 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
     /// @param i the bound index in question
     void setupBoundRecBranch(Acts::BoundIndices i) {
       tree->Branch(std::string("rec_" + bNames[i]).c_str(), &recBound[i]);
+      tree->Branch(std::string("var_" + bNames[i]).c_str(), &varBound[i]);
     }
 
     /// Setup the cluster related branch
@@ -209,6 +211,19 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
       recBound[Acts::eBoundPhi] = fullVect[Acts::eBoundPhi];
       recBound[Acts::eBoundTheta] = fullVect[Acts::eBoundTheta];
       recBound[Acts::eBoundTime] = fullVect[Acts::eBoundTime];
+
+      Acts::BoundSymMatrix fullVar =
+          m.expander() * m.covariance() * m.expander().transpose();
+      varBound[Acts::eBoundLoc0] =
+          std::sqrt(fullVar(Acts::eBoundLoc0, Acts::eBoundLoc0));
+      varBound[Acts::eBoundLoc1] =
+          std::sqrt(fullVar(Acts::eBoundLoc1, Acts::eBoundLoc1));
+      varBound[Acts::eBoundPhi] =
+          std::sqrt(fullVar(Acts::eBoundPhi, Acts::eBoundPhi));
+      varBound[Acts::eBoundTheta] =
+          std::sqrt(fullVar(Acts::eBoundTheta, Acts::eBoundTheta));
+      varBound[Acts::eBoundTime] =
+          std::sqrt(fullVar(Acts::eBoundTime, Acts::eBoundTime));
     }
 
     /// Convenience function to fill the cluster information

--- a/Examples/Io/Root/src/RootMeasurementWriter.cpp
+++ b/Examples/Io/Root/src/RootMeasurementWriter.cpp
@@ -61,6 +61,7 @@ ActsExamples::RootMeasurementWriter::RootMeasurementWriter(
       auto bIndices = m_cfg.boundIndices.valueAt(ikv);
       auto dTree = std::make_unique<DigitizationTree>(geoID);
       for (const auto& bIndex : bIndices) {
+        ACTS_VERBOSE("- setup branch for index: " << bIndex);
         dTree->setupBoundRecBranch(bIndex);
       }
       if (not m_cfg.inputClusters.empty()) {
@@ -68,7 +69,10 @@ ActsExamples::RootMeasurementWriter::RootMeasurementWriter(
       }
       dTrees.push_back({geoID, std::move(dTree)});
     }
+  } else {
+    ACTS_DEBUG("Bound indices are not declared, no reco setup.")
   }
+
   m_outputTrees = Acts::GeometryHierarchyMap<std::unique_ptr<DigitizationTree>>(
       std::move(dTrees));
 }

--- a/Examples/Run/Digitization/CMakeLists.txt
+++ b/Examples/Run/Digitization/CMakeLists.txt
@@ -47,3 +47,5 @@ install(
   TARGETS
     ActsExampleDigitizationTGeo 
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+add_subdirectory_if(DD4hep ACTS_BUILD_EXAMPLES_DD4HEP)

--- a/Examples/Run/Digitization/Common/DigitizationExample.cpp
+++ b/Examples/Run/Digitization/Common/DigitizationExample.cpp
@@ -125,7 +125,8 @@ int runDigitizationExample(
   if (vm["output-root"].template as<bool>()) {
     RootMeasurementWriter::Config measWriterRoot;
     measWriterRoot.inputMeasurements = digiCfg.outputMeasurements;
-    measWriterRoot.inputClusters = digiCfg.outputClusters;
+    measWriterRoot.inputClusters =
+        digiCfg.isSimpleSmearer ? std::string("") : digiCfg.outputClusters;
     measWriterRoot.inputSimHits = simHitReaderCfg.outputSimHits;
     measWriterRoot.inputMeasurementSimHitsMap =
         digiCfg.outputMeasurementSimHitsMap;

--- a/Examples/Run/Digitization/DD4hep/CMakeLists.txt
+++ b/Examples/Run/Digitization/DD4hep/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(
+  ActsExampleDigitizationDD4hep
+  DD4hepDigitizationExample.cpp)
+target_link_libraries(
+    ActsExampleDigitizationDD4hep
+  PRIVATE ActsExamplesDigitizationCommon ActsExamplesDetectorDD4hep)
+
+install(
+  TARGETS ActsExampleDigitizationDD4hep
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Examples/Run/Digitization/DD4hep/DD4hepDigitizationExample.cpp
+++ b/Examples/Run/Digitization/DD4hep/DD4hepDigitizationExample.cpp
@@ -1,0 +1,15 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/DD4hepDetector/DD4hepDetector.hpp"
+
+#include "DigitizationExample.hpp"
+
+int main(int argc, char* argv[]) {
+  return runDigitizationExample(argc, argv, std::make_shared<DD4hepDetector>());
+}

--- a/Examples/Scripts/CKF_timing_vs_mu.sh
+++ b/Examples/Scripts/CKF_timing_vs_mu.sh
@@ -39,7 +39,7 @@ done
 #check input for DDhep input
 if [ "${detector}" == DD4hep ]; then
    if [ -z "${dd4hepInput}" ]; then
-      echo "Empty input for --dd4hep-input. A file like $<src_dir>/Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml must be provided. Have to exit."
+      echo "Empty input for --dd4hep-input. A file like $<src_dir>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml must be provided. Have to exit."
       exit 1
    fi
    if [ ! -f "${dd4hepInput}" ]; then

--- a/Fatras/src/EventData/Particle.cpp
+++ b/Fatras/src/EventData/Particle.cpp
@@ -20,5 +20,6 @@ std::ostream& ActsFatras::operator<<(std::ostream& os,
   os << "|pdg=" << particle.pdg();
   os << "|q=" << particle.charge();
   os << "|m=" << particle.mass();
+  os << "|p=" << particle.absoluteMomentum();
   return os;
 }


### PR DESCRIPTION
This PR:
 * adds a DD4hep digitization example for debugging digitization issue
 * fixes one problem of `clusters` not being present when running smearing only
 * adds the variance to the `RootMeasurementWriter` in order to be able to do pulls/variance checks

![odd-residual](https://user-images.githubusercontent.com/26623879/116255007-2099e900-a772-11eb-8526-ea73e155c796.gif)

![odd-pull](https://user-images.githubusercontent.com/26623879/116255024-2394d980-a772-11eb-81a2-f0089bc6d2d1.gif)
