### PR TITLE
fix: Write surface only once in the MaterialMapJsonConverter

### DIFF
--- a/Plugins/Json/src/MaterialMapJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialMapJsonConverter.cpp
@@ -24,6 +24,7 @@
 #include <Acts/Surfaces/RadialBounds.hpp>
 #include <Acts/Surfaces/SurfaceBounds.hpp>
 
+#include <algorithm>
 #include <map>
 
 namespace {
@@ -256,6 +257,16 @@ void Acts::MaterialMapJsonConverter::convertToHierarchy(
     std::vector<std::pair<GeometryIdentifier, Acts::SurfaceAndMaterial>>&
         surfaceHierarchy,
     const Acts::TrackingVolume* tVolume) {
+  auto sameId =
+      [tVolume](
+          std::pair<GeometryIdentifier, Acts::TrackingVolumeAndMaterial> pair) {
+        return (tVolume->geometryId() == pair.first);
+      };
+  if (std::find_if(volumeHierarchy.begin(), volumeHierarchy.end(), sameId) !=
+      volumeHierarchy.end()) {
+    // this volume was already visited
+    return;
+  }
   if ((tVolume->volumeMaterial() != nullptr ||
        m_cfg.processNonMaterial == true) &&
       m_cfg.processVolumes == true) {


### PR DESCRIPTION
With this PR when converting a tracking geometry to a Hierarchy the volume that have already been added to the hierarchy won't be added a second time. This solve the issue that if a volume belong to multiple volumes (as it is the case for the Calorimeter in the Acts ATLAS implementation) the code would result in an error (since hierarchy can only have each identifier appear once)