### PR TITLE
refactor: Use std::optional for event range end requested

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -34,7 +34,7 @@ class Sequencer {
     /// number of events to skip at the beginning
     size_t skip = 0;
     /// number of events to process, SIZE_MAX to process all available events
-    size_t events = SIZE_MAX;
+    std::optional<size_t> events = std::nullopt;
     /// logging level
     Acts::Logging::Level logLevel = Acts::Logging::INFO;
     /// number of parallel threads to run, negative for automatic determination

--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -147,17 +147,20 @@ ActsExamples::Sequencer::determineEventsRange() const {
     return kInvalidEventsRange;
   }
   // events range was not defined by either the readers or user command line.
-  if ((beg == 0u) and (end == SIZE_MAX) and (m_cfg.events == SIZE_MAX)) {
+  if ((beg == 0u) and (end == SIZE_MAX) and (!m_cfg.events.has_value())) {
     ACTS_ERROR("Could not determine number of events");
     return kInvalidEventsRange;
   }
 
   // take user selection into account
   auto begSelected = saturatedAdd(beg, m_cfg.skip);
-  auto endRequested = saturatedAdd(begSelected, m_cfg.events);
-  auto endSelected = std::min(end, endRequested);
-  if (end < endRequested) {
-    ACTS_INFO("Restrict requested number of events to available ones");
+  auto endSelected = end;
+  if (m_cfg.events.has_value()) {
+    auto endRequested = saturatedAdd(begSelected, m_cfg.events.value());
+    endSelected = std::min(end, endRequested);
+    if (end < endRequested) {
+      ACTS_INFO("Restrict requested number of events to available ones");
+    }
   }
 
   return {begSelected, endSelected};

--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -54,7 +54,8 @@ int processGeometry(int argc, char* argv[],
 
   // Now read the standard options
   auto logLevel = ActsExamples::Options::readLogLevel(vm);
-  auto nEvents = ActsExamples::Options::readSequencerConfig(vm).events;
+  size_t nEvents =
+      ActsExamples::Options::readSequencerConfig(vm).events.value_or(1);
 
   // The geometry, material and decoration
   auto geometry = ActsExamples::Geometry::build(vm, detector);

--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[]) {
   // Why does this need number-of-events? If it really does emulate
   // per-event access patterns this should be switched to a proper
   // Sequencer-based tool. Otherwise it should be removed.
-  auto nEvents = ActsExamples::Options::readSequencerConfig(vm).events;
+  auto nEvents = ActsExamples::Options::readSequencerConfig(vm).events.value();
   auto bField = ActsExamples::Options::readMagneticField(vm);
 
   // Get the phi and eta range


### PR DESCRIPTION
Previously, `SIZE_MAX` was used to indicate that the full available end range of an input file was to be used. This caused issues when no input file was present (for example in the geometry examples) and `--events` was not given., since it would run `SIZE_MAX` events (see #707). 

This PR changes this to use `std::optional<size_t>`, so that the default is clearly communicated. The geometry example should now default to `1` if `--events` isn't supplied.

Fixes #707