### PR TITLE
ci: Run build jobs on main branch

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
       - 'release/**'
 
 env:


### PR DESCRIPTION
Fixes one replacement of `master` to `main` that we missed.