### PR TITLE
ci: Fix doxygen doc job

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -164,19 +164,19 @@ jobs:
       - name: Install dependencies
         run: >
           apt-get install -y doxygen
-          && pip3 install --upgrade pip
+          && pip install --upgrade pip
           && which pip3 && pip3 --version
           && which pip && pip --version
-          && pip3 install -r docs/requirements.txt
+          && pip install -r docs/requirements.txt
       - name: Info
         run: >
           doxygen --version
-          && pip3 freeze
-      # - name: Configure
-      #   run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
-      # - name: Build
-      #   run: cmake --build build -- docs-with-api
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: acts-docs
-      #     path: docs/_build/html/
+          && pip freeze
+      - name: Configure
+        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
+      - name: Build
+        run: cmake --build build -- docs-with-api
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-docs
+          path: docs/_build/html/

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -165,16 +165,18 @@ jobs:
         run: >
           apt-get install -y doxygen
           && pip3 install --upgrade pip
+          && which pip3 && pip3 --version
+          && which pip && pip --version
           && pip3 install -r docs/requirements.txt
       - name: Info
         run: >
           doxygen --version
           && pip3 freeze
-      - name: Configure
-        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
-      - name: Build
-        run: cmake --build build -- docs-with-api
-      - uses: actions/upload-artifact@v2
-        with:
-          name: acts-docs
-          path: docs/_build/html/
+      # - name: Configure
+      #   run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
+      # - name: Build
+      #   run: cmake --build build -- docs-with-api
+      # - uses: actions/upload-artifact@v2
+      #   with:
+      #     name: acts-docs
+      #     path: docs/_build/html/

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -164,6 +164,7 @@ jobs:
       - name: Install dependencies
         run: >
           apt-get install -y doxygen
+          && pip3 install --upgrade pip
           && pip3 install -r docs/requirements.txt
       - name: Info
         run: >

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Install dependencies
         run: >
           apt-get install -y doxygen
-          && pip install --upgrade pip
+          && pip3 install --upgrade pip
           && which pip3 && pip3 --version
           && which pip && pip --version
           && pip install -r docs/requirements.txt

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Info
         run: >
           doxygen --version
-          pip3 freeze
+          && pip3 freeze
       - name: Configure
         run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
       - name: Build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Info
         run: >
           doxygen --version
+          pip3 freeze
       - name: Configure
         run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
       - name: Build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -165,6 +165,9 @@ jobs:
         run: >
           apt-get install -y doxygen
           && pip3 install -r docs/requirements.txt
+      - name: Info
+        run: >
+          doxygen --version
       - name: Configure
         run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
       - name: Build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -165,13 +165,7 @@ jobs:
         run: >
           apt-get install -y doxygen
           && pip3 install --upgrade pip
-          && which pip3 && pip3 --version
-          && which pip && pip --version
           && pip install -r docs/requirements.txt
-      - name: Info
-        run: >
-          doxygen --version
-          && pip freeze
       - name: Configure
         run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
       - name: Build


### PR DESCRIPTION
Pip changed it's dependency resolution algorithm a while ago. The job used an older version of pip which installed an inconsistent set of dependencies with a dependency update over the weekend. The job now updates pip first to get the new resolution behavior, which should fix the issue.