### PR TITLE
refactor: Remove usage of using namespace in headers

### DIFF
--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -30,8 +30,6 @@
 // This is based original stepper code from the ATLAS RungeKuttePropagagor
 namespace Acts {
 
-using namespace Acts::UnitLiterals;
-
 /// @brief the AtlasStepper implementation for the
 class AtlasStepper {
  public:
@@ -1355,7 +1353,7 @@ class AtlasStepper {
   std::shared_ptr<const MagneticFieldProvider> m_bField;
 
   /// Overstep limit: could/should be dynamic
-  double m_overstepLimit = -50_um;
+  double m_overstepLimit = -50 * UnitConstants::um;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -28,8 +28,6 @@
 
 namespace Acts {
 
-using namespace Acts::UnitLiterals;
-
 /// @brief Runge-Kutta-Nystroem stepper based on Eigen implementation
 /// for the following ODE:
 ///
@@ -380,7 +378,7 @@ class EigenStepper {
   std::shared_ptr<const MagneticFieldProvider> m_bField;
 
   /// Overstep limit: could/should be dynamic
-  double m_overstepLimit = 100_um;
+  double m_overstepLimit = 100 * UnitConstants::um;
 };
 }  // namespace Acts
 

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -28,8 +28,6 @@
 
 namespace Acts {
 
-using namespace Acts::UnitLiterals;
-
 /// @brief struct for the Navigation options that are forwarded to
 ///        the geometry
 ///
@@ -67,7 +65,7 @@ struct NavigationOptions {
   /// The overstep tolerance for this navigation step
   /// @note must be negative as it describes overstepping
   /// @todo could be dynamic in the future (pT dependent)
-  double overstepLimit = -1_um;
+  double overstepLimit = -1 * UnitConstants::um;
 
   /// Constructor
   ///
@@ -88,7 +86,7 @@ struct NavigationOptions {
         startObject(sobject),
         endObject(eobject),
         pathLimit(ndir * std::numeric_limits<double>::max()),
-        overstepLimit(-1_um) {}
+        overstepLimit(-1 * UnitConstants::um) {}
 };
 
 /// Navigator class
@@ -676,6 +674,7 @@ class Navigator {
   /// @return boolean return triggers exit to stepper
   template <typename propagator_state_t, typename stepper_t>
   bool targetLayers(propagator_state_t& state, const stepper_t& stepper) const {
+    using namespace UnitLiterals;
     const auto& logger = state.options.logger;
 
     if (state.navigation.navigationBreak ||

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Options.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Options.hpp
@@ -14,8 +14,6 @@
 
 #include "GeantinoRecording.hpp"
 
-using namespace Acts::UnitLiterals;
-
 namespace ActsExamples {
 
 namespace Options {

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -32,8 +32,6 @@
 #include <memory>
 #include <optional>
 
-using namespace Acts::UnitLiterals;
-
 namespace ActsExamples {
 
 /// Using some short hands for Recorded Material
@@ -85,28 +83,29 @@ class PropagationAlgorithm : public BareAlgorithm {
     /// number of particles
     size_t ntests = 100;
     /// d0 gaussian sigma
-    double d0Sigma = 15_um;
+    double d0Sigma = 15 * Acts::UnitConstants::um;
     /// z0 gaussian sigma
-    double z0Sigma = 55_mm;
+    double z0Sigma = 55 * Acts::UnitConstants::mm;
     /// phi gaussian sigma (used for covariance transport)
     double phiSigma = 0.0001;
     /// theta gaussian sigma (used for covariance transport)
     double thetaSigma = 0.0001;
     /// qp gaussian sigma (used for covariance transport)
-    double qpSigma = 0.00001 / 1_GeV;
+    double qpSigma = 0.00001 / 1 * Acts::UnitConstants::GeV;
     /// t gaussian sigma (used for covariance transport)
-    double tSigma = 1_ns;
+    double tSigma = 1 * Acts::UnitConstants::ns;
     /// phi range
     std::pair<double, double> phiRange = {-M_PI, M_PI};
     /// eta range
     std::pair<double, double> etaRange = {-4., 4.};
     /// pt range
-    std::pair<double, double> ptRange = {100_MeV, 100_GeV};
+    std::pair<double, double> ptRange = {100 * Acts::UnitConstants::MeV,
+                                         100 * Acts::UnitConstants::GeV};
     /// looper protection
-    double ptLoopers = 500_MeV;
+    double ptLoopers = 500 * Acts::UnitConstants::MeV;
 
     /// Max step size steering
-    double maxStepSize = 3_m;
+    double maxStepSize = 3 * Acts::UnitConstants::m;
 
     /// The step collection to be stored
     std::string propagationStepCollection = "PropagationSteps";

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationOptions.hpp
@@ -16,9 +16,6 @@
 
 #include "PropagationAlgorithm.hpp"
 
-namespace po = boost::program_options;
-using namespace Acts::UnitLiterals;
-
 namespace ActsExamples {
 
 namespace Options {
@@ -28,6 +25,8 @@ namespace Options {
 /// @tparam aopt_t Type of the options class from boost
 template <typename aopt_t>
 void addPropagationOptions(aopt_t& opt) {
+  namespace po = boost::program_options;
+  using namespace Acts::UnitLiterals;
   opt.add_options()(
       "prop-debug", po::value<bool>()->default_value(false),
       "Run in debug mode, will create propagation screen output.")(
@@ -97,6 +96,7 @@ void addPropagationOptions(aopt_t& opt) {
 template <typename vmap_t, typename propagator_t>
 typename ActsExamples::PropagationAlgorithm<propagator_t>::Config
 readPropagationConfig(const vmap_t& vm, propagator_t propagator) {
+  using namespace Acts::UnitLiterals;
   typename ActsExamples::PropagationAlgorithm<propagator_t>::Config pAlgConfig(
       std::move(propagator));
 

--- a/Examples/Detectors/EmptyDetector/include/ActsExamples/EmptyDetector/EmptyDetectorOptions.hpp
+++ b/Examples/Detectors/EmptyDetector/include/ActsExamples/EmptyDetector/EmptyDetectorOptions.hpp
@@ -18,9 +18,6 @@ namespace ActsExamples {
 
 namespace Options {
 
-using namespace Acts::UnitLiterals;
-namespace po = boost::program_options;
-
 /// The empty geometry options, the are prefixes with geo-generic
 ///
 /// @tparam options_t Type of the options object (bound to boost API)
@@ -28,6 +25,8 @@ namespace po = boost::program_options;
 /// @param opt The provided object, where root specific options are attached
 template <typename options_t>
 void addEmptyGeometryOptions(options_t& opt) {
+  using namespace Acts::UnitLiterals;
+  namespace po = boost::program_options;
   opt.add_options()("geo-empty-radius", po::value<double>()->default_value(2_m),
                     "Radius of the empty cylinder [in m]. ")(
       "geo-empty-halfLength", po::value<double>()->default_value(10_m),

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -21,8 +21,6 @@
 class TFile;
 class TTree;
 
-using namespace Acts::UnitLiterals;
-
 namespace ActsExamples {
 
 /// Write out the performance of CombinatorialKalmanFilter (CKF), e.g.
@@ -56,7 +54,7 @@ class CKFPerformanceWriter final : public WriterT<TrajectoriesContainer> {
     /// Min number of measurements
     size_t nMeasurementsMin = 9;
     /// Min transverse momentum
-    double ptMin = 1_GeV;
+    double ptMin = 1 * Acts::UnitConstants::GeV;
     /// function to check if neural network predicted track label is duplicate
     std::function<bool(std::vector<float>&)> duplicatedPredictor = nullptr;
   };

--- a/Examples/Run/Geant4/GeantinoRecordingBase.hpp
+++ b/Examples/Run/Geant4/GeantinoRecordingBase.hpp
@@ -21,13 +21,12 @@
 
 #include "G4VUserDetectorConstruction.hh"
 
-using namespace ActsExamples;
-
 /// @brief method to process a geometry
 /// @param detector The detector descriptor instance
 inline int runGeantinoRecording(
     const boost::program_options::variables_map& vm,
     std::unique_ptr<G4VUserDetectorConstruction> g4detector) {
+  using namespace ActsExamples;
   Sequencer sequencer(Options::readSequencerConfig(vm));
   auto logLevel = Options::readLogLevel(vm);
   auto outputDir = ensureWritableDirectory(vm["output-dir"].as<std::string>());

--- a/Examples/Run/Reconstruction/Common/RecInput.cpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.cpp
@@ -104,6 +104,7 @@ ActsExamples::ParticleSmearing::Config setupParticleSmearing(
     std::shared_ptr<const ActsExamples::RandomNumbers> rnd,
     const std::string& inputParticles) {
   using namespace ActsExamples;
+  using namespace Acts::UnitLiterals;
 
   // Read some standard options
   auto logLevel = Options::readLogLevel(vars);

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
@@ -31,8 +31,6 @@ namespace Acts {
 class TGeoDetectorElement;
 class Surface;
 
-using namespace Acts::UnitLiterals;
-
 /// @class TGeoLayerBuilder
 ///
 /// This parses the gGeoManager and looks for a defined combination
@@ -63,7 +61,8 @@ class TGeoLayerBuilder : public ILayerBuilder {
     /// Layer splitting: parameter and tolerance
     std::vector<SplitConfig> splitConfigs = {};
     /// The envelope to be built around the layer
-    std::pair<double, double> envelope = {0_mm, 0_mm};
+    std::pair<double, double> envelope = {0 * UnitConstants::mm,
+                                          0 * UnitConstants::mm};
     /// Binning setup in l0: nbins (-1 -> automated), axis binning type
     std::tuple<int, BinningType> binning0 = {-1, equidistant};
     /// Binning setup in l1: nbins (-1 -> automated), axis binning type
@@ -74,7 +73,8 @@ class TGeoLayerBuilder : public ILayerBuilder {
         : volumeName(""),
           sensorNames({}),
           localAxes("XZY"),
-          envelope(std::pair<double, double>(1_mm, 1_mm)) {}
+          envelope(std::pair<double, double>(1 * UnitConstants::mm,
+                                             1 * UnitConstants::mm)) {}
   };
 
   /// @struct Config
@@ -83,7 +83,7 @@ class TGeoLayerBuilder : public ILayerBuilder {
     /// String based identification
     std::string configurationName = "undefined";
     /// Unit conversion
-    double unit = 1_cm;
+    double unit = 1 * UnitConstants::cm;
     /// Create an indentifier from TGeoNode
     std::shared_ptr<const ITGeoIdentifierProvider> identifierProvider = nullptr;
     /// Layer creator

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoParser.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoParser.hpp
@@ -22,8 +22,6 @@ class TGeoVolume;
 
 namespace Acts {
 
-using namespace UnitLiterals;
-
 /// @brief TGeoParser is a helper struct that
 /// walks recursively through a TGeometry and selects by
 /// string comparison the TGeoNodes that match the criteria
@@ -67,7 +65,7 @@ struct TGeoParser {
     /// The local axis definition of TGeo object wrt Acts::Surface
     std::string localAxes = "XYZ";
     /// Scaling from TGeo to ROOT
-    double unit = 1_cm;
+    double unit = 1 * UnitConstants::cm;
     /// Parse restrictions, several can apply
     std::vector<std::pair<BinningValue, ParseRange> > parseRanges = {};
   };

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -106,6 +106,7 @@ static inline std::string testBoundTrackParameters(IVisualization3D& helper) {
 }
 
 static inline std::string testMultiTrajectory(IVisualization3D& helper) {
+  using namespace UnitLiterals;
   std::stringstream ss;
 
   // Create a test context

--- a/Tests/UnitTests/Plugins/TGeo/TGeoLayerBuilderTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoLayerBuilderTests.cpp
@@ -20,6 +20,8 @@
 
 #include "TGeoManager.h"
 
+using namespace Acts::UnitLiterals;
+
 namespace Acts {
 
 namespace Test {


### PR DESCRIPTION
We got a bit lenient with not doing 

```cpp
using namespace Acts::UnitLiterals;
```
in header code. This is a bad idea, because it pollutes the global namespace in every compilation unit such a header is included in. As a workaround, you can put `using namespace` in any functions where the literals are needed.

This PR removes all of these cases, and also removes a few other instances of `using namespace` in headers.