### PR TITLE
ci: Fix metric generation path

### DIFF
--- a/CI/headwind.yml
+++ b/CI/headwind.yml
@@ -1,7 +1,7 @@
 collectors:
   - type: command
     arg: "CI/perf_headwind.py perf.csv"
-storage_dir: ../metrics
+storage_dir: ../metrics/metrics
 report_filter: |
   def func(metric, df):
     import pandas as pd


### PR DESCRIPTION
As I was saying, CI is fiddly.
The target path for the metric storage is wrong I think. I think this should fix it.