### PR TITLE
refactor!: Remove overloads of B field retrieval without cache

### DIFF
--- a/Core/include/Acts/MagneticField/ConstantBField.hpp
+++ b/Core/include/Acts/MagneticField/ConstantBField.hpp
@@ -30,14 +30,6 @@ class ConstantBField final : public MagneticFieldProvider {
   /// @param [in] B magnetic field vector in global coordinate system
   explicit ConstantBField(Vector3 B) : m_BField(std::move(B)) {}
 
-  /// @brief construct constant magnetic field from components
-  ///
-  /// @param [in] Bx magnetic field component in global x-direction
-  /// @param [in] By magnetic field component in global y-direction
-  /// @param [in] Bz magnetic field component in global z-direction
-  ConstantBField(double Bx = 0., double By = 0., double Bz = 0.)
-      : m_BField(Bx, By, Bz) {}
-
   /// @brief Get the B field at a position
   Vector3 getField() const { return m_BField; }
 
@@ -77,13 +69,6 @@ class ConstantBField final : public MagneticFieldProvider {
   ///         otherwise @c false
   /// @note The method will always return true for the constant B-Field
   bool isInside(const Vector3& /*position*/) const { return true; }
-
-  /// @brief update magnetic field vector from components
-  ///
-  /// @param [in] Bx magnetic field component in global x-direction
-  /// @param [in] By magnetic field component in global y-direction
-  /// @param [in] Bz magnetic field component in global z-direction
-  void setField(double Bx, double By, double Bz) { m_BField << Bx, By, Bz; }
 
   /// @brief update magnetic field vector
   ///

--- a/Core/include/Acts/MagneticField/ConstantBField.hpp
+++ b/Core/include/Acts/MagneticField/ConstantBField.hpp
@@ -38,13 +38,8 @@ class ConstantBField final : public MagneticFieldProvider {
   ConstantBField(double Bx = 0., double By = 0., double Bz = 0.)
       : m_BField(Bx, By, Bz) {}
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  Vector3 getField(const Vector3& /*position*/) const override {
-    return m_BField;
-  }
+  /// @brief Get the B field at a position
+  Vector3 getField() const { return m_BField; }
 
   /// @copydoc MagneticFieldProvider::getField(const
   /// Vector3&,MagneticFieldProvider::Cache&)
@@ -53,18 +48,6 @@ class ConstantBField final : public MagneticFieldProvider {
   ///       a consistent interface with other magnetic field services.
   Vector3 getField(const Vector3& /*position*/,
                    MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
-  }
-
-  /// @copydoc MagneticFieldProvider::getFieldGradient(const
-  /// Vector3&,ActsMatrix<3,3>&)
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  /// @note currently the derivative is not calculated
-  /// @todo return derivative
-  Vector3 getFieldGradient(const Vector3& /*position*/,
-                           ActsMatrix<3, 3>& /*derivative*/) const override {
     return m_BField;
   }
 

--- a/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
+++ b/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
@@ -300,8 +300,10 @@ class InterpolatedBFieldMap final : public MagneticFieldProvider {
     return MagneticFieldProvider::Cache::make<Cache>(mctx);
   }
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
-  Vector3 getField(const Vector3& position) const override {
+  /// @brief Get the B field at a position
+  ///
+  /// @param position The position to query at
+  Vector3 getField(const Vector3& position) const {
     return m_config.mapper.getField(position);
   }
 
@@ -314,16 +316,6 @@ class InterpolatedBFieldMap final : public MagneticFieldProvider {
       cache.fieldCell = getFieldCell(position);
     }
     return (*cache.fieldCell).getField(position);
-  }
-
-  /// @copydoc MagneticFieldProvider::getFieldGradient(const
-  /// Vector3&,ActsMatrix<3,3>&)
-  ///
-  /// @note currently the derivative is not calculated
-  /// @todo return derivative
-  Vector3 getFieldGradient(const Vector3& position,
-                           ActsMatrix<3, 3>& /*derivative*/) const override {
-    return m_config.mapper.getField(position);
   }
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const

--- a/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
+++ b/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
@@ -35,23 +35,6 @@ class MagneticFieldProvider {
   /// @return magnetic field vector at given position
   virtual Vector3 getField(const Vector3& position, Cache& cache) const = 0;
 
-  /// @brief retrieve magnetic field value
-  ///
-  /// @param [in] position global 3D position
-  /// @param [in,out] cache Cache object. Contains field cell used for
-  /// interpolation
-  ///
-  /// @return magnetic field vector at given position
-  virtual Vector3 getField(const Vector3& position) const = 0;
-
-  /// @brief retrieve magnetic field value & its gradient
-  ///
-  /// @param [in]  position   global 3D position
-  /// @param [out] derivative gradient of magnetic field vector as (3x3) matrix
-  /// @return magnetic field vector
-  virtual Vector3 getFieldGradient(const Vector3& position,
-                                   ActsMatrix<3, 3>& derivative) const = 0;
-
   /// @brief retrieve magnetic field value & its gradient
   ///
   /// @param [in]  position   global 3D position

--- a/Core/include/Acts/MagneticField/NullBField.hpp
+++ b/Core/include/Acts/MagneticField/NullBField.hpp
@@ -25,14 +25,6 @@ class NullBField final : public MagneticFieldProvider {
   /// @brief Default constructor
   NullBField() = default;
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  Vector3 getField(const Vector3& /*position*/) const override {
-    return m_BField;
-  }
-
   /// @copydoc MagneticFieldProvider::getField(const
   /// Vector3&,MagneticFieldProvider::Cache&)
   ///
@@ -40,18 +32,6 @@ class NullBField final : public MagneticFieldProvider {
   ///       a consistent interface with other magnetic field services.
   Vector3 getField(const Vector3& /*position*/,
                    MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
-  }
-
-  /// @copydoc MagneticFieldProvider::getFieldGradient(const
-  /// Vector3&,ActsMatrix<3,3>&)
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  /// @note currently the derivative is not calculated
-  /// @todo return derivative
-  Vector3 getFieldGradient(const Vector3& /*position*/,
-                           ActsMatrix<3, 3>& /*derivative*/) const override {
     return m_BField;
   }
 

--- a/Core/include/Acts/MagneticField/SharedBField.hpp
+++ b/Core/include/Acts/MagneticField/SharedBField.hpp
@@ -33,8 +33,10 @@ class SharedBField final : public MagneticFieldProvider {
   /// @tparam bField is the shared BField to be stored
   SharedBField(std::shared_ptr<const BField> bField) : m_bField(bField) {}
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
-  Vector3 getField(const Vector3& position) const override {
+  /// @brief Get the B field at a position
+  ///
+  /// @param position The position to query at
+  Vector3 getField(const Vector3& position) const {
     return m_bField->getField(position);
   }
 
@@ -48,7 +50,7 @@ class SharedBField final : public MagneticFieldProvider {
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
   /// Vector3&,ActsMatrix<3,3>&)
   Vector3 getFieldGradient(const Vector3& position,
-                           ActsMatrix<3, 3>& derivative) const override {
+                           ActsMatrix<3, 3>& derivative) const {
     return m_bField->getFieldGradient(position, derivative);
   }
 

--- a/Core/include/Acts/MagneticField/SolenoidBField.hpp
+++ b/Core/include/Acts/MagneticField/SolenoidBField.hpp
@@ -102,21 +102,15 @@ class SolenoidBField final : public MagneticFieldProvider {
   MagneticFieldProvider::Cache makeCache(
       const MagneticFieldContext& mctx) const override;
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
-  Vector3 getField(const Vector3& position) const override;
+  /// @brief Get the B field at a position
+  ///
+  /// @param position The position to query at
+  Vector3 getField(const Vector3& position) const;
 
   /// @copydoc MagneticFieldProvider::getField(const
   /// Vector3&,MagneticFieldProvider::Cache&)
   Vector3 getField(const Vector3& position,
                    MagneticFieldProvider::Cache& /*cache*/) const override;
-
-  /// @copydoc MagneticFieldProvider::getFieldGradient(const
-  /// Vector3&,ActsMatrix<3,3>&)
-  ///
-  /// @note currently the derivative is not calculated
-  /// @todo return derivative
-  Vector3 getFieldGradient(const Vector3& position,
-                           ActsMatrix<3, 3>& /*derivative*/) const override;
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
   /// Vector3&,ActsMatrix<3,3>&,MagneticFieldProvider::Cache&)

--- a/Core/src/MagneticField/SolenoidBField.cpp
+++ b/Core/src/MagneticField/SolenoidBField.cpp
@@ -55,11 +55,6 @@ Acts::Vector2 Acts::SolenoidBField::getField(const Vector2& position) const {
 }
 
 Acts::Vector3 Acts::SolenoidBField::getFieldGradient(
-    const Vector3& position, ActsMatrix<3, 3>& /*derivative*/) const {
-  return getField(position);
-}
-
-Acts::Vector3 Acts::SolenoidBField::getFieldGradient(
     const Vector3& position, ActsMatrix<3, 3>& /*derivative*/,
     MagneticFieldProvider::Cache& /*cache*/) const {
   return getField(position);

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -162,6 +162,8 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
   trackParameters.reserve(seeds.size());
   tracks.reserve(seeds.size());
 
+  auto bCache = m_cfg.magneticField->makeCache(ctx.magFieldContext);
+
   // Loop over all found seeds to estimate track parameters
   for (size_t iseed = 0; iseed < seeds.size(); ++iseed) {
     const auto& seed = seeds[iseed];
@@ -179,7 +181,7 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
 
     // Get the magnetic field at the bottom space point
     Acts::Vector3 field = m_cfg.magneticField->getField(
-        {bottomSP->x(), bottomSP->y(), bottomSP->z()});
+        {bottomSP->x(), bottomSP->y(), bottomSP->z()}, bCache);
     // Estimate the track parameters from seed
     auto optParams = Acts::estimateTrackParamsFromSeed(
         ctx.geoContext, seed.sp().begin(), seed.sp().end(), *surface, field,

--- a/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/ScalableBField.hpp
+++ b/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/ScalableBField.hpp
@@ -48,17 +48,6 @@ class ScalableBField final : public Acts::MagneticFieldProvider {
   /// @brief retrieve magnetic field value
   ///
   /// @param [in] position global position
-  /// @return magnetic field vector
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  Acts::Vector3 getField(const Acts::Vector3& /*position*/) const override {
-    return m_BField;
-  }
-
-  /// @brief retrieve magnetic field value
-  ///
-  /// @param [in] position global position
   /// @param [in] cache Cache object (is ignored)
   /// @return magnetic field vector
   ///
@@ -68,23 +57,6 @@ class ScalableBField final : public Acts::MagneticFieldProvider {
                          MagneticFieldProvider::Cache& gCache) const override {
     Cache& cache = gCache.get<Cache>();
     return m_BField * cache.scalor;
-  }
-
-  /// @brief retrieve magnetic field value & its gradient
-  ///
-  /// @param [in]  position   global position
-  /// @param [out] derivative gradient of magnetic field vector as (3x3)
-  /// matrix
-  /// @return magnetic field vector
-  ///
-  /// @note The @p position is ignored and only kept as argument to provide
-  ///       a consistent interface with other magnetic field services.
-  /// @note currently the derivative is not calculated
-  /// @todo return derivative
-  Acts::Vector3 getFieldGradient(
-      const Acts::Vector3& /*position*/,
-      Acts::ActsMatrix<3, 3>& /*derivative*/) const override {
-    return m_BField;
   }
 
   /// @brief retrieve magnetic field value & its gradient

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -81,6 +81,8 @@ class RootBFieldWriter {
     using namespace Acts;
     ACTS_LOCAL_LOGGER(std::move(p_logger))
 
+    Acts::MagneticFieldContext bFieldContext;
+
     // Check basic configuration
     if (cfg.treeName.empty()) {
       throw std::invalid_argument("Missing tree name");
@@ -285,6 +287,7 @@ class RootBFieldWriter {
       stepZ = fabs(minZ - maxZ) / nBinsZ;
       double stepPhi = (2 * M_PI) / nBinsPhi;
 
+      auto bCache = cfg.bField->makeCache(bFieldContext);
       for (size_t i = 0; i < nBinsPhi; i++) {
         double phi = minPhi + i * stepPhi;
         for (size_t k = 0; k < nBinsZ; k++) {
@@ -293,7 +296,7 @@ class RootBFieldWriter {
             double raw_r = minR + j * stepR;
             Acts::Vector3 position(raw_r * cos(phi), raw_r * sin(phi), raw_z);
             if (cfg.bField->isInside(position)) {
-              auto bField = cfg.bField->getField(position);
+              auto bField = cfg.bField->getField(position, bCache);
               z = raw_z / Acts::UnitConstants::mm;
               r = raw_r / Acts::UnitConstants::mm;
               Bz = bField.z() / Acts::UnitConstants::T;

--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -38,7 +38,6 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
                     double theta_step, size_t phi_steps, double phi_0,
                     double phi_step, size_t access_steps, double access_step) {
   std::cout << "[>>>] Start: step-wise access pattern ... " << std::endl;
-  size_t mismatched = 0;
   // initialize the field cache
   auto bCache = bField.makeCache(bFieldContext);
   // boost display
@@ -61,6 +60,7 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
           Acts::Vector3 position = currentStep * dir;
           // access the field with the cell
           auto field_from_cache = bField.getField(position, bCache);
+          (void)field_from_cache;  // we don't use this explicitly
           // increase the step
           currentStep += access_step;
           // show the progress bar
@@ -76,7 +76,6 @@ void accessRandom(const Acts::MagneticFieldProvider& bField,
                   const Acts::MagneticFieldContext& bFieldContext,
                   size_t totalSteps, double radius) {
   std::cout << "[>>>] Start: random access pattern ... " << std::endl;
-  size_t mismatched = 0;
   RandomEngine rng;
   UniformDist xDist(-radius, radius);
   UniformDist yDist(-radius, radius);
@@ -92,6 +91,7 @@ void accessRandom(const Acts::MagneticFieldProvider& bField,
     Acts::Vector3 position(xDist(rng), yDist(rng), zDist(rng));
     // access the field with the cell
     auto field_from_cache = bField.getField(position, bCache);
+    (void)field_from_cache;  // we don't use this explicitly
     // show the progress bar
     ++show_progress;
   }

--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -59,14 +59,8 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
         // now step through the magnetic field
         for (size_t istep = 0; istep < access_steps; ++istep) {
           Acts::Vector3 position = currentStep * dir;
-          // access the field directly
-          auto field_direct = bField.getField(position);
           // access the field with the cell
           auto field_from_cache = bField.getField(position, bCache);
-          // check
-          if (!field_direct.isApprox(field_from_cache)) {
-            ++mismatched;
-          }
           // increase the step
           currentStep += access_step;
           // show the progress bar
@@ -74,8 +68,7 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
         }
       }
     }
-    std::cout << "[<<<] End result : " << mismatched << "/" << totalSteps
-              << " mismatches" << std::endl;
+    std::cout << "[<<<] End result: total steps:" << totalSteps << std::endl;
   }
 }
 
@@ -97,19 +90,12 @@ void accessRandom(const Acts::MagneticFieldProvider& bField,
   // loop over the events - @todo move to parallel for
   for (size_t istep = 0; istep < totalSteps; ++istep) {
     Acts::Vector3 position(xDist(rng), yDist(rng), zDist(rng));
-    // access the field directly
-    auto field_direct = bField.getField(position);
     // access the field with the cell
     auto field_from_cache = bField.getField(position, bCache);
-    // check
-    if (!field_direct.isApprox(field_from_cache)) {
-      ++mismatched;
-    }
     // show the progress bar
     ++show_progress;
   }
-  std::cout << "[<<<] End result : " << mismatched << "/" << totalSteps
-            << " mismatches" << std::endl;
+  std::cout << "[<<<] End result: total steps: " << totalSteps << std::endl;
 }
 
 /// @brief main executable

--- a/Examples/Run/MagneticField/CMakeLists.txt
+++ b/Examples/Run/MagneticField/CMakeLists.txt
@@ -10,15 +10,15 @@ target_link_libraries(
     Boost::program_options)
 
 add_executable(
-  ActsExampleMagneticFieldAcess
+  ActsExampleMagneticFieldAccess
   BFieldAccessExample.cpp)
 target_link_libraries(
-  ActsExampleMagneticFieldAcess
+  ActsExampleMagneticFieldAccess
   PRIVATE
     ActsCore
     ActsExamplesFramework ActsExamplesCommon
     ActsExamplesMagneticField ActsExamplesIoRoot Boost::program_options)
 
 install(
-  TARGETS ActsExampleMagneticField ActsExampleMagneticFieldAcess
+  TARGETS ActsExampleMagneticField ActsExampleMagneticFieldAccess
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/Tests/Benchmarks/AtlasStepperBenchmark.cpp
+++ b/Tests/Benchmarks/AtlasStepperBenchmark.cpp
@@ -73,7 +73,8 @@ int main(int argc, char* argv[]) {
   using Propagator_type = Propagator<Stepper_type>;
   using Covariance = BoundSymMatrix;
 
-  auto bField = std::make_shared<BField_type>(0, 0, BzInT * UnitConstants::T);
+  auto bField =
+      std::make_shared<BField_type>(Vector3{0, 0, BzInT * UnitConstants::T});
   Stepper_type atlas_stepper(std::move(bField));
   Propagator_type propagator(std::move(atlas_stepper));
 

--- a/Tests/Benchmarks/EigenStepperBenchmark.cpp
+++ b/Tests/Benchmarks/EigenStepperBenchmark.cpp
@@ -73,7 +73,8 @@ int main(int argc, char* argv[]) {
   using Propagator_type = Propagator<Stepper_type>;
   using Covariance = BoundSymMatrix;
 
-  auto bField = std::make_shared<BField_type>(0, 0, BzInT * UnitConstants::T);
+  auto bField =
+      std::make_shared<BField_type>(Vector3{0, 0, BzInT * UnitConstants::T});
   Stepper_type atlas_stepper(std::move(bField));
   Propagator_type propagator(std::move(atlas_stepper));
 

--- a/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
+++ b/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
@@ -165,7 +165,7 @@ BOOST_DATA_TEST_CASE(FatrasSimulation, dataset, pdg, phi, eta, p,
   // construct the propagators
   Navigator navigator(trackingGeometry);
   ChargedStepper chargedStepper(
-      std::make_shared<Acts::ConstantBField>(0, 0, 1_T));
+      std::make_shared<Acts::ConstantBField>(Acts::Vector3{0, 0, 1_T}));
   ChargedPropagator chargedPropagator(std::move(chargedStepper), navigator);
   NeutralPropagator neutralPropagator(NeutralStepper(), navigator);
 

--- a/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
+++ b/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
@@ -86,6 +86,7 @@ auto makeFieldMap(const SolenoidBField& field) {
 
 Acts::SolenoidBField bSolenoidField({R, L, nCoils, bMagCenter});
 auto bFieldMap = makeFieldMap(bSolenoidField);
+auto bCache = bFieldMap.makeCache(Acts::MagneticFieldContext{});
 
 struct StreamWrapper {
   StreamWrapper(std::ofstream ofstr) : m_ofstr(std::move(ofstr)) {
@@ -118,7 +119,7 @@ BOOST_DATA_TEST_CASE(
 
   Vector3 pos(r * std::cos(phi), r * std::sin(phi), z);
   Vector3 B = bSolenoidField.getField(pos) / Acts::UnitConstants::T;
-  Vector3 Bm = bFieldMap.getField(pos) / Acts::UnitConstants::T;
+  Vector3 Bm = bFieldMap.getField(pos, bCache) / Acts::UnitConstants::T;
 
   // test less than 5% deviation
   if (std::abs(r - R) > 10 && (std::abs(z) < L / 3. || r > 20)) {

--- a/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
@@ -40,19 +40,17 @@ BOOST_DATA_TEST_CASE(ConstantBField_components,
                          bdata::random(-10_m, 10_m) ^ bdata::xrange(10),
                      x, y, z, bx, by, bz, index) {
   (void)index;
-  BOOST_TEST_CONTEXT("Eigen interface") {
-    const Vector3 Btrue(bx, by, bz);
-    const Vector3 pos(x, y, z);
-    const ConstantBField BField(Btrue);
+  const Vector3 Btrue(bx, by, bz);
+  const Vector3 pos(x, y, z);
+  const ConstantBField BField(Btrue);
 
-    auto bCache = BField.makeCache(mfContext);
+  auto bCache = BField.makeCache(mfContext);
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
-  }
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
 }
 
 /// @brief unit test for update of constant magnetic field
@@ -69,21 +67,19 @@ BOOST_DATA_TEST_CASE(ConstantBField_update,
                          bdata::random(-10_m, 10_m) ^ bdata::xrange(10),
                      x, y, z, bx, by, bz, index) {
   (void)index;
-  ConstantBField BField(0, 0, 0);
 
-  BOOST_TEST_CONTEXT("Eigen interface") {
-    const Vector3 Btrue(bx, by, bz);
-    const Vector3 pos(x, y, z);
-    BField.setField(bx, by, bz);
+  ConstantBField BField{Vector3{0, 0, 0}};
+  const Vector3 Btrue(bx, by, bz);
+  const Vector3 pos(x, y, z);
+  BField.setField(Vector3{bx, by, bz});
 
-    auto bCache = BField.makeCache(mfContext);
+  auto bCache = BField.makeCache(mfContext);
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
-  }
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
@@ -47,25 +47,7 @@ BOOST_DATA_TEST_CASE(ConstantBField_components,
 
     auto bCache = BField.makeCache(mfContext);
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0)));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos));
-
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
-  }
-
-  BOOST_TEST_CONTEXT("C-array initialised - Eigen retrieved") {
-    const ConstantBField BField(bx, by, bz);
-    const Vector3 Btrue(bx, by, bz);
-    const Vector3 pos(x, y, z);
-
-    auto bCache = BField.makeCache(mfContext);
-
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0)));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos));
+    BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
     BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
     BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
@@ -92,29 +74,11 @@ BOOST_DATA_TEST_CASE(ConstantBField_update,
   BOOST_TEST_CONTEXT("Eigen interface") {
     const Vector3 Btrue(bx, by, bz);
     const Vector3 pos(x, y, z);
-    BField.setField(Btrue);
-
-    auto bCache = BField.makeCache(mfContext);
-
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0)));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos));
-
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
-  }
-
-  BOOST_TEST_CONTEXT("C-array initialised - Eigen retrieved") {
-    const Vector3 Btrue(bx, by, bz);
-    const Vector3 pos(x, y, z);
     BField.setField(bx, by, bz);
 
     auto bCache = BField.makeCache(mfContext);
 
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(pos));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0)));
-    BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos));
+    BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
     BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
     BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));

--- a/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
@@ -49,7 +49,7 @@ using ReferencePropagator = Propagator<Stepper, Navigator>;
 using DirectPropagator = Propagator<Stepper, DirectNavigator>;
 
 const double Bz = 2_T;
-auto bField = std::make_shared<BField>(0, 0, Bz);
+auto bField = std::make_shared<BField>(Vector3{0, 0, Bz});
 Stepper estepper(bField);
 Stepper dstepper(bField);
 

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -272,8 +272,10 @@ BOOST_DATA_TEST_CASE(
   const auto& status = epropagator.propagate(start, options).value();
   // this test assumes state.options.loopFraction = 0.5
   // maximum momentum allowed
+  auto bCache = bField->makeCache(mfContext);
   double pmax = options.pathLimit *
-                bField->getField(start.position(tgContext)).norm() / M_PI;
+                bField->getField(start.position(tgContext), bCache).norm() /
+                M_PI;
   if (p < pmax) {
     BOOST_CHECK_LT(status.pathLength, options.pathLimit);
   } else {

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -55,7 +55,7 @@ using EigenStepperType = EigenStepper<>;
 using EigenPropagatorType = Propagator<EigenStepperType, Navigator>;
 using Covariance = BoundSymMatrix;
 
-auto bField = std::make_shared<BFieldType>(0, 0, 2_T);
+auto bField = std::make_shared<BFieldType>(Vector3{0, 0, 2_T});
 EigenStepperType estepper(bField);
 EigenPropagatorType epropagator(std::move(estepper), std::move(navigator));
 

--- a/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
@@ -173,7 +173,7 @@ BOOST_DATA_TEST_CASE(
   double q = -1 + 2 * charge;
 
   const double Bz = 2_T;
-  auto bField = std::make_shared<BField>(0, 0, Bz);
+  auto bField = std::make_shared<BField>(Vector3{0, 0, Bz});
   EigenStepper estepper(bField);
   EigenPropagator epropagator(std::move(estepper));
 

--- a/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
@@ -57,7 +57,7 @@ using EigenPropagator = Propagator<EigenStepper, Navigator>;
 using StraightLinePropagator = Propagator<StraightLineStepper, Navigator>;
 
 const double Bz = 2_T;
-auto bField = std::make_shared<BField>(0, 0, Bz);
+auto bField = std::make_shared<BField>(Vector3{0, 0, Bz});
 EigenStepper estepper(bField);
 EigenPropagator epropagator(std::move(estepper), std::move(navigatorES));
 

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -115,7 +115,7 @@ using EigenStepperType = EigenStepper<>;
 using EigenPropagatorType = Propagator<EigenStepperType>;
 
 const double Bz = 2_T;
-auto bField = std::make_shared<BFieldType>(0, 0, Bz);
+auto bField = std::make_shared<BFieldType>(Vector3{0, 0, Bz});
 EigenStepperType estepper(bField);
 EigenPropagatorType epropagator(std::move(estepper));
 

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -187,6 +187,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   double stepSize = 123.;
   double tolerance = 234.;
   auto bField = std::make_shared<ConstantBField>(Vector3(1., 2.5, 33.33));
+  auto bCache = bField->makeCache(mfContext);
 
   // Construct the parameters
   Vector3 pos(1., 2., 3.);
@@ -210,7 +211,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   CHECK_CLOSE_ABS(es.charge(esState), charge, eps);
   CHECK_CLOSE_ABS(es.time(esState), time, eps);
   //~ BOOST_CHECK_EQUAL(es.overstepLimit(esState), tolerance);
-  BOOST_CHECK_EQUAL(es.getField(esState, pos), bField->getField(pos));
+  BOOST_CHECK_EQUAL(es.getField(esState, pos), bField->getField(pos, bCache));
 
   // Step size modifies
   const std::string originalStepSize = esState.stepSize.toString();

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -737,7 +737,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   ////////////////////////////////////////////////////////////////////
 
   // Re-launch the configuration with magnetic field
-  bField->setField(0., 1_T, 0.);
+  bField->setField(Vector3{0., 1_T, 0.});
   EigenStepper<
       StepperExtensionList<DefaultExtension, DenseEnvironmentExtension>,
       detail::HighestValidAuctioneer>

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   std::mt19937 gen(mySeed);
 
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up EigenStepper
   EigenStepper<> stepper(bField);
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
   // Set debug mode
   bool debugMode = false;
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 2_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 2_T});
 
   // Set up EigenStepper
   // EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -39,7 +39,7 @@ MagneticFieldContext magFieldContext = MagneticFieldContext();
 ///
 BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_empty_input_test) {
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
   int mySeed = 31415;
   std::mt19937 gen(mySeed);
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_usertrack_test) {
   std::mt19937 gen(mySeed);
 
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
 
   for (unsigned int iEvent = 0; iEvent < nEvents; ++iEvent) {
     // Set up constant B-Field
-    auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+    auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
     // Set up Eigenstepper
     EigenStepper<> stepper(bField);
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
 
   for (unsigned int iEvent = 0; iEvent < nEvents; ++iEvent) {
     // Set up constant B-Field
-    auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+    auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
     // Set up Eigenstepper
     EigenStepper<> stepper(bField);
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
 ///
 BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 2_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 2_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
   std::mt19937 gen(mySeed);
 
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
   std::mt19937 gen(mySeed);
 
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/LinearizedTrackFactoryTests.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(linearized_track_factory_test) {
   std::mt19937 gen(mySeed);
 
   // Set up constant B-Field
-  auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+  auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
   // Set up Eigenstepper
   EigenStepper<> stepper(bField);

--- a/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(zscan_finder_test) {
     std::mt19937 gen(mySeed);
 
     // Set up constant B-Field
-    auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+    auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
     // Set up Eigenstepper
     EigenStepper<> stepper(bField);
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(zscan_finder_usertrack_test) {
     std::mt19937 gen(mySeed);
 
     // Set up constant B-Field
-    auto bField = std::make_shared<ConstantBField>(0.0, 0.0, 1_T);
+    auto bField = std::make_shared<ConstantBField>(Vector3{0.0, 0.0, 1_T});
 
     // Set up Eigenstepper
     EigenStepper<> stepper(bField);


### PR DESCRIPTION
This PR removes the overloads of `getField` and `getFieldGradient` from `Acts::MagneticFieldProvider`. The individual field provider can still implement such overloads, but aren't forced to anymore by the provider. This only requires a few changes, but one is that it effectively renders `BFieldAccessExample` void of functionality, other than being a literal example of how to use the provider.

Closes #782

BREAKING CHANGE: `Acts::MagneticFieldProvider` loses the following pure virtual overloads:
```cpp
virtual Vector3 getField(const Vector3& position) const = 0; 
virtual Vector3 getFieldGradient(const Vector3& position, ActsMatrix<3, 3>& derivative) const = 0;
```
Clients of generic magnetic field providers need to be adapted.