### PR TITLE
fix: Prevent rmin from going negative.

### DIFF
--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -544,6 +544,7 @@ Acts::VolumeConfig Acts::CylinderVolumeBuilder::analyzeContent(
             std::min(lConfig.rMin, rMinD - m_cfg.layerEnvelopeR.first);
         lConfig.rMax =
             std::max(lConfig.rMax, rMaxD + m_cfg.layerEnvelopeR.second);
+        lConfig.rMin = std::max(0.0, lConfig.rMin);
         lConfig.zMin = std::min(lConfig.zMin, zMinD - m_cfg.layerEnvelopeZ);
         lConfig.zMax = std::max(lConfig.zMax, zMaxD + m_cfg.layerEnvelopeZ);
       }


### PR DESCRIPTION
A problem that only occurs on the positive endcap despite being
a mirror of the negative endcap.

Here is the output of the dd4hep plugin in verbose mode:
[output.txt](https://github.com/acts-project/acts/files/6565645/output.txt)

Here is the output after the changes:
[output2.txt](https://github.com/acts-project/acts/files/6565683/output2.txt)

I seem to have made a little bit of progress but maybe created more problems... 

Here are some images of the detector: 
![image](https://user-images.githubusercontent.com/2065918/120090993-77297880-c0cc-11eb-8d8f-0f9a89feac38.png)
![image](https://user-images.githubusercontent.com/2065918/120091018-a2ac6300-c0cc-11eb-954b-42ec4cd775bf.png)

@asalzburger Did something change in the geometry construction in the last few major versions?

