### PR TITLE
refactor!: B field access returns Result

### DIFF
--- a/Core/include/Acts/MagneticField/ConstantBField.hpp
+++ b/Core/include/Acts/MagneticField/ConstantBField.hpp
@@ -38,9 +38,10 @@ class ConstantBField final : public MagneticFieldProvider {
   ///
   /// @note The @p position is ignored and only kept as argument to provide
   ///       a consistent interface with other magnetic field services.
-  Vector3 getField(const Vector3& /*position*/,
-                   MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
+  Result<Vector3> getField(
+      const Vector3& /*position*/,
+      MagneticFieldProvider::Cache& /*cache*/) const override {
+    return Result<Vector3>::success(m_BField);
   }
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
@@ -50,10 +51,10 @@ class ConstantBField final : public MagneticFieldProvider {
   ///       a consistent interface with other magnetic field services.
   /// @note currently the derivative is not calculated
   /// @todo return derivative
-  Vector3 getFieldGradient(
+  Result<Vector3> getFieldGradient(
       const Vector3& /*position*/, ActsMatrix<3, 3>& /*derivative*/,
       MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
+    return Result<Vector3>::success(m_BField);
   }
 
   /// @copydoc MagneticFieldProvider::makeCache(const MagneticFieldContext&)

--- a/Core/include/Acts/MagneticField/MagneticFieldError.hpp
+++ b/Core/include/Acts/MagneticField/MagneticFieldError.hpp
@@ -1,0 +1,27 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <system_error>
+
+namespace Acts {
+
+enum class MagneticFieldError {
+  OutOfBounds = 1,
+};
+
+std::error_code make_error_code(Acts::MagneticFieldError e);
+
+}  // namespace Acts
+
+namespace std {
+// register with STL
+template <>
+struct is_error_code_enum<Acts::MagneticFieldError> : std::true_type {};
+}  // namespace std

--- a/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
+++ b/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/MagneticField/detail/SmallObjectCache.hpp"
+#include "Acts/Utilities/Result.hpp"
 
 #include <array>
 #include <memory>
@@ -33,7 +34,8 @@ class MagneticFieldProvider {
   /// @param [in] position global 3D position
   ///
   /// @return magnetic field vector at given position
-  virtual Vector3 getField(const Vector3& position, Cache& cache) const = 0;
+  virtual Result<Vector3> getField(const Vector3& position,
+                                   Cache& cache) const = 0;
 
   /// @brief retrieve magnetic field value & its gradient
   ///
@@ -41,9 +43,9 @@ class MagneticFieldProvider {
   /// @param [out] derivative gradient of magnetic field vector as (3x3) matrix
   /// @param [in,out] cache Cache object. Contains field cell used for
   /// @return magnetic field vector
-  virtual Vector3 getFieldGradient(const Vector3& position,
-                                   ActsMatrix<3, 3>& derivative,
-                                   Cache& cache) const = 0;
+  virtual Result<Vector3> getFieldGradient(const Vector3& position,
+                                           ActsMatrix<3, 3>& derivative,
+                                           Cache& cache) const = 0;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/MagneticField/NullBField.hpp
+++ b/Core/include/Acts/MagneticField/NullBField.hpp
@@ -30,9 +30,10 @@ class NullBField final : public MagneticFieldProvider {
   ///
   /// @note The @p position is ignored and only kept as argument to provide
   ///       a consistent interface with other magnetic field services.
-  Vector3 getField(const Vector3& /*position*/,
-                   MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
+  Result<Vector3> getField(
+      const Vector3& /*position*/,
+      MagneticFieldProvider::Cache& /*cache*/) const override {
+    return Result<Vector3>::success(m_BField);
   }
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
@@ -42,10 +43,10 @@ class NullBField final : public MagneticFieldProvider {
   ///       a consistent interface with other magnetic field services.
   /// @note currently the derivative is not calculated
   /// @todo return derivative
-  Vector3 getFieldGradient(
+  Result<Vector3> getFieldGradient(
       const Vector3& /*position*/, ActsMatrix<3, 3>& /*derivative*/,
       MagneticFieldProvider::Cache& /*cache*/) const override {
-    return m_BField;
+    return Result<Vector3>::success(m_BField);
   }
 
   /// @copydoc MagneticFieldProvider::makeCache(const MagneticFieldContext&)

--- a/Core/include/Acts/MagneticField/SharedBField.hpp
+++ b/Core/include/Acts/MagneticField/SharedBField.hpp
@@ -33,32 +33,18 @@ class SharedBField final : public MagneticFieldProvider {
   /// @tparam bField is the shared BField to be stored
   SharedBField(std::shared_ptr<const BField> bField) : m_bField(bField) {}
 
-  /// @brief Get the B field at a position
-  ///
-  /// @param position The position to query at
-  Vector3 getField(const Vector3& position) const {
-    return m_bField->getField(position);
-  }
-
   /// @copydoc MagneticFieldProvider::getField(const
   /// Vector3&,MagneticFieldProvider::Cache&)
-  Vector3 getField(const Vector3& position,
-                   MagneticFieldProvider::Cache& cache) const override {
+  Result<Vector3> getField(const Vector3& position,
+                           MagneticFieldProvider::Cache& cache) const override {
     return m_bField->getField(position, cache);
   }
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
-  /// Vector3&,ActsMatrix<3,3>&)
-  Vector3 getFieldGradient(const Vector3& position,
-                           ActsMatrix<3, 3>& derivative) const {
-    return m_bField->getFieldGradient(position, derivative);
-  }
-
-  /// @copydoc MagneticFieldProvider::getFieldGradient(const
   /// Vector3&,ActsMatrix<3,3>&,MagneticFieldProvider::Cache&)
-  Vector3 getFieldGradient(const Vector3& position,
-                           ActsMatrix<3, 3>& derivative,
-                           MagneticFieldProvider::Cache& cache) const override {
+  Result<Vector3> getFieldGradient(
+      const Vector3& position, ActsMatrix<3, 3>& derivative,
+      MagneticFieldProvider::Cache& cache) const override {
     return m_bField->getFieldGradient(position, derivative, cache);
   }
 

--- a/Core/include/Acts/MagneticField/SolenoidBField.hpp
+++ b/Core/include/Acts/MagneticField/SolenoidBField.hpp
@@ -109,15 +109,16 @@ class SolenoidBField final : public MagneticFieldProvider {
 
   /// @copydoc MagneticFieldProvider::getField(const
   /// Vector3&,MagneticFieldProvider::Cache&)
-  Vector3 getField(const Vector3& position,
-                   MagneticFieldProvider::Cache& /*cache*/) const override;
+  Result<Vector3> getField(
+      const Vector3& position,
+      MagneticFieldProvider::Cache& /*cache*/) const override;
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
   /// Vector3&,ActsMatrix<3,3>&,MagneticFieldProvider::Cache&)
   ///
   /// @note currently the derivative is not calculated
   /// @todo return derivative
-  Vector3 getFieldGradient(
+  Result<Vector3> getFieldGradient(
       const Vector3& position, ActsMatrix<3, 3>& /*derivative*/,
       MagneticFieldProvider::Cache& /*cache*/) const override;
 

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -474,10 +474,13 @@ class AtlasStepper {
   /// @param [in,out] state is the stepper state associated with the track
   ///                 the magnetic field cell is used (and potentially updated)
   /// @param [in] pos is the field position
-  Vector3 getField(State& state, const Vector3& pos) const {
+  Result<Vector3> getField(State& state, const Vector3& pos) const {
     // get the field from the cell
-    state.field = m_bField->getField(pos, state.fieldCache);
-    return state.field;
+    auto res = m_bField->getField(pos, state.fieldCache);
+    if (res.ok()) {
+      state.field = *res;
+    }
+    return res;
   }
 
   Vector3 position(const State& state) const {
@@ -1127,7 +1130,11 @@ class AtlasStepper {
     if (state.stepping.newfield) {
       const Vector3 pos(R[0], R[1], R[2]);
       // This is sd.B_first in EigenStepper
-      f0 = getField(state.stepping, pos);
+      auto fRes = getField(state.stepping, pos);
+      if (!fRes.ok()) {
+        return fRes.error();
+      }
+      f0 = *fRes;
     } else {
       f0 = state.stepping.field;
     }
@@ -1162,7 +1169,11 @@ class AtlasStepper {
         // This is pos1 in EigenStepper
         const Vector3 pos(R[0] + A1 * S4, R[1] + B1 * S4, R[2] + C1 * S4);
         // This is sd.B_middle in EigenStepper
-        f = getField(state.stepping, pos);
+        auto fRes = getField(state.stepping, pos);
+        if (!fRes.ok()) {
+          return fRes.error();
+        }
+        f = *fRes;
       } else {
         f = f0;
       }
@@ -1188,7 +1199,11 @@ class AtlasStepper {
         // This is pos2 in EigenStepper
         const Vector3 pos(R[0] + h * A4, R[1] + h * B4, R[2] + h * C4);
         // This is sd.B_last in Eigen stepper
-        f = getField(state.stepping, pos);
+        auto fRes = getField(state.stepping, pos);
+        if (!fRes.ok()) {
+          return fRes.error();
+        }
+        f = *fRes;
       } else {
         f = f0;
       }

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -192,7 +192,7 @@ class EigenStepper {
   /// @param [in,out] state is the propagation state associated with the track
   ///                 the magnetic field cell is used (and potentially updated)
   /// @param [in] pos is the field position
-  Vector3 getField(State& state, const Vector3& pos) const {
+  Result<Vector3> getField(State& state, const Vector3& pos) const {
     // get the field from the cell
     return m_bField->getField(pos, state.fieldCache);
   }

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -117,7 +117,11 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   auto dir = direction(state.stepping);
 
   // First Runge-Kutta point (at current position)
-  sd.B_first = getField(state.stepping, pos);
+  auto fieldRes = getField(state.stepping, pos);
+  if (!fieldRes.ok()) {
+    return fieldRes.error();
+  }
+  sd.B_first = *fieldRes;
   if (!state.stepping.extension.validExtensionForStep(state, *this) ||
       !state.stepping.extension.k1(state, *this, sd.k1, sd.B_first, sd.kQoP)) {
     return 0.;
@@ -127,31 +131,46 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   // size, going up to the point where it can return an estimate of the local
   // integration error. The results are stated in the local variables above,
   // allowing integration to continue once the error is deemed satisfactory
-  const auto tryRungeKuttaStep = [&](const ConstrainedStep& h) -> bool {
+  const auto tryRungeKuttaStep = [&](const ConstrainedStep& h) -> Result<bool> {
+    // helpers because bool and std::error_code are ambiguous
+    constexpr auto success = &Result<bool>::success;
+    constexpr auto failure = &Result<bool>::failure;
+
     // State the square and half of the step size
     h2 = h * h;
     half_h = h * 0.5;
 
     // Second Runge-Kutta point
     const Vector3 pos1 = pos + half_h * dir + h2 * 0.125 * sd.k1;
-    sd.B_middle = getField(state.stepping, pos1);
+    auto field = getField(state.stepping, pos1);
+    if (!field.ok()) {
+      return failure(field.error());
+    }
+    sd.B_middle = *field;
+
+    std::cout << "B middle at " << pos1.transpose() << ": "
+              << sd.B_middle.transpose() << std::endl;
     if (!state.stepping.extension.k2(state, *this, sd.k2, sd.B_middle, sd.kQoP,
                                      half_h, sd.k1)) {
-      return false;
+      return success(false);
     }
 
     // Third Runge-Kutta point
     if (!state.stepping.extension.k3(state, *this, sd.k3, sd.B_middle, sd.kQoP,
                                      half_h, sd.k2)) {
-      return false;
+      return success(false);
     }
 
     // Last Runge-Kutta point
     const Vector3 pos2 = pos + h * dir + h2 * 0.5 * sd.k3;
-    sd.B_last = getField(state.stepping, pos2);
+    field = getField(state.stepping, pos2);
+    if (!field.ok()) {
+      return failure(field.error());
+    }
+    sd.B_last = *field;
     if (!state.stepping.extension.k4(state, *this, sd.k4, sd.B_last, sd.kQoP, h,
                                      sd.k3)) {
-      return false;
+      return success(false);
     }
 
     // Compute and check the local integration error estimate
@@ -160,14 +179,22 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
               std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
         1e-20);
 
-    return (error_estimate <= state.options.tolerance);
+    return success(error_estimate <= state.options.tolerance);
   };
 
   double stepSizeScaling = 1.;
   size_t nStepTrials = 0;
   // Select and adjust the appropriate Runge-Kutta step size as given
   // ATL-SOFT-PUB-2009-001
-  while (!tryRungeKuttaStep(state.stepping.stepSize)) {
+  while (true) {
+    auto res = tryRungeKuttaStep(state.stepping.stepSize);
+    if (!res.ok()) {
+      return res.error();
+    }
+    if (!!res.value()) {
+      break;
+    }
+
     stepSizeScaling =
         std::min(std::max(0.25, std::pow((state.options.tolerance /
                                           std::abs(2. * error_estimate)),

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -148,8 +148,6 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
     }
     sd.B_middle = *field;
 
-    std::cout << "B middle at " << pos1.transpose() << ": "
-              << sd.B_middle.transpose() << std::endl;
     if (!state.stepping.extension.k2(state, *this, sd.k2, sd.B_middle, sd.kQoP,
                                      half_h, sd.k1)) {
       return success(false);

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -48,7 +48,8 @@ auto Acts::Propagator<S, N>::propagate_impl(propagator_state_t& state) const
         result.pathLength += s;
         ACTS_VERBOSE("Step with size = " << s << " performed");
       } else {
-        ACTS_ERROR("Step failed: " << res.error());
+        ACTS_ERROR("Step failed with " << res.error() << ": "
+                                       << res.error().message());
         // pass error to caller
         return res.error();
       }

--- a/Core/include/Acts/Propagator/StepperConcept.hpp
+++ b/Core/include/Acts/Propagator/StepperConcept.hpp
@@ -91,7 +91,7 @@ using step_size_t = decltype(std::declval<T>().stepSize);
         static_assert(curvilinear_state_exists, "CurvilinearState type not found");
         constexpr static bool reset_state_exists = has_method<const S, void, reset_state_t, state&, const BoundVector&, const BoundSymMatrix&, const Surface&, const NavigationDirection, const double>;
         static_assert(reset_state_exists, "resetState method not found");
-        constexpr static bool get_field_exists = has_method<const S, Vector3, get_field_t, state&, const Vector3&>;
+        constexpr static bool get_field_exists = has_method<const S, Result<Vector3>, get_field_t, state&, const Vector3&>;
         static_assert(get_field_exists, "getField method not found");
         constexpr static bool position_exists = has_method<const S, Vector3, position_t, const state&>;
         static_assert(position_exists, "position method not found");

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -159,9 +159,9 @@ class StraightLineStepper {
   /// @param [in,out] state is the propagation state associated with the track
   ///                 the magnetic field cell is used (and potentially updated)
   /// @param [in] pos is the field position
-  Vector3 getField(State& /*state*/, const Vector3& /*pos*/) const {
+  Result<Vector3> getField(State& /*state*/, const Vector3& /*pos*/) const {
     // get the field from the cell
-    return Vector3(0., 0., 0.);
+    return Result<Vector3>::success({0., 0., 0.});
   }
 
   /// Global particle position accessor

--- a/Core/include/Acts/Propagator/detail/LoopProtection.hpp
+++ b/Core/include/Acts/Propagator/detail/LoopProtection.hpp
@@ -29,8 +29,16 @@ struct LoopProtection {
     // Estimate the loop protection limit
     if (state.options.loopProtection) {
       // Get the field at the start position
-      Vector3 field =
+      auto fieldRes =
           stepper.getField(state.stepping, stepper.position(state.stepping));
+      if (!fieldRes.ok()) {
+        // there's no great way to return the error here, so resort to warning
+        // and not applying the loop protection in this case
+        ACTS_WARNING(
+            "Field lookup was unsuccessful, this is very likely an error");
+        return;
+      }
+      Vector3 field = *fieldRes;
       const double B = field.norm();
       if (B != 0.) {
         // Transverse component at start is taken for the loop protection

--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -72,8 +72,12 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   Vector3 momentumAtPCA(phiV, th, qOvP);
 
   // get B-field z-component at current position
-  double Bz = m_cfg.bField->getField(VectorHelpers::position(positionAtPCA),
-                                     state.fieldCache)[eZ];
+  auto field = m_cfg.bField->getField(VectorHelpers::position(positionAtPCA),
+                                      state.fieldCache);
+  if (!field.ok()) {
+    return field.error();
+  }
+  double Bz = (*field)[eZ];
   double rho;
   // Curvature is infinite w/o b field
   if (Bz == 0. || std::abs(qOvP) < m_cfg.minQoP) {

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -207,7 +207,11 @@ Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
   double cotTheta = 1. / std::tan(theta);
 
   // get B-field z-component at current position
-  double bZ = m_cfg.bField->getField(trkSurfaceCenter, state.fieldCache)[eZ];
+  auto fieldRes = m_cfg.bField->getField(trkSurfaceCenter, state.fieldCache);
+  if (!fieldRes.ok()) {
+    return fieldRes.error();
+  }
+  double bZ = (*fieldRes)[eZ];
 
   // The radius
   double r;

--- a/Core/src/MagneticField/CMakeLists.txt
+++ b/Core/src/MagneticField/CMakeLists.txt
@@ -3,4 +3,5 @@ target_sources(
   PRIVATE
     BFieldMapUtils.cpp
     SolenoidBField.cpp
+    MagneticFieldError.cpp
 )

--- a/Core/src/MagneticField/MagneticFieldError.cpp
+++ b/Core/src/MagneticField/MagneticFieldError.cpp
@@ -1,0 +1,36 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/MagneticField/MagneticFieldError.hpp"
+
+namespace {
+
+class MagneticFieldErrorCategory : public std::error_category {
+ public:
+  // Return a short descriptive name for the category.
+  const char* name() const noexcept final { return "MagneticFieldError"; }
+
+  // Return what each enum means in text.
+  std::string message(int c) const final {
+    using Acts::MagneticFieldError;
+
+    switch (static_cast<MagneticFieldError>(c)) {
+      case MagneticFieldError::OutOfBounds:
+        return "Interpolation out of bounds was requested";
+      default:
+        return "unknown";
+    }
+  }
+};
+
+}  // namespace
+
+std::error_code Acts::make_error_code(Acts::MagneticFieldError e) {
+  static MagneticFieldErrorCategory c;
+  return {static_cast<int>(e), c};
+}

--- a/Core/src/MagneticField/SolenoidBField.cpp
+++ b/Core/src/MagneticField/SolenoidBField.cpp
@@ -45,19 +45,19 @@ Acts::Vector3 Acts::SolenoidBField::getField(const Vector3& position) const {
   return xyzField;
 }
 
-Acts::Vector3 Acts::SolenoidBField::getField(
+Acts::Result<Acts::Vector3> Acts::SolenoidBField::getField(
     const Vector3& position, MagneticFieldProvider::Cache& /*cache*/) const {
-  return getField(position);
+  return Result<Vector3>::success(getField(position));
 }
 
 Acts::Vector2 Acts::SolenoidBField::getField(const Vector2& position) const {
   return multiCoilField(position, m_scale);
 }
 
-Acts::Vector3 Acts::SolenoidBField::getFieldGradient(
+Acts::Result<Acts::Vector3> Acts::SolenoidBField::getFieldGradient(
     const Vector3& position, ActsMatrix<3, 3>& /*derivative*/,
     MagneticFieldProvider::Cache& /*cache*/) const {
-  return getField(position);
+  return Result<Vector3>::success(getField(position));
 }
 
 Acts::Vector2 Acts::SolenoidBField::multiCoilField(const Vector2& pos,

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -180,8 +180,14 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
     }
 
     // Get the magnetic field at the bottom space point
-    Acts::Vector3 field = m_cfg.magneticField->getField(
+    auto fieldRes = m_cfg.magneticField->getField(
         {bottomSP->x(), bottomSP->y(), bottomSP->z()}, bCache);
+    if (!fieldRes.ok()) {
+      ACTS_ERROR("Field lookup error: " << fieldRes.error());
+      return ProcessCode::ABORT;
+    }
+    Acts::Vector3 field = *fieldRes;
+
     // Estimate the track parameters from seed
     auto optParams = Acts::estimateTrackParamsFromSeed(
         ctx.geoContext, seed.sp().begin(), seed.sp().end(), *surface, field,

--- a/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/ScalableBField.hpp
+++ b/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/ScalableBField.hpp
@@ -53,10 +53,11 @@ class ScalableBField final : public Acts::MagneticFieldProvider {
   ///
   /// @note The @p position is ignored and only kept as argument to provide
   ///       a consistent interface with other magnetic field services.
-  Acts::Vector3 getField(const Acts::Vector3& /*position*/,
-                         MagneticFieldProvider::Cache& gCache) const override {
+  Acts::Result<Acts::Vector3> getField(
+      const Acts::Vector3& /*position*/,
+      MagneticFieldProvider::Cache& gCache) const override {
     Cache& cache = gCache.get<Cache>();
-    return m_BField * cache.scalor;
+    return Acts::Result<Acts::Vector3>::success(m_BField * cache.scalor);
   }
 
   /// @brief retrieve magnetic field value & its gradient
@@ -71,11 +72,11 @@ class ScalableBField final : public Acts::MagneticFieldProvider {
   ///       a consistent interface with other magnetic field services.
   /// @note currently the derivative is not calculated
   /// @todo return derivative
-  Acts::Vector3 getFieldGradient(
+  Acts::Result<Acts::Vector3> getFieldGradient(
       const Acts::Vector3& /*position*/, Acts::ActsMatrix<3, 3>& /*derivative*/,
       MagneticFieldProvider::Cache& gCache) const override {
     Cache& cache = gCache.get<Cache>();
-    return m_BField * cache.scalor;
+    return Acts::Result<Acts::Vector3>::success(m_BField * cache.scalor);
   }
 
   Acts::MagneticFieldProvider::Cache makeCache(

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -115,9 +115,10 @@ class RootBFieldWriter {
     auto mapper = cfg.bField->getMapper();
 
     // Access the minima and maxima of all axes
-    auto minima = mapper.getMin();
-    auto maxima = mapper.getMax();
-    auto nBins = mapper.getNBins();
+    auto grid = cfg.bField->getGrid();
+    auto minima = grid.minPosition();
+    auto maxima = grid.maxPosition();
+    auto nBins = cfg.bField->getNBins();
 
     if (cfg.gridType == GridType::xyz) {
       ACTS_INFO("Map will be written out in cartesian coordinates (x,y,z).");

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -113,12 +113,12 @@ class RootBFieldWriter {
 
     // Get the underlying mapper of the InterpolatedBFieldMap
     auto mapper = cfg.bField->getMapper();
+    auto grid = mapper.getGrid();
 
     // Access the minima and maxima of all axes
-    auto grid = cfg.bField->getGrid();
     auto minima = grid.minPosition();
     auto maxima = grid.maxPosition();
-    auto nBins = cfg.bField->getNBins();
+    auto nBins = mapper.getNBins();
 
     if (cfg.gridType == GridType::xyz) {
       ACTS_INFO("Map will be written out in cartesian coordinates (x,y,z).");

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -208,7 +208,7 @@ class RootBFieldWriter {
             double raw_z = minZ + k * stepZ;
             Acts::Vector3 position(raw_x, raw_y, raw_z);
             if (cfg.bField->isInside(position)) {
-              auto bField = cfg.bField->getField(position);
+              auto bField = cfg.bField->getField(position).value();
 
               x = raw_x / Acts::UnitConstants::mm;
               y = raw_y / Acts::UnitConstants::mm;
@@ -296,7 +296,7 @@ class RootBFieldWriter {
             double raw_r = minR + j * stepR;
             Acts::Vector3 position(raw_r * cos(phi), raw_r * sin(phi), raw_z);
             if (cfg.bField->isInside(position)) {
-              auto bField = cfg.bField->getField(position, bCache);
+              auto bField = cfg.bField->getField(position, bCache).value();
               z = raw_z / Acts::UnitConstants::mm;
               r = raw_r / Acts::UnitConstants::mm;
               Bz = bField.z() / Acts::UnitConstants::T;

--- a/Tests/Benchmarks/SolenoidFieldBenchmark.cpp
+++ b/Tests/Benchmarks/SolenoidFieldBenchmark.cpp
@@ -124,7 +124,7 @@ int main(int argc, char* argv[]) {
               << std::flush;
     auto cache = bFieldMap.makeCache(mctx);
     const auto map_cached_result_cache = Acts::Test::microBenchmark(
-        [&] { return bFieldMap.getField(fixedPos, cache); }, iters_map);
+        [&] { return bFieldMap.getField(fixedPos, cache).value(); }, iters_map);
     std::cout << map_cached_result_cache << std::endl;
     csv("interp_cache_fixed", map_cached_result_cache);
   }
@@ -138,7 +138,8 @@ int main(int argc, char* argv[]) {
               << std::flush;
     auto cache2 = bFieldMap.makeCache(mctx);
     const auto map_rand_result_cache = Acts::Test::microBenchmark(
-        [&] { return bFieldMap.getField(genPos(), cache2); }, iters_map);
+        [&] { return bFieldMap.getField(genPos(), cache2).value(); },
+        iters_map);
     std::cout << map_rand_result_cache << std::endl;
     csv("interp_cache_random", map_rand_result_cache);
   }
@@ -181,7 +182,7 @@ int main(int argc, char* argv[]) {
     const auto map_adv_result_cache = Acts::Test::microBenchmark(
         [&] {
           pos += dir * h;
-          return bFieldMap.getField(pos, cache);
+          return bFieldMap.getField(pos, cache).value();
         },
         iters_map);
     std::cout << map_adv_result_cache << std::endl;

--- a/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
+++ b/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
@@ -119,7 +119,7 @@ BOOST_DATA_TEST_CASE(
 
   Vector3 pos(r * std::cos(phi), r * std::sin(phi), z);
   Vector3 B = bSolenoidField.getField(pos) / Acts::UnitConstants::T;
-  Vector3 Bm = bFieldMap.getField(pos, bCache) / Acts::UnitConstants::T;
+  Vector3 Bm = bFieldMap.getField(pos, bCache).value() / Acts::UnitConstants::T;
 
   // test less than 5% deviation
   if (std::abs(r - R) > 10 && (std::abs(z) < L / 3. || r > 20)) {

--- a/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
@@ -48,9 +48,9 @@ BOOST_DATA_TEST_CASE(ConstantBField_components,
 
   BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache).value());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache).value());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache).value());
 }
 
 /// @brief unit test for update of constant magnetic field
@@ -77,9 +77,9 @@ BOOST_DATA_TEST_CASE(ConstantBField_update,
 
   BOOST_CHECK_EQUAL(Btrue, BField.getField());
 
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache));
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache));
-  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache));
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(pos, bCache).value());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(Vector3(0, 0, 0), bCache).value());
+  BOOST_CHECK_EQUAL(Btrue, BField.getField(-2 * pos, bCache).value());
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
@@ -82,10 +82,10 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
   // test the cache interface
   auto bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache = bCacheAny.get<BField_t::Cache>();
-  CHECK_CLOSE_REL(b.getField(pos, bCacheAny),
+  CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
                   BField::value({{perp(pos), pos.z()}}), 1e-6);
 
-  CHECK_CLOSE_REL(b.getField(pos, bCacheAny),
+  CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
                   BField::value({{perp(pos), pos.z()}}), 1e-6);
   auto& c = *bCache.fieldCell;
   BOOST_CHECK(c.isInside(pos));
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
   pos << 0, 1.5, -2.5;
   bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache2 = bCacheAny.get<BField_t::Cache>();
-  CHECK_CLOSE_REL(b.getField(pos, bCacheAny),
+  CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
                   BField::value({{perp(pos), pos.z()}}), 1e-6);
   c = *bCache2.fieldCell;
   BOOST_CHECK(c.isInside(pos));
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
   pos << 2, 3, -4;
   bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache3 = bCacheAny.get<BField_t::Cache>();
-  CHECK_CLOSE_REL(b.getField(pos, bCacheAny),
+  CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
                   BField::value({{perp(pos), pos.z()}}), 1e-6);
   c = *bCache3.fieldCell;
   BOOST_CHECK(c.isInside(pos));

--- a/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
 
   // magnetic field known on grid in (r,z)
   detail::EquidistantAxis r(0.0, 4.0, 4u);
-  detail::EquidistantAxis z(-5, 5, 5u);
+  detail::EquidistantAxis z(-5, 7, 6u);
 
   using Grid_t =
       detail::Grid<Vector3, detail::EquidistantAxis, detail::EquidistantAxis>;
@@ -76,22 +76,64 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
 
   // create BField service
   BField_t b(std::move(config));
-
-  Vector3 pos;
-  pos << -3, 2.5, 1.7;
-  // test the cache interface
   auto bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache = bCacheAny.get<BField_t::Cache>();
+
+  auto check = [&](double i) {
+    BOOST_CHECK(b.isInside({0, 0, i * 4.9}));
+    BOOST_CHECK(!b.isInside({0, 0, i * 5.1}));
+
+    BOOST_CHECK(b.isInside({i * 2.9, 0, 0}));
+    BOOST_CHECK(!b.isInside({i * 3.1, 0, 0}));
+
+    BOOST_CHECK(b.isInside({0, i * 2.9, 0}));
+    BOOST_CHECK(!b.isInside({0, i * 3.1, 0}));
+
+    BOOST_CHECK(b.isInside({2, 2.2, 0}));
+    BOOST_CHECK(!b.isInside({2, 3, 0}));
+
+    BOOST_CHECK(b.isInside({i * 2, 2.2, 0}));
+    BOOST_CHECK(!b.isInside({i * 2, 3, 0}));
+
+    BOOST_CHECK(b.isInside({2, i * 2.2, 0}));
+    BOOST_CHECK(!b.isInside({2, i * 3, 0}));
+
+    BOOST_CHECK(b.isInside({i * 2, i * 2.2, 0}));
+    BOOST_CHECK(!b.isInside({i * 2, i * 3, 0}));
+  };
+
+  check(1);
+  check(-1);
+
+  Vector3 pos;
+  pos << -3, 2.5,
+      1.7;  // this was previously checked, but is actually out of bounds
+  BOOST_CHECK(!b.isInside(pos));
+  BOOST_CHECK(!b.getField(pos, bCacheAny).ok());
+
+  pos << -1.6, 2.5, 1.7;
+  BOOST_CHECK(b.isInside(pos));
   CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
                   BField::value({{perp(pos), pos.z()}}), 1e-6);
 
-  CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
-                  BField::value({{perp(pos), pos.z()}}), 1e-6);
   auto& c = *bCache.fieldCell;
   BOOST_CHECK(c.isInside(pos));
   CHECK_CLOSE_REL(c.getField(pos), BField::value({{perp(pos), pos.z()}}), 1e-6);
 
+  ActsMatrix<3, 3> deriv;
+
+  pos << 1, 1, -5.5;  // this position is outside the grid
+  BOOST_CHECK(!b.isInside(pos));
+  BOOST_CHECK(!b.getField(pos, bCacheAny).ok());
+  BOOST_CHECK(!b.getFieldGradient(pos, deriv, bCacheAny).ok());
+
+  pos << 1, 6, -1.7;  // this position is outside the grid
+  BOOST_CHECK(!b.isInside(pos));
+  BOOST_CHECK(!b.getField(pos, bCacheAny).ok());
+  BOOST_CHECK(!b.getFieldGradient(pos, deriv, bCacheAny).ok());
+
   pos << 0, 1.5, -2.5;
+  BOOST_CHECK(b.isInside(pos));
   bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache2 = bCacheAny.get<BField_t::Cache>();
   CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
@@ -101,6 +143,10 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
   CHECK_CLOSE_REL(c.getField(pos), BField::value({{perp(pos), pos.z()}}), 1e-6);
 
   pos << 2, 3, -4;
+  BOOST_CHECK(!b.isInside(pos));
+
+  pos << 2, 2.2, -4;
+  BOOST_CHECK(b.isInside(pos));
   bCacheAny = b.makeCache(mfContext);
   BField_t::Cache& bCache3 = bCacheAny.get<BField_t::Cache>();
   CHECK_CLOSE_REL(b.getField(pos, bCacheAny).value(),
@@ -110,10 +156,10 @@ BOOST_AUTO_TEST_CASE(InterpolatedBFieldMap_rz) {
   CHECK_CLOSE_REL(c.getField(pos), BField::value({{perp(pos), pos.z()}}), 1e-6);
 
   // some field cell tests
-  BOOST_CHECK(c.isInside((pos << 3, 2, -3.7).finished()));
-  BOOST_CHECK(c.isInside((pos << -2, 3, -4.7).finished()));
+  BOOST_CHECK(not c.isInside((pos << 3, 2, -3.7).finished()));
+  BOOST_CHECK(not c.isInside((pos << -2, 3, -4.7).finished()));
   BOOST_CHECK(not c.isInside((pos << -2, 3, 4.7).finished()));
-  BOOST_CHECK(not c.isInside((pos << 0, 2, -4.7).finished()));
+  BOOST_CHECK(c.isInside((pos << 0, 2, -4.7).finished()));
   BOOST_CHECK(not c.isInside((pos << 5, 2, 14.).finished()));
 }
 }  // namespace Test

--- a/Tests/UnitTests/Core/MagneticField/SolenoidBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/SolenoidBFieldTests.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(TestSolenoidBField) {
   SolenoidBField bField(cfg);
 
   auto cache = bField.makeCache(mfContext);
-  CHECK_CLOSE_ABS(bField.getField({0, 0, 0}, cache), Vector3(0, 0, 2.0_T),
-                  1e-6_T);
+  CHECK_CLOSE_ABS(bField.getField({0, 0, 0}, cache).value(),
+                  Vector3(0, 0, 2.0_T), 1e-6_T);
 
   // std::ofstream outf("solenoid.csv");
   // outf << "x;y;z;B_x;B_y;B_z" << std::endl;
@@ -50,8 +50,8 @@ BOOST_AUTO_TEST_CASE(TestSolenoidBField) {
   for (size_t i = 0; i < steps; i++) {
     double r = 1.5 * cfg.radius / steps * i;
     BOOST_TEST_CONTEXT("r=" << r) {
-      Vector3 B1 = bField.getField({r, 0, 0}, cache);
-      Vector3 B2 = bField.getField({-r, 0, 0}, cache);
+      Vector3 B1 = bField.getField({r, 0, 0}, cache).value();
+      Vector3 B2 = bField.getField({-r, 0, 0}, cache).value();
       CHECK_SMALL(B1.x(), tol);
       CHECK_SMALL(B1.y(), tol);
       BOOST_CHECK_GT(std::abs(B1.z()), tol_B);  // greater than zero
@@ -63,10 +63,10 @@ BOOST_AUTO_TEST_CASE(TestSolenoidBField) {
         // double z = cfg.L/steps * j - (cfg.L/2.);
         double z = (1.5 * cfg.length / 2.) / steps * j;
         BOOST_TEST_CONTEXT("z=" << z) {
-          Vector3 B_zp_rp = bField.getField({r, 0, z}, cache);
-          Vector3 B_zn_rp = bField.getField({r, 0, -z}, cache);
-          Vector3 B_zp_rn = bField.getField({-r, 0, z}, cache);
-          Vector3 B_zn_rn = bField.getField({-r, 0, -z}, cache);
+          Vector3 B_zp_rp = bField.getField({r, 0, z}, cache).value();
+          Vector3 B_zn_rp = bField.getField({r, 0, -z}, cache).value();
+          Vector3 B_zp_rn = bField.getField({-r, 0, z}, cache).value();
+          Vector3 B_zn_rn = bField.getField({-r, 0, -z}, cache).value();
 
           // outf << r << ";0;" << z << ";" << B_zp_rp.x() << ";" <<
           // B_zp_rp.y() << ";" << B_zp_rp.z() << std::endl;

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -273,9 +273,9 @@ BOOST_DATA_TEST_CASE(
   // this test assumes state.options.loopFraction = 0.5
   // maximum momentum allowed
   auto bCache = bField->makeCache(mfContext);
-  double pmax = options.pathLimit *
-                bField->getField(start.position(tgContext), bCache).norm() /
-                M_PI;
+  double pmax =
+      options.pathLimit *
+      bField->getField(start.position(tgContext), bCache).value().norm() / M_PI;
   if (p < pmax) {
     BOOST_CHECK_LT(status.pathLength, options.pathLimit);
   } else {

--- a/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
@@ -57,9 +57,10 @@ struct Stepper {
   ///                 the magnetic field cell is used (and potentially
   ///                 updated)
   /// @param [in] pos is the field position
-  Vector3 getField(SteppingState& /*unused*/, const Vector3& /*unused*/) const {
+  Result<Vector3> getField(SteppingState& /*unused*/,
+                           const Vector3& /*unused*/) const {
     // get the field from the cell
-    return field;
+    return Result<Vector3>::success(field);
   }
 
   /// Access method - position

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -180,9 +180,9 @@ struct PropagatorState {
     void transportCovarianceToBound(State& /*unused*/,
                                     const Surface& /*surface*/) const {}
 
-    Vector3 getField(State& /*state*/, const Vector3& /*pos*/) const {
+    Result<Vector3> getField(State& /*state*/, const Vector3& /*pos*/) const {
       // get the field from the cell
-      return Vector3(0., 0., 0.);
+      return Result<Vector3>::success({0., 0., 0.});
     }
   };
 

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -211,7 +211,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   CHECK_CLOSE_ABS(es.charge(esState), charge, eps);
   CHECK_CLOSE_ABS(es.time(esState), time, eps);
   //~ BOOST_CHECK_EQUAL(es.overstepLimit(esState), tolerance);
-  BOOST_CHECK_EQUAL(es.getField(esState, pos), bField->getField(pos, bCache));
+  BOOST_CHECK_EQUAL(es.getField(esState, pos).value(),
+                    bField->getField(pos, bCache).value());
 
   // Step size modifies
   const std::string originalStepSize = esState.stepSize.toString();

--- a/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
@@ -87,9 +87,9 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
   Acts::Vector3 pos0_rz(0., 0., 0.);
   Acts::Vector3 pos1_rz(1., 0., 1.);
   Acts::Vector3 pos2_rz(0., 2., 2.);
-  auto value0_rz = mapper_rz.getField(pos0_rz);
-  auto value1_rz = mapper_rz.getField(pos1_rz);
-  auto value2_rz = mapper_rz.getField(pos2_rz);
+  auto value0_rz = mapper_rz.getField(pos0_rz).value();
+  auto value1_rz = mapper_rz.getField(pos1_rz).value();
+  auto value2_rz = mapper_rz.getField(pos2_rz).value();
   // calculate what the value should be at this point
   auto b0_rz =
       bField_rz.at(localToGlobalBin_rz({{0, 0}}, {{rPos.size(), zPos.size()}}));
@@ -113,9 +113,9 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
   Acts::Vector3 pos0_xyz(0., 0., 0.);
   Acts::Vector3 pos1_xyz(1., 1., 1.);
   Acts::Vector3 pos2_xyz(2., 2., 2.);
-  auto value0_xyz = mapper_xyz.getField(pos0_xyz);
-  auto value1_xyz = mapper_xyz.getField(pos1_xyz);
-  auto value2_xyz = mapper_xyz.getField(pos2_xyz);
+  auto value0_xyz = mapper_xyz.getField(pos0_xyz).value();
+  auto value1_xyz = mapper_xyz.getField(pos1_xyz).value();
+  auto value2_xyz = mapper_xyz.getField(pos2_xyz).value();
   // calculate what the value should be at this point
   auto b0_xyz = bField_xyz.at(localToGlobalBin_xyz(
       {{0, 0, 0}}, {{xPos.size(), yPos.size(), zPos.size()}}));
@@ -199,17 +199,17 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   Acts::Vector3 pos3(1.2, -1.3, 1.4);
   Acts::Vector3 pos4(-1.2, -1.3, 1.4);
 
-  auto value0_rz = mapper_rz.getField(pos0);
-  auto value1_rz = mapper_rz.getField(pos1);
-  auto value2_rz = mapper_rz.getField(pos2);
-  auto value3_rz = mapper_rz.getField(pos3);
-  auto value4_rz = mapper_rz.getField(pos4);
+  auto value0_rz = mapper_rz.getField(pos0).value();
+  auto value1_rz = mapper_rz.getField(pos1).value();
+  auto value2_rz = mapper_rz.getField(pos2).value();
+  auto value3_rz = mapper_rz.getField(pos3).value();
+  auto value4_rz = mapper_rz.getField(pos4).value();
 
-  auto value0_xyz = mapper_xyz.getField(pos0);
-  auto value1_xyz = mapper_xyz.getField(pos1);
-  auto value2_xyz = mapper_xyz.getField(pos2);
-  auto value3_xyz = mapper_xyz.getField(pos3);
-  auto value4_xyz = mapper_xyz.getField(pos4);
+  auto value0_xyz = mapper_xyz.getField(pos0).value();
+  auto value1_xyz = mapper_xyz.getField(pos1).value();
+  auto value2_xyz = mapper_xyz.getField(pos2).value();
+  auto value3_xyz = mapper_xyz.getField(pos3).value();
+  auto value4_xyz = mapper_xyz.getField(pos4).value();
 
   // check z- and phi-symmetry
   CHECK_CLOSE_REL(perp(value0_rz), perp(value1_rz), 1e-10);
@@ -322,11 +322,11 @@ BOOST_DATA_TEST_CASE(
   Acts::Vector3 pos3(x, -y, z);
   Acts::Vector3 pos4(-x, -y, z);
 
-  auto value0_rz = mapper_rz.getField(pos0);
-  auto value1_rz = mapper_rz.getField(pos1);
-  auto value2_rz = mapper_rz.getField(pos2);
-  auto value3_rz = mapper_rz.getField(pos3);
-  auto value4_rz = mapper_rz.getField(pos4);
+  auto value0_rz = mapper_rz.getField(pos0).value();
+  auto value1_rz = mapper_rz.getField(pos1).value();
+  auto value2_rz = mapper_rz.getField(pos2).value();
+  auto value3_rz = mapper_rz.getField(pos3).value();
+  auto value4_rz = mapper_rz.getField(pos4).value();
 
   // check z- and phi-symmetry
   CHECK_CLOSE_REL(perp(value0_rz), perp(value1_rz), 1e-10);
@@ -338,11 +338,11 @@ BOOST_DATA_TEST_CASE(
   CHECK_CLOSE_REL(perp(value0_rz), perp(value4_rz), 1e-10);
   CHECK_CLOSE_REL(value0_rz.z(), value4_rz.z(), 1e-10);
 
-  auto value0_xyz = mapper_xyz.getField(pos0);
-  auto value1_xyz = mapper_xyz.getField(pos1);
-  auto value2_xyz = mapper_xyz.getField(pos2);
-  auto value3_xyz = mapper_xyz.getField(pos3);
-  auto value4_xyz = mapper_xyz.getField(pos4);
+  auto value0_xyz = mapper_xyz.getField(pos0).value();
+  auto value1_xyz = mapper_xyz.getField(pos1).value();
+  auto value2_xyz = mapper_xyz.getField(pos2).value();
+  auto value3_xyz = mapper_xyz.getField(pos3).value();
+  auto value4_xyz = mapper_xyz.getField(pos4).value();
 
   // checkx-,y-,z-symmetry - need to check close (because of interpolation
   // there can be small differences)

--- a/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
@@ -26,14 +26,14 @@ namespace Test {
 
 BOOST_AUTO_TEST_CASE(bfield_creation) {
   // create grid values
-  std::vector<double> rPos = {0., 1., 2.};
-  std::vector<double> xPos = {0., 1., 2.};
-  std::vector<double> yPos = {0., 1., 2.};
-  std::vector<double> zPos = {0., 1., 2.};
+  std::vector<double> rPos = {0., 1., 2., 3.};
+  std::vector<double> xPos = {0., 1., 2., 3.};
+  std::vector<double> yPos = {0., 1., 2., 3.};
+  std::vector<double> zPos = {0., 1., 2., 3.};
 
   // create b field in rz
   std::vector<Acts::Vector2> bField_rz;
-  for (int i = 0; i < 9; i++) {
+  for (int i = 0; i < 27; i++) {
     bField_rz.push_back(Acts::Vector2(i, i));
   }
 
@@ -56,17 +56,22 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
   // always assigned to the left boundary)
   BOOST_CHECK(mapper_rz.getMax() == maxima_rz);
 
-  // create b field in xyz
-  std::vector<Acts::Vector3> bField_xyz;
-  for (int i = 0; i < 27; i++) {
-    bField_xyz.push_back(Acts::Vector3(i, i, i));
-  }
-
   auto localToGlobalBin_xyz = [](std::array<size_t, 3> binsXYZ,
                                  std::array<size_t, 3> nBinsXYZ) {
     return (binsXYZ.at(0) * (nBinsXYZ.at(1) * nBinsXYZ.at(2)) +
             binsXYZ.at(1) * nBinsXYZ.at(2) + binsXYZ.at(2));
   };
+
+  rPos = {0., 1., 2., 3.};
+  xPos = {0., 1., 2., 3.};
+  yPos = {0., 1., 2., 3.};
+  zPos = {0., 1., 2., 3.};
+
+  // create b field in xyz
+  std::vector<Acts::Vector3> bField_xyz;
+  for (int i = 0; i < 81; i++) {
+    bField_xyz.push_back(Acts::Vector3(i, i, i));
+  }
 
   // create b field mapper in xyz
   auto mapper_xyz = Acts::fieldMapperXYZ(localToGlobalBin_xyz, xPos, yPos, zPos,
@@ -156,7 +161,7 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   // check number of bins, minima & maxima
   std::vector<size_t> nBins_rz = {rPos.size(), 2 * zPos.size() - 1};
   std::vector<double> minima_rz = {0., -2.};
-  std::vector<double> maxima_rz = {3., 3.};
+  std::vector<double> maxima_rz = {2., 2.};
   BOOST_CHECK(mapper_rz.getNBins() == nBins_rz);
   auto vec = mapper_rz.getNBins();
   auto vec0 = mapper_rz.getMin();
@@ -184,7 +189,7 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   std::vector<size_t> nBins_xyz = {2 * xPos.size() - 1, 2 * yPos.size() - 1,
                                    2 * zPos.size() - 1};
   std::vector<double> minima_xyz = {-2., -2., -2.};
-  std::vector<double> maxima_xyz = {3., 3., 3.};
+  std::vector<double> maxima_xyz = {2., 2., 2.};
   BOOST_CHECK(mapper_xyz.getNBins() == nBins_xyz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
@@ -280,7 +285,7 @@ BOOST_DATA_TEST_CASE(
   // check number of bins, minima & maxima
   std::vector<size_t> nBins_rz = {rPos.size(), 2 * zPos.size() - 1};
   std::vector<double> minima_rz = {0., -((nBins - 1) * stepZ)};
-  std::vector<double> maxima_rz = {nBins * stepR, nBins * stepZ};
+  std::vector<double> maxima_rz = {(nBins - 1) * stepR, (nBins - 1) * stepZ};
   BOOST_CHECK(mapper_rz.getNBins() == nBins_rz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
@@ -306,8 +311,8 @@ BOOST_DATA_TEST_CASE(
                                    2 * zPos.size() - 1};
   std::vector<double> minima_xyz = {
       -((nBins - 1) * stepR), -((nBins - 1) * stepR), -((nBins - 1) * stepZ)};
-  std::vector<double> maxima_xyz = {nBins * stepR, nBins * stepR,
-                                    nBins * stepZ};
+  std::vector<double> maxima_xyz = {(nBins - 1) * stepR, (nBins - 1) * stepR,
+                                    (nBins - 1) * stepZ};
   BOOST_CHECK(mapper_xyz.getNBins() == nBins_xyz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)


### PR DESCRIPTION
Previously, we didn't have a mechanism to communicate that a field query failed. This is problematic, because it's not clear what to do when for instance our interpolated field goes out of bounds (see #784). This PR makes `MagneticFieldProvider` require the `getField` and `getFieldGradient` methods to return `Result<Vector3>` instead of the bare vector. This changes the public interface slightly, and all clients need to be adjusted.

Additionally, the `InterpolatedBFieldMap` now checks each time a field cell is created or if the field is queried directly, whether the query position is out of bounds of the map, and will return a new `MagneticFieldError::OutOfBounds` if that happens.

BREAKING CHANGE:
- The signature of field query methods in `MagneticFieldProvider` changes from
   ```cpp
   virtual Vector3 getField(const Vector3& position, Cache& cache) const = 0;
   virtual Vector3 getFieldGradient(const Vector3& position, ActsMatrix<3, 3>& derivative, Cache& cache) const = 0;
   ```
   to
   ```cpp
   virtual Result<Vector3> getField(const Vector3& position, Cache& cache) const = 0;
   virtual Result<Vector3> getFieldGradient(const Vector3& position, ActsMatrix<3, 3>& derivative, Cache& cache) const = 0;
   ```
- `InterpolatedBFieldMap::getMin` and `InterpolatedBFieldMap::getMax` now return the extent of the valid **interpolation domain**, rather than the raw grid extent.