### PR TITLE
refactor!: Make Navigator use a config struct

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -718,8 +718,7 @@ class Navigator {
           } else {
             s = state.stepping.stepSize.min();
           }
-          opening_angle = std::atan((1 - std::cos(s * ir)) / std::sin(s *
-        ir));
+          opening_angle = std::atan((1 - std::cos(s * ir)) / std::sin(s * ir));
         }
 
         ACTS_VERBOSE(volInfo(state) << "Estimating opening angle for frustum
@@ -794,8 +793,8 @@ class Navigator {
       ++state.navigation.navLayerIter;
     }
 
-    // Re-initialize target at last layer, only in case it is the target
-    // volume This avoids a wrong target volume estimation
+    // Re-initialize target at last layer, only in case it is the target volume
+    // This avoids a wrong target volume estimation
     if (state.navigation.currentVolume == state.navigation.targetVolume) {
       initializeTarget(state, stepper);
     }

--- a/Examples/Algorithms/Fatras/src/FatrasAlgorithm.cpp
+++ b/Examples/Algorithms/Fatras/src/FatrasAlgorithm.cpp
@@ -107,10 +107,11 @@ struct FatrasAlgorithmSimulationT final
       : simulation(
             ChargedSimulation(
                 ChargedPropagator(ChargedStepper(cfg.magneticField),
-                                  cfg.trackingGeometry),
+                                  Acts::Navigator{{cfg.trackingGeometry}}),
                 Acts::getDefaultLogger("Simulation", lvl)),
             NeutralSimulation(
-                NeutralPropagator(NeutralStepper(), cfg.trackingGeometry),
+                NeutralPropagator(NeutralStepper(),
+                                  Acts::Navigator{{cfg.trackingGeometry}}),
                 Acts::getDefaultLogger("Simulation", lvl))) {
     using namespace ActsFatras;
     using namespace ActsFatras::detail;

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmFunction.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithmFunction.cpp
@@ -48,10 +48,11 @@ ActsExamples::TrackFindingAlgorithm::makeTrackFinderFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField) {
   Stepper stepper(std::move(magneticField));
-  Navigator navigator(trackingGeometry);
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Navigator::Config cfg{trackingGeometry};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Navigator navigator(cfg);
   Propagator propagator(std::move(stepper), std::move(navigator));
   CKF trackFinder(std::move(propagator));
 

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunction.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunction.cpp
@@ -64,10 +64,11 @@ ActsExamples::TrackFittingAlgorithm::makeTrackFitterFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField) {
   Stepper stepper(std::move(magneticField));
-  Acts::Navigator navigator(trackingGeometry);
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Acts::Navigator::Config cfg{trackingGeometry};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Acts::Navigator navigator(cfg);
   Propagator propagator(std::move(stepper), std::move(navigator));
   Fitter trackFitter(std::move(propagator));
 

--- a/Examples/Run/Common/src/MaterialMappingBase.cpp
+++ b/Examples/Run/Common/src/MaterialMappingBase.cpp
@@ -117,10 +117,7 @@ int materialMappingExample(int argc, char* argv[],
   ActsExamples::MaterialMapping::Config mmAlgConfig(geoContext, mfContext);
   if (mapSurface) {
     // Get a Navigator
-    Acts::Navigator navigator(tGeometry);
-    navigator.resolveSensitive = true;
-    navigator.resolveMaterial = true;
-    navigator.resolvePassive = true;
+    Acts::Navigator navigator({tGeometry, true, true, true});
     // Make stepper and propagator
     SlStepper stepper;
     Propagator propagator(std::move(stepper), std::move(navigator));
@@ -133,7 +130,7 @@ int materialMappingExample(int argc, char* argv[],
   }
   if (mapVolume) {
     // Get a Navigator
-    Acts::Navigator navigator(tGeometry);
+    Acts::Navigator navigator({tGeometry});
     // Make stepper and propagator
     SlStepper stepper;
     Propagator propagator(std::move(stepper), std::move(navigator));

--- a/Examples/Run/Common/src/MaterialValidationBase.cpp
+++ b/Examples/Run/Common/src/MaterialValidationBase.cpp
@@ -53,10 +53,12 @@ ActsExamples::ProcessCode setupPropagation(
   auto logLevel = ActsExamples::Options::readLogLevel(vm);
 
   // Get a Navigator
-  Acts::Navigator navigator(tGeometry);
-  navigator.resolvePassive = true;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Acts::Navigator::Config cfg;
+  cfg.trackingGeometry = tGeometry;
+  cfg.resolvePassive = true;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Acts::Navigator navigator(cfg);
 
   // Resolve the bfield map template and create the propgator
   using Stepper = Acts::EigenStepper<
@@ -98,7 +100,7 @@ ActsExamples::ProcessCode setupStraightLinePropagation(
   auto logLevel = ActsExamples::Options::readLogLevel(vm);
 
   // Get a Navigator
-  Acts::Navigator navigator(tGeometry);
+  Acts::Navigator navigator({tGeometry});
 
   // Straight line stepper
   using SlStepper = Acts::StraightLineStepper;

--- a/Examples/Run/Common/src/PropagationExampleBase.cpp
+++ b/Examples/Run/Common/src/PropagationExampleBase.cpp
@@ -80,11 +80,11 @@ int propagationExample(int argc, char* argv[],
   auto setupPropagator = [&](auto&& stepper) {
     using Stepper = std::decay_t<decltype(stepper)>;
     using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
-    Acts::Navigator navigator(tGeometry);
-    navigator.resolveMaterial = vm["prop-resolve-material"].template as<bool>();
-    navigator.resolvePassive = vm["prop-resolve-passive"].template as<bool>();
-    navigator.resolveSensitive =
-        vm["prop-resolve-sensitive"].template as<bool>();
+    Acts::Navigator::Config navCfg{tGeometry};
+    navCfg.resolveMaterial = vm["prop-resolve-material"].template as<bool>();
+    navCfg.resolvePassive = vm["prop-resolve-passive"].template as<bool>();
+    navCfg.resolveSensitive = vm["prop-resolve-sensitive"].template as<bool>();
+    Acts::Navigator navigator(navCfg);
 
     Propagator propagator(std::move(stepper), std::move(navigator));
 

--- a/Tests/IntegrationTests/Autodiff/PropagationAutodiffDenseConstant.cpp
+++ b/Tests/IntegrationTests/Autodiff/PropagationAutodiffDenseConstant.cpp
@@ -82,7 +82,7 @@ inline Propagator makePropagator(double bz) {
 
   auto magField = std::make_shared<MagneticField>(Acts::Vector3(0.0, 0.0, bz));
   Stepper stepper(std::move(magField));
-  return Propagator(std::move(stepper), Acts::Navigator(makeDetector()));
+  return Propagator(std::move(stepper), Acts::Navigator({makeDetector()}));
 }
 
 inline RiddersPropagator makeRiddersPropagator(double bz) {
@@ -90,7 +90,8 @@ inline RiddersPropagator makeRiddersPropagator(double bz) {
 
   auto magField = std::make_shared<MagneticField>(Acts::Vector3(0.0, 0.0, bz));
   Stepper stepper(std::move(magField));
-  return RiddersPropagator(std::move(stepper), Acts::Navigator(makeDetector()));
+  return RiddersPropagator(std::move(stepper),
+                           Acts::Navigator({makeDetector()}));
 }
 
 }  // namespace

--- a/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
+++ b/Tests/IntegrationTests/Fatras/FatrasSimulationTests.cpp
@@ -163,7 +163,7 @@ BOOST_DATA_TEST_CASE(FatrasSimulation, dataset, pdg, phi, eta, p,
   auto trackingGeometry = geoBuilder();
 
   // construct the propagators
-  Navigator navigator(trackingGeometry);
+  Navigator navigator({trackingGeometry});
   ChargedStepper chargedStepper(
       std::make_shared<Acts::ConstantBField>(Acts::Vector3{0, 0, 1_T}));
   ChargedPropagator chargedPropagator(std::move(chargedStepper), navigator);

--- a/Tests/IntegrationTests/PropagationDenseConstant.cpp
+++ b/Tests/IntegrationTests/PropagationDenseConstant.cpp
@@ -79,7 +79,7 @@ inline Propagator makePropagator(double bz) {
 
   auto magField = std::make_shared<MagneticField>(Acts::Vector3(0.0, 0.0, bz));
   Stepper stepper(std::move(magField));
-  return Propagator(std::move(stepper), Acts::Navigator(makeDetector()));
+  return Propagator(std::move(stepper), Acts::Navigator{{makeDetector()}});
 }
 
 inline RiddersPropagator makeRiddersPropagator(double bz) {
@@ -87,7 +87,8 @@ inline RiddersPropagator makeRiddersPropagator(double bz) {
 
   auto magField = std::make_shared<MagneticField>(Acts::Vector3(0.0, 0.0, bz));
   Stepper stepper(std::move(magField));
-  return RiddersPropagator(std::move(stepper), Acts::Navigator(makeDetector()));
+  return RiddersPropagator(std::move(stepper),
+                           Acts::Navigator{{makeDetector()}});
 }
 
 }  // namespace

--- a/Tests/UnitTests/Core/Geometry/BVHDataTestCase.hpp
+++ b/Tests/UnitTests/Core/Geometry/BVHDataTestCase.hpp
@@ -77,7 +77,7 @@ BOOST_DATA_TEST_CASE(
   using PropagatorType = Propagator<Stepper, Navigator>;
 
   Stepper stepper{};
-  Navigator navigator(tg);
+  Navigator navigator({tg});
   PropagatorType propagator(std::move(stepper), navigator);
 
   using ActionList = Acts::ActionList<SteppingLogger>;

--- a/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
@@ -99,7 +99,7 @@ namespace Test {
 /// Test the filling and conversion
 BOOST_AUTO_TEST_CASE(SurfaceMaterialMapper_tests) {
   /// We need a Navigator, Stepper to build a Propagator
-  Navigator navigator(tGeometry);
+  Navigator navigator({tGeometry});
   StraightLineStepper stepper;
   SurfaceMaterialMapper::StraightLinePropagator propagator(
       std::move(stepper), std::move(navigator));

--- a/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(SurfaceMaterialMapper_tests) {
   std::shared_ptr<const TrackingGeometry> tGeometry = tgb.trackingGeometry(gc);
 
   /// We need a Navigator, Stepper to build a Propagator
-  Navigator navigator(tGeometry);
+  Navigator navigator({tGeometry});
   StraightLineStepper stepper;
   VolumeMaterialMapper::StraightLinePropagator propagator(std::move(stepper),
                                                           std::move(navigator));
@@ -231,7 +231,9 @@ BOOST_AUTO_TEST_CASE(VolumeMaterialMapper_comparison_tests) {
 
   // Construct a simple propagation through the detector
   StraightLineStepper sls;
-  Navigator nav(std::move(detector));
+  Navigator::Config navCfg;
+  navCfg.trackingGeometry = std::move(detector);
+  Navigator nav(navCfg);
   Propagator<StraightLineStepper, Navigator> prop(sls, nav);
 
   // Set some start parameters

--- a/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
@@ -40,7 +40,7 @@ CylindricalTrackingGeometry cGeometry(tgContext);
 auto tGeometry = cGeometry();
 
 // Create a navigator for this tracking geometry
-Navigator navigator(tGeometry);
+Navigator navigator({tGeometry});
 DirectNavigator dnavigator;
 
 using BField = ConstantBField;

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -48,7 +48,7 @@ CylindricalTrackingGeometry cGeometry(tgContext);
 auto tGeometry = cGeometry();
 
 // Get the navigator and provide the TrackingGeometry
-Navigator navigator(tGeometry);
+Navigator navigator({tGeometry});
 
 using BFieldType = ConstantBField;
 using EigenStepperType = EigenStepper<>;

--- a/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
@@ -105,10 +105,11 @@ BOOST_AUTO_TEST_CASE(kalman_extrapolator) {
   auto detector = cGeometry();
 
   // The Navigator through the detector geometry
-  Navigator navigator(detector);
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Navigator::Config cfg{detector};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Navigator navigator(cfg);
 
   // Configure propagation with deactivated B-field
   auto bField = std::make_shared<ConstantBField>(Vector3(0., 0., 0.));

--- a/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
@@ -48,8 +48,8 @@ CylindricalTrackingGeometry cGeometry(tgContext);
 auto tGeometry = cGeometry();
 
 // create a navigator for this tracking geometry
-Navigator navigatorES(tGeometry);
-Navigator navigatorSL(tGeometry);
+Navigator navigatorES({tGeometry});
+Navigator navigatorSL({tGeometry});
 
 using BField = ConstantBField;
 using EigenStepper = Acts::EigenStepper<>;

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -284,12 +284,6 @@ auto tGeometry = cGeometry();
 bool debug = true;
 
 BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
-  // create a navigator
-  Navigator navigator;
-  navigator.resolveSensitive = false;
-  navigator.resolveMaterial = false;
-  navigator.resolvePassive = false;
-
   // position and direction vector
   Vector4 position4(0., 0., 0, 0);
   Vector3 momentum(1., 1., 0);
@@ -309,103 +303,128 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
   // (1) Test for inactivity
   //
   // Run without anything present
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr));
+  {
+    Navigator::Config navCfg;
+    navCfg.resolveSensitive = false;
+    navCfg.resolveMaterial = false;
+    navCfg.resolvePassive = false;
+    Navigator navigator{navCfg};
+
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr));
+  }
 
   // Run with geometry but without resolving
-  navigator.trackingGeometry = tGeometry;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr));
+  {
+    Navigator::Config navCfg;
+    navCfg.resolveSensitive = false;
+    navCfg.resolveMaterial = false;
+    navCfg.resolvePassive = false;
+    navCfg.trackingGeometry = tGeometry;
+    Navigator navigator{navCfg};
+
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr));
+  }
 
   // Run with geometry and resolving but broken navigation for various reasons
-  navigator.resolveSensitive = true;
-  navigator.resolveMaterial = true;
-  navigator.resolvePassive = true;
-  state.navigation.navigationBreak = true;
-  // a) Because target is reached
-  state.navigation.targetReached = true;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr));
-  // b) Beacause of no target surface
-  state.navigation.targetReached = false;
-  state.navigation.targetSurface = nullptr;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr, nullptr,
-                                         nullptr, nullptr, nullptr));
-  // c) Because the target surface is reached
-  const Surface* startSurf = tGeometry->getBeamline();
-  state.stepping.pos4.segment<3>(Acts::ePos0) =
-      startSurf->center(state.geoContext);
-  const Surface* targetSurf = startSurf;
-  state.navigation.targetSurface = targetSurf;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
-                                         nullptr, nullptr, targetSurf, nullptr,
-                                         nullptr, nullptr, targetSurf));
+  {
+    Navigator::Config navCfg;
+    navCfg.resolveSensitive = true;
+    navCfg.resolveMaterial = true;
+    navCfg.resolvePassive = true;
+    navCfg.trackingGeometry = tGeometry;
+    Navigator navigator{navCfg};
 
-  //
-  // (2) Test the initialisation
-  //
-  // a) Initialise without additional information
-  state.navigation = Navigator::State();
-  state.stepping.pos4 << 0., 0., 0., 0.;
-  const TrackingVolume* worldVol = tGeometry->highestTrackingVolume();
-  const TrackingVolume* startVol = tGeometry->lowestTrackingVolume(
-      state.geoContext, stepper.position(state.stepping));
-  const Layer* startLay = startVol->associatedLayer(
-      state.geoContext, stepper.position(state.stepping));
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, worldVol, startVol,
-                                         startLay, nullptr, nullptr, startVol,
-                                         nullptr, nullptr, nullptr));
+    state.navigation.navigationBreak = true;
+    // a) Because target is reached
+    state.navigation.targetReached = true;
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr));
 
-  // b) Initialise having a start surface
-  state.navigation = Navigator::State();
-  state.navigation.startSurface = startSurf;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, worldVol, startVol,
-                                         startLay, startSurf, startSurf,
-                                         startVol, nullptr, nullptr, nullptr));
+    // b) Beacause of no target surface
+    state.navigation.targetReached = false;
+    state.navigation.targetSurface = nullptr;
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr, nullptr,
+                                           nullptr, nullptr, nullptr));
+    // c) Because the target surface is reached
+    const Surface* startSurf = tGeometry->getBeamline();
+    state.stepping.pos4.segment<3>(Acts::ePos0) =
+        startSurf->center(state.geoContext);
+    const Surface* targetSurf = startSurf;
+    state.navigation.targetSurface = targetSurf;
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(
+        state.navigation, nullptr, nullptr, nullptr, nullptr, targetSurf,
+        nullptr, nullptr, nullptr, targetSurf));
 
-  // c) Initialise having a start volume
-  state.navigation = Navigator::State();
-  state.navigation.startVolume = startVol;
-  navigator.status(state, stepper);
-  BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
-  BOOST_CHECK(testNavigatorStatePointers(state.navigation, worldVol, startVol,
-                                         startLay, nullptr, nullptr, startVol,
-                                         nullptr, nullptr, nullptr));
+    //
+    // (2) Test the initialisation
+    //
+    // a) Initialise without additional information
+    state.navigation = Navigator::State();
+    state.stepping.pos4 << 0., 0., 0., 0.;
+    const TrackingVolume* worldVol = tGeometry->highestTrackingVolume();
+    const TrackingVolume* startVol = tGeometry->lowestTrackingVolume(
+        state.geoContext, stepper.position(state.stepping));
+    const Layer* startLay = startVol->associatedLayer(
+        state.geoContext, stepper.position(state.stepping));
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, worldVol, startVol,
+                                           startLay, nullptr, nullptr, startVol,
+                                           nullptr, nullptr, nullptr));
+
+    // b) Initialise having a start surface
+    state.navigation = Navigator::State();
+    state.navigation.startSurface = startSurf;
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(
+        state.navigation, worldVol, startVol, startLay, startSurf, startSurf,
+        startVol, nullptr, nullptr, nullptr));
+
+    // c) Initialise having a start volume
+    state.navigation = Navigator::State();
+    state.navigation.startVolume = startVol;
+    navigator.status(state, stepper);
+    BOOST_CHECK(testNavigatorStateVectors(state.navigation, 0u, 0u, 0u, 0u));
+    BOOST_CHECK(testNavigatorStatePointers(state.navigation, worldVol, startVol,
+                                           startLay, nullptr, nullptr, startVol,
+                                           nullptr, nullptr, nullptr));
+  }
 }
 
 BOOST_AUTO_TEST_CASE(Navigator_target_methods) {
   // create a navigator
-  Navigator navigator;
-  navigator.trackingGeometry = tGeometry;
-  navigator.resolveSensitive = true;
-  navigator.resolveMaterial = true;
-  navigator.resolvePassive = false;
+  Navigator::Config navCfg;
+  navCfg.trackingGeometry = tGeometry;
+  navCfg.resolveSensitive = true;
+  navCfg.resolveMaterial = true;
+  navCfg.resolvePassive = false;
+  Navigator navigator{navCfg};
 
   // create a navigator for the Bounding Volume Hierarchy test
   CubicBVHTrackingGeometry grid(20, 1000, 5);
-  Navigator BVHNavigator;
-  BVHNavigator.trackingGeometry = grid.trackingGeometry;
-  BVHNavigator.resolveSensitive = true;
-  BVHNavigator.resolveMaterial = true;
-  BVHNavigator.resolvePassive = false;
+  Navigator::Config bvhNavCfg;
+  bvhNavCfg.trackingGeometry = grid.trackingGeometry;
+  bvhNavCfg.resolveSensitive = true;
+  bvhNavCfg.resolveMaterial = true;
+  bvhNavCfg.resolvePassive = false;
+  Navigator BVHNavigator{bvhNavCfg};
 
   // position and direction vector
   Vector4 position4(0., 0., 0, 0);

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -529,10 +529,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
       tgb.trackingGeometry(tgContext);
 
   // Build navigator
-  Navigator naviVac(vacuum);
-  naviVac.resolvePassive = true;
-  naviVac.resolveMaterial = true;
-  naviVac.resolveSensitive = true;
+  Navigator naviVac({vacuum, true, true, true});
 
   // Set initial parameters for the particle track
   Covariance cov = Covariance::Identity();
@@ -638,10 +635,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
       tgb.trackingGeometry(tgContext);
 
   // Build navigator
-  Navigator naviMat(material);
-  naviMat.resolvePassive = true;
-  naviMat.resolveMaterial = true;
-  naviMat.resolveSensitive = true;
+  Navigator naviMat({material, true, true, true});
 
   // Set initial parameters for the particle track
   Covariance cov = Covariance::Identity();
@@ -805,10 +799,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   std::shared_ptr<const TrackingGeometry> det = tgb.trackingGeometry(tgContext);
 
   // Build navigator
-  Navigator naviDet(det);
-  naviDet.resolvePassive = true;
-  naviDet.resolveMaterial = true;
-  naviDet.resolveSensitive = true;
+  Navigator naviDet({det, true, true, true});
 
   // Set initial parameters for the particle track
   CurvilinearTrackParameters sbtp(Vector4::Zero(), 0_degree, 90_degree, 5_GeV,
@@ -1051,10 +1042,7 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
       tgb.trackingGeometry(tgContext);
 
   // Build navigator
-  Navigator naviVac(detector);
-  naviVac.resolvePassive = true;
-  naviVac.resolveMaterial = true;
-  naviVac.resolveSensitive = true;
+  Navigator naviVac({detector, true, true, true});
 
   // Set initial parameters for the particle track
   CurvilinearTrackParameters sbtp(Vector4::Zero(), 0_degree, 90_degree,

--- a/Tests/UnitTests/Core/Seeding/EstimateTrackParamsFromSeedTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/EstimateTrackParamsFromSeedTest.cpp
@@ -79,10 +79,12 @@ std::default_random_engine rng(42);
 BOOST_AUTO_TEST_CASE(trackparameters_estimation_test) {
   // Construct a propagator with the cylinderal geometry and a constant magnetic
   // field along z
-  Acts::Navigator navigator(geometry);
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Acts::Navigator navigator({
+      geometry,
+      true,  // sensitive
+      true,  // material
+      false  // passive
+  });
   auto field =
       std::make_shared<Acts::ConstantBField>(Acts::Vector3(0.0, 0.0, 2._T));
   ConstantFieldStepper stepper(std::move(field));

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -156,10 +156,11 @@ struct Fixture {
   // Construct a straight-line propagator.
   static StraightPropagator makeStraightPropagator(
       std::shared_ptr<const Acts::TrackingGeometry> geo) {
-    Acts::Navigator navigator(std::move(geo));
-    navigator.resolvePassive = false;
-    navigator.resolveMaterial = true;
-    navigator.resolveSensitive = true;
+    Acts::Navigator::Config cfg{geo};
+    cfg.resolvePassive = false;
+    cfg.resolveMaterial = true;
+    cfg.resolveSensitive = true;
+    Acts::Navigator navigator{cfg};
     Acts::StraightLineStepper stepper;
     return StraightPropagator(std::move(stepper), std::move(navigator));
   }
@@ -167,10 +168,11 @@ struct Fixture {
   // Construct a propagator using a constant magnetic field along z.
   static ConstantFieldPropagator makeConstantFieldPropagator(
       std::shared_ptr<const Acts::TrackingGeometry> geo, double bz) {
-    Acts::Navigator navigator(std::move(geo));
-    navigator.resolvePassive = false;
-    navigator.resolveMaterial = true;
-    navigator.resolveSensitive = true;
+    Acts::Navigator::Config cfg{geo};
+    cfg.resolvePassive = false;
+    cfg.resolveMaterial = true;
+    cfg.resolveSensitive = true;
+    Acts::Navigator navigator{cfg};
     auto field =
         std::make_shared<Acts::ConstantBField>(Acts::Vector3(0.0, 0.0, bz));
     ConstantFieldStepper stepper(std::move(field));

--- a/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
@@ -83,10 +83,11 @@ struct TestOutlierFinder {
 // Construct a straight-line propagator.
 StraightPropagator makeStraightPropagator(
     std::shared_ptr<const Acts::TrackingGeometry> geo) {
-  Acts::Navigator navigator(std::move(geo));
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Acts::Navigator::Config cfg{geo};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Acts::Navigator navigator(cfg);
   Acts::StraightLineStepper stepper;
   return StraightPropagator(std::move(stepper), std::move(navigator));
 }
@@ -94,10 +95,11 @@ StraightPropagator makeStraightPropagator(
 // Construct a propagator using a constant magnetic field along z.
 ConstantFieldPropagator makeConstantFieldPropagator(
     std::shared_ptr<const Acts::TrackingGeometry> geo, double bz) {
-  Acts::Navigator navigator(std::move(geo));
-  navigator.resolvePassive = false;
-  navigator.resolveMaterial = true;
-  navigator.resolveSensitive = true;
+  Acts::Navigator::Config cfg{geo};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Acts::Navigator navigator(cfg);
   auto field =
       std::make_shared<Acts::ConstantBField>(Acts::Vector3(0.0, 0.0, bz));
   ConstantFieldStepper stepper(std::move(field));

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -222,10 +222,11 @@ static inline std::string testMultiTrajectory(IVisualization3D& helper) {
 
   // The KalmanFitter - we use the eigen stepper for covariance transport
   std::cout << "Construct KalmanFitter and perform fit" << std::endl;
-  Navigator rNavigator(detector);
-  rNavigator.resolvePassive = false;
-  rNavigator.resolveMaterial = true;
-  rNavigator.resolveSensitive = true;
+  Navigator::Config cfg{detector};
+  cfg.resolvePassive = false;
+  cfg.resolveMaterial = true;
+  cfg.resolveSensitive = true;
+  Navigator rNavigator(cfg);
 
   // Configure propagation with deactivated B-field
   auto bField = std::make_shared<ConstantBField>(Vector3(0., 0., 0.));


### PR DESCRIPTION
Navigator currently has a number of members that act as configuration properties. In order to comply with our general philosophy to use nested `Config` structs for these kinds of properties, this PR adds `Navigator::Config`.

BREAKING CHANGE: The constructor and public members of `Acts::Navigator` changes. When before it could be created like
```cpp
Acts::Navigator nav{tGeometry};
nav.resolveSensitive = true;
nav.resolveMaterial = true;
nav.resolvePassive = true;
```
it must now be created like 
```cpp
Acts::Navigator::Config cfg;
cfg.trackingGeometry = tGeometry;
nav.resolveSensitive = true;
nav.resolveMaterial = true;
nav.resolvePassive = true;
Acts::Navigator nav{cfg};
```
Since `trackingGeometry` is the first member of `Acts::Navigator::Config`, if you don't want to change the `resolve*` values, you can also write
```cpp
Acts::Navigator nav{{tGeometry}};
```