### PR TITLE
refactor!: Remove interpolated magnetic field mapper

### DIFF
--- a/Core/include/Acts/MagneticField/BFieldMapUtils.hpp
+++ b/Core/include/Acts/MagneticField/BFieldMapUtils.hpp
@@ -26,7 +26,7 @@ namespace Acts {
 
 class SolenoidBField;
 
-/// Method to setup the FieldMapper
+/// Method to setup the FieldMap
 /// @param localToGlobalBin Function mapping the local bins of r,z to the global
 /// bin of the map magnetic field value
 ///
@@ -66,18 +66,18 @@ class SolenoidBField;
 /// e.g. we have the grid values r={0,1} with BFieldValues={2,3} on the r axis.
 /// If the flag is set to true the r-axis grid values will be set to {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-Acts::InterpolatedBFieldMapper<
+Acts::InterpolatedBFieldMap<
     Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                        Acts::detail::EquidistantAxis>>
-fieldMapperRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
-                                         std::array<size_t, 2> nBinsRZ)>&
-                  localToGlobalBin,
-              std::vector<double> rPos, std::vector<double> zPos,
-              std::vector<Acts::Vector2> bField,
-              double lengthUnit = UnitConstants::mm,
-              double BFieldUnit = UnitConstants::T, bool firstQuadrant = false);
+fieldMapRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
+                                      std::array<size_t, 2> nBinsRZ)>&
+               localToGlobalBin,
+           std::vector<double> rPos, std::vector<double> zPos,
+           std::vector<Acts::Vector2> bField,
+           double lengthUnit = UnitConstants::mm,
+           double BFieldUnit = UnitConstants::T, bool firstQuadrant = false);
 
-/// Method to setup the FieldMapper
+/// Method to setup the FieldMap
 /// @param localToGlobalBin Function mapping the local bins of x,y,z to the
 /// global bin of the map magnetic field value
 ///
@@ -127,16 +127,16 @@ fieldMapperRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
 /// e.g. we have the grid values z={0,1} with BFieldValues={2,3} on the r axis.
 /// If the flag is set to true the z-axis grid values will be set to {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-Acts::InterpolatedBFieldMapper<Acts::detail::Grid<
+Acts::InterpolatedBFieldMap<Acts::detail::Grid<
     Acts::Vector3, Acts::detail::EquidistantAxis, Acts::detail::EquidistantAxis,
     Acts::detail::EquidistantAxis>>
-fieldMapperXYZ(const std::function<size_t(std::array<size_t, 3> binsXYZ,
-                                          std::array<size_t, 3> nBinsXYZ)>&
-                   localToGlobalBin,
-               std::vector<double> xPos, std::vector<double> yPos,
-               std::vector<double> zPos, std::vector<Acts::Vector3> bField,
-               double lengthUnit = UnitConstants::mm,
-               double BFieldUnit = UnitConstants::T, bool firstOctant = false);
+fieldMapXYZ(const std::function<size_t(std::array<size_t, 3> binsXYZ,
+                                       std::array<size_t, 3> nBinsXYZ)>&
+                localToGlobalBin,
+            std::vector<double> xPos, std::vector<double> yPos,
+            std::vector<double> zPos, std::vector<Acts::Vector3> bField,
+            double lengthUnit = UnitConstants::mm,
+            double BFieldUnit = UnitConstants::T, bool firstOctant = false);
 
 /// Function which takes an existing SolenoidBField instance and
 /// creates a field mapper by sampling grid points from the analytical
@@ -148,12 +148,10 @@ fieldMapperXYZ(const std::function<size_t(std::array<size_t, 3> binsXYZ,
 /// @param field the solenoid field instance
 ///
 /// @return A field mapper instance for use in interpolation.
-Acts::InterpolatedBFieldMapper<
+Acts::InterpolatedBFieldMap<
     Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                        Acts::detail::EquidistantAxis>>
-solenoidFieldMapper(std::pair<double, double> rlim,
-                    std::pair<double, double> zlim,
-                    std::pair<size_t, size_t> nbins,
-                    const SolenoidBField& field);
+solenoidFieldMap(std::pair<double, double> rlim, std::pair<double, double> zlim,
+                 std::pair<size_t, size_t> nbins, const SolenoidBField& field);
 
 }  // namespace Acts

--- a/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
+++ b/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
@@ -22,20 +22,30 @@
 
 namespace Acts {
 
-/// @brief struct for mapping global 3D positions to field values
+/// @ingroup MagneticField
+/// @brief interpolate magnetic field value from field values on a given grid
 ///
-/// @tparam DIM_POS Dimensionality of position in magnetic field map
-/// @tparam DIM_BFIELD Dimensionality of BField in magnetic field map
+/// This class implements a magnetic field service which is initialized by a
+/// field map defined by:
+/// - a list of field values on a regular grid in some n-Dimensional space,
+/// - a transformation of global 3D coordinates onto this n-Dimensional
+/// space.
+/// - a transformation of local n-Dimensional magnetic field coordinates into
+/// global (cartesian) 3D coordinates
 ///
-/// Global 3D positions are transformed into a @c DIM_POS Dimensional
-/// vector which
-/// is used to look up the magnetic field value in the underlying field map.
-template <typename G>
-struct InterpolatedBFieldMapper {
+/// The magnetic field value for a given global position is then determined by:
+/// - mapping the position onto the grid,
+/// - looking up the magnetic field values on the closest grid points,
+/// - doing a linear interpolation of these magnetic field values.
+///
+/// @tparam grid_t The Grid type which provides the field storage and
+/// interpolation
+template <typename grid_t>
+class InterpolatedBFieldMap : public MagneticFieldProvider {
  public:
-  using Grid_t = G;
-  using FieldType = typename Grid_t::value_type;
-  static constexpr size_t DIM_POS = Grid_t::DIM;
+  using Grid = grid_t;
+  using FieldType = typename Grid::value_type;
+  static constexpr size_t DIM_POS = Grid::DIM;
 
   /// @brief struct representing smallest grid unit in magnetic field grid
   ///
@@ -48,7 +58,6 @@ struct InterpolatedBFieldMapper {
    public:
     /// @brief default constructor
     ///
-    /// @param [in] transform   mapping of global 3D coordinates onto grid space
     /// @param [in] lowerLeft   generalized lower-left corner of hyper box
     ///                         (containing the minima of the hyper box along
     ///                         each Dimension)
@@ -57,12 +66,10 @@ struct InterpolatedBFieldMapper {
     ///                         each Dimension)
     /// @param [in] fieldValues field values at the hyper box corners sorted in
     ///                         the canonical order defined in Acts::interpolate
-    FieldCell(std::function<ActsVector<DIM_POS>(const Vector3&)> transformPos,
-              std::array<double, DIM_POS> lowerLeft,
+    FieldCell(std::array<double, DIM_POS> lowerLeft,
               std::array<double, DIM_POS> upperRight,
               std::array<Vector3, N> fieldValues)
-        : m_transformPos(std::move(transformPos)),
-          m_lowerLeft(std::move(lowerLeft)),
+        : m_lowerLeft(std::move(lowerLeft)),
           m_upperRight(std::move(upperRight)),
           m_fieldValues(std::move(fieldValues)) {}
 
@@ -72,10 +79,9 @@ struct InterpolatedBFieldMapper {
     /// @return magnetic field value at the given position
     ///
     /// @pre The given @c position must lie within the current field cell.
-    Vector3 getField(const Vector3& position) const {
+    Vector3 getField(const ActsVector<DIM_POS>& position) const {
       // defined in Interpolation.hpp
-      return interpolate(m_transformPos(position), m_lowerLeft, m_upperRight,
-                         m_fieldValues);
+      return interpolate(position, m_lowerLeft, m_upperRight, m_fieldValues);
     }
 
     /// @brief check whether given 3D position is inside this field cell
@@ -83,11 +89,9 @@ struct InterpolatedBFieldMapper {
     /// @param [in] position global 3D position
     /// @return @c true if position is inside the current field cell,
     ///         otherwise @c false
-    bool isInside(const Vector3& position) const {
-      const auto& gridCoordinates = m_transformPos(position);
+    bool isInside(const ActsVector<DIM_POS>& position) const {
       for (unsigned int i = 0; i < DIM_POS; ++i) {
-        if (gridCoordinates[i] < m_lowerLeft[i] ||
-            gridCoordinates[i] >= m_upperRight[i]) {
+        if (position[i] < m_lowerLeft[i] || position[i] >= m_upperRight[i]) {
           return false;
         }
       }
@@ -95,9 +99,6 @@ struct InterpolatedBFieldMapper {
     }
 
    private:
-    /// geometric transformation applied to global 3D positions
-    std::function<ActsVector<DIM_POS>(const Vector3&)> m_transformPos;
-
     /// generalized lower-left corner of the confining hyper-box
     std::array<double, DIM_POS> m_lowerLeft;
 
@@ -111,41 +112,44 @@ struct InterpolatedBFieldMapper {
     std::array<Vector3, N> m_fieldValues;
   };
 
+  struct Cache {
+    /// @brief Constructor with magnetic field context
+    ///
+    /// @param mcfg the magnetic field context
+    Cache(const MagneticFieldContext& /*mcfg*/) {}
+
+    std::optional<FieldCell> fieldCell;
+    bool initialized = false;
+  };
+
+  /// @brief  Config structure for the interpolated B field map
+  struct Config {
+    /// @brief mapping of global 3D coordinates (cartesian)
+    /// onto grid space
+    std::function<ActsVector<DIM_POS>(const Vector3&)> transformPos;
+
+    /// @brief calculating the global 3D coordinates
+    /// (cartesian) of the magnetic field with the local n dimensional field and
+    /// the global 3D position as input
+    std::function<Vector3(const FieldType&, const Vector3&)> transformBField;
+
+    /// @brief grid storing magnetic field values
+    Grid grid;
+
+    /// @brief global B-field scaling factor
+    ///
+    /// @note Negative values for @p scale are accepted and will invert the
+    ///       direction of the magnetic field.
+    double scale = 1.;
+  };
+
   /// @brief default constructor
   ///
-  /// @param [in] transformPos mapping of global 3D coordinates (cartesian)
-  /// onto grid space
-  /// @param [in] transformBField calculating the global 3D coordinates
-  /// (cartesian) of the magnetic field with the local n dimensional field and
-  /// the global 3D position as input
-  /// @param [in] grid      grid storing magnetic field values
-  InterpolatedBFieldMapper(
-      std::function<ActsVector<DIM_POS>(const Vector3&)> transformPos,
-      std::function<Vector3(const FieldType&, const Vector3&)> transformBField,
-      Grid_t grid)
-      : m_transformPos(std::move(transformPos)),
-        m_transformBField(std::move(transformBField)),
-        m_grid(std::move(grid)) {
-    typename Grid_t::index_t minBin{};
+  InterpolatedBFieldMap(Config cfg) : m_cfg{std::move(cfg)} {
+    typename Grid::index_t minBin{};
     minBin.fill(1);
-    m_lowerLeft = m_grid.lowerLeftBinEdge(minBin);
-    m_upperRight = m_grid.lowerLeftBinEdge(m_grid.numLocalBins());
-  }
-
-  /// @brief retrieve field at given position
-  ///
-  /// @param [in] position global 3D position
-  /// @return magnetic field value at the given position
-  ///
-  /// @pre The given @c position must lie within the range of the underlying
-  ///      magnetic field map.
-  Result<Vector3> getField(const Vector3& position) const {
-    if (!isInside(position)) {
-      return Result<Vector3>::failure(MagneticFieldError::OutOfBounds);
-    }
-
-    return Result<Vector3>::success(m_transformBField(
-        m_grid.interpolate(m_transformPos(position)), position));
+    m_lowerLeft = m_cfg.grid.lowerLeftBinEdge(minBin);
+    m_upperRight = m_cfg.grid.lowerLeftBinEdge(m_cfg.grid.numLocalBins());
   }
 
   /// @brief retrieve field cell for given position
@@ -156,34 +160,33 @@ struct InterpolatedBFieldMapper {
   /// @pre The given @c position must lie within the range of the underlying
   ///      magnetic field map.
   Result<FieldCell> getFieldCell(const Vector3& position) const {
-    const auto& gridPosition = m_transformPos(position);
-    const auto& indices = m_grid.localBinsFromPosition(gridPosition);
-    const auto& lowerLeft = m_grid.lowerLeftBinEdge(indices);
-    const auto& upperRight = m_grid.upperRightBinEdge(indices);
+    const auto& gridPosition = m_cfg.transformPos(position);
+    const auto& indices = m_cfg.grid.localBinsFromPosition(gridPosition);
+    const auto& lowerLeft = m_cfg.grid.lowerLeftBinEdge(indices);
+    const auto& upperRight = m_cfg.grid.upperRightBinEdge(indices);
 
     // loop through all corner points
     constexpr size_t nCorners = 1 << DIM_POS;
     std::array<Vector3, nCorners> neighbors{Vector3{0.0, 0.0, 0.0}};
-    const auto& cornerIndices = m_grid.closestPointsIndices(gridPosition);
+    const auto& cornerIndices = m_cfg.grid.closestPointsIndices(gridPosition);
 
-    if (!isInside(position)) {
+    if (!isInsideLocal(gridPosition)) {
       return MagneticFieldError::OutOfBounds;
     }
 
     size_t i = 0;
     for (size_t index : cornerIndices) {
-      neighbors.at(i++) = m_transformBField(m_grid.at(index), position);
+      neighbors.at(i++) = m_cfg.transformBField(m_cfg.grid.at(index), position);
     }
 
-    return FieldCell(m_transformPos, lowerLeft, upperRight,
-                     std::move(neighbors));
+    return FieldCell(lowerLeft, upperRight, std::move(neighbors));
   }
 
   /// @brief get the number of bins for all axes of the field map
   ///
   /// @return vector returning number of bins for all field map axes
   std::vector<size_t> getNBins() const {
-    auto nBinsArray = m_grid.numLocalBins();
+    auto nBinsArray = m_cfg.grid.numLocalBins();
     return std::vector<size_t>(nBinsArray.begin(), nBinsArray.end());
   }
 
@@ -207,7 +210,10 @@ struct InterpolatedBFieldMapper {
   /// @return @c true if position is inside the defined look-up grid,
   ///         otherwise @c false
   bool isInside(const Vector3& position) const {
-    const auto& gridPosition = m_transformPos(position);
+    return isInsideLocal(m_cfg.transformPos(position));
+  }
+
+  bool isInsideLocal(const ActsVector<DIM_POS>& gridPosition) const {
     for (unsigned int i = 0; i < DIM_POS; ++i) {
       if (gridPosition[i] < m_lowerLeft[i] ||
           gridPosition[i] >= m_upperRight[i]) {
@@ -220,101 +226,7 @@ struct InterpolatedBFieldMapper {
   /// @brief Get a const reference on the underlying grid structure
   ///
   /// @return grid reference
-  const Grid_t& getGrid() const { return m_grid; }
-
- private:
-  /// geometric transformation applied to global 3D positions
-  std::function<ActsVector<DIM_POS>(const Vector3&)> m_transformPos;
-  /// Transformation calculating the global 3D coordinates (cartesian) of the
-  /// magnetic field with the local n dimensional field and the global 3D
-  /// position as input
-  std::function<Vector3(const FieldType&, const Vector3&)> m_transformBField;
-  /// grid storing magnetic field values
-  Grid_t m_grid;
-
-  typename Grid_t::point_t m_lowerLeft;
-  typename Grid_t::point_t m_upperRight;
-};
-
-/// @ingroup MagneticField
-/// @brief interpolate magnetic field value from field values on a given grid
-///
-/// This class implements a magnetic field service which is initialized by a
-/// field map defined by:
-/// - a list of field values on a regular grid in some n-Dimensional space,
-/// - a transformation of global 3D coordinates onto this n-Dimensional
-/// space.
-/// - a transformation of local n-Dimensional magnetic field coordinates into
-/// global (cartesian) 3D coordinates
-///
-/// The magnetic field value for a given global position is then determined by:
-/// - mapping the position onto the grid,
-/// - looking up the magnetic field values on the closest grid points,
-/// - doing a linear interpolation of these magnetic field values.
-template <typename Mapper_t>
-class InterpolatedBFieldMap final : public MagneticFieldProvider {
- public:
-  /// @brief configuration object for magnetic field interpolation
-  struct Config {
-    Config(Mapper_t m) : mapper(m) {}
-
-    /// @brief global B-field scaling factor
-    ///
-    /// @note Negative values for @p scale are accepted and will invert the
-    ///       direction of the magnetic field.
-    double scale = 1.;
-
-    /// @brief object for global coordinate transformation and interpolation
-    ///
-    /// This object performs the mapping of the global 3D coordinates onto the
-    /// field grid and the interpolation of the field values on close-by grid
-    /// points.
-    Mapper_t mapper;
-  };
-
-  struct Cache {
-    /// @brief Constructor with magnetic field context
-    ///
-    /// @param mcfg the magnetic field context
-    Cache(const MagneticFieldContext& /*mcfg*/) {}
-
-    std::optional<typename Mapper_t::FieldCell> fieldCell;
-    bool initialized = false;
-  };
-
-  /// @brief create interpolated magnetic field map
-  ///
-  /// @param [in] config configuration object
-  InterpolatedBFieldMap(Config config) : m_config(std::move(config)) {}
-
-  /// @brief get configuration object
-  ///
-  /// @return copy of the internal configuration object
-  Config getConfiguration() const { return m_config; }
-
-  /// @brief get global scaling factor for magnetic field
-  ///
-  /// @return global factor for scaling the magnetic field
-  double getScale() const { return m_config.scale; }
-
-  /// @brief convenience method to access underlying field mapper
-  ///
-  /// @return the field mapper
-  Mapper_t getMapper() const { return m_config.mapper; }
-
-  /// @brief check whether given 3D position is inside look-up domain
-  ///
-  /// @param [in] position global 3D position
-  /// @return @c true if position is inside the defined BField map,
-  ///         otherwise @c false
-  bool isInside(const Vector3& position) const {
-    return m_config.mapper.isInside(position);
-  }
-
-  /// @brief update configuration
-  ///
-  /// @param [in] config new configuration object
-  void setConfiguration(const Config& config) { m_config = config; }
+  const Grid& getGrid() const { return m_cfg.grid; }
 
  public:
   /// @copydoc MagneticFieldProvider::makeCache(const MagneticFieldContext&)
@@ -323,9 +235,21 @@ class InterpolatedBFieldMap final : public MagneticFieldProvider {
     return MagneticFieldProvider::Cache::make<Cache>(mctx);
   }
 
-  /// @copydoc MagneticFieldProvider::getField(const Vector3&)
+  /// @brief retrieve field at given position
+  ///
+  /// @param [in] position global 3D position
+  /// @return magnetic field value at the given position
+  ///
+  /// @pre The given @c position must lie within the range of the underlying
+  ///      magnetic field map.
   Result<Vector3> getField(const Vector3& position) const {
-    return m_config.mapper.getField(position);
+    const auto gridPosition = m_cfg.transformPos(position);
+    if (!isInsideLocal(gridPosition)) {
+      return Result<Vector3>::failure(MagneticFieldError::OutOfBounds);
+    }
+
+    return Result<Vector3>::success(
+        m_cfg.transformBField(m_cfg.grid.interpolate(gridPosition), position));
   }
 
   /// @copydoc MagneticFieldProvider::getField(const
@@ -334,14 +258,15 @@ class InterpolatedBFieldMap final : public MagneticFieldProvider {
       const Vector3& position,
       MagneticFieldProvider::Cache& gcache) const override {
     Cache& cache = gcache.get<Cache>();
-    if (!cache.fieldCell || !(*cache.fieldCell).isInside(position)) {
+    const auto gridPosition = m_cfg.transformPos(position);
+    if (!cache.fieldCell || !(*cache.fieldCell).isInside(gridPosition)) {
       auto res = getFieldCell(position);
       if (!res.ok()) {
         return Result<Vector3>::failure(res.error());
       }
       cache.fieldCell = *res;
     }
-    return Result<Vector3>::success((*cache.fieldCell).getField(position));
+    return Result<Vector3>::success((*cache.fieldCell).getField(gridPosition));
   }
 
   /// @copydoc MagneticFieldProvider::getFieldGradient(const
@@ -357,20 +282,10 @@ class InterpolatedBFieldMap final : public MagneticFieldProvider {
   }
 
  private:
-  /// @brief retrieve field cell for given position
-  ///
-  /// @param [in] position global 3D position
-  /// @return field cell containing the given global position
-  ///
-  /// @pre The given @c position must lie within the range of the underlying
-  ///      magnetic field map.
-  Result<typename Mapper_t::FieldCell> getFieldCell(
-      const Vector3& position) const {
-    return m_config.mapper.getFieldCell(position);
-  }
+  Config m_cfg;
 
-  /// @brief configuration object
-  Config m_config;
+  typename Grid::point_t m_lowerLeft;
+  typename Grid::point_t m_upperRight;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
+++ b/Core/include/Acts/MagneticField/InterpolatedBFieldMap.hpp
@@ -213,6 +213,11 @@ class InterpolatedBFieldMap : public MagneticFieldProvider {
     return isInsideLocal(m_cfg.transformPos(position));
   }
 
+  /// @brief check whether given 3D position is inside look-up domain
+  ///
+  /// @param [in] position local N-D position
+  /// @return @c true if position is inside the defined look-up grid,
+  ///         otherwise @c false
   bool isInsideLocal(const ActsVector<DIM_POS>& gridPosition) const {
     for (unsigned int i = 0; i < DIM_POS; ++i) {
       if (gridPosition[i] < m_lowerLeft[i] ||
@@ -228,7 +233,6 @@ class InterpolatedBFieldMap : public MagneticFieldProvider {
   /// @return grid reference
   const Grid& getGrid() const { return m_cfg.grid; }
 
- public:
   /// @copydoc MagneticFieldProvider::makeCache(const MagneticFieldContext&)
   MagneticFieldProvider::Cache makeCache(
       const MagneticFieldContext& mctx) const override {

--- a/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
+++ b/Core/include/Acts/MagneticField/MagneticFieldProvider.hpp
@@ -46,6 +46,10 @@ class MagneticFieldProvider {
   virtual Result<Vector3> getFieldGradient(const Vector3& position,
                                            ActsMatrix<3, 3>& derivative,
                                            Cache& cache) const = 0;
+
+  virtual ~MagneticFieldProvider();
 };
+
+inline MagneticFieldProvider::~MagneticFieldProvider() = default;
 
 }  // namespace Acts

--- a/Core/src/MagneticField/BFieldMapUtils.cpp
+++ b/Core/src/MagneticField/BFieldMapUtils.cpp
@@ -20,15 +20,15 @@
 using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
-Acts::InterpolatedBFieldMapper<
+Acts::InterpolatedBFieldMap<
     Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                        Acts::detail::EquidistantAxis>>
-Acts::fieldMapperRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
-                                               std::array<size_t, 2> nBinsRZ)>&
-                        localToGlobalBin,
-                    std::vector<double> rPos, std::vector<double> zPos,
-                    std::vector<Acts::Vector2> bField, double lengthUnit,
-                    double BFieldUnit, bool firstQuadrant) {
+Acts::fieldMapRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
+                                            std::array<size_t, 2> nBinsRZ)>&
+                     localToGlobalBin,
+                 std::vector<double> rPos, std::vector<double> zPos,
+                 std::vector<Acts::Vector2> bField, double lengthUnit,
+                 double BFieldUnit, bool firstQuadrant) {
   // [1] Create Grid
   // sort the values
   std::sort(rPos.begin(), rPos.end());
@@ -124,20 +124,19 @@ Acts::fieldMapperRZ(const std::function<size_t(std::array<size_t, 2> binsRZ,
 
   // [5] Create the mapper & BField Service
   // create field mapping
-  return Acts::InterpolatedBFieldMapper<Grid_t>(transformPos, transformBField,
-                                                std::move(grid));
+  return Acts::InterpolatedBFieldMap<Grid_t>(
+      {transformPos, transformBField, std::move(grid)});
 }
 
-Acts::InterpolatedBFieldMapper<Acts::detail::Grid<
+Acts::InterpolatedBFieldMap<Acts::detail::Grid<
     Acts::Vector3, Acts::detail::EquidistantAxis, Acts::detail::EquidistantAxis,
     Acts::detail::EquidistantAxis>>
-Acts::fieldMapperXYZ(
-    const std::function<size_t(std::array<size_t, 3> binsXYZ,
-                               std::array<size_t, 3> nBinsXYZ)>&
-        localToGlobalBin,
-    std::vector<double> xPos, std::vector<double> yPos,
-    std::vector<double> zPos, std::vector<Acts::Vector3> bField,
-    double lengthUnit, double BFieldUnit, bool firstOctant) {
+Acts::fieldMapXYZ(const std::function<size_t(std::array<size_t, 3> binsXYZ,
+                                             std::array<size_t, 3> nBinsXYZ)>&
+                      localToGlobalBin,
+                  std::vector<double> xPos, std::vector<double> yPos,
+                  std::vector<double> zPos, std::vector<Acts::Vector3> bField,
+                  double lengthUnit, double BFieldUnit, bool firstOctant) {
   // [1] Create Grid
   // Sort the values
   std::sort(xPos.begin(), xPos.end());
@@ -244,17 +243,17 @@ Acts::fieldMapperXYZ(
 
   // [5] Create the mapper & BField Service
   // create field mapping
-  return Acts::InterpolatedBFieldMapper<Grid_t>(transformPos, transformBField,
-                                                std::move(grid));
+  return Acts::InterpolatedBFieldMap<Grid_t>(
+      {transformPos, transformBField, std::move(grid)});
 }
 
-Acts::InterpolatedBFieldMapper<
+Acts::InterpolatedBFieldMap<
     Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                        Acts::detail::EquidistantAxis>>
-Acts::solenoidFieldMapper(std::pair<double, double> rlim,
-                          std::pair<double, double> zlim,
-                          std::pair<size_t, size_t> nbins,
-                          const SolenoidBField& field) {
+Acts::solenoidFieldMap(std::pair<double, double> rlim,
+                       std::pair<double, double> zlim,
+                       std::pair<size_t, size_t> nbins,
+                       const SolenoidBField& field) {
   double rMin, rMax, zMin, zMax;
   std::tie(rMin, rMax) = rlim;
   std::tie(zMin, zMax) = zlim;
@@ -322,7 +321,7 @@ Acts::solenoidFieldMapper(std::pair<double, double> rlim,
 
   // Create the mapper & BField Service
   // create field mapping
-  Acts::InterpolatedBFieldMapper<Grid_t> mapper(transformPos, transformBField,
-                                                std::move(grid));
-  return mapper;
+  Acts::InterpolatedBFieldMap<Grid_t> map(
+      {transformPos, transformBField, std::move(grid)});
+  return map;
 }

--- a/Examples/Detectors/MagneticField/CMakeLists.txt
+++ b/Examples/Detectors/MagneticField/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(
   ActsExamplesMagneticField SHARED
-  src/FieldMapperRootIo.cpp
-  src/FieldMapperTextIo.cpp
+  src/FieldMapRootIo.cpp
+  src/FieldMapTextIo.cpp
   src/MagneticFieldOptions.cpp
   src/ScalableBFieldService.cpp)
 target_include_directories(

--- a/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/MagneticField.hpp
+++ b/Examples/Detectors/MagneticField/include/ActsExamples/MagneticField/MagneticField.hpp
@@ -20,18 +20,14 @@
 namespace ActsExamples {
 namespace detail {
 
-using InterpolatedMagneticFieldMapper2 = Acts::InterpolatedBFieldMapper<
+using InterpolatedMagneticField2 = Acts::InterpolatedBFieldMap<
     Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                        Acts::detail::EquidistantAxis>>;
-using InterpolatedMagneticField2 =
-    Acts::InterpolatedBFieldMap<InterpolatedMagneticFieldMapper2>;
 
-using InterpolatedMagneticFieldMapper3 =
-    Acts::InterpolatedBFieldMapper<Acts::detail::Grid<
+using InterpolatedMagneticField3 =
+    Acts::InterpolatedBFieldMap<Acts::detail::Grid<
         Acts::Vector3, Acts::detail::EquidistantAxis,
         Acts::detail::EquidistantAxis, Acts::detail::EquidistantAxis>>;
-using InterpolatedMagneticField3 =
-    Acts::InterpolatedBFieldMap<InterpolatedMagneticFieldMapper3>;
 
 }  // namespace detail
 

--- a/Examples/Detectors/MagneticField/src/FieldMapRootIo.cpp
+++ b/Examples/Detectors/MagneticField/src/FieldMapRootIo.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "FieldMapperRootIo.hpp"
+#include "FieldMapRootIo.hpp"
 
 #include "Acts/MagneticField/BFieldMapUtils.hpp"
 
@@ -15,8 +15,8 @@
 #include <TFile.h>
 #include <TTree.h>
 
-ActsExamples::detail::InterpolatedMagneticFieldMapper2
-ActsExamples::makeMagneticFieldMapperRzFromRoot(
+ActsExamples::detail::InterpolatedMagneticField2
+ActsExamples::makeMagneticFieldMapRzFromRoot(
     std::function<size_t(std::array<size_t, 2> binsRZ,
                          std::array<size_t, 2> nBinsRZ)>
         localToGlobalBin,
@@ -55,12 +55,12 @@ ActsExamples::makeMagneticFieldMapperRzFromRoot(
   }
   inputFile->Close();
   /// [2] use helper function in core
-  return Acts::fieldMapperRZ(localToGlobalBin, rPos, zPos, bField, lengthUnit,
-                             BFieldUnit, firstQuadrant);
+  return Acts::fieldMapRZ(localToGlobalBin, rPos, zPos, bField, lengthUnit,
+                          BFieldUnit, firstQuadrant);
 }
 
-ActsExamples::detail::InterpolatedMagneticFieldMapper3
-ActsExamples::makeMagneticFieldMapperXyzFromRoot(
+ActsExamples::detail::InterpolatedMagneticField3
+ActsExamples::makeMagneticFieldMapXyzFromRoot(
     std::function<size_t(std::array<size_t, 3> binsXYZ,
                          std::array<size_t, 3> nBinsXYZ)>
         localToGlobalBin,
@@ -104,6 +104,6 @@ ActsExamples::makeMagneticFieldMapperXyzFromRoot(
   }
   inputFile->Close();
 
-  return Acts::fieldMapperXYZ(localToGlobalBin, xPos, yPos, zPos, bField,
-                              lengthUnit, BFieldUnit, firstOctant);
+  return Acts::fieldMapXYZ(localToGlobalBin, xPos, yPos, zPos, bField,
+                           lengthUnit, BFieldUnit, firstOctant);
 }

--- a/Examples/Detectors/MagneticField/src/FieldMapRootIo.hpp
+++ b/Examples/Detectors/MagneticField/src/FieldMapRootIo.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -17,7 +17,7 @@
 
 namespace ActsExamples {
 
-/// Method to setup the FieldMapper
+/// Method to setup the FieldMap
 /// @param localToGlobalBin Function mapping the local bins of r,z to the
 /// global
 /// bin of the map magnetic field value e.g.: we have small grid with the
@@ -38,12 +38,10 @@ namespace ActsExamples {
 /// }
 /// @endcode
 /// @param[in] fieldMapFile Path to file containing field map in txt format
+/// @param[in] treeName The name of the root tree
 /// @param[in] lengthUnit The unit of the grid points
 /// @param[in] BFieldUnit The unit of the magnetic field
-/// @note This information is only used as a hint for the required size of
-///       the internal vectors. A correct value is not needed, but will help
-///       to speed up the field map initialization process.
-/// @param[in] firstOctant Flag if set to true indicating that only the
+/// @param[in] firstQuadrant Flag if set to true indicating that only the
 /// first
 /// quadrant of the grid points and the BField values has been given and
 /// that
@@ -53,14 +51,14 @@ namespace ActsExamples {
 /// If the flag is set to true the r-axis grid values will be set to
 /// {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromText(
+detail::InterpolatedMagneticField2 makeMagneticFieldMapRzFromRoot(
     std::function<size_t(std::array<size_t, 2> binsRZ,
                          std::array<size_t, 2> nBinsRZ)>
         localToGlobalBin,
-    std::string fieldMapFile, Acts::ActsScalar lengthUnit,
+    std::string fieldMapFile, std::string treeName, Acts::ActsScalar lengthUnit,
     Acts::ActsScalar BFieldUnit, bool firstOctant = false);
 
-/// Method to setup the FieldMapper
+/// Method to setup the FieldMap
 /// @param localToGlobalBin Function mapping the local bins of x,y,z to the
 /// global bin of the map magnetic field value e.g.: we have small grid with
 /// the
@@ -87,11 +85,9 @@ detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromText(
 /// }
 /// @endcode
 /// @param[in] fieldMapFile Path to file containing field map in txt format
+/// @param[in] treeName The name of the root tree
 /// @param[in] lengthUnit The unit of the grid points
 /// @param[in] BFieldUnit The unit of the magnetic field
-/// @note This information is only used as a hint for the required size of
-///       the internal vectors. A correct value is not needed, but will help
-///       to speed up the field map initialization process.
 /// @param[in] firstOctant Flag if set to true indicating that only the
 /// first
 /// octant of the grid points and the BField values has been given and that
@@ -101,11 +97,11 @@ detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromText(
 /// If the flag is set to true the z-axis grid values will be set to
 /// {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-detail::InterpolatedMagneticFieldMapper3 makeMagneticFieldMapperXyzFromText(
+detail::InterpolatedMagneticField3 makeMagneticFieldMapXyzFromRoot(
     std::function<size_t(std::array<size_t, 3> binsXYZ,
                          std::array<size_t, 3> nBinsXYZ)>
         localToGlobalBin,
-    std::string fieldMapFile, Acts::ActsScalar lengthUnit,
+    std::string fieldMapFile, std::string treeName, Acts::ActsScalar lengthUnit,
     Acts::ActsScalar BFieldUnit, bool firstOctant = false);
 
 }  // namespace ActsExamples

--- a/Examples/Detectors/MagneticField/src/FieldMapTextIo.cpp
+++ b/Examples/Detectors/MagneticField/src/FieldMapTextIo.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "FieldMapperTextIo.hpp"
+#include "FieldMapTextIo.hpp"
 
 #include "Acts/MagneticField/BFieldMapUtils.hpp"
 
@@ -18,8 +18,8 @@ namespace {
 constexpr size_t kDefaultSize = 1 << 15;
 }
 
-ActsExamples::detail::InterpolatedMagneticFieldMapper2
-ActsExamples::makeMagneticFieldMapperRzFromText(
+ActsExamples::detail::InterpolatedMagneticField2
+ActsExamples::makeMagneticFieldMapRzFromText(
     std::function<size_t(std::array<size_t, 2> binsRZ,
                          std::array<size_t, 2> nBinsRZ)>
         localToGlobalBin,
@@ -56,12 +56,12 @@ ActsExamples::makeMagneticFieldMapperRzFromText(
   zPos.shrink_to_fit();
   bField.shrink_to_fit();
   /// [2] use helper function in core
-  return Acts::fieldMapperRZ(localToGlobalBin, rPos, zPos, bField, lengthUnit,
-                             BFieldUnit, firstQuadrant);
+  return Acts::fieldMapRZ(localToGlobalBin, rPos, zPos, bField, lengthUnit,
+                          BFieldUnit, firstQuadrant);
 }
 
-ActsExamples::detail::InterpolatedMagneticFieldMapper3
-ActsExamples::makeMagneticFieldMapperXyzFromText(
+ActsExamples::detail::InterpolatedMagneticField3
+ActsExamples::makeMagneticFieldMapXyzFromText(
     std::function<size_t(std::array<size_t, 3> binsXYZ,
                          std::array<size_t, 3> nBinsXYZ)>
         localToGlobalBin,
@@ -101,6 +101,6 @@ ActsExamples::makeMagneticFieldMapperXyzFromText(
   yPos.shrink_to_fit();
   zPos.shrink_to_fit();
   bField.shrink_to_fit();
-  return Acts::fieldMapperXYZ(localToGlobalBin, xPos, yPos, zPos, bField,
-                              lengthUnit, BFieldUnit, firstOctant);
+  return Acts::fieldMapXYZ(localToGlobalBin, xPos, yPos, zPos, bField,
+                           lengthUnit, BFieldUnit, firstOctant);
 }

--- a/Examples/Detectors/MagneticField/src/FieldMapTextIo.hpp
+++ b/Examples/Detectors/MagneticField/src/FieldMapTextIo.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2021 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -38,10 +38,12 @@ namespace ActsExamples {
 /// }
 /// @endcode
 /// @param[in] fieldMapFile Path to file containing field map in txt format
-/// @param[in] treeName The name of the root tree
 /// @param[in] lengthUnit The unit of the grid points
 /// @param[in] BFieldUnit The unit of the magnetic field
-/// @param[in] firstQuadrant Flag if set to true indicating that only the
+/// @note This information is only used as a hint for the required size of
+///       the internal vectors. A correct value is not needed, but will help
+///       to speed up the field map initialization process.
+/// @param[in] firstOctant Flag if set to true indicating that only the
 /// first
 /// quadrant of the grid points and the BField values has been given and
 /// that
@@ -51,11 +53,11 @@ namespace ActsExamples {
 /// If the flag is set to true the r-axis grid values will be set to
 /// {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromRoot(
+detail::InterpolatedMagneticField2 makeMagneticFieldMapRzFromText(
     std::function<size_t(std::array<size_t, 2> binsRZ,
                          std::array<size_t, 2> nBinsRZ)>
         localToGlobalBin,
-    std::string fieldMapFile, std::string treeName, Acts::ActsScalar lengthUnit,
+    std::string fieldMapFile, Acts::ActsScalar lengthUnit,
     Acts::ActsScalar BFieldUnit, bool firstOctant = false);
 
 /// Method to setup the FieldMapper
@@ -85,9 +87,11 @@ detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromRoot(
 /// }
 /// @endcode
 /// @param[in] fieldMapFile Path to file containing field map in txt format
-/// @param[in] treeName The name of the root tree
 /// @param[in] lengthUnit The unit of the grid points
 /// @param[in] BFieldUnit The unit of the magnetic field
+/// @note This information is only used as a hint for the required size of
+///       the internal vectors. A correct value is not needed, but will help
+///       to speed up the field map initialization process.
 /// @param[in] firstOctant Flag if set to true indicating that only the
 /// first
 /// octant of the grid points and the BField values has been given and that
@@ -97,11 +101,11 @@ detail::InterpolatedMagneticFieldMapper2 makeMagneticFieldMapperRzFromRoot(
 /// If the flag is set to true the z-axis grid values will be set to
 /// {-1,0,1}
 /// and the BFieldValues will be set to {3,2,3}.
-detail::InterpolatedMagneticFieldMapper3 makeMagneticFieldMapperXyzFromRoot(
+detail::InterpolatedMagneticField3 makeMagneticFieldMapXyzFromText(
     std::function<size_t(std::array<size_t, 3> binsXYZ,
                          std::array<size_t, 3> nBinsXYZ)>
         localToGlobalBin,
-    std::string fieldMapFile, std::string treeName, Acts::ActsScalar lengthUnit,
+    std::string fieldMapFile, Acts::ActsScalar lengthUnit,
     Acts::ActsScalar BFieldUnit, bool firstOctant = false);
 
 }  // namespace ActsExamples

--- a/Examples/Detectors/MagneticField/src/MagneticFieldOptions.cpp
+++ b/Examples/Detectors/MagneticField/src/MagneticFieldOptions.cpp
@@ -24,8 +24,8 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
-#include "FieldMapperRootIo.hpp"
-#include "FieldMapperTextIo.hpp"
+#include "FieldMapRootIo.hpp"
+#include "FieldMapTextIo.hpp"
 
 void ActsExamples::Options::addMagneticFieldOptions(Description& desc) {
   using boost::program_options::bool_switch;
@@ -156,18 +156,16 @@ ActsExamples::Options::readMagneticField(const Variables& vars) {
 
       ACTS_INFO("Use XYZ field map");
       if (readRoot) {
-        auto mapper = makeMagneticFieldMapperXyzFromRoot(
+        auto map = makeMagneticFieldMapXyzFromRoot(
             std::move(mapBins), file.native(), tree, lengthUnit, fieldUnit,
             useOctantOnly);
-        InterpolatedMagneticField3::Config cfg(std::move(mapper));
-        return std::make_shared<InterpolatedMagneticField3>(std::move(cfg));
+        return std::make_shared<InterpolatedMagneticField3>(std::move(map));
 
       } else {
-        auto mapper = makeMagneticFieldMapperXyzFromText(
-            std::move(mapBins), file.native(), lengthUnit, fieldUnit,
-            useOctantOnly);
-        InterpolatedMagneticField3::Config cfg(std::move(mapper));
-        return std::make_shared<InterpolatedMagneticField3>(std::move(cfg));
+        auto map = makeMagneticFieldMapXyzFromText(std::move(mapBins),
+                                                   file.native(), lengthUnit,
+                                                   fieldUnit, useOctantOnly);
+        return std::make_shared<InterpolatedMagneticField3>(std::move(map));
       }
 
     } else if (type == "rz") {
@@ -178,18 +176,16 @@ ActsExamples::Options::readMagneticField(const Variables& vars) {
 
       ACTS_INFO("Use RZ field map");
       if (readRoot) {
-        auto mapper = makeMagneticFieldMapperRzFromRoot(
+        auto map = makeMagneticFieldMapRzFromRoot(
             std::move(mapBins), file.native(), tree, lengthUnit, fieldUnit,
             useOctantOnly);
-        InterpolatedMagneticField2::Config cfg(std::move(mapper));
-        return std::make_shared<InterpolatedMagneticField2>(std::move(cfg));
+        return std::make_shared<InterpolatedMagneticField2>(std::move(map));
 
       } else {
-        auto mapper = makeMagneticFieldMapperRzFromText(
-            std::move(mapBins), file.native(), lengthUnit, fieldUnit,
-            useOctantOnly);
-        InterpolatedMagneticField2::Config cfg(std::move(mapper));
-        return std::make_shared<InterpolatedMagneticField2>(std::move(cfg));
+        auto map = makeMagneticFieldMapRzFromText(std::move(mapBins),
+                                                  file.native(), lengthUnit,
+                                                  fieldUnit, useOctantOnly);
+        return std::make_shared<InterpolatedMagneticField2>(std::move(map));
       }
 
     } else {
@@ -225,10 +221,9 @@ ActsExamples::Options::readMagneticField(const Variables& vars) {
     getRange("bf-solenoid-map-zlim", Acts::UnitConstants::mm, zlim.first,
              zlim.second);
     const auto nbins = vars["bf-solenoid-map-nbins"].as<Reals<2>>();
-    auto mapper = Acts::solenoidFieldMapper(rlim, zlim, {nbins[0], nbins[1]},
-                                            solenoidField);
-    InterpolatedMagneticField2::Config cfg(std::move(mapper));
-    return std::make_shared<InterpolatedMagneticField2>(std::move(cfg));
+    auto map =
+        Acts::solenoidFieldMap(rlim, zlim, {nbins[0], nbins[1]}, solenoidField);
+    return std::make_shared<InterpolatedMagneticField2>(std::move(map));
   }
 
   // default option: no field

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -111,10 +111,6 @@ class RootBFieldWriter {
     double Bz;
     outputTree->Branch("Bz", &Bz);
 
-    // Get the underlying mapper of the InterpolatedBFieldMap
-    auto mapper = cfg.bField->getMapper();
-    auto grid = mapper.getGrid();
-
     // Access the minima and maxima of all axes
     auto grid = cfg.bField->getGrid();
     auto minima = grid.minPosition();

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootBFieldWriter.hpp
@@ -116,9 +116,10 @@ class RootBFieldWriter {
     auto grid = mapper.getGrid();
 
     // Access the minima and maxima of all axes
+    auto grid = cfg.bField->getGrid();
     auto minima = grid.minPosition();
     auto maxima = grid.maxPosition();
-    auto nBins = mapper.getNBins();
+    auto nBins = cfg.bField->getNBins();
 
     if (cfg.gridType == GridType::xyz) {
       ACTS_INFO("Map will be written out in cartesian coordinates (x,y,z).");

--- a/Tests/Benchmarks/SolenoidFieldBenchmark.cpp
+++ b/Tests/Benchmarks/SolenoidFieldBenchmark.cpp
@@ -48,12 +48,8 @@ int main(int argc, char* argv[]) {
 
   Acts::SolenoidBField bSolenoidField({R, L, nCoils, bMagCenter});
   std::cout << "Building interpolated field map" << std::endl;
-  auto mapper = Acts::solenoidFieldMapper({rMin, rMax}, {zMin, zMax},
+  auto bFieldMap = Acts::solenoidFieldMap({rMin, rMax}, {zMin, zMax},
                                           {nBinsR, nBinsZ}, bSolenoidField);
-  using BField_t = Acts::InterpolatedBFieldMap<decltype(mapper)>;
-
-  BField_t::Config cfg(std::move(mapper));
-  auto bFieldMap = BField_t(std::move(cfg));
   Acts::MagneticFieldContext mctx{};
 
   std::minstd_rand rng;

--- a/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
+++ b/Tests/IntegrationTests/InterpolatedSolenoidBFieldTest.cpp
@@ -54,16 +54,15 @@ auto makeFieldMap(const SolenoidBField& field) {
   std::cout << "zMin = " << zMin << std::endl;
   std::cout << "zMax = " << zMax << std::endl;
 
-  auto mapper =
-      solenoidFieldMapper({rMin, rMax}, {zMin, zMax}, {nBinsR, nBinsZ}, field);
+  auto map =
+      solenoidFieldMap({rMin, rMax}, {zMin, zMax}, {nBinsR, nBinsZ}, field);
   // I know this is the correct grid type
   using Grid_t =
       Acts::detail::Grid<Acts::Vector2, Acts::detail::EquidistantAxis,
                          Acts::detail::EquidistantAxis>;
-  const Grid_t& grid = mapper.getGrid();
+  const Grid_t& grid = map.getGrid();
   using index_t = Grid_t::index_t;
   using point_t = Grid_t::point_t;
-  using BField_t = Acts::InterpolatedBFieldMap<decltype(mapper)>;
 
   for (size_t i = 0; i <= nBinsR + 1; i++) {
     for (size_t j = 0; j <= nBinsZ + 1; j++) {
@@ -80,8 +79,7 @@ auto makeFieldMap(const SolenoidBField& field) {
     }
   }
 
-  BField_t::Config cfg(std::move(mapper));
-  return BField_t(std::move(cfg));
+  return map;
 }
 
 Acts::SolenoidBField bSolenoidField({R, L, nCoils, bMagCenter});

--- a/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BFieldMapUtilsTests.cpp
@@ -41,20 +41,20 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
                                 std::array<size_t, 2> nBinsRZ) {
     return (binsRZ.at(1) * nBinsRZ.at(0) + binsRZ.at(0));
   };
-  // create b field mapper in rz
-  auto mapper_rz = Acts::fieldMapperRZ(localToGlobalBin_rz, rPos, zPos,
-                                       bField_rz, 1, 1, false);
+  // create b field map in rz
+  auto map_rz =
+      Acts::fieldMapRZ(localToGlobalBin_rz, rPos, zPos, bField_rz, 1, 1, false);
   // check number of bins, minima & maxima
   std::vector<size_t> nBins_rz = {rPos.size(), zPos.size()};
   std::vector<double> minima_rz = {0., 0.};
   std::vector<double> maxima_rz = {3., 3.};
-  BOOST_CHECK(mapper_rz.getNBins() == nBins_rz);
+  BOOST_CHECK(map_rz.getNBins() == nBins_rz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  BOOST_CHECK(mapper_rz.getMin() == minima_rz);
+  BOOST_CHECK(map_rz.getMin() == minima_rz);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  BOOST_CHECK(mapper_rz.getMax() == maxima_rz);
+  BOOST_CHECK(map_rz.getMax() == maxima_rz);
 
   auto localToGlobalBin_xyz = [](std::array<size_t, 3> binsXYZ,
                                  std::array<size_t, 3> nBinsXYZ) {
@@ -73,28 +73,28 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
     bField_xyz.push_back(Acts::Vector3(i, i, i));
   }
 
-  // create b field mapper in xyz
-  auto mapper_xyz = Acts::fieldMapperXYZ(localToGlobalBin_xyz, xPos, yPos, zPos,
-                                         bField_xyz, 1, 1, false);
+  // create b field map in xyz
+  auto map_xyz = Acts::fieldMapXYZ(localToGlobalBin_xyz, xPos, yPos, zPos,
+                                   bField_xyz, 1, 1, false);
   // check number of bins, minima & maxima
   std::vector<size_t> nBins_xyz = {xPos.size(), yPos.size(), zPos.size()};
   std::vector<double> minima_xyz = {0., 0., 0.};
   std::vector<double> maxima_xyz = {3., 3., 3.};
-  BOOST_CHECK(mapper_xyz.getNBins() == nBins_xyz);
+  BOOST_CHECK(map_xyz.getNBins() == nBins_xyz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  BOOST_CHECK(mapper_xyz.getMin() == minima_xyz);
+  BOOST_CHECK(map_xyz.getMin() == minima_xyz);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  BOOST_CHECK(mapper_xyz.getMax() == maxima_xyz);
+  BOOST_CHECK(map_xyz.getMax() == maxima_xyz);
 
   // check if filled value is expected value in rz
   Acts::Vector3 pos0_rz(0., 0., 0.);
   Acts::Vector3 pos1_rz(1., 0., 1.);
   Acts::Vector3 pos2_rz(0., 2., 2.);
-  auto value0_rz = mapper_rz.getField(pos0_rz).value();
-  auto value1_rz = mapper_rz.getField(pos1_rz).value();
-  auto value2_rz = mapper_rz.getField(pos2_rz).value();
+  auto value0_rz = map_rz.getField(pos0_rz).value();
+  auto value1_rz = map_rz.getField(pos1_rz).value();
+  auto value2_rz = map_rz.getField(pos2_rz).value();
   // calculate what the value should be at this point
   auto b0_rz =
       bField_rz.at(localToGlobalBin_rz({{0, 0}}, {{rPos.size(), zPos.size()}}));
@@ -118,9 +118,9 @@ BOOST_AUTO_TEST_CASE(bfield_creation) {
   Acts::Vector3 pos0_xyz(0., 0., 0.);
   Acts::Vector3 pos1_xyz(1., 1., 1.);
   Acts::Vector3 pos2_xyz(2., 2., 2.);
-  auto value0_xyz = mapper_xyz.getField(pos0_xyz).value();
-  auto value1_xyz = mapper_xyz.getField(pos1_xyz).value();
-  auto value2_xyz = mapper_xyz.getField(pos2_xyz).value();
+  auto value0_xyz = map_xyz.getField(pos0_xyz).value();
+  auto value1_xyz = map_xyz.getField(pos1_xyz).value();
+  auto value2_xyz = map_xyz.getField(pos2_xyz).value();
   // calculate what the value should be at this point
   auto b0_xyz = bField_xyz.at(localToGlobalBin_xyz(
       {{0, 0, 0}}, {{xPos.size(), yPos.size(), zPos.size()}}));
@@ -151,8 +151,8 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   for (int i = 0; i < 9; i++) {
     bField_rz.push_back(Acts::Vector2(i, i));
   }
-  // the field mapper in rz
-  auto mapper_rz = Acts::fieldMapperRZ(
+  // the field map in rz
+  auto map_rz = Acts::fieldMapRZ(
       [](std::array<size_t, 2> binsRZ, std::array<size_t, 2> nBinsRZ) {
         return (binsRZ.at(1) * nBinsRZ.at(0) + binsRZ.at(0));
       },
@@ -162,23 +162,23 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   std::vector<size_t> nBins_rz = {rPos.size(), 2 * zPos.size() - 1};
   std::vector<double> minima_rz = {0., -2.};
   std::vector<double> maxima_rz = {2., 2.};
-  BOOST_CHECK(mapper_rz.getNBins() == nBins_rz);
-  auto vec = mapper_rz.getNBins();
-  auto vec0 = mapper_rz.getMin();
+  BOOST_CHECK(map_rz.getNBins() == nBins_rz);
+  auto vec = map_rz.getNBins();
+  auto vec0 = map_rz.getMin();
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  BOOST_CHECK(mapper_rz.getMin() == minima_rz);
+  BOOST_CHECK(map_rz.getMin() == minima_rz);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  BOOST_CHECK(mapper_rz.getMax() == maxima_rz);
+  BOOST_CHECK(map_rz.getMax() == maxima_rz);
 
   // the bfield values in xyz
   std::vector<Acts::Vector3> bField_xyz;
   for (int i = 0; i < 27; i++) {
     bField_xyz.push_back(Acts::Vector3(i, i, i));
   }
-  // the field mapper in xyz
-  auto mapper_xyz = Acts::fieldMapperXYZ(
+  // the field map in xyz
+  auto map_xyz = Acts::fieldMapXYZ(
       [](std::array<size_t, 3> binsXYZ, std::array<size_t, 3> nBinsXYZ) {
         return (binsXYZ.at(0) * (nBinsXYZ.at(1) * nBinsXYZ.at(2)) +
                 binsXYZ.at(1) * nBinsXYZ.at(2) + binsXYZ.at(2));
@@ -190,13 +190,13 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
                                    2 * zPos.size() - 1};
   std::vector<double> minima_xyz = {-2., -2., -2.};
   std::vector<double> maxima_xyz = {2., 2., 2.};
-  BOOST_CHECK(mapper_xyz.getNBins() == nBins_xyz);
+  BOOST_CHECK(map_xyz.getNBins() == nBins_xyz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  BOOST_CHECK(mapper_xyz.getMin() == minima_xyz);
+  BOOST_CHECK(map_xyz.getMin() == minima_xyz);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  BOOST_CHECK(mapper_xyz.getMax() == maxima_xyz);
+  BOOST_CHECK(map_xyz.getMax() == maxima_xyz);
 
   Acts::Vector3 pos0(1.2, 1.3, 1.4);
   Acts::Vector3 pos1(1.2, 1.3, -1.4);
@@ -204,17 +204,17 @@ BOOST_AUTO_TEST_CASE(bfield_symmetry) {
   Acts::Vector3 pos3(1.2, -1.3, 1.4);
   Acts::Vector3 pos4(-1.2, -1.3, 1.4);
 
-  auto value0_rz = mapper_rz.getField(pos0).value();
-  auto value1_rz = mapper_rz.getField(pos1).value();
-  auto value2_rz = mapper_rz.getField(pos2).value();
-  auto value3_rz = mapper_rz.getField(pos3).value();
-  auto value4_rz = mapper_rz.getField(pos4).value();
+  auto value0_rz = map_rz.getField(pos0).value();
+  auto value1_rz = map_rz.getField(pos1).value();
+  auto value2_rz = map_rz.getField(pos2).value();
+  auto value3_rz = map_rz.getField(pos3).value();
+  auto value4_rz = map_rz.getField(pos4).value();
 
-  auto value0_xyz = mapper_xyz.getField(pos0).value();
-  auto value1_xyz = mapper_xyz.getField(pos1).value();
-  auto value2_xyz = mapper_xyz.getField(pos2).value();
-  auto value3_xyz = mapper_xyz.getField(pos3).value();
-  auto value4_xyz = mapper_xyz.getField(pos4).value();
+  auto value0_xyz = map_xyz.getField(pos0).value();
+  auto value1_xyz = map_xyz.getField(pos1).value();
+  auto value2_xyz = map_xyz.getField(pos2).value();
+  auto value3_xyz = map_xyz.getField(pos3).value();
+  auto value4_xyz = map_xyz.getField(pos4).value();
 
   // check z- and phi-symmetry
   CHECK_CLOSE_REL(perp(value0_rz), perp(value1_rz), 1e-10);
@@ -275,8 +275,8 @@ BOOST_DATA_TEST_CASE(
   for (size_t i = 0; i < nBins * nBins; i++) {
     bField_rz.push_back(Acts::Vector2(i * bStepR, i * bStepZ));
   }
-  // the mapper in rz
-  auto mapper_rz = Acts::fieldMapperRZ(
+  // the map in rz
+  auto map_rz = Acts::fieldMapRZ(
       [](std::array<size_t, 2> binsRZ, std::array<size_t, 2> nBinsRZ) {
         return (binsRZ.at(1) * nBinsRZ.at(0) + binsRZ.at(0));
       },
@@ -286,21 +286,21 @@ BOOST_DATA_TEST_CASE(
   std::vector<size_t> nBins_rz = {rPos.size(), 2 * zPos.size() - 1};
   std::vector<double> minima_rz = {0., -((nBins - 1) * stepZ)};
   std::vector<double> maxima_rz = {(nBins - 1) * stepR, (nBins - 1) * stepZ};
-  BOOST_CHECK(mapper_rz.getNBins() == nBins_rz);
+  BOOST_CHECK(map_rz.getNBins() == nBins_rz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  CHECK_CLOSE_ABS(mapper_rz.getMin(), minima_rz, 1e-10);
+  CHECK_CLOSE_ABS(map_rz.getMin(), minima_rz, 1e-10);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  CHECK_CLOSE_ABS(mapper_rz.getMax(), maxima_rz, 1e-10);
+  CHECK_CLOSE_ABS(map_rz.getMax(), maxima_rz, 1e-10);
 
   // bfield in xyz
   std::vector<Acts::Vector3> bField_xyz;
   for (size_t i = 0; i < nBins * nBins * nBins; i++) {
     bField_xyz.push_back(Acts::Vector3(i * bStepR, i * bStepR, i * bStepZ));
   }
-  // the mapper in xyz
-  auto mapper_xyz = Acts::fieldMapperXYZ(
+  // the map in xyz
+  auto map_xyz = Acts::fieldMapXYZ(
       [](std::array<size_t, 3> binsXYZ, std::array<size_t, 3> nBinsXYZ) {
         return (binsXYZ.at(0) * (nBinsXYZ.at(1) * nBinsXYZ.at(2)) +
                 binsXYZ.at(1) * nBinsXYZ.at(2) + binsXYZ.at(2));
@@ -313,13 +313,13 @@ BOOST_DATA_TEST_CASE(
       -((nBins - 1) * stepR), -((nBins - 1) * stepR), -((nBins - 1) * stepZ)};
   std::vector<double> maxima_xyz = {(nBins - 1) * stepR, (nBins - 1) * stepR,
                                     (nBins - 1) * stepZ};
-  BOOST_CHECK(mapper_xyz.getNBins() == nBins_xyz);
+  BOOST_CHECK(map_xyz.getNBins() == nBins_xyz);
   // check minimum (should be first value because bin values are always
   // assigned to the left boundary)
-  CHECK_CLOSE_REL(mapper_xyz.getMin(), minima_xyz, 1e-10);
+  CHECK_CLOSE_REL(map_xyz.getMin(), minima_xyz, 1e-10);
   // check maximum (should be last value + 1 step because bin values are
   // always assigned to the left boundary)
-  CHECK_CLOSE_REL(mapper_xyz.getMax(), maxima_xyz, 1e-10);
+  CHECK_CLOSE_REL(map_xyz.getMax(), maxima_xyz, 1e-10);
 
   Acts::Vector3 pos0(x, y, z);
   Acts::Vector3 pos1(x, y, -z);
@@ -327,11 +327,11 @@ BOOST_DATA_TEST_CASE(
   Acts::Vector3 pos3(x, -y, z);
   Acts::Vector3 pos4(-x, -y, z);
 
-  auto value0_rz = mapper_rz.getField(pos0).value();
-  auto value1_rz = mapper_rz.getField(pos1).value();
-  auto value2_rz = mapper_rz.getField(pos2).value();
-  auto value3_rz = mapper_rz.getField(pos3).value();
-  auto value4_rz = mapper_rz.getField(pos4).value();
+  auto value0_rz = map_rz.getField(pos0).value();
+  auto value1_rz = map_rz.getField(pos1).value();
+  auto value2_rz = map_rz.getField(pos2).value();
+  auto value3_rz = map_rz.getField(pos3).value();
+  auto value4_rz = map_rz.getField(pos4).value();
 
   // check z- and phi-symmetry
   CHECK_CLOSE_REL(perp(value0_rz), perp(value1_rz), 1e-10);
@@ -343,11 +343,11 @@ BOOST_DATA_TEST_CASE(
   CHECK_CLOSE_REL(perp(value0_rz), perp(value4_rz), 1e-10);
   CHECK_CLOSE_REL(value0_rz.z(), value4_rz.z(), 1e-10);
 
-  auto value0_xyz = mapper_xyz.getField(pos0).value();
-  auto value1_xyz = mapper_xyz.getField(pos1).value();
-  auto value2_xyz = mapper_xyz.getField(pos2).value();
-  auto value3_xyz = mapper_xyz.getField(pos3).value();
-  auto value4_xyz = mapper_xyz.getField(pos4).value();
+  auto value0_xyz = map_xyz.getField(pos0).value();
+  auto value1_xyz = map_xyz.getField(pos1).value();
+  auto value2_xyz = map_xyz.getField(pos2).value();
+  auto value3_xyz = map_xyz.getField(pos3).value();
+  auto value4_xyz = map_xyz.getField(pos4).value();
 
   // checkx-,y-,z-symmetry - need to check close (because of interpolation
   // there can be small differences)


### PR DESCRIPTION
Since we're already on a streak of breaking changes related to the B field infrastructure, I thought this would be a good idea as well.

Turns out, with all B field types inheriting from `MagneticFieldProvider` we don't actually need `InterpolatedBFieldMapper` anymore, or rather, `InterpolatedBField**Mapper**` and `InterpolatedBField**Map**` can be one single type. This PR does that.

This depends on #825 and remains WIP until that is merged.

BREAKING CHANGE:
The instantiation of an interpolated B field changes from 
```cpp
using Grid_t = detail::Grid<Vector3, detail::EquidistantAxis, detail::EquidistantAxis>;
using Mapper_t = InterpolatedBFieldMapper<Grid_t>;
using BField_t = InterpolatedBFieldMap<Mapper_t>;

Grid_t g(std::make_tuple(std::move(r), std::move(z)));
Mapper_t mapper(transformPos, transformBField, std::move(g));
BField_t::Config config(std::move(mapper));
config.scale = 1.;

BField_t b(std::move(config));
```

```cpp
using Grid_t = detail::Grid<Vector3, detail::EquidistantAxis, detail::EquidistantAxis>;
using BField_t = InterpolatedBFieldMap<Grid_t>;

Grid_t g(std::make_tuple(std::move(r), std::move(z)));
BField_t::Config cfg;
cfg.transformPos = transformPos;
cfg.transformBField = transformBField;
cfg.grid = std::move(g);
cfg.scale = 1.;
BField_t b{std::move(cfg)};
```