### PR TITLE
fix: Added missing radial extent

### DIFF
--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -128,6 +128,7 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
                                      std::abs(zMax - pl.max(Acts::binZ))};
           pl.envelope[Acts::binR] = {std::abs(rMin - pl.min(Acts::binR)),
                                      std::abs(rMax - pl.max(Acts::binR))};
+          pl.extent.ranges[Acts::binR] = {rMin, rMax};
         }
       } else {
         throw std::logic_error(


### PR DESCRIPTION
- Not sure why it is needed but the ProtoLayer construction does not set the values.

See the [discussion here](https://github.com/acts-project/acts/issues/822)

