### PR TITLE
build: Set RPATH values on install

### DIFF
--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -27,3 +27,8 @@ set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} ${ACTS_S
 
 # silence warning about missing RPATH on Mac OSX
 set(CMAKE_MACOSX_RPATH 1)
+
+# bake where we found external dependencies, if they were not in the default library directories
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+# set relative library path for ACTS libraries
+set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
We don't set any RPATH on install at all right now. This means you have to reconstruct where the dependency libraries are that we built with, and you have to supply `LD_LIBRARY_PATH` to ACTS libs in the install directory. 

RPATH is there to solve exactly this, this PR makes it so that the RPATH includes

- Library directories from which libraries were taken, if they didn't come from a standard path (`/usr/lib`, `/usr/local/lib` etc)
- A relative path from the binaries to the `lib` directory

With this the install directory should stay relocatable, as long as no external dependencies were taken from non standard paths, or in that case, on the same machine.

Closes #831 