### PR TITLE
docs: Update how-to

### DIFF
--- a/docs/howto/howto.rst
+++ b/docs/howto/howto.rst
@@ -6,6 +6,7 @@ How-to guides
 
    run_fatras
    run_material_mapping
+   run_seeding
    run_sycl_seed_finding
    run_truth_tracking
    run_ckf_tracking

--- a/docs/howto/run_ckf_tracking.rst
+++ b/docs/howto/run_ckf_tracking.rst
@@ -38,7 +38,7 @@ The detector volumes and layers used in the space point maker are also configure
        --digi-config-file <source>/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json \
        --geo-selection-config-file <source>/Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json
        
-In default, the starting track parameters estimated from reconstructed seeds by the seeding algorithm is used to steer the CKF. Alternative options are using properly smeared track parameters of truth particles and using track parameters estimated from truth tracks, which can be configured by the options ``--ckf-truth-smeared-seeds`` and ``--ckf-truth-estimated-seeds``, respectively.
+In default, the starting track parameters estimated from reconstructed seeds by the seeding algorithm are used to steer the CKF. Alternative options are using properly smeared track parameters of truth particles and using track parameters estimated from truth tracks, which can be configured by the options ``--ckf-truth-smeared-seeds`` and ``--ckf-truth-estimated-seeds``, respectively.
 
 The magnetic field setup should be consistent between simulation and CKF tracking.
 

--- a/docs/howto/run_ckf_tracking.rst
+++ b/docs/howto/run_ckf_tracking.rst
@@ -38,6 +38,7 @@ The detector volumes and layers used in the space point maker are also configure
        --digi-config-file <source>/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json \
        --geo-selection-config-file <source>/Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json
        
+In default, the starting track parameters estimated from reconstructed seeds by the seeding algorithm is used to steer the CKF. Alternative options are using properly smeared track parameters of truth particles and using track parameters estimated from truth tracks, which can be configured by the options ``--ckf-truth-smeared-seeds`` and ``--ckf-truth-estimated-seeds``, respectively.
 
 The magnetic field setup should be consistent between simulation and CKF tracking.
 

--- a/docs/howto/run_ckf_tracking.rst
+++ b/docs/howto/run_ckf_tracking.rst
@@ -31,11 +31,10 @@ The detector volumes and layers used in the space point maker are also configure
 
    $ <build>/bin/ActsExampleCKFTracksGeneric \
        --input-dir=data/sim_trackML/ttbar_mu200 \
-       --bf-value=0 0 2 \
+       --bf-constant-tesla=0:0:2 \
        --ckf-selection-chi2max 15 \
        --ckf-selection-nmax 10 \
        --output-dir=data/reco_trackML/ttbar_mu200 \
-       --digi-smear \
        --digi-config-file <source>/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json \
        --geo-selection-config-file <source>/Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json
        

--- a/docs/howto/run_fatras.rst
+++ b/docs/howto/run_fatras.rst
@@ -137,3 +137,38 @@ particles.
        --bf-constant-tesla=0:0:2 
 
 The output file structure will be the same as discussed above.
+
+Simulate an Open Data detector
+--------------------------------
+
+Similar to the simulation of the generic detector, another example detector called *Open Data Detector* (ODD) based on the DD4hep description can be simulated with the ``ACTS_BUILD_DD4HEP_PLUGIN`` option enabled. For the DD4hep based detector, a xml file for the geometry description must be specified by the option ``--dd4hep-input``. In addition, a material mapping file must be provided via the option ``--mat-input-file`` in order to take into account the material effects in simulation. 
+
+The following command simulates 100 single muon events for the ODD in a 2T magnetic field.
+
+.. code-block:: console
+
+   $ <build>/bin/ActsExampleFatrasDD4hep \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \ 
+       --mat-input-type file \
+       --mat-input-file <source>/thirdparty/OpenDataDetector/config/odd-material-mapping.config \
+       --output-dir=data/sim_ODD/single_muon \
+       --output-csv \
+       --events=100 \
+       --bf-constant-tesla=0:0:2
+
+The following command simulates the top-pair events based on the previously generated
+top-pair sample for the ODD in a 2T magnetic field.
+
+.. code-block:: console
+
+   $ <build>/bin/ActsExampleFatrasDD4hep \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \ 
+       --mat-input-type file \
+       --mat-input-file <source>/thirdparty/OpenDataDetector/config/odd-material-mapping.config \
+       --input-dir=data/gen/ttbar_mu140 \
+       --output-dir=data/sim_generic/ttbar_mu140 \
+       --output-csv \
+       --select-eta=-3:3 \
+       --select-pt=0.5: \
+       --remove-neutral \
+       --bf-constant-tesla=0:0:2

--- a/docs/howto/run_fatras.rst
+++ b/docs/howto/run_fatras.rst
@@ -138,7 +138,7 @@ particles.
 
 The output file structure will be the same as discussed above.
 
-Simulate an Open Data detector
+Simulate a DD4hep based detector
 --------------------------------
 
 Similar to the simulation of the generic detector, another example detector called *Open Data Detector* (ODD) based on the DD4hep description can be simulated with the ``ACTS_BUILD_DD4HEP_PLUGIN`` option enabled. For the DD4hep based detector, a xml file for the geometry description must be specified by the option ``--dd4hep-input``. In addition, a material mapping file must be provided via the option ``--mat-input-file`` in order to take into account the material effects in simulation. 

--- a/docs/howto/run_fatras.rst
+++ b/docs/howto/run_fatras.rst
@@ -106,22 +106,19 @@ muons in a reasonable kinematic range are generated.
        --output-dir=data/sim_generic/single_muon \
        --output-csv \
        --events=100 \
-       --bf-value=0 0 2
+       --bf-constant-tesla=0:0:2
 
 For each event, the following files will be created
 
 -   ``event<number>-particles_initial.csv``
 -   ``event<number>-particles_final.csv``
--   ``event<number>-truth.csv``
 -   ``event<number>-hits.csv``
--   ``event<number>-cells.csv``
 
 where ``<number>`` is the event number. The first two files contain the
 initital and final states of simulated particles. The
 simulated particles can differ from the generated input particles: particles might not have been
 simulated due to kinematic cuts or additional particles might have been
-generated due to interactions. The truth contains the true intersection with all
-surfaces, while the hits and the cells describe the simulated detector readout.
+generated due to interactions. The hits describe the simulated detector readout.
 
 To use some of the previously generated truth datasets, the ``--input-dir``
 option must be set. The following command reads the previously generated
@@ -137,6 +134,6 @@ particles.
        --select-eta=-3:3 \
        --select-pt=0.5: \
        --remove-neutral \
-       --bf-value=0 0 2
+       --bf-constant-tesla=0:0:2 
 
 The output file structure will be the same as discussed above.

--- a/docs/howto/run_truth_tracking.rst
+++ b/docs/howto/run_truth_tracking.rst
@@ -21,10 +21,11 @@ information to group simulated hits into tracks) and fits them.
 
    $ <build>/bin/ActsExampleTruthTracksGeneric \
        --input-dir=data/sim_trackML/ttbar_mu200 \
-       --bf-value=0 0 2 \
+       --digi-config-file <source>/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json
+       --bf-constant-tesla=0:0:2 \
        --output-dir=data/reco_trackML/ttbar_mu200
 
-The magnetic field setup should be consistent between simulation and truth tracking. 
+The ``--digi-config-file`` specifies the path for the digitization configuration file. The magnetic field setup should be consistent between simulation and truth tracking. 
 
 Look at the truth tracking performance
 ----------------------


### PR DESCRIPTION
This PR fixes a few obsolete configurations for running the Fatras simulation and reco examples in the how-to guides. The how-to for ODD simulation is added.
