### PR TITLE
fix: Root readers ensure event ordering is consistent

### DIFF
--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
@@ -38,9 +38,7 @@ class RootMaterialTrackReader : public IReader {
     std::vector<std::string> fileList;         ///< The name of the input file
 
     /// Whether the events are ordered or not
-    bool orderedEvents = true;
-
-    unsigned int batchSize = 1;  ///!< The number of tracks per event
+    bool orderedEvents = false;
 
     /// The default logger
     std::shared_ptr<const Acts::Logger> logger;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
@@ -88,6 +88,9 @@ class RootMaterialTrackReader : public IReader {
   /// The input tree name
   TChain* m_inputChain = nullptr;
 
+  /// Event identifier.
+  uint32_t m_eventId;
+
   float m_v_x;    ///< start global x
   float m_v_y;    ///< start global y
   float m_v_z;    ///< start global z

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
@@ -37,6 +37,9 @@ class RootMaterialTrackReader : public IReader {
     std::string treeName = "material-tracks";  ///< name of the output tree
     std::vector<std::string> fileList;         ///< The name of the input file
 
+    /// Whether the events are ordered or not
+    bool orderedEvents = true;
+
     unsigned int batchSize = 1;  ///!< The number of tracks per event
 
     /// The default logger
@@ -90,6 +93,10 @@ class RootMaterialTrackReader : public IReader {
 
   /// Event identifier.
   uint32_t m_eventId;
+
+  /// The entry numbers for accessing events in increased order (there could be
+  /// multiple entries corresponding to one event number)
+  std::vector<long long> m_entryNumbers = {};
 
   float m_v_x;    ///< start global x
   float m_v_y;    ///< start global y

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
@@ -38,7 +38,7 @@ class RootMaterialTrackReader : public IReader {
     std::vector<std::string> fileList;         ///< The name of the input file
 
     /// Whether the events are ordered or not
-    bool orderedEvents = false;
+    bool orderedEvents = true;
 
     /// The default logger
     std::shared_ptr<const Acts::Logger> logger;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackWriter.hpp
@@ -91,6 +91,9 @@ class RootMaterialTrackWriter
   /// The output tree name
   TTree* m_outputTree;
 
+  /// Event identifier.
+  uint32_t m_eventId;
+
   float m_v_x;    ///< start global x
   float m_v_y;    ///< start global y
   float m_v_z;    ///< start global z

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
@@ -38,6 +38,9 @@ class RootParticleReader : public IReader {
     std::string inputFile;          ///< The name of the input file
     std::string inputDir;           ///< The name of the input dir
 
+    /// Whether the events are ordered or not
+    bool orderedEvents = true;
+
     /// The default logger
     std::shared_ptr<const Acts::Logger> logger;
 
@@ -89,6 +92,10 @@ class RootParticleReader : public IReader {
 
   /// Event identifier.
   uint32_t m_eventId;
+
+  /// The entry numbers for accessing events in increased order (there could be
+  /// multiple entries corresponding to one event number)
+  std::vector<long long> m_entryNumbers = {};
 
   std::vector<uint64_t>* m_particleId = new std::vector<uint64_t>;
   std::vector<int32_t>* m_particleType = new std::vector<int32_t>;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryParametersReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryParametersReader.hpp
@@ -37,6 +37,9 @@ class RootTrajectoryParametersReader : public IReader {
     std::string inputFile;  ///< The name of the input file
     std::string inputDir;   ///< The name of the input dir
 
+    /// Whether the events are ordered or not
+    bool orderedEvents = true;
+
     /// The default logger
     std::shared_ptr<const Acts::Logger> logger;
 
@@ -92,6 +95,10 @@ class RootTrajectoryParametersReader : public IReader {
   std::vector<unsigned int>* m_subTrajNr =
       new std::vector<unsigned int>;  ///< the multi-trajectory sub-trajectory
                                       ///< number
+
+  /// The entry numbers for accessing events in increased order (there could be
+  /// multiple entries corresponding to one event number)
+  std::vector<long long> m_entryNumbers = {};
 
   std::vector<unsigned long>* m_t_barcode =
       new std::vector<long unsigned int>;  ///< Truth particle barcode

--- a/Examples/Io/Root/src/RootMaterialTrackReader.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackReader.cpp
@@ -59,6 +59,7 @@ ActsExamples::RootMaterialTrackReader::RootMaterialTrackReader(
 
   // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
+    m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_id", "", "goff");
     // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootMaterialTrackReader.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackReader.cpp
@@ -57,10 +57,10 @@ ActsExamples::RootMaterialTrackReader::RootMaterialTrackReader(
   m_events = m_inputChain->GetEntries();
   ACTS_DEBUG("The full chain has " << m_events << " entries.");
 
-  // If the events are not in order, find the entry numbers for ordered events
+  // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
     m_inputChain->Draw("event_id", "", "goff");
-    // Get the indices of the events in increasing order
+    // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
                 m_entryNumbers.data(), false);
   }

--- a/Examples/Io/Root/src/RootMaterialTrackReader.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackReader.cpp
@@ -107,8 +107,8 @@ ActsExamples::ProcessCode ActsExamples::RootMaterialTrackReader::read(
     size_t startEntry = m_inputChain->GetEntries(findStartEntry.c_str());
     size_t batchSize = m_inputChain->GetEntries(findBatchSize.c_str());
     ACTS_VERBOSE("The event has " << batchSize
-                                  << " entries with the start entry " <<
-                 startEntry);
+                                  << " entries with the start entry "
+                                  << startEntry);
 
     // Loop over the entries for this event
     for (size_t ib = 0; ib < batchSize; ++ib) {

--- a/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
@@ -51,6 +51,7 @@ ActsExamples::RootMaterialTrackWriter::RootMaterialTrackWriter(
     throw std::bad_alloc();
 
   // Set the branches
+  m_outputTree->Branch("event_id", &m_eventId);
   m_outputTree->Branch("v_x", &m_v_x);
   m_outputTree->Branch("v_y", &m_v_y);
   m_outputTree->Branch("v_z", &m_v_z);
@@ -114,6 +115,7 @@ ActsExamples::ProcessCode ActsExamples::RootMaterialTrackWriter::writeT(
   // Exclusive access to the tree while writing
   std::lock_guard<std::mutex> lock(m_writeMutex);
 
+  m_eventId = ctx.eventNumber;
   // Loop over the material tracks and write them out
   for (auto& mtrack : materialTracks) {
     // Clearing the vector first

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -119,9 +119,23 @@ ActsExamples::ProcessCode ActsExamples::RootParticleReader::read(
     // Secondary vertex collection
     std::vector<uint32_t> secVtxCollection;
 
+    // Function to find the entry that has the event number as executed
+    auto getEntry = [&]() -> unsigned int {
+      for (unsigned int j = 0; j < m_inputChain->GetEntries(); ++j) {
+        m_inputChain->GetEntry(j);
+        if (m_eventId == context.eventNumber) {
+          return j;
+        }
+      }
+      return context.eventNumber;
+    };
+
     // Read the correct entry: batch size * event_number + ib
-    m_inputChain->GetEntry(context.eventNumber);
-    ACTS_VERBOSE("Reading entry: " << context.eventNumber);
+    auto entry = getEntry();
+    m_inputChain->GetEntry(entry);
+
+    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry "
+                                << entry << " of the input tree");
 
     unsigned int nParticles = m_particleId->size();
 

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -130,11 +130,10 @@ ActsExamples::ProcessCode ActsExamples::RootParticleReader::read(
       return context.eventNumber;
     };
 
-    // Read the correct entry: batch size * event_number + ib
+    // Read the correct entry
     auto entry = getEntry();
     m_inputChain->GetEntry(entry);
-
-    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry "
+    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry: "
                                 << entry << " of the input tree");
 
     unsigned int nParticles = m_particleId->size();

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -68,10 +68,10 @@ ActsExamples::RootParticleReader::RootParticleReader(
   m_events = m_inputChain->GetEntries();
   ACTS_DEBUG("The full chain has " << m_events << " entries.");
 
-  // If the events are not in order, find the entry numbers for ordered events
+  // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
     m_inputChain->Draw("event_id", "", "goff");
-    // Get the indices of the events in increasing order
+    // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
                 m_entryNumbers.data(), false);
   }

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -135,8 +135,8 @@ ActsExamples::ProcessCode ActsExamples::RootParticleReader::read(
       entry = m_entryNumbers[entry];
     }
     m_inputChain->GetEntry(entry);
-    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry: "
-                                << entry << " of the input tree");
+    ACTS_INFO("Reading event: " << context.eventNumber
+                                << " stored as entry: " << entry);
 
     unsigned int nParticles = m_particleId->size();
 

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -70,6 +70,7 @@ ActsExamples::RootParticleReader::RootParticleReader(
 
   // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
+    m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_id", "", "goff");
     // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
@@ -73,10 +73,10 @@ ActsExamples::RootTrajectoryParametersReader::RootTrajectoryParametersReader(
   m_events = m_inputChain->GetEntries();
   ACTS_DEBUG("The full chain has " << m_events << " entries.");
 
-  // If the events are not in order, find the entry numbers for ordered events
+  // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
     m_inputChain->Draw("event_nr", "", "goff");
-    // Get the indices of the events in increasing order
+    // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
                 m_entryNumbers.data(), false);
   }

--- a/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
@@ -132,9 +132,22 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryParametersReader::read(
     std::vector<Acts::BoundTrackParameters> trackParameterCollection;
     SimParticleContainer truthParticleCollection;
 
+    // Function to find the entry that has the event number as executed
+    auto getEntry = [&]() -> unsigned int {
+      for (unsigned int j = 0; j < m_inputChain->GetEntries(); ++j) {
+        m_inputChain->GetEntry(j);
+        if (m_eventNr == context.eventNumber) {
+          return j;
+        }
+      }
+      return context.eventNumber;
+    };
+
     // Read the correct entry: batch size * event_number + ib
-    m_inputChain->GetEntry(context.eventNumber);
-    ACTS_VERBOSE("Reading entry: " << context.eventNumber);
+    auto entry = getEntry();
+    m_inputChain->GetEntry(entry);
+    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry "
+                                << entry << " of the input tree");
 
     unsigned int nTracks = m_eLOC0_fit->size();
     for (unsigned int i = 0; i < nTracks; i++) {

--- a/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
@@ -143,10 +143,10 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryParametersReader::read(
       return context.eventNumber;
     };
 
-    // Read the correct entry: batch size * event_number + ib
+    // Read the correct entry
     auto entry = getEntry();
     m_inputChain->GetEntry(entry);
-    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry "
+    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry: "
                                 << entry << " of the input tree");
 
     unsigned int nTracks = m_eLOC0_fit->size();

--- a/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
@@ -75,6 +75,7 @@ ActsExamples::RootTrajectoryParametersReader::RootTrajectoryParametersReader(
 
   // If the events are not in order, get the entry numbers for ordered events
   if (not m_cfg.orderedEvents) {
+    m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_nr", "", "goff");
     // Sort to get the entry numbers of the ordered events
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryParametersReader.cpp
@@ -148,8 +148,8 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryParametersReader::read(
       entry = m_entryNumbers[entry];
     }
     m_inputChain->GetEntry(entry);
-    ACTS_INFO("Reading event: " << context.eventNumber << " stored as entry: "
-                                << entry << " of the input tree");
+    ACTS_INFO("Reading event: " << context.eventNumber
+                                << " stored as entry: " << entry);
 
     unsigned int nTracks = m_eLOC0_fit->size();
     for (unsigned int i = 0; i < nTracks; i++) {

--- a/Examples/Run/Vertexing/TrackReaderVertexingPerformanceWriterExample.cpp
+++ b/Examples/Run/Vertexing/TrackReaderVertexingPerformanceWriterExample.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
 
   RootParticleReader::Config particleReaderConfig;
   particleReaderConfig.particleCollection = "allTruthParticles";
-  particleReaderConfig.inputFile = "particles.root";
+  particleReaderConfig.inputFile = "particles_initial.root";
   particleReaderConfig.treeName = "particles";
   particleReaderConfig.inputDir = inputDir;
   sequencer.addReader(


### PR DESCRIPTION
The current Root readers read the event from the root file assuming that the event `eventId` is the entry `eventId` in the tree. This is OK if only one root file is being read, but in case two different root files are read in, objects from two different events might be processed if the root files are written in multi-threaded modes.

This PR fixes the issue by finding the entry that has the desirable event id first. This might be expensive and could be improved by a better solution in the future.