### PR TITLE
fix: trackAverage when surface has zero binning

### DIFF
--- a/Core/src/Material/AccumulatedSurfaceMaterial.cpp
+++ b/Core/src/Material/AccumulatedSurfaceMaterial.cpp
@@ -60,7 +60,7 @@ std::array<size_t, 3> Acts::AccumulatedSurfaceMaterial::accumulate(
 void Acts::AccumulatedSurfaceMaterial::trackAverage(const Vector3& gp,
                                                     bool emptyHit) {
   if (m_binUtility.dimensions() == 0) {
-    m_accumulatedMaterial[0][0].trackAverage();
+    m_accumulatedMaterial[0][0].trackAverage(emptyHit);
     return;
   }
 

--- a/Core/src/Material/AccumulatedSurfaceMaterial.cpp
+++ b/Core/src/Material/AccumulatedSurfaceMaterial.cpp
@@ -61,7 +61,9 @@ void Acts::AccumulatedSurfaceMaterial::trackAverage(const Vector3& gp,
                                                     bool emptyHit) {
   if (m_binUtility.dimensions() == 0) {
     m_accumulatedMaterial[0][0].trackAverage();
+    return;
   }
+
   std::array<size_t, 3> bTriple = m_binUtility.binTriple(gp);
   std::vector<std::array<size_t, 3>> trackBins = {bTriple};
   trackAverage(trackBins, emptyHit);


### PR DESCRIPTION
This PR fixes a small potential issue when the surface has zero dimension binning during the surface material mapping.