### PR TITLE
ci: Disable codecov-patch check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ coverage:
       default:
         target: auto
         threshold: 0.1%
+    patch: off


### PR DESCRIPTION
This has proven to be unreliable and hard to follow.
