### PR TITLE
fix: GdmlGeantinoRecording does not need DD4hep

### DIFF
--- a/Examples/Run/CMakeLists.txt
+++ b/Examples/Run/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(Common)
 # tools
 add_subdirectory(Digitization)
 add_subdirectory(Fatras)
-add_subdirectory_if(Geant4 ACTS_BUILD_EXAMPLES_DD4HEP AND ACTS_BUILD_EXAMPLES_GEANT4)
+add_subdirectory_if(Geant4 ACTS_BUILD_EXAMPLES_GEANT4)
 add_subdirectory(Generators)
 add_subdirectory(Geometry)
 add_subdirectory(HelloWorld)

--- a/Examples/Run/Geant4/CMakeLists.txt
+++ b/Examples/Run/Geant4/CMakeLists.txt
@@ -5,7 +5,6 @@ target_link_libraries(
   ActsExampleGeantinoRecordingGdml
   PRIVATE
     ActsExamplesCommon
-    ActsExamplesDetectorDD4hep
     ActsExamplesFramework
     ActsExamplesGeant4
     ActsExamplesIoRoot


### PR DESCRIPTION
For some reason, in `Examples/Run/Geant4/CMakeLists.txt` the target
`ActsExampleGeantinoRecordingGdml` links against `ActsExamplesDD4hep`,
which I don't think it has to. Consequently, the `Examples/Run/Geant4`
directory is only added if DD4hep is enabled. There is an extra
subdirectory that inside with DD4hep-aware code, so I think it's safe to
drop the dependency of all of `Examples/Run/Geant4` on DD4hep here.