### PR TITLE
refactor!: Reset navigation state in (C)KF

### DIFF
--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -124,6 +124,13 @@ class DirectNavigator {
     bool navigationBreak = false;
 
     /// Reset state
+    ///
+    /// @param geoContext is the geometry context
+    /// @param pos is the global position
+    /// @param dir is the momentum direction
+    /// @param navDir is the navigation direction
+    /// @param ssurface is the new starting surface
+    /// @param tsurface is the target surface
     void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,
                const Vector3& /*dir*/, const NavigationDirection /*navDir*/,
                const Surface* ssurface, const Surface* tsurface) {

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -125,7 +125,7 @@ class DirectNavigator {
     /// @param ssurface is the new starting surface
     /// @param tsurface is the target surface
     void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,
-               const Vector3& /*dir*/, const NavigationDirection& /*navDir*/,
+               const Vector3& /*dir*/, NavigationDirection /*navDir*/,
                const Surface* ssurface, const Surface* tsurface) {
       // Reset everything except the navSurfaces
       State newState = State();

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -124,11 +124,19 @@ class DirectNavigator {
     bool navigationBreak = false;
 
     /// Reset state
-    ///
     void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,
                const Vector3& /*dir*/, const NavigationDirection /*navDir*/,
                const Surface* ssurface, const Surface* tsurface) {
+      // Reset everything except the navSurfaces
+      State newState = State();
+      newState.navSurfaces = this->navSurfaces;
+      *this = newState;
+
+      // Reset others
+      navSurfaceIter =
+          std::find(navSurfaces.begin(), navSurfaces.end(), ssurface);
       startSurface = ssurface;
+      currentSurface = ssurface;
       targetSurface = tsurface;
     }
   };

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -38,6 +38,9 @@ class DirectNavigator {
   using SurfaceSequence = std::vector<const Surface*>;
   using SurfaceIter = std::vector<const Surface*>::iterator;
 
+  using NavigationLayers = std::vector<LayerIntersection>;
+  using NavigationLayerIter = NavigationLayers::iterator;
+
   /// Defaulted Constructed
   DirectNavigator() = default;
 
@@ -97,6 +100,12 @@ class DirectNavigator {
 
     /// Iterator the the next surface
     SurfaceIter navSurfaceIter = navSurfaces.begin();
+
+    // Navigation on layer level
+    /// the vector of navigation layers to work through
+    NavigationLayers navLayers = {};
+    /// the current layer iterator of the navigation state
+    NavigationLayerIter navLayerIter = navLayers.end();
 
     /// Navigation state - external interface: the start surface
     const Surface* startSurface = nullptr;

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -125,7 +125,7 @@ class DirectNavigator {
     /// @param ssurface is the new starting surface
     /// @param tsurface is the target surface
     void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,
-               const Vector3& /*dir*/, const NavigationDirection /*navDir*/,
+               const Vector3& /*dir*/, const NavigationDirection& /*navDir*/,
                const Surface* ssurface, const Surface* tsurface) {
       // Reset everything except the navSurfaces
       State newState = State();

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -38,9 +38,6 @@ class DirectNavigator {
   using SurfaceSequence = std::vector<const Surface*>;
   using SurfaceIter = std::vector<const Surface*>::iterator;
 
-  using NavigationLayers = std::vector<LayerIntersection>;
-  using NavigationLayerIter = NavigationLayers::iterator;
-
   /// Defaulted Constructed
   DirectNavigator() = default;
 

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -122,10 +122,6 @@ class DirectNavigator {
 
     /// Reset state
     ///
-    /// @param geoContext is the geometry context
-    /// @param pos is the global position
-    /// @param dir is the momentum direction
-    /// @param navDir is the navigation direction
     /// @param ssurface is the new starting surface
     /// @param tsurface is the target surface
     void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -101,12 +101,6 @@ class DirectNavigator {
     /// Iterator the the next surface
     SurfaceIter navSurfaceIter = navSurfaces.begin();
 
-    // Navigation on layer level
-    /// the vector of navigation layers to work through
-    NavigationLayers navLayers = {};
-    /// the current layer iterator of the navigation state
-    NavigationLayerIter navLayerIter = navLayers.end();
-
     /// Navigation state - external interface: the start surface
     const Surface* startSurface = nullptr;
     /// Navigation state - external interface: the current surface
@@ -128,6 +122,15 @@ class DirectNavigator {
     bool targetReached = false;
     /// Navigation state - external interface: a break has been detected
     bool navigationBreak = false;
+
+    /// Reset state
+    ///
+    void reset(const GeometryContext& /*geoContext*/, const Vector3& /*pos*/,
+               const Vector3& /*dir*/, const NavigationDirection /*navDir*/,
+               const Surface* ssurface, const Surface* tsurface) {
+      startSurface = ssurface;
+      targetSurface = tsurface;
+    }
   };
 
   /// @brief Navigator status call

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -214,35 +214,13 @@ class Navigator {
     Stage navigationStage = Stage::undefined;
 
     /// Reset state
-    ///
     void reset(const GeometryContext& geoContext, const Vector3& pos,
                const Vector3& dir, const NavigationDirection navDir,
                const Surface* ssurface, const Surface* tsurface) {
       // Reset everything first
-      navSurfaces = {};
-      navSurfaceIter = navSurfaces.end();
-      navLayers = {};
-      navLayerIter = navLayers.end();
-      navBoundaries = {};
-      navBoundaryIter = navBoundaries.end();
-      externalSurfaces = {};
-      worldVolume = nullptr;
-      startVolume = nullptr;
-      startLayer = nullptr;
-      startSurface = nullptr;
-      currentSurface = nullptr;
-      currentVolume = nullptr;
-      targetVolume = nullptr;
-      targetLayer = nullptr;
-      targetSurface = nullptr;
+      *this = State();
 
-      startLayerResolved = false;
-      targetReached = false;
-      lastHierarchySurfaceReached = false;
-      navigationBreak = false;
-      navigationStage = Stage::undefined;
-
-      // set the start, current and target objects
+      // Set the start, current and target objects
       startSurface = ssurface;
       if (ssurface->associatedLayer() != nullptr) {
         startLayer = ssurface->associatedLayer();

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -214,6 +214,13 @@ class Navigator {
     Stage navigationStage = Stage::undefined;
 
     /// Reset state
+    ///
+    /// @param geoContext is the geometry context
+    /// @param pos is the global position
+    /// @param dir is the momentum direction
+    /// @param navDir is the navigation direction
+    /// @param ssurface is the new starting surface
+    /// @param tsurface is the target surface
     void reset(const GeometryContext& geoContext, const Vector3& pos,
                const Vector3& dir, const NavigationDirection navDir,
                const Surface* ssurface, const Surface* tsurface) {
@@ -237,6 +244,7 @@ class Navigator {
                                        nullptr);
       navLayers =
           currentVolume->compatibleLayers(geoContext, pos, dir, navOpts);
+
       // Set the iterator to the first
       navLayerIter = navLayers.begin();
     }
@@ -409,9 +417,12 @@ class Navigator {
 
     // Call the navigation helper prior to actual navigation
     ACTS_VERBOSE(volInfo(state) << "Entering navigator::target.");
-
+    if (state.navigation.targetVolume) {
+      std::cout << "state.navigation.targetVolume is not null " << std::endl;
+    }
     // Initialize the target and target volume
     if (state.navigation.targetSurface and not state.navigation.targetVolume) {
+      std::cout << "initializeTarget in target " << std::endl;
       // Find out about the target as much as you can
       initializeTarget(state, stepper);
     }
@@ -790,6 +801,7 @@ class Navigator {
       }
 
       if (resolveLayers(state, stepper)) {
+        std::cout << "to resolveLayers " << std::endl;
         // The layer resolving worked
         return true;
       }
@@ -1066,6 +1078,9 @@ class Navigator {
                        << "Target volume estimated : "
                        << state.navigation.targetVolume->volumeName());
         }
+      }
+      if (state.navigation.targetVolume) {
+        std::cout << "state.navigation.targetVolume is set " << std::endl;
       }
     }
   }

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -417,12 +417,9 @@ class Navigator {
 
     // Call the navigation helper prior to actual navigation
     ACTS_VERBOSE(volInfo(state) << "Entering navigator::target.");
-    if (state.navigation.targetVolume) {
-      std::cout << "state.navigation.targetVolume is not null " << std::endl;
-    }
+
     // Initialize the target and target volume
     if (state.navigation.targetSurface and not state.navigation.targetVolume) {
-      std::cout << "initializeTarget in target " << std::endl;
       // Find out about the target as much as you can
       initializeTarget(state, stepper);
     }
@@ -801,7 +798,6 @@ class Navigator {
       }
 
       if (resolveLayers(state, stepper)) {
-        std::cout << "to resolveLayers " << std::endl;
         // The layer resolving worked
         return true;
       }
@@ -1078,9 +1074,6 @@ class Navigator {
                        << "Target volume estimated : "
                        << state.navigation.targetVolume->volumeName());
         }
-      }
-      if (state.navigation.targetVolume) {
-        std::cout << "state.navigation.targetVolume is set " << std::endl;
       }
     }
   }

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -222,7 +222,7 @@ class Navigator {
     /// @param ssurface is the new starting surface
     /// @param tsurface is the target surface
     void reset(const GeometryContext& geoContext, const Vector3& pos,
-               const Vector3& dir, const NavigationDirection& navDir,
+               const Vector3& dir, NavigationDirection navDir,
                const Surface* ssurface, const Surface* tsurface) {
       // Reset everything first
       *this = State();

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -222,7 +222,7 @@ class Navigator {
     /// @param ssurface is the new starting surface
     /// @param tsurface is the target surface
     void reset(const GeometryContext& geoContext, const Vector3& pos,
-               const Vector3& dir, const NavigationDirection navDir,
+               const Vector3& dir, const NavigationDirection& navDir,
                const Surface* ssurface, const Surface* tsurface) {
       // Reset everything first
       *this = State();

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -212,6 +212,56 @@ class Navigator {
     bool navigationBreak = false;
     // The navigation stage (@todo: integrate break, target)
     Stage navigationStage = Stage::undefined;
+
+    /// Reset state
+    ///
+    void reset(const GeometryContext& geoContext, const Vector3& pos,
+               const Vector3& dir, const NavigationDirection navDir,
+               const Surface* ssurface, const Surface* tsurface) {
+      // Reset everything first
+      navSurfaces = {};
+      navSurfaceIter = navSurfaces.end();
+      navLayers = {};
+      navLayerIter = navLayers.end();
+      navBoundaries = {};
+      navBoundaryIter = navBoundaries.end();
+      externalSurfaces = {};
+      worldVolume = nullptr;
+      startVolume = nullptr;
+      startLayer = nullptr;
+      startSurface = nullptr;
+      currentSurface = nullptr;
+      currentVolume = nullptr;
+      targetVolume = nullptr;
+      targetLayer = nullptr;
+      targetSurface = nullptr;
+
+      startLayerResolved = false;
+      targetReached = false;
+      lastHierarchySurfaceReached = false;
+      navigationBreak = false;
+      navigationStage = Stage::undefined;
+
+      // set the start, current and target objects
+      startSurface = ssurface;
+      if (ssurface->associatedLayer() != nullptr) {
+        startLayer = ssurface->associatedLayer();
+      }
+      if (startLayer->trackingVolume() != nullptr) {
+        startVolume = startLayer->trackingVolume();
+      }
+      currentSurface = startSurface;
+      currentVolume = startVolume;
+      targetSurface = tsurface;
+
+      // Get the compatible layers (including the current layer)
+      NavigationOptions<Layer> navOpts(navDir, true, true, true, true, nullptr,
+                                       nullptr);
+      navLayers =
+          currentVolume->compatibleLayers(geoContext, pos, dir, navOpts);
+      // Set the iterator to the first
+      navLayerIter = navLayers.begin();
+    }
   };
 
   /// Constructor with configuration object

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -474,21 +474,21 @@ class CombinatorialKalmanFilter {
       auto currentState =
           result.fittedStates.getTrackState(result.activeTips.back().first);
 
-      // Reset the navigation state
-      state.navigation.reset(state.geoContext, stepper.position(state.stepping),
-                             stepper.direction(state.stepping),
-                             state.stepping.navDir,
-                             &currentState.referenceSurface(), targetSurface);
-
       // Update the stepping state
       stepper.resetState(state.stepping, currentState.filtered(),
                          currentState.filteredCovariance(),
                          currentState.referenceSurface(), state.stepping.navDir,
                          state.options.maxStepSize);
 
+      // Reset the navigation state
+      state.navigation.reset(state.geoContext, stepper.position(state.stepping),
+                             stepper.direction(state.stepping),
+                             state.stepping.navDir,
+                             &currentState.referenceSurface(), targetSurface);
+
       // No Kalman filtering for the starting surface, but still need
       // to consider the material effects here
-      materialInteractor(state.navigation.startSurface, state, stepper);
+      materialInteractor(state.navigation.currentSurface, state, stepper);
     }
 
     /// @brief CombinatorialKalmanFilter actor operation :

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -475,37 +475,10 @@ class CombinatorialKalmanFilter {
           result.fittedStates.getTrackState(result.activeTips.back().first);
 
       // Reset the navigation state
-      {
-        const Surface* startSurface = nullptr;
-        const Layer* startLayer = nullptr;
-        const TrackingVolume* startVolume = nullptr;
-        startSurface = &currentState.referenceSurface();
-        if (startSurface->associatedLayer() != nullptr) {
-          startLayer = startSurface->associatedLayer();
-        }
-        if (startLayer->trackingVolume() != nullptr) {
-          startVolume = startLayer->trackingVolume();
-        }
-
-        state.navigation = typename propagator_t::NavigatorState();
-        // Reset the start, current and target objects
-        state.navigation.startSurface = startSurface;
-        state.navigation.startLayer = startLayer;
-        state.navigation.startVolume = startVolume;
-        state.navigation.currentSurface = startSurface;
-        state.navigation.currentVolume = startVolume;
-        state.navigation.targetSurface = targetSurface;
-
-        // Get the compatible layers (including the current layer)
-        NavigationOptions<Layer> navOpts(state.stepping.navDir, true, true,
-                                         true, true, nullptr, nullptr);
-        state.navigation.navLayers =
-            state.navigation.currentVolume->compatibleLayers(
-                state.geoContext, stepper.position(state.stepping),
-                stepper.direction(state.stepping), navOpts);
-        // Set the iterator to the first
-        state.navigation.navLayerIter = state.navigation.navLayers.begin();
-      }
+      state.navigation.reset(state.geoContext, stepper.position(state.stepping),
+                             stepper.direction(state.stepping),
+                             state.stepping.navDir,
+                             &currentState.referenceSurface(), targetSurface);
 
       // Update the stepping state
       stepper.resetState(state.stepping, currentState.filtered(),

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -153,9 +153,6 @@ struct KalmanFitterResult {
   // Indicator if smoothing has been done.
   bool smoothed = false;
 
-  // Indicator if the propagation state has been reset
-  bool reset = false;
-
   // Indicator if navigation direction has been reversed
   bool reversed = false;
 
@@ -407,8 +404,6 @@ class KalmanFitter {
                  result_type& result) const {
       // Remember the navigation direciton has been reversed
       result.reversed = true;
-      // The reset is used for resetting the navigation
-      result.reset = true;
 
       // Reverse navigation direction
       state.stepping.navDir =
@@ -427,19 +422,19 @@ class KalmanFitter {
         auto st =
             result.fittedStates.getTrackState(result.lastMeasurementIndex);
 
-        const Surface* startSurface = nullptr;
-        const Layer* startLayer = nullptr;
-        const TrackingVolume* startVolume = nullptr;
-        startSurface = &st.referenceSurface();
-        if (startSurface->associatedLayer() != nullptr) {
-          startLayer = startSurface->associatedLayer();
-        }
-        if (startLayer->trackingVolume() != nullptr) {
-          startVolume = startLayer->trackingVolume();
-        }
-
         // Reset navigation state
         {
+          const Surface* startSurface = nullptr;
+          const Layer* startLayer = nullptr;
+          const TrackingVolume* startVolume = nullptr;
+          startSurface = &st.referenceSurface();
+          if (startSurface->associatedLayer() != nullptr) {
+            startLayer = startSurface->associatedLayer();
+          }
+          if (startLayer->trackingVolume() != nullptr) {
+            startVolume = startLayer->trackingVolume();
+          }
+
           state.navigation = typename propagator_t::NavigatorState();
           // Reset the start, current and target objects
           state.navigation.startSurface = startSurface;

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -423,37 +423,10 @@ class KalmanFitter {
             result.fittedStates.getTrackState(result.lastMeasurementIndex);
 
         // Reset navigation state
-        {
-          const Surface* startSurface = nullptr;
-          const Layer* startLayer = nullptr;
-          const TrackingVolume* startVolume = nullptr;
-          startSurface = &st.referenceSurface();
-          if (startSurface->associatedLayer() != nullptr) {
-            startLayer = startSurface->associatedLayer();
-          }
-          if (startLayer->trackingVolume() != nullptr) {
-            startVolume = startLayer->trackingVolume();
-          }
-
-          state.navigation = typename propagator_t::NavigatorState();
-          // Reset the start, current and target objects
-          state.navigation.startSurface = startSurface;
-          state.navigation.startLayer = startLayer;
-          state.navigation.startVolume = startVolume;
-          state.navigation.currentSurface = startSurface;
-          state.navigation.currentVolume = startVolume;
-          state.navigation.targetSurface = targetSurface;
-
-          // Get the compatible layers (including the current layer)
-          NavigationOptions<Layer> navOpts(state.stepping.navDir, true, true,
-                                           true, true, nullptr, nullptr);
-          state.navigation.navLayers =
-              state.navigation.currentVolume->compatibleLayers(
-                  state.geoContext, stepper.position(state.stepping),
-                  stepper.direction(state.stepping), navOpts);
-          // Set the iterator to the first
-          state.navigation.navLayerIter = state.navigation.navLayers.begin();
-        }
+        state.navigation.reset(
+            state.geoContext, stepper.position(state.stepping),
+            stepper.direction(state.stepping), state.stepping.navDir,
+            &st.referenceSurface(), targetSurface);
 
         // Update the stepping state
         stepper.resetState(state.stepping, st.filtered(),

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -432,12 +432,6 @@ class KalmanFitter {
       // based on information on this state
       auto st = result.fittedStates.getTrackState(result.lastMeasurementIndex);
 
-      // Reset navigation state
-      state.navigation.reset(state.geoContext, stepper.position(state.stepping),
-                             stepper.direction(state.stepping),
-                             state.stepping.navDir, &st.referenceSurface(),
-                             targetSurface);
-
       // Update the stepping state
       stepper.resetState(state.stepping, st.filtered(), st.filteredCovariance(),
                          st.referenceSurface(), state.stepping.navDir,
@@ -447,6 +441,12 @@ class KalmanFitter {
       st.smoothed() = st.filtered();
       st.smoothedCovariance() = st.filteredCovariance();
       result.passedAgainSurfaces.push_back(&st.referenceSurface());
+
+      // Reset navigation state
+      state.navigation.reset(state.geoContext, stepper.position(state.stepping),
+                             stepper.direction(state.stepping),
+                             state.stepping.navDir, &st.referenceSurface(),
+                             targetSurface);
 
       // Update material effects for last measurement state in reversed
       // direction

--- a/Core/include/Acts/TrackFitting/KalmanFitterError.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitterError.hpp
@@ -19,6 +19,7 @@ enum class KalmanFitterError {
   SmoothFailed,
   OutputConversionFailed,
   NoMeasurementFound,
+  ReverseNavigationFailed,
 };
 
 std::error_code make_error_code(Acts::KalmanFitterError e);

--- a/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
@@ -183,7 +183,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldNoSurfaceForward) {
   // check the output status flags
   BOOST_CHECK(val.smoothed);
   BOOST_CHECK(not val.reversed);
-  BOOST_CHECK(not val.reset);
   BOOST_CHECK(val.finished);
   BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
 }
@@ -217,7 +216,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithSurfaceForward) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
   }
@@ -233,7 +231,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithSurfaceForward) {
     // check the output status flags
     BOOST_CHECK(not val.smoothed);
     BOOST_CHECK(val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.measurementStates, sourceLinks.size());
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
@@ -279,7 +276,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithSurfaceBackward) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
   }
@@ -296,7 +292,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithSurfaceBackward) {
     // check the output status flags
     BOOST_CHECK(not val.smoothed);
     BOOST_CHECK(val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
     // count the number of `smoothed` states
@@ -335,7 +330,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithSurfaceAtExit) {
   // check the output status flags
   BOOST_CHECK(val.smoothed);
   BOOST_CHECK(not val.reversed);
-  BOOST_CHECK(not val.reset);
   BOOST_CHECK(val.finished);
   BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
 }
@@ -367,7 +361,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldShuffled) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
   }
@@ -387,7 +380,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldShuffled) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
   }
@@ -424,7 +416,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithHole) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 1u);
   }
@@ -470,7 +461,6 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithOutliers) {
     // check the output status flags
     BOOST_CHECK(val.smoothed);
     BOOST_CHECK(not val.reversed);
-    BOOST_CHECK(not val.reset);
     BOOST_CHECK(val.finished);
     BOOST_CHECK_EQUAL(val.missedActiveSurfaces.size(), 0u);
   }


### PR DESCRIPTION
This PR simplifies the reset of the navigation state to enable the navigation to start from a new surface with provided position and momentum. It requires the `Navigator` `State` struct has a method `reset`.