### PR TITLE
fix: Howto material without spread

### DIFF
--- a/Examples/Scripts/MaterialMaping/Mat_map.C
+++ b/Examples/Scripts/MaterialMaping/Mat_map.C
@@ -178,7 +178,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
 
     // X0 as function of Phi for Validation input
     TCanvas *VM_X0_Phi = new TCanvas("VM_X0_Phi","Validation X0 Phi") ;
-    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi","","profile");
+    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi","exp(-v_eta)/(1+exp(-2*v_eta))","profile");
     Val_X0_Phi->SetMarkerStyle(7);
     Val_X0_Phi->Draw("HIST PC");
     Val_X0_Phi->GetXaxis()->SetTitle("Phi");
@@ -187,7 +187,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
 
     // X0 as function of Phi for Validation input
     TCanvas *VM_X0_Phi_spread = new TCanvas("VM_X0_Phi_spread","Validation X0 Phi") ;
-    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi_spread","","");
+    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi_spread","exp(-v_eta)/(1+exp(-2*v_eta))","");
     Val_X0_Phi_spread->GetXaxis()->SetTitle("Phi");
     Val_X0_Phi_spread->GetYaxis()->SetTitle("X0");
     VM_X0_Phi_spread->Print( (name+"/Val_mat_Phi_X0_spread.pdf").c_str());

--- a/Examples/Scripts/MaterialMaping/Mat_map_detector_plot.C
+++ b/Examples/Scripts/MaterialMaping/Mat_map_detector_plot.C
@@ -77,11 +77,11 @@ void Initialise_hist(std::vector<TH2F*>& detector_hist){
   TH2F * Map_scale;
 
   Map_X0    = new TH2F("Map_X0_detector","Map_X0_detector",
-                       100,-6,6,50,-3.2,3.2);
+                       100,-4,4,50,-3.2,3.2);
   Map_L0    = new TH2F("Map_L0_detector","Map_L0_detector",
-                       100,-6,6,50,-3.2,3.2);
+                       100,-4,4,50,-3.2,3.2);
   Map_scale = new TH2F("Map_Scale_detector","Map_Scale_detector",
-                       100,-6,6,50,-3.2,3.2);
+                       100,-4,4,50,-3.2,3.2);
   Map_X0->GetXaxis()->SetTitle("Eta");
   Map_X0->GetYaxis()->SetTitle("Phi");
   Map_X0->GetZaxis()->SetTitle("X0");

--- a/docs/howto/run_material_mapping.rst
+++ b/docs/howto/run_material_mapping.rst
@@ -91,7 +91,7 @@ Material Validation
 
 Now that the map has been written, you will want to validate it. First you can use the ``MaterialValidation`` example. This will perform propagation throughout the detector once it has been decorated with the material map. It will then output material tracks with the same format as the one obtain with the Geantino.
 
-By default, the Geantino scan is performed with no spread in z0 and d0, while the validation has a spread of 55 mm, to obtain meaningful result used the same spread for both (in our example a spread of 0). Another difference between the scan and the validation is that the first use a flat distribution in theta while the second use a flat distribution in eta, some reweighing might be necessary when comparing some of the distributions.
+By default, the Geantino scan is performed with no spread in :math:`z_0` and :math:`d_0`, while the validation has a spread of 55 mm, to obtain meaningful results, use the same spread for both (in our example a spread of 0). Another difference between the scan and the validation is that the first uses a flat distribution in :math:`\theta` while the second uses a flat distribution in :math:`\eta`, so some reweighing might be necessary when comparing some of the distributions.
 .. code-block:: console
 
   ./../build/bin/ActsExampleMaterialValidationDD4hep -n 1000 --mat-input-type file --mat-input-file material-maps.json --output-root --mat-output-file val-mat-map --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml --prop-z0-sigma 0.0 --prop-d0-sigma 0.0

--- a/docs/howto/run_material_mapping.rst
+++ b/docs/howto/run_material_mapping.rst
@@ -91,9 +91,10 @@ Material Validation
 
 Now that the map has been written, you will want to validate it. First you can use the ``MaterialValidation`` example. This will perform propagation throughout the detector once it has been decorated with the material map. It will then output material tracks with the same format as the one obtain with the Geantino.
 
+By default, the Geantino scan is performed with no spread in z0 and d0, while the validation has a spread of 55 mm, to obtain meaningful result used the same spread for both (in our example a spread of 0). Another difference between the scan and the validation is that the first use a flat distribution in theta while the second use a flat distribution in eta, some reweighing might be necessary when comparing some of the distributions.
 .. code-block:: console
 
-  ./../build/bin/ActsExampleMaterialValidationDD4hep -n 1000 --mat-input-type file --mat-input-file material-maps.json --output-root --mat-output-file val-mat-map --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml
+  ./../build/bin/ActsExampleMaterialValidationDD4hep -n 1000 --mat-input-type file --mat-input-file material-maps.json --output-root --mat-output-file val-mat-map --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml --prop-z0-sigma 0.0 --prop-d0-sigma 0.0
 
 To do the validation, five root macros are available in ``scripts/MaterialMaping``:
 


### PR DESCRIPTION
Fix the Howto for material mapping. Include the fact that the Z0 and D0 sigma need to be set to 0 in the validation to be correctly compare to the Geantino scan.  
Also modify the root  script to take into account that the Geantino scan is flat in theta where the Validation is flat in eta.