### PR TITLE
fix: DiscBounds binningValue incorrect for binPhi

### DIFF
--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -62,17 +62,15 @@ Acts::CylinderSurface& Acts::CylinderSurface::operator=(
 // return the binning position for ordering in the BinnedArray
 Acts::Vector3 Acts::CylinderSurface::binningPosition(
     const GeometryContext& gctx, BinningValue bValue) const {
-  const Acts::Vector3& sfCenter = center(gctx);
   // special binning type for R-type methods
   if (bValue == Acts::binR || bValue == Acts::binRPhi) {
     double R = bounds().get(CylinderBounds::eR);
     double phi = bounds().get(CylinderBounds::eAveragePhi);
-    return Vector3(sfCenter.x() + R * cos(phi), sfCenter.y() + R * sin(phi),
-                   sfCenter.z());
+    return localToGlobal(gctx, Vector2{phi * R, 0}, Vector3{});
   }
   // give the center as default for all of these binning types
   // binX, binY, binZ, binR, binPhi, binRPhi, binH, binEta
-  return sfCenter;
+  return center(gctx);
 }
 
 // return the measurement frame: it's the tangential plane

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -351,10 +351,13 @@ Acts::Vector3 Acts::DiscSurface::binningPosition(const GeometryContext& gctx,
 
 double Acts::DiscSurface::binningPositionValue(const GeometryContext& gctx,
                                                BinningValue bValue) const {
-  // only modify binR
   if (bValue == binR) {
-    return VectorHelpers::perp(center(gctx)) + m_bounds->binningValueR();
+    return VectorHelpers::perp(binningPosition(gctx, bValue));
   }
+  if (bValue == binPhi) {
+    return VectorHelpers::phi(binningPosition(gctx, bValue));
+  }
+
   return GeometryObject::binningPositionValue(gctx, bValue);
 }
 

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2016-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -341,10 +341,10 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx,
 
 Acts::Vector3 Acts::DiscSurface::binningPosition(const GeometryContext& gctx,
                                                  BinningValue bValue) const {
-  if (bValue == binR) {
+  if (bValue == binR || bValue == binPhi) {
     double r = m_bounds->binningValueR();
     double phi = m_bounds->binningValuePhi();
-    return Vector3(r * cos(phi), r * sin(phi), center(gctx).z());
+    return localToGlobal(gctx, Vector2{r, phi}, Vector3{});
   }
   return center(gctx);
 }

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -315,6 +315,13 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceBinningPosition) {
 
     bp = disc->binningPosition(tgContext, binPhi);
     BOOST_CHECK_EQUAL(bp, exp);
+
+    for (auto b : {binX, binY, binZ, binEta, binRPhi, binH, binMag}) {
+      BOOST_TEST_CONTEXT("binValue: " << b) {
+        BOOST_CHECK_EQUAL(disc->binningPosition(tgContext, b),
+                          disc->center(tgContext));
+      }
+    }
   }
 
   {
@@ -337,6 +344,13 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceBinningPosition) {
 
     bp = disc->binningPosition(tgContext, binPhi);
     BOOST_CHECK_EQUAL(bp, exp);
+
+    for (auto b : {binX, binY, binZ, binEta, binRPhi, binH, binMag}) {
+      BOOST_TEST_CONTEXT("binValue: " << b) {
+        BOOST_CHECK_EQUAL(disc->binningPosition(tgContext, b),
+                          disc->center(tgContext));
+      }
+    }
   }
 }
 

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2018 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,9 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Definitions/Units.hpp"
 #include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
+#include "Acts/Surfaces/AnnulusBounds.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/DiscTrapezoidBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
@@ -287,6 +289,55 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAlignment) {
   ActsMatrix<2, 3> expLoc3DToLocBound = ActsMatrix<2, 3>::Zero();
   expLoc3DToLocBound << 0, 1, 0, -1.0 / 3, 0, 0;
   CHECK_CLOSE_ABS(loc3DToLocBound, expLoc3DToLocBound, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(DiscSurfaceBinningPosition) {
+  using namespace Acts::UnitLiterals;
+  Vector3 s{5_mm, 7_mm, 10_cm};
+  Transform3 trf;
+  trf = Translation3(s) * AngleAxis3{0.5, Vector3::UnitZ()};
+
+  double minR = 300;
+  double maxR = 330;
+
+  {
+    // Radial Bounds
+    auto bounds = std::make_shared<RadialBounds>(minR, maxR, M_PI / 8, 0.1);
+    auto disc = Acts::Surface::makeShared<Acts::DiscSurface>(trf, bounds);
+
+    Vector3 bp = disc->binningPosition(tgContext, binR);
+    double r = (bounds->rMax() + bounds->rMin()) / 2.0;
+    double phi = bounds->get(RadialBounds::eAveragePhi);
+    Vector3 exp = Vector3{r * std::cos(phi), r * std::sin(phi), 0};
+    exp = trf * exp;
+
+    BOOST_CHECK_EQUAL(bp, exp);
+
+    bp = disc->binningPosition(tgContext, binPhi);
+    BOOST_CHECK_EQUAL(bp, exp);
+  }
+
+  {
+    // Annulus Bounds
+    double minPhiRel = -0.3;
+    double maxPhiRel = 0.2;
+    Vector2 origin{5_mm, 5_mm};
+    auto bounds = std::make_shared<AnnulusBounds>(minR, maxR, minPhiRel,
+                                                  maxPhiRel, origin);
+
+    auto disc = Acts::Surface::makeShared<Acts::DiscSurface>(trf, bounds);
+
+    Vector3 bp = disc->binningPosition(tgContext, binR);
+    double r = (bounds->rMax() + bounds->rMin()) / 2.0;
+    double phi = bounds->get(AnnulusBounds::eAveragePhi);
+    Vector3 exp = Vector3{r * std::cos(phi), r * std::sin(phi), 0};
+    exp = trf * exp;
+
+    BOOST_CHECK_EQUAL(bp, exp);
+
+    bp = disc->binningPosition(tgContext, binPhi);
+    BOOST_CHECK_EQUAL(bp, exp);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -312,9 +312,13 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceBinningPosition) {
     exp = trf * exp;
 
     BOOST_CHECK_EQUAL(bp, exp);
+    BOOST_CHECK_EQUAL(disc->binningPositionValue(tgContext, binR),
+                      VectorHelpers::perp(exp));
 
     bp = disc->binningPosition(tgContext, binPhi);
     BOOST_CHECK_EQUAL(bp, exp);
+    BOOST_CHECK_EQUAL(disc->binningPositionValue(tgContext, binPhi),
+                      VectorHelpers::phi(exp));
 
     for (auto b : {binX, binY, binZ, binEta, binRPhi, binH, binMag}) {
       BOOST_TEST_CONTEXT("binValue: " << b) {


### PR DESCRIPTION
`DiscBounds` has special logic for `binR`, where it asks its `DiscBounds` for a binning value. This logic is not invoked for `binPhi`, which I believe it should. Added a unit test to assert this behavior.

Also **I believe** binning value should be in global coordinates here. Previously this worked **if** local-to-global was only a translation along `z`, because the center `z` position was explicitly added. I think generically it should be global, therefore I changed it to apply the transform.

/cc @asalzburger @Corentin-Allaire 
