### PR TITLE
fix: Add missing include in PolymorphicValueTest.cpp

### DIFF
--- a/Tests/UnitTests/Core/Utilities/PolymorphicValueTest.cpp
+++ b/Tests/UnitTests/Core/Utilities/PolymorphicValueTest.cpp
@@ -10,6 +10,8 @@
 
 #include "Acts/Utilities/PolymorphicValue.hpp"
 
+#include <optional>
+
 namespace Acts {
 
 namespace Test {


### PR DESCRIPTION
#855 broke the build on my end because of a missing include in a test file. Here we simply add that include, and all is well.
cc @paulgessinger 