### PR TITLE
fix: Replace deprecated `tbb.h` include

### DIFF
--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -20,7 +20,8 @@
 #include <TROOT.h>
 #include <dfe/dfe_io_dsv.hpp>
 #include <dfe/dfe_namedtuple.hpp>
-#include <tbb/tbb.h>
+#include <tbb/parallel_for.h>
+#include <tbb/queuing_mutex.h>
 
 ActsExamples::Sequencer::Sequencer(const Sequencer::Config& cfg)
     : m_cfg(cfg),


### PR DESCRIPTION
Including `tbb/tbb.h` is apparently deprecated:

```console
In file included from ../Examples/Framework/src/Framework/Sequencer.cpp:23:
/usr/include/tbb/tbb.h:21:154: note: #pragma message: TBB Warning: tbb.h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.
   21 | #pragma message("TBB Warning: tbb.h contains deprecated functionality. For details, please see Deprecated Features appendix in the TBB reference manual.")
      |
```

This PR replaces it with separate includes.