### PR TITLE
docs: Fix doxygen parser problem by a workaround

### DIFF
--- a/Core/include/Acts/Utilities/Helpers.hpp
+++ b/Core/include/Acts/Utilities/Helpers.hpp
@@ -374,8 +374,7 @@ std::vector<const T*> unpack_shared_vector(
 /// that is callable with @c Args
 template <template <size_t> class Callable, size_t N, size_t NMAX,
           typename... Args>
-decltype(Callable<N>::invoke(std::declval<Args>()...)) template_switch(
-    size_t v, Args&&... args) {
+auto template_switch(size_t v, Args&&... args) {
   if (v == N) {
     return Callable<N>::invoke(std::forward<Args>(args)...);
   }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ sphinx>=2.0
 sphinx_rtd_theme>=0.4
 sphinx_markdown_tables
 recommonmark
-breathe==4.26.0
+breathe==4.30.0
 exhale
 m2r


### PR DESCRIPTION
Doxygen+breathe started breaking when bumping breathe to `4.26.1`, which was tracked in #661. While the error might be fixed with an as-of-yet unreleased version of doxygen, this PR includes a workaround that seems to make the doc build run through on breathe `4.30.0.`, which I believe is the current version and also showed this failure.

Resolves #661 