### PR TITLE
feat: introduce TGeoDetectorElementSplitter & splitted detector element constructors

### DIFF
--- a/Examples/Detectors/TGeoDetector/CMakeLists.txt
+++ b/Examples/Detectors/TGeoDetector/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(
   src/BuildTGeoDetector.cpp
   src/TGeoDetector.cpp
   src/TGeoDetectorOptions.cpp)
+  
 target_include_directories(
   ActsExamplesDetectorTGeo
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/Examples/Detectors/TGeoDetector/CMakeLists.txt
+++ b/Examples/Detectors/TGeoDetector/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   ActsExamplesDetectorTGeo SHARED
+  src/BuildTGeoDetector.cpp
   src/TGeoDetector.cpp
   src/TGeoDetectorOptions.cpp)
 target_include_directories(

--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Material/IMaterialDecorator.hpp"
 #include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
 

--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
@@ -8,14 +8,14 @@
 
 #pragma once
 
-
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
 #include "Acts/Material/IMaterialDecorator.hpp"
-#include <boost/program_options.hpp>
+#include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
 
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include <boost/program_options.hpp>
 
 namespace ActsExamples {
 namespace TGeo {
@@ -30,7 +30,8 @@ namespace TGeo {
 ///
 /// @param vm is the variable map from the options
 std::shared_ptr<const Acts::TrackingGeometry> buildTGeoDetector(
-    const boost::program_options::variables_map& vm, const Acts::GeometryContext& context,
+    const boost::program_options::variables_map& vm,
+    const Acts::GeometryContext& context,
     std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>&
         detElementStore,
     std::shared_ptr<const Acts::IMaterialDecorator> mdecorator);

--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/BuildTGeoDetector.hpp
@@ -8,30 +8,14 @@
 
 #pragma once
 
-#include "Acts/Geometry/CylinderVolumeBuilder.hpp"
-#include "Acts/Geometry/CylinderVolumeHelper.hpp"
+
 #include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/Geometry/LayerArrayCreator.hpp"
-#include "Acts/Geometry/LayerCreator.hpp"
-#include "Acts/Geometry/PassiveLayerBuilder.hpp"
-#include "Acts/Geometry/SurfaceArrayCreator.hpp"
-#include "Acts/Geometry/SurfaceBinningMatcher.hpp"
-#include "Acts/Geometry/TrackingGeometry.hpp"
-#include "Acts/Geometry/TrackingGeometryBuilder.hpp"
-#include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
-#include "Acts/Material/Material.hpp"
-#include "Acts/Material/MaterialSlab.hpp"
-#include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
-#include "Acts/Utilities/BinningType.hpp"
-#include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
 #include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
-#include "ActsExamples/Utilities/Options.hpp"
-
-#include <list>
-#include <vector>
-
-#include <TGeoManager.h>
+#include "Acts/Material/IMaterialDecorator.hpp"
 #include <boost/program_options.hpp>
+
+#include <vector>
+#include <memory>
 
 namespace ActsExamples {
 namespace TGeo {
@@ -45,201 +29,11 @@ namespace TGeo {
 /// @tparam variable_map_t is the variable map
 ///
 /// @param vm is the variable map from the options
-template <typename variable_maps_t>
 std::shared_ptr<const Acts::TrackingGeometry> buildTGeoDetector(
-    variable_maps_t& vm, const Acts::GeometryContext& context,
+    const boost::program_options::variables_map& vm, const Acts::GeometryContext& context,
     std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>&
         detElementStore,
-    std::shared_ptr<const Acts::IMaterialDecorator> mdecorator) {
-  Acts::Logging::Level surfaceLogLevel =
-      Acts::Logging::Level(vm["geo-surface-loglevel"].template as<size_t>());
-  Acts::Logging::Level layerLogLevel =
-      Acts::Logging::Level(vm["geo-layer-loglevel"].template as<size_t>());
-  Acts::Logging::Level volumeLogLevel =
-      Acts::Logging::Level(vm["geo-volume-loglevel"].template as<size_t>());
-
-  // configure surface array creator
-  Acts::SurfaceArrayCreator::Config sacConfig;
-  auto surfaceArrayCreator = std::make_shared<const Acts::SurfaceArrayCreator>(
-      sacConfig,
-      Acts::getDefaultLogger("SurfaceArrayCreator", surfaceLogLevel));
-  // configure the proto layer helper
-  Acts::ProtoLayerHelper::Config plhConfig;
-  auto protoLayerHelper = std::make_shared<const Acts::ProtoLayerHelper>(
-      plhConfig, Acts::getDefaultLogger("ProtoLayerHelper", layerLogLevel));
-  // configure the layer creator that uses the surface array creator
-  Acts::LayerCreator::Config lcConfig;
-  lcConfig.surfaceArrayCreator = surfaceArrayCreator;
-  auto layerCreator = std::make_shared<const Acts::LayerCreator>(
-      lcConfig, Acts::getDefaultLogger("LayerCreator", layerLogLevel));
-  // configure the layer array creator
-  Acts::LayerArrayCreator::Config lacConfig;
-  auto layerArrayCreator = std::make_shared<const Acts::LayerArrayCreator>(
-      lacConfig, Acts::getDefaultLogger("LayerArrayCreator", layerLogLevel));
-  // tracking volume array creator
-  Acts::TrackingVolumeArrayCreator::Config tvacConfig;
-  auto tVolumeArrayCreator =
-      std::make_shared<const Acts::TrackingVolumeArrayCreator>(
-          tvacConfig,
-          Acts::getDefaultLogger("TrackingVolumeArrayCreator", volumeLogLevel));
-  // configure the cylinder volume helper
-  Acts::CylinderVolumeHelper::Config cvhConfig;
-  cvhConfig.layerArrayCreator = layerArrayCreator;
-  cvhConfig.trackingVolumeArrayCreator = tVolumeArrayCreator;
-  auto cylinderVolumeHelper =
-      std::make_shared<const Acts::CylinderVolumeHelper>(
-          cvhConfig,
-          Acts::getDefaultLogger("CylinderVolumeHelper", volumeLogLevel));
-
-  //-------------------------------------------------------------------------------------
-  // list the volume builders
-  std::list<std::shared_ptr<const Acts::ITrackingVolumeBuilder>> volumeBuilders;
-
-  std::string rootFileName = vm["geo-tgeo-filename"].template as<std::string>();
-
-  // Create a beam pipe if configured to do so
-  if (vm.count("geo-tgeo-beampipe-parameters")) {
-    auto beamPipeParameters =
-        vm["geo-tgeo-beampipe-parameters"].template as<Options::Reals<3>>();
-    /// configure the beam pipe layer builder
-    Acts::PassiveLayerBuilder::Config bplConfig;
-    bplConfig.layerIdentification = "BeamPipe";
-    bplConfig.centralLayerRadii = std::vector<double>(1, beamPipeParameters[0]);
-    bplConfig.centralLayerHalflengthZ =
-        std::vector<double>(1, beamPipeParameters[1]);
-    bplConfig.centralLayerThickness =
-        std::vector<double>(1, beamPipeParameters[2]);
-    auto beamPipeBuilder = std::make_shared<const Acts::PassiveLayerBuilder>(
-        bplConfig,
-        Acts::getDefaultLogger("BeamPipeLayerBuilder", layerLogLevel));
-    // create the volume for the beam pipe
-    Acts::CylinderVolumeBuilder::Config bpvConfig;
-    bpvConfig.trackingVolumeHelper = cylinderVolumeHelper;
-    bpvConfig.volumeName = "BeamPipe";
-    bpvConfig.layerBuilder = beamPipeBuilder;
-    bpvConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
-                                1. * Acts::UnitConstants::mm};
-    bpvConfig.buildToRadiusZero = true;
-    auto beamPipeVolumeBuilder =
-        std::make_shared<const Acts::CylinderVolumeBuilder>(
-            bpvConfig,
-            Acts::getDefaultLogger("BeamPipeVolumeBuilder", volumeLogLevel));
-    // add to the list of builders
-    volumeBuilders.push_back(beamPipeVolumeBuilder);
-  }
-
-  // import the file from
-  TGeoManager::Import(rootFileName.c_str());
-
-  auto layerBuilderConfigs =
-      ActsExamples::Options::readTGeoLayerBuilderConfigs(vm);
-
-  // remember the layer builders to collect the detector elements
-  std::vector<std::shared_ptr<const Acts::TGeoLayerBuilder>> tgLayerBuilders;
-
-  for (auto& lbc : layerBuilderConfigs) {
-    std::shared_ptr<const Acts::LayerCreator> layerCreatorLB = nullptr;
-
-    if (lbc.autoSurfaceBinning) {
-      // Configure surface array creator (optionally) per layer builder
-      // (in order to configure them to work appropriately)
-      Acts::SurfaceArrayCreator::Config sacConfigLB;
-      sacConfigLB.surfaceMatcher = lbc.surfaceBinMatcher;
-      auto surfaceArrayCreatorLB =
-          std::make_shared<const Acts::SurfaceArrayCreator>(
-              sacConfigLB, Acts::getDefaultLogger(
-                               lbc.configurationName + "SurfaceArrayCreator",
-                               surfaceLogLevel));
-      // configure the layer creator that uses the surface array creator
-      Acts::LayerCreator::Config lcConfigLB;
-      lcConfigLB.surfaceArrayCreator = surfaceArrayCreatorLB;
-      layerCreatorLB = std::make_shared<const Acts::LayerCreator>(
-          lcConfigLB,
-          Acts::getDefaultLogger(lbc.configurationName + "LayerCreator",
-                                 layerLogLevel));
-    }
-
-    // Configure the proto layer helper
-    Acts::ProtoLayerHelper::Config plhConfigLB;
-    auto protoLayerHelperLB = std::make_shared<const Acts::ProtoLayerHelper>(
-        plhConfigLB,
-        Acts::getDefaultLogger(lbc.configurationName + "ProtoLayerHelper",
-                               layerLogLevel));
-
-    //-------------------------------------------------------------------------------------
-    lbc.layerCreator =
-        (layerCreatorLB != nullptr) ? layerCreatorLB : layerCreator;
-    lbc.protoLayerHelper =
-        (protoLayerHelperLB != nullptr) ? protoLayerHelperLB : protoLayerHelper;
-
-    auto layerBuilder = std::make_shared<const Acts::TGeoLayerBuilder>(
-        lbc, Acts::getDefaultLogger(lbc.configurationName + "LayerBuilder",
-                                    layerLogLevel));
-    // remember the layer builder
-    tgLayerBuilders.push_back(layerBuilder);
-
-    // build the pixel volume
-    Acts::CylinderVolumeBuilder::Config volumeConfig;
-    volumeConfig.trackingVolumeHelper = cylinderVolumeHelper;
-    volumeConfig.volumeName = lbc.configurationName;
-    volumeConfig.buildToRadiusZero = (volumeBuilders.size() == 0);
-    volumeConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
-                                   5. * Acts::UnitConstants::mm};
-    auto ringLayoutConfiguration =
-        [&](const std::vector<Acts::TGeoLayerBuilder::LayerConfig>& lConfigs)
-        -> void {
-      for (const auto& lcfg : lConfigs) {
-        for (const auto& scfg : lcfg.splitConfigs) {
-          if (scfg.first == Acts::binR and scfg.second > 0.) {
-            volumeConfig.ringTolerance =
-                std::max(volumeConfig.ringTolerance, scfg.second);
-            volumeConfig.checkRingLayout = true;
-          }
-        }
-      }
-    };
-    ringLayoutConfiguration(lbc.layerConfigurations[0]);
-    ringLayoutConfiguration(lbc.layerConfigurations[2]);
-    volumeConfig.layerBuilder = layerBuilder;
-    volumeConfig.volumeSignature = 0;
-    auto volumeBuilder = std::make_shared<const Acts::CylinderVolumeBuilder>(
-        volumeConfig,
-        Acts::getDefaultLogger(lbc.configurationName + "VolumeBuilder",
-                               volumeLogLevel));
-    // add to the list of builders
-    volumeBuilders.push_back(volumeBuilder);
-  }
-
-  //-------------------------------------------------------------------------------------
-  // create the tracking geometry
-  Acts::TrackingGeometryBuilder::Config tgConfig;
-  // Add the builders
-  tgConfig.materialDecorator = mdecorator;
-
-  for (auto& vb : volumeBuilders) {
-    tgConfig.trackingVolumeBuilders.push_back(
-        [=](const auto& gcontext, const auto& inner, const auto&) {
-          return vb->trackingVolume(gcontext, inner);
-        });
-  }
-  // Add the helper
-  tgConfig.trackingVolumeHelper = cylinderVolumeHelper;
-  auto cylinderGeometryBuilder =
-      std::make_shared<const Acts::TrackingGeometryBuilder>(
-          tgConfig,
-          Acts::getDefaultLogger("TrackerGeometryBuilder", volumeLogLevel));
-  // get the geometry
-  auto trackingGeometry = cylinderGeometryBuilder->trackingGeometry(context);
-  // collect the detector element store
-  for (auto& lBuilder : tgLayerBuilders) {
-    auto detElements = lBuilder->detectorElements();
-    detElementStore.insert(detElementStore.begin(), detElements.begin(),
-                           detElements.end());
-  }
-
-  /// return the tracking geometry
-  return trackingGeometry;
-}
+    std::shared_ptr<const Acts::IMaterialDecorator> mdecorator);
 
 }  // namespace TGeo
 }  // namespace ActsExamples

--- a/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
@@ -1,0 +1,245 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Geometry/CylinderVolumeBuilder.hpp"
+#include "Acts/Geometry/CylinderVolumeHelper.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/LayerArrayCreator.hpp"
+#include "Acts/Geometry/LayerCreator.hpp"
+#include "Acts/Geometry/PassiveLayerBuilder.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
+#include "Acts/Geometry/SurfaceBinningMatcher.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/Geometry/TrackingGeometryBuilder.hpp"
+#include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
+#include "Acts/Material/Material.hpp"
+#include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
+#include "Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp"
+#include "Acts/Utilities/BinningType.hpp"
+#include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
+#include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
+#include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include <list>
+#include <vector>
+
+#include <TGeoManager.h>
+
+/// @brief global method to build the generic tracking geometry
+// from a TGeo object.
+///
+/// It does *currently* not translate the material, this has
+/// to be done with a material mapping stage
+///
+/// @tparam variable_map_t is the variable map
+///
+/// @param vm is the variable map from the options
+std::shared_ptr<const Acts::TrackingGeometry> ActsExamples::TGeo::buildTGeoDetector(
+    const boost::program_options::variables_map& vm, const Acts::GeometryContext& context,
+    std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>&
+        detElementStore,
+    std::shared_ptr<const Acts::IMaterialDecorator> mdecorator) {
+  Acts::Logging::Level surfaceLogLevel =
+      Acts::Logging::Level(vm["geo-surface-loglevel"].template as<size_t>());
+  Acts::Logging::Level layerLogLevel =
+      Acts::Logging::Level(vm["geo-layer-loglevel"].template as<size_t>());
+  Acts::Logging::Level volumeLogLevel =
+      Acts::Logging::Level(vm["geo-volume-loglevel"].template as<size_t>());
+
+  // configure surface array creator
+  Acts::SurfaceArrayCreator::Config sacConfig;
+  auto surfaceArrayCreator = std::make_shared<const Acts::SurfaceArrayCreator>(
+      sacConfig,
+      Acts::getDefaultLogger("SurfaceArrayCreator", surfaceLogLevel));
+  // configure the proto layer helper
+  Acts::ProtoLayerHelper::Config plhConfig;
+  auto protoLayerHelper = std::make_shared<const Acts::ProtoLayerHelper>(
+      plhConfig, Acts::getDefaultLogger("ProtoLayerHelper", layerLogLevel));
+  // configure the layer creator that uses the surface array creator
+  Acts::LayerCreator::Config lcConfig;
+  lcConfig.surfaceArrayCreator = surfaceArrayCreator;
+  auto layerCreator = std::make_shared<const Acts::LayerCreator>(
+      lcConfig, Acts::getDefaultLogger("LayerCreator", layerLogLevel));
+  // configure the layer array creator
+  Acts::LayerArrayCreator::Config lacConfig;
+  auto layerArrayCreator = std::make_shared<const Acts::LayerArrayCreator>(
+      lacConfig, Acts::getDefaultLogger("LayerArrayCreator", layerLogLevel));
+  // tracking volume array creator
+  Acts::TrackingVolumeArrayCreator::Config tvacConfig;
+  auto tVolumeArrayCreator =
+      std::make_shared<const Acts::TrackingVolumeArrayCreator>(
+          tvacConfig,
+          Acts::getDefaultLogger("TrackingVolumeArrayCreator", volumeLogLevel));
+  // configure the cylinder volume helper
+  Acts::CylinderVolumeHelper::Config cvhConfig;
+  cvhConfig.layerArrayCreator = layerArrayCreator;
+  cvhConfig.trackingVolumeArrayCreator = tVolumeArrayCreator;
+  auto cylinderVolumeHelper =
+      std::make_shared<const Acts::CylinderVolumeHelper>(
+          cvhConfig,
+          Acts::getDefaultLogger("CylinderVolumeHelper", volumeLogLevel));
+
+  //-------------------------------------------------------------------------------------
+  // list the volume builders
+  std::list<std::shared_ptr<const Acts::ITrackingVolumeBuilder>> volumeBuilders;
+
+  std::string rootFileName = vm["geo-tgeo-filename"].template as<std::string>();
+
+  // Create a beam pipe if configured to do so
+  if (vm.count("geo-tgeo-beampipe-parameters")) {
+    auto beamPipeParameters =
+        vm["geo-tgeo-beampipe-parameters"].template as<Options::Reals<3>>();
+    /// configure the beam pipe layer builder
+    Acts::PassiveLayerBuilder::Config bplConfig;
+    bplConfig.layerIdentification = "BeamPipe";
+    bplConfig.centralLayerRadii = std::vector<double>(1, beamPipeParameters[0]);
+    bplConfig.centralLayerHalflengthZ =
+        std::vector<double>(1, beamPipeParameters[1]);
+    bplConfig.centralLayerThickness =
+        std::vector<double>(1, beamPipeParameters[2]);
+    auto beamPipeBuilder = std::make_shared<const Acts::PassiveLayerBuilder>(
+        bplConfig,
+        Acts::getDefaultLogger("BeamPipeLayerBuilder", layerLogLevel));
+    // create the volume for the beam pipe
+    Acts::CylinderVolumeBuilder::Config bpvConfig;
+    bpvConfig.trackingVolumeHelper = cylinderVolumeHelper;
+    bpvConfig.volumeName = "BeamPipe";
+    bpvConfig.layerBuilder = beamPipeBuilder;
+    bpvConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
+                                1. * Acts::UnitConstants::mm};
+    bpvConfig.buildToRadiusZero = true;
+    auto beamPipeVolumeBuilder =
+        std::make_shared<const Acts::CylinderVolumeBuilder>(
+            bpvConfig,
+            Acts::getDefaultLogger("BeamPipeVolumeBuilder", volumeLogLevel));
+    // add to the list of builders
+    volumeBuilders.push_back(beamPipeVolumeBuilder);
+  }
+
+  // import the file from
+  TGeoManager::Import(rootFileName.c_str());
+
+  auto layerBuilderConfigs =
+      ActsExamples::Options::readTGeoLayerBuilderConfigs(vm);
+
+  // remember the layer builders to collect the detector elements
+  std::vector<std::shared_ptr<const Acts::TGeoLayerBuilder>> tgLayerBuilders;
+
+  for (auto& lbc : layerBuilderConfigs) {
+    std::shared_ptr<const Acts::LayerCreator> layerCreatorLB = nullptr;
+
+    if (lbc.autoSurfaceBinning) {
+      // Configure surface array creator (optionally) per layer builder
+      // (in order to configure them to work appropriately)
+      Acts::SurfaceArrayCreator::Config sacConfigLB;
+      sacConfigLB.surfaceMatcher = lbc.surfaceBinMatcher;
+      auto surfaceArrayCreatorLB =
+          std::make_shared<const Acts::SurfaceArrayCreator>(
+              sacConfigLB, Acts::getDefaultLogger(
+                               lbc.configurationName + "SurfaceArrayCreator",
+                               surfaceLogLevel));
+      // configure the layer creator that uses the surface array creator
+      Acts::LayerCreator::Config lcConfigLB;
+      lcConfigLB.surfaceArrayCreator = surfaceArrayCreatorLB;
+      layerCreatorLB = std::make_shared<const Acts::LayerCreator>(
+          lcConfigLB,
+          Acts::getDefaultLogger(lbc.configurationName + "LayerCreator",
+                                 layerLogLevel));
+    }
+
+    // Configure the proto layer helper
+    Acts::ProtoLayerHelper::Config plhConfigLB;
+    auto protoLayerHelperLB = std::make_shared<const Acts::ProtoLayerHelper>(
+        plhConfigLB,
+        Acts::getDefaultLogger(lbc.configurationName + "ProtoLayerHelper",
+                               layerLogLevel));
+
+    //-------------------------------------------------------------------------------------
+    lbc.layerCreator =
+        (layerCreatorLB != nullptr) ? layerCreatorLB : layerCreator;
+    lbc.protoLayerHelper =
+        (protoLayerHelperLB != nullptr) ? protoLayerHelperLB : protoLayerHelper;
+
+
+    // @TODO Make configurable 
+    Acts::TGeoCylinderDiscSplitter::Config cdsConfig;
+    cdsConfig.circularSegments = 32;
+    cdsConfig.regularSegments = 6;
+    lbc.detectorElementSplitter 
+        = std::make_shared<const Acts::TGeoCylinderDiscSplitter>(cdsConfig);
+
+    auto layerBuilder = std::make_shared<const Acts::TGeoLayerBuilder>(
+        lbc, Acts::getDefaultLogger(lbc.configurationName + "LayerBuilder",
+                                    layerLogLevel));
+    // remember the layer builder
+    tgLayerBuilders.push_back(layerBuilder);
+
+    // build the pixel volume
+    Acts::CylinderVolumeBuilder::Config volumeConfig;
+    volumeConfig.trackingVolumeHelper = cylinderVolumeHelper;
+    volumeConfig.volumeName = lbc.configurationName;
+    volumeConfig.buildToRadiusZero = (volumeBuilders.size() == 0);
+    volumeConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
+                                   5. * Acts::UnitConstants::mm};
+    auto ringLayoutConfiguration =
+        [&](const std::vector<Acts::TGeoLayerBuilder::LayerConfig>& lConfigs)
+        -> void {
+      for (const auto& lcfg : lConfigs) {
+        for (const auto& scfg : lcfg.splitConfigs) {
+          if (scfg.first == Acts::binR and scfg.second > 0.) {
+            volumeConfig.ringTolerance =
+                std::max(volumeConfig.ringTolerance, scfg.second);
+            volumeConfig.checkRingLayout = true;
+          }
+        }
+      }
+    };
+    ringLayoutConfiguration(lbc.layerConfigurations[0]);
+    ringLayoutConfiguration(lbc.layerConfigurations[2]);
+    volumeConfig.layerBuilder = layerBuilder;
+    volumeConfig.volumeSignature = 0;
+    auto volumeBuilder = std::make_shared<const Acts::CylinderVolumeBuilder>(
+        volumeConfig,
+        Acts::getDefaultLogger(lbc.configurationName + "VolumeBuilder",
+                               volumeLogLevel));
+    // add to the list of builders
+    volumeBuilders.push_back(volumeBuilder);
+  }
+
+  //-------------------------------------------------------------------------------------
+  // create the tracking geometry
+  Acts::TrackingGeometryBuilder::Config tgConfig;
+  // Add the builders
+  tgConfig.materialDecorator = mdecorator;
+
+  for (auto& vb : volumeBuilders) {
+    tgConfig.trackingVolumeBuilders.push_back(
+        [=](const auto& gcontext, const auto& inner, const auto&) {
+          return vb->trackingVolume(gcontext, inner);
+        });
+  }
+  // Add the helper
+  tgConfig.trackingVolumeHelper = cylinderVolumeHelper;
+  auto cylinderGeometryBuilder =
+      std::make_shared<const Acts::TrackingGeometryBuilder>(
+          tgConfig,
+          Acts::getDefaultLogger("TrackerGeometryBuilder", volumeLogLevel));
+  // get the geometry
+  auto trackingGeometry = cylinderGeometryBuilder->trackingGeometry(context);
+  // collect the detector element store
+  for (auto& lBuilder : tgLayerBuilders) {
+    auto detElements = lBuilder->detectorElements();
+    detElementStore.insert(detElementStore.begin(), detElements.begin(),
+                           detElements.end());
+  }
+
+  /// return the tracking geometry
+  return trackingGeometry;
+}

--- a/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
@@ -16,7 +16,6 @@
 #include "Acts/Geometry/PassiveLayerBuilder.hpp"
 #include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Geometry/SurfaceBinningMatcher.hpp"
-#include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingGeometryBuilder.hpp"
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
 #include "Acts/Material/Material.hpp"

--- a/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/BuildTGeoDetector.cpp
@@ -6,6 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
+
 #include "Acts/Geometry/CylinderVolumeBuilder.hpp"
 #include "Acts/Geometry/CylinderVolumeHelper.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
@@ -19,10 +21,9 @@
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
 #include "Acts/Material/Material.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
-#include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
 #include "Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp"
+#include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
 #include "Acts/Utilities/BinningType.hpp"
-#include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
 #include "ActsExamples/TGeoDetector/BuildTGeoDetector.hpp"
 #include "ActsExamples/TGeoDetector/TGeoDetectorOptions.hpp"
 #include "ActsExamples/Utilities/Options.hpp"
@@ -41,8 +42,10 @@
 /// @tparam variable_map_t is the variable map
 ///
 /// @param vm is the variable map from the options
-std::shared_ptr<const Acts::TrackingGeometry> ActsExamples::TGeo::buildTGeoDetector(
-    const boost::program_options::variables_map& vm, const Acts::GeometryContext& context,
+std::shared_ptr<const Acts::TrackingGeometry>
+ActsExamples::TGeo::buildTGeoDetector(
+    const boost::program_options::variables_map& vm,
+    const Acts::GeometryContext& context,
     std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>&
         detElementStore,
     std::shared_ptr<const Acts::IMaterialDecorator> mdecorator) {
@@ -123,13 +126,13 @@ std::shared_ptr<const Acts::TrackingGeometry> ActsExamples::TGeo::buildTGeoDetec
     volumeBuilders.push_back(beamPipeVolumeBuilder);
   }
 
-  // import the file from
+  // Import the file from
   TGeoManager::Import(rootFileName.c_str());
 
   auto layerBuilderConfigs =
       ActsExamples::Options::readTGeoLayerBuilderConfigs(vm);
 
-  // remember the layer builders to collect the detector elements
+  // Remember the layer builders to collect the detector elements
   std::vector<std::shared_ptr<const Acts::TGeoLayerBuilder>> tgLayerBuilders;
 
   for (auto& lbc : layerBuilderConfigs) {
@@ -166,14 +169,6 @@ std::shared_ptr<const Acts::TrackingGeometry> ActsExamples::TGeo::buildTGeoDetec
         (layerCreatorLB != nullptr) ? layerCreatorLB : layerCreator;
     lbc.protoLayerHelper =
         (protoLayerHelperLB != nullptr) ? protoLayerHelperLB : protoLayerHelper;
-
-
-    // @TODO Make configurable 
-    Acts::TGeoCylinderDiscSplitter::Config cdsConfig;
-    cdsConfig.circularSegments = 32;
-    cdsConfig.regularSegments = 6;
-    lbc.detectorElementSplitter 
-        = std::make_shared<const Acts::TGeoCylinderDiscSplitter>(cdsConfig);
 
     auto layerBuilder = std::make_shared<const Acts::TGeoLayerBuilder>(
         lbc, Acts::getDefaultLogger(lbc.configurationName + "LayerBuilder",

--- a/Examples/Run/Common/src/CommonOptions.cpp
+++ b/Examples/Run/Common/src/CommonOptions.cpp
@@ -41,9 +41,9 @@ void ActsExamples::Options::addSequencerOptions(
                     "The number of events to process. If not given, all "
                     "available events will be processed.")(
       "skip", value<size_t>()->default_value(0),
-      "The number of events to skip")("jobs,j", value<int>()->default_value(-1),
-                                      "Number of parallel jobs, negative for "
-                                      "automatic.");
+      "The number of events to skip")(
+      "jobs,j", value<int>()->default_value(-1),
+      "Number of parallel jobs, negative for automatic.");
 }
 
 void ActsExamples::Options::addRandomNumbersOptions(
@@ -57,12 +57,9 @@ void ActsExamples::Options::addGeometryOptions(
   opt.add_options()("geo-surface-loglevel", value<size_t>()->default_value(3),
                     "The outoput log level for the surface building.")(
       "geo-layer-loglevel", value<size_t>()->default_value(3),
-      "The output log level for the layer building.")("geo-volume-loglevel",
-                                                      value<size_t>()
-                                                          ->default_value(3),
-                                                      "The output log level "
-                                                      "for the volume "
-                                                      "building.");
+      "The output log level for the layer building.")(
+      "geo-volume-loglevel", value<size_t>()->default_value(3),
+      "The output log level for the volume building.");
 }
 
 void ActsExamples::Options::addMaterialOptions(
@@ -71,9 +68,9 @@ void ActsExamples::Options::addMaterialOptions(
       "mat-input-type", value<std::string>()->default_value("build"),
       "The way material is loaded: 'none', 'build', 'proto', 'file'.")(
       "mat-input-file", value<std::string>()->default_value(""),
-      "Name of the material map input file, supported: '.json', '.cbor' or "
-      "'.root'.")("mat-output-file", value<std::string>()->default_value(""),
-                  "Name of the material map output file (without extension).")(
+      "Name of the material map input file, supported: '.json' or '.root'.")(
+      "mat-output-file", value<std::string>()->default_value(""),
+      "Name of the material map output file (without extension).")(
       "mat-output-sensitives", value<bool>()->default_value(true),
       "Write material information of sensitive surfaces.")(
       "mat-output-approaches", value<bool>()->default_value(true),
@@ -113,10 +110,6 @@ void ActsExamples::Options::addOutputOptions(
     opt.add_options()("output-json", bool_switch(),
                       "Switch on to write '.json' ouput file(s).");
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Cbor))
-    opt.add_options()("output-cbor", bool_switch(),
-                      "Switch on to write '.cbor' ouput file(s).");
-
   if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Txt))
     opt.add_options()("output-txt", bool_switch(),
                       "Switch on to write '.txt' ouput file(s).");
@@ -136,9 +129,7 @@ void ActsExamples::Options::addInputOptions(
                                            value<bool>()->default_value(false),
                                            "Switch on to read '.obj' file(s).")(
       "input-json", value<bool>()->default_value(false),
-      "Switch on to read '.json' file(s).")(
-      "input-cbor", value<bool>()->default_value(false),
-      "Switch on to read '.cbor' file(s).");
+      "Switch on to read '.json' file(s).");
 }
 
 boost::program_options::variables_map ActsExamples::Options::parse(

--- a/Examples/Run/Common/src/CommonOptions.cpp
+++ b/Examples/Run/Common/src/CommonOptions.cpp
@@ -41,9 +41,9 @@ void ActsExamples::Options::addSequencerOptions(
                     "The number of events to process. If not given, all "
                     "available events will be processed.")(
       "skip", value<size_t>()->default_value(0),
-      "The number of events to skip")(
-      "jobs,j", value<int>()->default_value(-1),
-      "Number of parallel jobs, negative for automatic.");
+      "The number of events to skip")("jobs,j", value<int>()->default_value(-1),
+                                      "Number of parallel jobs, negative for "
+                                      "automatic.");
 }
 
 void ActsExamples::Options::addRandomNumbersOptions(
@@ -59,7 +59,9 @@ void ActsExamples::Options::addGeometryOptions(
       "geo-layer-loglevel", value<size_t>()->default_value(3),
       "The output log level for the layer building.")(
       "geo-volume-loglevel", value<size_t>()->default_value(3),
-      "The output log level for the volume building.");
+      "The output log level "
+      "for the volume "
+      "building.");
 }
 
 void ActsExamples::Options::addMaterialOptions(
@@ -68,9 +70,9 @@ void ActsExamples::Options::addMaterialOptions(
       "mat-input-type", value<std::string>()->default_value("build"),
       "The way material is loaded: 'none', 'build', 'proto', 'file'.")(
       "mat-input-file", value<std::string>()->default_value(""),
-      "Name of the material map input file, supported: '.json' or '.root'.")(
-      "mat-output-file", value<std::string>()->default_value(""),
-      "Name of the material map output file (without extension).")(
+      "Name of the material map input file, supported: '.json', '.cbor' or "
+      "'.root'.")("mat-output-file", value<std::string>()->default_value(""),
+                  "Name of the material map output file (without extension).")(
       "mat-output-sensitives", value<bool>()->default_value(true),
       "Write material information of sensitive surfaces.")(
       "mat-output-approaches", value<bool>()->default_value(true),
@@ -110,6 +112,10 @@ void ActsExamples::Options::addOutputOptions(
     opt.add_options()("output-json", bool_switch(),
                       "Switch on to write '.json' ouput file(s).");
 
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Cbor))
+    opt.add_options()("output-cbor", bool_switch(),
+                      "Switch on to write '.cbor' ouput file(s).");
+
   if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Txt))
     opt.add_options()("output-txt", bool_switch(),
                       "Switch on to write '.txt' ouput file(s).");
@@ -129,7 +135,9 @@ void ActsExamples::Options::addInputOptions(
                                            value<bool>()->default_value(false),
                                            "Switch on to read '.obj' file(s).")(
       "input-json", value<bool>()->default_value(false),
-      "Switch on to read '.json' file(s).");
+      "Switch on to read '.json' file(s).")(
+      "input-cbor", value<bool>()->default_value(false),
+      "Switch on to read '.cbor' file(s).");
 }
 
 boost::program_options::variables_map ActsExamples::Options::parse(

--- a/Examples/Run/Common/src/CommonOptions.cpp
+++ b/Examples/Run/Common/src/CommonOptions.cpp
@@ -57,11 +57,12 @@ void ActsExamples::Options::addGeometryOptions(
   opt.add_options()("geo-surface-loglevel", value<size_t>()->default_value(3),
                     "The outoput log level for the surface building.")(
       "geo-layer-loglevel", value<size_t>()->default_value(3),
-      "The output log level for the layer building.")(
-      "geo-volume-loglevel", value<size_t>()->default_value(3),
-      "The output log level "
-      "for the volume "
-      "building.");
+      "The output log level for the layer building.")("geo-volume-loglevel",
+                                                      value<size_t>()
+                                                          ->default_value(3),
+                                                      "The output log level "
+                                                      "for the volume "
+                                                      "building.");
 }
 
 void ActsExamples::Options::addMaterialOptions(

--- a/Plugins/Legacy/include/Acts/Seeding/AtlasSeedfinder.ipp
+++ b/Plugins/Legacy/include/Acts/Seeding/AtlasSeedfinder.ipp
@@ -526,18 +526,19 @@ void Acts::Legacy::AtlasSeedfinder<SpacePoint>::fillLists() {
       // assign z-bin a value between 0 and 10 identifying the z-slice of a
       // space-point
       if (Z > 0.) {
-        Z < 250. ? z = 5
-                 : Z < 450. ? z = 6
-                            : Z < 925. ? z = 7
-                                       : Z < 1400. ? z = 8
-                                                   : Z < 2500. ? z = 9 : z = 10;
+        Z < 250.    ? z = 5
+        : Z < 450.  ? z = 6
+        : Z < 925.  ? z = 7
+        : Z < 1400. ? z = 8
+        : Z < 2500. ? z = 9
+                    : z = 10;
       } else {
-        Z > -250.
-            ? z = 5
-            : Z > -450.
-                  ? z = 4
-                  : Z > -925. ? z = 3
-                              : Z > -1400. ? z = 2 : Z > -2500. ? z = 1 : z = 0;
+        Z > -250.    ? z = 5
+        : Z > -450.  ? z = 4
+        : Z > -925.  ? z = 3
+        : Z > -1400. ? z = 2
+        : Z > -2500. ? z = 1
+                     : z = 0;
       }
       // calculate bin nr "n" for self made r-phi-z sorted 3D array "rfz_Sorted"
       // record number of sp in m_nsaz

--- a/Plugins/Legacy/include/Acts/Seeding/AtlasSeedfinder.ipp
+++ b/Plugins/Legacy/include/Acts/Seeding/AtlasSeedfinder.ipp
@@ -526,19 +526,18 @@ void Acts::Legacy::AtlasSeedfinder<SpacePoint>::fillLists() {
       // assign z-bin a value between 0 and 10 identifying the z-slice of a
       // space-point
       if (Z > 0.) {
-        Z < 250.    ? z = 5
-        : Z < 450.  ? z = 6
-        : Z < 925.  ? z = 7
-        : Z < 1400. ? z = 8
-        : Z < 2500. ? z = 9
-                    : z = 10;
+        Z < 250. ? z = 5
+                 : Z < 450. ? z = 6
+                            : Z < 925. ? z = 7
+                                       : Z < 1400. ? z = 8
+                                                   : Z < 2500. ? z = 9 : z = 10;
       } else {
-        Z > -250.    ? z = 5
-        : Z > -450.  ? z = 4
-        : Z > -925.  ? z = 3
-        : Z > -1400. ? z = 2
-        : Z > -2500. ? z = 1
-                     : z = 0;
+        Z > -250.
+            ? z = 5
+            : Z > -450.
+                  ? z = 4
+                  : Z > -925. ? z = 3
+                              : Z > -1400. ? z = 2 : Z > -2500. ? z = 1 : z = 0;
       }
       // calculate bin nr "n" for self made r-phi-z sorted 3D array "rfz_Sorted"
       // record number of sp in m_nsaz

--- a/Plugins/TGeo/CMakeLists.txt
+++ b/Plugins/TGeo/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   ActsPluginTGeo SHARED
+  src/TGeoCylinderDiscSplitter.cpp
   src/TGeoDetectorElement.cpp
   src/TGeoLayerBuilder.cpp
   src/TGeoParser.cpp

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -25,8 +25,10 @@ class ITGeoDetectorElementSplitter {
   ///
   /// @param gctx is a geometry context object
   /// @param tgnode is a TGeoNode that is translated
+  ///
+  /// @note If no split is performed the unsplit detector element is returned 
   virtual std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
-      const GeometryContext& gctx, const Acts::TGeoDetectorElement&) const = 0;
+      const GeometryContext& gctx, std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const = 0;
 };
 
 }  // namespace Acts

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -24,6 +24,9 @@ class TGeoDetectorElement;
 /// sub-elements
 class ITGeoDetectorElementSplitter {
  public:
+
+  virtual ~ITGeoDetectorElementSplitter() = default;
+
   /// Take a geometry context and TGeoElement and split it into sub elements
   ///
   /// @param gctx is a geometry context object

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -26,9 +26,10 @@ class ITGeoDetectorElementSplitter {
   /// @param gctx is a geometry context object
   /// @param tgnode is a TGeoNode that is translated
   ///
-  /// @note If no split is performed the unsplit detector element is returned 
+  /// @note If no split is performed the unsplit detector element is returned
   virtual std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
-      const GeometryContext& gctx, std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const = 0;
+      const GeometryContext& gctx,
+      std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const = 0;
 };
 
 }  // namespace Acts

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,17 +13,20 @@ class TGeoNode;
 
 namespace Acts {
 
-/// @brief ITGeoIdentierProvider
+class TGeoDetectorElement;
+
+/// @brief ITGeoElementSplitter
 ///
-/// Interface class that provides an Indentifier from a TGeoNode
-class ITGeoIdentifierProvider {
+/// Interface class that allows to define splitting of TGeoElements into
+/// sub-elements
+class ITGeoDetectorElementSplitter {
  public:
-  /// Take a geometry context and a TGeoNode and provide an identifier
+  /// Take a geometry context and TGeoElement and split it into sub elements
   ///
   /// @param gctx is a geometry context object
   /// @param tgnode is a TGeoNode that is translated
-  virtual Identifier identify(const GeometryContext& gctx,
-                              const TGeoNode& tgnode) const = 0;
+  virtual std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
+      const GeometryContext& gctx, const Acts::TGeoDetectorElement&) const = 0;
 };
 
 }  // namespace Acts

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -24,7 +24,6 @@ class TGeoDetectorElement;
 /// sub-elements
 class ITGeoDetectorElementSplitter {
  public:
-
   virtual ~ITGeoDetectorElementSplitter() = default;
 
   /// Take a geometry context and TGeoElement and split it into sub elements

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -9,6 +9,9 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Plugins/Identification/Identifier.hpp"
 
+#include <memory>
+#include <vector>
+
 class TGeoNode;
 
 namespace Acts {

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp
@@ -27,9 +27,11 @@ class ITGeoDetectorElementSplitter {
   /// Take a geometry context and TGeoElement and split it into sub elements
   ///
   /// @param gctx is a geometry context object
-  /// @param tgnode is a TGeoNode that is translated
+  /// @param tgde is a TGeoDetectorElement that is eventually split
   ///
   /// @note If no split is performed the unsplit detector element is returned
+  ///
+  /// @return a vector of TGeoDetectorElement objects
   virtual std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
       const GeometryContext& gctx,
       std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const = 0;

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
@@ -53,9 +53,11 @@ class TGeoCylinderDiscSplitter : public ITGeoDetectorElementSplitter {
   /// Take a geometry context and TGeoElement and split it into sub elements
   ///
   /// @param gctx is a geometry context object
-  /// @param tgde is the detector element to be split
+  /// @param tgde is a TGeoDetectorElement that is eventually split
   ///
   /// @note If no split is performed the unsplit detector element is returned
+  ///
+  /// @return a vector of TGeoDetectorElement objects
   std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
       const GeometryContext& gctx,
       std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const;

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
@@ -25,20 +25,27 @@ class TGeoDetectorElement;
 /// Split Cylinder and disks into submodules
 class TGeoCylinderDiscSplitter : public ITGeoDetectorElementSplitter {
  public:
-
-  /// Nested configuration struct 
+  /// Nested configuration struct
   struct Config {
-      int circularSegments = -1;
-      int regularSegments = -1;
+    /// Number of segments in phi for a disc
+    int cylinderPhiSegments = -1;
+    /// Number of segments in r for a disk
+    int cylinderLongitudinalSegments = -1;
+
+    /// Number of segments in phi for a disc
+    int discPhiSegments = -1;
+    /// Number of segments in r for a disk
+    int discRadialSegments = -1;
   };
 
-  /// Constructor 
+  /// Constructor
   ///
   /// @param cfg the configuration struct
   /// @param logger the logging object
-  TGeoCylinderDiscSplitter(const Config& cfg,
-                   std::unique_ptr<const Acts::Logger> logger =
-                       Acts::getDefaultLogger("TGeoCylinderDiscSplitter", Acts::Logging::INFO)); 
+  TGeoCylinderDiscSplitter(
+      const Config& cfg,
+      std::unique_ptr<const Acts::Logger> logger = Acts::getDefaultLogger(
+          "TGeoCylinderDiscSplitter", Acts::Logging::INFO));
 
   virtual ~TGeoCylinderDiscSplitter() = default;
 
@@ -47,19 +54,19 @@ class TGeoCylinderDiscSplitter : public ITGeoDetectorElementSplitter {
   /// @param gctx is a geometry context object
   /// @param tgde is the detector element to be split
   ///
-  /// @note If no split is performed the unsplit detector element is returned 
+  /// @note If no split is performed the unsplit detector element is returned
   std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
-      const GeometryContext& gctx, std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const;
+      const GeometryContext& gctx,
+      std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const;
 
-  private:
-   Config m_cfg;
+ private:
+  Config m_cfg;
 
-    /// Private access to the logger
-    const Acts::Logger& logger() const { return *m_logger; }
+  /// Private access to the logger
+  const Acts::Logger& logger() const { return *m_logger; }
 
-    /// Logging instance
-    std::unique_ptr<const Acts::Logger> m_logger;
-
+  /// Logging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
 };
 
 }  // namespace Acts

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
+#include <vector>
 
 class TGeoNode;
 

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp
@@ -1,0 +1,65 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Plugins/TGeo/ITGeoDetectorElementSplitter.hpp"
+#include "Acts/Utilities/Logger.hpp"
+
+#include <memory>
+
+class TGeoNode;
+
+namespace Acts {
+
+class TGeoDetectorElement;
+
+/// @brief TGeoCylinderDiscSplitter
+///
+/// Split Cylinder and disks into submodules
+class TGeoCylinderDiscSplitter : public ITGeoDetectorElementSplitter {
+ public:
+
+  /// Nested configuration struct 
+  struct Config {
+      int circularSegments = -1;
+      int regularSegments = -1;
+  };
+
+  /// Constructor 
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the logging object
+  TGeoCylinderDiscSplitter(const Config& cfg,
+                   std::unique_ptr<const Acts::Logger> logger =
+                       Acts::getDefaultLogger("TGeoCylinderDiscSplitter", Acts::Logging::INFO)); 
+
+  virtual ~TGeoCylinderDiscSplitter() = default;
+
+  /// Take a geometry context and TGeoElement and split it into sub elements
+  ///
+  /// @param gctx is a geometry context object
+  /// @param tgde is the detector element to be split
+  ///
+  /// @note If no split is performed the unsplit detector element is returned 
+  std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>> split(
+      const GeometryContext& gctx, std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const;
+
+  private:
+   Config m_cfg;
+
+    /// Private access to the logger
+    const Acts::Logger& logger() const { return *m_logger; }
+
+    /// Logging instance
+    std::unique_ptr<const Acts::Logger> m_logger;
+
+};
+
+}  // namespace Acts

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
@@ -19,6 +19,7 @@ namespace Acts {
 
 class ISurfaceMaterial;
 class SurfaceBounds;
+class PlanarBounds;
 class DigitizationModule;
 
 /// @class TGeoDetectorElement
@@ -36,6 +37,9 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
   using ContextType = GeometryContext;
 
   /// Constructor
+  ///
+  /// @note this constructor used auto-translation
+  ///
   /// @param identifier is the detector identifier
   /// @param tGeoNode is the TGeoNode which should be represented
   /// @param tGeoMatrix The Matrix to global (i.e. ACTS transform)
@@ -67,6 +71,23 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
       const std::string& axes = "XYZ", double scalor = 10.,
       std::shared_ptr<const Acts::ISurfaceMaterial> material = nullptr);
 
+  /// Constructor with pre-computed surface
+  ///
+  /// @note this detector element constructor needs everything 
+  /// pre-computed.
+  ///
+  /// @param identifier is the detector identifier
+  /// @param tGeoNode is the TGeoNode which should be represented
+  /// @param tgTransform the transform of this detector element
+  /// @param tgBounds the bounds of this surface
+  /// @param tgThickness the thickness of this detector element
+  TGeoDetectorElement(
+      const Identifier& identifier, 
+      const TGeoNode& tGeoNode,
+      const Transform3& tgTransform,
+      std::shared_ptr<const PlanarBounds> tgBounds,
+      double tgThickness=0.);
+
   ~TGeoDetectorElement() override;
 
   Identifier identifier() const final;
@@ -87,6 +108,11 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
 
   /// Returns the thickness of the module
   double thickness() const final;
+
+  /// Return the TGeoNode for back navigation
+  const TGeoNode& tgeoNode() const {
+    return *m_detElement;
+  }
 
  private:
   /// Pointer to TGeoNode (not owned)

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
@@ -73,7 +73,7 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
 
   /// Constructor with pre-computed surface
   ///
-  /// @note this detector element constructor needs everything 
+  /// @note this detector element constructor needs everything
   /// pre-computed.
   ///
   /// @param identifier is the detector identifier
@@ -81,12 +81,10 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
   /// @param tgTransform the transform of this detector element
   /// @param tgBounds the bounds of this surface
   /// @param tgThickness the thickness of this detector element
-  TGeoDetectorElement(
-      const Identifier& identifier, 
-      const TGeoNode& tGeoNode,
-      const Transform3& tgTransform,
-      std::shared_ptr<const PlanarBounds> tgBounds,
-      double tgThickness=0.);
+  TGeoDetectorElement(const Identifier& identifier, const TGeoNode& tGeoNode,
+                      const Transform3& tgTransform,
+                      std::shared_ptr<const PlanarBounds> tgBounds,
+                      double tgThickness = 0.);
 
   ~TGeoDetectorElement() override;
 
@@ -110,9 +108,7 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
   double thickness() const final;
 
   /// Return the TGeoNode for back navigation
-  const TGeoNode& tgeoNode() const {
-    return *m_detElement;
-  }
+  const TGeoNode& tgeoNode() const { return *m_detElement; }
 
  private:
   /// Pointer to TGeoNode (not owned)

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
@@ -62,8 +62,8 @@ class TGeoLayerBuilder : public ILayerBuilder {
     /// Layer splitting: parameter and tolerance
     std::vector<SplitConfig> splitConfigs = {};
     /// The envelope to be built around the layer
-    std::pair<double, double> envelope = {0 * UnitConstants::mm,
-                                          0 * UnitConstants::mm};
+    std::pair<double, double> envelope = {1 * UnitConstants::mm,
+                                          1 * UnitConstants::mm};
     /// Binning setup in l0: nbins (-1 -> automated), axis binning type
     std::tuple<int, BinningType> binning0 = {-1, equidistant};
     /// Binning setup in l1: nbins (-1 -> automated), axis binning type

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
@@ -29,6 +29,7 @@ class TGeoNode;
 namespace Acts {
 
 class TGeoDetectorElement;
+class ITGeoDetectorElementSplitter;
 class Surface;
 
 /// @class TGeoLayerBuilder
@@ -86,6 +87,9 @@ class TGeoLayerBuilder : public ILayerBuilder {
     double unit = 1 * UnitConstants::cm;
     /// Create an indentifier from TGeoNode
     std::shared_ptr<const ITGeoIdentifierProvider> identifierProvider = nullptr;
+    /// Split TGeoElement if a splitter is provided
+    std::shared_ptr<const ITGeoDetectorElementSplitter>
+        detectorElementSplitter = nullptr;
     /// Layer creator
     std::shared_ptr<const LayerCreator> layerCreator = nullptr;
     /// ProtoLayer helper

--- a/Plugins/TGeo/src/TGeoCylinderDiscSplitter.cpp
+++ b/Plugins/TGeo/src/TGeoCylinderDiscSplitter.cpp
@@ -37,7 +37,7 @@ Acts::TGeoCylinderDiscSplitter::split(
     // Splitting for discs detected
     if (sf.type() == Acts::Surface::Disc and
         sf.bounds().type() == Acts::SurfaceBounds::eDisc) {
-      ACTS_INFO("- splitting detected for a Disc shaped sensor.");
+      ACTS_DEBUG("- splitting detected for a Disc shaped sensor.");
 
       std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
           tgDetectorElements = {};
@@ -100,7 +100,7 @@ Acts::TGeoCylinderDiscSplitter::split(
 
     } else if (sf.type() == Acts::Surface::Cylinder and
                sf.bounds().type() == Acts::SurfaceBounds::eCylinder) {
-      ACTS_INFO("- splitting detected for a Cylinder shaped sensor.");
+      ACTS_DEBUG("- splitting detected for a Cylinder shaped sensor.");
 
       std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
           tgDetectorElements = {};
@@ -130,13 +130,6 @@ Acts::TGeoCylinderDiscSplitter::split(
 
       ActsScalar planeR = cylinderR * cosPhiHalf;
       ActsScalar planeHalfX = cylinderR * sinPhiHalf;
-
-      std::cout << "[ TGeoCylinderDiscSplitter ] R ( cyl ) = " << cylinderR
-                << std::endl;
-      std::cout << "[ TGeoCylinderDiscSplitter ] R (plane) = " << planeR
-                << std::endl;
-      std::cout << "[ TGeoCylinderDiscSplitter ] hX        = " << planeHalfX
-                << std::endl;
 
       for (size_t iz = 1; iz < zValues.size(); ++iz) {
         ActsScalar minZ = zValues[iz - 1];

--- a/Plugins/TGeo/src/TGeoCylinderDiscSplitter.cpp
+++ b/Plugins/TGeo/src/TGeoCylinderDiscSplitter.cpp
@@ -1,0 +1,100 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Plugins/TGeo/TGeoCylinderDiscSplitter.hpp"
+
+#include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Surfaces/TrapezoidBounds.hpp"
+
+Acts::TGeoCylinderDiscSplitter::TGeoCylinderDiscSplitter(
+    const TGeoCylinderDiscSplitter::Config& cfg,
+    std::unique_ptr<const Acts::Logger> logger)
+    : m_cfg(cfg), m_logger(std::move(logger)) {}
+
+std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
+Acts::TGeoCylinderDiscSplitter::split(
+    const GeometryContext& gctx,
+    std::shared_ptr<const Acts::TGeoDetectorElement> tgde) const {
+  // Segments are detected, attempt a split
+  if (m_cfg.circularSegments > 0 or m_cfg.regularSegments > 0) {
+    const Acts::Surface& sf = tgde->surface();
+
+    // Thickness
+    auto tgIdentifier = tgde->identifier();
+    const TGeoNode& tgNode = tgde->tgeoNode();
+    ActsScalar tgThickness = tgde->thickness();
+
+    // Splitting for discs
+    if (sf.type() == Acts::Surface::Disc and
+        sf.bounds().type() == Acts::SurfaceBounds::eDisc) {
+      std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
+          tgDetectorElements = {};
+      tgDetectorElements.reserve(std::abs(m_cfg.circularSegments) *
+                                 std::abs(m_cfg.regularSegments));
+
+      const Acts::Vector3 discCenter = sf.center(gctx);
+
+      const auto& boundValues = sf.bounds().values();
+      ActsScalar discMinR = boundValues[Acts::RadialBounds::eMinR];
+      ActsScalar discMaxR = boundValues[Acts::RadialBounds::eMaxR];
+
+      ActsScalar phiStep = 2 * M_PI / m_cfg.circularSegments;
+      ActsScalar cosPhiHalf = std::cos(0.5 * phiStep);
+      ActsScalar sinPhiHalf = std::sin(0.5 * phiStep);
+
+      std::vector<ActsScalar> radialValues = {};
+      if (m_cfg.regularSegments > 1) {
+        ActsScalar rStep = (discMaxR - discMinR) / m_cfg.regularSegments;
+        radialValues.reserve(m_cfg.regularSegments);
+        for (int ir = 0; ir <= m_cfg.regularSegments; ++ir) {
+          radialValues.push_back(discMinR + ir * rStep);
+        }
+      } else {
+        radialValues = {discMinR, discMaxR};
+      }
+
+      for (size_t ir = 1; ir < radialValues.size(); ++ir) {
+        ActsScalar minR = radialValues[ir - 1];
+        ActsScalar maxR = radialValues[ir];
+
+        ActsScalar maxLocY = maxR * cosPhiHalf;
+        ActsScalar minLocY = minR * cosPhiHalf;
+
+        ActsScalar hR = 0.5 * (maxLocY + minLocY);
+        ActsScalar hY = 0.5 * (maxLocY - minLocY);
+        ActsScalar hXminY = minR * sinPhiHalf;
+        ActsScalar hXmaxY = maxR * sinPhiHalf;
+
+        auto tgTrapezoid =
+            std::make_shared<Acts::TrapezoidBounds>(hXminY, hXmaxY, hY);
+
+        for (int im = 0; im < m_cfg.circularSegments; ++im) {
+          // Get the moduleTransform
+          double phi = -M_PI + im * phiStep;
+          auto tgTransform =
+              Transform3(Translation3(hR * std::cos(phi), hR * std::sin(phi),
+                                      discCenter.z()) *
+                         AngleAxis3(phi - 0.5 * M_PI, Vector3::UnitZ()));
+
+          // Create a new detector element per split
+          auto tgDetectorElement = std::make_shared<Acts::TGeoDetectorElement>(
+              tgIdentifier, tgNode, tgTransform, tgTrapezoid, tgThickness);
+
+          tgDetectorElements.push_back(tgDetectorElement);
+        }
+      }
+
+      return tgDetectorElements;
+    }
+  }
+  return {tgde};
+}

--- a/Plugins/TGeo/src/TGeoDetectorElement.cpp
+++ b/Plugins/TGeo/src/TGeoDetectorElement.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
+#include "Acts/Surfaces/PlanarBounds.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
@@ -89,6 +90,19 @@ Acts::TGeoDetectorElement::TGeoDetectorElement(
   if (m_surface != nullptr) {
     m_surface->assignSurfaceMaterial(std::move(material));
   }
+}
+
+Acts::TGeoDetectorElement::TGeoDetectorElement(
+    const Identifier& identifier, const TGeoNode& tGeoNode,
+    const Transform3& tgTransform, std::shared_ptr<const PlanarBounds> tgBounds,
+    double tgThickness)
+    : Acts::IdentifiedDetectorElement(),
+      m_detElement(&tGeoNode),
+      m_transform(tgTransform),
+      m_identifier(identifier),
+      m_bounds(tgBounds),
+      m_thickness(tgThickness) {
+  m_surface = Surface::makeShared<PlaneSurface>(tgBounds, *this);
 }
 
 Acts::TGeoDetectorElement::~TGeoDetectorElement() = default;

--- a/Plugins/TGeo/src/TGeoLayerBuilder.cpp
+++ b/Plugins/TGeo/src/TGeoLayerBuilder.cpp
@@ -200,7 +200,7 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
                 (m_cfg.detectorElementSplitter == nullptr)
                     ? std::vector<std::shared_ptr<
                           const Acts::TGeoDetectorElement>>{tgElement}
-                    : m_cfg.detectorElementSplitter->split(gctx, *tgElement);
+                    : m_cfg.detectorElementSplitter->split(gctx, tgElement);
 
         for (auto tge : tgElements) {
           m_elementStore.push_back(tge);


### PR DESCRIPTION
This PR introduces a new interface in the `TGeo` plugin that allows splitting of `TGeoDetectorElement` objects and adds a necessary constructor for this to the `TGeoDetectorElement`.

This will be needed for the ALICE o2 studies (generic splitter from disk to trapezoids), but also for the TGeo version of the ATLAS ITk, where dedicated splitters need to be written.

Tagging some interested parties: @paulgessinger @niermann999 @noemina 

The splitting has to be activated with a switch:

```shell
--geo-tgeo-cyl-disc-split
```

And then, consequently, all volumes need to define how they wanna perform the splitting, e.g. for no splitting:

```shell
--geo-tgeo-cyl-nz-segs -1
--geo-tgeo-cyl-nphi-segs -1
--geo-tgeo-disc-nr-segs -1
--geo-tgeo-disc-nphi-segs -1
```

versus splitting:

```shell
--geo-tgeo-cyl-nz-segs 6
--geo-tgeo-cyl-nphi-segs 32
--geo-tgeo-disc-nr-segs 6
--geo-tgeo-disc-nphi-segs 32
```
