### PR TITLE
fix: Boost warnings due to deprecations

### DIFF
--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -22,9 +22,11 @@
 #if ((BOOST_VERSION / 100) % 1000) <= 71
 // Boost <=1.71 and lower do not have progress_display.hpp as a replacement yet
 #include <boost/progress.hpp>
+using progress_display = boost::progress_display;
 #else
 // Boost >=1.72 can use this as a replacement
 #include <boost/timer/progress_display.hpp>
+using progress_display = boost::timer::progress_display;
 #endif
 
 /// The main executable
@@ -49,7 +51,7 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
   auto bCache = bField.makeCache(bFieldContext);
   // boost display
   size_t totalSteps = events * theta_steps * phi_steps * access_steps;
-  boost::timer::progress_display show_progress(totalSteps);
+  progress_display show_progress(totalSteps);
   // the event loop
   // loop over the events - @todo move to parallel for
   for (size_t ievt = 0; ievt < events; ++ievt) {
@@ -90,7 +92,7 @@ void accessRandom(const Acts::MagneticFieldProvider& bField,
 
   // initialize the field cache
   auto bCache = bField.makeCache(bFieldContext);
-  boost::timer::progress_display show_progress(totalSteps);
+  progress_display show_progress(totalSteps);
 
   // the event loop
   // loop over the events - @todo move to parallel for

--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -18,7 +18,14 @@
 #include <string>
 
 #include <boost/program_options.hpp>
+
+#if ((BOOST_VERSION / 100) % 1000) <= 71
+// Boost <=1.71 and lower do not have progress_display.hpp as a replacement yet
+#include <boost/progress.hpp>
+#else
+// Boost >=1.72 can use this as a replacement
 #include <boost/timer/progress_display.hpp>
+#endif
 
 /// The main executable
 ///

--- a/Examples/Run/MagneticField/BFieldAccessExample.cpp
+++ b/Examples/Run/MagneticField/BFieldAccessExample.cpp
@@ -18,7 +18,7 @@
 #include <string>
 
 #include <boost/program_options.hpp>
-#include <boost/progress.hpp>
+#include <boost/timer/progress_display.hpp>
 
 /// The main executable
 ///
@@ -42,7 +42,7 @@ void accessStepWise(const Acts::MagneticFieldProvider& bField,
   auto bCache = bField.makeCache(bFieldContext);
   // boost display
   size_t totalSteps = events * theta_steps * phi_steps * access_steps;
-  boost::progress_display show_progress(totalSteps);
+  boost::timer::progress_display show_progress(totalSteps);
   // the event loop
   // loop over the events - @todo move to parallel for
   for (size_t ievt = 0; ievt < events; ++ievt) {
@@ -83,7 +83,7 @@ void accessRandom(const Acts::MagneticFieldProvider& bField,
 
   // initialize the field cache
   auto bCache = bField.makeCache(bFieldContext);
-  boost::progress_display show_progress(totalSteps);
+  boost::timer::progress_display show_progress(totalSteps);
 
   // the event loop
   // loop over the events - @todo move to parallel for

--- a/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
@@ -9,7 +9,7 @@
 /// @file MagneticFieldInterfaceConsistencyTests.cpp
 
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"


### PR DESCRIPTION
Had to reopen from #665, because the target branch had changed.

Let's see what this looks like now.