### PR TITLE
fix: Move Geant4 actions into namespaces

### DIFF
--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GeantinoRecording.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GeantinoRecording.hpp
@@ -45,7 +45,7 @@ class GeantinoRecording final : public BareAlgorithm {
     /// The number of tracks per event.
     size_t tracksPerEvent = 0;
     /// Configuration of the generator action
-    PrimaryGeneratorAction::Config generationConfig;
+    Geant4::PrimaryGeneratorAction::Config generationConfig;
   };
 
   GeantinoRecording(Config&& cfg, Acts::Logging::Level lvl);

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/PrimaryGeneratorAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/PrimaryGeneratorAction.hpp
@@ -18,7 +18,7 @@
 class G4ParticleGun;
 class G4Event;
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4 {
 
 /// @class PrimaryGeneratorAction
 ///
@@ -91,4 +91,4 @@ class PrimaryGeneratorAction final : public G4VUserPrimaryGeneratorAction {
   G4ThreeVector m_direction;
 };
 
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4/src/EventAction.cpp
@@ -17,7 +17,7 @@
 
 #include "SteppingAction.hpp"
 
-using namespace ActsExamples;
+namespace ActsExamples::Geant4 {
 
 EventAction* EventAction::s_instance = nullptr;
 
@@ -71,3 +71,5 @@ const std::vector<Acts::RecordedMaterialTrack>& EventAction::materialTracks()
     const {
   return m_materialTracks;
 }
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/EventAction.hpp
+++ b/Examples/Algorithms/Geant4/src/EventAction.hpp
@@ -16,7 +16,7 @@
 #include <G4UserEventAction.hh>
 #include <globals.hh>
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4 {
 
 class SteppingAction;
 
@@ -64,4 +64,4 @@ class EventAction final : public G4UserEventAction {
   std::vector<Acts::RecordedMaterialTrack> m_materialTracks;
 };
 
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/GeantinoRecording.cpp
+++ b/Examples/Algorithms/Geant4/src/GeantinoRecording.cpp
@@ -22,6 +22,7 @@
 #include "SteppingAction.hpp"
 
 using namespace ActsExamples;
+using namespace ActsExamples::Geant4;
 
 GeantinoRecording::GeantinoRecording(GeantinoRecording::Config&& cfg,
                                      Acts::Logging::Level lvl)

--- a/Examples/Algorithms/Geant4/src/PrimaryGeneratorAction.cpp
+++ b/Examples/Algorithms/Geant4/src/PrimaryGeneratorAction.cpp
@@ -18,7 +18,7 @@
 #include <G4UnitsTable.hh>
 #include <Randomize.hh>
 
-using namespace ActsExamples;
+namespace ActsExamples::Geant4 {
 
 PrimaryGeneratorAction* PrimaryGeneratorAction::s_instance = nullptr;
 
@@ -84,3 +84,5 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
   m_particleGun->SetParticlePosition(m_position);
   m_particleGun->GeneratePrimaryVertex(anEvent);
 }
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/RunAction.cpp
+++ b/Examples/Algorithms/Geant4/src/RunAction.cpp
@@ -14,7 +14,7 @@
 
 #include "EventAction.hpp"
 
-using namespace ActsExamples;
+namespace ActsExamples::Geant4 {
 
 RunAction* RunAction::s_instance = nullptr;
 
@@ -50,3 +50,5 @@ void RunAction::EndOfRunAction(const G4Run* aRun) {
          << "\n------------------------------------------------------------\n"
          << G4endl;
 }
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/RunAction.hpp
+++ b/Examples/Algorithms/Geant4/src/RunAction.hpp
@@ -15,7 +15,7 @@
 
 class G4Run;
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4 {
 
 /// @class RunAction
 ///
@@ -45,4 +45,4 @@ class RunAction final : public G4UserRunAction {
   static RunAction* s_instance;
 };
 
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/SteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/SteppingAction.cpp
@@ -15,7 +15,7 @@
 #include <G4Material.hh>
 #include <G4Step.hh>
 
-using namespace ActsExamples;
+namespace ActsExamples::Geant4 {
 
 SteppingAction* SteppingAction::s_instance = nullptr;
 
@@ -136,3 +136,5 @@ void SteppingAction::clear() {
   m_materialSteps.clear();
   m_trackSteps.clear();
 }
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/SteppingAction.hpp
+++ b/Examples/Algorithms/Geant4/src/SteppingAction.hpp
@@ -16,7 +16,7 @@
 #include <G4UserSteppingAction.hh>
 #include <globals.hh>
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4 {
 
 /// @class SteppingAction
 ///
@@ -62,4 +62,4 @@ class SteppingAction final : public G4UserSteppingAction {
   ActsExamples::SimHitContainer::sequence_type m_trackSteps;
 };
 
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4HepMC/include/ActsExamples/Geant4HepMC/EventRecording.hpp
+++ b/Examples/Algorithms/Geant4HepMC/include/ActsExamples/Geant4HepMC/EventRecording.hpp
@@ -17,8 +17,9 @@
 #include <memory>
 #include <mutex>
 
-#include <G4VUserDetectorConstruction.hh>
 #include <HepMC3/GenEvent.h>
+
+#include "G4VUserDetectorConstruction.hh"
 
 class G4RunManager;
 

--- a/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
@@ -120,14 +120,16 @@ void followOutgoingParticles(HepMC3::GenEvent& event,
 }
 }  // namespace
 
-ActsExamples::EventAction* ActsExamples::EventAction::s_instance = nullptr;
+namespace ActsExamples::Geant4::HepMC3 {
 
-ActsExamples::EventAction* ActsExamples::EventAction::instance() {
+EventAction* EventAction::s_instance = nullptr;
+
+EventAction* EventAction::instance() {
   // Static acces function via G4RunManager
   return s_instance;
 }
 
-ActsExamples::EventAction::EventAction(std::vector<std::string> processFilter)
+EventAction::EventAction(std::vector<std::string> processFilter)
     : G4UserEventAction(), m_processFilter(std::move(processFilter)) {
   if (s_instance) {
     throw std::logic_error("Attempted to duplicate a singleton");
@@ -136,17 +138,17 @@ ActsExamples::EventAction::EventAction(std::vector<std::string> processFilter)
   }
 }
 
-ActsExamples::EventAction::~EventAction() {
+EventAction::~EventAction() {
   s_instance = nullptr;
 }
 
-void ActsExamples::EventAction::BeginOfEventAction(const G4Event*) {
+void EventAction::BeginOfEventAction(const G4Event*) {
   SteppingAction::instance()->clear();
-  m_event = HepMC3::GenEvent(HepMC3::Units::GEV, HepMC3::Units::MM);
-  m_event.add_beam_particle(std::make_shared<HepMC3::GenParticle>());
+  m_event = ::HepMC3::GenEvent(::HepMC3::Units::GEV, ::HepMC3::Units::MM);
+  m_event.add_beam_particle(std::make_shared<::HepMC3::GenParticle>());
 }
 
-void ActsExamples::EventAction::EndOfEventAction(const G4Event*) {
+void EventAction::EndOfEventAction(const G4Event*) {
   // Fast exit if the event is empty
   if (m_event.vertices().empty()) {
     return;
@@ -156,10 +158,11 @@ void ActsExamples::EventAction::EndOfEventAction(const G4Event*) {
   followOutgoingParticles(m_event, currentVertex, m_processFilter);
 }
 
-void ActsExamples::EventAction::clear() {
+void EventAction::clear() {
   SteppingAction::instance()->clear();
 }
 
-HepMC3::GenEvent& ActsExamples::EventAction::event() {
+::HepMC3::GenEvent& EventAction::event() {
   return m_event;
 }
+}  // namespace ActsExamples::Geant4::HepMC3

--- a/Examples/Algorithms/Geant4HepMC/src/EventAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventAction.hpp
@@ -16,7 +16,7 @@
 #include <HepMC3/GenEvent.h>
 #include <globals.hh>
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4::HepMC3 {
 
 /// The EventAction class is the realization of the Geant4 class
 /// G4UserEventAction and is writing out the collected RecordedMaterialTrack
@@ -44,14 +44,14 @@ class EventAction final : public G4UserEventAction {
   void clear();
 
   /// Getter of the created HepMC3 event
-  HepMC3::GenEvent& event();
+  ::HepMC3::GenEvent& event();
 
  private:
   /// Instance of the EventAction
   static EventAction* s_instance;
   /// The current HepMC3 event
-  HepMC3::GenEvent m_event;
+  ::HepMC3::GenEvent m_event;
   /// List of processes that can be combined to a single vertex
   std::vector<std::string> m_processFilter;
 };
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4::HepMC3

--- a/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.cpp
@@ -19,11 +19,12 @@
 #include <G4UnitsTable.hh>
 #include <Randomize.hh>
 
-ActsExamples::PrimaryGeneratorAction*
-    ActsExamples::PrimaryGeneratorAction::s_instance = nullptr;
+namespace ActsExamples::Geant4::HepMC3 {
 
-ActsExamples::PrimaryGeneratorAction::PrimaryGeneratorAction(G4int randomSeed1,
-                                                             G4int randomSeed2)
+PrimaryGeneratorAction* PrimaryGeneratorAction::s_instance = nullptr;
+
+PrimaryGeneratorAction::PrimaryGeneratorAction(G4int randomSeed1,
+                                               G4int randomSeed2)
     : G4VUserPrimaryGeneratorAction(), m_particleGun(nullptr) {
   // Configure the run
   if (s_instance) {
@@ -43,17 +44,16 @@ ActsExamples::PrimaryGeneratorAction::PrimaryGeneratorAction(G4int randomSeed1,
   CLHEP::HepRandom::getTheEngine()->setSeed(randomSeed1, randomSeed2);
 }
 
-ActsExamples::PrimaryGeneratorAction::~PrimaryGeneratorAction() {
+PrimaryGeneratorAction::~PrimaryGeneratorAction() {
   s_instance = nullptr;
 }
 
-ActsExamples::PrimaryGeneratorAction*
-ActsExamples::PrimaryGeneratorAction::instance() {
+PrimaryGeneratorAction* PrimaryGeneratorAction::instance() {
   // Static acces function via G4RunManager
   return s_instance;
 }
 
-void ActsExamples::PrimaryGeneratorAction::prepareParticleGun(
+void PrimaryGeneratorAction::prepareParticleGun(
     const ActsExamples::SimParticle& part) {
   constexpr double convertLength = CLHEP::mm / Acts::UnitConstants::mm;
   constexpr double convertEnergy = CLHEP::GeV / Acts::UnitConstants::GeV;
@@ -69,7 +69,9 @@ void ActsExamples::PrimaryGeneratorAction::prepareParticleGun(
   m_particleGun->SetParticleMomentumDirection({dir[0], dir[1], dir[2]});
 }
 
-void ActsExamples::PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
+void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
   // Produce the event
   m_particleGun->GeneratePrimaryVertex(anEvent);
 }
+
+}  // namespace ActsExamples::Geant4::HepMC3

--- a/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/PrimaryGeneratorAction.hpp
@@ -23,6 +23,8 @@ class G4Event;
 
 namespace ActsExamples {
 
+namespace Geant4::HepMC3 {
+
 /// The PrimaryGeneratorAction is the implementation of the Geant4
 /// class G4VUserPrimaryGeneratorAction. It generates a random direction
 /// and shoots a particle.
@@ -51,5 +53,6 @@ class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction {
   /// The Geant4 particle table
   G4ParticleTable* m_particleTable;
 };
+}  // namespace Geant4::HepMC3
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4HepMC/src/RunAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/RunAction.cpp
@@ -14,7 +14,7 @@
 
 #include "EventAction.hpp"
 
-using namespace ActsExamples;
+namespace ActsExamples::Geant4::HepMC3 {
 
 RunAction* RunAction::s_instance = nullptr;
 
@@ -40,3 +40,5 @@ void RunAction::BeginOfRunAction(const G4Run* /*unused*/) {
 }
 
 void RunAction::EndOfRunAction(const G4Run* /*unused*/) {}
+
+}  // namespace ActsExamples::Geant4::HepMC3

--- a/Examples/Algorithms/Geant4HepMC/src/RunAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/RunAction.hpp
@@ -15,7 +15,7 @@
 
 class G4Run;
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4::HepMC3 {
 
 /// The RunAction class is the implementation of the
 /// Geant4 class G4UserRunAction. It initiates the run
@@ -41,4 +41,4 @@ class RunAction final : public G4UserRunAction {
   static RunAction* s_instance;
 };
 
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4::HepMC3

--- a/Examples/Algorithms/Geant4HepMC/src/SteppingAction.hpp
+++ b/Examples/Algorithms/Geant4HepMC/src/SteppingAction.hpp
@@ -15,7 +15,7 @@
 #include <HepMC3/GenVertex.h>
 #include <globals.hh>
 
-namespace ActsExamples {
+namespace ActsExamples::Geant4::HepMC3 {
 
 /// Collects the particles history.
 class SteppingAction : public G4UserSteppingAction {
@@ -40,10 +40,10 @@ class SteppingAction : public G4UserSteppingAction {
   /// Instance of the SteppingAction
   static SteppingAction* s_instance;
   /// The end vertex of the previous step
-  std::shared_ptr<HepMC3::GenVertex> m_previousVertex = nullptr;
+  std::shared_ptr<::HepMC3::GenVertex> m_previousVertex = nullptr;
   /// List to veto events with certain processes
   std::vector<std::string> m_eventRejectionProcess;
   /// States whether an event was aborted
   bool m_eventAborted = false;
 };
-}  // namespace ActsExamples
+}  // namespace ActsExamples::Geant4::HepMC3


### PR DESCRIPTION
Previously these had the same symbol names between ExamplesGeant4 and ExamplesGeant4HepMC3. This is fine if these libraries are never linked together, but if that happens, it leads to crashes due to incompatible clashes. This moves both sets of classes into namespaces, to avoid clashes.

Fixes #874

/cc @FabianKlimpel 