### PR TITLE
feat: update OpenDataDetector to tip

### DIFF
--- a/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
@@ -162,6 +162,7 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
         endcapVolume.placeVolume(layerVolume, Position(0., 0., zeff));
     placedLayer.addPhysVolID("layer", layNum);
 
+  
     // Place the layer with appropriate Acts::Extension
     // Configure the ACTS extension
     Acts::ActsExtension* layerExtension = new Acts::ActsExtension();
@@ -170,6 +171,13 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     layerExtension->addValue(10., "r_max", "envelope");   
     layerExtension->addValue(10., "z_min", "envelope");
     layerExtension->addValue(10., "z_max", "envelope");        
+    // Check if the disk has a surface binning instruction
+    if (x_layer.hasChild("surface_binning")){
+      xml_comp_t sfBinning = x_layer.child(_Unicode(surface_binning));
+      layerExtension->addValue(sfBinning.attr<int>("nr"), "n_r", "surface_binning");
+      layerExtension->addValue(sfBinning.attr<int>("nphi"), "n_phi", "surface_binning");
+    }
+
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
     // Add the proto layer material
     for (xml_coll_t lmat(x_layer, _Unicode(layer_material)); lmat; ++lmat) {

--- a/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDPixelEndcap_geo.cpp
@@ -172,7 +172,7 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     layerExtension->addValue(10., "z_min", "envelope");
     layerExtension->addValue(10., "z_max", "envelope");        
     // Check if the disk has a surface binning instruction
-    if (x_layer.hasChild("surface_binning")){
+    if (x_layer.hasChild(_Unicode(surface_binning))){
       xml_comp_t sfBinning = x_layer.child(_Unicode(surface_binning));
       layerExtension->addValue(sfBinning.attr<int>("nr"), "n_r", "surface_binning");
       layerExtension->addValue(sfBinning.attr<int>("nphi"), "n_phi", "surface_binning");

--- a/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
@@ -170,6 +170,14 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     layerExtension->addValue(10, "r_max", "envelope");
     layerExtension->addValue(10, "z_min", "envelope");
     layerExtension->addValue(10, "z_max", "envelope");
+
+    // Check if the disk has a surface binning instruction
+    if (x_layer.hasChild("surface_binning")){
+      xml_comp_t sfBinning = x_layer.child(_Unicode(surface_binning));
+      layerExtension->addValue(sfBinning.attr<int>("nr"), "n_r", "surface_binning");
+      layerExtension->addValue(sfBinning.attr<int>("nphi"), "n_phi", "surface_binning");
+    }
+
     layerElement.addExtension<Acts::ActsExtension>(layerExtension);
 
     // Add the proto layer material

--- a/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
+++ b/thirdparty/OpenDataDetector/factory/ODDStripEndcap_geo.cpp
@@ -172,7 +172,7 @@ static Ref_t create_element(Detector& oddd, xml_h xml, SensitiveDetector sens) {
     layerExtension->addValue(10, "z_max", "envelope");
 
     // Check if the disk has a surface binning instruction
-    if (x_layer.hasChild("surface_binning")){
+    if (x_layer.hasChild(_Unicode(surface_binning))){
       xml_comp_t sfBinning = x_layer.child(_Unicode(surface_binning));
       layerExtension->addValue(sfBinning.attr<int>("nr"), "n_r", "surface_binning");
       layerExtension->addValue(sfBinning.attr<int>("nphi"), "n_phi", "surface_binning");

--- a/thirdparty/OpenDataDetector/xml/OpenDataLongStrips.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataLongStrips.xml
@@ -37,27 +37,27 @@
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
         <layer id="0" name="LongStripEndcapN0" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1300.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="1" name="LongStripEndcapN2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1600.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapN3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1900.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapN4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2250.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="3" name="LongStripEndcapN5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2600.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="4" name="LongStripEndcapN6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-3000.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <services>
@@ -156,27 +156,27 @@
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
         <layer id="0" name="LongStripEndcapP0" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1300.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
            <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="1" name="LongStripEndcapP2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1600.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapP3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1900.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapP4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2250.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="3" name="LongStripEndcapP5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2600.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="4" name="LongStripEndcapP6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="3000.*mm" vis="invisible">
-           <surface_binning nr=2 nphi=48/>
+           <surface_binning nr="2" nphi="48"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <services>

--- a/thirdparty/OpenDataDetector/xml/OpenDataLongStrips.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataLongStrips.xml
@@ -37,21 +37,27 @@
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
         <layer id="0" name="LongStripEndcapN0" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1300.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="1" name="LongStripEndcapN2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1600.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapN3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-1900.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapN4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2250.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="3" name="LongStripEndcapN5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-2600.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="4" name="LongStripEndcapN6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="-3000.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <services>
@@ -115,56 +121,62 @@
     <!--EndcapP-->
     <detector id="302" name="LongStripEndcapP" type="ODDStripEndcap" readout="LongStripEndcapReadout" vis="invisible">
         <dimensions name="LongStripEndcapShape" rmin="ls_env_rmin" rmax="ls_env_rmax" dz="ls_e_dz" z="ls_e_pz"/>
-        <ring name="Ring0" r="820.*mm" nphi="44" reflect="true" phi0="0." gap="8.*mm" z_offset="-15.*mm"> 
+        <ring name="Ring0" r="820.*mm" nphi="48" reflect="true" phi0="0." gap="8.*mm" z_offset="-15.*mm"> 
           <module name="LongStripEndcapModuleR0" vis="invisible">
-             <module_component name="Sensor" alpha="-0.02" x1="53.2*mm" x2="58.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="-0.02" x1="53.8*mm" x2="59.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="0.02" x1="53.2*mm" x2="58.6*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="0.02" x1="53.8*mm" x2="59.2*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
              <module_component name="Foam" alpha="0." x1="54.8*mm" x2="60.2*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.02" x1="53.2*mm" x2="58.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.02" x1="53.8*mm" x2="59.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="-0.02" x1="53.2*mm" x2="58.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="-0.02" x1="53.8*mm" x2="59.2*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
          </module>                   
           <support name="SupportRing0" rmin="720.*mm" rmax="735.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <support name="SupportRing1" rmin="900.*mm" rmax="920.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="922.*mm" gap="22.66*mm" nphi="64" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
     
-        <ring name="Ring1" r="990.*mm" nphi="52" reflect="true" phi0="0." gap="8.*mm" z_offset="15.*mm"> 
-          <module name="LongStripEndcapModuleR1" vis="invisible">
-             <module_component name="Sensor" alpha="-0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-             <module_component name="Board" alpha="-0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+        <ring name="Ring1" r="990.*mm" nphi="48" reflect="true" phi0="0." gap="8.*mm" z_offset="15.*mm"> 
+             <module name="LongStripEndcapModuleR1" vis="invisible">
+             <module_component name="Sensor" alpha="0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+             <module_component name="Board" alpha="0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
              <module_component name="Foam" alpha="0." x1="66.2*mm" x2="71.6*mm" length="82.8*mm" thickness="4.*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFoam" sensitive="false">
                <subtraction name="CoolingLine" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm">
                  <tubs name="FoamCutout" rmin="0." rmax="1.6*mm"  z_offset="0.*mm" dz="20.*mm"/>
                </subtraction>
                <tube name="CoolingPipe" rmin="1.4*mm" rmax="1.5*mm" dz="48.5*mm" x_offset="0.*mm" y_offset="0.*mm" z_offset="0.*mm" material="Ti" vis="orange" />
              </module_component>
-             <module_component name="Board" alpha="0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
-             <module_component name="Sensor" alpha="0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
-       </module> 
+             <module_component name="Board" alpha="-0.02" x1="64.6*mm" x2="70.*mm" length="78.*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.25*mm" z_offset="0.*mm" material="Kapton" vis="Kapton" sensitive="false"/>
+             <module_component name="Sensor" alpha="-0.02" x1="65.2*mm" x2="70.6*mm" length="80.8*mm" thickness="0.25*mm" x_offset="0.*mm" y_offset="-2.5*mm" z_offset="0.*mm" material="Silicon" vis="Silicon" sensitive="true"/>
+         </module>
           <support name="SupportRing1" rmin="1070.*mm" rmax="1090.*mm" dz="4.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
           <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="1092.*mm" gap="23.85*mm" nphi="72" z_offset="0.*mm" material="Ti" vis="orange"/>
         </ring>
         <layer id="0" name="LongStripEndcapP0" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1300.*mm" vis="invisible">
-          <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
+           <surface_binning nr=2 nphi=48/>
+           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="1" name="LongStripEndcapP2" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1600.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapP3" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="1900.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="2" name="LongStripEndcapP4" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2250.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="3" name="LongStripEndcapP5" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="2600.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <layer id="4" name="LongStripEndcapP6" rmin="720.*mm" rmax="1095.*mm" dz="100.*mm" z_offset="3000.*mm" vis="invisible">
+           <surface_binning nr=2 nphi=48/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_lst_endcap_bPhi" bins1="mat_lst_endcap_bR"/>
         </layer>
         <services>

--- a/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
@@ -25,7 +25,7 @@
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="145.*mm" gap="7.2*mm" nphi="32" z_offset="+6.1*mm" material="Ti" vis="orange"/>
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="170.*mm" gap="8.4*mm" nphi="32" z_offset="+4.*mm" material="Ti" vis="orange"/>
         <layer id="0" name="PixelEndcapN0" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-620.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapN1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-720.*mm" vis="invisible">
@@ -139,7 +139,7 @@
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="145.*mm" gap="7.2*mm" nphi="32" z_offset="-6.1*mm" material="Ti" vis="orange"/>
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="170.*mm" gap="8.4*mm" nphi="32" z_offset="-4.*mm" material="Ti" vis="orange"/>
         <layer id="0" name="PixelEndcapP0" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="620.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapP1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="720.*mm" vis="invisible">

--- a/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
@@ -29,31 +29,31 @@
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapN1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-720.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="2" name="PixelEndcapN2" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-840.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="3" name="PixelEndcapN3" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-980.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="4" name="PixelEndcapN4" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1120.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="5" name="PixelEndcapN5" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1320.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="6" name="PixelEndcapN6" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1520.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <disk name="PixelEndplate" z_offset="-1950.*mm" rmin="40.*mm" rmax="189.*mm" dz="5*mm" material="CarbonFiber" vis="CarbonFiber">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </disk>
         <support name="InnerSupportRail" rmin="190.*mm" rmax="200.*mm" dz="10.*mm" material="CarbonFiber" z_offset="000.*mm" nsides="1" vis="CarbonFiber"/>
@@ -143,31 +143,31 @@
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapP1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="720.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="2" name="PixelEndcapP2" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="840.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="3" name="PixelEndcapP3" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="980.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="4" name="PixelEndcapP4" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1120.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="5" name="PixelEndcapP5" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1320.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="6" name="PixelEndcapP6" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1520.*mm" vis="invisible">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <disk name="PixelEndplate" z_offset="1950.*mm" rmin="40.*mm" rmax="189.*mm" dz="5*mm" material="CarbonFiber" vis="CarbonFiber">
-          <surface_binning nr=2 nphi=36/>
+          <surface_binning nr="2" nphi="36"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </disk>
         <support name="InnerSupportRail" rmin="190.*mm" rmax="200.*mm" dz="10.*mm" material="CarbonFiber" z_offset="000.*mm" nsides="1" vis="CarbonFiber"/>

--- a/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataPixels.xml
@@ -25,27 +25,35 @@
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="145.*mm" gap="7.2*mm" nphi="32" z_offset="+6.1*mm" material="Ti" vis="orange"/>
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="170.*mm" gap="8.4*mm" nphi="32" z_offset="+4.*mm" material="Ti" vis="orange"/>
         <layer id="0" name="PixelEndcapN0" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-620.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapN1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-720.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="2" name="PixelEndcapN2" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-840.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="3" name="PixelEndcapN3" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-980.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="4" name="PixelEndcapN4" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1120.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="5" name="PixelEndcapN5" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1320.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="6" name="PixelEndcapN6" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="-1520.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <disk name="PixelEndplate" z_offset="-1950.*mm" rmin="40.*mm" rmax="189.*mm" dz="5*mm" material="CarbonFiber" vis="CarbonFiber">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </disk>
         <support name="InnerSupportRail" rmin="190.*mm" rmax="200.*mm" dz="10.*mm" material="CarbonFiber" z_offset="000.*mm" nsides="1" vis="CarbonFiber"/>
@@ -131,27 +139,35 @@
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="145.*mm" gap="7.2*mm" nphi="32" z_offset="-6.1*mm" material="Ti" vis="orange"/>
         <cooling_ring rmin="1.4*mm" rmax="1.6*mm" r="170.*mm" gap="8.4*mm" nphi="32" z_offset="-4.*mm" material="Ti" vis="orange"/>
         <layer id="0" name="PixelEndcapP0" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="620.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="1" name="PixelEndcapP1" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="720.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="2" name="PixelEndcapP2" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="840.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="3" name="PixelEndcapP3" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="980.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="4" name="PixelEndcapP4" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1120.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="5" name="PixelEndcapP5" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1320.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <layer id="6" name="PixelEndcapP6" rmin="28.*mm" rmax="186.*mm" dz="20.*mm" z_offset="1520.*mm" vis="invisible">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </layer>
         <disk name="PixelEndplate" z_offset="1950.*mm" rmin="40.*mm" rmax="189.*mm" dz="5*mm" material="CarbonFiber" vis="CarbonFiber">
+          <surface_binning nr=2 nphi=36/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_pix_endcap_bPhi" bins1="mat_pix_endcap_bR"/>
         </disk>
         <support name="InnerSupportRail" rmin="190.*mm" rmax="200.*mm" dz="10.*mm" material="CarbonFiber" z_offset="000.*mm" nsides="1" vis="CarbonFiber"/>

--- a/thirdparty/OpenDataDetector/xml/OpenDataShortStrips.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataShortStrips.xml
@@ -34,27 +34,27 @@
           <support name="SupportRing1" rmin="670.*mm" rmax="710.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
         </ring>
         <layer id="0" name="ShortStripEndcapN0" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1300.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="1" name="ShortStripEndcapN2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1550.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapN3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1850.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="3" name="ShortStripEndcapN4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2200.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="4" name="ShortStripEndcapN5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2550.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="5" name="ShortStripEndcapN6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2950.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <services>
@@ -149,27 +149,27 @@
           <support name="SupportRing1" rmin="670.*mm" rmax="710.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
         </ring>
         <layer id="0" name="ShortStripEndcapP0" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1300.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="1" name="ShortStripEndcapP2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1550.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapP3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1850.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapP4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2200.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="3" name="ShortStripEndcapP5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2550.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="4" name="ShortStripEndcapP6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2950.*mm" vis="invisible">
-          <surface_binning nr=3 nphi=42/>
+          <surface_binning nr="3" nphi="42"/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <services>

--- a/thirdparty/OpenDataDetector/xml/OpenDataShortStrips.xml
+++ b/thirdparty/OpenDataDetector/xml/OpenDataShortStrips.xml
@@ -34,21 +34,27 @@
           <support name="SupportRing1" rmin="670.*mm" rmax="710.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
         </ring>
         <layer id="0" name="ShortStripEndcapN0" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1300.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="1" name="ShortStripEndcapN2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1550.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapN3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-1850.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="3" name="ShortStripEndcapN4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2200.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="4" name="ShortStripEndcapN5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2550.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="5" name="ShortStripEndcapN6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="-2950.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <services>
@@ -143,21 +149,27 @@
           <support name="SupportRing1" rmin="670.*mm" rmax="710.*mm" dz="2.*mm" z_offset="0.*mm" material="CarbonFiber" vis="CarbonFiber"/>
         </ring>
         <layer id="0" name="ShortStripEndcapP0" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1300.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="1" name="ShortStripEndcapP2" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1550.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapP3" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="1850.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="2" name="ShortStripEndcapP4" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2200.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="3" name="ShortStripEndcapP5" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2550.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <layer id="4" name="ShortStripEndcapP6" rmin="210.*mm" rmax="715.*mm" dz="50.*mm" z_offset="2950.*mm" vis="invisible">
+          <surface_binning nr=3 nphi=42/>
           <layer_material surface="representing" binning="binPhi,binR" bins0="mat_sst_endcap_bPhi" bins1="mat_sst_endcap_bR"/>
         </layer>
         <services>


### PR DESCRIPTION
This PR updates the OpenDataDector to the version where both Long Strips endcaps are now covered with a sensible number of elements.

It also introduces a manual setting of the number of bins for the surface binning if requested.