### PR TITLE
fix: build passive layers for DD4hep

### DIFF
--- a/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
+++ b/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
@@ -551,7 +551,8 @@ void collectSubDetectors_dd4hep(dd4hep::DetElement& detElement,
     }
     if ((detExtension != nullptr) &&
         (detExtension->hasType("barrel", "detector") ||
-         detExtension->hasType("beampipe", "layer"))) {
+         detExtension->hasType("beampipe", "layer") ||
+         detExtension->hasType("passive cylinder", "layer"))) {
       subdetectors.push_back(childDetElement);
       continue;
     }


### PR DESCRIPTION
This PR fixes an issue that only the beam pipe was regarded as a passive layer to be built, an issue easily spotted in the OpenDataDetector setup.

With this one-line fix, suddenly the Solenoid and the Pixel Support Tube show up.

```shell
12:21:38    DD4hepConver   INFO      Translating DD4hep geometry into Acts geometry
12:21:38    DD4hepConver   INFO      Translating DD4hep sub detector: BeamPipe
12:21:38    DD4hepConver   INFO      Translating DD4hep sub detector: Pixels
12:21:38    DD4hepConver   INFO      Translating DD4hep sub detector: PST
12:21:38    DD4hepConver   INFO      Translating DD4hep sub detector: ShortStrips
12:21:38    DD4hepConver   INFO      Translating DD4hep sub detector: LongStrips
```

