### PR TITLE
feat: Implement a seeding cut on monotonicity in Z

### DIFF
--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -166,7 +166,8 @@ Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
         // middle and top spacepoint as it is between the middle and top
         // spacepoint. If not, the Z coordinate is not monotonic between the
         // points, and the seed is unlikely to be useful.
-        if (std::signbit(compatTopSP[t]->z() - spM->z()) != bmSign) {
+        if (m_config.requireMonotonicZ &&
+            std::signbit(compatTopSP[t]->z() - spM->z()) != bmSign) {
           continue;
         }
 

--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -134,6 +134,11 @@ Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
       float ErB = lb.Er;
       float iDeltaRB = lb.iDeltaR;
 
+      // Compute the sign of the difference between the Z coordinate of the
+      // middle and bottom space points. If this is true, the Z coordinate
+      // increases. If it is false, the Z coordinate decreases.
+      bool bmSign = std::signbit(spM->z() - compatBottomSP[b]->z());
+
       // 1+(cot^2(theta)) = 1/sin^2(theta)
       float iSinTheta2 = (1. + cotThetaB * cotThetaB);
       // calculate max scattering for min momentum at the seed's theta angle
@@ -156,6 +161,14 @@ Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
       impactParameters.clear();
       for (size_t t = 0; t < numTopSP; t++) {
         auto lt = linCircleTop[t];
+
+        // Check if the sign of the difference in Z is the same between the
+        // middle and top spacepoint as it is between the middle and top
+        // spacepoint. If not, the Z coordinate is not monotonic between the
+        // points, and the seed is unlikely to be useful.
+        if (std::signbit(compatTopSP[t]->z() - spM->z()) != bmSign) {
+          continue;
+        }
 
         // add errors of spB-spM and spM-spT pairs and add the correlation term
         // for errors on spM

--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -69,6 +69,10 @@ struct SeedfinderConfig {
   // which will make seeding very slow!
   float rMin = 33;
 
+  // If enabled, seed candidates for which the z-coordinate between the space
+  // points does not increase or decrease monotonically will be rejected.
+  bool requireMonotonicZ = false;
+
   // Unit in kiloTesla
   // FIXME: Acts units
   float bFieldInZ = 0.00208;

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
@@ -49,6 +49,7 @@ class SeedingAlgorithm final : public BareAlgorithm {
     float beamPosX = 0;
     float beamPosY = 0;
     float impactMax = 3.;
+    bool requireMonotonicZ = false;
   };
 
   /// Construct the seeding algorithm.

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -68,6 +68,7 @@ ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
   m_finderCfg.bFieldInZ = m_cfg.bFieldInZ;
   m_finderCfg.beamPos = Acts::Vector2(m_cfg.beamPosX, m_cfg.beamPosY);
   m_finderCfg.impactMax = m_cfg.impactMax;
+  m_finderCfg.requireMonotonicZ = m_cfg.requireMonotonicZ;
 }
 
 ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(

--- a/Examples/Run/Reconstruction/Common/SeedingExample.cpp
+++ b/Examples/Run/Reconstruction/Common/SeedingExample.cpp
@@ -136,6 +136,7 @@ int runSeedingExample(int argc, char* argv[],
   seedingCfg.beamPosX = 0;
   seedingCfg.beamPosY = 0;
   seedingCfg.impactMax = 3.;
+  seedingCfg.requireMonotonicZ = true;
   sequencer.addAlgorithm(
       std::make_shared<SeedingAlgorithm>(seedingCfg, logLevel));
 


### PR DESCRIPTION
I'm opening this pull request as a "request for comments" mostly, as it is something I stumbled across as a potential improvement, but I am not entirely certain it is valid, or even wanted in the Acts code. Please feel free to provide any feedback (including calling it a flat-out stupid idea).

Seeds are constructed from three space points, each with a z value. As I understand it, particles are unaffected by magnetic fields in the r-z plane, and thus the z values should, for almost all particles, follow a monotonic function. That is to say, they should either always go up (so the middle SP should have a higher z than the bottom SP, and the top SP should have a higher z than the middle SP, or they should always go down. My understanding is that tracks where z is not monotonic only happen if a particle scatters at an extraordinary angle, and that making seeds for such tracks is not worthwhile.

This commit adds an additional cut to the seed finding algorithm that checks whether candidate seeds have monotonic z coordinates. If not, the seed is rejected early.

In my testing, this change has a positive effect on the seeding efficiency, the fake rate, and the runtime performance. For a simulated event of 4000 pions, the efficiency goes up from 0.741 to 0.750, the fake rate goes down from 0.702 to 0.697, and the runtime of seeding goes down by roughly 15%.
