### PR TITLE
fix: Make smearers used in digitization thread-safe

### DIFF
--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
@@ -15,6 +15,7 @@
 
 #include <cmath>
 #include <limits>
+#include <mutex>
 #include <random>
 #include <string>
 #include <tuple>
@@ -28,10 +29,10 @@ namespace Digitization {
 /// @note This smearer will smear over module boundaries
 /// it has no notion of a parameter range is assumed
 struct Gauss {
-  std::normal_distribution<> dist{0., 1.};
+  double sigma;
 
   /// Construct with a @param sigma standard deviation
-  Gauss(double sigma) : dist(std::normal_distribution<>(0., sigma)) {}
+  Gauss(double sigma_) : sigma{sigma_} {}
 
   /// Call operator for the SmearFunction caller interface.
   ///
@@ -40,9 +41,9 @@ struct Gauss {
   ///
   /// @return a Result that is always ok()
   Acts::Result<std::pair<double, double>> operator()(double value,
-                                                     RandomEngine& rnd) {
-    return Acts::Result<std::pair<double, double>>(
-        std::make_pair<double, double>(value + dist(rnd), dist.stddev()));
+                                                     RandomEngine& rnd) const {
+    std::normal_distribution<> dist{0, sigma};
+    return std::pair{value + dist(rnd), dist.stddev()};
   }
 };
 
@@ -51,14 +52,13 @@ struct Gauss {
 /// In case a hit is smeared outside the range, a DigitizationError
 /// indicating the truncation
 struct GaussTrunc {
-  std::normal_distribution<> dist{0., 1.};
-
+  double sigma;
   std::pair<double, double> range = {std::numeric_limits<double>::lowest(),
                                      std::numeric_limits<double>::max()};
 
   /// Construct with a @param sigma standard deviation and @param range
-  GaussTrunc(double sigma, const std::pair<double, double>& range_)
-      : dist(std::normal_distribution<>(0., sigma)), range(range_) {}
+  GaussTrunc(double sigma_, const std::pair<double, double>& range_)
+      : sigma{sigma_}, range(range_) {}
 
   /// Call operator for the SmearFunction caller interface.
   ///
@@ -67,11 +67,11 @@ struct GaussTrunc {
   ///
   /// @return a Result that is ok() when inside range, other DigitizationError
   Acts::Result<std::pair<double, double>> operator()(double value,
-                                                     RandomEngine& rnd) {
+                                                     RandomEngine& rnd) const {
+    std::normal_distribution<> dist{0., sigma};
     double svalue = value + dist(rnd);
     if (svalue >= range.first and svalue <= range.second) {
-      return Acts::Result<std::pair<double, double>>(
-          std::pair<double, double>(svalue, dist.stddev()));
+      return std::pair{svalue, dist.stddev()};
     }
     return ActsFatras::DigitizationError::SmearingOutOfRange;
   }
@@ -82,7 +82,7 @@ struct GaussTrunc {
 /// In case a hit is smeared outside the range, the smearing will be
 /// repeated, until a maximum attempt number is reached
 struct GaussClipped {
-  std::normal_distribution<> dist{0., 1.};
+  double sigma;
 
   size_t maxAttemps = 1000;
 
@@ -90,8 +90,8 @@ struct GaussClipped {
                                      std::numeric_limits<double>::max()};
 
   /// Construct with a @param sigma standard deviation and @param range
-  GaussClipped(double sigma, const std::pair<double, double>& range_)
-      : dist(std::normal_distribution<>(0., sigma)), range(range_) {}
+  GaussClipped(double sigma_, const std::pair<double, double>& range_)
+      : sigma{sigma_}, range(range_) {}
 
   /// Call operator for the SmearFunction caller interface.
   ///
@@ -102,12 +102,12 @@ struct GaussClipped {
   ///
   /// @return a Result that is ok() when inside range, other DigitizationError
   Acts::Result<std::pair<double, double>> operator()(double value,
-                                                     RandomEngine& rnd) {
+                                                     RandomEngine& rnd) const {
+    std::normal_distribution<> dist{0., sigma};
     for (size_t attempt = 0; attempt < maxAttemps; ++attempt) {
       double svalue = value + dist(rnd);
       if (svalue >= range.first and svalue <= range.second) {
-        return Acts::Result<std::pair<double, double>>(
-            std::pair<double, double>(svalue, dist.stddev()));
+        return std::pair{svalue, dist.stddev()};
       }
     }
     return ActsFatras::DigitizationError::SmearingError;
@@ -119,8 +119,6 @@ struct GaussClipped {
 /// It estimates the bin borders and smears uniformly between them
 struct Uniform {
   Acts::BinningData binningData;
-
-  std::uniform_real_distribution<> dist{0., 1.};
 
   /// Construct with a @param pitch standard deviation and @param range
   Uniform(double pitch, const std::pair<double, double>& range_)
@@ -140,14 +138,14 @@ struct Uniform {
   ///
   /// @return a Result is uniformly distributed between bin borders
   Acts::Result<std::pair<double, double>> operator()(double value,
-                                                     RandomEngine& rnd) {
+                                                     RandomEngine& rnd) const {
     if (binningData.min < value and binningData.max > value) {
       auto bin = binningData.search(value);
       auto lower = binningData.boundaries()[bin];
       auto higher = binningData.boundaries()[bin + 1];
+      std::uniform_real_distribution<> dist{0., 1.};
       double svalue = lower + (higher - lower) * dist(rnd);
-      return Acts::Result<std::pair<double, double>>(
-          std::pair<double, double>(svalue, (higher - lower) / std::sqrt(12.)));
+      return std::pair{svalue, (higher - lower) / std::sqrt(12.)};
     }
     return ActsFatras::DigitizationError::SmearingError;
   }
@@ -176,15 +174,14 @@ struct Digital {
   /// @param rnd random generator to be used for the call (unused)
   ///
   /// @return a Result is uniformly distributed between bin borders
-  Acts::Result<std::pair<double, double>> operator()(double value,
-                                                     RandomEngine& /*unused*/) {
+  Acts::Result<std::pair<double, double>> operator()(
+      double value, RandomEngine& /*unused*/) const {
     if (binningData.min < value and binningData.max > value) {
       auto bin = binningData.search(value);
       auto lower = binningData.boundaries()[bin];
       auto higher = binningData.boundaries()[bin + 1];
       double svalue = 0.5 * (lower + higher);
-      return Acts::Result<std::pair<double, double>>(
-          std::pair<double, double>(svalue, (higher - lower) / std::sqrt(12.)));
+      return std::pair{svalue, (higher - lower) / std::sqrt(12.)};
     }
     return ActsFatras::DigitizationError::SmearingError;
   }

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
@@ -15,7 +15,6 @@
 
 #include <cmath>
 #include <limits>
-#include <mutex>
 #include <random>
 #include <string>
 #include <tuple>

--- a/Examples/Io/Json/src/JsonDigitizationConfig.cpp
+++ b/Examples/Io/Json/src/JsonDigitizationConfig.cpp
@@ -23,16 +23,16 @@ void ActsExamples::to_json(nlohmann::json& j,
       psc.smearFunction.target<const Digitization::Gauss>();
   if (gauss != nullptr) {
     j["type"] = "Gauss";
-    j["mean"] = gauss->dist.mean();
-    j["stddev"] = gauss->dist.stddev();
+    j["mean"] = 0;
+    j["stddev"] = gauss->sigma;
   }
   // Truncated gauss:
   const Digitization::GaussTrunc* gaussT =
       psc.smearFunction.target<const Digitization::GaussTrunc>();
   if (gaussT != nullptr) {
     j["type"] = "GaussTrunc";
-    j["mean"] = gaussT->dist.mean();
-    j["stddev"] = gaussT->dist.stddev();
+    j["mean"] = 0;
+    j["stddev"] = gaussT->sigma;
     j["range"] = gaussT->range;
   }
   // Clipped gauss:
@@ -40,8 +40,8 @@ void ActsExamples::to_json(nlohmann::json& j,
       psc.smearFunction.target<const Digitization::GaussClipped>();
   if (gaussC != nullptr) {
     j["type"] = "GaussClipped";
-    j["mean"] = gaussC->dist.mean();
-    j["stddev"] = gaussC->dist.stddev();
+    j["mean"] = 0;
+    j["stddev"] = gaussC->sigma;
     j["range"] = gaussC->range;
     j["max_attempts"] = gaussC->maxAttemps;
   }


### PR DESCRIPTION
The smearing callable structs used in the digitization have member variables to various `std::*_distribution` objects. These types of objects are not thread-safe as they contain state. This lead to non-reproducibility in the smearing. This PR moves the distribution object to the `operator()()` body, ensuring they are not shared across threads.

Fixes #869 

/cc @robertlangenberg 