### PR TITLE
fix: determineEventFilesRange is VERBOSE by default

### DIFF
--- a/Examples/Framework/src/Utilities/Paths.cpp
+++ b/Examples/Framework/src/Utilities/Paths.cpp
@@ -61,7 +61,7 @@ std::pair<size_t, size_t> ActsExamples::determineEventFilesRange(
   using boost::filesystem::path;
 
   ACTS_LOCAL_LOGGER(
-      Acts::getDefaultLogger("EventFilesRange", Acts::Logging::VERBOSE));
+      Acts::getDefaultLogger("EventFilesRange", Acts::Logging::INFO));
 
   // ensure directory path is valid
   auto dir_path = dir.empty() ? current_path() : path(dir);


### PR DESCRIPTION
This uses a local logger which is not configurable. It is set to `VERBOSE` by default leading to a lot of output if reading in CSV files. This PR changes the default to `INFO`.