### PR TITLE
fix: GCC10 warning about uninitialized value

### DIFF
--- a/Core/include/Acts/Propagator/StepperExtensionList.hpp
+++ b/Core/include/Acts/Propagator/StepperExtensionList.hpp
@@ -79,7 +79,8 @@ struct StepperExtensionList : private detail::Extendable<extensions...> {
   template <typename propagator_state_t, typename stepper_t>
   bool k(const propagator_state_t& state, const stepper_t& stepper,
          Vector3& knew, const Vector3& bField, std::array<double, 4>& kQoP,
-         const int i, const double h = 0., const Vector3& kprev = Vector3{}) {
+         const int i, const double h = 0.,
+         const Vector3& kprev = Vector3::Zero()) {
     // TODO replace with integer-templated lambda with C++20
     auto impl = [&, i, h](auto intType, auto& implRef) {
       constexpr int N = decltype(intType)::value;

--- a/Core/include/Acts/Propagator/detail/GenericDefaultExtension.hpp
+++ b/Core/include/Acts/Propagator/detail/GenericDefaultExtension.hpp
@@ -54,7 +54,7 @@ struct GenericDefaultExtension {
   bool k(const propagator_state_t& state, const stepper_t& stepper,
          ThisVector3& knew, const Vector3& bField, std::array<Scalar, 4>& kQoP,
          const int i = 0, const double h = 0.,
-         const ThisVector3& kprev = ThisVector3()) {
+         const ThisVector3& kprev = ThisVector3::Zero()) {
     auto qop =
         stepper.charge(state.stepping) / stepper.momentum(state.stepping);
     // First step does not rely on previous data

--- a/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
+++ b/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
@@ -101,7 +101,7 @@ struct GenericDenseEnvironmentExtension {
   bool k(const propagator_state_t& state, const stepper_t& stepper,
          ThisVector3& knew, const Vector3& bField, std::array<Scalar, 4>& kQoP,
          const int i = 0, const double h = 0.,
-         const ThisVector3& kprev = ThisVector3()) {
+         const ThisVector3& kprev = ThisVector3::Zero()) {
     // i = 0 is used for setup and evaluation of k
     if (i == 0) {
       // Set up container for energy loss

--- a/Plugins/Autodiff/include/Acts/Plugins/Autodiff/AutodiffExtensionWrapper.hpp
+++ b/Plugins/Autodiff/include/Acts/Plugins/Autodiff/AutodiffExtensionWrapper.hpp
@@ -49,7 +49,7 @@ struct AutodiffExtensionWrapper {
   bool k(const propagator_state_t& state, const stepper_t& stepper,
          Vector3& knew, const Vector3& bField, std::array<double, 4>& kQoP,
          const int i = 0, const double h = 0.,
-         const Vector3& kprev = Vector3()) {
+         const Vector3& kprev = Vector3::Zero()) {
     return m_doubleExtension.k(state, stepper, knew, bField, kQoP, i, h, kprev);
   }
 


### PR DESCRIPTION
The argument `knew` is defaulted to `Vector3D{}` which is uninitialized. This shows up as a warning in GCC10, see #887. This PR initializes the values to zero in this location, and also in a few other related locations.

Fixes #887.

@benjaminhuth , can you review?