### PR TITLE
chore: Update readme with new Zenodo DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 or *A Common Tracking Software* if you do not like recursive acronyms
 
-[![10.5281/zenodo.3606011](https://badgen.net/badge/DOI/10.5281%2Fzenodo.3606011/blue)](https://doi.org/10.5281/zenodo.3606011)
+[![10.5281/zenodo.5141418](https://zenodo.org/badge/DOI/10.5281/zenodo.5141418.svg)](https://doi.org/10.5281/zenodo.5141418)
 [![Chat on Mattermost](https://badgen.net/badge/chat/on%20mattermost/cyan)](https://mattermost.web.cern.ch/acts/)
 [![coverage](https://badgen.net/codecov/c/github/acts-project/acts/main)](https://codecov.io/gh/acts-project/acts/branch/main)
 [![Latest release](https://badgen.net/github/release/acts-project/acts)](https://github.com/acts-project/acts/releases)


### PR DESCRIPTION
To use the Zenodo Github integration, I had to create another upload on Zenodo, which is not a successor to the previous DOI. I linked the two uploads together, but there is a new 'stable' DOI now.