### PR TITLE
feat: Harmonization of algorithm, reader and writer interfaces

### DIFF
--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1092,7 +1092,9 @@ class KalmanFitter {
     }
 
     if (!kalmanResult.result.ok()) {
-      ACTS_ERROR("KalmanFilter failed: " << kalmanResult.result.error());
+      ACTS_ERROR("KalmanFilter failed: "
+                 << kalmanResult.result.error() << ", "
+                 << kalmanResult.result.error().message());
       return kalmanResult.result.error();
     }
 

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
@@ -41,15 +41,18 @@ class DigitizationAlgorithm final : public BareAlgorithm {
  public:
   /// Construct the smearing algorithm.
   ///
-  /// @param cfg is the algorithm configuration
-  /// @param lvl is the logging level
-  DigitizationAlgorithm(DigitizationConfig cfg, Acts::Logging::Level lvl);
+  /// @param config is the algorithm configuration
+  /// @param level is the logging level
+  DigitizationAlgorithm(DigitizationConfig config, Acts::Logging::Level level);
 
   /// Build measurement from simulation hits at input.
   ///
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
+
+  /// Get const access to the config
+  const DigitizationConfig& config() const { return m_cfg; }
 
  private:
   /// Helper method for the geometric channelizing part

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/PlanarSteppingAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/PlanarSteppingAlgorithm.hpp
@@ -52,15 +52,18 @@ class PlanarSteppingAlgorithm final : public BareAlgorithm {
 
   /// Construct the digitization algorithm.
   ///
-  /// @param cfg is the algorithm configuration
-  /// @param lvl is the logging level
-  PlanarSteppingAlgorithm(Config cfg, Acts::Logging::Level lvl);
+  /// @param config is the algorithm configuration
+  /// @param level is the logging level
+  PlanarSteppingAlgorithm(Config config, Acts::Logging::Level level);
 
   /// Build clusters from input simulation hits.
   ///
   /// @param txt is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   struct Digitizable {

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/SmearingAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/SmearingAlgorithm.hpp
@@ -34,7 +34,7 @@ class SmearingAlgorithm final : public BareAlgorithm {
   ///
   /// @param cfg is the algorithm configuration
   /// @param lvl is the logging level
-  SmearingAlgorithm(DigitizationConfig cfg, Acts::Logging::Level lvl);
+  SmearingAlgorithm(DigitizationConfig config, Acts::Logging::Level level);
 
   /// Build measurement from simulation hits at input.
   ///

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -25,9 +25,9 @@
 #include <type_traits>
 
 ActsExamples::DigitizationAlgorithm::DigitizationAlgorithm(
-    DigitizationConfig cfg, Acts::Logging::Level lvl)
-    : ActsExamples::BareAlgorithm("DigitizationAlgorithm", lvl),
-      m_cfg(std::move(cfg)) {
+    DigitizationConfig config, Acts::Logging::Level level)
+    : ActsExamples::BareAlgorithm("DigitizationAlgorithm", level),
+      m_cfg(std::move(config)) {
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");
   }
@@ -112,6 +112,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
     const AlgorithmContext& ctx) const {
   // Retrieve input
   const auto& simHits = ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimHits);
+  ACTS_DEBUG("Loaded " << simHits.size() << " sim hits");
 
   // Prepare output containers
   IndexSourceLinkContainer sourceLinks;

--- a/Examples/Algorithms/Digitization/src/PlanarSteppingAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/PlanarSteppingAlgorithm.cpp
@@ -31,9 +31,10 @@
 #include <stdexcept>
 
 ActsExamples::PlanarSteppingAlgorithm::PlanarSteppingAlgorithm(
-    ActsExamples::PlanarSteppingAlgorithm::Config cfg, Acts::Logging::Level lvl)
-    : ActsExamples::BareAlgorithm("PlanarSteppingAlgorithm", lvl),
-      m_cfg(std::move(cfg)) {
+    ActsExamples::PlanarSteppingAlgorithm::Config config,
+    Acts::Logging::Level level)
+    : ActsExamples::BareAlgorithm("PlanarSteppingAlgorithm", level),
+      m_cfg(std::move(config)) {
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing input hits collection");
   }

--- a/Examples/Algorithms/Digitization/src/SmearingAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/SmearingAlgorithm.cpp
@@ -21,10 +21,10 @@
 #include <stdexcept>
 #include <type_traits>
 
-ActsExamples::SmearingAlgorithm::SmearingAlgorithm(DigitizationConfig cfg,
-                                                   Acts::Logging::Level lvl)
-    : ActsExamples::BareAlgorithm("SmearingAlgorithm", lvl),
-      m_cfg(std::move(cfg)) {
+ActsExamples::SmearingAlgorithm::SmearingAlgorithm(DigitizationConfig config,
+                                                   Acts::Logging::Level level)
+    : ActsExamples::BareAlgorithm("SmearingAlgorithm", level),
+      m_cfg(std::move(config)) {
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");
   }

--- a/Examples/Algorithms/Fatras/include/ActsExamples/Fatras/FatrasAlgorithm.hpp
+++ b/Examples/Algorithms/Fatras/include/ActsExamples/Fatras/FatrasAlgorithm.hpp
@@ -91,6 +91,9 @@ class FatrasAlgorithm final : public BareAlgorithm {
   ActsExamples::ProcessCode execute(
       const AlgorithmContext& ctx) const final override;
 
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   Config m_cfg;
   std::unique_ptr<detail::FatrasAlgorithmSimulation> m_sim;

--- a/Examples/Algorithms/Fatras/src/FatrasAlgorithm.cpp
+++ b/Examples/Algorithms/Fatras/src/FatrasAlgorithm.cpp
@@ -170,6 +170,21 @@ ActsExamples::FatrasAlgorithm::FatrasAlgorithm(Config cfg,
   ACTS_DEBUG("hits on material surfaces: " << m_cfg.generateHitsOnMaterial);
   ACTS_DEBUG("hits on passive surfaces: " << m_cfg.generateHitsOnPassive);
 
+  if (!m_cfg.generateHitsOnSensitive && !m_cfg.generateHitsOnMaterial &&
+      !m_cfg.generateHitsOnPassive) {
+    ACTS_WARNING("FatrasAlgorithm not configured to generate any hits!");
+  }
+
+  if (!m_cfg.trackingGeometry) {
+    throw std::invalid_argument{"Missing tracking geometry"};
+  }
+  if (!m_cfg.magneticField) {
+    throw std::invalid_argument{"Missing magnetic field"};
+  }
+  if (!m_cfg.randomNumbers) {
+    throw std::invalid_argument("Missing random numbers tool");
+  }
+
   // construct the simulation for the specific magnetic field
   m_sim = std::make_unique<FatrasAlgorithmSimulationT>(m_cfg, lvl);
 }

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GeantinoRecording.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GeantinoRecording.hpp
@@ -48,11 +48,14 @@ class GeantinoRecording final : public BareAlgorithm {
     Geant4::PrimaryGeneratorAction::Config generationConfig;
   };
 
-  GeantinoRecording(Config&& cfg, Acts::Logging::Level lvl);
+  GeantinoRecording(Config config, Acts::Logging::Level level);
   ~GeantinoRecording();
 
   ActsExamples::ProcessCode execute(
       const ActsExamples::AlgorithmContext& ctx) const final override;
+
+  /// Readonly access to the configuration
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Geant4/src/GeantinoRecording.cpp
+++ b/Examples/Algorithms/Geant4/src/GeantinoRecording.cpp
@@ -24,10 +24,10 @@
 using namespace ActsExamples;
 using namespace ActsExamples::Geant4;
 
-GeantinoRecording::GeantinoRecording(GeantinoRecording::Config&& cfg,
-                                     Acts::Logging::Level lvl)
-    : BareAlgorithm("GeantinoRecording", lvl),
-      m_cfg(std::move(cfg)),
+GeantinoRecording::GeantinoRecording(GeantinoRecording::Config config,
+                                     Acts::Logging::Level level)
+    : BareAlgorithm("GeantinoRecording", level),
+      m_cfg(std::move(config)),
       m_runManager(std::make_unique<G4RunManager>()) {
   if (m_cfg.outputMaterialTracks.empty()) {
     throw std::invalid_argument("Missing output material tracks collection");

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.hpp
@@ -71,6 +71,9 @@ class EventGenerator final : public ActsExamples::IReader {
   /// Generate an event.
   ProcessCode read(const AlgorithmContext& context) final;
 
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   const Acts::Logger& logger() const { return *m_logger; }
 

--- a/Examples/Algorithms/HepMC/include/ActsExamples/HepMC/HepMCProcessExtractor.hpp
+++ b/Examples/Algorithms/HepMC/include/ActsExamples/HepMC/HepMCProcessExtractor.hpp
@@ -45,7 +45,9 @@ class HepMCProcessExtractor final : public ActsExamples::BareAlgorithm {
   };
 
   /// Constructor
-  HepMCProcessExtractor(Config cfg, Acts::Logging::Level level);
+  /// @param config the configuration
+  /// @param level the log level
+  HepMCProcessExtractor(Config config, Acts::Logging::Level level);
   ~HepMCProcessExtractor();
 
   ActsExamples::ProcessCode execute(

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagationAlgorithm.hpp
@@ -69,11 +69,11 @@ class PropagationAlgorithm : public BareAlgorithm {
     /// debug output
     bool debugOutput = false;
     /// Modify the behavior of the material interaction: energy loss
-    bool energyLoss = false;
+    bool energyLoss = true;
     /// Modify the behavior of the material interaction: scattering
-    bool multipleScattering = false;
+    bool multipleScattering = true;
     /// Modify the behavior of the material interaction: record
-    bool recordMaterialInteractions = false;
+    bool recordMaterialInteractions = true;
 
     /// number of particles
     size_t ntests = 100;
@@ -82,11 +82,11 @@ class PropagationAlgorithm : public BareAlgorithm {
     /// z0 gaussian sigma
     double z0Sigma = 55 * Acts::UnitConstants::mm;
     /// phi gaussian sigma (used for covariance transport)
-    double phiSigma = 0.0001;
+    double phiSigma = 0.001;
     /// theta gaussian sigma (used for covariance transport)
-    double thetaSigma = 0.0001;
+    double thetaSigma = 0.001;
     /// qp gaussian sigma (used for covariance transport)
-    double qpSigma = 0.00001 / 1 * Acts::UnitConstants::GeV;
+    double qpSigma = 0.0001 / 1 * Acts::UnitConstants::GeV;
     /// t gaussian sigma (used for covariance transport)
     double tSigma = 1 * Acts::UnitConstants::ns;
     /// phi range
@@ -128,6 +128,9 @@ class PropagationAlgorithm : public BareAlgorithm {
   /// @return is a process code indicating succes or not
   ActsExamples::ProcessCode execute(
       const AlgorithmContext& context) const final override;
+
+  /// Get const access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;  ///< the config class

--- a/Examples/Algorithms/Propagation/src/PropagationAlgorithm.cpp
+++ b/Examples/Algorithms/Propagation/src/PropagationAlgorithm.cpp
@@ -141,7 +141,14 @@ std::optional<Acts::BoundSymMatrix> PropagationAlgorithm::generateCovariance(
 }
 
 PropagationAlgorithm::PropagationAlgorithm(
-    const PropagationAlgorithm::Config& cfg, Acts::Logging::Level level)
-    : BareAlgorithm("PropagationAlgorithm", level), m_cfg(cfg) {}
+    const PropagationAlgorithm::Config& config, Acts::Logging::Level level)
+    : BareAlgorithm("PropagationAlgorithm", level), m_cfg(config) {
+  if (!m_cfg.propagatorImpl) {
+    throw std::invalid_argument("Config needs to contain a propagator");
+  }
+  if (!m_cfg.randomNumberSvc) {
+    throw std::invalid_argument("No random number generator given");
+  }
+}
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
@@ -63,6 +63,9 @@ class SeedingAlgorithm final : public BareAlgorithm {
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
 
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   Config m_cfg;
   Acts::SpacePointGridConfig m_gridCfg;

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SpacePointMaker.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SpacePointMaker.hpp
@@ -68,6 +68,9 @@ class SpacePointMaker final : public BareAlgorithm {
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
 
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   Config m_cfg;
 };

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
@@ -60,9 +60,9 @@ class TrackFindingAlgorithm final : public BareAlgorithm {
 
   /// Constructor of the track finding algorithm
   ///
-  /// @param cfg is the config struct to configure the algorithm
+  /// @param config is the config struct to configure the algorithm
   /// @param level is the logging level
-  TrackFindingAlgorithm(Config cfg, Acts::Logging::Level lvl);
+  TrackFindingAlgorithm(Config config, Acts::Logging::Level level);
 
   /// Framework execute method of the track finding algorithm
   ///
@@ -70,6 +70,9 @@ class TrackFindingAlgorithm final : public BareAlgorithm {
   /// @return a process code to steer the algorithm flow
   ActsExamples::ProcessCode execute(
       const ActsExamples::AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
@@ -97,6 +97,9 @@ class TrackParamsEstimationAlgorithm final : public BareAlgorithm {
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
 
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   Config m_cfg;
 

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -16,9 +16,9 @@
 #include <stdexcept>
 
 ActsExamples::TrackFindingAlgorithm::TrackFindingAlgorithm(
-    Config cfg, Acts::Logging::Level level)
+    Config config, Acts::Logging::Level level)
     : ActsExamples::BareAlgorithm("TrackFindingAlgorithm", level),
-      m_cfg(std::move(cfg)) {
+      m_cfg(std::move(config)) {
   if (m_cfg.inputMeasurements.empty()) {
     throw std::invalid_argument("Missing measurements input collection");
   }

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -153,6 +153,7 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
   SimSpacePointContainer spacePoints;
   if (not m_cfg.inputSeeds.empty()) {
     seeds = ctx.eventStore.get<SimSeedContainer>(m_cfg.inputSeeds);
+    ACTS_VERBOSE("Read " << seeds.size() << " seeds");
   } else {
     const auto& protoTracks =
         ctx.eventStore.get<ProtoTrackContainer>(m_cfg.inputProtoTracks);
@@ -161,6 +162,8 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
       std::copy(sps.begin(), sps.end(), std::back_inserter(spacePoints));
     }
     seeds = createSeeds(protoTracks, spacePoints);
+    ACTS_VERBOSE("Read " << protoTracks.size() << " proto tracks, and created "
+                         << seeds.size() << " seeds");
   }
 
   TrackParametersContainer trackParameters;
@@ -216,6 +219,9 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
       tracks.emplace_back(track);
     }
   }
+  ACTS_VERBOSE("Estimated " << trackParameters.size()
+                            << " track parameters and " << tracks.size()
+                            << " tracks");
 
   ctx.eventStore.add(m_cfg.outputTrackParameters, std::move(trackParameters));
   ctx.eventStore.add(m_cfg.outputProtoTracks, std::move(tracks));

--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp
@@ -39,6 +39,9 @@ class SurfaceSortingAlgorithm final : public BareAlgorithm {
 
   ActsExamples::ProcessCode execute(const AlgorithmContext& ctx) const final;
 
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
+
  private:
   Config m_cfg;
 };

--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
@@ -84,15 +84,18 @@ class TrackFittingAlgorithm final : public BareAlgorithm {
 
   /// Constructor of the fitting algorithm
   ///
-  /// @param cfg is the config struct to configure the algorihtm
+  /// @param config is the config struct to configure the algorihtm
   /// @param level is the logging level
-  TrackFittingAlgorithm(Config cfg, Acts::Logging::Level lvl);
+  TrackFittingAlgorithm(Config config, Acts::Logging::Level level);
 
   /// Framework execute method of the fitting algorithm
   ///
   /// @param ctx is the algorithm context that holds event-wise information
   /// @return a process code to steer the algporithm flow
   ActsExamples::ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   /// Helper function to call correct FitterFunction

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
@@ -16,9 +16,9 @@
 #include <stdexcept>
 
 ActsExamples::TrackFittingAlgorithm::TrackFittingAlgorithm(
-    Config cfg, Acts::Logging::Level level)
+    Config config, Acts::Logging::Level level)
     : ActsExamples::BareAlgorithm("TrackFittingAlgorithm", level),
-      m_cfg(std::move(cfg)) {
+      m_cfg(std::move(config)) {
   if (m_cfg.inputMeasurements.empty()) {
     throw std::invalid_argument("Missing input measurement collection");
   }
@@ -97,6 +97,10 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
       continue;
     }
 
+    ACTS_VERBOSE("Initial parameters: "
+                 << initialParams.fourPosition(ctx.geoContext).transpose()
+                 << " -> " << initialParams.unitDirection().transpose());
+
     // Clear & reserve the right size
     trackSourceLinks.clear();
     trackSourceLinks.reserve(protoTrack.size());
@@ -141,8 +145,9 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
       trajectories.emplace_back(std::move(fitOutput.fittedStates),
                                 std::move(trackTips), std::move(indexedParams));
     } else {
-      ACTS_WARNING("Fit failed for track " << itrack << " with error"
-                                           << result.error());
+      ACTS_WARNING("Fit failed for track "
+                   << itrack << " with error: " << result.error() << ", "
+                   << result.error().message());
       // Fit failed. Add an empty result so the output container has
       // the same number of entries as the input.
       trajectories.push_back(Trajectories());

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
@@ -72,9 +72,9 @@ ActsExamples::ParticleSelector::readConfig(const Options::Variables& vars) {
   return cfg;
 }
 
-ActsExamples::ParticleSelector::ParticleSelector(const Config& cfg,
-                                                 Acts::Logging::Level lvl)
-    : BareAlgorithm("ParticleSelector", lvl), m_cfg(cfg) {
+ActsExamples::ParticleSelector::ParticleSelector(const Config& config,
+                                                 Acts::Logging::Level level)
+    : BareAlgorithm("ParticleSelector", level), m_cfg(config) {
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input particles collection");
   }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
@@ -57,9 +57,12 @@ class ParticleSelector final : public BareAlgorithm {
   /// Construct particle selector config from user variables.
   static Config readConfig(const Options::Variables& vars);
 
-  ParticleSelector(const Config& cfg, Acts::Logging::Level lvl);
+  ParticleSelector(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.cpp
@@ -18,9 +18,9 @@
 #include <cmath>
 #include <vector>
 
-ActsExamples::ParticleSmearing::ParticleSmearing(const Config& cfg,
-                                                 Acts::Logging::Level lvl)
-    : BareAlgorithm("ParticleSmearing", lvl), m_cfg(cfg) {
+ActsExamples::ParticleSmearing::ParticleSmearing(const Config& config,
+                                                 Acts::Logging::Level level)
+    : BareAlgorithm("ParticleSmearing", level), m_cfg(config) {
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input truth particles collection");
   }
@@ -84,6 +84,22 @@ ActsExamples::ProcessCode ActsExamples::ParticleSmearing::execute(
       // compute smeared absolute momentum vector
       const double newP = std::max(0.0, p + sigmaP * stdNormal(rng));
       params[Acts::eBoundQOverP] = (q != 0) ? (q / newP) : (1 / newP);
+
+      ACTS_VERBOSE("Smearing particle (pos, time, phi, theta, q/p):");
+      ACTS_VERBOSE(" from: " << particle.position().transpose() << ", " << time
+                             << "," << phi << "," << theta << ","
+                             << (q != 0 ? q / p : 1 / p));
+      ACTS_VERBOSE("   to: " << perigee
+                                    ->localToGlobal(
+                                        ctx.geoContext,
+                                        Acts::Vector2{params[Acts::eBoundLoc0],
+                                                      params[Acts::eBoundLoc1]},
+                                        particle.unitDirection() * p)
+                                    .transpose()
+                             << ", " << params[Acts::eBoundTime] << ","
+                             << params[Acts::eBoundPhi] << ","
+                             << params[Acts::eBoundTheta] << ","
+                             << params[Acts::eBoundQOverP]);
 
       // build the track covariance matrix using the smearing sigmas
       Acts::BoundSymMatrix cov = Acts::BoundSymMatrix::Zero();

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
@@ -55,9 +55,12 @@ class ParticleSmearing final : public BareAlgorithm {
     std::shared_ptr<const RandomNumbers> randomNumbers = nullptr;
   };
 
-  ParticleSmearing(const Config& cfg, Acts::Logging::Level lvl);
+  ParticleSmearing(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const final override;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.cpp
@@ -16,9 +16,9 @@
 #include <stdexcept>
 #include <vector>
 
-ActsExamples::TrackSelector::TrackSelector(const Config& cfg,
-                                           Acts::Logging::Level lvl)
-    : BareAlgorithm("TrackSelector", lvl), m_cfg(cfg) {
+ActsExamples::TrackSelector::TrackSelector(const Config& config,
+                                           Acts::Logging::Level level)
+    : BareAlgorithm("TrackSelector", level), m_cfg(config) {
   if (m_cfg.inputTrackParameters.empty()) {
     throw std::invalid_argument("Missing input track parameters collection");
   }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.hpp
@@ -51,9 +51,12 @@ class TrackSelector final : public BareAlgorithm {
     bool removeNeutral = false;
   };
 
-  TrackSelector(const Config& cfg, Acts::Logging::Level lvl);
+  TrackSelector(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.cpp
@@ -70,9 +70,9 @@ ActsExamples::TruthSeedSelector::readConfig(const Options::Variables& vars) {
   return cfg;
 }
 
-TruthSeedSelector::TruthSeedSelector(const Config& cfg,
-                                     Acts::Logging::Level lvl)
-    : BareAlgorithm("TruthSeedSelector", lvl), m_cfg(cfg) {
+TruthSeedSelector::TruthSeedSelector(const Config& config,
+                                     Acts::Logging::Level level)
+    : BareAlgorithm("TruthSeedSelector", level), m_cfg(config) {
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input truth particles collection");
   }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.hpp
@@ -58,7 +58,7 @@ class TruthSeedSelector final : public BareAlgorithm {
     size_t nHitsMax = std::numeric_limits<size_t>::max();
   };
 
-  TruthSeedSelector(const Config& cfg, Acts::Logging::Level lvl);
+  TruthSeedSelector(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const override final;
 
@@ -67,6 +67,9 @@ class TruthSeedSelector final : public BareAlgorithm {
 
   /// Construct particle selector config from user variables.
   static Config readConfig(const Options::Variables& vars);
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.cpp
@@ -20,8 +20,9 @@
 
 using namespace ActsExamples;
 
-TruthTrackFinder::TruthTrackFinder(const Config& cfg, Acts::Logging::Level lvl)
-    : BareAlgorithm("TruthTrackFinder", lvl), m_cfg(cfg) {
+TruthTrackFinder::TruthTrackFinder(const Config& config,
+                                   Acts::Logging::Level level)
+    : BareAlgorithm("TruthTrackFinder", level), m_cfg(config) {
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input truth particles collection");
   }
@@ -49,11 +50,12 @@ ProcessCode TruthTrackFinder::execute(const AlgorithmContext& ctx) const {
   ProtoTrackContainer tracks;
   tracks.reserve(particles.size());
 
-  // create prototracks for all input particles
+  ACTS_VERBOSE("Create prototracks for " << particles.size() << " particles");
   for (const auto& particle : particles) {
     // find the corresponding hits for this particle
     const auto& hits =
         makeRange(particleHitsMap.equal_range(particle.particleId()));
+    ACTS_VERBOSE(" - Prototrack from " << hits.size() << " hits");
     // fill hit indices to create the proto track
     ProtoTrack track;
     track.reserve(hits.size());

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthTrackFinder.hpp
@@ -30,9 +30,12 @@ class TruthTrackFinder final : public BareAlgorithm {
     std::string outputProtoTracks;
   };
 
-  TruthTrackFinder(const Config& cfg, Acts::Logging::Level lvl);
+  TruthTrackFinder(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const override final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.cpp
@@ -17,9 +17,9 @@
 #include <stdexcept>
 #include <vector>
 
-ActsExamples::TruthVertexFinder::TruthVertexFinder(const Config& cfg,
-                                                   Acts::Logging::Level lvl)
-    : BareAlgorithm("TruthVertexFinder", lvl), m_cfg(cfg) {
+ActsExamples::TruthVertexFinder::TruthVertexFinder(const Config& config,
+                                                   Acts::Logging::Level level)
+    : BareAlgorithm("TruthVertexFinder", level), m_cfg(config) {
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input truth particles collection");
   }
@@ -31,9 +31,11 @@ ActsExamples::TruthVertexFinder::TruthVertexFinder(const Config& cfg,
 ActsExamples::ProcessCode ActsExamples::TruthVertexFinder::execute(
     const AlgorithmContext& ctx) const {
   // prepare input and output collections
+  ACTS_VERBOSE("Reading particles from " << m_cfg.inputParticles);
   const auto& particles =
       ctx.eventStore.get<SimParticleContainer>(m_cfg.inputParticles);
   ProtoVertexContainer protoVertices;
+  ACTS_VERBOSE("Have " << particles.size() << " particles");
 
   // assumes the begin/end iterator references the particles container
   auto addProtoVertex = [&](SimParticleContainer::const_iterator begin,
@@ -71,6 +73,8 @@ ActsExamples::ProcessCode ActsExamples::TruthVertexFinder::execute(
     }
   }
 
+  ACTS_VERBOSE("Write " << protoVertices.size() << " proto vertex to "
+                        << m_cfg.outputProtoVertices);
   ctx.eventStore.add(m_cfg.outputProtoVertices, std::move(protoVertices));
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.hpp
@@ -28,9 +28,12 @@ class TruthVertexFinder final : public BareAlgorithm {
     bool separateSecondaries = false;
   };
 
-  TruthVertexFinder(const Config& cfg, Acts::Logging::Level lvl);
+  TruthVertexFinder(const Config& config, Acts::Logging::Level level);
 
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -19,8 +19,6 @@ namespace ActsExamples {
 class AdaptiveMultiVertexFinderAlgorithm final : public BareAlgorithm {
  public:
   struct Config {
-    Config(std::shared_ptr<Acts::MagneticFieldProvider> magneticField)
-        : bField(magneticField) {}
     /// Input track parameters collection
     std::string inputTrackParameters;
     /// Output proto vertex collection
@@ -33,14 +31,17 @@ class AdaptiveMultiVertexFinderAlgorithm final : public BareAlgorithm {
     std::shared_ptr<Acts::MagneticFieldProvider> bField;
   };
 
-  AdaptiveMultiVertexFinderAlgorithm(const Config& cfg,
-                                     Acts::Logging::Level lvl);
+  AdaptiveMultiVertexFinderAlgorithm(const Config& config,
+                                     Acts::Logging::Level level);
 
   /// Find vertices using the adapative multi vertex finder algorithm.
   ///
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
@@ -19,8 +19,6 @@ namespace ActsExamples {
 class IterativeVertexFinderAlgorithm final : public BareAlgorithm {
  public:
   struct Config {
-    Config(std::shared_ptr<Acts::MagneticFieldProvider> magneticField)
-        : bField(magneticField) {}
     /// Input track parameters collection
     std::string inputTrackParameters;
     /// Output proto vertex collection
@@ -33,13 +31,17 @@ class IterativeVertexFinderAlgorithm final : public BareAlgorithm {
     std::shared_ptr<Acts::MagneticFieldProvider> bField;
   };
 
-  IterativeVertexFinderAlgorithm(const Config& cfg, Acts::Logging::Level lvl);
+  IterativeVertexFinderAlgorithm(const Config& config,
+                                 Acts::Logging::Level level);
 
   /// Find vertices using iterative vertex finder algorithm.
   ///
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/TutorialVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/TutorialVertexFinderAlgorithm.hpp
@@ -19,8 +19,6 @@ namespace ActsExamples {
 class TutorialVertexFinderAlgorithm final : public BareAlgorithm {
  public:
   struct Config {
-    Config(std::shared_ptr<Acts::MagneticFieldProvider> magneticField)
-        : bField(magneticField) {}
     /// Input track parameters collection
     std::string inputTrackParameters;
     /// Output proto vertex collection
@@ -36,6 +34,9 @@ class TutorialVertexFinderAlgorithm final : public BareAlgorithm {
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -20,12 +20,12 @@ namespace ActsExamples {
 class VertexFitterAlgorithm final : public BareAlgorithm {
  public:
   struct Config {
-    Config(std::shared_ptr<Acts::MagneticFieldProvider> magneticField)
-        : bField(magneticField) {}
     /// Input track parameters collection
     std::string inputTrackParameters;
     /// Input proto vertex collection
     std::string inputProtoVertices;
+    /// Output vertex collection
+    std::string outputVertices;
     /// The magnetic field
     std::shared_ptr<Acts::MagneticFieldProvider> bField;
     /// Constraint vertex fit bool
@@ -46,6 +46,9 @@ class VertexFitterAlgorithm final : public BareAlgorithm {
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -34,10 +34,10 @@
 #include "VertexingHelpers.hpp"
 
 ActsExamples::AdaptiveMultiVertexFinderAlgorithm::
-    AdaptiveMultiVertexFinderAlgorithm(const Config& cfg,
-                                       Acts::Logging::Level lvl)
-    : ActsExamples::BareAlgorithm("AdaptiveMultiVertexFinder", lvl),
-      m_cfg(cfg) {
+    AdaptiveMultiVertexFinderAlgorithm(const Config& config,
+                                       Acts::Logging::Level level)
+    : ActsExamples::BareAlgorithm("AdaptiveMultiVertexFinder", level),
+      m_cfg(config) {
   if (m_cfg.inputTrackParameters.empty()) {
     throw std::invalid_argument("Missing input track parameters collection");
   }

--- a/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
@@ -37,8 +37,9 @@
 #include "VertexingHelpers.hpp"
 
 ActsExamples::IterativeVertexFinderAlgorithm::IterativeVertexFinderAlgorithm(
-    const Config& cfg, Acts::Logging::Level lvl)
-    : ActsExamples::BareAlgorithm("IterativeVertexFinder", lvl), m_cfg(cfg) {
+    const Config& config, Acts::Logging::Level level)
+    : ActsExamples::BareAlgorithm("IterativeVertexFinder", level),
+      m_cfg(config) {
   if (m_cfg.inputTrackParameters.empty()) {
     throw std::invalid_argument("Missing input track parameters collection");
   }

--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -97,6 +97,9 @@ class Sequencer {
   /// the end-of-run hook for all configured writers.
   int run();
 
+  /// Get const access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   /// List of all configured algorithm names.
   std::vector<std::string> listAlgorithmNames() const;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMeasurementReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMeasurementReader.hpp
@@ -55,9 +55,9 @@ class CsvMeasurementReader final : public IReader {
 
   /// Construct the cluster reader.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvMeasurementReader(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvMeasurementReader(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 
@@ -66,6 +66,9 @@ class CsvMeasurementReader final : public IReader {
 
   /// Read out data from the input stream.
   ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMeasurementWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMeasurementWriter.hpp
@@ -44,7 +44,7 @@ class CsvMeasurementWriter final : public WriterT<MeasurementContainer> {
     /// Which measurement collection to write.
     std::string inputMeasurements;
     /// Which cluster collection to write (optional)
-    std::string inputClusters;
+    std::string inputClusters = "";
     /// Which simulated (truth) hits collection to use.
     std::string inputSimHits;
     /// Input collection to map measured hits to simulated hits.
@@ -52,13 +52,13 @@ class CsvMeasurementWriter final : public WriterT<MeasurementContainer> {
     /// Where to place output files
     std::string outputDir;
     /// Number of decimal digits for floating point precision in output.
-    size_t outputPrecision = std::numeric_limits<float>::max_digits10;
+    int outputPrecision = std::numeric_limits<float>::max_digits10;
   };
 
   /// Constructor with
-  /// @param cfg configuration struct
-  /// @param output logging level
-  CsvMeasurementWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config configuration struct
+  /// @param level logging level
+  CsvMeasurementWriter(const Config& config, Acts::Logging::Level level);
 
   /// Virtual destructor
   ~CsvMeasurementWriter() final override;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMultiTrajectoryWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvMultiTrajectoryWriter.hpp
@@ -46,10 +46,13 @@ class CsvMultiTrajectoryWriter : public WriterT<TrajectoriesContainer> {
   };
 
   /// constructor
-  /// @param cfg is the configuration object
-  /// @parm level is the output logging level
-  CsvMultiTrajectoryWriter(const Config& cfg,
+  /// @param config is the configuration object
+  /// @param level is the output logging level
+  CsvMultiTrajectoryWriter(const Config& config,
                            Acts::Logging::Level level = Acts::Logging::INFO);
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  protected:
   /// @brief Write method called by the base class

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvParticleReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvParticleReader.hpp
@@ -39,9 +39,9 @@ class CsvParticleReader final : public IReader {
 
   /// Construct the particle reader.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvParticleReader(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvParticleReader(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 
@@ -50,6 +50,9 @@ class CsvParticleReader final : public IReader {
 
   /// Read out data from the input stream.
   ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvPlanarClusterReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvPlanarClusterReader.hpp
@@ -55,9 +55,9 @@ class CsvPlanarClusterReader final : public IReader {
 
   /// Construct the cluster reader.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvPlanarClusterReader(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvPlanarClusterReader(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 
@@ -66,6 +66,9 @@ class CsvPlanarClusterReader final : public IReader {
 
   /// Read out data from the input stream.
   ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvPlanarClusterWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvPlanarClusterWriter.hpp
@@ -53,9 +53,12 @@ class CsvPlanarClusterWriter final
 
   /// Construct the cluster writer.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvPlanarClusterWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvPlanarClusterWriter(const Config& config, Acts::Logging::Level level);
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  protected:
   /// Type-specific write implementation.

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitReader.hpp
@@ -40,9 +40,9 @@ class CsvSimHitReader final : public IReader {
 
   /// Construct the simhit reader.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvSimHitReader(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvSimHitReader(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 
@@ -51,6 +51,9 @@ class CsvSimHitReader final : public IReader {
 
   /// Read out data from the input stream.
   ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSimHitWriter.hpp
@@ -45,9 +45,12 @@ class CsvSimHitWriter final : public WriterT<SimHitContainer> {
 
   /// Construct the cluster writer.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  CsvSimHitWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvSimHitWriter(const Config& config, Acts::Logging::Level level);
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  protected:
   /// Type-specific write implementation.

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvTrackingGeometryWriter.hpp
@@ -54,9 +54,9 @@ class CsvTrackingGeometryWriter : public IWriter {
 
   /// Construct the geometry writer.
   ///
-  /// @param cfg is the configuration object
-  /// @param lvl is the logging level
-  CsvTrackingGeometryWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  CsvTrackingGeometryWriter(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 

--- a/Examples/Io/Csv/src/CsvMeasurementReader.cpp
+++ b/Examples/Io/Csv/src/CsvMeasurementReader.cpp
@@ -27,12 +27,13 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvMeasurementReader::CsvMeasurementReader(
-    const ActsExamples::CsvMeasurementReader::Config& cfg,
-    Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+    const ActsExamples::CsvMeasurementReader::Config& config,
+    Acts::Logging::Level level)
+    : m_cfg(config),
       // TODO check that all files (hits,cells,truth) exists
-      m_eventsRange(determineEventFilesRange(cfg.inputDir, "measurements.csv")),
-      m_logger(Acts::getDefaultLogger("CsvMeasurementReader", lvl)) {
+      m_eventsRange(
+          determineEventFilesRange(m_cfg.inputDir, "measurements.csv")),
+      m_logger(Acts::getDefaultLogger("CsvMeasurementReader", level)) {
   if (m_cfg.outputMeasurements.empty()) {
     throw std::invalid_argument("Missing measurement output collection");
   }

--- a/Examples/Io/Csv/src/CsvMeasurementWriter.cpp
+++ b/Examples/Io/Csv/src/CsvMeasurementWriter.cpp
@@ -30,9 +30,10 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvMeasurementWriter::CsvMeasurementWriter(
-    const ActsExamples::CsvMeasurementWriter::Config& cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputMeasurements, "CsvMeasurementWriter", lvl), m_cfg(cfg) {
+    const ActsExamples::CsvMeasurementWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputMeasurements, "CsvMeasurementWriter", level),
+      m_cfg(config) {
   // Input container for measurements is already checked by base constructor
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");
@@ -82,7 +83,7 @@ ActsExamples::ProcessCode ActsExamples::CsvMeasurementWriter::writeT(
   meas.measurement_id = 0;
 
   ACTS_VERBOSE("Writing " << measurements.size()
-                          << " measurments in this event.");
+                          << " measurements in this event.");
 
   for (Index hitIdx = 0u; hitIdx < measurements.size(); ++hitIdx) {
     const auto& measurement = measurements[hitIdx];

--- a/Examples/Io/Csv/src/CsvMultiTrajectoryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvMultiTrajectoryWriter.cpp
@@ -21,10 +21,10 @@
 using namespace ActsExamples;
 
 CsvMultiTrajectoryWriter::CsvMultiTrajectoryWriter(
-    const CsvMultiTrajectoryWriter::Config& cfg, Acts::Logging::Level level)
-    : WriterT<TrajectoriesContainer>(cfg.inputTrajectories,
+    const CsvMultiTrajectoryWriter::Config& config, Acts::Logging::Level level)
+    : WriterT<TrajectoriesContainer>(config.inputTrajectories,
                                      "CsvMultiTrajectoryWriter", level),
-      m_cfg(cfg) {
+      m_cfg(config) {
   if (m_cfg.inputTrajectories.empty()) {
     throw std::invalid_argument("Missing input trajectories collection");
   }

--- a/Examples/Io/Csv/src/CsvParticleReader.cpp
+++ b/Examples/Io/Csv/src/CsvParticleReader.cpp
@@ -24,12 +24,12 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvParticleReader::CsvParticleReader(
-    const ActsExamples::CsvParticleReader::Config& cfg,
-    Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+    const ActsExamples::CsvParticleReader::Config& config,
+    Acts::Logging::Level level)
+    : m_cfg(config),
       m_eventsRange(
-          determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".csv")),
-      m_logger(Acts::getDefaultLogger("CsvParticleReader", lvl)) {
+          determineEventFilesRange(m_cfg.inputDir, m_cfg.inputStem + ".csv")),
+      m_logger(Acts::getDefaultLogger("CsvParticleReader", level)) {
   if (m_cfg.inputStem.empty()) {
     throw std::invalid_argument("Missing input filename stem");
   }

--- a/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
+++ b/Examples/Io/Csv/src/CsvPlanarClusterReader.cpp
@@ -25,12 +25,12 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvPlanarClusterReader::CsvPlanarClusterReader(
-    const ActsExamples::CsvPlanarClusterReader::Config& cfg,
-    Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+    const ActsExamples::CsvPlanarClusterReader::Config& config,
+    Acts::Logging::Level level)
+    : m_cfg(config),
       // TODO check that all files (hits,cells,truth) exists
-      m_eventsRange(determineEventFilesRange(cfg.inputDir, "hits.csv")),
-      m_logger(Acts::getDefaultLogger("CsvPlanarClusterReader", lvl)) {
+      m_eventsRange(determineEventFilesRange(config.inputDir, "hits.csv")),
+      m_logger(Acts::getDefaultLogger("CsvPlanarClusterReader", level)) {
   if (m_cfg.outputClusters.empty()) {
     throw std::invalid_argument("Missing cluster output collection");
   }

--- a/Examples/Io/Csv/src/CsvPlanarClusterWriter.cpp
+++ b/Examples/Io/Csv/src/CsvPlanarClusterWriter.cpp
@@ -23,9 +23,10 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvPlanarClusterWriter::CsvPlanarClusterWriter(
-    const ActsExamples::CsvPlanarClusterWriter::Config& cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputClusters, "CsvPlanarClusterWriter", lvl), m_cfg(cfg) {
+    const ActsExamples::CsvPlanarClusterWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputClusters, "CsvPlanarClusterWriter", level),
+      m_cfg(config) {
   // inputClusters is already checked by base constructor
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");

--- a/Examples/Io/Csv/src/CsvSimHitReader.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitReader.cpp
@@ -18,12 +18,13 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvSimHitReader::CsvSimHitReader(
-    const ActsExamples::CsvSimHitReader::Config& cfg, Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+    const ActsExamples::CsvSimHitReader::Config& config,
+    Acts::Logging::Level level)
+    : m_cfg(config),
       // TODO check that all files (hits,cells,truth) exists
       m_eventsRange(
-          determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".csv")),
-      m_logger(Acts::getDefaultLogger("CsvSimHitReader", lvl)) {
+          determineEventFilesRange(m_cfg.inputDir, m_cfg.inputStem + ".csv")),
+      m_logger(Acts::getDefaultLogger("CsvSimHitReader", level)) {
   if (m_cfg.inputStem.empty()) {
     throw std::invalid_argument("Missing input filename stem");
   }

--- a/Examples/Io/Csv/src/CsvSimHitWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSimHitWriter.cpp
@@ -21,8 +21,9 @@
 #include "CsvOutputData.hpp"
 
 ActsExamples::CsvSimHitWriter::CsvSimHitWriter(
-    const ActsExamples::CsvSimHitWriter::Config& cfg, Acts::Logging::Level lvl)
-    : WriterT(cfg.inputSimHits, "CsvSimHitWriter", lvl), m_cfg(cfg) {
+    const ActsExamples::CsvSimHitWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputSimHits, "CsvSimHitWriter", level), m_cfg(config) {
   // inputSimHits is already checked by base constructor
   if (m_cfg.outputStem.empty()) {
     throw std::invalid_argument("Missing ouput filename stem");

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -29,10 +29,10 @@
 using namespace ActsExamples;
 
 CsvTrackingGeometryWriter::CsvTrackingGeometryWriter(
-    const CsvTrackingGeometryWriter::Config& cfg, Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+    const CsvTrackingGeometryWriter::Config& config, Acts::Logging::Level level)
+    : m_cfg(config),
       m_world(nullptr),
-      m_logger(Acts::getDefaultLogger("CsvTrackingGeometryWriter", lvl))
+      m_logger(Acts::getDefaultLogger("CsvTrackingGeometryWriter", level))
 
 {
   if (not m_cfg.trackingGeometry) {

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3Writer.hpp
@@ -32,9 +32,9 @@ class HepMC3AsciiWriter final : public WriterT<std::vector<HepMC3::GenEvent>> {
 
   /// Construct the writer.
   ///
-  /// @param [in] cfg Config of the writer
-  /// @param [in] lvl The level of the logger
-  HepMC3AsciiWriter(const Config&& cfg, Acts::Logging::Level lvl);
+  /// @param [in] config Config of the writer
+  /// @param [in] level The level of the logger
+  HepMC3AsciiWriter(const Config& config, Acts::Logging::Level level);
 
   /// Writing events to file.
   ///

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -68,7 +68,8 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiReader::read(
   if (events.empty())
     return ActsExamples::ProcessCode::ABORT;
 
-  ACTS_VERBOSE(events.size() << " events read");
+  ACTS_VERBOSE(events.size()
+               << " events read, writing to " << m_cfg.outputEvents);
   ctx.eventStore.add(m_cfg.outputEvents, std::move(events));
 
   reader.close();

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -10,9 +10,9 @@
 
 #include "ActsExamples/Utilities/Paths.hpp"
 
-ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config&& cfg,
-                                                   Acts::Logging::Level lvl)
-    : WriterT(cfg.inputEvents, "HepMC3EventWriter", lvl), m_cfg(cfg) {
+ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config& config,
+                                                   Acts::Logging::Level level)
+    : WriterT(config.inputEvents, "HepMC3EventWriter", level), m_cfg(config) {
   if (m_cfg.outputStem.empty())
     throw std::invalid_argument("Missing output stem file name");
 }

--- a/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesWriter.hpp
+++ b/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesWriter.hpp
@@ -56,9 +56,9 @@ class JsonSurfacesWriter : public IWriter {
 
   /// Construct the geometry writer.
   ///
-  /// @param cfg is the configuration object
-  /// @param lvl is the logging level
-  JsonSurfacesWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  JsonSurfacesWriter(const Config& config, Acts::Logging::Level level);
 
   std::string name() const final override;
 
@@ -67,6 +67,9 @@ class JsonSurfacesWriter : public IWriter {
 
   /// Write geometry using the default context.
   ProcessCode endRun() final override;
+
+  /// Readonly access to config
+  const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;

--- a/Examples/Io/Json/src/JsonSurfacesWriter.cpp
+++ b/Examples/Io/Json/src/JsonSurfacesWriter.cpp
@@ -20,11 +20,11 @@
 
 using namespace ActsExamples;
 
-JsonSurfacesWriter::JsonSurfacesWriter(const JsonSurfacesWriter::Config& cfg,
-                                       Acts::Logging::Level lvl)
-    : m_cfg(cfg),
+JsonSurfacesWriter::JsonSurfacesWriter(const JsonSurfacesWriter::Config& config,
+                                       Acts::Logging::Level level)
+    : m_cfg(config),
       m_world(nullptr),
-      m_logger(Acts::getDefaultLogger("JsonSurfacesWriter", lvl)) {
+      m_logger(Acts::getDefaultLogger("JsonSurfacesWriter", level)) {
   if (not m_cfg.trackingGeometry) {
     throw std::invalid_argument("Missing tracking geometry");
   }

--- a/Examples/Io/NuclearInteractions/include/ActsExamples/Io/NuclearInteractions/RootNuclearInteractionParametersWriter.hpp
+++ b/Examples/Io/NuclearInteractions/include/ActsExamples/Io/NuclearInteractions/RootNuclearInteractionParametersWriter.hpp
@@ -29,10 +29,8 @@ class RootNuclearInteractionParametersWriter final
   struct Config {
     /// Input collection to map measured hits to simulated hits.
     std::string inputSimulationProcesses;
-    /// output directory.
-    std::string outputDir;
     /// output filename.
-    std::string outputFilename = "parameters.root";
+    std::string filePath = "parameters.root";
     /// file access mode.
     std::string fileMode = "RECREATE";
 
@@ -52,10 +50,10 @@ class RootNuclearInteractionParametersWriter final
 
   /// Constructor
   ///
-  /// @param cfg Configuration struct
+  /// @param config Configuration struct
   /// @param level Message level declaration
-  RootNuclearInteractionParametersWriter(const Config& cfg,
-                                         Acts::Logging::Level lvl);
+  RootNuclearInteractionParametersWriter(const Config& config,
+                                         Acts::Logging::Level level);
   ~RootNuclearInteractionParametersWriter() final override;
 
   /// End-of-run hook

--- a/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
+++ b/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
@@ -326,15 +326,16 @@ inline void recordKinematicParametrisation(
 
 ActsExamples::RootNuclearInteractionParametersWriter::
     RootNuclearInteractionParametersWriter(
-        const ActsExamples::RootNuclearInteractionParametersWriter::Config& cfg,
-        Acts::Logging::Level lvl)
-    : WriterT(cfg.inputSimulationProcesses,
-              "RootNuclearInteractionParametersWriter", lvl),
-      m_cfg(cfg) {
+        const ActsExamples::RootNuclearInteractionParametersWriter::Config&
+            config,
+        Acts::Logging::Level level)
+    : WriterT(config.inputSimulationProcesses,
+              "RootNuclearInteractionParametersWriter", level),
+      m_cfg(config) {
   if (m_cfg.inputSimulationProcesses.empty()) {
     throw std::invalid_argument("Missing input collection");
   }
-  if (m_cfg.outputFilename.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename for parameters");
   }
 }
@@ -352,7 +353,7 @@ ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
   std::lock_guard<std::mutex> lock(m_writeMutex);
 
   // The file
-  TFile* tf = TFile::Open(m_cfg.outputFilename.c_str(), m_cfg.fileMode.c_str());
+  TFile* tf = TFile::Open(m_cfg.filePath.c_str(), m_cfg.fileMode.c_str());
   gDirectory->cd();
   gDirectory->mkdir(
       std::to_string(m_eventFractionCollection[0].initialParticle.pdg())

--- a/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjTrackingGeometryWriter.hpp
+++ b/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjTrackingGeometryWriter.hpp
@@ -35,10 +35,6 @@ class ObjTrackingGeometryWriter {
   // The nested config class
   class Config {
    public:
-    std::shared_ptr<const Acts::Logger> logger;
-
-    std::string name = "";
-
     double outputScalor = 1.0;   ///< scale output values
     size_t outputPrecision = 6;  ///< floating point precision
 
@@ -47,15 +43,12 @@ class ObjTrackingGeometryWriter {
     Acts::ViewConfig sensitiveView = Acts::ViewConfig({0, 180, 240});
     Acts::ViewConfig passiveView = Acts::ViewConfig({240, 280, 0});
     Acts::ViewConfig gridView = Acts::ViewConfig({220, 0, 0});
-
-    Config(const std::string& lname = "ObjTrackingGeometryWriter",
-           Acts::Logging::Level lvl = Acts::Logging::INFO)
-        : logger(Acts::getDefaultLogger(lname, lvl)), name(lname) {}
   };
 
   /// Constructor
-  /// @param cfg is the configuration class
-  ObjTrackingGeometryWriter(const Config& cfg);
+  /// @param config is the configuration class
+  /// @param level the log level
+  ObjTrackingGeometryWriter(const Config& config, Acts::Logging::Level level);
 
   /// Framework name() method
   /// @return the name of the tool
@@ -69,6 +62,8 @@ class ObjTrackingGeometryWriter {
                                   const Acts::TrackingGeometry& tGeometry);
 
  private:
+  std::unique_ptr<const Acts::Logger> m_logger;  ///< the logger instance
+
   Config m_cfg;  ///< the config class
 
   /// process this volume
@@ -78,7 +73,7 @@ class ObjTrackingGeometryWriter {
              const Acts::TrackingVolume& tVolume);
 
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_cfg.logger; }
+  const Acts::Logger& logger() const { return *m_logger; }
 };
 
 }  // namespace ActsExamples

--- a/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjWriterOptions.hpp
+++ b/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjWriterOptions.hpp
@@ -14,8 +14,6 @@
 
 #include <iostream>
 
-namespace po = boost::program_options;
-
 namespace ActsExamples {
 
 namespace Options {
@@ -25,8 +23,8 @@ namespace Options {
 /// @tparam aopt_t Type of the options object (from BOOST)
 ///
 /// @param opt The options object, where string based options are attached
-template <typename aopt_t>
-void addObjWriterOptions(aopt_t& opt) {
+void addObjWriterOptions(boost::program_options::options_description& opt) {
+  namespace po = boost::program_options;
   opt.add_options()("obj-precision", po::value<int>()->default_value(6),
                     "Floating number output precission.")(
       "obj-scalor", po::value<double>()->default_value(1.),
@@ -59,12 +57,11 @@ void addObjWriterOptions(aopt_t& opt) {
 }
 
 /// read the evgen options and return a Config file
-template <class amap_t>
 ActsExamples::ObjTrackingGeometryWriter::Config
 readObjTrackingGeometryWriterConfig(
-    const amap_t& vm, const std::string& name,
-    Acts::Logging::Level loglevel = Acts::Logging::INFO) {
-  ActsExamples::ObjTrackingGeometryWriter::Config objTgConfig(name, loglevel);
+    const boost::program_options::variables_map& vm) {
+  namespace po = boost::program_options;
+  ActsExamples::ObjTrackingGeometryWriter::Config objTgConfig;
 
   objTgConfig.outputPrecision = vm["obj-precision"].template as<int>();
   objTgConfig.outputScalor = vm["obj-scalor"].template as<double>();

--- a/Examples/Io/Obj/src/ObjTrackingGeometryWriter.cpp
+++ b/Examples/Io/Obj/src/ObjTrackingGeometryWriter.cpp
@@ -17,11 +17,12 @@
 #include <iostream>
 
 ActsExamples::ObjTrackingGeometryWriter::ObjTrackingGeometryWriter(
-    const ActsExamples::ObjTrackingGeometryWriter::Config& cfg)
-    : m_cfg(cfg) {}
+    const ActsExamples::ObjTrackingGeometryWriter::Config& config,
+    Acts::Logging::Level level)
+    : m_logger{Acts::getDefaultLogger(name(), level)}, m_cfg(config) {}
 
 std::string ActsExamples::ObjTrackingGeometryWriter::name() const {
-  return m_cfg.name;
+  return "ObjTrackingGeometryWriter";
 }
 
 ActsExamples::ProcessCode ActsExamples::ObjTrackingGeometryWriter::write(

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -35,17 +35,16 @@ ActsExamples::CKFPerformanceWriter::CKFPerformanceWriter(
   if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
-  if (m_cfg.outputFilename.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
 
   // the output file can not be given externally since TFile accesses to the
   // same file from multiple threads are unsafe.
   // must always be opened internally
-  auto path = joinPaths(m_cfg.outputDir, m_cfg.outputFilename);
-  m_outputFile = TFile::Open(path.c_str(), "RECREATE");
+  m_outputFile = TFile::Open(m_cfg.filePath.c_str(), m_cfg.fileMode.c_str());
   if (not m_outputFile) {
-    throw std::invalid_argument("Could not open '" + path + "'");
+    throw std::invalid_argument("Could not open '" + m_cfg.filePath + "'");
   }
 
   // initialize the plot tools

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -40,10 +40,10 @@ class CKFPerformanceWriter final : public WriterT<TrajectoriesContainer> {
     std::string inputParticles;
     /// Input hit-particles map collection.
     std::string inputMeasurementParticlesMap;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "performance_ckf.root";
+    std::string filePath = "performance_ckf.root";
+    /// Output filemode
+    std::string fileMode = "RECREATE";
     /// Plot tool configurations.
     EffPlotTool::Config effPlotToolConfig;
     FakeRatePlotTool::Config fakeRatePlotToolConfig;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
@@ -26,27 +26,27 @@ using ProtoTrackContainer = ActsExamples::ProtoTrackContainer;
 }  // namespace
 
 ActsExamples::SeedingPerformanceWriter::SeedingPerformanceWriter(
-    ActsExamples::SeedingPerformanceWriter::Config cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputProtoTracks, "SeedingPerformanceWriter", lvl),
-      m_cfg(std::move(cfg)),
-      m_effPlotTool(m_cfg.effPlotToolConfig, lvl),
-      m_duplicationPlotTool(m_cfg.duplicationPlotToolConfig, lvl) {
+    ActsExamples::SeedingPerformanceWriter::Config config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputProtoTracks, "SeedingPerformanceWriter", level),
+      m_cfg(std::move(config)),
+      m_effPlotTool(m_cfg.effPlotToolConfig, level),
+      m_duplicationPlotTool(m_cfg.duplicationPlotToolConfig, level) {
   if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
   if (m_cfg.inputParticles.empty()) {
     throw std::invalid_argument("Missing input particles collection");
   }
-  if (m_cfg.outputFilename.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
 
   // the output file can not be given externally since TFile accesses to the
   // same file from multiple threads are unsafe.
   // must always be opened internally
-  auto path = joinPaths(m_cfg.outputDir, m_cfg.outputFilename);
-  m_outputFile = TFile::Open(path.c_str(), "RECREATE");
+  auto path = m_cfg.filePath;
+  m_outputFile = TFile::Open(path.c_str(), m_cfg.fileMode.c_str());
   if (not m_outputFile) {
     throw std::invalid_argument("Could not open '" + path + "'");
   }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp
@@ -30,17 +30,20 @@ class SeedingPerformanceWriter final : public WriterT<ProtoTrackContainer> {
     std::string inputMeasurementParticlesMap;
     /// Input truth particles collection.
     std::string inputParticles;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "performance_track_seeding.root";
+    std::string filePath = "performance_track_seeding.root";
+    /// Output file mode
+    std::string fileMode = "RECREATE";
     /// Plot tool configurations.
     EffPlotTool::Config effPlotToolConfig;
     DuplicationPlotTool::Config duplicationPlotToolConfig;
   };
 
   /// Construct from configuration and log level.
-  SeedingPerformanceWriter(Config cfg, Acts::Logging::Level lvl);
+  /// @param config The configuration
+  /// @param level
+  SeedingPerformanceWriter(Config config, Acts::Logging::Level level);
+
   ~SeedingPerformanceWriter() override;
 
   /// Finalize plots.

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp
@@ -29,13 +29,21 @@ class TrackFinderPerformanceWriter final : public WriterT<ProtoTrackContainer> {
     std::string inputMeasurementParticlesMap;
     /// Input particles collection.
     std::string inputParticles;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "performance_track_finder.root";
+    std::string filePath = "performance_track_finder.root";
+    /// Output file mode
+    std::string fileMode = "RECREATE";
+    /// Output tree name for the tracks
+    std::string treeNameTracks = "track_finder_tracks";
+    /// Output tree name for the particles
+    std::string treeNameParticles = "track_finder_particles";
   };
 
-  TrackFinderPerformanceWriter(Config cfg, Acts::Logging::Level lvl);
+  /// Constructor
+  /// @param config the configuration
+  /// @param level The log level
+  TrackFinderPerformanceWriter(Config config, Acts::Logging::Level level);
+
   ~TrackFinderPerformanceWriter() final override;
 
   ProcessCode endRun() final override;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -22,13 +22,13 @@
 using Acts::VectorHelpers::eta;
 
 ActsExamples::TrackFitterPerformanceWriter::TrackFitterPerformanceWriter(
-    ActsExamples::TrackFitterPerformanceWriter::Config cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputTrajectories, "TrackFitterPerformanceWriter", lvl),
-      m_cfg(std::move(cfg)),
-      m_resPlotTool(m_cfg.resPlotToolConfig, lvl),
-      m_effPlotTool(m_cfg.effPlotToolConfig, lvl),
-      m_trackSummaryPlotTool(m_cfg.trackSummaryPlotToolConfig, lvl)
+    ActsExamples::TrackFitterPerformanceWriter::Config config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputTrajectories, "TrackFitterPerformanceWriter", level),
+      m_cfg(std::move(config)),
+      m_resPlotTool(m_cfg.resPlotToolConfig, level),
+      m_effPlotTool(m_cfg.effPlotToolConfig, level),
+      m_trackSummaryPlotTool(m_cfg.trackSummaryPlotToolConfig, level)
 
 {
   // trajectories collection name is already checked by base ctor
@@ -38,14 +38,14 @@ ActsExamples::TrackFitterPerformanceWriter::TrackFitterPerformanceWriter(
   if (m_cfg.inputMeasurementParticlesMap.empty()) {
     throw std::invalid_argument("Missing hit-particles map input collection");
   }
-  if (m_cfg.outputFilename.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
 
   // the output file can not be given externally since TFile accesses to the
   // same file from multiple threads are unsafe.
   // must always be opened internally
-  auto path = joinPaths(m_cfg.outputDir, m_cfg.outputFilename);
+  auto path = m_cfg.filePath;
   m_outputFile = TFile::Open(path.c_str(), "RECREATE");
   if (not m_outputFile) {
     throw std::invalid_argument("Could not open '" + path + "'");

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp
@@ -39,10 +39,8 @@ class TrackFitterPerformanceWriter final
     std::string inputParticles;
     /// Input hit-particles map collection.
     std::string inputMeasurementParticlesMap;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "performance_track_fitter.root";
+    std::string filePath = "performance_track_fitter.root";
     /// Plot tool configurations.
     ResPlotTool::Config resPlotToolConfig;
     EffPlotTool::Config effPlotToolConfig;
@@ -50,7 +48,10 @@ class TrackFitterPerformanceWriter final
   };
 
   /// Construct from configuration and log level.
-  TrackFitterPerformanceWriter(Config cfg, Acts::Logging::Level lvl);
+  /// @param config The configuration
+  /// @param level The logger level
+  TrackFitterPerformanceWriter(Config config, Acts::Logging::Level level);
+
   ~TrackFitterPerformanceWriter() final override;
 
   /// Finalize plots.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialDecorator.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialDecorator.hpp
@@ -79,24 +79,12 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
     std::string rhotag = "rho";
     /// The name of the output file
     std::string fileName = "material-maps.root";
-    /// The default logger
-    std::shared_ptr<const Acts::Logger> logger;
-    // The name of the writer
-    std::string name = "";
-
-    /// Constructor
-    ///
-    /// @param lname Name of the writer tool
-    /// @param lvl The output logging level
-    Config(const std::string& lname = "MaterialReader",
-           Acts::Logging::Level lvl = Acts::Logging::INFO)
-        : logger(Acts::getDefaultLogger(lname, lvl)), name(lname) {}
   };
 
   /// Constructor
   ///
   /// @param cfg configuration struct for the reader
-  RootMaterialDecorator(const Config& cfg);
+  RootMaterialDecorator(const Config& config, Acts::Logging::Level level);
 
   /// Destructor
   ~RootMaterialDecorator();
@@ -135,6 +123,8 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   /// The config class
   Config m_cfg;
 
+  std::unique_ptr<const Acts::Logger> m_logger{nullptr};
+
   /// The input file
   TFile* m_inputFile{nullptr};
 
@@ -147,7 +137,7 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   bool m_clearSurfaceMaterial{true};
 
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_cfg.logger; }
+  const Acts::Logger& logger() const { return *m_logger; }
 };
 
 }  // namespace ActsExamples

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackReader.hpp
@@ -33,30 +33,17 @@ class RootMaterialTrackReader : public IReader {
   struct Config {
     std::string collection =
         "material-tracks";                     ///< material collection to read
-    std::string filePath = "";                 ///< path of the output file
     std::string treeName = "material-tracks";  ///< name of the output tree
-    std::vector<std::string> fileList;         ///< The name of the input file
+    std::vector<std::string> fileList;         ///< List of input files
 
     /// Whether the events are ordered or not
     bool orderedEvents = true;
-
-    /// The default logger
-    std::shared_ptr<const Acts::Logger> logger;
-
-    /// The name of the service
-    std::string name;
-
-    /// Constructor
-    /// @param lname The name of the Material reader
-    /// @parqam lvl The log level for the logger
-    Config(const std::string& lname = "MaterialReader",
-           Acts::Logging::Level lvl = Acts::Logging::INFO)
-        : logger(Acts::getDefaultLogger(lname, lvl)), name(lname) {}
   };
 
   /// Constructor
-  /// @param cfg The Configuration struct
-  RootMaterialTrackReader(const Config& cfg);
+  /// @param config The Configuration struct
+  /// @param level The log level
+  RootMaterialTrackReader(const Config& config, Acts::Logging::Level level);
 
   /// Destructor
   ~RootMaterialTrackReader();
@@ -73,9 +60,15 @@ class RootMaterialTrackReader : public IReader {
   ProcessCode read(
       const ActsExamples::AlgorithmContext& context) final override;
 
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
+  /// The logger
+  std::unique_ptr<const Acts::Logger> m_logger;
+
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_cfg.logger; }
+  const Acts::Logger& logger() const { return *m_logger; }
 
   /// The config class
   Config m_cfg;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMaterialTrackWriter.hpp
@@ -47,7 +47,6 @@ class RootMaterialTrackWriter
     std::string filePath = "";                 ///< path of the output file
     std::string fileMode = "RECREATE";         ///< file access mode
     std::string treeName = "material-tracks";  ///< name of the output tree
-    TFile* rootFile = nullptr;                 ///< common root file
 
     /// Re-calculate total values from individual steps (for cross-checks)
     bool recalculateTotals = false;
@@ -60,9 +59,9 @@ class RootMaterialTrackWriter
   };
 
   /// Constructor with
-  /// @param cfg configuration struct
-  /// @param output logging level
-  RootMaterialTrackWriter(const Config& cfg,
+  /// @param config configuration struct
+  /// @param level logging level
+  RootMaterialTrackWriter(const Config& config,
                           Acts::Logging::Level level = Acts::Logging::INFO);
 
   /// Virtual destructor
@@ -70,6 +69,9 @@ class RootMaterialTrackWriter
 
   /// Framework intialize method
   ActsExamples::ProcessCode endRun() final override;
+
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
 
  protected:
   // This implementation holds the actual writing method

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
@@ -244,13 +244,16 @@ class RootMeasurementWriter final : public WriterT<MeasurementContainer> {
   /// Constructor with
   /// @param cfg configuration struct
   /// @param output logging level
-  RootMeasurementWriter(const Config& cfg, Acts::Logging::Level lvl);
+  RootMeasurementWriter(const Config& config, Acts::Logging::Level level);
 
   /// Virtual destructor
   ~RootMeasurementWriter() final override;
 
   /// End-of-run hook
   ProcessCode endRun() final override;
+
+  /// Get const access to the config
+  const Config& config() const { return m_cfg; }
 
  protected:
   /// This implementation holds the actual writing method

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
@@ -34,36 +34,21 @@ class RootParticleReader : public IReader {
     std::string vertexPrimaryCollection;  ///< primary vertex collection to read
     std::string
         vertexSecondaryCollection;  ///< secondary vertex collection to read
-    std::string treeName;           ///< name of the output tree
-    std::string inputFile;          ///< The name of the input file
-    std::string inputDir;           ///< The name of the input dir
-
+    std::string treeName = "particles";  ///< name of the output tree
+    std::string filePath;                ///< The name of the input file
     /// Whether the events are ordered or not
     bool orderedEvents = true;
-
-    /// The default logger
-    std::shared_ptr<const Acts::Logger> logger;
-
-    /// The name of the service
-    std::string name;
-
-    /// Constructor
-    /// @param lname The name of the reader
-    /// @parqam lvl The log level for the logger
-    Config(const std::string& lname = "RootParticleReader",
-           Acts::Logging::Level lvl = Acts::Logging::INFO)
-        : logger(Acts::getDefaultLogger(lname, lvl)), name(lname) {}
   };
 
   /// Constructor
-  /// @param cfg The Configuration struct
-  RootParticleReader(const Config& cfg);
+  /// @param config The Configuration struct
+  RootParticleReader(const Config& config, Acts::Logging::Level level);
 
   /// Destructor
   ~RootParticleReader();
 
   /// Framework name() method
-  std::string name() const final override;
+  std::string name() const final override { return "RootParticleReader"; }
 
   /// Return the available events range.
   std::pair<size_t, size_t> availableEvents() const final override;
@@ -74,12 +59,17 @@ class RootParticleReader : public IReader {
   ProcessCode read(
       const ActsExamples::AlgorithmContext& context) final override;
 
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_cfg.logger; }
+  const Acts::Logger& logger() const { return *m_logger; }
 
   /// The config class
   Config m_cfg;
+
+  std::unique_ptr<const Acts::Logger> m_logger;
 
   /// mutex used to protect multi-threaded reads
   std::mutex m_read_mutex;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootPlanarClusterWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootPlanarClusterWriter.hpp
@@ -43,15 +43,14 @@ class RootPlanarClusterWriter
     std::string filePath = "";          ///< path of the output file
     std::string fileMode = "RECREATE";  ///< file access mode
     std::string treeName = "clusters";  ///< name of the output tree
-    TFile* rootFile = nullptr;          ///< common root file
     /// Tracking geometry required to access global-to-local transforms.
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
   };
 
   /// Constructor with
-  /// @param cfg configuration struct
-  /// @param output logging level
-  RootPlanarClusterWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config configuration struct
+  /// @param level logging level
+  RootPlanarClusterWriter(const Config& config, Acts::Logging::Level level);
 
   /// Virtual destructor
   ~RootPlanarClusterWriter() override;
@@ -72,8 +71,8 @@ class RootPlanarClusterWriter
  private:
   Config m_cfg;                    ///< the configuration object
   std::mutex m_writeMutex;         ///< protect multi-threaded writes
-  TFile* m_outputFile;             ///< the output file
-  TTree* m_outputTree;             ///< the output tree
+  TFile* m_outputFile{nullptr};    ///< the output file
+  TTree* m_outputTree{nullptr};    ///< the output tree
   int m_eventNr;                   ///< the event number of
   int m_volumeID;                  ///< volume identifier
   int m_layerID;                   ///< layer identifier

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootSimHitWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootSimHitWriter.hpp
@@ -43,9 +43,9 @@ class RootSimHitWriter final : public WriterT<SimHitContainer> {
 
   /// Construct the particle writer.
   ///
-  /// @params cfg is the configuration object
-  /// @params lvl is the logging level
-  RootSimHitWriter(const Config& cfg, Acts::Logging::Level lvl);
+  /// @param config is the configuration object
+  /// @param level is the logging level
+  RootSimHitWriter(const Config& config, Acts::Logging::Level level);
 
   /// Ensure underlying file is closed.
   ~RootSimHitWriter() final override;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackParameterWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackParameterWriter.hpp
@@ -40,23 +40,19 @@ class RootTrackParameterWriter final : public TrackParameterWriter {
     std::string inputMeasurementParticlesMap;
     /// Input collection to map measured hits to simulated hits.
     std::string inputMeasurementSimHitsMap;
-    /// output directory.
-    std::string outputDir;
     /// output filename.
-    std::string outputFilename = "estimatedparams.root";
+    std::string filePath = "estimatedparams.root";
     /// name of the output tree.
-    std::string outputTreename = "estimatedparams";
+    std::string treeName = "estimatedparams";
     /// file access mode.
     std::string fileMode = "RECREATE";
-    /// common root file.
-    TFile* rootFile = nullptr;
   };
 
   /// Constructor
   ///
-  /// @param cfg Configuration struct
+  /// @param config Configuration struct
   /// @param level Message level declaration
-  RootTrackParameterWriter(const Config& cfg,
+  RootTrackParameterWriter(const Config& config,
                            Acts::Logging::Level level = Acts::Logging::INFO);
 
   /// Virtual destructor

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
@@ -48,23 +48,20 @@ class RootTrajectoryStatesWriter final : public WriterT<TrajectoriesContainer> {
     std::string inputMeasurementParticlesMap;
     /// Input collection to map measured hits to simulated hits.
     std::string inputMeasurementSimHitsMap;
-    /// output directory.
-    std::string outputDir;
     /// output filename.
-    std::string outputFilename = "trackstates.root";
+    std::string filePath = "trackstates.root";
     /// name of the output tree.
-    std::string outputTreename = "trackstates";
+    std::string treeName = "trackstates";
     /// file access mode.
     std::string fileMode = "RECREATE";
-    /// common root file.
-    TFile* rootFile = nullptr;
   };
 
   /// Constructor
   ///
-  /// @param cfg Configuration struct
+  /// @param config Configuration struct
   /// @param level Message level declaration
-  RootTrajectoryStatesWriter(const Config& cfg, Acts::Logging::Level lvl);
+  RootTrajectoryStatesWriter(const Config& config, Acts::Logging::Level level);
+
   ~RootTrajectoryStatesWriter() final override;
 
   /// End-of-run hook

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryReader.hpp
@@ -34,35 +34,22 @@ class RootTrajectorySummaryReader : public IReader {
     std::string outputParticles =
         "outputParticles";                  ///< particle collection to read
     std::string treeName = "tracksummary";  ///< name of the input tree
-    std::string inputFile;                  ///< The name of the input file
-    std::string inputDir;                   ///< The name of the input dir
+    std::string filePath;                   ///< The name of the input file
 
     /// Whether the events are ordered or not
     bool orderedEvents = true;
-
-    /// The default logger
-    std::shared_ptr<const Acts::Logger> logger;
-
-    /// The name of the service
-    std::string name;
-
-    /// Constructor
-    /// @param lname The name of the reader
-    /// @parqam lvl The log level for the logger
-    Config(const std::string& lname = "TrackSummaryReader",
-           Acts::Logging::Level lvl = Acts::Logging::INFO)
-        : logger(Acts::getDefaultLogger(lname, lvl)), name(lname) {}
   };
 
   /// Constructor
-  /// @param cfg The Configuration struct
-  RootTrajectorySummaryReader(const Config& cfg);
+  /// @param config The Configuration struct
+  /// @param level The log level
+  RootTrajectorySummaryReader(const Config& config, Acts::Logging::Level level);
 
   /// Destructor
   ~RootTrajectorySummaryReader();
 
   /// Framework name() method
-  std::string name() const final override;
+  std::string name() const final override { return "RootTrackSummaryReader"; }
 
   /// Return the available events range.
   std::pair<size_t, size_t> availableEvents() const final override;
@@ -73,9 +60,15 @@ class RootTrajectorySummaryReader : public IReader {
   ProcessCode read(
       const ActsExamples::AlgorithmContext& context) final override;
 
+  /// Readonly access to the config
+  const Config& config() const { return m_cfg; }
+
  private:
+  /// The logger
+  std::unique_ptr<const Acts::Logger> m_logger;
+
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_cfg.logger; }
+  const Acts::Logger& logger() const { return *m_logger; }
 
   /// The config class
   Config m_cfg;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryWriter.hpp
@@ -46,23 +46,19 @@ class RootTrajectorySummaryWriter final
     std::string inputParticles;
     /// Input hit-particles map collection.
     std::string inputMeasurementParticlesMap;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "tracksummary.root";
+    std::string filePath = "tracksummary.root";
     /// Name of the output tree.
-    std::string outputTreename = "tracksummary";
+    std::string treeName = "tracksummary";
     /// File access mode.
     std::string fileMode = "RECREATE";
-    /// Common root file.
-    TFile* rootFile = nullptr;
   };
 
   /// Constructor
   ///
-  /// @param cfg Configuration struct
+  /// @param config Configuration struct
   /// @param level Message level declaration
-  RootTrajectorySummaryWriter(const Config& cfg, Acts::Logging::Level lvl);
+  RootTrajectorySummaryWriter(const Config& config, Acts::Logging::Level level);
   ~RootTrajectorySummaryWriter() final override;
 
   /// End-of-run hook

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootVertexPerformanceWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootVertexPerformanceWriter.hpp
@@ -45,16 +45,12 @@ class RootVertexPerformanceWriter final
     std::string inputVertices;
     /// Input reconstruction time.
     std::string inputTime;
-    /// Output directory.
-    std::string outputDir;
     /// Output filename.
-    std::string outputFilename = "vertexingperformance.root";
+    std::string filePath = "vertexingperformance.root";
     /// Name of the output tree.
-    std::string outputTreename = "vertextree";
+    std::string treeName = "vertextree";
     /// File access mode.
     std::string fileMode = "RECREATE";
-    /// Common root file.
-    TFile* rootFile = nullptr;
     /// Minimum fraction of tracks matched between truth
     /// and reco vertices to be matched for resolution plots
     double minTrackVtxMatchFraction = 0.5;
@@ -62,9 +58,10 @@ class RootVertexPerformanceWriter final
 
   /// Constructor
   ///
-  /// @param cfg Configuration struct
+  /// @param config Configuration struct
   /// @param level Message level declaration
-  RootVertexPerformanceWriter(const Config& cfg, Acts::Logging::Level lvl);
+  RootVertexPerformanceWriter(const Config& config, Acts::Logging::Level level);
+
   ~RootVertexPerformanceWriter() final override;
 
   /// End-of-run hook

--- a/Examples/Io/Root/src/RootMaterialDecorator.cpp
+++ b/Examples/Io/Root/src/RootMaterialDecorator.cpp
@@ -33,8 +33,11 @@
 #include <boost/algorithm/string/iter_find.hpp>
 
 ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
-    const ActsExamples::RootMaterialDecorator::Config& cfg)
-    : m_cfg(cfg), m_inputFile(nullptr) {
+    const ActsExamples::RootMaterialDecorator::Config& config,
+    Acts::Logging::Level level)
+    : m_cfg(config),
+      m_logger{Acts::getDefaultLogger("RootMaterialDecorator", level)},
+      m_inputFile(nullptr) {
   // Validate the configuration
   if (m_cfg.folderSurfaceNameBase.empty()) {
     throw std::invalid_argument("Missing surface folder name base");
@@ -42,10 +45,6 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
     throw std::invalid_argument("Missing volume folder name base");
   } else if (m_cfg.fileName.empty()) {
     throw std::invalid_argument("Missing file name");
-  } else if (!m_cfg.logger) {
-    throw std::invalid_argument("Missing logger");
-  } else if (m_cfg.name.empty()) {
-    throw std::invalid_argument("Missing service name");
   }
 
   // Setup ROOT I/O

--- a/Examples/Io/Root/src/RootMaterialTrackReader.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackReader.cpp
@@ -17,8 +17,12 @@
 #include <TMath.h>
 
 ActsExamples::RootMaterialTrackReader::RootMaterialTrackReader(
-    const ActsExamples::RootMaterialTrackReader::Config& cfg)
-    : ActsExamples::IReader(), m_cfg(cfg), m_events(0), m_inputChain(nullptr) {
+    const Config& config, Acts::Logging::Level level)
+    : ActsExamples::IReader(),
+      m_logger{Acts::getDefaultLogger(name(), level)},
+      m_cfg(config),
+      m_events(0),
+      m_inputChain(nullptr) {
   m_inputChain = new TChain(m_cfg.treeName.c_str());
 
   // Set the branches
@@ -45,6 +49,10 @@ ActsExamples::RootMaterialTrackReader::RootMaterialTrackReader(
   m_inputChain->SetBranchAddress("mat_A", &m_step_A);
   m_inputChain->SetBranchAddress("mat_Z", &m_step_Z);
   m_inputChain->SetBranchAddress("mat_rho", &m_step_rho);
+
+  if (m_cfg.fileList.empty()) {
+    throw std::invalid_argument{"No input files given"};
+  }
 
   // loop over the input files
   for (auto inputFile : m_cfg.fileList) {
@@ -80,7 +88,7 @@ ActsExamples::RootMaterialTrackReader::~RootMaterialTrackReader() {
 }
 
 std::string ActsExamples::RootMaterialTrackReader::name() const {
-  return m_cfg.name;
+  return "RootMaterialTrackReader";
 }
 
 std::pair<size_t, size_t>

--- a/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
@@ -25,11 +25,10 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 ActsExamples::RootMaterialTrackWriter::RootMaterialTrackWriter(
-    const ActsExamples::RootMaterialTrackWriter::Config& cfg,
+    const ActsExamples::RootMaterialTrackWriter::Config& config,
     Acts::Logging::Level level)
-    : WriterT(cfg.collection, "RootMaterialTrackWriter", level),
-      m_cfg(cfg),
-      m_outputFile(cfg.rootFile) {
+    : WriterT(config.collection, "RootMaterialTrackWriter", level),
+      m_cfg(config) {
   // An input collection name and tree name must be specified
   if (m_cfg.collection.empty()) {
     throw std::invalid_argument("Missing input collection");
@@ -38,12 +37,11 @@ ActsExamples::RootMaterialTrackWriter::RootMaterialTrackWriter(
   }
 
   // Setup ROOT I/O
+  m_outputFile = TFile::Open(m_cfg.filePath.c_str(), m_cfg.fileMode.c_str());
   if (m_outputFile == nullptr) {
-    m_outputFile = TFile::Open(m_cfg.filePath.c_str(), m_cfg.fileMode.c_str());
-    if (m_outputFile == nullptr) {
-      throw std::ios_base::failure("Could not open '" + m_cfg.filePath);
-    }
+    throw std::ios_base::failure("Could not open '" + m_cfg.filePath);
   }
+
   m_outputFile->cd();
   m_outputTree =
       new TTree(m_cfg.treeName.c_str(), "TTree from RootMaterialTrackWriter");
@@ -97,15 +95,14 @@ ActsExamples::RootMaterialTrackWriter::RootMaterialTrackWriter(
   }
 }
 
-ActsExamples::RootMaterialTrackWriter::~RootMaterialTrackWriter() {
-  m_outputFile->Close();
-}
+ActsExamples::RootMaterialTrackWriter::~RootMaterialTrackWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootMaterialTrackWriter::endRun() {
   // write the tree and close the file
   ACTS_INFO("Writing ROOT output File : " << m_cfg.filePath);
   m_outputFile->cd();
   m_outputTree->Write();
+  m_outputFile->Close();
   return ActsExamples::ProcessCode::SUCCESS;
 }
 

--- a/Examples/Io/Root/src/RootMeasurementWriter.cpp
+++ b/Examples/Io/Root/src/RootMeasurementWriter.cpp
@@ -28,9 +28,10 @@
 #include <TString.h>
 
 ActsExamples::RootMeasurementWriter::RootMeasurementWriter(
-    const ActsExamples::RootMeasurementWriter::Config& cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputMeasurements, "RootMeasurementWriter", lvl), m_cfg(cfg) {
+    const ActsExamples::RootMeasurementWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputMeasurements, "RootMeasurementWriter", level),
+      m_cfg(config) {
   // Input container for measurements is already checked by base constructor
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");
@@ -77,7 +78,9 @@ ActsExamples::RootMeasurementWriter::RootMeasurementWriter(
       std::move(dTrees));
 }
 
-ActsExamples::RootMeasurementWriter::~RootMeasurementWriter() {
+ActsExamples::RootMeasurementWriter::~RootMeasurementWriter() {}
+
+ActsExamples::ProcessCode ActsExamples::RootMeasurementWriter::endRun() {
   /// Close the file if it's yours
   m_outputFile->cd();
   for (auto dTree = m_outputTrees.begin(); dTree != m_outputTrees.end();
@@ -85,10 +88,7 @@ ActsExamples::RootMeasurementWriter::~RootMeasurementWriter() {
     (*dTree)->tree->Write();
   }
   m_outputFile->Close();
-}
 
-ActsExamples::ProcessCode ActsExamples::RootMeasurementWriter::endRun() {
-  // Write the tree
   return ProcessCode::SUCCESS;
 }
 

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -21,18 +21,20 @@
 #include <TMath.h>
 
 ActsExamples::RootParticleReader::RootParticleReader(
-    const ActsExamples::RootParticleReader::Config& cfg)
-    : ActsExamples::IReader(), m_cfg(cfg), m_events(0), m_inputChain(nullptr) {
+    const ActsExamples::RootParticleReader::Config& config,
+    Acts::Logging::Level level)
+    : ActsExamples::IReader(),
+      m_cfg(config),
+      m_logger(Acts::getDefaultLogger(name(), level)),
+      m_events(0),
+      m_inputChain(nullptr) {
   m_inputChain = new TChain(m_cfg.treeName.c_str());
 
-  if (m_cfg.inputFile.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing input filename");
   }
   if (m_cfg.treeName.empty()) {
     throw std::invalid_argument("Missing tree name");
-  }
-  if (m_cfg.inputDir.empty()) {
-    throw std::invalid_argument("Missing input directory");
   }
 
   // Set the branches
@@ -59,7 +61,7 @@ ActsExamples::RootParticleReader::RootParticleReader(
   m_inputChain->SetBranchAddress("generation", &m_generation);
   m_inputChain->SetBranchAddress("sub_particle", &m_subParticle);
 
-  auto path = joinPaths(m_cfg.inputDir, m_cfg.inputFile);
+  auto path = m_cfg.filePath;
 
   // add file to the input chain
   m_inputChain->Add(path.c_str());
@@ -76,10 +78,6 @@ ActsExamples::RootParticleReader::RootParticleReader(
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
                 m_entryNumbers.data(), false);
   }
-}
-
-std::string ActsExamples::RootParticleReader::name() const {
-  return m_cfg.name;
 }
 
 std::pair<size_t, size_t> ActsExamples::RootParticleReader::availableEvents()

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -65,11 +65,7 @@ ActsExamples::RootParticleWriter::RootParticleWriter(
   m_outputTree->Branch("sub_particle", &m_subParticle);
 }
 
-ActsExamples::RootParticleWriter::~RootParticleWriter() {
-  if (m_outputFile) {
-    m_outputFile->Close();
-  }
-}
+ActsExamples::RootParticleWriter::~RootParticleWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootParticleWriter::endRun() {
   if (m_outputFile) {
@@ -78,6 +74,11 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::endRun() {
     ACTS_INFO("Wrote particles to tree '" << m_cfg.treeName << "' in '"
                                           << m_cfg.filePath << "'");
   }
+
+  if (m_outputFile) {
+    m_outputFile->Close();
+  }
+
   return ProcessCode::SUCCESS;
 }
 

--- a/Examples/Io/Root/src/RootPropagationStepsWriter.cpp
+++ b/Examples/Io/Root/src/RootPropagationStepsWriter.cpp
@@ -69,12 +69,7 @@ ActsExamples::RootPropagationStepsWriter::RootPropagationStepsWriter(
   m_outputTree->Branch("step_usr", &m_step_usr);
 }
 
-ActsExamples::RootPropagationStepsWriter::~RootPropagationStepsWriter() {
-  /// Close the file if it's yours
-  if (m_cfg.rootFile == nullptr) {
-    m_outputFile->Close();
-  }
-}
+ActsExamples::RootPropagationStepsWriter::~RootPropagationStepsWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootPropagationStepsWriter::endRun() {
   // Write the tree
@@ -82,6 +77,10 @@ ActsExamples::ProcessCode ActsExamples::RootPropagationStepsWriter::endRun() {
   m_outputTree->Write();
   ACTS_VERBOSE("Wrote particles to tree '" << m_cfg.treeName << "' in '"
                                            << m_cfg.filePath << "'");
+  /// Close the file if it's yours
+  if (m_cfg.rootFile == nullptr) {
+    m_outputFile->Close();
+  }
   return ProcessCode::SUCCESS;
 }
 

--- a/Examples/Io/Root/src/RootSimHitWriter.cpp
+++ b/Examples/Io/Root/src/RootSimHitWriter.cpp
@@ -17,8 +17,9 @@
 #include <TTree.h>
 
 ActsExamples::RootSimHitWriter::RootSimHitWriter(
-    const ActsExamples::RootSimHitWriter::Config& cfg, Acts::Logging::Level lvl)
-    : WriterT(cfg.inputSimHits, "RootSimHitWriter", lvl), m_cfg(cfg) {
+    const ActsExamples::RootSimHitWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputSimHits, "RootSimHitWriter", level), m_cfg(config) {
   // inputParticles is already checked by base constructor
   if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing file path");
@@ -62,11 +63,7 @@ ActsExamples::RootSimHitWriter::RootSimHitWriter(
   m_outputTree->Branch("sensitive_id", &m_sensitiveId);
 }
 
-ActsExamples::RootSimHitWriter::~RootSimHitWriter() {
-  if (m_outputFile) {
-    m_outputFile->Close();
-  }
-}
+ActsExamples::RootSimHitWriter::~RootSimHitWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootSimHitWriter::endRun() {
   if (m_outputFile) {
@@ -74,6 +71,7 @@ ActsExamples::ProcessCode ActsExamples::RootSimHitWriter::endRun() {
     m_outputTree->Write();
     ACTS_VERBOSE("Wrote hits to tree '" << m_cfg.treeName << "' in '"
                                         << m_cfg.filePath << "'");
+    m_outputFile->Close();
   }
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Root/src/RootTrackParameterWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackParameterWriter.cpp
@@ -33,12 +33,11 @@ using Acts::VectorHelpers::phi;
 using Acts::VectorHelpers::theta;
 
 ActsExamples::RootTrackParameterWriter::RootTrackParameterWriter(
-    const ActsExamples::RootTrackParameterWriter::Config& cfg,
+    const ActsExamples::RootTrackParameterWriter::Config& config,
     Acts::Logging::Level level)
-    : TrackParameterWriter(cfg.inputTrackParameters, "RootTrackParameterWriter",
-                           level),
-      m_cfg(cfg),
-      m_outputFile(cfg.rootFile) {
+    : TrackParameterWriter(config.inputTrackParameters,
+                           "RootTrackParameterWriter", level),
+      m_cfg(config) {
   if (m_cfg.inputProtoTracks.empty()) {
     throw std::invalid_argument("Missing proto tracks input collection");
   }
@@ -55,24 +54,23 @@ ActsExamples::RootTrackParameterWriter::RootTrackParameterWriter(
     throw std::invalid_argument(
         "Missing hit-simulated-hits map input collection");
   }
-  if (m_cfg.outputFilename.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
-  if (m_cfg.outputTreename.empty()) {
+  if (m_cfg.treeName.empty()) {
     throw std::invalid_argument("Missing tree name");
   }
 
   // Setup ROOT I/O
   if (m_outputFile == nullptr) {
-    auto path = joinPaths(m_cfg.outputDir, m_cfg.outputFilename);
+    auto path = m_cfg.filePath;
     m_outputFile = TFile::Open(path.c_str(), m_cfg.fileMode.c_str());
     if (m_outputFile == nullptr) {
       throw std::ios_base::failure("Could not open '" + path);
     }
   }
   m_outputFile->cd();
-  m_outputTree =
-      new TTree(m_cfg.outputTreename.c_str(), m_cfg.outputTreename.c_str());
+  m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
   if (m_outputTree == nullptr)
     throw std::bad_alloc();
   else {
@@ -99,19 +97,15 @@ ActsExamples::RootTrackParameterWriter::RootTrackParameterWriter(
   }
 }
 
-ActsExamples::RootTrackParameterWriter::~RootTrackParameterWriter() {
-  if (m_outputFile) {
-    m_outputFile->Close();
-  }
-}
+ActsExamples::RootTrackParameterWriter::~RootTrackParameterWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootTrackParameterWriter::endRun() {
   if (m_outputFile) {
     m_outputFile->cd();
     m_outputTree->Write();
     ACTS_INFO("Write estimated parameters from seed to tree '"
-              << m_cfg.outputTreename << "' in '"
-              << joinPaths(m_cfg.outputDir, m_cfg.outputFilename) << "'");
+              << m_cfg.treeName << "' in '" << m_cfg.filePath << "'");
+    m_outputFile->Close();
   }
   return ProcessCode::SUCCESS;
 }
@@ -142,6 +136,8 @@ ActsExamples::ProcessCode ActsExamples::RootTrackParameterWriter::writeT(
 
   // Get the event number
   m_eventNr = ctx.eventNumber;
+
+  ACTS_VERBOSE("Writing " << trackParams.size() << " track parameters");
 
   // Loop over the estimated track parameters
   for (size_t iparams = 0; iparams < trackParams.size(); ++iparams) {

--- a/Examples/Io/Root/src/RootTrajectorySummaryReader.cpp
+++ b/Examples/Io/Root/src/RootTrajectorySummaryReader.cpp
@@ -21,15 +21,17 @@
 #include <TMath.h>
 
 ActsExamples::RootTrajectorySummaryReader::RootTrajectorySummaryReader(
-    const ActsExamples::RootTrajectorySummaryReader::Config& cfg)
-    : ActsExamples::IReader(), m_cfg(cfg), m_events(0), m_inputChain(nullptr) {
+    const ActsExamples::RootTrajectorySummaryReader::Config& config,
+    Acts::Logging::Level level)
+    : ActsExamples::IReader(),
+      m_logger{Acts::getDefaultLogger(name(), level)},
+      m_cfg(config),
+      m_events(0),
+      m_inputChain(nullptr) {
   m_inputChain = new TChain(m_cfg.treeName.c_str());
 
-  if (m_cfg.inputFile.empty()) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing input filename");
-  }
-  if (m_cfg.inputDir.empty()) {
-    throw std::invalid_argument("Missing input directory");
   }
 
   // Set the branches
@@ -80,7 +82,7 @@ ActsExamples::RootTrajectorySummaryReader::RootTrajectorySummaryReader(
   m_inputChain->SetBranchAddress("err_eQOP_fit", &m_err_eQOP_fit);
   m_inputChain->SetBranchAddress("err_eT_fit", &m_err_eT_fit);
 
-  auto path = joinPaths(m_cfg.inputDir, m_cfg.inputFile);
+  auto path = m_cfg.filePath;
 
   // add file to the input chain
   m_inputChain->Add(path.c_str());
@@ -97,10 +99,6 @@ ActsExamples::RootTrajectorySummaryReader::RootTrajectorySummaryReader(
     TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
                 m_entryNumbers.data(), false);
   }
-}
-
-std::string ActsExamples::RootTrajectorySummaryReader::name() const {
-  return m_cfg.name;
 }
 
 std::pair<size_t, size_t>

--- a/Examples/Io/Root/src/RootVertexPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/RootVertexPerformanceWriter.cpp
@@ -34,15 +34,14 @@ using Acts::VectorHelpers::phi;
 using Acts::VectorHelpers::theta;
 
 ActsExamples::RootVertexPerformanceWriter::RootVertexPerformanceWriter(
-    const ActsExamples::RootVertexPerformanceWriter::Config& cfg,
-    Acts::Logging::Level lvl)
-    : WriterT(cfg.inputVertices, "RootVertexPerformanceWriter", lvl),
-      m_cfg(cfg),
-      m_outputFile(cfg.rootFile) {
-  if (cfg.outputFilename.empty()) {
+    const ActsExamples::RootVertexPerformanceWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT(config.inputVertices, "RootVertexPerformanceWriter", level),
+      m_cfg(config) {
+  if (m_cfg.filePath.empty()) {
     throw std::invalid_argument("Missing output filename");
   }
-  if (m_cfg.outputTreename.empty()) {
+  if (m_cfg.treeName.empty()) {
     throw std::invalid_argument("Missing tree name");
   }
   if (m_cfg.inputAllTruthParticles.empty()) {
@@ -60,21 +59,15 @@ ActsExamples::RootVertexPerformanceWriter::RootVertexPerformanceWriter(
     throw std::invalid_argument(
         "Collection with all fitted track parameters missing");
   }
-  if (m_cfg.inputTime.empty()) {
-    throw std::invalid_argument("Input reconstruction time missing");
-  }
 
   // Setup ROOT I/O
+  auto path = m_cfg.filePath;
+  m_outputFile = TFile::Open(path.c_str(), m_cfg.fileMode.c_str());
   if (m_outputFile == nullptr) {
-    auto path = joinPaths(m_cfg.outputDir, m_cfg.outputFilename);
-    m_outputFile = TFile::Open(path.c_str(), m_cfg.fileMode.c_str());
-    if (m_outputFile == nullptr) {
-      throw std::ios_base::failure("Could not open '" + path);
-    }
+    throw std::ios_base::failure("Could not open '" + path);
   }
   m_outputFile->cd();
-  m_outputTree =
-      new TTree(m_cfg.outputTreename.c_str(), m_cfg.outputTreename.c_str());
+  m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
   if (m_outputTree == nullptr)
     throw std::bad_alloc();
   else {
@@ -90,16 +83,13 @@ ActsExamples::RootVertexPerformanceWriter::RootVertexPerformanceWriter(
   }
 }
 
-ActsExamples::RootVertexPerformanceWriter::~RootVertexPerformanceWriter() {
-  if (m_outputFile) {
-    m_outputFile->Close();
-  }
-}
+ActsExamples::RootVertexPerformanceWriter::~RootVertexPerformanceWriter() {}
 
 ActsExamples::ProcessCode ActsExamples::RootVertexPerformanceWriter::endRun() {
   if (m_outputFile) {
     m_outputFile->cd();
     m_outputTree->Write();
+    m_outputFile->Close();
   }
   return ProcessCode::SUCCESS;
 }
@@ -206,6 +196,9 @@ ActsExamples::ProcessCode ActsExamples::RootVertexPerformanceWriter::writeT(
   const auto& inputFittedTracks =
       ctx.eventStore.get<std::vector<Acts::BoundTrackParameters>>(
           m_cfg.inputFittedTracks);
+
+  ACTS_INFO(
+      "Total number of reconstructed tracks : " << inputFittedTracks.size());
 
   if (associatedTruthParticles.size() != inputFittedTracks.size()) {
     ACTS_WARNING(

--- a/Examples/Run/Common/src/CommonGeometry.cpp
+++ b/Examples/Run/Common/src/CommonGeometry.cpp
@@ -49,13 +49,13 @@ build(const boost::program_options::variables_map& vm,
       Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
       // Set up the json-based decorator
       matDeco = std::make_shared<const Acts::JsonMaterialDecorator>(
-          jsonGeoConvConfig, fileName);
+          jsonGeoConvConfig, fileName, Acts::Logging::INFO);
     } else if (fileName.find(".root") != std::string::npos) {
       // Set up the root-based decorator
       ActsExamples::RootMaterialDecorator::Config rootMatDecConfig;
       rootMatDecConfig.fileName = fileName;
       matDeco = std::make_shared<const ActsExamples::RootMaterialDecorator>(
-          rootMatDecConfig);
+          rootMatDecConfig, Acts::Logging::INFO);
     }
   }
 

--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -98,11 +98,10 @@ int processGeometry(int argc, char* argv[],
     if (vm["output-obj"].as<bool>()) {
       // Configure the tracking geometry writer
       auto tgObjWriterConfig =
-          ActsExamples::Options::readObjTrackingGeometryWriterConfig(
-              vm, "ObjTrackingGeometryWriter", volumeLogLevel);
+          ActsExamples::Options::readObjTrackingGeometryWriterConfig(vm);
       auto tgObjWriter =
           std::make_shared<ActsExamples::ObjTrackingGeometryWriter>(
-              tgObjWriterConfig);
+              tgObjWriterConfig, volumeLogLevel);
       // Write the tracking geometry object
       tgObjWriter->write(context, *tGeometry);
     }

--- a/Examples/Run/Common/src/MaterialMappingBase.cpp
+++ b/Examples/Run/Common/src/MaterialMappingBase.cpp
@@ -110,7 +110,7 @@ int materialMappingExample(int argc, char* argv[],
     matTrackReaderRootConfig.fileList = intputFiles;
     auto matTrackReaderRoot =
         std::make_shared<ActsExamples::RootMaterialTrackReader>(
-            matTrackReaderRootConfig);
+            matTrackReaderRootConfig, logLevel);
     sequencer.addReader(matTrackReaderRoot);
   }
 

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -200,8 +200,7 @@ int runRecCKFTracks(int argc, char* argv[],
     tfPerfCfg.inputParticles = inputParticles;
     tfPerfCfg.inputMeasurementParticlesMap =
         digiCfg.outputMeasurementParticlesMap;
-    tfPerfCfg.outputDir = outputDir;
-    tfPerfCfg.outputFilename = "performance_seeding_trees.root";
+    tfPerfCfg.filePath = outputDir + "/performance_seeding_trees.root";
     sequencer.addWriter(
         std::make_shared<TrackFinderPerformanceWriter>(tfPerfCfg, logLevel));
 
@@ -261,9 +260,8 @@ int runRecCKFTracks(int argc, char* argv[],
       digiCfg.outputMeasurementParticlesMap;
   trackStatesWriter.inputMeasurementSimHitsMap =
       digiCfg.outputMeasurementSimHitsMap;
-  trackStatesWriter.outputDir = outputDir;
-  trackStatesWriter.outputFilename = "trackstates_ckf.root";
-  trackStatesWriter.outputTreename = "trackstates";
+  trackStatesWriter.filePath = outputDir + "/trackstates_ckf.root";
+  trackStatesWriter.treeName = "trackstates";
   sequencer.addWriter(std::make_shared<RootTrajectoryStatesWriter>(
       trackStatesWriter, logLevel));
 
@@ -277,9 +275,8 @@ int runRecCKFTracks(int argc, char* argv[],
   trackSummaryWriter.inputParticles = particleReader.outputParticles;
   trackSummaryWriter.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  trackSummaryWriter.outputDir = outputDir;
-  trackSummaryWriter.outputFilename = "tracksummary_ckf.root";
-  trackSummaryWriter.outputTreename = "tracksummary";
+  trackSummaryWriter.filePath = outputDir + "/tracksummary_ckf.root";
+  trackSummaryWriter.treeName = "tracksummary";
   sequencer.addWriter(std::make_shared<RootTrajectorySummaryWriter>(
       trackSummaryWriter, logLevel));
 
@@ -292,7 +289,7 @@ int runRecCKFTracks(int argc, char* argv[],
   // The bottom seed could be the first, second or third hits on the truth track
   perfWriterCfg.nMeasurementsMin = particleSelectorCfg.nHitsMin - 3;
   perfWriterCfg.ptMin = 0.4_GeV;
-  perfWriterCfg.outputDir = outputDir;
+  perfWriterCfg.filePath = outputDir + "/performance_ckf.root";
 #ifdef ACTS_PLUGIN_ONNX
   // Onnx plugin related options
   // Path to default demo ML model for track classification

--- a/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
@@ -163,8 +163,7 @@ int runRecTruthTracks(int argc, char* argv[],
       digiCfg.outputMeasurementParticlesMap;
   trackStatesWriter.inputMeasurementSimHitsMap =
       digiCfg.outputMeasurementSimHitsMap;
-  trackStatesWriter.outputDir = outputDir;
-  trackStatesWriter.outputFilename = "trackstates_fitter.root";
+  trackStatesWriter.filePath = outputDir + "/trackstates_fitter.root";
   sequencer.addWriter(std::make_shared<RootTrajectoryStatesWriter>(
       trackStatesWriter, logLevel));
 
@@ -174,8 +173,7 @@ int runRecTruthTracks(int argc, char* argv[],
   trackSummaryWriter.inputParticles = inputParticles;
   trackSummaryWriter.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  trackSummaryWriter.outputDir = outputDir;
-  trackSummaryWriter.outputFilename = "tracksummary_fitter.root";
+  trackSummaryWriter.filePath = outputDir + "/tracksummary_fitter.root";
   sequencer.addWriter(std::make_shared<RootTrajectorySummaryWriter>(
       trackSummaryWriter, logLevel));
 
@@ -186,15 +184,16 @@ int runRecTruthTracks(int argc, char* argv[],
   perfFinder.inputParticles = inputParticles;
   perfFinder.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  perfFinder.outputDir = outputDir;
+  perfFinder.filePath = outputDir + "/performance_track_finder.root";
   sequencer.addWriter(
       std::make_shared<TrackFinderPerformanceWriter>(perfFinder, logLevel));
+
   TrackFitterPerformanceWriter::Config perfFitter;
   perfFitter.inputTrajectories = fitter.outputTrajectories;
   perfFitter.inputParticles = inputParticles;
   perfFitter.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  perfFitter.outputDir = outputDir;
+  perfFitter.filePath = outputDir + "/performance_track_fitter.root";
   sequencer.addWriter(
       std::make_shared<TrackFitterPerformanceWriter>(perfFitter, logLevel));
 

--- a/Examples/Run/Reconstruction/Common/SeedingExample.cpp
+++ b/Examples/Run/Reconstruction/Common/SeedingExample.cpp
@@ -121,7 +121,7 @@ int runSeedingExample(int argc, char* argv[],
   };
   seedingCfg.outputSeeds = "seeds";
   seedingCfg.outputProtoTracks = "prototracks";
-  seedingCfg.rMax = 200.;
+  seedingCfg.rMax = 100.;
   seedingCfg.deltaRMax = 60.;
   seedingCfg.collisionRegionMin = -250;
   seedingCfg.collisionRegionMax = 250.;
@@ -159,8 +159,7 @@ int runSeedingExample(int argc, char* argv[],
   tfPerfCfg.inputParticles = inputParticles;
   tfPerfCfg.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  tfPerfCfg.outputDir = outputDir;
-  tfPerfCfg.outputFilename = "performance_seeding_trees.root";
+  tfPerfCfg.filePath = outputDir + "/performance_seeding_trees.root";
   sequencer.addWriter(
       std::make_shared<TrackFinderPerformanceWriter>(tfPerfCfg, logLevel));
 
@@ -169,8 +168,7 @@ int runSeedingExample(int argc, char* argv[],
   seedPerfCfg.inputParticles = inputParticles;
   seedPerfCfg.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
-  seedPerfCfg.outputDir = outputDir;
-  seedPerfCfg.outputFilename = "performance_seeding_hists.root";
+  seedPerfCfg.filePath = outputDir + "/performance_seeding_hists.root";
   sequencer.addWriter(
       std::make_shared<SeedingPerformanceWriter>(seedPerfCfg, logLevel));
 
@@ -185,9 +183,8 @@ int runSeedingExample(int argc, char* argv[],
       digiCfg.outputMeasurementParticlesMap;
   trackParamsWriterCfg.inputMeasurementSimHitsMap =
       digiCfg.outputMeasurementSimHitsMap;
-  trackParamsWriterCfg.outputDir = outputDir;
-  trackParamsWriterCfg.outputFilename = "estimatedparams.root";
-  trackParamsWriterCfg.outputTreename = "estimatedparams";
+  trackParamsWriterCfg.filePath = outputDir + "/estimatedparams.root";
+  trackParamsWriterCfg.treeName = "estimatedparams";
   sequencer.addWriter(std::make_shared<RootTrackParameterWriter>(
       trackParamsWriterCfg, logLevel));
 

--- a/Examples/Run/Vertexing/ParticleReaderVertexingExample.cpp
+++ b/Examples/Run/Vertexing/ParticleReaderVertexingExample.cpp
@@ -88,7 +88,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<TrackParametersPrinter>(printTracks, logLevel));
 
   // find vertices
-  IterativeVertexFinderAlgorithm::Config findVertices(magneticField);
+  IterativeVertexFinderAlgorithm::Config findVertices;
+  findVertices.bField = magneticField;
   findVertices.inputTrackParameters = smearParticles.outputTrackParameters;
   findVertices.outputProtoVertices = "protovertices";
   sequencer.addAlgorithm(

--- a/Examples/Run/Vertexing/Pythia8/AdaptiveMultiVertexFinderExample.cpp
+++ b/Examples/Run/Vertexing/Pythia8/AdaptiveMultiVertexFinderExample.cpp
@@ -72,7 +72,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<ParticleSmearing>(smearParticles, logLevel));
 
   // find vertices
-  AdaptiveMultiVertexFinderAlgorithm::Config findVertices(magneticField);
+  AdaptiveMultiVertexFinderAlgorithm::Config findVertices;
+  findVertices.bField = magneticField;
   findVertices.inputTrackParameters = smearParticles.outputTrackParameters;
   findVertices.outputProtoVertices = "protovertices";
   sequencer.addAlgorithm(std::make_shared<AdaptiveMultiVertexFinderAlgorithm>(

--- a/Examples/Run/Vertexing/Pythia8/IterativeVertexFinderExample.cpp
+++ b/Examples/Run/Vertexing/Pythia8/IterativeVertexFinderExample.cpp
@@ -72,7 +72,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<ParticleSmearing>(smearParticles, logLevel));
 
   // find vertices
-  IterativeVertexFinderAlgorithm::Config findVertices(magneticField);
+  IterativeVertexFinderAlgorithm::Config findVertices;
+  findVertices.bField = magneticField;
   findVertices.inputTrackParameters = smearParticles.outputTrackParameters;
   findVertices.outputProtoVertices = "protovertices";
   sequencer.addAlgorithm(

--- a/Examples/Run/Vertexing/Pythia8/TutorialVertexFinderExample.cpp
+++ b/Examples/Run/Vertexing/Pythia8/TutorialVertexFinderExample.cpp
@@ -72,7 +72,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<ParticleSmearing>(smearParticles, logLevel));
 
   // find vertices
-  TutorialVertexFinderAlgorithm::Config findVertices(magneticField);
+  TutorialVertexFinderAlgorithm::Config findVertices;
+  findVertices.bField = magneticField;
   findVertices.inputTrackParameters = smearParticles.outputTrackParameters;
   findVertices.outputProtoVertices = "protovertices";
   sequencer.addAlgorithm(

--- a/Examples/Run/Vertexing/Pythia8/VertexFitterExample.cpp
+++ b/Examples/Run/Vertexing/Pythia8/VertexFitterExample.cpp
@@ -81,7 +81,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<TruthVertexFinder>(findVertices, logLevel));
 
   // fit vertices using the Billoir fitter
-  VertexFitterAlgorithm::Config fitVertices(magneticField);
+  VertexFitterAlgorithm::Config fitVertices;
+  fitVertices.bField = magneticField;
   fitVertices.inputTrackParameters = smearParticles.outputTrackParameters;
   fitVertices.inputProtoVertices = findVertices.outputProtoVertices;
   sequencer.addAlgorithm(

--- a/Examples/Run/Vertexing/TrackReaderVertexingPerformanceWriterExample.cpp
+++ b/Examples/Run/Vertexing/TrackReaderVertexingPerformanceWriterExample.cpp
@@ -61,11 +61,10 @@ int main(int argc, char* argv[]) {
 
   RootParticleReader::Config particleReaderConfig;
   particleReaderConfig.particleCollection = "allTruthParticles";
-  particleReaderConfig.inputFile = "particles_initial.root";
+  particleReaderConfig.filePath = inputDir + "/particles_initial.root";
   particleReaderConfig.treeName = "particles";
-  particleReaderConfig.inputDir = inputDir;
-  sequencer.addReader(
-      std::make_shared<RootParticleReader>(particleReaderConfig));
+  sequencer.addReader(std::make_shared<RootParticleReader>(
+      particleReaderConfig, Acts::Logging::INFO));
 
   // add additional particle selection
   auto select = ActsExamples::ParticleSelector::readConfig(vars);
@@ -77,10 +76,9 @@ int main(int argc, char* argv[]) {
   RootTrajectorySummaryReader::Config trackSummaryReader;
   trackSummaryReader.outputTracks = "fittedTrackParameters";
   trackSummaryReader.outputParticles = "associatedTruthParticles";
-  trackSummaryReader.inputFile = "tracksummary_fitter.root";
-  trackSummaryReader.inputDir = inputDir;
-  sequencer.addReader(
-      std::make_shared<RootTrajectorySummaryReader>(trackSummaryReader));
+  trackSummaryReader.filePath = inputDir + "/tracksummary_fitter.root";
+  sequencer.addReader(std::make_shared<RootTrajectorySummaryReader>(
+      trackSummaryReader, logLevel));
 
   // Apply some primary vertexing selection cuts
   TrackSelector::Config trackSelectorConfig;
@@ -95,7 +93,8 @@ int main(int argc, char* argv[]) {
       std::make_shared<TrackSelector>(trackSelectorConfig, logLevel));
 
   // find vertices
-  AdaptiveMultiVertexFinderAlgorithm::Config findVertices(magneticField);
+  AdaptiveMultiVertexFinderAlgorithm::Config findVertices;
+  findVertices.bField = magneticField;
   findVertices.inputTrackParameters = trackSelectorConfig.outputTrackParameters;
   findVertices.outputProtoVertices = "fittedProtoVertices";
   findVertices.outputVertices = "fittedVertices";
@@ -113,9 +112,8 @@ int main(int argc, char* argv[]) {
   vertexWriterConfig.inputFittedTracks = trackSummaryReader.outputTracks;
   vertexWriterConfig.inputVertices = findVertices.outputVertices;
   vertexWriterConfig.inputTime = findVertices.outputTime;
-  vertexWriterConfig.outputFilename = "vertexperformance_AMVF.root";
-  vertexWriterConfig.outputTreename = "amvf";
-  vertexWriterConfig.outputDir = outputDir;
+  vertexWriterConfig.filePath = outputDir + "/vertexperformance_AMVF.root";
+  vertexWriterConfig.treeName = "amvf";
   sequencer.addWriter(std::make_shared<RootVertexPerformanceWriter>(
       vertexWriterConfig, logLevel));
 


### PR DESCRIPTION
This PR harmonizes the algorithm, reader and writer interfaces to a large degree. They should now all accept the same constructor arguments, their configuration should be largely equivalent (ROOT r/w should take `filePath`, `fileMode` and `treeName`, where applicable, CSV r/w should take `inputDir`/`outputDir`, as we write one file per event.

Other changes include increased verbose output, and ROOT writers closing their `TFile`s in `endRun` (@Corentin-Allaire  and me discussed that this is generally desirable). 