### PR TITLE
refactor: Make the DigitizationConfigurator usable

### DIFF
--- a/Examples/Algorithms/CMakeLists.txt
+++ b/Examples/Algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory(Digitization)
+add_subdirectory_if(Digitization ACTS_BUILD_PLUGIN_DIGITIZATION AND ACTS_BUILD_PLUGIN_IDENTIFICATION)
 add_subdirectory_if(HepMC ACTS_BUILD_EXAMPLES_HEPMC3)
 add_subdirectory(Fatras)
 add_subdirectory_if(Geant4HepMC ACTS_BUILD_EXAMPLES_GEANT4 AND ACTS_BUILD_EXAMPLES_HEPMC3)

--- a/Examples/Algorithms/Digitization/CMakeLists.txt
+++ b/Examples/Algorithms/Digitization/CMakeLists.txt
@@ -12,10 +12,9 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(
   ActsExamplesDigitization
-  PRIVATE
-    ActsCore ActsPluginDigitization ActsPluginIdentification
-    ActsExamplesFramework
-    Boost::program_options)
+  PUBLIC
+    ActsCore ActsPluginDigitization ActsPluginIdentification ActsExamplesFramework)
+target_link_libraries(ActsExamplesDigitization PRIVATE Boost::program_options)
 
 install(
   TARGETS ActsExamplesDigitization

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
@@ -108,6 +108,9 @@ class DigitizationConfig {
       const Options::Variables &vars,
       Acts::GeometryHierarchyMap<DigiComponentsConfig> &&digiCfgs);
 
+  DigitizationConfig(
+      Acts::GeometryHierarchyMap<DigiComponentsConfig> &&digiCfgs);
+
   /// Input collection of simulated hits.
   std::string inputSimHits = "simhits";
   /// Output source links collection.
@@ -137,7 +140,7 @@ class DigitizationConfig {
 
   std::vector<
       std::pair<Acts::GeometryIdentifier, std::vector<Acts::BoundIndices>>>
-  getBoundIndices();
+  getBoundIndices() const;
 
  private:
   // Private initializer for SmearingAlgorithm

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfigurator.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfigurator.hpp
@@ -24,10 +24,10 @@
 #include "ActsExamples/Digitization/DigitizationOptions.hpp"
 #include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
 
+#include <map>
 #include <memory>
 
 namespace ActsExamples {
-namespace detail {
 
 /// Helper configurator that takes a simplified (per volume, per layer)
 /// Input digitization file and creates a full fletched per module
@@ -45,8 +45,8 @@ struct DigitizationConfigurator {
   Acts::GeometryHierarchyMap<DigiComponentsConfig> inputDigiComponents;
 
   /// Final collection of output components
-  using CollectedOutputComponents =
-      std::vector<std::pair<Acts::GeometryIdentifier, DigiComponentsConfig>>;
+  std::vector<std::pair<Acts::GeometryIdentifier, DigiComponentsConfig>>
+      outputDigiComponents;
 
   /// This tries to compactify the output map
   bool compactify = false;
@@ -54,9 +54,6 @@ struct DigitizationConfigurator {
   /// High level reference configurations for compactification
   std::map<Acts::GeometryIdentifier, DigiComponentsConfig>
       volumeLayerComponents;
-
-  /// Full output components for digitization
-  std::shared_ptr<CollectedOutputComponents> outputDigiComponents = nullptr;
 
   /// The visitor call for the geometry
   ///
@@ -265,7 +262,7 @@ struct DigitizationConfigurator {
             return;
           } else {
             volumeLayerComponents[volGeoId] = dOutputConfig;
-            outputDigiComponents->push_back({volGeoId, dOutputConfig});
+            outputDigiComponents.push_back({volGeoId, dOutputConfig});
           }
 
           // Check for a representing layer configuration, insert if not present
@@ -278,15 +275,14 @@ struct DigitizationConfigurator {
             return;
           } else {
             volumeLayerComponents[volLayGeoId] = dOutputConfig;
-            outputDigiComponents->push_back({volLayGeoId, dOutputConfig});
+            outputDigiComponents.push_back({volLayGeoId, dOutputConfig});
           }
         }
 
         // Insert into the output list
-        outputDigiComponents->push_back({geoId, dOutputConfig});
+        outputDigiComponents.push_back({geoId, dOutputConfig});
       }
     }
   }
 };
-}  // namespace detail
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Digitization/src/DigitizationConfig.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationConfig.cpp
@@ -71,6 +71,15 @@ ActsExamples::DigitizationConfig::DigitizationConfig(
     smearingConfig(vars);
 }
 
+ActsExamples::DigitizationConfig::DigitizationConfig(
+    Acts::GeometryHierarchyMap<DigiComponentsConfig>&& digiCfgs)
+    : isSimpleSmearer(false),
+      doMerge(false),
+      mergeNsigma(1.0),
+      mergeCommonCorner(false) {
+  digitizationConfigs = std::move(digiCfgs);
+}
+
 void ActsExamples::DigitizationConfig::smearingConfig(
     const Options::Variables& variables) {
   ACTS_LOCAL_LOGGER(
@@ -194,7 +203,7 @@ ActsExamples::createDigitizationAlgorithm(ActsExamples::DigitizationConfig& cfg,
 
 std::vector<
     std::pair<Acts::GeometryIdentifier, std::vector<Acts::BoundIndices>>>
-ActsExamples::DigitizationConfig::getBoundIndices() {
+ActsExamples::DigitizationConfig::getBoundIndices() const {
   std::vector<
       std::pair<Acts::GeometryIdentifier, std::vector<Acts::BoundIndices>>>
       bIndexInput;

--- a/Examples/Run/Digitization/Common/DigitizationConfigExample.cpp
+++ b/Examples/Run/Digitization/Common/DigitizationConfigExample.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Geometry/GeometryHierarchyMap.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "ActsExamples/Detector/IBaseDetector.hpp"
+#include "ActsExamples/Digitization/DigitizationConfigurator.hpp"
 #include "ActsExamples/Geometry/CommonGeometry.hpp"
 #include "ActsExamples/Io/Json/JsonDigitizationConfig.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
@@ -21,7 +22,6 @@
 #include <boost/program_options.hpp>
 
 #include "DigitizationInput.hpp"
-#include "detail/DigitizationConfigurator.hpp"
 
 using namespace ActsExamples;
 
@@ -55,17 +55,14 @@ int runDigitizationConfigExample(
   auto geometry = Geometry::build(vm, *detector);
 
   // Build a parser and visit the geometry
-  ActsExamples::detail::DigitizationConfigurator digiConfigurator;
+  ActsExamples::DigitizationConfigurator digiConfigurator;
   digiConfigurator.compactify = vm["digi-compactify-output"].as<bool>();
   digiConfigurator.inputDigiComponents = inputConfig;
-  digiConfigurator.outputDigiComponents =
-      std::make_shared<ActsExamples::detail::DigitizationConfigurator::
-                           CollectedOutputComponents>();
 
   geometry.first->visitSurfaces(digiConfigurator);
 
   Acts::GeometryHierarchyMap<DigiComponentsConfig> outputConfig(
-      *digiConfigurator.outputDigiComponents);
+      digiConfigurator.outputDigiComponents);
 
   if (not vm["dump-digi-config"].as<std::string>().empty()) {
     writeDigiConfigToJson(outputConfig,


### PR DESCRIPTION
This was previously only privately used in the
DigitizationConfigExample, but can be useful in other context.
At the same time, this introduces a constructor for `DigitizationConfig`
that only takes a finished geometry hierachy map (and no program options), which can for instance
be built with the configurator.