### PR TITLE
feat: Sequencer gets configurable iteration callback

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -26,6 +26,8 @@
 
 namespace ActsExamples {
 
+using IterationCallback = void (*)();
+
 /// A simple algorithm sequencer for event processing.
 ///
 /// This is the backbone of the framework. It reads events from file,
@@ -44,6 +46,7 @@ class Sequencer {
     int numThreads = -1;
     /// output directory for timing information, empty for working directory
     std::string outputDir;
+    IterationCallback iterationCallback = []() {};
   };
 
   Sequencer(const Config& cfg);

--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -46,6 +46,8 @@ class Sequencer {
     int numThreads = -1;
     /// output directory for timing information, empty for working directory
     std::string outputDir;
+    /// Callback that is invoked in the event loop.
+    /// @warning This function can be called from multiple threads and should therefore be thread-safe
     IterationCallback iterationCallback = []() {};
   };
 

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -287,6 +287,7 @@ int ActsExamples::Sequencer::run() {
             /// Decorate the context
             for (auto& cdr : m_decorators) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
+              ACTS_VERBOSE("Execute context decorator: " << cdr->name());
               if (cdr->decorate(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to decorate event context");
               }
@@ -295,6 +296,7 @@ int ActsExamples::Sequencer::run() {
             ACTS_VERBOSE("Execute readers");
             for (auto& rdr : m_readers) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
+              ACTS_VERBOSE("Execute reader: " << rdr->name());
               if (rdr->read(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to read input data");
               }
@@ -303,7 +305,7 @@ int ActsExamples::Sequencer::run() {
             ACTS_VERBOSE("Execute algorithms");
             for (auto& alg : m_algorithms) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
-              ACTS_VERBOSE("Execute Algorithm: " << alg->name());
+              ACTS_VERBOSE("Execute algorithm: " << alg->name());
               if (alg->execute(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to process event data");
               }
@@ -312,6 +314,7 @@ int ActsExamples::Sequencer::run() {
             ACTS_VERBOSE("Execute writers");
             for (auto& wrt : m_writers) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
+              ACTS_VERBOSE("Execute writer: " << wrt->name());
               if (wrt->write(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to write output data");
               }

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -270,6 +270,7 @@ int ActsExamples::Sequencer::run() {
                                                       Duration::zero());
 
           for (size_t event = r.begin(); event != r.end(); ++event) {
+            m_cfg.iterationCallback();
             // Use per-event store
             WhiteBoard eventStore(Acts::getDefaultLogger(
                 "EventStore#" + std::to_string(event), m_cfg.logLevel));
@@ -290,21 +291,25 @@ int ActsExamples::Sequencer::run() {
                 throw std::runtime_error("Failed to decorate event context");
               }
             }
-            // Read everything in
+
+            ACTS_VERBOSE("Execute readers");
             for (auto& rdr : m_readers) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
               if (rdr->read(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to read input data");
               }
             }
-            // Execute all algorithms
+
+            ACTS_VERBOSE("Execute algorithms");
             for (auto& alg : m_algorithms) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
+              ACTS_VERBOSE("Execute Algorithm: " << alg->name());
               if (alg->execute(++context) != ProcessCode::SUCCESS) {
                 throw std::runtime_error("Failed to process event data");
               }
             }
-            // Write out results
+
+            ACTS_VERBOSE("Execute writers");
             for (auto& wrt : m_writers) {
               StopWatch sw(localClocksAlgorithms[ialgo++]);
               if (wrt->write(++context) != ProcessCode::SUCCESS) {


### PR DESCRIPTION
The default is a noop function pointer.
The background is that for the python bindings, I need to hook into the
event loop to be able to correctly respond to Ctrl+C. This is the most
decoupled way to do this I could think of.

Also increases the amount of output `Sequencer` produces in verbose
mode.