### PR TITLE
refactor: Always create bound states in (C)KF

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -691,26 +691,20 @@ class CombinatorialKalmanFilter {
           tipState.nStates++;
           size_t currentTip = SIZE_MAX;
           if (isSensitive) {
-            // Transport & bind the state to the current surface
-            auto res = stepper.boundState(state.stepping, *surface);
-            if (!res.ok()) {
-              ACTS_ERROR("Error in filter: " << res.error());
-              return res.error();
-            }
-            const auto boundState = *res;
-            // Add a hole track state to the multitrajectory
-            currentTip =
-                addHoleState(stateMask, boundState, result, prevTip, logger);
             // Incremet of number of holes
             tipState.nHoles++;
-          } else if (surface->surfaceMaterial() != nullptr) {
-            // Transport & get curvilinear state instead of bound state
-            const auto curvilinearState =
-                stepper.curvilinearState(state.stepping);
-            // Add a passive material track state to the multitrajectory
-            currentTip = addPassiveState(stateMask, curvilinearState, result,
-                                         prevTip, logger);
           }
+
+          // Transport & bind the state to the current surface
+          auto res = stepper.boundState(state.stepping, *surface);
+          if (!res.ok()) {
+            ACTS_ERROR("Error in filter: " << res.error());
+            return res.error();
+          }
+          const auto boundState = *res;
+          // Add a hole track state to the multitrajectory
+          currentTip = addNonSourcelinkState(stateMask, boundState, result,
+                                             prevTip, logger);
 
           // Check the branch
           if (not m_branchStopper(tipState)) {
@@ -873,10 +867,10 @@ class CombinatorialKalmanFilter {
     /// @param logger The logger wrapper
     ///
     /// @return The tip of added state
-    size_t addHoleState(const TrackStatePropMask& stateMask,
-                        const BoundState& boundState, result_type& result,
-                        size_t prevTip = SIZE_MAX,
-                        LoggerWrapper logger = getDummyLogger()) const {
+    size_t addNonSourcelinkState(
+        const TrackStatePropMask& stateMask, const BoundState& boundState,
+        result_type& result, size_t prevTip = SIZE_MAX,
+        LoggerWrapper logger = getDummyLogger()) const {
       // Add a track state
       auto currentTip = result.fittedStates.addTrackState(stateMask, prevTip);
       ACTS_VERBOSE("Creating Hole track state with tip = " << currentTip);
@@ -906,54 +900,6 @@ class CombinatorialKalmanFilter {
       typeFlags.set(TrackStateFlag::ParameterFlag);
       typeFlags.set(TrackStateFlag::HoleFlag);
 
-      trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
-
-      return currentTip;
-    }
-
-    /// @brief CombinatorialKalmanFilter actor operation : add passive track
-    /// state
-    ///
-    /// @param stateMask The bitmask that instructs which components to allocate
-    /// @param curvilinearState The curvilinear state on in-sensive material
-    /// surface
-    /// @param result is the mutable result state object
-    /// and which to leave invalid
-    /// @param prevTip The index of the previous state
-    /// @param logger The logger wrapper
-    ///
-    /// @return The tip of added state
-    size_t addPassiveState(const TrackStatePropMask& stateMask,
-                           const CurvilinearState& curvilinearState,
-                           result_type& result, size_t prevTip = SIZE_MAX,
-                           LoggerWrapper logger = getDummyLogger()) const {
-      // Add a track state
-      auto currentTip = result.fittedStates.addTrackState(stateMask, prevTip);
-      ACTS_VERBOSE(
-          "Creating track state on in-sensitive material surface with tip = "
-          << currentTip);
-
-      // now get track state proxy back
-      auto trackStateProxy = result.fittedStates.getTrackState(currentTip);
-
-      // Set the track state flags
-      auto& typeFlags = trackStateProxy.typeFlags();
-      typeFlags.set(TrackStateFlag::MaterialFlag);
-      typeFlags.set(TrackStateFlag::ParameterFlag);
-
-      const auto& [curvilinearParams, jacobian, pathLength] = curvilinearState;
-      // Fill the track state
-      trackStateProxy.predicted() = curvilinearParams.parameters();
-      if (curvilinearParams.covariance().has_value()) {
-        trackStateProxy.predictedCovariance() = *curvilinearParams.covariance();
-      }
-      trackStateProxy.jacobian() = jacobian;
-      trackStateProxy.pathLength() = pathLength;
-      // Set the surface; reuse the existing curvilinear surface
-      trackStateProxy.setReferenceSurface(
-          curvilinearParams.referenceSurface().getSharedPtr());
-      // Set the filtered parameter index to be the same with predicted
-      // parameter
       trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
 
       return currentTip;

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -604,41 +604,28 @@ class KalmanFitter {
 
             // Count the missed surface
             result.missedActiveSurfaces.push_back(surface);
-
-            // Transport & bind the state to the current surface
-            auto res = stepper.boundState(state.stepping, *surface);
-            if (!res.ok()) {
-              ACTS_ERROR("Propagate to hole surface failed: " << res.error());
-              return res.error();
-            }
-            auto& [boundParams, jacobian, pathLength] = *res;
-
-            // Fill the track state
-            trackStateProxy.predicted() = std::move(boundParams.parameters());
-            if (boundParams.covariance().has_value()) {
-              trackStateProxy.predictedCovariance() =
-                  std::move(*boundParams.covariance());
-            }
-            trackStateProxy.jacobian() = std::move(jacobian);
-            trackStateProxy.pathLength() = std::move(pathLength);
           } else if (surface->surfaceMaterial() != nullptr) {
             ACTS_VERBOSE("Detected in-sensitive surface "
                          << surface->geometryId());
-
-            // Transport & get curvilinear state instead of bound state
-            auto [curvilinearParams, jacobian, pathLength] =
-                stepper.curvilinearState(state.stepping);
-
-            // Fill the track state
-            trackStateProxy.predicted() =
-                std::move(curvilinearParams.parameters());
-            if (curvilinearParams.covariance().has_value()) {
-              trackStateProxy.predictedCovariance() =
-                  std::move(*curvilinearParams.covariance());
-            }
-            trackStateProxy.jacobian() = std::move(jacobian);
-            trackStateProxy.pathLength() = std::move(pathLength);
           }
+
+          // Transport & bind the state to the current surface
+          auto res = stepper.boundState(state.stepping, *surface);
+          if (!res.ok()) {
+            ACTS_ERROR("Propagate to surface " << surface->geometryId()
+                                               << " failed: " << res.error());
+            return res.error();
+          }
+          auto& [boundParams, jacobian, pathLength] = *res;
+
+          // Fill the track state
+          trackStateProxy.predicted() = std::move(boundParams.parameters());
+          if (boundParams.covariance().has_value()) {
+            trackStateProxy.predictedCovariance() =
+                std::move(*boundParams.covariance());
+          }
+          trackStateProxy.jacobian() = std::move(jacobian);
+          trackStateProxy.pathLength() = std::move(pathLength);
 
           // Set the filtered parameter index to be the same with predicted
           // parameter


### PR DESCRIPTION
In the current (C)KF, a curvilinear state is created if the track reaches the passive material surface. This was initially implemented due to the reason that a bound state on a Cylinder surface is not working properly. However, this seems to be not the case any more. Hence, bound states are alwasy created, which should be more accurate.



