### PR TITLE
refactor!: Use common units for seed finding

### DIFF
--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -209,7 +209,7 @@ namespace PhysicalConstants {
 /// Reduced Planck constant h/2*pi.
 ///
 /// Computed from CODATA 2018 constants to double precision.
-inline constexpr double hbar =
+constexpr double hbar =
     6.582119569509066e-25 * UnitConstants::GeV * UnitConstants::s;
 }  // namespace PhysicalConstants
 

--- a/Core/include/Acts/Seeding/BinnedSPGroup.hpp
+++ b/Core/include/Acts/Seeding/BinnedSPGroup.hpp
@@ -249,7 +249,7 @@ class BinnedSPGroup {
       std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> botBinFinder,
       std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> tBinFinder,
       std::unique_ptr<SpacePointGrid<external_spacepoint_t>> grid,
-      const SeedfinderConfig<external_spacepoint_t>& config);
+      const SeedfinderConfig<external_spacepoint_t>& _config);
 
   size_t size() { return m_binnedSP.size(); }
 

--- a/Core/include/Acts/Seeding/BinnedSPGroup.ipp
+++ b/Core/include/Acts/Seeding/BinnedSPGroup.ipp
@@ -16,7 +16,8 @@ Acts::BinnedSPGroup<external_spacepoint_t>::BinnedSPGroup(
     std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> botBinFinder,
     std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> tBinFinder,
     std::unique_ptr<SpacePointGrid<external_spacepoint_t>> grid,
-    const SeedfinderConfig<external_spacepoint_t>& config) {
+    const SeedfinderConfig<external_spacepoint_t>& _config) {
+  auto config = _config.toInternalUnits();
   static_assert(
       std::is_same<
           typename std::iterator_traits<spacepoint_iterator_t>::value_type,

--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -14,7 +14,7 @@ template <typename external_spacepoint_t>
 SeedFilter<external_spacepoint_t>::SeedFilter(
     SeedFilterConfig config,
     IExperimentCuts<external_spacepoint_t>* expCuts /* = 0*/)
-    : m_cfg(config), m_experimentCuts(expCuts) {}
+    : m_cfg(config.toInternalUnits()), m_experimentCuts(expCuts) {}
 
 // function to filter seeds based on all seeds with same bottom- and
 // middle-spacepoint.

--- a/Core/include/Acts/Seeding/SeedFilterConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFilterConfig.hpp
@@ -34,7 +34,7 @@ struct SeedFilterConfig {
   size_t compatSeedLimit = 2;
   // Tool to apply experiment specific cuts on collected middle space points
 
-  SeedFilterConfig toInternalUnits() {
+  SeedFilterConfig toInternalUnits() const {
     using namespace Acts::UnitLiterals;
     SeedFilterConfig config = *this;
     config.deltaRMin /= 1_mm;

--- a/Core/include/Acts/Seeding/SeedFilterConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFilterConfig.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "Acts/Definitions/Units.hpp"
+
 // System include(s).
 #include <cstddef>
 
@@ -16,14 +18,14 @@ namespace Acts {
 struct SeedFilterConfig {
   // the allowed delta between two inverted seed radii for them to be considered
   // compatible.
-  float deltaInvHelixDiameter = 0.00003;
+  float deltaInvHelixDiameter = 0.00003 * 1. / Acts::UnitConstants::mm;
   // the impact parameters (d0) is multiplied by this factor and subtracted from
   // weight
   float impactWeightFactor = 1.;
   // seed weight increased by this value if a compatible seed has been found.
   float compatSeedWeight = 200.;
   // minimum distance between compatible seeds to be considered for weight boost
-  float deltaRMin = 5.;
+  float deltaRMin = 5. * Acts::UnitConstants::mm;
   // in dense environments many seeds may be found per middle space point.
   // only seeds with the highest weight will be kept if this limit is reached.
   unsigned int maxSeedsPerSpM = 10;
@@ -31,6 +33,15 @@ struct SeedFilterConfig {
   // compatible seed?
   size_t compatSeedLimit = 2;
   // Tool to apply experiment specific cuts on collected middle space points
+
+  SeedFilterConfig toInternalUnits() {
+    using namespace Acts::UnitLiterals;
+    SeedFilterConfig config = *this;
+    config.deltaRMin /= 1_mm;
+    config.deltaInvHelixDiameter /= 1. / 1_mm;
+
+    return config;
+  }
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -17,7 +17,7 @@ namespace Acts {
 template <typename external_spacepoint_t, typename platform_t>
 Seedfinder<external_spacepoint_t, platform_t>::Seedfinder(
     Acts::SeedfinderConfig<external_spacepoint_t> config)
-    : m_config(std::move(config)) {
+    : m_config(config.toInternalUnits()) {
   // calculation of scattering using the highland formula
   // convert pT to p once theta angle is known
   m_config.highland = 13.6 * std::sqrt(m_config.radLengthPerSeed) *

--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -29,7 +29,7 @@ struct SeedfinderConfig {
   // cot of maximum theta angle
   // equivalent to 2.7 eta (pseudorapidity)
   float cotThetaMax = 7.40627;
-  // minimum distancein r between two measurements within one seed
+  // minimum distance in r between two measurements within one seed
   float deltaRMin = 5 * Acts::UnitConstants::mm;
   // maximum distance in r between two measurements within one seed
   float deltaRMax = 270 * Acts::UnitConstants::mm;

--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Definitions/Units.hpp"
 
 #include <memory>
 
@@ -25,14 +26,14 @@ struct SeedfinderConfig {
   // Seed Cuts
   // lower cutoff for seeds in MeV
   // FIXME: Acts units
-  float minPt = 400.;
+  float minPt = 400. * Acts::UnitConstants::MeV;
   // cot of maximum theta angle
   // equivalent to 2.7 eta (pseudorapidity)
   float cotThetaMax = 7.40627;
   // minimum distance in mm in r between two measurements within one seed
-  float deltaRMin = 5;
+  float deltaRMin = 5 * Acts::UnitConstants::mm;
   // maximum distance in mm in r between two measurements within one seed
-  float deltaRMax = 270;
+  float deltaRMax = 270 * Acts::UnitConstants::mm;
 
   // FIXME: this is not used yet
   //        float upperPtResolutionPerSeed = 20* Acts::GeV;
@@ -44,12 +45,12 @@ struct SeedfinderConfig {
 
   // impact parameter in mm
   // FIXME: Acts units
-  float impactMax = 20.;
+  float impactMax = 20. * Acts::UnitConstants::mm;
 
   // how many sigmas of scattering angle should be considered?
   float sigmaScattering = 5;
   // Upper pt limit for scattering calculation
-  float maxPtScattering = 10000;
+  float maxPtScattering = 10 * Acts::UnitConstants::GeV;
 
   // for how many seeds can one SpacePoint be the middle SpacePoint?
   int maxSeedsPerSpM = 5;
@@ -57,24 +58,25 @@ struct SeedfinderConfig {
   // Geometry Settings
   // Detector ROI
   // limiting location of collision region in z
-  float collisionRegionMin = -150;
-  float collisionRegionMax = +150;
+  float collisionRegionMin = -150 * Acts::UnitConstants::mm;
+  float collisionRegionMax = +150 * Acts::UnitConstants::mm;
   float phiMin = -M_PI;
   float phiMax = M_PI;
   // limiting location of measurements
-  float zMin = -2800;
-  float zMax = 2800;
-  float rMax = 600;
+  float zMin = -2800 * Acts::UnitConstants::mm;
+  float zMax = 2800 * Acts::UnitConstants::mm;
+  float rMax = 600 * Acts::UnitConstants::mm;
   // WARNING: if rMin is smaller than impactMax, the bin size will be 2*pi,
   // which will make seeding very slow!
-  float rMin = 33;
+  float rMin = 33 * Acts::UnitConstants::mm;
 
   // Unit in kiloTesla
   // FIXME: Acts units
-  float bFieldInZ = 0.00208;
+  float bFieldInZ = 2.08 * Acts::UnitConstants::T;
   // location of beam in x,y plane.
   // used as offset for Space Points
-  Acts::Vector2 beamPos{0, 0};
+  Acts::Vector2 beamPos{0 * Acts::UnitConstants::mm,
+                        0 * Acts::UnitConstants::mm};
 
   // average radiation lengths of material on the length of a seed. used for
   // scattering.
@@ -87,8 +89,8 @@ struct SeedfinderConfig {
   // will be added to spacepoint measurement uncertainties (and therefore also
   // multiplied by sigmaError)
   // FIXME: call align1 and align2
-  float zAlign = 0;
-  float rAlign = 0;
+  float zAlign = 0 * Acts::UnitConstants::mm;
+  float rAlign = 0 * Acts::UnitConstants::mm;
   // used for measurement (+alignment) uncertainties.
   // find seeds within 5sigma error ellipse
   float sigmaError = 5;
@@ -104,6 +106,31 @@ struct SeedfinderConfig {
   int maxBlockSize = 1024;
   int nTrplPerSpBLimit = 100;
   int nAvgTrplPerSpBLimit = 2;
+
+  SeedfinderConfig toInternalUnits() const {
+    using namespace Acts::UnitLiterals;
+    SeedfinderConfig config = *this;
+    config.minPt /= 1_MeV;
+    config.deltaRMin /= 1_mm;
+    config.deltaRMax /= 1_mm;
+    config.impactMax /= 1_mm;
+    config.maxPtScattering /= 1_MeV;  // correct?
+    config.collisionRegionMin /= 1_MeV;
+    config.collisionRegionMax /= 1_MeV;
+    config.zMin /= 1_mm;
+    config.zMax /= 1_mm;
+    config.rMax /= 1_mm;
+    config.rMin /= 1_mm;
+    config.bFieldInZ /= 1000. * 1_T;
+
+    config.beamPos[0] /= 1_mm;
+    config.beamPos[1] /= 1_mm;
+
+    config.zAlign /= 1_mm;
+    config.rAlign /= 1_mm;
+
+    return config;
+  }
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -24,15 +24,14 @@ struct SeedfinderConfig {
   std::shared_ptr<Acts::SeedFilter<SpacePoint>> seedFilter;
 
   // Seed Cuts
-  // lower cutoff for seeds in MeV
-  // FIXME: Acts units
+  // lower cutoff for seeds
   float minPt = 400. * Acts::UnitConstants::MeV;
   // cot of maximum theta angle
   // equivalent to 2.7 eta (pseudorapidity)
   float cotThetaMax = 7.40627;
-  // minimum distance in mm in r between two measurements within one seed
+  // minimum distancein r between two measurements within one seed
   float deltaRMin = 5 * Acts::UnitConstants::mm;
-  // maximum distance in mm in r between two measurements within one seed
+  // maximum distance in r between two measurements within one seed
   float deltaRMax = 270 * Acts::UnitConstants::mm;
 
   // FIXME: this is not used yet
@@ -43,8 +42,7 @@ struct SeedfinderConfig {
   // leads to this value being the cutoff. unit is 1/mm. default value
   // of 0.00003 leads to all helices with radius>33m to be considered compatible
 
-  // impact parameter in mm
-  // FIXME: Acts units
+  // impact parameter
   float impactMax = 20. * Acts::UnitConstants::mm;
 
   // how many sigmas of scattering angle should be considered?
@@ -70,8 +68,6 @@ struct SeedfinderConfig {
   // which will make seeding very slow!
   float rMin = 33 * Acts::UnitConstants::mm;
 
-  // Unit in kiloTesla
-  // FIXME: Acts units
   float bFieldInZ = 2.08 * Acts::UnitConstants::T;
   // location of beam in x,y plane.
   // used as offset for Space Points

--- a/Core/include/Acts/Seeding/SpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/Definitions/Units.hpp"
 #include "Acts/Seeding/InternalSpacePoint.hpp"
 #include "Acts/Utilities/detail/Axis.hpp"
 #include "Acts/Utilities/detail/Grid.hpp"
@@ -17,24 +18,37 @@
 namespace Acts {
 
 struct SpacePointGridConfig {
-  // magnetic field in kTesla
+  // magnetic field
   float bFieldInZ;
-  // minimum pT to be found by seedfinder in MeV
+  // minimum pT to be found by seedfinder
   float minPt;
   // maximum extension of sensitive detector layer relevant for seeding as
-  // distance from x=y=0 (i.e. in r) in mm
+  // distance from x=y=0 (i.e. in r)
   float rMax;
   // maximum extension of sensitive detector layer relevant for seeding in
-  // positive direction in z in mm
+  // positive direction in z
   float zMax;
   // maximum extension of sensitive detector layer relevant for seeding in
-  // negative direction in z in mm
+  // negative direction in z
   float zMin;
   // maximum distance in r from middle space point to bottom or top spacepoint
-  // in mm
   float deltaRMax;
   // maximum forward direction expressed as cot(theta)
   float cotThetaMax;
+
+  SpacePointGridConfig toInternalUnits() const {
+    using namespace Acts::UnitLiterals;
+    SpacePointGridConfig config = *this;
+
+    config.bFieldInZ /= 1000_T;
+    config.minPt /= 1_MeV;
+    config.rMax /= 1_mm;
+    config.zMax /= 1_mm;
+    config.zMin /= 1_mm;
+    config.deltaRMax /= 1_mm;
+
+    return config;
+  }
 };
 template <typename external_spacepoint_t>
 using SpacePointGrid =
@@ -49,7 +63,7 @@ class SpacePointGridCreator {
  public:
   template <typename external_spacepoint_t>
   static std::unique_ptr<SpacePointGrid<external_spacepoint_t>> createGrid(
-      const Acts::SpacePointGridConfig& config);
+      const Acts::SpacePointGridConfig& _config);
 };
 }  // namespace Acts
 #include "Acts/Seeding/SpacePointGrid.ipp"

--- a/Core/include/Acts/Seeding/SpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/SpacePointGrid.ipp
@@ -13,7 +13,9 @@
 template <typename SpacePoint>
 std::unique_ptr<Acts::SpacePointGrid<SpacePoint>>
 Acts::SpacePointGridCreator::createGrid(
-    const Acts::SpacePointGridConfig& config) {
+    const Acts::SpacePointGridConfig& _config) {
+  Acts::SpacePointGridConfig config = _config.toInternalUnits();
+
   int phiBins;
   // for no magnetic field, create 100 phi-bins
   if (config.bFieldInZ == 0) {

--- a/Examples/Run/Reconstruction/Common/SeedingExample.cpp
+++ b/Examples/Run/Reconstruction/Common/SeedingExample.cpp
@@ -121,21 +121,21 @@ int runSeedingExample(int argc, char* argv[],
   };
   seedingCfg.outputSeeds = "seeds";
   seedingCfg.outputProtoTracks = "prototracks";
-  seedingCfg.rMax = 100.;
-  seedingCfg.deltaRMax = 60.;
-  seedingCfg.collisionRegionMin = -250;
-  seedingCfg.collisionRegionMax = 250.;
-  seedingCfg.zMin = -2000.;
-  seedingCfg.zMax = 2000.;
+  seedingCfg.rMax = 100._mm;
+  seedingCfg.deltaRMax = 60._mm;
+  seedingCfg.collisionRegionMin = -250_mm;
+  seedingCfg.collisionRegionMax = 250._mm;
+  seedingCfg.zMin = -2000._mm;
+  seedingCfg.zMax = 2000._mm;
   seedingCfg.maxSeedsPerSpM = 1;
   seedingCfg.cotThetaMax = 7.40627;  // 2.7 eta
   seedingCfg.sigmaScattering = 50;
   seedingCfg.radLengthPerSeed = 0.1;
-  seedingCfg.minPt = 500.;
-  seedingCfg.bFieldInZ = 0.00199724;
+  seedingCfg.minPt = 500._MeV;
+  seedingCfg.bFieldInZ = 1.99724_T;
   seedingCfg.beamPosX = 0;
   seedingCfg.beamPosY = 0;
-  seedingCfg.impactMax = 3.;
+  seedingCfg.impactMax = 3._mm;
   sequencer.addAlgorithm(
       std::make_shared<SeedingAlgorithm>(seedingCfg, logLevel));
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Seedfinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/Seedfinder.ipp
@@ -16,7 +16,7 @@ namespace Acts {
 template <typename external_spacepoint_t>
 Seedfinder<external_spacepoint_t, Acts::Cuda>::Seedfinder(
     Acts::SeedfinderConfig<external_spacepoint_t> config)
-    : m_config(std::move(config)) {
+    : m_config(config.toInternalUnits()) {
   // calculation of scattering using the highland formula
   // convert pT to p once theta angle is known
   m_config.highland = 13.6 * std::sqrt(m_config.radLengthPerSeed) *

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -34,8 +34,8 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
     const SeedFilterConfig& seedFilterConfig,
     const TripletFilterConfig& tripletFilterConfig, int device,
     std::unique_ptr<const Logger> incomingLogger)
-    : m_commonConfig(std::move(commonConfig)),
-      m_seedFilterConfig(seedFilterConfig),
+    : m_commonConfig(commonConfig.toInternalUnits()),
+      m_seedFilterConfig(seedFilterConfig.toInternalUnits()),
       m_tripletFilterConfig(tripletFilterConfig),
       m_device(device),
       m_logger(std::move(incomingLogger)) {

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
@@ -25,7 +25,7 @@ Seedfinder<external_spacepoint_t>::Seedfinder(
     Acts::SeedfinderConfig<external_spacepoint_t> config,
     const Acts::Sycl::DeviceExperimentCuts& cuts,
     Acts::Sycl::QueueWrapper wrappedQueue)
-    : m_config(config),
+    : m_config(config.toInternalUnits()),
       m_deviceCuts(cuts),
       m_wrappedQueue(std::move(wrappedQueue)) {
   // init m_config

--- a/Tests/UnitTests/Core/Seeding/SeedfinderTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/SeedfinderTest.cpp
@@ -26,6 +26,8 @@
 #include "ATLASCuts.hpp"
 #include "SpacePoint.hpp"
 
+using namespace Acts::UnitLiterals;
+
 std::vector<const SpacePoint*> readFile(std::string filename) {
   std::string line;
   int layer;
@@ -114,23 +116,23 @@ int main(int argc, char** argv) {
 
   Acts::SeedfinderConfig<SpacePoint> config;
   // silicon detector max
-  config.rMax = 160.;
-  config.deltaRMin = 5.;
-  config.deltaRMax = 160.;
-  config.collisionRegionMin = -250.;
-  config.collisionRegionMax = 250.;
-  config.zMin = -2800.;
-  config.zMax = 2800.;
+  config.rMax = 160._mm;
+  config.deltaRMin = 5._mm;
+  config.deltaRMax = 160._mm;
+  config.collisionRegionMin = -250._mm;
+  config.collisionRegionMax = 250._mm;
+  config.zMin = -2800._mm;
+  config.zMax = 2800._mm;
   config.maxSeedsPerSpM = 5;
   // 2.7 eta
   config.cotThetaMax = 7.40627;
   config.sigmaScattering = 1.00000;
 
-  config.minPt = 500.;
-  config.bFieldInZ = 0.00199724;
+  config.minPt = 500._MeV;
+  config.bFieldInZ = 1.99724_T;
 
-  config.beamPos = {-.5, -.5};
-  config.impactMax = 10.;
+  config.beamPos = {-.5_mm, -.5_mm};
+  config.impactMax = 10._mm;
 
   auto bottomBinFinder = std::make_shared<Acts::BinFinder<SpacePoint>>(
       Acts::BinFinder<SpacePoint>());

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SeedfinderCudaTest.cpp
@@ -29,6 +29,8 @@
 #include "ATLASCuts.hpp"
 #include "SpacePoint.hpp"
 
+using namespace Acts::UnitLiterals;
+
 std::vector<const SpacePoint*> readFile(std::string filename) {
   std::string line;
   int layer;
@@ -166,23 +168,23 @@ int main(int argc, char** argv) {
   // Set seed finder configuration
   Acts::SeedfinderConfig<SpacePoint> config;
   // silicon detector max
-  config.rMax = 160.;
-  config.deltaRMin = 5.;
-  config.deltaRMax = 160.;
-  config.collisionRegionMin = -250.;
-  config.collisionRegionMax = 250.;
-  config.zMin = -2800.;
-  config.zMax = 2800.;
+  config.rMax = 160._mm;
+  config.deltaRMin = 5._mm;
+  config.deltaRMax = 160._mm;
+  config.collisionRegionMin = -250._mm;
+  config.collisionRegionMax = 250._mm;
+  config.zMin = -2800._mm;
+  config.zMax = 2800._mm;
   config.maxSeedsPerSpM = 5;
   // 2.7 eta
   config.cotThetaMax = 7.40627;
   config.sigmaScattering = 1.00000;
 
-  config.minPt = 500.;
-  config.bFieldInZ = 0.00199724;
+  config.minPt = 500._MeV;
+  config.bFieldInZ = 1.99724_T;
 
-  config.beamPos = {-.5, -.5};
-  config.impactMax = 10.;
+  config.beamPos = {-.5_mm, -.5_mm};
+  config.impactMax = 10._mm;
 
   // cuda
   cudaDeviceProp prop;

--- a/Tests/UnitTests/Plugins/Cuda/Seeding2/main.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding2/main.cpp
@@ -33,6 +33,8 @@
 #include <iterator>
 #include <memory>
 
+using namespace Acts::UnitLiterals;
+
 int main(int argc, char* argv[]) {
   // Interpret the command line arguments passed to the executable.
   CommandLineArguments cmdl;
@@ -59,21 +61,21 @@ int main(int argc, char* argv[]) {
   // Set up the seedfinder configuration.
   Acts::SeedfinderConfig<TestSpacePoint> sfConfig;
   // silicon detector max
-  sfConfig.rMax = 160.;
-  sfConfig.deltaRMin = 5.;
-  sfConfig.deltaRMax = 160.;
-  sfConfig.collisionRegionMin = -250.;
-  sfConfig.collisionRegionMax = 250.;
-  sfConfig.zMin = -2800.;
-  sfConfig.zMax = 2800.;
+  sfConfig.rMax = 160._mm;
+  sfConfig.deltaRMin = 5._mm;
+  sfConfig.deltaRMax = 160._mm;
+  sfConfig.collisionRegionMin = -250._mm;
+  sfConfig.collisionRegionMax = 250._mm;
+  sfConfig.zMin = -2800._mm;
+  sfConfig.zMax = 2800._mm;
   sfConfig.maxSeedsPerSpM = 5;
   // 2.7 eta
   sfConfig.cotThetaMax = 7.40627;
   sfConfig.sigmaScattering = 1.00000;
-  sfConfig.minPt = 500.;
-  sfConfig.bFieldInZ = 0.00199724;
-  sfConfig.beamPos = {-.5, -.5};
-  sfConfig.impactMax = 10.;
+  sfConfig.minPt = 500._MeV;
+  sfConfig.bFieldInZ = 1.99724_T;
+  sfConfig.beamPos = {-.5_mm, -.5_mm};
+  sfConfig.impactMax = 10._mm;
 
   // Use a size slightly smaller than what modern GPUs are capable of. This is
   // because for debugging we can't use all available threads in a block, and

--- a/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
+++ b/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
@@ -36,6 +36,8 @@
 #include "CommandLineArguments.h"
 #include "SpacePoint.hpp"
 
+using namespace Acts::UnitLiterals;
+
 auto readFile(const std::string& filename) -> std::vector<const SpacePoint*> {
   std::string line;
   std::vector<const SpacePoint*> readSP;
@@ -83,21 +85,21 @@ auto setupSeedfinderConfiguration()
     -> Acts::SeedfinderConfig<external_spacepoint_t> {
   Acts::SeedfinderConfig<SpacePoint> config;
   // silicon detector max
-  config.rMax = 160.;
-  config.deltaRMin = 5.;
-  config.deltaRMax = 160.;
-  config.collisionRegionMin = -250.;
-  config.collisionRegionMax = 250.;
-  config.zMin = -2800.;
-  config.zMax = 2800.;
+  config.rMax = 160._mm;
+  config.deltaRMin = 5._mm;
+  config.deltaRMax = 160._mm;
+  config.collisionRegionMin = -250._mm;
+  config.collisionRegionMax = 250._mm;
+  config.zMin = -2800._mm;
+  config.zMax = 2800._mm;
   config.maxSeedsPerSpM = 5;
   // 2.7 eta
   config.cotThetaMax = 7.40627;
   config.sigmaScattering = 1.00000;
-  config.minPt = 500.;
-  config.bFieldInZ = 0.00199724;
-  config.beamPos = {-.5, -.5};
-  config.impactMax = 10.;
+  config.minPt = 500._MeV;
+  config.bFieldInZ = 1.99724_T;
+  config.beamPos = {-.5_mm, -.5_mm};
+  config.impactMax = 10._mm;
 
   // for sycl
   config.nTrplPerSpBLimit = 100;


### PR DESCRIPTION
The seed finding config currently uses implicit units. This PR switches to explicit units using the common `Acts::UnitConstants`. Since we don't want to do the conversion to seeding-internal units all the time, it does this once in the constructor, where special methods `toInternalUnits` are called which return a copy of the config with the members converted to internal units.

This should result in no changes to the actual calculations, and only to the configuration interface.

BREAKING CHANGE:
The seeding configuration structs `SpacePointGridConfig`, `SeedFilterConfig` and `SeedFinderConfig` change to now use ACTS units.