### PR TITLE
feat: add another script executable, add program options

### DIFF
--- a/Examples/Scripts/TrackingPerformance/CMakeLists.txt
+++ b/Examples/Scripts/TrackingPerformance/CMakeLists.txt
@@ -5,3 +5,12 @@ install(
   TARGETS
   ActsExampleResidualsAndPulls
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+
+add_executable(ActsExamplePerigeeParameters PerigeeParameters.cpp)
+target_link_libraries(ActsExamplePerigeeParameters ROOT::Core ROOT::Hist ROOT::Tree ROOT::TreePlayer Boost::program_options)
+  
+install(
+  TARGETS
+  ActsExamplePerigeeParameters
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})  

--- a/Examples/Scripts/TrackingPerformance/CMakeLists.txt
+++ b/Examples/Scripts/TrackingPerformance/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(ActsExampleResidualsAndPulls ResidualsAndPulls.cpp)
-target_link_libraries(ActsExampleResidualsAndPulls ROOT::Core ROOT::Hist ROOT::Tree ROOT::TreePlayer)
+target_link_libraries(ActsExampleResidualsAndPulls ROOT::Core ROOT::Hist ROOT::Tree ROOT::TreePlayer Boost::program_options)
 
 install(
   TARGETS

--- a/Examples/Scripts/TrackingPerformance/CommonUtils.h
+++ b/Examples/Scripts/TrackingPerformance/CommonUtils.h
@@ -24,7 +24,7 @@ void setHistStyle(hist_t* hist, short color = 1) {
   hist->SetMarkerStyle(20);
   hist->SetMarkerSize(0.8);
   hist->SetLineWidth(2);
-  // hist->SetTitle("");
+  hist->SetTitle("");
   hist->SetLineColor(color);
   hist->SetMarkerColor(color);
 }

--- a/Examples/Scripts/TrackingPerformance/PerigeeParameters.cpp
+++ b/Examples/Scripts/TrackingPerformance/PerigeeParameters.cpp
@@ -1,0 +1,74 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+#include <TApplication.h>
+#include <boost/program_options.hpp>
+
+#include "perigeeParamResolution.C"
+
+using namespace boost::program_options;
+
+int main(int argc, char** argv) {
+  std::cout << "*** ACTS Perigee parameter plotting" << std::endl;
+
+  try {
+    options_description description("*** Usage:");
+
+    // Add the program options
+    auto ao = description.add_options();
+    ao("help,h", "Display this help message");
+    ao("silent,s", bool_switch(), "Silent mode (without X-window/display).");
+    ao("input,i", value<std::string>()->default_value(""),
+       "Input ROOT file containing the input TTree.");
+    ao("fit", bool_switch(), "Fit the smoothed parameters.");
+    ao("save", value<std::string>()->default_value("png"),
+       "Output save format (to be interpreted by ROOT).");
+
+    // Set up the variables map
+    variables_map vm;
+    store(command_line_parser(argc, argv).options(description).run(), vm);
+    notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << description;
+    }
+
+    // Parse the parameters
+    auto iFile = vm["input"].as<std::string>();
+    auto saveAs = vm["save"].as<std::string>();
+
+    TApplication* tApp = vm["silent"].as<bool>()
+                             ? nullptr
+                             : new TApplication("ResidualAndPulls", 0, 0);
+
+    // Run the actual resolution estimation
+    switch (perigeeParamResolution(iFile, vm["fit"].as<bool>())) {
+      case -1: {
+        std::cout << "*** Input file could not be opened, check name/path."
+                  << std::endl;
+      } break;
+      default: {
+        std::cout << "*** Successful run." << std::endl;
+      };
+    }
+
+    if (tApp != nullptr) {
+      tApp->Run();
+    }
+
+  } catch (std::exception& e) {
+    std::cerr << e.what() << "\n";
+  }
+
+  std::cout << "*** Done." << std::endl;
+  return 1;
+}

--- a/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
+++ b/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
@@ -6,30 +6,85 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <exception>
 #include <iostream>
+#include <string>
 
 #include <TApplication.h>
+#include <boost/program_options.hpp>
 
 #include "boundParamResolution.C"
 
-int main(int argc, char **argv) {
-  if (argc > 1) {
-    std::string farg = argv[1];
-    if (farg == "-h" or farg.find("help") != std::string::npos) {
-      std::cout << "*** ACTS Residual and Pull plotting " << std::endl;
-      std::cout << "*** Usage: ./ActsExampleResidualAndPulls input_file "
-                   "input_tree output_file <save_extension>"
-                << std::endl;
+using namespace boost::program_options;
+
+int main(int argc, char** argv) {
+  std::cout << "*** ACTS Residual and Pull plotting " << std::endl;
+
+  try {
+    options_description description("*** Usage:");
+
+    // Add the program options
+    auto ao = description.add_options();
+    ao("help,h", "Display this help message");
+    ao("silent,s", bool_switch(), "Silent mode (without X-window/display).");
+    ao("input,i", value<std::string>()->default_value(""),
+       "Input ROOT file containing the input TTree.");
+    ao("tree,t", value<std::string>()->default_value("trackstates"),
+       "Input TTree name.");
+    ao("output,o", value<std::string>()->default_value(""),
+       "Output ROOT file with histograms");
+    ao("predicted", bool_switch(), "Analyze the predicted parameters.");
+    ao("filtered", bool_switch(), "Analyze the filtered parameters.");
+    ao("smoothed", bool_switch(), "Analyze the smoothed parameters.");
+    ao("fit", bool_switch(), "Fit the smoothed parameters.");
+    ao("save", value<std::string>()->default_value("png"),
+       "Output save format (to be interpreted by ROOT).");
+
+    // Set up the variables map
+    variables_map vm;
+    store(command_line_parser(argc, argv).options(description).run(), vm);
+    notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << description;
     }
-    if (argc >= 4) {
-      TApplication theApp("ResidualAndPulls", 0, 0);
-      std::string inputFile = farg;
-      std::string inputTree = argv[2];
-      std::string outputFile = argv[3];
-      std::string saveAs = (argc > 4) ? std::string(argv[4]) : std::string("");
-      boundParamResolution(inputFile, inputTree, outputFile, saveAs);
-      theApp.Run();
+
+    // Parse the parameters
+    auto iFile = vm["input"].as<std::string>();
+    auto iTree = vm["tree"].as<std::string>();
+    auto oFile = vm["output"].as<std::string>();
+    auto saveAs = vm["save"].as<std::string>();
+
+    TApplication* tApp = vm["silent"].as<bool>()
+                             ? nullptr
+                             : new TApplication("ResidualAndPulls", 0, 0);
+
+    // Run the actual resolution estimation
+    switch (boundParamResolution(
+        iFile, iTree, oFile, vm["predicted"].as<bool>(),
+        vm["filtered"].as<bool>(), vm["smoothed"].as<bool>(),
+        vm["fit"].as<bool>(), saveAs)) {
+      case -1: {
+        std::cout << "*** Input file could not be opened, check name/path."
+                  << std::endl;
+      } break;
+      case -2: {
+        std::cout << "*** Input tree could not be found, check name."
+                  << std::endl;
+      } break;
+      default: {
+        std::cout << "*** Successful run." << std::endl;
+      };
     }
+
+    if (tApp != nullptr) {
+      tApp->Run();
+    }
+
+  } catch (std::exception& e) {
+    std::cerr << e.what() << "\n";
   }
+
+  std::cout << "*** Done." << std::endl;
   return 1;
 }

--- a/Examples/Scripts/TrackingPerformance/boundParamResolution.C
+++ b/Examples/Scripts/TrackingPerformance/boundParamResolution.C
@@ -24,19 +24,29 @@
 #include <TProfile2D.h>
 #include <TStyle.h>
 #include <TTree.h>
+#include <Terror.h>
 
 #include "CommonUtils.h"
 #include "TreeReader.h"
 
 using namespace ROOT;
 
-// (loc1, phi, theta, q/p, t) at all track states from root file produced by the
-// RootTrajectoryStatesWriter
-//
-void boundParamResolution(const std::string& inFile,
-                          const std::string& treeName,
-                          const std::string& outFile,
-                          const std::string& saveAs = "") {
+/// Plot the bound parameter resoltuions
+///
+/// (loc1, phi, theta, q/p, t) at all track states from root file produced by
+/// the RootTrajectoryStatesWriter
+///
+/// @param inFile the input root file
+/// @param treeNAme the input tree name (default: 'trackstates)
+/// @param outFile the output root file
+/// @param pTypes the track parameter types (prd, flt, smt)
+/// @param saveAs the plot saving type
+int boundParamResolution(const std::string& inFile, const std::string& treeName,
+                         const std::string& outFile, bool predicted = true,
+                         bool filtered = true, bool smoothed = true,
+                         bool fitSmoothed = true,
+                         const std::string& saveAs = "") {
+  // Some style options
   gStyle->SetOptFit(0000);
   gStyle->SetOptStat(0000);
   gStyle->SetPadLeftMargin(0.20);
@@ -44,8 +54,18 @@ void boundParamResolution(const std::string& inFile,
   gStyle->SetPadTopMargin(0.1);
   gStyle->SetPadBottomMargin(0.15);
 
-  // Pull range
-  double pullRange = 7;
+  // Pull range, residual ranges are automatically determined
+  double pullRange = 6;
+  //
+  // Residual ranges should be largest in predicted and smallest in smoothed,
+  // hence reverse the order.
+  //
+  std::string range_tag = "smt";
+  if (predicted) {
+    range_tag = "prt";
+  } else if (filtered) {
+    range_tag = "flt";
+  }
 
   // Section 0: file handling ---------------------------------------------
   //
@@ -53,8 +73,20 @@ void boundParamResolution(const std::string& inFile,
   // Create output root file
   std::cout << "Opening file: " << inFile << std::endl;
   TFile* file = TFile::Open(inFile.c_str(), "read");
+
+  // Bail out if no tree was found
+  if (file == nullptr) {
+    return -1;
+  }
+
   std::cout << "Reading tree: " << treeName << std::endl;
   TTree* tree = (TTree*)file->Get(treeName.c_str());
+
+  // Bail out if no tree was found
+  if (tree == nullptr) {
+    return -2;
+  }
+
   TFile* out = TFile::Open(outFile.c_str(), "recreate");
   out->cd();
 
@@ -75,7 +107,18 @@ void boundParamResolution(const std::string& inFile,
   h2_volID_layID->Write();
   // Geometry size
   geometryCanvas->cd(2);
-  tree->Draw("sqrt(g_x_smt*g_x_smt+g_y_smt*g_y_smt):g_z_smt>>geo_dim");
+  std::string rz_draw_string = "(sqrt(g_x_";
+  rz_draw_string += range_tag;
+  rz_draw_string += "*g_x_";
+  rz_draw_string += range_tag;
+  rz_draw_string += "+g_y_";
+  rz_draw_string += range_tag;
+  rz_draw_string += "*g_y_";
+  rz_draw_string += range_tag;
+  rz_draw_string += ")):g_z_";
+  rz_draw_string += range_tag;
+  rz_draw_string += ">>geo_dim";
+  tree->Draw(rz_draw_string.c_str());
   auto h2_geo_dim = dynamic_cast<TH2F*>(out->Get("geo_dim"));
   setHistStyle(h2_geo_dim, 2);
   float detectorZ = 1.15 * h2_geo_dim->GetXaxis()->GetXmax();
@@ -111,14 +154,18 @@ void boundParamResolution(const std::string& inFile,
   // Helper for assigning branches to the input tree
   TrackStatesReader tsReader(tree, false);
 
+  // Section 3: Histogram booking ...
 
-  // Section 3: Histogram booking
   TCanvas* rangeCanvas =
       new TCanvas("rangeCanvas", "Range Estimation", 10, 10, 900, 600);
   rangeCanvas->Divide(3, 2);
-  std::vector<std::string> res_smts = {"res_eLOC0_smt", "res_eLOC1_smt",
-                                       "res_ePHI_smt",  "res_eTHETA_smt",
-                                       "res_eQOP_smt",  "res_eT_smt"};
+
+  std::vector<std::string> res_ranges = {std::string("res_eLOC0_") + range_tag,
+                                         std::string("res_eLOC1_") + range_tag,
+                                         std::string("res_ePHI_") + range_tag,
+                                         std::string("res_eTHETA_") + range_tag,
+                                         std::string("res_eQOP_") + range_tag,
+                                         std::string("res_eT_") + range_tag};
 
   /// Helper method to make a volLayId string for identification & cut
   ///
@@ -146,9 +193,9 @@ void boundParamResolution(const std::string& inFile,
     std::array<float, 6> ranges = {0., 0., 0., 0., 0., 0.};
     for (unsigned int ir = 0; ir < 6; ++ir) {
       rangeCanvas->cd(ir + 1);
-      std::string drawString = res_smts[ir] + ">>";
+      std::string drawString = res_ranges[ir] + ">>";
       std::string histString =
-          vlIdCut[0] + std::string("range_") + res_smts[ir];
+          vlIdCut[0] + std::string("range_") + res_ranges[ir];
       tree->Draw((drawString + histString).c_str(), vlIdCut[1].c_str());
       auto h1_range = dynamic_cast<TH1F*>(out->Get(histString.c_str()));
       h1_range->Write();
@@ -178,67 +225,81 @@ void boundParamResolution(const std::string& inFile,
 
   for (unsigned int ipar = 0; ipar < paramNames.size(); ++ipar) {
     const auto& par = paramNames[ipar];
-    p2d_res_zr_prt[ipar] =
-        new TProfile2D(Form("all_prof_res_prt_%s", par.c_str()),
-                       Form("residual profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
-    p2d_res_zr_flt[ipar] =
-        new TProfile2D(Form("all_prof_res_flt_%s", par.c_str()),
-                       Form("residual profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
-    p2d_res_zr_smt[ipar] =
-        new TProfile2D(Form("all_prof_res_smt_%s", par.c_str()),
-                       Form("residual profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
 
-    p2d_pull_zr_prt[ipar] =
-        new TProfile2D(Form("all_prof_pull_prt_%s", par.c_str()),
-                       Form("pull profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
-    p2d_pull_zr_flt[ipar] =
-        new TProfile2D(Form("all_prof_pull_flt_%s", par.c_str()),
-                       Form("pull profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
-    p2d_pull_zr_smt[ipar] =
-        new TProfile2D(Form("all_prof_pull_smt_%s", par.c_str()),
-                       Form("pull profile of %s", par.c_str()), 100,
-                       -detectorZ, detectorZ, 50, 0., detectorR);
+    if (predicted) {
+      p2d_res_zr_prt[ipar] =
+          new TProfile2D(Form("all_prof_res_prt_%s", par.c_str()),
+                         Form("residual profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
 
-    p2d_res_zr_prt[ipar]->SetErrorOption("s");
-    p2d_res_zr_flt[ipar]->SetErrorOption("s");
-    p2d_res_zr_smt[ipar]->SetErrorOption("s");
-    p2d_pull_zr_prt[ipar]->SetErrorOption("s");
-    p2d_pull_zr_flt[ipar]->SetErrorOption("s");
-    p2d_pull_zr_smt[ipar]->SetErrorOption("s");
+      p2d_pull_zr_prt[ipar] =
+          new TProfile2D(Form("all_prof_pull_prt_%s", par.c_str()),
+                         Form("pull profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
 
-    p2d_res_zr_prt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_res_zr_prt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_res_zr_prt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
-    p2d_res_zr_flt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_res_zr_flt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_res_zr_flt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
-    p2d_res_zr_smt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_res_zr_smt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_res_zr_smt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+      p2d_res_zr_prt[ipar]->SetErrorOption("s");
+      p2d_res_zr_prt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_res_zr_prt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_res_zr_prt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+      setHistStyle(p2d_res_zr_prt[ipar], 1);
 
-    p2d_pull_zr_prt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_pull_zr_prt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_pull_zr_prt[ipar]->GetZaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
-    p2d_pull_zr_flt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_pull_zr_flt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_pull_zr_prt[ipar]->GetZaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
-    p2d_pull_zr_smt[ipar]->GetXaxis()->SetTitle("z [mm]");
-    p2d_pull_zr_smt[ipar]->GetYaxis()->SetTitle("R [mm]");
-    p2d_pull_zr_prt[ipar]->GetZaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
+      p2d_pull_zr_prt[ipar]->SetErrorOption("s");
+      p2d_pull_zr_prt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_pull_zr_prt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_pull_zr_prt[ipar]->GetZaxis()->SetTitle(
+          Form("pull_{%s}", par.c_str()));
+      setHistStyle(p2d_pull_zr_prt[ipar], 1);
+    }
 
-    // set style
-    setHistStyle(p2d_res_zr_prt[ipar], 1);
-    setHistStyle(p2d_res_zr_flt[ipar], 2);
-    setHistStyle(p2d_res_zr_smt[ipar], 4);
+    if (filtered) {
+      p2d_res_zr_flt[ipar] =
+          new TProfile2D(Form("all_prof_res_flt_%s", par.c_str()),
+                         Form("residual profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
+      p2d_pull_zr_flt[ipar] =
+          new TProfile2D(Form("all_prof_pull_flt_%s", par.c_str()),
+                         Form("pull profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
 
-    setHistStyle(p2d_pull_zr_prt[ipar], 1);
-    setHistStyle(p2d_pull_zr_flt[ipar], 2);
-    setHistStyle(p2d_pull_zr_smt[ipar], 4);
+      p2d_res_zr_flt[ipar]->SetErrorOption("s");
+      p2d_res_zr_flt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_res_zr_flt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_res_zr_flt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+      setHistStyle(p2d_res_zr_flt[ipar], 2);
+
+      p2d_pull_zr_flt[ipar]->SetErrorOption("s");
+      p2d_pull_zr_flt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_pull_zr_flt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_pull_zr_flt[ipar]->GetZaxis()->SetTitle(
+          Form("pull_{%s}", par.c_str()));
+      setHistStyle(p2d_pull_zr_flt[ipar], 2);
+    }
+
+    if (smoothed) {
+      p2d_res_zr_smt[ipar] =
+          new TProfile2D(Form("all_prof_res_smt_%s", par.c_str()),
+                         Form("residual profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
+
+      p2d_pull_zr_smt[ipar] =
+          new TProfile2D(Form("all_prof_pull_smt_%s", par.c_str()),
+                         Form("pull profile of %s", par.c_str()), 100,
+                         -detectorZ, detectorZ, 50, 0., detectorR);
+
+      p2d_res_zr_smt[ipar]->SetErrorOption("s");
+      p2d_pull_zr_smt[ipar]->SetErrorOption("s");
+
+      p2d_res_zr_smt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_res_zr_smt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_res_zr_smt[ipar]->GetZaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+      setHistStyle(p2d_res_zr_smt[ipar], 4);
+
+      p2d_pull_zr_smt[ipar]->GetXaxis()->SetTitle("z [mm]");
+      p2d_pull_zr_smt[ipar]->GetYaxis()->SetTitle("R [mm]");
+      p2d_pull_zr_smt[ipar]->GetZaxis()->SetTitle(
+          Form("pull_{%s}", par.c_str()));
+      setHistStyle(p2d_pull_zr_smt[ipar], 4);
+    }
   }
 
   // Resiudal / Pull histograms
@@ -267,53 +328,68 @@ void boundParamResolution(const std::string& inFile,
       for (const auto& [par, resRange] : paramResidualRange) {
         // histogram creation
         std::string id_par = vlIdCut[0] + par;
-        // residual hists
-        res_prt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("res_prt_%s")).c_str(), par.c_str()),
-            Form("residual of %s", par.c_str()), 100, -1 * resRange, resRange);
-        res_flt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("res_flt_%s")).c_str(), par.c_str()),
-            Form("residual of %s", par.c_str()), 100, -1 * resRange, resRange);
-        res_smt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("res_smt_%s")).c_str(), par.c_str()),
-            Form("residual of %s", par.c_str()), 100, -1 * resRange, resRange);
 
-        // pull hists
-        pull_prt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("pull_prt_%s")).c_str(),
-                 par.c_str()),
-            Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
-        pull_flt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("pull_flt_%s")).c_str(),
-                 par.c_str()),
-            Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
-        pull_smt[id_par] = new TH1F(
-            Form((vlIdCut[0] + std::string("pull_smt_%s")).c_str(),
-                 par.c_str()),
-            Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
+        if (predicted) {
+          res_prt[id_par] =
+              new TH1F(Form((vlIdCut[0] + std::string("res_prt_%s")).c_str(),
+                            par.c_str()),
+                       Form("residual of %s", par.c_str()), 100, -1 * resRange,
+                       resRange);
+          res_prt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+          res_prt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(res_prt[id_par], 1);
 
-        res_prt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
-        res_prt[id_par]->GetYaxis()->SetTitle("Entries");
-        res_flt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
-        res_flt[id_par]->GetYaxis()->SetTitle("Entries");
-        res_smt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
-        res_smt[id_par]->GetYaxis()->SetTitle("Entries");
+          pull_prt[id_par] = new TH1F(
+              Form((vlIdCut[0] + std::string("pull_prt_%s")).c_str(),
+                   par.c_str()),
+              Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
+          pull_prt[id_par]->GetXaxis()->SetTitle(
+              Form("pull_{%s}", par.c_str()));
+          pull_prt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(pull_smt[id_par], 4);
+        }
 
-        pull_prt[id_par]->GetXaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
-        pull_prt[id_par]->GetYaxis()->SetTitle("Entries");
-        pull_flt[id_par]->GetXaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
-        pull_flt[id_par]->GetYaxis()->SetTitle("Entries");
-        pull_smt[id_par]->GetXaxis()->SetTitle(Form("pull_{%s}", par.c_str()));
-        pull_smt[id_par]->GetYaxis()->SetTitle("Entries");
+        if (filtered) {
+          res_flt[id_par] =
+              new TH1F(Form((vlIdCut[0] + std::string("res_flt_%s")).c_str(),
+                            par.c_str()),
+                       Form("residual of %s", par.c_str()), 100, -1 * resRange,
+                       resRange);
+          res_flt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+          res_flt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(res_flt[id_par], 2);
 
-        // set style
-        setHistStyle(res_prt[id_par], 1);
-        setHistStyle(res_flt[id_par], 2);
-        setHistStyle(res_smt[id_par], 4);
+          pull_flt[id_par] = new TH1F(
+              Form((vlIdCut[0] + std::string("pull_flt_%s")).c_str(),
+                   par.c_str()),
+              Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
+          pull_flt[id_par]->GetXaxis()->SetTitle(
+              Form("pull_{%s}", par.c_str()));
+          pull_flt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(pull_flt[id_par], 2);
+        }
 
-        setHistStyle(pull_prt[id_par], 1);
-        setHistStyle(pull_flt[id_par], 2);
-        setHistStyle(pull_smt[id_par], 4);
+        if (smoothed) {
+          res_smt[id_par] =
+              new TH1F(Form((vlIdCut[0] + std::string("res_smt_%s")).c_str(),
+                            par.c_str()),
+                       Form("residual of %s", par.c_str()), 100, -1 * resRange,
+                       resRange);
+
+          res_smt[id_par]->GetXaxis()->SetTitle(Form("r_{%s}", par.c_str()));
+          res_smt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(res_smt[id_par], 4);
+
+          pull_smt[id_par] = new TH1F(
+              Form((vlIdCut[0] + std::string("pull_smt_%s")).c_str(),
+                   par.c_str()),
+              Form("pull of %s", par.c_str()), 100, -1 * pullRange, pullRange);
+
+          pull_smt[id_par]->GetXaxis()->SetTitle(
+              Form("pull_{%s}", par.c_str()));
+          pull_smt[id_par]->GetYaxis()->SetTitle("Entries");
+          setHistStyle(pull_smt[id_par], 1);
+        }
       }
     }
   }
@@ -327,7 +403,7 @@ void boundParamResolution(const std::string& inFile,
 
     for (unsigned int i = 0; i < tsReader.nMeasurements; i++) {
       // global profile filling
-      if (tsReader.predicted->at(i)) {
+      if (predicted and tsReader.predicted->at(i)) {
         float x_prt = tsReader.g_x_prt->at(i);
         float y_prt = tsReader.g_y_prt->at(i);
         float r_prt = std::sqrt(x_prt * x_prt + y_prt * y_prt);
@@ -345,7 +421,7 @@ void boundParamResolution(const std::string& inFile,
         p2d_pull_zr_prt[4]->Fill(z_prt, r_prt, tsReader.pull_QOP_prt->at(i));
         p2d_pull_zr_prt[5]->Fill(z_prt, r_prt, tsReader.pull_T_prt->at(i));
       }
-      if (tsReader.filtered->at(i)) {
+      if (filtered and tsReader.filtered->at(i)) {
         float x_flt = tsReader.g_x_flt->at(i);
         float y_flt = tsReader.g_y_flt->at(i);
         float r_flt = std::sqrt(x_flt * x_flt + y_flt * y_flt);
@@ -363,7 +439,7 @@ void boundParamResolution(const std::string& inFile,
         p2d_pull_zr_flt[4]->Fill(z_flt, r_flt, tsReader.pull_QOP_flt->at(i));
         p2d_pull_zr_flt[5]->Fill(z_flt, r_flt, tsReader.pull_T_flt->at(i));
       }
-      if (tsReader.smoothed->at(i)) {
+      if (smoothed and tsReader.smoothed->at(i)) {
         float x_smt = tsReader.g_x_smt->at(i);
         float y_smt = tsReader.g_y_smt->at(i);
         float r_smt = std::sqrt(x_smt * x_smt + y_smt * y_smt);
@@ -392,47 +468,56 @@ void boundParamResolution(const std::string& inFile,
       for (const auto& fid : fillIds) {
         auto vlID = volLayIdCut(fid[0], fid[1])[0];
         // Fill predicated parameters
-        if (tsReader.predicted->at(i)) {
+        if (predicted and tsReader.predicted->at(i)) {
           res_prt[vlID + paramNames[0]]->Fill(tsReader.res_LOC0_prt->at(i), 1);
           res_prt[vlID + paramNames[1]]->Fill(tsReader.res_LOC1_prt->at(i), 1);
           res_prt[vlID + paramNames[2]]->Fill(tsReader.res_PHI_prt->at(i), 1);
           res_prt[vlID + paramNames[3]]->Fill(tsReader.res_THETA_prt->at(i), 1);
           res_prt[vlID + paramNames[4]]->Fill(tsReader.res_QOP_prt->at(i), 1);
           res_prt[vlID + paramNames[5]]->Fill(tsReader.res_T_prt->at(i), 1);
-          pull_prt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_prt->at(i), 1);
-          pull_prt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_prt->at(i), 1);
+          pull_prt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_prt->at(i),
+                                               1);
+          pull_prt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_prt->at(i),
+                                               1);
           pull_prt[vlID + paramNames[2]]->Fill(tsReader.pull_PHI_prt->at(i), 1);
-          pull_prt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_prt->at(i), 1);
+          pull_prt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_prt->at(i),
+                                               1);
           pull_prt[vlID + paramNames[4]]->Fill(tsReader.pull_QOP_prt->at(i), 1);
           pull_prt[vlID + paramNames[5]]->Fill(tsReader.pull_T_prt->at(i), 1);
         }
         // Fill filtered parameters
-        if (tsReader.filtered->at(i)) {
+        if (filtered and tsReader.filtered->at(i)) {
           res_flt[vlID + paramNames[0]]->Fill(tsReader.res_LOC0_flt->at(i), 1);
           res_flt[vlID + paramNames[1]]->Fill(tsReader.res_LOC1_flt->at(i), 1);
           res_flt[vlID + paramNames[2]]->Fill(tsReader.res_PHI_flt->at(i), 1);
           res_flt[vlID + paramNames[3]]->Fill(tsReader.res_THETA_flt->at(i), 1);
           res_flt[vlID + paramNames[4]]->Fill(tsReader.res_QOP_flt->at(i), 1);
           res_flt[vlID + paramNames[5]]->Fill(tsReader.res_T_flt->at(i), 1);
-          pull_flt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_flt->at(i), 1);
-          pull_flt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_flt->at(i), 1);
+          pull_flt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_flt->at(i),
+                                               1);
+          pull_flt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_flt->at(i),
+                                               1);
           pull_flt[vlID + paramNames[2]]->Fill(tsReader.pull_PHI_flt->at(i), 1);
-          pull_flt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_flt->at(i), 1);
+          pull_flt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_flt->at(i),
+                                               1);
           pull_flt[vlID + paramNames[4]]->Fill(tsReader.pull_QOP_flt->at(i), 1);
           pull_flt[vlID + paramNames[5]]->Fill(tsReader.pull_T_flt->at(i), 1);
         }
         // Fill smoothed parameters
-        if (tsReader.smoothed->at(i)) {
+        if (smoothed and tsReader.smoothed->at(i)) {
           res_smt[vlID + paramNames[0]]->Fill(tsReader.res_LOC0_smt->at(i), 1);
           res_smt[vlID + paramNames[1]]->Fill(tsReader.res_LOC1_smt->at(i), 1);
           res_smt[vlID + paramNames[2]]->Fill(tsReader.res_PHI_smt->at(i), 1);
           res_smt[vlID + paramNames[3]]->Fill(tsReader.res_THETA_smt->at(i), 1);
           res_smt[vlID + paramNames[4]]->Fill(tsReader.res_QOP_smt->at(i), 1);
           res_smt[vlID + paramNames[5]]->Fill(tsReader.res_T_smt->at(i), 1);
-          pull_smt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_smt->at(i), 1);
-          pull_smt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_smt->at(i), 1);
+          pull_smt[vlID + paramNames[0]]->Fill(tsReader.pull_LOC0_smt->at(i),
+                                               1);
+          pull_smt[vlID + paramNames[1]]->Fill(tsReader.pull_LOC1_smt->at(i),
+                                               1);
           pull_smt[vlID + paramNames[2]]->Fill(tsReader.pull_PHI_smt->at(i), 1);
-          pull_smt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_smt->at(i), 1);
+          pull_smt[vlID + paramNames[3]]->Fill(tsReader.pull_THETA_smt->at(i),
+                                               1);
           pull_smt[vlID + paramNames[4]]->Fill(tsReader.pull_QOP_smt->at(i), 1);
           pull_smt[vlID + paramNames[5]]->Fill(tsReader.pull_T_smt->at(i), 1);
         }
@@ -463,7 +548,8 @@ void boundParamResolution(const std::string& inFile,
       if (res_pull == "pull") {
         profiles[ipar]->GetZaxis()->SetRangeUser(-1. * pullRange, pullRange);
       }
-      adaptColorPalette(profiles[ipar], -1. * pullRange, pullRange, 0., 0.25, 104);
+      adaptColorPalette(profiles[ipar], -1. * pullRange, pullRange, 0., 0.25,
+                        104);
       profiles[ipar]->Draw("colz");
       profiles[ipar]->Write();
     }
@@ -517,12 +603,18 @@ void boundParamResolution(const std::string& inFile,
   };
 
   // Plotting profiles: res/pulls
-  plotProfiles(p2d_res_zr_prt, "res", "prt");
-  plotProfiles(p2d_res_zr_flt, "res", "flt");
-  plotProfiles(p2d_res_zr_smt, "res", "smt");
-  plotProfiles(p2d_pull_zr_prt, "pull", "prt");
-  plotProfiles(p2d_pull_zr_flt, "pull", "flt");
-  plotProfiles(p2d_pull_zr_smt, "pull", "smt");
+  if (predicted) {
+    plotProfiles(p2d_res_zr_prt, "res", "prt");
+    plotProfiles(p2d_pull_zr_prt, "pull", "prt");
+  }
+  if (filtered) {
+    plotProfiles(p2d_res_zr_flt, "res", "flt");
+    plotProfiles(p2d_pull_zr_flt, "pull", "flt");
+  }
+  if (smoothed) {
+    plotProfiles(p2d_res_zr_smt, "res", "smt");
+    plotProfiles(p2d_pull_zr_smt, "pull", "smt");
+  }
 
   // Plotting residual
   TCanvas* residuals =
@@ -539,28 +631,32 @@ void boundParamResolution(const std::string& inFile,
       // Residual plotting
       for (size_t ipar = 0; ipar < paramNames.size(); ipar++) {
         residuals->cd(ipar + 1);
-        // Draw them
-        res_smt[vlID + paramNames.at(ipar)]->Draw("");
-        res_prt[vlID + paramNames.at(ipar)]->Draw("same");
-        res_flt[vlID + paramNames.at(ipar)]->Draw("same");
-        // Write them
-        pull_smt[vlID + paramNames.at(ipar)]->Write();
-        pull_prt[vlID + paramNames.at(ipar)]->Write();
-        pull_flt[vlID + paramNames.at(ipar)]->Write();
 
-        int binmax = res_smt[vlID + paramNames.at(ipar)]->GetMaximumBin();
-        int bincontent =
-            res_smt[vlID + paramNames.at(ipar)]->GetBinContent(binmax);
-
-        res_smt[vlID + paramNames.at(ipar)]->GetYaxis()->SetRangeUser(
-            0, bincontent * 1.2);
         TLegend* legend = new TLegend(0.7, 0.7, 0.9, 0.9);
-        legend->AddEntry(res_prt[vlID + paramNames.at(ipar)], "prediction",
-                         "lp");
-        legend->AddEntry(res_flt[vlID + paramNames.at(ipar)], "filtering",
-                         "lp");
-        legend->AddEntry(res_smt[vlID + paramNames.at(ipar)], "smoothing",
-                         "lp");
+
+        // Draw them
+        if (smoothed) {
+          res_smt[vlID + paramNames.at(ipar)]->DrawNormalized("");
+          res_smt[vlID + paramNames.at(ipar)]->Write();
+          legend->AddEntry(res_smt[vlID + paramNames.at(ipar)], "smoothed",
+                           "lp");
+        }
+        if (filtered) {
+          std::string drawOptions = smoothed ? "same" : "";
+          res_flt[vlID + paramNames.at(ipar)]->DrawNormalized(
+              drawOptions.c_str());
+          res_flt[vlID + paramNames.at(ipar)]->Write();
+          legend->AddEntry(res_flt[vlID + paramNames.at(ipar)], "filtered",
+                           "lp");
+        }
+        if (predicted) {
+          std::string drawOptions = (smoothed or filtered) ? "same" : "";
+          res_prt[vlID + paramNames.at(ipar)]->DrawNormalized("same");
+          res_prt[vlID + paramNames.at(ipar)]->Write();
+          legend->AddEntry(res_prt[vlID + paramNames.at(ipar)], "predicted",
+                           "lp");
+        }
+
         legend->SetBorderSize(0);
         legend->SetFillStyle(0);
         legend->SetTextFont(42);
@@ -573,28 +669,69 @@ void boundParamResolution(const std::string& inFile,
       // Pull plotting & writing
       for (size_t ipar = 0; ipar < paramNames.size(); ipar++) {
         pulls->cd(ipar + 1);
-        // Draw them
-        pull_smt[vlID + paramNames.at(ipar)]->Draw("");
-        pull_prt[vlID + paramNames.at(ipar)]->Draw("same");
-        pull_flt[vlID + paramNames.at(ipar)]->Draw("same");
-        // Write them
-        pull_smt[vlID + paramNames.at(ipar)]->Write();
-        pull_prt[vlID + paramNames.at(ipar)]->Write();
-        pull_flt[vlID + paramNames.at(ipar)]->Write();
 
-        int binmax = pull_smt[vlID + paramNames.at(ipar)]->GetMaximumBin();
-        int bincontent =
-            pull_smt[vlID + paramNames.at(ipar)]->GetBinContent(binmax);
-
-        pull_smt[vlID + paramNames.at(ipar)]->GetYaxis()->SetRangeUser(
-            0, bincontent * 1.2);
         TLegend* legend = new TLegend(0.7, 0.7, 0.9, 0.9);
-        legend->AddEntry(pull_prt[vlID + paramNames.at(ipar)], "prediction",
-                         "lp");
-        legend->AddEntry(pull_flt[vlID + paramNames.at(ipar)], "filtering",
-                         "lp");
-        legend->AddEntry(pull_smt[vlID + paramNames.at(ipar)], "smoothing",
-                         "lp");
+        // Fit the smoothed distribution
+        if (smoothed) {
+          Double_t scale =
+              1. / pull_smt[vlID + paramNames.at(ipar)]->Integral();
+          pull_smt[vlID + paramNames.at(ipar)]->Sumw2();
+          pull_smt[vlID + paramNames.at(ipar)]->Scale(scale);
+          pull_smt[vlID + paramNames.at(ipar)]->Draw("pe");
+          pull_smt[vlID + paramNames.at(ipar)]->Write();
+
+          legend->AddEntry(pull_smt[vlID + paramNames.at(ipar)], "smoothed",
+                           "pe");
+
+          if (fitSmoothed) {
+            pull_smt[vlID + paramNames.at(ipar)]->Fit("gaus", "q");
+            TF1* gauss =
+                pull_smt[vlID + paramNames.at(ipar)]->GetFunction("gaus");
+            float mu = gauss->GetParameter(1);
+            float sigma = gauss->GetParameter(2);
+
+            // Draw the sigma
+            TString mu_info;
+            mu_info += mu;
+            TString sigma_info;
+            sigma_info += sigma;
+
+            TString mfit_info = "#mu = ";
+            mfit_info += mu_info(0, 5);
+
+            TString sfit_info = "#sigma = ";
+            sfit_info += sigma_info(0, 5);
+
+            legend->AddEntry(gauss,
+                             sfit_info.Data(), "l");
+            legend->AddEntry(pull_smt[vlID + paramNames.at(ipar)],
+                             mfit_info.Data(), "");
+
+          }
+        }
+
+        if (filtered) {
+          std::string drawOptions = smoothed ? "same" : "";
+
+          pull_flt[vlID + paramNames.at(ipar)]->DrawNormalized(
+              drawOptions.c_str());
+          pull_flt[vlID + paramNames.at(ipar)]->Write();
+
+          legend->AddEntry(pull_flt[vlID + paramNames.at(ipar)], "filtered",
+                           "lp");
+        }
+
+        if (predicted) {
+          std::string drawOptions = (smoothed or filtered) ? "same" : "";
+
+          pull_prt[vlID + paramNames.at(ipar)]->DrawNormalized(
+              drawOptions.c_str());
+          pull_prt[vlID + paramNames.at(ipar)]->Write();
+
+          legend->AddEntry(pull_prt[vlID + paramNames.at(ipar)], "predicted",
+                           "lp");
+        }
+
         legend->SetBorderSize(0);
         legend->SetFillStyle(0);
         legend->SetTextFont(42);
@@ -609,6 +746,5 @@ void boundParamResolution(const std::string& inFile,
   }
 
   // out->Close();
+  return 0;
 }
-
-

--- a/Examples/Scripts/TrackingPerformance/perigeeParamResolution.C
+++ b/Examples/Scripts/TrackingPerformance/perigeeParamResolution.C
@@ -1,67 +1,90 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <TF1.h>
-#include <TH1F.h>
-#include <TMath.h>
-#include <TTree.h>
 #include <iostream>
 #include <map>
 #include <vector>
 
+#include <TCanvas.h>
+#include <TF1.h>
+#include <TFile.h>
+#include <TH1F.h>
+#include <TLegend.h>
+#include <TMath.h>
+#include <TStyle.h>
+#include <TTree.h>
+
 using namespace ROOT;
 
-void
-setHistStyle(TH1F* hist, short color);
+void setHistStyle(TH1F* hist, short color);
 
-// This ROOT script will plot the residual and pull of perigee track parameters (d0,
-// z0, phi, theta, q/p, t) from root file produced by the TrackFitterPerformanceWriter 
+// This ROOT script will plot the residual and pull of perigee track parameters
+// (d0, z0, phi, theta, q/p, t) from root file produced by the
+// TrackFitterPerformanceWriter
 //
-void
-perigeeParamResolution(const std::string& inFile)
-{
+int perigeeParamResolution(const std::string& inFile, bool fit = true) {
   gStyle->SetOptFit(0000);
   gStyle->SetOptStat(0000);
   gStyle->SetPadLeftMargin(0.20);
   gStyle->SetPadRightMargin(0.05);
   gStyle->SetPadTopMargin(0.1);
   gStyle->SetPadBottomMargin(0.15);
- 
+
   // Open root file written by RootTrajectoryWriter
   std::cout << "Opening file: " << inFile << std::endl;
-  TFile*  file = TFile::Open(inFile.c_str(), "read");
- 
-  // Track parameter name
-  std::vector<std::string> paramNames
-      = {"d0", "z0", "phi", "theta", "qop", "t"};
+  TFile* file = TFile::Open(inFile.c_str(), "read");
 
-  map<string, TH1F*> res;
-  map<string, TH1F*> pull;
-
-  // Create the hists and set up
-  for (const auto& par: paramNames) {
-    // residual hists
-    res[par] = (TH1F*) file->Get(Form("res_%s", par.c_str()));
-    // pull hists
-    pull[par] = (TH1F*) file->Get(Form("pull_%s", par.c_str())); 
-
-    // set style
-    setHistStyle(res[par], 2);
-    setHistStyle(pull[par], 2);
+  if (file == nullptr) {
+    return -1;
   }
 
+  // Track parameter name
+  std::vector<std::array<std::string, 4>> paramNames = {
+      {"d0", "(d_{0}^{rec} - d_{0}^{true})", "[mm]", "#sigma(d_{0})"},
+      {"z0", "(z_{0}^{rec} - z_{0}^{true})", "[mm]", "#sigma(z_{0})"},
+      {"phi", "(#phi^{rec} - #phi^{true})", "", "#sigma(#phi)"},
+      {"theta", "(#theta^{rec} - #theta^{true})", "", "#sigma(#theta)"},
+      {"qop", "((q/p)^{rec} - (q/p)^{true})", "[GeV^{-1}]", "#sigma(q/p)"},
+      {"t", "(t^{rec} - t^{true})", "[ns]", "#sigma(t)"}};
+
+  std::map<std::string, TH1F*> res;
+  std::map<std::string, TH1F*> pull;
+
+  // Create the hists and set up
+  for (const auto& parterms : paramNames) {
+    std::string par = parterms[0];
+
+    // residual hists
+    res[par] = (TH1F*)file->Get(Form("res_%s", par.c_str()));
+    // pull hists
+    pull[par] = (TH1F*)file->Get(Form("pull_%s", par.c_str()));
+
+    // set style
+    setHistStyle(res[par], kBlack);
+    setHistStyle(pull[par], kBlack);
+  }
 
   // plotting residual
   TCanvas* c1 = new TCanvas("c1", "c1", 1200, 800);
   c1->Divide(3, 2);
   for (size_t ipar = 0; ipar < paramNames.size(); ipar++) {
     c1->cd(ipar + 1);
-    res[paramNames.at(ipar)]->Draw("");
+    auto resHist = res[paramNames.at(ipar)[0]];
+
+    std::string xtitle = paramNames.at(ipar)[1] + std::string(" ");
+    xtitle += paramNames.at(ipar)[2];
+
+    Double_t scale = 1. / resHist->Integral();
+    resHist->Scale(scale);
+
+    resHist->GetXaxis()->SetTitle(xtitle.c_str());
+    resHist->GetYaxis()->SetTitle("Arb. Units");
+    resHist->Draw("hist");
   }
 
   // plotting pull
@@ -69,14 +92,53 @@ perigeeParamResolution(const std::string& inFile)
   c2->Divide(3, 2);
   for (size_t ipar = 0; ipar < paramNames.size(); ipar++) {
     c2->cd(ipar + 1);
-    pull[paramNames.at(ipar)]->Draw("");
+
+    TLegend* legend = new TLegend(0.7, 0.7, 0.9, 0.9);
+
+    auto pullHist = pull[paramNames.at(ipar)[0]];
+
+    Double_t scale = 1. / pullHist->Integral();
+    pullHist->Scale(scale);
+
+    if (fit) {
+      pullHist->Fit("gaus", "q");
+      TF1* gauss = pullHist->GetFunction("gaus");
+      float mu = gauss->GetParameter(1);
+      float sigma = gauss->GetParameter(2);
+
+      // Draw the sigma
+      TString mu_info;
+      mu_info += mu;
+      TString sigma_info;
+      sigma_info += sigma;
+
+      TString mfit_info = "#mu = ";
+      mfit_info += mu_info(0, 5);
+
+      TString sfit_info = "#sigma = ";
+      sfit_info += sigma_info(0, 5);
+
+      legend->AddEntry(gauss, sfit_info.Data(), "l");
+      legend->AddEntry(gauss, mfit_info.Data(), "");
+    }
+
+    std::string xtitle = paramNames.at(ipar)[1] + std::string("/");
+    xtitle += paramNames.at(ipar)[3];
+
+    pullHist->GetXaxis()->SetTitle(xtitle.c_str());
+    pullHist->GetYaxis()->SetTitle("Arb. Units");
+
+    pullHist->Draw("pe");
+    legend->SetBorderSize(0);
+    legend->SetFillStyle(0);
+    legend->SetTextFont(42);
+    legend->Draw();
   }
+  return 1;
 }
 
 // function to set up the histgram style
-void
-setHistStyle(TH1F* hist, short color = 1)
-{
+void setHistStyle(TH1F* hist, short color = 1) {
   hist->GetXaxis()->SetTitleSize(0.05);
   hist->GetYaxis()->SetTitleSize(0.05);
   hist->GetXaxis()->SetLabelSize(0.05);
@@ -87,7 +149,7 @@ setHistStyle(TH1F* hist, short color = 1)
   hist->SetMarkerStyle(20);
   hist->SetMarkerSize(0.8);
   hist->SetLineWidth(2);
-  //hist->SetTitle("");
+  hist->SetTitle("");
   hist->SetLineColor(1);
   hist->SetMarkerColor(color);
 }


### PR DESCRIPTION
This PR partly harmonizes the Executables in the `Script/TrackingPerformance` folder.
Currently one can run:
  * ActsExampleResidualAndPulls
  * ActsExamplePerigeeParameters

both steered by program options, the efficiency & fake-rate executable with also follow in a separate PR.

The naming of the plots is slightly refined and a quite option to produce plots from shell scripts (e.g. automatically from test runs in the CI is added).

![all_pulls](https://user-images.githubusercontent.com/26623879/129563982-e06493bb-da74-4c71-954d-ffab50e4227a.png)

![all_residuals](https://user-images.githubusercontent.com/26623879/129563995-cca431a2-423c-4aad-9588-0690e7eb52ba.png)


