### PR TITLE
fix: Static initialization of vector of strings

### DIFF
--- a/Core/include/Acts/Utilities/BinningType.hpp
+++ b/Core/include/Acts/Utilities/BinningType.hpp
@@ -46,7 +46,10 @@ enum BinningValue : int {
 };
 
 /// @brief screen output option
-static const std::vector<std::string> binningValueNames = {
-    "binX",    "binY", "binZ",   "binR",  "binPhi",
-    "binRPhi", "binH", "binEta", "binMag"};
+inline const std::vector<std::string>& binningValueNames() {
+  static const std::vector<std::string> _binningValueNames = {
+      "binX",    "binY", "binZ",   "binR",  "binPhi",
+      "binRPhi", "binH", "binEta", "binMag"};
+  return _binningValueNames;
+}
 }  // namespace Acts

--- a/Core/src/Geometry/Extent.cpp
+++ b/Core/src/Geometry/Extent.cpp
@@ -14,7 +14,7 @@
 std::ostream& Acts::Extent::toStream(std::ostream& sl) const {
   sl << "Extent in space : " << std::endl;
   for (size_t ib = 0; ib < static_cast<size_t>(binValues); ++ib) {
-    sl << "  - value :" << std::setw(10) << binningValueNames[ib]
+    sl << "  - value :" << std::setw(10) << binningValueNames()[ib]
        << " | range = [" << ranges[ib].first << ", " << ranges[ib].second << "]"
        << std::endl;
   }

--- a/Core/src/Geometry/ProtoLayerHelper.cpp
+++ b/Core/src/Geometry/ProtoLayerHelper.cpp
@@ -63,7 +63,7 @@ std::vector<Acts::ProtoLayer> Acts::ProtoLayerHelper::protoLayers(
   std::vector<std::vector<const Surface*>> sortSurfaces = {surfaces};
   for (const auto& sorting : sortings) {
     ACTS_VERBOSE("-> Sorting a set of " << sortSurfaces.size() << " in "
-                                        << binningValueNames[sorting.first]);
+                                        << binningValueNames()[sorting.first]);
     std::vector<std::vector<const Surface*>> subSurfaces;
     for (const auto& ssurfaces : sortSurfaces) {
       ACTS_VERBOSE("-> Surfaces for this sorting step: " << ssurfaces.size());

--- a/Core/src/Geometry/TrackingVolumeArrayCreator.cpp
+++ b/Core/src/Geometry/TrackingVolumeArrayCreator.cpp
@@ -23,7 +23,7 @@ Acts::TrackingVolumeArrayCreator::trackingVolumeArray(
     const GeometryContext& gctx, const TrackingVolumeVector& tVolumes,
     BinningValue bValue) const {
   // MSG_VERBOSE("Create VolumeArray of "<< tVolumes.size() << " TrackingVolumes
-  // with binning in : " << binningValueNames[bValue] );
+  // with binning in : " << binningValueNames()[bValue] );
   // let's copy and sort
   TrackingVolumeVector volumes(tVolumes);
   // sort it accordingly to the binning value

--- a/Plugins/DD4hep/src/ConvertDD4hepMaterial.cpp
+++ b/Plugins/DD4hep/src/ConvertDD4hepMaterial.cpp
@@ -31,9 +31,9 @@ std::shared_ptr<Acts::ProtoSurfaceMaterial> Acts::createProtoMaterial(
   // Loop over the bins
   for (auto& bin : binning) {
     // finding the iterator position to determine the binning value
-    auto bit = std::find(Acts::binningValueNames.begin(),
-                         Acts::binningValueNames.end(), bin.first);
-    size_t indx = std::distance(Acts::binningValueNames.begin(), bit);
+    auto bit = std::find(Acts::binningValueNames().begin(),
+                         Acts::binningValueNames().end(), bin.first);
+    size_t indx = std::distance(Acts::binningValueNames().begin(), bit);
     Acts::BinningValue bval = Acts::BinningValue(indx);
     Acts::BinningOption bopt = bin.second;
     double min = 0.;

--- a/Plugins/Json/src/UtilitiesJsonConverter.cpp
+++ b/Plugins/Json/src/UtilitiesJsonConverter.cpp
@@ -15,7 +15,7 @@ void Acts::to_json(nlohmann::json& j, const Acts::BinningData& bd) {
   j["min"] = bd.min;
   j["max"] = bd.max;
   j["option"] = (bd.option == Acts::open ? "open" : "closed");
-  j["value"] = Acts::binningValueNames[bd.binvalue];
+  j["value"] = Acts::binningValueNames()[bd.binvalue];
   int bins = bd.bins();
   // Write sub bin data if present
   if (bd.subBinningData != nullptr) {
@@ -46,10 +46,10 @@ void Acts::from_json(const nlohmann::json& j, Acts::BinningData& bd) {
   float max = j["max"];
   int bins = j["bins"];
   std::string valueName = j["value"];
-  auto valueIter = std::find(Acts::binningValueNames.begin(),
-                             Acts::binningValueNames.end(), valueName);
+  auto valueIter = std::find(Acts::binningValueNames().begin(),
+                             Acts::binningValueNames().end(), valueName);
   Acts::BinningValue bValue = static_cast<Acts::BinningValue>(
-      valueIter - Acts::binningValueNames.begin());
+      valueIter - Acts::binningValueNames().begin());
   if (bins == 1) {
     bd = Acts::BinningData(bValue, min, max);
     return;

--- a/Plugins/TGeo/src/TGeoLayerBuilder.cpp
+++ b/Plugins/TGeo/src/TGeoLayerBuilder.cpp
@@ -140,7 +140,7 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
     if (not layerCfg.parseRanges.empty()) {
       for (const auto& pRange : layerCfg.parseRanges) {
         ACTS_DEBUG("- layer parsing restricted in "
-                   << binningValueNames[pRange.first] << " to ["
+                   << binningValueNames()[pRange.first] << " to ["
                    << pRange.second.first << "/" << pRange.second.second
                    << "].");
       }
@@ -148,7 +148,7 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
     if (not layerCfg.splitConfigs.empty()) {
       for (const auto& sConfig : layerCfg.splitConfigs) {
         ACTS_DEBUG("- layer splitting attempt in "
-                   << binningValueNames[sConfig.first] << " with tolerance "
+                   << binningValueNames()[sConfig.first] << " with tolerance "
                    << sConfig.second << ".");
       }
     }
@@ -175,7 +175,7 @@ void Acts::TGeoLayerBuilder::buildLayers(const GeometryContext& gctx,
       ACTS_DEBUG("- applying  " << layerCfg.parseRanges.size()
                                 << " search restrictions.");
       for (const auto& prange : layerCfg.parseRanges) {
-        ACTS_VERBOSE(" - range " << binningValueNames[prange.first]
+        ACTS_VERBOSE(" - range " << binningValueNames()[prange.first]
                                  << " within [ " << prange.second.first << ", "
                                  << prange.second.second << "]");
       }


### PR DESCRIPTION
This caused problems for me when opening the ActsCore shared lib through python. Also, it's generally safer to try not to use statically initialized global variables. This changes this to a function that statically initializes it in the body (safe) and returns a const ref only.
