### PR TITLE
perf: Use map to accelerate parameter estimator

### DIFF
--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -76,6 +76,13 @@ ActsExamples::TrackParamsEstimationAlgorithm::createSeeds(
     const ActsExamples::SimSpacePointContainer& spacePoints) const {
   SimSeedContainer seeds;
   seeds.reserve(protoTracks.size());
+
+  std::unordered_map<Index, const SimSpacePoint*> spMap;
+
+  for (const SimSpacePoint& i : spacePoints) {
+    spMap.emplace(i.measurementIndex(), &i);
+  }
+
   for (std::size_t itrack = 0; itrack < protoTracks.size(); ++itrack) {
     // The list of hits and the initial start parameters
     const auto& protoTrack = protoTracks[itrack];
@@ -88,13 +95,9 @@ ActsExamples::TrackParamsEstimationAlgorithm::createSeeds(
     spacePointsOnTrack.reserve(protoTrack.size());
     // Loop over the hit index on the proto track to find the space points
     for (const auto& hitIndex : protoTrack) {
-      auto it =
-          std::find_if(spacePoints.begin(), spacePoints.end(),
-                       [&](const SimSpacePoint& spacePoint) {
-                         return (spacePoint.measurementIndex() == hitIndex);
-                       });
-      if (it != spacePoints.end()) {
-        spacePointsOnTrack.push_back(&(*it));
+      auto it = spMap.find(hitIndex);
+      if (it != spMap.end()) {
+        spacePointsOnTrack.push_back(it->second);
       }
     }
     // At least three space points are required


### PR DESCRIPTION
While I was playing around with the seeding, I noticed that the `TrackParamsEstimationAlgorithm` was a significant source of overhead for high pile-up events. When processing events with 4000 pions, the time taken to run this algorithm starts to approach the runtime of seeding itself. For much larger events, in the neighbourhood of 12000 pions (where we get higher fake rates), the result was even worse with the track parameter estimation taking hundreds of milliseconds. The reason for this is simple: given |_S_| spacepoints (which in itself linear in the number of particles), the track parameter estimation performs an _O_(|_S_|) lookup operation for each of the _O_(1) hits in each seed. In total, there are _O_(|_S_|) (or even _O_(|_S_|<sup>3</sup>) in the uncapped case) seeds, and so the track parameter estimation is a somewhat expensive _O_(|_S_|<sup>2</sup>) algorithm.

In this commit, I replace the _O_(|_S_|) lookup operation by an equivalent O(log |S|) operation permitted by `std::map`. This reduces the overall complexity to _O_(|_S_| log |_S_|), providing a significant speed-up. For the previously mentioned 12000 pion events, the processing time of this specific algorithm on my laptop drops from 259 milliseconds to 21 milliseconds: a speed-up of a factor twelve.