### PR TITLE
perf: Remove extraneous copies in seedfinder

### DIFF
--- a/Core/include/Acts/Seeding/Seedfinder.hpp
+++ b/Core/include/Acts/Seeding/Seedfinder.hpp
@@ -56,10 +56,6 @@ class Seedfinder {
     std::vector<std::pair<
         float, std::unique_ptr<const InternalSeed<external_spacepoint_t>>>>
         seedsPerSpM;
-
-    std::vector<std::pair<
-        float, std::unique_ptr<const InternalSeed<external_spacepoint_t>>>>
-        sameTrackSeeds;
   };
 
   /// The only constructor. Requires a config object.

--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -230,15 +230,9 @@ void Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
         }
       }
       if (!state.topSpVec.empty()) {
-        state.sameTrackSeeds.clear();
         m_config.seedFilter->filterSeeds_2SpFixed(
             *state.compatBottomSP[b], *spM, state.topSpVec, state.curvatures,
-            state.impactParameters, Zob,
-            std::back_inserter(state.sameTrackSeeds));
-        state.seedsPerSpM.insert(
-            state.seedsPerSpM.end(),
-            std::make_move_iterator(state.sameTrackSeeds.begin()),
-            std::make_move_iterator(state.sameTrackSeeds.end()));
+            state.impactParameters, Zob, std::back_inserter(state.seedsPerSpM));
       }
     }
     m_config.seedFilter->filterSeeds_1SpFixed(state.seedsPerSpM, outIt);


### PR DESCRIPTION
This is just a tiny little improvement on #905. I noticed that we are currently using an output iterator function to write some results to a vector, and then copying that vector over to append it to another, existing vector. I think it would be (very marginally) quicker and neater to avoid this extra copy and just have the function take the insertion iterator of the vector we are planning to write to in the end.