### PR TITLE
fix: GeometryView3D default output directory doesn't work.

### DIFF
--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -22,6 +22,9 @@
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
 
+#include <limits.h>
+#include <unistd.h>
+
 namespace {
 std::string joinPaths(const std::string& a, const std::string& b) {
   if (b.substr(0, 1) == "/" || a.empty()) {
@@ -34,6 +37,13 @@ std::string joinPaths(const std::string& a, const std::string& b) {
 
   return a + "/" + b;
 }
+
+std::string getWorkingDirectory() {
+  char buffer[PATH_MAX];
+  return (getcwd(buffer, sizeof(buffer)) ? std::string(buffer)
+                                         : std::string(""));
+}
+
 }  // namespace
 
 void Acts::GeometryView3D::drawPolyhedron(IVisualization3D& helper,
@@ -66,7 +76,9 @@ void Acts::GeometryView3D::drawSurfaceArray(
     IVisualization3D& helper, const SurfaceArray& surfaceArray,
     const GeometryContext& gctx, const Transform3& transform,
     const ViewConfig& sensitiveConfig, const ViewConfig& passiveConfig,
-    const ViewConfig& gridConfig, const std::string& outputDir) {
+    const ViewConfig& gridConfig, const std::string& _outputDir) {
+  std::string outputDir =
+      _outputDir == "." ? getWorkingDirectory() : _outputDir;
   // Draw all the surfaces
   Extent arrayExtent;
   for (const auto& sf : surfaceArray.surfaces()) {
@@ -161,7 +173,10 @@ void Acts::GeometryView3D::drawVolume(IVisualization3D& helper,
 void Acts::GeometryView3D::drawLayer(
     IVisualization3D& helper, const Layer& layer, const GeometryContext& gctx,
     const ViewConfig& layerConfig, const ViewConfig& sensitiveConfig,
-    const ViewConfig& gridConfig, const std::string& outputDir) {
+    const ViewConfig& gridConfig, const std::string& _outputDir) {
+  std::string outputDir =
+      _outputDir == "." ? getWorkingDirectory() : _outputDir;
+
   if (layerConfig.visible) {
     auto layerVolume = layer.representingVolume();
     if (layerVolume != nullptr) {
@@ -192,7 +207,9 @@ void Acts::GeometryView3D::drawTrackingVolume(
     const GeometryContext& gctx, const ViewConfig& containerView,
     const ViewConfig& volumeView, const ViewConfig& layerView,
     const ViewConfig& sensitiveView, const ViewConfig& gridView, bool writeIt,
-    const std::string& tag, const std::string& outputDir) {
+    const std::string& tag, const std::string& _outputDir) {
+  std::string outputDir =
+      _outputDir == "." ? getWorkingDirectory() : _outputDir;
   if (tVolume.confinedVolumes() != nullptr) {
     const auto& subVolumes = tVolume.confinedVolumes()->arrayObjects();
     for (const auto& tv : subVolumes) {

--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -99,6 +99,7 @@ int processGeometry(int argc, char* argv[],
       // Configure the tracking geometry writer
       auto tgObjWriterConfig =
           ActsExamples::Options::readObjTrackingGeometryWriterConfig(vm);
+      tgObjWriterConfig.outputDir = outputDir;
       auto tgObjWriter =
           std::make_shared<ActsExamples::ObjTrackingGeometryWriter>(
               tgObjWriterConfig, volumeLogLevel);


### PR DESCRIPTION
In #917 I introduced an output directory to `GeometryView3D`. I set the default to "." as that usually means the current directory. Due to the way we currently look for file extensions, this didn't actually work. I didn't actually test the default, so that broke the output writing.

This PR works around this by checking if the default value "." is given, and replaces this with the actual `$PWD`. This is not super robust, and ideally we should revise all of this using `boost::filesystem`, which I'll try to do in a future PR.

Aside from this, this PR also make the geometry examples correctly pipe through the `--output-dir` option to the geometry view output.