### PR TITLE
fix: Use width/sqrt(12) in smearing digi config file for generic detector

### DIFF
--- a/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json
+++ b/Examples/Algorithms/Digitization/share/default-smearing-config-generic.json
@@ -1,90 +1,179 @@
 {
-  "acts-geometry-hierarchy-map" : {
-    "format-version" : 0,
-    "value-identifier" : "digitization-configuration"
-  },
-                                  "entries"
-      : [
+    "acts-geometry-hierarchy-map": {
+        "format-version": 0,
+        "value-identifier": "digitization-configuration"
+    },
+    "entries": [
         {
-          "volume" : 7,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"}
-            ]
-          }
+            "volume": 7,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 8,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"}
-            ]
-          }
+            "volume": 8,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 9,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 0.05, "type" : "Gauss"}
-            ]
-          }
+            "volume": 9,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.014433756729740645,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 12,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.08, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 1.2, "type" : "Gauss"}
-            ]
-          }
+            "volume": 12,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.023094010767585032,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.34641016151377546,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 13,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.08, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 1.2, "type" : "Gauss"}
-            ]
-          }
+            "volume": 13,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.023094010767585032,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.34641016151377546,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 14,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.08, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 1.2, "type" : "Gauss"}
-            ]
-          }
+            "volume": 14,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.023094010767585032,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 0.34641016151377546,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 16,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.12, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 10.8, "type" : "Gauss"}
-            ]
-          }
+            "volume": 16,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.034641016151377546,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 3.1176914536239795,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 17,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.12, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 10.8, "type" : "Gauss"}
-            ]
-          }
+            "volume": 17,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.034641016151377546,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 3.1176914536239795,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         },
         {
-          "volume" : 18,
-          "value" : {
-            "smearing" : [
-              {"index" : 0, "mean" : 0.0, "stddev" : 0.12, "type" : "Gauss"},
-              {"index" : 1, "mean" : 0.0, "stddev" : 10.8, "type" : "Gauss"}
-            ]
-          }
+            "volume": 18,
+            "value": {
+                "smearing": [
+                    {
+                        "index": 0,
+                        "mean": 0.0,
+                        "stddev": 0.034641016151377546,
+                        "type": "Gauss"
+                    },
+                    {
+                        "index": 1,
+                        "mean": 0.0,
+                        "stddev": 3.1176914536239795,
+                        "type": "Gauss"
+                    }
+                ]
+            }
         }
-      ]
+    ]
 }


### PR DESCRIPTION
Previously I carelessly set the smearing widths equal to the pixel or strip dimensions. This is ill-advised as the resulting measurement only falls in the right pixel ~68% of the time. In this PR, smearing widths are changed to dimensions/sqrt(12). 

closes #946 

cc @robertlangenberg 

