### PR TITLE
chore: Add boost and eigen bundled sources in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ The Acts project contains copies of the following external packages:
     under the MIT license.
 -   [OpenDataDetector](https://github.com/acts-project/OpenDataDetector)
     licensed under the MPLv2 license.
+-   [boost](https://www.boost.org/) 
+    licensed under the Boost Software License.
+-   [eigen3](https://eigen.tuxfamily.org/index.php?title=Main_Page)
+    licensed under the MPLv2 license.


### PR DESCRIPTION
Adds the boost and eigen bundled sources to the mentions of third party sources in our README.