### PR TITLE
fix: Collision region should be in millimetres

### DIFF
--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -111,8 +111,8 @@ struct SeedfinderConfig {
     config.deltaRMax /= 1_mm;
     config.impactMax /= 1_mm;
     config.maxPtScattering /= 1_MeV;  // correct?
-    config.collisionRegionMin /= 1_MeV;
-    config.collisionRegionMax /= 1_MeV;
+    config.collisionRegionMin /= 1_mm;
+    config.collisionRegionMax /= 1_mm;
     config.zMin /= 1_mm;
     config.zMax /= 1_mm;
     config.rMax /= 1_mm;


### PR DESCRIPTION
In #941, the collision region bounds in the _z_ axis were mistakenly defined to be in MeV where they should be in millimetres. This change doesn't negatively impact physics performance per se because it makes the collision region one thousand times larger than it should be, but it can have significant influence on the compute performance. This commit changes the unit back to millimetres, as it should be.