### PR TITLE
docs: Recommend recursive git clone for ODD compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ following commands will clone the repository, configure, and build the core
 library
 
 ```sh
-git clone https://github.com/acts-project/acts <source-dir>
+git clone --recursive https://github.com/acts-project/acts <source-dir>
 cmake -B <build-dir> -S <source-dir>
 cmake --build <build-dir>
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,7 @@ following commands will clone the repository, configure, and build the core
 library:
 
 ```console
-$ git clone https://github.com/acts-project/acts <source-dir>
+$ git clone --recursive https://github.com/acts-project/acts <source-dir>
 $ cmake -B <build-dir> -S <source-dir>
 $ cmake --build <build-dir>
 ```


### PR DESCRIPTION
Now that the OpenDataDetector is a submodule, people cloning the ACTS repository should probably default to using recursive git clone, otherwise docs examples based on the ODD will not work.