### PR TITLE
feat: rework Geant4 simulation (2/X)

### DIFF
--- a/Examples/Algorithms/Geant4/CMakeLists.txt
+++ b/Examples/Algorithms/Geant4/CMakeLists.txt
@@ -3,8 +3,12 @@ set(ACTS_EXAMPLES_G4SOURCES
     src/GdmlDetectorConstruction.cpp
     src/Geant4Options.cpp
     src/Geant4Simulation.cpp
+    src/MagneticFieldWrapper.cpp
     src/MaterialPhysicsList.cpp
     src/MaterialSteppingAction.cpp
+    src/ParticleTrackingAction.cpp
+    src/SensitiveSurfaceMapper.cpp
+    src/SensitiveSteppingAction.cpp
     src/SimParticleTranslation.cpp)
 
 if (ACTS_BUILD_EXAMPLES_DD4HEP)

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
@@ -28,7 +28,7 @@ class G4MagneticField;
 
 namespace ActsExamples {
 
-class Geant4SurfaceMapper;
+class SensitiveSurfaceMapper;
 
 /// Algorithm to run Geant4 simulation in the ActsExamples framework
 ///
@@ -80,8 +80,12 @@ class Geant4Simulation final : public BareAlgorithm {
     /// Detector construction object.
     G4VUserDetectorConstruction* detectorConstruction = nullptr;
 
-    /// The ACTS Magnetic field provider
+    /// The (wrapped) ACTS Magnetic field provider as a Geant4 module
     G4MagneticField* magneticField = nullptr;
+
+    // The ACTS to Geant4 sensitive wrapper
+    std::shared_ptr<const SensitiveSurfaceMapper> sensitiveSurfaceMapper =
+        nullptr;
   };
 
   /// Constructor with arguments

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/MagneticFieldWrapper.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/MagneticFieldWrapper.hpp
@@ -1,0 +1,61 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+
+#include <memory>
+
+#include <G4MagneticField.hh>
+
+namespace Acts {
+class MagneticFieldProvider;
+}
+
+namespace ActsExamples {
+
+/// A magnetic field wrapper for the Acts magnetic field
+/// to be used with Geant4.
+class MagneticFieldWrapper : public G4MagneticField {
+ public:
+  /// Configuration of the Magnetic Field Action
+  struct Config {
+    /// Access to the ACTS magnetic field
+    std::shared_ptr<const Acts::MagneticFieldProvider> magneticField = nullptr;
+  };
+
+  /// Construct the magnetic field action
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the ACTS logging instance
+  MagneticFieldWrapper(const Config& cfg,
+                       std::unique_ptr<const Acts::Logger> logger =
+                           Acts::getDefaultLogger("MagneticFieldWrapper",
+                                                  Acts::Logging::INFO));
+  ~MagneticFieldWrapper() override = default;
+
+  /// Public get field interface
+  ///
+  /// @param Point is the field request point
+  /// @param Bfield [in,out] is the field value
+  ///
+  void GetFieldValue(const G4double Point[4], G4double* Bfield) const final;
+
+ protected:
+  Config m_cfg;
+
+ private:
+  /// Private access method to the logging instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+  /// The looging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleTrackingAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleTrackingAction.hpp
@@ -37,13 +37,13 @@ class ParticleTrackingAction : public G4UserTrackingAction {
                                                     Acts::Logging::INFO));
   ~ParticleTrackingAction() override = default;
 
-  /// Action before the the track is processed in the
+  /// Action before the track is processed in the
   /// the simulation, this will record the initial particle
   ///
   /// @param aTrack the current Geant4 track
   void PreUserTrackingAction(const G4Track* aTrack) final;
 
-  /// Action before the the track is processed in the
+  /// Action after the track is processed in the
   /// the simulation, this will record the final particle
   ///
   /// @param aTrack the current Geant4 track

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleTrackingAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleTrackingAction.hpp
@@ -1,0 +1,68 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/SimParticle.hpp"
+
+#include <memory>
+#include <string>
+
+#include <G4Track.hh>
+#include <G4UserTrackingAction.hh>
+
+namespace ActsExamples {
+
+/// The G4UserTrackingAction that is called for every track in
+/// the simulation process.
+///
+/// It records the initial and final particle state
+class ParticleTrackingAction : public G4UserTrackingAction {
+ public:
+  struct Config {};
+
+  /// Construct the stepping action
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the ACTS logging instance
+  ParticleTrackingAction(const Config& cfg,
+                         std::unique_ptr<const Acts::Logger> logger =
+                             Acts::getDefaultLogger("ParticleTrackingAction",
+                                                    Acts::Logging::INFO));
+  ~ParticleTrackingAction() override = default;
+
+  /// Action before the the track is processed in the
+  /// the simulation, this will record the initial particle
+  ///
+  /// @param aTrack the current Geant4 track
+  void PreUserTrackingAction(const G4Track* aTrack) final;
+
+  /// Action before the the track is processed in the
+  /// the simulation, this will record the final particle
+  ///
+  /// @param aTrack the current Geant4 track
+  void PostUserTrackingAction(const G4Track* aTrack) final;
+
+ protected:
+  Config m_cfg;
+
+ private:
+  /// Convert a G4Track to a SimParticle
+  ///
+  /// @param aTrack the current Geant4 track
+  SimParticle convert(const G4Track& aTrack) const;
+
+  /// Private access method to the logging instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+  /// The looging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSteppingAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSteppingAction.hpp
@@ -1,0 +1,61 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+
+#include <memory>
+#include <string>
+
+#include <G4UserSteppingAction.hh>
+
+namespace ActsExamples {
+
+/// The G4SteppingAction that is called for every step in
+/// the simulation process.
+///
+/// It checks whether a sensitive volume is present (via string tag)
+/// and records (if necessary) the hit.
+class SensitiveSteppingAction : public G4UserSteppingAction {
+ public:
+  /// Configuration of the Stepping action
+  struct Config {
+    /// Selection for hit recording
+    bool charged = true;
+    bool neutral = false;
+    bool primary = true;
+    bool secondary = false;
+  };
+
+  /// Construct the stepping action
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the ACTS logging instance
+  SensitiveSteppingAction(const Config& cfg,
+                          std::unique_ptr<const Acts::Logger> logger =
+                              Acts::getDefaultLogger("SensitiveSteppingAction",
+                                                     Acts::Logging::INFO));
+  ~SensitiveSteppingAction() override = default;
+
+  /// @brief Interface Method doing the step and records the data
+  /// @param step is the Geant4 step of the particle
+  void UserSteppingAction(const G4Step* step) final override;
+
+ protected:
+  Config m_cfg;
+
+ private:
+  /// Private access method to the logging instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+  /// The looging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSurfaceMapper.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSurfaceMapper.hpp
@@ -1,0 +1,77 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Utilities/Logger.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class G4VPhysicalVolume;
+
+namespace Acts {
+class TrackingGeometry;
+}
+
+namespace ActsExamples {
+
+/// This Mapper takes a (non-const) Geant4 geometry and maps
+/// it such that name will be containing the mapping prefix
+/// and the Acts::GeometryIdentifier of the surface.
+///
+/// This allows to directly associate Geant4 hits to the sensitive
+/// elements of the Acts::TrackingGeoemtry w/o map lookup.
+class SensitiveSurfaceMapper {
+ public:
+  static constexpr const char* mappingPrefix = "ActsGeoID#";
+
+  /// Configuration struct for the surface mapper
+  struct Config {
+    std::vector<std::string> materialMappings = {};
+    std::vector<std::string> volumeMappings = {};
+
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry = nullptr;
+  };
+
+  /// Constructor with:
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the logging instance
+  SensitiveSurfaceMapper(const Config& cfg,
+                         std::unique_ptr<const Acts::Logger> logger =
+                             Acts::getDefaultLogger("SensitiveSurfaceMapper",
+                                                    Acts::Logging::INFO));
+  ~SensitiveSurfaceMapper() = default;
+
+  /// Recursive mapping function that walks through the Geant4
+  /// hierarchy and applies name remapping to the Physical volumes
+  /// of the Geant4 geometry.
+  ///
+  /// @param g4PhysicalVolume the current physical volume in process
+  /// @param motherPosition the absolute position of the mother
+  /// @param sCounter  a counter of how many volumes have been remapped
+  void remapSensitiveNames(G4VPhysicalVolume* g4PhysicalVolume,
+                           const Acts::Vector3 motherPosition,
+                           int& sCounter) const;
+
+ protected:
+  /// Configuration object
+  Config m_cfg;
+
+ private:
+  /// Private access method to the logging instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+  /// The looging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSurfaceMapper.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/SensitiveSurfaceMapper.hpp
@@ -35,7 +35,7 @@ class SensitiveSurfaceMapper {
 
   /// Configuration struct for the surface mapper
   struct Config {
-    std::vector<std::string> materialMappings = {};
+    std::vector<std::string> materialMappings = {"Silicon"};
     std::vector<std::string> volumeMappings = {};
 
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry = nullptr;

--- a/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
@@ -12,6 +12,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Geant4/EventStoreRegistry.hpp"
+#include "ActsExamples/Geant4/SensitiveSurfaceMapper.hpp"
 
 #include <iostream>
 #include <stdexcept>
@@ -87,6 +88,19 @@ ActsExamples::Geant4Simulation::Geant4Simulation(
 
     // Propagate down to all childrend
     g4World->GetLogicalVolume()->SetFieldManager(fieldMgr, true);
+  }
+
+  // Map simulation to reconstruction geometry
+  if (m_cfg.sensitiveSurfaceMapper != nullptr) {
+    ACTS_INFO(
+        "Remapping selected volumes from Geant4 to Acts::Surface::GeometryID");
+
+    G4VPhysicalVolume* g4World = m_cfg.detectorConstruction->Construct();
+    int sCounter = 0;
+    m_cfg.sensitiveSurfaceMapper->remapSensitiveNames(
+        g4World, Acts::Vector3(0., 0., 0.), sCounter);
+
+    ACTS_INFO("Remapping successful for " << sCounter << " selected volumes.");
   }
 }
 

--- a/Examples/Algorithms/Geant4/src/MagneticFieldWrapper.cpp
+++ b/Examples/Algorithms/Geant4/src/MagneticFieldWrapper.cpp
@@ -1,0 +1,43 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/MagneticFieldWrapper.hpp"
+
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
+#include "Acts/MagneticField/MagneticFieldProvider.hpp"
+
+#include <G4SystemOfUnits.hh>
+#include <G4UnitsTable.hh>
+
+ActsExamples::MagneticFieldWrapper::MagneticFieldWrapper(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : G4MagneticField(), m_cfg(cfg), m_logger(std::move(logger)) {}
+
+void ActsExamples::MagneticFieldWrapper::GetFieldValue(const G4double Point[4],
+                                                       G4double* Bfield) const {
+  constexpr double convertLength = CLHEP::mm / Acts::UnitConstants::mm;
+  constexpr double convertField = CLHEP::tesla / Acts::UnitConstants::T;
+
+  auto bCache = m_cfg.magneticField->makeCache(Acts::MagneticFieldContext());
+
+  auto fieldRes = m_cfg.magneticField->getField(
+      {convertLength * Point[0], convertLength * Point[1],
+       convertLength * Point[2]},
+      bCache);
+  if (!fieldRes.ok()) {
+    ACTS_ERROR("Field lookup error: " << fieldRes.error());
+    return;
+  }
+  // Get the field now
+  const Acts::Vector3& field = *fieldRes;
+
+  Bfield[0] = convertField * field[0];
+  Bfield[1] = convertField * field[1];
+  Bfield[2] = convertField * field[2];
+}

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -1,0 +1,67 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/ParticleTrackingAction.hpp"
+
+#include "Acts/Definitions/Units.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/Geant4/EventStoreRegistry.hpp"
+
+#include <G4ParticleDefinition.hh>
+#include <G4RunManager.hh>
+#include <G4Track.hh>
+#include <G4UnitsTable.hh>
+#include <globals.hh>
+
+ActsExamples::ParticleTrackingAction::ParticleTrackingAction(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : G4UserTrackingAction(), m_cfg(cfg), m_logger(std::move(logger)) {}
+
+void ActsExamples::ParticleTrackingAction::PreUserTrackingAction(
+    const G4Track* aTrack) {
+  auto g4RunManager = G4RunManager::GetRunManager();
+  unsigned int eventID = g4RunManager->GetCurrentEvent()->GetEventID();
+
+  auto& eventData = EventStoreRegistry::eventData[eventID];
+  eventData.particlesInitial.push_back(convert(*aTrack));
+}
+
+void ActsExamples::ParticleTrackingAction::PostUserTrackingAction(
+    const G4Track* aTrack) {
+  auto g4RunManager = G4RunManager::GetRunManager();
+  unsigned int eventID = g4RunManager->GetCurrentEvent()->GetEventID();
+
+  auto& eventData = EventStoreRegistry::eventData[eventID];
+  eventData.particlesFinal.push_back(convert(*aTrack));
+}
+
+ActsExamples::SimParticle ActsExamples::ParticleTrackingAction::convert(
+    const G4Track& aTrack) const {
+  // Unit conversions G4->::ACTS
+  constexpr double convertTime = Acts::UnitConstants::s / CLHEP::s;
+  constexpr double convertLength = Acts::UnitConstants::mm / CLHEP::mm;
+  constexpr double convertEnergy = Acts::UnitConstants::GeV / CLHEP::GeV;
+
+  // Get all the information from the Track
+  const G4ParticleDefinition* particleDef = aTrack.GetParticleDefinition();
+  G4double mass = particleDef->GetPDGMass();
+  G4double charge = particleDef->GetPDGCharge();
+  G4int pdg = particleDef->GetPDGEncoding();
+  G4int id = aTrack.GetTrackID();
+  G4ThreeVector pPosition = convertLength * aTrack.GetPosition();
+  G4double pTime = convertTime * aTrack.GetGlobalTime();
+  G4ThreeVector pDirection = aTrack.GetMomentumDirection();
+  G4double p = convertEnergy * aTrack.GetKineticEnergy();
+  // Now create the Particle
+  ActsExamples::SimParticle aParticle(SimBarcode(id), Acts::PdgParticle(pdg),
+                                      charge, mass);
+  aParticle.setPosition4(pPosition[0], pPosition[1], pPosition[2], pTime);
+  aParticle.setDirection(pDirection[0], pDirection[1], pDirection[2]);
+  aParticle.setAbsoluteMomentum(p);
+  return aParticle;
+}

--- a/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
@@ -1,0 +1,120 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/SensitiveSteppingAction.hpp"
+
+#include "Acts/Definitions/Units.hpp"
+#include "ActsExamples/Geant4/EventStoreRegistry.hpp"
+#include "ActsExamples/Geant4/SensitiveSurfaceMapper.hpp"
+
+#include <G4RunManager.hh>
+#include <G4Step.hh>
+#include <G4StepPoint.hh>
+#include <G4Track.hh>
+#include <G4UnitsTable.hh>
+#include <G4VPhysicalVolume.hh>
+
+ActsExamples::SensitiveSteppingAction::SensitiveSteppingAction(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : G4UserSteppingAction(), m_cfg(cfg), m_logger(std::move(logger)) {}
+
+void ActsExamples::SensitiveSteppingAction::UserSteppingAction(
+    const G4Step* step) {
+  // Unit conversions G4->::ACTS
+  constexpr double convertTime = Acts::UnitConstants::s / CLHEP::s;
+  constexpr double convertLength = Acts::UnitConstants::mm / CLHEP::mm;
+  constexpr double convertEnergy = Acts::UnitConstants::GeV / CLHEP::GeV;
+
+  auto g4RunManager = G4RunManager::GetRunManager();
+  unsigned int eventNr = g4RunManager->GetCurrentEvent()->GetEventID();
+
+  // The particle after the step
+  G4Track* track = step->GetTrack();
+  G4PrimaryParticle* primaryParticle =
+      track->GetDynamicParticle()->GetPrimaryParticle();
+
+  // Bail out if charged & configured to do so
+  G4double absCharge = std::abs(track->GetParticleDefinition()->GetPDGCharge());
+  if (not m_cfg.charged and absCharge > 0.) {
+    return;
+  }
+
+  // Bail out if neutral & configured to do so
+  if (not m_cfg.neutral and absCharge == 0.) {
+    return;
+  }
+
+  // Bail out if it is a primary & configured to be ignored
+  if (not m_cfg.primary and primaryParticle != nullptr) {
+    return;
+  }
+
+  // Bail out if it is a secondary & configured to be ignored
+  if (not m_cfg.secondary and primaryParticle == nullptr) {
+    return;
+  }
+
+  // Get the physical volume & check if it has the sensitive string name
+  G4VPhysicalVolume* volume = track->GetVolume();
+  std::string volumeName = volume->GetName();
+
+  std::string mappingPfx(SensitiveSurfaceMapper::mappingPrefix);
+
+  if (volumeName.find(mappingPfx) != std::string::npos) {
+    ACTS_VERBOSE("Step in senstive volume " << volumeName);
+
+    // Get PreStepPoint and PostStepPoint
+    G4StepPoint* preStepPoint = step->GetPreStepPoint();
+    G4StepPoint* postStepPoint = step->GetPostStepPoint();
+
+    G4ThreeVector preStepPosition = convertLength * preStepPoint->GetPosition();
+    G4double preStepTime = convertTime * preStepPoint->GetGlobalTime();
+    G4ThreeVector postStepPosition =
+        convertLength * postStepPoint->GetPosition();
+    G4double postStepTime = convertTime * postStepPoint->GetGlobalTime();
+
+    G4ThreeVector preStepMomentum = convertEnergy * preStepPoint->GetMomentum();
+    G4double preStepEnergy = convertEnergy * preStepPoint->GetTotalEnergy();
+    G4ThreeVector postStepMomentum =
+        convertEnergy * postStepPoint->GetMomentum();
+    G4double postStepEnergy = convertEnergy * postStepPoint->GetTotalEnergy();
+
+    Acts::ActsScalar hX = 0.5 * (preStepPosition[0] + postStepPosition[0]);
+    Acts::ActsScalar hY = 0.5 * (preStepPosition[1] + postStepPosition[1]);
+    Acts::ActsScalar hZ = 0.5 * (preStepPosition[2] + postStepPosition[2]);
+    Acts::ActsScalar hT = 0.5 * (preStepTime + postStepTime);
+
+    Acts::ActsScalar mXpre = preStepMomentum[0];
+    Acts::ActsScalar mYpre = preStepMomentum[1];
+    Acts::ActsScalar mZpre = preStepMomentum[2];
+    Acts::ActsScalar mEpre = preStepEnergy;
+    Acts::ActsScalar mXpost = postStepMomentum[0];
+    Acts::ActsScalar mYpost = postStepMomentum[1];
+    Acts::ActsScalar mZpost = postStepMomentum[2];
+    Acts::ActsScalar mEpost = postStepEnergy;
+
+    // Cast out the GeometryIdentifier
+    volumeName.erase(0, mappingPfx.size());
+
+    Acts::GeometryIdentifier::Value sGeoVal = std::stoul(volumeName);
+    Acts::GeometryIdentifier geoID(sGeoVal);
+
+    SimBarcode particleID(track->GetTrackID());
+    Acts::Vector4 particlePosition(hX, hY, hZ, hT);
+    Acts::Vector4 beforeMomentum(mXpre, mYpre, mZpre, mEpre);
+    Acts::Vector4 afterMomentum(mXpost, mYpost, mZpost, mEpost);
+
+    // Retrieve the event data registry
+    auto& eventData = EventStoreRegistry::eventData[eventNr];
+
+    // Fill into the registry
+    eventData.hits.emplace_back(geoID, particleID, particlePosition,
+                                beforeMomentum, afterMomentum,
+                                eventData.hits.size());
+  }
+}

--- a/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
@@ -1,0 +1,99 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/SensitiveSurfaceMapper.hpp"
+
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/Geometry/Layer.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <stdexcept>
+
+#include <G4LogicalVolume.hh>
+#include <G4Material.hh>
+#include <G4VPhysicalVolume.hh>
+#include <globals.hh>
+
+ActsExamples::SensitiveSurfaceMapper::SensitiveSurfaceMapper(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : m_cfg(cfg), m_logger(std::move(logger)) {
+  if (m_cfg.trackingGeometry == nullptr) {
+    throw std::invalid_argument("No Acts::TrackingGeometry provided.");
+  }
+}
+
+void ActsExamples::SensitiveSurfaceMapper::remapSensitiveNames(
+    G4VPhysicalVolume* g4PhysicalVolume, const Acts::Vector3 motherPosition,
+    int& sCounter) const {
+  auto g4LogicalVolume = g4PhysicalVolume->GetLogicalVolume();
+  auto g4SensitiveDetector = g4LogicalVolume->GetSensitiveDetector();
+
+  G4int nDaughters = g4LogicalVolume->GetNoDaughters();
+
+  constexpr double convertLength = CLHEP::mm / Acts::UnitConstants::mm;
+
+  // Get the relative translation of the G4 object
+  auto g4RelTranslation = g4PhysicalVolume->GetTranslation();
+  Acts::Vector3 g4RelPosition(g4RelTranslation[0] * convertLength,
+                              g4RelTranslation[1] * convertLength,
+                              g4RelTranslation[2] * convertLength);
+
+  if (nDaughters == 0) {
+    std::string volumeMaterialName = g4LogicalVolume->GetMaterial()->GetName();
+    if (g4SensitiveDetector != nullptr or
+        volumeMaterialName.find("Silicon") != std::string::npos) {
+      // Find the associated ACTS object
+      Acts::Vector3 g4AbsPosition = g4RelPosition + motherPosition;
+      auto actsLayer = m_cfg.trackingGeometry->associatedLayer(
+          Acts::GeometryContext(), g4AbsPosition);
+
+      // Prepare the mapped surface
+      const Acts::Surface* mappedSurface = nullptr;
+
+      if (actsLayer and actsLayer->surfaceArray()) {
+        auto actsSurfaces = actsLayer->surfaceArray()->at(g4AbsPosition);
+        if (not actsSurfaces.empty()) {
+          // Fast matching: search
+          for (const auto& as : actsSurfaces) {
+            if (as->center(Acts::GeometryContext()).isApprox(g4AbsPosition)) {
+              mappedSurface = as;
+              break;
+            }
+          }
+        }
+        if (mappedSurface == nullptr) {
+          // Slow matching: Fallback, loop over all layer surfaces
+          for (const auto& as : actsLayer->surfaceArray()->surfaces()) {
+            if (as->center(Acts::GeometryContext()).isApprox(g4AbsPosition)) {
+              mappedSurface = as;
+              break;
+            }
+          }
+        }
+      }
+      // A mapped surface was found, a new name will be set that
+      // contains the GeometryID/
+      if (mappedSurface != nullptr) {
+        ++sCounter;
+        std::string mappedVolumeName = SensitiveSurfaceMapper::mappingPrefix;
+        mappedVolumeName += std::to_string(mappedSurface->geometryId().value());
+        ACTS_VERBOSE("Remap sensitive volume: " << g4PhysicalVolume->GetName());
+        ACTS_VERBOSE("                    to: " << mappedVolumeName);
+        g4PhysicalVolume->SetName(mappedVolumeName.c_str());
+      }
+    }
+  } else {
+    // Step down to all daughters
+    for (G4int id = 0; id < nDaughters; ++id) {
+      remapSensitiveNames(g4LogicalVolume->GetDaughter(id),
+                          motherPosition + g4RelPosition, sCounter);
+    }
+  }
+}

--- a/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
@@ -46,9 +46,13 @@ void ActsExamples::SensitiveSurfaceMapper::remapSensitiveNames(
                               g4RelTranslation[2] * convertLength);
 
   if (nDaughters == 0) {
+    std::string volumeName = g4LogicalVolume->GetName();
     std::string volumeMaterialName = g4LogicalVolume->GetMaterial()->GetName();
     if (g4SensitiveDetector != nullptr or
-        volumeMaterialName.find("Silicon") != std::string::npos) {
+        std::find(m_cfg.materialMappings.begin(), m_cfg.materialMappings.end(),
+                  volumeMaterialName) != m_cfg.materialMappings.end() or
+        std::find(m_cfg.volumeMappings.begin(), m_cfg.volumeMappings.end(),
+                  volumeName) != m_cfg.volumeMappings.end()) {
       // Find the associated ACTS object
       Acts::Vector3 g4AbsPosition = g4RelPosition + motherPosition;
       auto actsLayer = m_cfg.trackingGeometry->associatedLayer(

--- a/Examples/Framework/include/ActsExamples/EventData/SimHit.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimHit.hpp
@@ -13,6 +13,8 @@
 
 namespace ActsExamples {
 
+using SimBarcode = ::ActsFatras::Barcode;
+
 using SimHit = ::ActsFatras::Hit;
 /// Store hits ordered by geometry identifier.
 using SimHitContainer = GeometryIdMultiset<::ActsFatras::Hit>;

--- a/Examples/Io/Csv/src/CsvParticleReader.cpp
+++ b/Examples/Io/Csv/src/CsvParticleReader.cpp
@@ -8,10 +8,10 @@
 
 #include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
 
+#include "Acts/Definitions/Units.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
-#include <Acts/Definitions/Units.hpp>
 
 #include <fstream>
 #include <ios>
@@ -66,14 +66,14 @@ ActsExamples::ProcessCode ActsExamples::CsvParticleReader::read(
     particle.setPosition4(
         data.vx * Acts::UnitConstants::mm, data.vy * Acts::UnitConstants::mm,
         data.vz * Acts::UnitConstants::mm, data.vt * Acts::UnitConstants::ns);
-    // only used for direction; normalization/units do not matter
+    // Only used for direction; normalization/units do not matter
     particle.setDirection(data.px, data.py, data.pz);
     particle.setAbsoluteMomentum(std::hypot(data.px, data.py, data.pz) *
                                  Acts::UnitConstants::GeV);
     unordered.push_back(std::move(particle));
   }
 
-  // write ordered particles container to the EventStore
+  // Write ordered particles container to the EventStore
   SimParticleContainer particles;
   particles.insert(unordered.begin(), unordered.end());
   ctx.eventStore.add(m_cfg.outputParticles, std::move(particles));

--- a/Examples/Run/Common/src/CommonSimulation.cpp
+++ b/Examples/Run/Common/src/CommonSimulation.cpp
@@ -43,7 +43,7 @@ void setupInput(
     std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers) {
   auto logLevel = Options::readLogLevel(vars);
 
-  if (not vars["input-dir"].empty()) {    
+  if (not vars["input-dir"].empty()) {
     // read particle input from csv file
     CsvParticleReader::Config readParticles;
     readParticles.inputDir = vars["input-dir"].as<std::string>();

--- a/Examples/Run/Common/src/CommonSimulation.cpp
+++ b/Examples/Run/Common/src/CommonSimulation.cpp
@@ -43,7 +43,7 @@ void setupInput(
     std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers) {
   auto logLevel = Options::readLogLevel(vars);
 
-  if (not vars["input-dir"].empty()) {
+  if (not vars["input-dir"].empty()) {    
     // read particle input from csv file
     CsvParticleReader::Config readParticles;
     readParticles.inputDir = vars["input-dir"].as<std::string>();

--- a/Examples/Run/Fatras/Common/Fatras.cpp
+++ b/Examples/Run/Fatras/Common/Fatras.cpp
@@ -96,7 +96,7 @@ int runFatras(int argc, char* argv[],
   for (auto cdr : contextDecorators) {
     sequencer.addContextDecorator(cdr);
   }
-  // Setup algorithm chain
+  // Setup input, algorithm chain, output
   Simulation::setupInput(vars, sequencer, randomNumbers);
   setupFatrasSimulation(vars, sequencer, randomNumbers, trackingGeometry);
   Simulation::setupOutput(vars, sequencer);

--- a/Examples/Run/Geant4/Common/Geant4.cpp
+++ b/Examples/Run/Geant4/Common/Geant4.cpp
@@ -16,15 +16,22 @@
 
 #include "Geant4.hpp"
 
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "ActsExamples/Detector/IBaseDetector.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Geant4/EventStoreRegistry.hpp"
 #include "ActsExamples/Geant4/G4DetectorConstructionFactory.hpp"
 #include "ActsExamples/Geant4/Geant4Simulation.hpp"
+#include "ActsExamples/Geant4/MagneticFieldWrapper.hpp"
 #include "ActsExamples/Geant4/MaterialPhysicsList.hpp"
 #include "ActsExamples/Geant4/MaterialSteppingAction.hpp"
+#include "ActsExamples/Geant4/ParticleTrackingAction.hpp"
+#include "ActsExamples/Geant4/SensitiveSteppingAction.hpp"
+#include "ActsExamples/Geant4/SensitiveSurfaceMapper.hpp"
 #include "ActsExamples/Geant4/SimParticleTranslation.hpp"
 #include "ActsExamples/Io/Root/RootMaterialTrackWriter.hpp"
+#include "ActsExamples/MagneticField/MagneticFieldOptions.hpp"
 #include "ActsExamples/Options/CommonOptions.hpp"
 #include "ActsExamples/Options/ParticleGunOptions.hpp"
 #include "ActsExamples/Simulation/CommonSimulation.hpp"
@@ -39,15 +46,17 @@
 
 namespace ActsExamples {
 
-void setupGeant4Simulation(const ActsExamples::Options::Variables& vars,
-                           ActsExamples::Sequencer& sequencer,
-                           G4RunManager* runManager,
-                           G4VUserDetectorConstruction* detector,
-                           std::vector<G4UserRunAction*> runActions,
-                           std::vector<G4UserEventAction*> eventActions,
-                           std::vector<G4UserTrackingAction*> trackingActions,
-                           std::vector<G4UserSteppingAction*> steppingActions,
-                           bool materialRecording) {
+void setupGeant4Simulation(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer, G4RunManager* runManager,
+    G4VUserDetectorConstruction* detector,
+    std::vector<G4UserRunAction*> runActions,
+    std::vector<G4UserEventAction*> eventActions,
+    std::vector<G4UserTrackingAction*> trackingActions,
+    std::vector<G4UserSteppingAction*> steppingActions,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+    std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
+    bool materialRecording) {
   // Create an event Store registry
   EventStoreRegistry esRegistry;
 
@@ -60,7 +69,8 @@ void setupGeant4Simulation(const ActsExamples::Options::Variables& vars,
 
   // Read the particle from the generator
   SimParticleTranslation::Config g4PrCfg;
-  g4PrCfg.inputParticles = Simulation::kParticlesInitial;
+  g4PrCfg.inputParticles = materialRecording ? Simulation::kParticlesInitial
+                                             : Simulation::kParticlesSelection;
   if (materialRecording) {
     g4PrCfg.forceParticle = true;
     g4PrCfg.forcedMass = 0.;
@@ -79,6 +89,29 @@ void setupGeant4Simulation(const ActsExamples::Options::Variables& vars,
   g4Cfg.eventActions = eventActions;
   g4Cfg.trackingActions = trackingActions;
   g4Cfg.steppingActions = steppingActions;
+
+  // An ACTS Magnetic field is provided
+  if (magneticField != nullptr) {
+    MagneticFieldWrapper::Config g4FieldCfg;
+    g4FieldCfg.magneticField = magneticField;
+    g4Cfg.magneticField = new MagneticFieldWrapper(g4FieldCfg);
+  }
+
+  // An ACTS TrackingGeometry is provided, so simulation for sensitive
+  // detectors is turned on - they need to get matched first
+  if (trackingGeometry != nullptr) {
+    SensitiveSurfaceMapper::Config ssmCfg;
+    ssmCfg.trackingGeometry = trackingGeometry;
+    g4Cfg.sensitiveSurfaceMapper =
+        std::make_shared<const SensitiveSurfaceMapper>(
+            ssmCfg,
+            Acts::getDefaultLogger("SensitiveSurfaceMapper", g4loglevel));
+
+    // Add the output collection
+    g4Cfg.outputSimHits = Simulation::kSimHits;
+    g4Cfg.outputParticlesInitial = Simulation::kParticlesInitial;
+    g4Cfg.outputParticlesFinal = Simulation::kParticlesFinal;
+  }
 
   sequencer.addAlgorithm(std::make_shared<Geant4Simulation>(g4Cfg, g4loglevel));
 
@@ -132,7 +165,8 @@ int runMaterialRecording(
 
   // Set up the Geant4 Simulation
   setupGeant4Simulation(vars, sequencer, runManager, detector, runActions,
-                        eventActions, trackingActions, steppingActions, true);
+                        eventActions, trackingActions, steppingActions, nullptr,
+                        nullptr, true);
 
   // setup the output writing
   if (vars["output-root"].as<bool>()) {
@@ -147,6 +181,60 @@ int runMaterialRecording(
     sequencer.addWriter(std::make_shared<RootMaterialTrackWriter>(
         materialTrackWriter, logLevel));
   }
+
+  auto result = sequencer.run();
+  delete runManager;
+  return result;
+}
+
+int runGeant4Simulation(
+    const ActsExamples::Options::Variables& vars,
+    std::shared_ptr<ActsExamples::G4DetectorConstructionFactory>
+        g4DetectorFactory,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry) {
+  // Basic services
+  auto randomNumbers =
+      std::make_shared<RandomNumbers>(Options::readRandomNumbersConfig(vars));
+
+  // Output level and log level
+  auto g4loglevel =
+      Acts::Logging::Level(vars["g4-loglevel"].as<unsigned int>());
+
+  // The Genat4 run manager instance
+  G4RunManager* runManager = new G4RunManager();
+  runManager->SetUserInitialization(new FTFP_BERT);
+
+  // Release the detector construction
+  G4VUserDetectorConstruction* detector = (*g4DetectorFactory)().release();
+
+  // The Geant4 actions needed
+  std::vector<G4UserRunAction*> runActions = {};
+  std::vector<G4UserEventAction*> eventActions = {};
+  std::vector<G4UserTrackingAction*> trackingActions = {};
+  std::vector<G4UserSteppingAction*> steppingActions = {};
+
+  ParticleTrackingAction::Config g4TrackCfg;
+  ParticleTrackingAction* particleAction = new ParticleTrackingAction(
+      g4TrackCfg, Acts::getDefaultLogger("ParticleTrackingAction", g4loglevel));
+  trackingActions.push_back(particleAction);
+
+  SensitiveSteppingAction::Config g4StepCfg;
+  SensitiveSteppingAction* sensitiveStepping = new SensitiveSteppingAction(
+      g4StepCfg, Acts::getDefaultLogger("SensitiveSteppingAction", g4loglevel));
+  steppingActions.push_back(sensitiveStepping);
+
+  // Set up the sequencer
+  Sequencer sequencer(Options::readSequencerConfig(vars));
+
+  // Set up the magnetic field
+  auto magneticField = ActsExamples::Options::readMagneticField(vars);
+
+  // Setup algorithm chain: Input / Simulation / Output
+  Simulation::setupInput(vars, sequencer, randomNumbers);
+  setupGeant4Simulation(vars, sequencer, runManager, detector, runActions,
+                        eventActions, trackingActions, steppingActions,
+                        trackingGeometry, magneticField);
+  Simulation::setupOutput(vars, sequencer);
 
   auto result = sequencer.run();
   delete runManager;

--- a/Examples/Run/Geant4/Common/Geant4.hpp
+++ b/Examples/Run/Geant4/Common/Geant4.hpp
@@ -14,6 +14,11 @@
 #include <memory>
 #include <vector>
 
+namespace Acts {
+class TrackingGeometry;
+class MagneticFieldProvider;
+}  // namespace Acts
+
 class G4VUserDetectorConstruction;
 class G4RunManager;
 class G4UserRunAction;
@@ -35,6 +40,8 @@ class G4DetectorConstructionFactory;
 /// @param eventActions the list of Geant4 user event action
 /// @param trackingActions the list of Geant4 user tracking action
 /// @param steppingActions the list of Geant4 user stepping action
+/// @param trackingGeometry the tracking geometry for the sennsitive mapping
+/// @param magneticField the ACTS magnetic field to be wrapped
 /// @param materialRecording boolean flag to run material mapping
 ///
 void setupGeant4Simulation(
@@ -45,6 +52,8 @@ void setupGeant4Simulation(
     std::vector<G4UserEventAction*> eventActions = {},
     std::vector<G4UserTrackingAction*> trackingActions = {},
     std::vector<G4UserSteppingAction*> steppingActions = {},
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry = nullptr,
+    std::shared_ptr<const Acts::MagneticFieldProvider> magneticField = nullptr,
     bool materialRecording = false);
 
 /// Specific setup: Material Recording
@@ -56,5 +65,17 @@ int runMaterialRecording(
     const ActsExamples::Options::Variables& vars,
     std::shared_ptr<ActsExamples::G4DetectorConstructionFactory>
         g4DetectorFactory);
+
+/// Specific setup: Geant4 Simulation
+///
+/// @param vars the parsed variables
+/// @param sequencer the event sequencer
+/// @param g4DetectorFactory is the detector to be used
+/// @param trackingGeometry the tracking geometry for the sennsitive mapping
+int runGeant4Simulation(
+    const ActsExamples::Options::Variables& vars,
+    std::shared_ptr<ActsExamples::G4DetectorConstructionFactory>
+        g4DetectorFactory,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry);
 
 }  // namespace ActsExamples

--- a/Examples/Run/Geant4/DD4hep/CMakeLists.txt
+++ b/Examples/Run/Geant4/DD4hep/CMakeLists.txt
@@ -1,4 +1,24 @@
 add_executable(
+  ActsExampleGeant4DD4hep
+  DD4hepGeant4Simulation.cpp)
+target_link_libraries(
+  ActsExampleGeant4DD4hep
+  PRIVATE
+    ActsExamplesCommon
+    ActsExamplesDetectorDD4hep
+    ActsExamplesFramework
+    ActsExamplesGeant4
+    ActsExamplesGeant4Common
+    ActsExamplesMagneticField
+    ActsExamplesIoRoot
+    Boost::program_options)
+
+install(
+  TARGETS ActsExampleGeant4DD4hep
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+
+add_executable(
   ActsExampleMaterialRecordingDD4hep
   DD4hepMaterialRecording.cpp)
 target_link_libraries(

--- a/Examples/Run/Geant4/DD4hep/DD4hepGeant4Simulation.cpp
+++ b/Examples/Run/Geant4/DD4hep/DD4hepGeant4Simulation.cpp
@@ -1,0 +1,53 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/DD4hepDetector/DD4hepDetectorOptions.hpp"
+#include "ActsExamples/DD4hepDetector/DD4hepGeometryService.hpp"
+#include "ActsExamples/DDG4/DDG4DetectorConstruction.hpp"
+#include "ActsExamples/Geant4/Geant4Options.hpp"
+#include "ActsExamples/MagneticField/MagneticFieldOptions.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
+#include "ActsExamples/Simulation/CommonSimulation.hpp"
+
+#include <boost/program_options.hpp>
+
+#include "Geant4.hpp"
+
+int main(int argc, char* argv[]) {
+  using namespace ActsExamples;
+  using namespace ActsExamples::Simulation;
+
+  // Setup and parse options
+  auto desc = Options::makeDefaultOptions();
+  Options::addSequencerOptions(desc);
+  Options::addDD4hepOptions(desc);
+  Simulation::addInputOptions(desc);  // These are specific to the simulation
+  Options::addRandomNumbersOptions(desc);
+  Options::addGeant4Options(desc);
+  Options::addOutputOptions(desc, OutputFormat::Root | OutputFormat::Csv);
+  Options::addMagneticFieldOptions(desc);
+
+  auto vars = Options::parse(desc, argc, argv);
+  if (vars.empty()) {
+    return EXIT_FAILURE;
+  }
+
+  // Setup the DD4hep detector
+  auto dd4hepCfg = Options::readDD4hepConfig<po::variables_map>(vars);
+  auto geometrySvc = std::make_shared<DD4hep::DD4hepGeometryService>(dd4hepCfg);
+  auto magneticField = ActsExamples::Options::readMagneticField(vars);
+  auto uniqueTrackingGeometry =
+      geometrySvc->trackingGeometry(Acts::GeometryContext());
+  auto trackingGeometry = std::shared_ptr<const Acts::TrackingGeometry>(
+      uniqueTrackingGeometry.release());
+
+  return runGeant4Simulation(
+      vars,
+      std::make_unique<DDG4DetectorConstructionFactory>(*geometrySvc->lcdd()),
+      trackingGeometry);
+}


### PR DESCRIPTION
This PR is the second pull request for the Geant4 simulation and introduces the full simulation for single particles.
It uses the same `Geant4Simulation` algorithm and establishes a symmetric setup between `Fatras` and `Geant4` simulation.

e.g. `Fatras`:
```shell
./ActsExamplesFatrasDD4hep <args>
```

and `Geant4`:
```shell
./ActsExamplesGeant4DD4hep <args>
```

Can now be run with the same argument list.