### PR TITLE
fix: assign the vertex and direction at first step

### DIFF
--- a/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
@@ -94,7 +94,7 @@ ActsExamples::Geant4Simulation::~Geant4Simulation() {}
 
 ActsExamples::ProcessCode ActsExamples::Geant4Simulation::execute(
     const ActsExamples::AlgorithmContext& ctx) const {
-  // Ensure exclusive access to the geant run manager
+  // Ensure exclusive access to the Geant4 run manager
   std::lock_guard<std::mutex> guard(m_runManagerLock);
 
   // Create and re-reference

--- a/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
@@ -95,10 +95,16 @@ void ActsExamples::MaterialSteppingAction::UserSteppingAction(
   mInteraction.materialSlab = slab;
   mInteraction.pathCorrection = (step->GetStepLength() / CLHEP::mm);
 
-  size_t trackID = step->GetTrack()->GetTrackID();
+  G4Track* g4Track = step->GetTrack();
+  size_t trackID = g4Track->GetTrackID();
   auto& materialTracks = eventData.materialTracks;
   if (materialTracks.size() < trackID) {
     Acts::RecordedMaterialTrack rmTrack;
+    const auto& g4Vertex = g4Track->GetVertexPosition();
+    Acts::Vector3 vertex(g4Vertex[0], g4Vertex[1], g4Vertex[2]);
+    const auto& g4Direction = g4Track->GetMomentumDirection();
+    Acts::Vector3 direction(g4Direction[0], g4Direction[1], g4Direction[2]);
+    rmTrack.first = {vertex, direction};
     rmTrack.second.materialInteractions.push_back(mInteraction);
     materialTracks.push_back(rmTrack);
   } else {


### PR DESCRIPTION
This PR fixes an issue that the vertex and momentum direction have not been appropriately set in the reworked MaterialRecording example.