### PR TITLE
feat: add space-point-reader

### DIFF
--- a/Examples/Io/Csv/CMakeLists.txt
+++ b/Examples/Io/Csv/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   src/CsvPlanarClusterWriter.cpp
   src/CsvSimHitReader.cpp
   src/CsvSimHitWriter.cpp
+  src/CsvSpacePointReader.cpp
   src/CsvTrackingGeometryWriter.cpp
   src/CsvMultiTrajectoryWriter.cpp )
 target_include_directories(

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvOptionsReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvOptionsReader.hpp
@@ -12,6 +12,7 @@
 #include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
 #include "ActsExamples/Io/Csv/CsvPlanarClusterReader.hpp"
 #include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
 #include "ActsExamples/Utilities/OptionsFwd.hpp"
 
 namespace ActsExamples {
@@ -26,6 +27,10 @@ ActsExamples::CsvParticleReader::Config readCsvParticleReaderConfig(
 
 /// Read the CSV sim hit reader config.
 ActsExamples::CsvSimHitReader::Config readCsvSimHitReaderConfig(
+    const Variables& vm);
+
+/// Read the CSV space point reader config.
+ActsExamples::CsvSpacePointReader::Config readCsvSpacePointReaderConfig(
     const Variables& vm);
 
 /// Read the CSV measurement reader config.

--- a/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSpacePointReader.hpp
+++ b/Examples/Io/Csv/include/ActsExamples/Io/Csv/CsvSpacePointReader.hpp
@@ -1,0 +1,63 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/Framework/IReader.hpp"
+
+#include <memory>
+#include <string>
+
+namespace ActsExamples {
+
+/// Read in a simhit collection in comma-separated-value format.
+///
+/// This reads one files per event in the configured input directory. By default
+/// it reads files in the current working directory. Files are assumed to be
+/// named using the following schema
+///
+///     event000000001-<stem>.csv
+///     event000000002-<stem>.csv
+///
+/// and each line in the file corresponds to one simhit.
+class CsvSpacePointReader final : public IReader {
+public:
+ struct Config {
+   /// Where to read input files from.
+   std::string inputDir;
+   /// Input filename stem.
+   std::string inputStem;
+   /// Output space point collections.
+   std::vector<std::string> outputSpacePoints;
+ };
+
+ /// Construct the simhit reader.
+ ///
+ /// @params cfg is the configuration object
+ /// @params lvl is the logging level
+ CsvSpacePointReader(const Config& cfg, Acts::Logging::Level lvl);
+
+ std::string name() const final override;
+
+ /// Return the available events range.
+ std::pair<size_t, size_t> availableEvents() const final override;
+
+ /// Read out data from the input stream.
+ ProcessCode read(const ActsExamples::AlgorithmContext& ctx) final override;
+
+private:
+ Config m_cfg;
+ std::pair<size_t, size_t> m_eventsRange;
+ std::unique_ptr<const Acts::Logger> m_logger;
+
+ const Acts::Logger& logger() const { return *m_logger; }
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Csv/src/CsvOptionsReader.cpp
+++ b/Examples/Io/Csv/src/CsvOptionsReader.cpp
@@ -28,6 +28,15 @@ ActsExamples::Options::readCsvSimHitReaderConfig(const Variables& vm) {
   return cfg;
 }
 
+ActsExamples::CsvSpacePointReader::Config
+ActsExamples::Options::readCsvSpacePointReaderConfig(const Variables& vm) {
+  ActsExamples::CsvSpacePointReader::Config cfg;
+  if (not vm["input-dir"].empty()) {
+    cfg.inputDir = vm["input-dir"].as<std::string>();
+  }
+  return cfg;
+}
+
 ActsExamples::CsvMeasurementReader::Config
 ActsExamples::Options::readCsvMeasurementReaderConfig(const Variables& vm) {
   ActsExamples::CsvMeasurementReader::Config cfg;

--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -199,6 +199,22 @@ struct LayerVolumeData {
                  max_v0, min_v1, max_v1, min_v2, max_v2);
 };
 
+struct SpacePointData {
+  /// Event-unique measurement identifier. Each value can appear at most once.
+  uint64_t measurement_id;
+  /// Module identifier.
+  uint64_t module_idhash;
+  /// Space point type pixel, strip, strip overlap
+  int32_t sp_type;
+  /// Space point information
+  float sp_x, sp_y, sp_z, sp_radius;
+  float sp_covr, sp_covz;
+
+  DFE_NAMEDTUPLE(SpacePointData, measurement_id, sp_type, module_idhash, 
+                 sp_x, sp_y, sp_z, sp_radius, 
+                 sp_covr, sp_covz);
+};
+
 struct SurfaceGridData {
   /// Surface identifier. Not available in the TrackML datasets.
   uint64_t geometry_id;

--- a/Examples/Io/Csv/src/CsvSpacePointReader.cpp
+++ b/Examples/Io/Csv/src/CsvSpacePointReader.cpp
@@ -1,0 +1,87 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2017 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
+
+#include "ActsExamples/EventData/SimSpacePoint.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
+#include <Acts/Definitions/Units.hpp>
+
+#include <fstream>
+#include <ios>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <dfe/dfe_io_dsv.hpp>
+
+#include "CsvOutputData.hpp"
+
+ActsExamples::CsvSpacePointReader::CsvSpacePointReader(
+    const ActsExamples::CsvSpacePointReader::Config& cfg,
+    Acts::Logging::Level lvl)
+    : m_cfg(cfg),
+      m_eventsRange(
+          determineEventFilesRange(cfg.inputDir, cfg.inputStem + ".csv")),
+      m_logger(Acts::getDefaultLogger("CsvSpacePointReader", lvl)) {
+  if (m_cfg.inputStem.empty()) {
+    throw std::invalid_argument("Missing input filename stem");
+  }
+}
+
+std::string ActsExamples::CsvSpacePointReader::CsvSpacePointReader::name() const {
+  return "CsvSpacePointReader";
+}
+
+std::pair<size_t, size_t> ActsExamples::CsvSpacePointReader::availableEvents()
+    const {
+  return m_eventsRange;
+}
+
+ActsExamples::ProcessCode ActsExamples::CsvSpacePointReader::read(
+    const ActsExamples::AlgorithmContext& ctx) {
+  SimSpacePointContainer spacePointsPixel;
+  SimSpacePointContainer spacePointsStrip;
+  SimSpacePointContainer spacePointsStripOverlap;
+  
+  auto path = perEventFilepath(m_cfg.inputDir, m_cfg.inputStem + ".csv",
+                               ctx.eventNumber);
+
+  dfe::NamedTupleCsvReader<SpacePointData> reader(path);
+  SpacePointData data;
+
+  while (reader.read(data)) {
+    std::cout << data.measurement_id << ", " << data.sp_type << ", " << data.module_idhash << ", " << 
+    data.sp_x << ", " << data.sp_y << ", " << data.sp_z << ", " << data.sp_radius << ", " << 
+    data.sp_covr << ", " << data.sp_covz << std::endl;
+    
+    Acts::Vector3 globalPos(data.sp_x, data.sp_y, data.sp_z);
+    
+    if (data.sp_type==0)
+      spacePointsPixel.emplace_back(globalPos, data.sp_covr, data.sp_covz, data.measurement_id);
+    else if (data.sp_type==1)
+      spacePointsStrip.emplace_back(globalPos, data.sp_covr, data.sp_covz, data.measurement_id);
+    else if (data.sp_type==2)
+      spacePointsStripOverlap.emplace_back(globalPos, data.sp_covr, data.sp_covz, data.measurement_id);
+    else {
+      ACTS_ERROR("Invalid space point type " << data.sp_type);
+      return ProcessCode::ABORT;
+    }
+  }
+
+  ACTS_DEBUG("Created " << spacePointsPixel.size() << " pixel space points");
+  ACTS_DEBUG("Created " << spacePointsStrip.size() << " strip space points");
+  ACTS_DEBUG("Created " << spacePointsStripOverlap.size() << " overlap space points");
+  
+  ctx.eventStore.add("PixelSpacePoints", std::move(spacePointsPixel));
+  ctx.eventStore.add("StripSpacePoints", std::move(spacePointsStrip));
+  ctx.eventStore.add("OverlapSpacePoints", std::move(spacePointsStripOverlap));
+  
+  return ProcessCode::SUCCESS;
+}

--- a/Examples/Run/Reconstruction/Common/RecInput.cpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.cpp
@@ -1,0 +1,152 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Detector/IBaseDetector.hpp"
+#ifdef ACTS_PLUGIN_ONNX
+#include "Acts/Plugins/Onnx/MLTrackClassifier.hpp"
+#endif
+#include "ActsExamples/Digitization/DigitizationOptions.hpp"
+#include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
+#include "ActsExamples/Geometry/CommonGeometry.hpp"
+#include "ActsExamples/Io/Json/JsonDigitizationConfig.hpp"
+#include "ActsExamples/Io/Performance/CKFPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp"
+//#include "ActsExamples/Io/Root/RootTrajectoryParametersWriter.hpp"
+#include "ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
+#include "ActsExamples/TrackFinding/SeedingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/SpacePointMaker.hpp"
+#include "ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/TrackFindingOptions.hpp"
+#include "ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp"
+#include "ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp"
+#include "ActsExamples/TrackFitting/TrackFittingOptions.hpp"
+#include "ActsExamples/TruthTracking/ParticleSmearing.hpp"
+#include "ActsExamples/TruthTracking/TruthTrackFinder.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include "RecInput.hpp"
+
+ActsExamples::CsvSimHitReader::Config setupSimHitReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read truth hits from CSV files
+  auto simHitReaderCfg = Options::readCsvSimHitReaderConfig(vars);
+  simHitReaderCfg.inputStem = "hits";
+  simHitReaderCfg.outputSimHits = "hits";
+  sequencer.addReader(
+      std::make_shared<CsvSimHitReader>(simHitReaderCfg, logLevel));
+
+  return simHitReaderCfg;
+}
+
+ActsExamples::CsvParticleReader::Config setupParticleReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read particles (initial states) and clusters from CSV files
+  auto particleReader = Options::readCsvParticleReaderConfig(vars);
+  particleReader.inputStem = "particles_initial";
+  particleReader.outputParticles = "particles_initial";
+  sequencer.addReader(
+      std::make_shared<CsvParticleReader>(particleReader, logLevel));
+
+  return particleReader;
+}
+
+ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read truth hits from CSV files
+  auto spacePointReaderCfg = Options::readCsvSpacePointReaderConfig(vars);
+  spacePointReaderCfg.inputStem = "spacepoints";
+  sequencer.addReader(
+      std::make_shared<CsvSpacePointReader>(spacePointReaderCfg, logLevel));
+  
+  return spacePointReaderCfg;
+}
+
+ActsExamples::DigitizationConfig setupDigitization(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    std::shared_ptr<const ActsExamples::RandomNumbers> rnd,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+    const std::string& inputSimHits) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  auto digiCfg = ActsExamples::DigitizationConfig(
+      vars, ActsExamples::readDigiConfigFromJson(
+                vars["digi-config-file"].as<std::string>()));
+  // Common options for digitization
+  digiCfg.inputSimHits = inputSimHits;
+  digiCfg.randomNumbers = rnd;
+  digiCfg.trackingGeometry = trackingGeometry;
+  sequencer.addAlgorithm(
+      ActsExamples::createDigitizationAlgorithm(digiCfg, logLevel));
+
+  if (not vars["dump-digi-config"].as<std::string>().empty()) {
+    writeDigiConfigToJson(digiCfg.digitizationConfigs,
+                          vars["dump-digi-config"].as<std::string>());
+  }
+
+  return digiCfg;
+}
+
+ActsExamples::ParticleSmearing::Config setupParticleSmearing(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    std::shared_ptr<const ActsExamples::RandomNumbers> rnd,
+    const std::string& inputParticles) {
+  using namespace ActsExamples;
+  using namespace Acts::UnitLiterals;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Create smeared particles states
+  ParticleSmearing::Config particleSmearingCfg;
+  particleSmearingCfg.inputParticles = inputParticles;
+  particleSmearingCfg.outputTrackParameters = "smearedparameters";
+  particleSmearingCfg.randomNumbers = rnd;
+  // Gaussian sigmas to smear particle parameters
+  particleSmearingCfg.sigmaD0 = 20_um;
+  particleSmearingCfg.sigmaD0PtA = 30_um;
+  particleSmearingCfg.sigmaD0PtB = 0.3 / 1_GeV;
+  particleSmearingCfg.sigmaZ0 = 20_um;
+  particleSmearingCfg.sigmaZ0PtA = 30_um;
+  particleSmearingCfg.sigmaZ0PtB = 0.3 / 1_GeV;
+  particleSmearingCfg.sigmaPhi = 1_degree;
+  particleSmearingCfg.sigmaTheta = 1_degree;
+  particleSmearingCfg.sigmaPRel = 0.01;
+  particleSmearingCfg.sigmaT0 = 1_ns;
+  particleSmearingCfg.initialVarInflation =
+      vars["fit-initial-variance-inflation"].template as<Options::Reals<6>>();
+  sequencer.addAlgorithm(
+      std::make_shared<ParticleSmearing>(particleSmearingCfg, logLevel));
+
+  return particleSmearingCfg;
+}

--- a/Examples/Run/Reconstruction/Common/RecInput.hpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.hpp
@@ -1,0 +1,86 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsExamples/Digitization/SmearingAlgorithm.hpp"
+#include "ActsExamples/Framework/Sequencer.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Geometry/CommonGeometry.hpp"
+#include "ActsExamples/Io/Csv/CsvOptionsReader.hpp"
+#include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
+#include "ActsExamples/TruthTracking/ParticleSmearing.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include <memory>
+#include <string>
+
+#include <boost/filesystem.hpp>
+
+/// Setup sim hit csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for sim hits csv reader
+ActsExamples::CsvSimHitReader::Config setupSimHitReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer);
+
+/// Setup sim particle csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for sim particles csv reader
+ActsExamples::CsvParticleReader::Config setupParticleReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer);
+
+/// Setup space point csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for space points csv reader
+ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer);
+
+/// Setup sim hit smearing
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+/// @param randomNumbers The random number service
+/// @param trackingGeometry The TrackingGeometry for the tracking setup
+/// @param inputSimHits The input sim hit collection (e.g. from sim hit reader)
+///
+/// @return config for hit smearing
+ActsExamples::DigitizationConfig setupDigitization(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
+    const std::string& inputSimHits);
+
+/// Setup particle smearing
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+/// @param randomNumbers The random number service
+/// @param inputParticles The input particle collection (e.g. from particle
+/// reader or from particle selection)
+///
+/// @return config for particle smearing
+ActsExamples::ParticleSmearing::Config setupParticleSmearing(
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers,
+    const std::string& inputParticles);


### PR DESCRIPTION
This pull request introduces a spacepoint reader ActsExamples::CsvSpacePointReader that reads spacepoints from a CSV files.

Files are assumed to be named using the following schema:
event000000001-spacepoints.csv
event000000002-spacepoints.csv
and each line in the file corresponds to one simhit.