### PR TITLE
fix: allow layer search in original volume after fast initialization

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -312,6 +312,12 @@ class Navigator {
           // this was the last surface, check if we have layers
           if (!state.navigation.navLayers.empty()) {
             ++state.navigation.navLayerIter;
+          } else if (state.navigation.startLayer != nullptr and
+                     state.navigation.currentSurface->associatedLayer() ==
+                         state.navigation.startLayer) {
+            // this was the start layer, switch to layer target next
+            state.navigation.navigationStage = Stage::layerTarget;
+            return;
           } else {
             // no layers, go to boundary
             state.navigation.navigationStage = Stage::boundaryTarget;
@@ -423,7 +429,6 @@ class Navigator {
       // Find out about the target as much as you can
       initializeTarget(state, stepper);
     }
-
     // Try targeting the surfaces - then layers - then boundaries
     if (state.navigation.navigationStage <= Stage::surfaceTarget and
         targetSurfaces(state, stepper)) {
@@ -603,7 +608,6 @@ class Navigator {
     if (state.navigation.navigationBreak) {
       return false;
     }
-
     // Make sure resolve Surfaces is called on the start layer
     if (state.navigation.startLayer and
         not state.navigation.startLayerResolved) {
@@ -716,6 +720,7 @@ class Navigator {
   template <typename propagator_state_t, typename stepper_t>
   bool targetLayers(propagator_state_t& state, const stepper_t& stepper) const {
     using namespace UnitLiterals;
+
     const auto& logger = state.options.logger;
 
     if (state.navigation.navigationBreak ||


### PR DESCRIPTION
This PR is a fix to #926.

It allows the search for layers after the (fast-associated) starting layer has been processed.


