### PR TITLE
fix: KF return and CKF logging

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -709,9 +709,9 @@ class CombinatorialKalmanFilter {
             return res.error();
           }
           const auto boundState = *res;
-          // Add a hole track state to the multitrajectory
+          // Add a hole or material track state to the multitrajectory
           currentTip = addNonSourcelinkState(stateMask, boundState, result,
-                                             prevTip, logger);
+                                             isSensitive, prevTip, logger);
 
           // Check the branch
           if (not m_branchStopper(tipState)) {
@@ -864,24 +864,28 @@ class CombinatorialKalmanFilter {
       return std::make_pair(std::move(currentTip), std::move(tipState));
     }
 
-    /// @brief CombinatorialKalmanFilter actor operation : add hole track state
+    /// @brief CombinatorialKalmanFilter actor operation : add hole or material track state
     ///
     /// @param stateMask The bitmask that instructs which components to allocate
     /// @param boundState The bound state on current surface
     /// @param result is the mutable result state object
     /// and which to leave invalid
+    /// @param isSensitive The surface is sensitive or passive
     /// @param prevTip The index of the previous state
     /// @param logger The logger wrapper
     ///
     /// @return The tip of added state
     size_t addNonSourcelinkState(
         const TrackStatePropMask& stateMask, const BoundState& boundState,
-        result_type& result, size_t prevTip = SIZE_MAX,
+        result_type& result, bool isSensitive, size_t prevTip = SIZE_MAX,
         LoggerWrapper logger = getDummyLogger()) const {
       // Add a track state
       auto currentTip = result.fittedStates.addTrackState(stateMask, prevTip);
-      ACTS_VERBOSE("Creating Hole track state with tip = " << currentTip);
-
+      if (isSensitive) {
+        ACTS_VERBOSE("Creating Hole track state with tip = " << currentTip);
+      } else {
+        ACTS_VERBOSE("Creating Material track state with tip = " << currentTip);
+      }
       // now get track state proxy back
       auto trackStateProxy = result.fittedStates.getTrackState(currentTip);
 

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1083,9 +1083,9 @@ class KalmanFitter {
     /// Get the result of the fit
     auto kalmanResult = propRes.template get<KalmanResult>();
 
-    /// It could happen that the fit ends in zero processed states.
+    /// It could happen that the fit ends in zero measurement states.
     /// The result gets meaningless so such case is regarded as fit failure.
-    if (kalmanResult.result.ok() and not kalmanResult.processedStates) {
+    if (kalmanResult.result.ok() and not kalmanResult.measurementStates) {
       kalmanResult.result = Result<void>(KalmanFitterError::NoMeasurementFound);
     }
 
@@ -1185,9 +1185,9 @@ class KalmanFitter {
     /// Get the result of the fit
     auto kalmanResult = propRes.template get<KalmanResult>();
 
-    /// It could happen that the fit ends in zero processed states.
+    /// It could happen that the fit ends in zero measurement states.
     /// The result gets meaningless so such case is regarded as fit failure.
-    if (kalmanResult.result.ok() and not kalmanResult.processedStates) {
+    if (kalmanResult.result.ok() and not kalmanResult.measurementStates) {
       kalmanResult.result = Result<void>(KalmanFitterError::NoMeasurementFound);
     }
 


### PR DESCRIPTION
This PR fixes #984 and #994 . 

The reason for #984 is that after #956, a track might have non-zero `processedStates`, but zero `measurementStates`. So we return a failure explicity in KF if `measurementStates` is zero.

The inaccurate logging in `addNonSourcelinkState` as mentioned in #994 is fixed.
