### PR TITLE
fix: Set target surface to null for forward filtering in CKF

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -481,10 +481,12 @@ class CombinatorialKalmanFilter {
                          state.options.maxStepSize);
 
       // Reset the navigation state
+      // Set targetSurface to nullptr for forward filtering; it's only needed
+      // after smoothing
       state.navigation.reset(state.geoContext, stepper.position(state.stepping),
                              stepper.direction(state.stepping),
                              state.stepping.navDir,
-                             &currentState.referenceSurface(), targetSurface);
+                             &currentState.referenceSurface(), nullptr);
 
       // No Kalman filtering for the starting surface, but still need
       // to consider the material effects here


### PR DESCRIPTION
This PR fixes #961.

The reason for #961 is that the `reset` of navigation state with a target surface (i.e. a perigee surface at the beam line) in CKF will confuse the navigator. For example, when the navigation state is reset to `vol=13|lay=8|sen=1028`, the `Target volume estimated :` might be exactly the same as the start volume if a target surface is set. This will result in `Re-initialzing cancelled as it is the first step` and the navigator will not proceed to find the boundary surfaces.

Therefore, a `nullptr` `targetSurface` is passed to the navigator during `reset`.

The detailed logs with and without the fix can be found below.
