### PR TITLE
refactor: VecMem-ification of the Sycl Seedfinder Plugin

### DIFF
--- a/Plugins/Sycl/CMakeLists.txt
+++ b/Plugins/Sycl/CMakeLists.txt
@@ -1,3 +1,14 @@
+# This file is part of the Acts project.
+#
+# Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Set up the usage of VecMem.
+include(ActsVecMem)
+
 add_library(
   ActsPluginSycl SHARED
   # header files
@@ -29,7 +40,8 @@ target_include_directories(
 
 target_link_libraries(
   ActsPluginSycl
-  PUBLIC ActsCore)
+  PUBLIC ActsCore vecmem::core
+  PRIVATE vecmem::sycl)
 
 acts_target_setup_sycl(ActsPluginSycl DEPENDENCY PRIVATE)
 

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/CreateSeedsForGroupSycl.hpp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/CreateSeedsForGroupSycl.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,10 +11,16 @@
 // System include(s)
 #include <vector>
 
+// VecMem include(s).
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/containers/jagged_vector.hpp"
+
 // SYCL plugin include(s)
 #include "Acts/Plugins/Sycl/Seeding/DeviceExperimentCuts.hpp"
 #include "Acts/Plugins/Sycl/Seeding/detail/Types.hpp"
 #include "Acts/Plugins/Sycl/Utilities/QueueWrapper.hpp"
+
 
 namespace Acts::Sycl {
 
@@ -33,11 +39,13 @@ namespace Acts::Sycl {
 ///                      point structures of top space points
 /// @param[out] seeds holds of the generated seed indices and weight
 void createSeedsForGroupSycl(
-    const QueueWrapper& wrappedQueue,
+    QueueWrapper wrappedQueue,
+    vecmem::memory_resource& resource,
+    vecmem::memory_resource* device_resource,
     const detail::DeviceSeedfinderConfig& seedfinderConfig,
     const DeviceExperimentCuts& deviceCuts,
-    const std::vector<detail::DeviceSpacePoint>& bottomSPs,
-    const std::vector<detail::DeviceSpacePoint>& middleSPs,
-    const std::vector<detail::DeviceSpacePoint>& topSPs,
+    vecmem::vector<detail::DeviceSpacePoint>& bottomSPs,
+    vecmem::vector<detail::DeviceSpacePoint>& middleSPs,
+    vecmem::vector<detail::DeviceSpacePoint>& topSPs,
     std::vector<std::vector<detail::SeedData>>& seeds);
 }  // namespace Acts::Sycl

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.hpp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -17,6 +17,9 @@
 #include "Acts/Plugins/Sycl/Seeding/detail/Types.hpp"
 #include "Acts/Plugins/Sycl/Utilities/QueueWrapper.hpp"
 
+// VecMem include(s).
+#include "vecmem/memory/memory_resource.hpp"
+
 namespace Acts::Sycl {
 
 template <typename external_spacepoint_t>
@@ -25,7 +28,9 @@ class Seedfinder {
   Seedfinder(
       Acts::SeedfinderConfig<external_spacepoint_t> config,
       const Acts::Sycl::DeviceExperimentCuts& cuts,
-      Acts::Sycl::QueueWrapper wrappedQueue = Acts::Sycl::QueueWrapper());
+      Acts::Sycl::QueueWrapper wrappedQueue,
+      vecmem::memory_resource& resource,
+      vecmem::memory_resource* device_resource = nullptr);
 
   ~Seedfinder() = default;
   Seedfinder() = delete;
@@ -56,6 +61,12 @@ class Seedfinder {
 
   /// Wrapper around a SYCL queue object.
   QueueWrapper m_wrappedQueue;
+
+  /// host/shared memory resource to use in the seed-finder
+  vecmem::memory_resource* m_resource;
+
+  /// Device memory resource for use
+  vecmem::memory_resource* m_device_resource;
 };
 
 }  // namespace Acts::Sycl

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
@@ -30,7 +30,7 @@ Seedfinder<external_spacepoint_t>::Seedfinder(
     Acts::Sycl::QueueWrapper wrappedQueue,
     vecmem::memory_resource& resource,
     vecmem::memory_resource* device_resource)
-    : m_config(config),
+    : m_config(config.toInternalUnits()),
       m_deviceCuts(cuts),
       m_wrappedQueue(std::move(wrappedQueue)),
       m_resource(&resource),
@@ -143,7 +143,7 @@ Seedfinder<external_spacepoint_t>::createSeedsForGroup(
           weight, std::make_unique<const InternalSeed<external_spacepoint_t>>(
                       bottomSP, middleSP, topSP, 0)));
     }
-    m_config.seedFilter->filterSeeds_1SpFixed(seedsPerSPM, outputVec);
+    m_config.seedFilter->filterSeeds_1SpFixed(seedsPerSPM, std::back_inserter(outputVec));
   }
   return outputVec;
 }

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Seeding/Seedfinder.ipp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,6 +10,9 @@
 #include <algorithm>
 #include <cmath>
 #include <utility>
+
+// VecMem include(s).
+#include "vecmem/containers/vector.hpp"
 
 // Acts include(s).
 #include "Acts/Seeding/InternalSeed.hpp"
@@ -24,10 +27,14 @@ template <typename external_spacepoint_t>
 Seedfinder<external_spacepoint_t>::Seedfinder(
     Acts::SeedfinderConfig<external_spacepoint_t> config,
     const Acts::Sycl::DeviceExperimentCuts& cuts,
-    Acts::Sycl::QueueWrapper wrappedQueue)
-    : m_config(config.toInternalUnits()),
+    Acts::Sycl::QueueWrapper wrappedQueue,
+    vecmem::memory_resource& resource,
+    vecmem::memory_resource* device_resource)
+    : m_config(config),
       m_deviceCuts(cuts),
-      m_wrappedQueue(std::move(wrappedQueue)) {
+      m_wrappedQueue(std::move(wrappedQueue)),
+      m_resource(&resource),
+      m_device_resource(device_resource) {
   // init m_config
   m_config.highland = 13.6f * std::sqrt(m_config.radLengthPerSeed) *
                       (1 + 0.038f * std::log(m_config.radLengthPerSeed));
@@ -72,9 +79,11 @@ Seedfinder<external_spacepoint_t>::createSeedsForGroup(
   // that are easily comprehensible by the GPU. This allows us
   // less memory access operations than with simple (float) arrays.
 
-  std::vector<detail::DeviceSpacePoint> deviceBottomSPs;
-  std::vector<detail::DeviceSpacePoint> deviceMiddleSPs;
-  std::vector<detail::DeviceSpacePoint> deviceTopSPs;
+  // Creating VecMem vectors of the space points, linked to the host/shared memory resource
+  // They will be filled and passed to CreateSeedsForGroup().
+  vecmem::vector<detail::DeviceSpacePoint> deviceBottomSPs(m_resource);
+  vecmem::vector<detail::DeviceSpacePoint> deviceMiddleSPs(m_resource);
+  vecmem::vector<detail::DeviceSpacePoint> deviceTopSPs(m_resource);
 
   std::vector<const Acts::InternalSpacePoint<external_spacepoint_t>*>
       bottomSPvec;
@@ -84,31 +93,38 @@ Seedfinder<external_spacepoint_t>::createSeedsForGroup(
 
   for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : bottomSPs) {
     bottomSPvec.push_back(SP);
-    deviceBottomSPs.push_back(
-        detail::DeviceSpacePoint{SP->x(), SP->y(), SP->z(), SP->radius(),
-                                 SP->varianceR(), SP->varianceZ()});
+  }
+  deviceBottomSPs.reserve(bottomSPvec.size());
+  for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : bottomSPvec) {
+    deviceBottomSPs.push_back({SP->x(), SP->y(), SP->z(), SP->radius(),
+                               SP->varianceR(), SP->varianceZ()});
   }
 
   for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : middleSPs) {
     middleSPvec.push_back(SP);
-    deviceMiddleSPs.push_back(
-        detail::DeviceSpacePoint{SP->x(), SP->y(), SP->z(), SP->radius(),
-                                 SP->varianceR(), SP->varianceZ()});
+  }
+  deviceMiddleSPs.reserve(middleSPvec.size());
+  for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : middleSPvec) {
+    deviceMiddleSPs.push_back({SP->x(), SP->y(), SP->z(), SP->radius(),
+                               SP->varianceR(), SP->varianceZ()});
   }
 
   for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : topSPs) {
     topSPvec.push_back(SP);
-    deviceTopSPs.push_back(
-        detail::DeviceSpacePoint{SP->x(), SP->y(), SP->z(), SP->radius(),
-                                 SP->varianceR(), SP->varianceZ()});
+  }
+  deviceTopSPs.reserve(topSPvec.size());
+  for (const Acts::InternalSpacePoint<external_spacepoint_t>* SP : topSPvec) {
+    deviceTopSPs.push_back({SP->x(), SP->y(), SP->z(), SP->radius(),
+                            SP->varianceR(), SP->varianceZ()});
   }
 
+  //std::vector<std::vector<detail::SeedData>> seeds;
   std::vector<std::vector<detail::SeedData>> seeds;
 
   // Call the SYCL seeding algorithm
-  createSeedsForGroupSycl(m_wrappedQueue, m_deviceConfig, m_deviceCuts,
-                          deviceBottomSPs, deviceMiddleSPs, deviceTopSPs,
-                          seeds);
+  createSeedsForGroupSycl(m_wrappedQueue, *m_resource, m_device_resource, m_deviceConfig,
+                          m_deviceCuts, deviceBottomSPs, deviceMiddleSPs,
+                          deviceTopSPs, seeds);
 
   // Iterate through seeds returned by the SYCL algorithm and perform the last
   // step of filtering for fixed middle SP.
@@ -127,8 +143,7 @@ Seedfinder<external_spacepoint_t>::createSeedsForGroup(
           weight, std::make_unique<const InternalSeed<external_spacepoint_t>>(
                       bottomSP, middleSP, topSP, 0)));
     }
-    m_config.seedFilter->filterSeeds_1SpFixed(seedsPerSPM,
-                                              std::back_inserter(outputVec));
+    m_config.seedFilter->filterSeeds_1SpFixed(seedsPerSPM, outputVec);
   }
   return outputVec;
 }

--- a/Plugins/Sycl/include/Acts/Plugins/Sycl/Utilities/QueueWrapper.hpp
+++ b/Plugins/Sycl/include/Acts/Plugins/Sycl/Utilities/QueueWrapper.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -31,6 +31,10 @@ class QueueWrapper {
   QueueWrapper(const std::string& = "",
                std::unique_ptr<const Logger> logger =
                    getDefaultLogger("Sycl::QueueWrapper", Logging::INFO));
+  /// Constructor around an existing queue object
+  QueueWrapper(cl::sycl::queue& queue,
+               std::unique_ptr<const Logger> logger =
+                   getDefaultLogger("Sycl::QueueWrapper", Logging::INFO));
   /// Move constructor
   /// It takes ownership (if it is given).
   QueueWrapper(QueueWrapper&& parent) noexcept;
@@ -46,8 +50,25 @@ class QueueWrapper {
   /// Copy assignment operator
   QueueWrapper& operator=(const QueueWrapper& other);
 
-  /// Get stored pointer
-  cl::sycl::queue* getQueue() const;
+  /// @name Accessor functions/operators
+  /// @{
+
+  /// Get stored pointer (const)
+  const cl::sycl::queue* getQueue() const;
+  /// Get stored pointer (non-const)
+  cl::sycl::queue* getQueue();
+
+  /// Operator implementing smart pointer behaviour (const)
+  const cl::sycl::queue* operator->() const;
+  /// Operator implementing smart pointer behaviour (non-const)
+  cl::sycl::queue* operator->();
+
+  /// De-referencing operator (const)
+  const cl::sycl::queue& operator*() const;
+  /// De-referencing operator (non-const)
+  cl::sycl::queue& operator*();
+
+  /// @}
 
  private:
   /// Raw pointer to SYCL queue object

--- a/Plugins/Sycl/src/Seeding/CreateSeedsForGroupSycl.cpp
+++ b/Plugins/Sycl/src/Seeding/CreateSeedsForGroupSycl.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,6 +13,7 @@
 #include <exception>
 #include <functional>
 #include <vector>
+#include <memory>
 
 // Acts include(s)
 #include "Acts/Utilities/Logger.hpp"
@@ -25,6 +26,13 @@
 #include "../Utilities/Arrays.hpp"
 #include "DupletSearch.hpp"
 #include "LinearTransform.hpp"
+#include "TripletSearch.hpp"
+#include "TripletFilter.hpp"
+
+// VecMem include(s).
+#include "vecmem/containers/data/jagged_vector_buffer.hpp"
+#include "vecmem/containers/data/vector_buffer.hpp"
+#include "vecmem/utils/sycl/copy.hpp"
 
 // SYCL include
 #include <CL/sycl.hpp>
@@ -37,13 +45,15 @@ class triplet_search_kernel;
 class filter_2sp_fixed_kernel;
 
 void createSeedsForGroupSycl(
-    const QueueWrapper& wrappedQueue,
+    QueueWrapper wrappedQueue,
+    vecmem::memory_resource& resource,
+    vecmem::memory_resource* device_resource,
     const detail::DeviceSeedfinderConfig& seedfinderConfig,
     const DeviceExperimentCuts& deviceCuts,
-    const std::vector<detail::DeviceSpacePoint>& bottomSPs,
-    const std::vector<detail::DeviceSpacePoint>& middleSPs,
-    const std::vector<detail::DeviceSpacePoint>& topSPs,
-    std::vector<std::vector<detail::SeedData>>& seeds) {
+    vecmem::vector<detail::DeviceSpacePoint>& bottomSPs,
+    vecmem::vector<detail::DeviceSpacePoint>& middleSPs,
+    vecmem::vector<detail::DeviceSpacePoint>& topSPs,
+    std::vector<std::vector<detail::SeedData>>& seeds) __attribute__((optnone)) {
   // Each vector stores data of space points in simplified
   // structures of float variables
   // M: number of middle space points
@@ -56,25 +66,20 @@ void createSeedsForGroupSycl(
   // Up to the Nth space point, the sum of compatible bottom/top space points.
   // We need these for indexing other vectors later in the algorithm.
   // These are prefix sum arrays, with a leading zero.
-  std::vector<uint32_t> sumBotCompUptoMid(M + 1, 0);
-  std::vector<uint32_t> sumTopCompUptoMid(M + 1, 0);
-  std::vector<uint32_t> sumBotTopCombined(M + 1, 0);
+  // Those will be created with either host or shared memory resource
+  vecmem::vector<uint32_t> sumBotMidPrefix(&resource);
+  sumBotMidPrefix.push_back(0);
+  vecmem::vector<uint32_t> sumTopMidPrefix(&resource);
+  sumTopMidPrefix.push_back(0);
+  vecmem::vector<uint32_t> sumBotTopCombPrefix(&resource);
+  sumBotTopCombPrefix.push_back(0);
 
   // After completing the duplet search, we'll have successfully contructed
   // two bipartite graphs for bottom-middle and top-middle space points.
   // We store the indices of the middle space points of the corresponding
   // edges.
-  std::vector<uint32_t> indMidBotComp;
-  std::vector<uint32_t> indMidTopComp;
-
-  // Number of edges for middle-bottom and middle-top duplet bipartite graphs.
-  uint64_t edgesBottom = 0;
-  uint64_t edgesTop = 0;
-  // Number of possible compatible triplets. This is the sum of the
-  // combination of the number of compatible bottom and compatible top duplets
-  // per middle space point. (nb0*nt0 + nb1*nt1 + ... where nbk is the number
-  // of comp. bot. SPs for the kth middle SP)
-  uint64_t edgesComb = 0;
+  vecmem::vector<uint32_t> indMidBotComp(&resource);
+  vecmem::vector<uint32_t> indMidTopComp(&resource);
 
   try {
     auto* q = wrappedQueue.getQueue();
@@ -82,26 +87,7 @@ void createSeedsForGroupSycl(
         q->get_device().get_info<cl::sycl::info::device::global_mem_size>();
     uint64_t maxWorkGroupSize =
         q->get_device().get_info<cl::sycl::info::device::max_work_group_size>();
-
-    // Device allocations
-    auto deviceBottomSPs = make_device_array<detail::DeviceSpacePoint>(B, *q);
-    auto deviceMiddleSPs = make_device_array<detail::DeviceSpacePoint>(M, *q);
-    auto deviceTopSPs = make_device_array<detail::DeviceSpacePoint>(T, *q);
-
-    // The limit of compatible bottom [top] space points per middle space
-    // point is B [T]. Temporarily we reserve buffers of this size (M*B and
-    // M*T). We store the indices of bottom [top] space points in bottomSPs
-    // [topSPs]. We move the indices to optimal size vectors for easier
-    // indexing.
-    auto deviceTmpIndBot = make_device_array<uint32_t>(M * B, *q);
-    auto deviceTmpIndTop = make_device_array<uint32_t>(M * T, *q);
-
-    q->memcpy(deviceBottomSPs.get(), bottomSPs.data(),
-              sizeof(detail::DeviceSpacePoint) * (B));
-    q->memcpy(deviceMiddleSPs.get(), middleSPs.data(),
-              sizeof(detail::DeviceSpacePoint) * (M));
-    q->memcpy(deviceTopSPs.get(), topSPs.data(),
-              sizeof(detail::DeviceSpacePoint) * (T));
+    vecmem::sycl::copy copy(wrappedQueue.getQueue());
 
     // Calculate 2 dimensional range of bottom-middle duplet search kernel
     // We'll have a total of M*B threads globally, but we need to give the
@@ -113,77 +99,128 @@ void createSeedsForGroupSycl(
     cl::sycl::nd_range<2> topDupletNDRange =
         calculate2DimNDRange(M, T, maxWorkGroupSize);
 
-    // Count compatible bottom/top space points per middle space point.
-    std::vector<uint32_t> countBotDuplets(M, 0);
-    std::vector<uint32_t> countTopDuplets(M, 0);
+    // Create views of the space point vectors. 
+    // They will be constructed differently depending on the number of memory resources given.
+    std::unique_ptr<vecmem::data::vector_buffer<detail::DeviceSpacePoint>> deviceBottomSPs,
+                                                                           deviceTopSPs,
+                                                                           deviceMiddleSPs;
+    vecmem::data::vector_view<detail::DeviceSpacePoint> bottomSPsView,
+                                                        topSPsView,
+                                                        middleSPsView;
+    if (!device_resource){
+      bottomSPsView = vecmem::get_data(bottomSPs);
+      topSPsView = vecmem::get_data(topSPs);
+      middleSPsView = vecmem::get_data(middleSPs);
+    } else {
+      deviceBottomSPs = std::make_unique<vecmem::data::vector_buffer
+                                          <detail::DeviceSpacePoint>>
+                                              (B, *device_resource);
+      deviceTopSPs = std::make_unique<vecmem::data::vector_buffer
+                                          <detail::DeviceSpacePoint>>
+                                              (T, *device_resource);
+      deviceMiddleSPs = std::make_unique<vecmem::data::vector_buffer
+                                          <detail::DeviceSpacePoint>>
+                                              (M, *device_resource);
 
+      copy(vecmem::get_data(bottomSPs), *deviceBottomSPs);
+      copy(vecmem::get_data(topSPs), *deviceTopSPs);
+      copy(vecmem::get_data(middleSPs), *deviceMiddleSPs);
+
+      bottomSPsView = vecmem::get_data(*deviceBottomSPs);
+      topSPsView = vecmem::get_data(*deviceTopSPs);
+      middleSPsView = vecmem::get_data(*deviceMiddleSPs);
+    }
     //*********************************************//
     // ********** DUPLET SEARCH - BEGIN ********** //
     //*********************************************//
+
+    // Create the output data of the duplet search - jagged vectors.
+    std::unique_ptr<vecmem::data::jagged_vector_buffer<uint32_t>> midBotDupletBuffer;
+    std::unique_ptr<vecmem::data::jagged_vector_buffer<uint32_t>> midTopDupletBuffer;
+    if (!device_resource) {
+      midBotDupletBuffer = std::make_unique<vecmem::data::jagged_vector_buffer<uint32_t>>
+                                                (std::vector<std::size_t>(M, 0),
+                                                  std::vector<std::size_t>(M,B),
+                                                  resource);
+      midTopDupletBuffer = std::make_unique<vecmem::data::jagged_vector_buffer<uint32_t>>
+                                                (std::vector<std::size_t>(M, 0),
+                                                  std::vector<std::size_t>(M, T),
+                                                  resource);
+    } else {
+      midBotDupletBuffer = std::make_unique<vecmem::data::jagged_vector_buffer<uint32_t>>
+                                                (std::vector<std::size_t>(M, 0),
+                                                  std::vector<std::size_t>(M,B),
+                                                  *device_resource, &resource);
+      midTopDupletBuffer = std::make_unique<vecmem::data::jagged_vector_buffer<uint32_t>>
+                                                (std::vector<std::size_t>(M, 0),
+                                                  std::vector<std::size_t>(M, T),
+                                                  *device_resource, &resource);
+    }
+    copy.setup(*midBotDupletBuffer);
+    copy.setup(*midTopDupletBuffer);
 
     // Atomic accessor type used throughout the code.
     using AtomicAccessor =
         sycl::ONEAPI::atomic_accessor<uint32_t, 1,
                                       sycl::ONEAPI::memory_order::relaxed,
                                       sycl::ONEAPI::memory_scope::device>;
-    {
-      // Allocate temporary buffers on top of the count arrays booked in USM.
-      sycl::buffer<uint32_t> countBotBuf(countBotDuplets.data(), M);
-      sycl::buffer<uint32_t> countTopBuf(countTopDuplets.data(), M);
+  {
 
-      // Perform the middle-bottom duplet search.
-      q->submit([&](cl::sycl::handler& h) {
-        AtomicAccessor countBotDupletsAcc(countBotBuf, h);
-        detail::DupletSearch<detail::SpacePointType::Bottom, AtomicAccessor>
-            kernel(M, deviceMiddleSPs, B, deviceBottomSPs, deviceTmpIndBot,
-                   countBotDupletsAcc, seedfinderConfig);
-        h.parallel_for<class DupletSearchBottomKernel>(bottomDupletNDRange,
-                                                       kernel);
-      });
+    // Perform the middle-bottom duplet search.
+    q->submit([&](cl::sycl::handler& h) {
+      detail::DupletSearch<detail::SpacePointType::Bottom>
+          kernel(middleSPsView, bottomSPsView,
+                 *midBotDupletBuffer, seedfinderConfig);
+      h.parallel_for<class DupletSearchBottomKernel>(bottomDupletNDRange,
+                                                     kernel);
+    });
 
-      // Perform the middle-top duplet search.
-      q->submit([&](cl::sycl::handler& h) {
-        AtomicAccessor countTopDupletsAcc(countTopBuf, h);
-        detail::DupletSearch<detail::SpacePointType::Top, AtomicAccessor>
-            kernel(M, deviceMiddleSPs, T, deviceTopSPs, deviceTmpIndTop,
-                   countTopDupletsAcc, seedfinderConfig);
-        h.parallel_for<class DupletSearchTopKernel>(topDupletNDRange, kernel);
-      });
-    }  // sync (buffers get destroyed and duplet counts are copied back to
-       // countBotDuplets and countTopDuplets)
-
+    // Perform the middle-top duplet search.
+    q->submit([&](cl::sycl::handler& h) {
+      detail::DupletSearch<detail::SpacePointType::Top>
+          kernel(middleSPsView, topSPsView,
+                 *midTopDupletBuffer, seedfinderConfig);
+      h.parallel_for<class DupletSearchTopKernel>(topDupletNDRange, kernel);
+    });
+  }
     //*********************************************//
     // *********** DUPLET SEARCH - END *********** //
     //*********************************************//
 
-    // retrieve results from counting duplets
-    {
-      // Construct prefix sum arrays of duplet counts.
-      // These will later be used to index other arrays based on middle SP
-      // indices.
-      for (uint32_t i = 1; i < M + 1; ++i) {
-        sumBotCompUptoMid[i] +=
-            sumBotCompUptoMid[i - 1] + countBotDuplets[i - 1];
-        sumTopCompUptoMid[i] +=
-            sumTopCompUptoMid[i - 1] + countTopDuplets[i - 1];
-        sumBotTopCombined[i] += sumBotTopCombined[i - 1] +
-                                countTopDuplets[i - 1] * countBotDuplets[i - 1];
-      }
+    // Get the sizes of the inner vectors of the jagged vector - number of compatible bottom/top SPs for each MiddleSP.
+    auto countBotDuplets = copy.get_sizes(*midBotDupletBuffer);
+    auto countTopDuplets = copy.get_sizes(*midTopDupletBuffer);
+    // Construct prefix sum arrays of duplet counts.
+    // These will later be used to index other arrays based on middle SP
+    // indices.
+    for (uint32_t i = 1; i < M + 1; ++i) {
+      sumBotMidPrefix.push_back(
+          sumBotMidPrefix.at(i - 1) + countBotDuplets[i - 1]);
+      sumTopMidPrefix.push_back(
+          sumTopMidPrefix.at(i - 1) + countTopDuplets[i - 1]);
+      sumBotTopCombPrefix.push_back(
+          sumBotTopCombPrefix.at(i - 1) +
+          countBotDuplets[i - 1] *
+          countTopDuplets[i - 1]);
+    }
+    // Number of edges for middle-bottom and middle-top duplet bipartite graphs.
+    const uint64_t edgesBottom = sumBotMidPrefix[M];
+    const uint64_t edgesTop = sumTopMidPrefix[M];
+    // Number of possible compatible triplets. This is the sum of the
+    // combination of the number of compatible bottom and compatible top duplets
+    // per middle space point. (nb0*nt0 + nb1*nt1 + ... where nbk is the number
+    // of comp. bot. SPs for the kth middle SP)
+    const uint64_t edgesComb = sumBotTopCombPrefix[M];
 
-      edgesBottom = sumBotCompUptoMid[M];
-      edgesTop = sumTopCompUptoMid[M];
-      edgesComb = sumBotTopCombined[M];
+    indMidBotComp.reserve(edgesBottom);
+    indMidTopComp.reserve(edgesTop);
 
-      indMidBotComp.reserve(edgesBottom);
-      indMidTopComp.reserve(edgesTop);
-
-      // Fill arrays of middle SP indices of found duplets (bottom and top).
-      for (uint32_t mid = 0; mid < M; ++mid) {
-        std::fill_n(std::back_inserter(indMidBotComp), countBotDuplets[mid],
-                    mid);
-        std::fill_n(std::back_inserter(indMidTopComp), countTopDuplets[mid],
-                    mid);
-      }
+    // Fill arrays of middle SP indices of found duplets (bottom and top).
+    for (uint32_t mid = 0; mid < M; ++mid) {
+      std::fill_n(std::back_inserter(indMidBotComp), countBotDuplets[mid],
+                  mid);
+      std::fill_n(std::back_inserter(indMidTopComp), countTopDuplets[mid],
+                  mid);
     }
 
     if (edgesBottom > 0 && edgesTop > 0) {
@@ -199,7 +236,6 @@ void createSeedsForGroupSycl(
       // EXPLANATION OF INDEXING (fisrt part)
       /*
         (for bottom-middle duplets, but it is the same for middle-tops)
-
         In case we have 4 middle SP and 5 bottom SP, our temporary array of
         the compatible bottom duplet indices would look like this:
              ---------------------
@@ -212,133 +248,181 @@ void createSeedsForGroupSycl(
         described by a graph of nodes for middle and bottom SPs, and edges
         between one middle and one bottom SP, but never two middle or two
         bottom SPs.
-
         We will flatten this matrix out, and store the indices the
-        following way (this is deviceIndBot):
+        following way (this is indBotDupletBuffer):
         -------------------------------------
         | 0 | 3 | 4 | 1 | 3 | 2 | 4 | 2 | 1 |
         -------------------------------------
-
         Also the length of this array is equal to edgesBottom, which is 9 in
         this example. It is the number of the edges of the bottom-middle
         bipartite graph.
-
         To find out where the indices of bottom SPs start for a particular
         middle SP, we use prefix sum arrays.
         We know how many duplets were found for each middle SP (this is
-        deviceCountBotDuplets).
+        countBotDuplets).
         -----------------
         | 4 | 2 | 0 | 3 |
         -----------------
-
         We will make a prefix sum array of these counts, with a leading zero:
-        (this is deviceSumBot)
+        (this is sumBotMidPrefix)
         ---------------------
         | 0 | 4 | 6 | 6 | 9 |
         ---------------------
-
         If we have the middle SP with index 1, then we know that the indices
         of the compatible bottom SPs are in the range (left closed, right
-        open) [deviceSumBot[1] , deviceSumBot[2] ) of deviceIndBot. In this
+        open) [sumBotMidPrefix[1] , sumBotMidPrefix[2] ) of indBotDUpletBuffer. In this
         case, these indices are 3 and 2, so we'd use these to index
-        deviceBottomSPs to gather data about the bottom SP.
-
+        views of bottomSPs to gather data about the bottom SP.
         To be able to get the indices of middle SPs in constant time inside
         kernels, we will also prepare arrays that store the indices of the
-        middleSPs of the edges (deviceMidIndPerBot).
+        middleSPs of the edges (indMidBotComp).
         -------------------------------------
         | 0 | 0 | 0 | 0 | 1 | 1 | 3 | 3 | 3 |
         -------------------------------------
-
         (For the same purpose, we could also do a binary search on the
-        deviceSumBot array, and we will do exactly that later, in the triplet
+        sumBotMidPrefix array, and we will do exactly that later, in the triplet
         search kernel.)
-
         We will execute the coordinate transformation on edgesBottom threads,
         or 9 in our example.
-
         The size of the array storing our transformed coordinates
-        (deviceLinBot) is also edgesBottom, the sum of bottom duplets we
+        (linearBotBuffer) is also edgesBottom, the sum of bottom duplets we
         found so far.
       */
-
-      sycl::buffer<uint32_t> numTopDupletsBuf(countTopDuplets.data(), M);
 
       // We store the indices of the BOTTOM/TOP space points of the edges of
       // the bottom-middle and top-middle bipartite duplet graphs. They index
       // the bottomSPs and topSPs vectors.
-      auto deviceIndBot = make_device_array<uint32_t>(edgesBottom, *q);
-      auto deviceIndTop = make_device_array<uint32_t>(edgesTop, *q);
 
       // We store the indices of the MIDDLE space points of the edges of the
       // bottom-middle and top-middle bipartite duplet graphs.
       // They index the middleSP vector.
-      auto deviceMidIndPerBot = make_device_array<uint32_t>(edgesBottom, *q);
-      auto deviceMidIndPerTop = make_device_array<uint32_t>(edgesTop, *q);
+      // indMidBotComp;
+      // indMidTopComp;
 
       // Partial sum arrays of deviceNumBot and deviceNum
-      auto deviceSumBot = make_device_array<uint32_t>(M + 1, *q);
-      auto deviceSumTop = make_device_array<uint32_t>(M + 1, *q);
-
       // Partial sum array of the combinations of compatible bottom and top
       // space points per middle space point.
-      auto deviceSumComb = make_device_array<uint32_t>(M + 1, *q);
-
       // Allocations for coordinate transformation.
-      auto deviceLinBot =
-          make_device_array<detail::DeviceLinEqCircle>(edgesBottom, *q);
-      auto deviceLinTop =
-          make_device_array<detail::DeviceLinEqCircle>(edgesTop, *q);
 
-      q->memcpy(deviceMidIndPerBot.get(), indMidBotComp.data(),
-                sizeof(uint32_t) * edgesBottom);
-      q->memcpy(deviceMidIndPerTop.get(), indMidTopComp.data(),
-                sizeof(uint32_t) * edgesTop);
-      q->memcpy(deviceSumBot.get(), sumBotCompUptoMid.data(),
-                sizeof(uint32_t) * (M + 1));
-      q->memcpy(deviceSumTop.get(), sumTopCompUptoMid.data(),
-                sizeof(uint32_t) * (M + 1));
-      q->memcpy(deviceSumComb.get(), sumBotTopCombined.data(),
-                sizeof(uint32_t) * (M + 1));
-      q->wait();
 
+      // Buffers for Flattening the jagged vectors
+      std::unique_ptr<vecmem::data::vector_buffer<uint32_t>> indBotDupletBuffer;
+      std::unique_ptr<vecmem::data::vector_buffer<uint32_t>> indTopDupletBuffer;
+      if (!device_resource){
+        indBotDupletBuffer = std::make_unique<vecmem::data::vector_buffer<uint32_t>>
+                                                              (edgesBottom, resource);
+        indTopDupletBuffer = std::make_unique<vecmem::data::vector_buffer<uint32_t>>
+                                                              (edgesTop, resource);
+      } else {
+        indBotDupletBuffer = std::make_unique<vecmem::data::vector_buffer<uint32_t>>
+                                                              (edgesBottom, *device_resource);
+        indTopDupletBuffer = std::make_unique<vecmem::data::vector_buffer<uint32_t>>
+                                                              (edgesTop, *device_resource);
+      }
+      copy.setup(*indBotDupletBuffer);
+      copy.setup(*indTopDupletBuffer);
+
+      // Pointers constructed in case the device memory resource was given.
+      std::unique_ptr<vecmem::data::vector_buffer<uint32_t>> device_sumBotMidPrefix,
+                                                             device_sumTopMidPrefix,
+                                                             device_sumBotTopCombPrefix;
+      // Vecmem views of the prefix sums used throughout the later code.
+      vecmem::data::vector_view<uint32_t> sumBotMidView,
+                                          sumTopMidView,
+                                          sumBotTopCombView;
+
+      // Same behaviour for the vectors of indices
+      std::unique_ptr<vecmem::data::vector_buffer<uint32_t>> device_indMidBotComp,
+                                                             device_indMidTopComp;
+      vecmem::data::vector_view<uint32_t> indMidBotCompView,
+                                          indMidTopCompView;
       // Copy indices from temporary matrices to final, optimal size vectors.
       // We will use these for easier indexing.
       {
-        const uint32_t* deviceMidIndPerBotPtr = deviceMidIndPerBot.get();
-        const uint32_t* deviceTmpIndBotPtr = deviceTmpIndBot.get();
-        const uint32_t* deviceSumBotPtr = deviceSumBot.get();
-        uint32_t* deviceIndBotPtr = deviceIndBot.get();
+        if (!device_resource){
+          sumBotMidView = vecmem::get_data(sumBotMidPrefix);
+          sumTopMidView = vecmem::get_data(sumTopMidPrefix);
+          sumBotTopCombView = vecmem::get_data(sumBotTopCombPrefix);
+
+          indMidBotCompView = vecmem::get_data(indMidBotComp);
+          indMidTopCompView = vecmem::get_data(indMidTopComp);
+        } else {
+          device_sumBotMidPrefix = std::make_unique<vecmem::data::vector_buffer<uint32_t>>(M+1, *device_resource);
+          device_sumTopMidPrefix = std::make_unique<vecmem::data::vector_buffer<uint32_t>>(M+1, *device_resource);
+          device_sumBotTopCombPrefix = std::make_unique<vecmem::data::vector_buffer<uint32_t>>(M+1, *device_resource);
+
+          device_indMidBotComp = std::make_unique<vecmem::data::vector_buffer<uint32_t>>(edgesBottom, *device_resource);
+          device_indMidTopComp = std::make_unique<vecmem::data::vector_buffer<uint32_t>>(edgesTop, *device_resource);
+          
+          copy(vecmem::get_data(sumBotMidPrefix), *device_sumBotMidPrefix);
+          copy(vecmem::get_data(sumTopMidPrefix), *device_sumTopMidPrefix);
+          copy(vecmem::get_data(sumBotTopCombPrefix), *device_sumBotTopCombPrefix);
+        
+          copy(vecmem::get_data(indMidBotComp), *device_indMidBotComp);
+          copy(vecmem::get_data(indMidTopComp), *device_indMidTopComp);
+
+          sumBotMidView = vecmem::get_data(*device_sumBotMidPrefix);
+          sumTopMidView = vecmem::get_data(*device_sumTopMidPrefix);
+          sumBotTopCombView = vecmem::get_data(*device_sumBotTopCombPrefix);
+
+          indMidBotCompView = vecmem::get_data(*device_indMidBotComp);
+          indMidTopCompView = vecmem::get_data(*device_indMidTopComp);
+        }
+        auto midBotDupletView = vecmem::get_data(*midBotDupletBuffer);
+        auto indBotDupletView = vecmem::get_data(*indBotDupletBuffer);
         q->submit([&](cl::sycl::handler& h) {
           h.parallel_for<ind_copy_bottom_kernel>(
               edgesBotNdRange, [=](cl::sycl::nd_item<1> item) {
                 auto idx = item.get_global_linear_id();
                 if (idx < edgesBottom) {
-                  auto mid = deviceMidIndPerBotPtr[idx];
-                  auto ind =
-                      deviceTmpIndBotPtr[mid * B + idx - deviceSumBotPtr[mid]];
-                  deviceIndBotPtr[idx] = ind;
+                  vecmem::device_vector<uint32_t>
+                         deviceIndMidBot(indMidBotCompView),
+                         sumBotMidPrefix(sumBotMidView),
+                         indBotDuplets(indBotDupletView);
+                  vecmem::jagged_device_vector<const uint32_t>
+                      midBotDuplets(midBotDupletView);
+                  auto mid = deviceIndMidBot[idx];
+                  auto ind = midBotDuplets[mid][idx - sumBotMidPrefix[mid]];                                      
+                  indBotDuplets[idx] = ind;
                 }
               });
         });
-
-        const uint32_t* deviceMidIndPerTopPtr = deviceMidIndPerTop.get();
-        const uint32_t* deviceTmpIndTopPtr = deviceTmpIndTop.get();
-        const uint32_t* deviceSumTopPtr = deviceSumTop.get();
-        uint32_t* deviceIndTopPtr = deviceIndTop.get();
+        auto midTopDupletView = vecmem::get_data(*midTopDupletBuffer);
+        auto indTopDupletView = vecmem::get_data(*indTopDupletBuffer);
         q->submit([&](cl::sycl::handler& h) {
           h.parallel_for<ind_copy_top_kernel>(
               edgesTopNdRange, [=](cl::sycl::nd_item<1> item) {
                 auto idx = item.get_global_linear_id();
                 if (idx < edgesTop) {
-                  auto mid = deviceMidIndPerTopPtr[idx];
-                  auto ind =
-                      deviceTmpIndTopPtr[mid * T + idx - deviceSumTopPtr[mid]];
-                  deviceIndTopPtr[idx] = ind;
+                  vecmem::device_vector<uint32_t>
+                          deviceIndMidTop(indMidTopCompView),
+                          sumTopMidPrefix(sumTopMidView),
+                          indTopDuplets(indTopDupletView);
+                  vecmem::jagged_device_vector<const uint32_t>
+                      midTopDuplets(midTopDupletView);
+                  auto mid = deviceIndMidTop[idx];
+                  auto ind = midTopDuplets[mid][idx - sumTopMidPrefix[mid]];
+                  indTopDuplets[idx] = ind;
                 }
               });
         });
       }  // sync
+      // Create the output data of the linear transform
+      std::unique_ptr<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>> linearBotBuffer;
+      std::unique_ptr<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>> linearTopBuffer;
+      if (!device_resource){
+        linearBotBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>>
+                                                              (edgesBottom, resource);
+        linearTopBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>>
+                                                              (edgesTop, resource);
+      } else {
+        linearBotBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>>
+                                                              (edgesBottom, *device_resource);
+        linearTopBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceLinEqCircle>>
+                                                              (edgesTop, *device_resource);
+      }
+      copy.setup(*linearBotBuffer);
+      copy.setup(*linearTopBuffer);
 
       //************************************************//
       // *** LINEAR EQUATION TRANSFORMATION - BEGIN *** //
@@ -352,8 +436,9 @@ void createSeedsForGroupSycl(
       // coordinate transformation middle-bottom pairs
       auto linB = q->submit([&](cl::sycl::handler& h) {
         detail::LinearTransform<detail::SpacePointType::Bottom> kernel(
-            M, deviceMiddleSPs, B, deviceBottomSPs, deviceMidIndPerBot,
-            deviceIndBot, edgesBottom, deviceLinBot);
+            middleSPsView, bottomSPsView,
+            indMidBotCompView, *indBotDupletBuffer, 
+            edgesBottom, *linearBotBuffer);
         h.parallel_for<class TransformCoordBottomKernel>(edgesBotNdRange,
                                                          kernel);
       });
@@ -361,8 +446,9 @@ void createSeedsForGroupSycl(
       // coordinate transformation middle-top pairs
       auto linT = q->submit([&](cl::sycl::handler& h) {
         detail::LinearTransform<detail::SpacePointType::Top> kernel(
-            M, deviceMiddleSPs, T, deviceTopSPs, deviceMidIndPerTop,
-            deviceIndTop, edgesTop, deviceLinTop);
+            middleSPsView, topSPsView, 
+            indMidTopCompView, *indTopDupletBuffer, 
+            edgesTop, *linearTopBuffer);
         h.parallel_for<class TransformCoordTopKernel>(edgesTopNdRange, kernel);
       });
 
@@ -384,10 +470,10 @@ void createSeedsForGroupSycl(
         (nb0*nt0 + nb1*nt1 + ... where nbk is the number of compatible bottom
         SPs for the kth middle SP, similarly ntb is for tops)
 
-        sumBotTopCombined is a prefix sum array (of length M+1) of the
+        sumBotTopCombPrefix is a prefix sum array (of length M+1) of the
         calculated combinations.
 
-        sumBotTopCombined:
+        sumBotTopCombPrefix:
         ________________________________________________________
         |     |         |                   |     |  M         | M = number
         |  0  | nb0*nt0 | nb0*nt0 + nb1*nt1 | ... |  ∑ nbi+nti | of middle
@@ -418,7 +504,7 @@ void createSeedsForGroupSycl(
 
         Inside the triplet search kernel we start with a binary search, to
         find out which middle SP the thread corresponds to. Note, that
-        sumBotTopCombined is a monotone increasing series of values which
+        sumBotTopCombPrefix is a monotone increasing series of values which
         allows us to do a binary search on it.
 
         Inside the triplet search kernel we count the triplets for fixed
@@ -431,7 +517,7 @@ void createSeedsForGroupSycl(
         middle SP j<=M.)
 
         This will be numTripletFilterThreads =
-            sumBotCompUptoMid[lastMiddle] - sumBotCompUptoMid[firstMiddle]
+            sumBotMidPrefix[lastMiddle] - sumBotMidPrefix[firstMiddle]
 
         If the triplet search and triplet filter kernel finished, we continue
         summing up possible triplet combinations from the (k+1)th middle SP.
@@ -448,22 +534,34 @@ void createSeedsForGroupSycl(
                                                 sizeof(detail::SeedData)) *
                                                2));
 
-      auto deviceCurvImpact =
-          make_device_array<detail::DeviceTriplet>(maxMemoryAllocation, *q);
-
+      std::unique_ptr<vecmem::data::vector_buffer
+                                  <detail::DeviceTriplet>>
+                                            curvImpactBuffer;
+      std::unique_ptr<vecmem::data::vector_buffer
+                                  <detail::SeedData>>
+                                            seedArrayBuffer;
+      if (!device_resource){
+        curvImpactBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceTriplet>>
+                                                                  (maxMemoryAllocation, resource);
+        seedArrayBuffer = std::make_unique<vecmem::data::vector_buffer<detail::SeedData>>
+                                                                  (maxMemoryAllocation, 0, resource);                                                                  
+      } else {
+        curvImpactBuffer = std::make_unique<vecmem::data::vector_buffer<detail::DeviceTriplet>>
+                                                                  (maxMemoryAllocation, *device_resource);
+        seedArrayBuffer = std::make_unique<vecmem::data::vector_buffer<detail::SeedData>>
+                                                                  (maxMemoryAllocation, 0, *device_resource);
+      }                                                                 
+      copy.setup(*curvImpactBuffer);
+      copy.setup(*seedArrayBuffer);
       // Reserve memory in advance for seed indices and weight
       // Other way around would allocating it inside the loop
       // -> less memory usage, but more frequent allocation and deallocation
-      auto deviceSeedArray =
-          make_device_array<detail::SeedData>(maxMemoryAllocation, *q);
 
       // Counting the seeds in the second kernel allows us to copy back the
       // right number of seeds, and no more.
 
       seeds.resize(M);
-      uint32_t sumSeeds = 0;
       std::vector<uint32_t> deviceCountTriplets(edgesBottom, 0);
-
       // Do the triplet search and triplet filter for 2 sp fixed for middle
       // space points in the interval [firstMiddle, lastMiddle).
 
@@ -472,25 +570,22 @@ void createSeedsForGroupSycl(
            firstMiddle = lastMiddle) {
         // Determine the interval [firstMiddle, lastMiddle) right end based
         // on memory requirements.
-        while (lastMiddle + 1 <= M && (sumBotTopCombined[lastMiddle + 1] -
-                                           sumBotTopCombined[firstMiddle] <
+        while (lastMiddle + 1 <= M && (sumBotTopCombPrefix[lastMiddle + 1] -
+                                           sumBotTopCombPrefix[firstMiddle] <
                                        maxMemoryAllocation)) {
           ++lastMiddle;
         }
 
         const auto numTripletSearchThreads =
-            sumBotTopCombined[lastMiddle] - sumBotTopCombined[firstMiddle];
+            sumBotTopCombPrefix[lastMiddle] - sumBotTopCombPrefix[firstMiddle];
 
         if (numTripletSearchThreads == 0)
           continue;
 
-        sumSeeds = 0;
         deviceCountTriplets.resize(edgesBottom, 0);
-
+        copy.setup(*seedArrayBuffer);
         const auto numTripletFilterThreads =
-            sumBotCompUptoMid[lastMiddle] - sumBotCompUptoMid[firstMiddle];
-
-        const auto sumCombUptoFirstMiddle = sumBotTopCombined[firstMiddle];
+            sumBotMidPrefix[lastMiddle] - sumBotMidPrefix[firstMiddle];
 
         // Nd_range with maximum block size for triplet search and filter.
         // (global and local range is already given)
@@ -502,316 +597,44 @@ void createSeedsForGroupSycl(
 
         sycl::buffer<uint32_t> countTripletsBuf(deviceCountTriplets.data(),
                                                 edgesBottom);
-
-        const uint32_t* deviceSumCombPtr = deviceSumComb.get();
-        const uint32_t* deviceSumBotPtr = deviceSumBot.get();
-        const uint32_t* deviceSumTopPtr = deviceSumTop.get();
-        const detail::DeviceLinEqCircle* deviceLinBotPtr = deviceLinBot.get();
-        const detail::DeviceLinEqCircle* deviceLinTopPtr = deviceLinTop.get();
-        const detail::DeviceSpacePoint* deviceMiddleSPsPtr =
-            deviceMiddleSPs.get();
-        const uint32_t* deviceIndTopPtr = deviceIndTop.get();
-        detail::DeviceTriplet* deviceCurvImpactPtr = deviceCurvImpact.get();
+        
         auto tripletKernel = q->submit([&](cl::sycl::handler& h) {
           h.depends_on({linB, linT});
           AtomicAccessor countTripletsAcc(countTripletsBuf, h);
-          auto numTopDupletsAcc = numTopDupletsBuf.get_access<
-              sycl::access::mode::read, sycl::access::target::global_buffer>(h);
-          h.parallel_for<triplet_search_kernel>(
-              tripletSearchNDRange, [=](cl::sycl::nd_item<1> item) {
-                const uint32_t idx = item.get_global_linear_id();
-                if (idx < numTripletSearchThreads) {
-                  // Retrieve the index of the corresponding middle
-                  // space point by binary search
-                  auto L = firstMiddle;
-                  auto R = lastMiddle;
-                  auto mid = L;
-                  while (L < R - 1) {
-                    mid = (L + R) / 2;
-                    // To be able to search in deviceSumComb, we need
-                    // to use an offset (sumCombUptoFirstMiddle).
-                    if (idx + sumCombUptoFirstMiddle < deviceSumCombPtr[mid]) {
-                      R = mid;
-                    } else {
-                      L = mid;
-                    }
-                  }
-                  mid = L;
-
-                  const auto numT = numTopDupletsAcc[mid];
-                  const auto threadIdxForMiddleSP =
-                      (idx - deviceSumCombPtr[mid] + sumCombUptoFirstMiddle);
-
-                  // NOTES ON THREAD MAPPING TO SPACE POINTS
-                  /*
-                    We need to map bottom and top SP indices to this
-                    thread.
-
-                    So we are mapping one bottom and one top SP to this thread
-                    (we already have a middle SP) which gives us a tiplet.
-
-                    This is done in the following way: We
-                    calculated the number of possible triplet
-                    combinations for this middle SP (let it be
-                    num_comp_bot*num_comp_top). Let num_comp_bot = 2
-                    and num_comp_top=3 in this example. So we have 2
-                    compatible bottom and 3 compatible top SP for this
-                    middle SP.
-
-                    That gives us 6 threads altogether:
-                               ===========================================
-                    thread:    |  0   |  1   |  2   |  3   |  4   |  5   |
-                    bottom id: | bot0 | bot0 | bot0 | bot1 | bot1 | bot1 |
-                    top id:    | top0 | top1 | top2 | top0 | top1 | top2 |
-                               ===========================================
-
-                    If we divide 6 by the number of compatible top SP
-                    for this middle SP, or deviceNumTopDuplets[mid]
-                    which is 3 now, we get the id for the bottom SP.
-                    Similarly, if we take modulo
-                    deviceNumTopDuplets[mid], we get the id for the
-                    top SP.
-
-                    So if threadIdxForMiddleSP = 3, then ib = 1 and it = 0.
-
-                    We can use these ids together with
-                    deviceSumBot[mid] and deviceSumTop[mid] to be able
-                    to index our other arrays.
-
-                    These other arrays are deviceIndBot and deviceIndTop.
-
-                    So to retrieve the bottom SP index for this thread, we'd
-                    have to index the deviceIndBot array at
-                      deviceSumBot[mid] + ib
-                    which is the id for the bottom SP that we just calculated
-                    (ib = 1 in the example).
-                  */
-
-                  const auto ib =
-                      deviceSumBotPtr[mid] + (threadIdxForMiddleSP / numT);
-                  const auto it =
-                      deviceSumTopPtr[mid] + (threadIdxForMiddleSP % numT);
-
-                  const auto linBotEq = deviceLinBotPtr[ib];
-                  const auto linTopEq = deviceLinTopPtr[it];
-                  const auto midSP = deviceMiddleSPsPtr[mid];
-
-                  const auto Vb = linBotEq.v;
-                  const auto Ub = linBotEq.u;
-                  const auto Erb = linBotEq.er;
-                  const auto cotThetab = linBotEq.cotTheta;
-                  const auto iDeltaRb = linBotEq.iDeltaR;
-
-                  const auto Vt = linTopEq.v;
-                  const auto Ut = linTopEq.u;
-                  const auto Ert = linTopEq.er;
-                  const auto cotThetat = linTopEq.cotTheta;
-                  const auto iDeltaRt = linTopEq.iDeltaR;
-
-                  const auto rM = midSP.r;
-                  const auto varianceRM = midSP.varR;
-                  const auto varianceZM = midSP.varZ;
-
-                  auto iSinTheta2 = (1.f + cotThetab * cotThetab);
-                  auto scatteringInRegion2 =
-                      seedfinderConfig.maxScatteringAngle2 * iSinTheta2;
-                  scatteringInRegion2 *= seedfinderConfig.sigmaScattering *
-                                         seedfinderConfig.sigmaScattering;
-                  auto error2 =
-                      Ert + Erb +
-                      2.f * (cotThetab * cotThetat * varianceRM + varianceZM) *
-                          iDeltaRb * iDeltaRt;
-                  auto deltaCotTheta = cotThetab - cotThetat;
-                  auto deltaCotTheta2 = deltaCotTheta * deltaCotTheta;
-
-                  deltaCotTheta = cl::sycl::abs(deltaCotTheta);
-                  auto error = cl::sycl::sqrt(error2);
-                  auto dCotThetaMinusError2 =
-                      deltaCotTheta2 + error2 - 2.f * deltaCotTheta * error;
-                  auto dU = Ut - Ub;
-
-                  if ((!(deltaCotTheta2 - error2 > 0.f) ||
-                       !(dCotThetaMinusError2 > scatteringInRegion2)) &&
-                      !(dU == 0.f)) {
-                    auto A = (Vt - Vb) / dU;
-                    auto S2 = 1.f + A * A;
-                    auto B = Vb - A * Ub;
-                    auto B2 = B * B;
-
-                    auto iHelixDiameter2 = B2 / S2;
-                    auto pT2scatter =
-                        4.f * iHelixDiameter2 * seedfinderConfig.pT2perRadius;
-                    auto p2scatter = pT2scatter * iSinTheta2;
-                    auto Im = cl::sycl::abs((A - B * rM) * rM);
-
-                    if (!(S2 < B2 * seedfinderConfig.minHelixDiameter2) &&
-                        !((deltaCotTheta2 - error2 > 0.f) &&
-                          (dCotThetaMinusError2 >
-                           p2scatter * seedfinderConfig.sigmaScattering *
-                               seedfinderConfig.sigmaScattering)) &&
-                        !(Im > seedfinderConfig.impactMax)) {
-                      const auto top = deviceIndTopPtr[it];
-                      // this will be the t-th top space point for
-                      // fixed middle and bottom SP
-                      auto t = countTripletsAcc[ib].fetch_add(1);
-                      /*
-                        deviceSumComb[mid] - sumCombUptoFirstMiddle:
-                        gives the memory location reserved for this
-                        middle SP
-
-                        (idx-deviceSumComb[mid]+sumCombUptoFirstMiddle:
-                        this is the nth thread for this middle SP
-
-                        (idx-deviceSumComb[mid]+sumCombUptoFirstMiddle)/numT:
-                        this is the mth bottom SP for this middle SP
-
-                        multiplying this by numT gives the memory
-                        location for this middle and bottom SP
-
-                        and by adding t to it, we will end up storing
-                        compatible triplet candidates for this middle
-                        and bottom SP right next to each other
-                        starting from the given memory location
-                      */
-                      const auto tripletIdx = deviceSumCombPtr[mid] -
-                                              sumCombUptoFirstMiddle +
-                                              (((idx - deviceSumCombPtr[mid] +
-                                                 sumCombUptoFirstMiddle) /
-                                                numT) *
-                                               numT) +
-                                              t;
-
-                      detail::DeviceTriplet T;
-                      T.curvature = B / cl::sycl::sqrt(S2);
-                      T.impact = Im;
-                      T.topSPIndex = top;
-                      deviceCurvImpactPtr[tripletIdx] = T;
-                    }
-                  }
-                }
-              });
-        });
-
+          detail::TripletSearch<AtomicAccessor>
+              kernel(sumBotTopCombView, numTripletSearchThreads,
+                     firstMiddle, lastMiddle, *midTopDupletBuffer, 
+                     sumBotMidView, sumTopMidView,
+                     *linearBotBuffer, *linearTopBuffer,
+                     middleSPsView, *indTopDupletBuffer,
+                     countTripletsAcc, seedfinderConfig, *curvImpactBuffer);
+          h.parallel_for<class triplet_search_kernel>(
+              tripletSearchNDRange, kernel); });
         {
-          const uint32_t* deviceMidIndPerBotPtr = deviceMidIndPerBot.get();
-          const uint32_t* deviceIndBotPtr = deviceIndBot.get();
-          const detail::DeviceTriplet* deviceCurvImpactConstPtr =
-              deviceCurvImpact.get();
-          const detail::DeviceSpacePoint* deviceBottomSPsPtr =
-              deviceBottomSPs.get();
-          const detail::DeviceSpacePoint* deviceTopSPsPtr = deviceTopSPs.get();
-          detail::SeedData* deviceSeedArrayPtr = deviceSeedArray.get();
-          sycl::buffer<uint32_t> countSeedsBuf(&sumSeeds, 1);
           q->submit([&](cl::sycl::handler& h) {
             h.depends_on(tripletKernel);
-            AtomicAccessor countSeedsAcc(countSeedsBuf, h);
             auto countTripletsAcc = countTripletsBuf.get_access<
                 sycl::access::mode::read, sycl::access::target::global_buffer>(
                 h);
-            auto numTopDupletsAcc = numTopDupletsBuf.get_access<
-                sycl::access::mode::read, sycl::access::target::global_buffer>(
-                h);
-            h.parallel_for<filter_2sp_fixed_kernel>(
-                tripletFilterNDRange, [=](cl::sycl::nd_item<1> item) {
-                  if (item.get_global_linear_id() < numTripletFilterThreads) {
-                    const auto idx = deviceSumBotPtr[firstMiddle] +
-                                     item.get_global_linear_id();
-                    const auto mid = deviceMidIndPerBotPtr[idx];
-                    const auto bot = deviceIndBotPtr[idx];
-
-                    const auto tripletBegin =
-                        deviceSumCombPtr[mid] - sumCombUptoFirstMiddle +
-                        (idx - deviceSumBotPtr[mid]) * numTopDupletsAcc[mid];
-                    const auto tripletEnd =
-                        tripletBegin + countTripletsAcc[idx];
-
-                    for (auto i1 = tripletBegin; i1 < tripletEnd; ++i1) {
-                      const auto current = deviceCurvImpactConstPtr[i1];
-                      const auto top = current.topSPIndex;
-
-                      const auto invHelixDiameter = current.curvature;
-                      const auto lowerLimitCurv =
-                          invHelixDiameter -
-                          seedfinderConfig.deltaInvHelixDiameter;
-                      const auto upperLimitCurv =
-                          invHelixDiameter +
-                          seedfinderConfig.deltaInvHelixDiameter;
-                      const auto currentTop_r = deviceTopSPsPtr[top].r;
-                      auto weight = -(current.impact *
-                                      seedfinderConfig.impactWeightFactor);
-
-                      uint32_t compatCounter = 0;
-
-                      // By default compatSeedLimit is 2 -> 2 is
-                      // currently hard coded, because variable length
-                      // arrays are not supported in SYCL kernels.
-                      float compatibleSeedR[2];
-                      for (auto i2 = tripletBegin;
-                           i2 < tripletEnd &&
-                           compatCounter < seedfinderConfig.compatSeedLimit;
-                           ++i2) {
-                        const auto other = deviceCurvImpactConstPtr[i2];
-
-                        const auto otherCurv = other.curvature;
-                        const auto otherTop_r =
-                            deviceTopSPsPtr[other.topSPIndex].r;
-                        const float deltaR =
-                            cl::sycl::abs(currentTop_r - otherTop_r);
-                        if (deltaR >= seedfinderConfig.filterDeltaRMin &&
-                            otherCurv >= lowerLimitCurv &&
-                            otherCurv <= upperLimitCurv) {
-                          uint32_t c = 0;
-                          for (;
-                               c < compatCounter &&
-                               cl::sycl::abs(compatibleSeedR[c] - otherTop_r) >=
-                                   seedfinderConfig.filterDeltaRMin;
-                               ++c) {
-                          }
-                          if (c == compatCounter) {
-                            compatibleSeedR[c] = otherTop_r;
-                            ++compatCounter;
-                          }
-                        }
-                      }
-
-                      weight +=
-                          compatCounter * seedfinderConfig.compatSeedWeight;
-
-                      const auto bottomSP = deviceBottomSPsPtr[bot];
-                      const auto middleSP = deviceMiddleSPsPtr[mid];
-                      const auto topSP = deviceTopSPsPtr[top];
-
-                      weight +=
-                          deviceCuts.seedWeight(bottomSP, middleSP, topSP);
-
-                      if (deviceCuts.singleSeedCut(weight, bottomSP, middleSP,
-                                                   topSP)) {
-                        const auto i = countSeedsAcc[0].fetch_add(1);
-                        detail::SeedData D;
-                        D.bottom = bot;
-                        D.top = top;
-                        D.middle = mid;
-                        D.weight = weight;
-                        deviceSeedArrayPtr[i] = D;
-                      }
-                    }
-                  }
-                });
+            detail::TripletFilter<AtomicAccessor>
+                kernel(numTripletFilterThreads, sumBotMidView,
+                       firstMiddle, indMidBotCompView,
+                       *indBotDupletBuffer, sumBotTopCombView,
+                       *midTopDupletBuffer, *curvImpactBuffer, topSPsView,
+                       middleSPsView, bottomSPsView,
+                       countTripletsAcc, *seedArrayBuffer, 
+                       seedfinderConfig, deviceCuts);
+            h.parallel_for<class filter_2sp_fixed_kernel>(
+                tripletFilterNDRange, kernel);
           });
-        }  // sync, countSeedsBuf gets destroyed and its value is copied back to
-           // sumSeeds
+        } // sync
+        // Retrieve results from triplet search
+        std::vector<detail::SeedData> seedArray;
+        copy(*seedArrayBuffer, seedArray);
 
-        if (sumSeeds != 0) {
-          std::vector<detail::SeedData> hostSeedArray(sumSeeds);
-          auto e0 = q->memcpy(hostSeedArray.data(), deviceSeedArray.get(),
-                              sumSeeds * sizeof(detail::SeedData));
-          e0.wait();
-
-          for (uint32_t t = 0; t < sumSeeds; ++t) {
-            auto m = hostSeedArray[t].middle;
-            seeds[m].push_back(hostSeedArray[t]);
+          for (auto & t : seedArray) {
+            seeds[t.middle].push_back(t);
           }
-        }
       }
 
       //************************************************//

--- a/Plugins/Sycl/src/Seeding/DupletSearch.hpp
+++ b/Plugins/Sycl/src/Seeding/DupletSearch.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,6 +14,12 @@
 #include "../Utilities/Arrays.hpp"
 #include "SpacePointType.hpp"
 
+// VecMem include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/device_vector.hpp"
+
 // SYCL include(s).
 #include <CL/sycl.hpp>
 
@@ -23,7 +29,7 @@
 namespace Acts::Sycl::detail {
 
 /// Functor taking care of finding viable spacepoint duplets
-template <SpacePointType OtherSPType, class AtomicAccessorType>
+template <SpacePointType OtherSPType>
 class DupletSearch {
   // Sanity check(s).
   static_assert((OtherSPType == SpacePointType::Bottom) ||
@@ -34,19 +40,13 @@ class DupletSearch {
 
  public:
   /// Constructor with all the necessary arguments
-  DupletSearch(uint32_t nMiddleSPs,
-               const device_array<DeviceSpacePoint>& middleSPs,
-               uint32_t nOtherSPs,
-               const device_array<DeviceSpacePoint>& otherSPs,
-               device_array<uint32_t>& middleOtherSPIndices,
-               const AtomicAccessorType& middleOtherSPCounts,
+  DupletSearch(vecmem::data::vector_view<const DeviceSpacePoint> middleSPs,
+               vecmem::data::vector_view<const DeviceSpacePoint> otherSPs,
+               vecmem::data::jagged_vector_view<uint32_t> middleOtherSPIndices,
                const DeviceSeedfinderConfig& config)
-      : m_nMiddleSPs(nMiddleSPs),
-        m_middleSPs(middleSPs.get()),
-        m_nOtherSPs(nOtherSPs),
-        m_otherSPs(otherSPs.get()),
-        m_middleOtherSPIndices(middleOtherSPIndices.get()),
-        m_middleOtherSPCounts(middleOtherSPCounts),
+      : m_middleSPs(middleSPs),
+        m_otherSPs(otherSPs),
+        m_middleOtherSPIndices(middleOtherSPIndices),
         m_config(config) {}
 
   /// Operator performing the duplet search
@@ -58,15 +58,18 @@ class DupletSearch {
     // We check whether this thread actually makes sense (within bounds).
     // The number of threads is usually a factor of 2, or 3*2^k (k \in N), etc.
     // Without this check we may index out of arrays.
-    if ((middleIndex >= m_nMiddleSPs) || (otherIndex >= m_nOtherSPs)) {
+    if ((middleIndex >= m_middleSPs.size()) ||
+        (otherIndex >= m_otherSPs.size())) {
       return;
     }
 
     // Create a copy of the spacepoint objects for the current thread. On
     // dedicated GPUs this provides a better performance than accessing
     // variables one-by-one from global device memory.
-    const DeviceSpacePoint middleSP = m_middleSPs[middleIndex];
-    const DeviceSpacePoint otherSP = m_otherSPs[otherIndex];
+    const vecmem::device_vector<const DeviceSpacePoint> middleSPs(m_middleSPs);
+    const DeviceSpacePoint middleSP = middleSPs[middleIndex];
+    const vecmem::device_vector<const DeviceSpacePoint> otherSPs(m_otherSPs);
+    const DeviceSpacePoint otherSP = otherSPs[otherIndex];
 
     // Calculate the variables that the duplet quality selection are based on.
     // Note that the asserts of the functor make sure that 'OtherSPType' must be
@@ -86,27 +89,21 @@ class DupletSearch {
         (cl::sycl::abs(cotTheta) <= m_config.cotThetaMax) &&
         (zOrigin >= m_config.collisionRegionMin) &&
         (zOrigin <= m_config.collisionRegionMax)) {
-      // We keep counting duplets with atomic access.
-      const uint32_t ind = m_middleOtherSPCounts[middleIndex].fetch_add(1);
-      m_middleOtherSPIndices[middleIndex * m_nOtherSPs + ind] = otherIndex;
+      // Create device vector based on the view and push to it
+      vecmem::jagged_device_vector<uint32_t>
+          middleOtherSPIndices(m_middleOtherSPIndices);
+      middleOtherSPIndices.at(middleIndex).push_back(otherIndex);
     }
   }
 
  private:
-  /// Total number of middle spacepoints
-  uint32_t m_nMiddleSPs;
-  /// Pointer to the middle spacepoints (in global device memory)
-  const DeviceSpacePoint* m_middleSPs;
-  /// Total number of "other" (bottom or top) spacepoints
-  uint32_t m_nOtherSPs;
-  /// Pointer to the "other" (bottom or top) spacepoints (in global device mem.)
-  const DeviceSpacePoint* m_otherSPs;
+  /// Middle spacepoints
+  vecmem::data::vector_view<const DeviceSpacePoint> m_middleSPs;
+  /// "Other" (bottom or top) spacepoints
+  vecmem::data::vector_view<const DeviceSpacePoint> m_otherSPs;
 
   /// The 2D array storing the compatible middle-other spacepoint indices
-  uint32_t* m_middleOtherSPIndices;
-  /// The atomic accessor used for modifying the count of compatible
-  /// middle-other spacepoint duplets
-  AtomicAccessorType m_middleOtherSPCounts;
+  vecmem::data::jagged_vector_view<uint32_t> m_middleOtherSPIndices;
 
   /// Configuration for the seed finding
   DeviceSeedfinderConfig m_config;

--- a/Plugins/Sycl/src/Seeding/LinearTransform.hpp
+++ b/Plugins/Sycl/src/Seeding/LinearTransform.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,6 +21,10 @@
 #include <cassert>
 #include <cstdint>
 
+// VecMem include(s).
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
+
 namespace Acts::Sycl::detail {
 
 /// Functor performing a linear coordinate transformation on spacepoint pairs
@@ -35,21 +39,17 @@ class LinearTransform {
 
  public:
   /// Constructor with all the necessary arguments
-  LinearTransform(uint32_t nMiddleSPs,
-                  const device_array<DeviceSpacePoint>& middleSPs,
-                  uint32_t nOtherSPs,
-                  const device_array<DeviceSpacePoint>& otherSPs,
-                  const device_array<uint32_t>& middleIndexLUT,
-                  const device_array<uint32_t>& otherIndexLUT, uint32_t nEdges,
-                  device_array<DeviceLinEqCircle>& resultArray)
-      : m_nMiddleSPs(nMiddleSPs),
-        m_middleSPs(middleSPs.get()),
-        m_nOtherSPs(nOtherSPs),
-        m_otherSPs(otherSPs.get()),
-        m_middleIndexLUT(middleIndexLUT.get()),
-        m_otherIndexLUT(otherIndexLUT.get()),
+  LinearTransform(vecmem::data::vector_view<const DeviceSpacePoint> middleSPs,
+                  vecmem::data::vector_view<const DeviceSpacePoint> otherSPs,
+                  vecmem::data::vector_view<uint32_t> middleIndexLUT,
+                  vecmem::data::vector_view<uint32_t> otherIndexLUT, uint32_t nEdges,
+                  vecmem::data::vector_view<detail::DeviceLinEqCircle> resultArray)
+      : m_middleSPs(middleSPs),
+        m_otherSPs(otherSPs),
+        m_middleIndexLUT(middleIndexLUT),
+        m_otherIndexLUT(otherIndexLUT),
         m_nEdges(nEdges),
-        m_resultArray(resultArray.get()) {}
+        m_resultArray(resultArray) {}
 
   /// Operator performing the coordinate linear transformation
   void operator()(cl::sycl::nd_item<1> item) const {
@@ -63,18 +63,24 @@ class LinearTransform {
     // Note that using asserts with the CUDA backend of dpc++ is not working
     // quite correctly at the moment. :-( So these checks may need to be
     // disabled if you need to build for an NVidia backend in Debug mode.
-    const uint32_t middleIndex = m_middleIndexLUT[idx];
-    assert(middleIndex < m_nMiddleSPs);
-    (void)m_nMiddleSPs;
-    const uint32_t otherIndex = m_otherIndexLUT[idx];
-    assert(otherIndex < m_nOtherSPs);
-    (void)m_nOtherSPs;
+    vecmem::device_vector<uint32_t> 
+                   middleIndexLUT(m_middleIndexLUT);
+    const uint32_t middleIndex = middleIndexLUT[idx];
+    assert(middleIndex < m_middleSPs.size());
+    (void)m_middleSPs.size();
+    vecmem::device_vector<uint32_t> 
+                  otherIndexLUT(m_otherIndexLUT);
+    const uint32_t otherIndex = otherIndexLUT[idx];
+    assert(otherIndex < m_otherSPs.size());
+    (void)m_otherSPs.size();
 
     // Create a copy of the spacepoint objects for the current thread. On
     // dedicated GPUs this provides a better performance than accessing
     // variables one-by-one from global device memory.
-    const DeviceSpacePoint middleSP = m_middleSPs[middleIndex];
-    const DeviceSpacePoint otherSP = m_otherSPs[otherIndex];
+    const vecmem::device_vector<const DeviceSpacePoint> middleSPs(m_middleSPs);
+    const DeviceSpacePoint middleSP = middleSPs[middleIndex];
+    const vecmem::device_vector<const DeviceSpacePoint> otherSPs(m_otherSPs);
+    const DeviceSpacePoint otherSP = otherSPs[otherIndex];
 
     // Calculate some "helper variables" for the coordinate linear
     // transformation.
@@ -104,31 +110,29 @@ class LinearTransform {
          (result.cotTheta * result.cotTheta) * (middleSP.varR + otherSP.varR)) *
         iDeltaR2;
 
-    // Store the result object in device global memory.
-    m_resultArray[idx] = result;
+    // Store the result in the result vector
+    vecmem::device_vector<detail::DeviceLinEqCircle>
+                          resultArray(m_resultArray);
+    resultArray[idx] = result;
     return;
   }
 
  private:
-  /// Total number of middle spacepoints
-  uint32_t m_nMiddleSPs;
   /// Pointer to the middle spacepoints (in global device memory)
-  const DeviceSpacePoint* m_middleSPs;
-  /// Total number of "other" (bottom or top) spacepoints
-  uint32_t m_nOtherSPs;
+  vecmem::data::vector_view<const DeviceSpacePoint> m_middleSPs;
   /// Pointer to the "other" (bottom or top) spacepoints (in global device mem.)
-  const DeviceSpacePoint* m_otherSPs;
+  vecmem::data::vector_view<const DeviceSpacePoint> m_otherSPs;
 
   /// Look-Up Table from the iteration index to the middle spacepoint index
-  const uint32_t* m_middleIndexLUT;
+  vecmem::data::vector_view<uint32_t> m_middleIndexLUT;
   /// Loop-Up Table from the iteration index to the "other" spacepoint index
-  const uint32_t* m_otherIndexLUT;
+  vecmem::data::vector_view<uint32_t> m_otherIndexLUT;
 
   /// Total number of elements in the result array
   uint32_t m_nEdges;
 
   /// The result array in device global memory
-  DeviceLinEqCircle* m_resultArray;
+  vecmem::data::vector_view<detail::DeviceLinEqCircle> m_resultArray;
 
 };  // class LinearTransform
 

--- a/Plugins/Sycl/src/Seeding/TripletFilter.hpp
+++ b/Plugins/Sycl/src/Seeding/TripletFilter.hpp
@@ -1,0 +1,187 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Local include(s).
+#include "Acts/Plugins/Sycl/Seeding/detail/Types.hpp"
+
+#include "../Utilities/Arrays.hpp"
+#include "SpacePointType.hpp"
+
+// VecMem include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/device_vector.hpp"
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// System include(s).
+#include <cstdint>
+
+namespace Acts::Sycl::detail {
+using AtomicAccessorFilter =
+    sycl::accessor<uint32_t, 1, sycl::access::mode::read>;
+/// Functor performing Triplet Filter
+template<class AtomicAccessorType>
+class TripletFilter {
+
+    public:
+    /// Constructor
+    TripletFilter(const uint32_t numTripletFilterThreads,
+                  vecmem::data::vector_view<uint32_t> sumBotMidView,
+                  const uint32_t firstMiddle,
+                  vecmem::data::vector_view<uint32_t> indMidBotCompView,
+                  vecmem::data::vector_view<uint32_t> indBotDupletView,
+                  vecmem::data::vector_view<uint32_t> sumBotTopCombView,
+                  vecmem::data::jagged_vector_view<uint32_t> midTopDupletView,
+                  vecmem::data::vector_view<detail::DeviceTriplet> curvImpactView,
+                  vecmem::data::vector_view<const detail::DeviceSpacePoint> topSPsView,
+                  vecmem::data::vector_view<const detail::DeviceSpacePoint> middleSPsView,
+                  vecmem::data::vector_view<const detail::DeviceSpacePoint> bottomSPsView,
+                  const AtomicAccessorFilter& countTripletsAcc,
+                  vecmem::data::vector_view<detail::SeedData> seedArrayView,
+                  const DeviceSeedfinderConfig& config,
+                  const DeviceExperimentCuts& cuts)
+        : m_numTripletFilterThreads(numTripletFilterThreads),
+          m_sumBotMidView(sumBotMidView),
+          m_firstMiddle(firstMiddle),
+          m_indMidBotCompView(indMidBotCompView),
+          m_indBotDupletView(indBotDupletView),
+          m_sumBotTopCombView(sumBotTopCombView),
+          m_midTopDupletView(midTopDupletView),
+          m_curvImpactView(curvImpactView),
+          m_topSPsView(topSPsView),
+          m_middleSPsView(middleSPsView),
+          m_bottomSPsView(bottomSPsView),
+          m_countTripletsAcc(countTripletsAcc),
+          m_seedArrayView(seedArrayView),
+          m_config(config),
+          m_cuts(cuts) {}
+
+    /// Operator performing filtering 
+    void operator()(cl::sycl::nd_item<1> item) const {
+        if (item.get_global_linear_id() < m_numTripletFilterThreads) {
+            vecmem::device_vector<uint32_t>
+                    sumBotMidPrefix(m_sumBotMidView),
+                    deviceIndMidBot(m_indMidBotCompView),
+                    deviceIndBotDuplets(m_indBotDupletView),
+                    sumBotTopCombPrefix(m_sumBotTopCombView);
+            vecmem::jagged_device_vector<uint32_t>
+                    midTopDuplets(m_midTopDupletView);
+            const auto idx = sumBotMidPrefix[m_firstMiddle] +
+                                item.get_global_linear_id();
+            const auto mid = deviceIndMidBot[idx];
+            const auto bot = deviceIndBotDuplets[idx];
+            const auto sumCombUptoFirstMiddle = 
+                sumBotTopCombPrefix[m_firstMiddle];
+            const auto tripletBegin =
+                sumBotTopCombPrefix[mid] - sumCombUptoFirstMiddle +
+                (idx - sumBotMidPrefix[mid]) * midTopDuplets.at(mid).size();
+            const auto tripletEnd =
+                tripletBegin + m_countTripletsAcc[idx];
+            const vecmem::device_vector
+                    <detail::DeviceTriplet>
+                        deviceCurvImpactConst(m_curvImpactView);
+            for (auto i1 = tripletBegin; i1 < tripletEnd; ++i1) {
+                const auto current = deviceCurvImpactConst[i1];
+                const auto top = current.topSPIndex;
+
+                const auto invHelixDiameter = current.curvature;
+                const auto lowerLimitCurv =
+                    invHelixDiameter -
+                    m_config.deltaInvHelixDiameter;
+                const auto upperLimitCurv =
+                    invHelixDiameter +
+                    m_config.deltaInvHelixDiameter;
+                const vecmem::device_vector
+                    <const detail::DeviceSpacePoint>
+                                topSPs(m_topSPsView);
+                const auto currentTop_r = topSPs[top].r;
+                auto weight = -(current.impact *
+                                m_config.impactWeightFactor);
+
+                uint32_t compatCounter = 0;
+                // By default compatSeedLimit is 2 -> 2 is
+                // currently hard coded, because variable length
+                // arrays are not supported in SYCL kernels.
+                float compatibleSeedR[2];
+                for (auto i2 = tripletBegin;
+                    i2 < tripletEnd &&
+                    compatCounter < m_config.compatSeedLimit;
+                    ++i2) {
+                    const auto other = deviceCurvImpactConst[i2];
+
+                    const auto otherCurv = other.curvature;
+                    const auto otherTop_r =
+                        topSPs[other.topSPIndex].r;
+                    const float deltaR =
+                        cl::sycl::abs(currentTop_r - otherTop_r);
+                    if (deltaR >= m_config.filterDeltaRMin &&
+                        otherCurv >= lowerLimitCurv &&
+                        otherCurv <= upperLimitCurv) {
+                        uint32_t c = 0;
+                        for (;
+                            c < compatCounter &&
+                            cl::sycl::abs(compatibleSeedR[c] - otherTop_r) >=
+                                m_config.filterDeltaRMin;
+                            ++c) {
+                        }
+                        if (c == compatCounter) {
+                            compatibleSeedR[c] = otherTop_r;
+                            ++compatCounter;
+                        }
+                    }
+                }
+                weight +=
+                    compatCounter * m_config.compatSeedWeight;
+                const vecmem::device_vector
+                    <const detail::DeviceSpacePoint>
+                                middleSPs(m_middleSPsView),
+                                bottomSPs(m_bottomSPsView);
+                const auto bottomSP = bottomSPs[bot];
+                const auto middleSP = middleSPs[mid];
+                const auto topSP = topSPs[top];
+
+                weight +=
+                    m_cuts.seedWeight(bottomSP, middleSP, topSP);
+
+                if (m_cuts.singleSeedCut(weight, bottomSP, middleSP,
+                                            topSP)) {
+                    detail::SeedData D;
+                    D.bottom = bot;
+                    D.top = top;
+                    D.middle = mid;
+                    D.weight = weight;
+                    vecmem::device_vector<detail::SeedData>
+                                            seedArray(m_seedArrayView);
+                    seedArray.push_back(D);
+                }
+            }
+        }
+    }
+    private:
+    const uint32_t m_numTripletFilterThreads;
+    vecmem::data::vector_view<uint32_t> m_sumBotMidView;
+    const uint32_t m_firstMiddle;
+    vecmem::data::vector_view<uint32_t> m_indMidBotCompView;
+    vecmem::data::vector_view<uint32_t> m_indBotDupletView;
+    vecmem::data::vector_view<uint32_t> m_sumBotTopCombView;
+    vecmem::data::jagged_vector_view<uint32_t> m_midTopDupletView;
+    vecmem::data::vector_view<detail::DeviceTriplet> m_curvImpactView;
+    vecmem::data::vector_view<const detail::DeviceSpacePoint> m_topSPsView;
+    vecmem::data::vector_view<const detail::DeviceSpacePoint> m_middleSPsView;
+    vecmem::data::vector_view<const detail::DeviceSpacePoint> m_bottomSPsView;
+    AtomicAccessorFilter m_countTripletsAcc;
+    vecmem::data::vector_view<detail::SeedData> m_seedArrayView;
+    DeviceSeedfinderConfig m_config;
+    DeviceExperimentCuts m_cuts;
+}; // struct TripletFilter
+} // namespace Acts::Sycl::detail

--- a/Plugins/Sycl/src/Seeding/TripletSearch.hpp
+++ b/Plugins/Sycl/src/Seeding/TripletSearch.hpp
@@ -1,0 +1,274 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Local include(s).
+#include "Acts/Plugins/Sycl/Seeding/detail/Types.hpp"
+
+#include "../Utilities/Arrays.hpp"
+#include "SpacePointType.hpp"
+
+// VecMem include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/device_vector.hpp"
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// System include(s).
+#include <cstdint>
+
+namespace Acts::Sycl::detail {
+
+/// Functor performing Triplet Search
+template <class AtomicAccessorType>
+class TripletSearch {
+
+    public:
+    /// Constructor
+    TripletSearch(vecmem::data::vector_view<uint32_t> sumBotTopCombView,
+                  const uint32_t numTripletSearchThreads,
+                  const uint32_t firstMiddle,
+                  const uint32_t lastMiddle,
+                  vecmem::data::jagged_vector_view<const uint32_t> midTopDupletView,
+                  vecmem::data::vector_view<uint32_t> sumBotMidView,
+                  vecmem::data::vector_view<uint32_t> sumTopMidView,
+                  vecmem::data::vector_view<detail::DeviceLinEqCircle> linearBotView,
+                  vecmem::data::vector_view<detail::DeviceLinEqCircle> linearTopView,
+                  vecmem::data::vector_view<const detail::DeviceSpacePoint> middleSPsView,
+                  vecmem::data::vector_view<uint32_t> indTopDupletview,
+                  const AtomicAccessorType& countTripletsAcc,
+                  const DeviceSeedfinderConfig& config,
+                  vecmem::data::vector_view<detail::DeviceTriplet> curvImpactView)
+          : m_sumBotTopCombView(sumBotTopCombView),
+            m_numTripletSearchThreads(numTripletSearchThreads),
+            m_firstMiddle(firstMiddle),
+            m_lastMiddle(lastMiddle),
+            m_midTopDupletView(midTopDupletView),
+            m_sumBotMidView(sumBotMidView),
+            m_sumTopMidView(sumTopMidView),
+            m_linearBotView(linearBotView),
+            m_linearTopView(linearTopView),
+            m_middleSPsView(middleSPsView),
+            m_indTopDupletView(indTopDupletview),
+            m_countTripletsAcc(countTripletsAcc),
+            m_config(config),
+            m_curvImpactView(curvImpactView) {}
+
+    /// Operator performing the triplet search
+    void operator()(cl::sycl::nd_item<1> item) const {
+        // Get the index
+        const uint32_t idx = item.get_global_linear_id();
+        if (idx < m_numTripletSearchThreads) {
+            // Retrieve the index of the corresponding middle
+            // space point by binary search
+            vecmem::device_vector<uint32_t>
+                     sumBotTopCombPrefix(m_sumBotTopCombView);
+            const auto sumCombUptoFirstMiddle = 
+                     sumBotTopCombPrefix[m_firstMiddle];
+            auto L = m_firstMiddle;
+            auto R = m_lastMiddle;
+            auto mid = L;
+            while (L < R - 1) {
+                mid = (L + R) / 2;
+                // To be able to search in sumBotTopCombPrefix, we need
+                // to use an offset (sumCombUptoFirstMiddle).
+                if (idx + sumCombUptoFirstMiddle < sumBotTopCombPrefix[mid]) {
+                    R = mid;
+                } else {
+                    L = mid;
+                }
+            }
+            mid = L;
+            vecmem::jagged_device_vector<const uint32_t>
+                    midTopDuplets(m_midTopDupletView);
+            const auto numT = midTopDuplets.at(mid).size();
+            const auto threadIdxForMiddleSP =
+                (idx - sumBotTopCombPrefix[mid] + sumCombUptoFirstMiddle);
+            /*
+                NOTES ON THREAD MAPPING TO SPACE POINTS
+                
+                We need to map bottom and top SP indices to this
+                thread.
+
+                So we are mapping one bottom and one top SP to this thread
+                (we already have a middle SP) which gives us a tiplet.
+
+                This is done in the following way: We
+                calculated the number of possible triplet
+                combinations for this middle SP (let it be
+                num_comp_bot*num_comp_top). Let num_comp_bot = 2
+                and num_comp_top=3 in this example. So we have 2
+                compatible bottom and 3 compatible top SP for this
+                middle SP.
+
+                That gives us 6 threads altogether:
+                            ===========================================
+                thread:    |  0   |  1   |  2   |  3   |  4   |  5   |
+                bottom id: | bot0 | bot0 | bot0 | bot1 | bot1 | bot1 |
+                top id:    | top0 | top1 | top2 | top0 | top1 | top2 |
+                            ===========================================
+
+                If we divide 6 by the number of compatible top SP
+                for this middle SP, or deviceNumTopDuplets[mid]
+                which is 3 now, we get the id for the bottom SP.
+                Similarly, if we take modulo
+                deviceNumTopDuplets[mid], we get the id for the
+                top SP.
+
+                So if threadIdxForMiddleSP = 3, then ib = 1 and it = 0.
+
+                We can use these ids together with
+                sumBotMidPrefix[mid] and deviceSumTop[mid] to be able
+                to index our other arrays.
+
+                These other arrays are deviceIndBot and deviceIndTop.
+
+                So to retrieve the bottom SP index for this thread, we'd
+                have to index the deviceIndBot array at
+                    sumBotMidPrefix[mid] + ib
+                which is the id for the bottom SP that we just calculated
+                (ib = 1 in the example).
+            */
+
+            vecmem::device_vector<uint32_t>
+                      sumBotMidPrefix(m_sumBotMidView),
+                      sumTopMidPrefix(m_sumTopMidView);                     
+            const auto ib =
+                sumBotMidPrefix[mid] + (threadIdxForMiddleSP / numT);
+            const auto it =
+                sumTopMidPrefix[mid] + (threadIdxForMiddleSP % numT);
+            vecmem::device_vector<detail::DeviceLinEqCircle>
+                                    deviceLinBot(m_linearBotView),
+                                    deviceLinTop(m_linearTopView);
+            const auto linBotEq = deviceLinBot[ib];
+            const auto linTopEq = deviceLinTop[it];
+            const vecmem::device_vector<const detail::DeviceSpacePoint>
+                                        middleSPs(m_middleSPsView);
+            const auto midSP = middleSPs[mid];
+
+            const auto Vb = linBotEq.v;
+            const auto Ub = linBotEq.u;
+            const auto Erb = linBotEq.er;
+            const auto cotThetab = linBotEq.cotTheta;
+            const auto iDeltaRb = linBotEq.iDeltaR;
+
+            const auto Vt = linTopEq.v;
+            const auto Ut = linTopEq.u;
+            const auto Ert = linTopEq.er;
+            const auto cotThetat = linTopEq.cotTheta;
+            const auto iDeltaRt = linTopEq.iDeltaR;
+
+            const auto rM = midSP.r;
+            const auto varianceRM = midSP.varR;
+            const auto varianceZM = midSP.varZ;
+
+            auto iSinTheta2 = (1.f + cotThetab * cotThetab);
+            auto scatteringInRegion2 =
+                m_config.maxScatteringAngle2 * iSinTheta2;
+            scatteringInRegion2 *= m_config.sigmaScattering *
+                                    m_config.sigmaScattering;
+            auto error2 =
+                Ert + Erb +
+                2.f * (cotThetab * cotThetat * varianceRM + varianceZM) *
+                    iDeltaRb * iDeltaRt;
+            auto deltaCotTheta = cotThetab - cotThetat;
+            auto deltaCotTheta2 = deltaCotTheta * deltaCotTheta;
+
+            deltaCotTheta = cl::sycl::abs(deltaCotTheta);
+            auto error = cl::sycl::sqrt(error2);
+            auto dCotThetaMinusError2 =
+                deltaCotTheta2 + error2 - 2.f * deltaCotTheta * error;
+            auto dU = Ut - Ub;
+
+            if ((!(deltaCotTheta2 - error2 > 0.f) ||
+                 !(dCotThetaMinusError2 > scatteringInRegion2)) &&
+                !(dU == 0.f)) {
+              auto A = (Vt - Vb) / dU;
+              auto S2 = 1.f + A * A;
+              auto B = Vb - A * Ub;
+              auto B2 = B * B;
+
+              auto iHelixDiameter2 = B2 / S2;
+              auto pT2scatter =
+              4.f * iHelixDiameter2 * m_config.pT2perRadius;
+              auto p2scatter = pT2scatter * iSinTheta2;
+              auto Im = cl::sycl::abs((A - B * rM) * rM);
+
+              if (!(S2 < B2 * m_config.minHelixDiameter2) &&
+                  !((deltaCotTheta2 - error2 > 0.f) &&
+                    (dCotThetaMinusError2 >
+                     p2scatter * m_config.sigmaScattering *
+                     m_config.sigmaScattering)) &&
+                    !(Im > m_config.impactMax)) {
+                    vecmem::device_vector<uint32_t> 
+                        deviceIndTopDuplets(m_indTopDupletView);
+                    const auto top = deviceIndTopDuplets[it];
+                    // this will be the t-th top space point for
+                    // fixed middle and bottom SP
+                    auto t = m_countTripletsAcc[ib].fetch_add(1);
+                    /* 
+                        sumBotTopCombPrefix[mid] - sumCombUptoFirstMiddle:
+                        gives the memory location reserved for this
+                        middle SP
+
+                        (idx-sumBotTopCombPrefix[mid]+sumCombUptoFirstMiddle:
+                        this is the nth thread for this middle SP
+
+                        (idx-sumBotTopCombPrefix[mid]+sumCombUptoFirstMiddle)/numT:
+                        this is the mth bottom SP for this middle SP
+
+                        multiplying this by numT gives the memory
+                        location for this middle and bottom SP
+
+                        and by adding t to it, we will end up storing
+                        compatible triplet candidates for this middle
+                        and bottom SP right next to each other
+                        starting from the given memory 
+                    */
+                    const auto tripletIdx = sumBotTopCombPrefix[mid] -
+                                              sumCombUptoFirstMiddle +
+                                              (((idx - sumBotTopCombPrefix[mid] +
+                                                 sumCombUptoFirstMiddle) /
+                                                numT) *
+                                               numT) +
+                                              t;
+
+                      detail::DeviceTriplet T;
+                      T.curvature = B / cl::sycl::sqrt(S2);
+                      T.impact = Im;
+                      T.topSPIndex = top;
+                      vecmem::device_vector
+                          <detail::DeviceTriplet>
+                              deviceCurvImpact(m_curvImpactView);
+                      deviceCurvImpact[tripletIdx] = T;
+             }
+        }
+      }
+    }
+    private:
+        vecmem::data::vector_view<uint32_t> m_sumBotTopCombView;
+        const uint32_t m_numTripletSearchThreads;
+        const uint32_t m_firstMiddle;
+        const u_int32_t m_lastMiddle;
+        vecmem::data::jagged_vector_view<const uint32_t> m_midTopDupletView;
+        vecmem::data::vector_view<uint32_t> m_sumBotMidView;
+        vecmem::data::vector_view<uint32_t> m_sumTopMidView;
+        vecmem::data::vector_view<detail::DeviceLinEqCircle> m_linearBotView;
+        vecmem::data::vector_view<detail::DeviceLinEqCircle> m_linearTopView;
+        vecmem::data::vector_view<const detail::DeviceSpacePoint> m_middleSPsView;
+        vecmem::data::vector_view<uint32_t> m_indTopDupletView;
+        AtomicAccessorType m_countTripletsAcc;
+        DeviceSeedfinderConfig m_config;
+        vecmem::data::vector_view<detail::DeviceTriplet> m_curvImpactView;
+};  // struct TripletSearch
+
+} // namespace Acts::Sycl::detail

--- a/Plugins/Sycl/src/Utilities/QueueWrapper.cpp
+++ b/Plugins/Sycl/src/Utilities/QueueWrapper.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -47,6 +47,11 @@ QueueWrapper::QueueWrapper(const std::string& deviceNameSubstring,
   ACTS_INFO("Running on: "
             << m_queue->get_device().get_info<cl::sycl::info::device::name>());
 }
+
+QueueWrapper::QueueWrapper(cl::sycl::queue& queue,
+                           std::unique_ptr<const Logger> incomingLogger)
+    : m_queue(&queue), m_ownsQueue(false),
+      m_logger(std::move(incomingLogger)) {}
 
 QueueWrapper::QueueWrapper(QueueWrapper&& parent) noexcept
     : m_queue(parent.m_queue),
@@ -100,8 +105,28 @@ QueueWrapper& QueueWrapper::operator=(const QueueWrapper& other) {
   return *this;
 }
 
-cl::sycl::queue* QueueWrapper::getQueue() const {
+const cl::sycl::queue* QueueWrapper::getQueue() const {
   return m_queue;
+}
+
+cl::sycl::queue* QueueWrapper::getQueue() {
+  return m_queue;
+}
+
+const cl::sycl::queue* QueueWrapper::operator->() const {
+  return m_queue;
+}
+
+cl::sycl::queue* QueueWrapper::operator->() {
+  return m_queue;
+}
+
+const cl::sycl::queue& QueueWrapper::operator*() const {
+  return *m_queue;
+}
+
+cl::sycl::queue& QueueWrapper::operator*() {
+  return *m_queue;
 }
 
 }  // namespace Acts::Sycl

--- a/Tests/UnitTests/Plugins/Sycl/Seeding/CMakeLists.txt
+++ b/Tests/UnitTests/Plugins/Sycl/Seeding/CMakeLists.txt
@@ -1,3 +1,14 @@
+# This file is part of the Acts project.
+#
+# Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Set up the usage of VecMem.
+include(ActsVecMem)
+
 add_executable(ActsUnitTestSeedfinderSycl
   SeedfinderSyclTest.cpp
   CommandLineArguments.h
@@ -5,5 +16,5 @@ add_executable(ActsUnitTestSeedfinderSycl
   ATLASCuts.hpp
   SpacePoint.hpp)
 target_link_libraries(ActsUnitTestSeedfinderSycl
-  PRIVATE Boost::program_options ActsCore ActsPluginSycl)
-  
+  PRIVATE Boost::program_options ActsCore ActsPluginSycl
+          vecmem::core vecmem::sycl)

--- a/Tests/UnitTests/Plugins/Sycl/Seeding/CommandLineArguments.h
+++ b/Tests/UnitTests/Plugins/Sycl/Seeding/CommandLineArguments.h
@@ -1,13 +1,13 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #pragma once
-#include <fstream>
+
 #include <string>
 
 struct CommandLineArguments {

--- a/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
+++ b/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
@@ -40,6 +40,8 @@
 #include "CommandLineArguments.h"
 #include "SpacePoint.hpp"
 
+using namespace Acts::UnitLiterals;
+
 auto readFile(const std::string& filename) -> std::vector<const SpacePoint*> {
   std::string line;
   std::vector<const SpacePoint*> readSP;
@@ -87,21 +89,21 @@ auto setupSeedfinderConfiguration()
     -> Acts::SeedfinderConfig<external_spacepoint_t> {
   Acts::SeedfinderConfig<SpacePoint> config;
   // silicon detector max
-  config.rMax = 160.;
-  config.deltaRMin = 5.;
-  config.deltaRMax = 160.;
-  config.collisionRegionMin = -250.;
-  config.collisionRegionMax = 250.;
-  config.zMin = -2800.;
-  config.zMax = 2800.;
+  config.rMax = 160._mm;
+  config.deltaRMin = 5._mm;
+  config.deltaRMax = 160._mm;
+  config.collisionRegionMin = -250._mm;
+  config.collisionRegionMax = 250._mm;
+  config.zMin = -2800._mm;
+  config.zMax = 2800._mm;
   config.maxSeedsPerSpM = 5;
   // 2.7 eta
   config.cotThetaMax = 7.40627;
   config.sigmaScattering = 1.00000;
-  config.minPt = 500.;
-  config.bFieldInZ = 0.00199724;
-  config.beamPos = {-.5, -.5};
-  config.impactMax = 10.;
+  config.minPt = 500._MeV;
+  config.bFieldInZ = 1.99724_T;
+  config.beamPos = {-.5_mm, -.5_mm};
+  config.impactMax = 10._mm;
 
   // for sycl
   config.nTrplPerSpBLimit = 100;
@@ -194,10 +196,12 @@ auto main(int argc, char** argv) -> int {
   std::vector<std::vector<Acts::Seed<SpacePoint>>> seedVector_cpu;
 
   if (!cmdlTool.onlyGpu) {
+    decltype(normalSeedfinder)::State state;
     for (auto groupIt = spGroup.begin(); !(groupIt == spGroup.end());
          ++groupIt) {
-      seedVector_cpu.push_back(normalSeedfinder.createSeedsForGroup(
-          groupIt.bottom(), groupIt.middle(), groupIt.top()));
+      normalSeedfinder.createSeedsForGroup(
+          state, std::back_inserter(seedVector_cpu.emplace_back()),
+          groupIt.bottom(), groupIt.middle(), groupIt.top());
       group_count++;
       if (!cmdlTool.allgroup && group_count >= cmdlTool.groups) {
         break;

--- a/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
+++ b/Tests/UnitTests/Plugins/Sycl/Seeding/SeedfinderSyclTest.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,6 +19,10 @@
 #include "Acts/Seeding/SpacePointGrid.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
+#include "vecmem/memory/sycl/shared_memory_resource.hpp"
+#include "vecmem/memory/sycl/device_memory_resource.hpp"
+#include "vecmem/memory/sycl/host_memory_resource.hpp"
+
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -35,8 +39,6 @@
 #include "ATLASCuts.hpp"
 #include "CommandLineArguments.h"
 #include "SpacePoint.hpp"
-
-using namespace Acts::UnitLiterals;
 
 auto readFile(const std::string& filename) -> std::vector<const SpacePoint*> {
   std::string line;
@@ -85,21 +87,21 @@ auto setupSeedfinderConfiguration()
     -> Acts::SeedfinderConfig<external_spacepoint_t> {
   Acts::SeedfinderConfig<SpacePoint> config;
   // silicon detector max
-  config.rMax = 160._mm;
-  config.deltaRMin = 5._mm;
-  config.deltaRMax = 160._mm;
-  config.collisionRegionMin = -250._mm;
-  config.collisionRegionMax = 250._mm;
-  config.zMin = -2800._mm;
-  config.zMax = 2800._mm;
+  config.rMax = 160.;
+  config.deltaRMin = 5.;
+  config.deltaRMax = 160.;
+  config.collisionRegionMin = -250.;
+  config.collisionRegionMax = 250.;
+  config.zMin = -2800.;
+  config.zMax = 2800.;
   config.maxSeedsPerSpM = 5;
   // 2.7 eta
   config.cotThetaMax = 7.40627;
   config.sigmaScattering = 1.00000;
-  config.minPt = 500._MeV;
-  config.bFieldInZ = 1.99724_T;
-  config.beamPos = {-.5_mm, -.5_mm};
-  config.impactMax = 10._mm;
+  config.minPt = 500.;
+  config.bFieldInZ = 0.00199724;
+  config.beamPos = {-.5, -.5};
+  config.impactMax = 10.;
 
   // for sycl
   config.nTrplPerSpBLimit = 100;
@@ -148,11 +150,13 @@ auto main(int argc, char** argv) -> int {
 
   const Acts::Logging::Level logLvl =
       cmdlTool.csvFormat ? Acts::Logging::WARNING : Acts::Logging::INFO;
+  Acts::Sycl::QueueWrapper
+      queue(cmdlTool.deviceName,
+            Acts::getDefaultLogger("Sycl::QueueWrapper", logLvl));
+  vecmem::sycl::host_memory_resource resource(queue.getQueue());
+  vecmem::sycl::device_memory_resource device_resource(queue.getQueue());
   Acts::Sycl::Seedfinder<SpacePoint> syclSeedfinder(
-      config, deviceAtlasCuts,
-      Acts::Sycl::QueueWrapper(
-          cmdlTool.deviceName,
-          Acts::getDefaultLogger("Sycl::QueueWrapper", logLvl)));
+      config, deviceAtlasCuts, queue, resource, &device_resource);
   Acts::Seedfinder<SpacePoint> normalSeedfinder(config);
   auto globalTool =
       [=](const SpacePoint& sp, float /*unused*/, float /*unused*/,
@@ -190,12 +194,10 @@ auto main(int argc, char** argv) -> int {
   std::vector<std::vector<Acts::Seed<SpacePoint>>> seedVector_cpu;
 
   if (!cmdlTool.onlyGpu) {
-    decltype(normalSeedfinder)::State state;
     for (auto groupIt = spGroup.begin(); !(groupIt == spGroup.end());
          ++groupIt) {
-      normalSeedfinder.createSeedsForGroup(
-          state, std::back_inserter(seedVector_cpu.emplace_back()),
-          groupIt.bottom(), groupIt.middle(), groupIt.top());
+      seedVector_cpu.push_back(normalSeedfinder.createSeedsForGroup(
+          groupIt.bottom(), groupIt.middle(), groupIt.top()));
       group_count++;
       if (!cmdlTool.allgroup && group_count >= cmdlTool.groups) {
         break;

--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -5,14 +5,14 @@ if (NOT CMAKE_BUILD_TYPE)
 endif() 
 
 set(ACTS_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wunused-local-typedefs")
-set(ACTS_CXX_FLAGS_DEBUG "--coverage")
+#set(ACTS_CXX_FLAGS_DEBUG "--coverage")
 set(ACTS_CXX_FLAGS_MINSIZEREL "")
 set(ACTS_CXX_FLAGS_RELEASE "")
 set(ACTS_CXX_FLAGS_RELWITHDEBINFO "")
 
 # Acts linker flags
-set(ACTS_EXE_LINKER_FLAGS_DEBUG "--coverage")
-set(ACTS_SHARED_LINKER_FLAGS_DEBUG "--coverage ")
+#set(ACTS_EXE_LINKER_FLAGS_DEBUG "--coverage")
+#set(ACTS_SHARED_LINKER_FLAGS_DEBUG "--coverage ")
 
 # assign to global CXX flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ACTS_CXX_FLAGS}")

--- a/cmake/ActsVecMem.cmake
+++ b/cmake/ActsVecMem.cmake
@@ -1,0 +1,42 @@
+# This file is part of the Acts project.
+#
+# Copyright (C) 2021 CERN for the benefit of the Acts project
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
+# Look for VecMem, quietly first time around. Since if it is not found (which is
+# likely), it prints multiple lines of warnings.
+find_package( vecmem QUIET )
+
+# If it was found, then we're finished.
+if( vecmem_FOUND )
+   # Call find_package again, just to nicely print where it is picked up from.
+   find_package( vecmem )
+   return()
+endif()
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.11 )
+include( FetchContent )
+
+# Tell the user what's happening.
+message( STATUS "Building VecMem as part of the Acts project" )
+
+# Declare where to get VecMem from.
+FetchContent_Declare( VecMem
+   GIT_REPOSITORY "https://github.com/acts-project/vecmem.git"
+   GIT_TAG "9b1a7c3fa6efa63a69e09f3a736d56c9c82fdb45" )
+
+# Prevent VecMem from building its tests. As it would interfere with how Acts
+# builds/uses GoogleTest.
+set( BUILD_TESTING FALSE )
+
+# Get it into the current directory.
+FetchContent_Populate( VecMem )
+add_subdirectory( "${vecmem_SOURCE_DIR}" "${vecmem_BINARY_DIR}"
+   EXCLUDE_FROM_ALL )


### PR DESCRIPTION
The current implementation of the Sycl Seedfinder uses pointers to manage memory allocations on the host and on the device. This PR changes this approach by implementing VecMem for memory management.

Under the supervision of @krasznaa, I updated the code so that it works fully on VecMem objects. A short summary of the changes is the following: 
- Inside the `CreateSeedsForGroupSycl()` all the host and device objects are now `vecmem::vector(s)` or `vecmem::data::vector_buffer(s)`. They are received in the kernels as `vecmem::data::vector_view(s)` and manipulated there as `vecmem::device_vector(s)`.
- The `vecmem::jagged_vector` was used for the Duplet finding and as a result, the atomic count was removed from the `DupletSearch` kernels. 
- The Sycl seedfinder is now able to accept device and host memory resources or shared memory resource. To control this different behaviour, a bunch of if statements and unique pointers were written inside the `CreateSeedsForGroupSycl.cpp`.
- The `TripletSearch` and `TripletFinding` kernels were moved to separate files and rewritten as function objects. 
