### PR TITLE
refactor: G4 event registry uses thread_local

### DIFF
--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/EventStoreRegistry.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/EventStoreRegistry.hpp
@@ -29,7 +29,7 @@ class EventStoreRegistry {
  public:
   /// Nested containers struct to give access to the
   /// shared event data.
-  struct Access {
+  struct State {
     /// The current event store
     WhiteBoard* store = nullptr;
     /// Initial and final particle collections
@@ -41,10 +41,9 @@ class EventStoreRegistry {
     std::vector<Acts::RecordedMaterialTrack> materialTracks;
   };
 
-  EventStoreRegistry() = default;
-  virtual ~EventStoreRegistry() = default;
+  EventStoreRegistry() = delete;
 
-  static std::map<unsigned int, Access> eventData;
+  static State& eventData();
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/src/EventStoreRegistry.cpp
+++ b/Examples/Algorithms/Geant4/src/EventStoreRegistry.cpp
@@ -8,6 +8,11 @@
 
 #include "ActsExamples/Geant4/EventStoreRegistry.hpp"
 
-std::map<unsigned int, ActsExamples::EventStoreRegistry::Access>
-    ActsExamples::EventStoreRegistry::eventData =
-        std::map<unsigned int, ActsExamples::EventStoreRegistry::Access>();
+namespace ActsExamples {
+
+EventStoreRegistry::State& EventStoreRegistry::eventData() {
+  static thread_local State state;
+  return state;
+}
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
@@ -111,10 +111,9 @@ ActsExamples::ProcessCode ActsExamples::Geant4Simulation::execute(
   // Ensure exclusive access to the Geant4 run manager
   std::lock_guard<std::mutex> guard(m_runManagerLock);
 
-  // Create and re-reference
-  EventStoreRegistry::eventData[ctx.eventNumber] = EventStoreRegistry::Access{};
-  EventStoreRegistry::Access& eventData =
-      EventStoreRegistry::eventData[ctx.eventNumber];
+  // Get and reset event registry state
+  auto& eventData = EventStoreRegistry::eventData();
+  eventData = EventStoreRegistry::State{};
 
   // Register the current event store to the registry
   // this will allow access from the User*Actions
@@ -127,14 +126,14 @@ ActsExamples::ProcessCode ActsExamples::Geant4Simulation::execute(
   // Output handling: Initial/Final particles
   if (not m_cfg.outputParticlesInitial.empty() and
       not m_cfg.outputParticlesFinal.empty()) {
-    // Initial state of partciles
+    // Initial state of particles
     SimParticleContainer outputParticlesInitial;
     outputParticlesInitial.insert(eventData.particlesInitial.begin(),
                                   eventData.particlesInitial.end());
     // Register to the event store
     ctx.eventStore.add(m_cfg.outputParticlesInitial,
                        std::move(outputParticlesInitial));
-    // Final state of partciles
+    // Final state of particles
     SimParticleContainer outputParticlesFinal;
     outputParticlesFinal.insert(eventData.particlesFinal.begin(),
                                 eventData.particlesFinal.end());
@@ -156,9 +155,6 @@ ActsExamples::ProcessCode ActsExamples::Geant4Simulation::execute(
     ctx.eventStore.add(m_cfg.outputMaterialTracks,
                        std::move(eventData.materialTracks));
   }
-
-  // Clear the EventStoreRegistry
-  EventStoreRegistry::eventData.erase(ctx.eventNumber);
 
   return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
@@ -27,11 +27,8 @@ ActsExamples::MaterialSteppingAction::~MaterialSteppingAction() {}
 
 void ActsExamples::MaterialSteppingAction::UserSteppingAction(
     const G4Step* step) {
-  auto g4RunManager = G4RunManager::GetRunManager();
-  unsigned int eventNr = g4RunManager->GetCurrentEvent()->GetEventID();
-
   // Get the event data
-  auto& eventData = EventStoreRegistry::eventData[eventNr];
+  auto& eventData = EventStoreRegistry::eventData();
 
   // Get the material & check if it is present
   G4Material* material = step->GetPreStepPoint()->GetMaterial();

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -24,19 +24,13 @@ ActsExamples::ParticleTrackingAction::ParticleTrackingAction(
 
 void ActsExamples::ParticleTrackingAction::PreUserTrackingAction(
     const G4Track* aTrack) {
-  auto g4RunManager = G4RunManager::GetRunManager();
-  unsigned int eventID = g4RunManager->GetCurrentEvent()->GetEventID();
-
-  auto& eventData = EventStoreRegistry::eventData[eventID];
+  auto& eventData = EventStoreRegistry::eventData();
   eventData.particlesInitial.push_back(convert(*aTrack));
 }
 
 void ActsExamples::ParticleTrackingAction::PostUserTrackingAction(
     const G4Track* aTrack) {
-  auto g4RunManager = G4RunManager::GetRunManager();
-  unsigned int eventID = g4RunManager->GetCurrentEvent()->GetEventID();
-
-  auto& eventData = EventStoreRegistry::eventData[eventID];
+  auto& eventData = EventStoreRegistry::eventData();
   eventData.particlesFinal.push_back(convert(*aTrack));
 }
 

--- a/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
@@ -30,9 +30,6 @@ void ActsExamples::SensitiveSteppingAction::UserSteppingAction(
   constexpr double convertLength = Acts::UnitConstants::mm / CLHEP::mm;
   constexpr double convertEnergy = Acts::UnitConstants::GeV / CLHEP::GeV;
 
-  auto g4RunManager = G4RunManager::GetRunManager();
-  unsigned int eventNr = g4RunManager->GetCurrentEvent()->GetEventID();
-
   // The particle after the step
   G4Track* track = step->GetTrack();
   G4PrimaryParticle* primaryParticle =
@@ -110,7 +107,7 @@ void ActsExamples::SensitiveSteppingAction::UserSteppingAction(
     Acts::Vector4 afterMomentum(mXpost, mYpost, mZpost, mEpost);
 
     // Retrieve the event data registry
-    auto& eventData = EventStoreRegistry::eventData[eventNr];
+    auto& eventData = EventStoreRegistry::eventData();
 
     // Fill into the registry
     eventData.hits.emplace_back(geoID, particleID, particlePosition,

--- a/Examples/Algorithms/Geant4/src/SimParticleTranslation.cpp
+++ b/Examples/Algorithms/Geant4/src/SimParticleTranslation.cpp
@@ -42,7 +42,7 @@ void ActsExamples::SimParticleTranslation::GeneratePrimaries(G4Event* anEvent) {
 
   ACTS_DEBUG("Primary Generator Action for Event: " << eventID);
 
-  auto& eventData = EventStoreRegistry::eventData[eventID];
+  auto& eventData = EventStoreRegistry::eventData();
   WhiteBoard* eventStore = eventData.store;
   if (eventStore == nullptr) {
     ACTS_WARNING("No EventStore instance could be found for this event!");

--- a/Examples/Run/Geant4/Common/Geant4.cpp
+++ b/Examples/Run/Geant4/Common/Geant4.cpp
@@ -57,9 +57,6 @@ void setupGeant4Simulation(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
     bool materialRecording) {
-  // Create an event Store registry
-  EventStoreRegistry esRegistry;
-
   auto g4loglevel =
       Acts::Logging::Level(vars["g4-loglevel"].as<unsigned int>());
 


### PR DESCRIPTION
This PR changes the `EventRegistry` that was added for the G4 algorithm to not use an `std::map` with the event number as a key (which is unstable, and not the same between G4 and the ACTS sequencer) to simply use a thread local static variable.

I also renamed `EventRegistry::Access` to `EventRegistry::State`.