### PR TITLE
feat: allow sampling in eta

### DIFF
--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -25,7 +25,10 @@ ActsExamples::ParametricParticleGenerator::ParametricParticleGenerator(
       // ensure upper bound is included. see e.g.
       // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
       m_cosThetaMax(std::nextafter(std::cos(m_cfg.thetaMax),
-                                   std::numeric_limits<double>::max())) {}
+                                   std::numeric_limits<double>::max())),
+      // in case we force uniform eta generation
+      m_etaMin(-std::log(std::tan(0.5 * m_cfg.thetaMin))),
+      m_etaMax(-std::log(std::tan(0.5 * m_cfg.thetaMax))) {}
 
 ActsExamples::SimParticleContainer
 ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) {
@@ -46,6 +49,7 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) {
   };
   UniformReal phiDist(m_cfg.phiMin, m_cfg.phiMax);
   UniformReal cosThetaDist(m_cosThetaMin, m_cosThetaMax);
+  UniformReal etaDist(m_etaMin, m_etaMax);
   UniformReal pDist(m_cfg.pMin, m_cfg.pMax);
 
   SimParticleContainer particles;
@@ -61,12 +65,21 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) {
     const Acts::PdgParticle pdg = pdgChoices[type];
     const double q = qChoices[type];
     const double phi = phiDist(rng);
-    const double cosTheta = cosThetaDist(rng);
-    const double sinTheta = std::sqrt(1 - cosTheta * cosTheta);
     double p = pDist(rng);
 
     // we already have sin/cos theta. they can be used directly to
     Acts::Vector3 dir;
+    double cosTheta = 0.;
+    double sinTheta = 0.;
+    if (not m_cfg.forceEtaGeneration) {
+      cosTheta = cosThetaDist(rng);
+      sinTheta = std::sqrt(1 - cosTheta * cosTheta);
+    } else {
+      const double eta = etaDist(rng);
+      const double theta = 2 * std::atan(std::exp(-eta));
+      sinTheta = std::sin(theta);
+      cosTheta = std::cos(theta);
+    }
     dir[Acts::eMom0] = sinTheta * std::cos(phi);
     dir[Acts::eMom1] = sinTheta * std::sin(phi);
     dir[Acts::eMom2] = cosTheta;

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.cpp
@@ -71,7 +71,7 @@ ActsExamples::ParametricParticleGenerator::operator()(RandomEngine& rng) {
     Acts::Vector3 dir;
     double cosTheta = 0.;
     double sinTheta = 0.;
-    if (not m_cfg.forceEtaGeneration) {
+    if (not m_cfg.etaUniform) {
       cosTheta = cosThetaDist(rng);
       sinTheta = std::sqrt(1 - cosTheta * cosTheta);
     } else {

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
@@ -35,8 +35,14 @@ class ParametricParticleGenerator : public EventGenerator::ParticlesGenerator {
     ///
     /// This intentionally uses theta instead of eta so it can represent the
     /// full direction space with finite values.
+    ///
+    /// @note This is the standard generation, for detector performance
+    /// classification, where a flat distribution in eta can be useful,
+    /// this can be set by the forceEtaGeneration flag;
+    ///
     double thetaMin = 0.0;
     double thetaMax = M_PI;
+    bool forceEtaGeneration = false;
     /// Low, high (exclusive) for absolute/transverse momentum.
     double pMin = 1 * Acts::UnitConstants::GeV;
     double pMax = 10 * Acts::UnitConstants::GeV;
@@ -62,6 +68,8 @@ class ParametricParticleGenerator : public EventGenerator::ParticlesGenerator {
   double m_mass;
   double m_cosThetaMin;
   double m_cosThetaMax;
+  double m_etaMin;
+  double m_etaMax;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
@@ -38,11 +38,11 @@ class ParametricParticleGenerator : public EventGenerator::ParticlesGenerator {
     ///
     /// @note This is the standard generation, for detector performance
     /// classification, where a flat distribution in eta can be useful,
-    /// this can be set by the forceEtaGeneration flag;
+    /// this can be set by the etaUniform flag;
     ///
     double thetaMin = 0.0;
     double thetaMax = M_PI;
-    bool forceEtaGeneration = false;
+    bool etaUniform = false;
     /// Low, high (exclusive) for absolute/transverse momentum.
     double pMin = 1 * Acts::UnitConstants::GeV;
     double pMax = 10 * Acts::UnitConstants::GeV;

--- a/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
@@ -33,7 +33,7 @@ void ActsExamples::Options::addParticleGunOptions(Description& desc) {
   opt("gen-eta",
       value<Interval>()->value_name("MIN:MAX")->default_value({-4.0, 4.0}),
       "Pseudo-rapidity generation range");
-  opt("gen-sample-eta", bool_switch(),
+  opt("gen-eta-uniform", bool_switch(),
       "Sample eta directly and not cos(theta).");
   opt("gen-mom-gev",
       value<Interval>()->value_name("MIN:MAX")->default_value({1.0, 10.0}),
@@ -76,7 +76,7 @@ ActsExamples::Options::readParticleGunOptions(const Variables& vars) {
   double etaMin, etaMax;
   getRange("gen-eta", 1.0, etaMin, etaMax);
 
-  pgCfg.forceEtaGeneration = vars["gen-sample-eta"].template as<bool>();
+  pgCfg.forceEtaGeneration = vars["gen-eta-uniform"].template as<bool>();
   pgCfg.thetaMin = 2 * std::atan(std::exp(-etaMin));
   pgCfg.thetaMax = 2 * std::atan(std::exp(-etaMax));
   getRange("gen-mom-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);

--- a/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
@@ -76,7 +76,7 @@ ActsExamples::Options::readParticleGunOptions(const Variables& vars) {
   double etaMin, etaMax;
   getRange("gen-eta", 1.0, etaMin, etaMax);
 
-  pgCfg.forceEtaGeneration = vars["gen-eta-uniform"].template as<bool>();
+  pgCfg.etaUniform = vars["gen-eta-uniform"].template as<bool>();
   pgCfg.thetaMin = 2 * std::atan(std::exp(-etaMin));
   pgCfg.thetaMax = 2 * std::atan(std::exp(-etaMax));
   getRange("gen-mom-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);

--- a/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Options/ParticleGunOptions.cpp
@@ -33,6 +33,8 @@ void ActsExamples::Options::addParticleGunOptions(Description& desc) {
   opt("gen-eta",
       value<Interval>()->value_name("MIN:MAX")->default_value({-4.0, 4.0}),
       "Pseudo-rapidity generation range");
+  opt("gen-sample-eta", bool_switch(),
+      "Sample eta directly and not cos(theta).");
   opt("gen-mom-gev",
       value<Interval>()->value_name("MIN:MAX")->default_value({1.0, 10.0}),
       "Absolute (or transverse) momentum generation range in GeV");
@@ -73,6 +75,8 @@ ActsExamples::Options::readParticleGunOptions(const Variables& vars) {
   // user config sets eta but the generator takes theta
   double etaMin, etaMax;
   getRange("gen-eta", 1.0, etaMin, etaMax);
+
+  pgCfg.forceEtaGeneration = vars["gen-sample-eta"].template as<bool>();
   pgCfg.thetaMin = 2 * std::atan(std::exp(-etaMin));
   pgCfg.thetaMax = 2 * std::atan(std::exp(-etaMax));
   getRange("gen-mom-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);


### PR DESCRIPTION
This mini-PR adds a new option `--gen-sample-eta` to the `ParametricParticleGenerator` that allows to draw a flat eta distribution. This can be useful for detector performance classification, to populate the eta-phi plane uniquely. It can also be favourable for the material mapping to have a flat eta distribution.

The following shows the `eta` distributions of generated particles:
 * blue: standard sampling in `cos(theta)`
 * red: flat `eta` sampling with the `--gen-sample-eta` switch opted on
 
![Screenshot 2021-09-23 at 14 37 25](https://user-images.githubusercontent.com/26623879/134508355-79212740-4441-44a0-bf25-204e2e92bb8b.png)

