### PR TITLE
ci: Remove CVMFS based LCG jobs again

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -158,47 +158,6 @@ jobs:
         run: ./build-downstream-nodeps/bin/ShowActsVersion
              && CI/check_boost_eigen_versions.sh ./build-downstream-nodeps/bin/ShowActsVersion
 
-  lcg:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        LCG:
-          # Disable these jobs temporarily to relieve pressure on the CI
-          #- LCG_97apython3/x86_64-centos7-gcc9-opt
-          #- LCG_98python3/x86_64-centos7-gcc10-opt
-          #- LCG_99/x86_64-centos7-gcc10-opt
-          - LCG_100/x86_64-centos7-gcc10-opt
-          - LCG_100/x86_64-centos8-gcc10-opt
-    env:
-      INSTALL_DIR: ${{ github.workspace }}/install
-    steps:
-      - uses: actions/checkout@v2
-      - uses: cvmfs-contrib/github-action-cvmfs@v2
-      - uses: aidasoft/run-lcg-view@v1
-        with:
-          release-platform: ${{ matrix.LCG }}
-          run: |
-            export INSTALL_DIR=${{ github.workspace }}/install
-            cmake -B build -S . \
-              -GNinja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_CXX_FLAGS=-Werror \
-              -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
-              -DACTS_BUILD_EVERYTHING=on \
-              -DACTS_LOG_FAILURE_THRESHOLD=WARNING
-            cmake --build build -- 
-            cmake --build build -- test
-            cmake --build build -- integrationtests
-            cmake --build build -- install
-            cmake -B build-downstream -S Tests/DownstreamProject \
-              -GNinja \
-              -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_CXX_FLAGS=-Werror \
-              -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
-            cmake --build build-downstream --
-            ./build-downstream/bin/ShowActsVersion
   macos:
     runs-on: macos-10.15
     env:


### PR DESCRIPTION
We had more trouble with them than they add value, so let's get rid of them again for now.
