### PR TITLE
fix: A bug in the Triplet finding algorithm

### DIFF
--- a/Plugins/Sycl/src/Seeding/CreateSeedsForGroupSycl.cpp
+++ b/Plugins/Sycl/src/Seeding/CreateSeedsForGroupSycl.cpp
@@ -566,8 +566,10 @@ void createSeedsForGroupSycl(
         const auto numTripletSearchThreads =
             sumBotTopCombPrefix[lastMiddle] - sumBotTopCombPrefix[firstMiddle];
 
-        if (numTripletSearchThreads == 0)
+        if (numTripletSearchThreads == 0) {
+          ++lastMiddle;
           continue;
+        }
 
         deviceCountTriplets.resize(edgesBottom, 0);
         copy.setup(*seedArrayBuffer);


### PR DESCRIPTION
As we found out with @krasznaa, there was a bug in the current implementation of the Sycl Seedfinder algorithm. It came out in a particular case when the first part of the algorithm - the `Duplet finding`, didn't find any duplets. In this scenario, the `Triplet finding` was running forever and the code didn't terminate.

The problem appeared inside the `loop` of the `Triplet finding`. 

In the current implementation, finding triplets is splitted into several parts to limit the memory allocations on the GPU. The range of the particular iteration is taken from the `firstMiddle` and `lastMiddle` indices. The current logic follows somewhat those steps:
```
firstMiddle = lastMiddle = 0
while  firstMiddle < MiddleSPs 
   do 
     ++lastMiddle                  // until maxMemory is reached
     numThreads = calcThreads()    // calculate the number of threads for the GPU kernel
     if numThreads != 0:
        tripletSearch(numThreads)
    else: 
        continue
    firstMiddle = lastMiddle
```
Currently, the increment of the `lastMiddle` index is performed under the condition. This condition is not satisfied if there are 0 Duplets found and therefore both `firstMiddle` and `lastMiddle` stay always 0. 

The fix for this issue is to increment the `lastMiddle` index even when there are 0 `numThreads` calculated and then continue to the next iteration.