### PR TITLE
feat: MultiTrajectory chi2 handling

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -124,7 +124,7 @@ struct IndexData {
   IndexType ijacobian = kInvalid;
   IndexType iprojector = kInvalid;
 
-  double chi2;
+  double chi2 = 0;
   double pathLength;
   TrackStateType typeFlags;
 

--- a/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryHelpers.hpp
@@ -61,16 +61,17 @@ TrajectoryState trajectoryState(
     const auto& volume = geoID.volume();
     const auto& layer = geoID.layer();
     trajState.nStates++;
-    trajState.chi2Sum += state.chi2();
     trajState.NDF += state.calibratedSize();
     auto typeFlags = state.typeFlags();
     if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
-      if (typeFlags.test(Acts::TrackStateFlag::SharedHitFlag))
+      if (typeFlags.test(Acts::TrackStateFlag::SharedHitFlag)) {
         trajState.nSharedHits++;
+      }
       trajState.nMeasurements++;
       trajState.measurementChi2.push_back(state.chi2());
       trajState.measurementVolume.push_back(volume);
       trajState.measurementLayer.push_back(layer);
+      trajState.chi2Sum += state.chi2();
     } else if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
       trajState.nOutliers++;
       trajState.outlierChi2.push_back(state.chi2());
@@ -113,16 +114,17 @@ VolumeTrajectoryStateContainer trajectoryState(
     // The trajectory state for this volume
     auto& trajState = trajStateContainer[volume];
     trajState.nStates++;
-    trajState.chi2Sum += state.chi2();
     trajState.NDF += state.calibratedSize();
     auto typeFlags = state.typeFlags();
     if (typeFlags.test(Acts::TrackStateFlag::MeasurementFlag)) {
-      if (typeFlags.test(Acts::TrackStateFlag::SharedHitFlag))
+      if (typeFlags.test(Acts::TrackStateFlag::SharedHitFlag)) {
         trajState.nSharedHits++;
+      }
       trajState.nMeasurements++;
       trajState.measurementChi2.push_back(state.chi2());
       trajState.measurementVolume.push_back(volume);
       trajState.measurementLayer.push_back(layer);
+      trajState.chi2Sum += state.chi2();
     } else if (typeFlags.test(Acts::TrackStateFlag::OutlierFlag)) {
       trajState.nOutliers++;
       trajState.outlierChi2.push_back(state.chi2());

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -915,9 +915,6 @@ class CombinatorialKalmanFilter {
 
       trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
 
-      // non source link contribution to chi2 sum should be 0
-      trackStateProxy.chi2() = 0;
-
       return currentTip;
     }
 

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -915,6 +915,9 @@ class CombinatorialKalmanFilter {
 
       trackStateProxy.data().ifiltered = trackStateProxy.data().ipredicted;
 
+      // non source link contribution to chi2 sum should be 0
+      trackStateProxy.chi2() = 0;
+
       return currentTip;
     }
 


### PR DESCRIPTION
This PR makes `MultiTrajectory` always initialize the `chi2` value to `0`. In addition, I updated `MultiTrajectoryHelpers::trajectoryState` to only add track state `chi2` to the overall `chi2sum` for measurement track states.
Outlier track states' `chi2` is still recorded in the separate `outlierChi2`. 
I think this makes sense since the outlier is not actually used in the fit, and the track state can only contain the *predicted* `chi2` rather than the *filtered* `chi2` that the measurement states have.

Does this make sense @XiaocongAi?