### PR TITLE
feat: MultiTrajectory improvements

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -176,11 +176,10 @@ class TrackStateProxy {
 
   // Constructor and assignment operator to construct ReadOnly TrackStateProxy
   // from ReadWrite (mutable -> const)
-  TrackStateProxy(const TrackStateProxy<source_link_t, M, false>& other)
+  TrackStateProxy(const TrackStateProxy<M, false>& other)
       : m_traj{other.m_traj}, m_istate{other.m_istate} {}
 
-  TrackStateProxy& operator=(
-      const TrackStateProxy<source_link_t, M, false>& other) {
+  TrackStateProxy& operator=(const TrackStateProxy<M, false>& other) {
     m_traj = other.m_traj;
     m_istate = other.m_istate;
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -213,7 +213,7 @@ class TrackStateProxy {
   /// @param mask An optional mask to determine what to copy from
   /// @param onlyAllocated Whether to only copy allocated components
   /// @note If the this track state proxy does not have compatible allocations
-  ///       with the source track state proxy, and @p onlyAllocated is false, 
+  ///       with the source track state proxy, and @p onlyAllocated is false,
   ///       an exception is thrown.
   /// @note The mask parameter will not cause a copy of components that are
   ///       not allocated in the source track state proxy.

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -88,7 +88,13 @@ struct GrowableColumns {
   size_t size() const { return m_size; }
 
   /// Resize the storage column, without changing the allocated capacity
-  void resize(size_t size) { size = 0; }
+  void resize(size_t size) {
+    if (size > m_size) {
+      addCol(size - m_size);
+    } else {
+      m_size = size;
+    }
+  }
 
   /// Clear the storage of the storage column
   /// Equivalent to ``resize(0)``

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -88,6 +88,7 @@ struct GrowableColumns {
   size_t size() const { return m_size; }
 
   /// Resize the storage column, without changing the allocated capacity
+  /// @param size The new size of the storage
   void resize(size_t size) {
     if (size > m_size) {
       addCol(size - m_size);
@@ -210,8 +211,10 @@ class TrackStateProxy {
   /// Copy the contents of another track state proxy into this one
   /// @param other The other track state to copy from
   /// @param mask An optional mask to determine what to copy from
+  /// @param onlyAllocated Whether to only copy allocated components
   /// @note If the this track state proxy does not have compatible allocations
-  ///       with the source track state proxy, an exception is thrown.
+  ///       with the source track state proxy, and @p onlyAllocated is false, 
+  ///       an exception is thrown.
   /// @note The mask parameter will not cause a copy of components that are
   ///       not allocated in the source track state proxy.
   template <bool RO = ReadOnly, bool ReadOnlyOther,

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(Build) {
 
 BOOST_AUTO_TEST_CASE(Clear) {
   constexpr TrackStatePropMask kMask = TrackStatePropMask::Predicted;
-  MultiTrajectory<TestSourceLink> t;
+  MultiTrajectory t;
   BOOST_CHECK_EQUAL(t.size(), 0);
 
   auto i0 = t.addTrackState(kMask);
@@ -804,8 +804,8 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCopyDiffMTJ) {
   std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
                            PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
 
-  MultiTrajectory<TestSourceLink> mj;
-  MultiTrajectory<TestSourceLink> mj2;
+  MultiTrajectory mj;
+  MultiTrajectory mj2;
   auto mkts = [&](PM mask) { return mj.getTrackState(mj.addTrackState(mask)); };
   auto mkts2 = [&](PM mask) {
     return mj2.getTrackState(mj2.addTrackState(mask));
@@ -859,15 +859,12 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCopyDiffMTJ) {
 
 BOOST_AUTO_TEST_CASE(ProxyAssignment) {
   constexpr TrackStatePropMask kMask = TrackStatePropMask::Predicted;
-  MultiTrajectory<TestSourceLink> t;
+  MultiTrajectory t;
   auto i0 = t.addTrackState(kMask);
 
-  MultiTrajectory<TestSourceLink>::TrackStateProxy tp =
-      t.getTrackState(i0);  // mutable
-  MultiTrajectory<TestSourceLink>::TrackStateProxy tp2{
-      tp};  // mutable to mutable
-  MultiTrajectory<TestSourceLink>::ConstTrackStateProxy tp3{
-      tp};  // mutable to const
+  MultiTrajectory::TrackStateProxy tp = t.getTrackState(i0);  // mutable
+  MultiTrajectory::TrackStateProxy tp2{tp};       // mutable to mutable
+  MultiTrajectory::ConstTrackStateProxy tp3{tp};  // mutable to const
   // const to mutable: this won't compile
   // MultiTrajectory::TrackStateProxy tp4{tp3};
 }

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -190,6 +190,23 @@ BOOST_AUTO_TEST_CASE(Build) {
   BOOST_CHECK_EQUAL_COLLECTIONS(act.begin(), act.end(), exp.begin(), exp.end());
 }
 
+BOOST_AUTO_TEST_CASE(Clear) {
+  constexpr TrackStatePropMask kMask = TrackStatePropMask::Predicted;
+  MultiTrajectory<TestSourceLink> t;
+  BOOST_CHECK_EQUAL(t.size(), 0);
+
+  auto i0 = t.addTrackState(kMask);
+  // trajectory bifurcates here into multiple hypotheses
+  auto i1a = t.addTrackState(kMask, i0);
+  auto i1b = t.addTrackState(kMask, i0);
+  t.addTrackState(kMask, i1a);
+  t.addTrackState(kMask, i1b);
+
+  BOOST_CHECK_EQUAL(t.size(), 5);
+  t.clear();
+  BOOST_CHECK_EQUAL(t.size(), 0);
+}
+
 BOOST_AUTO_TEST_CASE(ApplyWithAbort) {
   constexpr TrackStatePropMask kMask = TrackStatePropMask::Predicted;
 
@@ -779,6 +796,80 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCopy) {
   BOOST_CHECK_EQUAL(ts1.pathLength(), ts2.pathLength());  // always copied
   BOOST_CHECK_EQUAL(&ts1.referenceSurface(),
                     &ts2.referenceSurface());  // always copied
+}
+
+BOOST_AUTO_TEST_CASE(TrackStateProxyCopyDiffMTJ) {
+  using PM = TrackStatePropMask;
+
+  std::array<PM, 6> values{PM::Predicted, PM::Filtered,     PM::Smoothed,
+                           PM::Jacobian,  PM::Uncalibrated, PM::Calibrated};
+
+  MultiTrajectory<TestSourceLink> mj;
+  MultiTrajectory<TestSourceLink> mj2;
+  auto mkts = [&](PM mask) { return mj.getTrackState(mj.addTrackState(mask)); };
+  auto mkts2 = [&](PM mask) {
+    return mj2.getTrackState(mj2.addTrackState(mask));
+  };
+
+  // orthogonal ones
+  for (PM a : values) {
+    for (PM b : values) {
+      auto tsa = mkts(a);
+      auto tsb = mkts2(b);
+      // doesn't work
+      if (a != b) {
+        BOOST_CHECK_THROW(tsa.copyFrom(tsb), std::runtime_error);
+        BOOST_CHECK_THROW(tsb.copyFrom(tsa), std::runtime_error);
+      } else {
+        tsa.copyFrom(tsb);
+        tsb.copyFrom(tsa);
+      }
+    }
+  }
+
+  // make sure they are actually on different MultiTrajectories
+  BOOST_CHECK_EQUAL(mj.size(), 36);
+  BOOST_CHECK_EQUAL(mj2.size(), 36);
+
+  auto ts1 = mkts(PM::Filtered | PM::Predicted);  // this has both
+  ts1.filtered().setRandom();
+  ts1.filteredCovariance().setRandom();
+  ts1.predicted().setRandom();
+  ts1.predictedCovariance().setRandom();
+
+  // ((src XOR dst) & src) == 0
+  auto ts2 = mkts2(PM::Predicted);
+  ts2.predicted().setRandom();
+  ts2.predictedCovariance().setRandom();
+
+  // they are different before
+  BOOST_CHECK(ts1.predicted() != ts2.predicted());
+  BOOST_CHECK(ts1.predictedCovariance() != ts2.predictedCovariance());
+
+  // ts1 -> ts2 fails
+  BOOST_CHECK_THROW(ts2.copyFrom(ts1), std::runtime_error);
+  BOOST_CHECK(ts1.predicted() != ts2.predicted());
+  BOOST_CHECK(ts1.predictedCovariance() != ts2.predictedCovariance());
+
+  // ts2 -> ts1 is ok
+  ts1.copyFrom(ts2);
+  BOOST_CHECK(ts1.predicted() == ts2.predicted());
+  BOOST_CHECK(ts1.predictedCovariance() == ts2.predictedCovariance());
+}
+
+BOOST_AUTO_TEST_CASE(ProxyAssignment) {
+  constexpr TrackStatePropMask kMask = TrackStatePropMask::Predicted;
+  MultiTrajectory<TestSourceLink> t;
+  auto i0 = t.addTrackState(kMask);
+
+  MultiTrajectory<TestSourceLink>::TrackStateProxy tp =
+      t.getTrackState(i0);  // mutable
+  MultiTrajectory<TestSourceLink>::TrackStateProxy tp2{
+      tp};  // mutable to mutable
+  MultiTrajectory<TestSourceLink>::ConstTrackStateProxy tp3{
+      tp};  // mutable to const
+  // const to mutable: this won't compile
+  // MultiTrajectory::TrackStateProxy tp4{tp3};
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This does three things:
1. `MultiTrajectory` and it's internal column storage can be queried for
   their size and "cleared", meaning their logical size reduced to zero,
   while keeping their capacity
2. `ConstTrackStateProxy` is now (auto-)constructible from
   `TrackStateProxy`. This is necessary to enable interfaces for certain
   components to accept `ConstTrackStateProxy` and passing a non-const
   `TrackStateProxy`
3. Allows `MultiTrajectory::TrackStateProxy::copyFrom` to also copy
   regardless of underlying allocation. If this flag id set to `false`,
   the method will copy everyhing which has a valid index **potentially
   overwriting information in other track states via shared storage**
