### PR TITLE
feat: Introduced new flags for how Boost, Eigen and VecMem would be set up. (2021.11.05.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -44,11 +44,11 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
-          -DACTS_BUILD_EVERYTHING=on
+          -DACTS_BUILD_EVERYTHING=ON
           -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
           -DACTS_LOG_FAILURE_THRESHOLD=WARNING
       - name: Build
-        run: ${SETUP} && cmake --build build -- 
+        run: ${SETUP} && cmake --build build --
       - name: Unit tests
         run: ${SETUP} && cmake --build build -- test
       - name: Integration tests
@@ -60,12 +60,12 @@ jobs:
         if: contains(matrix.image, 'ubuntu')
         shell: bash
         run: >
-          ${SETUP} 
+          ${SETUP}
           && source /usr/local/bin/thisroot.sh
           && source /usr/local/bin/thisdd4hep_only.sh
           && /usr/local/bin/download_geant4_data.sh
           && source /usr/local/bin/geant4.sh
-          && source build/python/setup.sh 
+          && source build/python/setup.sh
           && pip3 install -r Examples/Python/tests/requirements.txt
           && pytest -rFs
       - name: Install
@@ -122,9 +122,9 @@ jobs:
           -DACTS_BUILD_UNITTESTS=ON
           -DACTS_BUILD_INTEGRATIONTESTS=ON
           -DACTS_LOG_FAILURE_THRESHOLD=WARNING
-          -DACTS_USE_SYSTEM_BOOST=off
-          -DACTS_USE_SYSTEM_EIGEN3=off
-          -DACTS_BUILD_PLUGIN_JSON=on
+          -DACTS_USE_SYSTEM_BOOST=OFF
+          -DACTS_USE_SYSTEM_EIGEN3=OFF
+          -DACTS_BUILD_PLUGIN_JSON=ON
       - name: Build
         run: ${SETUP} && cmake --build build --
       - name: Unit tests
@@ -145,8 +145,8 @@ jobs:
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
           -DACTS_LOG_FAILURE_THRESHOLD=WARNING
-          -DACTS_USE_SYSTEM_BOOST=off
-          -DACTS_USE_SYSTEM_EIGEN3=off        
+          -DACTS_USE_SYSTEM_BOOST=OFF
+          -DACTS_USE_SYSTEM_EIGEN3=OFF
           -DACTS_BUILD_EXAMPLES=ON
       - name: Build Examples
         run: ${SETUP} && cmake --build build --
@@ -195,7 +195,7 @@ jobs:
           -DCMAKE_CXX_STANDARD=17
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
           -DCMAKE_PREFIX_PATH=/usr/local/acts
-          -DACTS_BUILD_EVERYTHING=on
+          -DACTS_BUILD_EVERYTHING=ON
           -DACTS_LOG_FAILURE_THRESHOLD=WARNING
       - name: Build
         run: cmake --build build  --
@@ -253,6 +253,7 @@ jobs:
           -DCMAKE_CXX_COMPILER=clang++
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
+          -DACTS_SETUP_VECMEM=ON
           -DACTS_BUILD_PLUGIN_SYCL=ON
           -DACTS_BUILD_UNITTESTS=ON
       - name: Build
@@ -272,7 +273,7 @@ jobs:
           && pip3 install --upgrade pip
           && pip install -r docs/requirements.txt
       - name: Configure
-        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=on
+        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=ON
       - name: Build
         run: cmake --build build -- docs-with-api
       - uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(ACTS_BUILD_PLUGIN_JSON "Build json plugin" OFF)
 option(ACTS_USE_SYSTEM_NLOHMANN_JSON "Use nlohmann::json provided by the system instead of the bundled version" OFF)
 option(ACTS_BUILD_PLUGIN_LEGACY "Build legacy plugin" OFF)
 option(ACTS_BUILD_PLUGIN_ONNX "Build ONNX plugin" OFF)
+option(ACTS_SETUP_VECMEM "Explicitly set up vecmem for the project" OFF)
 option(ACTS_USE_SYSTEM_VECMEM "Use a system-provided vecmem installation" OFF)
 option(ACTS_BUILD_PLUGIN_SYCL "Build SYCL plugin" OFF)
 option(ACTS_BUILD_PLUGIN_TGEO "Build TGeo plugin" OFF)
@@ -58,7 +59,9 @@ option(ACTS_BUILD_INTEGRATIONTESTS "Build integration tests" OFF)
 option(ACTS_BUILD_UNITTESTS "Build unit tests" OFF)
 # other options
 option(ACTS_BUILD_DOCS "Build documentation" OFF)
+option(ACTS_SETUP_BOOST "Explicitly set up Boost for the project" ON)
 option(ACTS_USE_SYSTEM_BOOST "Use a system-provided boost" ON)
+option(ACTS_SETUP_EIGEN3 "Explicitly set up Eigen3 for the project" ON)
 option(ACTS_USE_SYSTEM_EIGEN3 "Use a system-provided eigen3" ON)
 
 # handle option inter-dependencies and the everything flag
@@ -142,19 +145,31 @@ set(_acts_tbb_version 2020.1)
 
 # required packages
 
-if (ACTS_USE_SYSTEM_BOOST)
-  # NOTE we use boost::filesystem instead of std::filesystem since the later
-  # is not uniformly supported even on compilers that nominally support C++17
-  # NOTE FindBoost.cmake looks for BoostConfig.cmake first, before running it's own logic.
-  find_package(Boost ${_acts_boost_version} REQUIRED COMPONENTS filesystem program_options unit_test_framework)
-else()
-  add_subdirectory(thirdparty/boost)
+if (ACTS_SETUP_BOOST)
+  if (ACTS_USE_SYSTEM_BOOST)
+    # NOTE we use boost::filesystem instead of std::filesystem since the later
+    # is not uniformly supported even on compilers that nominally support C++17
+    # NOTE FindBoost.cmake looks for BoostConfig.cmake first, before running it's own logic.
+    find_package(Boost ${_acts_boost_version} REQUIRED COMPONENTS filesystem program_options unit_test_framework)
+  else()
+    add_subdirectory(thirdparty/boost)
+  endif()
 endif()
 
-if (ACTS_USE_SYSTEM_EIGEN3)
-  find_package(Eigen3 ${_acts_eigen3_version} REQUIRED CONFIG)
-else()
-  add_subdirectory(thirdparty/eigen3)
+if (ACTS_SETUP_EIGEN3)
+  if (ACTS_USE_SYSTEM_EIGEN3)
+    find_package(Eigen3 ${_acts_eigen3_version} REQUIRED CONFIG)
+  else()
+    add_subdirectory(thirdparty/eigen3)
+  endif()
+endif()
+
+if (ACTS_SETUP_VECMEM)
+  if (ACTS_USE_SYSTEM_VECMEM)
+    find_package(vecmem REQUIRED)
+  else()
+    add_subdirectory(thirdparty/vecmem)
+  endif()
 endif()
 
 # the `<project_name>_VERSION` variables set by `setup(... VERSION ...)` have
@@ -214,11 +229,6 @@ if(ACTS_BUILD_PLUGIN_ONNX)
 endif()
 if(ACTS_BUILD_PLUGIN_SYCL)
   find_package(SYCL REQUIRED)
-  if (ACTS_USE_SYSTEM_VECMEM)
-    find_package(vecmem REQUIRED)
-  else()
-    add_subdirectory(thirdparty/vecmem)
-  endif()
 endif()
 if(ACTS_BUILD_PLUGIN_TGEO)
   find_package(ROOT ${_acts_root_version} REQUIRED CONFIG COMPONENTS Geom)


### PR DESCRIPTION
Made it possible not to set them up at all. In case Acts is built as part of a "larger" project, like [traccc](https://github.com/acts-project/traccc). And that "larger" project wants to set these up according to its own liking.

At the same time fixed the capitalisation of the flags in the CI configuration. (`on` != `ON` in CMake lingo.)

I used the same naming here that I've set up in the "traccc projects" in the last weeks. See for instance:
  - https://github.com/acts-project/algebra-plugins/pull/27
  - https://github.com/acts-project/detray/pull/129

Making this kind of update will be vital for setting up the build of Acts in [traccc](https://github.com/acts-project/traccc) in the same way.