### PR TITLE
ci: Add new LCG versions, and C8 build

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v13
+    container: ghcr.io/acts-project/ubuntu2004:v14
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -49,7 +49,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v13
+    container: ghcr.io/acts-project/ubuntu2004:v14
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,12 +14,14 @@ env:
 jobs:
   linux:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:v13
+    container: ghcr.io/acts-project/${{ matrix.image }}:v14
     strategy:
       matrix:
         image:
-          - centos7-lcg97apython3-gcc9
-          - centos7-lcg98python3-gcc10
+          - centos7-lcg100-gcc10
+          - centos7-lcg101-gcc11
+          - centos8-lcg100-gcc10
+          - centos8-lcg101-gcc11
           - ubuntu2004
     env:
       SETUP: true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:v13
+    container: ghcr.io/acts-project/format10:v14
     steps:
       - uses: actions/checkout@v2
       - name: Check


### PR DESCRIPTION
This PR replaces our builds

- centos7-lcg97apython3-gcc9
- centos7-lcg98python3-gcc10

with these new ones:

- centos7-lcg100-gcc10
- centos7-lcg101-gcc11
- centos8-lcg100-gcc10
- centos8-lcg101-gcc11
- 