### PR TITLE
fix: Fail wrapping in case of overlap

### DIFF
--- a/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
@@ -356,6 +356,15 @@ struct WrappingConfig {
           // set the Central Wrapping
           wCondition = CentralWrapping;
           wConditionScreen = "[centrally inserted]";
+        } else if ((existingVolumeConfig.rMax > containerVolumeConfig.rMin &&
+                    existingVolumeConfig.rMin < containerVolumeConfig.rMin) ||
+                   (existingVolumeConfig.rMax > containerVolumeConfig.rMax &&
+                    existingVolumeConfig.rMin < containerVolumeConfig.rMax)) {
+          // The volumes are overlapping this shouldn't be happening return an
+          // error
+          throw std::invalid_argument(
+              "Volumes are overlapping, this shouldn't be happening. Please "
+              "check your geometry building.");
         }
 
         // check if gaps are needed


### PR DESCRIPTION
It was notice in the building of the ATLAS tracking geometry that if two volumes overlap then the wrapping won't do anything but will also not return any error. This PR add a throw in case of overlapping volumes.
