### PR TITLE
fix: vertex constraints 

### DIFF
--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -34,8 +34,10 @@ class VertexFitterAlgorithm final : public BareAlgorithm {
     Acts::Vector4 constraintPos = Acts::Vector4(0, 0, 0, 0);
     /// Vertex constraint covariance matrix
     Acts::SymMatrix4 constraintCov =
-        Acts::Vector4(3 * Acts::UnitConstants::mm*Acts::UnitConstants::mm, 3 * Acts::UnitConstants::mm*Acts::UnitConstants::mm,
-                      10 * Acts::UnitConstants::mm*Acts::UnitConstants::mm, 1 * Acts::UnitConstants::ns*Acts::UnitConstants::ns)
+        Acts::Vector4(3 * Acts::UnitConstants::mm * Acts::UnitConstants::mm,
+                      3 * Acts::UnitConstants::mm * Acts::UnitConstants::mm,
+                      10 * Acts::UnitConstants::mm * Acts::UnitConstants::mm,
+                      1 * Acts::UnitConstants::ns * Acts::UnitConstants::ns)
             .asDiagonal();
   };
 

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -31,11 +31,11 @@ class VertexFitterAlgorithm final : public BareAlgorithm {
     /// Constraint vertex fit bool
     bool doConstrainedFit = false;
     /// Vertex constraint position
-    Acts::Vector3 constraintPos = Acts::Vector3(0, 0, 0);
+    Acts::Vector4 constraintPos = Acts::Vector4(0, 0, 0, 0);
     /// Vertex constraint covariance matrix
-    Acts::SymMatrix3 constraintCov =
-        Acts::Vector3(3 * Acts::UnitConstants::mm, 3 * Acts::UnitConstants::mm,
-                      10 * Acts::UnitConstants::mm)
+    Acts::SymMatrix4 constraintCov =
+        Acts::Vector4(3 * Acts::UnitConstants::mm*Acts::UnitConstants::mm, 3 * Acts::UnitConstants::mm*Acts::UnitConstants::mm,
+                      10 * Acts::UnitConstants::mm*Acts::UnitConstants::mm, 1 * Acts::UnitConstants::ns*Acts::UnitConstants::ns)
             .asDiagonal();
   };
 

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -106,8 +106,8 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
       // Vertex constraint
       Acts::Vertex<Acts::BoundTrackParameters> theConstraint;
 
-      theConstraint.setCovariance(m_cfg.constraintCov);
-      theConstraint.setPosition(m_cfg.constraintPos);
+      theConstraint.setFullCovariance(m_cfg.constraintCov);
+      theConstraint.setFullPosition(m_cfg.constraintPos);
 
       // Vertex fitter options
       VertexFitterOptions vfOptionsConstr(ctx.geoContext, ctx.magFieldContext,


### PR DESCRIPTION
This very small PR fixes the settings of position and covariance matrix of the vertex constraint in the VertexFitterAlgorithm.hpp. When I ran the Billoir fitter with the old settings, I got the following errors:

14:15:37    VertexFit      ERROR     Error in vertex fit with constraint.
14:15:37    VertexFit      ERROR     Numeric failure in calculation.

Looking at the FullBilloirVertexFitterTests.cpp in /Tests/UnitTests/Core/Vertexing, showed that the constraints had a dimension missing (and also wrong units), which resolved the issue.
