### PR TITLE
fix: Warning in navigation when targeting perigee

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -389,8 +389,14 @@ class Navigator {
       }
     } else if (state.navigation.currentVolume ==
                state.navigation.targetVolume) {
-      ACTS_WARNING(volInfo(state) << "No further navigation action, proceed to "
-                                     "target. This is very likely an error");
+      if (state.navigation.targetSurface == nullptr) {
+        ACTS_WARNING(volInfo(state)
+                     << "No further navigation action, proceed to "
+                        "target. This is very likely an error");
+      } else {
+        ACTS_VERBOSE(volInfo(state)
+                     << "No further navigation action, proceed to target.");
+      }
       // Set navigation break and release the navigation step size
       state.navigation.navigationBreak = true;
       stepper.releaseStepSize(state.stepping);
@@ -398,7 +404,6 @@ class Navigator {
       ACTS_VERBOSE(volInfo(state)
                    << "Status could not be determined - good luck.");
     }
-    return;
   }
 
   /// @brief Navigator target call

--- a/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
+++ b/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
@@ -33,7 +33,8 @@ template <typename stepper_t>
 Acts::Intersection3D::Status updateSingleSurfaceStatus(
     const stepper_t& stepper, typename stepper_t::State& state,
     const Surface& surface, const BoundaryCheck& bcheck, LoggerWrapper logger) {
-  ACTS_VERBOSE("Update single surface status for surface: " << surface.geometryId());
+  ACTS_VERBOSE(
+      "Update single surface status for surface: " << surface.geometryId());
 
   auto sIntersection =
       surface.intersect(state.geoContext, stepper.position(state),
@@ -53,7 +54,8 @@ Acts::Intersection3D::Status updateSingleSurfaceStatus(
       double cLimit = intersection.pathLength;
       ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
                                                   << ", " << cLimit);
-      bool accept = (cLimit > oLimit and cLimit * cLimit < pLimit * pLimit + s_onSurfaceTolerance);
+      bool accept = (cLimit > oLimit and
+                     cLimit * cLimit < pLimit * pLimit + s_onSurfaceTolerance);
       if (accept) {
         ACTS_VERBOSE("Intersection is WITHIN limit");
         stepper.setStepSize(state, state.navDir * cLimit);
@@ -69,8 +71,8 @@ Acts::Intersection3D::Status updateSingleSurfaceStatus(
           ACTS_VERBOSE("- intersection path length "
                        << std::abs(cLimit) << " is over the path limit "
                        << (std::abs(pLimit) + s_onSurfaceTolerance)
-                       << " (including tolerance of "
-                       << s_onSurfaceTolerance << ")");
+                       << " (including tolerance of " << s_onSurfaceTolerance
+                       << ")");
         }
       }
 

--- a/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
+++ b/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
@@ -33,7 +33,7 @@ template <typename stepper_t>
 Acts::Intersection3D::Status updateSingleSurfaceStatus(
     const stepper_t& stepper, typename stepper_t::State& state,
     const Surface& surface, const BoundaryCheck& bcheck, LoggerWrapper logger) {
-  ACTS_VERBOSE("Update single surface status for surface: " << &surface);
+  ACTS_VERBOSE("Update single surface status for surface: " << surface.geometryId());
 
   auto sIntersection =
       surface.intersect(state.geoContext, stepper.position(state),
@@ -53,7 +53,7 @@ Acts::Intersection3D::Status updateSingleSurfaceStatus(
       double cLimit = intersection.pathLength;
       ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
                                                   << ", " << cLimit);
-      bool accept = (cLimit > oLimit and cLimit * cLimit < pLimit * pLimit);
+      bool accept = (cLimit > oLimit and cLimit * cLimit < pLimit * pLimit + s_onSurfaceTolerance);
       if (accept) {
         ACTS_VERBOSE("Intersection is WITHIN limit");
         stepper.setStepSize(state, state.navDir * cLimit);
@@ -70,7 +70,7 @@ Acts::Intersection3D::Status updateSingleSurfaceStatus(
                        << std::abs(cLimit) << " is over the path limit "
                        << (std::abs(pLimit) + s_onSurfaceTolerance)
                        << " (including tolerance of "
-                       << s_curvilinearProjTolerance << ")");
+                       << s_onSurfaceTolerance << ")");
         }
       }
 


### PR DESCRIPTION
This warning popped up in a number of places, but mostly when targeting
parigee surfaces, e.g. in the vertexing or in the KF when the backward
smoothing propagation is enabled. It's possible this only occurs with a
beampipe layer.

I **think** what's happening is two things:
- The on-surface tolerance wasn't applied correctly in one location (I think we do this in other spots, like when we're looking for compatible layers in volumes, and compatible surfaces in layers.)
- If we actually have a target surface (and it's still reachable), this
  navigation state is probably still valid. We are on the final layer,
  the navigator realizes it won't find the perigee surfaces through the
  tracking geometry. It looks up the volume from the target surface
  position, and determines that we are in fact in the target volume
  already, so it only needs to *proceed to target* to be done.

As a tentative solution I've included the `s_onSurfaceTolerance` in the
check in `SteppingHelper` (@asalzburger can you advise if that seems
correct here?), and split the output into a warning in case there is no
target surface (which I still think is a bug/edge case we should warn on), and a verbose messagge in case we do have it.

One could supplement the last change by checking if at this point the
target surface is still reachable, but I'm not sure this should be done
only for reason of providing output.