### PR TITLE
feat: Add ostream-operator for IntersectionStatus

### DIFF
--- a/Core/include/Acts/Utilities/Intersection.hpp
+++ b/Core/include/Acts/Utilities/Intersection.hpp
@@ -25,13 +25,12 @@ enum class IntersectionStatus : int {
 };
 
 /// Ostream-operator for the IntersectionStatus enum
-inline std::ostream &operator<<(std::ostream &os, IntersectionStatus status) {
-    constexpr static std::array<const char *, 3> names = {{
-       "missed/unreachable", "reachable", "onSurface"
-    }};
+inline std::ostream& operator<<(std::ostream& os, IntersectionStatus status) {
+  constexpr static std::array<const char*, 3> names = {
+      {"missed/unreachable", "reachable", "onSurface"}};
 
-    os << names[static_cast<std::size_t>(status)];
-    return os;
+  os << names[static_cast<std::size_t>(status)];
+  return os;
 }
 
 ///  @struct Intersection

--- a/Core/include/Acts/Utilities/Intersection.hpp
+++ b/Core/include/Acts/Utilities/Intersection.hpp
@@ -16,18 +16,31 @@
 #include <limits>
 namespace Acts {
 
+/// Status enum
+enum class IntersectionStatus : int {
+  missed = 0,
+  unreachable = 0,
+  reachable = 1,
+  onSurface = 2
+};
+
+/// Ostream-operator for the IntersectionStatus enum
+inline std::ostream &operator<<(std::ostream &os, IntersectionStatus status) {
+    constexpr static std::array<const char *, 3> names = {{
+       "missed/unreachable", "reachable", "onSurface"
+    }};
+
+    os << names[static_cast<std::size_t>(status)];
+    return os;
+}
+
 ///  @struct Intersection
 ///
 ///  Intersection struct used for position
 template <unsigned int DIM>
 struct Intersection {
-  /// Nested Status enum
-  enum class Status : int {
-    missed = 0,
-    unreachable = 0,
-    reachable = 1,
-    onSurface = 2
-  };
+  /// Status enum
+  using Status = IntersectionStatus;
 
   /// Position of the intersection
   ActsVector<DIM> position = ActsVector<DIM>::Zero();

--- a/Tests/UnitTests/Core/Utilities/IntersectionTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/IntersectionTests.cpp
@@ -206,5 +206,19 @@ BOOST_AUTO_TEST_CASE(ObjectIntersectionTest) {
   BOOST_CHECK_EQUAL(unionSetCst.size(), 5u);
 }
 
+BOOST_AUTO_TEST_CASE(IntersectionStatusPrinting) {
+  std::array<IntersectionStatus, 4> status_values = {
+      {IntersectionStatus::missed, IntersectionStatus::unreachable,
+       IntersectionStatus::reachable, IntersectionStatus::onSurface}};
+  std::array<std::string, 4> expected_messages = {
+      {"missed/unreachable", "missed/unreachable", "reachable", "onSurface"}};
+
+  for (int i = 0; i < 4; ++i) {
+    std::stringstream ss;
+    ss << status_values[i];
+    BOOST_CHECK(ss.str() == expected_messages[i]);
+  }
+}
+
 }  // namespace Test
 }  // namespace Acts


### PR DESCRIPTION
This is the first part of my GSF pull-request series, where I often need to print the Intersection status for debugging. I split up this PR, since it is independent on the following ones.

Basically this pulls the nested `enum class Status` out of the `Intersection<DIM>` template struct to a `enum class IntersectionStatus` at namespace scope. The `IntersectionStatus` is broadcasted into the `Intersection<DIM>` with a `using Status = IntersectionStatus` to remain compatability.

This is done because otherwise the `Status`-enum would depend on the template-parameter `DIM` and thus the `operator<<` would also needed to be templated on `DIM` which makes things more complicated than they need to be.

