### PR TITLE
refactor: Use `small_vector` in `surfaceOnApproach`

### DIFF
--- a/Core/src/Geometry/GenericApproachDescriptor.cpp
+++ b/Core/src/Geometry/GenericApproachDescriptor.cpp
@@ -13,6 +13,8 @@
 
 #include <algorithm>
 
+#include <boost/container/small_vector.hpp>
+
 void Acts::GenericApproachDescriptor::registerLayer(const Layer& lay) {
   // go through the surfaces
   for (auto& sf : m_surfaceCache) {
@@ -25,7 +27,8 @@ Acts::ObjectIntersection<Acts::Surface>
 Acts::GenericApproachDescriptor::approachSurface(
     const GeometryContext& gctx, const Vector3& position,
     const Vector3& direction, const BoundaryCheck& bcheck) const {
-  std::vector<ObjectIntersection<Surface>> sIntersections;
+  // almost always 2
+  boost::container::small_vector<ObjectIntersection<Surface>, 2> sIntersections;
   sIntersections.reserve(m_surfaceCache.size());
   for (auto& sf : m_surfaceCache) {
     auto sfIntersection = sf->intersect(gctx, position, direction, bcheck);


### PR DESCRIPTION
Reduces the number of heap allocations in that method. As the number of approach surfaces is *almost always* 2, I think this makes sense to use a `small_vector` for.