### PR TITLE
refactor: Move LoggerWrapper methods to inline

### DIFF
--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -498,7 +498,10 @@ class LoggerWrapper {
   ///
   /// @param lvl The level to check
   /// @return Whether to print at this level or not.
-  bool doPrint(const Logging::Level& lvl) const;
+  bool doPrint(const Logging::Level& lvl) const {
+    assert(m_logger != nullptr);
+    return m_logger->doPrint(lvl);
+  }
 
   /// Add a logging message at a given level
   /// @param lvl The level to print at
@@ -509,7 +512,10 @@ class LoggerWrapper {
   /// Enables using the logging macros `ACTS_*` when an instance of this class
   /// is assigned to a local variable `logger`.
   /// @return Reference to the logger instance.
-  const Logger& operator()() const;
+  const Logger& operator()() const {
+    assert(m_logger != nullptr);
+    return *m_logger;
+  }
 
  private:
   const Logger* m_logger;

--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 // STL include(s)
+#include <cassert>
 #include <ctime>
 #include <exception>
 #include <functional>

--- a/Core/src/Utilities/Logger.cpp
+++ b/Core/src/Utilities/Logger.cpp
@@ -14,20 +14,10 @@ namespace Acts {
 
 LoggerWrapper::LoggerWrapper(const Logger& logger) : m_logger(&logger) {}
 
-bool LoggerWrapper::doPrint(const Logging::Level& lvl) const {
-  assert(m_logger != nullptr);
-  return m_logger->doPrint(lvl);
-}
-
 void LoggerWrapper::log(const Logging::Level& lvl,
                         const std::string& input) const {
   assert(m_logger != nullptr);
   return m_logger->log(lvl, input);
-}
-
-const Logger& LoggerWrapper::operator()() const {
-  assert(m_logger != nullptr);
-  return *m_logger;
 }
 
 namespace Logging {
@@ -47,9 +37,6 @@ std::unique_ptr<const Logger> makeDummyLogger() {
   return std::make_unique<const Logger>(std::move(output), std::move(print));
 }
 
-std::unique_ptr<const Logger> s_dummyLogger{makeDummyLogger()};
-LoggerWrapper s_dummyLoggerWrapper{*s_dummyLogger};
-
 }  // namespace
 }  // namespace Logging
 
@@ -67,6 +54,10 @@ std::unique_ptr<const Logger> getDefaultLogger(const std::string& name,
 }
 
 LoggerWrapper getDummyLogger() {
-  return Logging::s_dummyLoggerWrapper;
+  static const std::unique_ptr<const Logger> logger =
+      Logging::makeDummyLogger();
+  static const LoggerWrapper loggerWrapper{*logger};
+
+  return loggerWrapper;
 }
 }  // namespace Acts


### PR DESCRIPTION
We call `LoggerWrapper::operator()()` and `LoggerWrapper::doPrint` **a lot**, so I think it makes sense to have them in the header so they can be inlined.

Also changes the way the singleton `DummyWrapper` works: now it uses a safer idiom with static initialization right inside the function.