### PR TITLE
fix: Add smearing options to ckf tracking example

### DIFF
--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearingOptions.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearingOptions.cpp
@@ -23,7 +23,7 @@ void ActsExamples::Options::addParticleSmearingOptions(Description& desc) {
       "Smear the initial time in ns");
   opt("smear-sigma-momentum", value<Reals<3>>()->default_value({{1, 1, 0.05}}),
       "Smear the initial phi (degree), theta (degree) and momentum (relative)");
-  opt("fit-initial-variance-inflation",
+  opt("smear-initial-variance-inflation",
       value<Reals<6>>()->default_value({{1., 1., 1., 1., 1., 1.}}),
       "Inflate the initial covariance matrix");
 }
@@ -51,7 +51,7 @@ ActsExamples::Options::readParticleSmearingOptions(
   cfg.sigmaTheta = sigmaMomOpts[1] * Acts::UnitConstants::degree;
   cfg.sigmaPRel = sigmaMomOpts[2];
   auto varInflation =
-      vars["fit-initial-variance-inflation"].template as<Reals<6>>();
+      vars["smear-initial-variance-inflation"].template as<Reals<6>>();
   cfg.initialVarInflation = {varInflation[0], varInflation[1], varInflation[2],
                              varInflation[3], varInflation[4], varInflation[5]};
   return cfg;

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -75,7 +75,8 @@ int runRecCKFTracks(int argc, char* argv[],
   Options::addFittingOptions(desc);
   Options::addTrackFindingOptions(desc);
   addRecCKFOptions(desc);
-  Options::addDigitizationOptions(desc);Options::addParticleSmearingOptions(desc);
+  Options::addDigitizationOptions(desc);
+  Options::addParticleSmearingOptions(desc);
   Options::addSpacePointMakerOptions(desc);
   Options::addCsvWriterOptions(desc);
 

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -75,7 +75,7 @@ int runRecCKFTracks(int argc, char* argv[],
   Options::addFittingOptions(desc);
   Options::addTrackFindingOptions(desc);
   addRecCKFOptions(desc);
-  Options::addDigitizationOptions(desc);
+  Options::addDigitizationOptions(desc);Options::addParticleSmearingOptions(desc);
   Options::addSpacePointMakerOptions(desc);
   Options::addCsvWriterOptions(desc);
 


### PR DESCRIPTION
The CKF tracking example crashes due to missing particle smearing options. The initial inflation option clashes with an option of the same name in the fitting options and has been renamed.