### PR TITLE
feat - Make binning explicitly configurable in TGeo example

### DIFF
--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/JsonTGeoDetectorConfig.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/JsonTGeoDetectorConfig.hpp
@@ -13,8 +13,10 @@
 #include "ActsExamples/TGeoDetector/TGeoDetector.hpp"
 #include "ActsExamples/TGeoDetector/TGeoITkModuleSplitter.hpp"
 #include "ActsExamples/Utilities/Options.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 
 #include <map>
+#include <string>
 
 // Namespace of the module splitters
 namespace Acts {
@@ -40,6 +42,12 @@ void to_json(nlohmann::json& j,
                      {"geo-tgeo-disc-nphi-segs", cdc.discPhiSegments},
                      {"geo-tgeo-disc-nr-segs", cdc.discRadialSegments}};
 }
+
+// enum specilization by nlohman library
+NLOHMANN_JSON_SERIALIZE_ENUM(Acts::BinningType, {
+    {Acts::BinningType::equidistant, "equidistant"},
+    {Acts::BinningType::arbitrary, "arbitrary"},
+})
 
 }  // namespace Acts
 
@@ -117,6 +125,9 @@ void from_json(const nlohmann::json& j,
   vol.zRange = j.at("geo-tgeo-layer-z-ranges");
   vol.splitTolR = j.at("geo-tgeo-layer-r-split");
   vol.splitTolZ = j.at("geo-tgeo-layer-z-split");
+  //Set binning manually
+  vol.binning0 = j.at("geo-tgeo-binning0");
+  vol.binning1 = j.at("geo-tgeo-binning1");
 
   vol.cylinderDiscSplit = j.at("geo-tgeo-cyl-disc-split");
   if (vol.cylinderDiscSplit) {
@@ -153,7 +164,8 @@ void to_json(nlohmann::json& j, const TGeoDetector::Config::Volume& vol) {
   j["geo-tgeo-layer-z-ranges"] = vol.zRange;
   j["geo-tgeo-layer-r-split"] = vol.splitTolR;
   j["geo-tgeo-layer-z-split"] = vol.splitTolZ;
-  j["geo-tgeo-cyl-disc-split"] = vol.cylinderDiscSplit;
+  j["geo-tgeo-binning0"] = vol.binning0;
+  j["geo-tgeo-binning1"] = vol.binning1;
 
   j["geo-tgeo-cyl-disc-split"] = vol.cylinderDiscSplit;
   j["geo-tgeo-itk-module-split"] = vol.itkModuleSplit;

--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Detector/IBaseDetector.hpp"
 #include "ActsExamples/Utilities/Options.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 
 #include <map>
 #include <memory>
@@ -99,6 +100,8 @@ struct TGeoDetector : public ActsExamples::IBaseDetector {
       LayerTriplet<Options::Interval> zRange;
       LayerTriplet<double> splitTolR{0};
       LayerTriplet<double> splitTolZ{0};
+      LayerTriplet<std::vector<std::pair<int, Acts::BinningType>>> binning0;
+      LayerTriplet<std::vector<std::pair<int, Acts::BinningType>>> binning1;
 
       Options::Interval binToleranceR;
       Options::Interval binTolerancePhi;

--- a/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
@@ -102,6 +102,8 @@ std::vector<Acts::TGeoLayerBuilder::Config> makeLayerBuilderConfigs(
       if (0 < stz) {
         lConfig.splitConfigs.emplace_back(Acts::binZ, stz);
       }
+      lConfig.binning0 = volume.binning0.at(ncp);
+      lConfig.binning1 = volume.binning1.at(ncp);
 
       layerBuilderConfig.layerConfigurations[ncp].push_back(lConfig);
     }

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoLayerBuilder.hpp
@@ -44,7 +44,7 @@ class Surface;
 /// split into layers.
 class TGeoLayerBuilder : public ILayerBuilder {
  public:
-  ///  Helper config structs for volume parsin
+  ///  Helper config structs for volume parsing
   struct LayerConfig {
    public:
     using RangeConfig = std::pair<BinningValue, std::pair<double, double>>;
@@ -65,9 +65,9 @@ class TGeoLayerBuilder : public ILayerBuilder {
     std::pair<double, double> envelope = {1 * UnitConstants::mm,
                                           1 * UnitConstants::mm};
     /// Binning setup in l0: nbins (-1 -> automated), axis binning type
-    std::tuple<int, BinningType> binning0 = {-1, equidistant};
+    std::vector<std::pair<int, BinningType>> binning0 = {{-1, equidistant}};
     /// Binning setup in l1: nbins (-1 -> automated), axis binning type
-    std::tuple<int, BinningType> binning1 = {-1, equidistant};
+    std::vector<std::pair<int, BinningType>> binning1 = {{-1, equidistant}};
 
     // Default constructor
     LayerConfig()


### PR DESCRIPTION
This PR makes the surface binning in the TGeo Detector example explicitly configurable. In the json configuration a vector of bins for ```loc0``` and ```loc1``` is added for the negative, central and positive detector regions respectively. The binning must be set per layer, meaning that the number of layers must be known when configuring the detector building. Alternatively, a single binning entry of ```0``` can be used to trigger autobinning.
