### PR TITLE
fix: Enable copyFrom const track proxy for MultiTrajectory

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -658,6 +658,7 @@ class TrackStateProxy {
 
   friend class Acts::MultiTrajectory;
   friend class TrackStateProxy<M, true>;
+  friend class TrackStateProxy<M, false>;
 };
 
 // implement track state visitor concept

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -868,4 +868,19 @@ BOOST_AUTO_TEST_CASE(ProxyAssignment) {
   // MultiTrajectory::TrackStateProxy tp4{tp3};
 }
 
+// Check if the copy from const does compile, assume the copy is done correctly
+BOOST_AUTO_TEST_CASE(CopyFromConst) {
+  using PM = TrackStatePropMask;
+  MultiTrajectory mj;
+
+  const auto idx_a = mj.addTrackState(PM::All);
+  const auto idx_b = mj.addTrackState(PM::All);
+
+  auto mutableProxy = mj.getTrackState(idx_a);
+  auto constProxy =
+      static_cast<const MultiTrajectory&>(mj).getTrackState(idx_b);
+
+  mutableProxy.copyFrom(constProxy);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -876,11 +876,15 @@ BOOST_AUTO_TEST_CASE(CopyFromConst) {
   const auto idx_a = mj.addTrackState(PM::All);
   const auto idx_b = mj.addTrackState(PM::All);
 
-  auto mutableProxy = mj.getTrackState(idx_a);
-  auto constProxy =
-      static_cast<const MultiTrajectory&>(mj).getTrackState(idx_b);
+  MultiTrajectory::TrackStateProxy mutableProxy = mj.getTrackState(idx_a);
+
+  const MultiTrajectory& cmj = mj;
+  MultiTrajectory::ConstTrackStateProxy constProxy = cmj.getTrackState(idx_b);
 
   mutableProxy.copyFrom(constProxy);
+
+  // copy mutable to const: this won't compile
+  // constProxy.copyFrom(mutableProxy);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a `friend class` statement in the `MultiTrajectory` that enables `copyFrom(...)` from a `ConstTrackStateProxy` to a mutable `TrackStateProxy`.

I added this to the UnitTest, but this for now only checks if this compiles.