### PR TITLE
ci: Don't run builds on docs-only changes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -2,7 +2,11 @@ name: Builds
 
 on:
   push:
+    paths-ignore:
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "docs/**"
     branches:
       - main
       - 'release/**'
@@ -267,23 +271,3 @@ jobs:
         run: >
           source /opt/intel/oneapi/setvars.sh
           && cmake --build build --
-  docs:
-    runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v9
-    env:
-        DOXYGEN_WARN_AS_ERROR: YES
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: >
-          apt-get install -y doxygen
-          && pip3 install --upgrade pip
-          && pip install -r docs/requirements.txt
-      - name: Configure
-        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=ON
-      - name: Build
-        run: cmake --build build -- docs-with-api
-      - uses: actions/upload-artifact@v2
-        with:
-          name: acts-docs
-          path: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - main
       - 'release/**'
 
+jobs:
   docs:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v9

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Documentation
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+  docs:
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v9
+    env:
+        DOXYGEN_WARN_AS_ERROR: YES
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: >
+          apt-get install -y doxygen
+          && pip3 install --upgrade pip
+          && pip install -r docs/requirements.txt
+      - name: Configure
+        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=ON
+      - name: Build
+        run: cmake --build build -- docs-with-api
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-docs
+          path: docs/_build/html/

--- a/docs/core/definitions/algebra.rst
+++ b/docs/core/definitions/algebra.rst
@@ -15,6 +15,7 @@ The basic scalar type can be defined via this file and is set per default to `do
 It is recommended within the code to deduce the Scalar type from the Event Data object, e.g.
 
 .. code-block:: cpp
- using Scalar = Vector3::Scalar;
+
+   using Scalar = Vector3::Scalar;
 
 Currently only the `Core` package builds with `float` precision.


### PR DESCRIPTION
This PR uses [a feature](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-ignoring-paths) of GitHub actions to skip our C++ builds in case **only** files in `docs/` change. This requires moving the doc CI job to a separate workflow.