### PR TITLE
fix: Prevent FPE in AMVF if covariance is not invertible

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -530,8 +530,14 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
     } else {
       // Use full 3d information for significance
       SymMatrix4 sumCov = candidateCov + otherCov;
-      significance =
-          std::sqrt(deltaPos.dot((sumCov.inverse().eval()) * deltaPos));
+      SymMatrix4 sumCovInverse;
+      bool invertible;
+      sumCov.computeInverseWithCheck(sumCovInverse, invertible);
+      if (invertible) {
+        significance = std::sqrt(deltaPos.dot(sumCovInverse * deltaPos));
+      } else {
+        return true;
+      }
     }
     if (significance < m_cfg.maxMergeVertexSignificance) {
       return true;


### PR DESCRIPTION
It's unclear to me how this covariance can end up not being invertible. I briefly discussed with @baschlag whether returning `true`, i.e. treating the vertex as *merged* is correct, and we think it's safer to do so, and therefore discard the vertex one level up the call chain.

I'm going to cherry pick this PR into branch `release/v15.x` to create a bugfix tag for the `v15` release.