### PR TITLE
fix: Bug when sorting the SP in SeedFinder

### DIFF
--- a/Core/include/Acts/Seeding/InternalSpacePoint.hpp
+++ b/Core/include/Acts/Seeding/InternalSpacePoint.hpp
@@ -41,15 +41,18 @@ class InternalSpacePoint {
   const float& varianceR() const { return m_varianceR; }
   const float& varianceZ() const { return m_varianceZ; }
   const SpacePoint& sp() const { return m_sp; }
+  const float& cotTheta() const { return m_cotTheta; }
+  void setCotTheta(float& cotTheta) const { m_cotTheta = cotTheta; }
 
  protected:
-  float m_x;               // x-coordinate in beam system coordinates
-  float m_y;               // y-coordinate in beam system coordinates
-  float m_z;               // z-coordinate in beam system coordinetes
-  float m_r;               // radius       in beam system coordinates
-  float m_varianceR;       //
-  float m_varianceZ;       //
-  const SpacePoint& m_sp;  // external space point
+  float m_x;                 // x-coordinate in beam system coordinates
+  float m_y;                 // y-coordinate in beam system coordinates
+  float m_z;                 // z-coordinate in beam system coordinetes
+  float m_r;                 // radius       in beam system coordinates
+  float m_varianceR;         //
+  float m_varianceZ;         //
+  mutable float m_cotTheta;  //
+  const SpacePoint& m_sp;    // external space point
 };
 
 /////////////////////////////////////////////////////////////////////////////////
@@ -83,6 +86,7 @@ inline InternalSpacePoint<SpacePoint>::InternalSpacePoint(
   m_r = sp.m_r;
   m_varianceR = sp.m_varianceR;
   m_varianceZ = sp.m_varianceZ;
+  m_cotTheta = sp.m_cotTheta;
 }
 
 }  // end of namespace Acts

--- a/Core/include/Acts/Seeding/SeedFinderUtils.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.ipp
@@ -96,6 +96,11 @@ void transformCoordinates(
   }
   // sort the SP in order of cotTheta
   if (enableCutsForSortedSP) {
+    std::sort(vec.begin(), vec.end(),
+              [](const InternalSpacePoint<external_spacepoint_t>* a,
+                 const InternalSpacePoint<external_spacepoint_t>* b) -> bool {
+                return (a->cotTheta() < b->cotTheta());
+              });
     std::sort(linCircleVec.begin(), linCircleVec.end(),
               [](const LinCircle& a, const LinCircle& b) -> bool {
                 return (a.cotTheta < b.cotTheta);


### PR DESCRIPTION
In PR #1084 I mentioned that we were seeing a degradation in tracking efficiency when sorting the SP in cotangent of theta in the `SeedFinder`. However I realised that I was sorting only the `linCircleVec` vector in `SeedFinder` and the `compatBottomSP` and `compatTopSP` vectors should also be sorted. 

This PR solves the bug and now the efficiency and the output should be the same as without the sorting.

@paulgessinger @robertlangenberg @noemina 