### PR TITLE
ci: Black version locked to 22.1.0

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Install black
-        run: pip install black
+        run: pip install black==22.1.0
       - name: Run black format check
         run: black --check . --extend-exclude ".*thirdparty.*"
 

--- a/CI/check_license.py
+++ b/CI/check_license.py
@@ -22,7 +22,7 @@ class bcolors:
     UNDERLINE = "\033[4m"
 
 
-CROSS_SYMBOL = u"\u2717"
+CROSS_SYMBOL = "\u2717"
 
 
 def err(string):

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -79,7 +79,7 @@ def test_pythia8(tmp_path, seq):
 
     fp = tmp_path / "pythia8_particles.root"
     assert fp.exists()
-    assert fp.stat().st_size > 2 ** 10 * 50
+    assert fp.stat().st_size > 2**10 * 50
     assert_entries(fp, "particles", events)
 
     assert len(list((tmp_path / "csv").iterdir())) > 0
@@ -127,7 +127,7 @@ def test_fatras(trk_geo, tmp_path, field, assert_root_hash):
     for f, tn, exp_entries in root_files:
         rfp = tmp_path / f
         assert rfp.exists()
-        assert rfp.stat().st_size > 2 ** 10 * 10
+        assert rfp.stat().st_size > 2**10 * 10
 
         assert_entries(rfp, tn, exp_entries)
         assert_root_hash(f, rfp)
@@ -226,7 +226,7 @@ def test_propagation(tmp_path, trk_geo, field, seq, assert_root_hash):
     for fn, tn, ee in root_files:
         fp = tmp_path / fn
         assert fp.exists()
-        assert fp.stat().st_size > 2 ** 10 * 50
+        assert fp.stat().st_size > 2**10 * 50
         assert_entries(fp, tn, ee)
         assert_root_hash(fn, fp)
 
@@ -249,7 +249,7 @@ def test_material_recording(tmp_path, material_recording, assert_root_hash):
     for fn, tn, ee in root_files:
         fp = material_recording / fn
         assert fp.exists()
-        assert fp.stat().st_size > 2 ** 10 * 50
+        assert fp.stat().st_size > 2**10 * 50
         assert_entries(fp, tn, ee)
         assert_root_hash(fn, fp)
 

--- a/Examples/Python/tests/test_writer.py
+++ b/Examples/Python/tests/test_writer.py
@@ -126,7 +126,7 @@ def test_root_prop_step_writer(
     s.run()
 
     assert file.exists()
-    assert file.stat().st_size > 2 ** 10 * 50
+    assert file.stat().st_size > 2**10 * 50
     assert_root_hash(file.name, file)
 
 
@@ -246,7 +246,7 @@ def test_root_clusters_writer(
 
     s.run()
     assert out.exists()
-    assert out.stat().st_size > 2 ** 10 * 50
+    assert out.stat().st_size > 2**10 * 50
     assert_root_hash(out.name, out)
 
 


### PR DESCRIPTION
The recent black (python formatter) version changed the format output. This PR updates the format of three files and locks black to `22.1.0` now.