### PR TITLE
fix: Make TGeo ITk splitting entry optional

### DIFF
--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/JsonTGeoDetectorConfig.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/JsonTGeoDetectorConfig.hpp
@@ -141,12 +141,17 @@ void from_json(const nlohmann::json& j,
     vol.discNPhiSegments = cdConfig.discPhiSegments;
   }
 
-  vol.itkModuleSplit = j.at("geo-tgeo-itk-module-split");
-  if (vol.itkModuleSplit) {
-    ActsExamples::TGeoITkModuleSplitter::Config itkConfig =
-        j.at("Splitters").at("ITk");
-    vol.barrelMap = itkConfig.barrelMap;
-    vol.discMap = itkConfig.discMap;
+  // Don't require ITk module splitting to be present
+  if (j.count("geo-tgeo-itk-module-split") != 0) {
+    vol.itkModuleSplit = j.at("geo-tgeo-itk-module-split");
+    if (vol.itkModuleSplit) {
+      ActsExamples::TGeoITkModuleSplitter::Config itkConfig =
+          j.at("Splitters").at("ITk");
+      vol.barrelMap = itkConfig.barrelMap;
+      vol.discMap = itkConfig.discMap;
+    }
+  } else {
+    vol.itkModuleSplit = false;
   }
 }
 
@@ -179,10 +184,12 @@ void to_json(nlohmann::json& j, const TGeoDetector::Config::Volume& vol) {
   cdConfig.discPhiSegments = vol.discNPhiSegments;
   j["Splitters"]["CylinderDisk"] = cdConfig;
 
-  ActsExamples::TGeoITkModuleSplitter::Config itkConfig;
-  itkConfig.barrelMap = vol.barrelMap;
-  itkConfig.discMap = vol.discMap;
-  j["Splitters"]["ITk"] = itkConfig;
+  if (vol.itkModuleSplit) {
+    ActsExamples::TGeoITkModuleSplitter::Config itkConfig;
+    itkConfig.barrelMap = vol.barrelMap;
+    itkConfig.discMap = vol.discMap;
+    j["Splitters"]["ITk"] = itkConfig;
+  }
 }
 
 }  // namespace ActsExamples

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
@@ -44,6 +44,8 @@ class RootTrajectoryStatesWriter final : public WriterT<TrajectoriesContainer> {
     std::string inputParticles;
     /// Input collection of simulated hits.
     std::string inputSimHits;
+    /// Input collection of measurements.
+    std::string inputClusters;
     /// Input hit-particles map collection.
     std::string inputMeasurementParticlesMap;
     /// Input collection to map measured hits to simulated hits.
@@ -119,6 +121,9 @@ class RootTrajectoryStatesWriter final : public WriterT<TrajectoriesContainer> {
   std::vector<float> m_pull_x_hit;  ///< hit pull x
   std::vector<float> m_pull_y_hit;  ///< hit pull y
   std::vector<int> m_dim_hit;       ///< dimension of measurement
+  std::vector<int> m_cltr_size;     ///< cluster size
+  std::vector<int> m_cltr_size_loc0;///< cluster size in local x
+  std::vector<int> m_cltr_size_loc1;///< cluster size in local y
 
   std::array<int, 3> m_nParams;  ///< number of states which have
                                  ///< filtered/predicted/smoothed parameters

--- a/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
@@ -331,17 +331,6 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryStatesWriter::writeT(
         auto [truthLocal, truthPos4, truthUnitDir] =
             averageSimHits(ctx.geoContext, surface, simHits, indices);
 
-        if (not clusters.empty()) {
-          const auto& c = clusters[hitIdx];
-          m_cltr_size.push_back(c.sizeLoc0);
-          m_cltr_size_loc0.push_back(c.sizeLoc1);
-          m_cltr_size_loc1.push_back(c.channels.size());
-        }
-        else {
-          m_cltr_size.push_back(99);
-          m_cltr_size_loc0.push_back(99);
-          m_cltr_size_loc1.push_back(99);
-        }
         // momemtum averaging makes even less sense than averaging position and
         // direction. use the first momentum or set q/p to zero
         float truthQOP = 0.0f;
@@ -349,6 +338,18 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryStatesWriter::writeT(
           // we assume that the indices are within valid ranges so we do not
           // need to check their validity again.
           const auto simHitIdx0 = indices.begin()->second;
+          // Save cluster information for this simHit
+          int sizeLoc0 = -1, sizeLoc1 = -1, size = -1;
+          if (not clusters.empty()) {
+            const auto& c = clusters[simHitIdx0];
+            sizeLoc0 = c.sizeLoc0 < 100 && c.sizeLoc0 > 0 ? c.sizeLoc0 : -1;
+            sizeLoc1 = c.sizeLoc1 < 100 && c.sizeLoc1 > 0 ? c.sizeLoc1 : -1;
+            size = c.channels.size() < 1000 && c.channels.size() > 0 ? c.channels.size() : -1;
+          }
+          m_cltr_size_loc0.push_back(sizeLoc0);
+          m_cltr_size_loc1.push_back(sizeLoc1);
+          m_cltr_size.push_back(size);
+          
           const auto& simHit0 = *simHits.nth(simHitIdx0);
           const auto p =
               simHit0.momentum4Before().template segment<3>(Acts::eMom0).norm();

--- a/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecCKFTracks.cpp
@@ -21,6 +21,7 @@
 #include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
 #include "ActsExamples/Io/Performance/CKFPerformanceWriter.hpp"
 #include "ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp"
+#include "ActsExamples/Io/Root/RootMeasurementWriter.hpp"
 #include "ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp"
 #include "ActsExamples/Io/Root/RootTrajectorySummaryWriter.hpp"
 #include "ActsExamples/MagneticField/MagneticFieldOptions.hpp"
@@ -115,6 +116,21 @@ int runRecCKFTracks(int argc, char* argv[],
   // Run the sim hits smearing
   auto digiCfg = setupDigitization(vm, sequencer, rnd, trackingGeometry,
                                    simHitReaderCfg.outputSimHits);
+
+  /*RootMeasurementWriter::Config measWriterRoot;
+  measWriterRoot.inputMeasurements = digiCfg.outputMeasurements;
+  measWriterRoot.inputClusters = digiCfg.outputClusters;
+  measWriterRoot.inputSimHits = simHitReaderCfg.outputSimHits;
+  measWriterRoot.inputMeasurementSimHitsMap =
+    digiCfg.outputMeasurementSimHitsMap;
+  measWriterRoot.filePath =
+    joinPaths(outputDir, std::string(digiCfg.outputMeasurements) + ".root");
+  measWriterRoot.boundIndices =
+    Acts::GeometryHierarchyMap<std::vector<Acts::BoundIndices>>(
+        digiCfg.getBoundIndices());
+  measWriterRoot.trackingGeometry = trackingGeometry;
+  sequencer.addWriter(
+    std::make_shared<RootMeasurementWriter>(measWriterRoot, logLevel));*/
 
   // Run the particle selection
   // The pre-selection will select truth particles satisfying provided criteria
@@ -282,6 +298,7 @@ int runRecCKFTracks(int argc, char* argv[],
   // selection algorithm is used.
   trackStatesWriter.inputParticles = particleReader.outputParticles;
   trackStatesWriter.inputSimHits = simHitReaderCfg.outputSimHits;
+  trackStatesWriter.inputClusters = digiCfg.outputClusters;
   trackStatesWriter.inputMeasurementParticlesMap =
       digiCfg.outputMeasurementParticlesMap;
   trackStatesWriter.inputMeasurementSimHitsMap =


### PR DESCRIPTION
This PR makes the ITk module splitting entry in the json config file of the TGeo Example optional. 
