### PR TITLE
fix: Remove rMinMiddleSP and rMaxMiddleSP in the SeedFinder config

### DIFF
--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -55,8 +55,6 @@ struct SeedfinderConfig {
   std::vector<std::vector<float>> rRangeMiddleSP;
   bool useVariableMiddleSPRange = false;
   float deltaRMiddleSPRange = 10.;
-  float rMinMiddleSP;
-  float rMaxMiddleSP;
 
   // seed confirmation
   bool seedConfirmation = false;


### PR DESCRIPTION
`rMinMiddleSP` and `rMaxMiddleSP` do not need to be configured in the SeedFinder config, so this PR removes them