### PR TITLE
fix: Fixing units in SeedFinderConfig

### DIFF
--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -54,7 +54,7 @@ struct SeedfinderConfig {
   // radial range for middle SP
   std::vector<std::vector<float>> rRangeMiddleSP;
   bool useVariableMiddleSPRange = false;
-  float deltaRMiddleSPRange = 10.;
+  float deltaRMiddleSPRange = 10. * Acts::UnitConstants::mm;
   float rMinMiddleSP;
   float rMaxMiddleSP;
 
@@ -148,6 +148,11 @@ struct SeedfinderConfig {
     config.minPt /= 1_MeV;
     config.deltaRMin /= 1_mm;
     config.deltaRMax /= 1_mm;
+    config.deltaRMinTopSP /= 1_mm;
+    config.deltaRMaxTopSP /= 1_mm;
+    config.deltaRMinBottomSP /= 1_mm;
+    config.deltaRMaxBottomSP /= 1_mm;
+    config.deltaRMiddleSPRange /= 1_mm;
     config.impactMax /= 1_mm;
     config.maxPtScattering /= 1_MeV;  // correct?
     config.collisionRegionMin /= 1_mm;


### PR DESCRIPTION
This PR fixes the units of `deltaRMiddleSPRange` to external ACTS units and adds `deltaRMiddleSPRange`, `deltaRMinTopSP`, `deltaRMaxTopSP`, `deltaRMinBottomSP` and `deltaRMaxBottomSP` to the `toInternalUnits` method.