### PR TITLE
fix: Coulombs Unit

### DIFF
--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -140,7 +140,7 @@ constexpr double g = 1.0 / 1.782662e-24;
 constexpr double kg = 1.0 / 1.782662e-27;
 // Charge, native unit e (elementary charge)
 constexpr double e = 1.0;
-constexpr double C = 1.602176634e19;
+constexpr double C = 6.2415091e18;
 // Magnetic field, native unit GeV/(e*mm)
 constexpr double T = 0.000299792458;  // equivalent to c in appropriate SI units
 constexpr double Gauss = 1e-4 * T;

--- a/Tests/UnitTests/Core/Definitions/UnitsTests.cpp
+++ b/Tests/UnitTests/Core/Definitions/UnitsTests.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(DecayWidthTime) {
 }
 
 BOOST_AUTO_TEST_CASE(Charge) {
-  CHECK_CLOSE_REL(1_C, 1.602176634e19_e, eps);
+  CHECK_CLOSE_REL(1_C, 6.2415091e18_e, eps);
 }
 
 BOOST_AUTO_TEST_CASE(MagneticField) {


### PR DESCRIPTION
Since `e=1` the C unit should be `C = 1/1.602176634e-19 = 6.2415091e18` so that `e = 1.602176634e−19 C` is respected