### PR TITLE
feat: Implement blocked matrix multiplication

### DIFF
--- a/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
@@ -155,6 +155,48 @@ BOOST_AUTO_TEST_CASE(test_matrix_dimension_switch) {
   }
 }
 
+typedef std::tuple<
+    // Square matrix tests
+    std::pair<ActsMatrix<4, 4>, ActsMatrix<4, 4>>,
+    std::pair<ActsMatrix<8, 8>, ActsMatrix<8, 8>>,
+
+    // Square odd matrix tests
+    std::pair<ActsMatrix<3, 3>, ActsMatrix<3, 3>>,
+    std::pair<ActsMatrix<7, 7>, ActsMatrix<7, 7>>,
+
+    // Non-square matrix tests
+    std::pair<ActsMatrix<3, 4>, ActsMatrix<4, 3>>,
+    std::pair<ActsMatrix<3, 8>, ActsMatrix<8, 4>>,
+    std::pair<ActsMatrix<4, 3>, ActsMatrix<3, 8>>,
+    std::pair<ActsMatrix<7, 3>, ActsMatrix<3, 7>>,
+    std::pair<ActsMatrix<8, 3>, ActsMatrix<3, 7>>,
+    std::pair<ActsMatrix<8, 7>, ActsMatrix<7, 4>>,
+
+    // Very large matrix tests for sanity
+    std::pair<ActsMatrix<37, 81>, ActsMatrix<81, 59>>,
+    std::pair<ActsMatrix<38, 82>, ActsMatrix<82, 60>>,
+    std::pair<ActsMatrix<37, 82>, ActsMatrix<82, 59>>,
+    std::pair<ActsMatrix<38, 81>, ActsMatrix<81, 60>>>
+    MatrixProductTypes;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(BlockedMatrixMultiplication, Matrices,
+                              MatrixProductTypes) {
+  using A = typename Matrices::first_type;
+  using B = typename Matrices::second_type;
+  using C = ActsMatrix<A::RowsAtCompileTime, B::ColsAtCompileTime>;
+
+  for (std::size_t i = 0; i < 100; ++i) {
+    A a = A::Random();
+    B b = B::Random();
+
+    C ref = a * b;
+    C res = blockedMult(a, b);
+
+    BOOST_CHECK(ref.isApprox(res));
+    BOOST_CHECK(res.isApprox(ref));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace Test
 }  // namespace Acts


### PR DESCRIPTION
Eigen uses a built-in cost model to determine how it should perform certain matrix operations. In general, this works quite well, but there are some edge cases where Eigen can struggle to output efficient code. An especially apparent instance of this is when multiplying 8x8 matrices, which we do very commonly in operations such as stepping. In these cases, we observe that Eigen emits code for generalized matrix-matrix multiplication, rather than specialized code for small matrices. This adds significant overhead to the matrix multiplication, and it slows down some parts of our code a lot.

Our proposed solution is to implement a wrapper around Eigen's matrix multiplication code that breaks a multiplication down into smaller operations through a technique called blocking. A matrix of size 2ix2j can be split into four matrices of sizes ixj, which can then be multiplied and added to provide a correct multiplication of the parent matrices. In this way, we can encourage Eigen to emit code for its hand-optimized small-matrix operations, which should give speed-up in some cases.

The operation is also supported for odd-sized matrices.