### PR TITLE
fix: Fix issue with applying transformation to bevelled cylinders

### DIFF
--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -67,7 +67,7 @@ Acts::OrientedSurfaces Acts::CylinderVolumeBounds::orientedSurfaces(
   double bevelMaxZ = get(eBevelMaxZ);
   Transform3 transMinZ, transMaxZ;
   if (bevelMinZ != 0.) {
-    double sy = 1 - 1/std::cos(bevelMinZ);
+    double sy = 1 - 1 / std::cos(bevelMinZ);
     transMinZ = transform * vMinZ *
                 Eigen::AngleAxisd(-bevelMinZ, Eigen::Vector3d(1., 0., 0.)) *
                 Eigen::Scaling(1., 1. + sy, 1.);
@@ -75,7 +75,7 @@ Acts::OrientedSurfaces Acts::CylinderVolumeBounds::orientedSurfaces(
     transMinZ = transform * vMinZ;
   }
   if (bevelMaxZ != 0.) {
-    double sy = 1 - 1/std::cos(bevelMaxZ);
+    double sy = 1 - 1 / std::cos(bevelMaxZ);
     transMaxZ = transform * vMaxZ *
                 Eigen::AngleAxisd(bevelMaxZ, Eigen::Vector3d(1., 0., 0.)) *
                 Eigen::Scaling(1., 1. + sy, 1.);

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -67,9 +67,7 @@ Acts::OrientedSurfaces Acts::CylinderVolumeBounds::orientedSurfaces(
   double bevelMaxZ = get(eBevelMaxZ);
   Transform3 transMinZ, transMaxZ;
   if (bevelMinZ != 0.) {
-    double rmax = get(eMaxR);
-    double rmin = get(eMinR);
-    double sy = (rmax + rmin) * (1 - std::cos(bevelMinZ)) / std::cos(bevelMinZ);
+    double sy = 1 - 1/std::cos(bevelMinZ);
     transMinZ = transform * vMinZ *
                 Eigen::AngleAxisd(-bevelMinZ, Eigen::Vector3d(1., 0., 0.)) *
                 Eigen::Scaling(1., 1. + sy, 1.);
@@ -77,9 +75,7 @@ Acts::OrientedSurfaces Acts::CylinderVolumeBounds::orientedSurfaces(
     transMinZ = transform * vMinZ;
   }
   if (bevelMaxZ != 0.) {
-    double rmax = get(eMaxR);
-    double rmin = get(eMinR);
-    double sy = (rmax + rmin) * (1 - std::cos(bevelMaxZ)) / std::cos(bevelMaxZ);
+    double sy = 1 - 1/std::cos(bevelMaxZ);
     transMaxZ = transform * vMaxZ *
                 Eigen::AngleAxisd(bevelMaxZ, Eigen::Vector3d(1., 0., 0.)) *
                 Eigen::Scaling(1., 1. + sy, 1.);

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -167,7 +167,12 @@ std::vector<Acts::Vector3> Acts::CylinderBounds::createCircles(
   if ((bevelMinZ != 0. || bevelMaxZ != 0.) && vertices.size() % 2 == 0) {
     auto halfWay = vertices.end() - vertices.size() / 2;
     double mult{1};
-    auto func = [&mult](Vector3& v) { v(2) += v(1) * mult; };
+    auto func = [&mult, &ctrans](Vector3& v) 
+	{ 
+	  v = ctrans.inverse() * v;
+          v(2) += v(1) * mult; 
+	  v = ctrans * v;
+	};
     if (bevelMinZ != 0.) {
       mult = std::tan(-bevelMinZ);
       std::for_each(vertices.begin(), halfWay, func);

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -167,12 +167,11 @@ std::vector<Acts::Vector3> Acts::CylinderBounds::createCircles(
   if ((bevelMinZ != 0. || bevelMaxZ != 0.) && vertices.size() % 2 == 0) {
     auto halfWay = vertices.end() - vertices.size() / 2;
     double mult{1};
-    auto func = [&mult, &ctrans](Vector3& v) 
-	{ 
-	  v = ctrans.inverse() * v;
-          v(2) += v(1) * mult; 
-	  v = ctrans * v;
-	};
+    auto func = [&mult, &ctrans](Vector3& v) {
+      v = ctrans.inverse() * v;
+      v(2) += v(1) * mult;
+      v = ctrans * v;
+    };
     if (bevelMinZ != 0.) {
       mult = std::tan(-bevelMinZ);
       std::for_each(vertices.begin(), halfWay, func);

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -167,8 +167,9 @@ std::vector<Acts::Vector3> Acts::CylinderBounds::createCircles(
   if ((bevelMinZ != 0. || bevelMaxZ != 0.) && vertices.size() % 2 == 0) {
     auto halfWay = vertices.end() - vertices.size() / 2;
     double mult{1};
-    auto func = [&mult, &ctrans](Vector3& v) {
-      v = ctrans.inverse() * v;
+    auto invCtrans = ctrans.inverse();
+    auto func = [&mult, &ctrans, &invCtrans](Vector3& v) {
+      v = invCtrans * v;
       v(2) += v(1) * mult;
       v = ctrans * v;
     };


### PR DESCRIPTION
Applying transforms to the cylinder did not work as intended. These fixes should place the side disks at the right place as well as fixing the visualization of the cylinder length. 