### PR TITLE
feat: ITk seeding example

### DIFF
--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -21,16 +21,16 @@ struct SeedConfirmationRange {
   float rMaxSeedConf;
   size_t nTopForLargeR;
   size_t nTopForSmallR;
-	
-	SeedConfirmationRange(float zMinSC = std::numeric_limits<float>::min(),
-												float zMaxSC = std::numeric_limits<float>::max(),
-												float rMaxSC = std::numeric_limits<float>::max(),
-												size_t nTopLargeR = 0, size_t nTopSmallR = 0)
-	: zMinSeedConf(zMinSC),
-	zMaxSeedConf(zMaxSC),
-	rMaxSeedConf(rMaxSC),
-	nTopForLargeR(nTopLargeR),
-	nTopForSmallR(nTopSmallR) {}
+
+  SeedConfirmationRange(float zMinSC = std::numeric_limits<float>::min(),
+                        float zMaxSC = std::numeric_limits<float>::max(),
+                        float rMaxSC = std::numeric_limits<float>::max(),
+                        size_t nTopLargeR = 0, size_t nTopSmallR = 0)
+      : zMinSeedConf(zMinSC),
+        zMaxSeedConf(zMaxSC),
+        rMaxSeedConf(rMaxSC),
+        nTopForLargeR(nTopLargeR),
+        nTopForSmallR(nTopSmallR) {}
 };
 
 // forward declaration to avoid cyclic dependence

--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -19,9 +19,18 @@ struct SeedConfirmationRange {
   float zMinSeedConf;
   float zMaxSeedConf;
   float rMaxSeedConf;
-  size_t nTopSeedConf;
   size_t nTopForLargeR;
   size_t nTopForSmallR;
+	
+	SeedConfirmationRange(float zMinSC = std::numeric_limits<float>::min(),
+												float zMaxSC = std::numeric_limits<float>::max(),
+												float rMaxSC = std::numeric_limits<float>::max(),
+												size_t nTopLargeR = 0, size_t nTopSmallR = 0)
+	: zMinSeedConf(zMinSC),
+	zMaxSeedConf(zMaxSC),
+	rMaxSeedConf(rMaxSC),
+	nTopForLargeR(nTopLargeR),
+	nTopForSmallR(nTopSmallR) {}
 };
 
 // forward declaration to avoid cyclic dependence

--- a/Examples/Run/Reconstruction/CMakeLists.txt
+++ b/Examples/Run/Reconstruction/CMakeLists.txt
@@ -119,6 +119,17 @@ target_link_libraries(
       ActsExamplesRecTracksCommon)
 # =================================================
 
+# Seeding for ITk detector
+add_executable(
+  ActsExampleSeedingITk
+  ITkSeedingExample.cpp)
+target_link_libraries(
+  ActsExampleSeedingITk
+  PRIVATE
+    ActsExamplesRecTracksCommon
+    ActsExamplesDetectorGeneric
+)
+
 install(
   TARGETS
     ActsExampleTruthTracksGeneric
@@ -129,6 +140,7 @@ install(
     ActsExampleCKFTracksTelescope
     ActsExampleSeedingGeneric
     ActsExampleSeedingTGeo
+    ActsExampleSeedingITk
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_subdirectory_if(DD4hep ACTS_BUILD_EXAMPLES_DD4HEP)

--- a/Examples/Run/Reconstruction/Common/CMakeLists.txt
+++ b/Examples/Run/Reconstruction/Common/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   ActsExamplesRecTracksCommon SHARED
   RecTruthTracks.cpp
+  RecInput.cpp
   RecCKFTracks.cpp
   SeedingExample.cpp
   MeasurementsToSpacepoints.cpp

--- a/Examples/Run/Reconstruction/Common/RecInput.cpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.cpp
@@ -32,56 +32,56 @@
 #include "RecInput.hpp"
 
 ActsExamples::CsvSimHitReader::Config setupSimHitReading(
-																												 const ActsExamples::Options::Variables& vars,
-																												 ActsExamples::Sequencer& sequencer) {
-	using namespace ActsExamples;
-	
-	// Read some standard options
-	auto logLevel = Options::readLogLevel(vars);
-	
-	// Read truth hits from CSV files
-	auto simHitReaderCfg = Options::readCsvSimHitReaderConfig(vars);
-	simHitReaderCfg.inputStem = "hits";
-	simHitReaderCfg.outputSimHits = "hits";
-	sequencer.addReader(
-											std::make_shared<CsvSimHitReader>(simHitReaderCfg, logLevel));
-	
-	return simHitReaderCfg;
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read truth hits from CSV files
+  auto simHitReaderCfg = Options::readCsvSimHitReaderConfig(vars);
+  simHitReaderCfg.inputStem = "hits";
+  simHitReaderCfg.outputSimHits = "hits";
+  sequencer.addReader(
+      std::make_shared<CsvSimHitReader>(simHitReaderCfg, logLevel));
+
+  return simHitReaderCfg;
 }
 
 ActsExamples::CsvParticleReader::Config setupParticleReading(
-																														 const ActsExamples::Options::Variables& vars,
-																														 ActsExamples::Sequencer& sequencer) {
-	using namespace ActsExamples;
-	
-	// Read some standard options
-	auto logLevel = Options::readLogLevel(vars);
-	
-	// Read particles (initial states) and clusters from CSV files
-	auto particleReader = Options::readCsvParticleReaderConfig(vars);
-	particleReader.inputStem = "particles_initial";
-	particleReader.outputParticles = "particles_initial";
-	sequencer.addReader(
-											std::make_shared<CsvParticleReader>(particleReader, logLevel));
-	
-	return particleReader;
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read particles (initial states) and clusters from CSV files
+  auto particleReader = Options::readCsvParticleReaderConfig(vars);
+  particleReader.inputStem = "particles_initial";
+  particleReader.outputParticles = "particles_initial";
+  sequencer.addReader(
+      std::make_shared<CsvParticleReader>(particleReader, logLevel));
+
+  return particleReader;
 }
 
 ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
-																																 const ActsExamples::Options::Variables& vars,
-																																 ActsExamples::Sequencer& sequencer,
-																																 const std::string& inputCollectionName) {
-	using namespace ActsExamples;
-	
-	// Read some standard options
-	auto logLevel = Options::readLogLevel(vars);
-	
-	// Read truth hits from CSV files
-	auto spacePointReaderCfg = Options::readCsvSpacePointReaderConfig(vars);
-	spacePointReaderCfg.inputStem = "spacepoints";
-	spacePointReaderCfg.inputCollection = inputCollectionName;
-	sequencer.addReader(
-											std::make_shared<CsvSpacePointReader>(spacePointReaderCfg, logLevel));
-	
-	return spacePointReaderCfg;
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    const std::string& inputCollectionName) {
+  using namespace ActsExamples;
+
+  // Read some standard options
+  auto logLevel = Options::readLogLevel(vars);
+
+  // Read truth hits from CSV files
+  auto spacePointReaderCfg = Options::readCsvSpacePointReaderConfig(vars);
+  spacePointReaderCfg.inputStem = "spacepoints";
+  spacePointReaderCfg.inputCollection = inputCollectionName;
+  sequencer.addReader(
+      std::make_shared<CsvSpacePointReader>(spacePointReaderCfg, logLevel));
+
+  return spacePointReaderCfg;
 }

--- a/Examples/Run/Reconstruction/Common/RecInput.cpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.cpp
@@ -1,0 +1,87 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Detector/IBaseDetector.hpp"
+#ifdef ACTS_PLUGIN_ONNX
+#include "Acts/Plugins/Onnx/MLTrackClassifier.hpp"
+#endif
+#include "ActsExamples/Digitization/DigitizationOptions.hpp"
+#include "ActsExamples/Geometry/CommonGeometry.hpp"
+#include "ActsExamples/Io/Json/JsonDigitizationConfig.hpp"
+#include "ActsExamples/Io/Performance/CKFPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp"
+#include "ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
+#include "ActsExamples/TrackFinding/SeedingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/SpacePointMaker.hpp"
+#include "ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/TrackFindingOptions.hpp"
+#include "ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp"
+#include "ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp"
+#include "ActsExamples/TrackFitting/TrackFittingOptions.hpp"
+#include "ActsExamples/TruthTracking/TruthTrackFinder.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include "RecInput.hpp"
+
+ActsExamples::CsvSimHitReader::Config setupSimHitReading(
+																												 const ActsExamples::Options::Variables& vars,
+																												 ActsExamples::Sequencer& sequencer) {
+	using namespace ActsExamples;
+	
+	// Read some standard options
+	auto logLevel = Options::readLogLevel(vars);
+	
+	// Read truth hits from CSV files
+	auto simHitReaderCfg = Options::readCsvSimHitReaderConfig(vars);
+	simHitReaderCfg.inputStem = "hits";
+	simHitReaderCfg.outputSimHits = "hits";
+	sequencer.addReader(
+											std::make_shared<CsvSimHitReader>(simHitReaderCfg, logLevel));
+	
+	return simHitReaderCfg;
+}
+
+ActsExamples::CsvParticleReader::Config setupParticleReading(
+																														 const ActsExamples::Options::Variables& vars,
+																														 ActsExamples::Sequencer& sequencer) {
+	using namespace ActsExamples;
+	
+	// Read some standard options
+	auto logLevel = Options::readLogLevel(vars);
+	
+	// Read particles (initial states) and clusters from CSV files
+	auto particleReader = Options::readCsvParticleReaderConfig(vars);
+	particleReader.inputStem = "particles_initial";
+	particleReader.outputParticles = "particles_initial";
+	sequencer.addReader(
+											std::make_shared<CsvParticleReader>(particleReader, logLevel));
+	
+	return particleReader;
+}
+
+ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
+																																 const ActsExamples::Options::Variables& vars,
+																																 ActsExamples::Sequencer& sequencer,
+																																 const std::string& inputCollectionName) {
+	using namespace ActsExamples;
+	
+	// Read some standard options
+	auto logLevel = Options::readLogLevel(vars);
+	
+	// Read truth hits from CSV files
+	auto spacePointReaderCfg = Options::readCsvSpacePointReaderConfig(vars);
+	spacePointReaderCfg.inputStem = "spacepoints";
+	spacePointReaderCfg.inputCollection = inputCollectionName;
+	sequencer.addReader(
+											std::make_shared<CsvSpacePointReader>(spacePointReaderCfg, logLevel));
+	
+	return spacePointReaderCfg;
+}

--- a/Examples/Run/Reconstruction/Common/RecInput.hpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.hpp
@@ -1,0 +1,54 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsExamples/Framework/Sequencer.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/Geometry/CommonGeometry.hpp"
+#include "ActsExamples/Io/Csv/CsvOptionsReader.hpp"
+#include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+
+#include <memory>
+#include <string>
+
+#include <boost/filesystem.hpp>
+
+/// Setup sim hit csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for sim hits csv reader
+ActsExamples::CsvSimHitReader::Config setupSimHitReading(
+																												 const ActsExamples::Options::Variables& vars,
+																												 ActsExamples::Sequencer& sequencer);
+
+/// Setup sim particle csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for sim particles csv reader
+ActsExamples::CsvParticleReader::Config setupParticleReading(
+																														 const ActsExamples::Options::Variables& vars,
+																														 ActsExamples::Sequencer& sequencer);
+
+/// Setup space point csv reader
+///
+/// @param vars The configuration variables
+/// @param sequencer The framework sequencer
+///
+/// @return config for space points csv reader
+ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
+																																 const ActsExamples::Options::Variables& vars,
+																																 ActsExamples::Sequencer& sequencer,
+																																 const std::string& inputCollectionName = "");

--- a/Examples/Run/Reconstruction/Common/RecInput.hpp
+++ b/Examples/Run/Reconstruction/Common/RecInput.hpp
@@ -29,8 +29,8 @@
 ///
 /// @return config for sim hits csv reader
 ActsExamples::CsvSimHitReader::Config setupSimHitReading(
-																												 const ActsExamples::Options::Variables& vars,
-																												 ActsExamples::Sequencer& sequencer);
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer);
 
 /// Setup sim particle csv reader
 ///
@@ -39,8 +39,8 @@ ActsExamples::CsvSimHitReader::Config setupSimHitReading(
 ///
 /// @return config for sim particles csv reader
 ActsExamples::CsvParticleReader::Config setupParticleReading(
-																														 const ActsExamples::Options::Variables& vars,
-																														 ActsExamples::Sequencer& sequencer);
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer);
 
 /// Setup space point csv reader
 ///
@@ -49,6 +49,6 @@ ActsExamples::CsvParticleReader::Config setupParticleReading(
 ///
 /// @return config for space points csv reader
 ActsExamples::CsvSpacePointReader::Config setupSpacePointReading(
-																																 const ActsExamples::Options::Variables& vars,
-																																 ActsExamples::Sequencer& sequencer,
-																																 const std::string& inputCollectionName = "");
+    const ActsExamples::Options::Variables& vars,
+    ActsExamples::Sequencer& sequencer,
+    const std::string& inputCollectionName = "");

--- a/Examples/Run/Reconstruction/ITkSeedingExample.cpp
+++ b/Examples/Run/Reconstruction/ITkSeedingExample.cpp
@@ -1,0 +1,198 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2021 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "ActsExamples/Detector/IBaseDetector.hpp"
+#include "ActsExamples/Framework/Sequencer.hpp"
+#include "ActsExamples/Geometry/CommonGeometry.hpp"
+#include "ActsExamples/Io/Csv/CsvOptionsReader.hpp"
+#include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp"
+#include "ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp"
+#include "ActsExamples/Io/Root/RootTrackParameterWriter.hpp"
+#include "ActsExamples/MagneticField/MagneticFieldOptions.hpp"
+#include "ActsExamples/Options/CommonOptions.hpp"
+#include "ActsExamples/TrackFinding/SeedingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/SpacePointMaker.hpp"
+#include "ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp"
+#include "ActsExamples/TruthTracking/TruthSeedSelector.hpp"
+#include "ActsExamples/Utilities/Options.hpp"
+#include "ActsExamples/Utilities/Paths.hpp"
+
+#include <memory>
+
+#include <boost/program_options.hpp>
+
+#include "RecInput.hpp"
+
+#include "Acts/Seeding/SeedFilter.hpp"
+
+using namespace Acts::UnitLiterals;
+using namespace ActsExamples;
+
+int main(int argc, char* argv[]) {
+  
+  // Setup and parse options
+  auto desc = Options::makeDefaultOptions();
+  Options::addSequencerOptions(desc);
+  Options::addOutputOptions(desc, OutputFormat::DirectoryOnly);
+  Options::addInputOptions(desc);
+  Options::addMagneticFieldOptions(desc);
+  
+  // Add specific options for this geometry
+  auto vm = Options::parse(desc, argc, argv);
+  if (vm.empty()) {
+    return EXIT_FAILURE;
+  }
+  
+  for (const auto& it : vm) {
+    std::cout << it.first.c_str() << " ";
+    auto& value = it.second.value();
+    if (auto v = boost::any_cast<std::string>(&value))
+      std::cout << *v;
+    else if (auto a = boost::any_cast<float>(&value))
+      std::cout << *a;
+    else if (auto b = boost::any_cast<double>(&value))
+      std::cout << *b;
+    else if (auto c = boost::any_cast<int>(&value))
+      std::cout << *c;
+    else if (auto d = boost::any_cast<bool>(&value))
+      std::cout << *d;
+    else if (auto e = boost::any_cast<size_t>(&value))
+      std::cout << *e;
+    else 
+      std::cout << "wrong cast...";
+    std::cout << std::endl;
+  }
+  
+  Sequencer sequencer(Options::readSequencerConfig(vm));  
+  
+  // Now read the standard options
+  auto logLevel = Options::readLogLevel(vm);
+  auto outputDir = ensureWritableDirectory(vm["output-dir"].as<std::string>());
+ 
+  // Setup the magnetic field
+  Options::setupMagneticFieldServices(vm, sequencer);
+  auto magneticField = Options::readMagneticField(vm);
+
+	// ====== Pixel SP =======
+
+	// TODO: add strip space points
+	// Read the space points and build the container
+	auto spReaderCfg = setupSpacePointReading(vm, sequencer, "pixel");
+	spReaderCfg.outputSpacePoints = "PixelSpacePoints";
+	
+	// Seeding addAlgorithm
+  SeedingAlgorithm::Config seedingCfg;
+  seedingCfg.inputSpacePoints = {"PixelSpacePoints"};
+  seedingCfg.outputSeeds = "PixelSeeds";
+  seedingCfg.outputProtoTracks = "prototracks";
+
+	seedingCfg.gridConfig.rMax = 320._mm; // pixel: 320 mm, strip: 1000 mm
+  seedingCfg.seedFinderConfig.rMax = seedingCfg.gridConfig.rMax;
+
+  seedingCfg.seedFilterConfig.deltaRMin = 20._mm; // pixel: 20 mm
+  seedingCfg.seedFinderConfig.deltaRMin = seedingCfg.seedFilterConfig.deltaRMin;
+	
+	seedingCfg.seedFinderConfig.deltaRMinTopSP = 6._mm; // pixel: 6 mm, strip: 20 mm
+	seedingCfg.seedFinderConfig.deltaRMinBottomSP = 6._mm; // pixel: 6 mm, strip: 20 mm
+
+	seedingCfg.gridConfig.deltaRMax = 280._mm; // pixel: 280 mm, strip: 600 mm
+  seedingCfg.seedFinderConfig.deltaRMax = seedingCfg.gridConfig.deltaRMax;
+	
+	seedingCfg.seedFinderConfig.deltaRMaxTopSP = 280._mm; // pixel: 280 mm, strip: 3000 mm
+	seedingCfg.seedFinderConfig.deltaRMaxBottomSP = 120._mm; // pixel: 120 mm, strip: 3000 mm
+
+  seedingCfg.seedFinderConfig.collisionRegionMin = -200._mm; // pixel: 200 mm, strip: 200 mm
+  seedingCfg.seedFinderConfig.collisionRegionMax = 200._mm; // pixel: 200 mm, strip: 200 mm
+
+  seedingCfg.gridConfig.zMin = -3000._mm;
+  seedingCfg.gridConfig.zMax = 3000._mm;
+  seedingCfg.seedFinderConfig.zMin = seedingCfg.gridConfig.zMin;
+  seedingCfg.seedFinderConfig.zMax = seedingCfg.gridConfig.zMax;
+
+  seedingCfg.seedFilterConfig.maxSeedsPerSpM = 4;
+  seedingCfg.seedFinderConfig.maxSeedsPerSpM =
+      seedingCfg.seedFilterConfig.maxSeedsPerSpM;
+	
+	seedingCfg.gridConfig.cotThetaMax = 27.2899; // pixel: 27.2899 , strip: 900
+  seedingCfg.seedFinderConfig.cotThetaMax = seedingCfg.gridConfig.cotThetaMax;
+
+	// number of standard deviations of Coulomb scattering angle that should be considered
+	seedingCfg.seedFinderConfig.sigmaScattering = 2;
+	// radiation length in Highland equation
+	seedingCfg.seedFinderConfig.radLengthPerSeed = 0.09804522341059585;
+	
+  seedingCfg.gridConfig.minPt = 900._MeV;
+  seedingCfg.seedFinderConfig.minPt = seedingCfg.gridConfig.minPt;
+
+	seedingCfg.gridConfig.bFieldInZ = 1.997244311_T;
+  seedingCfg.seedFinderConfig.bFieldInZ = seedingCfg.gridConfig.bFieldInZ;
+
+  seedingCfg.seedFinderConfig.beamPos = {0_mm, 0_mm};
+
+  seedingCfg.gridConfig.impactMax = 2._mm; // pixel: 2 mm, strip: 20 mm
+  seedingCfg.seedFinderConfig.impactMax = seedingCfg.gridConfig.impactMax;
+	
+	seedingCfg.seedFinderConfig.maxPtScattering = 1000000._GeV;
+  
+	// enable non equidistant binning in z, in case the binning is not defined the edges are evaluated automatically using equidistant binning
+  seedingCfg.gridConfig.zBinEdges = {-3000., -2500., -1400., -925., -450., -250., 
+                                            250., 450., 925., 1400., 2500., 3000.};
+  seedingCfg.seedFinderConfig.zBinEdges = seedingCfg.gridConfig.zBinEdges;
+	// enable cotTheta sorting in SeedFinder
+	seedingCfg.seedFinderConfig.enableCutsForSortedSP = true; // pixel: true
+	
+  // Guide for building neighbors:
+	// z == 6: central z region, |z|<250mm
+  // [-3000, -2500., -1400., -925., -450., -250.,  250.,  450.,  925.,  1400.,  2500.,  3000]
+  //       1       2       3      4      5      6      7      8      9       10      11        z bin index
+  // --------------------------------------------------------------------------------------------> Z[mm]
+  // Z=-3000                                  IP,Z=0                                  Z=+3000
+  //
+	// allows to specify the number of neighbors desired for each bin
+	// {-1,1} means one neighbor on the left and one on the right
+  // vector containing the map of z bins for the top SP, if the vector is empty the algorithm returns the 8 surrounding bins
+	// for ITk pixel and strip: zBinNeighborsTop = {{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,1},{0,1},{0,1},{0,1},{0,1},{0,0}};
+	seedingCfg.zBinNeighborsTop = {{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,1},{0,1},{0,1},{0,1},{0,1},{0,0}};
+  // vector containing the map of z bins for the bottom SP
+  // for ITk pixel: zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,1},{0,1},{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}};
+	// for ITk strip: zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,2},{0,1},{0,0},{-1,0},{-2,0},{-1,0},{-1,0},{-1,0}};
+	seedingCfg.zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,1},{0,1},{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}};
+	// numPhiNeighbors for the Grid means "how many phiBin neighbors (plus the current bin) should cover the full deflection of a minimum pT particle"
+	// numPhiNeighbors for the BinFinder sets how many neighboring phi bins at each side of the current bin are returned
+	seedingCfg.gridConfig.numPhiNeighbors = 1;
+	
+  // radial range for middle SP cut:
+	// if useVariableMiddleSPRange is set to false, the vector rRangeMiddleSP can be used to define a fixed r range for each z bin: {{rMin, rMax}, ...}
+	// if useVariableMiddleSPRange is set to false and the vector is empty, the cuts won't be applied
+	// if useVariableMiddleSPRange is true, the values in rRangeMiddleSP will be filled automatically based on r values of the SPs
+  seedingCfg.seedFinderConfig.rRangeMiddleSP = {{40., 90.},{40., 200.},{46., 200.},{46., 200.},{46., 250.},{46., 250.},{46., 250.},{46., 200.},{46., 200.},{40., 200.},{40., 90.}};
+	seedingCfg.seedFinderConfig.useVariableMiddleSPRange = true;
+	seedingCfg.seedFinderConfig.deltaRMiddleSPRange = 10.; // pixel: 10 mm
+
+	// enable ITk seed confirmation cuts
+	seedingCfg.seedFinderConfig.seedConfirmation = true;
+	// contains parameters for central seed confirmation (zMinSeedConf, zMaxSeedConf, rMaxSeedConf, nTopForLargeR, nTopForSmallR)
+	seedingCfg.seedFinderConfig.centralSeedConfirmationRange = Acts::SeedConfirmationRange(250., -250., 140., 1, 2);
+	// contains parameters for forward seed confirmation
+	seedingCfg.seedFinderConfig.forwardSeedConfirmationRange = Acts::SeedConfirmationRange(3000., -3000., 140., 1, 2);
+	
+	// parameters for the calculation of the weght of the seeds in the seed filter
+	seedingCfg.seedFilterConfig.impactWeightFactor = 100.;
+	seedingCfg.seedFilterConfig.compatSeedWeight = 100.;
+	// maximum number of seeds allowed after the filter
+	seedingCfg.seedFilterConfig.compatSeedLimit = 3;
+	
+	sequencer.addAlgorithm(std::make_shared<SeedingAlgorithm>(seedingCfg, logLevel));
+  
+	return sequencer.run();
+}

--- a/Examples/Run/Reconstruction/ITkSeedingExample.cpp
+++ b/Examples/Run/Reconstruction/ITkSeedingExample.cpp
@@ -151,6 +151,8 @@ int main(int argc, char* argv[]) {
 
   // enable non equidistant binning in z, in case the binning is not defined the
   // edges are evaluated automatically using equidistant binning
+  // ITk binning:
+  // [-3000,-2500.,-1400.,-925.,-450.,-250.,250.,450.,925.,1400.,2500.,3000]
   seedingCfg.gridConfig.zBinEdges = {-3000., -2500., -1400., -925.,
                                      -450.,  -250.,  250.,   450.,
                                      925.,   1400.,  2500.,  3000.};
@@ -158,15 +160,7 @@ int main(int argc, char* argv[]) {
   // enable cotTheta sorting in SeedFinder
   seedingCfg.seedFinderConfig.enableCutsForSortedSP = true;  // pixel: true
 
-  // Guide for building neighbors:
-  // z == 6: central z region, |z|<250mm
-  // [-3000, -2500., -1400., -925., -450., -250.,  250.,  450.,  925.,  1400.,
-  // 2500.,  3000]
-  //       1       2       3      4      5      6      7      8      9       10
-  //       11        z bin index
-  // -------------------------------------------------------------------------------------------->
-  // Z[mm] Z=-3000                                  IP,Z=0 Z=+3000
-  //
+  // Guide for building ITk neighbors:
   // allows to specify the number of neighbors desired for each bin
   // {-1,1} means one neighbor on the left and one on the right
   // vector containing the map of z bins for the top SP, if the vector is empty

--- a/Examples/Run/Reconstruction/ITkSeedingExample.cpp
+++ b/Examples/Run/Reconstruction/ITkSeedingExample.cpp
@@ -8,13 +8,14 @@
 
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/Seeding/SeedFilter.hpp"
 #include "ActsExamples/Detector/IBaseDetector.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Geometry/CommonGeometry.hpp"
 #include "ActsExamples/Io/Csv/CsvOptionsReader.hpp"
 #include "ActsExamples/Io/Csv/CsvParticleReader.hpp"
-#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
 #include "ActsExamples/Io/Csv/CsvSimHitReader.hpp"
+#include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
 #include "ActsExamples/Io/Performance/SeedingPerformanceWriter.hpp"
 #include "ActsExamples/Io/Performance/TrackFinderPerformanceWriter.hpp"
 #include "ActsExamples/Io/Root/RootTrackParameterWriter.hpp"
@@ -33,26 +34,23 @@
 
 #include "RecInput.hpp"
 
-#include "Acts/Seeding/SeedFilter.hpp"
-
 using namespace Acts::UnitLiterals;
 using namespace ActsExamples;
 
 int main(int argc, char* argv[]) {
-  
   // Setup and parse options
   auto desc = Options::makeDefaultOptions();
   Options::addSequencerOptions(desc);
   Options::addOutputOptions(desc, OutputFormat::DirectoryOnly);
   Options::addInputOptions(desc);
   Options::addMagneticFieldOptions(desc);
-  
+
   // Add specific options for this geometry
   auto vm = Options::parse(desc, argc, argv);
   if (vm.empty()) {
     return EXIT_FAILURE;
   }
-  
+
   for (const auto& it : vm) {
     std::cout << it.first.c_str() << " ";
     auto& value = it.second.value();
@@ -68,51 +66,57 @@ int main(int argc, char* argv[]) {
       std::cout << *d;
     else if (auto e = boost::any_cast<size_t>(&value))
       std::cout << *e;
-    else 
+    else
       std::cout << "wrong cast...";
     std::cout << std::endl;
   }
-  
-  Sequencer sequencer(Options::readSequencerConfig(vm));  
-  
+
+  Sequencer sequencer(Options::readSequencerConfig(vm));
+
   // Now read the standard options
   auto logLevel = Options::readLogLevel(vm);
   auto outputDir = ensureWritableDirectory(vm["output-dir"].as<std::string>());
- 
+
   // Setup the magnetic field
   Options::setupMagneticFieldServices(vm, sequencer);
   auto magneticField = Options::readMagneticField(vm);
 
-	// ====== Pixel SP =======
+  // ====== Pixel SP =======
 
-	// TODO: add strip space points
-	// Read the space points and build the container
-	auto spReaderCfg = setupSpacePointReading(vm, sequencer, "pixel");
-	spReaderCfg.outputSpacePoints = "PixelSpacePoints";
-	
-	// Seeding addAlgorithm
+  // TODO: add strip space points
+  // Read the space points and build the container
+  auto spReaderCfg = setupSpacePointReading(vm, sequencer, "pixel");
+  spReaderCfg.outputSpacePoints = "PixelSpacePoints";
+
+  // Seeding addAlgorithm
   SeedingAlgorithm::Config seedingCfg;
   seedingCfg.inputSpacePoints = {"PixelSpacePoints"};
   seedingCfg.outputSeeds = "PixelSeeds";
   seedingCfg.outputProtoTracks = "prototracks";
 
-	seedingCfg.gridConfig.rMax = 320._mm; // pixel: 320 mm, strip: 1000 mm
+  seedingCfg.gridConfig.rMax = 320._mm;  // pixel: 320 mm, strip: 1000 mm
   seedingCfg.seedFinderConfig.rMax = seedingCfg.gridConfig.rMax;
 
-  seedingCfg.seedFilterConfig.deltaRMin = 20._mm; // pixel: 20 mm
+  seedingCfg.seedFilterConfig.deltaRMin = 20._mm;  // pixel: 20 mm
   seedingCfg.seedFinderConfig.deltaRMin = seedingCfg.seedFilterConfig.deltaRMin;
-	
-	seedingCfg.seedFinderConfig.deltaRMinTopSP = 6._mm; // pixel: 6 mm, strip: 20 mm
-	seedingCfg.seedFinderConfig.deltaRMinBottomSP = 6._mm; // pixel: 6 mm, strip: 20 mm
 
-	seedingCfg.gridConfig.deltaRMax = 280._mm; // pixel: 280 mm, strip: 600 mm
+  seedingCfg.seedFinderConfig.deltaRMinTopSP =
+      6._mm;  // pixel: 6 mm, strip: 20 mm
+  seedingCfg.seedFinderConfig.deltaRMinBottomSP =
+      6._mm;  // pixel: 6 mm, strip: 20 mm
+
+  seedingCfg.gridConfig.deltaRMax = 280._mm;  // pixel: 280 mm, strip: 600 mm
   seedingCfg.seedFinderConfig.deltaRMax = seedingCfg.gridConfig.deltaRMax;
-	
-	seedingCfg.seedFinderConfig.deltaRMaxTopSP = 280._mm; // pixel: 280 mm, strip: 3000 mm
-	seedingCfg.seedFinderConfig.deltaRMaxBottomSP = 120._mm; // pixel: 120 mm, strip: 3000 mm
 
-  seedingCfg.seedFinderConfig.collisionRegionMin = -200._mm; // pixel: 200 mm, strip: 200 mm
-  seedingCfg.seedFinderConfig.collisionRegionMax = 200._mm; // pixel: 200 mm, strip: 200 mm
+  seedingCfg.seedFinderConfig.deltaRMaxTopSP =
+      280._mm;  // pixel: 280 mm, strip: 3000 mm
+  seedingCfg.seedFinderConfig.deltaRMaxBottomSP =
+      120._mm;  // pixel: 120 mm, strip: 3000 mm
+
+  seedingCfg.seedFinderConfig.collisionRegionMin =
+      -200._mm;  // pixel: 200 mm, strip: 200 mm
+  seedingCfg.seedFinderConfig.collisionRegionMax =
+      200._mm;  // pixel: 200 mm, strip: 200 mm
 
   seedingCfg.gridConfig.zMin = -3000._mm;
   seedingCfg.gridConfig.zMax = 3000._mm;
@@ -122,77 +126,101 @@ int main(int argc, char* argv[]) {
   seedingCfg.seedFilterConfig.maxSeedsPerSpM = 4;
   seedingCfg.seedFinderConfig.maxSeedsPerSpM =
       seedingCfg.seedFilterConfig.maxSeedsPerSpM;
-	
-	seedingCfg.gridConfig.cotThetaMax = 27.2899; // pixel: 27.2899 , strip: 900
+
+  seedingCfg.gridConfig.cotThetaMax = 27.2899;  // pixel: 27.2899 , strip: 900
   seedingCfg.seedFinderConfig.cotThetaMax = seedingCfg.gridConfig.cotThetaMax;
 
-	// number of standard deviations of Coulomb scattering angle that should be considered
-	seedingCfg.seedFinderConfig.sigmaScattering = 2;
-	// radiation length in Highland equation
-	seedingCfg.seedFinderConfig.radLengthPerSeed = 0.09804522341059585;
-	
+  // number of standard deviations of Coulomb scattering angle that should be
+  // considered
+  seedingCfg.seedFinderConfig.sigmaScattering = 2;
+  // radiation length in Highland equation
+  seedingCfg.seedFinderConfig.radLengthPerSeed = 0.09804522341059585;
+
   seedingCfg.gridConfig.minPt = 900._MeV;
   seedingCfg.seedFinderConfig.minPt = seedingCfg.gridConfig.minPt;
 
-	seedingCfg.gridConfig.bFieldInZ = 1.997244311_T;
+  seedingCfg.gridConfig.bFieldInZ = 1.997244311_T;
   seedingCfg.seedFinderConfig.bFieldInZ = seedingCfg.gridConfig.bFieldInZ;
 
   seedingCfg.seedFinderConfig.beamPos = {0_mm, 0_mm};
 
-  seedingCfg.gridConfig.impactMax = 2._mm; // pixel: 2 mm, strip: 20 mm
+  seedingCfg.gridConfig.impactMax = 2._mm;  // pixel: 2 mm, strip: 20 mm
   seedingCfg.seedFinderConfig.impactMax = seedingCfg.gridConfig.impactMax;
-	
-	seedingCfg.seedFinderConfig.maxPtScattering = 1000000._GeV;
-  
-	// enable non equidistant binning in z, in case the binning is not defined the edges are evaluated automatically using equidistant binning
-  seedingCfg.gridConfig.zBinEdges = {-3000., -2500., -1400., -925., -450., -250., 
-                                            250., 450., 925., 1400., 2500., 3000.};
-  seedingCfg.seedFinderConfig.zBinEdges = seedingCfg.gridConfig.zBinEdges;
-	// enable cotTheta sorting in SeedFinder
-	seedingCfg.seedFinderConfig.enableCutsForSortedSP = true; // pixel: true
-	
-  // Guide for building neighbors:
-	// z == 6: central z region, |z|<250mm
-  // [-3000, -2500., -1400., -925., -450., -250.,  250.,  450.,  925.,  1400.,  2500.,  3000]
-  //       1       2       3      4      5      6      7      8      9       10      11        z bin index
-  // --------------------------------------------------------------------------------------------> Z[mm]
-  // Z=-3000                                  IP,Z=0                                  Z=+3000
-  //
-	// allows to specify the number of neighbors desired for each bin
-	// {-1,1} means one neighbor on the left and one on the right
-  // vector containing the map of z bins for the top SP, if the vector is empty the algorithm returns the 8 surrounding bins
-	// for ITk pixel and strip: zBinNeighborsTop = {{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,1},{0,1},{0,1},{0,1},{0,1},{0,0}};
-	seedingCfg.zBinNeighborsTop = {{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,1},{0,1},{0,1},{0,1},{0,1},{0,0}};
-  // vector containing the map of z bins for the bottom SP
-  // for ITk pixel: zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,1},{0,1},{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}};
-	// for ITk strip: zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,2},{0,1},{0,0},{-1,0},{-2,0},{-1,0},{-1,0},{-1,0}};
-	seedingCfg.zBinNeighborsBottom = {{0,1},{0,1},{0,1},{0,1},{0,1},{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}};
-	// numPhiNeighbors for the Grid means "how many phiBin neighbors (plus the current bin) should cover the full deflection of a minimum pT particle"
-	// numPhiNeighbors for the BinFinder sets how many neighboring phi bins at each side of the current bin are returned
-	seedingCfg.gridConfig.numPhiNeighbors = 1;
-	
-  // radial range for middle SP cut:
-	// if useVariableMiddleSPRange is set to false, the vector rRangeMiddleSP can be used to define a fixed r range for each z bin: {{rMin, rMax}, ...}
-	// if useVariableMiddleSPRange is set to false and the vector is empty, the cuts won't be applied
-	// if useVariableMiddleSPRange is true, the values in rRangeMiddleSP will be filled automatically based on r values of the SPs
-  seedingCfg.seedFinderConfig.rRangeMiddleSP = {{40., 90.},{40., 200.},{46., 200.},{46., 200.},{46., 250.},{46., 250.},{46., 250.},{46., 200.},{46., 200.},{40., 200.},{40., 90.}};
-	seedingCfg.seedFinderConfig.useVariableMiddleSPRange = true;
-	seedingCfg.seedFinderConfig.deltaRMiddleSPRange = 10.; // pixel: 10 mm
 
-	// enable ITk seed confirmation cuts
-	seedingCfg.seedFinderConfig.seedConfirmation = true;
-	// contains parameters for central seed confirmation (zMinSeedConf, zMaxSeedConf, rMaxSeedConf, nTopForLargeR, nTopForSmallR)
-	seedingCfg.seedFinderConfig.centralSeedConfirmationRange = Acts::SeedConfirmationRange(250., -250., 140., 1, 2);
-	// contains parameters for forward seed confirmation
-	seedingCfg.seedFinderConfig.forwardSeedConfirmationRange = Acts::SeedConfirmationRange(3000., -3000., 140., 1, 2);
-	
-	// parameters for the calculation of the weght of the seeds in the seed filter
-	seedingCfg.seedFilterConfig.impactWeightFactor = 100.;
-	seedingCfg.seedFilterConfig.compatSeedWeight = 100.;
-	// maximum number of seeds allowed after the filter
-	seedingCfg.seedFilterConfig.compatSeedLimit = 3;
-	
-	sequencer.addAlgorithm(std::make_shared<SeedingAlgorithm>(seedingCfg, logLevel));
-  
-	return sequencer.run();
+  seedingCfg.seedFinderConfig.maxPtScattering = 1000000._GeV;
+
+  // enable non equidistant binning in z, in case the binning is not defined the
+  // edges are evaluated automatically using equidistant binning
+  seedingCfg.gridConfig.zBinEdges = {-3000., -2500., -1400., -925.,
+                                     -450.,  -250.,  250.,   450.,
+                                     925.,   1400.,  2500.,  3000.};
+  seedingCfg.seedFinderConfig.zBinEdges = seedingCfg.gridConfig.zBinEdges;
+  // enable cotTheta sorting in SeedFinder
+  seedingCfg.seedFinderConfig.enableCutsForSortedSP = true;  // pixel: true
+
+  // Guide for building neighbors:
+  // z == 6: central z region, |z|<250mm
+  // [-3000, -2500., -1400., -925., -450., -250.,  250.,  450.,  925.,  1400.,
+  // 2500.,  3000]
+  //       1       2       3      4      5      6      7      8      9       10
+  //       11        z bin index
+  // -------------------------------------------------------------------------------------------->
+  // Z[mm] Z=-3000                                  IP,Z=0 Z=+3000
+  //
+  // allows to specify the number of neighbors desired for each bin
+  // {-1,1} means one neighbor on the left and one on the right
+  // vector containing the map of z bins for the top SP, if the vector is empty
+  // the algorithm returns the 8 surrounding bins for ITk pixel and strip:
+  // zBinNeighborsTop =
+  // {{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,1},{0,1},{0,1},{0,1},{0,1},{0,0}};
+  seedingCfg.zBinNeighborsTop = {{0, 0},  {-1, 0}, {-1, 0}, {-1, 0},
+                                 {-1, 0}, {-1, 1}, {0, 1},  {0, 1},
+                                 {0, 1},  {0, 1},  {0, 0}};
+  // vector containing the map of z bins for the bottom SP
+  // for ITk pixel: zBinNeighborsBottom =
+  // {{0,1},{0,1},{0,1},{0,1},{0,1},{0,0},{-1,0},{-1,0},{-1,0},{-1,0},{-1,0}};
+  // for ITk strip: zBinNeighborsBottom =
+  // {{0,1},{0,1},{0,1},{0,2},{0,1},{0,0},{-1,0},{-2,0},{-1,0},{-1,0},{-1,0}};
+  seedingCfg.zBinNeighborsBottom = {{0, 1},  {0, 1},  {0, 1},  {0, 1},
+                                    {0, 1},  {0, 0},  {-1, 0}, {-1, 0},
+                                    {-1, 0}, {-1, 0}, {-1, 0}};
+  // numPhiNeighbors for the Grid means "how many phiBin neighbors (plus the
+  // current bin) should cover the full deflection of a minimum pT particle"
+  // numPhiNeighbors for the BinFinder sets how many neighboring phi bins at
+  // each side of the current bin are returned
+  seedingCfg.gridConfig.numPhiNeighbors = 1;
+
+  // radial range for middle SP cut:
+  // if useVariableMiddleSPRange is set to false, the vector rRangeMiddleSP can
+  // be used to define a fixed r range for each z bin: {{rMin, rMax}, ...} if
+  // useVariableMiddleSPRange is set to false and the vector is empty, the cuts
+  // won't be applied if useVariableMiddleSPRange is true, the values in
+  // rRangeMiddleSP will be filled automatically based on r values of the SPs
+  seedingCfg.seedFinderConfig.rRangeMiddleSP = {
+      {40., 90.},  {40., 200.}, {46., 200.}, {46., 200.},
+      {46., 250.}, {46., 250.}, {46., 250.}, {46., 200.},
+      {46., 200.}, {40., 200.}, {40., 90.}};
+  seedingCfg.seedFinderConfig.useVariableMiddleSPRange = true;
+  seedingCfg.seedFinderConfig.deltaRMiddleSPRange = 10.;  // pixel: 10 mm
+
+  // enable ITk seed confirmation cuts
+  seedingCfg.seedFinderConfig.seedConfirmation = true;
+  // contains parameters for central seed confirmation (zMinSeedConf,
+  // zMaxSeedConf, rMaxSeedConf, nTopForLargeR, nTopForSmallR)
+  seedingCfg.seedFinderConfig.centralSeedConfirmationRange =
+      Acts::SeedConfirmationRange(250., -250., 140., 1, 2);
+  // contains parameters for forward seed confirmation
+  seedingCfg.seedFinderConfig.forwardSeedConfirmationRange =
+      Acts::SeedConfirmationRange(3000., -3000., 140., 1, 2);
+
+  // parameters for the calculation of the weght of the seeds in the seed filter
+  seedingCfg.seedFilterConfig.impactWeightFactor = 100.;
+  seedingCfg.seedFilterConfig.compatSeedWeight = 100.;
+  // maximum number of seeds allowed after the filter
+  seedingCfg.seedFilterConfig.compatSeedLimit = 3;
+
+  sequencer.addAlgorithm(
+      std::make_shared<SeedingAlgorithm>(seedingCfg, logLevel));
+
+  return sequencer.run();
 }


### PR DESCRIPTION
This PR adds the `ITkSeedingExample.cpp` to run the ITk seeding.
It shows how to configure the non-equidistant binning in z (#1005), the seed confirmation cuts (#1084), the radial range for middle SP cut (#1084) and the vector containing the map of z neighbours (#1052 and #1038).

It contains all the parameters to run the seeding for ITk **pixel** space points (I intend to extend this to ITk strip SPs soon).

@noemina @paulgessinger 