### PR TITLE
fix: Clang (13) warning in BoundingBox

### DIFF
--- a/Core/include/Acts/Utilities/BoundingBox.hpp
+++ b/Core/include/Acts/Utilities/BoundingBox.hpp
@@ -101,6 +101,12 @@ class AxisAlignedBoundingBox {
   AxisAlignedBoundingBox(const self_t& other) = default;
 
   /**
+   * Copy assignment operator from other bounding box.
+   * @param other The other AABB
+   */
+  AxisAlignedBoundingBox& operator=(const self_t& other) = default;
+
+  /**
    * Constructor from an entity pointer, and the min and max vertices.
    * @param entity The entity to store
    * @param vmin The minimum vertex.


### PR DESCRIPTION
I noticed a warning:

```
[715/1093] Building CXX object Tests/UnitTests/Core/Geo...pezoidVolumeBounds.dir/TrapezoidVolumeBoundsTests.cpp.o
In file included from ../Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp:13:
In file included from ../Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp:12:
In file included from ../Core/include/Acts/Geometry/Volume.hpp:15:
../Core/include/Acts/Utilities/BoundingBox.hpp:101:3: warning: definition of implicit copy assignment operator for 'AxisAlignedBoundingBox<Acts::Volume, double, 3>' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
  AxisAlignedBoundingBox(const self_t& other) = default;
  ^
../Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp:40:6: note: in implicit copy assignment operator for 'Acts::AxisAlignedBoundingBox<Acts::Volume, double, 3>' first required here
  bb = tvb.boundingBox(&trf);
     ^
1 warning generated.
```

in a build with clang-13. This PR should remove this warning by
defaulting the copy assignment operator.
