### PR TITLE
build: Allow python bindings to be used from install

### DIFF
--- a/Examples/Python/CMakeLists.txt
+++ b/Examples/Python/CMakeLists.txt
@@ -5,6 +5,8 @@ set(_python_dir "${CMAKE_BINARY_DIR}/python")
 file(MAKE_DIRECTORY ${_python_dir})
 file(MAKE_DIRECTORY ${_python_dir}/acts)
 
+set(_python_install_dir "python/acts")
+
 pybind11_add_module(ActsPythonBindings 
   src/ModuleEntry.cpp
   src/Base.cpp
@@ -22,9 +24,9 @@ pybind11_add_module(ActsPythonBindings
   src/TrackFinding.cpp
   src/Vertexing.cpp
 )
-install(TARGETS ActsPythonBindings DESTINATION .)
+install(TARGETS ActsPythonBindings DESTINATION ${_python_install_dir})
 
-set_target_properties(ActsPythonBindings PROPERTIES INSTALL_RPATH "\$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+set_target_properties(ActsPythonBindings PROPERTIES INSTALL_RPATH "\$ORIGIN/../../${CMAKE_INSTALL_LIBDIR}")
 set_target_properties(ActsPythonBindings PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${_python_dir}/acts)
 
 target_link_libraries(ActsPythonBindings PUBLIC 
@@ -70,8 +72,8 @@ if(ACTS_BUILD_PLUGIN_DD4HEP AND ACTS_BUILD_EXAMPLES_DD4HEP)
     ActsExamplesDetectorDD4hep)
   add_dependencies(ActsPythonBindings ActsPythonBindingsDD4hep)
 
-  install(TARGETS ActsPythonBindingsDD4hep DESTINATION .)
-  set_target_properties(ActsPythonBindingsDD4hep PROPERTIES INSTALL_RPATH "\$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+  install(TARGETS ActsPythonBindingsDD4hep DESTINATION ${_python_install_dir})
+  set_target_properties(ActsPythonBindingsDD4hep PROPERTIES INSTALL_RPATH "\$ORIGIN../../${CMAKE_INSTALL_LIBDIR}")
   set_target_properties(ActsPythonBindingsDD4hep PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${_python_dir}/acts)
   list(APPEND py_files examples/dd4hep.py)
 endif()
@@ -97,8 +99,8 @@ if(ACTS_BUILD_EXAMPLES_GEANT4)
     ActsPythonUtilities)
   add_dependencies(ActsPythonBindings ActsPythonBindingsGeant4)
 
-  install(TARGETS ActsPythonBindingsGeant4 DESTINATION .)
-  set_target_properties(ActsPythonBindingsGeant4 PROPERTIES INSTALL_RPATH "\$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+  install(TARGETS ActsPythonBindingsGeant4 DESTINATION ${_python_install_dir})
+  set_target_properties(ActsPythonBindingsGeant4 PROPERTIES INSTALL_RPATH "\$ORIGIN../../${CMAKE_INSTALL_LIBDIR}")
   set_target_properties(ActsPythonBindingsGeant4 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${_python_dir}/acts)
   list(APPEND py_files examples/geant4/__init__.py)
 
@@ -110,8 +112,8 @@ if(ACTS_BUILD_EXAMPLES_GEANT4)
       ActsExamplesDetectorDD4hep)
     add_dependencies(ActsPythonBindings ActsPythonBindingsDDG4)
 
-    install(TARGETS ActsPythonBindingsDDG4 DESTINATION .)
-    set_target_properties(ActsPythonBindingsDDG4 PROPERTIES INSTALL_RPATH "\$ORIGIN/${CMAKE_INSTALL_LIBDIR}")
+    install(TARGETS ActsPythonBindingsDDG4 DESTINATION ${_python_install_dir})
+    set_target_properties(ActsPythonBindingsDDG4 PROPERTIES INSTALL_RPATH "\$ORIGIN../../${CMAKE_INSTALL_LIBDIR}")
     set_target_properties(ActsPythonBindingsDDG4 PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${_python_dir}/acts)
     list(APPEND py_files examples/geant4/dd4hep.py)
   endif()
@@ -136,7 +138,8 @@ endif()
 
 
 add_custom_target(ActsPythonGlueCode)
-configure_file(setup.sh.in ${_python_dir}/setup.sh)
+configure_file(setup.sh.in ${_python_dir}/setup.sh COPYONLY)
+install(FILES setup.sh.in DESTINATION "python" RENAME setup.sh)
 
 
 foreach(f ${py_files})
@@ -146,5 +149,7 @@ file(MAKE_DIRECTORY ${_dir})
 
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/python/acts/${f} ${_target} SYMBOLIC)
 endforeach()
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python/acts/ DESTINATION ${_python_install_dir})
 
 add_dependencies(ActsPythonBindings ActsPythonGlueCode)

--- a/Examples/Python/setup.sh.in
+++ b/Examples/Python/setup.sh.in
@@ -1,1 +1,3 @@
-export PYTHONPATH=@_python_dir@:$PYTHONPATH
+python_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}"  )" &> /dev/null && pwd  )
+
+export PYTHONPATH=$python_dir:$PYTHONPATH


### PR DESCRIPTION
This PR adds some changes to enable the python bindings to be used from an install. Instead of `source $BUILD/python/setup.sh` you can now do `source $INSTALL/python/setup.sh`. 

The folder `python` won't make sense if ACTS is installed into a directory alongside other projects, but I would argue in that case you would not want to enable the python bindings anyway.