### PR TITLE
feat: Allow setting ACTS_LOG_FAILURE_THRESHOLD at runtime

### DIFF
--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -171,6 +171,41 @@ constexpr Level FAILURE_THRESHOLD =
     Level::MAX;
 #endif
 
+/// Function which returns the failure threshold for log messages.
+/// This can either be from a compilation option or from an environment
+/// variable.
+/// @return The log level failure threshold
+inline Level getFailureThreshold() {
+  static const Level threshold{[]() -> Level {
+    Level level = FAILURE_THRESHOLD;
+    const char* envvar = std::getenv("ACTS_LOG_FAILURE_THRESHOLD");
+    if (envvar == nullptr) {
+      return level;
+    }
+    std::string slevel = envvar;
+    if (slevel == "VERBOSE") {
+      level = std::min(level, Level::VERBOSE);
+    } else if (slevel == "DEBUG") {
+      level = std::min(level, Level::DEBUG);
+    } else if (slevel == "INFO") {
+      level = std::min(level, Level::INFO);
+    } else if (slevel == "WARNING") {
+      level = std::min(level, Level::WARNING);
+    } else if (slevel == "ERROR") {
+      level = std::min(level, Level::ERROR);
+    } else if (slevel == "FATAL") {
+      level = std::min(level, Level::FATAL);
+    } else {
+      std::cerr << "ACTS_LOG_FAILURE_THRESHOLD environment variable is set to "
+                   "unknown value: "
+                << slevel << std::endl;
+    }
+    return level;
+  }()};
+
+  return threshold;
+}
+
 /// @brief abstract base class for printing debug output
 ///
 /// Implementations of this interface need to define how and where to @a print
@@ -215,7 +250,7 @@ class DefaultFilterPolicy final : public OutputFilterPolicy {
   ///
   /// @param [in] lvl threshold debug level
   explicit DefaultFilterPolicy(const Level& lvl) : m_level(lvl) {
-    if (lvl > FAILURE_THRESHOLD) {
+    if (lvl > getFailureThreshold()) {
       throw std::runtime_error(
           "Requested debug level is incompatible with "
           "the ACTS_LOG_FAILURE_THRESHOLD configuration");
@@ -428,7 +463,7 @@ class DefaultPrintPolicy final : public OutputPrintPolicy {
   /// @param [in] input text of debug message
   void flush(const Level& lvl, const std::string& input) final {
     (*m_out) << input << std::endl;
-    if (lvl >= FAILURE_THRESHOLD) {
+    if (lvl >= getFailureThreshold()) {
       throw std::runtime_error(
           "Previous debug message exceeds the "
           "ACTS_LOG_FAILURE_THRESHOLD configuration, bailing out");

--- a/Tests/UnitTests/Core/Utilities/LoggerTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/LoggerTests.cpp
@@ -50,7 +50,7 @@ void debug_level_test(const char* output_file, Logging::Level lvl) {
 
   // If fail-on-error is enabled, then the logger will not, and should not,
   // tolerate being set up with a coarser debug level.
-  if (lvl > Logging::FAILURE_THRESHOLD) {
+  if (lvl > Logging::getFailureThreshold()) {
     BOOST_CHECK_THROW(detail::create_logger("TestLogger", &logfile, lvl),
                       std::runtime_error);
     return;
@@ -62,7 +62,7 @@ void debug_level_test(const char* output_file, Logging::Level lvl) {
 
   // Test logging at a certain debug level
   auto test_logging = [](auto&& test_operation, Logging::Level test_lvl) {
-    if (test_lvl >= Logging::FAILURE_THRESHOLD) {
+    if (test_lvl >= Logging::getFailureThreshold()) {
       BOOST_CHECK_THROW(test_operation(), std::runtime_error);
     } else {
       test_operation();


### PR DESCRIPTION
The physics perf monitoring in #1193 runs on the ODD, which currently
throws a number of ERRORs. To circumvent this, this PR allows setting
the threshold through an environment variable, in addition to the
compile time option.

PLEASE FOLLOW THE CHECKLIST BELOW WHEN CREATING A NEW PULL REQUEST. THE
CHECKLIST IS FOR YOUR INFORMATION AND MUST BE REMOVED BEFORE SUBMITTING THE PULL
REQUEST.
