### PR TITLE
fix: Reduce memory usage of multiplication tests

### DIFF
--- a/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
@@ -155,28 +155,10 @@ BOOST_AUTO_TEST_CASE(test_matrix_dimension_switch) {
   }
 }
 
-typedef std::tuple<
-    // Square matrix tests
-    std::pair<ActsMatrix<4, 4>, ActsMatrix<4, 4>>,
-    std::pair<ActsMatrix<8, 8>, ActsMatrix<8, 8>>,
-
-    // Square odd matrix tests
-    std::pair<ActsMatrix<3, 3>, ActsMatrix<3, 3>>,
-    std::pair<ActsMatrix<7, 7>, ActsMatrix<7, 7>>,
-
-    // Non-square matrix tests
-    std::pair<ActsMatrix<3, 4>, ActsMatrix<4, 3>>,
-    std::pair<ActsMatrix<3, 8>, ActsMatrix<8, 4>>,
-    std::pair<ActsMatrix<4, 3>, ActsMatrix<3, 8>>,
-    std::pair<ActsMatrix<7, 3>, ActsMatrix<3, 7>>,
-    std::pair<ActsMatrix<8, 3>, ActsMatrix<3, 7>>,
-    std::pair<ActsMatrix<8, 7>, ActsMatrix<7, 4>>,
-
-    // Very large matrix tests for sanity
-    std::pair<ActsMatrix<37, 81>, ActsMatrix<81, 59>>,
-    std::pair<ActsMatrix<38, 82>, ActsMatrix<82, 60>>,
-    std::pair<ActsMatrix<37, 82>, ActsMatrix<82, 59>>,
-    std::pair<ActsMatrix<38, 81>, ActsMatrix<81, 60>>>
+typedef std::tuple<std::pair<ActsMatrix<3, 3>, ActsMatrix<3, 3>>,
+                   std::pair<ActsMatrix<4, 4>, ActsMatrix<4, 4>>,
+                   std::pair<ActsMatrix<8, 8>, ActsMatrix<8, 8>>,
+                   std::pair<ActsMatrix<8, 7>, ActsMatrix<7, 4>>>
     MatrixProductTypes;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(BlockedMatrixMultiplication, Matrices,


### PR DESCRIPTION
As mentioned in #1199, #1184 has ballooned the memory usage of the helper test build. This is because we are instantiating a lot of tests, generating a lot of function calls and types. The amount of tests is, to be honest, a little bit excessive. This commit reduces the number of tests, such that we only test MxN by NxP tests, where M,N,P is 3,3,3, 4,4,4, 8,8,8, and 8,7,4. This should still cover most of the edge cases and use cases.

Closes #1199.