### PR TITLE
ci: Python fixes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -88,7 +88,7 @@ jobs:
         run: >
           ${SETUP}
           && echo "::group::Dependencies"
-          && pip3 install histcmp==0.3.0
+          && pip3 install histcmp==0.3.1
           && source /usr/local/bin/thisroot.sh
           && source /usr/local/bin/thisdd4hep_only.sh
           && source /usr/local/bin/geant4.sh

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: Install black
-        run: pip install black==22.1.0
+        run: pip install black==22.3.0
       - name: Run black format check
         run: black --check . --extend-exclude ".*thirdparty.*"
 


### PR DESCRIPTION
Click had a breaking change in a minor version bump `8.0.4` -> `8.1.0` (see https://github.com/tiangolo/typer/issues/377) and black `22.1.0` has an incompatibility with click `8.1.0` (bumping to
`22.3.0` should fix this)