### PR TITLE
fix: Match seed finder util .hpp and .ipp types

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderUtils.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.hpp
@@ -52,7 +52,7 @@ LinCircle transformCoordinates(InternalSpacePoint<external_spacepoint_t>& sp,
 /// @param[out] linCircleVec The output vector to write to.
 template <typename external_spacepoint_t>
 void transformCoordinates(
-    const std::vector<InternalSpacePoint<external_spacepoint_t>*>& vec,
+    std::vector<InternalSpacePoint<external_spacepoint_t>*>& vec,
     InternalSpacePoint<external_spacepoint_t>& spM, bool bottom,
     bool enableCutsForSortedSP, std::vector<LinCircle>& linCircleVec);
 }  // namespace Acts


### PR DESCRIPTION
I've discovered that #1143 introduces a subtle but rather nefarious bug in the seed finder utilities: the `const` qualifier on one of the types was removed in the `.ipp` file, but not in the corresponding `.hpp` file. This means that any code importing the `.hpp` will gladly compile the code, but because a matching implementation is not present in the `.ipp` file, it will rely on this implementation being made available at link time. In this particular case, that never happens, and we run into rather hard to debug linking errors. This commit resolves the issue by making sure that the function signatures between the `.hpp` file and the `.ipp` file are the same.
