### PR TITLE
ci: Decouple LCG and Ubuntu builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -121,10 +121,13 @@ jobs:
       - name: Install
         run: cmake --build build -- install
 
+      - name: Package build
+        run: tar czf ../build.tar.gz -C build . 
+
       - uses: actions/upload-artifact@v3
         with:
           name: acts-linux-ubuntu
-          path: build
+          path: build.tar.gz
 
       - name: Downstream configure
         run: >
@@ -160,7 +163,9 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: acts-linux-ubuntu
-          path: build
+
+      - name: Unpack build
+        run: mkdir build && tar xf build.tar.gz -C build
 
       - name: Examples
         run: ./CI/run_examples.sh
@@ -195,13 +200,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: acts-linux-ubuntu
-          path: build
+
+      - name: Unpack build
+        run: mkdir build && tar xf build.tar.gz -C build
 
       - name: Physics performance checks
         shell: bash
         run: >
           echo "::group::Dependencies"
           && pip3 install histcmp==0.3.1
+          && /usr/local/bin/download_geant4_data.sh
           && source /usr/local/bin/thisroot.sh
           && source /usr/local/bin/thisdd4hep_only.sh
           && source /usr/local/bin/geant4.sh

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -160,6 +160,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: acts-linux-ubuntu
+          path: build
 
       - name: Examples
         run: ./CI/run_examples.sh
@@ -167,7 +168,7 @@ jobs:
       - name: Python level tests
         shell: bash
         run: >
-          && /usr/local/bin/download_geant4_data.sh
+          /usr/local/bin/download_geant4_data.sh
           && source /usr/local/bin/thisroot.sh
           && source /usr/local/bin/thisdd4hep_only.sh
           && source /usr/local/bin/geant4.sh
@@ -194,11 +195,12 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: acts-linux-ubuntu
+          path: build
 
       - name: Physics performance checks
         shell: bash
         run: >
-          && echo "::group::Dependencies"
+          echo "::group::Dependencies"
           && pip3 install histcmp==0.3.1
           && source /usr/local/bin/thisroot.sh
           && source /usr/local/bin/thisdd4hep_only.sh

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,7 +12,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 jobs:
-  linux:
+  lcg:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/${{ matrix.image }}:v15
     strategy:
@@ -22,29 +22,12 @@ jobs:
           - centos7-lcg101-gcc11
           - centos8-lcg100-gcc10
           - centos8-lcg101-gcc11
-          - ubuntu2004
     env:
-      SETUP: true
-      SETUP_LCG: source /opt/lcg_view/setup.sh
+      SETUP: source /opt/lcg_view/setup.sh
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
     steps:
-      - name: Install git lfs
-        if: contains(matrix.image, 'ubuntu')
-        run: apt install -y git-lfs
-
       - uses: actions/checkout@v3
-        if: contains(matrix.image, 'ubuntu')
-        with:
-          submodules: true
-          lfs: true
-
-      - uses: actions/checkout@v3
-        if: "!contains(matrix.image, 'ubuntu')"
-
-      - name: Define setup script
-        if: contains(matrix.image, 'lcg')
-        run: echo "SETUP=${SETUP_LCG}" >> $GITHUB_ENV
 
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
@@ -61,51 +44,24 @@ jobs:
           -DACTS_BUILD_EVERYTHING=ON
           -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
           -DACTS_FORCE_ASSERTIONS=ON
+
       - name: Build
         run: ${SETUP} && cmake --build build --
+
       - name: Unit tests
         run: ${SETUP} && cmake --build build -- test
+
       - name: Integration tests
         run: ${SETUP} && cmake --build build -- integrationtests
-      - name: Examples
-        if: contains(matrix.image, 'ubuntu')
-        run: ${SETUP} && ./CI/run_examples.sh
-      - name: Python level tests
-        if: contains(matrix.image, 'ubuntu')
-        shell: bash
-        run: >
-          ${SETUP}
-          && /usr/local/bin/download_geant4_data.sh
-          && source /usr/local/bin/thisroot.sh
-          && source /usr/local/bin/thisdd4hep_only.sh
-          && source /usr/local/bin/geant4.sh
-          && source build/python/setup.sh
-          && pip3 install -r Examples/Python/tests/requirements.txt
-          && pytest -rFs
-      - name: Physics performance checks
-        if: contains(matrix.image, 'ubuntu')
-        shell: bash
-        run: >
-          ${SETUP}
-          && echo "::group::Dependencies"
-          && pip3 install histcmp==0.3.1
-          && source /usr/local/bin/thisroot.sh
-          && source /usr/local/bin/thisdd4hep_only.sh
-          && source /usr/local/bin/geant4.sh
-          && source build/python/setup.sh
-          && echo "::endgroup::"
-          && CI/physmon/phys_perf_mon.sh physmon
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: physmon
-          path: physmon
+
       - name: Install
         run: ${SETUP} && cmake --build build -- install
+
       - uses: actions/upload-artifact@v2
         with:
           name: acts-${{ matrix.image }}
           path: ${{ env.INSTALL_DIR }}
+
       - name: Downstream configure
         run: >
           ${SETUP} &&
@@ -115,10 +71,107 @@ jobs:
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17
           -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
+
       - name: Downstream build
         run: ${SETUP} && cmake --build build-downstream --
+
       - name: Downstream run
         run: ${SETUP} && ./build-downstream/bin/ShowActsVersion
+
+
+  linux:
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v15
+    env:
+      INSTALL_DIR: ${{ github.workspace }}/install
+      ACTS_LOG_FAILURE_THRESHOLD: WARNING
+    steps:
+      - name: Install git lfs
+        run: apt install -y git-lfs
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: true
+
+      - name: Configure
+        # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
+        # dd4hep CMake configuration that gets triggered on recent CMake
+        # versions 
+        run: >
+          cmake -B build -S .
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_STANDARD=17
+          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+          -DACTS_BUILD_EVERYTHING=ON
+          -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
+          -DACTS_FORCE_ASSERTIONS=ON
+
+      - name: Build
+        run: cmake --build build --
+
+      - name: Unit tests
+        run: cmake --build build -- test
+
+      - name: Integration tests
+        run: cmake --build build -- integrationtests
+
+      - name: Examples
+        run: ./CI/run_examples.sh
+
+      - name: Python level tests
+        shell: bash
+        run: >
+          && /usr/local/bin/download_geant4_data.sh
+          && source /usr/local/bin/thisroot.sh
+          && source /usr/local/bin/thisdd4hep_only.sh
+          && source /usr/local/bin/geant4.sh
+          && source build/python/setup.sh
+          && pip3 install -r Examples/Python/tests/requirements.txt
+          && pytest -rFs
+
+      - name: Physics performance checks
+        shell: bash
+        run: >
+          && echo "::group::Dependencies"
+          && pip3 install histcmp==0.3.1
+          && source /usr/local/bin/thisroot.sh
+          && source /usr/local/bin/thisdd4hep_only.sh
+          && source /usr/local/bin/geant4.sh
+          && source build/python/setup.sh
+          && echo "::endgroup::"
+          && CI/physmon/phys_perf_mon.sh physmon
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: physmon
+          path: physmon
+
+      - name: Install
+        run: cmake --build build -- install
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-${{ matrix.image }}
+          path: ${{ env.INSTALL_DIR }}
+
+      - name: Downstream configure
+        run: >
+          cmake -B build-downstream -S Tests/DownstreamProject
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_STANDARD=17
+          -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
+
+      - name: Downstream build
+        run: cmake --build build-downstream --
+
+      - name: Downstream run
+        run: ./build-downstream/bin/ShowActsVersion
 
   linux-nodeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install
         run: ${SETUP} && cmake --build build -- install
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: acts-${{ matrix.image }}
           path: ${{ env.INSTALL_DIR }}
@@ -79,7 +79,7 @@ jobs:
         run: ${SETUP} && ./build-downstream/bin/ShowActsVersion
 
 
-  linux:
+  linux_ubuntu:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v15
     env:
@@ -118,6 +118,49 @@ jobs:
       - name: Integration tests
         run: cmake --build build -- integrationtests
 
+      - name: Install
+        run: cmake --build build -- install
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: acts-linux-ubuntu
+          path: build
+
+      - name: Downstream configure
+        run: >
+          cmake -B build-downstream -S Tests/DownstreamProject
+          -GNinja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS=-Werror
+          -DCMAKE_CXX_STANDARD=17
+          -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
+
+      - name: Downstream build
+        run: cmake --build build-downstream --
+
+      - name: Downstream run
+        run: ./build-downstream/bin/ShowActsVersion
+
+  linux_examples_test:
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v15
+    needs: [linux_ubuntu]
+    env:
+      ACTS_LOG_FAILURE_THRESHOLD: FATAL
+
+    steps:
+      - name: Install git lfs
+        run: apt install -y git-lfs
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: true
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: acts-linux-ubuntu
+
       - name: Examples
         run: ./CI/run_examples.sh
 
@@ -131,6 +174,26 @@ jobs:
           && source build/python/setup.sh
           && pip3 install -r Examples/Python/tests/requirements.txt
           && pytest -rFs
+
+  linux_physmon:
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v15
+    needs: [linux_ubuntu]
+    env:
+      ACTS_LOG_FAILURE_THRESHOLD: FATAL
+
+    steps:
+      - name: Install git lfs
+        run: apt install -y git-lfs
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: true
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: acts-linux-ubuntu
 
       - name: Physics performance checks
         shell: bash
@@ -149,29 +212,6 @@ jobs:
         with:
           name: physmon
           path: physmon
-
-      - name: Install
-        run: cmake --build build -- install
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: acts-${{ matrix.image }}
-          path: ${{ env.INSTALL_DIR }}
-
-      - name: Downstream configure
-        run: >
-          cmake -B build-downstream -S Tests/DownstreamProject
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_CXX_STANDARD=17
-          -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
-
-      - name: Downstream build
-        run: cmake --build build-downstream --
-
-      - name: Downstream run
-        run: ./build-downstream/bin/ShowActsVersion
 
   linux-nodeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -122,7 +122,7 @@ jobs:
         run: cmake --build build -- install
 
       - name: Package build
-        run: tar czf ../build.tar.gz -C build . 
+        run: tar czf build.tar.gz -C build . 
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This allows getting rid of some `if/else` branching between these, and allows splitting up the follow up checks (examples+pytest and phys monitoring) into separate jobs that depend on the build job result. This means they can run independently of each other and if either fails, the other will still run and provide output.