### PR TITLE
ci: Update macOS CI dependencies

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -216,7 +216,7 @@ jobs:
           brew install cmake eigen ninja
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.494c52d.tar.gz
+          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.5e0adfa.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the


### PR DESCRIPTION
It seems like with the current macOS version on GH Actions and the latest tarball, DD4hep complains about a ROOT python version mismatch. My PR to DD4hep which adds flag to relax this behavior hasn't made it into a release yet, so right now I just regenerated the macOS deps to match the versions again.

Let's see if this works now.