### PR TITLE
ci: Bump docker image versions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build_debug:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v15
+    container: ghcr.io/acts-project/ubuntu2004:v21
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -49,7 +49,7 @@ jobs:
           file: ./build/coverage/cov.xml
   build_performance:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v15
+    container: ghcr.io/acts-project/ubuntu2004:v21
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -208,6 +208,7 @@ jobs:
         shell: bash
         run: >
           echo "::group::Dependencies"
+          && git config --global safe.directory "$GITHUB_WORKSPACE"
           && pip3 install histcmp==0.3.1
           && /usr/local/bin/download_geant4_data.sh
           && source /usr/local/bin/thisroot.sh

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -405,7 +405,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           && cmake -B build -S .
           -GNinja
-          -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2022.0.2/linux/bin-llvm/clang++
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DACTS_SETUP_VECMEM=ON

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   lcg:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/${{ matrix.image }}:v15
+    container: ghcr.io/acts-project/${{ matrix.image }}:v21
     strategy:
       matrix:
         image:
@@ -81,7 +81,7 @@ jobs:
 
   linux_ubuntu:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v15
+    container: ghcr.io/acts-project/ubuntu2004:v21
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
@@ -146,7 +146,7 @@ jobs:
 
   linux_examples_test:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v15
+    container: ghcr.io/acts-project/ubuntu2004:v21
     needs: [linux_ubuntu]
     env:
       ACTS_LOG_FAILURE_THRESHOLD: FATAL
@@ -183,7 +183,7 @@ jobs:
 
   linux_physmon:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v15
+    container: ghcr.io/acts-project/ubuntu2004:v21
     needs: [linux_ubuntu]
     env:
       ACTS_LOG_FAILURE_THRESHOLD: FATAL
@@ -362,7 +362,7 @@ jobs:
         run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu1804_cuda:v9
+    container: ghcr.io/acts-project/ubuntu1804_cuda:v21
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -378,7 +378,7 @@ jobs:
         run: cmake --build build --
   exatrkx:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_exatrkx:v17
+    container: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
     steps:
       - uses: actions/checkout@v2
       - name: Configure
@@ -394,7 +394,7 @@ jobs:
         run: cmake --build build --
   sycl:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004_oneapi:v9
+    container: ghcr.io/acts-project/ubuntu2004_oneapi:v21
     defaults:
       run:
         shell: bash
@@ -417,7 +417,7 @@ jobs:
           && cmake --build build --
   docs:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v9
+    container: ghcr.io/acts-project/ubuntu2004:v21
     env:
         DOXYGEN_WARN_AS_ERROR: YES
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/format10:v21
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check
-        run: CI/check_format .
-      - uses: actions/upload-artifact@v1
+        run: echo $PWD && ls -al && CI/check_format .
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: changed
@@ -23,7 +23,7 @@ jobs:
   format-py:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - name: Install black
         run: pip install black==22.3.0
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:alpine3.6
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check
         run: >
           apk add --no-cache git
@@ -43,14 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     container: python:alpine3.6
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check
         run: >
           CI/check_include_guards.py . --fail-global --exclude "*thirdparty/*"
   boost_test_macro:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check
         run: >
           CI/check_boost_test_macro.sh
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:alpine3.6
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Check
         run: >
           CI/check_smearing_config.py .

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format10:v15
+    container: ghcr.io/acts-project/format10:v21
     steps:
       - uses: actions/checkout@v2
       - name: Check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check
-        run: echo $PWD && ls -al && CI/check_format .
+        run: >
+          git config --global safe.directory "$GITHUB_WORKSPACE"
+          && CI/check_format .
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 build:
   stage: build
-  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v17
+  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
   tags:
     - docker
   artifacts:
@@ -30,7 +30,7 @@ test:
   stage: test
   dependencies:
     - build
-  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v17
+  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
   tags:
     - docker-gpu-nvidia
   script:


### PR DESCRIPTION
Bumps to v21 of the docker images for the CI, this should fix the failures seen in the ExaTrkX job.

Also works around [this](https://github.blog/2022-04-12-git-security-vulnerability-announced/) security vulnerability in git, which now requires you to make folders as safe for the search for a top-level `.git` folder.