### PR TITLE
ci: Add ccache to CI builds

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -2,8 +2,8 @@ name: Analysis
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+      # - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -19,12 +19,25 @@ jobs:
   build_debug:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v21
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Install ccache
+        run: apt-get install -y ccache
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache-linux_ubuntu_debug
+
       - name: Configure
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_CXX_FLAGS="-Werror -gz -g1"
           -DACTS_BUILD_UNITTESTS=on
@@ -51,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v21
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: pip3 install git+https://github.com/paulgessinger/cmakeperf.git@ece8fc8
       - name: Configure
@@ -76,7 +89,7 @@ jobs:
     needs: build_performance
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: pip3 install git+https://github.com/paulgessinger/headwind.git@eeeaa80
       - uses: actions/download-artifact@v2

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,6 +12,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXSIZE: 250M
 
 # NOTE this only builds core unittests to reduce the output size. if we
 #      found a way to have Github actions not fail regularly with this job

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
+  CCACHE_DIR: ${{ github.workspace }}/ccache
 
 # NOTE this only builds core unittests to reduce the output size. if we
 #      found a way to have Github actions not fail regularly with this job
@@ -19,8 +20,6 @@ jobs:
   build_debug:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v21
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
-  CCACHE_MAXSIZE: 250M
+  CCACHE_MAXSIZE: 1G
 
 # NOTE this only builds core unittests to reduce the output size. if we
 #      found a way to have Github actions not fail regularly with this job

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install git lfs
+      - name: Install ccache
         run: yum install -y ccache
 
       - name: Cache build
@@ -46,7 +46,7 @@ jobs:
           ${SETUP} &&
           cmake -B build -S .
           -GNinja
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,6 +11,7 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXSIZE: 250M
 
 jobs:
   lcg:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -404,6 +404,8 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
+      - uses: actions/checkout@v2
+
       - name: Install ccache
         run: apt install -y ccache
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -29,6 +29,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install git lfs
+        run: yum install -y ccache
+
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+          with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
         # dd4hep CMake configuration that gets triggered on recent CMake
@@ -37,6 +46,7 @@ jobs:
           ${SETUP} &&
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17
@@ -85,14 +95,21 @@ jobs:
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - name: Install git lfs
-        run: apt install -y git-lfs
+        run: apt install -y git-lfs ccache
 
       - uses: actions/checkout@v3
         with:
           submodules: true
           lfs: true
+
+      - name: Cache multiple paths
+        uses: actions/cache@v3
+          with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
 
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
@@ -101,6 +118,7 @@ jobs:
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Install git lfs
         run: yum install -y ccache
 
-      - name: Cache multiple paths
+      - name: Cache build
         uses: actions/cache@v3
-          with:
+        with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache
 
@@ -105,9 +105,9 @@ jobs:
           submodules: true
           lfs: true
 
-      - name: Cache multiple paths
+      - name: Cache build
         uses: actions/cache@v3
-          with:
+        with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -99,7 +99,7 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - name: Install git lfs and ccache
-        run: apt install -y git-lfs ccache
+        run: apt-get install -y git-lfs ccache
 
       - uses: actions/checkout@v3
         with:
@@ -172,7 +172,7 @@ jobs:
 
     steps:
       - name: Install git lfs
-        run: apt install -y git-lfs
+        run: apt-get install -y git-lfs
 
       - uses: actions/checkout@v3
         with:
@@ -209,7 +209,7 @@ jobs:
 
     steps:
       - name: Install git lfs
-        run: apt install -y git-lfs
+        run: apt-get install -y git-lfs
 
       - uses: actions/checkout@v3
         with:
@@ -407,7 +407,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install ccache
-        run: apt install -y ccache
+        run: apt-get install -y ccache
 
       - name: Cache build
         uses: actions/cache@v3
@@ -435,7 +435,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install ccache
-        run: apt install -y ccache
+        run: apt-get install -y ccache
 
       - name: Cache build
         uses: actions/cache@v3
@@ -466,7 +466,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install ccache
-        run: apt install -y ccache
+        run: apt-get install -y ccache
 
       - name: Cache build
         uses: actions/cache@v3

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,6 +10,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
+  CCACHE_DIR: ${{ github.workspace }}/ccache
 
 jobs:
   lcg:
@@ -26,7 +27,6 @@ jobs:
       SETUP: source /opt/lcg_view/setup.sh
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v3
 
@@ -96,7 +96,6 @@ jobs:
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - name: Install git lfs and ccache
         run: apt-get install -y git-lfs ccache
@@ -262,7 +261,6 @@ jobs:
       SETUP: source /opt/lcg/ROOT/v6.24.00-e7098/x86_64-centos8-gcc10-opt/bin/thisroot.sh
       PRELOAD: export LD_PRELOAD=/opt/lcg/gcc/10/x86_64-centos8/lib64/libstdc++.so.6
       INSTALL_DIR: ${{ github.workspace }}/install
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -341,7 +339,6 @@ jobs:
     runs-on: macos-11
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -401,8 +398,6 @@ jobs:
   cuda:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu1804_cuda:v21
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
 
@@ -430,8 +425,6 @@ jobs:
   exatrkx:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
       - name: Install ccache
@@ -458,8 +451,6 @@ jobs:
   sycl:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004_oneapi:v21
-    env:
-      CCACHE_DIR: ${{ github.workspace }}/ccache
     defaults:
       run:
         shell: bash

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
-  CCACHE_MAXSIZE: 250M
+  CCACHE_MAXSIZE: 1G
 
 jobs:
   lcg:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-${{ matrix.image }}
 
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
@@ -110,7 +110,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-linux_ubuntu
 
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
@@ -274,7 +274,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-linux-nodeps
 
       - name: Configure
         run: >
@@ -411,7 +411,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-cuda
 
       - name: Configure
         run: >
@@ -439,7 +439,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-exatrkx
 
       - name: Configure
         run: >
@@ -470,7 +470,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache
+          key: ${{ runner.os  }}-ccache-sycl
 
       - name: Configure
         run: >

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,6 +26,7 @@ jobs:
       SETUP: source /opt/lcg_view/setup.sh
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v3
 
@@ -46,7 +47,7 @@ jobs:
           ${SETUP} &&
           cmake -B build -S .
           -GNinja
-          -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=$(find / -type f -name "ccache")
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17
@@ -97,7 +98,7 @@ jobs:
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
       CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
-      - name: Install git lfs
+      - name: Install git lfs and ccache
         run: apt install -y git-lfs ccache
 
       - uses: actions/checkout@v3
@@ -261,16 +262,25 @@ jobs:
       SETUP: source /opt/lcg/ROOT/v6.24.00-e7098/x86_64-centos8-gcc10-opt/bin/thisroot.sh
       PRELOAD: export LD_PRELOAD=/opt/lcg/gcc/10/x86_64-centos8/lib64/libstdc++.so.6
       INSTALL_DIR: ${{ github.workspace }}/install
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
           # Install tbb-devel also to build the examples
         run: >
-          dnf -y install ninja-build tbb-devel
+          dnf -y install ninja-build tbb-devel ccache
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=$(find / -type f -name "ccache")
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
@@ -331,15 +341,23 @@ jobs:
     runs-on: macos-11
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: >
-          brew install cmake eigen ninja
+          brew install cmake eigen ninja ccache
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
           && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.5e0adfa.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
         # dd4hep CMake configuration that gets triggered on recent CMake
@@ -347,6 +365,7 @@ jobs:
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=17
@@ -382,12 +401,23 @@ jobs:
   cuda:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu1804_cuda:v21
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
-      - uses: actions/checkout@v2
+      - name: Install ccache
+        run: apt install -y ccache
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER=/usr/bin/g++-8
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
@@ -398,12 +428,24 @@ jobs:
   exatrkx:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     steps:
       - uses: actions/checkout@v2
+      - name: Install ccache
+        run: apt install -y ccache
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         run: >
           cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror
           -DACTS_BUILD_PLUGIN_EXATRKX=ON
@@ -414,16 +456,28 @@ jobs:
   sycl:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004_oneapi:v21
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/ccache
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
+      - name: Install ccache
+        run: apt install -y ccache
+
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ runner.os  }}-ccache
+
       - name: Configure
         run: >
           source /opt/intel/oneapi/setvars.sh
           && cmake -B build -S .
           -GNinja
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER=/opt/intel/oneapi/compiler/2022.0.2/linux/bin-llvm/clang++
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror


### PR DESCRIPTION
After @andiwand suggested it, I looked at this again, and it could potentially improve our build times significantly.

The caching here follows GitHubs caching implementation, where the cache is scoped to the branch in addition to what we configure. New PR branches (also from forks apparently) should be seeded from the main branch's cache, which is nice. 

This branch currently installs ccache on each job individually, but I have a PR running to add ccache directly to all of our docker images: https://github.com/acts-project/machines/pull/52.