### PR TITLE
fix: prevent debug printout crashing Python TGeoDetector.create()

### DIFF
--- a/Examples/Python/python/acts/examples/__init__.py
+++ b/Examples/Python/python/acts/examples/__init__.py
@@ -215,7 +215,7 @@ def dump_args_calls(
     import collections
 
     for n in dir(mod):
-        if n.startswith("_") or n == "Config":
+        if n.startswith("_") or n == "Config" or n == "Interval":
             continue
         f = getattr(mod, n)
         if not (

--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -5,6 +5,7 @@ u = acts.UnitConstants
 geo_dir = pathlib.Path("acts-itk")
 outputDir = pathlib.Path.cwd()
 
+# acts.examples.dump_args_calls(locals())
 detector, trackingGeometry, decorators = itk.buildITkGeometry(geo_dir)
 field = acts.ConstantBField(acts.Vector3(0.0, 0.0, 2.0 * u.T))
 rnd = acts.examples.RandomNumbers(seed=42)
@@ -14,10 +15,6 @@ from fatras import addFatras
 from digitization import addDigitization
 from seeding import addSeeding, TruthSeedRanges
 from ckf_tracks import addCKFTracks, CKFPerformanceConfig
-
-# from seeding import SeedingAlgorithm, ParticleSmearingSigmas
-
-# acts.examples.dump_args_calls(locals())
 
 s = acts.examples.Sequencer(events=100, numThreads=-1)
 s = addParticleGun(
@@ -42,6 +39,7 @@ s = addDigitization(
     outputDirRoot=outputDir,
     rnd=rnd,
 )
+# from seeding import SeedingAlgorithm, ParticleSmearingSigmas
 s = addSeeding(
     s,
     trackingGeometry,

--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -12,8 +12,12 @@ rnd = acts.examples.RandomNumbers(seed=42)
 from particle_gun import addParticleGun, MomentumConfig, EtaConfig, ParticleConfig
 from fatras import addFatras
 from digitization import addDigitization
-from seeding import addSeeding, SeedingAlgorithm, TruthSeedRanges
+from seeding import addSeeding, TruthSeedRanges
 from ckf_tracks import addCKFTracks, CKFPerformanceConfig
+
+# from seeding import SeedingAlgorithm, ParticleSmearingSigmas
+
+# acts.examples.dump_args_calls(locals())
 
 s = acts.examples.Sequencer(events=100, numThreads=-1)
 s = addParticleGun(
@@ -43,6 +47,8 @@ s = addSeeding(
     trackingGeometry,
     field,
     TruthSeedRanges(pt=(1.0 * u.GeV, None), eta=(-4.0, 4.0), nHits=(9, None)),
+    # SeedingAlgorithm.TruthEstimated,
+    # SeedingAlgorithm.TruthSmeared, ParticleSmearingSigmas(pRel=0.01), rnd=rnd,
     geoSelectionConfigFile=geo_dir / "itk-hgtd/geoSelection-ITk.json",
     outputDirRoot=outputDir,
 )


### PR DESCRIPTION
* Prevent `dump_args_calls` from instrumenting `Interval` and screwing up `TGeoDetector.create()`
* Add a couple of commented-out options to `full_chain_itk.py`:
  * show different seeding options
  * add `dump_args_calls` to debug Python bindings