### PR TITLE
fix: ODD with macOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,7 @@ build:
       -DCMAKE_BUILD_TYPE=Release 
       -DCMAKE_CXX_FLAGS=-w 
       -DCMAKE_CUDA_FLAGS=-w 
+      -DCMAKE_CUDA_ARCHITECTURES="75;86"
       -DACTS_BUILD_PLUGIN_EXATRKX=ON 
       -DACTS_BUILD_EXAMPLES_EXATRKX=ON 
       -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
@@ -86,7 +87,7 @@ test:
   stage: test
   dependencies:
     - build
-  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v22
+  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v23
   tags:
     - docker-gpu-nvidia
   script:

--- a/Examples/Scripts/Python/common.py
+++ b/Examples/Scripts/Python/common.py
@@ -30,7 +30,6 @@ def getOpenDataDetector(mdecorator=None):
         env_vars = ["DYLD_LIBRARY_PATH", "DD4HEP_LIBRARY_PATH"]
         lib_name = "libOpenDataDetector.dylib"
 
-
     if lib_name is not None and len(env_vars) > 0:
         found = False
         for env_var in env_vars:

--- a/Examples/Scripts/Python/common.py
+++ b/Examples/Scripts/Python/common.py
@@ -28,7 +28,8 @@ def getOpenDataDetector(mdecorator=None):
         lib_name = "libOpenDataDetector.so"
     elif sys.platform == "darwin":
         env_vars = ["DYLD_LIBRARY_PATH", "DD4HEP_LIBRARY_PATH"]
-        lib_name = "libOpenDataDetector.dyld"
+        lib_name = "libOpenDataDetector.dylib"
+
 
     if lib_name is not None and len(env_vars) > 0:
         found = False
@@ -41,7 +42,7 @@ def getOpenDataDetector(mdecorator=None):
         if not found:
             msg = (
                 "Unable to find OpenDataDetector factory library. "
-                f"You might need to point {'/'.join(env_vars)} at it"
+                f"You might need to point {'/'.join(env_vars)} to build/thirdparty/OpenDataDetector/factory"
             )
             raise RuntimeError(msg)
 

--- a/Examples/Scripts/Python/common.py
+++ b/Examples/Scripts/Python/common.py
@@ -42,7 +42,7 @@ def getOpenDataDetector(mdecorator=None):
         if not found:
             msg = (
                 "Unable to find OpenDataDetector factory library. "
-                f"You might need to point {'/'.join(env_vars)} to build/thirdparty/OpenDataDetector/factory"
+                f"You might need to point {'/'.join(env_vars)} to build/thirdparty/OpenDataDetector/factory or other ODD install location"
             )
             raise RuntimeError(msg)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -310,6 +310,26 @@ The following environment variables might be useful.
 | HepMC3_DIR           | Search path for the HepMC3 installation  |
 | Pythia8_DIR          | Search path for the Pythia8 installation |
 
+## The OpenDataDetector
+
+Acts comes packaged with a detector modeled using DD4Hep that can be used to test your algorithms. It comes equipped with a magnetic field file as well as an already built material map. 
+It is available via the git submodule feature by performing the following steps (git lfs need to be installed on your machine) :
+
+.. code-block:: console
+  
+  git submodule init
+  git submodule update
+
+To use it, you will then need to build acts with the ACTS_BUILD_ODD option and then point either LD_LIBRARY_PATH on Linux or  
+DYLD_LIBRARY_PATH and DD4HEP_LIBRARY_PATH on MacOs to the install path of the ODD factory (for example : build/thirdparty/OpenDataDetector/factory).
+
+You can now use the ODD in the python binding by using : 
+
+```oddMaterialDeco = acts.IMaterialDecorator.fromFile("PATH_TO_Acts/thirdparty/OpenDataDetector/data/odd-material-maps.root")
+detector, trackingGeometry, decorators = getOpenDataDetector(oddMaterialDeco)
+```
+
+
 ## Using Acts
 
 When using Acts in your own CMake-based project, you need to include the


### PR DESCRIPTION
This fix the common.py to be able to use the ODD with macOs. It also make the error message a bit more explicite if the path to the ODD factory was not set.