### PR TITLE
docs: fix spelling, grammar, (image-)links; unify reccuring expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ include(ActsCompilerOptions) # default compile options
 include(ActsComponentsHelpers) # handle components via add_..._if commands
 include(ActsStaticAnalysis)
 
-# place build products in `<build_dir>/bin` and `<build_dir>/lib` for simple use
+# place build products in `<build>/bin` and `<build>/lib` for simple use
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 

--- a/Core/include/Acts/Definitions/Common.hpp
+++ b/Core/include/Acts/Definitions/Common.hpp
@@ -32,7 +32,7 @@ static constexpr ActsScalar s_onSurfaceTolerance = 1e-4;
 static constexpr ActsScalar s_curvilinearProjTolerance = 0.999995;
 
 /// @enum NavigationDirection
-/// The navigation direciton is always with
+/// The navigation direction is always with
 /// respect to a given momentum or direction
 enum class NavigationDirection : int { Backward = -1, Forward = 1 };
 

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -66,7 +66,7 @@ class EigenStepper {
     /// @param [in] gctx is the context object for the geometry
     /// @param [in] fieldCacheIn is the cache object for the magnetic field
     /// @param [in] par The track parameters at start
-    /// @param [in] ndir The navigation direciton w.r.t momentum
+    /// @param [in] ndir The navigation direction w.r.t momentum
     /// @param [in] ssize is the maximum step size
     /// @param [in] stolerance is the stepping tolerance
     ///

--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
@@ -250,7 +250,7 @@ class MultiEigenStepperLoop
     /// @param [in] mctx is the context object for the magnetic field
     /// @param [in] bfield the shared magnetic filed provider
     /// @param [in] multipars The track multi-component track-parameters at start
-    /// @param [in] ndir The navigation direciton w.r.t momentum
+    /// @param [in] ndir The navigation direction w.r.t momentum
     /// @param [in] ssize is the maximum step size
     /// @param [in] stolerance is the stepping tolerance
     ///

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -54,7 +54,7 @@ class StraightLineStepper {
     /// @param [in] gctx is the context object for the geometry
     /// @param [in] mctx is the context object for the magnetic field
     /// @param [in] par The track parameters at start
-    /// @param [in] ndir The navigation direciton w.r.t momentum
+    /// @param [in] ndir The navigation direction w.r.t momentum
     /// @param [in] ssize is the maximum step size
     /// @param [in] stolerance is the stepping tolerance
     ///

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -477,7 +477,7 @@ class KalmanFitter {
         return KalmanFitterError::ReverseNavigationFailed;
       }
 
-      // Remember the navigation direciton has been reversed
+      // Remember the navigation direction has been reversed
       result.reversed = true;
 
       // Reverse navigation direction

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -27,7 +27,7 @@ namespace ActsExamples {
 /// track efficiency, fake rate etc.
 /// @TODO: add duplication plots
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing file
 ///
 /// Safe to use from multiple writer threads - uses a std::mutex lock.

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.hpp
@@ -25,7 +25,7 @@ namespace ActsExamples {
 ///
 /// Efficiency here is the fraction of smoothed tracks compared to all tracks.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing file
 ///
 /// Safe to use from multiple writer threads - uses a std::mutex lock.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootMeasurementWriter.hpp
@@ -39,7 +39,7 @@ namespace ActsExamples {
 /// in the root file for optimised data writing speed
 /// The event number is part of the written data.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing file
 ///
 /// Safe to use from multiple writer threads - uses a std::mutex lock.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootPlanarClusterWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootPlanarClusterWriter.hpp
@@ -28,7 +28,7 @@ namespace ActsExamples {
 /// in the root file for optimised data writing speed
 /// The event number is part of the written data.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing file
 ///
 /// Safe to use from multiple writer threads - uses a std::mutex lock.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootPropagationStepsWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootPropagationStepsWriter.hpp
@@ -27,7 +27,7 @@ using PropagationSteps = std::vector<Acts::detail::Step>;
 /// data writing speed.
 /// The event number is part of the written data.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing file
 ///
 /// Safe to use from multiple writer threads - uses a std::mutex lock.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectoryStatesWriter.hpp
@@ -30,7 +30,7 @@ namespace ActsExamples {
 /// Each entry in the TTree corresponds to one trajectory for optimum
 /// writing speed. The event number is part of the written data.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing
 /// file
 ///

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrajectorySummaryWriter.hpp
@@ -31,7 +31,7 @@ namespace ActsExamples {
 /// Each entry in the TTree corresponds to all reconstructed trajectories in one
 /// single event. The event number is part of the written data.
 ///
-/// A common file can be provided for to the writer to attach his TTree,
+/// A common file can be provided for the writer to attach his TTree,
 /// this is done by setting the Config::rootFile pointer to an existing
 /// file
 ///

--- a/Examples/Scripts/Benchmarking/CKF_timing_vs_mu.sh
+++ b/Examples/Scripts/Benchmarking/CKF_timing_vs_mu.sh
@@ -39,7 +39,7 @@ done
 #check input for DDhep input
 if [ "${detector}" == DD4hep ]; then
    if [ -z "${dd4hepInput}" ]; then
-      echo "Empty input for --dd4hep-input. A file like $<src_dir>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml must be provided. Have to exit."
+      echo "Empty input for --dd4hep-input. A file like $<source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml must be provided. Have to exit."
       exit 1
    fi
    if [ ! -f "${dd4hepInput}" ]; then

--- a/Examples/Scripts/Benchmarking/KF_timing.sh
+++ b/Examples/Scripts/Benchmarking/KF_timing.sh
@@ -42,7 +42,7 @@ done
 #check input for DDhep input
 if [ "${detector}" == DD4hep ]; then
    if [ -z "${dd4hepInput}" ]; then
-      echo "Empty input for --dd4hep-input. A file like $<src_dir>/Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml must be provided. Have to exit"
+      echo "Empty input for --dd4hep-input. A file like $<source/Examples/Detectors/DD4hepDetector/compact/OpenDataDetector/OpenDataDetector.xml must be provided. Have to exit"
       exit 1
    fi 
    if [ ! -f "${dd4hepInput}" ]; then 

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceDrift.hpp
@@ -33,7 +33,7 @@ struct PlanarSurfaceDrift {
   /// @param surface The nominal intersection surface
   /// @param thickness The emulated module/depletion thickness
   /// @param pos The position in global coordinates
-  /// @param dir The direciton in global coordinates
+  /// @param dir The direction in global coordinates
   /// @param driftdir The drift direction in local (surface) coordinates
   /// @note a drift direction of (0,0,0) is drift to central plane
   ///       any other a drift direction with driftDir.z() != 0.

--- a/Plugins/ExaTrkX/README.md
+++ b/Plugins/ExaTrkX/README.md
@@ -7,7 +7,7 @@ This plugin contains a track finding module based on Graph Neural Networks (GNNs
 To build the plugin, enable the appropriate CMake options:
 
 ```cmake
-cmake -B <builddir> -S <srcdir> \
+cmake -B <build> -S <source> \
   -D ACTS_BUILD_EXATRKX_PLUGIN=ON \
   -D ACTS_BUILD_EXAMPLES_EXATRKX=ON \
   -D ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON \
@@ -32,7 +32,7 @@ The Examples of this plugin provide a python-script using the python-bindings to
 /Examples/Scripts/Python/ExaTrkX.py
 ```
 
-In order that python can find the `acts.examples` module, setup your `PYTHONPATH` with `source <builddir>/python/setup.sh.
+In order that python can find the `acts.examples` module, setup your `PYTHONPATH` with `source <build>/python/setup.sh.
 
 ## Required files
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ following commands will clone the repository, configure, and build the core
 library
 
 ```sh
-git clone --recursive https://github.com/acts-project/acts <source-dir>
-cmake -B <build-dir> -S <source-dir>
-cmake --build <build-dir>
+git clone --recursive https://github.com/acts-project/acts <source>
+cmake -B <build> -S <source>
+cmake --build <build>
 ```
 
 For more details, e.g. specific versions and additional dependencies, have a

--- a/Tests/DownstreamProject/CMakeLists.txt
+++ b/Tests/DownstreamProject/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(
     PluginLegacy
     PluginTGeo)
 
-# place artifacts in GNU-like paths, e.g. binaries in `<build_dir>/bin`
+# place artifacts in GNU-like paths, e.g. binaries in `<build>/bin`
 include(GNUInstallDirs)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")

--- a/Tests/DownstreamProjectNodeps/CMakeLists.txt
+++ b/Tests/DownstreamProjectNodeps/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ActsDownstreamProjectNodeps)
 
 find_package(Acts CONFIG REQUIRED COMPONENTS Core)
 
-# place artifacts in GNU-like paths, e.g. binaries in `<build_dir>/bin`
+# place artifacts in GNU-like paths, e.g. binaries in `<build>/bin`
 include(GNUInstallDirs)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ on_readthedocs = os.environ.get("READTHEDOCS", None) == "True"
 
 project = "Acts"
 author = "The Acts authors"
-copyright = "2014–2021 CERN for the benefit of the Acts project"
+copyright = "2014–2022 CERN for the benefit of the Acts project"
 # version = '@PROJECT_VERSION@'
 # release = '@PROJECT_VERSION@'
 

--- a/docs/core/geometry.md
+++ b/docs/core/geometry.md
@@ -246,7 +246,7 @@ Very simple helper methods for 3D libraries exist, they are certainly not
 optimised, but used for templating:
 
 * `TGeoDetectorElement` connects a TGeo volume to a `Surface`
-* `DD4HepDetectorElement` connects a DD4Hep volume (based on TGeo) to a `Surface`
+* `DD4HepDetectorElement` connects a DD4hep volume (based on TGeo) to a `Surface`
 
 ## Layer building
 

--- a/docs/core/seeding.rst
+++ b/docs/core/seeding.rst
@@ -14,7 +14,7 @@ The most typical way to create seeds is to combine measurements. In a homogeneou
 Acts Implementation
 -------------------
 
-The seeding implementation in Core/include/Acts/Seeding/ is based on the ATLAS track seeding. It was rewritten with a focus on parallelism and maintainability and as detector agnostic as possible, only assuming a (near) homogeneous magnetic field with particles originating from the central detector region. Cuts are configurable and can be plugged in as algorithm which is called by the seeding. The seeding works on measurements or “SpacePoints” (SP), which need to provide x,y,z coordinates with the z axis being along the magnetic field, and x and y. The interaction region must be close to :math:`x=y=0`, such that the interaction region has a smaller detector radius :math:`r = \sqrt(x^2+y^2)` than the measurements closest to the interaction region, see also :numref:`3dim`.
+The seeding implementation in Core/include/Acts/Seeding/ is based on the ATLAS track seeding. It was rewritten with a focus on parallelism and maintainability and as detector agnostic as possible, only assuming a (near) homogeneous magnetic field with particles originating from the central detector region. Cuts are configurable and can be plugged in as algorithm which is called by the seeding. The seeding works on measurements or “SpacePoints” (SP), which need to provide x,y,z coordinates with the z axis being along the magnetic field, and x and y. The interaction region must be close to :math:`x=y=0`, such that the interaction region has a smaller detector radius :math:`r = \sqrt{x^2+y^2}` than the measurements closest to the interaction region, see also :numref:`3dim`.
 
 
 .. figure:: ../figures/seeding/3Dcoordinates.svg

--- a/docs/core/utilities/grid_axis.md
+++ b/docs/core/utilities/grid_axis.md
@@ -1,6 +1,6 @@
 # Grid and axis
 
-The `Grid` template class provides a generic binned `Grid` implementation in $N$ dimensions. `Grid` accepts a variadic list of `Axis` types, where the number of axes equals the number of desired dimensions of the `Grid`.
+The `Grid` template class provides a generic binned `Grid` implementation in :math:`N` dimensions. `Grid` accepts a variadic list of `Axis` types, where the number of axes equals the number of desired dimensions of the `Grid`.
 
 ## Axis
 `Axis` accepts two template parameters:
@@ -19,15 +19,17 @@ enum class AxisType { Equidistant, Variable };
 
 ### AxisType
 
-`AxisType` defines whether an axis is fully determined by $x_\text{min}$, $x_\text{max}$ and $N_\text{bins}$, or if there are variable bin boundaries $x_i = \{x_1, \ldots x_N\}$.
+`AxisType` defines whether an axis is fully determined by :math:`x_\text{min}`, :math:`x_\text{max}` and :math:`N_\text{bins}`, or if there are variable bin boundaries :math:`x_i = \{x_1, \ldots x_N\}`.
 The axis boundaries and, if necessary, the bin boundaries are provided in the constructor.
 
 
-If at all possible, `Equidistant` is preferrable, since bin $b$ can then be calculated in constant time for given $x$ as
+If at all possible, `Equidistant` is preferrable, since bin :math:`b` can then be calculated in constant time for given :math:`x` as
 
-$$b = \frac{\mathrm{floor}(x - x_\text{min})}{w} + 1$$
+.. math::
 
-where $b \in \{0, 1, \ldots N_\text{bins}\}$. If the type is `Variable`, a search for the correct bin is performed over the bin boundaries.
+  b = \frac{\mathrm{floor}(x - x_\text{min})}{w} + 1
+
+where :math:`b \in \{0, 1, \ldots N_\text{bins}\}`. If the type is `Variable`, a search for the correct bin is performed over the bin boundaries.
 
 ### AxisBoundaryType
 
@@ -42,7 +44,7 @@ There are three options:
 
 ## Grid creation
 
-The types of the axes have to be known at compile-time, since they are provided to the `Grid` as template parameters. Thus the number of dimensions $N$ of the `Grid` is also fixed at compile-time.
+The types of the axes have to be known at compile-time, since they are provided to the `Grid` as template parameters. Thus the number of dimensions :math:`N` of the `Grid` is also fixed at compile-time.
 The axes can be any combination of the aforementioned variations.
 
 ```cpp
@@ -56,7 +58,7 @@ The `Grid` performs a lookup by recursively visiting each axis and having it per
 ## Local vs global bin indices
 
 The underlying data structure of the `Grid` is a one-dimensional `std::vector<T>`, where `T` is the template parameter determining the stored value type. The index of this vector is referred to as the **global bin index**.
-The logical index structure, where each global bin is addressed by an $N$-dimensional vector of integers is called **local bin indices**. The two can be converted into one another using
+The logical index structure, where each global bin is addressed by an :math:`N`-dimensional vector of integers is called **local bin indices**. The two can be converted into one another using
 
 ```cpp
 using index_t = std::array<size_t, N>;
@@ -64,7 +66,7 @@ index_t getLocalBinIndices(size_t bin) const;
 size_t getGlobalBinIndex(const index_t& localBins) const;
 ```
 
-The local bin indices are always defined from 1 to $N_\text{bins}$ for the respective axis. Bins 0 and $N_\text{bins} + 1$ address the underflow and overflow bins, **which are always present, even if `AxisBoundaryType != Open`**.
+The local bin indices are always defined from 1 to :math:`N_\text{bins}` for the respective axis. Bins 0 and :math:`N_\text{bins} + 1` address the underflow and overflow bins, **which are always present, even if `AxisBoundaryType != Open`**.
 
 ## Finding neighbors
 
@@ -77,7 +79,7 @@ b x b | 1    | 2    | 3    |
 2     | -1,0 |  B   | +1,0 |
 3     | x    | 0,-1 | x    |
 
-Here, the corner combinations are still missing (also true for $N>2$). This is then turned into a hypercube which in $N=2$ results in:
+Here, the corner combinations are still missing (also true for :math:`N>2`). This is then turned into a hypercube which in :math:`N=2` results in:
 
 b x b | 1     | 2    | 3     |
 ------|-------|------|-------|

--- a/docs/core/utilities/grid_axis.md
+++ b/docs/core/utilities/grid_axis.md
@@ -1,6 +1,6 @@
 # Grid and axis
 
-The `Grid` template class provides a generic binned `Grid` implementation in :math:`N` dimensions. `Grid` accepts a variadic list of `Axis` types, where the number of axes equals the number of desired dimensions of the `Grid`.
+The `Grid` template class provides a generic binned `Grid` implementation in $N$ dimensions. `Grid` accepts a variadic list of `Axis` types, where the number of axes equals the number of desired dimensions of the `Grid`.
 
 ## Axis
 `Axis` accepts two template parameters:
@@ -19,17 +19,15 @@ enum class AxisType { Equidistant, Variable };
 
 ### AxisType
 
-`AxisType` defines whether an axis is fully determined by :math:`x_\text{min}`, :math:`x_\text{max}` and :math:`N_\text{bins}`, or if there are variable bin boundaries :math:`x_i = \{x_1, \ldots x_N\}`.
+`AxisType` defines whether an axis is fully determined by $x_\text{min}$, $x_\text{max}$ and $N_\text{bins}$, or if there are variable bin boundaries $x_i = \{x_1, \ldots x_N\}$.
 The axis boundaries and, if necessary, the bin boundaries are provided in the constructor.
 
 
-If at all possible, `Equidistant` is preferrable, since bin :math:`b` can then be calculated in constant time for given :math:`x` as
+If at all possible, `Equidistant` is preferrable, since bin $b$ can then be calculated in constant time for given $x$ as
 
-.. math::
+$$b = \frac{\mathrm{floor}(x - x_\text{min})}{w} + 1$$
 
-  b = \frac{\mathrm{floor}(x - x_\text{min})}{w} + 1
-
-where :math:`b \in \{0, 1, \ldots N_\text{bins}\}`. If the type is `Variable`, a search for the correct bin is performed over the bin boundaries.
+where $b \in \{0, 1, \ldots N_\text{bins}\}$. If the type is `Variable`, a search for the correct bin is performed over the bin boundaries.
 
 ### AxisBoundaryType
 
@@ -44,7 +42,7 @@ There are three options:
 
 ## Grid creation
 
-The types of the axes have to be known at compile-time, since they are provided to the `Grid` as template parameters. Thus the number of dimensions :math:`N` of the `Grid` is also fixed at compile-time.
+The types of the axes have to be known at compile-time, since they are provided to the `Grid` as template parameters. Thus the number of dimensions $N$ of the `Grid` is also fixed at compile-time.
 The axes can be any combination of the aforementioned variations.
 
 ```cpp
@@ -58,7 +56,7 @@ The `Grid` performs a lookup by recursively visiting each axis and having it per
 ## Local vs global bin indices
 
 The underlying data structure of the `Grid` is a one-dimensional `std::vector<T>`, where `T` is the template parameter determining the stored value type. The index of this vector is referred to as the **global bin index**.
-The logical index structure, where each global bin is addressed by an :math:`N`-dimensional vector of integers is called **local bin indices**. The two can be converted into one another using
+The logical index structure, where each global bin is addressed by an $N$-dimensional vector of integers is called **local bin indices**. The two can be converted into one another using
 
 ```cpp
 using index_t = std::array<size_t, N>;
@@ -66,7 +64,7 @@ index_t getLocalBinIndices(size_t bin) const;
 size_t getGlobalBinIndex(const index_t& localBins) const;
 ```
 
-The local bin indices are always defined from 1 to :math:`N_\text{bins}` for the respective axis. Bins 0 and :math:`N_\text{bins} + 1` address the underflow and overflow bins, **which are always present, even if `AxisBoundaryType != Open`**.
+The local bin indices are always defined from 1 to $N_\text{bins}$ for the respective axis. Bins 0 and $N_\text{bins} + 1$ address the underflow and overflow bins, **which are always present, even if `AxisBoundaryType != Open`**.
 
 ## Finding neighbors
 
@@ -79,7 +77,7 @@ b x b | 1    | 2    | 3    |
 2     | -1,0 |  B   | +1,0 |
 3     | x    | 0,-1 | x    |
 
-Here, the corner combinations are still missing (also true for :math:`N>2`). This is then turned into a hypercube which in :math:`N=2` results in:
+Here, the corner combinations are still missing (also true for $N>2$). This is then turned into a hypercube which in $N=2$ results in:
 
 b x b | 1     | 2    | 3     |
 ------|-------|------|-------|

--- a/docs/examples/howto/run_alignment.rst
+++ b/docs/examples/howto/run_alignment.rst
@@ -53,4 +53,4 @@ Alignment can be run to estimate the misalignment, which can then be further use
        --output-dir=data/reco_misalignedTrackML_aligned/single_muon
 
 
-The ``--reco-with-misalignment-correction`` must be true to turn on the alignment, and the ``--alignment-geo-config-file`` is a jason file to specify which detector objects are to be aligned. Currently, only module level alignment is possible. 
+The ``--reco-with-misalignment-correction`` must be true to turn on the alignment, and the ``--alignment-geo-config-file`` is a JSON file to specify which detector objects are to be aligned. Currently, only module level alignment is possible. 

--- a/docs/examples/howto/run_ckf_tracking.rst
+++ b/docs/examples/howto/run_ckf_tracking.rst
@@ -50,11 +50,11 @@ This file includes a few efficiency plots showing the CKF efficiency, fake rate,
 
 Example plots to show the CKF efficiency, fake rate and duplication rate for the ttbar sample generated above:
 
-.. image:: ../figures/performance/CKF/trackeff_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/CKF/trackeff_vs_eta_ttbar_pu200.png
    :width: 300
 
-.. image:: ../figures/performance/CKF/fakerate_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/CKF/fakerate_vs_eta_ttbar_pu200.png
    :width: 300
 
-.. image:: ../figures/performance/CKF/duplicationrate_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/CKF/duplicationrate_vs_eta_ttbar_pu200.png
    :width: 300

--- a/docs/examples/howto/run_ckf_tracking.rst
+++ b/docs/examples/howto/run_ckf_tracking.rst
@@ -24,8 +24,8 @@ Currently, there are two configurable criteria to select compatible source links
 * Global maximum number of measurements on a surface. This could be set up via ``--ckf-selection-nmax`` 
 
 The digitization of the truth hits must also be configured. Since the command-line configuration of this step can get unwieldy,
-an example json configuration file for the smearing digitizer is provided with the source code.
-The detector volumes and layers used in the space point maker are also configured using another example json file in the source code.
+an example JSON configuration file for the smearing digitizer is provided with the source code.
+The detector volumes and layers used in the space point maker are also configured using another example JSON file in the source code.
 
 .. code-block:: console
 

--- a/docs/examples/howto/run_fatras.rst
+++ b/docs/examples/howto/run_fatras.rst
@@ -11,7 +11,7 @@ Fatras simulation executables. With this option alone, Fatras can be run for
 the generic detector using a particle gun or externally generated particle
 input data.
 
-Additional options might be need enable different generators or detectors.
+Additional options might be needed to enable different generators or detectors.
 The ``ACTS_BUILD_EXAMPLES_PYTHIA8=on`` option enables Pythia8-based event
 generator excutables. To be able to run e.g. DD4hep-base detectors, the
 ``ACTS_BUILD_EXAMPLES_DD4hep=on`` option must be set. The full list of

--- a/docs/examples/howto/run_material_mapping.rst
+++ b/docs/examples/howto/run_material_mapping.rst
@@ -18,7 +18,7 @@ For this particular example the ODD will also be needed. To use it, don't forget
    $ git submodule init
    $ git submodule update
 
-Once Acts has been built we can start the mapping. The mapping is divided in two aspects: the surface mapping in which the material is mapped onto the closest surfaces (following the propagation direction) and the volume mapping in which the material is mapped onto a 3D (or 2D) grid associated to a volume. The first step is to select which surfaces and volumes we will want to map material onto. This is done by association of a ``Acts::ProtoSurfaceMaterial`` (or a ``Acts::ProtoVolumeMaterial``) with the surfaces (or volumes) of interest. In the case of the ODD and some other DD4hep detectors this is done at the building step. For other detectors, or if one wants to be able to control precisely which layer will be mapped on and with which binning, an additional step is required.
+Once Acts has been built we can start the mapping. The mapping is divided in two aspects: the surface mapping in which the material is mapped onto the closest surfaces (following the propagation direction) and the volume mapping in which the material is mapped onto a 3D (or 2D) grid associated to a volume. The first step is to select which surfaces and volumes we will want to map material onto. This is done by association of an ``Acts::ProtoSurfaceMaterial`` (or an ``Acts::ProtoVolumeMaterial``) with the surfaces (or volumes) of interest. In the case of the ODD and some other DD4hep detectors this is done at the building step. For other detectors, or if one wants to be able to control precisely which layer will be mapped on and with which binning, an additional step is required.
 
 Mapping and configuration
 -------------------------

--- a/docs/examples/howto/run_material_mapping.rst
+++ b/docs/examples/howto/run_material_mapping.rst
@@ -11,23 +11,28 @@ Prerequisites
 -------------
 As a prerequisite you will need to build ACTS with the Examples, Geant4 and the JSON plugin (``ACTS_BUILD_EXAMPLES``, ``ACTS_BUILD_EXAMPLES_GEANT4`` and ``ACTS_BUILD_PLUGIN_JSON``) enabled, please refer to the general how-to ACTS guide. Depending on the type of detector you want to map you will need to use some additional packages, in our case ``ACTS_BUILD_EXAMPLES_DD4HEP`` and ``ACTS_BUILD_PLUGIN_TGEO`` are needed.
 
-For this particular example the ODD will also be need. To use it, don't forget to get the corresponding submodule and the recompile the ACTS code if needed.
+For this particular example the ODD will also be needed. To use it, don't forget to get the corresponding submodule and then recompile the ACTS code if needed.
 
 .. code-block:: console
   
-  git submodule init
-  git submodule update
+   $ git submodule init
+   $ git submodule update
 
-Once Acts has been built we can start the mapping. The mapping is divided in two aspects: the surface mapping in which the material is mapped onto the closest surfaces (following the propagation direction) and the volume mapping in which the material is mapped onto a 3D (or 2D) grid associated to a volume. The first step is to select which surfaces and volumes we will want to map material onto. This is done by association a ``Acts::ProtoSurfaceMaterial`` (or a ``Acts::ProtoVolumeMaterial``) to the surfaces (or volumes) of interest. In the case of the ODD and some other DD4hep detectors this is done at the building step. For other detectors, or if one wants to be able to control precisely which layer will be mapped on and with which binning, an additional step is required.
+Once Acts has been built we can start the mapping. The mapping is divided in two aspects: the surface mapping in which the material is mapped onto the closest surfaces (following the propagation direction) and the volume mapping in which the material is mapped onto a 3D (or 2D) grid associated to a volume. The first step is to select which surfaces and volumes we will want to map material onto. This is done by association of a ``Acts::ProtoSurfaceMaterial`` (or a ``Acts::ProtoVolumeMaterial``) with the surfaces (or volumes) of interest. In the case of the ODD and some other DD4hep detectors this is done at the building step. For other detectors, or if one wants to be able to control precisely which layer will be mapped on and with which binning, an additional step is required.
 
 Mapping and configuration
 -------------------------
 
-First we will need to extract the list of all the surfaces and volumes in our detector, to do so we will use the GeometryExample:
+First we need to extract the list of all the surfaces and volumes in our detector, to do so we will use the GeometryExample:
 
 .. code-block:: console
 
-  ./../build/bin/ActsExampleGeometryDD4hep -n1 -j1 --mat-output-file geometry-map  --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml --output-json --mat-output-allmaterial true --mat-output-sensitives false
+   $ <build>/bin/ActsExampleGeometryDD4hep -n1 -j1 \
+       --mat-output-file geometry-map \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
+       --output-json \
+       --mat-output-allmaterial true \
+       --mat-output-sensitives false
 
 This algorithm is useful to obtain a visualisation of your detector using the different types of output available (``output-obj`` gives ``.obj`` with a 3D representation of the different subdetectors, for example). Here, we use ``output-json`` to obtain a map of all the surfaces and volumes in the detector with a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``), ``mat-output-allmaterial`` ensure that a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``) is associated to all the surfaces (or volumes), enforcing all of them to be written.
 Four types of surfaces exist:
@@ -67,13 +72,13 @@ The first one take as an input the surfaces map previously generated and will re
 
 .. code-block:: console
 
-  python3 ../Examples/Scripts/MaterialMapping/writeMapConfig.py geometry-map.json config-map.json
+   $ python3 <source>/Examples/Scripts/MaterialMapping/writeMapConfig.py geometry-map.json config-map.json
 
 Then edit the config-map.json file
 
 .. code-block:: console
 
-  python3 ../Examples/Scripts/MaterialMapping/configureMap.py geometry-map.json config-map.json
+   $ python3 <source>/Examples/Scripts/MaterialMapping/configureMap.py geometry-map.json config-map.json
 
 Geantino scan
 -------------
@@ -82,7 +87,9 @@ The next step is to do a geantino scan of our detector. For this we will use the
 
 .. code-block:: console
 
-  ./../build/bin/ActsExampleMaterialRecordingDD4hep -j1 --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml --output-root -n10000
+   $ <build>/bin/ActsExampleMaterialRecordingDD4hep -n1000 -j1 \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
+       --output-root
 
 
 The result of the geantino scan will be a root file containing material tracks. Those contain the direction and production vertex of the geantino, the total material accumulated and all the interaction points in the detector.
@@ -94,33 +101,52 @@ With the surfaces map and the material track we can finally do the material mapp
 
 .. code-block:: console
 
-  ./../build/bin/ActsExampleMaterialMappingDD4hep -j1 --input-root true --input-files geant4_material_tracks.root --mat-input-type file --mat-input-file geometry-map.json --output-root --output-json --output-cbor --mat-output-file material-maps --mat-mapping-surfaces true --mat-mapping-volumes true --mat-mapping-volume-stepsize 1 --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml
+   $ <build>/bin/ActsExampleMaterialMappingDD4hep -j1 \
+       --input-root true \
+       --input-files geant4_material_tracks.root \
+       --mat-input-type file \
+       --mat-input-file geometry-map.json \
+       --output-root \
+       --output-json \
+       --output-cbor \
+       --mat-output-file material-maps \
+       --mat-mapping-surfaces true \
+       --mat-mapping-volumes true \
+       --mat-mapping-volume-stepsize 1 \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml
 
-Note that technically when using DD4Hep (in particular for the ODD) using the option ``--mat-input-type`` is not strictly necessary as the DD4Hep geometry can hold the information of which surface to map onto with which binning. The goal of this how-to being to explain how to make a material map regardless of the detector, we will ignore that option.
+Note that technically when using DD4hep (in particular for the ODD) using the option ``--mat-input-type`` is not strictly necessary as the DD4hep geometry can hold the information of which surface to map onto with which binning. We will ignore this option, since the goal of this guide is to explain how to make a material map regardless of the detector.
 
 As an output you will obtain the material map as a root and JSON file and a new material track collection in a root file. This new collection adds to each material interaction the associated surface during the mapping. This can be used for the control plots.
-Depending on what you want to do there are three option you can change :
+Depending on what you want to do there are three options you can change:
 
 - ``mat-mapping-surfaces`` : determine if material is mapped onto surfaces
 - ``mat-mapping-volumes`` : determine if material is mapped onto volumes
 - ``mat-mapping-volume-stepsize`` : determine the step size used in the sampling of the volume. This should be small compared to the bin size.
 
 
-In addition to root and Json output, one can also output the material map to a Cbor file (Concise Binary Object Representation). Doing so result in file of the order of 10 time smaller than the json one, but that are no longer human-readable. This should be done once the map has been optimised and you want to export it. 
+In addition to root and JSON output, one can also output the material map to a Cbor file (Concise Binary Object Representation). Doing so results in a file about 10 time smaller than the JSON one, but that file is no longer human-readable. This should be done once the map has been optimised and you want to export it. 
 
 .. note::
-  You can map onto surfaces and volumes separately (for example if you want to optimise one then the other). In that case after mapping one of those you will need to use the resulting JSON material map as an input to the ``mat-input-file``.
+  You can map onto surfaces and volumes separately (for example if you want to optimise first one then the other). In that case after mapping one of those you will need to use the resulting JSON material map as an input to the ``mat-input-file``.
 
 Material Validation
 -------------------
 
-Now that the map has been written, you will want to validate it. First you can use the ``MaterialValidation`` example. This will perform propagation throughout the detector once it has been decorated with the material map. It will then output material tracks with the same format as the one obtain with the Geantino.
+Now that the map has been written, you may want to validate it. First you can use the ``MaterialValidation`` example. This will perform propagation throughout the detector once it has been decorated with the material map. It will then output material tracks with the same format as the one obtain with the Geantino.
 
 By default, the Geantino scan is performed with no spread in :math:`z_0` and :math:`d_0`, while the validation has a spread of 55 mm, to obtain meaningful results, use the same spread for both (in our example a spread of 0). Another difference between the scan and the validation is that the first uses a flat distribution in :math:`\theta` while the second uses a flat distribution in :math:`\eta`, so some reweighing might be necessary when comparing some of the distributions.
 
 .. code-block:: console
 
-  ./../build/bin/ActsExampleMaterialValidationDD4hep -n 1000 --mat-input-type file --mat-input-file material-maps.json --output-root --mat-output-file val-mat-map --dd4hep-input ../thirdparty/OpenDataDetector/xml/OpenDataDetector.xml --prop-z0-sigma 0.0 --prop-d0-sigma 0.0
+   $ <build>/bin/ActsExampleMaterialValidationDD4hep -n1000 \
+       --mat-input-type file \
+       --mat-input-file material-maps.json \
+       --output-root \
+       --mat-output-file val-mat-map \
+       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
+       --prop-z0-sigma 0.0 \
+       --prop-d0-sigma 0.0
 
 To do the validation, five root macros are available in ``scripts/MaterialMapping``:
 
@@ -134,23 +160,21 @@ To do the validation, five root macros are available in ``scripts/MaterialMappin
 
   mkdir Validation
 
-  root -l -b ../Examples/Scripts/MaterialMapping/Mat_map.C'("propagation-material.root","material-maps_tracks.root","Validation")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map.C'("propagation-material.root","material-maps_tracks.root","Validation")'
   .q
 
   mkdir Surfaces
-  cd Surfaces
-  mkdir prop_plot
-  mkdir map_plot
-  mkdir ratio_plot
-  mkdir dist_plot
-  mkdir 1D_plot
-  cd ..
+  mkdir Surfaces/prop_plot
+  mkdir Surfaces/map_plot
+  mkdir Surfaces/ratio_plot
+  mkdir Surfaces/dist_plot
+  mkdir Surfaces/1D_plot
 
-  root -l -b ../Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("propagation-material.root","material-maps_tracks.root","geometry-map.json",100000,"Surfaces/ratio_plot","Surfaces/prop_plot","Surfaces/map_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("propagation-material.root","material-maps_tracks.root","geometry-map.json",100000,"Surfaces/ratio_plot","Surfaces/prop_plot","Surfaces/map_plot")'
   .q
-  root -l -b ../Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("material-maps_tracks.root","geometry-map.json",-1,"Surfaces/dist_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("material-maps_tracks.root","geometry-map.json",-1,"Surfaces/dist_plot")'
   .q
-  root -l -b ../Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("material-maps_tracks.root","geometry-map.json",100000,"Surfaces/1D_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("material-maps_tracks.root","geometry-map.json",100000,"Surfaces/1D_plot")'
   .q
 
 Using the validation plots you can then adapt the binning and the mapped surface to improve the mapping.
@@ -159,7 +183,7 @@ On top of those plots :
 
 .. code-block:: console
 
-  root -l -b ../Examples/Scripts/MaterialMapping/Mat_map_detector_plot_ratio.C'("propagation-material.root","material-maps_tracks.root",{X,Y,Z},100000,"Det_ratio","Det_Acts","Det_G4")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_detector_plot_ratio.C'("propagation-material.root","material-maps_tracks.root",{X,Y,Z},100000,"Det_ratio","Det_Acts","Det_G4")'
   .q
 
 Can be use with X,Y,Z is a list of volumes, this will plot the material ratio between the map and the Geantino scan for the given volumes.

--- a/docs/examples/howto/run_seeding.rst
+++ b/docs/examples/howto/run_seeding.rst
@@ -63,10 +63,10 @@ The example also generates output root files in the output directory.
 In ``performance_seeding_hists.root``, you can find the efficiency plots.
 The plots below are examples of the efficiency plots produced using the ttbar sample with 200 pile-up vertices.
 
-.. image:: ../figures/performance/seeding/seeding_eff_vs_pt.png
+.. image:: ../../figures/performance/seeding/seeding_eff_vs_pt.png
    :width: 300
 
-.. image:: ../figures/performance/seeding/seeding_eff_vs_eta.png
+.. image:: ../../figures/performance/seeding/seeding_eff_vs_eta.png
    :width: 300
 
 

--- a/docs/examples/howto/run_truth_tracking.rst
+++ b/docs/examples/howto/run_truth_tracking.rst
@@ -40,18 +40,18 @@ The truth tracking will generate three root files (the name of those root files 
 
 Example plots to show the fitting efficiency versus eta and pT for ttbar sample generated above:
 
-.. image:: ../figures/performance/fitter/trackeff_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/fitter/trackeff_vs_eta_ttbar_pu200.png
    :width: 300
 
-.. image:: ../figures/performance/fitter/trackeff_vs_pT_ttbar_pu200.png
+.. image:: ../../figures/performance/fitter/trackeff_vs_pT_ttbar_pu200.png
    :width: 300
 
 Example plots to show the average number of measurments and holes versus eta for ttbar sample generated above:
 
-.. image:: ../figures/performance/fitter/nMeasurements_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/fitter/nMeasurements_vs_eta_ttbar_pu200.png
    :width: 300
 
-.. image:: ../figures/performance/fitter/nHoles_vs_eta_ttbar_pu200.png
+.. image:: ../../figures/performance/fitter/nHoles_vs_eta_ttbar_pu200.png
    :width: 300
 
 To draw the resolution (residual and pull) of fitted perigee track parameters for e.g. ttbar sample, one could use:
@@ -64,5 +64,5 @@ To draw the resolution (residual and pull) of fitted perigee track parameters fo
 
 An example plot of the pull distribution of fitted perigee track parameters for the ttbar sample generated above:
 
-.. image:: ../figures/performance/fitter/pull_perigee_parameters_ttbar_pu200.png
+.. image:: ../../figures/performance/fitter/pull_perigee_parameters_ttbar_pu200.png
    :width: 600

--- a/docs/examples/howto/run_truth_tracking.rst
+++ b/docs/examples/howto/run_truth_tracking.rst
@@ -58,7 +58,7 @@ To draw the resolution (residual and pull) of fitted perigee track parameters fo
 
 .. code-block:: console
 
- $ root <source>/Examples/Scripts/perigeeParamResolution.C("rec_ttbar_pu200/performance_track_fitter.root")'
+ $ root <source>/Examples/Scripts/perigeeParamResolution.C'("rec_ttbar_pu200/performance_track_fitter.root")'
 
 ``<source>`` here is used to identify the path of the source directory. 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -191,7 +191,7 @@ package manager. [Sphinx][sphinx] and its extensions can be installed using the
 Python package manager via
 
 ```console
-$ cd <path/to/repository>
+$ cd <source>
 # --user installs to a user-specific directory instead of the system
 $ pip install --user -r docs/requirements.txt
 ```
@@ -199,7 +199,7 @@ $ pip install --user -r docs/requirements.txt
 To activate the documentation build targets, the `ACTS_BUILD_DOCS` option has to be set
 
 ```console
-$ cmake -B <build> -S <path/to/repository> -DACTS_BUILD_DOCS=on
+$ cmake -B <build> -S <source> -DACTS_BUILD_DOCS=on
 ```
 
 Then the documentation can be build with either of the following two build

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -32,13 +32,13 @@ The following dependencies are optional and are needed to build additional
 components:
 
 -   [CUDA](https://developer.nvidia.com/cuda-zone) for the CUDA plugin and the Exa.TrkX plugin and its examples
--   [DD4Hep](http://dd4hep.cern.ch) >= 1.11 for the DD4Hep plugin and some examples
+-   [DD4hep](http://dd4hep.cern.ch) >= 1.11 for the DD4hep plugin and some examples
 -   [Doxygen](http://doxygen.org) >= 1.8.15 for the documentation
 -   [Geant4](http://geant4.org/) for some examples
 -   [HepMC](https://gitlab.cern.ch/hepmc/HepMC3) >= 3.2.1 for some examples
 -   [Intel Threading Building Blocks](https://01.org/tbb) >= 2020.1 for the examples
 -   [ONNX Runtime](https://onnxruntime.ai/) for the ONNX plugin, the Exa.TrkX plugin and some examples
--   [Pythia8](http://home.thep.lu.se/~torbjorn/Pythia.html) for some examples
+-   [Pythia8](https://pythia.org) for some examples
 -   [ROOT](https://root.cern.ch) >= 6.20 for the TGeo plugin and the examples
 -   [Sphinx](https://www.sphinx-doc.org) >= 2.0 with [Breathe](https://breathe.readthedocs.io/en/latest/), [Exhale](https://exhale.readthedocs.io/en/latest/), and [recommonmark](https://recommonmark.readthedocs.io/en/latest/index.html) extensions for the documentation
 -   [SYCL](https://www.khronos.org/sycl/) for the SYCL plugin

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,9 +9,9 @@ following commands will clone the repository, configure, and build the core
 library:
 
 ```console
-$ git clone --recursive https://github.com/acts-project/acts <source-dir>
-$ cmake -B <build-dir> -S <source-dir>
-$ cmake --build <build-dir>
+$ git clone --recursive https://github.com/acts-project/acts <source>
+$ cmake -B <build> -S <source>
+$ cmake --build <build>
 ```
 
 For a full list of dependencies, including specific versions, see the
@@ -199,16 +199,16 @@ $ pip install --user -r docs/requirements.txt
 To activate the documentation build targets, the `ACTS_BUILD_DOCS` option has to be set
 
 ```console
-$ cmake -B <build-dir> -S <path/to/repository> -DACTS_BUILD_DOCS=on
+$ cmake -B <build> -S <path/to/repository> -DACTS_BUILD_DOCS=on
 ```
 
 Then the documentation can be build with either of the following two build
 targets
 
 ```console
-$ cmake --build <build-dir> docs # default fast option
+$ cmake --build <build> --target docs # default fast option
 # or
-$ cmake --build <build-dir> docs-with-api # full documentation
+$ cmake --build <build> --target docs-with-api # full documentation
 ```
 
 The default option includes the Doxygen, Sphinx, and the Breathe extension, i.e.
@@ -230,7 +230,7 @@ CMake options can be set by adding `-D<OPTION>=<VALUE>` to the configuration
 command. The following command would e.g. enable the unit tests
 
 ```console
-$ cmake -B <build-dir> -S <source-dir> -DACTS_BUILD_UNITTESTS=ON
+$ cmake -B <build> -S <source> -DACTS_BUILD_UNITTESTS=ON
 ```
 
 Multiple options can be given. `cmake` caches the options so that only changed
@@ -299,7 +299,7 @@ documentation](https://cmake.org/documentation/).
 The build is also affected by some environment variables. They can be set by prepending them to the configuration call:
 
 ```console
-$ DD4hep_DIR=<path/to/dd4hep> cmake -B <build-dir> -S <source-dir>
+$ DD4hep_DIR=<path/to/dd4hep> cmake -B <build> -S <source>
 ```
 
 The following environment variables might be useful.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ description of track parameters and measurements.
 Key features:
 
 -   A tracking geometry description which can be constructed manually or from
-    TGeo and DD4Hep input.
+    TGeo and DD4hep input.
 -   Simple event data model.
 -   Implementations of common algorithms for track propagation and fitting.
 -   Implementations of basic seed finding algorithms.


### PR DESCRIPTION
I fixed mainly those things I stumbled over during my first days, since some of them caused a little confusion for me.

- spelling/grammar/typos
- missing images links: the relative links were pointing to the wrong layer
- updated link to Pythia8: they changed their website
- missing expressions in commands

I unified some expressions:
- DD4hep instead of DD4Hep
- <build> and <source> instead of <build_dir>, <path-to-build>, <bld>, ...
- multiline cmake expressions for the terminal