### PR TITLE
ci: Bump macos dependencies

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -364,7 +364,7 @@ jobs:
           brew install cmake eigen ninja ccache
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.5e0adfa.tar.gz
+          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.395f534.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
 
       - name: Cache build


### PR DESCRIPTION
CI was complaining about mismatch in python minor version in the macos build. this should both bump the version and relax the python requirements. also introduces recent changes in ci-dependencies by @andiwand 