### PR TITLE
refactor: Move propagator options to general fitter options

### DIFF
--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
@@ -44,6 +44,7 @@ class TrackFittingAlgorithm final : public BareAlgorithm {
     std::reference_wrapper<const MeasurementCalibrator> calibrator;
     const Acts::Surface* referenceSurface = nullptr;
     Acts::LoggerWrapper logger;
+    Acts::PropagatorPlainOptions propOptions;
   };
 
   /// Fit function that takes the above parameters and runs a fit

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunctionsGsf.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunctionsGsf.cpp
@@ -36,7 +36,7 @@ auto makeGsfOptions(
                               options.calibrationContext,
                               extensions,
                               options.logger,
-                              Acts::PropagatorPlainOptions(),
+                              options.propOptions,
                               &(*options.referenceSurface),
                               f.maxComponents,
                               f.abortOnError,

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunctionsKalman.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithmFunctionsKalman.cpp
@@ -55,7 +55,7 @@ auto makeKfOptions(
 
   Acts::KalmanFitterOptions kfOptions(
       options.geoContext, options.magFieldContext, options.calibrationContext,
-      extensions, options.logger, Acts::PropagatorPlainOptions(),
+      extensions, options.logger, options.propOptions,
       &(*options.referenceSurface));
 
   kfOptions.multipleScattering = f.multipleScattering;


### PR DESCRIPTION
This PR makes the propagator options a dedicated member of the `GeneralFitterOptions` struct so that it can be explicitly configured for both the KF and GSF.