### PR TITLE
ci: Retry nodeps build if it fails the first time

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -304,7 +304,7 @@ jobs:
           -DACTS_USE_SYSTEM_EIGEN3=OFF
           -DACTS_BUILD_PLUGIN_JSON=ON
       - name: Build
-        run: ${SETUP} && cmake --build build --
+        run: ${SETUP} && ( cmake --build build -- || cmake --build build -- )
       - name: Unit tests
         run: ${SETUP} && ${PRELOAD} && cmake --build build -- test
       - name: Integration tests


### PR DESCRIPTION
For some reason the inclusion of ccache seems to have made the nodeps
build (specifically the boost build) fail sporadically. Since it works
most of the time and we want to keep using ccache for this build as
well, this PR attempts to just rertry the build step once if it fails.