### PR TITLE
refact python examples vertex_fitting.py

### DIFF
--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -37,6 +37,7 @@ def addVertexFitting(
     field,
     outputDirRoot: Optional[Union[Path, str]] = None,
     associatedParticles: str = "associatedTruthParticles",
+    trackParameters: str = "trackparameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
     logLevel: Optional[acts.logging.Level] = None,
 ):
@@ -69,7 +70,6 @@ def addVertexFitting(
     inputParticles = "particles_input"
     outputVertices = "fittedVertices"
     selectedParticles = "particles_selected"
-    trackParameters = "trackparameters"
 
     outputTime = ""
     if vertexFinder == VertexFinder.Truth:


### PR DESCRIPTION
in order to use `vertex_fitting.py` in ODD I need to modify the `trackParameters` to use a different name to match the one produced by [`seeding.py`](https://github.com/acts-project/acts/blob/main/Examples/Scripts/Python/seeding.py#L362)