### PR TITLE
fix: `data` is private in MultiTrajectory GrowableColumns

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -60,7 +60,7 @@ inline auto TrackStateProxy<M, ReadOnly>::parameters() const -> Parameters {
     idx = data().ipredicted;
   }
 
-  return Parameters(m_traj->m_params.data.col(idx).data());
+  return Parameters(m_traj->m_params.col(idx).data());
 }
 
 template <size_t M, bool ReadOnly>
@@ -73,7 +73,7 @@ inline auto TrackStateProxy<M, ReadOnly>::covariance() const -> Covariance {
   } else {
     idx = data().ipredicted;
   }
-  return Covariance(m_traj->m_cov.data.col(idx).data());
+  return Covariance(m_traj->m_cov.col(idx).data());
 }
 
 template <size_t M, bool ReadOnly>


### PR DESCRIPTION
When accessing `parameters` or `covariance` through the generic accessors (i.e. not `predicted`, `filtered`, or `smoothed`), the public `col()` function should be used instead of direct access to the private `data` member.

Marked WIP until some more tests complete and confirmed working as intended.