### PR TITLE
feat: Bump ODD and ActsDD4hep glue lib

### DIFF
--- a/thirdparty/actsdd4hep/CMakeLists.txt
+++ b/thirdparty/actsdd4hep/CMakeLists.txt
@@ -8,7 +8,7 @@ message( STATUS "Building ActsDD4hep glue library as part of the ACTS project" )
 # Declare where to get VecMem from.
 set( ACTS_ACTSDD4HEP_GIT_REPOSITORY "https://github.com/acts-project/acts-dd4hep.git"
    CACHE STRING "Git repository to take ActsDD4hep glue library from from" )
-set( ACTS_ACTSDD4HEP_GIT_TAG "v1.0.0" CACHE STRING "Version of ActsDD4hep glue library to build" )
+set( ACTS_ACTSDD4HEP_GIT_TAG "v1.0.1" CACHE STRING "Version of ActsDD4hep glue library to build" )
 mark_as_advanced( ACTS_ACTSDD4HEP_GIT_REPOSITORY ACTS_ACTSDD4HEP_GIT_TAG )
 FetchContent_Declare( actsdd4hep
    GIT_REPOSITORY "${ACTS_ACTSDD4HEP_GIT_REPOSITORY}"


### PR DESCRIPTION
This bumps ODD to current main, and the ActsDD4hep glue library to `v1.0.1`.