### PR TITLE
ci: Use rerunfailures to retry the flaky vertexing test

### DIFF
--- a/Examples/Python/tests/requirements.in
+++ b/Examples/Python/tests/requirements.in
@@ -2,3 +2,4 @@ pytest
 pytest-check
 uproot
 awkward
+pytest-rerunfailures

--- a/Examples/Python/tests/requirements.txt
+++ b/Examples/Python/tests/requirements.txt
@@ -26,7 +26,10 @@ pytest==7.0.1
     # via
     #   -r requirements.in
     #   pytest-check
+    #   pytest-rerunfailures
 pytest-check==1.0.4
+    # via -r requirements.in
+pytest-rerunfailures==10.2
     # via -r requirements.in
 tomli==2.0.1
     # via pytest

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -935,6 +935,7 @@ import itertools
     ],
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.flaky(reruns=2)
 def test_vertex_fitting_reading(
     tmp_path, ptcl_gun, rng, finder, inputTracks, entries, assert_root_hash
 ):


### PR DESCRIPTION
This test is unfortunately flaky and produces differing output
sometimes. Until we can fix the underlying issue, retry the job.

Example of failure: https://github.com/acts-project/acts/runs/7296836937?check_suite_focus=true
Issue: https://github.com/acts-project/acts/issues/1091