### PR TITLE
refactor: Log threshold error reporting

### DIFF
--- a/Core/src/Utilities/Logger.cpp
+++ b/Core/src/Utilities/Logger.cpp
@@ -71,7 +71,8 @@ void setFailureThreshold(Level level) {
 void setFailureThreshold(Level) {
   throw std::logic_error{
       "Compile-time log failure threshold defined (ACTS_LOG_FAILURE_THRESHOLD "
-      "or ACTS_ENABLE_LOG_FAILURE_THRESHOLD are set), unable to override"};
+      "is set or ACTS_ENABLE_LOG_FAILURE_THRESHOLD is OFF), unable to "
+      "override"};
 }
 
 #endif

--- a/Core/src/Utilities/Logger.cpp
+++ b/Core/src/Utilities/Logger.cpp
@@ -70,7 +70,8 @@ void setFailureThreshold(Level level) {
 
 void setFailureThreshold(Level) {
   throw std::logic_error{
-      "Compile-time log failure threshold defined, unable to override"};
+      "Compile-time log failure threshold defined (ACTS_LOG_FAILURE_THRESHOLD "
+      "or ACTS_ENABLE_LOG_FAILURE_THRESHOLD are set), unable to override"};
 }
 
 #endif

--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -18,6 +18,7 @@ if (
         f"`ACTS_LOG_FAILURE_THRESHOLD={os.environ['ACTS_LOG_FAILURE_THRESHOLD']}`"
         "However, a compile-time value is set via CMake, i.e. "
         f"`ACTS_LOG_FAILURE_THRESHOLD={logging.getFailureThreshold().name}`. "
+        "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`, which disables runtime thresholds."
     )
     if "PYTEST_CURRENT_TEST" in os.environ:
         # test environment, fail hard

--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -1,11 +1,29 @@
 from pathlib import Path
 from typing import Union
+import os
+import warnings
 
 
 from .ActsPythonBindings import *
 from .ActsPythonBindings import __version__
 from . import ActsPythonBindings
 from ._adapter import _patch_config
+
+if (
+    "ACTS_LOG_FAILURE_THRESHOLD" in os.environ
+    and os.environ["ACTS_LOG_FAILURE_THRESHOLD"] != logging.getFailureThreshold().name
+):
+    error = (
+        "Runtime log failure threshold is given in environment variable "
+        f"`ACTS_LOG_FAILURE_THRESHOLD={os.environ['ACTS_LOG_FAILURE_THRESHOLD']}`"
+        "However, a compile-time value is set via CMake, i.e. "
+        f"`ACTS_LOG_FAILURE_THRESHOLD={logging.getFailureThreshold().name}`. "
+    )
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        # test environment, fail hard
+        raise RuntimeError(error)
+    else:
+        warnings.warn(error + "\nThe compile-time threshold will be used in this case!")
 
 
 def Propagator(stepper, navigator):

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -96,16 +96,16 @@ void addLogging(Acts::Python::Context& ctx) {
   auto& m = ctx.get("main");
   auto logging = m.def_submodule("logging", "");
 
-  auto level = py::enum_<Acts::Logging::Level>(logging, "Level")
-                   .value("VERBOSE", Acts::Logging::VERBOSE)
-                   .value("DEBUG", Acts::Logging::DEBUG)
-                   .value("INFO", Acts::Logging::INFO)
-                   .value("WARNING", Acts::Logging::WARNING)
-                   .value("ERROR", Acts::Logging::ERROR)
-                   .value("FATAL", Acts::Logging::FATAL)
-                   .export_values();
+  auto levelEnum = py::enum_<Acts::Logging::Level>(logging, "Level")
+                       .value("VERBOSE", Acts::Logging::VERBOSE)
+                       .value("DEBUG", Acts::Logging::DEBUG)
+                       .value("INFO", Acts::Logging::INFO)
+                       .value("WARNING", Acts::Logging::WARNING)
+                       .value("ERROR", Acts::Logging::ERROR)
+                       .value("FATAL", Acts::Logging::FATAL)
+                       .export_values();
 
-  level
+  levelEnum
       .def("__lt__", [](Acts::Logging::Level self,
                         Acts::Logging::Level other) { return self < other; })
       .def("__gt__", [](Acts::Logging::Level self,

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -96,14 +96,25 @@ void addLogging(Acts::Python::Context& ctx) {
   auto& m = ctx.get("main");
   auto logging = m.def_submodule("logging", "");
 
-  py::enum_<Acts::Logging::Level>(logging, "Level")
-      .value("VERBOSE", Acts::Logging::VERBOSE)
-      .value("DEBUG", Acts::Logging::DEBUG)
-      .value("INFO", Acts::Logging::INFO)
-      .value("WARNING", Acts::Logging::WARNING)
-      .value("ERROR", Acts::Logging::ERROR)
-      .value("FATAL", Acts::Logging::FATAL)
-      .export_values();
+  auto level = py::enum_<Acts::Logging::Level>(logging, "Level")
+                   .value("VERBOSE", Acts::Logging::VERBOSE)
+                   .value("DEBUG", Acts::Logging::DEBUG)
+                   .value("INFO", Acts::Logging::INFO)
+                   .value("WARNING", Acts::Logging::WARNING)
+                   .value("ERROR", Acts::Logging::ERROR)
+                   .value("FATAL", Acts::Logging::FATAL)
+                   .export_values();
+
+  level
+      .def("__lt__", [](Acts::Logging::Level self,
+                        Acts::Logging::Level other) { return self < other; })
+      .def("__gt__", [](Acts::Logging::Level self,
+                        Acts::Logging::Level other) { return self > other; })
+      .def("__le__", [](Acts::Logging::Level self,
+                        Acts::Logging::Level other) { return self <= other; })
+      .def("__ge__", [](Acts::Logging::Level self, Acts::Logging::Level other) {
+        return self >= other;
+      });
 
   auto makeLogFunction = [](Acts::Logging::Level level) {
     return

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -32,8 +32,9 @@ except RuntimeError:
     warnings.warn(
         "Runtime log failure threshold could not be set. "
         "Compile-time value is probably set via CMake, i.e. "
-        f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set. The "
-        "pytest test-suite can produce false results in this configuration"
+        f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set, "
+        "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`. "
+        "The pytest test-suite can produce false results in this configuration"
     )
 
 

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -29,12 +29,17 @@ try:
         acts.logging.setFailureThreshold(acts.logging.WARNING)
 except RuntimeError:
     # Repackage with different error string
+    errtype = (
+        "negative"
+        if acts.logging.getFailureThreshold() < acts.logging.WARNING
+        else "positive"
+    )
     warnings.warn(
         "Runtime log failure threshold could not be set. "
         "Compile-time value is probably set via CMake, i.e. "
         f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set, "
         "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`. "
-        "The pytest test-suite can produce false results in this configuration"
+        f"The pytest test-suite can produce false-{errtype} results in this configuration"
     )
 
 

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -25,14 +25,15 @@ import acts
 import acts.examples
 
 try:
-    acts.logging.setFailureThreshold(acts.logging.WARNING)
+    if acts.logging.getFailureThreshold() != acts.logging.WARNING:
+        acts.logging.setFailureThreshold(acts.logging.WARNING)
 except RuntimeError:
     # Repackage with different error string
-    raise RuntimeError(
+    warnings.warn(
         "Runtime log failure threshold could not be set. "
         "Compile-time value is probably set via CMake, i.e. "
         f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set. The "
-        "pytest test-suite will not work in this configuration."
+        "pytest test-suite can produce false results in this configuration"
     )
 
 

--- a/Examples/Python/tests/helpers/__init__.py
+++ b/Examples/Python/tests/helpers/__init__.py
@@ -89,8 +89,9 @@ def failure_threshold(level: acts.logging.Level, enabled: bool = True):
             raise RuntimeError(
                 "Runtime log failure threshold could not be set. "
                 "Compile-time value is probably set via CMake, i.e. "
-                f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set. The "
-                "pytest test-suite will not work in this configuration."
+                f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set, "
+                "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`. "
+                "The pytest test-suite will not work in this configuration."
             )
 
         yield

--- a/Examples/Python/tests/helpers/__init__.py
+++ b/Examples/Python/tests/helpers/__init__.py
@@ -80,8 +80,8 @@ doHashChecks = os.environ.get("ROOT_HASH_CHECKS", "") != "" or "CI" in os.enviro
 
 @contextlib.contextmanager
 def failure_threshold(level: acts.logging.Level, enabled: bool = True):
-    if enabled:
-        prev = acts.logging.getFailureThreshold()
+    prev = acts.logging.getFailureThreshold()
+    if enabled and prev != level:
         try:
             acts.logging.setFailureThreshold(level)
         except RuntimeError:

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -346,7 +346,12 @@ def test_event_recording(tmp_path):
     env = os.environ.copy()
     env["NEVENTS"] = "1"
     env["ACTS_LOG_FAILURE_THRESHOLD"] = "WARNING"
-    subprocess.check_call([str(script)], cwd=tmp_path, env=env)
+    subprocess.check_call(
+        [str(script)],
+        cwd=tmp_path,
+        env=env,
+        stderr=subprocess.STDOUT,
+    )
 
     from acts.examples.hepmc3 import HepMC3AsciiReader
 
@@ -640,7 +645,10 @@ def test_volume_material_mapping(material_recording, tmp_path, assert_root_hash)
         pytest.param(
             getOpenDataDetector,
             540,
-            marks=pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up"),
+            marks=[
+                pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up"),
+                pytest.mark.slow,
+            ],
         ),
         (functools.partial(AlignedDetector.create, iovSize=1), 450),
     ],
@@ -1027,4 +1035,9 @@ def test_full_chain_odd_example(tmp_path):
     env = os.environ.copy()
     env["NEVENTS"] = "1"
     env["ACTS_LOG_FAILURE_THRESHOLD"] = "WARNING"
-    subprocess.check_call([str(script)], cwd=tmp_path, env=env)
+    subprocess.check_call(
+        [str(script)],
+        cwd=tmp_path,
+        env=env,
+        stderr=subprocess.STDOUT,
+    )

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -274,6 +274,7 @@ def test_seeding_orthogonal(tmp_path, trk_geo, field, assert_root_hash):
     assert_csv_output(csv, "particles_initial")
 
 
+@pytest.mark.slow
 def test_propagation(tmp_path, trk_geo, field, seq, assert_root_hash):
     from propagation import runPropagation
 
@@ -644,6 +645,7 @@ def test_volume_material_mapping(material_recording, tmp_path, assert_root_hash)
         (functools.partial(AlignedDetector.create, iovSize=1), 450),
     ],
 )
+@pytest.mark.slow
 def test_geometry_example(geoFactory, nobj, tmp_path):
     detector, trackingGeometry, decorators = geoFactory()
 
@@ -825,6 +827,7 @@ def test_digitization_config_example(trk_geo, tmp_path):
     ],
     ids=["full_seeding", "truth_estimated", "truth_smeared"],
 )
+@pytest.mark.slow
 def test_ckf_tracks_example(
     tmp_path, assert_root_hash, truthSmeared, truthEstimated, detector_config
 ):
@@ -1008,6 +1011,7 @@ def test_vertex_fitting_reading(
 
 
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
+@pytest.mark.slow
 def test_full_chain_odd_example(tmp_path):
     # This test literally only ensures that the full chain example can run without erroring out
     getOpenDataDetector()  # just to make sure it can build


### PR DESCRIPTION
After some discussion on Mattermost, I'm updating the error reporting strategy for log failure thresholds again.

This PR changes pytest to not fail on init, but it will report a python warning if a compile time threshold is set, and it is not WARNING (as that is the baseline for the majority of python tests). `failure_threshold` (currently only used in the GSF tests) will throw an exception if the target level is different from the current one and the compile time threshold is set.

I also added a way to sort of automatically have tests fail that use subprocess (G4 based tests). Here we use env vars to set the log failure threshold of the child process at runtime.
The python `__init__.py` will check if the `ACTS_LOG_FAILURE_THRESHOLD` environment variable is set to anything else than the compile-time threshold (if that is set). If it executes inside the python test environment, it will throw an exception right there (i.e. the subprocess exits with 1, leading to a test failure). Outside of the python test environment, it will just print a warning. 

(I also mark a few additional tests as `slow` in this PR, to enable filtering them out if desired)