### PR TITLE
feat: improve Python named-type argument checks

### DIFF
--- a/Examples/Python/python/acts/examples/__init__.py
+++ b/Examples/Python/python/acts/examples/__init__.py
@@ -147,12 +147,14 @@ def NamedTypeArgs(**namedTypeArgs):
                         kwargs[k] = cls(v)
 
             newargs = []
-            for a in args:
+            for i,a in enumerate(args):
                 k = namedTypeClasses.get(type(a))
                 if k is None:
                     newargs.append(a)
+                    if i > len(newargs):
+                        raise TypeError(f"{func.__name__}() positional argument {i} follows named-type arguments, which were converted to keyword arguments")
                 elif k in kwargs:
-                    raise KeyError(k)
+                    raise TypeError(f"{func.__name__}() keyword argument repeated: {k}")
                 else:
                     kwargs[k] = a
             return func(*newargs, **kwargs)


### PR DESCRIPTION
* `@NamedTypeArgs` decorator checks we don't have named-type `kwargs` following positional `args`.
* Improve exception message if we have repeated `kwargs`
