### PR TITLE
chore: clang-tidy readability-braces-around-statements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: '-*,readability-container-size-empty,readability-implicit-bool-cast,readability-implicit-bool-conversion,modernize-use-equals-default,modernize-use-override'
+Checks: '-*,readability-container-size-empty,readability-implicit-bool-cast,readability-implicit-bool-conversion,modernize-use-equals-default,modernize-use-override,readability-braces-around-statements'
 HeaderFilterRegex: '.*(?<!nlohmann\/json)\.(hpp|cpp|ipp)$'
 AnalyzeTemporaryDtors: true

--- a/CI/clang_tidy/limits.yml
+++ b/CI/clang_tidy/limits.yml
@@ -3,7 +3,7 @@ limits:
   # "readability-named-parameter": 0
   "readability-container-size-empty": 0
   # "modernize-use-using": 0
-  #"readability-braces-around-statements": 0
+  "readability-braces-around-statements": 0
   "modernize-use-override": 0
   "modernize-use-equals-default" : 0
   "readability-implicit-bool-cast": 0

--- a/Core/src/Geometry/CuboidVolumeBuilder.cpp
+++ b/Core/src/Geometry/CuboidVolumeBuilder.cpp
@@ -197,9 +197,11 @@ std::shared_ptr<Acts::TrackingVolume> Acts::CuboidVolumeBuilder::buildVolume(
                                BinningType::arbitrary, BinningValue::binX));
 
   // Build confined volumes
-  if (cfg.trackingVolumes.empty())
-    for (VolumeConfig vc : cfg.volumeCfg)
+  if (cfg.trackingVolumes.empty()) {
+    for (VolumeConfig vc : cfg.volumeCfg) {
       cfg.trackingVolumes.push_back(buildVolume(gctx, vc));
+    }
+  }
 
   std::shared_ptr<TrackingVolume> trackVolume;
   if (layVec.empty()) {

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -423,13 +423,14 @@ bool Acts::CylinderVolumeHelper::estimateAndCheckDimension(
 
   ACTS_VERBOSE("Parsing the " << layers.size()
                               << " layers to gather overall dimensions");
-  if (cylinderVolumeBounds != nullptr)
+  if (cylinderVolumeBounds != nullptr) {
     ACTS_DEBUG("Cylinder volume bounds are given: (rmin/rmax/dz) = "
                << "(" << cylinderVolumeBounds->get(CylinderVolumeBounds::eMinR)
                << "/" << cylinderVolumeBounds->get(CylinderVolumeBounds::eMaxR)
                << "/"
                << cylinderVolumeBounds->get(CylinderVolumeBounds::eHalfLengthZ)
                << ")");
+  }
 
   // prepare for parsing the layers
   double layerRmin = 10e10;
@@ -591,8 +592,9 @@ bool Acts::CylinderVolumeHelper::interGlueTrackingVolume(
     // list the volume names:
     //  and make the screen output readable
     size_t ivol = 0;
-    for (auto& vol : volumes)
+    for (auto& vol : volumes) {
       ACTS_VERBOSE("[" << ivol++ << "] - volume : " << vol->volumeName());
+    }
 
     // the needed iterators
     auto tVolIter = volumes.begin();
@@ -702,23 +704,27 @@ bool Acts::CylinderVolumeHelper::interGlueTrackingVolume(
     ACTS_VERBOSE("[GV] Register " << glueVolumesNegativeFace.size()
                                   << " volumes at face negativeFaceXY:");
     for (tVolIter = glueVolumesNegativeFace.begin();
-         tVolIter != glueVolumesNegativeFace.end(); ++tVolIter)
+         tVolIter != glueVolumesNegativeFace.end(); ++tVolIter) {
       ACTS_VERBOSE("   -> volume '" << (*tVolIter)->volumeName() << "'");
+    }
     ACTS_VERBOSE("[GV] Register " << glueVolumesPositiveFace.size()
                                   << " volumes at face positiveFaceXY: ");
     for (tVolIter = glueVolumesPositiveFace.begin();
-         tVolIter != glueVolumesPositiveFace.end(); ++tVolIter)
+         tVolIter != glueVolumesPositiveFace.end(); ++tVolIter) {
       ACTS_VERBOSE("   -> volume '" << (*tVolIter)->volumeName() << "'");
+    }
     ACTS_VERBOSE("[GV] Register " << glueVolumesInnerTube.size()
                                   << " volumes at face tubeInnerCover: ");
     for (tVolIter = glueVolumesInnerTube.begin();
-         tVolIter != glueVolumesInnerTube.end(); ++tVolIter)
+         tVolIter != glueVolumesInnerTube.end(); ++tVolIter) {
       ACTS_VERBOSE("   -> volume '" << (*tVolIter)->volumeName() << "'");
+    }
     ACTS_VERBOSE("[GV] Register " << glueVolumesOuterTube.size()
                                   << " volumes at face tubeOuterCover:");
     for (tVolIter = glueVolumesOuterTube.begin();
-         tVolIter != glueVolumesOuterTube.end(); ++tVolIter)
+         tVolIter != glueVolumesOuterTube.end(); ++tVolIter) {
       ACTS_VERBOSE("   -> volume '" << (*tVolIter)->volumeName());
+    }
   }
   // return success
   return true;

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -109,8 +109,9 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
       addTranslation * transform, cBounds, std::move(sArray), layerThickness,
       std::move(ad), active);
 
-  if (!cLayer)
+  if (!cLayer) {
     ACTS_ERROR("Creation of cylinder layer did not succeed!");
+  }
   associateSurfacesToLayer(*cLayer);
 
   // now return
@@ -181,8 +182,9 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
       addTranslation * transform, cBounds, std::move(sArray), layerThickness,
       std::move(ad), active);
 
-  if (!cLayer)
+  if (!cLayer) {
     ACTS_ERROR("Creation of cylinder layer did not succeed!");
+  }
   associateSurfacesToLayer(*cLayer);
 
   // now return
@@ -245,8 +247,9 @@ Acts::MutableLayerPtr Acts::LayerCreator::discLayer(
       DiscLayer::create(addTranslation * transform, dBounds, std::move(sArray),
                         layerThickness, std::move(ad), active);
 
-  if (!dLayer)
+  if (!dLayer) {
     ACTS_ERROR("Creation of disc layer did not succeed!");
+  }
   associateSurfacesToLayer(*dLayer);
   // return the layer
   return dLayer;

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -466,10 +466,11 @@ Acts::SurfaceArrayCreator::createVariableAxis(
     const Acts::Surface* backSurface = keys.back();
     const Acts::PlanarBounds* backBounds =
         dynamic_cast<const Acts::PlanarBounds*>(&(backSurface->bounds()));
-    if (backBounds == nullptr)
+    if (backBounds == nullptr) {
       ACTS_ERROR(
           "Given SurfaceBounds are not planar - not implemented for "
           "other bounds yet! ");
+    }
     // get the global vertices
     std::vector<Acts::Vector3> backVertices =
         makeGlobalVertices(gctx, *backSurface, backBounds->vertices(segments));

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -96,10 +96,13 @@ const Acts::TrackingVolume* Acts::TrackingVolume::lowestTrackingVolume(
   }
 
   // search for dense volumes
-  if (!m_confinedDenseVolumes.empty())
-    for (auto& denseVolume : m_confinedDenseVolumes)
-      if (denseVolume->inside(position, tol))
+  if (!m_confinedDenseVolumes.empty()) {
+    for (auto& denseVolume : m_confinedDenseVolumes) {
+      if (denseVolume->inside(position, tol)) {
         return denseVolume.get();
+      }
+    }
+  }
 
   // there is no lower sub structure
   return this;

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -55,8 +55,9 @@ Acts::AnnulusBounds::AnnulusBounds(
                 (std::pow(m, 2) + 1);
 
     Vector2 v1(x1, m * x1);
-    if (v1.dot(dir) > 0)
+    if (v1.dot(dir) > 0) {
       return v1;
+    }
     return {x2, m * x2};
   };
 

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -57,12 +57,13 @@ bool Acts::CylinderBounds::inside(const Vector2& lposition,
         lposition[0] > radius ? 2 * radius - lposition[0] : lposition[0];
     Vector2 shiftedlposition = shifted(lposition);
     if ((std::fabs(shiftedlposition[0]) <= halfPhi &&
-         std::fabs(shiftedlposition[1]) <= halfLengthZ))
+         std::fabs(shiftedlposition[1]) <= halfLengthZ)) {
       return true;
-    else if ((lposition[1] >= -(localx * std::tan(bevelMinZ) + halfLengthZ)) &&
-             (lposition[1] <= (localx * std::tan(bevelMaxZ) + halfLengthZ)))
+    } else if ((lposition[1] >=
+                -(localx * std::tan(bevelMinZ) + halfLengthZ)) &&
+               (lposition[1] <= (localx * std::tan(bevelMaxZ) + halfLengthZ))) {
       return true;
-    else {
+    } else {
       // check within tolerance
       auto boundaryCheck = bcheck.transformed(jacobian());
 

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -233,8 +233,9 @@ Acts::SurfaceIntersection Acts::CylinderSurface::intersect(
       [&](const Vector3& solution,
           Intersection3D::Status status) -> Intersection3D::Status {
     // No check to be done, return current status
-    if (!bcheck)
+    if (!bcheck) {
       return status;
+    }
     const auto& cBounds = bounds();
     if (cBounds.coversFullAzimuth() and
         bcheck.type() == BoundaryCheck::Type::eAbsolute) {

--- a/Examples/Algorithms/Digitization/src/ModuleClusters.cpp
+++ b/Examples/Algorithms/Digitization/src/ModuleClusters.cpp
@@ -108,8 +108,9 @@ void ModuleClusters::merge() {
       // indices (a good example of this would a for a timing
       // detector).
 
-      for (std::vector<ModuleValue>& remerged : mergeParameters(cellv))
+      for (std::vector<ModuleValue>& remerged : mergeParameters(cellv)) {
         newVals.push_back(squash(remerged));
+      }
     }
     m_moduleValues = std::move(newVals);
   } else {
@@ -142,8 +143,9 @@ std::vector<std::vector<ModuleValue>> ModuleClusters::mergeParameters(
 
   std::vector<bool> used(values.size(), false);
   for (size_t i = 0; i < values.size(); i++) {
-    if (used.at(i))
+    if (used.at(i)) {
       continue;
+    }
 
     retv.emplace_back();
     std::vector<ModuleValue>& thisvec = retv.back();
@@ -157,8 +159,9 @@ std::vector<std::vector<ModuleValue>> ModuleClusters::mergeParameters(
     // next unseen one
     for (size_t j = i + 1; j < values.size(); j++) {
       // Still may have already been used, so check it
-      if (used.at(j))
+      if (used.at(j)) {
         continue;
+      }
 
       // Now look for a match between current cluster and value `j' Consider
       // them matched until we find evidence to the contrary. This
@@ -234,8 +237,9 @@ ModuleValue ModuleClusters::squash(std::vector<ModuleValue>& values) {
       if (std::find(m_geoIndices.begin(), m_geoIndices.end(), idx) ==
           m_geoIndices.end()) {
         if (std::find(mval.paramIndices.begin(), mval.paramIndices.end(),
-                      idx) == mval.paramIndices.end())
+                      idx) == mval.paramIndices.end()) {
           mval.paramIndices.push_back(idx);
+        }
         if (mval.paramValues.size() < (j + 1)) {
           mval.paramValues.push_back(0);
           mval.paramVariances.push_back(0);

--- a/Examples/Algorithms/Geant4/src/MaterialPhysicsList.cpp
+++ b/Examples/Algorithms/Geant4/src/MaterialPhysicsList.cpp
@@ -33,6 +33,7 @@ void ActsExamples::MaterialPhysicsList::ConstructProcess() {
 void ActsExamples::MaterialPhysicsList::SetCuts() {
   SetCutsWithDefault();
 
-  if (verboseLevel > 0)
+  if (verboseLevel > 0) {
     DumpCutValuesTable();
+  }
 }

--- a/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventAction.cpp
@@ -155,32 +155,37 @@ void EventAction::EndOfEventAction(const G4Event*) {
   }
   // Filter irrelevant processes
   auto currentVertex = m_event.vertices()[0];
-  for (auto& bp : m_event.beams())
-    if (!bp->end_vertex())
+  for (auto& bp : m_event.beams()) {
+    if (!bp->end_vertex()) {
       currentVertex->add_particle_in(bp);
+    }
+  }
   followOutgoingParticles(m_event, currentVertex, m_processFilter);
   // Remove vertices w/o outgoing particles and particles w/o production
   // vertices
   while (true) {
     bool sane = true;
     for (auto v : m_event.vertices()) {
-      if (!v)
+      if (!v) {
         continue;
+      }
       if (v->particles_out().empty()) {
         m_event.remove_vertex(v);
         sane = false;
       }
     }
     for (auto p : m_event.particles()) {
-      if (!p)
+      if (!p) {
         continue;
+      }
       if (!p->production_vertex()) {
         m_event.remove_particle(p);
         sane = false;
       }
     }
-    if (sane)
+    if (sane) {
       break;
+    }
   }
 }
 

--- a/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/EventRecording.cpp
@@ -138,23 +138,26 @@ ActsExamples::ProcessCode ActsExamples::EventRecording::execute(
         while (true) {
           bool sane = true;
           for (auto v : event.vertices()) {
-            if (!v)
+            if (!v) {
               continue;
+            }
             if (v->particles_out().empty()) {
               event.remove_vertex(v);
               sane = false;
             }
           }
           for (auto p : event.particles()) {
-            if (!p)
+            if (!p) {
               continue;
+            }
             if (!p->production_vertex()) {
               event.remove_particle(p);
               sane = false;
             }
           }
-          if (sane)
+          if (sane) {
             break;
+          }
         }
         events.push_back(std::move(event));
       }

--- a/Examples/Algorithms/Geant4HepMC/src/SteppingAction.cpp
+++ b/Examples/Algorithms/Geant4HepMC/src/SteppingAction.cpp
@@ -97,7 +97,7 @@ void SteppingAction::UserSteppingAction(const G4Step* step) {
       event.add_vertex(vertex);
       vertex->set_status(1);
       vertex->add_attribute("NextProcessOf" + trackId, process);
-    } else
+    } else {
       // Search for an existing vertex
       for (const auto& vertex : event.vertices()) {
         if (vertex->position() == prePos) {
@@ -114,11 +114,13 @@ void SteppingAction::UserSteppingAction(const G4Step* step) {
           vertex->add_attribute("InitialParametersOf-" + trackId, preMom4);
         }
       }
-    if (track->GetCreatorProcess() != nullptr)
+    }
+    if (track->GetCreatorProcess() != nullptr) {
       postParticle->add_attribute(
           "CreatorProcessOf-" + trackId,
           std::make_shared<::HepMC3::StringAttribute>(
               track->GetCreatorProcess()->GetProcessName()));
+    }
   } else {
     // Add particle from same track to vertex
     m_previousVertex->add_particle_out(postParticle);

--- a/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
+++ b/Examples/Algorithms/HepMC/src/HepMCProcessExtractor.cpp
@@ -103,7 +103,7 @@ std::vector<ActsExamples::SimParticle> selectOutgoingParticles(
   } else {
     // Store the leftovers if it dies
     for (const HepMC3::ConstGenParticlePtr& procPartOut :
-         endVertex->particles_out())
+         endVertex->particles_out()) {
       if (procPartOut->attribute<HepMC3::IntAttribute>("TrackID")->value() ==
               trackID &&
           procPartOut->end_vertex()) {
@@ -113,6 +113,7 @@ std::vector<ActsExamples::SimParticle> selectOutgoingParticles(
               ActsExamples::HepMC3Particle::particle(dyingPartOut));
         }
       }
+    }
   }
 
   // Record the particles produced in this process

--- a/Examples/Detectors/DD4hepDetector/src/DD4hepGeometryService.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/DD4hepGeometryService.cpp
@@ -30,8 +30,9 @@ ActsExamples::DD4hep::DD4hepGeometryService::DD4hepGeometryService(
 }
 
 ActsExamples::DD4hep::DD4hepGeometryService::~DD4hepGeometryService() {
-  if (m_lcdd != nullptr)
+  if (m_lcdd != nullptr) {
     m_lcdd->destroyInstance();
+  }
 }
 
 ActsExamples::ProcessCode
@@ -72,8 +73,9 @@ ActsExamples::DD4hep::DD4hepGeometryService::buildDD4hepGeometry() {
 
 dd4hep::DetElement
 ActsExamples::DD4hep::DD4hepGeometryService::dd4hepGeometry() {
-  if (!m_dd4hepGeometry)
+  if (!m_dd4hepGeometry) {
     buildDD4hepGeometry();
+  }
   return m_dd4hepGeometry;
 }
 
@@ -86,8 +88,9 @@ ActsExamples::DD4hep::DD4hepGeometryService::DD4hepGeometryService::lcdd() {
 }
 
 TGeoNode* ActsExamples::DD4hep::DD4hepGeometryService::tgeoGeometry() {
-  if (!m_dd4hepGeometry)
+  if (!m_dd4hepGeometry) {
     buildDD4hepGeometry();
+  }
   return m_dd4hepGeometry.placement().ptr();
 }
 
@@ -120,14 +123,15 @@ void ActsExamples::DD4hep::sortFCChhDetElements(
   std::vector<dd4hep::DetElement> muon;
   for (auto& detElement : det) {
     std::string detName = detElement.name();
-    if (detName.find("Muon") != std::string::npos)
+    if (detName.find("Muon") != std::string::npos) {
       muon.push_back(detElement);
-    else if (detName.find("ECal") != std::string::npos)
+    } else if (detName.find("ECal") != std::string::npos) {
       eCal.push_back(detElement);
-    else if (detName.find("HCal") != std::string::npos)
+    } else if (detName.find("HCal") != std::string::npos) {
       hCal.push_back(detElement);
-    else
+    } else {
       tracker.push_back(detElement);
+    }
   }
   sort(muon.begin(), muon.end(),
        [](const dd4hep::DetElement& a, const dd4hep::DetElement& b) {

--- a/Examples/Detectors/GenericDetector/src/BuildGenericDetector.cpp
+++ b/Examples/Detectors/GenericDetector/src/BuildGenericDetector.cpp
@@ -61,8 +61,9 @@ std::vector<std::vector<Acts::Vector3>> modulePositionsDisc(
   } else {
     double totalLength = 0;
     // sum up the total length
-    for (auto& mhlength : moduleHalfLength)
+    for (auto& mhlength : moduleHalfLength) {
       totalLength += 2 * mhlength;
+    }
     // now calculate the overlap (equal pay)
     double rOverlap = (totalLength - deltaR) / (moduleHalfLength.size() - 1);
     // and now fill the radii and gaps

--- a/Examples/Detectors/MagneticField/src/FieldMapTextIo.cpp
+++ b/Examples/Detectors/MagneticField/src/FieldMapTextIo.cpp
@@ -42,8 +42,9 @@ ActsExamples::makeMagneticFieldMapRzFromText(
   double br = 0., bz = 0.;
   while (std::getline(map_file, line)) {
     if (line.empty() || line[0] == '%' || line[0] == '#' ||
-        line.find_first_not_of(' ') == std::string::npos)
+        line.find_first_not_of(' ') == std::string::npos) {
       continue;
+    }
 
     std::istringstream tmp(line);
     tmp >> r >> z >> br >> bz;
@@ -86,8 +87,9 @@ ActsExamples::makeMagneticFieldMapXyzFromText(
   double bx = 0., by = 0., bz = 0.;
   while (std::getline(map_file, line)) {
     if (line.empty() || line[0] == '%' || line[0] == '#' ||
-        line.find_first_not_of(' ') == std::string::npos)
+        line.find_first_not_of(' ') == std::string::npos) {
       continue;
+    }
 
     std::istringstream tmp(line);
     tmp >> x >> y >> z >> bx >> by >> bz;

--- a/Examples/Io/Csv/src/CsvMultiTrajectoryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvMultiTrajectoryWriter.cpp
@@ -141,10 +141,12 @@ ProcessCode CsvMultiTrajectoryWriter::writeT(
     std::sort(matchedTracks.begin(), matchedTracks.end(),
               [](const RecoTrackInfo& lhs, const RecoTrackInfo& rhs) {
                 // sort by nMajorityHits
-                if (lhs.first.nMajorityHits > rhs.first.nMajorityHits)
+                if (lhs.first.nMajorityHits > rhs.first.nMajorityHits) {
                   return true;
-                if (lhs.first.nMajorityHits < rhs.first.nMajorityHits)
+                }
+                if (lhs.first.nMajorityHits < rhs.first.nMajorityHits) {
                   return false;
+                }
                 // sort by nOutliers
                 return (lhs.first.nOutliers < rhs.first.nOutliers);
               });

--- a/Examples/Io/HepMC3/src/HepMC3Event.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Event.cpp
@@ -72,18 +72,24 @@ bool compareVertices(const std::shared_ptr<ActsExamples::SimVertex>& actsVertex,
   // Compare position, time, number of incoming and outgoing particles between
   // both vertices. Return false if one criterium does not match, else true.
   HepMC3::FourVector genVec = genVertex->position();
-  if (actsVertex->position4[0] != genVec.x())
+  if (actsVertex->position4[0] != genVec.x()) {
     return false;
-  if (actsVertex->position4[1] != genVec.y())
+  }
+  if (actsVertex->position4[1] != genVec.y()) {
     return false;
-  if (actsVertex->position4[2] != genVec.z())
+  }
+  if (actsVertex->position4[2] != genVec.z()) {
     return false;
-  if (actsVertex->position4[3] != genVec.t())
+  }
+  if (actsVertex->position4[3] != genVec.t()) {
     return false;
-  if (actsVertex->incoming.size() != genVertex->particles_in().size())
+  }
+  if (actsVertex->incoming.size() != genVertex->particles_in().size()) {
     return false;
-  if (actsVertex->outgoing.size() != genVertex->particles_out().size())
+  }
+  if (actsVertex->outgoing.size() != genVertex->particles_out().size()) {
     return false;
+  }
   return true;
 }
 }  // namespace
@@ -96,11 +102,11 @@ void ActsExamples::HepMC3Event::momentumUnit(HepMC3::GenEvent& event,
                                              const double momentumUnit) {
   // Check, if the momentum unit fits Acts::UnitConstants::MeV or _GeV
   HepMC3::Units::MomentumUnit mom;
-  if (momentumUnit == Acts::UnitConstants::MeV)
+  if (momentumUnit == Acts::UnitConstants::MeV) {
     mom = HepMC3::Units::MomentumUnit::MEV;
-  else if (momentumUnit == Acts::UnitConstants::GeV)
+  } else if (momentumUnit == Acts::UnitConstants::GeV) {
     mom = HepMC3::Units::MomentumUnit::GEV;
-  else {
+  } else {
     // Report invalid momentum unit and set GeV
     std::cout << "Invalid unit of momentum: " << momentumUnit << std::endl;
     std::cout << "Momentum unit [GeV] will be used instead" << std::endl;
@@ -114,11 +120,11 @@ void ActsExamples::HepMC3Event::lengthUnit(HepMC3::GenEvent& event,
                                            const double lengthUnit) {
   // Check, if the length unit fits Acts::UnitConstants::mm or _cm
   HepMC3::Units::LengthUnit len;
-  if (lengthUnit == Acts::UnitConstants::mm)
+  if (lengthUnit == Acts::UnitConstants::mm) {
     len = HepMC3::Units::LengthUnit::MM;
-  else if (lengthUnit == Acts::UnitConstants::cm)
+  } else if (lengthUnit == Acts::UnitConstants::cm) {
     len = HepMC3::Units::LengthUnit::CM;
-  else {
+  } else {
     // Report invalid length unit and set mm
     std::cout << "Invalid unit of length: " << lengthUnit << std::endl;
     std::cout << "Length unit [mm] will be used instead" << std::endl;
@@ -199,12 +205,13 @@ void ActsExamples::HepMC3Event::removeVertex(
     HepMC3::GenEvent& event, const std::shared_ptr<SimVertex>& vertex) {
   const std::vector<HepMC3::GenVertexPtr> genVertices = event.vertices();
   // Walk over every recorded vertex
-  for (auto& genVertex : genVertices)
+  for (auto& genVertex : genVertices) {
     if (compareVertices(vertex, genVertex)) {
       // Remove vertex if it matches actsVertex
       event.remove_vertex(genVertex);
       break;
     }
+  }
 }
 
 ///
@@ -247,9 +254,10 @@ std::vector<ActsExamples::SimParticle> ActsExamples::HepMC3Event::particles(
       event.particles();
 
   // Translate all particles
-  for (auto& genParticle : genParticles)
+  for (auto& genParticle : genParticles) {
     actsParticles.push_back(HepMC3Particle::particle(
         std::make_shared<HepMC3::GenParticle>(*genParticle)));
+  }
 
   return actsParticles;
 }
@@ -273,9 +281,10 @@ std::vector<ActsExamples::SimParticle> ActsExamples::HepMC3Event::beams(
   const std::vector<HepMC3::ConstGenParticlePtr> genBeams = event.beams();
 
   // Translate beam particles and store the result
-  for (auto& genBeam : genBeams)
+  for (auto& genBeam : genBeams) {
     actsBeams.push_back(HepMC3Particle::particle(
         std::make_shared<HepMC3::GenParticle>(*genBeam)));
+  }
   return actsBeams;
 }
 
@@ -287,9 +296,10 @@ std::vector<ActsExamples::SimParticle> ActsExamples::HepMC3Event::finalState(
   // Walk over every vertex
   for (auto& particle : particles) {
     // Collect particles without end vertex
-    if (!particle->end_vertex())
+    if (!particle->end_vertex()) {
       fState.push_back(HepMC3Particle::particle(
           std::make_shared<HepMC3::GenParticle>(*particle)));
+    }
   }
   return fState;
 }

--- a/Examples/Io/HepMC3/src/HepMC3Particle.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Particle.cpp
@@ -34,22 +34,24 @@ std::unique_ptr<ActsExamples::SimVertex>
 ActsExamples::HepMC3Particle::productionVertex(
     const std::shared_ptr<HepMC3::GenParticle> particle) {
   // Return the vertex if it exists
-  if (particle->production_vertex())
+  if (particle->production_vertex()) {
     return HepMC3Vertex::processVertex(
         std::make_shared<HepMC3::GenVertex>(*particle->production_vertex()));
-  else
+  } else {
     return nullptr;
+  }
 }
 
 std::unique_ptr<ActsExamples::SimVertex>
 ActsExamples::HepMC3Particle::endVertex(
     const std::shared_ptr<HepMC3::GenParticle> particle) {
   // Return the vertex if it exists
-  if (particle->end_vertex())
+  if (particle->end_vertex()) {
     return HepMC3Vertex::processVertex(
         std::make_shared<HepMC3::GenVertex>(*(particle->end_vertex())));
-  else
+  } else {
     return nullptr;
+  }
 }
 
 int ActsExamples::HepMC3Particle::pdgID(

--- a/Examples/Io/HepMC3/src/HepMC3Reader.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Reader.cpp
@@ -65,8 +65,9 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiReader::read(
     reader.read_event(event);
   }
 
-  if (events.empty())
+  if (events.empty()) {
     return ActsExamples::ProcessCode::ABORT;
+  }
 
   ACTS_VERBOSE(events.size()
                << " events read, writing to " << m_cfg.outputEvents);

--- a/Examples/Io/HepMC3/src/HepMC3Vertex.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Vertex.cpp
@@ -19,9 +19,10 @@ std::vector<ActsExamples::SimParticle> genParticlesToActs(
     const std::vector<HepMC3::GenParticlePtr>& genParticles) {
   std::vector<ActsExamples::SimParticle> actsParticles;
   // Translate all particles
-  for (auto& genParticle : genParticles)
+  for (auto& genParticle : genParticles) {
     actsParticles.push_back(ActsExamples::HepMC3Particle::particle(
         std::make_shared<HepMC3::GenParticle>(*genParticle)));
+  }
   return actsParticles;
 }
 
@@ -126,8 +127,9 @@ void ActsExamples::HepMC3Vertex::removeParticleIn(
     std::shared_ptr<SimParticle> particle) {
   // Remove particle if it exists
   if (HepMC3::GenParticlePtr genParticle =
-          matchParticles(vertex->particles_in(), particle))
+          matchParticles(vertex->particles_in(), particle)) {
     vertex->remove_particle_in(genParticle);
+  }
 }
 
 void ActsExamples::HepMC3Vertex::removeParticleOut(
@@ -135,8 +137,9 @@ void ActsExamples::HepMC3Vertex::removeParticleOut(
     std::shared_ptr<SimParticle> particle) {
   // Remove particle if it exists
   if (HepMC3::GenParticlePtr genParticle =
-          matchParticles(vertex->particles_out(), particle))
+          matchParticles(vertex->particles_out(), particle)) {
     vertex->remove_particle_out(genParticle);
+  }
 }
 
 void ActsExamples::HepMC3Vertex::position(

--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -13,8 +13,9 @@
 ActsExamples::HepMC3AsciiWriter::HepMC3AsciiWriter(const Config& config,
                                                    Acts::Logging::Level level)
     : WriterT(config.inputEvents, "HepMC3EventWriter", level), m_cfg(config) {
-  if (m_cfg.outputStem.empty())
+  if (m_cfg.outputStem.empty()) {
     throw std::invalid_argument("Missing output stem file name");
+  }
 }
 
 ActsExamples::ProcessCode ActsExamples::HepMC3AsciiWriter::writeT(
@@ -28,8 +29,9 @@ ActsExamples::ProcessCode ActsExamples::HepMC3AsciiWriter::writeT(
 
   for (const auto& event : events) {
     writer.write_event(event);
-    if (writer.failed())
+    if (writer.failed()) {
       return ActsExamples::ProcessCode::ABORT;
+    }
   }
 
   writer.close();

--- a/Examples/Io/Json/src/JsonGeometryList.cpp
+++ b/Examples/Io/Json/src/JsonGeometryList.cpp
@@ -22,16 +22,21 @@ void ActsExamples::from_json(const nlohmann::json& data,
 
 void ActsExamples::to_json(nlohmann::json& data,
                            const Acts::GeometryIdentifier& geoId) {
-  if (geoId.volume() != 0u)
+  if (geoId.volume() != 0u) {
     data["volume"] = geoId.volume();
-  if (geoId.boundary() != 0u)
+  }
+  if (geoId.boundary() != 0u) {
     data["boundary"] = geoId.boundary();
-  if (geoId.layer() != 0u)
+  }
+  if (geoId.layer() != 0u) {
     data["layer"] = geoId.layer();
-  if (geoId.approach() != 0u)
+  }
+  if (geoId.approach() != 0u) {
     data["approach"] = geoId.approach();
-  if (geoId.sensitive() != 0u)
+  }
+  if (geoId.sensitive() != 0u) {
     data["sensitive"] = geoId.sensitive();
+  }
 }
 
 void ActsExamples::from_json(const nlohmann::json& data,

--- a/Examples/Io/NuclearInteractions/src/NuclearInteractionOptions.cpp
+++ b/Examples/Io/NuclearInteractions/src/NuclearInteractionOptions.cpp
@@ -41,8 +41,9 @@ Acts::ActsDynamicVector readVector(const std::string&& vectorName) {
     Acts::ActsDynamicVector result;
     const unsigned int sizeVec = vector->size();
     result.resize(sizeVec);
-    for (unsigned int i = 0; i < sizeVec; i++)
+    for (unsigned int i = 0; i < sizeVec; i++) {
       result(i) = (*vector)[i];
+    }
 
     return result;
   }
@@ -102,12 +103,14 @@ void readKinematicParameters(
               invariantMassEigenvalues, invariantMassEigenvectors,
               invariantMassMean);
       if (softInteractionParameters) {
-        if (mult >= parameters.softKinematicParameters.size())
+        if (mult >= parameters.softKinematicParameters.size()) {
           parameters.softKinematicParameters.resize(mult + 1);
+        }
         parameters.softKinematicParameters[mult] = kinematicParameters;
       } else {
-        if (mult >= parameters.hardKinematicParameters.size())
+        if (mult >= parameters.hardKinematicParameters.size()) {
           parameters.hardKinematicParameters.resize(mult + 1);
+        }
         parameters.hardKinematicParameters[mult] = kinematicParameters;
       }
     }
@@ -177,8 +180,10 @@ ActsExamples::Options::readParametrisations(const std::string& fileName) {
       parameters.pdgMap.reserve(branchingPdgIds.size());
       for (unsigned int i = 0; i < branchingPdgIds.size(); i++) {
         auto it = parameters.pdgMap.begin();
-        while (it->first != branchingPdgIds[i] && it != parameters.pdgMap.end())
+        while (it->first != branchingPdgIds[i] &&
+               it != parameters.pdgMap.end()) {
           it++;
+        }
 
         const auto target =
             std::make_pair(targetPdgIds[i], targetPdgProbability[i]);

--- a/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
+++ b/Examples/Io/NuclearInteractions/src/RootNuclearInteractionParametersWriter.cpp
@@ -34,11 +34,12 @@ void labelEvents(
     for (const ActsExamples::SimParticle& p : event.finalParticles) {
       // Search for the maximum in particles with the same PDG ID as the
       // interacting one
-      if (p.pdg() == event.initialParticle.pdg())
+      if (p.pdg() == event.initialParticle.pdg()) {
         maxMom = std::max(p.absoluteMomentum(), maxMom);
-      // And the maximum among the others
-      else
+        // And the maximum among the others
+      } else {
         maxMomOthers = std::max(p.absoluteMomentum(), maxMomOthers);
+      }
     }
 
     // Label the initial momentum
@@ -60,8 +61,9 @@ void labelEvents(
     pt = ptVec.norm();
 
     // Use the final state p_T as veto for the soft label
-    if (event.soft && pt <= event.interactingParticle.transverseMomentum())
+    if (event.soft && pt <= event.interactingParticle.transverseMomentum()) {
       event.soft = false;
+    }
 
     // Store the multiplicity
     event.multiplicity = event.finalParticles.size();
@@ -105,8 +107,9 @@ buildNotNormalisedMap(TH1F const* hist) {
   }
 
   // Set the bin borders
-  for (iBin = 1; iBin <= nBins; iBin++)
+  for (iBin = 1; iBin <= nBins; iBin++) {
     histoBorders[iBin - 1] = hist->GetXaxis()->GetBinLowEdge(iBin);
+  }
   histoBorders[nBins] = hist->GetXaxis()->GetXmax();
 
   return std::make_tuple(histoBorders, temp_HistoContents, integral);
@@ -147,8 +150,9 @@ std::pair<std::vector<float>, std::vector<uint32_t>> buildMap(
   std::vector<double>& histoContents = std::get<1>(map);
 
   // Fast exit if the histogram is empty
-  if (histoContents.empty())
+  if (histoContents.empty()) {
     return std::make_pair(std::get<0>(map), std::vector<uint32_t>());
+  }
 
   // Set the bin content
   std::vector<uint32_t> normalisedHistoContents(nBins);
@@ -184,8 +188,9 @@ std::pair<std::vector<float>, std::vector<uint32_t>> buildMap(TH1F const* hist,
   std::vector<double>& histoContents = std::get<1>(map);
 
   // Fast exit if the histogram is empty
-  if (histoContents.empty())
+  if (histoContents.empty()) {
     return std::make_pair(std::get<0>(map), std::vector<uint32_t>());
+  }
 
   // Set the bin content
   std::vector<uint32_t> normalisedHistoContents(nBins);
@@ -346,8 +351,9 @@ ActsExamples::RootNuclearInteractionParametersWriter::
 ActsExamples::ProcessCode
 ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
   namespace Parametrisation = detail::NuclearInteractionParametrisation;
-  if (m_eventFractionCollection.empty())
+  if (m_eventFractionCollection.empty()) {
     return ProcessCode::ABORT;
+  }
 
   // Exclusive access to the file while writing
   std::lock_guard<std::mutex> lock(m_writeMutex);
@@ -374,9 +380,10 @@ ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
       Parametrisation::cumulativeNuclearInteractionProbability(
           m_eventFractionCollection, m_cfg.interactionProbabilityBins);
 
-  if (m_cfg.writeOptionalHistograms)
+  if (m_cfg.writeOptionalHistograms) {
     gDirectory->WriteObject(nuclearInteractionProbability,
                             "NuclearInteractionHistogram");
+  }
   const auto mapNIprob =
       buildMap(nuclearInteractionProbability, m_cfg.nSimulatedEvents);
   gDirectory->WriteObject(&mapNIprob.first, "NuclearInteractionBinBorders");
@@ -420,8 +427,9 @@ ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
   ACTS_DEBUG("Parametrisation of multiplicity probabilities finished");
 
   gDirectory->cd("soft");
-  if (m_cfg.writeOptionalHistograms)
+  if (m_cfg.writeOptionalHistograms) {
     gDirectory->WriteObject(multiplicity.first, "MultiplicityHistogram");
+  }
   const auto multProbSoft = buildMap(multiplicity.first);
   gDirectory->WriteObject(&multProbSoft.first, "MultiplicityBinBorders");
   gDirectory->WriteObject(&multProbSoft.second, "MultiplicityBinContents");
@@ -433,8 +441,9 @@ ActsExamples::RootNuclearInteractionParametersWriter::endRun() {
                std::to_string(i) + " particle(s) final state finished");
   }
   gDirectory->cd("../hard");
-  if (m_cfg.writeOptionalHistograms)
+  if (m_cfg.writeOptionalHistograms) {
     gDirectory->WriteObject(multiplicity.second, "MultiplicityHistogram");
+  }
   const auto multProbHard = buildMap(multiplicity.second);
   gDirectory->WriteObject(&multProbHard.first, "MultiplicityBinBorders");
   gDirectory->WriteObject(&multProbHard.second, "MultiplicityBinContents");

--- a/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
+++ b/Examples/Io/NuclearInteractions/src/detail/NuclearInteractionParametrisation.cpp
@@ -60,17 +60,22 @@ std::pair<Vector, Matrix> calculateMeanAndCovariance(
     unsigned int multiplicity, const EventProperties& events) {
   // Calculate the mean
   Vector mean = Vector::Zero(multiplicity);
-  for (const std::vector<float>& event : events)
-    for (unsigned int j = 0; j < multiplicity; j++)
+  for (const std::vector<float>& event : events) {
+    for (unsigned int j = 0; j < multiplicity; j++) {
       mean[j] += event[j];
+    }
+  }
   mean /= (float)events.size();
 
   // Calculate the covariance matrix
   Matrix covariance = Matrix::Zero(multiplicity, multiplicity);
-  for (unsigned int i = 0; i < multiplicity; i++)
-    for (unsigned int j = 0; j < multiplicity; j++)
-      for (unsigned int k = 0; k < events.size(); k++)
+  for (unsigned int i = 0; i < multiplicity; i++) {
+    for (unsigned int j = 0; j < multiplicity; j++) {
+      for (unsigned int k = 0; k < events.size(); k++) {
         covariance(i, j) += (events[k][i] - mean[i]) * (events[k][j] - mean[j]);
+      }
+    }
+  }
   covariance /= (float)events.size();
 
   return std::make_pair(mean, covariance);
@@ -93,8 +98,9 @@ Parametrisation buildMomentumParameters(const EventCollection& events,
                                         unsigned int nBins) {
   // Strip off data
   auto momenta = prepareMomenta(events, multiplicity, soft);
-  if (momenta.empty())
+  if (momenta.empty()) {
     return Parametrisation();
+  }
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(momenta, nBins);
@@ -139,24 +145,27 @@ EventProperties prepareMomenta(const EventCollection& events,
 ProbabilityDistributions buildMomPerMult(const EventProperties& events,
                                          unsigned int nBins) {
   // Fast exit
-  if (events.empty())
+  if (events.empty()) {
     return {};
+  }
   const unsigned int multMax = events[0].size();
 
   // Find the range of each histogram
   std::vector<float> min(multMax, std::numeric_limits<float>::max());
   std::vector<float> max(multMax, 0);
-  for (const std::vector<float>& event : events)
+  for (const std::vector<float>& event : events) {
     for (unsigned int i = 0; i < multMax; i++) {
       min[i] = std::min(event[i], min[i]);
       max[i] = std::max(event[i], max[i]);
     }
+  }
 
   // Evaluate the range of the histograms
   // This is used to avoid entries in over-/underflow bins
   std::vector<float> diff(multMax);
-  for (unsigned int i = 0; i < multMax; i++)
+  for (unsigned int i = 0; i < multMax; i++) {
     diff[i] = (max[i] - min[i]) * 0.1;
+  }
 
   // Build the histograms
   ProbabilityDistributions histos(multMax);
@@ -176,8 +185,9 @@ ProbabilityDistributions buildMomPerMult(const EventProperties& events,
 EventProperties convertEventToGaussian(const ProbabilityDistributions& histos,
                                        const EventProperties& events) {
   // Fast exit
-  if (events.empty())
+  if (events.empty()) {
     return {};
+  }
   const unsigned int multMax = events[0].size();
 
   // Loop over the events
@@ -220,8 +230,9 @@ Parametrisation buildInvariantMassParameters(const EventCollection& events,
                                              bool soft, unsigned int nBins) {
   // Strip off data
   auto invariantMasses = prepareInvariantMasses(events, multiplicity, soft);
-  if (invariantMasses.empty())
+  if (invariantMasses.empty()) {
     return Parametrisation();
+  }
 
   // Build histos
   ProbabilityDistributions histos = buildMomPerMult(invariantMasses, nBins);
@@ -244,8 +255,9 @@ cumulativePDGprobability(const EventCollection& events) {
 
   // Count how many and which particles were created by which particle
   for (const EventFraction& event : events) {
-    if (event.finalParticles.empty())
+    if (event.finalParticles.empty()) {
       continue;
+    }
     if (!event.soft) {
       counter[event.initialParticle.pdg()][event.finalParticles[0].pdg()]++;
     }
@@ -312,10 +324,11 @@ cumulativeMultiplicityProbability(const EventCollection& events,
                minHard, std::min(maxHard, multiplicityMax) + 1);
   for (const EventFraction& event : events) {
     if (event.multiplicity <= multiplicityMax) {
-      if (event.soft)
+      if (event.soft) {
         softHisto->Fill(event.multiplicity);
-      else
+      } else {
         hardHisto->Fill(event.multiplicity);
+      }
     }
   }
 
@@ -325,9 +338,11 @@ cumulativeMultiplicityProbability(const EventCollection& events,
 TVectorF softProbability(const EventCollection& events) {
   float counter = 0.;
   // Count the soft events
-  for (const EventFraction& event : events)
-    if (event.soft)
+  for (const EventFraction& event : events) {
+    if (event.soft) {
       counter++;
+    }
+  }
 
   TVectorF result(1);
   result[0] = counter / (float)events.size();

--- a/Examples/Io/Root/src/RootBFieldWriter.cpp
+++ b/Examples/Io/Root/src/RootBFieldWriter.cpp
@@ -40,8 +40,9 @@ void RootBFieldWriter::run(const Config& config,
   outputFile->cd();
   TTree* outputTree =
       new TTree(config.treeName.c_str(), config.treeName.c_str());
-  if (outputTree == nullptr)
+  if (outputTree == nullptr) {
     throw std::bad_alloc();
+  }
 
   // The position values
   double z;

--- a/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackWriter.cpp
@@ -45,8 +45,9 @@ ActsExamples::RootMaterialTrackWriter::RootMaterialTrackWriter(
   m_outputFile->cd();
   m_outputTree =
       new TTree(m_cfg.treeName.c_str(), "TTree from RootMaterialTrackWriter");
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
+  }
 
   // Set the branches
   m_outputTree->Branch("event_id", &m_eventId);

--- a/Examples/Io/Root/src/RootPlanarClusterWriter.cpp
+++ b/Examples/Io/Root/src/RootPlanarClusterWriter.cpp
@@ -48,8 +48,9 @@ ActsExamples::RootPlanarClusterWriter::RootPlanarClusterWriter(
   }
   m_outputFile->cd();
   m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
+  }
 
   // Set the branches
   m_outputTree->Branch("event_nr", &m_eventNr);

--- a/Examples/Io/Root/src/RootPropagationStepsWriter.cpp
+++ b/Examples/Io/Root/src/RootPropagationStepsWriter.cpp
@@ -45,8 +45,9 @@ ActsExamples::RootPropagationStepsWriter::RootPropagationStepsWriter(
 
   m_outputTree = new TTree(m_cfg.treeName.c_str(),
                            "TTree from RootPropagationStepsWriter");
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
+  }
 
   // Set the branches
   m_outputTree->Branch("event_nr", &m_eventNr);

--- a/Examples/Io/Root/src/RootTrackParameterWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackParameterWriter.cpp
@@ -71,9 +71,9 @@ ActsExamples::RootTrackParameterWriter::RootTrackParameterWriter(
   }
   m_outputFile->cd();
   m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
-  else {
+  } else {
     // The estimated track parameters
     m_outputTree->Branch("event_nr", &m_eventNr);
     m_outputTree->Branch("loc0", &m_loc0);

--- a/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
@@ -68,9 +68,9 @@ ActsExamples::RootTrajectoryStatesWriter::RootTrajectoryStatesWriter(
   }
   m_outputFile->cd();
   m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
-  else {
+  } else {
     // I/O parameters
     m_outputTree->Branch("event_nr", &m_eventNr);
     m_outputTree->Branch("multiTraj_nr", &m_multiTrajNr);
@@ -239,8 +239,9 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryStatesWriter::writeT(
   using HitParticlesMap = IndexMultimap<ActsFatras::Barcode>;
   using HitSimHitsMap = IndexMultimap<Index>;
 
-  if (m_outputFile == nullptr)
+  if (m_outputFile == nullptr) {
     return ProcessCode::SUCCESS;
+  }
 
   auto& gctx = ctx.geoContext;
   // Read additional input collections

--- a/Examples/Io/Root/src/RootTrajectorySummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectorySummaryWriter.cpp
@@ -60,9 +60,9 @@ ActsExamples::RootTrajectorySummaryWriter::RootTrajectorySummaryWriter(
   }
   m_outputFile->cd();
   m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
-  else {
+  } else {
     // I/O parameters
     m_outputTree->Branch("event_nr", &m_eventNr);
     m_outputTree->Branch("multiTraj_nr", &m_multiTrajNr);
@@ -148,8 +148,9 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectorySummaryWriter::writeT(
     const AlgorithmContext& ctx, const TrajectoriesContainer& trajectories) {
   using HitParticlesMap = IndexMultimap<ActsFatras::Barcode>;
 
-  if (m_outputFile == nullptr)
+  if (m_outputFile == nullptr) {
     return ProcessCode::SUCCESS;
+  }
 
   // Read additional input collections
   const auto& particles =

--- a/Examples/Io/Root/src/RootVertexPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/RootVertexPerformanceWriter.cpp
@@ -68,9 +68,9 @@ ActsExamples::RootVertexPerformanceWriter::RootVertexPerformanceWriter(
   }
   m_outputFile->cd();
   m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
-  if (m_outputTree == nullptr)
+  if (m_outputTree == nullptr) {
     throw std::bad_alloc();
-  else {
+  } else {
     // I/O parameters
     m_outputTree->Branch("diffx", &m_diffx);
     m_outputTree->Branch("diffy", &m_diffy);
@@ -152,8 +152,9 @@ ActsExamples::ProcessCode ActsExamples::RootVertexPerformanceWriter::writeT(
   m_nrecoVtx = vertices.size();
 
   ACTS_DEBUG("Number of reco vertices in event: " << m_nrecoVtx);
-  if (m_outputFile == nullptr)
+  if (m_outputFile == nullptr) {
     return ProcessCode::SUCCESS;
+  }
 
   // Read truth particle input collection
   const auto& allTruthParticles =

--- a/Examples/Run/Common/src/CommonMaterialMapping.cpp
+++ b/Examples/Run/Common/src/CommonMaterialMapping.cpp
@@ -78,8 +78,9 @@ int runMaterialMapping(int argc, char* argv[],
 
   /// Decorate the context
   for (auto& cdr : contextDecorators) {
-    if (cdr->decorate(context) != ActsExamples::ProcessCode::SUCCESS)
+    if (cdr->decorate(context) != ActsExamples::ProcessCode::SUCCESS) {
       throw std::runtime_error("Failed to decorate event context");
+    }
   }
 
   /// Default contexts

--- a/Examples/Run/Common/src/CommonOptions.cpp
+++ b/Examples/Run/Common/src/CommonOptions.cpp
@@ -107,29 +107,35 @@ void ActsExamples::Options::addOutputOptions(
   opt.add_options()("output-dir", value<std::string>()->default_value(""),
                     "Output directory location.");
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Root))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Root)) {
     opt.add_options()("output-root", bool_switch(),
                       "Switch on to write '.root' output file(s).");
+  }
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Csv))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Csv)) {
     opt.add_options()("output-csv", bool_switch(),
                       "Switch on to write '.csv' output file(s).");
+  }
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Obj))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Obj)) {
     opt.add_options()("output-obj", bool_switch(),
                       "Switch on to write '.obj' ouput file(s).");
+  }
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Json))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Json)) {
     opt.add_options()("output-json", bool_switch(),
                       "Switch on to write '.json' ouput file(s).");
+  }
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Cbor))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Cbor)) {
     opt.add_options()("output-cbor", bool_switch(),
                       "Switch on to write '.cbor' ouput file(s).");
+  }
 
-  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Txt))
+  if (ACTS_CHECK_BIT(formatFlags, OutputFormat::Txt)) {
     opt.add_options()("output-txt", bool_switch(),
                       "Switch on to write '.txt' ouput file(s).");
+  }
 }
 
 void ActsExamples::Options::addInputOptions(

--- a/Examples/Run/Common/src/GeometryExampleBase.cpp
+++ b/Examples/Run/Common/src/GeometryExampleBase.cpp
@@ -78,8 +78,9 @@ int processGeometry(int argc, char* argv[],
 
     /// Decorate the context
     for (auto& cdr : contextDecorators) {
-      if (cdr->decorate(context) != ActsExamples::ProcessCode::SUCCESS)
+      if (cdr->decorate(context) != ActsExamples::ProcessCode::SUCCESS) {
         throw std::runtime_error("Failed to decorate event context");
+      }
     }
 
     std::string geoContextStr = "";

--- a/Examples/Run/HepMC3/HepMC3Example.cpp
+++ b/Examples/Run/HepMC3/HepMC3Example.cpp
@@ -59,14 +59,16 @@ int main(int argc, char** argv) {
   using namespace ActsExamples::HepMC3Event;
   std::cout << "Event data:" << std::endl;
   std::cout << "Units: ";
-  if (momentumUnit(genevt) == Acts::UnitConstants::GeV)
+  if (momentumUnit(genevt) == Acts::UnitConstants::GeV) {
     std::cout << "[GEV], ";
-  else if (momentumUnit(genevt) == Acts::UnitConstants::MeV)
+  } else if (momentumUnit(genevt) == Acts::UnitConstants::MeV) {
     std::cout << "[MeV], ";
-  if (lengthUnit(genevt) == Acts::UnitConstants::mm)
+  }
+  if (lengthUnit(genevt) == Acts::UnitConstants::mm) {
     std::cout << "[mm]" << std::endl;
-  else if (lengthUnit(genevt) == Acts::UnitConstants::cm)
+  } else if (lengthUnit(genevt) == Acts::UnitConstants::cm) {
     std::cout << "[cm]" << std::endl;
+  }
   Acts::Vector3 evtPos = eventPos(genevt);
   std::cout << "Event position: " << evtPos(0) << ", " << evtPos(1) << ", "
             << evtPos(2) << std::endl;
@@ -74,9 +76,9 @@ int main(int argc, char** argv) {
 
   std::cout << "Beam particles: ";
   std::vector<ActsExamples::SimParticle> beam = beams(genevt);
-  if (beam.empty())
+  if (beam.empty()) {
     std::cout << "none" << std::endl;
-  else {
+  } else {
     for (auto& pbeam : beam) {
       std::cout << ActsFatras::findName(
                        static_cast<Acts::PdgParticle>(pbeam.pdg()))
@@ -88,9 +90,9 @@ int main(int argc, char** argv) {
   std::cout << std::endl << "Vertices: ";
   std::vector<std::unique_ptr<ActsExamples::SimVertex>> vertices =
       ActsExamples::HepMC3Event::vertices(genevt);
-  if (vertices.empty())
+  if (vertices.empty()) {
     std::cout << "none" << std::endl;
-  else {
+  } else {
     std::cout << std::endl;
     for (auto& vertex : vertices) {
       for (auto& particle : vertex->incoming) {

--- a/Fatras/Geant4/src/DummyDetectorConstruction.cpp
+++ b/Fatras/Geant4/src/DummyDetectorConstruction.cpp
@@ -49,11 +49,12 @@ void ActsFatras::DummyDetectorConstruction::dummyDetector() {
 
   // G4 material: vacuum setup
   G4Material* g4vacuum = G4Material::GetMaterial("Vacuum", false);
-  if (g4vacuum == nullptr)
+  if (g4vacuum == nullptr) {
     g4vacuum =
         new G4Material("FatrasDummyVacuum", 1., 1.01 * CLHEP::g / CLHEP::mole,
                        CLHEP::universe_mean_density, kStateGas,
                        0.1 * CLHEP::kelvin, 1.e-19 * CLHEP::pascal);
+  }
 
   // Build the logical and physical volume
   m_worldLog =

--- a/Fatras/Geant4/src/PDGtoG4Converter.cpp
+++ b/Fatras/Geant4/src/PDGtoG4Converter.cpp
@@ -22,9 +22,9 @@ G4ParticleDefinition* ActsFatras::PDGtoG4Converter::getParticleDefinition(
       it = m_pdgG4ParticleMap.find(pdgCode);
 
   // Find the corresponding particle and return it
-  if (it != m_pdgG4ParticleMap.end())
+  if (it != m_pdgG4ParticleMap.end()) {
     return it->second;
-  else {
+  } else {
     // Rescue mechanism: If the particle is neutral and its anti-particle is
     // stored then return that one instead
     it = m_pdgG4ParticleMap.find(makeAbsolutePdgParticle(pdgCode));
@@ -131,8 +131,9 @@ void ActsFatras::PDGtoG4Converter::fillPredefinedParticles() {
 }
 
 void ActsFatras::PDGtoG4Converter::addParticle(G4ParticleDefinition* pDef) {
-  if (pDef == nullptr)
+  if (pDef == nullptr) {
     return;
+  }
 
   m_pdgG4ParticleMap[static_cast<Acts::PdgParticle>(pDef->GetPDGEncoding())] =
       pDef;

--- a/Fatras/src/Physics/NuclearInteraction/NuclearInteraction.cpp
+++ b/Fatras/src/Physics/NuclearInteraction/NuclearInteraction.cpp
@@ -15,10 +15,12 @@ const detail::NuclearInteractionParameters& NuclearInteraction::findParameters(
     const detail::NuclearInteractionParametrisation& parametrisation,
     float particleMomentum) const {
   // Return lowest/highest if momentum outside the boundary
-  if (particleMomentum <= parametrisation.front().first)
+  if (particleMomentum <= parametrisation.front().first) {
     return parametrisation.front().second;
-  if (particleMomentum >= parametrisation.back().first)
+  }
+  if (particleMomentum >= parametrisation.back().first) {
     return parametrisation.back().second;
+  }
 
   // Find the two neighbouring parametrisations
   const auto lowerBound = std::lower_bound(
@@ -34,7 +36,7 @@ const detail::NuclearInteractionParameters& NuclearInteraction::findParameters(
   const float weight = (momentumUpperNeighbour - particleMomentum) /
                        (momentumUpperNeighbour - momentumLowerNeighbour);
   return (rnd < weight) ? std::prev(lowerBound, 1)->second : lowerBound->second;
-}
+}  // namespace ActsFatras
 
 unsigned int NuclearInteraction::sampleDiscreteValues(
     double rnd,
@@ -69,8 +71,9 @@ Particle::Scalar NuclearInteraction::sampleContinuousValues(
   // Find the bin
   const uint32_t int_rnd = UINT32_MAX * rnd;
   // Fast exit for non-normalised CDFs like interaction probabiltiy
-  if (int_rnd > distribution.second.back())
+  if (int_rnd > distribution.second.back()) {
     return std::numeric_limits<Scalar>::infinity();
+  }
   const auto it = std::upper_bound(distribution.second.begin(),
                                    distribution.second.end(), int_rnd);
   size_t iBin = std::min((size_t)std::distance(distribution.second.begin(), it),
@@ -84,8 +87,9 @@ Particle::Scalar NuclearInteraction::sampleContinuousValues(
     return distribution.first[iBin] +
            (distribution.first[iBin + 1] - distribution.first[iBin]) *
                (dcont > 0 ? (int_rnd - basecont) / dcont : 0.5);
-  } else
+  } else {
     return distribution.first[iBin];
+  }
 }
 
 unsigned int NuclearInteraction::finalStateMultiplicity(

--- a/Fatras/src/Utilities/LandauDistribution.cpp
+++ b/Fatras/src/Utilities/LandauDistribution.cpp
@@ -179,10 +179,12 @@ double ActsFatras::LandauDistribution::quantile(double z) {
       40.157721, 41.622399, 43.202525, 44.912465, 46.769077, 48.792279,
       51.005773, 53.437996, 56.123356, 59.103894};
 
-  if (z <= 0)
+  if (z <= 0) {
     return -std::numeric_limits<double>::infinity();
-  if (z >= 1)
+  }
+  if (z >= 1) {
     return std::numeric_limits<double>::infinity();
+  }
 
   double ranlan, u, v;
   u = 1000 * z;

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -236,9 +236,10 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::centralLayers(
                                    detExtension->getValue("z_max", "envelope")};
       } else if (geoShape != nullptr) {
         TGeoTubeSeg* tube = dynamic_cast<TGeoTubeSeg*>(geoShape);
-        if (tube == nullptr)
+        if (tube == nullptr) {
           ACTS_ERROR(
               " Cylinder layer has wrong shape - needs to be TGeoTubeSeg!");
+        }
 
         // extract the boundaries
         double rMin = tube->GetRmin() * UnitConstants::cm;

--- a/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepVolumeBuilder.cpp
@@ -58,9 +58,10 @@ Acts::DD4hepVolumeBuilder::centralVolumes() const {
 
     if (geoShape != nullptr) {
       TGeoTubeSeg* tube = dynamic_cast<TGeoTubeSeg*>(geoShape);
-      if (tube == nullptr)
+      if (tube == nullptr) {
         ACTS_ERROR(
             "[L] Cylinder layer has wrong shape - needs to be TGeoTubeSeg!");
+      }
 
       // Extract the boundaries
       rMin = tube->GetRmin() * UnitConstants::cm;

--- a/Tests/Benchmarks/RayFrustumBenchmark.cpp
+++ b/Tests/Benchmarks/RayFrustumBenchmark.cpp
@@ -93,8 +93,9 @@ int main(int /*argc*/, char** /*argv[]*/) {
     double tmin = -INFINITY, tmax = INFINITY;
 
     for (size_t i = 0; i < 3; i++) {
-      if (d[i] == 0.0)
+      if (d[i] == 0.0) {
         continue;
+      }
       double t1 = (box.min()[i] - origin[i]) / d[i];
       double t2 = (box.max()[i] - origin[i]) / d[i];
       tmin = std::max(tmin, std::min(t1, t2));

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -89,8 +89,9 @@ struct EndOfWorld {
     const double tolerance = state.options.targetTolerance;
     if (maxX - std::abs(stepper.position(state.stepping).x()) <= tolerance ||
         std::abs(stepper.position(state.stepping).y()) >= 0.5_m ||
-        std::abs(stepper.position(state.stepping).z()) >= 0.5_m)
+        std::abs(stepper.position(state.stepping).z()) >= 0.5_m) {
       return true;
+    }
     return false;
   }
 };
@@ -574,8 +575,9 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   for (const auto& pos : stepResult.position) {
     CHECK_SMALL(pos.y(), 1_um);
     CHECK_SMALL(pos.z(), 1_um);
-    if (pos == stepResult.position.back())
+    if (pos == stepResult.position.back()) {
       CHECK_CLOSE_ABS(pos.x(), 1_m, 1_um);
+    }
   }
   for (const auto& mom : stepResult.momentum) {
     CHECK_CLOSE_ABS(mom, startMom, 1_keV);

--- a/Tests/UnitTests/Core/Seeding/SeedfinderTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/SeedfinderTest.cpp
@@ -47,8 +47,9 @@ std::vector<const SpacePoint*> readFile(std::string filename) {
         float f22 = varianceR;
         float wid = varianceZ;
         float cov = wid * wid * .08333;
-        if (cov < f22)
+        if (cov < f22) {
           cov = f22;
+        }
         if (std::abs(z) > 450.) {
           varianceZ = 9. * cov;
           varianceR = .06;


### PR DESCRIPTION
Adds `{}` around all occurrences flagged by clang-tidy.
