### PR TITLE
test: assert ConstrainedStep size

### DIFF
--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -95,10 +95,14 @@ struct ConstrainedStep {
   /// Cast operator to double, returning the min/max value
   /// depending on the direction
   operator Scalar() const {
+    Scalar result;
     if (direction == NavigationDirection::Forward) {
-      return (*std::min_element(values.begin(), values.end()));
+      result = *(std::min_element(values.begin(), values.end()));
+    } else {
+      result = *(std::max_element(values.begin(), values.end()));
     }
-    return (*std::max_element(values.begin(), values.end()));
+    assert(std::abs(result) < max_scalar);
+    return result;
   }
 
   /// Access to a specific value

--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -101,7 +101,7 @@ struct ConstrainedStep {
     } else {
       result = (*std::max_element(values.begin(), values.end()));
     }
-    assert(std::abs(result) < max_scalar);
+    assert(std::abs(result) < std::numeric_limits<Scalar>::max());
     return result;
   }
 

--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -97,9 +97,9 @@ struct ConstrainedStep {
   operator Scalar() const {
     Scalar result;
     if (direction == NavigationDirection::Forward) {
-      result = *(std::min_element(values.begin(), values.end()));
+      result = (*std::min_element(values.begin(), values.end()));
     } else {
-      result = *(std::max_element(values.begin(), values.end()));
+      result = (*std::max_element(values.begin(), values.end()));
     }
     assert(std::abs(result) < max_scalar);
     return result;


### PR DESCRIPTION
while working on https://github.com/acts-project/acts/issues/1345 I stumbled across `ConstrainedStep` and the way how it converts to a `Scalar`. I believe there are cases where it will return `+/- max` which will break the propagation

in this PR I add an `assert` to catch those cases