### PR TITLE
fix: Add missing import for exatrkx example

### DIFF
--- a/Examples/Scripts/Python/exatrkx.py
+++ b/Examples/Scripts/Python/exatrkx.py
@@ -10,6 +10,7 @@ from acts import UnitConstants as u
 if "__main__" == __name__:
     import os
     from digitization import configureDigitization
+    from acts.examples.reconstruction import addExaTrkx
 
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 


### PR DESCRIPTION
After #1309, there's an import missing in `exatrkx.py`. This job isn't in the *required* checks, so the PR was merged with this failure.

I think this should fix this.

/cc @tboldagh @benjaminhuth