### PR TITLE
fix: improve Python full-chain ITk example

### DIFF
--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -55,7 +55,7 @@ s = addFatras(
     s,
     trackingGeometry,
     field,
-    # ParticleSelectorConfig(eta=(-4.0, 4.0), pt=(1.0 * u.GeV, 10.0 * u.GeV), removeNeutral=True),
+    # ParticleSelectorConfig(eta=(-4.0, 4.0), pt=(150 * u.MeV, None), removeNeutral=True),
     outputDirRoot=outputDir,
     rnd=rnd,
 )
@@ -82,7 +82,7 @@ s = addCKFTracks(
     s,
     trackingGeometry,
     field,
-    CKFPerformanceConfig(ptMin=400.0 * u.MeV, nMeasurementsMin=6),
+    CKFPerformanceConfig(ptMin=1.0 * u.GeV, nMeasurementsMin=6),
     outputDirRoot=outputDir,
 )
 


### PR DESCRIPTION
For ttbar + PU200 example code (commented out in `full_chain_itk.py`), change particle selector pT > 1 GeV to pT > 0.15 GeV.

This change allows lower momentum particles to be included in the simulation. They may not be reconstructed and certainly won't be included in the efficiency calculation, but do provide more realistic hits in the detector to test the pattern recognition. @asalzburger suggested Fatras should still be able to cope with 150 MeV.

Note, that this is in code that is commented out in the example script. The PR merely provides a better example for anyone wanting to test ITk with ttbar and pile-up.