### PR TITLE
ci: Set up backport action that reacts to labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,35 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: tibdex/backport@v2
+        with:
+          github_token: ${{ secrets.BACKPORT_TOKEN }}
+          title_template: "<%= title %> [backport #<%= number %> to <%= base %>]"
+          labels_template: '["backport"]'
+          body_template: >
+            Backport <%= mergeCommitSha %> from #<%= number %>.
+
+            ---
+
+            <%= body %>
+

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -2,4 +2,7 @@ version = 1
 
 merge.message.title = "pull_request_title"
 merge.message.body = "pull_request_body"
+merge.message.cut_body_before = "--- BEGIN COMMIT MESSAGE ---"
+merge.message.cut_body_and_text = true
 merge.method = "squash"
+merge.message.include_coauthors = true


### PR DESCRIPTION
This PR should configure a backport action that can be triggered via
labels. The action will create a backport PR targetting the branch
specified in the label. Kodiak's config has been updated to deal with
this nicely (hopefully).