### PR TITLE
ci: Change policybot config to only require approvals for main

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -8,6 +8,9 @@ approval_rules:
     count: 1
     teams:
     - "acts-project/reviewers"
+  if:
+    targets_branch:
+      pattern: "^(main)$"
   options:
     allow_author: false # just for completeness
     allow_contributor: true # Update button 'contributions' should be ignored


### PR DESCRIPTION
In order not to overcomplicate our process, I want to skip the approval requirement for branches other than `main`.