### PR TITLE
ci: Disable macOS job in v9.1.x

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Downstream run
         run: ${SETUP} && ./build-downstream/bin/ShowActsVersion
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
     steps:
@@ -78,7 +78,7 @@ jobs:
           brew install cmake eigen ninja
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.43e0201.tar.gz
+          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.f2b4e25.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
       - name: Configure
         # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -67,57 +67,6 @@ jobs:
         run: ${SETUP} && cmake --build build-downstream --
       - name: Downstream run
         run: ${SETUP} && ./build-downstream/bin/ShowActsVersion
-  macos:
-    runs-on: macos-11
-    env:
-      INSTALL_DIR: ${{ github.workspace }}/install
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: >
-          brew install cmake eigen ninja
-          && sudo mkdir /usr/local/acts
-          && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.f2b4e25.tar.gz
-          && tar -xf deps.tar.gz -C /usr/local/acts
-      - name: Configure
-        # setting CMAKE_CXX_STANDARD=17 is a workaround for a bug in the
-        # dd4hep CMake configuration that gets triggered on recent CMake
-        # versions such as the one installed via homebrew
-        run: >
-          cmake -B build -S .
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_CXX_STANDARD=17
-          -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
-          -DCMAKE_PREFIX_PATH=/usr/local/acts
-          -DACTS_BUILD_EVERYTHING=on
-          -DACTS_LOG_FAILURE_THRESHOLD=WARNING
-      - name: Build
-        run: cmake --build build  --
-      - name: Unit tests
-        run: cmake --build build -- test
-      - name: Integration tests
-        run: cmake --build build -- integrationtests
-      - name: Install
-        run: cmake --build build -- install
-      - uses: actions/upload-artifact@v2
-        with:
-          name: acts-macos
-          path: ${{ env.INSTALL_DIR }}
-      - name: Downstream configure
-        run: >
-          cmake -B build-downstream -S Tests/DownstreamProject
-          -GNinja
-          -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS=-Werror
-          -DCMAKE_CXX_STANDARD=17
-          -DCMAKE_PREFIX_PATH="${INSTALL_DIR};/usr/local/acts"
-      - name: Downstream build
-        run: cmake --build build-downstream --
-      - name: Downstream run
-        run: ./build-downstream/bin/ShowActsVersion
   cuda:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu1804_cuda:v9


### PR DESCRIPTION
It's too much work to get the macOS job to build correctly for that old release, so I'm removing it for that series.