### PR TITLE
fix: initialising world in GdmlDetectorConstruction [backport #1371 to develop/v19.x]

### DIFF
--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GdmlDetectorConstruction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GdmlDetectorConstruction.hpp
@@ -28,7 +28,7 @@ class GdmlDetectorConstruction final : public G4VUserDetectorConstruction {
   /// Path to the Gdml file
   std::string m_path;
   /// Cached worled volume
-  G4VPhysicalVolume* m_world;
+  G4VPhysicalVolume* m_world = nullptr;
 };
 
 }  // namespace ActsExamples


### PR DESCRIPTION
Backport 511528b19a94e8fb62d552ae983f76762d94916c from #1371.
---
This PR is a one-liner (a few characters actually), which fixes the initialised world value to `nullptr` hence the detector construction runs now after checking
```c++
if (m_world == nullptr){
construct()
}
```