### PR TITLE
chore: clang-tidy modernize-use-nullptr [backport #1358 to develop/v19.x]

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
 ---
-Checks: '-*,readability-container-size-empty,readability-implicit-bool-cast,readability-implicit-bool-conversion,modernize-use-equals-default,modernize-use-override,modernize-use-using,readability-braces-around-statements,performance-move-const-arg'
+Checks: '-*,readability-container-size-empty,readability-implicit-bool-cast,readability-implicit-bool-conversion,modernize-use-equals-default,modernize-use-override,modernize-use-using,readability-braces-around-statements,modernize-use-nullptr,performance-move-const-arg'
 HeaderFilterRegex: '.*(?<!nlohmann\/json)\.(hpp|cpp|ipp)$'
 AnalyzeTemporaryDtors: true

--- a/CI/clang_tidy/limits.yml
+++ b/CI/clang_tidy/limits.yml
@@ -11,5 +11,5 @@ limits:
   # "modernize-use-default-member-init": 0
   # "performance-unnecessary-value-param": 0
   # "modernize-use-equals-default": 0
-  # "modernize-use-nullptr": 0
+  "modernize-use-nullptr": 0
   "performance-move-const-arg": 0

--- a/Examples/Algorithms/Geant4/src/DDG4DetectorConstruction.cpp
+++ b/Examples/Algorithms/Geant4/src/DDG4DetectorConstruction.cpp
@@ -30,7 +30,7 @@ G4VPhysicalVolume* ActsExamples::DDG4DetectorConstruction::Construct() {
     g4map.attach(geo_info);
     // All volumes are deleted in ~G4PhysicalVolumeStore()
     m_world = geo_info->world();
-    m_detector.apply("DD4hepVolumeManager", 0, 0);
+    m_detector.apply("DD4hepVolumeManager", 0, nullptr);
     // Create Geant4 volume manager
     g4map.volumeManager();
   }

--- a/Examples/Detectors/DD4hepDetector/src/DD4hepGeometryService.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/DD4hepGeometryService.cpp
@@ -65,7 +65,7 @@ ActsExamples::DD4hep::DD4hepGeometryService::buildDD4hepGeometry() {
     m_lcdd->fromCompact(file.c_str());
   }
   m_lcdd->volumeManager();
-  m_lcdd->apply("DD4hepVolumeManager", 0, 0);
+  m_lcdd->apply("DD4hepVolumeManager", 0, nullptr);
   m_dd4hepGeometry = m_lcdd->world();
 
   return ActsExamples::ProcessCode::SUCCESS;

--- a/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
+++ b/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
@@ -97,9 +97,10 @@ int main(int argc, char** argv) {
           {snames[is], rmins[is], rmaxs[is], zmins[is], zmaxs[is]});
     }
 
-    TApplication* tApp = vm["silent"].as<bool>()
-                             ? nullptr
-                             : new TApplication("ResidualAndPulls", 0, 0);
+    TApplication* tApp =
+        vm["silent"].as<bool>()
+            ? nullptr
+            : new TApplication("ResidualAndPulls", nullptr, nullptr);
 
     materialComposition(iFile, iTree, oFile, bins, eta, dRegion);
 

--- a/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
+++ b/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
@@ -56,9 +56,10 @@ int main(int argc, char** argv) {
     auto oFile = vm["output"].as<std::string>();
     auto saveAs = vm["save"].as<std::string>();
 
-    TApplication* tApp = vm["silent"].as<bool>()
-                             ? nullptr
-                             : new TApplication("ResidualAndPulls", 0, 0);
+    TApplication* tApp =
+        vm["silent"].as<bool>()
+            ? nullptr
+            : new TApplication("ResidualAndPulls", nullptr, nullptr);
 
     // Run the actual resolution estimation
     switch (boundParamResolution(

--- a/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
+++ b/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
@@ -137,9 +137,10 @@ int main(int argc, char** argv) {
       ptBorders = {0., std::numeric_limits<double>::infinity()};
     }
 
-    TApplication* tApp = vm["silent"].as<bool>()
-                             ? nullptr
-                             : new TApplication("TrackSummary", 0, 0);
+    TApplication* tApp =
+        vm["silent"].as<bool>()
+            ? nullptr
+            : new TApplication("TrackSummary", nullptr, nullptr);
 
     std::bitset<7> residualPulls;
     std::bitset<5> auxiliaries;

--- a/Fatras/Geant4/src/DummyDetectorConstruction.cpp
+++ b/Fatras/Geant4/src/DummyDetectorConstruction.cpp
@@ -57,17 +57,19 @@ void ActsFatras::DummyDetectorConstruction::dummyDetector() {
   }
 
   // Build the logical and physical volume
-  m_worldLog =
-      m_worldLog != nullptr
-          ? new (m_worldLog)
-                G4LogicalVolume(worldBox, g4vacuum, "WorldLogical", 0, 0, 0)
-          : new G4LogicalVolume(worldBox, g4vacuum, "WorldLogical", 0, 0, 0);
-  m_worldPhys = m_worldPhys != nullptr
-                    ? new (m_worldPhys) G4PVPlacement(
-                          0, G4ThreeVector(0., 0., 0), "WorldPhysical",
-                          m_worldLog, 0, false, 0)
-                    : new G4PVPlacement(0, materialPosition, "WorldPhysical",
-                                        m_worldLog, 0, false, 0);
+  m_worldLog = m_worldLog != nullptr
+                   ? new (m_worldLog)
+                         G4LogicalVolume(worldBox, g4vacuum, "WorldLogical",
+                                         nullptr, nullptr, nullptr)
+                   : new G4LogicalVolume(worldBox, g4vacuum, "WorldLogical",
+                                         nullptr, nullptr, nullptr);
+  m_worldPhys =
+      m_worldPhys != nullptr
+          ? new (m_worldPhys)
+                G4PVPlacement(nullptr, G4ThreeVector(0., 0., 0),
+                              "WorldPhysical", m_worldLog, nullptr, false, 0)
+          : new G4PVPlacement(nullptr, materialPosition, "WorldPhysical",
+                              m_worldLog, nullptr, false, 0);
 }
 
 G4VPhysicalVolume* ActsFatras::DummyDetectorConstruction::Construct() {

--- a/Tests/IntegrationTests/Legacy/ATLSeedingIntegrationTest.cpp
+++ b/Tests/IntegrationTests/Legacy/ATLSeedingIntegrationTest.cpp
@@ -39,7 +39,7 @@ std::vector<Acts::Legacy::Seed<SpacePoint>> runSeeding(
   const Acts::Legacy::Seed<SpacePoint>* seed = seedMaker.next();
   int numSeeds = 0;
   std::vector<Acts::Legacy::Seed<SpacePoint>> seedVec;
-  while (seed != 0) {
+  while (seed != nullptr) {
     numSeeds++;
     auto spIter = seed->spacePoints().begin();
     spIter++;


### PR DESCRIPTION
Backport 789ce6962892025d24dd08ae87766c4e6543a632 from #1358.
---
This enables the `modernize-use-nullptr` check in clang-tidy. This prevents using `0` for a null pointer.
This PR also changes `0` to `nullptr` wherever already used as a null pointer.