### PR TITLE
fix: Comparison bug in updateSingleSurfaceStatus [backport #1107 to develop/v9.1.x]

### DIFF
--- a/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
+++ b/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
@@ -50,39 +50,22 @@ Acts::Intersection3D::Status updateSingleSurfaceStatus(
     // Path and overstep limit checking
     double pLimit = state.stepSize.value(ConstrainedStep::aborter);
     double oLimit = stepper.overstepLimit(state);
-    auto checkIntersection = [&](const Intersection3D& intersection) -> bool {
-      double cLimit = intersection.pathLength;
-      ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
-                                                  << ", " << cLimit);
-      bool accept = (cLimit > oLimit and
-                     cLimit * cLimit < pLimit * pLimit + s_onSurfaceTolerance);
-      if (accept) {
-        ACTS_VERBOSE("Intersection is WITHIN limit");
-        stepper.setStepSize(state, state.navDir * cLimit);
-      }
 
-      else {
-        ACTS_VERBOSE("Intersection is OUTSIDE limit because: ");
-        if (cLimit <= oLimit) {
-          ACTS_VERBOSE("- intersection path length "
-                       << cLimit << " <= overstep limit " << oLimit);
-        }
-        if (cLimit * cLimit > pLimit * pLimit + s_onSurfaceTolerance) {
-          ACTS_VERBOSE("- intersection path length "
-                       << std::abs(cLimit) << " is over the path limit "
-                       << (std::abs(pLimit) + s_onSurfaceTolerance)
-                       << " (including tolerance of " << s_onSurfaceTolerance
-                       << ")");
-        }
-      }
-
-      return accept;
-    };
     // If either of the two intersections are viable return reachable
-    if (checkIntersection(sIntersection.intersection) or
-        (sIntersection.alternative and
-         checkIntersection(sIntersection.alternative))) {
+    if (detail::checkIntersection(sIntersection.intersection, pLimit, oLimit,
+                                  s_onSurfaceTolerance, logger)) {
       ACTS_VERBOSE("Surface is reachable");
+      stepper.setStepSize(state,
+                          state.navDir * sIntersection.intersection.pathLength);
+      return Intersection3D::Status::reachable;
+    }
+
+    if (sIntersection.alternative and
+        detail::checkIntersection(sIntersection.alternative, pLimit, oLimit,
+                                  s_onSurfaceTolerance, logger)) {
+      ACTS_VERBOSE("Surface is reachable");
+      stepper.setStepSize(state,
+                          state.navDir * sIntersection.alternative.pathLength);
       return Intersection3D::Status::reachable;
     }
   }

--- a/Core/include/Acts/Utilities/Intersection.hpp
+++ b/Core/include/Acts/Utilities/Intersection.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <limits>
 namespace Acts {
@@ -163,5 +164,61 @@ struct SameSurfaceIntersection {
     return (i1.object == i2.object);
   }
 };
+
+namespace detail {
+
+/// This function checks if an intersection is valid for the specified
+/// path-limit and overstep-limit
+///
+/// @tparam intersection_t Type of the intersection object
+/// @tparam logger_t The logger type, which defaults to std::false_type to
+/// prevent the generation of logging code
+///
+/// @param intersection The intersection to check
+/// @param pLimit The path-limit
+/// @param oLimit The overstep-limit
+/// @param tolerance The tolerance that is applied to the path-limit criterion
+/// @param logger A optionally supplied logger which prints out a lot of infos
+/// at VERBOSE level
+template <typename intersection_t, typename logger_t = std::false_type>
+bool checkIntersection(const intersection_t& intersection, double pLimit,
+                       double oLimit, double tolerance,
+                       [[maybe_unused]] logger_t logger = logger_t{}) {
+  constexpr bool doLogging = not std::is_same_v<logger_t, std::false_type>;
+
+  const double cLimit = intersection.pathLength;
+
+  if constexpr (doLogging) {
+    ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
+                                                << ", " << cLimit);
+  }
+
+  const bool coCriterion = cLimit > oLimit;
+  const bool cpCriterion = std::abs(cLimit) < std::abs(pLimit) + tolerance;
+
+  const bool accept = coCriterion and cpCriterion;
+
+  if constexpr (doLogging) {
+    if (accept) {
+      ACTS_VERBOSE("Intersection is WITHIN limit");
+    } else {
+      ACTS_VERBOSE("Intersection is OUTSIDE limit because: ");
+      if (not coCriterion) {
+        ACTS_VERBOSE("- intersection path length "
+                     << cLimit << " <= overstep limit " << oLimit);
+      }
+      if (not cpCriterion) {
+        ACTS_VERBOSE("- intersection path length "
+                     << std::abs(cLimit) << " is over the path limit "
+                     << (std::abs(pLimit) + tolerance)
+                     << " (including tolerance of " << tolerance << ")");
+      }
+    }
+  }
+
+  return accept;
+}
+
+}  // namespace detail
 
 }  // namespace Acts

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -500,69 +500,25 @@ Acts::TrackingVolume::compatibleBoundaries(
     }
 
     ACTS_VERBOSE("Check intersection with surface "
-                 << &bSurface->surfaceRepresentation());
-    double cLimit = sIntersection.intersection.pathLength;
-    ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
-                                                << ", " << cLimit);
-
-    // Check if the surface is within limit
-    bool withinLimit =
-        (cLimit > oLimit and
-         cLimit * cLimit <= pLimit * pLimit + s_onSurfaceTolerance);
-    if (withinLimit) {
-      ACTS_VERBOSE("Intersection is WITHIN limit");
-      sIntersection.intersection.pathLength *=
-          std::copysign(1., options.navDir);
+                 << bSurface->surfaceRepresentation().geometryId());
+    if (detail::checkIntersection(sIntersection.intersection, pLimit, oLimit,
+                                  s_onSurfaceTolerance, logger)) {
       return BoundaryIntersection(sIntersection.intersection, bSurface,
                                   sIntersection.object);
-    } else {
-      ACTS_VERBOSE("Intersection is OUTSIDE limit because: ");
-      if (cLimit <= oLimit) {
-        ACTS_VERBOSE("- intersection path length "
-                     << cLimit << " <= overstep limit " << oLimit);
-      }
-      if (cLimit * cLimit > pLimit * pLimit + s_onSurfaceTolerance) {
-        ACTS_VERBOSE("- intersection path length "
-                     << std::abs(cLimit) << " is over the path limit "
-                     << (std::abs(pLimit) + s_onSurfaceTolerance)
-                     << " (including tolerance of "
-                     << s_curvilinearProjTolerance << ")");
-      }
     }
 
-    // Check the alternative
     if (sIntersection.alternative) {
       ACTS_VERBOSE("Consider alternative");
-      // Test the alternative
-      cLimit = sIntersection.alternative.pathLength;
-      ACTS_VERBOSE(" -> pLimit, oLimit, cLimit: " << pLimit << ", " << oLimit
-                                                  << ", " << cLimit);
-      withinLimit = (cLimit > oLimit and
-                     cLimit * cLimit <= pLimit * pLimit + s_onSurfaceTolerance);
-      if (sIntersection.alternative and withinLimit) {
-        ACTS_VERBOSE("Intersection is WITHIN limit");
-        sIntersection.alternative.pathLength *=
-            std::copysign(1., options.navDir);
+      if (detail::checkIntersection(sIntersection.alternative, pLimit, oLimit,
+                                    s_onSurfaceTolerance, logger)) {
         return BoundaryIntersection(sIntersection.alternative, bSurface,
                                     sIntersection.object);
-      } else {
-        ACTS_VERBOSE("Intersection is OUTSIDE limit because: ");
-        if (cLimit <= oLimit) {
-          ACTS_VERBOSE("- intersection path length "
-                       << cLimit << " <= overstep limit " << oLimit);
-        }
-        if (cLimit * cLimit > pLimit * pLimit + s_onSurfaceTolerance) {
-          ACTS_VERBOSE("- intersection path length "
-                       << std::abs(cLimit) << " is over the path limit "
-                       << (std::abs(pLimit) + s_onSurfaceTolerance)
-                       << " (including tolerance of "
-                       << s_curvilinearProjTolerance << ")");
-        }
+        ;
       }
     } else {
       ACTS_VERBOSE("No alternative for intersection");
     }
-    // Return an invalid one
+
     ACTS_VERBOSE("No intersection accepted");
     return BoundaryIntersection();
   };


### PR DESCRIPTION
Backport 34adc81917fb6700e2c621414151f6008327f199 from #1107.
---
I think I found actually two small bugs in the `updateSingleSurfaceStatus` function:

1) The first one is older I think: when `pLimit == cLimit + s_onSurfaceTolerance`, then the intersection is not accepted, but there is also no message printed out, because it is only checkt for `<` and `>`, but one should be `<=` or `>=` in this case I think.

2) With the `s_onSurfaceTolerance`, I think we do not compare what we accually want here anymore:

   What we check is something like `a*a < b*b + c`, but what we (I think) want to check is `|a| < |b| + c`. This is obviously not the same (e.g. with a=4, b=3, c=2).

   So I know also added `std::abs` in the computation of the `accept`-boolean. Not sure if that is the best way, since it seems that was not done for performance reasons or something like that before. One could also change the verbose message to print out the actual criterion...