### PR TITLE
fix: TrackingVolume intersection check didn't copy sign [backport #1115 to develop/v9.1.x]

### DIFF
--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -503,6 +503,8 @@ Acts::TrackingVolume::compatibleBoundaries(
                  << bSurface->surfaceRepresentation().geometryId());
     if (detail::checkIntersection(sIntersection.intersection, pLimit, oLimit,
                                   s_onSurfaceTolerance, logger)) {
+      sIntersection.intersection.pathLength *=
+          std::copysign(1., options.navDir);
       return BoundaryIntersection(sIntersection.intersection, bSurface,
                                   sIntersection.object);
     }
@@ -511,6 +513,8 @@ Acts::TrackingVolume::compatibleBoundaries(
       ACTS_VERBOSE("Consider alternative");
       if (detail::checkIntersection(sIntersection.alternative, pLimit, oLimit,
                                     s_onSurfaceTolerance, logger)) {
+        sIntersection.alternative.pathLength *=
+            std::copysign(1., options.navDir);
         return BoundaryIntersection(sIntersection.alternative, bSurface,
                                     sIntersection.object);
         ;


### PR DESCRIPTION
Backport 67afb407cae99d38c5ac061abb4d86aae1e67ce3 from #1115.
---
I noticed in #1103 that the navigation failed in backward mode after we merged #1107.

Indeed, during the change in #1107, `TrackingVolume` lost a line that copied the sign from the navigation direction onto the path length in `compatibleBoundaries`. This made the navigation go haywire when it tried to target boundaries in reverse propagation mode.

This PR adds that back in, and should fix #1103's test runs.