### PR TITLE
ci: Do not run build jobs on docs-only changes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,6 +7,8 @@ on:
       - main
       - 'release/**'
       - 'develop/**'
+  paths-ignore:
+    - "docs/**"
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
@@ -602,23 +604,3 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           && cmake --build build
 
-  docs:
-    runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/ubuntu2004:v29
-    env:
-        DOXYGEN_WARN_AS_ERROR: YES
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: >
-          apt-get install -y doxygen
-          && pip3 install --upgrade pip
-          && pip install -r docs/requirements.txt
-      - name: Configure
-        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=ON
-      - name: Build
-        run: cmake --build build --target docs-with-api
-      - uses: actions/upload-artifact@v2
-        with:
-          name: acts-docs
-          path: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,33 @@
+name: Docs
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+      - 'develop/**'
+  paths:
+    - "docs/**"
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    container: ghcr.io/acts-project/ubuntu2004:v29
+    env:
+        DOXYGEN_WARN_AS_ERROR: YES
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: >
+          apt-get install -y doxygen
+          && pip3 install --upgrade pip
+          && pip install -r docs/requirements.txt
+      - name: Configure
+        run: cmake -B build -S . -GNinja -DACTS_BUILD_DOCS=ON
+      - name: Build
+        run: cmake --build build --target docs-with-api
+      - uses: actions/upload-artifact@v2
+        with:
+          name: acts-docs
+          path: docs/_build/html/

--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -1,0 +1,31 @@
+rules:
+  - required_checks:
+      - Lint PR / Validate PR title
+      - WIP
+      - milestone-set
+    required_pattern:
+      - "review-required: *"
+
+ - branch_filter:
+     - "main"
+     - "develop/*"
+   paths_ignore:
+     - "docs/*" 
+
+   required_checks:
+     - codecov/project
+     - Docs / docs
+
+   required_pattern:
+     - "Builds / *"
+     - "Checks / *"
+     - "Analysis / *"
+     - "CI Bridge / *"
+
+ - branch_filter:
+     - "main"
+     - "develop/*"
+   paths:
+     - "docs/*" 
+   required_checks:
+     - Docs / docs


### PR DESCRIPTION
This should skip all the build jobs if only files inside docs were changed. Once merged, in principle merge-sentinel should only require the correct jobs 🤞 