### PR TITLE
ci: Fix path-ignore for docs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -9,8 +9,8 @@ on:
       - main
       - 'release/**'
       - 'develop/**'
-  paths-ignore:
-    - "docs/**"
+    paths-ignore:
+      - "docs/**"
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,8 +7,8 @@ on:
       - main
       - 'release/**'
       - 'develop/**'
-  paths-ignore:
-    - "docs/**"
+    paths-ignore:
+      - "docs/**"
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
I had a typo in the previous yml file changes. This should make the default jobs run again.