### PR TITLE
fix: change typeid check to dynamic_cast

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/WhiteBoard.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/WhiteBoard.hpp
@@ -100,11 +100,14 @@ inline const T& ActsExamples::WhiteBoard::get(const std::string& name) const {
     throw std::out_of_range("Object '" + name + "' does not exists");
   }
   const IHolder* holder = it->second.get();
-  if (typeid(T) != holder->type()) {
-    throw std::out_of_range("Type mismatch for object '" + name + "'");
-  }
+
+  const auto* castedHolder = dynamic_cast<const HolderT<T>*>(holder);
+  if (castedHolder == nullptr){
+      throw std::out_of_range("Type mismatch for object '" + name + "'");
+    }
+
   ACTS_VERBOSE("Retrieved object '" << name << "'");
-  return reinterpret_cast<const HolderT<T>*>(holder)->value;
+  return castedHolder->value;
 }
 
 inline bool ActsExamples::WhiteBoard::exists(const std::string& name) const {


### PR DESCRIPTION
This PR changes the way we check for compatibility in the `WhiteBoard` as sometimes the typeid check would fail, even if the cast would work.

The reason for the failure is not fully understood, but a `dynamic_cast` is ok in this case, as this is not a time-critical operation.