### PR TITLE
ci: Move Analysis job from required pattern to explicit name

### DIFF
--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -15,11 +15,11 @@ rules:
     required_checks:
      - codecov/project
      - Docs / docs
+     - Analysis / build_debug
 
     required_pattern:
      - "Builds / *"
      - "Checks / *"
-     - "Analysis / *"
      - "CI Bridge / *"
 
   - branch_filter:


### PR DESCRIPTION
Otherwise it requires Analysis jobs that are only triggered on main.