### PR TITLE
feat: Enable Delegates to conveniently use stateful lambdas [backport #1410 to develop/v19.x]

### DIFF
--- a/Tests/UnitTests/Core/Utilities/DelegateTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/DelegateTests.cpp
@@ -167,4 +167,36 @@ BOOST_AUTO_TEST_CASE(DelegateReferenceMember) {
   // d.connect<&SignatureTest::noModify>(&s);
 }
 
+BOOST_AUTO_TEST_CASE(StatefullLambdas) {
+  std::vector<int> v;
+
+  auto lambda = [&](int n) -> int {
+    v.push_back(n);
+    return v.size();
+  };
+
+  Delegate<int(int)> d(lambda);
+
+  BOOST_CHECK(d);
+  BOOST_CHECK(d.connected());
+  BOOST_CHECK(d(2) == 1);
+
+  d.disconnect();
+  d = lambda;
+
+  BOOST_CHECK(d);
+  BOOST_CHECK(d.connected());
+  BOOST_CHECK(d(2) == 2);
+
+  d.disconnect();
+  d.connect(lambda);
+
+  BOOST_CHECK(d);
+  BOOST_CHECK(d.connected());
+  BOOST_CHECK(d(2) == 3);
+
+  // This should not compile because of deleted && overloads
+  // d.connect([&](int a){ v.push_back(a); return v.size(); });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backport f6731263d4ead325f67348c98a0a34eae30bb4ec from #1410.
---
This PR adds functionality to the `Acts::Delegate`, that enables to construct, assign and connect stateful lambdas like this:

```c++
int n = 0;
auto lambda = [&](){ ++n; };

Acts::Delegate<void()> d(lambda);
d = lambda;
d.connect(lambda);
```

The use of temporary stateful lambdas is forbidden due to deleted overloads with `Callable &&`:
```c++
Acts::Delegate<void()> d([&](){ ++n; }); // compile error
```

I havn't checked yet if this can simplify code somewhere in Core or Examples, but I ran in situations myself where this would be useful.