### PR TITLE
refactor: Improve ActsPythonBindings tracing

### DIFF
--- a/Examples/Python/python/acts/_adapter.py
+++ b/Examples/Python/python/acts/_adapter.py
@@ -5,16 +5,12 @@ from typing import Optional, Callable, Dict, Any
 import acts
 
 
-def _unwrap(typ):
-    return typ.__wrapped__ if hasattr(typ, "__wrapped__") else typ
-
-
 def _make_config_adapter(fn):
     @functools.wraps(fn)
     def wrapped(self, *args, **kwargs):
         if len(args) > 0:
             maybe_config = args[0]
-            if isinstance(maybe_config, _unwrap(type(self).Config)):
+            if isinstance(maybe_config, inspect.unwrap(type(self).Config)):
                 # is already config, nothing to do here
                 fn(self, maybe_config, *args[1:], **kwargs)
                 return
@@ -80,7 +76,7 @@ def _patch_config(m):
 def _detector_create(cls, config_class=None):
     def create(*args, mdecorator=None, **kwargs):
         if mdecorator is not None:
-            if not isinstance(mdecorator, _unwrap(acts.IMaterialDecorator)):
+            if not isinstance(mdecorator, inspect.unwrap(acts.IMaterialDecorator)):
                 raise TypeError("Material decorator is not valid")
         if config_class is None:
             cfg = cls.Config()

--- a/Examples/Python/python/acts/_adapter.py
+++ b/Examples/Python/python/acts/_adapter.py
@@ -5,12 +5,16 @@ from typing import Optional, Callable, Dict, Any
 import acts
 
 
+def _unwrap(typ):
+    return typ.__wrapped__ if hasattr(typ, "__wrapped__") else typ
+
+
 def _make_config_adapter(fn):
     @functools.wraps(fn)
     def wrapped(self, *args, **kwargs):
         if len(args) > 0:
             maybe_config = args[0]
-            if isinstance(maybe_config, type(self).Config):
+            if isinstance(maybe_config, _unwrap(type(self).Config)):
                 # is already config, nothing to do here
                 fn(self, maybe_config, *args[1:], **kwargs)
                 return
@@ -76,7 +80,7 @@ def _patch_config(m):
 def _detector_create(cls, config_class=None):
     def create(*args, mdecorator=None, **kwargs):
         if mdecorator is not None:
-            if not isinstance(mdecorator, acts.IMaterialDecorator):
+            if not isinstance(mdecorator, _unwrap(acts.IMaterialDecorator)):
                 raise TypeError("Material decorator is not valid")
         if config_class is None:
             cfg = cls.Config()

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -128,7 +128,7 @@ def addSeeding(
     field: acts.MagneticFieldProvider,
     geoSelectionConfigFile: Optional[Union[Path, str]] = None,
     seedingAlgorithm: SeedingAlgorithm = SeedingAlgorithm.Default,
-    truthSeedRanges: TruthSeedRanges = TruthSeedRanges(),
+    truthSeedRanges: Optional[TruthSeedRanges] = TruthSeedRanges(),
     particleSmearingSigmas: ParticleSmearingSigmas = ParticleSmearingSigmas(),
     initialVarInflation: Optional[list] = None,
     seedfinderConfigArg: SeedfinderConfigArg = SeedfinderConfigArg(),
@@ -155,6 +155,7 @@ def addSeeding(
     truthSeedRanges : TruthSeedRanges(rho, z, phi, eta, absEta, pt, nHits)
         TruthSeedSelector configuration. Each range is specified as a tuple of (min,max).
         Defaults of no cuts specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.hpp
+        If specified as None, don't run ParticleSmearing at all (and use addCKFTracks(selectedParticles="particles_initial"))
     particleSmearingSigmas : ParticleSmearingSigmas(d0, d0PtA, d0PtB, z0, z0PtA, z0PtB, t0, phi, theta, pRel)
         ParticleSmearing configuration.
         Defaults specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
@@ -270,7 +271,7 @@ def addSeeding(
             truthTrackFinder = acts.examples.TruthTrackFinder(
                 level=customLogLevel(),
                 inputParticles=selectedParticles,
-                inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                inputMeasurementParticlesMap="measurement_particles_map",
                 outputProtoTracks="prototracks",
             )
             s.addAlgorithm(truthTrackFinder)
@@ -506,7 +507,7 @@ def addSeeding(
                     level=customLogLevel(),
                     inputProtoTracks=inputProtoTracks,
                     inputParticles=selectedParticles,  # the original selected particles after digitization
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     filePath=str(outputDirRoot / "performance_seeding_trees.root"),
                 )
             )
@@ -516,7 +517,7 @@ def addSeeding(
                     level=customLogLevel(acts.logging.DEBUG),
                     inputProtoTracks=inputProtoTracks,
                     inputParticles=selectedParticles,
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     filePath=str(outputDirRoot / "performance_seeding_hists.root"),
                 )
             )
@@ -528,7 +529,7 @@ def addSeeding(
                     inputProtoTracks=parEstimateAlg.config.outputProtoTracks,
                     inputParticles=inputParticles,
                     inputSimHits="simhits",
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     inputMeasurementSimHitsMap="measurement_simhits_map",
                     filePath=str(outputDirRoot / "estimatedparams.root"),
                     treeName="estimatedparams",

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -5,6 +5,7 @@ import acts.examples.dd4hep
 from common import getOpenDataDetectorDirectory
 from acts.examples.odd import getOpenDataDetector
 
+# acts.examples.dump_args_calls(locals())  # show python binding calls
 
 u = acts.UnitConstants
 outputDir = pathlib.Path.cwd() / "odd_output"


### PR DESCRIPTION
* Improves how `acts.examples.dump_args_calls()` finds the `acts.ActsPythonBindings` functions to wrap with `dump_args()`. This should now find them all.
  * I've used it with `full_chain_itk.py`, `full_chain_odd.py`, and `vertex_fitting.py`
* For brevity, `dump_args()` doesn't print `Config()` calls with no arguments.
* fix for `addSeeding(truthSeedRanges=None)` (unrelated, except the above helped debug)