### PR TITLE
refactor: Improve ActsPythonBindings tracing [backport #1425 to develop/v19.x]

### DIFF
--- a/Examples/Python/python/acts/_adapter.py
+++ b/Examples/Python/python/acts/_adapter.py
@@ -10,7 +10,7 @@ def _make_config_adapter(fn):
     def wrapped(self, *args, **kwargs):
         if len(args) > 0:
             maybe_config = args[0]
-            if isinstance(maybe_config, type(self).Config):
+            if isinstance(maybe_config, inspect.unwrap(type(self).Config)):
                 # is already config, nothing to do here
                 fn(self, maybe_config, *args[1:], **kwargs)
                 return
@@ -76,7 +76,7 @@ def _patch_config(m):
 def _detector_create(cls, config_class=None):
     def create(*args, mdecorator=None, **kwargs):
         if mdecorator is not None:
-            if not isinstance(mdecorator, acts.IMaterialDecorator):
+            if not isinstance(mdecorator, inspect.unwrap(acts.IMaterialDecorator)):
                 raise TypeError("Material decorator is not valid")
         if config_class is None:
             cfg = cls.Config()

--- a/Examples/Python/python/acts/examples/__init__.py
+++ b/Examples/Python/python/acts/examples/__init__.py
@@ -70,7 +70,7 @@ def _makeLayerTriplet(*args, **kwargs):
             all(
                 (isinstance(v, tuple) or isinstance(v, list))
                 and isinstance(v[0], int)
-                and isinstance(v[1], TGeoDetector.Config.BinningType)
+                and isinstance(v[1], inspect.unwrap(TGeoDetector.Config.BinningType))
                 for v in vv
             )
             for vv in (negative, central, positive)
@@ -110,8 +110,8 @@ def _process_volume_intervals(kwargs):
     _kwargs = kwargs.copy()
 
     v = TGeoDetector.Config.Volume()
-    for name, value in inspect.getmembers(TGeoDetector.Config.Volume):
-        if not isinstance(getattr(v, name), Interval):
+    for name, value in inspect.getmembers(inspect.unwrap(TGeoDetector.Config.Volume)):
+        if not isinstance(getattr(v, name), inspect.unwrap(Interval)):
             continue
         if not name in _kwargs:
             continue
@@ -194,8 +194,6 @@ def dump_args(func):
 
     @wraps(func)
     def dump_args_wrapper(*args, **kwargs):
-        import inspect
-
         try:
             func_args = inspect.signature(func).bind(*args, **kwargs).arguments
             func_args_str = ", ".join(
@@ -206,34 +204,84 @@ def dump_args(func):
                 list(map("{0!r}".format, args))
                 + list(map("{0[0]} = {0[1]!r}".format, kwargs.items()))
             )
-        print(f"{func.__module__}.{func.__qualname__} ( {func_args_str} )")
+        if not (
+            func_args_str == ""
+            and any([a == "Config" for a in func.__qualname__.split(".")])
+        ):
+            print(f"{func.__module__}.{func.__qualname__} ( {func_args_str} )")
         return func(*args, **kwargs)
+
+    # fix up any attributes broken by the wrapping
+    for name in dir(func):
+        if not name.startswith("__"):
+            obj = getattr(func, name)
+            wrapped = getattr(dump_args_wrapper, name, None)
+            if type(obj) is not type(wrapped):
+                setattr(dump_args_wrapper, name, obj)
 
     return dump_args_wrapper
 
 
-def dump_args_calls(
-    myLocal=None,
-    mod=sys.modules[__name__],
-):
+def dump_args_calls(myLocal=None, mods=None, quiet=False):
     """
-    Wrap all calls to acts.examples Python bindings in dump_args.
+    Wrap all Python bindings calls to acts and its submodules in dump_args.
     Specify myLocal=locals() to include imported symbols too.
     """
     import collections
 
-    for n in dir(mod):
-        if n.startswith("_") or n == "Config" or n == "Interval":
-            continue
-        f = getattr(mod, n)
-        if not (
-            isinstance(f, collections.abc.Callable)
-            and f.__module__.startswith("acts.ActsPythonBindings")
-            and not hasattr(f, "__wrapped__")
+    def _allmods(mod, base, found):
+        import types
+
+        mods = [mod]
+        found.add(mod)
+        for name, obj in sorted(
+            vars(mod).items(),
+            key=lambda m: (2, m[0])
+            if m[0] == "ActsPythonBindings"
+            else (1, m[0])
+            if m[0].startswith("_")
+            else (0, m[0]),
         ):
-            continue
-        dump_args_calls(myLocal, f)  # wrap class's contained methods
-        w = dump_args(f)
-        setattr(mod, n, w)
-        if myLocal and hasattr(myLocal, n):
-            setattr(myLocal, n, w)
+            if (
+                not name.startswith("__")
+                and type(obj) is types.ModuleType
+                and obj.__name__.startswith(base)
+                and f"{mod.__name__}.{name}" in sys.modules
+                and obj not in found
+            ):
+                mods += _allmods(obj, base, found)
+        return mods
+
+    if mods is None:
+        mods = _allmods(acts, "acts.", set())
+    elif not isinstance(mods, list):
+        mods = [mods]
+
+    donemods = []
+    alldone = 0
+    for mod in mods:
+        done = 0
+        for name in dir(mod):
+            # if name in {"Config", "Interval", "IMaterialDecorator"}: continue  # skip here if we don't fix up attributes in dump_args and unwrap classes elsewhere
+            obj = getattr(mod, name, None)
+            if not (
+                not name.startswith("__")
+                and isinstance(obj, collections.abc.Callable)
+                and hasattr(obj, "__module__")
+                and obj.__module__.startswith("acts.ActsPythonBindings")
+                and not hasattr(obj, "__wrapped__")
+            ):
+                continue
+            # wrap class's contained methods
+            done += dump_args_calls(myLocal, [obj], True)
+            wrapped = dump_args(obj)
+            setattr(mod, name, wrapped)
+            if myLocal and hasattr(myLocal, name):
+                setattr(myLocal, name, wrapped)
+            done += 1
+        if done:
+            alldone += done
+            donemods.append(f"{mod.__name__}:{done}")
+    if not quiet and donemods:
+        print("dump_args for module functions:", ", ".join(donemods))
+    return alldone

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -128,7 +128,7 @@ def addSeeding(
     field: acts.MagneticFieldProvider,
     geoSelectionConfigFile: Optional[Union[Path, str]] = None,
     seedingAlgorithm: SeedingAlgorithm = SeedingAlgorithm.Default,
-    truthSeedRanges: TruthSeedRanges = TruthSeedRanges(),
+    truthSeedRanges: Optional[TruthSeedRanges] = TruthSeedRanges(),
     particleSmearingSigmas: ParticleSmearingSigmas = ParticleSmearingSigmas(),
     initialVarInflation: Optional[list] = None,
     seedfinderConfigArg: SeedfinderConfigArg = SeedfinderConfigArg(),
@@ -155,6 +155,7 @@ def addSeeding(
     truthSeedRanges : TruthSeedRanges(rho, z, phi, eta, absEta, pt, nHits)
         TruthSeedSelector configuration. Each range is specified as a tuple of (min,max).
         Defaults of no cuts specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedSelector.hpp
+        If specified as None, don't run ParticleSmearing at all (and use addCKFTracks(selectedParticles="particles_initial"))
     particleSmearingSigmas : ParticleSmearingSigmas(d0, d0PtA, d0PtB, z0, z0PtA, z0PtB, t0, phi, theta, pRel)
         ParticleSmearing configuration.
         Defaults specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
@@ -270,7 +271,7 @@ def addSeeding(
             truthTrackFinder = acts.examples.TruthTrackFinder(
                 level=customLogLevel(),
                 inputParticles=selectedParticles,
-                inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                inputMeasurementParticlesMap="measurement_particles_map",
                 outputProtoTracks="prototracks",
             )
             s.addAlgorithm(truthTrackFinder)
@@ -506,7 +507,7 @@ def addSeeding(
                     level=customLogLevel(),
                     inputProtoTracks=inputProtoTracks,
                     inputParticles=selectedParticles,  # the original selected particles after digitization
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     filePath=str(outputDirRoot / "performance_seeding_trees.root"),
                 )
             )
@@ -516,7 +517,7 @@ def addSeeding(
                     level=customLogLevel(acts.logging.DEBUG),
                     inputProtoTracks=inputProtoTracks,
                     inputParticles=selectedParticles,
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     filePath=str(outputDirRoot / "performance_seeding_hists.root"),
                 )
             )
@@ -528,7 +529,7 @@ def addSeeding(
                     inputProtoTracks=parEstimateAlg.config.outputProtoTracks,
                     inputParticles=inputParticles,
                     inputSimHits="simhits",
-                    inputMeasurementParticlesMap=selAlg.config.inputMeasurementParticlesMap,
+                    inputMeasurementParticlesMap="measurement_particles_map",
                     inputMeasurementSimHitsMap="measurement_simhits_map",
                     filePath=str(outputDirRoot / "estimatedparams.root"),
                     treeName="estimatedparams",

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -5,6 +5,7 @@ import acts.examples.dd4hep
 from common import getOpenDataDetectorDirectory
 from acts.examples.odd import getOpenDataDetector
 
+# acts.examples.dump_args_calls(locals())  # show python binding calls
 
 u = acts.UnitConstants
 outputDir = pathlib.Path.cwd() / "odd_output"


### PR DESCRIPTION
Backport b945729b1751cb2e991fc5f5538769ca3bfb294a from #1425.
---
* Improves how `acts.examples.dump_args_calls()` finds the `acts.ActsPythonBindings` functions to wrap with `dump_args()`. This should now find them all.
  * I've used it with `full_chain_itk.py`, `full_chain_odd.py`, and `vertex_fitting.py`
* For brevity, `dump_args()` doesn't print `Config()` calls with no arguments.
* fix for `addSeeding(truthSeedRanges=None)` (unrelated, except the above helped debug)