### PR TITLE
docs: Use DEVNULL instead of PIPE in apidoc subprocess

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,10 +102,11 @@ if on_readthedocs or tags.has("run_apidoc"):
     print("Executing breathe apidoc in", cwd)
     subprocess.check_call(
         [sys.executable, "-m", "breathe.apidoc", "_build/doxygen-xml", "-o", "api"],
-        stdout=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
         cwd=cwd,
         env=env,
     )
+    print("breathe apidoc completed")
 
 # -- Markdown bridge setup hook (must come last, not sure why) ----------------
 


### PR DESCRIPTION
I suspect this might have been failing our docs build for a while.