### PR TITLE
docs: Use DEVNULL instead of PIPE in apidoc subprocess [backport #1431 to develop/v19.x]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,10 +102,11 @@ if on_readthedocs or tags.has("run_apidoc"):
     print("Executing breathe apidoc in", cwd)
     subprocess.check_call(
         [sys.executable, "-m", "breathe.apidoc", "_build/doxygen-xml", "-o", "api"],
-        stdout=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
         cwd=cwd,
         env=env,
     )
+    print("breathe apidoc completed")
 
 # -- Markdown bridge setup hook (must come last, not sure why) ----------------
 


### PR DESCRIPTION
Backport d9117a0c595651461af9f9685fdfe5e5637c8a3f from #1431.
---
I suspect this might have been failing our docs build for a while.