### PR TITLE
refactor: Change ConstrainedStep to be explicit [backport of #1347 to develop/v9.1.x]

### DIFF
--- a/Core/include/Acts/Definitions/Common.hpp
+++ b/Core/include/Acts/Definitions/Common.hpp
@@ -14,7 +14,7 @@
 
 namespace Acts {
 
-/// Tolerance for bein numerical equal for geometry building
+/// Tolerance for being numerical equal for geometry building
 static constexpr ActsScalar s_epsilon =
     3 * std::numeric_limits<ActsScalar>::epsilon();
 
@@ -30,10 +30,13 @@ static constexpr ActsScalar s_onSurfaceTolerance = 1e-4;
 /// validity tested with IntegrationTests/PropagationTest
 static constexpr ActsScalar s_curvilinearProjTolerance = 0.999995;
 
-/// @enum NavigationDirection
 /// The navigation direciton is always with
 /// respect to a given momentum or direction
 enum NavigationDirection : int { backward = -1, forward = 1 };
+inline constexpr NavigationDirection directionFromStepSize(double value) {
+  assert(value != 0);
+  return value > 0 ? forward : backward;
+}
 
 ///  This is a steering enum to tell which material update stage:
 /// - preUpdate  : update on approach of a surface

--- a/Core/include/Acts/Definitions/Common.hpp
+++ b/Core/include/Acts/Definitions/Common.hpp
@@ -29,6 +29,7 @@ static constexpr ActsScalar s_onSurfaceTolerance = 1e-4;
 /// this allows using the same curvilinear frame to eta = 6,
 /// validity tested with IntegrationTests/PropagationTest
 static constexpr ActsScalar s_curvilinearProjTolerance = 0.999995;
+
 /// @enum NavigationDirection
 /// The navigation direciton is always with
 /// respect to a given momentum or direction

--- a/Core/include/Acts/Definitions/Common.hpp
+++ b/Core/include/Acts/Definitions/Common.hpp
@@ -29,10 +29,11 @@ static constexpr ActsScalar s_onSurfaceTolerance = 1e-4;
 /// this allows using the same curvilinear frame to eta = 6,
 /// validity tested with IntegrationTests/PropagationTest
 static constexpr ActsScalar s_curvilinearProjTolerance = 0.999995;
-
+/// @enum NavigationDirection
 /// The navigation direciton is always with
 /// respect to a given momentum or direction
 enum NavigationDirection : int { backward = -1, forward = 1 };
+
 inline constexpr NavigationDirection directionFromStepSize(double value) {
   assert(value != 0);
   return value > 0 ? forward : backward;

--- a/Core/include/Acts/Propagator/ConstrainedStep.hpp
+++ b/Core/include/Acts/Propagator/ConstrainedStep.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <iomanip>
 #include <limits>
 #include <sstream>
@@ -20,7 +21,24 @@
 namespace Acts {
 
 /// A constrained step class for the steppers
-struct ConstrainedStep {
+///
+/// As simple as this class looks it hides a few very important details:
+/// - Overstepping handling. The step size sign will flip if we happened to pass
+/// our target.
+/// - Convergence handling. Smaller and smaller step sizes have to be used in
+/// order to converge on a target.
+///
+/// Because of the points mentioned above, the update function will always
+/// prefer step sizes that point opposite the nagivation direction. A side
+/// effect of this is that we will propagate in the opposite direction if the
+/// target is "behind us".
+///
+/// The hierarchy is:
+/// - Overstepping resolution / backpropagation
+/// - Convergence
+/// - Step into the void with `std::numeric_limits<Scalar>::max()`
+class ConstrainedStep {
+ public:
   using Scalar = ActsScalar;
 
   /// the types of constraints
@@ -30,13 +48,51 @@ struct ConstrainedStep {
   /// from user     - this is user given for what reason ever
   enum Type : int { accuracy = 0, actor = 1, aborter = 2, user = 3 };
 
-  /// the step size tuple
-  std::array<Scalar, 4> values = {
-      {std::numeric_limits<Scalar>::max(), std::numeric_limits<Scalar>::max(),
-       std::numeric_limits<Scalar>::max(), std::numeric_limits<Scalar>::max()}};
+  /// Number of iterations needed by the stepsize finder
+  /// (e.g. Runge-Kutta) of the stepper.
+  size_t nStepTrials = std::numeric_limits<size_t>::max();
 
-  /// The Navigation direction
-  NavigationDirection direction = forward;
+  constexpr ConstrainedStep() = default;
+
+  /// constructor from Scalar
+  /// navigation direction is inferred by the sign of the step size
+  /// @param value is the user given initial value
+  constexpr explicit ConstrainedStep(Scalar value) {
+    m_values[user] = std::abs(value);
+    m_direction = Acts::directionFromStepSize(value);
+  }
+
+  /// set accuracy by one Scalar
+  ///
+  /// this will set only the accuracy, as this is the most
+  /// exposed to the Propagator
+  ///
+  /// @param value is the new accuracy value
+  constexpr void setValue(Scalar value) {
+    /// set the accuracy value
+    m_values[accuracy] = value * m_direction;
+  }
+
+  /// returns the min step size
+  constexpr Scalar value() const { return value(currentType()); }
+
+  /// Access a specific value
+  ///
+  /// @param type is the requested parameter type
+  constexpr Scalar value(Type type) const {
+    return m_values[type] * m_direction;
+  }
+
+  /// Access the currently leading type
+  constexpr Type currentType() const {
+    return Type(std::min_element(m_values.begin(), m_values.end()) -
+                m_values.begin());
+  }
+
+  /// release a certain constraint value
+  ///
+  /// @param type is the constraint type to be released
+  constexpr void release(Type type) { m_values[type] = kNotSet; }
 
   /// Update the step size of a certain type
   ///
@@ -45,114 +101,67 @@ struct ConstrainedStep {
   ///
   /// @param value is the new value to be updated
   /// @param type is the constraint type
-  void update(const Scalar& value, Type type, bool releaseStep = false) {
+  /// @param releaseStep Allow step size to increase again
+  constexpr void update(Scalar value, Type type, bool releaseStep = false) {
     if (releaseStep) {
       release(type);
     }
-    // The check the current value and set it if appropriate
-    Scalar cValue = values[type];
-    values[type] = std::abs(cValue) < std::abs(value) ? cValue : value;
-  }
-
-  /// release a certain constraint value
-  /// to the (signed) biggest value available, hence
-  /// it depends on the direction
-  ///
-  /// @param type is the constraint type to be released
-  void release(Type type) {
-    Scalar mvalue = (direction == forward)
-                        ? (*std::max_element(values.begin(), values.end()))
-                        : (*std::min_element(values.begin(), values.end()));
-    values[type] = mvalue;
-  }
-
-  /// constructor from double
-  /// @paramn value is the user given initial value
-  ConstrainedStep(Scalar value) : direction(value > 0. ? forward : backward) {
-    values[accuracy] *= direction;
-    values[actor] *= direction;
-    values[aborter] *= direction;
-    values[user] = value;
-  }
-
-  /// The assignment operator from one double
-  /// @note this will set only the accuracy, as this is the most
-  /// exposed to the Propagator, this adapts also the direction
-  ///
-  /// @param value is the new accuracy value
-  ConstrainedStep& operator=(const Scalar& value) {
-    /// set the accuracy value
-    values[accuracy] = value;
-    // set/update the direction
-    direction = value > 0. ? forward : backward;
-    return (*this);
-  }
-
-  /// Cast operator to double, returning the min/max value
-  /// depending on the direction
-  operator Scalar() const {
-    if (direction == forward) {
-      return (*std::min_element(values.begin(), values.end()));
+    // check the current value and set it if appropriate
+    // this will also allow signed values due to overstepping
+    if (std::abs(value) <= std::abs(m_values[type])) {
+      m_values[type] = value * m_direction;
     }
-    return (*std::max_element(values.begin(), values.end()));
   }
 
-  /// Access to a specific value
-  ///
-  /// @param type is the resquested parameter type
-  Scalar value(Type type) const { return values[type]; }
-
-  /// Return the maximum step constraint
-  /// @return The max step constraint
-  Scalar max() const {
-    return (*std::max_element(values.begin(), values.end()));
+  constexpr void scale(Scalar factor) {
+    assert(factor > 0 && "ConstrainedStep scale factor was zero or negative.");
+    m_values[accuracy] = value() * factor * m_direction;
   }
 
-  /// Return the minimum step constraint
-  /// @return The min step constraint
-  Scalar min() const {
-    return (*std::min_element(values.begin(), values.end()));
+  std::ostream& toStream(std::ostream& os) const {
+    // Helper method to avoid unreadable screen output
+    auto streamValue = [&](Type type) {
+      Scalar val = value(type);
+      os << std::setw(5);
+      if (std::abs(val) == kNotSet) {
+        os << (val > 0 ? "+∞" : "-∞");
+      } else {
+        os << val;
+      }
+    };
+
+    os << "(";
+    streamValue(accuracy);
+    os << ", ";
+    streamValue(actor);
+    os << ", ";
+    streamValue(aborter);
+    os << ", ";
+    streamValue(user);
+    os << ")";
+
+    return os;
   }
 
-  /// Access to currently leading min type
-  ///
-  Type currentType() const {
-    if (direction == forward) {
-      return Type(std::min_element(values.begin(), values.end()) -
-                  values.begin());
-    }
-    return Type(std::max_element(values.begin(), values.end()) -
-                values.begin());
+  std::string toString() const {
+    std::stringstream dstream;
+    toStream(dstream);
+    return dstream.str();
   }
 
-  /// return the split value as string for debugging
-  std::string toString() const;
+ private:
+  inline static constexpr auto kNotSet = std::numeric_limits<Scalar>::max();
+
+  /// the step size tuple
+  /// all values point in the `m_direction`
+  std::array<Scalar, 4> m_values = {kNotSet, kNotSet, kNotSet, kNotSet};
+  /// the navigation direction
+  /// the direction is invariant after initialization
+  NavigationDirection m_direction = forward;
 };
 
-inline std::string ConstrainedStep::toString() const {
-  std::stringstream dstream;
-
-  // Helper method to avoid unreadable screen output
-  auto streamValue = [&](ConstrainedStep cstep) -> void {
-    Scalar val = values[cstep];
-    dstream << std::setw(5);
-    if (std::abs(val) == std::numeric_limits<Scalar>::max()) {
-      dstream << (val > 0 ? "+∞" : "-∞");
-    } else {
-      dstream << val;
-    }
-  };
-
-  dstream << "(";
-  streamValue(accuracy);
-  dstream << ", ";
-  streamValue(actor);
-  dstream << ", ";
-  streamValue(aborter);
-  dstream << ", ";
-  streamValue(user);
-  dstream << " )";
-  return dstream.str();
+inline std::ostream& operator<<(std::ostream& os, const ConstrainedStep& step) {
+  return step.toStream(os);
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -129,7 +129,7 @@ class EigenStepper {
     double pathAccumulated = 0.;
 
     /// Adaptive step size of the runge-kutta integration
-    ConstrainedStep stepSize{std::numeric_limits<double>::max()};
+    ConstrainedStep stepSize;
 
     /// Last performed step (for overstep limit calculation)
     double previousStepSize = 0.;
@@ -266,8 +266,16 @@ class EigenStepper {
   /// @param stype [in] The step size type to be set
   void setStepSize(State& state, double stepSize,
                    ConstrainedStep::Type stype = ConstrainedStep::actor) const {
-    state.previousStepSize = state.stepSize;
+    state.previousStepSize = state.stepSize.value();
     state.stepSize.update(stepSize, stype, true);
+  }
+
+  /// Get the step size
+  ///
+  /// @param state [in] The stepping state (thread-local cache)
+  /// @param stype [in] The step size type to be returned
+  double getStepSize(const State& state, ConstrainedStep::Type stype) const {
+    return state.stepSize.value(stype);
   }
 
   /// Release the Step size

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -131,11 +131,13 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   // size, going up to the point where it can return an estimate of the local
   // integration error. The results are stated in the local variables above,
   // allowing integration to continue once the error is deemed satisfactory
-  const auto tryRungeKuttaStep = [&](const ConstrainedStep& h) -> Result<bool> {
+  const auto tryRungeKuttaStep =
+      [&](const ConstrainedStep& step) -> Result<bool> {
     // helpers because bool and std::error_code are ambiguous
     constexpr auto success = &Result<bool>::success;
     constexpr auto failure = &Result<bool>::failure;
 
+    const double h = step.value();
     // State the square and half of the step size
     h2 = h * h;
     half_h = h * 0.5;
@@ -172,10 +174,10 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
     }
 
     // Compute and check the local integration error estimate
-    error_estimate = std::max(
+    error_estimate =
         h2 * ((sd.k1 - sd.k2 - sd.k3 + sd.k4).template lpNorm<1>() +
-              std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3])),
-        1e-20);
+              std::abs(sd.kQoP[0] - sd.kQoP[1] - sd.kQoP[2] + sd.kQoP[3]));
+    error_estimate = std::max(error_estimate, 1e-20);
 
     return success(error_estimate <= state.options.tolerance);
   };
@@ -194,16 +196,15 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
     }
 
     stepSizeScaling =
-        std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(2. * error_estimate)),
-                                         0.25)),
-                 4.);
-
-    state.stepping.stepSize = state.stepping.stepSize * stepSizeScaling;
+        std::min(std::max(0.25f, std::sqrt(std::sqrt(static_cast<float>(
+                                     state.options.tolerance /
+                                     std::abs(2. * error_estimate))))),
+                 4.0f);
+    state.stepping.stepSize.scale(stepSizeScaling);
 
     // If step size becomes too small the particle remains at the initial
     // place
-    if (std::abs(state.stepping.stepSize) <
+    if (std::abs(state.stepping.stepSize.value()) <
         std::abs(state.options.stepSizeCutOff)) {
       // Not moving due to too low momentum needs an aborter
       return EigenStepperError::StepSizeStalled;
@@ -219,7 +220,7 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   }
 
   // use the adjusted step size
-  const double h = state.stepping.stepSize;
+  const double h = state.stepping.stepSize.value();
 
   // When doing error propagation, update the associated Jacobian matrix
   if (state.stepping.covTransport) {
@@ -252,12 +253,12 @@ Acts::Result<double> Acts::EigenStepper<E, A>::step(
   state.stepping.pathAccumulated += h;
   if (state.stepping.stepSize.currentType() ==
       ConstrainedStep::Type::accuracy) {
-    state.stepping.stepSize =
-        state.stepping.stepSize *
-        std::min(std::max(0.25, std::pow((state.options.tolerance /
-                                          std::abs(error_estimate)),
-                                         0.25)),
-                 4.);
+    stepSizeScaling = std::min(
+        std::max(0.25f,
+                 std::sqrt(std::sqrt(static_cast<float>(
+                     state.options.tolerance / std::abs(error_estimate))))),
+        4.0f);
+    state.stepping.stepSize.scale(stepSizeScaling);
   }
   return h;
 }

--- a/Core/include/Acts/Propagator/StandardAborters.hpp
+++ b/Core/include/Acts/Propagator/StandardAborters.hpp
@@ -61,8 +61,9 @@ struct PathLimitReached {
     double distance = state.stepping.navDir * std::abs(internalLimit) -
                       state.stepping.pathAccumulated;
     double tolerance = state.options.targetTolerance;
-    state.stepping.stepSize.update(distance, ConstrainedStep::aborter);
-    bool limitReached = (distance * distance < tolerance * tolerance);
+    state.stepping.previousStepSize = state.stepping.stepSize.value();
+    state.stepping.stepSize.update(distance, ConstrainedStep::aborter, false);
+    bool limitReached = (std::abs(distance) < std::abs(tolerance));
     if (limitReached) {
       ACTS_VERBOSE("Target: x | "
                    << "Path limit reached at distance " << distance);

--- a/Core/include/Acts/Propagator/detail/SteppingLogger.hpp
+++ b/Core/include/Acts/Propagator/detail/SteppingLogger.hpp
@@ -26,7 +26,7 @@ namespace detail {
 
 /// @brief the step information for
 struct Step {
-  ConstrainedStep stepSize = 0.;
+  ConstrainedStep stepSize;
   Vector3 position = Vector3(0., 0., 0.);
   Vector3 momentum = Vector3(0., 0., 0.);
   std::shared_ptr<const Surface> surface = nullptr;

--- a/Tests/UnitTests/Core/Propagator/AbortListTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AbortListTests.cpp
@@ -62,7 +62,7 @@ struct PropagatorState {
     // Navigation direction
     NavigationDirection navDir = forward;
     // adaptive sep size of the runge-kutta integration
-    ConstrainedStep stepSize = std::numeric_limits<double>::max();
+    ConstrainedStep stepSize;
   };
 
   /// emulate the options template
@@ -115,22 +115,22 @@ BOOST_AUTO_TEST_CASE(AbortListTest_PathLimit) {
   // It should not abort yet
   BOOST_CHECK(!abortList(result, state, stepper));
   // The step size should be adapted to 1 meter now
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, 1_m);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), 1_m);
   // Let's do a step of 90 cm now
   state.stepping.pathAccumulated = 90_cm;
   // Still no abort yet
   BOOST_CHECK(!abortList(result, state, stepper));
   // 10 cm are left
   // The step size should be adapted to 10 cm now
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, 10_cm);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), 10_cm);
 
   // Approach the target
   while (!abortList(result, state, stepper)) {
-    state.stepping.pathAccumulated += 0.5 * state.stepping.stepSize;
+    state.stepping.pathAccumulated += 0.5 * state.stepping.stepSize.value();
   }
 
   // now we need to be smaller than the tolerance
-  BOOST_CHECK_LT(state.stepping.stepSize, 1_um);
+  BOOST_CHECK_LT(state.stepping.stepSize.value(), 1_um);
 
   // Check if you can expand the AbortList
   EndOfWorld eow;

--- a/Tests/UnitTests/Core/Propagator/AbortListTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AbortListTests.cpp
@@ -63,6 +63,7 @@ struct PropagatorState {
     NavigationDirection navDir = forward;
     // adaptive sep size of the runge-kutta integration
     ConstrainedStep stepSize;
+    double previousStepSize;
   };
 
   /// emulate the options template

--- a/Tests/UnitTests/Core/Propagator/ActionListTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ActionListTests.cpp
@@ -40,7 +40,7 @@ struct PropagatorState {
     double pathAccumulated = 0.;
 
     // adaptive sep size of the runge-kutta integration
-    ConstrainedStep stepSize = std::numeric_limits<double>::max();
+    ConstrainedStep stepSize;
   };
 
   /// emulate the options template

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(ConstructState) {
   BOOST_CHECK_EQUAL(state.pVector[7], charge / absMom);
   BOOST_CHECK_EQUAL(state.navDir, navDir);
   BOOST_CHECK_EQUAL(state.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(state.stepSize, navDir * stepSize);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), navDir * stepSize);
   BOOST_CHECK_EQUAL(state.previousStepSize, 0.);
   BOOST_CHECK_EQUAL(state.tolerance, tolerance);
 }
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(ConstructStateWithCovariance) {
   BOOST_CHECK_EQUAL(state.pVector[7], charge / absMom);
   BOOST_CHECK_EQUAL(state.navDir, navDir);
   BOOST_CHECK_EQUAL(state.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(state.stepSize, navDir * stepSize);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), navDir * stepSize);
   BOOST_CHECK_EQUAL(state.previousStepSize, 0.);
   BOOST_CHECK_EQUAL(state.tolerance, tolerance);
 }
@@ -255,8 +255,8 @@ BOOST_AUTO_TEST_CASE(Step) {
 
   // extract the actual step size
   auto h = res.value();
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, navDir * stepSize);
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, h);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), navDir * stepSize);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), h);
 
   // check that the position has moved
   auto deltaPos = (stepper.position(state.stepping) - pos).eval();
@@ -288,8 +288,8 @@ BOOST_AUTO_TEST_CASE(StepWithCovariance) {
 
   // extract the actual step size
   auto h = res.value();
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, navDir * stepSize);
-  BOOST_CHECK_EQUAL(state.stepping.stepSize, h);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), navDir * stepSize);
+  BOOST_CHECK_EQUAL(state.stepping.stepSize.value(), h);
 
   // check that the position has moved
   auto deltaPos = (stepper.position(state.stepping) - pos).eval();
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(Reset) {
   BOOST_CHECK_EQUAL(stepper.time(stateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(stateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(stateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(stateCopy.stepSize, ndir * stepSize);
+  BOOST_CHECK_EQUAL(stateCopy.stepSize.value(), ndir * stepSize);
   BOOST_CHECK_EQUAL(stateCopy.previousStepSize,
                     state.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(stateCopy.tolerance, state.stepping.tolerance);
@@ -413,8 +413,8 @@ BOOST_AUTO_TEST_CASE(Reset) {
   BOOST_CHECK_EQUAL(stepper.time(stateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(stateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(stateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(stateCopy.stepSize,
-                    ndir * std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(stateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(stateCopy.previousStepSize,
                     state.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(stateCopy.tolerance, state.stepping.tolerance);
@@ -436,7 +436,8 @@ BOOST_AUTO_TEST_CASE(Reset) {
   BOOST_CHECK_EQUAL(stepper.time(stateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(stateCopy.navDir, forward);
   BOOST_CHECK_EQUAL(stateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(stateCopy.stepSize, std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(stateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(stateCopy.previousStepSize,
                     state.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(stateCopy.tolerance, state.stepping.tolerance);
@@ -521,10 +522,10 @@ BOOST_AUTO_TEST_CASE(StepSize) {
 
   stepper.setStepSize(state, 5_cm);
   BOOST_CHECK_EQUAL(state.previousStepSize, navDir * stepSize);
-  BOOST_CHECK_EQUAL(state.stepSize, 5_cm);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), 5_cm);
 
   stepper.releaseStepSize(state);
-  BOOST_CHECK_EQUAL(state.stepSize, navDir * stepSize);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), navDir * stepSize);
 }
 
 // test step size modification with target surfaces
@@ -549,16 +550,16 @@ BOOST_AUTO_TEST_CASE(StepSizeSurface) {
       target->intersect(state.geoContext, stepper.position(state),
                         state.navDir * stepper.direction(state), false),
       false);
-  BOOST_CHECK_EQUAL(state.stepSize, distance);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), distance);
 
   // start with a different step size
-  state.stepSize = navDir * stepSize;
+  state.stepSize.setValue(navDir * stepSize);
   stepper.updateStepSize(
       state,
       target->intersect(state.geoContext, stepper.position(state),
                         state.navDir * stepper.direction(state), false),
       true);
-  BOOST_CHECK_EQUAL(state.stepSize, distance);
+  BOOST_CHECK_EQUAL(state.stepSize.value(), distance);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Propagator/ConstrainedStepTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ConstrainedStepTests.cpp
@@ -23,85 +23,85 @@ namespace Test {
 // and the standard aborters
 BOOST_AUTO_TEST_CASE(ConstrainedStepTest) {
   // forward stepping test
-  ConstrainedStep stepSize_p = 0.25;
+  ConstrainedStep stepSize_p(0.25);
 
   // All of the types should be 0.25 now
-  BOOST_CHECK_EQUAL(stepSize_p.values[ConstrainedStep::accuracy],
+  BOOST_CHECK_EQUAL(stepSize_p.value(ConstrainedStep::accuracy),
                     std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_p.values[ConstrainedStep::actor],
+  BOOST_CHECK_EQUAL(stepSize_p.value(ConstrainedStep::actor),
                     std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_p.values[ConstrainedStep::aborter],
+  BOOST_CHECK_EQUAL(stepSize_p.value(ConstrainedStep::aborter),
                     std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_p.values[ConstrainedStep::user], 0.25);
+  BOOST_CHECK_EQUAL(stepSize_p.value(ConstrainedStep::user), 0.25);
 
   // Check the cast operation to double
-  BOOST_CHECK_EQUAL(stepSize_p, 0.25);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.25);
 
   // now we update the accuracy
   stepSize_p.update(0.1, ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_p, 0.1);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.1);
 
   // now we update the actor to smaller
   stepSize_p.update(0.05, ConstrainedStep::actor);
-  BOOST_CHECK_EQUAL(stepSize_p, 0.05);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.05);
   // we increase the actor, but do not release the step size
   stepSize_p.update(0.15, ConstrainedStep::actor, false);
-  BOOST_CHECK_EQUAL(stepSize_p, 0.05);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.05);
   // we increase the actor, but now DO release the step size
   // it falls back to the accuracy
   stepSize_p.update(0.15, ConstrainedStep::actor, true);
-  BOOST_CHECK_EQUAL(stepSize_p, 0.1);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.1);
 
   // now set two and update them
   stepSize_p.update(0.05, ConstrainedStep::user);
   stepSize_p.update(0.03, ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_p, 0.03);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.03);
 
   // now we release the accuracy - to the highest available value
   stepSize_p.release(ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_p.values[ConstrainedStep::accuracy],
+  BOOST_CHECK_EQUAL(stepSize_p.value(ConstrainedStep::accuracy),
                     std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_p, 0.05);
+  BOOST_CHECK_EQUAL(stepSize_p.value(), 0.05);
 
   // backward stepping test
-  ConstrainedStep stepSize_n = -0.25;
+  ConstrainedStep stepSize_n(-0.25);
 
   // All of the types should be 0.25 now
-  BOOST_CHECK_EQUAL(stepSize_n.values[ConstrainedStep::accuracy],
+  BOOST_CHECK_EQUAL(stepSize_n.value(ConstrainedStep::accuracy),
                     -std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_n.values[ConstrainedStep::actor],
+  BOOST_CHECK_EQUAL(stepSize_n.value(ConstrainedStep::actor),
                     -std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_n.values[ConstrainedStep::aborter],
+  BOOST_CHECK_EQUAL(stepSize_n.value(ConstrainedStep::aborter),
                     -std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_n.values[ConstrainedStep::user], -0.25);
+  BOOST_CHECK_EQUAL(stepSize_n.value(ConstrainedStep::user), -0.25);
 
   // Check the cast operation to double
-  BOOST_CHECK_EQUAL(stepSize_n, -0.25);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.25);
 
   // now we update the accuracy
   stepSize_n.update(-0.1, ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_n, -0.1);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.1);
 
   // now we update the actor to smaller
   stepSize_n.update(-0.05, ConstrainedStep::actor);
-  BOOST_CHECK_EQUAL(stepSize_n, -0.05);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.05);
   // we increase the actor and accuracy is smaller again, without reset
   stepSize_n.update(-0.15, ConstrainedStep::actor, false);
-  BOOST_CHECK_EQUAL(stepSize_n, -0.05);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.05);
   // we increase the actor and accuracy is smaller again, with reset
   stepSize_n.update(-0.15, ConstrainedStep::actor, true);
-  BOOST_CHECK_EQUAL(stepSize_n, -0.1);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.1);
 
   // now set two and update them
   stepSize_n.update(-0.05, ConstrainedStep::user);
   stepSize_n.update(-0.03, ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_n, -0.03);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.03);
 
   // now we release the accuracy - to the highest available value
   stepSize_n.release(ConstrainedStep::accuracy);
-  BOOST_CHECK_EQUAL(stepSize_n.values[ConstrainedStep::accuracy],
+  BOOST_CHECK_EQUAL(stepSize_n.value(ConstrainedStep::accuracy),
                     -std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(stepSize_n, -0.05);
+  BOOST_CHECK_EQUAL(stepSize_n.value(), -0.05);
 }
 
 }  // namespace Test

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -133,8 +133,12 @@ struct PropagatorState {
     void setStepSize(
         State& state, double stepSize,
         ConstrainedStep::Type stype = ConstrainedStep::actor) const {
-      state.previousStepSize = state.stepSize;
+      state.previousStepSize = state.stepSize.value();
       state.stepSize.update(stepSize, stype, true);
+    }
+
+    double getStepSize(const State& state, ConstrainedStep::Type stype) const {
+      return state.stepSize.value(stype);
     }
 
     void releaseStepSize(State& state) const {
@@ -229,9 +233,9 @@ struct PropagatorState {
 template <typename stepper_state_t>
 void step(stepper_state_t& sstate) {
   // update the cache position
-  sstate.pos4[Acts::ePos0] += sstate.stepSize * sstate.dir[Acts::eMom0];
-  sstate.pos4[Acts::ePos1] += sstate.stepSize * sstate.dir[Acts::eMom1];
-  sstate.pos4[Acts::ePos2] += sstate.stepSize * sstate.dir[Acts::eMom2];
+  sstate.pos4[Acts::ePos0] += sstate.stepSize.value() * sstate.dir[Acts::eMom0];
+  sstate.pos4[Acts::ePos1] += sstate.stepSize.value() * sstate.dir[Acts::eMom1];
+  sstate.pos4[Acts::ePos2] += sstate.stepSize.value() * sstate.dir[Acts::eMom2];
   // create navigation parameters
   return;
 }
@@ -471,7 +475,8 @@ BOOST_AUTO_TEST_CASE(Navigator_target_methods) {
   // Cache the beam pipe radius
   double beamPipeR = perp(state.navigation.navLayerIter->intersection.position);
   // step size has been updated
-  CHECK_CLOSE_ABS(state.stepping.stepSize, beamPipeR, s_onSurfaceTolerance);
+  CHECK_CLOSE_ABS(state.stepping.stepSize.value(), beamPipeR,
+                  s_onSurfaceTolerance);
   if (debug) {
     std::cout << "<<< Test 1a >>> initialize at "
               << toString(state.stepping.pos4) << std::endl;

--- a/Tests/UnitTests/Core/Propagator/StepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StepperTests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_state_test) {
   BOOST_CHECK_EQUAL(esState.cov, Covariance::Zero());
   BOOST_CHECK_EQUAL(esState.navDir, ndir);
   BOOST_CHECK_EQUAL(esState.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esState.stepSize, ndir * stepSize);
+  BOOST_CHECK_EQUAL(esState.stepSize.value(), ndir * stepSize);
   BOOST_CHECK_EQUAL(esState.previousStepSize, 0.);
   BOOST_CHECK_EQUAL(esState.tolerance, tolerance);
 
@@ -219,10 +219,10 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
 
   es.setStepSize(esState, 1337.);
   BOOST_CHECK_EQUAL(esState.previousStepSize, ndir * stepSize);
-  BOOST_CHECK_EQUAL(esState.stepSize, 1337.);
+  BOOST_CHECK_EQUAL(esState.stepSize.value(), 1337.);
 
   es.releaseStepSize(esState);
-  BOOST_CHECK_EQUAL(esState.stepSize, -123.);
+  BOOST_CHECK_EQUAL(esState.stepSize.value(), -123.);
   BOOST_CHECK_EQUAL(es.outputStepSize(esState), originalStepSize);
 
   // Test the curvilinear state construction
@@ -348,7 +348,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(esStateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize, ndir * stepSize2);
+  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(), ndir * stepSize2);
   BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(esStateCopy.tolerance, ps.stepping.tolerance);
 
@@ -373,8 +373,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(esStateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize,
-                    ndir * std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(esStateCopy.tolerance, ps.stepping.tolerance);
 
@@ -399,7 +399,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(esStateCopy.navDir, forward);
   BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize, std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(esStateCopy.tolerance, ps.stepping.tolerance);
 
@@ -425,14 +426,14 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
       targetSurface->intersect(esState.geoContext, es.position(esState),
                                esState.navDir * es.direction(esState), false),
       false);
-  CHECK_CLOSE_ABS(esState.stepSize, 2., eps);
-  esState.stepSize = ndir * stepSize;
+  CHECK_CLOSE_ABS(esState.stepSize.value(), 2., eps);
+  esState.stepSize.setValue(ndir * stepSize);
   es.updateStepSize(
       esState,
       targetSurface->intersect(esState.geoContext, es.position(esState),
                                esState.navDir * es.direction(esState), false),
       true);
-  CHECK_CLOSE_ABS(esState.stepSize, 2., eps);
+  CHECK_CLOSE_ABS(esState.stepSize.value(), 2., eps);
 
   // Test the bound state construction
   auto boundState = es.boundState(esState, *plane).value();
@@ -472,9 +473,9 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
 
   // Test a case where no step size adjustment is required
   ps.options.tolerance = 2. * 4.4258e+09;
-  double h0 = esState.stepSize;
+  double h0 = esState.stepSize.value();
   es.step(ps);
-  CHECK_CLOSE_ABS(h0, esState.stepSize, eps);
+  CHECK_CLOSE_ABS(h0, esState.stepSize.value(), eps);
 
   // Produce some errors
   auto nBfield = std::make_shared<NullBField>();

--- a/Tests/UnitTests/Core/Propagator/StraightLineStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StraightLineStepperTests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_state_test) {
   CHECK_CLOSE_OR_SMALL(sls.time(slsState), time, eps, eps);
   BOOST_CHECK_EQUAL(slsState.navDir, ndir);
   BOOST_CHECK_EQUAL(slsState.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsState.stepSize, ndir * stepSize);
+  BOOST_CHECK_EQUAL(slsState.stepSize.value(), ndir * stepSize);
   BOOST_CHECK_EQUAL(slsState.previousStepSize, 0.);
   BOOST_CHECK_EQUAL(slsState.tolerance, tolerance);
 
@@ -136,10 +136,10 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
 
   sls.setStepSize(slsState, 1337.);
   BOOST_CHECK_EQUAL(slsState.previousStepSize, ndir * stepSize);
-  BOOST_CHECK_EQUAL(slsState.stepSize, 1337.);
+  BOOST_CHECK_EQUAL(slsState.stepSize.value(), 1337.);
 
   sls.releaseStepSize(slsState);
-  BOOST_CHECK_EQUAL(slsState.stepSize, -123.);
+  BOOST_CHECK_EQUAL(slsState.stepSize.value(), -123.);
   BOOST_CHECK_EQUAL(sls.outputStepSize(slsState), originalStepSize);
 
   // Test the curvilinear state construction
@@ -180,8 +180,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
 
   ps.stepping.covTransport = false;
   double h = sls.step(ps).value();
-  BOOST_CHECK_EQUAL(ps.stepping.stepSize, ndir * stepSize);
-  BOOST_CHECK_EQUAL(ps.stepping.stepSize, h);
+  BOOST_CHECK_EQUAL(ps.stepping.stepSize.value(), ndir * stepSize);
+  BOOST_CHECK_EQUAL(ps.stepping.stepSize.value(), h);
   CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, 1e-6);
   BOOST_CHECK_GT(sls.position(ps.stepping).norm(), newPos.norm());
   CHECK_CLOSE_ABS(sls.direction(ps.stepping), newMom.normalized(), 1e-6);
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
 
   ps.stepping.covTransport = true;
   double h2 = sls.step(ps).value();
-  BOOST_CHECK_EQUAL(ps.stepping.stepSize, ndir * stepSize);
+  BOOST_CHECK_EQUAL(ps.stepping.stepSize.value(), ndir * stepSize);
   BOOST_CHECK_EQUAL(h2, h);
   CHECK_CLOSE_COVARIANCE(ps.stepping.cov, cov, 1e-6);
   BOOST_CHECK_GT(sls.position(ps.stepping).norm(), newPos.norm());
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
   CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
   BOOST_CHECK_EQUAL(slsStateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize, ndir * stepSize2);
+  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(), ndir * stepSize2);
   BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
                     ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(slsStateCopy.tolerance, ps.stepping.tolerance);
@@ -267,8 +267,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
   CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
   BOOST_CHECK_EQUAL(slsStateCopy.navDir, ndir);
   BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize,
-                    ndir * std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
                     ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(slsStateCopy.tolerance, ps.stepping.tolerance);
@@ -294,7 +294,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
   CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
   BOOST_CHECK_EQUAL(slsStateCopy.navDir, forward);
   BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize, std::numeric_limits<double>::max());
+  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(),
+                    std::numeric_limits<double>::max());
   BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
                     ps.stepping.previousStepSize);
   BOOST_CHECK_EQUAL(slsStateCopy.tolerance, ps.stepping.tolerance);
@@ -321,14 +322,14 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
                          slsState.geoContext, sls.position(slsState),
                          slsState.navDir * sls.direction(slsState), false),
                      false);
-  CHECK_CLOSE_ABS(slsState.stepSize, 2, 1e-6);
-  slsState.stepSize = ndir * stepSize;
+  CHECK_CLOSE_ABS(slsState.stepSize.value(), 2, 1e-6);
+  slsState.stepSize.setValue(ndir * stepSize);
   sls.updateStepSize(slsState,
                      targetSurface->intersect(
                          slsState.geoContext, sls.position(slsState),
                          slsState.navDir * sls.direction(slsState), false),
                      true);
-  CHECK_CLOSE_ABS(slsState.stepSize, 2, 1e-6);
+  CHECK_CLOSE_ABS(slsState.stepSize.value(), 2, 1e-6);
 
   // Test the bound state construction
   auto boundState = sls.boundState(slsState, *plane).value();


### PR DESCRIPTION
Backport 8f77ccf453310655c3050183073b9b59bd9761cf from #1347.
---
while working on https://github.com/acts-project/acts/issues/1345 I stumbled across `ConstrainedStep` and the way how it converts to a Scalar. I believe there are cases where it will return `+/- max` which will break the propagation

similar to https://github.com/acts-project/acts/pull/1346 but more intrusive and meant to fix the underlying bug

in this PR I rearranged the code and added a few short hands for common code in `ConstrainedStep`