### PR TITLE
fix: navigator priority with negative boundary distance [backport #1433 to develop/v19.x]

### DIFF
--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -553,11 +553,30 @@ Acts::TrackingVolume::compatibleBoundaries(
     processBoundaries(bSurfacesConfined);
   }
 
+  auto comparator = [](double a, double b) {
+    // sign function would be nice but ...
+    if ((a > 0 && b > 0) || (a < 0 && b < 0)) {
+      return a < b;
+    }
+    if (a > 0) {  // b < 0
+      return true;
+    }
+    return false;
+  };
+
   // Sort them accordingly to the navigation direction
   if (options.navDir == NavigationDirection::Forward) {
-    std::sort(bIntersections.begin(), bIntersections.end());
+    std::sort(bIntersections.begin(), bIntersections.end(),
+              [&](const auto& a, const auto& b) {
+                return comparator(a.intersection.pathLength,
+                                  b.intersection.pathLength);
+              });
   } else {
-    std::sort(bIntersections.begin(), bIntersections.end(), std::greater<>());
+    std::sort(bIntersections.begin(), bIntersections.end(),
+              [&](const auto& a, const auto& b) {
+                return comparator(-a.intersection.pathLength,
+                                  -b.intersection.pathLength);
+              });
   }
   return bIntersections;
 }


### PR DESCRIPTION
Backport 7ca1bb859256a2610ea52eebaac2ce99c4611506 from #1433.
---
trying to fix a bug discovered with fatras here https://github.com/acts-project/acts/issues/1385

in some special cases the propagation will get stuck in a loop as the navigator is flip-flopping the target boundary of two volumes. one ahead and one behind.

these changes reorder the priority of the boundaries. first we will target everything in propagation direction and only if there are none left we will allow opposite direction