### PR TITLE
refactor: debug print particle id value [backport #1435 to develop/v19.x]

### DIFF
--- a/Fatras/src/EventData/Particle.cpp
+++ b/Fatras/src/EventData/Particle.cpp
@@ -16,7 +16,8 @@ ActsFatras::Particle::Particle(Barcode particleId, Acts::PdgParticle pdg)
 std::ostream& ActsFatras::operator<<(std::ostream& os,
                                      const ActsFatras::Particle& particle) {
   // compact format w/ only identity information but no kinematics
-  os << "id=(" << particle.particleId() << ")";
+  os << "id=" << particle.particleId().value() << "(" << particle.particleId()
+     << ")";
   os << "|pdg=" << particle.pdg();
   os << "|q=" << particle.charge();
   os << "|m=" << particle.mass();


### PR DESCRIPTION
Backport 5dccd51e3f07dcfb08cc5b25f05bb47fe40e9650 from #1435.
---
while working on https://github.com/acts-project/acts/issues/1385 these changes were quite helpful for finding the "broken" particles in the CSV