### PR TITLE
refactor: consistent naming for simhits

### DIFF
--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/SurfaceSortingAlgorithm.hpp
@@ -28,7 +28,7 @@ class SurfaceSortingAlgorithm final : public BareAlgorithm {
     /// Input proto track collection
     std::string inputProtoTracks;
     /// Input simulated hit collection
-    std::string inputSimulatedHits;
+    std::string inputSimHits;
     /// Input measurement to simulated hit map for truth position
     std::string inputMeasurementSimHitsMap;
     /// Output proto track collection

--- a/Examples/Algorithms/TrackFitting/src/SurfaceSortingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/SurfaceSortingAlgorithm.cpp
@@ -36,8 +36,7 @@ ActsExamples::ProcessCode ActsExamples::SurfaceSortingAlgorithm::execute(
 
   const auto& protoTracks =
       ctx.eventStore.get<ProtoTrackContainer>(m_cfg.inputProtoTracks);
-  const auto& simHits =
-      ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimHits);
+  const auto& simHits = ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimHits);
   const auto& simHitsMap =
       ctx.eventStore.get<HitSimHitsMap>(m_cfg.inputMeasurementSimHitsMap);
 

--- a/Examples/Algorithms/TrackFitting/src/SurfaceSortingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/SurfaceSortingAlgorithm.cpp
@@ -19,7 +19,7 @@ ActsExamples::SurfaceSortingAlgorithm::SurfaceSortingAlgorithm(
   if (m_cfg.inputProtoTracks.empty()) {
     throw std::invalid_argument("Missing input proto track collection");
   }
-  if (m_cfg.inputSimulatedHits.empty()) {
+  if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing input simulated hits collection");
   }
   if (m_cfg.inputMeasurementSimHitsMap.empty()) {
@@ -37,7 +37,7 @@ ActsExamples::ProcessCode ActsExamples::SurfaceSortingAlgorithm::execute(
   const auto& protoTracks =
       ctx.eventStore.get<ProtoTrackContainer>(m_cfg.inputProtoTracks);
   const auto& simHits =
-      ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimulatedHits);
+      ctx.eventStore.get<SimHitContainer>(m_cfg.inputSimHits);
   const auto& simHitsMap =
       ctx.eventStore.get<HitSimHitsMap>(m_cfg.inputMeasurementSimHitsMap);
 

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -558,8 +558,8 @@ def addKalmanTracks(
         srfSortAlg = acts.examples.SurfaceSortingAlgorithm(
             level=acts.logging.INFO,
             inputProtoTracks="prototracks",
-            inputSimulatedHits=outputSimHits,
-            inputMeasurementSimHitsMap=digiAlg.config.outputMeasurementSimHitsMap,
+            inputSimHits="simhits",
+            inputMeasurementSimHitsMap="measurement_simhits_map",
             outputProtoTracks="sortedprototracks",
         )
         s.addAlgorithm(srfSortAlg)

--- a/Examples/Python/src/TrackFitting.cpp
+++ b/Examples/Python/src/TrackFitting.cpp
@@ -40,7 +40,7 @@ void addTrackFitting(Context& ctx) {
 
     ACTS_PYTHON_STRUCT_BEGIN(c, Config);
     ACTS_PYTHON_MEMBER(inputProtoTracks);
-    ACTS_PYTHON_MEMBER(inputSimulatedHits);
+    ACTS_PYTHON_MEMBER(inputSimHits);
     ACTS_PYTHON_MEMBER(inputMeasurementSimHitsMap);
     ACTS_PYTHON_MEMBER(outputProtoTracks);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Run/Alignment/Common/DetectorAlignment.cpp
+++ b/Examples/Run/Alignment/Common/DetectorAlignment.cpp
@@ -141,7 +141,7 @@ int runDetectorAlignment(
   SurfaceSortingAlgorithm::Config sorterCfg;
   // Setup the surface sorter if running direct navigator
   sorterCfg.inputProtoTracks = trackFinderCfg.outputProtoTracks;
-  sorterCfg.inputSimulatedHits = simHitReaderCfg.outputSimHits;
+  sorterCfg.inputSimHits = simHitReaderCfg.outputSimHits;
   sorterCfg.inputMeasurementSimHitsMap = digiCfg.outputMeasurementSimHitsMap;
   sorterCfg.outputProtoTracks = "sortedprototracks";
   if (dirNav) {

--- a/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
+++ b/Examples/Run/Reconstruction/Common/RecTruthTracks.cpp
@@ -123,7 +123,7 @@ int runRecTruthTracks(int argc, char* argv[],
   SurfaceSortingAlgorithm::Config sorterCfg;
   // Setup the surface sorter if running direct navigator
   sorterCfg.inputProtoTracks = trackFinderCfg.outputProtoTracks;
-  sorterCfg.inputSimulatedHits = simHitReaderCfg.outputSimHits;
+  sorterCfg.inputSimHits = simHitReaderCfg.outputSimHits;
   sorterCfg.inputMeasurementSimHitsMap = digiCfg.outputMeasurementSimHitsMap;
   sorterCfg.outputProtoTracks = "sortedprototracks";
   if (dirNav) {

--- a/Examples/Run/Reconstruction/ExaTrkX/TrackFindingExaTrkXGeneric.cpp
+++ b/Examples/Run/Reconstruction/ExaTrkX/TrackFindingExaTrkXGeneric.cpp
@@ -198,7 +198,7 @@ int main(int argc, char** argv) {
   SurfaceSortingAlgorithm::Config sorterCfg;
   // Setup the surface sorter if running direct navigator
   sorterCfg.inputProtoTracks = trkFinderCfg.outputProtoTracks;
-  sorterCfg.inputSimulatedHits = simHitReaderCfg.outputSimHits;
+  sorterCfg.inputSimHits = simHitReaderCfg.outputSimHits;
   sorterCfg.inputMeasurementSimHitsMap = digiCfg.outputMeasurementSimHitsMap;
   sorterCfg.outputProtoTracks = "sortedprototracks";
   if (dirNav) {


### PR DESCRIPTION
rename `SimulatedHits` vs `SimHits`