### PR TITLE
refactor: no return for add* python helpers [backport #1404 to develop/v19.x]

### DIFF
--- a/CI/physmon/physmon.py
+++ b/CI/physmon/physmon.py
@@ -111,7 +111,7 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
 
         rnd = acts.examples.RandomNumbers(seed=42)
 
-        s = addParticleGun(
+        addParticleGun(
             s,
             EtaConfig(-4.0, 4.0),
             ParticleConfig(4, acts.PdgParticle.eMuon, True),
@@ -120,14 +120,14 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             rnd=rnd,
         )
 
-        s = addFatras(
+        addFatras(
             s,
             trackingGeometry,
             field,
             rnd=rnd,
         )
 
-        s = addDigitization(
+        addDigitization(
             s,
             trackingGeometry,
             field,
@@ -135,7 +135,7 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             rnd=rnd,
         )
 
-        s = addSeeding(
+        addSeeding(
             s,
             trackingGeometry,
             field,
@@ -166,7 +166,7 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             rnd=rnd,  # only used by SeedingAlgorithm.TruthSmeared
         )
 
-        s = addCKFTracks(
+        addCKFTracks(
             s,
             trackingGeometry,
             field,

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -140,7 +140,7 @@ def addSeeding(
     outputDirRoot: Optional[Union[Path, str]] = None,
     logLevel: Optional[acts.logging.Level] = None,
     rnd: Optional[acts.examples.RandomNumbers] = None,
-) -> acts.examples.Sequencer:
+) -> None:
     """This function steers the seeding
     Parameters
     ----------
@@ -545,7 +545,7 @@ def addKalmanTracks(
     field: acts.MagneticFieldProvider,
     directNavigation=False,
     reverseFilteringMomThreshold=0 * u.GeV,
-):
+) -> None:
     truthTrkFndAlg = acts.examples.TruthTrackFinder(
         level=acts.logging.INFO,
         inputParticles="truth_seeds_selected",
@@ -600,7 +600,7 @@ def addTruthTrackingGsf(
     s: acts.examples.Sequencer,
     trackingGeometry: acts.TrackingGeometry,
     field: acts.MagneticFieldProvider,
-):
+) -> None:
     gsfOptions = {
         "maxComponents": 12,
         "abortOnError": False,
@@ -645,7 +645,7 @@ def addCKFTracks(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     selectedParticles: str = "truth_seeds_selected",
-) -> acts.examples.Sequencer:
+) -> None:
     """This function steers the seeding
 
     Parameters
@@ -762,7 +762,7 @@ def addExaTrkx(
     geometrySelection: Union[Path, str],
     onnxModelDir: Union[Path, str],
     outputDirRoot: Optional[Union[Path, str]] = None,
-) -> acts.examples.Sequencer:
+) -> None:
 
     # Run the particle selection
     # The pre-selection will select truth particles satisfying provided criteria
@@ -843,7 +843,7 @@ def addVertexFitting(
     trackParameters: str = "trackparameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
     logLevel: Optional[acts.logging.Level] = None,
-):
+) -> None:
     """This function steers the vertex fitting
 
     Parameters

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -3,10 +3,8 @@ from pathlib import Path
 from collections import namedtuple
 from collections.abc import Iterable
 
-
 import acts
 from acts.examples import (
-    Sequencer,
     RandomNumbers,
     EventGenerator,
     FixedMultiplicityGenerator,
@@ -55,7 +53,7 @@ ParticleSelectorConfig = namedtuple(
     particleConfig=ParticleConfig,
 )
 def addParticleGun(
-    s: Sequencer,
+    s: acts.examples.Sequencer,
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     momentumConfig: MomentumConfig = MomentumConfig(),
@@ -66,7 +64,7 @@ def addParticleGun(
     vtxGen: Optional[EventGenerator.VertexGenerator] = None,
     printParticles: bool = False,
     rnd: Optional[RandomNumbers] = None,
-) -> Sequencer:
+) -> None:
     """This function steers the particle generation using the particle gun
 
     Parameters
@@ -183,11 +181,8 @@ def addPythia8(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     printParticles: bool = False,
-    returnEvGen: bool = False,
-) -> Union[acts.examples.Sequencer, acts.examples.EventGenerator]:
+) -> None:
     """This function steers the particle generation using Pythia8
-
-    NB. this is a reimplementation of common.addPythia8, which is maintained for now for compatibility.
 
     Parameters
     ----------
@@ -211,9 +206,6 @@ def addPythia8(
         the output folder for the Root output, None triggers no output
     printParticles : bool, False
         print generated particles
-    returnEvGen: bool, False
-        returns EventGenerator instead of Sequencer.
-        This option  is included for compatibility and will be removed when common.addPythia8 is removed.
     """
 
     if int(s.config.logLevel) <= int(acts.logging.DEBUG):
@@ -305,7 +297,7 @@ def addPythia8(
             )
         )
 
-    return evGen if returnEvGen else s
+    return s
 
 
 @acts.examples.NamedTypeArgs(
@@ -319,7 +311,7 @@ def addFatras(
     outputDirRoot: Optional[Union[Path, str]] = None,
     rnd: Optional[acts.examples.RandomNumbers] = None,
     preselectParticles: Optional[ParticleSelectorConfig] = ParticleSelectorConfig(),
-) -> acts.examples.Sequencer:
+) -> None:
     """This function steers the detector simulation using Fatras
 
     Parameters
@@ -404,7 +396,7 @@ def addSimWriters(
     inputSimHits: Optional[str] = None,
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
-) -> acts.examples.Sequencer:
+) -> None:
     if outputDirCsv is not None:
         outputDirCsv = Path(outputDirCsv)
         if not outputDirCsv.exists():
@@ -480,7 +472,7 @@ def addGeant4(
     outputDirRoot: Optional[Union[Path, str]] = None,
     seed: Optional[int] = None,
     preselectParticles: bool = True,
-) -> acts.examples.Sequencer:
+) -> None:
     """This function steers the detector simulation using Geant4
 
     Parameters

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -384,7 +384,7 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
         addDigitization,
     )
 
-    seq = addParticleGun(
+    addParticleGun(
         seq,
         MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, True),
         EtaConfig(-4.0, 4.0, True),
@@ -394,7 +394,7 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
         rnd=rnd,
     )
 
-    seq = addFatras(
+    addFatras(
         seq,
         trk_geo,
         field,
@@ -404,7 +404,7 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
     )
 
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
-    seq = addDigitization(
+    addDigitization(
         seq,
         trk_geo,
         field,
@@ -423,7 +423,7 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
     )
     from acts.examples.itk import itkSeedingAlgConfig
 
-    seq = addSeeding(
+    addSeeding(
         seq,
         trk_geo,
         field,
@@ -434,7 +434,9 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
         / "Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json",
         inputParticles="particles_final",  # use this to reproduce the original root_file_hashes.txt - remove to fix
         outputDirRoot=str(tmp_path),
-    ).run()
+    )
+
+    seq.run()
 
     del seq
 

--- a/Examples/Scripts/Python/ckf_tracks.py
+++ b/Examples/Scripts/Python/ckf_tracks.py
@@ -53,7 +53,7 @@ def runCKFTracks(
     outputDir = Path(outputDir)
 
     if inputParticlePath is None:
-        s = addParticleGun(
+        addParticleGun(
             s,
             EtaConfig(-2.0, 2.0),
             ParticleConfig(4, acts.PdgParticle.eMuon, True),
@@ -75,14 +75,14 @@ def runCKFTracks(
             )
         )
 
-    s = addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
         rnd=rnd,
     )
 
-    s = addDigitization(
+    addDigitization(
         s,
         trackingGeometry,
         field,
@@ -90,7 +90,7 @@ def runCKFTracks(
         rnd=rnd,
     )
 
-    s = addSeeding(
+    addSeeding(
         s,
         trackingGeometry,
         field,
@@ -119,7 +119,7 @@ def runCKFTracks(
         rnd=rnd,  # only used by SeedingAlgorithm.TruthSmeared
     )
 
-    s = addCKFTracks(
+    addCKFTracks(
         s,
         trackingGeometry,
         field,

--- a/Examples/Scripts/Python/digitization.py
+++ b/Examples/Scripts/Python/digitization.py
@@ -34,7 +34,7 @@ def configureDigitization(
     rnd = acts.examples.RandomNumbers(seed=42)
 
     if particlesInput is None:
-        s = addParticleGun(
+        addParticleGun(
             s,
             EtaConfig(-2.0, 2.0),
             ParticleConfig(4, acts.PdgParticle.eMuon, True),
@@ -53,7 +53,7 @@ def configureDigitization(
         s.addReader(evGen)
 
     outputDir = Path(outputDir)
-    s = addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
@@ -61,7 +61,7 @@ def configureDigitization(
     )
     from acts.examples.simulation import addDigitization
 
-    s = addDigitization(
+    addDigitization(
         s,
         trackingGeometry,
         field,

--- a/Examples/Scripts/Python/exatrkx.py
+++ b/Examples/Scripts/Python/exatrkx.py
@@ -52,6 +52,6 @@ if "__main__" == __name__:
         s=s,
     )
 
-    s = addExaTrkx(s, trackingGeometry, geometrySelection, onnxdir, outputDir)
+    addExaTrkx(s, trackingGeometry, geometrySelection, onnxdir, outputDir)
 
     s.run()

--- a/Examples/Scripts/Python/fatras.py
+++ b/Examples/Scripts/Python/fatras.py
@@ -12,13 +12,13 @@ def runFatras(trackingGeometry, field, outputDir, s: acts.examples.Sequencer = N
     s = s or acts.examples.Sequencer(events=100, numThreads=-1)
     s.config.logLevel = acts.logging.INFO
     rnd = acts.examples.RandomNumbers()
-    s = addParticleGun(
+    addParticleGun(
         s,
         EtaConfig(-2.0, 2.0),
         rnd=rnd,
     )
     outputDir = Path(outputDir)
-    return addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
@@ -26,6 +26,7 @@ def runFatras(trackingGeometry, field, outputDir, s: acts.examples.Sequencer = N
         outputDirRoot=outputDir,
         rnd=rnd,
     )
+    return s
 
 
 if "__main__" == __name__:

--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -33,15 +33,15 @@ from acts.examples.reconstruction import (
 from acts.examples.itk import itkSeedingAlgConfig
 
 s = acts.examples.Sequencer(events=100, numThreads=-1)
-s = addParticleGun(
+addParticleGun(
     s,
-    MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, True),
-    EtaConfig(-4.0, 4.0, True),
-    ParticleConfig(1, acts.PdgParticle.eMuon, True),
+    MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
+    EtaConfig(-4.0, 4.0, uniform=True),
+    ParticleConfig(1, acts.PdgParticle.eMuon, randomizeCharge=True),
     rnd=rnd,
 )
 # # Uncomment addPythia8 and ParticleSelectorConfig, instead of addParticleGun, to generate ttbar with mu=200 pile-up.
-# s = addPythia8(
+# addPythia8(
 #     s,
 #     hardProcess=["Top:qqbar2ttbar=on"],
 #     vtxGen=acts.examples.GaussianVertexGenerator(
@@ -51,7 +51,7 @@ s = addParticleGun(
 #     rnd=rnd,
 #     outputDirRoot=outputDir,
 # )
-s = addFatras(
+addFatras(
     s,
     trackingGeometry,
     field,
@@ -59,7 +59,7 @@ s = addFatras(
     outputDirRoot=outputDir,
     rnd=rnd,
 )
-s = addDigitization(
+addDigitization(
     s,
     trackingGeometry,
     field,
@@ -67,7 +67,7 @@ s = addDigitization(
     outputDirRoot=outputDir,
     rnd=rnd,
 )
-s = addSeeding(
+addSeeding(
     s,
     trackingGeometry,
     field,
@@ -78,7 +78,7 @@ s = addSeeding(
     geoSelectionConfigFile=geo_dir / "itk-hgtd/geoSelection-ITk.json",
     outputDirRoot=outputDir,
 )
-s = addCKFTracks(
+addCKFTracks(
     s,
     trackingGeometry,
     field,

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import argparse
 import pathlib, acts, acts.examples
 import acts.examples.dd4hep
 from common import getOpenDataDetectorDirectory
@@ -42,21 +41,21 @@ from acts.examples.reconstruction import (
 
 s = acts.examples.Sequencer(events=100, numThreads=-1, logLevel=acts.logging.INFO)
 
-s = addParticleGun(
+addParticleGun(
     s,
-    MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, True),
-    EtaConfig(-3.0, 3.0, True),
-    ParticleConfig(2, acts.PdgParticle.eMuon, True),
+    MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
+    EtaConfig(-3.0, 3.0, uniform=True),
+    ParticleConfig(2, acts.PdgParticle.eMuon, randomizeCharge=True),
     rnd=rnd,
 )
-s = addFatras(
+addFatras(
     s,
     trackingGeometry,
     field,
     outputDirRoot=outputDir,
     rnd=rnd,
 )
-s = addDigitization(
+addDigitization(
     s,
     trackingGeometry,
     field,
@@ -64,14 +63,14 @@ s = addDigitization(
     outputDirRoot=outputDir,
     rnd=rnd,
 )
-s = addSeeding(
+addSeeding(
     s,
     trackingGeometry,
     field,
     geoSelectionConfigFile=oddSeedingSel,
     outputDirRoot=outputDir,
 )
-s = addCKFTracks(
+addCKFTracks(
     s,
     trackingGeometry,
     field,
@@ -90,7 +89,7 @@ s.addAlgorithm(
         ptMin=500 * u.MeV,
     )
 )
-s = addVertexFitting(
+addVertexFitting(
     s,
     field,
     vertexFinder=VertexFinder.Iterative,

--- a/Examples/Scripts/Python/geant4.py
+++ b/Examples/Scripts/Python/geant4.py
@@ -21,13 +21,13 @@ def runGeant4(
     s.config.logLevel = acts.logging.INFO
     rnd = acts.examples.RandomNumbers()
     seed = 42
-    s = addParticleGun(
+    addParticleGun(
         s,
         EtaConfig(-2.0, 2.0),
         rnd=rnd,
     )
     outputDir = Path(outputDir)
-    return addGeant4(
+    addGeant4(
         s,
         geometryService,
         trackingGeometry,
@@ -36,6 +36,7 @@ def runGeant4(
         outputDirRoot=outputDir,
         seed=seed,
     )
+    return s
 
 
 if "__main__" == __name__:

--- a/Examples/Scripts/Python/particle_gun.py
+++ b/Examples/Scripts/Python/particle_gun.py
@@ -10,7 +10,7 @@ def runParticleGun(outputDir, s=None):
     s = s or Sequencer(events=10, numThreads=-1)
     s.config.logLevel = acts.logging.INFO
     outputDir = Path(outputDir)
-    return addParticleGun(
+    addParticleGun(
         s,
         EtaConfig(-4.0, 4.0),
         ParticleConfig(2),
@@ -18,6 +18,7 @@ def runParticleGun(outputDir, s=None):
         outputDirRoot=outputDir,
         printParticles=True,
     )
+    return s
 
 
 if "__main__" == __name__:

--- a/Examples/Scripts/Python/pythia8.py
+++ b/Examples/Scripts/Python/pythia8.py
@@ -25,12 +25,14 @@ def runPythia8(
         events=10, numThreads=-1, logLevel=acts.logging.INFO
     )
 
-    return addPythia8(
+    addPythia8(
         s,
         rnd=rnd,
         outputDirCsv=outputDir / "csv" if outputCsv else None,
         outputDirRoot=outputDir if outputRoot else None,
     )
+
+    return s
 
 
 if "__main__" == __name__:

--- a/Examples/Scripts/Python/seeding.py
+++ b/Examples/Scripts/Python/seeding.py
@@ -66,7 +66,7 @@ def runSeeding(
     rnd = acts.examples.RandomNumbers(seed=42)
     outputDir = Path(outputDir)
 
-    s = addParticleGun(
+    addParticleGun(
         s,
         EtaConfig(-2.0, 2.0),
         ParticleConfig(4, acts.PdgParticle.eMuon, True),
@@ -77,7 +77,7 @@ def runSeeding(
         rnd=rnd,
     )
 
-    s = addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
@@ -88,7 +88,7 @@ def runSeeding(
     )
 
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
-    s = addDigitization(
+    addDigitization(
         s,
         trackingGeometry,
         field,
@@ -103,7 +103,7 @@ def runSeeding(
         SeedfinderConfigArg,
     )
 
-    s = addSeeding(
+    addSeeding(
         s,
         trackingGeometry,
         field,

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -45,7 +45,7 @@ def runTruthTrackingGsf(
     outputDir = Path(outputDir)
 
     if inputParticlePath is None:
-        s = addParticleGun(
+        addParticleGun(
             s,
             EtaConfig(-2.0, 2.0),
             ParticleConfig(4, acts.PdgParticle.eMuon, True),
@@ -67,14 +67,14 @@ def runTruthTrackingGsf(
             )
         )
 
-    s = addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
         rnd=rnd,
     )
 
-    s = addDigitization(
+    addDigitization(
         s,
         trackingGeometry,
         field,
@@ -82,7 +82,7 @@ def runTruthTrackingGsf(
         rnd=rnd,
     )
 
-    s = addSeeding(
+    addSeeding(
         s,
         trackingGeometry,
         field,
@@ -98,7 +98,7 @@ def runTruthTrackingGsf(
 
     s.addAlgorithm(truthTrkFndAlg)
 
-    s = addTruthTrackingGsf(s, trackingGeometry, field)
+    addTruthTrackingGsf(s, trackingGeometry, field)
 
     # Output
     s.addWriter(

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -43,7 +43,7 @@ def runTruthTrackingKalman(
     outputDir = Path(outputDir)
 
     if inputParticlePath is None:
-        s = addParticleGun(
+        addParticleGun(
             s,
             EtaConfig(-2.0, 2.0),
             ParticleConfig(2, acts.PdgParticle.eMuon, False),
@@ -65,14 +65,14 @@ def runTruthTrackingKalman(
             )
         )
 
-    s = addFatras(
+    addFatras(
         s,
         trackingGeometry,
         field,
         rnd=rnd,
     )
 
-    s = addDigitization(
+    addDigitization(
         s,
         trackingGeometry,
         field,
@@ -80,7 +80,7 @@ def runTruthTrackingKalman(
         rnd=rnd,
     )
 
-    s = addSeeding(
+    addSeeding(
         s,
         trackingGeometry,
         field,
@@ -92,7 +92,7 @@ def runTruthTrackingKalman(
         ),
     )
 
-    s = addKalmanTracks(
+    addKalmanTracks(
         s, trackingGeometry, field, directNavigation, reverseFilteringMomThreshold
     )
 

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -93,7 +93,7 @@ def runVertexFitting(
 
     logger.info("Using vertex finder: %s", vertexFinder.name)
 
-    return addVertexFitting(
+    addVertexFitting(
         s,
         field,
         outputDirRoot=outputDir if outputRoot else None,
@@ -101,6 +101,8 @@ def runVertexFitting(
         trackParameters=trackParameters,
         vertexFinder=vertexFinder,
     )
+
+    return s
 
 
 if "__main__" == __name__:


### PR DESCRIPTION
Backport afb91a583e6db641c9b39354c7494da5726b8681 from #1404.
---
after working on the full chain doc I wondered why we do `s = addSomething(s, ...)` all the time. to me it looks kind of confusing as the reader might think `s` is changing every time we add something.

maybe we want to remove the return value of the add functions completely? @paulgessinger @timadye 