### PR TITLE
feat: Algorithm lifecycle methods: initialize & finalize

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
@@ -15,8 +15,10 @@
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
 #include "ActsExamples/MagneticField/MagneticField.hpp"
 
+#include <atomic>
 #include <functional>
 #include <vector>
 
@@ -90,8 +92,13 @@ class TrackFindingAlgorithm final : public BareAlgorithm {
   void computeSharedHits(const source_link_accessor_container_t& sourcelinks,
                          TrackFinderResult&) const;
 
+  ActsExamples::ProcessCode finalize() const override;
+
  private:
   Config m_cfg;
+
+  mutable std::atomic<size_t> m_nTotalSeeds;
+  mutable std::atomic<size_t> m_nFailedSeeds;
 };
 
 template <typename source_link_accessor_container_t>

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -14,6 +14,7 @@
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/EventData/Trajectories.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 
 #include <stdexcept>
@@ -102,6 +103,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
 
   // Loop over the track finding results for all initial parameters
   for (std::size_t iseed = 0; iseed < initialParameters.size(); ++iseed) {
+    m_nTotalSeeds++;
     // The result for this seed
     auto& result = results[iseed];
     if (result.ok()) {
@@ -121,6 +123,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
     } else {
       ACTS_WARNING("Track finding failed for seed " << iseed << " with error"
                                                     << result.error());
+      m_nFailedSeeds++;
       // Track finding failed. Add an empty result so the output container has
       // the same number of entries as the input.
       trajectories.push_back(Trajectories());
@@ -134,4 +137,14 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
   ctx.eventStore.add(m_cfg.outputTrackParameters,
                      std::move(trackParametersContainer));
   return ActsExamples::ProcessCode::SUCCESS;
+}
+
+ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::finalize()
+    const {
+  ACTS_INFO("TrackFindingAlgorithm statistics:");
+  ACTS_INFO("- total seeds: " << m_nTotalSeeds);
+  ACTS_INFO("- failed seeds: " << m_nFailedSeeds);
+  ACTS_INFO("- failure ratio: " << static_cast<double>(m_nFailedSeeds) /
+                                       m_nTotalSeeds);
+  return ProcessCode::SUCCESS;
 }

--- a/Examples/Framework/include/ActsExamples/Framework/BareAlgorithm.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/BareAlgorithm.hpp
@@ -46,6 +46,9 @@ class BareAlgorithm : public IAlgorithm {
   virtual ProcessCode execute(
       const AlgorithmContext& context) const override = 0;
 
+  ProcessCode initialize() const override { return ProcessCode::SUCCESS; }
+  ProcessCode finalize() const override { return ProcessCode::SUCCESS; }
+
  protected:
   const Acts::Logger& logger() const { return *m_logger; }
 

--- a/Examples/Framework/include/ActsExamples/Framework/BareAlgorithm.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/BareAlgorithm.hpp
@@ -46,7 +46,9 @@ class BareAlgorithm : public IAlgorithm {
   virtual ProcessCode execute(
       const AlgorithmContext& context) const override = 0;
 
+  /// Initialize the algorithm
   ProcessCode initialize() const override { return ProcessCode::SUCCESS; }
+  /// Finalize the algorithm
   ProcessCode finalize() const override { return ProcessCode::SUCCESS; }
 
  protected:

--- a/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
@@ -28,6 +28,8 @@ class IAlgorithm {
 
   /// Execute the algorithm for one event.
   virtual ProcessCode execute(const AlgorithmContext& context) const = 0;
+  virtual ProcessCode initialize() const = 0;
+  virtual ProcessCode finalize() const = 0;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
@@ -28,7 +28,9 @@ class IAlgorithm {
 
   /// Execute the algorithm for one event.
   virtual ProcessCode execute(const AlgorithmContext& context) const = 0;
+  /// Initialize the algorithm
   virtual ProcessCode initialize() const = 0;
+  /// Finalize the algorithm
   virtual ProcessCode finalize() const = 0;
 };
 

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -269,6 +269,15 @@ int ActsExamples::Sequencer::run() {
     service->startRun();
   }
 
+  ACTS_VERBOSE("Initialize algorithms");
+  for (auto& alg : m_algorithms) {
+    ACTS_VERBOSE("Initialize algorithm: " << alg->name());
+    if (alg->initialize() != ProcessCode::SUCCESS) {
+      ACTS_FATAL("Failed to initialize algorithm: " << alg->name());
+      throw std::runtime_error("Failed to process event data");
+    }
+  }
+
   // execute the parallel event loop
   std::atomic<size_t> nProcessedEvents = 0;
   size_t nTotalEvents = eventsRange.second - eventsRange.first;
@@ -351,6 +360,15 @@ int ActsExamples::Sequencer::run() {
           }
         });
   });
+
+  ACTS_VERBOSE("Finalize algorithms");
+  for (auto& alg : m_algorithms) {
+    ACTS_VERBOSE("Finalize algorithm: " << alg->name());
+    if (alg->initialize() != ProcessCode::SUCCESS) {
+      ACTS_FATAL("Failed to Finalize algorithm: " << alg->name());
+      throw std::runtime_error("Failed to process event data");
+    }
+  }
 
   // run end-of-run hooks
   for (auto& wrt : m_writers) {

--- a/Examples/Python/src/ModuleEntry.cpp
+++ b/Examples/Python/src/ModuleEntry.cpp
@@ -24,27 +24,37 @@ namespace py = pybind11;
 using namespace ActsExamples;
 
 namespace {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
 class PyIAlgorithm : public IAlgorithm {
  public:
   using IAlgorithm::IAlgorithm;
 
   std::string name() const override {
     py::gil_scoped_acquire acquire{};
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
     PYBIND11_OVERRIDE_PURE(std::string, IAlgorithm, name);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
   }
 
   ProcessCode execute(const AlgorithmContext& ctx) const override {
     py::gil_scoped_acquire acquire{};
     PYBIND11_OVERRIDE_PURE(ProcessCode, IAlgorithm, execute, ctx);
   }
+
+  ProcessCode initialize() const override {
+    py::gil_scoped_acquire acquire{};
+    PYBIND11_OVERRIDE_PURE(ProcessCode, IAlgorithm, initialize);
+  }
+
+  ProcessCode finalize() const override {
+    py::gil_scoped_acquire acquire{};
+    PYBIND11_OVERRIDE_PURE(ProcessCode, IAlgorithm, finalize);
+  }
 };
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 class PyBareAlgorithm : public BareAlgorithm {
  public:


### PR DESCRIPTION
While working on #1417, I was missing a way for an algorithm to collect performance numbers while running (thread-safe) and printing them when finalizing. I believe this is going to be more and more important, so this PR is adding simple `initialize` and `finalize` methods to our algorithm interface. They are defaulted by `BareAlgorithm` so all other algorithms don't necessarily have to implement.

This PR uses this mechanism to add some output on the number of failed seeds to the end of the TrackFindingAlgorithm, but there should be more cases where this will be helpful.