### PR TITLE
feat: Update RootVertexPerformanceWriter to work with track finding

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
@@ -61,6 +61,8 @@ class TrackFindingAlgorithm final : public BareAlgorithm {
     std::string outputTrajectories;
     /// Output track parameters collection.
     std::string outputTrackParameters;
+    /// Output track parameters tips w.r.t outputTrajectories.
+    std::string outputTrackParametersTips;
     /// Type erased track finder function.
     std::shared_ptr<TrackFinderFunction> findTracks;
     /// CKF measurement selector config

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -35,6 +35,15 @@ ActsExamples::TrackFindingAlgorithm::TrackFindingAlgorithm(
   if (m_cfg.outputTrajectories.empty()) {
     throw std::invalid_argument("Missing trajectories output collection");
   }
+
+  if (m_cfg.outputTrackParameters.empty()) {
+    throw std::invalid_argument(
+        "Missing track parameter tips output collection");
+  }
+
+  if (m_cfg.outputTrackParametersTips.empty()) {
+    throw std::invalid_argument("Missing track parameters output collection");
+  }
 }
 
 ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
@@ -53,6 +62,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
 
   // Prepare the output data with TrackParameters
   TrackParametersContainer trackParametersContainer;
+  std::vector<std::pair<size_t, size_t>> trackParametersTips;
 
   // Construct a perigee surface as the target surface
   auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
@@ -116,6 +126,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
       for (const auto tip : traj.tips()) {
         if (traj.hasTrackParameters(tip)) {
           trackParametersContainer.push_back(traj.trackParameters(tip));
+          trackParametersTips.push_back({trajectories.size() - 1, tip});
         }
       }
     } else {
@@ -133,5 +144,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
   ctx.eventStore.add(m_cfg.outputTrajectories, std::move(trajectories));
   ctx.eventStore.add(m_cfg.outputTrackParameters,
                      std::move(trackParametersContainer));
+  ctx.eventStore.add(m_cfg.outputTrackParametersTips,
+                     std::move(trackParametersTips));
   return ActsExamples::ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootVertexPerformanceWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootVertexPerformanceWriter.hpp
@@ -41,6 +41,14 @@ class RootVertexPerformanceWriter final
     std::string inputAssociatedTruthParticles;
     /// All event fitted tracks
     std::string inputFittedTracks;
+    /// All event fitted tracks indices
+    std::string inputFittedTracksIndices;
+    /// All event fitted tracks tips
+    std::string inputAllFittedTracksTips;
+    /// Trajectories object from track finidng
+    std::string inputTrajectories;
+    /// Input hit-particles map collection.
+    std::string inputMeasurementParticlesMap;
     /// Input vertex collection.
     std::string inputVertices;
     /// Input reconstruction time.
@@ -54,6 +62,9 @@ class RootVertexPerformanceWriter final
     /// Minimum fraction of tracks matched between truth
     /// and reco vertices to be matched for resolution plots
     double minTrackVtxMatchFraction = 0.5;
+    /// Minimum fraction of hits associated to particle to consider
+    /// as truth matched
+    double truthMatchProbMin = 0.5;
   };
 
   /// Constructor
@@ -87,6 +98,20 @@ class RootVertexPerformanceWriter final
       m_diffy;  ///< Difference in y positon between reco and true vtx
   std::vector<float>
       m_diffz;  ///< Difference in z positon between reco and true vtx
+
+  std::vector<float> m_truthX;
+  std::vector<float> m_truthY;
+  std::vector<float> m_truthZ;
+
+  std::vector<float> m_recoX;
+  std::vector<float> m_recoY;
+  std::vector<float> m_recoZ;
+
+  std::vector<float> m_covXX;
+  std::vector<float> m_covYY;
+  std::vector<float> m_covXY;
+  std::vector<float> m_covYX;
+  std::vector<float> m_trackVtxMatchFraction;
 
   int m_nrecoVtx = -1;           ///< Number of reconstructed vertices
   int m_ntrueVtx = -1;           ///< Number of true vertices

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -684,6 +684,7 @@ def addCKFTracks(
         inputInitialTrackParameters="estimatedparameters",
         outputTrajectories="trajectories",
         outputTrackParameters="fittedTrackParameters",
+        outputTrackParametersTips="fittedTrackParametersTips",
         findTracks=acts.examples.TrackFindingAlgorithm.makeTrackFinderFunction(
             trackingGeometry, field
         ),
@@ -844,6 +845,7 @@ def addVertexFitting(
     field,
     outputDirRoot: Optional[Union[Path, str]] = None,
     associatedParticles: str = "particles_input",
+    trajectories: Optional[str] = None,
     trackParameters: str = "trackparameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
     logLevel: Optional[acts.logging.Level] = None,
@@ -934,17 +936,26 @@ def addVertexFitting(
                 "Using RootVertexPerformanceWriter with smeared particles is not necessarily supported. "
                 "Please get in touch with us"
             )
+        kwargs = {}
+        if trajectories is not None:
+            kwargs["inputTrajectories"] = "trajectories"
+        else:
+            kwargs["inputAssociatedTruthParticles"] = associatedParticles
         s.addWriter(
             RootVertexPerformanceWriter(
-                level=customLogLevel(),
+                level=acts.logging.VERBOSE,
                 inputAllTruthParticles=inputParticles,
                 inputSelectedTruthParticles=selectedParticles,
-                inputAssociatedTruthParticles=associatedParticles,
                 inputFittedTracks=trackParameters,
+                inputFittedTracksIndices="outputTrackIndices",
+                inputAllFittedTracksTips="fittedTrackParametersTips",
+                inputMeasurementParticlesMap="measurement_particles_map",
                 inputVertices=outputVertices,
+                minTrackVtxMatchFraction=0.0,
                 inputTime=outputTime,
                 treeName="vertexing",
                 filePath=str(outputDirRoot / "performance_vertexing.root"),
+                **kwargs,
             )
         )
 

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -436,12 +436,17 @@ void addOutput(Context& ctx) {
     ACTS_PYTHON_MEMBER(inputSelectedTruthParticles);
     ACTS_PYTHON_MEMBER(inputAssociatedTruthParticles);
     ACTS_PYTHON_MEMBER(inputFittedTracks);
+    ACTS_PYTHON_MEMBER(inputFittedTracksIndices);
+    ACTS_PYTHON_MEMBER(inputAllFittedTracksTips);
+    ACTS_PYTHON_MEMBER(inputTrajectories);
+    ACTS_PYTHON_MEMBER(inputMeasurementParticlesMap);
     ACTS_PYTHON_MEMBER(inputVertices);
     ACTS_PYTHON_MEMBER(inputTime);
     ACTS_PYTHON_MEMBER(filePath);
     ACTS_PYTHON_MEMBER(treeName);
     ACTS_PYTHON_MEMBER(fileMode);
     ACTS_PYTHON_MEMBER(minTrackVtxMatchFraction);
+    ACTS_PYTHON_MEMBER(truthMatchProbMin);
     ACTS_PYTHON_STRUCT_END();
   }
 

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -315,6 +315,7 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_MEMBER(inputInitialTrackParameters);
     ACTS_PYTHON_MEMBER(outputTrajectories);
     ACTS_PYTHON_MEMBER(outputTrackParameters);
+    ACTS_PYTHON_MEMBER(outputTrackParametersTips);
     ACTS_PYTHON_MEMBER(findTracks);
     ACTS_PYTHON_MEMBER(measurementSelectorCfg);
     ACTS_PYTHON_STRUCT_END();


### PR DESCRIPTION
Previously, the `RootVertexPerformanceWriter` assumed a 1:1 correspondence between truth particles and reconstructed tracks. This PR implements hit based truth matching to enable this to run.