### PR TITLE
refactor: Remove dependency on deprecated std::binary_function

### DIFF
--- a/Core/include/Acts/Geometry/GeometryObjectSorter.hpp
+++ b/Core/include/Acts/Geometry/GeometryObjectSorter.hpp
@@ -21,7 +21,7 @@
 namespace Acts {
 
 template <class T>
-class ObjectSorterT : public std::binary_function<T, T, bool> {
+class ObjectSorterT {
  public:
   /// Constructor from a binning value
   ///
@@ -80,7 +80,7 @@ class ObjectSorterT : public std::binary_function<T, T, bool> {
 
 /// This will check on absolute distance
 template <class T>
-class DistanceSorterT : public std::binary_function<T, T, bool> {
+class DistanceSorterT {
  public:
   /// Constructor from a binning value
   ///
@@ -160,7 +160,7 @@ class DistanceSorterT : public std::binary_function<T, T, bool> {
 };
 
 template <class T>
-class GeometryObjectSorterT : public std::binary_function<T, T, bool> {
+class GeometryObjectSorterT {
  public:
   /// Constructor from a binning value
   ///


### PR DESCRIPTION
My newest `gcc` warns about some code is inheriting from `std::binary_function`, which is indeed deprecated since C++11 and officially removed in C++17 (https://en.cppreference.com/w/cpp/utility/functional/binary_function), so maybe we should get rid of it.

It seems enough to just remove the inheritance, so its a pretty easy fix.