### PR TITLE
fix: Set s_binningValues as const

### DIFF
--- a/Core/include/Acts/Utilities/BinningType.hpp
+++ b/Core/include/Acts/Utilities/BinningType.hpp
@@ -46,7 +46,7 @@ enum BinningValue : int {
 };
 
 /// @brief static list of all binning values
-static std::vector<BinningValue> s_binningValues = {
+static const std::vector<BinningValue> s_binningValues = {
     binX, binY, binZ, binR, binPhi, binRPhi, binH, binEta, binMag};
 
 /// @brief screen output option


### PR DESCRIPTION
Setting `s_binningValues` as `const` as well. The Atlas Thread-check is complaining about this since it suspect this may be not thread safe.