### PR TITLE
feat: Checks for configuration of delta R values in seed finder [backport #1378 to develop/v19.x]

### DIFF
--- a/Core/include/Acts/Seeding/SeedfinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedfinderConfig.hpp
@@ -36,13 +36,13 @@ struct SeedfinderConfig {
   // maximum distance in r between two measurements within one seed
   float deltaRMax = 270 * Acts::UnitConstants::mm;
   // minimum distance in r between middle and top SP
-  float deltaRMinTopSP = 5 * Acts::UnitConstants::mm;
+  float deltaRMinTopSP = std::numeric_limits<float>::quiet_NaN();
   // maximum distance in r between middle and top SP
-  float deltaRMaxTopSP = 270 * Acts::UnitConstants::mm;
+  float deltaRMaxTopSP = std::numeric_limits<float>::quiet_NaN();
   // minimum distance in r between middle and bottom SP
-  float deltaRMinBottomSP = 5 * Acts::UnitConstants::mm;
+  float deltaRMinBottomSP = std::numeric_limits<float>::quiet_NaN();
   // maximum distance in r between middle and bottom SP
-  float deltaRMaxBottomSP = 270 * Acts::UnitConstants::mm;
+  float deltaRMaxBottomSP = std::numeric_limits<float>::quiet_NaN();
   // radial bin size for filling space point grid
   float binSizeR = 1. * Acts::UnitConstants::mm;
   // force sorting in R in space point grid bins

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -55,6 +55,38 @@ ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
     throw std::invalid_argument("Inconsistent config deltaRMax");
   }
 
+  static_assert(std::numeric_limits<decltype(
+                    m_cfg.seedFinderConfig.deltaRMaxTopSP)>::has_quiet_NaN,
+                "Value of deltaRMaxTopSP must support NaN values");
+
+  static_assert(std::numeric_limits<decltype(
+                    m_cfg.seedFinderConfig.deltaRMinTopSP)>::has_quiet_NaN,
+                "Value of deltaRMinTopSP must support NaN values");
+
+  static_assert(std::numeric_limits<decltype(
+                    m_cfg.seedFinderConfig.deltaRMaxBottomSP)>::has_quiet_NaN,
+                "Value of deltaRMaxBottomSP must support NaN values");
+
+  static_assert(std::numeric_limits<decltype(
+                    m_cfg.seedFinderConfig.deltaRMinBottomSP)>::has_quiet_NaN,
+                "Value of deltaRMinBottomSP must support NaN values");
+
+  if (std::isnan(m_cfg.seedFinderConfig.deltaRMaxTopSP)) {
+    m_cfg.seedFinderConfig.deltaRMaxTopSP = m_cfg.seedFinderConfig.deltaRMax;
+  }
+
+  if (std::isnan(m_cfg.seedFinderConfig.deltaRMinTopSP)) {
+    m_cfg.seedFinderConfig.deltaRMinTopSP = m_cfg.seedFinderConfig.deltaRMin;
+  }
+
+  if (std::isnan(m_cfg.seedFinderConfig.deltaRMaxBottomSP)) {
+    m_cfg.seedFinderConfig.deltaRMaxBottomSP = m_cfg.seedFinderConfig.deltaRMax;
+  }
+
+  if (std::isnan(m_cfg.seedFinderConfig.deltaRMinBottomSP)) {
+    m_cfg.seedFinderConfig.deltaRMinBottomSP = m_cfg.seedFinderConfig.deltaRMin;
+  }
+
   if (m_cfg.gridConfig.zMin != m_cfg.seedFinderConfig.zMin) {
     throw std::invalid_argument("Inconsistent config zMin");
   }


### PR DESCRIPTION
Backport c1dda470d82bf479e21e4488339351b340f63022 from #1378.
---
This changes the initialisation of `deltaRMinTopSP`, `deltaRMaxTopSP`, `deltaRMinBottomSP` and `deltaRMaxBottomSP` to quiet_NaN. If the user does not configure these values, they take the values of `deltaRMin` and `deltaRMax`.

I think this makes the configuration easier and avoids errors when the user wants to use the same values for top and bottom.

@robertlangenberg 