### PR TITLE
docs: Switch to doxygen FAIL_ON_WARNINGS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2004:v29
     env:
-        DOXYGEN_WARN_AS_ERROR: YES
+        DOXYGEN_WARN_AS_ERROR: FAIL_ON_WARNINGS
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
Instead of exiting at the first warning that's treated as error, doxygen
will continue processing and exit fith a non-zero status code. This has
the benefit that all WARNINGs are visible at the same time.