### PR TITLE
fix: any direction for helical track linearizer [backport #1363 to develop/v9.1.x]

### DIFF
--- a/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
+++ b/Core/include/Acts/Vertexing/HelicalTrackLinearizer.ipp
@@ -19,17 +19,20 @@ Acts::Result<Acts::LinearizedTrack> Acts::
   const std::shared_ptr<PerigeeSurface> perigeeSurface =
       Surface::makeShared<PerigeeSurface>(linPointPos);
 
+  auto intersection = perigeeSurface->intersect(gctx, params.position(gctx),
+                                                params.unitDirection(), false);
+
   // Create propagator options
   auto logger = getDefaultLogger("HelTrkLinProp", Logging::INFO);
   propagator_options_t pOptions(gctx, mctx, LoggerWrapper{*logger});
-  pOptions.direction = backward;
+  pOptions.direction =
+      intersection.intersection.pathLength >= 0 ? forward : backward;
 
   const BoundTrackParameters* endParams = nullptr;
   // Do the propagation to linPointPos
   auto result = m_cfg.propagator->propagate(params, *perigeeSurface, pOptions);
   if (result.ok()) {
     endParams = (*result).endParameters.get();
-
   } else {
     return result.error();
   }


### PR DESCRIPTION
Backport 8639c37faff32a288e2417df0a7f099131132b35 from #1363
---
Previously the `HelicalTrackLinearizer` assumed that the vertex we are fitting has to be reachable by back propagation. This is not always the case. In this PR we try to estimate the direction in which we will find the vertex and use it for the propagation.