### PR TITLE
ci: Fix GPU CI on A4000 [backport of #1252 to develop/v19.0.x]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,17 @@ build:
     - git checkout $HEAD_SHA
     - cd ..
     - mkdir build
-    - cmake -B build -S src -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS=-w -DCMAKE_CUDA_FLAGS=-w -DACTS_BUILD_PLUGIN_EXATRKX=ON -DACTS_BUILD_EXAMPLES_EXATRKX=ON -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
+    - >
+      cmake -B build -S src 
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      -GNinja 
+      -DCMAKE_BUILD_TYPE=Release 
+      -DCMAKE_CXX_FLAGS=-w 
+      -DCMAKE_CUDA_FLAGS=-w 
+      -DCMAKE_CUDA_ARCHITECTURES="75;86"
+      -DACTS_BUILD_PLUGIN_EXATRKX=ON 
+      -DACTS_BUILD_EXAMPLES_EXATRKX=ON 
+      -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
     - cmake --build build --
 
 
@@ -30,7 +40,7 @@ test:
   stage: test
   dependencies:
     - build
-  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v21
+  image: ghcr.io/acts-project/ubuntu2004_exatrkx:v23
   tags:
     - docker-gpu-nvidia
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ build:
     - mkdir build
     - >
       cmake -B build -S src 
-      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       -GNinja 
       -DCMAKE_BUILD_TYPE=Release 
       -DCMAKE_CXX_FLAGS=-w 


### PR DESCRIPTION
Backport 190d85b5e4fde34d0bcc0bf1bf728ba6ca7722f6 from #1252
---
Test if the ci job runs on the new a4000 GPU