### PR TITLE
fix: Sequencer correctly calls algorithm finalize [backport #1514 to develop/v19.x]

### DIFF
--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -364,8 +364,8 @@ int ActsExamples::Sequencer::run() {
   ACTS_VERBOSE("Finalize algorithms");
   for (auto& alg : m_algorithms) {
     ACTS_VERBOSE("Finalize algorithm: " << alg->name());
-    if (alg->initialize() != ProcessCode::SUCCESS) {
-      ACTS_FATAL("Failed to Finalize algorithm: " << alg->name());
+    if (alg->finalize() != ProcessCode::SUCCESS) {
+      ACTS_FATAL("Failed to finalize algorithm: " << alg->name());
       throw std::runtime_error("Failed to process event data");
     }
   }


### PR DESCRIPTION
Backport 487a6cc58b9a5075575210d15f2b6485eb629219 from #1514.
---
This was not happening due to a type previously.