### PR TITLE
feat: split deltaR in seedFinderOrthogonal [backport #1471 to develop/v19.x]

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -51,8 +51,8 @@ auto SeedFinderOrthogonal<external_spacepoint_t>::validTupleOrthoRangeLH(
    * Cut: Ensure that we search only in Δr_min ≤ r - r_L ≤ Δr_max, as defined
    * by the seeding configuration and the given lower spacepoint.
    */
-  res[DimR].shrinkMin(rL + m_config.deltaRMin);
-  res[DimR].shrinkMax(rL + m_config.deltaRMax);
+  res[DimR].shrinkMin(rL + m_config.deltaRMinTopSP);
+  res[DimR].shrinkMax(rL + m_config.deltaRMaxTopSP);
 
   /*
    * Cut: Now that we have constrained r, we can use that new r range to
@@ -117,8 +117,8 @@ auto SeedFinderOrthogonal<external_spacepoint_t>::validTupleOrthoRangeHL(
    * Cut: Ensure that we search only in Δr_min ≤ r_H - r ≤ Δr_max, as defined
    * by the seeding configuration and the given higher spacepoint.
    */
-  res[DimR].shrinkMin(rM - m_config.deltaRMax);
-  res[DimR].shrinkMax(rM - m_config.deltaRMin);
+  res[DimR].shrinkMin(rM - m_config.deltaRMaxBottomSP);
+  res[DimR].shrinkMax(rM - m_config.deltaRMinBottomSP);
 
   /*
    * Cut: Now that we have constrained r, we can use that new r range to

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
@@ -28,10 +28,14 @@ struct SeedFinderOrthogonalConfig {
   // cot of maximum theta angle
   // equivalent to 2.7 eta (pseudorapidity)
   float cotThetaMax = 7.40627;
-  // minimum distance in r between two measurements within one seed
-  float deltaRMin = 5 * Acts::UnitConstants::mm;
-  // maximum distance in r between two measurements within one seed
-  float deltaRMax = 270 * Acts::UnitConstants::mm;
+  // minimum distance in r between middle and top SP in one seed
+  float deltaRMinTopSP = 5 * Acts::UnitConstants::mm;
+  // maximum distance in r between middle and top SP in one seed
+  float deltaRMaxTopSP = 270 * Acts::UnitConstants::mm;
+  // minimum distance in r between middle and bottom SP in one seed
+  float deltaRMinBottomSP = 5 * Acts::UnitConstants::mm;
+  // maximum distance in r between middle and bottom SP in one seed
+  float deltaRMaxBottomSP = 270 * Acts::UnitConstants::mm;
 
   // impact parameter
   float impactMax = 20. * Acts::UnitConstants::mm;
@@ -88,8 +92,10 @@ struct SeedFinderOrthogonalConfig {
     using namespace Acts::UnitLiterals;
     SeedFinderOrthogonalConfig config = *this;
     config.minPt /= 1_MeV;
-    config.deltaRMin /= 1_mm;
-    config.deltaRMax /= 1_mm;
+    config.deltaRMinTopSP /= 1_mm;
+    config.deltaRMaxTopSP /= 1_mm;
+    config.deltaRMinBottomSP /= 1_mm;
+    config.deltaRMaxBottomSP /= 1_mm;
     config.impactMax /= 1_mm;
     config.maxPtScattering /= 1_MeV;
     config.collisionRegionMin /= 1_mm;

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingOrthogonalAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingOrthogonalAlgorithm.hpp
@@ -43,8 +43,10 @@ class SeedingOrthogonalAlgorithm final : public BareAlgorithm {
     Acts::SeedFinderOrthogonalConfig<SimSpacePoint> seedFinderConfig;
 
     float rMax = 200.;
-    float deltaRMin = 1.;
-    float deltaRMax = 60.;
+    float deltaRMinTopSP = 1.;
+    float deltaRMaxTopSP = 60.;
+    float deltaRMinBottomSP = 1.;
+    float deltaRMaxBottomSP = 60.;
     float collisionRegionMin = -250;
     float collisionRegionMax = 250.;
     float zMin = -2000.;

--- a/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
@@ -43,8 +43,10 @@ ActsExamples::SeedingOrthogonalAlgorithm::SeedingOrthogonalAlgorithm(
           Acts::SeedFilter<SimSpacePoint>(filterCfg));
 
   m_cfg.seedFinderConfig.rMax = m_cfg.rMax;
-  m_cfg.seedFinderConfig.deltaRMin = m_cfg.deltaRMin;
-  m_cfg.seedFinderConfig.deltaRMax = m_cfg.deltaRMax;
+  m_cfg.seedFinderConfig.deltaRMinTopSP = m_cfg.deltaRMinTopSP;
+  m_cfg.seedFinderConfig.deltaRMaxTopSP = m_cfg.deltaRMaxTopSP;
+  m_cfg.seedFinderConfig.deltaRMinBottomSP = m_cfg.deltaRMinBottomSP;
+  m_cfg.seedFinderConfig.deltaRMaxBottomSP = m_cfg.deltaRMaxBottomSP;
   m_cfg.seedFinderConfig.collisionRegionMin = m_cfg.collisionRegionMin;
   m_cfg.seedFinderConfig.collisionRegionMax = m_cfg.collisionRegionMax;
   m_cfg.seedFinderConfig.zMin = m_cfg.zMin;

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -75,8 +75,9 @@ SeedFilterConfigArg = namedtuple(
         "maxSeedsPerSpMConf",
         "maxQualitySeedsPerSpMConf",
         "useDeltaRorTopRadius",
+        "deltaRMin",
     ],
-    defaults=[None] * 10,
+    defaults=[None] * 11,
 )
 
 SpacePointGridConfigArg = namedtuple(
@@ -86,9 +87,10 @@ SpacePointGridConfigArg = namedtuple(
         "zBinEdges",
         "phiBinDeflectionCoverage",
         "impactMax",
+        "deltaRMax",
         "phi",  # (min,max)
     ],
-    defaults=[None] * 4 + [(None, None)] * 1,
+    defaults=[None] * 5 + [(None, None)] * 1,
 )
 
 SeedingAlgorithmConfigArg = namedtuple(
@@ -348,7 +350,11 @@ def addSeeding(
             seedFilterConfig = acts.SeedFilterConfig(
                 **acts.examples.defaultKWArgs(
                     maxSeedsPerSpM=seedFinderConfig.maxSeedsPerSpM,
-                    deltaRMin=seedFinderConfig.deltaRMin,
+                    deltaRMin=(
+                        seedFinderConfig.deltaRMin
+                        if seedFilterConfigArg.deltaRMin is None
+                        else seedFilterConfigArg.deltaRMin
+                    ),
                     impactWeightFactor=seedFilterConfigArg.impactWeightFactor,
                     compatSeedWeight=seedFilterConfigArg.compatSeedWeight,
                     compatSeedLimit=seedFilterConfigArg.compatSeedLimit,
@@ -375,7 +381,11 @@ def addSeeding(
                     ),
                     zMax=seedFinderConfig.zMax,
                     zMin=seedFinderConfig.zMin,
-                    deltaRMax=seedFinderConfig.deltaRMax,
+                    deltaRMax=(
+                        seedFinderConfig.deltaRMax
+                        if spacePointGridConfigArg.deltaRMax is None
+                        else spacePointGridConfigArg.deltaRMax
+                    ),
                     cotThetaMax=seedFinderConfig.cotThetaMax,
                     phiMin=spacePointGridConfigArg.phi[0],
                     phiMax=spacePointGridConfigArg.phi[1],
@@ -410,8 +420,26 @@ def addSeeding(
                 **acts.examples.defaultKWArgs(
                     rMin=seedfinderConfigArg.r[0],
                     rMax=seedfinderConfigArg.r[1],
-                    deltaRMin=seedfinderConfigArg.deltaR[0],
-                    deltaRMax=seedfinderConfigArg.deltaR[1],
+                    deltaRMinTopSP=(
+                        seedfinderConfigArg.deltaR[0]
+                        if seedfinderConfigArg.deltaRTopSP[0] is None
+                        else seedfinderConfigArg.deltaRTopSP[0]
+                    ),
+                    deltaRMaxTopSP=(
+                        seedfinderConfigArg.deltaR[1]
+                        if seedfinderConfigArg.deltaRTopSP[1] is None
+                        else seedfinderConfigArg.deltaRTopSP[1]
+                    ),
+                    deltaRMinBottomSP=(
+                        seedfinderConfigArg.deltaR[0]
+                        if seedfinderConfigArg.deltaRBottomSP[0] is None
+                        else seedfinderConfigArg.deltaRBottomSP[0]
+                    ),
+                    deltaRMaxBottomSP=(
+                        seedfinderConfigArg.deltaR[1]
+                        if seedfinderConfigArg.deltaRBottomSP[1] is None
+                        else seedfinderConfigArg.deltaRBottomSP[1]
+                    ),
                     deltaRMiddleMinSPRange=seedfinderConfigArg.deltaRMiddleSPRange[0],
                     deltaRMiddleMaxSPRange=seedfinderConfigArg.deltaRMiddleSPRange[1],
                     collisionRegionMin=seedfinderConfigArg.collisionRegion[0],
@@ -452,7 +480,11 @@ def addSeeding(
             seedFilterConfig = acts.SeedFilterConfig(
                 **acts.examples.defaultKWArgs(
                     maxSeedsPerSpM=seedFinderConfig.maxSeedsPerSpM,
-                    deltaRMin=seedFinderConfig.deltaRMin,
+                    deltaRMin=(
+                        seedfinderConfigArg.deltaR[0]
+                        if seedFilterConfigArg.deltaRMin is None
+                        else seedFilterConfigArg.deltaRMin
+                    ),
                     impactWeightFactor=seedFilterConfigArg.impactWeightFactor,
                     compatSeedWeight=seedFilterConfigArg.compatSeedWeight,
                     compatSeedLimit=seedFilterConfigArg.compatSeedLimit,

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -155,9 +155,10 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_STRUCT_BEGIN(c, Config);
     ACTS_PYTHON_MEMBER(minPt);
     ACTS_PYTHON_MEMBER(cotThetaMax);
-    ACTS_PYTHON_MEMBER(deltaRMin);
-    ACTS_PYTHON_MEMBER(deltaRMax);
-
+    ACTS_PYTHON_MEMBER(deltaRMinBottomSP);
+    ACTS_PYTHON_MEMBER(deltaRMaxBottomSP);
+    ACTS_PYTHON_MEMBER(deltaRMinTopSP);
+    ACTS_PYTHON_MEMBER(deltaRMaxTopSP);
     ACTS_PYTHON_MEMBER(impactMax);
     ACTS_PYTHON_MEMBER(sigmaScattering);
     ACTS_PYTHON_MEMBER(maxPtScattering);


### PR DESCRIPTION
Backport d54fa8491d7ef14e2c298418b289028310206794 from #1471.
---
This PR splits `deltaRMin` and `deltaRMax` in seedfinderOrthogonal into `deltaRMinBottomSP`, `deltaRMinTopSP`, `deltaRMaxBottomSP` and `deltaRMinTopSP` and allows for different deltaR values for the middle-bottom and middle-top duplets. 