### PR TITLE
refactor: python examples log level overwrite mechanism [backport of #1448 to develop/v19.x]

### DIFF
--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python3
-import acts
-from acts.examples import TGeoDetector
 from pathlib import Path
 import math
+
+import acts
+import acts.examples
+from acts.examples import TGeoDetector
 
 from acts.examples.reconstruction import (
     SeedfinderConfigArg,
@@ -21,6 +22,7 @@ def buildITkGeometry(
     logLevel=acts.logging.WARNING,
 ):
 
+    customLogLevel = acts.examples.defaultLogging(logLevel=logLevel)
     logger = acts.logging.getLogger("buildITkGeometry")
 
     matDeco = None
@@ -29,7 +31,7 @@ def buildITkGeometry(
         logger.info("Adding material from %s", file.absolute())
         matDeco = acts.IMaterialDecorator.fromFile(
             file,
-            level=acts.logging.Level(min(acts.logging.INFO.value, logLevel.value)),
+            level=customLogLevel(maxLevel=acts.logging.INFO),
         )
 
     tgeo_fileName = geo_dir / "itk-hgtd/ATLAS-ITk-HGTD.tgeo.root"
@@ -40,9 +42,9 @@ def buildITkGeometry(
         return TGeoDetector.create(
             jsonFile=str(jsonFile),
             fileName=str(tgeo_fileName),
-            surfaceLogLevel=logLevel,
-            layerLogLevel=logLevel,
-            volumeLogLevel=logLevel,
+            surfaceLogLevel=customLogLevel(),
+            layerLogLevel=customLogLevel(),
+            volumeLogLevel=customLogLevel(),
             mdecorator=matDeco,
         )
 
@@ -59,9 +61,9 @@ def buildITkGeometry(
         beamPipeRadius=23.934 * u.mm,
         beamPipeHalflengthZ=3000.0 * u.mm,
         beamPipeLayerThickness=0.8 * u.mm,
-        surfaceLogLevel=logLevel,
-        layerLogLevel=logLevel,
-        volumeLogLevel=logLevel,
+        surfaceLogLevel=customLogLevel(),
+        layerLogLevel=customLogLevel(),
+        volumeLogLevel=customLogLevel(),
         volumes=[
             Volume(
                 name="InnerPixels",

--- a/Examples/Python/python/acts/examples/odd.py
+++ b/Examples/Python/python/acts/examples/odd.py
@@ -1,8 +1,19 @@
 from pathlib import Path
 import sys, os
 
+import acts
+import acts.examples
 
-def getOpenDataDetector(odd_dir, mdecorator=None):
+
+def getOpenDataDetector(
+    odd_dir: Path,
+    mdecorator=None,
+    logLevel=acts.logging.INFO,
+):
+
+    import acts.examples.dd4hep
+
+    customLogLevel = acts.examples.defaultLogging(logLevel=logLevel)
 
     odd_xml = odd_dir / "xml" / "OpenDataDetector.xml"
     if not odd_xml.exists():
@@ -33,10 +44,9 @@ def getOpenDataDetector(odd_dir, mdecorator=None):
             )
             raise RuntimeError(msg)
 
-    import acts.examples.dd4hep
-
     dd4hepConfig = acts.examples.dd4hep.DD4hepGeometryService.Config(
-        xmlFileNames=[str(odd_xml)]
+        xmlFileNames=[str(odd_xml)],
+        logLevel=customLogLevel(),
     )
     detector = acts.examples.dd4hep.DD4hepDetector()
 
@@ -45,7 +55,7 @@ def getOpenDataDetector(odd_dir, mdecorator=None):
         mdecorator = acts.JsonMaterialDecorator(
             rConfig=config,
             jFileName=str(odd_dir / "config/odd-material-mapping-config.json"),
-            level=acts.logging.WARNING,
+            level=customLogLevel(minLevel=acts.logging.WARNING),
         )
 
     trackingGeometry, deco = detector.finalize(dd4hepConfig, mdecorator)

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -64,6 +64,7 @@ def addParticleGun(
     vtxGen: Optional[EventGenerator.VertexGenerator] = None,
     printParticles: bool = False,
     rnd: Optional[RandomNumbers] = None,
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the particle generation using the particle gun
 
@@ -93,15 +94,14 @@ def addParticleGun(
         random number generator
     """
 
-    if int(s.config.logLevel) <= int(acts.logging.DEBUG):
-        acts.examples.dump_args_calls(locals())
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Preliminaries
     rnd = rnd or RandomNumbers(seed=228)
 
     # Input
     evGen = EventGenerator(
-        level=s.config.logLevel,
+        level=customLogLevel(),
         generators=[
             EventGenerator.Generator(
                 multiplicity=FixedMultiplicityGenerator(n=multiplicity),
@@ -132,7 +132,8 @@ def addParticleGun(
     if printParticles:
         s.addAlgorithm(
             ParticlesPrinter(
-                level=s.config.logLevel, inputParticles=evGen.config.outputParticles
+                level=customLogLevel(),
+                inputParticles=evGen.config.outputParticles,
             )
         )
 
@@ -143,7 +144,7 @@ def addParticleGun(
 
         s.addWriter(
             CsvParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles=evGen.config.outputParticles,
                 outputDir=str(outputDirCsv),
                 outputStem="particles",
@@ -157,7 +158,7 @@ def addParticleGun(
 
         s.addWriter(
             RootParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles=evGen.config.outputParticles,
                 filePath=str(outputDirRoot / "particles.root"),
             )
@@ -181,6 +182,7 @@ def addPythia8(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     printParticles: bool = False,
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the particle generation using Pythia8
 
@@ -208,8 +210,7 @@ def addPythia8(
         print generated particles
     """
 
-    if int(s.config.logLevel) <= int(acts.logging.DEBUG):
-        acts.examples.dump_args_calls(locals())
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Preliminaries
     rnd = rnd or acts.examples.RandomNumbers()
@@ -226,7 +227,7 @@ def addPythia8(
                 multiplicity=acts.examples.FixedMultiplicityGenerator(n=nhard),
                 vertex=vtxGen,
                 particles=acts.examples.pythia8.Pythia8Generator(
-                    level=s.config.logLevel,
+                    level=customLogLevel(),
                     **acts.examples.defaultKWArgs(
                         pdgBeam0=beam[0],
                         pdgBeam1=beam[1],
@@ -242,7 +243,7 @@ def addPythia8(
                 multiplicity=acts.examples.FixedMultiplicityGenerator(n=npileup),
                 vertex=vtxGen,
                 particles=acts.examples.pythia8.Pythia8Generator(
-                    level=s.config.logLevel,
+                    level=customLogLevel(),
                     **acts.examples.defaultKWArgs(
                         pdgBeam0=beam[0],
                         pdgBeam1=beam[1],
@@ -255,7 +256,7 @@ def addPythia8(
 
     # Input
     evGen = acts.examples.EventGenerator(
-        level=s.config.logLevel,
+        level=customLogLevel(),
         generators=generators,
         outputParticles="particles_input",
         randomNumbers=rnd,
@@ -266,7 +267,8 @@ def addPythia8(
     if printParticles:
         s.addAlgorithm(
             acts.examples.ParticlesPrinter(
-                level=s.config.logLevel, inputParticles=evGen.config.outputParticles
+                level=customLogLevel(),
+                inputParticles=evGen.config.outputParticles,
             )
         )
 
@@ -277,7 +279,7 @@ def addPythia8(
 
         s.addWriter(
             acts.examples.CsvParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles=evGen.config.outputParticles,
                 outputDir=str(outputDirCsv),
                 outputStem="particles",
@@ -291,7 +293,7 @@ def addPythia8(
 
         s.addWriter(
             acts.examples.RootParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles=evGen.config.outputParticles,
                 filePath=str(outputDirRoot / "pythia8_particles.root"),
             )
@@ -311,6 +313,7 @@ def addFatras(
     outputDirRoot: Optional[Union[Path, str]] = None,
     rnd: Optional[acts.examples.RandomNumbers] = None,
     preselectParticles: Optional[ParticleSelectorConfig] = ParticleSelectorConfig(),
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the detector simulation using Fatras
 
@@ -332,8 +335,7 @@ def addFatras(
         Specify preselectParticles=None to inhibit ParticleSelector altogether.
     """
 
-    if int(s.config.logLevel) <= int(acts.logging.DEBUG):
-        acts.examples.dump_args_calls(locals())
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Preliminaries
     rnd = rnd or acts.examples.RandomNumbers()
@@ -361,7 +363,7 @@ def addFatras(
                     removeCharged=preselectParticles.removeCharged,
                     removeNeutral=preselectParticles.removeNeutral,
                 ),
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles="particles_input",
                 outputParticles=particles_selected,
             )
@@ -371,7 +373,7 @@ def addFatras(
 
     # Simulation
     alg = acts.examples.FatrasSimulation(
-        level=s.config.logLevel,
+        level=customLogLevel(),
         inputParticles=particles_selected,
         outputParticlesInitial="particles_initial",
         outputParticlesFinal="particles_final",
@@ -386,7 +388,13 @@ def addFatras(
     s.addAlgorithm(alg)
 
     # Output
-    addSimWriters(s, alg.config.outputSimHits, outputDirCsv, outputDirRoot)
+    addSimWriters(
+        s,
+        alg.config.outputSimHits,
+        outputDirCsv,
+        outputDirRoot,
+        logLevel=logLevel,
+    )
 
     return s
 
@@ -396,14 +404,18 @@ def addSimWriters(
     inputSimHits: Optional[str] = None,
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
+
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
+
     if outputDirCsv is not None:
         outputDirCsv = Path(outputDirCsv)
         if not outputDirCsv.exists():
             outputDirCsv.mkdir()
         s.addWriter(
             acts.examples.CsvParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 outputDir=str(outputDirCsv),
                 inputParticles="particles_final",
                 outputStem="particles_final",
@@ -416,7 +428,7 @@ def addSimWriters(
             outputDirRoot.mkdir()
         s.addWriter(
             acts.examples.RootParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles="particles_final",
                 filePath=str(outputDirRoot / "fatras_particles_final.root"),
             )
@@ -425,7 +437,7 @@ def addSimWriters(
     if outputDirCsv is not None:
         s.addWriter(
             acts.examples.CsvParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 outputDir=str(outputDirCsv),
                 inputParticles="particles_initial",
                 outputStem="particles_initial",
@@ -435,7 +447,7 @@ def addSimWriters(
     if outputDirRoot is not None:
         s.addWriter(
             acts.examples.RootParticleWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles="particles_initial",
                 filePath=str(outputDirRoot / "fatras_particles_initial.root"),
             )
@@ -444,7 +456,7 @@ def addSimWriters(
     if outputDirCsv is not None:
         s.addWriter(
             acts.examples.CsvSimHitWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputSimHits=inputSimHits,
                 outputDir=str(outputDirCsv),
                 outputStem="hits",
@@ -454,7 +466,7 @@ def addSimWriters(
     if outputDirRoot is not None:
         s.addWriter(
             acts.examples.RootSimHitWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputSimHits=inputSimHits,
                 filePath=str(outputDirRoot / "hits.root"),
             )
@@ -472,6 +484,7 @@ def addGeant4(
     outputDirRoot: Optional[Union[Path, str]] = None,
     seed: Optional[int] = None,
     preselectParticles: bool = True,
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the detector simulation using Geant4
 
@@ -492,15 +505,14 @@ def addGeant4(
     from acts.examples.geant4 import Geant4Simulation, geant4SimulationConfig
     from acts.examples.geant4.dd4hep import DDG4DetectorConstruction
 
-    if int(s.config.logLevel) <= int(acts.logging.DEBUG):
-        acts.examples.dump_args_calls(locals())
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Selector
     if preselectParticles:
         particles_selected = "particles_selected"
         s.addAlgorithm(
             acts.examples.ParticleSelector(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputParticles="particles_input",
                 outputParticles=particles_selected,
             )
@@ -510,7 +522,7 @@ def addGeant4(
 
     g4detector = DDG4DetectorConstruction(geometryService)
     g4conf = geant4SimulationConfig(
-        level=s.config.logLevel,
+        level=customLogLevel(),
         detector=g4detector,
         inputParticles="particles_input",
         trackingGeometry=trackingGeometry,
@@ -523,7 +535,7 @@ def addGeant4(
 
     # Simulation
     alg = Geant4Simulation(
-        level=s.config.logLevel,
+        level=customLogLevel(),
         config=g4conf,
     )
 
@@ -531,7 +543,13 @@ def addGeant4(
     s.addAlgorithm(alg)
 
     # Output
-    addSimWriters(s, g4conf.outputSimHits, outputDirCsv, outputDirRoot)
+    addSimWriters(
+        s,
+        g4conf.outputSimHits,
+        outputDirCsv,
+        outputDirRoot,
+        logLevel=logLevel,
+    )
 
     return s
 
@@ -545,6 +563,7 @@ def addDigitization(
     outputDirRoot: Optional[Union[Path, str]] = None,
     rnd: Optional[acts.examples.RandomNumbers] = None,
     doMerge: Optional[bool] = None,
+    logLevel: Optional[acts.logging.Level] = None,
 ) -> acts.examples.Sequencer:
     """This function steers the digitization step
 
@@ -564,8 +583,7 @@ def addDigitization(
         random number generator
     """
 
-    if int(s.config.logLevel) <= int(acts.logging.DEBUG):
-        acts.examples.dump_args_calls(locals())
+    customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Preliminaries
     rnd = rnd or acts.examples.RandomNumbers()
@@ -584,7 +602,7 @@ def addDigitization(
         outputMeasurementSimHitsMap="measurement_simhits_map",
         doMerge=doMerge,
     )
-    digiAlg = acts.examples.DigitizationAlgorithm(digiCfg, s.config.logLevel)
+    digiAlg = acts.examples.DigitizationAlgorithm(digiCfg, customLogLevel())
 
     s.addAlgorithm(digiAlg)
 
@@ -601,7 +619,7 @@ def addDigitization(
             trackingGeometry=trackingGeometry,
         )
         rmwConfig.addBoundIndicesFromDigiConfig(digiAlg.config)
-        s.addWriter(acts.examples.RootMeasurementWriter(rmwConfig, s.config.logLevel))
+        s.addWriter(acts.examples.RootMeasurementWriter(rmwConfig, customLogLevel()))
 
     if outputDirCsv is not None:
         outputDirCsv = Path(outputDirCsv)
@@ -609,7 +627,7 @@ def addDigitization(
             outputDirCsv.mkdir()
         s.addWriter(
             acts.examples.CsvMeasurementWriter(
-                level=s.config.logLevel,
+                level=customLogLevel(),
                 inputMeasurements=digiAlg.config.outputMeasurements,
                 inputClusters=digiAlg.config.outputClusters,
                 inputSimHits=digiAlg.config.inputSimHits,


### PR DESCRIPTION
Backport 433a379bf53912a5ef3d515ebb23f2bf3d1af331 from #1448
---
I noticed that some python `add*` functions provide a mechanism to overwrite the `logLevel` but others don't which made me change `reconstruction.py` locally from time to time

I tried to generalize the existing functionality and extract it into a helper function. then I applied it to all the `add*` functions

after some [discussion](https://github.com/acts-project/acts/pull/1448#issuecomment-1225324331) I removed `dump_args_calls` from the `add*` functions as this can have side effects and break the CI
