### PR TITLE
docs: remove --recursive on git clone in quick start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ following commands will clone the repository, configure, and build the core
 library
 
 ```sh
-git clone --recursive https://github.com/acts-project/acts <source>
+git clone https://github.com/acts-project/acts <source>
 cmake -B <build> -S <source>
 cmake --build <build>
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -9,7 +9,7 @@ following commands will clone the repository, configure, and build the core
 library:
 
 ```console
-$ git clone --recursive https://github.com/acts-project/acts <source>
+$ git clone https://github.com/acts-project/acts <source>
 $ cmake -B <build> -S <source>
 $ cmake --build <build>
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -347,7 +347,7 @@ The following environment variables might be useful.
 ## The OpenDataDetector
 
 Acts comes packaged with a detector modeled using DD4hep that can be used to test your algorithms. It comes equipped with a magnetic field file as well as an already built material map. 
-It is available via the git submodule feature by performing the following steps (git lfs need to be installed on your machine):
+It is available via the git submodule feature by performing the following steps ([`git lfs`](https://git-lfs.github.com/) need to be installed on your machine):
 
 ```console
 $ git submodule init


### PR DESCRIPTION
Our first quick-start command
```
git clone --recursive https://github.com/acts-project/acts
```
doesn't work out of the box for many (most?) people, because `--recursive` checks out `thirdparty/OpenDataDetector`, which requires `git-lfs`, which isn't usually installed by default. It's on lxplus, but I didn't find it anywhere else by default.

I propose to remove the `--recursive` option in the quick-start docs. The [ODD quick-start](https://acts.readthedocs.io/en/latest/getting_started.html#the-opendatadetector) already explains `git submodule`, so there is no assumption that the user has already used `git clone --recursive`. Maybe this could also add a link to `git lfs` (I'll see about a small update).

An alternative would be to add `git-lfs` to the list of dependencies, but this could be misleading as it isn't a compile-time dependency.