### PR TITLE
refactor: use TrackSelector in addVertexFitting

### DIFF
--- a/CI/physmon/physmon.py
+++ b/CI/physmon/physmon.py
@@ -40,6 +40,7 @@ from acts.examples.reconstruction import (
     CKFPerformanceConfig,
     addVertexFitting,
     VertexFinder,
+    TrackSelectorRanges,
 )
 
 
@@ -177,9 +178,15 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             outputDirCsv=None,
         )
 
-        s = addVertexFitting(
+        addVertexFitting(
             s,
             field,
+            TrackSelectorRanges(
+                removeNeutral=True,
+                absEta=(2.5, None),
+                loc0=(None, 4.0 * u.mm),
+                pt=(500 * u.MeV, None),
+            ),
             vertexFinder=VertexFinder.Iterative,
             trajectories="trajectories",
             outputDirRoot=tp,

--- a/CI/physmon/physmon.py
+++ b/CI/physmon/physmon.py
@@ -177,19 +177,6 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             outputDirCsv=None,
         )
 
-        s.addAlgorithm(
-            acts.examples.TrackSelector(
-                level=acts.logging.INFO,
-                inputTrackParameters="fittedTrackParameters",
-                outputTrackParameters="trackparameters",
-                outputTrackIndices="outputTrackIndices",
-                removeNeutral=True,
-                absEtaMax=2.5,
-                loc0Max=4.0 * u.mm,  # rho max
-                ptMin=500 * u.MeV,
-            )
-        )
-
         s = addVertexFitting(
             s,
             field,

--- a/CI/physmon/physmon.py
+++ b/CI/physmon/physmon.py
@@ -183,7 +183,7 @@ for truthSmearedSeeded, truthEstimatedSeeded, label in [
             field,
             TrackSelectorRanges(
                 removeNeutral=True,
-                absEta=(2.5, None),
+                absEta=(None, 2.5),
                 loc0=(None, 4.0 * u.mm),
                 pt=(500 * u.MeV, None),
             ),

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -111,10 +111,10 @@ TrackParamsEstimationConfig = namedtuple(
     defaults=[(None, None)],
 )
 
-TrackSelectorConfig = namedtuple(
-    "TrackSelectorConfig",
-    ["absEtaMax", "ptMin"],
-    defaults=[2.5, 500 * u.MeV],
+TrackSelectorRanges = namedtuple(
+    "TrackSelectorRanges",
+    ["absEta", "pt"],
+    defaults=[(None, None)] * 2,
 )
 
 

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -908,8 +908,9 @@ def addVertexFitting(
     associatedParticles: str = "particles_input",
     trajectories: Optional[str] = None,
     trackParameters: str = "fittedTrackParameters",
+    trackIndices: str = "outputTrackIndices",
     vertexFinder: VertexFinder = VertexFinder.Truth,
-    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
+    trackSelectorRanges: Optional[TrackSelectorRanges] = TrackSelectorRanges(),
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting
@@ -943,7 +944,6 @@ def addVertexFitting(
 
     if trackSelectorRanges is not None:
         selectedTrackParameters = "trackparameters"
-        trackIndices = "outputTrackIndices"
 
         trackSelector = acts.examples.TrackSelector(
             level=customLogLevel(),
@@ -972,7 +972,6 @@ def addVertexFitting(
         s.addAlgorithm(trackSelector)
     else:
         selectedTrackParameters = trackParameters
-        trackIndices = ""
 
     inputParticles = "particles_input"
     outputVertices = "fittedVertices"

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -941,10 +941,10 @@ def addVertexFitting(
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
-    selectedTrackParameters = "trackparameters"
-    trackIndices = "outputTrackIndices"
-
     if trackSelectorRanges is not None:
+        selectedTrackParameters = "trackparameters"
+        trackIndices = "outputTrackIndices"
+
         trackSelector = acts.examples.TrackSelector(
             level=customLogLevel(),
             inputTrackParameters=trackParameters,
@@ -972,6 +972,7 @@ def addVertexFitting(
         s.addAlgorithm(trackSelector)
     else:
         selectedTrackParameters = trackParameters
+        trackIndices = ""
 
     inputParticles = "particles_input"
     outputVertices = "fittedVertices"

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -942,8 +942,10 @@ def addVertexFitting(
             outputTrackIndices=trackIndices,
             **acts.examples.defaultKWArgs(
                 removeNeutral=trackSelectorRanges.removeNeutral,
+                absEtaMin=trackSelectorRanges.absEta[0],
                 absEtaMax=trackSelectorRanges.absEta[1],
                 ptMin=trackSelectorRanges.pt[0],
+                ptMax=trackSelectorRanges.pt[1],
             ),
         )
         s.addAlgorithm(trackSelector)

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -910,7 +910,7 @@ def addVertexFitting(
     trackParameters: str = "fittedTrackParameters",
     trackIndices: str = "outputTrackIndices",
     vertexFinder: VertexFinder = VertexFinder.Truth,
-    trackSelectorRanges: Optional[TrackSelectorRanges] = TrackSelectorRanges(),
+    trackSelectorRanges: TrackSelectorRanges = TrackSelectorRanges(),
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -890,6 +890,9 @@ class VertexFinder(Enum):
     Iterative = (3,)
 
 
+@acts.examples.NamedTypeArgs(
+    trackSelectorRanges=TrackSelectorRanges
+)
 def addVertexFitting(
     s,
     field,
@@ -898,7 +901,7 @@ def addVertexFitting(
     trajectories: Optional[str] = None,
     trackParameters: str = "fittedTrackParameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
-    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
+    trackSelectorRanges: Optional[TrackSelectorRanges] = TrackSelectorRanges(),
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting
@@ -914,6 +917,9 @@ def addVertexFitting(
         RootVertexPerformanceWriter.inputAssociatedTruthParticles
     vertexFinder : VertexFinder, Truth
         vertexFinder algorithm: one of Truth, AMVF, Iterative
+    trackSelectorRanges : TrackSelectorRanges(absEta, pt)
+        TrackSelector configuration. Each range is specified as a tuple of (min,max).
+        Defaults of no cuts specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.hpp
     logLevel : acts.logging.Level, None
         logging level to override setting given in `s`
     """
@@ -930,7 +936,7 @@ def addVertexFitting(
     selectedTrackParameters = "trackparameters"
     trackIndices = "outputTrackIndices"
 
-    if trackSelectorConfig is not None:
+    if trackSelectorRanges is not None:
         trackSelector = acts.examples.TrackSelector(
             level=customLogLevel(),
             inputTrackParameters=trackParameters,

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -936,9 +936,11 @@ def addVertexFitting(
             inputTrackParameters=trackParameters,
             outputTrackParameters=selectedTrackParameters,
             outputTrackIndices=trackIndices,
-            removeNeutral=True,
-            absEtaMax=trackSelectorConfig.absEtaMax,
-            ptMin=trackSelectorConfig.ptMin,
+            **acts.examples.defaultKWArgs(
+               removeNeutral=trackSelectorRanges.removeNeutral,
+               absEtaMax=trackSelectorRanges.absEta[1],
+               ptMin=trackSelectorRanges.pt[0],
+            ),
         )
         s.addAlgorithm(trackSelector)
     else:

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -113,8 +113,8 @@ TrackParamsEstimationConfig = namedtuple(
 
 TrackSelectorRanges = namedtuple(
     "TrackSelectorRanges",
-    ["absEta", "pt"],
-    defaults=[(None, None)] * 2,
+    ["removeNeutral", "absEta", "pt"],
+    defaults=[None] * 1 + [(None, None)] * 2,
 )
 
 

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -926,7 +926,7 @@ def addVertexFitting(
         RootVertexPerformanceWriter.inputAssociatedTruthParticles
     vertexFinder : VertexFinder, Truth
         vertexFinder algorithm: one of Truth, AMVF, Iterative
-    trackSelectorRanges : TrackSelectorRanges(absEta, pt)
+    trackSelectorRanges : TrackSelectorRanges(loc0, loc1, time, eta, absEta, pt, phi, removeNeutral, removeCharged)
         TrackSelector configuration. Each range is specified as a tuple of (min,max).
         Defaults of no cuts specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackSelector.hpp
     logLevel : acts.logging.Level, None

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -113,8 +113,18 @@ TrackParamsEstimationConfig = namedtuple(
 
 TrackSelectorRanges = namedtuple(
     "TrackSelectorRanges",
-    ["removeNeutral", "absEta", "pt"],
-    defaults=[None] * 1 + [(None, None)] * 2,
+    [
+        "loc0",
+        "loc1",
+        "time",
+        "eta",
+        "absEta",
+        "pt",
+        "phi",
+        "removeNeutral",
+        "removeCharged",
+    ],
+    defaults=[(None, None)] * 7 + [None] * 2,
 )
 
 
@@ -899,7 +909,7 @@ def addVertexFitting(
     trajectories: Optional[str] = None,
     trackParameters: str = "fittedTrackParameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
-    trackSelectorRanges: Optional[TrackSelectorRanges] = TrackSelectorRanges(),
+    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting
@@ -941,11 +951,22 @@ def addVertexFitting(
             outputTrackParameters=selectedTrackParameters,
             outputTrackIndices=trackIndices,
             **acts.examples.defaultKWArgs(
-                removeNeutral=trackSelectorRanges.removeNeutral,
+                loc0Min=trackSelectorRanges.loc0[0],
+                loc0Max=trackSelectorRanges.loc0[1],
+                loc1Min=trackSelectorRanges.loc1[0],
+                loc1Max=trackSelectorRanges.loc1[1],
+                timeMin=trackSelectorRanges.time[0],
+                timeMax=trackSelectorRanges.time[1],
+                phiMin=trackSelectorRanges.phi[0],
+                phiMax=trackSelectorRanges.phi[1],
+                etaMin=trackSelectorRanges.eta[0],
+                etaMax=trackSelectorRanges.eta[1],
                 absEtaMin=trackSelectorRanges.absEta[0],
                 absEtaMax=trackSelectorRanges.absEta[1],
                 ptMin=trackSelectorRanges.pt[0],
                 ptMax=trackSelectorRanges.pt[1],
+                removeCharged=trackSelectorRanges.removeCharged,
+                removeNeutral=trackSelectorRanges.removeNeutral,
             ),
         )
         s.addAlgorithm(trackSelector)

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -890,9 +890,7 @@ class VertexFinder(Enum):
     Iterative = (3,)
 
 
-@acts.examples.NamedTypeArgs(
-    trackSelectorRanges=TrackSelectorRanges
-)
+@acts.examples.NamedTypeArgs(trackSelectorRanges=TrackSelectorRanges)
 def addVertexFitting(
     s,
     field,
@@ -943,9 +941,9 @@ def addVertexFitting(
             outputTrackParameters=selectedTrackParameters,
             outputTrackIndices=trackIndices,
             **acts.examples.defaultKWArgs(
-               removeNeutral=trackSelectorRanges.removeNeutral,
-               absEtaMax=trackSelectorRanges.absEta[1],
-               ptMin=trackSelectorRanges.pt[0],
+                removeNeutral=trackSelectorRanges.removeNeutral,
+                absEtaMax=trackSelectorRanges.absEta[1],
+                ptMin=trackSelectorRanges.pt[0],
             ),
         )
         s.addAlgorithm(trackSelector)

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -898,7 +898,7 @@ def addVertexFitting(
     trajectories: Optional[str] = None,
     trackParameters: str = "fittedTrackParameters",
     vertexFinder: VertexFinder = VertexFinder.Truth,
-    trackSelectorConfig: Optional[TrackSelectorConfig] = TrackSelectorConfig(),
+    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -77,18 +77,6 @@ addCKFTracks(
     CKFPerformanceConfig(ptMin=400.0 * u.MeV, nMeasurementsMin=6),
     outputDirRoot=outputDir,
 )
-s.addAlgorithm(
-    acts.examples.TrackSelector(
-        level=acts.logging.INFO,
-        inputTrackParameters="fittedTrackParameters",
-        outputTrackParameters="trackparameters",
-        outputTrackIndices="outputTrackIndices",
-        removeNeutral=True,
-        absEtaMax=2.5,
-        loc0Max=4.0 * u.mm,  # rho max
-        ptMin=500 * u.MeV,
-    )
-)
 addVertexFitting(
     s,
     field,

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -37,6 +37,7 @@ from acts.examples.reconstruction import (
     CKFPerformanceConfig,
     addVertexFitting,
     VertexFinder,
+    TrackSelectorRanges,
 )
 
 s = acts.examples.Sequencer(events=100, numThreads=-1, logLevel=acts.logging.INFO)
@@ -80,6 +81,7 @@ addCKFTracks(
 addVertexFitting(
     s,
     field,
+    TrackSelectorRanges(pt=(400.0 * u.MeV, None)),
     vertexFinder=VertexFinder.Iterative,
     outputDirRoot=outputDir,
     trajectories="trajectories",

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -81,7 +81,9 @@ addCKFTracks(
 addVertexFitting(
     s,
     field,
-    TrackSelectorRanges(pt=(400.0 * u.MeV, None), absEta=(None, 2.5), removeNeutral=True),
+    TrackSelectorRanges(
+        pt=(400.0 * u.MeV, None), absEta=(None, 3.0), removeNeutral=True
+    ),
     vertexFinder=VertexFinder.Iterative,
     outputDirRoot=outputDir,
     trajectories="trajectories",

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -81,7 +81,7 @@ addCKFTracks(
 addVertexFitting(
     s,
     field,
-    TrackSelectorRanges(pt=(400.0 * u.MeV, None)),
+    TrackSelectorRanges(pt=(400.0 * u.MeV, None), absEta=(None, 2.5), removeNeutral=True),
     vertexFinder=VertexFinder.Iterative,
     outputDirRoot=outputDir,
     trajectories="trajectories",

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -69,8 +69,6 @@ def runVertexFitting(
         )
         s.addAlgorithm(ptclSmearing)
         associatedParticles = selectedParticles
-
-        trackSelectorRanges = TrackSelectorRanges()
     else:
         logger.info("Reading track summary from %s", inputTrackSummary.resolve())
         assert inputTrackSummary.exists()
@@ -96,7 +94,7 @@ def runVertexFitting(
     addVertexFitting(
         s,
         field,
-        trackSelectorRanges,
+        trackSelectorRanges=trackSelectorRanges,
         outputDirRoot=outputDir if outputRoot else None,
         associatedParticles=associatedParticles,
         trackParameters=trackParameters,

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -5,7 +5,11 @@ from typing import Optional
 import acts
 from acts.examples import Sequencer, ParticleSelector, ParticleSmearing
 from acts.examples.simulation import addPythia8
-from acts.examples.reconstruction import addVertexFitting, VertexFinder, TrackSelectorRanges
+from acts.examples.reconstruction import (
+    addVertexFitting,
+    VertexFinder,
+    TrackSelectorRanges,
+)
 
 u = acts.UnitConstants
 

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -5,7 +5,7 @@ from typing import Optional
 import acts
 from acts.examples import Sequencer, ParticleSelector, ParticleSmearing
 from acts.examples.simulation import addPythia8
-from acts.examples.reconstruction import addVertexFitting, VertexFinder
+from acts.examples.reconstruction import addVertexFitting, VertexFinder, TrackSelectorRanges
 
 u = acts.UnitConstants
 
@@ -54,6 +54,7 @@ def runVertexFitting(
     s.addAlgorithm(ptclSelector)
 
     trackParameters = "trackparameters"
+    trackSelectorRanges = TrackSelectorRanges()
     if inputTrackSummary is None or inputParticlePath is None:
         logger.info("Using smeared particles")
 
@@ -78,17 +79,11 @@ def runVertexFitting(
         )
         s.addReader(trackSummaryReader)
 
-        s.addAlgorithm(
-            acts.examples.TrackSelector(
-                level=acts.logging.INFO,
-                inputTrackParameters=trackSummaryReader.config.outputTracks,
-                outputTrackParameters=trackParameters,
-                outputTrackIndices="outputTrackIndices",
-                removeNeutral=True,
-                absEtaMax=2.5,
-                loc0Max=4.0 * u.mm,  # rho max
-                ptMin=500 * u.MeV,
-            )
+        trackSelectorRanges = TrackSelectorRanges(
+            removeNeutral=True,
+            absEta=(None, 2.5),
+            loc0=(None, 4.0 * u.mm),  # rho max
+            pt=(500 * u.MeV, None),
         )
 
     logger.info("Using vertex finder: %s", vertexFinder.name)
@@ -96,6 +91,7 @@ def runVertexFitting(
     addVertexFitting(
         s,
         field,
+        trackSelectorRanges,
         outputDirRoot=outputDir if outputRoot else None,
         associatedParticles=associatedParticles,
         trackParameters=trackParameters,

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -69,6 +69,8 @@ def runVertexFitting(
         )
         s.addAlgorithm(ptclSmearing)
         associatedParticles = selectedParticles
+
+        trackSelectorRanges = None
     else:
         logger.info("Reading track summary from %s", inputTrackSummary.resolve())
         assert inputTrackSummary.exists()

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -99,6 +99,7 @@ def runVertexFitting(
         outputDirRoot=outputDir if outputRoot else None,
         associatedParticles=associatedParticles,
         trackParameters=trackParameters,
+        trackSelectorRanges=None,
         vertexFinder=vertexFinder,
     )
 

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -57,8 +57,7 @@ def runVertexFitting(
     )
     s.addAlgorithm(ptclSelector)
 
-    trackParameters = "trackparameters"
-    trackSelectorRanges = TrackSelectorRanges()
+    trackParameters = "fittedTrackParameters"
     if inputTrackSummary is None or inputParticlePath is None:
         logger.info("Using smeared particles")
 
@@ -70,13 +69,15 @@ def runVertexFitting(
         )
         s.addAlgorithm(ptclSmearing)
         associatedParticles = selectedParticles
+
+        trackSelectorRanges = TrackSelectorRanges()
     else:
         logger.info("Reading track summary from %s", inputTrackSummary.resolve())
         assert inputTrackSummary.exists()
         associatedParticles = "associatedTruthParticles"
         trackSummaryReader = acts.examples.RootTrajectorySummaryReader(
             level=acts.logging.VERBOSE,
-            outputTracks="fittedTrackParameters",
+            outputTracks=trackParameters,
             outputParticles=associatedParticles,
             filePath=str(inputTrackSummary.resolve()),
             orderedEvents=False,

--- a/Examples/Scripts/Python/vertex_fitting.py
+++ b/Examples/Scripts/Python/vertex_fitting.py
@@ -99,7 +99,6 @@ def runVertexFitting(
         outputDirRoot=outputDir if outputRoot else None,
         associatedParticles=associatedParticles,
         trackParameters=trackParameters,
-        trackSelectorRanges=None,
         vertexFinder=vertexFinder,
     )
 


### PR DESCRIPTION
follow-up of https://github.com/acts-project/acts/pull/1538

@timadye noticed that we have to use `s.addAlgorithm(acts.examples.TrackSelector(...` in the full chain examples in order to have vertexing. this PR integrates the track selection into the `addVertexFitting` helper