### PR TITLE
feat: use Range1D<> class for extent [backport #1424 to develop/v19.x]

### DIFF
--- a/Core/include/Acts/Utilities/BinningType.hpp
+++ b/Core/include/Acts/Utilities/BinningType.hpp
@@ -45,6 +45,10 @@ enum BinningValue : int {
   binValues = 9
 };
 
+/// @brief static list of all binning values
+static std::vector<BinningValue> s_binningValues = {
+    binX, binY, binZ, binR, binPhi, binRPhi, binH, binEta, binMag};
+
 /// @brief screen output option
 inline const std::vector<std::string>& binningValueNames() {
   static const std::vector<std::string> _binningValueNames = {

--- a/Core/include/Acts/Utilities/Enumerate.hpp
+++ b/Core/include/Acts/Utilities/Enumerate.hpp
@@ -1,0 +1,48 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2022 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+namespace Acts {
+/// Helper utility to allow indexed enumeration with structured binding
+///
+/// Usage:
+///
+/// for (auto [ i, value ] = enumerate(container) ) { ... };
+///
+/// with 'container' any stl-like container
+///
+template <typename container_type,
+          typename container_type_iter =
+              decltype(std::begin(std::declval<container_type>())),
+          typename = decltype(std::end(std::declval<container_type>()))>
+constexpr auto enumerate(container_type &&iterable) {
+  struct iterator {
+    size_t i;
+    container_type_iter iter;
+
+    bool operator!=(const iterator &rhs) const { return iter != rhs.iter; }
+
+    /** Increase index and iterator at once */
+    void operator++() {
+      ++i;
+      ++iter;
+    }
+
+    /** Tie them together for returning */
+    auto operator*() const { return std::tie(i, *iter); }
+  };
+  struct iterable_wrapper {
+    container_type iterable;
+    auto begin() { return iterator{0, std::begin(iterable)}; }
+    auto end() { return iterator{0, std::end(iterable)}; }
+  };
+  return iterable_wrapper{std::forward<container_type>(iterable)};
+}
+
+}  // namespace Acts

--- a/Core/src/Geometry/Polyhedron.cpp
+++ b/Core/src/Geometry/Polyhedron.cpp
@@ -44,7 +44,7 @@ Acts::Extent Acts::Polyhedron::extent(const Transform3& transform) const {
   auto vtxs = vertices;
   std::transform(vtxs.begin(), vtxs.end(), vtxs.begin(), [&](auto& v) {
     auto vt = (transform * v);
-    extent.check(vt);
+    extent.extend(vt);
     return (vt);
   });
 
@@ -59,9 +59,8 @@ Acts::Extent Acts::Polyhedron::extent(const Transform3& transform) const {
         tface.push_back(vtxs[f]);
       }
       if (detail::VerticesHelper::isInsidePolygon(origin, tface)) {
-        extent.ranges[binR].first = 0.;
-        extent.ranges[binPhi].first = -M_PI;
-        extent.ranges[binPhi].second = M_PI;
+        extent.range(binR).setMin(0.);
+        extent.range(binPhi).set(-M_PI, M_PI);
         break;
       }
     }
@@ -90,7 +89,7 @@ Acts::Extent Acts::Polyhedron::extent(const Transform3& transform) const {
       for (size_t iv = 1; iv < vtxs.size() + 1; ++iv) {
         size_t fpoint = iv < vtxs.size() ? iv : 0;
         double testR = radialDistance(vtxs[fpoint], vtxs[iv - 1]);
-        extent.ranges[binR].first = std::min(extent.ranges[binR].first, testR);
+        extent.range(binR).expandMin(testR);
       }
     }
   }

--- a/Core/src/Geometry/ProtoLayerHelper.cpp
+++ b/Core/src/Geometry/ProtoLayerHelper.cpp
@@ -29,7 +29,7 @@ std::vector<Acts::ProtoLayer> Acts::ProtoLayerHelper::protoLayers(
   /// @return the referece of the SurfaceCluster for insertion
   auto findCluster = [&](const Extent& extent) -> SurfaceCluster& {
     for (auto& cluster : clusteredSurfaces) {
-      if (cluster.first.intersects(extent, sorting.first, sorting.second)) {
+      if (cluster.first.intersects(extent, sorting.first)) {
         return cluster;
       }
     }
@@ -41,16 +41,16 @@ std::vector<Acts::ProtoLayer> Acts::ProtoLayerHelper::protoLayers(
   // Loop over surfaces and sort into clusters
   for (auto& sf : surfaces) {
     auto sfExtent = sf->polyhedronRepresentation(gctx, 1).extent();
+    sfExtent.envelope()[sorting.first] = {sorting.second, sorting.second};
     auto& sfCluster = findCluster(sfExtent);
     sfCluster.first.extend(sfExtent);
     sfCluster.second.push_back(sf);
   }
-
   // Loop over clusters and create ProtoLayer
   protoLayers.reserve(clusteredSurfaces.size());
   for (auto& clusters : clusteredSurfaces) {
-    ACTS_VERBOSE("Creatingg ProtoLayer with " << clusters.second.size()
-                                              << " surfaces.");
+    ACTS_VERBOSE("Creating ProtoLayer with " << clusters.second.size()
+                                             << " surfaces.");
     protoLayers.push_back(ProtoLayer(gctx, clusters.second));
   }
   return protoLayers;

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -195,7 +195,7 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
       // stable and we do not need to create local copies.
       spacePointPtrs.push_back(&spacePoint);
       // store x,y,z values in extent
-      rRangeSPExtent.check({spacePoint.x(), spacePoint.y(), spacePoint.z()});
+      rRangeSPExtent.extend({spacePoint.x(), spacePoint.y(), spacePoint.z()});
     }
   }
 

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -115,8 +115,8 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
           // manually create a proto layer
           double eiz = (z != 0.) ? z - m_cfg.defaultThickness : 0.;
           double eoz = (z != 0.) ? z + m_cfg.defaultThickness : 0.;
-          pl.extent.ranges[Acts::binZ] = {eiz, eoz};
-          pl.extent.ranges[Acts::binR] = {rMin, rMax};
+          pl.extent.range(Acts::binZ).set(eiz, eoz);
+          pl.extent.range(Acts::binR).set(rMin, rMax);
           pl.envelope[Acts::binR] = {0., 0.};
           pl.envelope[Acts::binZ] = {0., 0.};
         } else {
@@ -128,7 +128,7 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
                                      std::abs(zMax - pl.max(Acts::binZ))};
           pl.envelope[Acts::binR] = {std::abs(rMin - pl.min(Acts::binR)),
                                      std::abs(rMax - pl.max(Acts::binR))};
-          pl.extent.ranges[Acts::binR] = {rMin, rMax};
+          pl.extent.range(Acts::binR).set(rMin, rMax);
         }
       } else {
         throw std::logic_error(
@@ -254,8 +254,8 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::centralLayers(
           // manually create a proto layer
           double eir = (r != 0.) ? r - m_cfg.defaultThickness : 0.;
           double eor = (r != 0.) ? r + m_cfg.defaultThickness : 0.;
-          pl.extent.ranges[Acts::binR] = {eir, eor};
-          pl.extent.ranges[Acts::binZ] = {-dz, dz};
+          pl.extent.range(Acts::binR).set(eir, eor);
+          pl.extent.range(Acts::binZ).set(-dz, dz);
           pl.envelope[Acts::binR] = {0., 0.};
           pl.envelope[Acts::binZ] = {0., 0.};
         } else {

--- a/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
@@ -297,8 +297,8 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
 
   // CASE III
   ProtoLayer pl3;
-  pl3.extent.ranges[Acts::binR] = {1, 20};
-  pl3.extent.ranges[Acts::binZ] = {-25, 25};
+  pl3.extent.range(Acts::binR).set(1, 20);
+  pl3.extent.range(Acts::binZ).set(-25, 25);
   layer = std::dynamic_pointer_cast<CylinderLayer>(
       p_LC->cylinderLayer(tgContext, srf, equidistant, equidistant, pl3));
   CHECK_CLOSE_REL(layer->thickness(), 19, 1e-3);
@@ -331,8 +331,8 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createDiscLayer, LayerCreatorFixture) {
   draw_surfaces(surfaces, "LayerCreator_createDiscLayer_EC_1.obj");
 
   ProtoLayer pl(tgContext, surfaces);
-  pl.extent.ranges[binZ] = {-10, 10};
-  pl.extent.ranges[binR] = {5., 25.};
+  pl.extent.range(binZ).set(-10, 10);
+  pl.extent.range(binR).set(5., 25.);
   std::shared_ptr<DiscLayer> layer = std::dynamic_pointer_cast<DiscLayer>(
       p_LC->discLayer(tgContext, surfaces, equidistant, equidistant, pl));
   CHECK_CLOSE_REL(layer->thickness(), 20, 1e-3);

--- a/Tests/UnitTests/Core/Geometry/ProtoLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ProtoLayerTests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(ProtoLayerTests) {
   auto pLayerSf = createProtoLayer(Transform3::Identity());
   auto pLayerSfShared = createProtoLayer(Transform3::Identity());
 
-  BOOST_CHECK(pLayerSf.extent.ranges == pLayerSfShared.extent.ranges);
+  BOOST_CHECK(pLayerSf.extent.range() == pLayerSfShared.extent.range());
   BOOST_CHECK(pLayerSf.envelope == pLayerSfShared.envelope);
 
   // CHECK That you have 4 surfaces
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ProtoLayerTests) {
   BOOST_CHECK(pLayerSf.surfaces().size() == 5);
 
   // That should invalidate the ranges
-  BOOST_CHECK(pLayerSf.extent.ranges != pLayerSfShared.extent.ranges);
+  BOOST_CHECK(!(pLayerSf.extent.range() == pLayerSfShared.extent.range()));
 
   // Test 1 - identity transform
   auto protoLayer = createProtoLayer(Transform3::Identity());

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -296,14 +296,14 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceBinningPosition) {
   exp = trf * exp;
 
   Vector3 bp = cylinder->binningPosition(testContext, binR);
-  BOOST_CHECK_EQUAL(bp, exp);
-  BOOST_CHECK_EQUAL(cylinder->binningPositionValue(testContext, binR),
-                    VectorHelpers::perp(exp));
+  CHECK_CLOSE_ABS(bp, exp, 1e-10);
+  CHECK_CLOSE_ABS(cylinder->binningPositionValue(testContext, binR),
+                  VectorHelpers::perp(exp), 1e-10);
 
   bp = cylinder->binningPosition(testContext, binRPhi);
-  BOOST_CHECK_EQUAL(bp, exp);
-  BOOST_CHECK_EQUAL(cylinder->binningPositionValue(testContext, binRPhi),
-                    VectorHelpers::phi(exp) * VectorHelpers::perp(exp));
+  CHECK_CLOSE_ABS(bp, exp, 1e-10);
+  CHECK_CLOSE_ABS(cylinder->binningPositionValue(testContext, binRPhi),
+                  VectorHelpers::phi(exp) * VectorHelpers::perp(exp), 1e-10);
 
   for (auto b : {binX, binY, binZ, binEta, binH, binMag}) {
     BOOST_TEST_CONTEXT("binValue: " << b) {

--- a/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PolyhedronSurfacesTests.cpp
@@ -91,14 +91,14 @@ BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
     // Check the extent in space
     double r = hzpos * std::tan(alpha);
     auto extent = oneConePh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0_mm, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0_mm, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hzpos, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0_mm, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0_mm, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hzpos, 1e-6);
 
     /// The full cone on one side
     auto conePiece = std::make_shared<ConeBounds>(alpha, hzpmin, hzpos);
@@ -109,14 +109,14 @@ BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
     // Check the extent in space
     double rmin = hzpmin * std::tan(alpha);
     extent = oneConePiecePh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, rmin, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, hzpmin, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hzpos, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() rmin, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() hzpmin, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hzpos, 1e-6);
 
     // The full cone on both sides
     auto coneBoth = std::make_shared<ConeBounds>(alpha, hzneg, hzpos);
@@ -126,14 +126,14 @@ BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
     BOOST_CHECK_EQUAL(twoConesPh.faces.size(), expectedFaces);
     BOOST_CHECK_EQUAL(twoConesPh.vertices.size(), expectedFaces + 1);
     extent = twoConesPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0_mm, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, hzneg, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hzpos, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0_mm, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() hzneg, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hzpos, 1e-6);
 
     // A centered sectoral cone on both sides
     auto sectoralBoth =
@@ -143,11 +143,11 @@ BOOST_AUTO_TEST_CASE(ConeSurfacePolyhedrons) {
     auto sectoralConesPh =
         sectoralCones->polyhedronRepresentation(tgContext, segments);
     extent = sectoralConesPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0_mm, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, hzneg, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hzpos, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0_mm, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() hzneg, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hzpos, 1e-6);
   }
 }
 
@@ -178,14 +178,14 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
     BOOST_CHECK_EQUAL(fullCylinderPh.vertices.size(), expectedVertices);
     // Check the extent in space
     auto extent = fullCylinderPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, -hZ, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() -hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hZ, 1e-6);
 
     /// The full cone on one side
     auto sectorCentered = std::make_shared<CylinderBounds>(r, phiSector, hZ);
@@ -196,14 +196,14 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
 
     // Check the extent in space
     extent = centerSectoredCylinderPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, r * std::cos(phiSector), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -r * std::sin(phiSector), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, r * std::sin(phiSector), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, -hZ, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() r * std::cos(phiSector), 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -r * std::sin(phiSector), 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() r * std::sin(phiSector), 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() -hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hZ, 1e-6);
 
     /// The full cone on one side
     auto sectorShifted =
@@ -215,10 +215,10 @@ BOOST_AUTO_TEST_CASE(CylinderSurfacePolyhedrons) {
 
     // Check the extent in space
     extent = shiftedSectoredCylinderPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, r, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, -hZ, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() r, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() -hZ, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() hZ, 1e-6);
   }
 }
 
@@ -262,44 +262,44 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
     BOOST_CHECK_EQUAL(fullDiscPh.vertices.size(), expectedVertices);
 
     auto extent = fullDiscPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     // Ring disc
     auto radial = std::make_shared<RadialBounds>(innerR, outerR);
     auto radialDisc = Surface::makeShared<DiscSurface>(transform, radial);
     auto radialPh = radialDisc->polyhedronRepresentation(tgContext, segments);
     extent = radialPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, innerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() innerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     // Sectoral disc - around 0.
     auto sector = std::make_shared<RadialBounds>(0., outerR, phiSector);
     auto sectorDisc = Surface::makeShared<DiscSurface>(transform, sector);
     auto sectorPh = sectorDisc->polyhedronRepresentation(tgContext, segments);
     extent = sectorPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -outerR * std::sin(phiSector),
+    CHECK_CLOSE_ABS((extent.range(binX).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -outerR * std::sin(phiSector),
                     1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, outerR * std::sin(phiSector),
+    CHECK_CLOSE_ABS((extent.range(binY).max() outerR * std::sin(phiSector),
                     1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     // Sectoral ring - around 0.
     auto sectorRing = std::make_shared<RadialBounds>(innerR, outerR, phiSector);
@@ -308,17 +308,17 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
     auto sectorRingDiscPh =
         sectorRingDisc->polyhedronRepresentation(tgContext, segments);
     extent = sectorRingDiscPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, innerR * std::cos(phiSector),
+    CHECK_CLOSE_ABS((extent.range(binX).min() innerR * std::cos(phiSector),
                     1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -outerR * std::sin(phiSector),
+    CHECK_CLOSE_ABS((extent.range(binX).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -outerR * std::sin(phiSector),
                     1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, outerR * std::sin(phiSector),
+    CHECK_CLOSE_ABS((extent.range(binY).max() outerR * std::sin(phiSector),
                     1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, innerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() innerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     // Sectoral disc - shifted
     auto sectorRingShifted =
@@ -328,10 +328,10 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
     auto sectorRingDiscShiftedPh =
         sectorRingDiscShifted->polyhedronRepresentation(tgContext, segments);
     extent = sectorRingDiscShiftedPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, innerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() innerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     // Trapezoid for a disc
     double halfXmin = 10_mm;
@@ -343,10 +343,10 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
     auto trapezoidDiscSfPh =
         trapezoidDiscSf->polyhedronRepresentation(tgContext, segments);
     extent = trapezoidDiscSfPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, innerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() innerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     auto trapezoidDiscShifted = std::make_shared<DiscTrapezoidBounds>(
         halfXmin, halfXmax, innerR, outerR, averagePhi);
@@ -355,10 +355,10 @@ BOOST_AUTO_TEST_CASE(DiscSurfacePolyhedrons) {
     auto trapezoidDiscShiftedSfPh =
         trapezoidDiscShiftedSf->polyhedronRepresentation(tgContext, segments);
     extent = trapezoidDiscShiftedSfPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, innerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, outerR, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() innerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() outerR, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     double minRadius = 7.;
     double maxRadius = 12.;
@@ -391,10 +391,10 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
   auto shiftedPh = shiftedPlane->polyhedronRepresentation(tgContext, 1);
   auto shiftedExtent = shiftedPh.extent();
   // Let's check the extent
-  CHECK_CLOSE_ABS(shiftedExtent.ranges[binX].first, -rhX, 1e-6);
-  CHECK_CLOSE_ABS(shiftedExtent.ranges[binX].second, rhX, 1e-6);
-  CHECK_CLOSE_ABS(shiftedExtent.ranges[binY].first, -rhY + shiftY, 1e-6);
-  CHECK_CLOSE_ABS(shiftedExtent.ranges[binY].second, rhY + shiftY, 1e-6);
+  CHECK_CLOSE_ABS(shifted(extent.range(binX).min() -rhX, 1e-6);
+  CHECK_CLOSE_ABS(shifted(extent.range(binX).max() rhX, 1e-6);
+  CHECK_CLOSE_ABS(shifted(extent.range(binY).min() -rhY + shiftY, 1e-6);
+  CHECK_CLOSE_ABS(shifted(extent.range(binY).max() rhY + shiftY, 1e-6);
 
   for (const auto& mode : testModes) {
     unsigned int segments = std::get<unsigned int>(mode);
@@ -407,15 +407,15 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
     auto rectangularPh =
         rectangularPlane->polyhedronRepresentation(tgContext, segments);
     auto extent = rectangularPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -rhX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, rhX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -rhY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, rhY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second,
+    CHECK_CLOSE_ABS((extent.range(binX).min() -rhX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() rhX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -rhY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() rhY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max()
                     std::sqrt(rhX * rhX + rhY * rhY), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
     BOOST_CHECK(rectangularPh.vertices.size() == 4);
     BOOST_CHECK(rectangularPh.faces.size() == 1);
     std::vector<size_t> expectedRect = {0, 1, 2, 3};
@@ -434,15 +434,15 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
     extent = trapezoidalPh.extent();
 
     double thX = std::max(thX1, thX2);
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -thX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, thX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -thY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, thY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second,
+    CHECK_CLOSE_ABS((extent.range(binX).min() -thX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() thX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -thY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() thY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max()
                     std::sqrt(thX * thX + thY * thY), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
     BOOST_CHECK(trapezoidalPh.vertices.size() == 4);
     BOOST_CHECK(trapezoidalPh.faces.size() == 1);
     std::vector<size_t> expectedTra = {0, 1, 2, 3};
@@ -456,14 +456,14 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
     auto ellispoidPh =
         ellipsoidPlane->polyhedronRepresentation(tgContext, segments);
     extent = ellispoidPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -rMaxX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, rMaxX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -rMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -rMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, rMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -rMaxX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() rMaxX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     double rMinX = 10_mm;
     double rMinY = 20_mm;
@@ -475,13 +475,14 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
         ellipsoidRingPlane->polyhedronRepresentation(tgContext, segments);
 
     extent = ellispoidPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -rMaxX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, rMaxX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -rMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, rMinX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second, rMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).min() -rMaxX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() rMaxX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() rMinX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max() rMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
 
     /// ConvextPolygonBounds test
     std::vector<Vector2> vtxs = {
@@ -508,15 +509,15 @@ BOOST_AUTO_TEST_CASE(PlaneSurfacePolyhedrons) {
     BOOST_CHECK(diamondPh.vertices.size() == 6);
     BOOST_CHECK(diamondPh.faces.size() == 1);
     extent = diamondPh.extent();
-    CHECK_CLOSE_ABS(extent.ranges[binX].first, -hMedX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binX].second, hMedX, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].first, -hMinY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binY].second, hMaxY, 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binR].second,
+    CHECK_CLOSE_ABS((extent.range(binX).min() -hMedX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binX).max() hMedX, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).min() -hMinY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binY).max() hMaxY, 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binR).max()
                     std::sqrt(hMaxX * hMaxX + hMaxY * hMaxY), 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].first, 0., 1e-6);
-    CHECK_CLOSE_ABS(extent.ranges[binZ].second, 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).min() 0., 1e-6);
+    CHECK_CLOSE_ABS((extent.range(binZ).max() 0., 1e-6);
   }
 }
 


### PR DESCRIPTION
Backport 81e9573deab82bb96645ad3a8d48800d535db527 from #1424.
---
This PR uses the later introduced `Range1D<>` class in the `Geometry/Extent` class instead of duplication of the code concerning intersection, min/max, shrinking.

As a direct consequence, the code becomes more readable, by explicitly calling `range(binValue).min()` instead of `ranges[binValue].first` when the meaning of first is not clear from the context.
