### PR TITLE
refactor: improve full_chain_itk.py example [backport #1513 to develop/v19.x]

### DIFF
--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-import pathlib, acts, acts.examples
-from acts.examples.itk import buildITkGeometry
-
-u = acts.UnitConstants
-geo_dir = pathlib.Path("acts-itk")
-outputDir = pathlib.Path.cwd()
-
-# acts.examples.dump_args_calls(locals())  # show acts.examples python binding calls
-detector, trackingGeometry, decorators = buildITkGeometry(geo_dir)
-field = acts.examples.MagneticFieldMapXyz(str(geo_dir / "bfield/ATLAS-BField-xyz.root"))
-rnd = acts.examples.RandomNumbers(seed=42)
-
+import pathlib, acts, acts.examples, acts.examples.itk
 from acts.examples.simulation import (
     addParticleGun,
     MomentumConfig,
@@ -24,41 +13,54 @@ from acts.examples.simulation import (
 from acts.examples.reconstruction import (
     addSeeding,
     TruthSeedRanges,
-    SeedingAlgorithm,
-    ParticleSmearingSigmas,
     addCKFTracks,
     CKFPerformanceConfig,
 )
 
-from acts.examples.itk import itkSeedingAlgConfig
+ttbar_pu200 = False
+u = acts.UnitConstants
+geo_dir = pathlib.Path("acts-itk")
+outputDir = pathlib.Path.cwd()
+# acts.examples.dump_args_calls(locals())  # show acts.examples python binding calls
+
+detector, trackingGeometry, decorators = acts.examples.itk.buildITkGeometry(geo_dir)
+field = acts.examples.MagneticFieldMapXyz(str(geo_dir / "bfield/ATLAS-BField-xyz.root"))
+rnd = acts.examples.RandomNumbers(seed=42)
 
 s = acts.examples.Sequencer(events=100, numThreads=-1)
-addParticleGun(
-    s,
-    MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
-    EtaConfig(-4.0, 4.0, uniform=True),
-    ParticleConfig(1, acts.PdgParticle.eMuon, randomizeCharge=True),
-    rnd=rnd,
-)
-# # Uncomment addPythia8 and ParticleSelectorConfig, instead of addParticleGun, to generate ttbar with mu=200 pile-up.
-# addPythia8(
-#     s,
-#     hardProcess=["Top:qqbar2ttbar=on"],
-#     vtxGen=acts.examples.GaussianVertexGenerator(
-#         stddev=acts.Vector4(0.0125 * u.mm, 0.0125 * u.mm, 55.5 * u.mm, 5.0 * u.ns),
-#         mean=acts.Vector4(0, 0, 0, 0),
-#     ),
-#     rnd=rnd,
-#     outputDirRoot=outputDir,
-# )
+
+if not ttbar_pu200:
+    addParticleGun(
+        s,
+        MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
+        EtaConfig(-4.0, 4.0, uniform=True),
+        ParticleConfig(1, acts.PdgParticle.eMuon, randomizeCharge=True),
+        rnd=rnd,
+    )
+else:
+    addPythia8(
+        s,
+        hardProcess=["Top:qqbar2ttbar=on"],
+        npileup=200,
+        vtxGen=acts.examples.GaussianVertexGenerator(
+            stddev=acts.Vector4(0.0125 * u.mm, 0.0125 * u.mm, 55.5 * u.mm, 5.0 * u.ns),
+            mean=acts.Vector4(0, 0, 0, 0),
+        ),
+        rnd=rnd,
+        outputDirRoot=outputDir,
+    )
+
 addFatras(
     s,
     trackingGeometry,
     field,
-    # ParticleSelectorConfig(eta=(-4.0, 4.0), pt=(150 * u.MeV, None), removeNeutral=True),
+    ParticleSelectorConfig(eta=(-4.0, 4.0), pt=(150 * u.MeV, None), removeNeutral=True)
+    if ttbar_pu200
+    else ParticleSelectorConfig(),
     outputDirRoot=outputDir,
     rnd=rnd,
 )
+
 addDigitization(
     s,
     trackingGeometry,
@@ -67,22 +69,24 @@ addDigitization(
     outputDirRoot=outputDir,
     rnd=rnd,
 )
+
 addSeeding(
     s,
     trackingGeometry,
     field,
-    TruthSeedRanges(pt=(1.0 * u.GeV, None), eta=(-4.0, 4.0), nHits=(9, None)),
-    # SeedingAlgorithm.TruthEstimated,
-    # SeedingAlgorithm.TruthSmeared, ParticleSmearingSigmas(pRel=0.01), rnd=rnd,
-    *itkSeedingAlgConfig("PixelSpacePoints"),
+    TruthSeedRanges(pt=(1.0 * u.GeV, None), eta=(-4.0, 4.0), nHits=(9, None))
+    if ttbar_pu200
+    else TruthSeedRanges(),
+    *acts.examples.itk.itkSeedingAlgConfig("PixelSpacePoints"),
     geoSelectionConfigFile=geo_dir / "itk-hgtd/geoSelection-ITk.json",
     outputDirRoot=outputDir,
 )
+
 addCKFTracks(
     s,
     trackingGeometry,
     field,
-    CKFPerformanceConfig(ptMin=1.0 * u.GeV, nMeasurementsMin=6),
+    CKFPerformanceConfig(ptMin=1.0 * u.GeV if ttbar_pu200 else 0.0, nMeasurementsMin=6),
     outputDirRoot=outputDir,
 )
 


### PR DESCRIPTION
Backport b99368a581df64aaa03e2b25a998b155cc4c57ab from #1513.
---
* `full_chain_itk.py` can now run ttbar+PU200 selected by a flag (`ttbar_pu200`), rather than commented-out code.
* Remove truth selection for particle gun. This is not needed and can give problems if a lower generated pT range is selected.
* Remove previously commented-out `SeedingAlgorithm.TruthEstimated` and `SeedingAlgorithm.TruthSmeared` options.
* simplify imports