### PR TITLE
fix: maybe-uninitialized warning in SpacepointBuilder [backport #1543 to develop/v19.x]

### DIFF
--- a/Core/include/Acts/SpacePointFormation/detail/SpacePointBuilder.ipp
+++ b/Core/include/Acts/SpacePointFormation/detail/SpacePointBuilder.ipp
@@ -28,8 +28,8 @@ void SpacePointBuilder<spacepoint_t>::buildSpacePoint(
     std::back_insert_iterator<container_t<spacepoint_t>> spacePointIt) const {
   const unsigned int num_meas = measurements.size();
 
-  Acts::Vector3 gPos;
-  Acts::Vector2 gCov;
+  Acts::Vector3 gPos = Acts::Vector3::Zero();
+  Acts::Vector2 gCov = Acts::Vector2::Zero();
 
   if (num_meas == 1) {  // pixel SP formation
 


### PR DESCRIPTION
Backport f3b20f70284ab6e210f3c4681d08370750fdf010 from #1543.
---
My new GCC does emit a `-Wmaybe-uninitialized` warning in the `SpacePointBuilder.ipp`. Indeed, in the Error case (the `else` branch in the `buildSpacePoint` function) the values `gpos` and `gCov` seems to stay uninitialized.

I'm not sure if zero initialization is actually the best thing to do here (maybe @toyamaza can comment on that), maybe return a `Result<void>` could  also be an option?