### PR TITLE
ci: Bump histcmp to v0.5.1 [backport of #1556 to develop/v19.x]

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -254,7 +254,7 @@ jobs:
         run: >
           echo "::group::Dependencies"
           && git config --global safe.directory "$GITHUB_WORKSPACE"
-          && pip3 install histcmp==0.4.4
+          && pip3 install histcmp==0.5.1
           && pip3 install -r Examples/Scripts/requirements.txt
           && /usr/local/bin/download_geant4_data.sh
           && source /usr/local/bin/thisroot.sh

--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -25,8 +25,8 @@ function run() {
     echo "::group::Comparing $a vs. $b"
 
     histcmp \
-        --label-reference=$refcommit \
-        --label-monitored=$commit \
+        --label-reference=reference \
+        --label-monitored=monitored \
         "$@"
 
     ec=$(($ec | $?))


### PR DESCRIPTION
Backport of 48a155c03198a8a645b200117a12c0ba889150b4 from #1556
---
This intends to fix the issue seen in #1541, along with some other improvements. The CI should be green on this one, otherwise I have to go back and fix histcmp accordingly.