### PR TITLE
fix: Remove example spacepoint from seeding code

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -506,7 +506,7 @@ void SeedFinderOrthogonal<external_spacepoint_t>::processFromMiddleSP(
    * Create a vector to contain protoseeds.
    */
   std::vector<std::pair<
-      float, std::unique_ptr<const InternalSeed<ActsExamples::SimSpacePoint>>>>
+      float, std::unique_ptr<const InternalSeed<external_spacepoint_t>>>>
       protoseeds;
 
   int numQualitySeeds = 0;


### PR DESCRIPTION
As pointed out in #1557, the existing orthogonal seed finding code uses the `SimSpacePoint` from the ACTS examples namespace, which should not be used in the ACTS core. This commit gets rid of the uses of this type.

Fixes #1557.