### PR TITLE
feat: break loop over triplets in seed finder

### DIFF
--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -256,6 +256,10 @@ void Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
     size_t t0 = 0;
 
     for (size_t b = 0; b < numBotSP; b++) {
+      // break if we reached the last top SP
+      if (t0 == numTopSP)
+        break;
+
       auto lb = state.linCircleBottom[b];
       float Zob = lb.Zo;
       float cotThetaB = lb.cotTheta;

--- a/Core/include/Acts/Seeding/Seedfinder.ipp
+++ b/Core/include/Acts/Seeding/Seedfinder.ipp
@@ -257,8 +257,9 @@ void Seedfinder<external_spacepoint_t, platform_t>::createSeedsForGroup(
 
     for (size_t b = 0; b < numBotSP; b++) {
       // break if we reached the last top SP
-      if (t0 == numTopSP)
+      if (t0 == numTopSP) {
         break;
+      }
 
       auto lb = state.linCircleBottom[b];
       float Zob = lb.Zo;


### PR DESCRIPTION
break loop over triplets if reached the last top SP in seed finder to avoid unnecessary calculations