### PR TITLE
refactor: Improve verbose logging in Kalman Filter [backport #1581 to develop/v19.x]

### DIFF
--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -314,7 +314,10 @@ class KalmanFitter {
         return;
       }
 
-      ACTS_VERBOSE("KalmanFitter step");
+      ACTS_VERBOSE("KalmanFitter step at pos: "
+                   << stepper.position(state.stepping).transpose()
+                   << " dir: " << stepper.direction(state.stepping).transpose()
+                   << " momentum: " << stepper.momentum(state.stepping));
 
       // Add the measurement surface as external surface to navigator.
       // We will try to hit those surface by ignoring boundary checks.


### PR DESCRIPTION
Backport cd5da0c203c4daebc8eb5b57981373706cf2c985 from #1581.
---
This is a super small PR, that additionally prints some information in the KF verbose logger, I believe the current position of the propagation is a missing information there. I need this very often, e.g. during the debugging of the GSF and have it there in all my local branches.

I would like it to add this to the main branch, since it shouldn't cost performance and then I do not need to add this always manually.