### PR TITLE
fix: Add required flags to cmdline args in analysis scripts [backport #1570 to develop/v19.x]

### DIFF
--- a/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
+++ b/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     auto ao = description.add_options();
     ao("help,h", "Display this help message");
     ao("silent,s", bool_switch(), "Silent mode (without X-window/display).");
-    ao("input,i", value<std::string>()->default_value(""),
+    ao("input,i", value<std::string>()->required(),
        "Input ROOT file containing the input TTree.");
     ao("tree,t", value<std::string>()->default_value("trackstates"),
        "Input TTree name.");
@@ -43,12 +43,13 @@ int main(int argc, char** argv) {
     // Set up the variables map
     variables_map vm;
     store(command_line_parser(argc, argv).options(description).run(), vm);
-    notify(vm);
 
     if (vm.count("help") != 0u) {
       std::cout << description;
-      return 0;
+      return 1;
     }
+
+    notify(vm);
 
     // Parse the parameters
     auto iFile = vm["input"].as<std::string>();

--- a/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
+++ b/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
        "(Optionally) limit number of events to be processed.");
     ao("peak-events,p", value<unsigned long>()->default_value(0),
        "(Optionally) limit number of events for the range peaking.");
-    ao("input,i", value<std::vector<std::string>>(),
+    ao("input,i", value<std::vector<std::string>>()->required(),
        "Input ROOT file(s) containing the input TTree.");
     ao("tree,t", value<std::string>()->default_value("tracksummary"),
        "Input TTree/TChain name.");
@@ -71,7 +71,8 @@ int main(int argc, char** argv) {
     ao("phi-range",
        value<Interval>()->value_name("MIN:MAX")->default_value({-M_PI, M_PI}),
        "Range for the phi bins.");
-    ao("pt-borders", value<VariableReals>(), "Transverse momentum borders.");
+    ao("pt-borders", value<VariableReals>()->required(),
+       "Transverse momentum borders.");
     ao("config-output", value<std::string>()->default_value(""),
        "(Optional) output histrogram configuration json file.");
     ao("config-input", value<std::string>()->default_value(""),
@@ -97,12 +98,13 @@ int main(int argc, char** argv) {
     // Set up the variables map
     variables_map vm;
     store(command_line_parser(argc, argv).options(description).run(), vm);
-    notify(vm);
 
     if (vm.count("help") != 0u) {
       std::cout << description;
       return 1;
     }
+
+    notify(vm);
 
     // Events
     unsigned long nEntries = vm["events"].as<unsigned long>();


### PR DESCRIPTION
Backport 1941fbc99046a2b7fadff62778bd375a7cd56579 from #1570.
---
The analysis scripts could fail with `boost::any_cast` errors if some arguments where not provided. However, what arguments exactely could only be found out in the source code.

This adds a few required flags that explicitly say what is needed.