### PR TITLE
ci: Bump macOS dependencies again [backport #1583 to develop/v19.x]

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -458,7 +458,7 @@ jobs:
           brew install cmake eigen ninja ccache
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.1e4136f.tar.gz
+          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.52aa83d.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
 
       - name: Cache build


### PR DESCRIPTION
Backport of 465fe6fa692aa672091c8eb1dac02a28abeb015c from #1583 
---
This is because the python version got out of sync again.
