### PR TITLE
docs: fix caption of figure in seeding documentation

### DIFF
--- a/docs/core/seeding.md
+++ b/docs/core/seeding.md
@@ -160,7 +160,7 @@ bottom SP.
 :::{figure} ../figures/seeding/impactParameter.svg
 :width: 400px
 :align: center
-oi
+Helix representation in $x/y$ reference frame with central space-point (SP$_m$) in the origin.
 :::
 
 Assuming the middle layer SP is in the origin of the $x/y$ frame, as in {numref}`impactParameter`. 


### PR DESCRIPTION
By mistake I forgot to add a caption to one of the figures from #1476