### PR TITLE
Make Python for examples version ≥3.8 required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ endmacro()
 # when a particular package is actually needed.
 # plugin dependencies
 if(ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS)
-  find_package(Python COMPONENTS Interpreter Development)
+  find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development)
   if(ACTS_USE_SYSTEM_PYBIND11) 
     find_package(pybind11 CONFIG REQUIRED)
   else()


### PR DESCRIPTION
As it stands, we import Python when building the Python bindings, but we do not require it at configuration time, and we do not specify a minimum version. In practice, the examples do not work with Python versions lower than 3.8. This commit, therefore, makes the Python package required in the CMake build system, and requires version 3.8 or higher.