### PR TITLE
ci: update macos deps

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -479,7 +479,7 @@ jobs:
           brew install cmake eigen ninja ccache
           && sudo mkdir /usr/local/acts
           && sudo chown $USER /usr/local/acts
-          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.52aa83d.tar.gz
+          && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ci/macOS/deps.ce7b5a4.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
 
       - name: Cache build


### PR DESCRIPTION
with https://github.com/acts-project/ci-dependencies/pull/12 I added a specific python version to the macos ci dependencies which hopefully resolves the root/dd4hep issue for now