### PR TITLE
fix: enable examples if python examples are enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set_option_if(
   OR ACTS_BUILD_EXAMPLES_HEPMC3
   OR ACTS_BUILD_EXAMPLES_PYTHIA8
   OR ACTS_BUILD_EXAMPLES_EXATRKX
+  OR ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS
   OR ACTS_BUILD_EVERYTHING)
 # core plugins might be required by examples or depend on each other
 set_option_if(


### PR DESCRIPTION
set `ACTS_BUILD_EXAMPLES` if `ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS`