### PR TITLE
refactor: configurable variables in seed confirmation

### DIFF
--- a/Core/include/Acts/Seeding/SeedConfirmationRangeConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedConfirmationRangeConfig.hpp
@@ -23,11 +23,19 @@ struct SeedConfirmationRangeConfig {
   // compatible top required
   float rMaxSeedConf =
       std::numeric_limits<float>::max();  // Acts::UnitConstants::mm
+
   // number of compatible top SPs of seed if bottom radius is larger than
   // rMaxSeedConf
   size_t nTopForLargeR = 0;
   // number of compatible top SPs of seed if bottom radius is smaller than
   // rMaxSeedConf
   size_t nTopForSmallR = 0;
+
+  // minimum radius for bottom SP in seed confirmation
+  float seedConfMinBottomRadius = 60. * Acts::UnitConstants::mm;
+  // maximum zOrigin in seed confirmation
+  float seedConfMaxZOrigin = 150. * Acts::UnitConstants::mm;
+  // minimum impact parameter for seed confirmation
+  float minImpactSeedConf = 1. * Acts::UnitConstants::mm;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -32,9 +32,10 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
         float, std::unique_ptr<const InternalSeed<external_spacepoint_t>>>>&
         outCont) const {
   // seed confirmation
+  SeedConfirmationRangeConfig seedConfRange;
   if (m_cfg.seedConfirmation) {
     // check if bottom SP is in the central or forward region
-    SeedConfirmationRangeConfig seedConfRange =
+    seedConfRange =
         (bottomSP.z() > m_cfg.centralSeedConfirmationRange.zMaxSeedConf ||
          bottomSP.z() < m_cfg.centralSeedConfirmationRange.zMinSeedConf)
             ? m_cfg.forwardSeedConfirmationRange
@@ -149,10 +150,11 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
           (seedFilterState.numQualitySeeds and deltaSeedConf == 0)) {
         continue;
       }
-      bool seedRangeCuts = bottomSP.radius() < m_cfg.seedConfMinBottomRadius ||
-                           std::abs(zOrigin) > m_cfg.seedConfMaxZOrigin;
+      bool seedRangeCuts =
+          bottomSP.radius() < seedConfRange.seedConfMinBottomRadius ||
+          std::abs(zOrigin) > seedConfRange.seedConfMaxZOrigin;
       if (seedRangeCuts and deltaSeedConf == 0 and
-          impact > m_cfg.minImpactSeedConf) {
+          impact > seedConfRange.minImpactSeedConf) {
         continue;
       }
 

--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -31,6 +31,22 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
     std::vector<std::pair<
         float, std::unique_ptr<const InternalSeed<external_spacepoint_t>>>>&
         outCont) const {
+  // seed confirmation
+  if (m_cfg.seedConfirmation) {
+    // check if bottom SP is in the central or forward region
+    SeedConfirmationRangeConfig seedConfRange =
+        (bottomSP.z() > m_cfg.centralSeedConfirmationRange.zMaxSeedConf ||
+         bottomSP.z() < m_cfg.centralSeedConfirmationRange.zMinSeedConf)
+            ? m_cfg.forwardSeedConfirmationRange
+            : m_cfg.centralSeedConfirmationRange;
+    // set the minimum number of top SP depending on whether the bottom SP is
+    // in the central or forward region
+    seedFilterState.nTopSeedConf =
+        bottomSP.radius() > seedConfRange.rMaxSeedConf
+            ? seedConfRange.nTopForLargeR
+            : seedConfRange.nTopForSmallR;
+  }
+
   size_t maxWeightSeedIndex = 0;
   bool maxWeightSeed = false;
   float weightMax = -std::numeric_limits<float>::max();

--- a/Core/include/Acts/Seeding/SeedFilterConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFilterConfig.hpp
@@ -53,12 +53,6 @@ struct SeedFilterConfig {
   SeedConfirmationRangeConfig centralSeedConfirmationRange;
   // contains parameters for forward seed confirmation
   SeedConfirmationRangeConfig forwardSeedConfirmationRange;
-  // minimum radius for bottom SP in seed confirmation
-  float seedConfMinBottomRadius = 60. * Acts::UnitConstants::mm;
-  // maximum zOrigin in seed confirmation
-  float seedConfMaxZOrigin = 150. * Acts::UnitConstants::mm;
-  // minimum impact parameter for seed confirmation
-  float minImpactSeedConf = 1. * Acts::UnitConstants::mm;
 
   // maximum number of lower quality seeds in seed confirmation
   int maxSeedsPerSpMConf = std::numeric_limits<int>::max();
@@ -76,9 +70,6 @@ struct SeedFilterConfig {
     SeedFilterConfig config = *this;
     config.deltaRMin /= 1_mm;
     config.deltaInvHelixDiameter /= 1. / 1_mm;
-    config.seedConfMinBottomRadius /= 1_mm;
-    config.seedConfMaxZOrigin /= 1_mm;
-    config.minImpactSeedConf /= 1_mm;
 
     return config;
   }

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -314,6 +314,9 @@ def itkSeedingAlgConfig(inputSpacePointsType):
         rMaxSeedConf=140 * u.mm,
         nTopForLargeR=1,
         nTopForSmallR=2,
+        seedConfMinBottomRadius=60.0 * u.mm,
+        seedConfMaxZOrigin=150.0 * u.mm,
+        minImpactSeedConf=1.0 * u.mm,
     )  # contains parameters for seed confirmation
     forwardSeedConfirmationRange = acts.SeedConfirmationRangeConfig(
         zMinSeedConf=-3000 * u.mm,
@@ -321,6 +324,9 @@ def itkSeedingAlgConfig(inputSpacePointsType):
         rMaxSeedConf=140 * u.mm,
         nTopForLargeR=1,
         nTopForSmallR=2,
+        seedConfMinBottomRadius=60.0 * u.mm,
+        seedConfMaxZOrigin=150.0 * u.mm,
+        minImpactSeedConf=1.0 * u.mm,
     )
     compatSeedWeight = 100
     curvatureSortingInFilter = True

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -129,6 +129,9 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_MEMBER(rMaxSeedConf);
     ACTS_PYTHON_MEMBER(nTopForLargeR);
     ACTS_PYTHON_MEMBER(nTopForSmallR);
+    ACTS_PYTHON_MEMBER(seedConfMinBottomRadius);
+    ACTS_PYTHON_MEMBER(seedConfMaxZOrigin);
+    ACTS_PYTHON_MEMBER(minImpactSeedConf);
     ACTS_PYTHON_STRUCT_END();
     patchKwargsConstructor(c);
   }


### PR DESCRIPTION
This PR moves some variables related to seed confirmation from `seedFilterConfig` to `seedConfirmationRangeConfig` and makes them configurable in python