### PR TITLE
feat: examples restore vertexing track selector

### DIFF
--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -679,7 +679,7 @@ def addCKFTracks(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     selectedParticles: str = "truth_seeds_selected",
-    trackSelectorRanges: Optional[TrackSelectorRanges] = TrackSelectorRanges(),
+    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
     writeTrajectories: bool = True,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
@@ -726,11 +726,9 @@ def addCKFTracks(
         inputInitialTrackParameters="estimatedparameters",
         outputTrajectories="trajectories",
         outputTrackParameters=outputTrackParameters
-        if trackSelectorRanges is None
-        else "fittedTrackParametersTmp",
+        + ("" if trackSelectorRanges is None else "Tmp"),
         outputTrackParametersTips=outputTrackParametersTips
-        if trackSelectorRanges is None
-        else "fittedTrackParametersTipsTmp",
+        + ("" if trackSelectorRanges is None else "Tmp"),
         findTracks=acts.examples.TrackFindingAlgorithm.makeTrackFinderFunction(
             trackingGeometry, field
         ),
@@ -1023,6 +1021,7 @@ def addVertexFitting(
     trackParameters: str = "filteredTrackParameters",
     trackParametersTips: Optional[str] = "filteredTrackParametersTips",
     vertexFinder: VertexFinder = VertexFinder.Truth,
+    trackSelectorRanges: Optional[TrackSelectorRanges] = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the vertex fitting
@@ -1050,6 +1049,20 @@ def addVertexFitting(
     )
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
+
+    if trackSelectorRanges is not None:
+        addTrackSelection(
+            s,
+            trackSelectorRanges,
+            inputTrackParameters=trackParameters,
+            inputTrackParametersTips=trackParametersTips,
+            outputTrackParameters=trackParameters + "Tmp",
+            outputTrackParametersTips=trackParametersTips + "Tmp",
+            logLevel=customLogLevel(),
+        )
+
+        trackParameters = trackParameters + "Tmp"
+        trackParametersTips = trackParametersTips + "Tmp"
 
     inputParticles = "particles_input"
     outputVertices = "fittedVertices"

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1012,6 +1012,9 @@ class VertexFinder(Enum):
     Iterative = (3,)
 
 
+@acts.examples.NamedTypeArgs(
+    trackSelectorRanges=TrackSelectorRanges,
+)
 def addVertexFitting(
     s,
     field,


### PR DESCRIPTION
https://github.com/acts-project/acts/pull/1579/ remove the track selector from `addVertexing` which is still required. see https://github.com/acts-project/acts/pull/1636

https://github.com/acts-project/acts/pull/1588 should clean this up a little