### PR TITLE
refactor: required for new ITk geometry

### DIFF
--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -53,6 +53,22 @@ def buildITkGeometry(
     equidistant = TGeoDetector.Config.BinningType.equidistant
     arbitrary = TGeoDetector.Config.BinningType.arbitrary
 
+    # ## Create TGeo geometry from `tgeo_fileName = itk-hgtd/ATLAS-ITk-HGTD.tgeo.root`.
+    # The `subVolumeName` and `sensitiveNames` specified below may change with new geometry versions
+    # in the root file (it changed ATLAS-P2-23 -> ATLAS-P2-RUN4-01-00-00).
+    # `TGeoParser` searches the tree below `subVolumeName` for all elements that match any of the
+    # list of `sensitiveNames` wildcards and also fall inside the `rRange`/`zRange` selections.
+    # If no `TGeoDetectorElements`` are found for an ACTS `Volume()`, then `TGeoDetector.create()`
+    # raises an exception along the lines of:
+    # 1. Missing tracking geometry - or
+    # 2. Incorrect binning configuration found: Number of configurations does not match number of protolayers
+    # Unless you know in advance, working out what names to change may not be trivial.
+    # I (@timadye) used a combination of
+    # * adding `printf`s in `Acts::TGeoParser::select()` (useful to find what it found with the old version),
+    # * printing object descendants from root (good for making long lists, but navigation cumbersome), and
+    # * browsing `TGeoManager` with ROOT's `TBrowser` (easy to navigate, but have to scan through long lists by eye).
+    # If the detector has moved significantly, it may be necessary to change the `rRange`/`zRange`.
+    # This specification should be kept in sync with `itk-hgtd/tgeo-atlas-itk-hgtd.json`.
     return TGeoDetector.create(
         fileName=str(tgeo_fileName),
         mdecorator=matDeco,

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -71,8 +71,8 @@ def buildITkGeometry(
                 binToleranceZ=(5 * u.mm, 5 * u.mm),
                 binTolerancePhi=(0.025 * u.mm, 0.025 * u.mm),
                 layers=LayerTriplet(True),
-                subVolumeName=LayerTriplet("Pixel::Pixel"),
-                sensitiveNames=LayerTriplet(["Pixel::siLog"]),
+                subVolumeName=LayerTriplet("ITkPixel__ITkPixelDetector"),
+                sensitiveNames=LayerTriplet(["ITkPixel__*_Sensor"]),
                 sensitiveAxes=LayerTriplet("YZX"),
                 rRange=LayerTriplet((0 * u.mm, 135 * u.mm)),
                 zRange=LayerTriplet(
@@ -109,8 +109,8 @@ def buildITkGeometry(
                 binToleranceZ=(5 * u.mm, 5 * u.mm),
                 binTolerancePhi=(0.025 * u.mm, 0.025 * u.mm),
                 layers=LayerTriplet(True),
-                subVolumeName=LayerTriplet("Pixel::Pixel"),
-                sensitiveNames=LayerTriplet(["Pixel::siLog"]),
+                subVolumeName=LayerTriplet("ITkPixel__ITkPixelDetector"),
+                sensitiveNames=LayerTriplet(["ITkPixel__*_Sensor"]),
                 sensitiveAxes=LayerTriplet("YZX"),
                 rRange=LayerTriplet((135 * u.mm, 350 * u.mm)),
                 zRange=LayerTriplet(
@@ -149,15 +149,11 @@ def buildITkGeometry(
                 binToleranceZ=(5 * u.mm, 5 * u.mm),
                 binTolerancePhi=(0.025 * u.mm, 0.025 * u.mm),
                 layers=LayerTriplet(True),
-                subVolumeName=LayerTriplet(
-                    negative="*",
-                    central="SCT::SCT_Barrel",
-                    positive="*",
-                ),
+                subVolumeName=LayerTriplet("ITkStrip__ITkStrip"),
                 sensitiveNames=LayerTriplet(
-                    negative=["SCT::ECSensor*"],
-                    central=["SCT::BRLSensor*"],
-                    positive=["SCT::ECSensor*"],
+                    negative=["ITkStrip__ECSensor*"],
+                    central=["ITkStrip__BRLSensor*"],
+                    positive=["ITkStrip__ECSensor*"],
                 ),
                 sensitiveAxes=LayerTriplet("XYZ"),
                 rRange=LayerTriplet(
@@ -225,8 +221,8 @@ def buildITkGeometry(
                 binToleranceZ=(5 * u.mm, 5 * u.mm),
                 binTolerancePhi=(0.25 * u.mm, 0.25 * u.mm),
                 layers=LayerTriplet(positive=True, central=False, negative=True),
-                subVolumeName=LayerTriplet("HGTD::HGTD"),
-                sensitiveNames=LayerTriplet(["HGTD::HGTDSiSensor*"]),
+                subVolumeName=LayerTriplet("HGTD__HGTD"),
+                sensitiveNames=LayerTriplet(["HGTD__HGTDSiSensor*"]),
                 sensitiveAxes=LayerTriplet("XYZ"),
                 rRange=LayerTriplet(
                     negative=(0 * u.mm, 1050 * u.mm),


### PR DESCRIPTION
New element names in `buildITkGeometry` for updated ATLAS ITk and HGTD geometry, `ATLAS-P2-RUN4-01-00-00`.
This supports the new geometry TGeo root file just added to the [`acts-itk`](https://gitlab.cern.ch/atlas/acts-itk) repo.

* Note that without this PR, the latest version of `acts-itk` (tag [`ATLAS-P2-RUN4-01-00-00`](https://gitlab.cern.ch/atlas/acts-itk/-/tree/ATLAS-P2-RUN4-01-00-00)) will not work. `acts-itk` tag [`ATLAS-P2-23`](https://gitlab.cern.ch/atlas/acts-itk/-/tree/ATLAS-P2-23) can be used instead.

* With this PR, `acts-itk` [`master`](https://gitlab.cern.ch/atlas/acts-itk) (or tag [`ATLAS-P2-RUN4-01-00-00`](https://gitlab.cern.ch/atlas/acts-itk/-/tree/ATLAS-P2-RUN4-01-00-00)) should be used.

* The error message from `itk.py` indicating a version mismatch is:
```
ValueError: Incorrect binning configuration found: Number of configurations does not match number of protolayers in subvolume Pixel::Pixel. Quitting.
```