### PR TITLE
feat: Add thickness and pitch again to csv geometry writing

### DIFF
--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -174,11 +174,15 @@ struct SurfaceData {
   float bound_param5 = -1.f;
   float bound_param6 = -1.f;
 
+  float module_t = -1.f;
+  float pitch_u = -1.f;
+  float pitch_v = -1.f;
+
   DFE_NAMEDTUPLE(SurfaceData, geometry_id, volume_id, boundary_id, layer_id,
                  module_id, cx, cy, cz, rot_xu, rot_xv, rot_xw, rot_yu, rot_yv,
                  rot_yw, rot_zu, rot_zv, rot_zw, bounds_type, bound_param0,
                  bound_param1, bound_param2, bound_param3, bound_param4,
-                 bound_param5, bound_param6);
+                 bound_param5, bound_param6, module_t, pitch_u, pitch_v);
 };
 
 struct LayerVolumeData {

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -99,7 +99,7 @@ void fillSurfaceData(SurfaceData& data, const Acts::Surface& surface,
     (*dataBoundParameters[ipar]) = boundValues[ipar];
   }
 
-  if (surface.associatedDetectorElement()) {
+  if (surface.associatedDetectorElement() != nullptr) {
     data.module_t = surface.associatedDetectorElement()->thickness() /
                     Acts::UnitConstants::mm;
 
@@ -107,13 +107,13 @@ void fillSurfaceData(SurfaceData& data, const Acts::Surface& surface,
         dynamic_cast<const Acts::IdentifiedDetectorElement*>(
             surface.associatedDetectorElement());
 
-    if (detElement and detElement->digitizationModule()) {
+    if (detElement != nullptr and detElement->digitizationModule()) {
       auto dModule = detElement->digitizationModule();
       // dynamic_cast to CartesianSegmentation
       const auto* cSegmentation =
           dynamic_cast<const Acts::CartesianSegmentation*>(
               &(dModule->segmentation()));
-      if (cSegmentation) {
+      if (cSegmentation != nullptr) {
         auto pitch = cSegmentation->pitch();
         data.pitch_u = pitch.first / Acts::UnitConstants::mm;
         data.pitch_v = pitch.second / Acts::UnitConstants::mm;

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -98,6 +98,28 @@ void fillSurfaceData(SurfaceData& data, const Acts::Surface& surface,
   for (size_t ipar = 0; ipar < boundValues.size(); ++ipar) {
     (*dataBoundParameters[ipar]) = boundValues[ipar];
   }
+
+  if (surface.associatedDetectorElement()) {
+    data.module_t = surface.associatedDetectorElement()->thickness() /
+                    Acts::UnitConstants::mm;
+
+    const auto* detElement =
+        dynamic_cast<const Acts::IdentifiedDetectorElement*>(
+            surface.associatedDetectorElement());
+
+    if (detElement and detElement->digitizationModule()) {
+      auto dModule = detElement->digitizationModule();
+      // dynamic_cast to CartesianSegmentation
+      const auto* cSegmentation =
+          dynamic_cast<const Acts::CartesianSegmentation*>(
+              &(dModule->segmentation()));
+      if (cSegmentation) {
+        auto pitch = cSegmentation->pitch();
+        data.pitch_u = pitch.first / Acts::UnitConstants::mm;
+        data.pitch_v = pitch.second / Acts::UnitConstants::mm;
+      }
+    }
+  }
 }
 
 /// Write a single surface.


### PR DESCRIPTION
This is needed by the Exa.TrkX data reader. This was once part of ACTS, but was removed (not sure why).