### PR TITLE
refactor: Add precondition check for MTJ `applyBackward` and `visitBackwards`

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -915,6 +915,11 @@ class MultiTrajectory {
     static_assert(detail_lt::VisitorConcept<F, TrackStateProxy>,
                   "Callable needs to satisfy VisitorConcept");
 
+    if (iendpoint == MultiTrajectoryTraits::kInvalid) {
+      throw std::runtime_error(
+          "Cannot apply backwards with kInvalid as endpoint");
+    }
+
     while (true) {
       auto ts = getTrackState(iendpoint);
       if constexpr (std::is_same_v<std::invoke_result_t<F, TrackStateProxy>,

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -177,7 +177,7 @@ void MultiTrajectory<D>::visitBackwards(IndexType iendpoint,
 
   if (iendpoint == MultiTrajectoryTraits::kInvalid) {
     throw std::runtime_error(
-        "Cannot apply backwards with kInvalid as endpoint");
+        "Cannot visit backwards with kInvalid as endpoint");
   }
 
   while (true) {

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -175,6 +175,11 @@ void MultiTrajectory<D>::visitBackwards(IndexType iendpoint,
   static_assert(detail_lt::VisitorConcept<F, ConstTrackStateProxy>,
                 "Callable needs to satisfy VisitorConcept");
 
+  if (iendpoint == MultiTrajectoryTraits::kInvalid) {
+    throw std::runtime_error(
+        "Cannot apply backwards with kInvalid as endpoint");
+  }
+
   while (true) {
     auto ts = getTrackState(iendpoint);
     if constexpr (std::is_same_v<std::invoke_result_t<F, ConstTrackStateProxy>,


### PR DESCRIPTION
If not checked, this leads to a segfault by trying to access the proxy or the previous proxy.