### PR TITLE
fix: Add check in TrackFitterPerformanceWriter

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -109,6 +109,11 @@ ActsExamples::ProcessCode ActsExamples::TrackFitterPerformanceWriter::writeT(
     const auto& trackTips = traj.tips();
     const auto& mj = traj.multiTrajectory();
 
+    if(trackTips.empty()) {
+      ACTS_WARNING("No trajectory found for entry " << itraj);
+      continue;
+    }
+
     // Check the size of the trajectory entry indices. For track fitting, there
     // should be at most one trajectory
     if (trackTips.size() > 1) {

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -109,7 +109,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFitterPerformanceWriter::writeT(
     const auto& trackTips = traj.tips();
     const auto& mj = traj.multiTrajectory();
 
-    if(trackTips.empty()) {
+    if (trackTips.empty()) {
       ACTS_WARNING("No trajectory found for entry " << itraj);
       continue;
     }


### PR DESCRIPTION
Check if we have a valid trajectory before trying to access it and emit a warning.