### PR TITLE
fix: telescope detector python binding + add test

### DIFF
--- a/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetector.hpp
+++ b/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetector.hpp
@@ -50,7 +50,8 @@ struct TelescopeDetector : public IBaseDetector {
            std::shared_ptr<const Acts::IMaterialDecorator> mdecorator) override;
 
   std::pair<ActsExamples::IBaseDetector::TrackingGeometryPtr, ContextDecorators>
-  finalize(const Config& cfg, std::shared_ptr<const Acts::IMaterialDecorator>);
+  finalize(const Config& cfg,
+           const std::shared_ptr<const Acts::IMaterialDecorator>& /*unused*/);
 };
 
 }  // namespace Telescope

--- a/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetector.hpp
+++ b/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetector.hpp
@@ -50,7 +50,7 @@ struct TelescopeDetector : public IBaseDetector {
            std::shared_ptr<const Acts::IMaterialDecorator> mdecorator) override;
 
   std::pair<ActsExamples::IBaseDetector::TrackingGeometryPtr, ContextDecorators>
-  finalize(const Config& cfg);
+  finalize(const Config& cfg, std::shared_ptr<const Acts::IMaterialDecorator>);
 };
 
 }  // namespace Telescope

--- a/Examples/Detectors/TelescopeDetector/src/TelescopeDetector.cpp
+++ b/Examples/Detectors/TelescopeDetector/src/TelescopeDetector.cpp
@@ -47,9 +47,8 @@ auto ActsExamples::Telescope::TelescopeDetector::finalize(
 }
 
 auto ActsExamples::Telescope::TelescopeDetector::finalize(
-    const Config& cfg,
-    std::shared_ptr<const Acts::IMaterialDecorator> /*unused*/)
-    -> std::pair<TrackingGeometryPtr, ContextDecorators> {
+    const Config& cfg, const std::shared_ptr<const Acts::IMaterialDecorator> &
+    /*unused*/) -> std::pair<TrackingGeometryPtr, ContextDecorators> {
   DetectorElement::ContextType nominalContext;
 
   if (cfg.surfaceType > 1) {

--- a/Examples/Detectors/TelescopeDetector/src/TelescopeDetector.cpp
+++ b/Examples/Detectors/TelescopeDetector/src/TelescopeDetector.cpp
@@ -25,7 +25,7 @@ void ActsExamples::Telescope::TelescopeDetector::addOptions(
 
 auto ActsExamples::Telescope::TelescopeDetector::finalize(
     const boost::program_options::variables_map& vm,
-    std::shared_ptr<const Acts::IMaterialDecorator> /*mdecorator*/)
+    std::shared_ptr<const Acts::IMaterialDecorator> /*unused*/)
     -> std::pair<TrackingGeometryPtr, ContextDecorators> {
   Config cfg;
 
@@ -43,10 +43,12 @@ auto ActsExamples::Telescope::TelescopeDetector::finalize(
   cfg.surfaceType = vm["geo-tele-surface"].template as<int>();
   cfg.binValue = vm["geo-tele-alignaxis"].template as<int>();
 
-  return finalize(cfg);
+  return finalize(cfg, {});
 }
 
-auto ActsExamples::Telescope::TelescopeDetector::finalize(const Config& cfg)
+auto ActsExamples::Telescope::TelescopeDetector::finalize(
+    const Config& cfg,
+    std::shared_ptr<const Acts::IMaterialDecorator> /*unused*/)
     -> std::pair<TrackingGeometryPtr, ContextDecorators> {
   DetectorElement::ContextType nominalContext;
 

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -68,8 +68,11 @@ void addDetector(Context& ctx) {
         py::class_<TelescopeDetector, IBaseDetector,
                    std::shared_ptr<TelescopeDetector>>(mex, "TelescopeDetector")
             .def(py::init<>())
-            .def("finalize", py::overload_cast<const Config&>(
-                                 &TelescopeDetector::finalize));
+            .def("finalize",
+                 py::overload_cast<
+                     const Config&,
+                     std::shared_ptr<const Acts::IMaterialDecorator>>(
+                     &TelescopeDetector::finalize));
 
     py::class_<Config>(td, "Config")
         .def(py::init<>())

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -71,7 +71,7 @@ void addDetector(Context& ctx) {
             .def("finalize",
                  py::overload_cast<
                      const Config&,
-                     std::shared_ptr<const Acts::IMaterialDecorator>>(
+                     const std::shared_ptr<const Acts::IMaterialDecorator>&>(
                      &TelescopeDetector::finalize));
 
     py::class_<Config>(td, "Config")

--- a/Examples/Python/tests/test_detectors.py
+++ b/Examples/Python/tests/test_detectors.py
@@ -32,6 +32,22 @@ def test_generic_geometry():
     assert count_surfaces(geo) == 18728
 
 
+def test_telescope_geometry():
+    n_surfaces = 10
+
+    detector, geo, contextDecorators = acts.examples.TelescopeDetector.create(
+        bounds=[100, 100],
+        positions=[10 * n for i in range(n_surfaces)],
+        binValue=0,
+    )
+
+    assert detector is not None
+    assert geo is not None
+    assert contextDecorators is not None
+
+    assert count_surfaces(geo) == n_surfaces
+
+
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep is not set up")
 def test_odd():
     config = acts.MaterialMapJsonConverter.Config()

--- a/Examples/Python/tests/test_detectors.py
+++ b/Examples/Python/tests/test_detectors.py
@@ -37,7 +37,7 @@ def test_telescope_geometry():
 
     detector, geo, contextDecorators = acts.examples.TelescopeDetector.create(
         bounds=[100, 100],
-        positions=[10 * n for i in range(n_surfaces)],
+        positions=[10 * i for i in range(n_surfaces)],
         binValue=0,
     )
 


### PR DESCRIPTION
This fixes the telescope detector which was not working anymore after the last clang-tidy changes.