### PR TITLE
fix: GX2F: update track state parameters and converge

### DIFF
--- a/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
+++ b/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
@@ -350,7 +350,7 @@ class Chi2Fitter {
         // add a full TrackState entry multi trajectory
         // (this allocates storage for all components, we will set them later)
 
-        size_t index;
+        size_t currentTrackIndex;
         if (updateNumber == 0) {
           result.lastTrackIndex =
               result.fittedStates
@@ -358,18 +358,19 @@ class Chi2Fitter {
                       ~(TrackStatePropMask::Smoothed |
                         TrackStatePropMask::Filtered),
                       result.lastTrackIndex);
-          index = result.lastTrackIndex;
+          currentTrackIndex = result.lastTrackIndex;
         } else {
           result.fittedStates->visitBackwards(
               result.lastTrackIndex, [&](auto proxy) {
                 if (&proxy.referenceSurface() == surface) {
-                  index = proxy.index();
+                  currentTrackIndex = proxy.index();
                 }
               });
         }
 
         // now get track state proxy back
-        auto trackStateProxy = result.fittedStates->getTrackState(index);
+        auto trackStateProxy =
+            result.fittedStates->getTrackState(currentTrackIndex);
 
         trackStateProxy.setReferenceSurface(surface->getSharedPtr());
 


### PR DESCRIPTION
The previous implementation could not update the track state parameters.
The updated Jacobian was overridden by `stepper.transportCovarianceToBound`. Therefore, every time the identity matrix was used in place of the Jacobian.
A second problem was the handling of surfaces in the update steps. Now, during the first iteration, proxies are created for each surface. During further iterations those surfaces are visited again.