### PR TITLE
fix: Make `Range1D` a proper half-open interval

### DIFF
--- a/Core/include/Acts/Utilities/Range1D.hpp
+++ b/Core/include/Acts/Utilities/Range1D.hpp
@@ -198,7 +198,7 @@ class Range1D {
   ///
   /// @return true The range is degenerate and has size zero
   /// @return false The range is not degenerate
-  bool degenerate(void) const { return m_min > m_max; }
+  bool degenerate(void) const { return m_min >= m_max; }
 
   /// @brief Determine if the range contains a given value
   ///
@@ -222,7 +222,7 @@ class Range1D {
   /// @return true The ranges intersect
   /// @return false The ranges do not intersect
   bool operator&&(const Range1D<Type>& o) const {
-    return m_min <= o.max() && o.min() <= m_max;
+    return m_min < o.max() && o.min() < m_max;
   }
 
   /// @brief Determine whether the range is equal to another range

--- a/Tests/UnitTests/Core/Utilities/Range1DTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/Range1DTests.cpp
@@ -528,15 +528,28 @@ BOOST_AUTO_TEST_CASE(intersection5_double) {
   BOOST_CHECK(i.degenerate());
 }
 
-BOOST_AUTO_TEST_CASE(intersects_edge_int) {
-  Acts::Range1D<int> r(-10, 10);
+BOOST_AUTO_TEST_CASE(intersects_edge_int_positive) {
+  Acts::Range1D<int> r(-10, 11);
   Acts::Range1D<int> q(10, 20);
 
   BOOST_CHECK((r && q));
 }
 
-BOOST_AUTO_TEST_CASE(single_value_not_degenerate_int) {
+BOOST_AUTO_TEST_CASE(intersects_edge_int_negative) {
+  Acts::Range1D<int> r(-10, 10);
+  Acts::Range1D<int> q(10, 20);
+
+  BOOST_CHECK(!(r && q));
+}
+
+BOOST_AUTO_TEST_CASE(single_value_not_degenerate_int_positive) {
   Acts::Range1D<int> r(10, 10);
+
+  BOOST_CHECK(r.degenerate());
+}
+
+BOOST_AUTO_TEST_CASE(single_value_not_degenerate_int_negative) {
+  Acts::Range1D<int> r(10, 11);
 
   BOOST_CHECK(!r.degenerate());
 }


### PR DESCRIPTION
Previously, the `Range1D` class checked for degeneracy as if it were a closed interval, but it is designed to be half-open. This commit changes the logic to represent this.