### PR TITLE
fix: If ITk module splitting is enabled also split back side modules.

### DIFF
--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
@@ -133,6 +133,10 @@ struct TGeoDetector {
       bool itkModuleSplit = false;
       std::map<std::string, unsigned int> barrelMap;
       std::map<std::string, std::vector<std::pair<double, double>>> discMap;
+      /// pairs of regular expressions to match sensor names and category keys
+      /// for either the barrelMap or the discMap
+      std::map<std::string, std::string>
+          splitPatterns;  // @TODO in principle vector<pair< > > would be good enough
     };
 
     std::vector<Volume> volumes;

--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoITkModuleSplitter.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoITkModuleSplitter.hpp
@@ -14,7 +14,9 @@
 
 #include <map>
 #include <memory>
+#include <regex>
 #include <string>
+#include <tuple>
 #include <vector>
 
 class TGeoNode;
@@ -37,6 +39,7 @@ class TGeoITkModuleSplitter : public Acts::ITGeoDetectorElementSplitter {
     // Map the nodes name to the splitting parameters
     std::map<std::string, unsigned int> barrelMap = {};
     std::map<std::string, std::vector<SplitRange>> discMap = {};
+    std::map<std::string, std::string> splitPatterns;
   };
 
   /// Constructor
@@ -65,6 +68,13 @@ class TGeoITkModuleSplitter : public Acts::ITGeoDetectorElementSplitter {
       const override;
 
  private:
+  /// Categorise module split patterns as barrel or disc module splits
+  ///
+  /// Mark the split pattern as either barrel or disc module split
+  /// depending on whether the split category is found in the
+  /// barrel or disc map, and compile the regular expression.
+  void initSplitCategories();
+
   /// Take a geometry context and TGeoElement in the Itk barrel region
   /// and split it into sub elements.
   ///
@@ -98,6 +108,9 @@ class TGeoITkModuleSplitter : public Acts::ITGeoDetectorElementSplitter {
 
   /// Contains the splitting parameters, sorted by sensor type
   Config m_cfg;
+
+  /// regular expressions to match sensors for barrel or disk module splits
+  std::vector<std::tuple<std::regex, std::string, bool>> m_splitCategories;
 
   /// Private access to the logger
   const Acts::Logger& logger() const { return *m_logger; }

--- a/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
@@ -122,6 +122,7 @@ std::vector<Acts::TGeoLayerBuilder::Config> makeLayerBuilderConfigs(
       ActsExamples::TGeoITkModuleSplitter::Config itkConfig;
       itkConfig.barrelMap = volume.barrelMap;
       itkConfig.discMap = volume.discMap;
+      itkConfig.splitPatterns = volume.splitPatterns;
       layerBuilderConfig.detectorElementSplitter =
           std::make_shared<ActsExamples::TGeoITkModuleSplitter>(itkConfig);
     }

--- a/Examples/Detectors/TGeoDetector/src/TGeoITkModuleSplitter.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoITkModuleSplitter.cpp
@@ -17,7 +17,31 @@
 ActsExamples::TGeoITkModuleSplitter::TGeoITkModuleSplitter(
     const ActsExamples::TGeoITkModuleSplitter::Config& cfg,
     std::unique_ptr<const Acts::Logger> logger)
-    : m_cfg(cfg), m_logger(std::move(logger)) {}
+    : m_cfg(cfg), m_logger(std::move(logger)) {
+  initSplitCategories();
+}
+
+void ActsExamples::TGeoITkModuleSplitter::initSplitCategories() {
+  m_splitCategories.reserve(m_cfg.splitPatterns.size());
+  for (const std::pair<const std::string, std::string>& pattern_split_category :
+       m_cfg.splitPatterns) {
+    // mark pattern for disc or barrel modul splits:
+    bool is_disk = false;
+    if (m_cfg.discMap.find(pattern_split_category.second) !=
+        m_cfg.discMap.end()) {
+      is_disk = true;
+    } else if (m_cfg.barrelMap.find(pattern_split_category.second) ==
+               m_cfg.barrelMap.end()) {
+      ACTS_ERROR(
+          pattern_split_category.second +
+          " is neither a category name for barrel or disk module splits.");
+      continue;
+    }
+    m_splitCategories.push_back(
+        std::make_tuple(std::regex(pattern_split_category.first),
+                        pattern_split_category.second, is_disk));
+  }
+}
 
 /// If applicable, returns a split detector element
 inline std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
@@ -28,40 +52,21 @@ ActsExamples::TGeoITkModuleSplitter::split(
   const TGeoNode& node = detElement->tgeoNode();
   auto sensorName = std::string(node.GetName());
 
-  if (sensorName.find("BRL") != std::string::npos) {
-    if (sensorName.find("MS") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitBarrelModule(
-          gctx, detElement, m_cfg.barrelMap.at("MS"));
-    }
-    if (sensorName.find("SS") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitBarrelModule(
-          gctx, detElement, m_cfg.barrelMap.at("SS"));
-    }
-  }
-  if (sensorName.find("EC") != std::string::npos) {
-    if (sensorName.find("Sensor0") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC0"));
-    }
-    if (sensorName.find("Sensor1") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC1"));
-    }
-    if (sensorName.find("Sensor2") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC2"));
-    }
-    if (sensorName.find("Sensor3") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC3"));
-    }
-    if (sensorName.find("Sensor4") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC4"));
-    }
-    if (sensorName.find("Sensor5") != std::string::npos) {
-      return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
-          gctx, detElement, m_cfg.discMap.at("EC5"));
+  static const char* category_names[2] = {"barrel", "disc"};
+  for (const std::tuple<std::regex, std::string, bool>& split_category :
+       m_splitCategories) {
+    if (std::regex_match(sensorName, std::get<0>(split_category))) {
+      ACTS_INFO("Splitting " +
+                std::string(category_names[std::get<2>(split_category)]) +
+                " node " + sensorName + " using split ranges of category " +
+                std::get<1>(split_category));
+      if (!std::get<2>(split_category)) {
+        return ActsExamples::TGeoITkModuleSplitter::splitBarrelModule(
+            gctx, detElement, m_cfg.barrelMap.at(std::get<1>(split_category)));
+      } else {
+        return ActsExamples::TGeoITkModuleSplitter::splitDiscModule(
+            gctx, detElement, m_cfg.discMap.at(std::get<1>(split_category)));
+      }
     }
   }
   ACTS_DEBUG("No matching configuration found. Node " +

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -231,6 +231,16 @@ def buildITkGeometry(
                     "EC4": [[756.901, 811.482], [811.482, 866.062]],
                     "EC5": [[867.462, 907.623], [907.623, 967.785]],
                 },
+                splitPatterns={
+                    ".*BRL.*MS.*": "MS",
+                    ".*BRL.*SS.*": "SS",
+                    ".*EC.*Sensor(|Back)0.*": "EC0",
+                    ".*EC.*Sensor(|Back)1.*": "EC1",
+                    ".*EC.*Sensor(|Back)2.*": "EC2",
+                    ".*EC.*Sensor(|Back)3.*": "EC3",
+                    ".*EC.*Sensor(|Back)4.*": "EC4",
+                    ".*EC.*Sensor(|Back)5.*": "EC5",
+                },
             ),
             Volume(
                 name="HGTD",

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -159,6 +159,7 @@ void addDetector(Context& ctx) {
     ACTS_PYTHON_MEMBER(itkModuleSplit);
     ACTS_PYTHON_MEMBER(barrelMap);
     ACTS_PYTHON_MEMBER(discMap);
+    ACTS_PYTHON_MEMBER(splitPatterns);
 
     ACTS_PYTHON_MEMBER(layers);
     ACTS_PYTHON_MEMBER(subVolumeName);


### PR DESCRIPTION
When creating a TGeo detector and ITk module splitting is enabled also split the back sides of modules (not just the front side). Also made the patterns configurable which match sensor names to the barrel and disk split configuration categories.

