### PR TITLE
refactor: transpose vectors in AMVF logging

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -56,7 +56,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
     allVerticesPtr.push_back(&vtxCandidate);
 
     ACTS_DEBUG("Position of current vertex candidate after seeding: "
-               << vtxCandidate.fullPosition());
+               << vtxCandidate.fullPosition().transpose());
     if (vtxCandidate.position().z() ==
         vertexingOptions.vertexConstraint.position().z()) {
       ACTS_DEBUG(
@@ -93,7 +93,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
       return fitResult.error();
     }
     ACTS_DEBUG("New position of current vertex candidate after fit: "
-               << vtxCandidate.fullPosition());
+               << vtxCandidate.fullPosition().transpose());
     // Check if vertex is good vertex
     auto [nCompatibleTracks, isGoodVertex] =
         checkVertexAndCompatibleTracks(vtxCandidate, seedTracks, fitterState);

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -291,7 +291,7 @@ Acts::Result<void> Acts::
         ACTS_VERBOSE("Track weight too low. Skip track.");
       }
     }  // End loop over tracks at vertex
-    ACTS_VERBOSE("New vertex position: " << vtx->fullPosition());
+    ACTS_VERBOSE("New vertex position: " << vtx->fullPosition().transpose());
   }  // End loop over vertex collection
 
   return {};


### PR DESCRIPTION
reduce AMVF logging lines by transposing vectors before printing