### PR TITLE
feat: Add python bindings to HoughTransform algorithm

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/HoughTransformSeeder.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/HoughTransformSeeder.hpp
@@ -94,7 +94,8 @@ using LayerIDFinder = Acts::Delegate<ResultUnsigned(
     double)>;  // (double r) this function will map the r of a measurement to a
                // layer.
 using SliceTester = Acts::Delegate<ResultBool(
-    double, unsigned, int)>;  // (double z,unsigned layer, int slice)
+    double, unsigned, int)>;  // (double z,unsigned layer, int slice) returns
+                              // true if measurement in slice
 
 namespace Acts {
 class TrackingGeometry;

--- a/Examples/Algorithms/TrackFinding/src/HoughTransformSeeder.cpp
+++ b/Examples/Algorithms/TrackFinding/src/HoughTransformSeeder.cpp
@@ -17,6 +17,7 @@
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsExamples/EventData/SimSeed.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsExamples/TrackFinding/DefaultHoughFunctions.hpp"
 
 #include <stdexcept>
 
@@ -43,28 +44,28 @@ ActsExamples::HoughTransformSeeder::HoughTransformSeeder(
   }
 
   if (!foundInput) {
-    ACTS_ERROR("Missing some kind of input");
+    throw std::invalid_argument("Missing some kind of input");
   }
 
   if (m_cfg.outputProtoTracks.empty()) {
-    ACTS_ERROR("Missing hough tracks output collection");
+    throw std::invalid_argument("Missing hough tracks output collection");
   }
   if (m_cfg.inputSourceLinks.empty()) {
-    ACTS_ERROR("Missing source link input collection");
+    throw std::invalid_argument("Missing source link input collection");
   }
 
   if (not m_cfg.trackingGeometry) {
-    ACTS_ERROR("Missing tracking geometry");
+    throw std::invalid_argument("Missing tracking geometry");
   }
 
   if (m_cfg.geometrySelection.empty()) {
-    ACTS_ERROR("Missing geometry selection");
+    throw std::invalid_argument("Missing geometry selection");
   }
   // ensure geometry selection contains only valid inputs
   for (const auto& geoId : m_cfg.geometrySelection) {
     if ((geoId.approach() != 0u) or (geoId.boundary() != 0u) or
         (geoId.sensitive() != 0u)) {
-      ACTS_ERROR(
+      throw std::invalid_argument(
           "Invalid geometry selection: only volume and layer are allowed to be "
           "set");
     }
@@ -114,6 +115,13 @@ ActsExamples::HoughTransformSeeder::HoughTransformSeeder(
     m_bins_y.push_back(
         unquant(m_cfg.yMin, m_cfg.yMax, m_cfg.houghHistSize_y, i));
   }
+
+  m_cfg.fieldCorrector
+      .connect<&ActsExamples::DefaultHoughFunctions::fieldCorrectionDefault>();
+  m_cfg.layerIDFinder
+      .connect<&ActsExamples::DefaultHoughFunctions::findLayerIDDefault>();
+  m_cfg.sliceTester
+      .connect<&ActsExamples::DefaultHoughFunctions::inSliceDefault>();
 }
 
 ActsExamples::ProcessCode ActsExamples::HoughTransformSeeder::execute(
@@ -131,7 +139,8 @@ ActsExamples::ProcessCode ActsExamples::HoughTransformSeeder::execute(
   protoTracks.clear();
 
   // loop over our subregions and run the Hough Transform on each
-  for (auto subregion : m_cfg.subRegions) {
+  for (int subregion : m_cfg.subRegions) {
+    ACTS_DEBUG("Processing subregion " << subregion);
     ActsExamples::HoughHist m_houghHist = createHoughHist(subregion);
 
     for (unsigned y = 0; y < m_cfg.houghHistSize_y; y++) {
@@ -428,7 +437,10 @@ void ActsExamples::HoughTransformSeeder::addSpacePoints(
   // construct the combined input container of space point pointers from all
   // configured input sources.
   for (const auto& isp : m_cfg.inputSpacePoints) {
-    for (auto& sp : ctx.eventStore.get<SimSpacePointContainer>(isp)) {
+    auto spContainer = ctx.eventStore.get<SimSpacePointContainer>(isp);
+    ACTS_DEBUG("Inserting " << spContainer.size() << " space points from "
+                            << isp);
+    for (auto& sp : spContainer) {
       double r = std::hypot(sp.x(), sp.y());
       double z = sp.z();
       float phi = std::atan2(sp.y(), sp.x());
@@ -456,6 +468,9 @@ void ActsExamples::HoughTransformSeeder::addMeasurements(
       ctx.eventStore.get<MeasurementContainer>(m_cfg.inputMeasurements);
   const auto& sourceLinks =
       ctx.eventStore.get<IndexSourceLinkContainer>(m_cfg.inputSourceLinks);
+
+  ACTS_DEBUG("Inserting " << measurements.size() << " space points from "
+                          << m_cfg.inputMeasurements);
 
   for (Acts::GeometryIdentifier geoId : m_cfg.geometrySelection) {
     // select volume/layer depending on what is set in the geometry id

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -12,6 +12,7 @@
 #include "ActsExamples/TrackFinding/AmbiguityResolutionAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/SeedingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/SeedingOrthogonalAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/HoughTransformSeeder.hpp"
 #include "ActsExamples/TrackFinding/SpacePointMaker.hpp"
 #include "ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp"
@@ -223,6 +224,13 @@ void addTrackFinding(Context& ctx) {
       ActsExamples::SeedingOrthogonalAlgorithm, mex,
       "SeedingOrthogonalAlgorithm", inputSpacePoints, outputSeeds,
       outputProtoTracks, seedFilterConfig, seedFinderConfig, seedFinderOptions);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(
+    ActsExamples::HoughTransformSeeder, mex,
+    "HoughTransformSeeder", inputSpacePoints, outputSeeds, outputProtoTracks,
+    inputSourceLinks, trackingGeometry, geometrySelection, inputMeasurements,
+    subRegions, nLayers, xMin, xMax, yMin, yMax, houghHistSize_x, houghHistSize_y,
+    hitExtend_x, threshold, localMaxWindowSize, kA);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       ActsExamples::TrackParamsEstimationAlgorithm, mex,


### PR DESCRIPTION
This PR adds python binding to the the HoughTransform algorithm in examples.
So far, it does not add python helper to set it up in test job. However I tested these bindings in the itk_full_chain job up to the level that I could see this algorithm digests some data.

Tagging @jahreda for a review.


