### PR TITLE
fix: MultiTrajectory specialize DynamicColumn for bool

### DIFF
--- a/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
@@ -24,6 +24,72 @@ using MultiTrajectoryTraits::IndexType;
 constexpr auto kInvalid = MultiTrajectoryTraits::kInvalid;
 constexpr auto MeasurementSizeMax = MultiTrajectoryTraits::MeasurementSizeMax;
 
+struct DynamicColumnBase {
+  virtual ~DynamicColumnBase() = 0;
+
+  virtual std::any get(size_t i) = 0;
+  virtual std::any get(size_t i) const = 0;
+
+  virtual void add() = 0;
+  virtual void clear() = 0;
+
+  virtual std::unique_ptr<DynamicColumnBase> clone() const = 0;
+};
+
+inline DynamicColumnBase::~DynamicColumnBase() = default;
+
+template <typename T>
+struct DynamicColumn : public DynamicColumnBase {
+  ~DynamicColumn() override = default;
+
+  std::any get(size_t i) override {
+    assert(i < m_vector.size() && "DynamicColumn out of bounds");
+    return &m_vector[i];
+  }
+
+  std::any get(size_t i) const override {
+    assert(i < m_vector.size() && "DynamicColumn out of bounds");
+    return &m_vector[i];
+  }
+
+  void add() override { m_vector.emplace_back(); }
+  void clear() override { m_vector.clear(); }
+
+  std::unique_ptr<DynamicColumnBase> clone() const override {
+    return std::make_unique<DynamicColumn<T>>(*this);
+  }
+
+  std::vector<T> m_vector;
+};
+
+template <>
+struct DynamicColumn<bool> : public DynamicColumnBase {
+  struct Wrapper {
+    bool value;
+  };
+
+  ~DynamicColumn() override = default;
+
+  std::any get(size_t i) override {
+    assert(i < m_vector.size() && "DynamicColumn out of bounds");
+    return &m_vector[i].value;
+  }
+
+  std::any get(size_t i) const override {
+    assert(i < m_vector.size() && "DynamicColumn out of bounds");
+    return &m_vector[i].value;
+  }
+
+  void add() override { m_vector.emplace_back(); }
+  void clear() override { m_vector.clear(); }
+
+  std::unique_ptr<DynamicColumnBase> clone() const override {
+    return std::make_unique<DynamicColumn<bool>>(*this);
+  }
+
+  std::vector<Wrapper> m_vector;
+};
+
 class VectorMultiTrajectoryBase {
  public:
   struct Statistics {
@@ -162,70 +228,6 @@ class VectorMultiTrajectoryBase {
   };
 
   VectorMultiTrajectoryBase(VectorMultiTrajectoryBase&& other) = default;
-
-  struct DynamicColumnBase {
-    virtual ~DynamicColumnBase() = 0;
-
-    virtual std::any get(size_t i) = 0;
-    virtual std::any get(size_t i) const = 0;
-
-    virtual void add() = 0;
-    virtual void clear() = 0;
-
-    virtual std::unique_ptr<DynamicColumnBase> clone() const = 0;
-  };
-
-  template <typename T>
-  struct DynamicColumn : public DynamicColumnBase {
-    ~DynamicColumn() override = default;
-
-    std::any get(size_t i) override {
-      assert(i < m_vector.size() && "DynamicColumn out of bounds");
-      return &m_vector[i];
-    }
-
-    std::any get(size_t i) const override {
-      assert(i < m_vector.size() && "DynamicColumn out of bounds");
-      return &m_vector[i];
-    }
-
-    void add() override { m_vector.emplace_back(); }
-    void clear() override { m_vector.clear(); }
-
-    std::unique_ptr<DynamicColumnBase> clone() const override {
-      return std::make_unique<DynamicColumn<T>>(*this);
-    }
-
-    std::vector<T> m_vector;
-  };
-
-  template <>
-  struct DynamicColumn<bool> : public DynamicColumnBase {
-    struct Wrapper {
-      bool value;
-    };
-
-    ~DynamicColumn() override = default;
-
-    std::any get(size_t i) override {
-      assert(i < m_vector.size() && "DynamicColumn out of bounds");
-      return &m_vector[i].value;
-    }
-
-    std::any get(size_t i) const override {
-      assert(i < m_vector.size() && "DynamicColumn out of bounds");
-      return &m_vector[i].value;
-    }
-
-    void add() override { m_vector.emplace_back(); }
-    void clear() override { m_vector.clear(); }
-
-    std::unique_ptr<DynamicColumnBase> clone() const override {
-      return std::make_unique<DynamicColumn<bool>>(*this);
-    }
-
-    std::vector<Wrapper> m_vector;
-  };
 
   // BEGIN INTERFACE HELPER
   template <typename T>
@@ -476,7 +478,8 @@ class VectorMultiTrajectory final
 
   template <typename T>
   constexpr void addColumn_impl(const std::string& key) {
-    m_dynamic.insert({hashString(key), std::make_unique<DynamicColumn<T>>()});
+    m_dynamic.insert(
+        {hashString(key), std::make_unique<detail_vmt::DynamicColumn<T>>()});
   }
 
   constexpr bool hasColumn_impl(HashedString key) const {

--- a/Core/src/EventData/VectorMultiTrajectory.cpp
+++ b/Core/src/EventData/VectorMultiTrajectory.cpp
@@ -22,9 +22,6 @@
 
 namespace Acts {
 
-detail_vmt::VectorMultiTrajectoryBase::DynamicColumnBase::~DynamicColumnBase() =
-    default;
-
 auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
                                                IndexType iprevious)
     -> IndexType {


### PR DESCRIPTION
As vector is specialized on bool, which prevents getting references to the underlying bool mechanisms, we have to specialize `DynamiColumn` to break this specialization of vector.

I'm also rolling in another small const-correctness fix to dynamic columns into this PR.