### PR TITLE
fix: remove `CustomDefaultLogger.cpp`-entry from docs

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -125,15 +125,6 @@ the following way (tested under Unix)
 $ LD_PRELOAD=<YOUR_SHARED_LIBRARY> path/to/your/exectuable
 ```
 
-For an example have a look at [`CustomDefaultLogger.cpp`](https://github.com/acts-project/acts/blob/main/Examples/Run/Misc/CustomDefaultLogger.cpp) which you can use as
-follows:
-
-```console
-$ cd <ACTS/INSTALL/DIRECTORY>
-$ source bin/setup.sh
-$ LD_PRELOAD=lib/libActsCustomLogger.so bin/Examples/ActsGenericDetector
-```
-
 ## Logging thresholds
 
 Generally, log levels in ACTS are only of informative value: even


### PR DESCRIPTION
As stated in issue [Issue#1734](https://github.com/acts-project/acts/issues/1734), the CI fails at the full-docs-build, after we removed the CustomDefaultLogger.

Since the logging will be revised, this part is now removed from the docs and should be updated in the future.

This PR is also a followup to [PR#1724](https://github.com/acts-project/acts/pull/1724) to some extent.