### PR TITLE
fix: Remove progress_display where it is not used

### DIFF
--- a/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
+++ b/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
@@ -6,6 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "materialComposition.C"
+
 #include "ActsExamples/Utilities/Options.hpp"
 
 #include <exception>
@@ -14,19 +16,6 @@
 
 #include <TApplication.h>
 #include <boost/program_options.hpp>
-
-#define BOOST_AVAILABLE 1
-#if ((BOOST_VERSION / 100) % 1000) <= 71
-// Boost <=1.71 and lower do not have progress_display.hpp as a replacement yet
-#include <boost/progress.hpp>
-using progress_display = boost::progress_display;
-#else
-// Boost >=1.72 can use this as a replacement
-#include <boost/timer/progress_display.hpp>
-using progress_display = boost::timer::progress_display;
-#endif
-
-#include "materialComposition.C"
 
 using namespace boost::program_options;
 using VariableReals = ActsExamples::Options::VariableReals;

--- a/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
+++ b/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
@@ -15,17 +15,6 @@
 #include <TApplication.h>
 #include <boost/program_options.hpp>
 
-#define BOOST_AVAILABLE 1
-#if ((BOOST_VERSION / 100) % 1000) <= 71
-// Boost <=1.71 and lower do not have progress_display.hpp as a replacement yet
-#include <boost/progress.hpp>
-using progress_display = boost::progress_display;
-#else
-// Boost >=1.72 can use this as a replacement
-#include <boost/timer/progress_display.hpp>
-using progress_display = boost::timer::progress_display;
-#endif
-
 #define NLOHMANN_AVAILABLE 1
 #include <nlohmann/json.hpp>
 


### PR DESCRIPTION
Solves part of the issue #1736 by removing inclusion of the headers related to progress_display as it was unused. 