### PR TITLE
fix: Multistepper error condition

### DIFF
--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
@@ -221,7 +221,7 @@ Result<double> MultiEigenStepperLoop<E, R, A>::step(
   }
 
   // Return error if there is no ok result
-  if (errorSteps == results.size()) {
+  if (stepping.components.empty()) {
     return MultiStepperError::AllComponentsSteppingError;
   }
 


### PR DESCRIPTION
There was a wrong abort condition in the `EigenMultiStepperLoop`'s step function, I think a leftover from a previous refactoring. This could lead to rare cases of not aborting the propagation, if all components have a stepping failure.
The new condition should fix this.