### PR TITLE
refactor!: MTJ uncalibrated -> uncalibratedSourceLink

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -316,9 +316,10 @@ class TrackStateProxy {
       }
 
       // need to do it this way since other might be nullptr
-      component<std::optional<SourceLink>, hashString("uncalibrated")>() =
+      component<std::optional<SourceLink>,
+                hashString("uncalibratedSourceLink")>() =
           other.template component<std::optional<SourceLink>,
-                                   hashString("uncalibrated")>();
+                                   hashString("uncalibratedSourceLink")>();
 
       if (ACTS_CHECK_BIT(src, PM::Jacobian)) {
         jacobian() = other.jacobian();
@@ -366,9 +367,10 @@ class TrackStateProxy {
       }
 
       // need to do it this way since other might be nullptr
-      component<std::optional<SourceLink>, hashString("uncalibrated")>() =
+      component<std::optional<SourceLink>,
+                hashString("uncalibratedSourceLink")>() =
           other.template component<std::optional<SourceLink>,
-                                   hashString("uncalibrated")>();
+                                   hashString("uncalibratedSourceLink")>();
 
       if (ACTS_CHECK_BIT(mask, PM::Jacobian) && has<hashString("jacobian")>() &&
           other.template has<hashString("jacobian")>()) {
@@ -730,19 +732,21 @@ class TrackStateProxy {
 
   /// Uncalibrated measurement in the form of a source link. Const version
   /// @return The uncalibrated measurement source link
-  const SourceLink& uncalibrated() const;
+  const SourceLink& uncalibratedSourceLink() const;
 
   /// Set an uncalibrated source link
   /// @param sourceLink The uncalibrated source link to set
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
-  void setUncalibrated(const SourceLink& sourceLink) {
-    component<std::optional<SourceLink>, hashString("uncalibrated")>() =
-        sourceLink;
+  void setUncalibratedSourceLink(const SourceLink& sourceLink) {
+    component<std::optional<SourceLink>,
+              hashString("uncalibratedSourceLink")>() = sourceLink;
   }
 
   /// Check if the point has an associated uncalibrated measurement.
   /// @return Whether it is set
-  bool hasUncalibrated() const { return has<hashString("uncalibrated")>(); }
+  bool hasUncalibratedSourceLink() const {
+    return has<hashString("uncalibratedSourceLink")>();
+  }
 
   /// Check if the point has an associated calibrated measurement.
   /// @return Whether it is set

--- a/Core/include/Acts/EventData/MultiTrajectory.ipp
+++ b/Core/include/Acts/EventData/MultiTrajectory.ipp
@@ -76,10 +76,11 @@ inline auto TrackStateProxy<D, M, ReadOnly>::projector() const -> Projector {
 }
 
 template <typename D, size_t M, bool ReadOnly>
-inline auto TrackStateProxy<D, M, ReadOnly>::uncalibrated() const
+inline auto TrackStateProxy<D, M, ReadOnly>::uncalibratedSourceLink() const
     -> const SourceLink& {
-  assert(has<hashString("uncalibrated")>());
-  return component<std::optional<SourceLink>, hashString("uncalibrated")>()
+  assert(has<hashString("uncalibratedSourceLink")>());
+  return component<std::optional<SourceLink>,
+                   hashString("uncalibratedSourceLink")>()
       .value();
 }
 

--- a/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
@@ -183,7 +183,7 @@ class VectorMultiTrajectoryBase {
         return instance.m_index[istate].ijacobian != kInvalid;
       case "projector"_hash:
         return instance.m_index[istate].iprojector != kInvalid;
-      case "uncalibrated"_hash:
+      case "uncalibratedSourceLink"_hash:
         return instance.m_sourceLinks[instance.m_index[istate].iuncalibrated]
             .has_value();
       case "previous"_hash:
@@ -224,7 +224,7 @@ class VectorMultiTrajectoryBase {
         return &instance.m_index[istate].ijacobian;
       case "projector"_hash:
         return &instance.m_projectors[instance.m_index[istate].iprojector];
-      case "uncalibrated"_hash:
+      case "uncalibratedSourceLink"_hash:
         return &instance.m_sourceLinks[instance.m_index[istate].iuncalibrated];
       case "calibratedSourceLink"_hash:
         return &instance.m_sourceLinks[instance.m_index[istate]
@@ -264,7 +264,7 @@ class VectorMultiTrajectoryBase {
       case "jacobian"_hash:
       case "projector"_hash:
       case "previous"_hash:
-      case "uncalibrated"_hash:
+      case "uncalibratedSourceLink"_hash:
       case "calibratedSourceLink"_hash:
       case "referenceSurface"_hash:
       case "measdim"_hash:

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -848,7 +848,7 @@ class CombinatorialKalmanFilter {
 
         ts.setReferenceSurface(boundParams.referenceSurface().getSharedPtr());
 
-        ts.setUncalibrated(sourceLink);
+        ts.setUncalibratedSourceLink(sourceLink);
 
         // now calibrate the track state
         m_extensions.calibrator(gctx, ts);

--- a/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
+++ b/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
@@ -392,7 +392,7 @@ class Chi2Fitter {
         trackStateProxy.setReferenceSurface(surface->getSharedPtr());
 
         // assign the source link to the track state
-        trackStateProxy.setUncalibrated(sourcelink_it->second);
+        trackStateProxy.setUncalibratedSourceLink(sourcelink_it->second);
 
         // Fill the track state
         trackStateProxy.predicted() = std::move(boundParams.parameters());

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -703,7 +703,7 @@ class KalmanFitter {
         trackStateProxy.setReferenceSurface(surface->getSharedPtr());
 
         // Assign the source link to the detached track state
-        trackStateProxy.setUncalibrated(sourcelink_it->second);
+        trackStateProxy.setUncalibratedSourceLink(sourcelink_it->second);
 
         // Fill the track state
         trackStateProxy.predicted() = std::move(boundParams.parameters());

--- a/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
+++ b/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
@@ -60,7 +60,7 @@ auto kalmanHandleMeasurement(
   trackStateProxy.setReferenceSurface(surface.getSharedPtr());
 
   // assign the source link to the track state
-  trackStateProxy.setUncalibrated(source_link);
+  trackStateProxy.setUncalibratedSourceLink(source_link);
 
   // Fill the track state
   trackStateProxy.predicted() = std::move(boundParams.parameters());

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp
@@ -136,8 +136,9 @@ void TrackFindingAlgorithm::computeSharedHits(
         continue;
       }
 
-      std::size_t hitIndex =
-          state.uncalibrated().template get<IndexSourceLink>().index();
+      std::size_t hitIndex = state.uncalibratedSourceLink()
+                                 .template get<IndexSourceLink>()
+                                 .index();
 
       // Check if hit not already used
       if (firstTrackOnTheHit.at(hitIndex) ==

--- a/Examples/Algorithms/TrackFinding/src/AmbiguityResolutionAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/AmbiguityResolutionAlgorithm.cpp
@@ -56,7 +56,7 @@ std::vector<std::size_t> computeSharedHits(
       }
 
       const std::size_t indexHit =
-          state.uncalibrated()
+          state.uncalibratedSourceLink()
               .template get<ActsExamples::IndexSourceLink>()
               .index();
 
@@ -79,7 +79,7 @@ std::vector<std::size_t> computeSharedHits(
       }
 
       const std::size_t indexHit =
-          state.uncalibrated()
+          state.uncalibratedSourceLink()
               .template get<ActsExamples::IndexSourceLink>()
               .index();
 

--- a/Examples/Algorithms/TrackFinding/src/TrajectoriesToPrototracks.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrajectoriesToPrototracks.cpp
@@ -32,7 +32,7 @@ ProcessCode TrajectoriesToPrototracks::execute(
         }
 
         const auto& source_link =
-            state.uncalibrated().template get<IndexSourceLink>();
+            state.uncalibratedSourceLink().template get<IndexSourceLink>();
         track.push_back(source_link.index());
 
         return true;

--- a/Examples/Framework/include/ActsExamples/EventData/Measurement.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/Measurement.hpp
@@ -47,7 +47,7 @@ class MeasurementCalibrator {
       Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy
           trackState) const {
     const IndexSourceLink& sourceLink =
-        trackState.uncalibrated().get<IndexSourceLink>();
+        trackState.uncalibratedSourceLink().get<IndexSourceLink>();
     assert(m_measurements and
            "Undefined measurement container in DigitizedCalibrator");
     assert((sourceLink.index() < m_measurements->size()) and

--- a/Examples/Framework/src/Validation/TrackClassification.cpp
+++ b/Examples/Framework/src/Validation/TrackClassification.cpp
@@ -76,7 +76,7 @@ void ActsExamples::identifyContributingParticles(
     }
     // register all particles that generated this hit
     const IndexSourceLink& sl =
-        state.uncalibrated().template get<IndexSourceLink>();
+        state.uncalibratedSourceLink().template get<IndexSourceLink>();
     auto hitIndex = sl.index();
     for (auto hitParticle : makeRange(hitParticlesMap.equal_range(hitIndex))) {
       increaseHitCount(particleHitCounts, hitParticle.second);

--- a/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
@@ -314,7 +314,8 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryStatesWriter::writeT(
 
         // get the truth hits corresponding to this trackState
         // Use average truth in the case of multiple contributing sim hits
-        const auto& sl = state.uncalibrated().template get<IndexSourceLink>();
+        const auto& sl =
+            state.uncalibratedSourceLink().template get<IndexSourceLink>();
         const auto hitIdx = sl.index();
         auto indices = makeRange(hitSimHitsMap.equal_range(hitIdx));
         auto [truthLocal, truthPos4, truthUnitDir] =

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/TestSourceLink.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/TestSourceLink.hpp
@@ -83,18 +83,19 @@ Acts::BoundVariantMeasurement testSourceLinkCalibratorReturn(
     const GeometryContext& /*gctx*/,
     typename trajectory_t::TrackStateProxy trackState) {
   const TestSourceLink& sl =
-      trackState.uncalibrated().template get<TestSourceLink>();
+      trackState.uncalibratedSourceLink().template get<TestSourceLink>();
   if ((sl.indices[0] != Acts::eBoundSize) and
       (sl.indices[1] != Acts::eBoundSize)) {
-    auto meas = makeMeasurement(trackState.uncalibrated(), sl.parameters,
-                                sl.covariance, sl.indices[0], sl.indices[1]);
+    auto meas =
+        makeMeasurement(trackState.uncalibratedSourceLink(), sl.parameters,
+                        sl.covariance, sl.indices[0], sl.indices[1]);
     trackState.allocateCalibrated(2);
     trackState.setCalibrated(meas);
     return meas;
   } else if (sl.indices[0] != Acts::eBoundSize) {
-    auto meas =
-        makeMeasurement(trackState.uncalibrated(), sl.parameters.head<1>(),
-                        sl.covariance.topLeftCorner<1, 1>(), sl.indices[0]);
+    auto meas = makeMeasurement(
+        trackState.uncalibratedSourceLink(), sl.parameters.head<1>(),
+        sl.covariance.topLeftCorner<1, 1>(), sl.indices[0]);
     trackState.allocateCalibrated(1);
     trackState.setCalibrated(meas);
     return meas;

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/TestTrackState.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/TestTrackState.hpp
@@ -116,7 +116,7 @@ void fillTrackState(const TestTrackState& pc, TrackStatePropMask mask,
   ts.chi2() = pc.chi2;
   ts.pathLength() = pc.pathLength;
   // source link defines the uncalibrated measurement
-  ts.setUncalibrated(Acts::SourceLink{pc.sourceLink});
+  ts.setUncalibratedSourceLink(Acts::SourceLink{pc.sourceLink});
   // create calibrated measurements from source link
   if (ACTS_CHECK_BIT(mask, TrackStatePropMask::Calibrated)) {
     testSourceLinkCalibrator<VectorMultiTrajectory>(Acts::GeometryContext{},

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -410,11 +410,13 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCrossTalk) {
     // create a new (invalid) source link
     TestSourceLink invalid;
     invalid.sourceId = -1;
-    BOOST_CHECK_NE(tsa.uncalibrated().get<TestSourceLink>(), invalid);
-    BOOST_CHECK_NE(tsb.uncalibrated().get<TestSourceLink>(), invalid);
-    tsb.setUncalibrated(SourceLink{invalid});
-    BOOST_CHECK_EQUAL(tsa.uncalibrated().get<TestSourceLink>(), invalid);
-    BOOST_CHECK_EQUAL(tsb.uncalibrated().get<TestSourceLink>(), invalid);
+    BOOST_CHECK_NE(tsa.uncalibratedSourceLink().get<TestSourceLink>(), invalid);
+    BOOST_CHECK_NE(tsb.uncalibratedSourceLink().get<TestSourceLink>(), invalid);
+    tsb.setUncalibratedSourceLink(SourceLink{invalid});
+    BOOST_CHECK_EQUAL(tsa.uncalibratedSourceLink().get<TestSourceLink>(),
+                      invalid);
+    BOOST_CHECK_EQUAL(tsb.uncalibratedSourceLink().get<TestSourceLink>(),
+                      invalid);
   }
   {
     // reset measurements w/ full parameters
@@ -478,7 +480,7 @@ BOOST_AUTO_TEST_CASE(TrackStateReassignment) {
 
   // use temporary measurement to reset calibrated data
   TestTrackState ttsb(rng, 2u);
-  ts.setUncalibrated(SourceLink{ttsb.sourceLink});
+  ts.setUncalibratedSourceLink(SourceLink{ttsb.sourceLink});
   auto meas = testSourceLinkCalibratorReturn<VectorMultiTrajectory>(gctx, ts);
   auto m2 = std::get<Measurement<BoundIndices, 2u>>(meas);
 
@@ -524,8 +526,9 @@ BOOST_DATA_TEST_CASE(TrackStateProxyStorage, bd::make({1u, 2u}),
   // check that chi2 is set
   BOOST_CHECK_EQUAL(ts.chi2(), pc.chi2);
 
-  // check that the uncalibrated source link is set
-  BOOST_CHECK_EQUAL(ts.uncalibrated().get<TestSourceLink>(), pc.sourceLink);
+  // check that the uncalibratedSourceLink source link is set
+  BOOST_CHECK_EQUAL(ts.uncalibratedSourceLink().get<TestSourceLink>(),
+                    pc.sourceLink);
 
   // check that the calibrated measurement is set
   BOOST_CHECK(ts.hasCalibrated());
@@ -600,7 +603,8 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyAllocations) {
   BOOST_CHECK(!tsnone.has<"calibrated"_hash>());
   BOOST_CHECK(!tsnone.has<"projector"_hash>());
   BOOST_CHECK(
-      !tsnone.has<"uncalibrated"_hash>());  // separate optional mechanism
+      !tsnone.has<"uncalibratedSourceLink"_hash>());  // separate optional
+                                                      // mechanism
   BOOST_CHECK(tsnone.has<"calibratedSourceLink"_hash>());
   BOOST_CHECK(tsnone.has<"referenceSurface"_hash>());
   BOOST_CHECK(tsnone.has<"measdim"_hash>());
@@ -617,8 +621,9 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyAllocations) {
   tsall.allocateCalibrated(5);
   BOOST_CHECK(tsall.has<"calibrated"_hash>());
   BOOST_CHECK(tsall.has<"projector"_hash>());
-  BOOST_CHECK(!tsall.has<"uncalibrated"_hash>());  // separate optional
-                                                   // mechanism: nullptr
+  BOOST_CHECK(
+      !tsall.has<"uncalibratedSourceLink"_hash>());  // separate optional
+                                                     // mechanism: nullptr
   BOOST_CHECK(tsall.has<"calibratedSourceLink"_hash>());
   BOOST_CHECK(tsall.has<"referenceSurface"_hash>());
   BOOST_CHECK(tsall.has<"measdim"_hash>());
@@ -770,8 +775,8 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCopy) {
   BOOST_CHECK_NE(ts1.smoothed(), ts2.smoothed());
   BOOST_CHECK_NE(ts1.smoothedCovariance(), ts2.smoothedCovariance());
 
-  BOOST_CHECK_NE(ts1.uncalibrated().get<TestSourceLink>(),
-                 ts2.uncalibrated().get<TestSourceLink>());
+  BOOST_CHECK_NE(ts1.uncalibratedSourceLink().get<TestSourceLink>(),
+                 ts2.uncalibratedSourceLink().get<TestSourceLink>());
 
   BOOST_CHECK_NE(ts1.calibratedSourceLink().get<TestSourceLink>(),
                  ts2.calibratedSourceLink().get<TestSourceLink>());
@@ -800,8 +805,8 @@ BOOST_AUTO_TEST_CASE(TrackStateProxyCopy) {
   BOOST_CHECK_EQUAL(ts1.smoothed(), ts2.smoothed());
   BOOST_CHECK_EQUAL(ts1.smoothedCovariance(), ts2.smoothedCovariance());
 
-  BOOST_CHECK_EQUAL(ts1.uncalibrated().get<TestSourceLink>(),
-                    ts2.uncalibrated().get<TestSourceLink>());
+  BOOST_CHECK_EQUAL(ts1.uncalibratedSourceLink().get<TestSourceLink>(),
+                    ts2.uncalibratedSourceLink().get<TestSourceLink>());
 
   BOOST_CHECK_EQUAL(ts1.calibratedSourceLink().get<TestSourceLink>(),
                     ts2.calibratedSourceLink().get<TestSourceLink>());

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -315,7 +315,8 @@ BOOST_AUTO_TEST_CASE(ZeroFieldForward) {
     size_t nummismatchedHits = 0u;
     for (const auto trackState : track.trackStates()) {
       numHits += 1u;
-      const auto& sl = trackState.uncalibrated().template get<TestSourceLink>();
+      const auto& sl =
+          trackState.uncalibratedSourceLink().template get<TestSourceLink>();
       if (trackId != sl.sourceId) {
         nummismatchedHits++;
       }
@@ -371,7 +372,8 @@ BOOST_AUTO_TEST_CASE(ZeroFieldBackward) {
     size_t nummismatchedHits = 0u;
     for (const auto trackState : track.trackStates()) {
       numHits += 1u;
-      const auto& sl = trackState.uncalibrated().template get<TestSourceLink>();
+      const auto& sl =
+          trackState.uncalibratedSourceLink().template get<TestSourceLink>();
       if (trackId != sl.sourceId) {
         nummismatchedHits++;
       }

--- a/Tests/UnitTests/Core/TrackFitting/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GainMatrixUpdaterTests.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(Update) {
   ts.predicted() = trkPar;
   ts.predictedCovariance() = trkCov;
   ts.pathLength() = 0.;
-  ts.setUncalibrated(SourceLink{std::move(sourceLink)});
+  ts.setUncalibratedSourceLink(SourceLink{std::move(sourceLink)});
   testSourceLinkCalibrator<VectorMultiTrajectory>(tgContext, ts);
 
   // Check that the state has storage available


### PR DESCRIPTION
Closes #1613.
This changes the uncalibrated source link access functions to be symmetric with the calibrated functions.