### PR TITLE
fix: missing includes in SeedFinderOrthogonal

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -6,9 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "Acts/Geometry/Extent.hpp"
 #include "Acts/Seeding/SeedFilter.hpp"
 #include "Acts/Seeding/SeedFinderOrthogonalConfig.hpp"
 #include "Acts/Seeding/SeedFinderUtils.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 
 #include <cmath>
 #include <functional>


### PR DESCRIPTION
Missing includes in `SeedFinderOrthogonal`. Without this PR, the acts code (`v22.0.0`) will not compile as is in Athena, obliging the costumer to include manually in their code the missing includes.

Compilation was complaining with:
```'Extent' is not a member of 'Acts'```
and 
```'binR' is not a member of 'Acts'```