### PR TITLE
fix: maybe-uninitialized warning in DetectorVolume.cpp

### DIFF
--- a/Core/src/Geometry/DetectorVolume.cpp
+++ b/Core/src/Geometry/DetectorVolume.cpp
@@ -203,8 +203,8 @@ void Acts::Experimental::DetectorVolume::createBoundingBox(
       vertices.push_back(v);
     }
   }
-  Acts::Vector3 vmin;
-  Acts::Vector3 vmax;
+  Acts::Vector3 vmin = Acts::Vector3::Zero();
+  Acts::Vector3 vmax = Acts::Vector3::Zero();
   for (const auto& v : vertices) {
     vmin = vmin.cwiseMin(v);
     vmax = vmax.cwiseMax(v);


### PR DESCRIPTION
My GCC reports a `-Wmaybe-uninitialized` warning, this PR should fix it.