### PR TITLE
docs: Add new CERN students to `CITATION.cff`

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -88,6 +88,30 @@
     {
       "affiliation": "Stanford University",
       "name": "Rocky Bala Garg"
+    },
+    {
+      "affiliation": "CERN / TU Wien",
+      "name": "Andreas Stefl"
+    },
+    {
+      "affiliation": "CERN / University of Coimbra",
+      "name": "Luis Falda Coelho",
+      "orcid": "0000-0002-2298-3605"
+    },
+    {
+      "affiliation": "CERN / University of Graz",
+      "name": "Alexander J. Pfleger",
+      "orcid": "0000-0001-5524-7738"
+    },
+    {
+      "affiliation": "University of Lisbon",
+      "name": "Guilherme Almeida",
+      "orcid": "0000-0002-4257-4278"
+    },
+    {
+      "affiliation": "CERN / University of Amsterdam",
+      "name": "Stephen Nicholas Swatman",
+      "orcid": "0000-0002-3747-3229"
     }
   ],
   "access_right": "open",

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,9 @@ The following people have contributed to the project (in alphabetical order):
 
 - Xiaocong Ai, DESY
 - Corentin Allaire, CERN
+- Guilherme Almeida, University of Lisbon
 - Noemi Calace, CERN
+- Luis Falda Coelho, CERN, University of Coimbra
 - Paul Gessinger, JGU Mainz
 - Hadrien Grasland, CNRS
 - Heather Gray, LBNL
@@ -11,5 +13,8 @@ The following people have contributed to the project (in alphabetical order):
 - Moritz Kiehn, CERN
 - Fabian Klimpel, CERN
 - Robert Langenberg, UMass
+- Alexander J. Pfleger, CERN, University of Graz
 - Andreas Salzburger, CERN
 - Bastian Schlag, CERN, JGU Mainz
+- Andreas Stefl, CERN, TU Wien
+- Stephen Nicholas Swatman, CERN, University of Amsterdam

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -67,6 +67,25 @@ authors:
   family-names: Garg
   name-particle: Bala
   affiliation: Stanford University
+- given-names: Andreas
+  family-names: Stefl
+  affiliation: CERN / TU Wien
+- given-names: Luis Falda
+  family-names: Coelho
+  affiliation: CERN / University of Coimbra
+  orcid: https://orcid.org/0000-0002-2298-3605
+- given-names: Alexander J.
+  family-names: Pfleger
+  affiliation: CERN / University of Graz
+  orcid: https://orcid.org/0000-0001-5524-7738
+- given-names: Guilherme
+  family-names: Almeida
+  affiliation: University of Lisbon
+  orcid: https://orcid.org/0000-0002-4257-4278
+- given-names: Stephen Nicholas
+  family-names: Swatman
+  affiliation: CERN / University of Amsterdam
+  orcid: https://orcid.org/0000-0002-3747-3229
 version: 10.0.0
 date-released: 2021-07-28
 repository-code: https://github.com/acts-project/acts


### PR DESCRIPTION
This commit adds several of the recent CERN contributors to the `CITATION.cff` file. In particular, it adds @andiwand, @LuisFelipeCoelho, @AJPfleger, @guilhermeAlmeida1, and myself.

If you are listed above please check that I got your information right.

If you are not listed above but you would like to be please consider that I only added the people for whom I could pass by their office to ask for their affiliations. Feel free to add yourself. :smile: 