### PR TITLE
feat: throw runtime_error in seed finder if deltaR values were not initialised

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -23,16 +23,16 @@ SeedFinder<external_spacepoint_t, platform_t>::SeedFinder(
         "SeedFinderConfig not in ACTS internal units in SeedFinder");
   }
   if (std::numeric_limits<decltype(config.deltaRMaxTopSP)>::has_quiet_NaN) {
-    throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(config.deltaRMinTopSP)>::has_quiet_NaN) {
-    throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(config.deltaRMaxBottomSP)>::has_quiet_NaN) {
-    throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
   if (std::numeric_limits<decltype(config.deltaRMinBottomSP)>::has_quiet_NaN) {
-    throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }
 

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -22,16 +22,17 @@ SeedFinder<external_spacepoint_t, platform_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderConfig not in ACTS internal units in SeedFinder");
   }
-  if (std::numeric_limits<decltype(config.deltaRMaxTopSP)>::has_quiet_NaN) {
+	float a = std::numeric_limits<float>::quiet_NaN();
+  if (isnan(a)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(config.deltaRMinTopSP)>::has_quiet_NaN) {
+  if (isnan(config.deltaRMinTopSP)) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(config.deltaRMaxBottomSP)>::has_quiet_NaN) {
+  if (isnan(config.deltaRMaxBottomSP)) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (std::numeric_limits<decltype(config.deltaRMinBottomSP)>::has_quiet_NaN) {
+  if (isnan(config.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -22,8 +22,7 @@ SeedFinder<external_spacepoint_t, platform_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderConfig not in ACTS internal units in SeedFinder");
   }
-	float a = std::numeric_limits<float>::quiet_NaN();
-  if (isnan(a)) {
+  if (isnan(config.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
   if (isnan(config.deltaRMinTopSP)) {

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -22,16 +22,16 @@ SeedFinder<external_spacepoint_t, platform_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderConfig not in ACTS internal units in SeedFinder");
   }
-  if (isnan(config.deltaRMaxTopSP)) {
+  if (std::isnan(config.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (isnan(config.deltaRMinTopSP)) {
+  if (std::isnan(config.deltaRMinTopSP)) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (isnan(config.deltaRMaxBottomSP)) {
+  if (std::isnan(config.deltaRMaxBottomSP)) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (isnan(config.deltaRMinBottomSP)) {
+  if (std::isnan(config.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -22,6 +22,18 @@ SeedFinder<external_spacepoint_t, platform_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderConfig not in ACTS internal units in SeedFinder");
   }
+  if (std::numeric_limits<decltype(config.deltaRMaxTopSP)>::has_quiet_NaN) {
+    throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(config.deltaRMinTopSP)>::has_quiet_NaN) {
+    throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(config.deltaRMaxBottomSP)>::has_quiet_NaN) {
+    throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(config.deltaRMinBottomSP)>::has_quiet_NaN) {
+    throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+  }
 }
 
 template <typename external_spacepoint_t, typename platform_t>

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
@@ -26,16 +26,16 @@ SeedFinder<external_spacepoint_t, Acts::Cuda>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderOptions not in ACTS internal units in "
         "Cuda/Seeding/SeedFinder");
-  if (isnan(m_config.deltaRMaxTopSP)) {
+  if (std::isnan(m_config.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (isnan(m_config.deltaRMinTopSP)) {
+  if (std::isnan(m_config.deltaRMinTopSP)) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (isnan(m_config.deltaRMaxBottomSP)) {
+  if (std::isnan(m_config.deltaRMaxBottomSP)) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (isnan(m_config.deltaRMinBottomSP)) {
+  if (std::isnan(m_config.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
@@ -26,6 +26,20 @@ SeedFinder<external_spacepoint_t, Acts::Cuda>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderOptions not in ACTS internal units in "
         "Cuda/Seeding/SeedFinder");
+  if (std::numeric_limits<decltype(m_config.deltaRMaxTopSP)>::has_quiet_NaN) {
+        throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(m_config.deltaRMinTopSP)>::has_quiet_NaN) {
+        throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(
+          m_config.deltaRMaxBottomSP)>::has_quiet_NaN) {
+                throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(
+          m_config.deltaRMinBottomSP)>::has_quiet_NaN) {
+        throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+  }
 }
 
 // CUDA seed finding

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
@@ -26,18 +26,16 @@ SeedFinder<external_spacepoint_t, Acts::Cuda>::SeedFinder(
     throw std::runtime_error(
         "SeedFinderOptions not in ACTS internal units in "
         "Cuda/Seeding/SeedFinder");
-  if (std::numeric_limits<decltype(m_config.deltaRMaxTopSP)>::has_quiet_NaN) {
+  if (isnan(m_config.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(m_config.deltaRMinTopSP)>::has_quiet_NaN) {
+  if (isnan(m_config.deltaRMinTopSP)) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(
-          m_config.deltaRMaxBottomSP)>::has_quiet_NaN) {
+  if (isnan(m_config.deltaRMaxBottomSP)) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (std::numeric_limits<decltype(
-          m_config.deltaRMinBottomSP)>::has_quiet_NaN) {
+  if (isnan(m_config.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
@@ -27,18 +27,18 @@ SeedFinder<external_spacepoint_t, Acts::Cuda>::SeedFinder(
         "SeedFinderOptions not in ACTS internal units in "
         "Cuda/Seeding/SeedFinder");
   if (std::numeric_limits<decltype(m_config.deltaRMaxTopSP)>::has_quiet_NaN) {
-        throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(m_config.deltaRMinTopSP)>::has_quiet_NaN) {
-        throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(
           m_config.deltaRMaxBottomSP)>::has_quiet_NaN) {
-                throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
   if (std::numeric_limits<decltype(
           m_config.deltaRMinBottomSP)>::has_quiet_NaN) {
-        throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 }
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -56,10 +56,10 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
   if (std::isnan(m_commonConfig.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (std::isnan(m_commonConfig.deltaRMinTopSP) {
+  if (std::isnan(m_commonConfig.deltaRMinTopSP)) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (std::isnan(m_commonConfig.deltaRMaxBottomSP) {
+  if (std::isnan(m_commonConfig.deltaRMaxBottomSP)) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
   if (std::isnan(m_commonConfig.deltaRMinBottomSP)) {

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -53,16 +53,16 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFilterConfig not in ACTS internal units in "
         "Cuda/Seeding2/SeedFinder");
-  if (isnan(m_commonConfig.deltaRMaxTopSP)) {
+  if (std::isnan(m_commonConfig.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (isnan(m_commonConfig.deltaRMinTopSP) {
+  if (std::isnan(m_commonConfig.deltaRMinTopSP) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (isnan(m_commonConfig.deltaRMaxBottomSP) {
+  if (std::isnan(m_commonConfig.deltaRMaxBottomSP) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (isnan(m_commonConfig.deltaRMinBottomSP)) {
+  if (std::isnan(m_commonConfig.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -53,6 +53,22 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFilterConfig not in ACTS internal units in "
         "Cuda/Seeding2/SeedFinder");
+  if (std::numeric_limits<decltype(
+          m_commonConfig.deltaRMaxTopSP)>::has_quiet_NaN) {
+                throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(
+          m_commonConfig.deltaRMinTopSP)>::has_quiet_NaN) {
+                throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(
+          m_commonConfig.deltaRMaxBottomSP)>::has_quiet_NaN) {
+                throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+  }
+  if (std::numeric_limits<decltype(
+          m_commonConfig.deltaRMinBottomSP)>::has_quiet_NaN) {
+                throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+  }
 
   // Tell the user what CUDA device will be used by the object.
   if (static_cast<std::size_t>(m_device) < Info::instance().devices().size()) {

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -53,20 +53,16 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
     throw std::runtime_error(
         "SeedFilterConfig not in ACTS internal units in "
         "Cuda/Seeding2/SeedFinder");
-  if (std::numeric_limits<decltype(
-          m_commonConfig.deltaRMaxTopSP)>::has_quiet_NaN) {
+  if (isnan(m_commonConfig.deltaRMaxTopSP)) {
     throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(
-          m_commonConfig.deltaRMinTopSP)>::has_quiet_NaN) {
+  if (isnan(m_commonConfig.deltaRMinTopSP) {
     throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
-  if (std::numeric_limits<decltype(
-          m_commonConfig.deltaRMaxBottomSP)>::has_quiet_NaN) {
+  if (isnan(m_commonConfig.deltaRMaxBottomSP) {
     throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
-  if (std::numeric_limits<decltype(
-          m_commonConfig.deltaRMinBottomSP)>::has_quiet_NaN) {
+  if (isnan(m_commonConfig.deltaRMinBottomSP)) {
     throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -55,19 +55,19 @@ SeedFinder<external_spacepoint_t>::SeedFinder(
         "Cuda/Seeding2/SeedFinder");
   if (std::numeric_limits<decltype(
           m_commonConfig.deltaRMaxTopSP)>::has_quiet_NaN) {
-                throw std::runtime_error(("Value of deltaRMaxTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(
           m_commonConfig.deltaRMinTopSP)>::has_quiet_NaN) {
-                throw std::runtime_error(("Value of deltaRMinTopSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinTopSP was not initialised");
   }
   if (std::numeric_limits<decltype(
           m_commonConfig.deltaRMaxBottomSP)>::has_quiet_NaN) {
-                throw std::runtime_error(("Value of deltaRMaxBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMaxBottomSP was not initialised");
   }
   if (std::numeric_limits<decltype(
           m_commonConfig.deltaRMinBottomSP)>::has_quiet_NaN) {
-                throw std::runtime_error(("Value of deltaRMinBottomSP was not initialised");
+    throw std::runtime_error("Value of deltaRMinBottomSP was not initialised");
   }
 
   // Tell the user what CUDA device will be used by the object.


### PR DESCRIPTION
PR #1378 has changed the default values of `deltaRMinTopSP`, `deltaRMaxTopSP`, `deltaRMinBottomSP` and `deltaRMaxBottomSP` to NAN.

As suggested by @osbornjd, we need to check that these variables have been correctly initialised in the seeder itself and not just in the SeedingAlgorithm, since the experiments will have their own seeding algorithms implemented within their own frameworks. This PR adds checks and exceptions to seedFinder if those values were NAN.