### PR TITLE
fix: SeedFinder(Orthogonal) handling of interna units for config and options object

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -21,6 +21,9 @@ namespace Acts {
 template <typename T>
 class SeedFilter;
 
+template<typename T>
+class SeedFinderOrthogonalConfig;
+
 template <typename SpacePoint>
 struct SeedFinderConfig {
   std::shared_ptr<Acts::SeedFilter<SpacePoint>> seedFilter;
@@ -266,6 +269,27 @@ struct SeedFinderOptions {
         std::pow(config.highland / options.pTPerHelixRadius, 2);
     options.sigmapT2perRadius =
         options.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
+    return options;
+  }
+  template <typename SpacePoint>
+  SeedFinderOptions calculateDerivedQuantities(
+      const SeedFinderOrthogonalConfig<SpacePoint>& config) {
+    if (!isInInternalUnits) {
+      throw std::runtime_error(
+			       "Derived quantities in SeedFinderOptions can only be calculated from "
+			       "Acts internal units");
+    }
+    SeedFinderOptions options = *this;
+    // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV and
+    // millimeter
+    // TODO: change using ACTS units
+    options.pTPerHelixRadius = 300. * options.bFieldInZ;
+    options.minHelixDiameter2 =
+      std::pow(config.minPt * 2 / options.pTPerHelixRadius, 2);
+    options.pT2perRadius =
+      std::pow(config.highland / options.pTPerHelixRadius, 2);
+    options.sigmapT2perRadius =
+      options.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
     return options;
   }
 };

--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -21,7 +21,7 @@ namespace Acts {
 template <typename T>
 class SeedFilter;
 
-template<typename T>
+template <typename T>
 class SeedFinderOrthogonalConfig;
 
 template <typename SpacePoint>
@@ -276,8 +276,8 @@ struct SeedFinderOptions {
       const SeedFinderOrthogonalConfig<SpacePoint>& config) {
     if (!isInInternalUnits) {
       throw std::runtime_error(
-			       "Derived quantities in SeedFinderOptions can only be calculated from "
-			       "Acts internal units");
+          "Derived quantities in SeedFinderOptions can only be calculated from "
+          "Acts internal units");
     }
     SeedFinderOptions options = *this;
     // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV and
@@ -285,11 +285,11 @@ struct SeedFinderOptions {
     // TODO: change using ACTS units
     options.pTPerHelixRadius = 300. * options.bFieldInZ;
     options.minHelixDiameter2 =
-      std::pow(config.minPt * 2 / options.pTPerHelixRadius, 2);
+        std::pow(config.minPt * 2 / options.pTPerHelixRadius, 2);
     options.pT2perRadius =
-      std::pow(config.highland / options.pTPerHelixRadius, 2);
+        std::pow(config.highland / options.pTPerHelixRadius, 2);
     options.sigmapT2perRadius =
-      options.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
+        options.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
     return options;
   }
 };

--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -22,7 +22,7 @@ template <typename T>
 class SeedFilter;
 
 template <typename T>
-class SeedFinderOrthogonalConfig;
+struct SeedFinderOrthogonalConfig;
 
 template <typename SpacePoint>
 struct SeedFinderConfig {
@@ -209,6 +209,11 @@ struct SeedFinderConfig {
     return config;
   }
   SeedFinderConfig calculateDerivedQuantities() const {
+    if (!isInInternalUnits) {
+      throw std::runtime_error(
+          "Derived quantities in SeedFinderConfig can only be calculated from "
+          "Acts internal units");
+    }
     SeedFinderConfig config = *this;
     // calculation of scattering using the highland formula
     // convert pT to p once theta angle is known

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -225,7 +225,23 @@ template <typename external_spacepoint_t>
 SeedFinderOrthogonal<external_spacepoint_t>::SeedFinderOrthogonal(
     const SeedFinderOrthogonalConfig<external_spacepoint_t> &config,
     const SeedFinderOptions &options)
-    : m_config(config), m_options(options) {}
+    : m_config(config), m_options(options) {
+  // Oblige the user to pass objects already in Internal Units
+  // This is beacuse the config object can be set during initialization
+  // and then never changed again during the entire execution.
+  // Thus it will already have derived variables computed, and be a constant
+  // object
+  if (not m_config.isInInternalUnits) {
+    throw std::runtime_error(
+        "SeedFinderOrthogonalConfig not in ACTS internal units in "
+        "SeedFinderOrthogonal");
+  }
+  if (not m_options.isInInternalUnits) {
+    throw std::runtime_error(
+        "SeedfinderOptions is not in ACTS internal units in "
+        "SeedFinderOrthogonal");
+  }
+}
 
 template <typename external_spacepoint_t>
 template <typename output_container_t>

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -212,7 +212,7 @@ bool SeedFinderOrthogonal<external_spacepoint_t>::validTuple(
       // the distance of the straight line from the origin (radius of the
       // circle) is related to aCoef and bCoef by d^2 = bCoef^2 / (1 +
       // aCoef^2) = 1 / (radius^2) and we can apply the cut on the curvature
-      if ((bCoef * bCoef) > (1 + aCoef * aCoef) / m_config.minHelixDiameter2) {
+      if ((bCoef * bCoef) > (1 + aCoef * aCoef) / m_options.minHelixDiameter2) {
         return false;
       }
     }
@@ -225,23 +225,7 @@ template <typename external_spacepoint_t>
 SeedFinderOrthogonal<external_spacepoint_t>::SeedFinderOrthogonal(
     const SeedFinderOrthogonalConfig<external_spacepoint_t> &config,
     const SeedFinderOptions &options)
-    : m_config(config.toInternalUnits()), m_options(options.toInternalUnits()) {
-  // calculation of scattering using the highland formula
-  // convert pT to p once theta angle is known
-  m_config.highland = 13.6 * std::sqrt(config.radLengthPerSeed) *
-                      (1 + 0.038 * std::log(config.radLengthPerSeed));
-  float maxScatteringAngle = config.highland / config.minPt;
-  m_config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
-  // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV and
-  // millimeter
-  // TODO: change using ACTS units
-  m_config.pTPerHelixRadius = 300. * m_options.bFieldInZ;
-  m_config.minHelixDiameter2 =
-      std::pow(config.minPt * 2 / config.pTPerHelixRadius, 2);
-  m_config.pT2perRadius =
-      std::pow(config.highland / config.pTPerHelixRadius, 2);
-  m_config.sigmapT2perRadius =
-      config.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
+    : m_config(config), m_options(options) {
 }
 
 template <typename external_spacepoint_t>
@@ -391,16 +375,16 @@ void SeedFinderOrthogonal<external_spacepoint_t>::filterCandidates(
       float B2 = B * B;
       // sqrt(S2)/B = 2 * helixradius
       // calculated radius must not be smaller than minimum radius
-      if (S2 < B2 * m_config.minHelixDiameter2) {
+      if (S2 < B2 * m_options.minHelixDiameter2) {
         continue;
       }
       // 1/helixradius: (B/sqrt(S2))*2 (we leave everything squared)
       float iHelixDiameter2 = B2 / S2;
       // calculate scattering for p(T) calculated from seed curvature
-      float pT2scatter = 4 * iHelixDiameter2 * m_config.pT2perRadius;
+      float pT2scatter = 4 * iHelixDiameter2 * m_options.pT2perRadius;
       // if pT > maxPtScattering, calculate allowed scattering angle using
       // maxPtScattering instead of pt.
-      float pT = m_config.pTPerHelixRadius * std::sqrt(S2 / B2) / 2.;
+      float pT = m_options.pTPerHelixRadius * std::sqrt(S2 / B2) / 2.;
       if (pT > m_config.maxPtScattering) {
         float pTscatter = m_config.highland / m_config.maxPtScattering;
         pT2scatter = pTscatter * pTscatter;

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -225,8 +225,7 @@ template <typename external_spacepoint_t>
 SeedFinderOrthogonal<external_spacepoint_t>::SeedFinderOrthogonal(
     const SeedFinderOrthogonalConfig<external_spacepoint_t> &config,
     const SeedFinderOptions &options)
-    : m_config(config), m_options(options) {
-}
+    : m_config(config), m_options(options) {}
 
 template <typename external_spacepoint_t>
 template <typename output_container_t>

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
@@ -128,7 +128,7 @@ struct SeedFinderOrthogonalConfig {
     // calculation of scattering using the highland formula
     // convert pT to p once theta angle is known
     config.highland = 13.6 * std::sqrt(radLengthPerSeed) *
-      (1 + 0.038 * std::log(radLengthPerSeed));
+                      (1 + 0.038 * std::log(radLengthPerSeed));
     const float maxScatteringAngle = config.highland / minPt;
     config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
     return config;

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
@@ -103,10 +103,6 @@ struct SeedFinderOrthogonalConfig {
   // derived values, set on SeedFinder construction
   float highland = 0;
   float maxScatteringAngle2 = 0;
-  float pTPerHelixRadius = 0;
-  float minHelixDiameter2 = 0;
-  float pT2perRadius = 0;
-  float sigmapT2perRadius = 0;
 
   SeedFinderOrthogonalConfig toInternalUnits() const {
     using namespace Acts::UnitLiterals;
@@ -127,6 +123,16 @@ struct SeedFinderOrthogonalConfig {
 
     return config;
   }
+  SeedFinderOrthogonalConfig calculateDerivedQuantities() const {
+    SeedFinderOrthogonalConfig config = *this;
+    // calculation of scattering using the highland formula
+    // convert pT to p once theta angle is known
+    config.highland = 13.6 * std::sqrt(radLengthPerSeed) *
+      (1 + 0.038 * std::log(radLengthPerSeed));
+    const float maxScatteringAngle = config.highland / minPt;
+    config.maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
+    return config;
+  };
 };
 
 }  // namespace Acts

--- a/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
@@ -46,28 +46,8 @@ ActsExamples::SeedingOrthogonalAlgorithm::SeedingOrthogonalAlgorithm(
       std::make_unique<Acts::SeedFilter<SimSpacePoint>>(
           Acts::SeedFilter<SimSpacePoint>(m_cfg.seedFilterConfig));
 
-  // calculation of scattering using the highland formula
-  // convert pT to p once theta angle is known
-  m_cfg.seedFinderConfig.highland =
-      13.6 * std::sqrt(m_cfg.seedFinderConfig.radLengthPerSeed) *
-      (1 + 0.038 * std::log(m_cfg.seedFinderConfig.radLengthPerSeed));
-  float maxScatteringAngle =
-      m_cfg.seedFinderConfig.highland / m_cfg.seedFinderConfig.minPt;
-  m_cfg.seedFinderConfig.maxScatteringAngle2 =
-      maxScatteringAngle * maxScatteringAngle;
-  // helix radius in homogeneous magnetic field. Units are Kilotesla, MeV and
-  // millimeter
-  // TODO: change using ACTS units
-  m_cfg.seedFinderConfig.pTPerHelixRadius =
-      300. * m_cfg.seedFinderOptions.bFieldInZ;
-  m_cfg.seedFinderConfig.minHelixDiameter2 =
-      std::pow(m_cfg.seedFinderConfig.minPt * 2 /
-                   m_cfg.seedFinderConfig.pTPerHelixRadius,
-               2);
-
-  m_cfg.seedFinderConfig.pT2perRadius = std::pow(
-      m_cfg.seedFinderConfig.highland / m_cfg.seedFinderConfig.pTPerHelixRadius,
-      2);
+  m_cfg.seedFinderConfig = m_cfg.seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
+  m_cfg.seedFinderOptions = m_cfg.seedFinderOptions.toInternalUnits().calculateDerivedQuantities(m_cfg.seedFinderConfig);
 }
 
 ActsExamples::ProcessCode ActsExamples::SeedingOrthogonalAlgorithm::execute(

--- a/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
@@ -46,8 +46,11 @@ ActsExamples::SeedingOrthogonalAlgorithm::SeedingOrthogonalAlgorithm(
       std::make_unique<Acts::SeedFilter<SimSpacePoint>>(
           Acts::SeedFilter<SimSpacePoint>(m_cfg.seedFilterConfig));
 
-  m_cfg.seedFinderConfig = m_cfg.seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
-  m_cfg.seedFinderOptions = m_cfg.seedFinderOptions.toInternalUnits().calculateDerivedQuantities(m_cfg.seedFinderConfig);
+  m_cfg.seedFinderConfig =
+      m_cfg.seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
+  m_cfg.seedFinderOptions =
+      m_cfg.seedFinderOptions.toInternalUnits().calculateDerivedQuantities(
+          m_cfg.seedFinderConfig);
 }
 
 ActsExamples::ProcessCode ActsExamples::SeedingOrthogonalAlgorithm::execute(

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -155,9 +155,6 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_MEMBER(deltaPhiMax);
     ACTS_PYTHON_MEMBER(highland);
     ACTS_PYTHON_MEMBER(maxScatteringAngle2);
-    ACTS_PYTHON_MEMBER(pTPerHelixRadius);
-    ACTS_PYTHON_MEMBER(minHelixDiameter2);
-    ACTS_PYTHON_MEMBER(pT2perRadius);
     ACTS_PYTHON_MEMBER(useVariableMiddleSPRange);
     ACTS_PYTHON_MEMBER(deltaRMiddleMinSPRange);
     ACTS_PYTHON_MEMBER(deltaRMiddleMaxSPRange);


### PR DESCRIPTION
Removing some derived variables from the `SeedFinderOrthogonalConfig`. These variables are derived from the magnetic filed and, as such, have to be recomputed for every event, while the other variables in the config are constant. 

These variables are already present in the `SeedFinderOptions` class, so I've added proper functions for their computation from the `SeedFinderOrthogonalConfig`. That's the same computation used for `SeedFinderConfig` but since they are two different classes I had to add a dedicated function that performs the same computation... not ideal imho

In addition (and probably main point in all of this PR): fixing issue computation of variables in the config and options objects related to a mis-handling of internal units

/cc @tbold @stephenswat 
