### PR TITLE
fix: Let addGeant4 respect particle selection

### DIFF
--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -594,7 +594,7 @@ def addGeant4(
     g4conf = geant4SimulationConfig(
         level=customLogLevel(),
         detector=g4detectorConstruction,
-        inputParticles="particles_selected",
+        inputParticles=particles_selected,
         trackingGeometry=trackingGeometry,
         magneticField=field,
         volumeMappings=volumeMappings,

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -594,7 +594,7 @@ def addGeant4(
     g4conf = geant4SimulationConfig(
         level=customLogLevel(),
         detector=g4detectorConstruction,
-        inputParticles="particles_input",
+        inputParticles="particles_selected",
         trackingGeometry=trackingGeometry,
         magneticField=field,
         volumeMappings=volumeMappings,


### PR DESCRIPTION
Fix the addGeant4 python function. With this fix the input of the geant4 simulation is changed to `particles_selected` which mean that the particle selector won't be ignored anymore.