### PR TITLE
fix: sequencer timing output

### DIFF
--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -409,8 +409,11 @@ int ActsExamples::Sequencer::run() {
     ACTS_DEBUG("  " << names[i] << ": "
                     << perEvent(clocksAlgorithms[i], numEvents));
   }
-  storeTiming(names, clocksAlgorithms, numEvents,
-              joinPaths(m_cfg.outputDir, m_cfg.outputTimingFile));
+
+  if (!m_cfg.outputDir.empty()) {
+    storeTiming(names, clocksAlgorithms, numEvents,
+                joinPaths(m_cfg.outputDir, m_cfg.outputTimingFile));
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
only output timing data if we have an output directory