### PR TITLE
feat: Add option to use odd with G4

### DIFF
--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1016,7 +1016,7 @@ def addTrajectoryWriters(
         if not outputDirCsv.exists():
             outputDirCsv.mkdir()
 
-        if trackSummaryWriter:
+        if writeSummary:
             csvMTJWriter = acts.examples.CsvMultiTrajectoryWriter(
                 level=customLogLevel(),
                 inputTrajectories=trajectories,

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -25,6 +25,7 @@ from common import getOpenDataDetectorDirectory
 from acts.examples.odd import getOpenDataDetector
 
 ttbar_pu200 = False
+g4_simulation = False
 u = acts.UnitConstants
 geoDir = getOpenDataDetectorDirectory()
 outputDir = pathlib.Path.cwd() / "odd_output"
@@ -73,19 +74,40 @@ with acts.FpeMonitor():
             rnd=rnd,
             outputDirRoot=outputDir,
         )
-
-    addFatras(
-        s,
-        trackingGeometry,
-        field,
-        ParticleSelectorConfig(
-            eta=(-3.0, 3.0), pt=(150 * u.MeV, None), removeNeutral=True
+    if not g4_simulation:
+        addFatras(
+            s,
+            trackingGeometry,
+            field,
+            ParticleSelectorConfig(
+                eta=(-3.0, 3.0), pt=(150 * u.MeV, None), removeNeutral=True
+            )
+            if ttbar_pu200
+            else ParticleSelectorConfig(),
+            outputDirRoot=outputDir,
+            rnd=rnd,
         )
-        if ttbar_pu200
-        else ParticleSelectorConfig(),
-        outputDirRoot=outputDir,
-        rnd=rnd,
-    )
+    if g4_simulation:
+        if Sequencer.config.numThreads != 1:
+            raise ValueError("Geant 4 simulation does not support multi-threading")
+
+        # Pythia can sometime simulate particles outside the world volume, a cut on the Z of the track help mitigate this effect
+        # Older version of G4 might not work, this as has been tested on version `geant4-11-00-patch-03`
+        # For more detail see issue #1578
+        addGeant4(
+            s,
+            detector,
+            trackingGeometry,
+            field,
+            preselectParticles=ParticleSelectorConfig(
+                eta=(-3.0, 3.0),
+                absZ=(0, 1e4),
+                pt=(150 * u.MeV, None),
+                removeNeutral=True,
+            ),
+            outputDirCsv=outputDir,
+            rnd=rnd,
+        )
 
     addDigitization(
         s,

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -74,21 +74,8 @@ with acts.FpeMonitor():
             rnd=rnd,
             outputDirRoot=outputDir,
         )
-    if not g4_simulation:
-        addFatras(
-            s,
-            trackingGeometry,
-            field,
-            ParticleSelectorConfig(
-                eta=(-3.0, 3.0), pt=(150 * u.MeV, None), removeNeutral=True
-            )
-            if ttbar_pu200
-            else ParticleSelectorConfig(),
-            outputDirRoot=outputDir,
-            rnd=rnd,
-        )
     if g4_simulation:
-        if Sequencer.config.numThreads != 1:
+        if s.config.numThreads != 1:
             raise ValueError("Geant 4 simulation does not support multi-threading")
 
         # Pythia can sometime simulate particles outside the world volume, a cut on the Z of the track help mitigate this effect
@@ -106,6 +93,19 @@ with acts.FpeMonitor():
                 removeNeutral=True,
             ),
             outputDirCsv=outputDir,
+            rnd=rnd,
+        )
+    else:
+        addFatras(
+            s,
+            trackingGeometry,
+            field,
+            ParticleSelectorConfig(
+                eta=(-3.0, 3.0), pt=(150 * u.MeV, None), removeNeutral=True
+            )
+            if ttbar_pu200
+            else ParticleSelectorConfig(),
+            outputDirRoot=outputDir,
             rnd=rnd,
         )
 


### PR DESCRIPTION
This add the option to use the G4 simulation with the Odd getting around the problem noticed in issue #1578.
Incidently it also fix a bug while using the odd full chain with only csv writting