### PR TITLE
refactor: Material mapping howto for python bindings 

### DIFF
--- a/Examples/Scripts/MaterialMapping/Mat_map.C
+++ b/Examples/Scripts/MaterialMapping/Mat_map.C
@@ -178,7 +178,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
 
     // X0 as function of Phi for Validation input
     TCanvas *VM_X0_Phi = new TCanvas("VM_X0_Phi","Validation X0 Phi") ;
-    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi","exp(-v_eta)/(1+exp(-2*v_eta))","profile");
+    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi","","profile");
     Val_X0_Phi->SetMarkerStyle(7);
     Val_X0_Phi->Draw("HIST PC");
     Val_X0_Phi->GetXaxis()->SetTitle("Phi");
@@ -187,7 +187,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
 
     // X0 as function of Phi for Validation input
     TCanvas *VM_X0_Phi_spread = new TCanvas("VM_X0_Phi_spread","Validation X0 Phi") ;
-    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi_spread","exp(-v_eta)/(1+exp(-2*v_eta))","");
+    Val_file->Draw("t_X0:v_phi>>Val_X0_Phi_spread","","");
     Val_X0_Phi_spread->GetXaxis()->SetTitle("Phi");
     Val_X0_Phi_spread->GetYaxis()->SetTitle("X0");
     VM_X0_Phi_spread->Print( (name+"/Val_mat_Phi_X0_spread.pdf").c_str());
@@ -235,7 +235,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
     geantino_file->Draw("t_X0:v_eta>>geantino_X0_Eta_spread","","");
     geantino_X0_Eta_spread->GetXaxis()->SetTitle("Eta");
     geantino_X0_Eta_spread->GetYaxis()->SetTitle("X0");
-    GM_X0_Eta->Print( (name+"/geant_mat_Eta_X0_spread.pdf").c_str());
+    GM_X0_Eta_spread->Print( (name+"/geant_mat_Eta_X0_spread.pdf").c_str());
 
     // X0 as function of Phi for Geantino input
     TCanvas *GM_X0_Phi = new TCanvas("GM_X0_Phi","Geantino X0 Phi") ;
@@ -251,7 +251,7 @@ void Mat_map(std::string Val = "", std::string geantino = "", std::string name =
     geantino_file->Draw("t_X0:v_phi>>geantino_X0_Phi_spread","","");
     geantino_X0_Phi_spread->GetXaxis()->SetTitle("Phi");
     geantino_X0_Phi_spread->GetYaxis()->SetTitle("X0");
-    GM_X0_Phi->Print( (name+"/geant_mat_Phi_X0_spread.pdf").c_str());
+    GM_X0_Phi_spread->Print( (name+"/geant_mat_Phi_X0_spread.pdf").c_str());
 
     // 2D map of X0 for Geantino input
     TCanvas *GM_2D = new TCanvas("GM_2D","Geantino X0 2D") ;

--- a/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C
+++ b/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C
@@ -32,6 +32,7 @@ void plot_ratio(std::vector<TH2F*> Map_prop, std::vector<TH2F*> Map_geant, const
     c1->SetBottomMargin(0.14);
     Map_prop[0]->Divide(Map_geant[0]);
     Map_prop[0]->GetZaxis()->SetTitle("X0 ratio");
+    Map_prop[0]->SetMaximum(2.);
     Map_prop[0]->Draw("COLZ");
     vol->Draw();
     surface->Draw();
@@ -63,6 +64,7 @@ void plot_ratio(std::vector<TH2F*> Map_prop, std::vector<TH2F*> Map_geant, const
     c1->SetBottomMargin(0.14);
     Map_prop[0]->Divide(Map_geant[0]);
     Map_prop[0]->GetZaxis()->SetTitle("X0 ratio");
+    Map_prop[0]->SetMaximum(2.);
     Map_prop[0]->Draw("COLZ");
     vol->Draw();
     surface->Draw();

--- a/Examples/Scripts/Python/geometry.py
+++ b/Examples/Scripts/Python/geometry.py
@@ -25,10 +25,10 @@ def runGeometry(
     decorators,
     outputDir,
     events=1,
-    outputObj=False,
-    outputCsv=False,
+    outputObj=True,
+    outputCsv=True,
     outputJson=True,
-    outputRoot=False,
+    outputRoot=True,
 ):
 
     for ievt in range(events):
@@ -88,10 +88,8 @@ def runGeometry(
 
 
 if "__main__" == __name__:
-    # detector, trackingGeometry, decorators = AlignedDetector.create()
+    detector, trackingGeometry, decorators = AlignedDetector.create()
     # detector, trackingGeometry, decorators = GenericDetector.create()
-    detector, trackingGeometry, decorators = getOpenDataDetector(
-        getOpenDataDetectorDirectory()
-    )
+    # detector, trackingGeometry, decorators = getOpenDataDetector(getOpenDataDetectorDirectory())
 
     runGeometry(trackingGeometry, decorators, outputDir=os.getcwd())

--- a/Examples/Scripts/Python/geometry.py
+++ b/Examples/Scripts/Python/geometry.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+from common import getOpenDataDetectorDirectory
 from acts.examples.odd import getOpenDataDetector
 from acts.examples import (
     GenericDetector,
@@ -24,10 +25,10 @@ def runGeometry(
     decorators,
     outputDir,
     events=1,
-    outputObj=True,
-    outputCsv=True,
+    outputObj=False,
+    outputCsv=False,
     outputJson=True,
-    outputRoot=True,
+    outputRoot=False,
 ):
 
     for ievt in range(events):
@@ -87,8 +88,10 @@ def runGeometry(
 
 
 if "__main__" == __name__:
-    detector, trackingGeometry, decorators = AlignedDetector.create()
+    # detector, trackingGeometry, decorators = AlignedDetector.create()
     # detector, trackingGeometry, decorators = GenericDetector.create()
-    # detector, trackingGeometry, decorators = getOpenDataDetector(getOpenDataDetectorDirectory() )
+    detector, trackingGeometry, decorators = getOpenDataDetector(
+        getOpenDataDetectorDirectory()
+    )
 
     runGeometry(trackingGeometry, decorators, outputDir=os.getcwd())

--- a/Examples/Scripts/Python/material_mapping.py
+++ b/Examples/Scripts/Python/material_mapping.py
@@ -37,6 +37,7 @@ def runMaterialMapping(
     mapSurface=True,
     mapVolume=True,
     readCachedSurfaceInformation=False,
+    mappingStep=1,
     s=None,
 ):
     s = s or Sequencer(numThreads=1)
@@ -91,7 +92,7 @@ def runMaterialMapping(
         )
         propagator = Propagator(stepper, navigator)
         mapper = VolumeMaterialMapper(
-            level=acts.logging.INFO, propagator=propagator, mappingStep=999
+            level=acts.logging.INFO, propagator=propagator, mappingStep=mappingStep
         )
         mmAlgCfg.materialVolumeMapper = mapper
 

--- a/Examples/Scripts/Python/material_recording.py
+++ b/Examples/Scripts/Python/material_recording.py
@@ -16,6 +16,7 @@ import acts.examples.dd4hep
 import acts.examples.geant4
 import acts.examples.geant4.dd4hep
 from common import getOpenDataDetectorDirectory
+from acts.examples.odd import getOpenDataDetector
 
 u = acts.UnitConstants
 
@@ -86,9 +87,10 @@ def runMaterialRecording(g4geo, outputDir, tracksPerEvent=10000, s=None):
 
 if "__main__" == __name__:
 
-    dd4hepSvc = acts.examples.dd4hep.DD4hepGeometryService(
-        xmlFileNames=[str(getOpenDataDetectorDirectory() / "xml/OpenDataDetector.xml")]
+    detector, trackingGeometry, decorators = getOpenDataDetector(
+        getOpenDataDetectorDirectory()
     )
-    g4geo = acts.examples.geant4.dd4hep.DDG4DetectorConstruction(dd4hepSvc)
+
+    g4geo = acts.examples.geant4.dd4hep.DDG4DetectorConstruction(detector)
 
     runMaterialRecording(g4geo=g4geo, tracksPerEvent=100, outputDir=os.getcwd()).run()

--- a/Examples/Scripts/Python/material_validation.py
+++ b/Examples/Scripts/Python/material_validation.py
@@ -41,6 +41,8 @@ def runMaterialValidation(
         sterileLogger=True,
         propagationStepCollection="propagation-steps",
         recordMaterialInteractions=True,
+        d0Sigma=0,
+        z0Sigma=0,
     )
 
     s.addAlgorithm(alg)

--- a/docs/howto/run_material_mapping.rst
+++ b/docs/howto/run_material_mapping.rst
@@ -30,16 +30,32 @@ Once Acts has been built we can start the mapping. The mapping is divided in two
 Mapping and configuration
 -------------------------
 
-First we need to extract the list of all the surfaces and volumes in our detector, to do so we will use the GeometryExample:
+First we need to extract the list of all the surfaces and volumes in our detector, to do so we will use the ``geometry.py`` script :
 
-.. code-block:: console
+.. code-block::
 
-   $ <build>/bin/ActsExampleGeometryDD4hep -n1 -j1 \
-       --mat-output-file geometry-map \
-       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
-       --output-json \
-       --mat-output-allmaterial true \
-       --mat-output-sensitives false
+   $ python3 <source>/Examples/Scripts/Python/geometry.py 
+
+Ideally the following options should be use in the python file :
+
+.. code-block::
+
+   def runGeometry(
+      trackingGeometry,
+      decorators,
+      outputDir,
+      events=1,
+      outputObj=False,
+      outputCsv=False,
+      outputJson=True,
+      outputRoot=False,
+   ):
+
+For the following example we will be remapping the material of the ODD so we will get our detector via the following line :
+
+.. code-block::  console
+
+   detector, trackingGeometry, decorators = getOpenDataDetector(getOpenDataDetectorDirectory() )
 
 This algorithm is useful to obtain a visualisation of your detector using the different types of output available (``output-obj`` gives ``.obj`` with a 3D representation of the different subdetectors, for example). Here, we use ``output-json`` to obtain a map of all the surfaces and volumes in the detector with a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``), ``mat-output-allmaterial`` ensure that a ``ProtoSurfaceMaterial`` (or a ``ProtoVolumeMaterial``) is associated to all the surfaces (or volumes), enforcing all of them to be written.
 Four types of surfaces exist:
@@ -126,48 +142,32 @@ The same script can be used to dump a steering file that can help you selecting 
 Geantino scan
 -------------
 
-The next step is to do a geantino scan of our detector. For this we will use the ``MaterialRecording`` application:
+The next step is to do a geantino scan of our detector. For this we will use the ``material_recording.py`` script:
 
 .. code-block:: console
 
-   $ <build>/bin/ActsExampleMaterialRecordingDD4hep -n1000 -j1 \
-       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
-       --output-root
-
+   $ python3 <source>/Examples/Scripts/Python/material_recording.py 
 
 The result of the geantino scan will be a root file containing material tracks. Those contain the direction and production vertex of the geantino, the total material accumulated and all the interaction points in the detector.
 
 Material Mapping
 ----------------
 
-With the surfaces map and the material track we can finally do the material mapping using the ``MaterialMapping`` application:
+With the surfaces map and the material track we can finally do the material mapping using the ``material_mapping.py`` script:
 
 .. code-block:: console
 
-   $ <build>/bin/ActsExampleMaterialMappingDD4hep -j1 \
-       --input-root true \
-       --input-files geant4_material_tracks.root \
-       --mat-input-type file \
-       --mat-input-file geometry-map.json \
-       --output-root \
-       --output-json \
-       --output-cbor \
-       --mat-output-file material-maps \
-       --mat-mapping-surfaces true \
-       --mat-mapping-volumes true \
-       --mat-mapping-volume-stepsize 1 \
-       --mat-mapping-read-surfaces false \
-       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml
+   $ python3 <source>/Examples/Scripts/Python/material_mapping.py 
 
-Note that technically when using DD4hep (in particular for the ODD) using the option ``--mat-input-type`` is not strictly necessary as the DD4hep geometry can hold the information of which surface to map onto with which binning. We will ignore this option, since the goal of this guide is to explain how to make a material map regardless of the detector.
+Note that technically when using DD4hep (in particular for the ODD) defining a ``matDeco`` in the main function is not strictly necessary as the DD4hep geometry can hold the information of which surface to map onto with which binning. We will ignore this option, since the goal of this guide is to explain how to make a material map regardless of the detector.
 
 As an output you will obtain the material map as a root and JSON file and a new material track collection in a root file. This new collection adds to each material interaction the associated surface during the mapping. This can be used for the control plots.
 Depending on what you want to do there are three options you can change:
 
-- ``mat-mapping-surfaces``: determine if material is mapped onto surfaces
-- ``mat-mapping-volumes``: determine if material is mapped onto volumes
-- ``mat-mapping-volume-stepsize``: determine the step size used in the sampling of the volume. This should be small compared to the bin size.
-
+- ``mapSurface``: determine if material is mapped onto surfaces
+- ``mapVolume``: determine if material is mapped onto volumes
+- ``mappingStep``: determine the step size used in the sampling of the volume. This should be small compared to the bin size.
+- ``readCachedSurfaceInformation`` if added the material-surface association will be taken from the input material track file (doesn't work with geantino file, you need to use the material track file obtained from running the material mapping).
 
 In addition to root and JSON output, one can also output the material map to a Cbor file (Concise Binary Object Representation). Doing so results in a file about 10 time smaller than the JSON one, but that file is no longer human-readable. This should be done once the map has been optimised and you want to export it. 
 
@@ -186,14 +186,7 @@ By default, the Geantino scan is performed with no spread in :math:`z_0` and :ma
 
 .. code-block:: console
 
-   $ <build>/bin/ActsExampleMaterialValidationDD4hep -n1000 \
-       --mat-input-type file \
-       --mat-input-file material-maps.json \
-       --output-root \
-       --mat-output-file val-mat-map \
-       --dd4hep-input <source>/thirdparty/OpenDataDetector/xml/OpenDataDetector.xml \
-       --prop-z0-sigma 0.0 \
-       --prop-d0-sigma 0.0
+   $ python3 <source>/Examples/Scripts/Python/material_validation.py 
 
 To do the validation, five root macros are available in ``scripts/MaterialMapping``:
 
@@ -207,7 +200,7 @@ To do the validation, five root macros are available in ``scripts/MaterialMappin
 
   mkdir Validation
 
-  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map.C'("propagation-material.root","material-maps_tracks.root","Validation")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map.C'("propagation-material.root","material-map_tracks.root","Validation")''
   .q
 
   mkdir Surfaces
@@ -217,11 +210,11 @@ To do the validation, five root macros are available in ``scripts/MaterialMappin
   mkdir Surfaces/dist_plot
   mkdir Surfaces/1D_plot
 
-  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("propagation-material.root","material-maps_tracks.root",100000,"Surfaces/ratio_plot","Surfaces/prop_plot","Surfaces/map_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_ratio.C'("propagation-material.root","material-map_tracks.root",100000,"Surfaces/ratio_plot","Surfaces/prop_plot","Surfaces/map_plot")'
   .q
-  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("material-maps_tracks.root",-1,"Surfaces/dist_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_dist.C'("material-map_tracks.root",-1,"Surfaces/dist_plot")'
   .q
-  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("material-maps_tracks.root",100000,"Surfaces/1D_plot")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_surface_plot_1D.C'("material-map_tracks.root",100000,"Surfaces/1D_plot")'
   .q
 
 Using the validation plots you can then adapt the binning and the mapped surface to improve the mapping.
@@ -230,7 +223,7 @@ On top of those plots:
 
 .. code-block:: console
 
-  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_detector_plot_ratio.C'("propagation-material.root","material-maps_tracks.root",{X,Y,Z},100000,"Det_ratio","Det_Acts","Det_G4")'
+  root -l -b <source>/Examples/Scripts/MaterialMapping/Mat_map_detector_plot_ratio.C'("propagation-material.root","material-map_tracks.root",{X,Y,Z},100000,"Det_ratio","Det_Acts","Det_G4")'
   .q
 
 Can be use with X,Y,Z is a list of volumes, this will plot the material ratio between the map and the Geantino scan for the given volumes.
@@ -239,4 +232,4 @@ Can be use with X,Y,Z is a list of volumes, this will plot the material ratio be
 Using a different detector
 --------------------------
 
-If you want to use a different type of detector, you will first need to ensure that the relevant packages were added during the compilation. After that, if your detector is a DD4hep detector you will just need to replace the path given to the ``--dd4hep-input`` option. In case it is another type of detector implementation, you can replace DD4hep in the name of the algorithm by what corresponds to your detector implementation. For more information on how to include your detector in that case you can refer to the documentation of the algorithm using the ``-h`` option.
+If you want to use a different type of detector, you will first need to ensure that the relevant packages were added during the compilation. After this you can just replace the detector initialisation in the different main function. For reference you can base your self on the Odd for DD4Hep detector and on the ITk for TGeo detector. 

--- a/docs/howto/run_material_mapping.rst
+++ b/docs/howto/run_material_mapping.rst
@@ -36,7 +36,7 @@ First we need to extract the list of all the surfaces and volumes in our detecto
 
    $ python3 <source>/Examples/Scripts/Python/geometry.py 
 
-Ideally the following options should be use in the python file :
+Ideally the following options should be used in the python file :
 
 .. code-block::
 
@@ -51,7 +51,7 @@ Ideally the following options should be use in the python file :
       outputRoot=False,
    ):
 
-For the following example we will be remapping the material of the ODD so we will get our detector via the following line :
+For the following example we will be remapping the material of the ODD, we will thus get our detector via the following line :
 
 .. code-block::  console
 


### PR DESCRIPTION
I have been procrastinating on this for way too long. In this PR, I update the material mapping howto to use the python bindings. The relevant bindings have been tested and updated to work as expected. I Also done some update of the plotting script (even if they should probably be phased out) to solve the remaining issue with them. 

In the near future I plan to update the material mapping autotuning, once it is done I will update the corresponding doc. 