### PR TITLE
fix: G4 material converter

### DIFF
--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -22,6 +22,8 @@
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
+#include <cassert>
+
 #include "G4Box.hh"
 #include "G4LogicalVolume.hh"
 #include "G4Material.hh"
@@ -30,8 +32,6 @@
 #include "G4Tubs.hh"
 #include "G4VPhysicalVolume.hh"
 #include "G4VSolid.hh"
-
-#include <cassert>
 
 Acts::Transform3 Acts::Geant4AlgebraConverter::transform(
     const G4ThreeVector& g4Trans) {

--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -31,6 +31,8 @@
 #include "G4VPhysicalVolume.hh"
 #include "G4VSolid.hh"
 
+#include <cassert>
+
 Acts::Transform3 Acts::Geant4AlgebraConverter::transform(
     const G4ThreeVector& g4Trans) {
   Transform3 gTransform = Transform3::Identity();
@@ -301,12 +303,14 @@ std::shared_ptr<Acts::HomogeneousSurfaceMaterial>
 Acts::Geant4MaterialConverter::surfaceMaterial(const G4Material& g4Material,
                                                ActsScalar original,
                                                ActsScalar compressed) {
+  assert(g4Material.GetNumberOfElements() == 1);
+
   ActsScalar compression = original / compressed;
 
   auto g4X0 = g4Material.GetRadlen();
   auto g4L0 = g4Material.GetNuclearInterLength();
   auto g4Z = g4Material.GetZ();
-  auto g4A = g4Material.GetZ();
+  auto g4A = (*g4Material.GetElementVector())[0]->GetN();
   auto g4Rho = g4Material.GetDensity();
 
   Material mat = Material::fromMassDensity(


### PR DESCRIPTION
nucleus charge VS effective mass

somehow there is no nice solution to get the relative atomic mass in G4 so I had to go through the element class