### PR TITLE
feat: mark state as outlier if reverse filtering missed the surface

### DIFF
--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -474,6 +474,8 @@ class KalmanFitter {
                     // If reversed filtering missed this surface, then there is
                     // no smoothed parameter
                     trackState.unset(TrackStatePropMask::Smoothed);
+		    // mark as outlier
+		    trackState.typeFlags().set(TrackStateFlag::OutlierFlag);
                   }
                 });
           }

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -474,8 +474,8 @@ class KalmanFitter {
                     // If reversed filtering missed this surface, then there is
                     // no smoothed parameter
                     trackState.unset(TrackStatePropMask::Smoothed);
-		    // mark as outlier
-		    trackState.typeFlags().set(TrackStateFlag::OutlierFlag);
+                    // mark as outlier
+                    trackState.typeFlags().set(TrackStateFlag::OutlierFlag);
                   }
                 });
           }


### PR DESCRIPTION
As the title says, marking with `TrackStateFlag::Outlier` if the reverse filtering has missed the surface and there are no smoothed parameters
