### PR TITLE
refactor: GX2F uses TrackContainer + log message cleanup

### DIFF
--- a/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
+++ b/Core/include/Acts/TrackFitting/Chi2Fitter.hpp
@@ -294,7 +294,7 @@ class Chi2Fitter {
       if (surface != nullptr) {
         auto res = processSurface(surface, state, stepper, result);
         if (!res.ok()) {
-          ACTS_ERROR("chi2 | Error in processSurface: " << res.error());
+          ACTS_ERROR("gError in processSurface: " << res.error());
           result.result = res.error();
         }
       }
@@ -305,7 +305,7 @@ class Chi2Fitter {
             (result.measurementStates > 0 and
              state.navigation.navigationBreak)) {
           result.missedActiveSurfaces.resize(result.measurementHoles);
-          ACTS_VERBOSE("chi2 | Finalize...");
+          ACTS_VERBOSE("gFinalize...");
           result.finished = true;
         }
       }
@@ -350,7 +350,7 @@ class Chi2Fitter {
       auto sourcelink_it = inputMeasurements->find(surface->geometryId());
       // inputMeasurements is a std::map<GeometryIdentifier, source_link_t>
       if (sourcelink_it != inputMeasurements->end()) {
-        ACTS_VERBOSE("chi2 |    processSurface: Measurement surface "
+        ACTS_VERBOSE("g   processSurface: Measurement surface "
                      << surface->geometryId() << " detected.");
 
         // add a full TrackState entry multi trajectory
@@ -377,7 +377,7 @@ class Chi2Fitter {
 
           if (!foundExistingSurface) {
             ACTS_VERBOSE(
-                "chi2 |    processSurface: Found new surface during update.");
+                "g   processSurface: Found new surface during update.");
             result.lastTrackIndex = result.fittedStates->addTrackState(
                 ~(TrackStatePropMask::Smoothed | TrackStatePropMask::Filtered),
                 result.lastTrackIndex);
@@ -459,7 +459,7 @@ class Chi2Fitter {
           typeFlags.set(TrackStateFlag::MeasurementFlag);
           ++result.measurementStates;
         } else {
-          ACTS_VERBOSE("chi2 | Measurement is determined to be an outlier.");
+          ACTS_VERBOSE("gMeasurement is determined to be an outlier.");
           typeFlags.set(TrackStateFlag::OutlierFlag);
         }
 
@@ -637,8 +637,8 @@ class Chi2Fitter {
                                               holder_t>::TrackProxy> {
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyways, so the map can own them.
-    ACTS_VERBOSE("chi2 | preparing " << std::distance(it, end)
-                                     << " input measurements");
+    ACTS_VERBOSE("gpreparing " << std::distance(it, end)
+                               << " input measurements");
     std::map<GeometryIdentifier, std::reference_wrapper<const SourceLink>>
         inputMeasurements;
 
@@ -696,8 +696,7 @@ class Chi2Fitter {
       auto result = m_propagator.template propagate(
           updatedStartParameters, propOptions, std::move(inputResult));
       if (!result.ok()) {
-        ACTS_ERROR("chi2 | it=" << i
-                                << " | propagation failed: " << result.error());
+        ACTS_ERROR("git=" << i << " | propagation failed: " << result.error());
         return result.error();
       }
 
@@ -711,9 +710,9 @@ class Chi2Fitter {
       }
 
       if (!c2rCurrent.result.ok()) {
-        ACTS_ERROR("chi2 | it=" << i << " | Chi2Fitter failed: "
-                                << c2rCurrent.result.error() << ", "
-                                << c2rCurrent.result.error().message());
+        ACTS_ERROR("git=" << i << " | Chi2Fitter failed: "
+                          << c2rCurrent.result.error() << ", "
+                          << c2rCurrent.result.error().message());
         return c2rCurrent.result.error();
       }
 
@@ -730,7 +729,7 @@ class Chi2Fitter {
       c2rCurrent.chisquare = c2rCurrent.residuals.transpose() *
                              c2rCurrent.covariance.inverse() *
                              c2rCurrent.residuals;
-      ACTS_VERBOSE("chi2 | it=" << i << " | χ² = " << c2rCurrent.chisquare);
+      ACTS_VERBOSE("git=" << i << " | χ² = " << c2rCurrent.chisquare);
 
       // copy over data from previous runs (namely chisquares vector)
       c2rCurrent.chisquares.reserve(c2r.chisquares.size() + 1);
@@ -759,8 +758,8 @@ class Chi2Fitter {
               c2r.collectorDerive1Chi2Sum);
 
       BoundVector newParamsVec = vParams.parameters() - delta_start_parameters;
-      ACTS_VERBOSE("chi2 | it=" << i << " | updated parameters = "
-                                << newParamsVec.transpose());
+      ACTS_VERBOSE("git=" << i << " | updated parameters = "
+                          << newParamsVec.transpose());
       c2r.fittedParameters =
           BoundTrackParameters(vParams.referenceSurface().getSharedPtr(),
                                newParamsVec, vParams.covariance());

--- a/Examples/Algorithms/TrackFittingChi2/include/ActsExamples/TrackFittingChi2/TrackFittingChi2Algorithm.hpp
+++ b/Examples/Algorithms/TrackFittingChi2/include/ActsExamples/TrackFittingChi2/TrackFittingChi2Algorithm.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/EventData/SourceLink.hpp"
 #include "Acts/EventData/VectorMultiTrajectory.hpp"
+#include "Acts/EventData/VectorTrackContainer.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/TrackFitting/Chi2Fitter.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
@@ -35,8 +36,11 @@ class TrackFittingChi2Algorithm final : public BareAlgorithm {
   using TrackFitterChi2Options =
       Acts::Experimental::Chi2FitterOptions<Acts::VectorMultiTrajectory>;
 
-  using TrackFitterChi2Result = Acts::Result<
-      Acts::Experimental::Chi2FitterResult<Acts::VectorMultiTrajectory>>;
+  using TrackContainer =
+      Acts::TrackContainer<Acts::VectorTrackContainer,
+                           Acts::VectorMultiTrajectory, std::shared_ptr>;
+
+  using TrackFitterChi2Result = Acts::Result<TrackContainer::TrackProxy>;
 
   /// Fit function that takes the above parameters and runs a fit
   /// @note This is separated into a virtual interface to keep compilation units
@@ -46,8 +50,7 @@ class TrackFittingChi2Algorithm final : public BareAlgorithm {
     virtual ~TrackFitterChi2Function() = default;
     virtual TrackFitterChi2Result operator()(
         const std::vector<Acts::SourceLink>&, const TrackParameters&,
-        const TrackFitterChi2Options&,
-        std::shared_ptr<Acts::VectorMultiTrajectory>& trajectory) const = 0;
+        const TrackFitterChi2Options&, TrackContainer&) const = 0;
   };
 
   struct Config {
@@ -106,7 +109,7 @@ class TrackFittingChi2Algorithm final : public BareAlgorithm {
       const Acts::Experimental::Chi2FitterOptions<Acts::VectorMultiTrajectory>&
           options,
       const std::vector<const Acts::Surface*>& surfSequence,
-      std::shared_ptr<Acts::VectorMultiTrajectory>& trajectory) const;
+      TrackContainer& trackContainer) const;
 
   Config m_cfg;
 };
@@ -119,14 +122,14 @@ ActsExamples::TrackFittingChi2Algorithm::fitTrack(
         options,
     // const Acts::Chi2FitterOptions& options,
     const std::vector<const Acts::Surface*>& surfSequence,
-    std::shared_ptr<Acts::VectorMultiTrajectory>& trajectory) const {
+    TrackContainer& trackContainer) const {
   (void)surfSequence;  // TODO: silence unused parameter warning
   //   if (m_cfg.directNavigation) {
   //     return (*m_cfg.dFit)(sourceLinks, initialParameters, options,
   //     surfSequence);
   //   }
 
-  return (*m_cfg.fit)(sourceLinks, initialParameters, options, trajectory);
+  return (*m_cfg.fit)(sourceLinks, initialParameters, options, trackContainer);
 }
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2Algorithm.cpp
+++ b/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2Algorithm.cpp
@@ -8,7 +8,7 @@
 
 #include "ActsExamples/TrackFittingChi2/TrackFittingChi2Algorithm.hpp"
 
-#include "Acts/EventData/VectorMultiTrajectory.hpp"
+#include "Acts/EventData/Track.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsExamples/EventData/Trajectories.hpp"
@@ -122,36 +122,44 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingChi2Algorithm::execute(
       }
     }
 
+    auto trackContainer = std::make_shared<Acts::VectorTrackContainer>();
+    auto trackStateContainer = std::make_shared<Acts::VectorMultiTrajectory>();
+    auto tracks =
+        std::make_unique<TrackContainer>(trackContainer, trackStateContainer);
+
+    tracks->addColumn<Acts::ActsScalar>("chi2");
+    static Acts::ConstTrackAccessor<Acts::ActsScalar> chisquare{"chi2"};
+
     ACTS_DEBUG("chi2algo | invoke fitter");
-    auto mtj = std::make_shared<Acts::VectorMultiTrajectory>();
     auto result = fitTrack(trackSourceLinks, initialParams, chi2Options,
-                           surfSequence, mtj);
+                           surfSequence, *tracks);
 
     if (result.ok()) {
       ACTS_DEBUG("chi2algo | result ok");
       // Get the fit output object
-      auto& fitOutput = result.value();
+      auto& track = result.value();
       // The track entry indices container. One element here.
       std::vector<Acts::MultiTrajectoryTraits::IndexType> trackTips;
       trackTips.reserve(1);
-      trackTips.emplace_back(fitOutput.lastMeasurementIndex);
+      trackTips.emplace_back(track.tipIndex());
       // The fitted parameters container. One element (at most) here.
       Trajectories::IndexedParameters indexedParams;
-      ACTS_VERBOSE("chi2algo | final χ² = " << fitOutput.chisquare);
-      ACTS_VERBOSE("chi2algo | lastMeasurementIndex = "
-                   << fitOutput.lastMeasurementIndex);
+      ACTS_VERBOSE("chi2algo | final χ² = " << chisquare(track));
+      ACTS_VERBOSE("chi2algo | lastMeasurementIndex = " << track.tipIndex());
 
-      if (fitOutput.fittedParameters) {
-        const auto& params = fitOutput.fittedParameters.value();
+      if (track.hasReferenceSurface()) {
         ACTS_VERBOSE("chi2algo | Fitted parameters for track "
-                     << itrack << ": " << params.parameters().transpose());
+                     << itrack << ": " << track.parameters().transpose());
         // Push the fitted parameters to the container
-        indexedParams.emplace(fitOutput.lastMeasurementIndex, params);
+        indexedParams.emplace(
+            std::pair{track.tipIndex(),
+                      TrackParameters{track.referenceSurface().getSharedPtr(),
+                                      track.parameters(), track.covariance()}});
       } else {
         ACTS_DEBUG("chi2algo | No fitted parameters for track " << itrack);
       }
       // store the result
-      trajectories.emplace_back(fitOutput.fittedStates, std::move(trackTips),
+      trajectories.emplace_back(trackStateContainer, std::move(trackTips),
                                 std::move(indexedParams));
     } else {
       ACTS_WARNING("Fit failed for track "

--- a/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2Algorithm.cpp
+++ b/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2Algorithm.cpp
@@ -99,10 +99,9 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingChi2Algorithm::execute(
       continue;
     }
 
-    ACTS_VERBOSE("chi2algo | ev="
-                 << ctx.eventNumber << " | initial parameters: "
-                 << initialParams.fourPosition(ctx.geoContext).transpose()
-                 << " -> " << initialParams.unitDirection().transpose());
+    ACTS_VERBOSE("ev=" << ctx.eventNumber << " | initial parameters: "
+                       << initialParams.fourPosition(ctx.geoContext).transpose()
+                       << " -> " << initialParams.unitDirection().transpose());
 
     // Clear & reserve the right size
     trackSourceLinks.clear();
@@ -130,12 +129,12 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingChi2Algorithm::execute(
     tracks->addColumn<Acts::ActsScalar>("chi2");
     static Acts::ConstTrackAccessor<Acts::ActsScalar> chisquare{"chi2"};
 
-    ACTS_DEBUG("chi2algo | invoke fitter");
+    ACTS_DEBUG("invoke fitter");
     auto result = fitTrack(trackSourceLinks, initialParams, chi2Options,
                            surfSequence, *tracks);
 
     if (result.ok()) {
-      ACTS_DEBUG("chi2algo | result ok");
+      ACTS_DEBUG("result ok");
       // Get the fit output object
       auto& track = result.value();
       // The track entry indices container. One element here.
@@ -144,11 +143,11 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingChi2Algorithm::execute(
       trackTips.emplace_back(track.tipIndex());
       // The fitted parameters container. One element (at most) here.
       Trajectories::IndexedParameters indexedParams;
-      ACTS_VERBOSE("chi2algo | final χ² = " << chisquare(track));
-      ACTS_VERBOSE("chi2algo | lastMeasurementIndex = " << track.tipIndex());
+      ACTS_VERBOSE("final χ² = " << chisquare(track));
+      ACTS_VERBOSE("lastMeasurementIndex = " << track.tipIndex());
 
       if (track.hasReferenceSurface()) {
-        ACTS_VERBOSE("chi2algo | Fitted parameters for track "
+        ACTS_VERBOSE("Fitted parameters for track "
                      << itrack << ": " << track.parameters().transpose());
         // Push the fitted parameters to the container
         indexedParams.emplace(
@@ -156,7 +155,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingChi2Algorithm::execute(
                       TrackParameters{track.referenceSurface().getSharedPtr(),
                                       track.parameters(), track.covariance()}});
       } else {
-        ACTS_DEBUG("chi2algo | No fitted parameters for track " << itrack);
+        ACTS_DEBUG("No fitted parameters for track " << itrack);
       }
       // store the result
       trajectories.emplace_back(trackStateContainer, std::move(trackTips),

--- a/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2AlgorithmFunction.cpp
+++ b/Examples/Algorithms/TrackFittingChi2/src/TrackFittingChi2AlgorithmFunction.cpp
@@ -37,9 +37,10 @@ struct TrackFitterChi2FunctionImpl
       const ActsExamples::TrackParameters& initialParameters,
       const ActsExamples::TrackFittingChi2Algorithm::TrackFitterChi2Options&
           options,
-      std::shared_ptr<Acts::VectorMultiTrajectory>& trajectory) const override {
+      ActsExamples::TrackFittingChi2Algorithm::TrackContainer& trackContainer)
+      const override {
     return trackFitterChi2.fit(sourceLinks.begin(), sourceLinks.end(),
-                               initialParameters, options, trajectory);
+                               initialParameters, options, trackContainer);
   };
 };
 

--- a/Tests/UnitTests/Core/TrackFitting/Chi2FitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Chi2FitterTests.cpp
@@ -12,6 +12,7 @@
 #include "Acts/EventData/Measurement.hpp"
 #include "Acts/EventData/SourceLink.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/EventData/VectorTrackContainer.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
@@ -198,12 +199,15 @@ BOOST_AUTO_TEST_CASE(ZeroFieldNoSurfaceForward) {
 
   // BOOST_TEST_INFO("Test Case ZeroFieldNoSurfaceForward: running .fit()...");
 
-  auto res =
-      chi2Zero.fit(sourceLinks.begin(), sourceLinks.end(), start, chi2Options);
+  Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
+                              Acts::VectorMultiTrajectory{}};
+
+  auto res = chi2Zero.fit(sourceLinks.begin(), sourceLinks.end(), start,
+                          chi2Options, tracks);
   BOOST_REQUIRE(res.ok());
 
   const auto& val = res.value();
-  BOOST_CHECK(val.finished);
+  BOOST_CHECK(val.hasReferenceSurface());
 }
 
 // TODO: add more test cases, for holes, outliers, ...


### PR DESCRIPTION
Contrary to what I said before, the GX2F was not yet using `Acts::TrackContainer`. This PR switches it over. 
I also cleaned up some of the log messages in the Chi2 fitter and algorithm, the prefixes there are unnecessary because the loggers already print their own names.