### PR TITLE
fix: Move GeoIdHook implementation to hpp

### DIFF
--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -137,7 +137,8 @@ std::ostream& operator<<(std::ostream& os, GeometryIdentifier id);
 struct GeometryIdentifierHook {
   virtual ~GeometryIdentifierHook() = default;
   virtual Acts::GeometryIdentifier decorateIdentifier(
-      Acts::GeometryIdentifier identifier, const Acts::Surface& surface) const;
+    Acts::GeometryIdentifier identifier, const Acts::Surface& /*surface*/) const
+  { return identifier; }
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -137,8 +137,10 @@ std::ostream& operator<<(std::ostream& os, GeometryIdentifier id);
 struct GeometryIdentifierHook {
   virtual ~GeometryIdentifierHook() = default;
   virtual Acts::GeometryIdentifier decorateIdentifier(
-    Acts::GeometryIdentifier identifier, const Acts::Surface& /*surface*/) const
-  { return identifier; }
+      Acts::GeometryIdentifier identifier,
+      const Acts::Surface& /*surface*/) const {
+    return identifier;
+  }
 };
 
 }  // namespace Acts

--- a/Core/src/Geometry/GeometryIdentifier.cpp
+++ b/Core/src/Geometry/GeometryIdentifier.cpp
@@ -37,9 +37,3 @@ std::ostream& Acts::operator<<(std::ostream& os, Acts::GeometryIdentifier id) {
   }
   return os;
 }
-
-Acts::GeometryIdentifier Acts::GeometryIdentifierHook::decorateIdentifier(
-    Acts::GeometryIdentifier identifier,
-    const Acts::Surface& /*unused*/) const {
-  return identifier;
-}


### PR DESCRIPTION
Related to https://github.com/acts-project/acts/issues/1829 

This is a quick bypass of the compilation issue in Athena, in order to move to tag `v23`