### PR TITLE
fix: GSF SourceLink reference

### DIFF
--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -236,7 +236,7 @@ struct GaussianSumFitter {
         inputMeasurements;
     for (auto it = begin; it != end; ++it) {
       const SourceLink& sl = *it;
-      inputMeasurements.emplace(sl.geometryId(), *it);
+      inputMeasurements.emplace(sl.geometryId(), sl);
     }
 
     ACTS_VERBOSE(


### PR DESCRIPTION
Building Athena (ATLAS' software platform) using ACTS v22.0.1 as externals and calling the GSF fitter lead to a fatal crash during compilation. This issue was fixed by explicitly using the SourceLink rather than its reference wrapper when storing the input measurements.

This PR should be ready to be merged.

Thanks to Hadrien Grasland for his help.
