### PR TITLE
feat: configurable charge smearing in geometric digitization & exact digitization

### DIFF
--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
@@ -56,10 +56,22 @@ struct GeometricConfig {
   };
   double thickness = 0.;
   /// Charge generation
-  ChargeGenerator charge = [](Acts::ActsScalar path, Acts::ActsScalar,
-                              RandomEngine &) -> Acts::ActsScalar {
-    return path;
-  };
+  ActsFatras::SingleParameterSmearFunction<ActsExamples::RandomEngine>
+      chargeSmearer;
+
+  Acts::ActsScalar charge(Acts::ActsScalar path, Acts::ActsScalar,
+                          RandomEngine &rng) const {
+    if (!chargeSmearer) {
+      return path;
+    }
+
+    auto res = chargeSmearer(path, rng);
+    if (res.ok()) {
+      return res->first;
+    } else {
+      throw std::runtime_error(res.error().message());
+    }
+  }
   double threshold = 0.;
   /// Position and Covariance generation
   bool digital = false;

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfigurator.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfigurator.hpp
@@ -75,8 +75,8 @@ struct DigitizationConfigurator {
               dInputConfig->geometricDigiConfig.drift;
           dOutputConfig.geometricDigiConfig.thickness =
               dInputConfig->geometricDigiConfig.thickness;
-          dOutputConfig.geometricDigiConfig.charge =
-              dInputConfig->geometricDigiConfig.charge;
+          dOutputConfig.geometricDigiConfig.chargeSmearer =
+              dInputConfig->geometricDigiConfig.chargeSmearer;
           dOutputConfig.geometricDigiConfig.digital =
               dInputConfig->geometricDigiConfig.digital;
           dOutputConfig.geometricDigiConfig.variances =

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/Smearers.hpp
@@ -23,6 +23,22 @@
 namespace ActsExamples {
 namespace Digitization {
 
+/// Exact smearing of a single parameter.
+///
+struct Exact {
+  /// Call operator for the SmearFunction caller interface.
+  ///
+  /// @param value parameter to be smeared
+  /// @param rnd random generator to be used for the call
+  ///
+  /// @return a Result that is always ok(), and just returns
+  /// the value and a stddev of 0.0
+  Acts::Result<std::pair<double, double>> operator()(
+      double value, RandomEngine& /*unused*/) const {
+    return std::pair{value, 0.0};
+  }
+};
+
 /// Gaussian smearing of a single parameter.
 ///
 /// @note This smearer will smear over module boundaries

--- a/Examples/Io/Json/src/JsonDigitizationConfig.cpp
+++ b/Examples/Io/Json/src/JsonDigitizationConfig.cpp
@@ -15,13 +15,10 @@
 #include <fstream>
 #include <functional>
 
-using namespace ActsExamples;
-
+namespace ActsExamples {
 namespace {
-void smearingDistToJson(
-    nlohmann::json& j,
-    const ActsFatras::SingleParameterSmearFunction<ActsExamples::RandomEngine>&
-        f) {
+void to_json(nlohmann::json& j, const ActsFatras::SingleParameterSmearFunction<
+                                    ActsExamples::RandomEngine>& f) {
   // Gauss:
   const Digitization::Gauss* gauss = f.target<const Digitization::Gauss>();
   if (gauss != nullptr) {
@@ -64,7 +61,7 @@ void smearingDistToJson(
   }
 }
 
-void smearingDistFromJson(
+void from_json(
     const nlohmann::json& j,
     ActsFatras::SingleParameterSmearFunction<ActsExamples::RandomEngine>& f) {
   std::string sType = j["type"];
@@ -91,17 +88,18 @@ void smearingDistFromJson(
 }
 
 }  // namespace
+}  // namespace ActsExamples
 
 void ActsExamples::to_json(nlohmann::json& j,
                            const ActsExamples::ParameterSmearingConfig& psc) {
   j["index"] = psc.index;
-  smearingDistToJson(j, psc.smearFunction);
+  to_json(j, psc.smearFunction);
 }
 
 void ActsExamples::from_json(const nlohmann::json& j,
                              ActsExamples::ParameterSmearingConfig& psc) {
   psc.index = static_cast<Acts::BoundIndices>(j["index"]);
-  smearingDistFromJson(j, psc.smearFunction);
+  from_json(j, psc.smearFunction);
 }
 
 void ActsExamples::to_json(nlohmann::json& j,
@@ -115,6 +113,7 @@ void ActsExamples::to_json(nlohmann::json& j,
   j["thickness"] = gdc.thickness;
   j["threshold"] = gdc.threshold;
   j["digital"] = gdc.digital;
+  to_json(j["charge-smearing"], gdc.chargeSmearer);
 }
 
 void ActsExamples::from_json(const nlohmann::json& j,
@@ -125,7 +124,8 @@ void ActsExamples::from_json(const nlohmann::json& j,
   from_json(j["segmentation"], gdc.segmentation);
   gdc.thickness = j["thickness"];
   gdc.threshold = j["threshold"];
-  gdc.digital = j["digital"];
+  gdc.digital = j["digital"];   
+  from_json(j["charge-smearing"], gdc.chargeSmearer);
 }
 
 void ActsExamples::to_json(nlohmann::json& j,


### PR DESCRIPTION
This makes path smearing configurable in the geometric digitization config like this:

```json
"charge-smearing": {
  "mean" : 0.0, "stddev" : 0.000, "type" : "Gauss"
}
```

For the charge smearing the `ActsFatras::SingleParameterSmearer<Rng>` is reused.

It also adds an `Exact` smearer, that does not smear, which is useful for debugging I think:

```json
"charge-smearing": {
  "type" : "Exact"
}
```

This can also be used in the smearing digitization to make a truth-digitization:
```json
{
    "volume" : 16,
    "value" : {
        "smearing" : [
          {"index" : 0, "type" : "Exact"},
          {"index" : 1, "type" : "Exact"}
        ]
    }
}
```