### PR TITLE
ci: Mark ODD tests, move away from exact event count checks

### DIFF
--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -238,12 +238,7 @@ DetectorConfig = namedtuple(
 )
 
 
-@pytest.fixture(
-    params=[
-        "generic",
-        "odd",
-    ]
-)
+@pytest.fixture(params=["generic", pytest.param("odd", marks=pytest.mark.odd)])
 def detector_config(request):
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -835,6 +835,7 @@ def test_volume_material_mapping(material_recording, tmp_path, assert_root_hash)
             marks=[
                 pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up"),
                 pytest.mark.slow,
+                pytest.mark.odd,
             ],
         ),
         (functools.partial(AlignedDetector.create, iovSize=1), 450),

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -1082,6 +1082,7 @@ def test_ckf_tracks_example(
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 @pytest.mark.skipif(not pythia8Enabled, reason="Pythia8 not set up")
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_vertex_fitting(tmp_path):
     detector, trackingGeometry, decorators = getOpenDataDetector(

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -52,7 +52,7 @@ def assert_csv_output(csv_path, stem):
     assert all([f.stat().st_size > 100 for f in csv_path.iterdir()])
 
 
-def assert_entries(root_file, tree_name, exp):
+def assert_entries(root_file, tree_name, exp=None, non_zero=False):
     __tracebackhide__ = True
     import ROOT
 
@@ -62,7 +62,15 @@ def assert_entries(root_file, tree_name, exp):
     rf = ROOT.TFile.Open(str(root_file))
     keys = [k.GetName() for k in rf.GetListOfKeys()]
     assert tree_name in keys
-    assert rf.Get(tree_name).GetEntries() == exp, f"{root_file}:{tree_name}"
+    if non_zero:
+        assert rf.Get(tree_name).GetEntries() > 0, f"{root_file}:{tree_name}"
+    if exp is not None:
+        assert rf.Get(tree_name).GetEntries() == exp, f"{root_file}:{tree_name}"
+
+
+def assert_has_entries(root_file, tree_name):
+    __tracebackhide__ = True
+    assert_entries(root_file, tree_name, non_zero=True)
 
 
 @pytest.mark.slow
@@ -103,22 +111,19 @@ def test_fatras(trk_geo, tmp_path, field, assert_root_hash):
         (
             "fatras_particles_final.root",
             "particles",
-            nevents,
         ),
         (
             "fatras_particles_initial.root",
             "particles",
-            nevents,
         ),
         (
             "hits.root",
             "hits",
-            115,
         ),
     ]
 
     assert len(list(csv.iterdir())) == 0
-    for rf, _, _ in root_files:
+    for rf, _ in root_files:
         assert not (tmp_path / rf).exists()
 
     seq = Sequencer(events=nevents)
@@ -129,16 +134,17 @@ def test_fatras(trk_geo, tmp_path, field, assert_root_hash):
     assert_csv_output(csv, "particles_final")
     assert_csv_output(csv, "particles_initial")
     assert_csv_output(csv, "hits")
-    for f, tn, exp_entries in root_files:
+    for f, tn in root_files:
         rfp = tmp_path / f
         assert rfp.exists()
         assert rfp.stat().st_size > 2**10 * 10
 
-        assert_entries(rfp, tn, exp_entries)
+        assert_has_entries(rfp, tn)
         assert_root_hash(f, rfp)
 
 
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.skipif(not geant4Enabled, reason="Geant4 not set up")
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_geant4(tmp_path, assert_root_hash):
@@ -202,36 +208,30 @@ def test_seeding(tmp_path, trk_geo, field, assert_root_hash):
         (
             "estimatedparams.root",
             "estimatedparams",
-            371,
         ),
         (
             "performance_seeding_trees.root",
             "track_finder_tracks",
-            371,
         ),
         (
             "performance_seeding_hists.root",
             None,
-            0,
         ),
         (
             "particles.root",
             "particles",
-            seq.config.events,
         ),
         (
             "fatras_particles_final.root",
             "particles",
-            seq.config.events,
         ),
         (
             "fatras_particles_initial.root",
             "particles",
-            seq.config.events,
         ),
     ]
 
-    for fn, _, _ in root_files:
+    for fn, _ in root_files:
         fp = tmp_path / fn
         assert not fp.exists()
 
@@ -241,13 +241,13 @@ def test_seeding(tmp_path, trk_geo, field, assert_root_hash):
 
     del seq
 
-    for fn, tn, exp_entries in root_files:
+    for fn, tn in root_files:
         fp = tmp_path / fn
         assert fp.exists()
         assert fp.stat().st_size > 100
 
         if tn is not None:
-            assert_entries(fp, tn, exp_entries)
+            assert_has_entries(fp, tn)
             assert_root_hash(fn, fp)
 
     assert_csv_output(csv, "particles")
@@ -341,36 +341,30 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
         (
             "estimatedparams.root",
             "estimatedparams",
-            25,
         ),
         (
             "performance_seeding_trees.root",
             "track_finder_tracks",
-            25,
         ),
         (
             "performance_seeding_hists.root",
             None,
-            0,
         ),
         (
             "particles.root",
             "particles",
-            seq.config.events,
         ),
         (
             "fatras_particles_final.root",
             "particles",
-            seq.config.events,
         ),
         (
             "fatras_particles_initial.root",
             "particles",
-            seq.config.events,
         ),
     ]
 
-    for fn, _, _ in root_files:
+    for fn, _ in root_files:
         fp = tmp_path / fn
         assert not fp.exists()
 
@@ -443,13 +437,13 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
 
     del seq
 
-    for fn, tn, exp_entries in root_files:
+    for fn, tn in root_files:
         fp = tmp_path / fn
         assert fp.exists()
         assert fp.stat().st_size > 100
 
         if tn is not None:
-            assert_entries(fp, tn, exp_entries)
+            assert_has_entries(fp, tn)
             assert_root_hash(fn, fp)
 
     assert_csv_output(csv, "particles")
@@ -491,6 +485,7 @@ def test_propagation(tmp_path, trk_geo, field, seq, assert_root_hash):
 
 
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.skipif(not geant4Enabled, reason="Geant4 not set up")
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_material_recording(tmp_path, material_recording, assert_root_hash):
@@ -512,6 +507,7 @@ def test_material_recording(tmp_path, material_recording, assert_root_hash):
 
 
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.skipif(not hepmc3Enabled, reason="HepMC3 plugin not available")
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 @pytest.mark.skipif(not geant4Enabled, reason="Geant4 not set up")
@@ -604,7 +600,7 @@ def test_truth_tracking_kalman(
         assert fp.exists()
         assert fp.stat().st_size > 1024
         if tn is not None:
-            assert_entries(fp, tn, ee)
+            assert_has_entries(fp, tn)
             assert_root_hash(fn, fp)
 
 
@@ -672,6 +668,7 @@ def test_particle_gun(tmp_path, assert_root_hash):
 
 
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_material_mapping(material_recording, tmp_path, assert_root_hash):
     map_file = tmp_path / "material-map_tracks.root"
@@ -744,6 +741,7 @@ def test_material_mapping(material_recording, tmp_path, assert_root_hash):
 
 
 @pytest.mark.slow
+@pytest.mark.odd
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_volume_material_mapping(material_recording, tmp_path, assert_root_hash):
     map_file = tmp_path / "material-map-volume_tracks.root"
@@ -918,17 +916,17 @@ def test_digitization_example(trk_geo, tmp_path, assert_root_hash):
 
     assert len(list(csv_dir.iterdir())) == 3 * s.config.events
     assert all(f.stat().st_size > 50 for f in csv_dir.iterdir())
-    for tn, nev in (
-        (8, 407),
-        (9, 0),
-        (12, 11),
-        (13, 375),
-        (14, 2),
-        (16, 25),
-        (17, 146),
-        (18, 9),
+    assert_entries(root_file, "vol9", 0)
+    for tn in (
+        8,
+        12,
+        13,
+        14,
+        16,
+        17,
+        18,
     ):
-        assert_entries(root_file, f"vol{tn}", nev)
+        assert_has_entries(root_file, f"vol{tn}")
 
     assert_root_hash(root_file.name, root_file)
 
@@ -973,18 +971,20 @@ def test_digitization_example_input(trk_geo, tmp_path, assert_root_hash):
 
     assert len(list(csv_dir.iterdir())) == 3 * pgs.config.events
     assert all(f.stat().st_size > 50 for f in csv_dir.iterdir())
-    for tn, nev in (
-        (7, 0),
-        (8, 193),
-        (9, 0),
-        (12, 1),
-        (13, 183),
-        (14, 6),
-        (16, 3),
-        (17, 76),
-        (18, 10),
+
+    assert_entries(root_file, "vol7", 0)
+    assert_entries(root_file, "vol9", 0)
+
+    for tn in (
+        8,
+        12,
+        13,
+        14,
+        16,
+        17,
+        18,
     ):
-        assert_entries(root_file, f"vol{tn}", nev)
+        assert_has_entries(root_file, f"vol{tn}")
     assert_root_hash(root_file.name, root_file)
 
 
@@ -1208,6 +1208,7 @@ def test_vertex_fitting_reading(
 
 
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
+@pytest.mark.odd
 @pytest.mark.slow
 def test_full_chain_odd_example(tmp_path):
     # This test literally only ensures that the full chain example can run without erroring out

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -917,15 +917,7 @@ def test_digitization_example(trk_geo, tmp_path, assert_root_hash):
     assert len(list(csv_dir.iterdir())) == 3 * s.config.events
     assert all(f.stat().st_size > 50 for f in csv_dir.iterdir())
     assert_entries(root_file, "vol9", 0)
-    for tn in (
-        8,
-        12,
-        13,
-        14,
-        16,
-        17,
-        18,
-    ):
+    for tn in (8, 12, 13, 14, 16, 17, 18):
         assert_has_entries(root_file, f"vol{tn}")
 
     assert_root_hash(root_file.name, root_file)
@@ -975,15 +967,7 @@ def test_digitization_example_input(trk_geo, tmp_path, assert_root_hash):
     assert_entries(root_file, "vol7", 0)
     assert_entries(root_file, "vol9", 0)
 
-    for tn in (
-        8,
-        12,
-        13,
-        14,
-        16,
-        17,
-        18,
-    ):
+    for tn in (8, 12, 13, 14, 16, 17, 18):
         assert_has_entries(root_file, f"vol{tn}")
     assert_root_hash(root_file.name, root_file)
 

--- a/Examples/Python/tests/test_reader.py
+++ b/Examples/Python/tests/test_reader.py
@@ -138,6 +138,7 @@ def test_root_reader_interface(reader, conf_const, tmp_path):
 
 @pytest.mark.slow
 @pytest.mark.root
+@pytest.mark.odd
 @pytest.mark.skipif(not geant4Enabled, reason="Geant4 not set up")
 def test_root_material_track_reader(material_recording):
 

--- a/Examples/Python/tests/test_writer.py
+++ b/Examples/Python/tests/test_writer.py
@@ -414,6 +414,7 @@ def test_csv_writer_interface(writer, conf_const, tmp_path, trk_geo):
 
 
 @pytest.mark.root
+@pytest.mark.odd
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_root_material_writer(tmp_path, assert_root_hash):
     from acts.examples.dd4hep import DD4hepDetector
@@ -436,6 +437,7 @@ def test_root_material_writer(tmp_path, assert_root_hash):
 
 
 @pytest.mark.json
+@pytest.mark.odd
 @pytest.mark.parametrize("fmt", [JsonFormat.Json, JsonFormat.Cbor])
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 def test_json_material_writer(tmp_path, fmt):
@@ -535,6 +537,7 @@ def hepmc_data(hepmc_data_impl: Path, tmp_path):
 @pytest.mark.skipif(not hepmc3Enabled, reason="HepMC3 plugin not available")
 @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
 @pytest.mark.skipif(not geant4Enabled, reason="Geant4 not set up")
+@pytest.mark.odd
 @pytest.mark.slow
 def test_hepmc3_histogram(hepmc_data, tmp_path):
     from acts.examples.hepmc3 import (

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
     json
     slow
     edm4hep
+    odd


### PR DESCRIPTION
The event count checks should be covered by the hash checks, and we have a much better way of obtaining local references with the hashes in any case.