### PR TITLE
feat: Add TrajectoryPrinter helper algorithm

### DIFF
--- a/Examples/Algorithms/Utilities/CMakeLists.txt
+++ b/Examples/Algorithms/Utilities/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   ActsExamplesUtilities SHARED
-  src/TrajectoriesToPrototracks.cpp)
+  src/TrajectoriesToPrototracks.cpp
+  src/TrajectoryPrinter.cpp)
 target_include_directories(
   ActsExamplesUtilities
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)

--- a/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrajectoryPrinter.hpp
+++ b/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrajectoryPrinter.hpp
@@ -1,0 +1,39 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Framework/BareAlgorithm.hpp"
+
+namespace ActsExamples {
+
+class TrajectoryPrinter final : public BareAlgorithm {
+ public:
+  struct Config {
+    std::string inputTrajectories = "trajectories";
+  };
+
+  /// Construct the algorithm.
+  ///
+  /// @param cfg is the algorithm configuration
+  /// @param lvl is the logging level
+  TrajectoryPrinter(Config cfg, Acts::Logging::Level lvl)
+      : BareAlgorithm("TrajectoryPrinter", lvl), m_cfg(std::move(cfg)) {}
+
+  /// Run the algorithm.
+  ///
+  /// @param ctx is the algorithm context with event information
+  /// @return a process code indication success or failure
+  ProcessCode execute(const AlgorithmContext& ctx) const final;
+
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
+ private:
+  Config m_cfg;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Utilities/src/TrajectoryPrinter.cpp
+++ b/Examples/Algorithms/Utilities/src/TrajectoryPrinter.cpp
@@ -1,0 +1,68 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2022 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Utilities/TrajectoryPrinter.hpp"
+
+#include "Acts/EventData/MultiTrajectoryHelpers.hpp"
+#include "ActsExamples/EventData/IndexSourceLink.hpp"
+#include "ActsExamples/EventData/ProtoTrack.hpp"
+#include "ActsExamples/EventData/Track.hpp"
+#include "ActsExamples/EventData/Trajectories.hpp"
+#include "ActsExamples/Framework/WhiteBoard.hpp"
+
+namespace ActsExamples {
+
+ProcessCode TrajectoryPrinter::execute(const AlgorithmContext& ctx) const {
+  const auto trajectories =
+      ctx.eventStore.get<TrajectoriesContainer>(m_cfg.inputTrajectories);
+
+  std::vector<unsigned int> nTracksPerSeedCount;
+  nTracksPerSeedCount.push_back(0);
+
+  for (std::size_t iTraj = 0; iTraj < trajectories.size(); ++iTraj) {
+    ACTS_INFO("- trajectory #" << iTraj);
+    const auto& traj = trajectories[iTraj];
+    const auto& mj = traj.multiTrajectory();
+
+    if (traj.tips().size() + 1 >= nTracksPerSeedCount.size()) {
+      nTracksPerSeedCount.resize(traj.tips().size() + 1);
+    }
+    nTracksPerSeedCount.at(traj.tips().size()) += 1;
+
+    ACTS_INFO(" -> " << traj.tips().size() << " tips");
+    for (auto trackTip : traj.tips()) {
+      const auto& fittedParameters = traj.trackParameters(trackTip);
+      ACTS_INFO(" --> tip: " << trackTip << ""
+                             << " with "
+                             << fittedParameters.parameters().transpose());
+      auto trajState =
+          Acts::MultiTrajectoryHelpers::trajectoryState(mj, trackTip);
+
+      ACTS_INFO(" --> tip state:");
+      ACTS_INFO("     - nStates: " << trajState.nStates);
+      ACTS_INFO("     - nMeasurements: " << trajState.nMeasurements);
+      ACTS_INFO("     - nOutliers: " << trajState.nOutliers);
+      ACTS_INFO("     - nHoles: " << trajState.nHoles);
+      ACTS_INFO("     - chi2Sum: " << trajState.chi2Sum);
+      ACTS_INFO("     - NDF: " << trajState.NDF);
+      ACTS_INFO("     - nSharedHits: " << trajState.nSharedHits);
+
+      // for (const auto ts : mj.trackStateRange(trackTip)) {
+      // }
+    }
+  }
+
+  ACTS_INFO("" << trajectories.size() << " trajectories total");
+  for (size_t idx = 0; idx < nTracksPerSeedCount.size(); idx++) {
+    ACTS_INFO(" - " << idx << " tracks -> " << nTracksPerSeedCount.at(idx)
+                    << " times");
+  }
+  return ProcessCode::SUCCESS;
+}
+
+}  // namespace ActsExamples

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -881,10 +881,12 @@ def addCKFTracks(
 
     s.addWhiteboardAlias("trajectories", trackFinder.config.outputTrajectories)
 
-    s.addAlgorithm(acts.examples.TrajectoryPrinter(
-        level=customLogLevel(),
-        inputTrajectories=trackFinder.config.outputTrajectories
-    ))
+    s.addAlgorithm(
+        acts.examples.TrajectoryPrinter(
+            level=customLogLevel(),
+            inputTrajectories=trackFinder.config.outputTrajectories,
+        )
+    )
 
     if trackSelectorRanges is not None:
         trackSelector = addTrackSelection(

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -881,6 +881,11 @@ def addCKFTracks(
 
     s.addWhiteboardAlias("trajectories", trackFinder.config.outputTrajectories)
 
+    s.addAlgorithm(acts.examples.TrajectoryPrinter(
+        level=customLogLevel(),
+        inputTrajectories=trackFinder.config.outputTrajectories
+    ))
+
     if trackSelectorRanges is not None:
         trackSelector = addTrackSelection(
             s,

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -17,6 +17,7 @@
 #include "ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp"
 #include "ActsExamples/Utilities/TrajectoriesToPrototracks.hpp"
+#include "ActsExamples/Utilities/TrajectoryPrinter.hpp"
 
 #include <memory>
 
@@ -283,6 +284,23 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_STRUCT_BEGIN(c, Config);
     ACTS_PYTHON_MEMBER(inputTrajectories);
     ACTS_PYTHON_MEMBER(outputPrototracks);
+    ACTS_PYTHON_STRUCT_END();
+  }
+
+  {
+    using Alg = ActsExamples::TrajectoryPrinter;
+    using Config = Alg::Config;
+
+    auto alg =
+        py::class_<Alg, ActsExamples::BareAlgorithm, std::shared_ptr<Alg>>(
+            mex, "TrajectoryPrinter")
+            .def(py::init<const Config&, Acts::Logging::Level>(),
+                 py::arg("config"), py::arg("level"))
+            .def_property_readonly("config", &Alg::config);
+
+    auto c = py::class_<Config>(alg, "Config").def(py::init<>());
+    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_MEMBER(inputTrajectories);
     ACTS_PYTHON_STRUCT_END();
   }
 


### PR DESCRIPTION
This PR adds a helper algorithm that prints out Trajectories. I'm using this to debug. It might not be useful for a long time, but I thought it might make sense to add it at this point in time anyway.