### PR TITLE
feat: Enable removing tracks from container

### DIFF
--- a/Core/include/Acts/EventData/Track.hpp
+++ b/Core/include/Acts/EventData/Track.hpp
@@ -522,6 +522,14 @@ class TrackContainer {
     return m_container->addTrack_impl();
   }
 
+  /// Remove a track at index @p itrack from the container
+  /// @note This invalidates all track proxies!
+  /// @param itrack The index of the track to remmove
+  template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
+  void removeTrack(IndexType itrack) {
+    m_container->removeTrack_impl(itrack);
+  }
+
   /// Add a dymanic column to the track container
   /// @param key the name of the column to be added
   template <typename T, bool RO = ReadOnly, typename = std::enable_if_t<!RO>>

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -80,21 +80,29 @@ class VectorTrackContainerBase {
     }
   }
 
-  void checkConsistency() const {
+  bool checkConsistency() const {
     size_t size = m_tipIndex.size();
     (void)size;
 
-    assert(m_tipIndex.size() == size);
-    assert(m_params.size() == size);
-    assert(m_cov.size() == size);
-    assert(m_referenceSurfaces.size() == size);
-    assert(m_nMeasurements.size() == size);
-    assert(m_nHoles.size() == size);
+    bool result = true;
+    result = result && m_tipIndex.size() == size;
+    assert(result);
+    result = result && m_params.size() == size;
+    assert(result);
+    result = result && m_cov.size() == size;
+    assert(result);
+    result = result && m_referenceSurfaces.size() == size;
+    assert(result);
+    result = result && m_nMeasurements.size() == size;
+    assert(result);
+    result = result && m_nHoles.size() == size;
 
     for (const auto& [key, col] : m_dynamic) {
       (void)key;
-      assert(col->size() == size);
+      result = result && col->size() == size;
     }
+
+    return result;
   }
 
  public:
@@ -107,7 +115,7 @@ class VectorTrackContainerBase {
   }
 
   std::size_t size_impl() const {
-    checkConsistency();
+    assert(checkConsistency());
     return m_tipIndex.size();
   }
   // END INTERFACE HELPER
@@ -194,13 +202,13 @@ class ConstVectorTrackContainer final
   ConstVectorTrackContainer(const ConstVectorTrackContainer& other) = default;
   ConstVectorTrackContainer(const VectorTrackContainer& other)
       : VectorTrackContainerBase{other} {
-    checkConsistency();
+    assert(checkConsistency());
   }
 
   ConstVectorTrackContainer(ConstVectorTrackContainer&&) = default;
   ConstVectorTrackContainer(VectorTrackContainer&& other)
       : VectorTrackContainerBase{std::move(other)} {
-    checkConsistency();
+    assert(checkConsistency());
   }
 
  public:
@@ -225,7 +233,7 @@ class ConstVectorTrackContainer final
 inline VectorTrackContainer::VectorTrackContainer(
     const ConstVectorTrackContainer& other)
     : VectorTrackContainerBase{other} {
-  checkConsistency();
+  assert(checkConsistency());
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -82,6 +82,7 @@ class VectorTrackContainerBase {
 
   void checkConsistency() const {
     size_t size = m_tipIndex.size();
+    (void)size;
 
     assert(m_tipIndex.size() == size);
     assert(m_params.size() == size);
@@ -91,6 +92,7 @@ class VectorTrackContainerBase {
     assert(m_nHoles.size() == size);
 
     for (const auto& [key, col] : m_dynamic) {
+      (void)key;
       assert(col->size() == size);
     }
   }

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -37,15 +37,7 @@ class VectorTrackContainerBase {
  protected:
   VectorTrackContainerBase() = default;
 
-  VectorTrackContainerBase(const VectorTrackContainerBase& other)
-      : m_tipIndex{other.m_tipIndex},
-        m_params{other.m_params},
-        m_cov{other.m_cov},
-        m_referenceSurfaces{other.m_referenceSurfaces} {
-    for (const auto& [key, value] : other.m_dynamic) {
-      m_dynamic.insert({key, value->clone()});
-    }
-  };
+  VectorTrackContainerBase(const VectorTrackContainerBase& other);
 
   VectorTrackContainerBase(VectorTrackContainerBase&& other) = default;
 
@@ -88,6 +80,21 @@ class VectorTrackContainerBase {
     }
   }
 
+  void checkConsistency() const {
+    size_t size = m_tipIndex.size();
+
+    assert(m_tipIndex.size() == size);
+    assert(m_params.size() == size);
+    assert(m_cov.size() == size);
+    assert(m_referenceSurfaces.size() == size);
+    assert(m_nMeasurements.size() == size);
+    assert(m_nHoles.size() == size);
+
+    for (const auto& [key, col] : m_dynamic) {
+      assert(col->size() == size);
+    }
+  }
+
  public:
   constexpr bool hasColumn_impl(HashedString key) const {
     using namespace Acts::HashedStringLiteral;
@@ -97,7 +104,10 @@ class VectorTrackContainerBase {
     }
   }
 
-  std::size_t size_impl() const { return m_tipIndex.size(); }
+  std::size_t size_impl() const {
+    checkConsistency();
+    return m_tipIndex.size();
+  }
   // END INTERFACE HELPER
 
   std::vector<IndexType> m_tipIndex;
@@ -115,6 +125,8 @@ class VectorTrackContainerBase {
 }  // namespace detail_vtc
 
 class VectorTrackContainer;
+class ConstVectorTrackContainer;
+
 template <>
 struct IsReadOnlyTrackContainer<VectorTrackContainer> : std::false_type {};
 
@@ -123,6 +135,8 @@ class VectorTrackContainer final : public detail_vtc::VectorTrackContainerBase {
   VectorTrackContainer() : VectorTrackContainerBase{} {}
   VectorTrackContainer(const VectorTrackContainer& other) = default;
   VectorTrackContainer(VectorTrackContainer&&) = default;
+
+  VectorTrackContainer(const ConstVectorTrackContainer& other);
 
  public:
   // BEGIN INTERFACE
@@ -137,23 +151,9 @@ class VectorTrackContainer final : public detail_vtc::VectorTrackContainerBase {
         *this, key, itrack);
   }
 
-  IndexType addTrack_impl() {
-    m_tipIndex.emplace_back();
+  IndexType addTrack_impl();
 
-    m_params.emplace_back();
-    m_cov.emplace_back();
-    m_referenceSurfaces.emplace_back();
-
-    m_nMeasurements.emplace_back();
-    m_nHoles.emplace_back();
-
-    // dynamic columns
-    for (auto& [key, vec] : m_dynamic) {
-      vec->add();
-    }
-
-    return m_tipIndex.size() - 1;
-  }
+  void removeTrack_impl(IndexType itrack);
 
   template <typename T>
   constexpr void addColumn_impl(const std::string& key) {
@@ -191,11 +191,15 @@ class ConstVectorTrackContainer final
 
   ConstVectorTrackContainer(const ConstVectorTrackContainer& other) = default;
   ConstVectorTrackContainer(const VectorTrackContainer& other)
-      : VectorTrackContainerBase{other} {}
+      : VectorTrackContainerBase{other} {
+    checkConsistency();
+  }
 
   ConstVectorTrackContainer(ConstVectorTrackContainer&&) = default;
   ConstVectorTrackContainer(VectorTrackContainer&& other)
-      : VectorTrackContainerBase{std::move(other)} {}
+      : VectorTrackContainerBase{std::move(other)} {
+    checkConsistency();
+  }
 
  public:
   // BEGIN INTERFACE
@@ -209,7 +213,17 @@ class ConstVectorTrackContainer final
     return ConstParameters{m_params[itrack].data()};
   }
 
+  ConstCovariance covariance(IndexType itrack) const {
+    return ConstCovariance{m_cov[itrack].data()};
+  }
+
   // END INTERFACE
 };
+
+inline VectorTrackContainer::VectorTrackContainer(
+    const ConstVectorTrackContainer& other)
+    : VectorTrackContainerBase{other} {
+  checkConsistency();
+}
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/detail/DynamicColumn.hpp
+++ b/Core/include/Acts/EventData/detail/DynamicColumn.hpp
@@ -21,6 +21,8 @@ struct DynamicColumnBase {
 
   virtual void add() = 0;
   virtual void clear() = 0;
+  virtual void erase(size_t i) = 0;
+  virtual size_t size() const = 0;
 
   virtual std::unique_ptr<DynamicColumnBase> clone() const = 0;
 };
@@ -39,6 +41,8 @@ struct DynamicColumn : public DynamicColumnBase {
 
   void add() override { m_vector.emplace_back(); }
   void clear() override { m_vector.clear(); }
+  void erase(size_t i) override { m_vector.erase(m_vector.begin() + i); }
+  size_t size() const override { return m_vector.size(); }
 
   std::unique_ptr<DynamicColumnBase> clone() const override {
     return std::make_unique<DynamicColumn<T>>(*this);
@@ -65,6 +69,8 @@ struct DynamicColumn<bool> : public DynamicColumnBase {
 
   void add() override { m_vector.emplace_back(); }
   void clear() override { m_vector.clear(); }
+  void erase(size_t i) override { m_vector.erase(m_vector.begin() + i); }
+  size_t size() const override { return m_vector.size(); }
 
   std::unique_ptr<DynamicColumnBase> clone() const override {
     return std::make_unique<DynamicColumn<bool>>(*this);

--- a/Core/src/EventData/CMakeLists.txt
+++ b/Core/src/EventData/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(
     CorrectedTransformationFreeToBound.cpp
     TrackStatePropMask.cpp
     VectorMultiTrajectory.cpp
+    VectorTrackContainer.cpp
 )

--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -1,0 +1,75 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/EventData/VectorTrackContainer.hpp"
+
+namespace Acts {
+
+namespace detail_vtc {
+
+VectorTrackContainerBase::VectorTrackContainerBase(
+    const VectorTrackContainerBase& other)
+    : m_tipIndex{other.m_tipIndex},
+      m_params{other.m_params},
+      m_cov{other.m_cov},
+      m_referenceSurfaces{other.m_referenceSurfaces},
+      m_nMeasurements{other.m_nMeasurements},
+      m_nHoles{other.m_nHoles} {
+  for (const auto& [key, value] : other.m_dynamic) {
+    m_dynamic.insert({key, value->clone()});
+  }
+
+  checkConsistency();
+}
+}  // namespace detail_vtc
+
+VectorTrackContainer::IndexType VectorTrackContainer::addTrack_impl() {
+  checkConsistency();
+
+  m_tipIndex.emplace_back();
+
+  m_params.emplace_back();
+  m_cov.emplace_back();
+  m_referenceSurfaces.emplace_back();
+
+  m_nMeasurements.emplace_back();
+  m_nHoles.emplace_back();
+
+  // dynamic columns
+  for (auto& [key, vec] : m_dynamic) {
+    vec->add();
+  }
+
+  checkConsistency();
+
+  return m_tipIndex.size() - 1;
+}
+
+void VectorTrackContainer::removeTrack_impl(IndexType itrack) {
+  auto erase = [&](auto& vec) {
+    assert(itrack < vec.size() && "Index is out of range");
+    auto it = vec.begin();
+    std::advance(it, itrack);
+    vec.erase(it);
+  };
+
+  erase(m_tipIndex);
+
+  erase(m_params);
+  erase(m_cov);
+  erase(m_referenceSurfaces);
+
+  erase(m_nMeasurements);
+  erase(m_nHoles);
+
+  for (auto& [key, vec] : m_dynamic) {
+    vec->erase(itrack);
+  }
+}
+
+}  // namespace Acts

--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -24,12 +24,12 @@ VectorTrackContainerBase::VectorTrackContainerBase(
     m_dynamic.insert({key, value->clone()});
   }
 
-  checkConsistency();
+  assert(checkConsistency());
 }
 }  // namespace detail_vtc
 
 VectorTrackContainer::IndexType VectorTrackContainer::addTrack_impl() {
-  checkConsistency();
+  assert(checkConsistency());
 
   m_tipIndex.emplace_back();
 
@@ -45,7 +45,7 @@ VectorTrackContainer::IndexType VectorTrackContainer::addTrack_impl() {
     vec->add();
   }
 
-  checkConsistency();
+  assert(checkConsistency());
 
   return m_tipIndex.size() - 1;
 }


### PR DESCRIPTION
This also moves some method definitions to a cpp file for VectorTrackContainer, and adds the ability to copy a const track vector container to a mutable one (for modification).