### PR TITLE
chore: improve coloring for residuals and pulls script

### DIFF
--- a/Examples/Scripts/TrackingPerformance/boundParamResolution.C
+++ b/Examples/Scripts/TrackingPerformance/boundParamResolution.C
@@ -695,6 +695,7 @@ int boundParamResolution(const std::string& inFile, const std::string& treeName,
             pull_smt[vlID + paramNames.at(ipar)]->Fit("gaus", "q");
             TF1* gauss =
                 pull_smt[vlID + paramNames.at(ipar)]->GetFunction("gaus");
+            gauss->SetLineColor(kGreen);
             float mu = gauss->GetParameter(1);
             float sigma = gauss->GetParameter(2);
 


### PR DESCRIPTION
color of the fit used to be the same as the predicted which made the plots hard to read