### PR TITLE
refactor: improve G4 python bindings

### DIFF
--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -579,7 +579,7 @@ def addGeant4(
         the output folder for the Root output, None triggers no output
     """
 
-    from acts.examples.geant4 import Geant4Simulation, geant4SimulationConfig
+    from acts.examples.geant4 import Geant4Simulation, makeGeant4SimulationConfig
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
@@ -600,9 +600,10 @@ def addGeant4(
             raise AttributeError("detector not given")
         g4detectorConstruction = getG4DetectorContruction(detector)
 
-    g4conf = geant4SimulationConfig(
+    g4conf = makeGeant4SimulationConfig(
         level=customLogLevel(),
         detector=g4detectorConstruction,
+        randomNumbers=rnd,
         inputParticles=particles_selected,
         trackingGeometry=trackingGeometry,
         magneticField=field,
@@ -612,7 +613,6 @@ def addGeant4(
     g4conf.outputSimHits = "simhits"
     g4conf.outputParticlesInitial = "particles_initial"
     g4conf.outputParticlesFinal = "particles_final"
-    g4conf.randomNumbers = rnd
 
     # Simulation
     alg = Geant4Simulation(

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -116,9 +116,9 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
         // Read the particle from the generator
         SimParticleTranslation::Config g4PrCfg;
         g4PrCfg.inputParticles = inputParticles;
-        g4PrCfg.forcedPdgCode = 999;
-        g4PrCfg.forcedCharge = 0.;
+        g4PrCfg.forceParticle = true;
         g4PrCfg.forcedMass = 0.;
+        g4PrCfg.forcedPdgCode = 999;
 
         auto g4Cfg = makeGeant4Config(level, std::move(randomNumbers), detector,
                                       physicsList, g4PrCfg);

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -81,51 +81,56 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
       eventActions, trackingActions, steppingActions, detectorConstruction,
       magneticField, sensitiveSurfaceMapper);
 
-  mod.def(
-      "materialRecordingConfig",
-      [](Acts::Logging::Level level, G4VUserDetectorConstruction* detector,
+  auto makeGeant4Config =
+      [](Acts::Logging::Level& level,
          std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers,
-         const std::string& inputParticles,
-         const std::string& outputMaterialTracks) {
-        // The Geant4 actions needed
-        std::vector<G4UserRunAction*> runActions = {};
-        std::vector<G4UserEventAction*> eventActions = {};
-        std::vector<G4UserTrackingAction*> trackingActions = {};
+         G4VUserDetectorConstruction* detector, G4VUserPhysicsList* physicsList,
+         const SimParticleTranslation::Config& prCfg)
+      -> Geant4Simulation::Config {
+    Geant4Simulation::Config g4Cfg;
 
-        // Set the main Geant4 algorithm, primary generation, detector
-        // construction
-        Geant4Simulation::Config g4Cfg;
-        g4Cfg.randomNumbers = std::move(randomNumbers);
-        g4Cfg.runManager = std::make_shared<G4RunManager>();
-        g4Cfg.runManager->SetUserInitialization(new MaterialPhysicsList(
-            Acts::getDefaultLogger("MaterialPhysicsList", level)));
+    // Set the main Geant4 algorithm, primary generation, detector
+    // construction
+    g4Cfg.randomNumbers = std::move(randomNumbers);
+    g4Cfg.runManager = std::make_shared<G4RunManager>();
+    g4Cfg.runManager->SetUserInitialization(physicsList);
 
-        MaterialSteppingAction::Config mStepCfg;
-        mStepCfg.excludeMaterials = {"Air", "Vacuum"};
-        std::vector<G4UserSteppingAction*> steppingActions = {
-            new MaterialSteppingAction(
-                mStepCfg,
-                Acts::getDefaultLogger("MaterialSteppingAction", level))};
+    // Set the primarty generator
+    g4Cfg.primaryGeneratorAction = new SimParticleTranslation(
+        prCfg, Acts::getDefaultLogger("SimParticleTranslation", level));
+    g4Cfg.detectorConstruction = detector;
+
+    return g4Cfg;
+  };
+
+  mod.def(
+      "makeGeant4MaterialRecordingConfig",
+      [makeGeant4Config](
+          Acts::Logging::Level level, G4VUserDetectorConstruction* detector,
+          std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers,
+          const std::string& inputParticles,
+          const std::string& outputMaterialTracks) {
+        auto physicsList = new MaterialPhysicsList(
+            Acts::getDefaultLogger("MaterialPhysicsList", level));
 
         // Read the particle from the generator
         SimParticleTranslation::Config g4PrCfg;
         g4PrCfg.inputParticles = inputParticles;
-        g4PrCfg.forceParticle = true;
-        g4PrCfg.forcedMass = 0.;
         g4PrCfg.forcedPdgCode = 999;
+        g4PrCfg.forcedCharge = 0.;
+        g4PrCfg.forcedMass = 0.;
+
+        auto g4Cfg = makeGeant4Config(level, std::move(randomNumbers), detector,
+                                      physicsList, g4PrCfg);
+
+        MaterialSteppingAction::Config mStepCfg;
+        mStepCfg.excludeMaterials = {"Air", "Vacuum"};
+        auto steppingAction = new MaterialSteppingAction(
+            mStepCfg, Acts::getDefaultLogger("MaterialSteppingAction", level));
+        g4Cfg.steppingActions = {steppingAction};
+
         // Set the material tracks at output
         g4Cfg.outputMaterialTracks = outputMaterialTracks;
-
-        // Set the primarty generator
-        g4Cfg.primaryGeneratorAction = new SimParticleTranslation(
-            g4PrCfg, Acts::getDefaultLogger("SimParticleTranslation", level));
-        g4Cfg.detectorConstruction = detector;
-
-        // Set the user actions
-        g4Cfg.runActions = runActions;
-        g4Cfg.eventActions = eventActions;
-        g4Cfg.trackingActions = trackingActions;
-        g4Cfg.steppingActions = steppingActions;
 
         return g4Cfg;
       },
@@ -133,54 +138,36 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
       "outputMaterialTracks"_a);
 
   mod.def(
-      "geant4SimulationConfig",
-      [](Acts::Logging::Level& level, G4VUserDetectorConstruction* detector,
-         const std::string& inputParticles,
-         const std::shared_ptr<const Acts::TrackingGeometry>& trackingGeometry,
-         const std::shared_ptr<const Acts::MagneticFieldProvider>&
-             magneticField,
-         const std::vector<std::string>& volumeMappings,
-         const std::vector<std::string>& materialMappings) {
-        // The Geant4 actions needed
-        std::vector<G4UserRunAction*> runActions = {};
-        std::vector<G4UserEventAction*> eventActions = {};
-        std::vector<G4UserTrackingAction*> trackingActions = {};
-        std::vector<G4UserSteppingAction*> steppingActions = {};
-
-        // Set the main Geant4 algorithm, primary generation, detector
-        // construction
-        Geant4Simulation::Config g4Cfg;
-
-        g4Cfg.runManager = std::make_shared<G4RunManager>();
-        g4Cfg.runManager->SetUserInitialization(new FTFP_BERT());
-
-        ParticleTrackingAction::Config g4TrackCfg;
-        ParticleTrackingAction* particleAction = new ParticleTrackingAction(
-            g4TrackCfg,
-            Acts::getDefaultLogger("ParticleTrackingAction", level));
-        trackingActions.push_back(particleAction);
-
-        SensitiveSteppingAction::Config g4StepCfg;
-        SensitiveSteppingAction* sensitiveStepping =
-            new SensitiveSteppingAction(
-                g4StepCfg,
-                Acts::getDefaultLogger("SensitiveSteppingAction", level));
-        steppingActions.push_back(sensitiveStepping);
+      "makeGeant4SimulationConfig",
+      [makeGeant4Config](
+          Acts::Logging::Level& level, G4VUserDetectorConstruction* detector,
+          std::shared_ptr<const ActsExamples::RandomNumbers> randomNumbers,
+          const std::string& inputParticles,
+          const std::shared_ptr<const Acts::TrackingGeometry>& trackingGeometry,
+          const std::shared_ptr<const Acts::MagneticFieldProvider>&
+              magneticField,
+          const std::vector<std::string>& volumeMappings,
+          const std::vector<std::string>& materialMappings) {
+        auto physicsList = new FTFP_BERT();
 
         // Read the particle from the generator
         SimParticleTranslation::Config g4PrCfg;
         g4PrCfg.inputParticles = inputParticles;
 
-        // Set the primarty generator
-        g4Cfg.primaryGeneratorAction = new SimParticleTranslation(
-            g4PrCfg, Acts::getDefaultLogger("SimParticleTranslation", level));
-        g4Cfg.detectorConstruction = detector;
+        auto g4Cfg = makeGeant4Config(level, std::move(randomNumbers), detector,
+                                      physicsList, g4PrCfg);
 
-        // Set the user actions
-        g4Cfg.runActions = runActions;
-        g4Cfg.eventActions = eventActions;
-        g4Cfg.trackingActions = trackingActions;
-        g4Cfg.steppingActions = steppingActions;
+        ParticleTrackingAction::Config g4TrackCfg;
+        ParticleTrackingAction* particleAction = new ParticleTrackingAction(
+            g4TrackCfg,
+            Acts::getDefaultLogger("ParticleTrackingAction", level));
+        g4Cfg.trackingActions.push_back(particleAction);
+
+        SensitiveSteppingAction::Config g4StepCfg;
+        G4UserSteppingAction* steppingAction = new SensitiveSteppingAction(
+            g4StepCfg,
+            Acts::getDefaultLogger("SensitiveSteppingAction", level));
+        g4Cfg.steppingActions.push_back(steppingAction);
 
         // An ACTS Magnetic field is provided
         if (magneticField) {
@@ -211,7 +198,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
 
         return g4Cfg;
       },
-      "level"_a, "detector"_a, "inputParticles"_a,
+      "level"_a, "detector"_a, "randomNumbers"_a, "inputParticles"_a,
       py::arg("trackingGeometry") = nullptr, py::arg("magneticField") = nullptr,
       py::arg("volumeMappings") = std::vector<std::string>{},
       py::arg("materialMappings") = std::vector<std::string>{});

--- a/Examples/Scripts/Python/material_recording.py
+++ b/Examples/Scripts/Python/material_recording.py
@@ -56,7 +56,7 @@ def runMaterialRecording(g4geo, outputDir, tracksPerEvent=10000, s=None):
 
     s.addReader(evGen)
 
-    g4AlgCfg = acts.examples.geant4.materialRecordingConfig(
+    g4AlgCfg = acts.examples.geant4.makeGeant4MaterialRecordingConfig(
         level=acts.logging.INFO,
         detector=g4geo,
         inputParticles=evGen.config.outputParticles,


### PR DESCRIPTION
- improve naming: `geant4SimulationConfig` -> `makeGeant4SimulationConfig`
- put sim and material track config generation on common grounds
- wire random numbers through arguments instead of setting it from the python wrappers

cc @Corentin-Allaire I hope this does not break your material tracks :crossed_fingers: 