### PR TITLE
feat: deltaPhiMax variable from orthogonal seeding configurable with python 

### DIFF
--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -360,7 +360,7 @@ def itkSeedingAlgConfig(inputSpacePointsType):
     phiBinDeflectionCoverage = 3
     numPhiNeighbors = 1
     # only used in orthogonal seeding
-    deltaPhiMax = 0.25
+    deltaPhiMax = 0.025
 
     # variables that change for pixel and strip SPs:
     if inputSpacePointsType == "PixelSpacePoints":

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -359,6 +359,8 @@ def itkSeedingAlgConfig(inputSpacePointsType):
     phiMax = 2 * math.pi
     phiBinDeflectionCoverage = 3
     numPhiNeighbors = 1
+    # only used in orthogonal seeding
+    deltaPhiMax = 0.25
 
     # variables that change for pixel and strip SPs:
     if inputSpacePointsType == "PixelSpacePoints":
@@ -484,6 +486,7 @@ def itkSeedingAlgConfig(inputSpacePointsType):
         radLengthPerSeed=radLengthPerSeed,
         minPt=minPt,
         impactMax=impactMax,
+        deltaPhiMax=deltaPhiMax,
         interactionPointCut=interactionPointCut,
         arithmeticAverageCotTheta=arithmeticAverageCotTheta,
         deltaZMax=deltaZMax,

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -34,6 +34,7 @@ SeedFinderConfigArg = namedtuple(
         "radLengthPerSeed",
         "minPt",
         "impactMax",
+        "deltaPhiMax",
         "interactionPointCut",
         "arithmeticAverageCotTheta",
         "deltaZMax",
@@ -56,7 +57,7 @@ SeedFinderConfigArg = namedtuple(
         "r",  # (min,max)
         "z",  # (min,max)
     ],
-    defaults=[None] * 20 + [(None, None)] * 7,
+    defaults=[None] * 21 + [(None, None)] * 7,
 )
 SeedFinderOptionsArg = namedtuple(
     "SeedFinderOptions", ["beamPos", "bFieldInZ"], defaults=[(None, None), None]
@@ -201,7 +202,7 @@ def addSeeding(
     initialVarInflation : list
         List of 6 scale factors to inflate the initial covariance matrix
         Defaults (all 1) specified in Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSmearing.hpp
-    seedFinderConfigArg : SeedFinderConfigArg(maxSeedsPerSpM, cotThetaMax, sigmaScattering, radLengthPerSeed, minPt, impactMax, interactionPointCut, arithmeticAverageCotTheta, deltaZMax, maxPtScattering, zBinEdges, skipPreviousTopSP, zBinsCustomLooping, rRangeMiddleSP, useVariableMiddleSPRange, binSizeR, forceRadialSorting, seedConfirmation, centralSeedConfirmationRange, forwardSeedConfirmationRange, deltaR, deltaRBottomSP, deltaRTopSP, deltaRMiddleSPRange, collisionRegion, r, z)
+    seedFinderConfigArg : SeedFinderConfigArg(maxSeedsPerSpM, cotThetaMax, sigmaScattering, radLengthPerSeed, minPt, impactMax, deltaPhiMax, interactionPointCut, arithmeticAverageCotTheta, deltaZMax, maxPtScattering, zBinEdges, skipPreviousTopSP, zBinsCustomLooping, rRangeMiddleSP, useVariableMiddleSPRange, binSizeR, forceRadialSorting, seedConfirmation, centralSeedConfirmationRange, forwardSeedConfirmationRange, deltaR, deltaRBottomSP, deltaRTopSP, deltaRMiddleSPRange, collisionRegion, r, z)
         SeedFinderConfig settings. deltaR, deltaRBottomSP, deltaRTopSP, deltaRMiddleSPRange, collisionRegion, r, z are ranges specified as a tuple of (min,max). beamPos is specified as (x,y).
         Defaults specified in Core/include/Acts/Seeding/SeedFinderConfig.hpp
     seedFinderOptionsArg :  SeedFinderOptionsArg(bFieldInZ, beamPos)
@@ -624,6 +625,7 @@ def addOrthogonalSeeding(
             radLengthPerSeed=seedFinderConfigArg.radLengthPerSeed,
             minPt=seedFinderConfigArg.minPt,
             impactMax=seedFinderConfigArg.impactMax,
+            deltaPhiMax=seedFinderConfigArg.deltaPhiMax,
             interactionPointCut=seedFinderConfigArg.interactionPointCut,
             deltaZMax=seedFinderConfigArg.deltaZMax,
             maxPtScattering=seedFinderConfigArg.maxPtScattering,

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -137,6 +137,7 @@ void addTrackFinding(Context& ctx) {
     ACTS_PYTHON_MEMBER(deltaRMinTopSP);
     ACTS_PYTHON_MEMBER(deltaRMaxTopSP);
     ACTS_PYTHON_MEMBER(impactMax);
+    ACTS_PYTHON_MEMBER(deltaPhiMax);
     ACTS_PYTHON_MEMBER(deltaZMax);
     ACTS_PYTHON_MEMBER(sigmaScattering);
     ACTS_PYTHON_MEMBER(maxPtScattering);


### PR DESCRIPTION
This PR enables the configuration of `deltaPhiMax` with python bindings.

This variable is used only by the ortogonal seeding to restrict the phi search range. I believe this could be understood as something similar to what we do in the default seeding when we choose a certain number of neighbouring phi bins to search for SPs. 

I have set it to 0.025 in the ITk configuration because it improves the time performance by about 15% in the ITk PPP example, (when compared to the default value 0.085) without changing the physics performance. I still need to test it for SSS. @stephenswat @noemina 