### PR TITLE
refactor: Seeding algo level bin finders

### DIFF
--- a/Core/include/Acts/Seeding/BinnedSPGroup.hpp
+++ b/Core/include/Acts/Seeding/BinnedSPGroup.hpp
@@ -194,8 +194,8 @@ class BinnedSPGroupIterator {
   }
 
   BinnedSPGroupIterator(const SpacePointGrid<external_spacepoint_t>* spgrid,
-                        BinFinder<external_spacepoint_t>* botBinFinder,
-                        BinFinder<external_spacepoint_t>* tBinFinder,
+                        const BinFinder<external_spacepoint_t>* botBinFinder,
+                        const BinFinder<external_spacepoint_t>* tBinFinder,
                         std::vector<size_t> bins = {}) {
     grid = spgrid;
     m_bottomBinFinder = botBinFinder;
@@ -215,8 +215,8 @@ class BinnedSPGroupIterator {
   }
 
   BinnedSPGroupIterator(const SpacePointGrid<external_spacepoint_t>* spgrid,
-                        BinFinder<external_spacepoint_t>* botBinFinder,
-                        BinFinder<external_spacepoint_t>* tBinFinder,
+                        const BinFinder<external_spacepoint_t>* botBinFinder,
+                        const BinFinder<external_spacepoint_t>* tBinFinder,
                         size_t phiInd, size_t zInd,
                         std::vector<size_t> bins = {}) {
     m_bottomBinFinder = botBinFinder;
@@ -252,8 +252,8 @@ class BinnedSPGroupIterator {
   size_t zIndex = 1;
   size_t outputIndex = 0;
   std::array<long unsigned int, 2ul> phiZbins;
-  BinFinder<external_spacepoint_t>* m_bottomBinFinder;
-  BinFinder<external_spacepoint_t>* m_topBinFinder;
+  const BinFinder<external_spacepoint_t>* m_bottomBinFinder;
+  const BinFinder<external_spacepoint_t>* m_topBinFinder;
   std::vector<size_t> customZorder;
   // 	bool start = true;
 };
@@ -270,8 +270,9 @@ class BinnedSPGroup {
   BinnedSPGroup<external_spacepoint_t>(
       spacepoint_iterator_t spBegin, spacepoint_iterator_t spEnd,
       callable_t&& toGlobal,
-      std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> botBinFinder,
-      std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> tBinFinder,
+      std::shared_ptr<const Acts::BinFinder<external_spacepoint_t>>
+          botBinFinder,
+      std::shared_ptr<const Acts::BinFinder<external_spacepoint_t>> tBinFinder,
       std::unique_ptr<SpacePointGrid<external_spacepoint_t>> grid,
       Acts::Extent& rRangeSPExtent,
       const SeedFinderConfig<external_spacepoint_t>& _config,
@@ -298,8 +299,8 @@ class BinnedSPGroup {
 
   // BinFinder must return std::vector<Acts::Seeding::Bin> with content of
   // each bin sorted in r (ascending)
-  std::shared_ptr<BinFinder<external_spacepoint_t>> m_topBinFinder;
-  std::shared_ptr<BinFinder<external_spacepoint_t>> m_bottomBinFinder;
+  std::shared_ptr<const BinFinder<external_spacepoint_t>> m_topBinFinder;
+  std::shared_ptr<const BinFinder<external_spacepoint_t>> m_bottomBinFinder;
 
   std::vector<size_t> m_bins;
 };

--- a/Core/include/Acts/Seeding/BinnedSPGroup.ipp
+++ b/Core/include/Acts/Seeding/BinnedSPGroup.ipp
@@ -10,8 +10,8 @@ template <typename spacepoint_iterator_t, typename callable_t>
 Acts::BinnedSPGroup<external_spacepoint_t>::BinnedSPGroup(
     spacepoint_iterator_t spBegin, spacepoint_iterator_t spEnd,
     callable_t&& toGlobal,
-    std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> botBinFinder,
-    std::shared_ptr<Acts::BinFinder<external_spacepoint_t>> tBinFinder,
+    std::shared_ptr<const Acts::BinFinder<external_spacepoint_t>> botBinFinder,
+    std::shared_ptr<const Acts::BinFinder<external_spacepoint_t>> tBinFinder,
     std::unique_ptr<SpacePointGrid<external_spacepoint_t>> grid,
     Acts::Extent& rRangeSPExtent,
     const SeedFinderConfig<external_spacepoint_t>& config,

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Seeding/SpacePointGrid.hpp"
 #include "ActsExamples/EventData/SimSpacePoint.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
 
 #include <string>
 #include <vector>
@@ -47,8 +48,8 @@ class SeedingAlgorithm final : public BareAlgorithm {
     bool allowSeparateRMax = false;
 
     // vector containing the map of z bins in the top and bottom layers
-    std::vector<std::pair<int, int> > zBinNeighborsTop;
-    std::vector<std::pair<int, int> > zBinNeighborsBottom;
+    std::vector<std::pair<int, int>> zBinNeighborsTop;
+    std::vector<std::pair<int, int>> zBinNeighborsBottom;
     // number of phiBin neighbors at each side of the current bin that will be
     // used to search for SPs
     int numPhiNeighbors = 0;
@@ -71,6 +72,8 @@ class SeedingAlgorithm final : public BareAlgorithm {
 
  private:
   Acts::SeedFinder<SimSpacePoint> m_seedFinder;
+  std::shared_ptr<const Acts::BinFinder<SimSpacePoint>> m_bottomBinFinder;
+  std::shared_ptr<const Acts::BinFinder<SimSpacePoint>> m_topBinFinder;
   Config m_cfg;
 };
 

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -180,6 +180,11 @@ ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
         });
   }
 
+  m_bottomBinFinder = std::make_shared<const Acts::BinFinder<SimSpacePoint>>(
+      m_cfg.zBinNeighborsBottom, m_cfg.numPhiNeighbors);
+  m_topBinFinder = std::make_shared<const Acts::BinFinder<SimSpacePoint>>(
+      m_cfg.zBinNeighborsTop, m_cfg.numPhiNeighbors);
+
   m_cfg.seedFinderConfig.seedFilter =
       std::make_unique<Acts::SeedFilter<SimSpacePoint>>(m_cfg.seedFilterConfig);
   m_seedFinder = Acts::SeedFinder<SimSpacePoint>(m_cfg.seedFinderConfig);
@@ -219,17 +224,11 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
   // extent used to store r range for middle spacepoint
   Acts::Extent rRangeSPExtent;
 
-  auto bottomBinFinder = std::make_shared<Acts::BinFinder<SimSpacePoint>>(
-      Acts::BinFinder<SimSpacePoint>(m_cfg.zBinNeighborsBottom,
-                                     m_cfg.numPhiNeighbors));
-  auto topBinFinder = std::make_shared<Acts::BinFinder<SimSpacePoint>>(
-      Acts::BinFinder<SimSpacePoint>(m_cfg.zBinNeighborsTop,
-                                     m_cfg.numPhiNeighbors));
   auto grid = Acts::SpacePointGridCreator::createGrid<SimSpacePoint>(
       m_cfg.gridConfig, m_cfg.gridOptions);
   auto spacePointsGrouping = Acts::BinnedSPGroup<SimSpacePoint>(
       spacePointPtrs.begin(), spacePointPtrs.end(), extractGlobalQuantities,
-      bottomBinFinder, topBinFinder, std::move(grid), rRangeSPExtent,
+      m_bottomBinFinder, m_topBinFinder, std::move(grid), rRangeSPExtent,
       m_cfg.seedFinderConfig, m_cfg.seedFinderOptions);
 
   // safely clamp double to float


### PR DESCRIPTION
Currently the SeedingAlgorithm creates the bin finders on every event. I don't think that's needed, but for const-reasons I have to change their argument types to be const everywhere.