### PR TITLE
refactor: Use pointer-to-impl pattern to improve algorithms

### DIFF
--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -165,7 +165,7 @@ class IterativeVertexFinder {
 
  private:
   /// Configuration object
-  const Config m_cfg;
+  Config m_cfg;
 
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -36,6 +36,8 @@ class AdaptiveMultiVertexFinderAlgorithm final : public BareAlgorithm {
   AdaptiveMultiVertexFinderAlgorithm(const Config& config,
                                      Acts::Logging::Level level);
 
+  ProcessCode initialize() override;
+
   /// Find vertices using the adapative multi vertex finder algorithm.
   ///
   /// @param ctx is the algorithm context with event information
@@ -45,8 +47,13 @@ class AdaptiveMultiVertexFinderAlgorithm final : public BareAlgorithm {
   /// Get readonly access to the config parameters
   const Config& config() const { return m_cfg; }
 
+  ~AdaptiveMultiVertexFinderAlgorithm() override;
+
  private:
   Config m_cfg;
+
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "ActsExamples/Framework/BareAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
 
 #include <string>
 
@@ -36,17 +37,24 @@ class IterativeVertexFinderAlgorithm final : public BareAlgorithm {
   IterativeVertexFinderAlgorithm(const Config& config,
                                  Acts::Logging::Level level);
 
+  ~IterativeVertexFinderAlgorithm();
+
   /// Find vertices using iterative vertex finder algorithm.
   ///
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
 
+  ProcessCode initialize() final;
+
   /// Get readonly access to the config parameters
   const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;
+
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -45,17 +45,24 @@ class VertexFitterAlgorithm final : public BareAlgorithm {
 
   VertexFitterAlgorithm(const Config& cfg, Acts::Logging::Level lvl);
 
+  ~VertexFitterAlgorithm();
+
   /// Fit the input vertices.
   ///
   /// @param ctx is the algorithm context with event information
   /// @return a process code indication success or failure
   ProcessCode execute(const AlgorithmContext& ctx) const final;
 
+  ProcessCode initialize() final;
+
   /// Get readonly access to the config parameters
   const Config& config() const { return m_cfg; }
 
  private:
   Config m_cfg;
+
+  struct Impl;
+  std::unique_ptr<Impl> m_impl;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -90,13 +90,14 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::initialize() {
 
   // Set up deterministic annealing with user-defined temperatures
   Acts::AnnealingUtility::Config annealingConfig;
-  annealingConfig.setOfTemperatures = {8.0,       4.0,       2.0,
-                                       1.4142136, 1.2247449, 1.0};
+  annealingConfig.setOfTemperatures = {1.};
   Acts::AnnealingUtility annealingUtility(annealingConfig);
 
   // Set up the vertex fitter with user-defined annealing
   Fitter::Config fitterCfg(ipEstimator);
   fitterCfg.annealingTool = annealingUtility;
+  fitterCfg.minWeight = 0.001;
+  fitterCfg.doSmoothing = true;
   Fitter fitter(fitterCfg, logger().cloneWithSuffix("AMVFitter"));
 
   // Set up the vertex seed finder
@@ -106,6 +107,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::initialize() {
                               std::move(linearizer), m_cfg.bField);
   // We do not want to use a beamspot constraint here
   finderConfig.useBeamSpotConstraint = false;
+  finderConfig.tracksMaxZinterval = 1. * Acts::UnitConstants::mm;
 
   // Instantiate the finder
   m_impl = std::make_unique<Impl>(


### PR DESCRIPTION
Currently, the vertexing algorithms recreate their tools every event. In order not having to put all the types in the header, using the pointer-to-impl pattern, we can keep them in the cpp file.

Not sure if this is a good pattern overall, but I wanted to try it out. Thoughts?