### PR TITLE
chore: odd full chain - only root output by default

### DIFF
--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -122,8 +122,8 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
                 pt=(150 * u.MeV, None),
                 removeNeutral=True,
             ),
-            # outputDirRoot=outputDir,
-            outputDirCsv=outputDir,
+            outputDirRoot=outputDir,
+            # outputDirCsv=outputDir,
             rnd=rnd,
         )
     else:


### PR DESCRIPTION
currently we have mixed csv and root output for the simulation. this PR is fixing that