### PR TITLE
fix: Sequencer use-after-move in sequencer data flow check

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -85,7 +85,7 @@ class Sequencer {
   /// Append a sequence element to the sequence
   ///
   /// @throws std::invalid_argument if the element is NULL.
-  void addElement(std::shared_ptr<SequenceElement> element);
+  void addElement(const std::shared_ptr<SequenceElement> &element);
 
   /// Add a writer to the set of writers.
   ///

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -114,7 +114,7 @@ void Sequencer::addElement(std::shared_ptr<SequenceElement> element) {
     throw std::invalid_argument("Can not add empty/NULL element");
   }
 
-  m_sequenceElements.push_back(std::move(element));
+  m_sequenceElements.push_back(element);
 
   if (!m_cfg.runDataFlowChecks) {
     return;

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -109,7 +109,7 @@ void Sequencer::addWriter(std::shared_ptr<IWriter> writer) {
   addElement(std::move(writer));
 }
 
-void Sequencer::addElement(std::shared_ptr<SequenceElement> element) {
+void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
   if (not element) {
     throw std::invalid_argument("Can not add empty/NULL element");
   }


### PR DESCRIPTION
If Sequencer data flow checks are turned on, there's a use-after-move bug that this PR fixes.