### PR TITLE
feat: Added a function that draws the detector volume with inner surfaces

### DIFF
--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -103,6 +103,7 @@ struct GeometryView3D {
   /// @param [in,out] helper The visualization helper
   /// @param volume The DetectorVolume to be drawn
   /// @param gctx The geometry context for which it is drawn
+  /// @param drawSurface switches on/off the drawing of the volumes' surfaces
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param unconnected The config for unconnected portals
@@ -110,9 +111,13 @@ struct GeometryView3D {
       IVisualization3D& helper,
       const Acts::Experimental::DetectorVolume& volume,
       const GeometryContext& gctx,
+      bool drawSurfaces,
       const Transform3& transform = Transform3::Identity(),
       const ViewConfig& connected = ViewConfig({0, 255, 0}),
-      const ViewConfig& unconnected = ViewConfig({255, 0, 0}));
+      const ViewConfig& unconnected = ViewConfig({255, 0, 0}),
+      const ViewConfig& viewConfig = s_viewSensitive);
+
+
 
   /// Helper method to draw AbstractVolume objects
   ///

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -110,14 +110,11 @@ struct GeometryView3D {
   static void drawDetectorVolume(
       IVisualization3D& helper,
       const Acts::Experimental::DetectorVolume& volume,
-      const GeometryContext& gctx,
-      bool drawSurfaces,
+      const GeometryContext& gctx, bool drawSurfaces,
       const Transform3& transform = Transform3::Identity(),
       const ViewConfig& connected = ViewConfig({0, 255, 0}),
       const ViewConfig& unconnected = ViewConfig({255, 0, 0}),
       const ViewConfig& viewConfig = s_viewSensitive);
-
-
 
   /// Helper method to draw AbstractVolume objects
   ///

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -103,7 +103,7 @@ struct GeometryView3D {
   /// @param [in,out] helper The visualization helper
   /// @param volume The DetectorVolume to be drawn
   /// @param gctx The geometry context for which it is drawn
-  /// @param drawSurface switches on/off the drawing of the volumes' surfaces
+  /// @param drawSurfaces switches on/off the drawing of the volumes' surfaces
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param unconnected The config for unconnected portals

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -107,6 +107,7 @@ struct GeometryView3D {
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param unconnected The config for unconnected portals
+  /// @param ViewConfig The drawing configuration
   static void drawDetectorVolume(
       IVisualization3D& helper,
       const Acts::Experimental::DetectorVolume& volume,

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -107,7 +107,7 @@ struct GeometryView3D {
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param unconnected The config for unconnected portals
-  /// @param ViewConfig The drawing configuration
+  /// @param viewConfig The drawing configuration
   static void drawDetectorVolume(
       IVisualization3D& helper,
       const Acts::Experimental::DetectorVolume& volume,

--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -191,44 +191,43 @@ void Acts::GeometryView3D::drawPortal(IVisualization3D& helper,
 
 void Acts::GeometryView3D::drawDetectorVolume(
     IVisualization3D& helper, const Experimental::DetectorVolume& volume,
-    const GeometryContext& gctx,  bool drawSurfaces,
-    const Transform3& transform, const ViewConfig& connected, 
-    const ViewConfig& unconnected, const ViewConfig& viewConfig) {
+    const GeometryContext& gctx, bool drawSurfaces, const Transform3& transform,
+    const ViewConfig& connected, const ViewConfig& unconnected,
+    const ViewConfig& viewConfig) {
   // draw the envelope first
   auto portals = volume.portals();
   for (auto portal : portals) {
     drawPortal(helper, *portal, gctx, transform, connected, unconnected);
   }
 
-  //draw the surfaces of the mother volume 
-  if(drawSurfaces){
+  // draw the surfaces of the mother volume
+  if (drawSurfaces) {
     auto surfaces = volume.surfaces();
-    for(auto surface : surfaces){
+    for (auto surface : surfaces) {
       drawSurface(helper, *surface, gctx, transform, viewConfig);
     }
   }
-  // recurse if there are subvolumes, otherwise draw the portals and the surfaces if tag is true
+  // recurse if there are subvolumes, otherwise draw the portals and the
+  // surfaces if tag is true
   auto subvolumes = volume.volumes();
   for (auto subvolume : subvolumes) {
     if (!subvolume->volumes().empty()) {
-      drawDetectorVolume(helper, *subvolume, gctx, drawSurfaces, transform, connected,
-                         unconnected, viewConfig);
+      drawDetectorVolume(helper, *subvolume, gctx, drawSurfaces, transform,
+                         connected, unconnected, viewConfig);
     } else {
       auto sub_portals = subvolume->portals();
       for (auto sub_portal : sub_portals) {
         drawPortal(helper, *sub_portal, gctx, transform, connected,
                    unconnected);
       }
-      if(drawSurfaces){
+      if (drawSurfaces) {
         auto sub_surfaces = subvolume->surfaces();
-        for(auto sub_surface : sub_surfaces){
+        for (auto sub_surface : sub_surfaces) {
           drawSurface(helper, *sub_surface, gctx, transform, viewConfig);
         }
-
       }
     }
   }
-  
 }
 
 void Acts::GeometryView3D::drawLayer(

--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -191,27 +191,44 @@ void Acts::GeometryView3D::drawPortal(IVisualization3D& helper,
 
 void Acts::GeometryView3D::drawDetectorVolume(
     IVisualization3D& helper, const Experimental::DetectorVolume& volume,
-    const GeometryContext& gctx, const Transform3& transform,
-    const ViewConfig& connected, const ViewConfig& unconnected) {
+    const GeometryContext& gctx,  bool drawSurfaces,
+    const Transform3& transform, const ViewConfig& connected, 
+    const ViewConfig& unconnected, const ViewConfig& viewConfig) {
   // draw the envelope first
   auto portals = volume.portals();
   for (auto portal : portals) {
     drawPortal(helper, *portal, gctx, transform, connected, unconnected);
   }
-  // recurse if there are subvolumes, otherwise draw the portals
+
+  //draw the surfaces of the mother volume 
+  if(drawSurfaces){
+    auto surfaces = volume.surfaces();
+    for(auto surface : surfaces){
+      drawSurface(helper, *surface, gctx, transform, viewConfig);
+    }
+  }
+  // recurse if there are subvolumes, otherwise draw the portals and the surfaces if tag is true
   auto subvolumes = volume.volumes();
   for (auto subvolume : subvolumes) {
     if (!subvolume->volumes().empty()) {
-      drawDetectorVolume(helper, *subvolume, gctx, transform, connected,
-                         unconnected);
+      drawDetectorVolume(helper, *subvolume, gctx, drawSurfaces, transform, connected,
+                         unconnected, viewConfig);
     } else {
       auto sub_portals = subvolume->portals();
       for (auto sub_portal : sub_portals) {
         drawPortal(helper, *sub_portal, gctx, transform, connected,
                    unconnected);
       }
+      if(drawSurfaces){
+        auto sub_surfaces = subvolume->surfaces();
+        for(auto sub_surface : sub_surfaces){
+          drawSurface(helper, *sub_surface, gctx, transform, viewConfig);
+        }
+
+      }
     }
   }
+  
 }
 
 void Acts::GeometryView3D::drawLayer(


### PR DESCRIPTION
Added the `drawDetectorVolumeWithSurfaces` function that draws the detector volume with the sub-volumes and their surfaces . Any comments and recommendations are more than welcome. 
@andiwand @Matthewharri @asalzburger 