### PR TITLE
fix: itk_seeding script runs again

### DIFF
--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -15,6 +15,10 @@ from acts.examples.reconstruction import (
 
 u = acts.UnitConstants
 
+from enum import Enum
+class InputSpacePointsType(Enum):
+    PixelSpacePoints = 0
+    StripSpacePoints = 1
 
 def buildITkGeometry(
     geo_dir: Path,
@@ -284,10 +288,8 @@ def buildITkGeometry(
     )
 
 
-def itkSeedingAlgConfig(inputSpacePointsType):
-
-    if inputSpacePointsType not in ["PixelSpacePoints", "StripSpacePoints"]:
-        raise RuntimeError("Invalid inputSpacePointsType")
+def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
+    assert isinstance(inputSpacePointsType, InputSpacePointsType)
 
     # variables that do not change for pixel and strip SPs:
     zMax = 3000 * u.mm
@@ -364,7 +366,7 @@ def itkSeedingAlgConfig(inputSpacePointsType):
     deltaPhiMax = 0.025
 
     # variables that change for pixel and strip SPs:
-    if inputSpacePointsType == "PixelSpacePoints":
+    if inputSpacePointsType is  InputSpacePointsType.PixelSpacePoints:
         outputSeeds = "PixelSeeds"
         allowSeparateRMax = False
         rMaxGridConfig = 320 * u.mm
@@ -427,7 +429,7 @@ def itkSeedingAlgConfig(inputSpacePointsType):
         maxSeedsPerSpMConf = 5
         maxQualitySeedsPerSpMConf = 5
         useDeltaRorTopRadius = True
-    elif inputSpacePointsType == "StripSpacePoints":
+    elif inputSpacePointsType is InputSpacePointsType.StripSpacePoints:
         outputSeeds = "StripSeeds"
         allowSeparateRMax = True
         rMaxGridConfig = 1000.0 * u.mm

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -16,9 +16,12 @@ from acts.examples.reconstruction import (
 u = acts.UnitConstants
 
 from enum import Enum
+
+
 class InputSpacePointsType(Enum):
     PixelSpacePoints = 0
     StripSpacePoints = 1
+
 
 def buildITkGeometry(
     geo_dir: Path,
@@ -366,7 +369,7 @@ def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
     deltaPhiMax = 0.025
 
     # variables that change for pixel and strip SPs:
-    if inputSpacePointsType is  InputSpacePointsType.PixelSpacePoints:
+    if inputSpacePointsType is InputSpacePointsType.PixelSpacePoints:
         outputSeeds = "PixelSeeds"
         allowSeparateRMax = False
         rMaxGridConfig = 320 * u.mm

--- a/Examples/Python/tests/test_examples.py
+++ b/Examples/Python/tests/test_examples.py
@@ -409,14 +409,14 @@ def test_itk_seeding(tmp_path, trk_geo, field, assert_root_hash):
         addSeeding,
         TruthSeedRanges,
     )
-    from acts.examples.itk import itkSeedingAlgConfig
+    from acts.examples.itk import itkSeedingAlgConfig, InputSpacePointsType
 
     addSeeding(
         seq,
         trk_geo,
         field,
         TruthSeedRanges(pt=(1.0 * u.GeV, None), eta=(-4, 4), nHits=(9, None)),
-        *itkSeedingAlgConfig("PixelSpacePoints"),
+        *itkSeedingAlgConfig(InputSpacePointsType.PixelSpacePoints),
         acts.logging.VERBOSE,
         geoSelectionConfigFile=srcdir
         / "Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json",

--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -86,7 +86,7 @@ addSeeding(
     if ttbar_pu200
     else TruthSeedRanges(),
     seedingAlgorithm=SeedingAlgorithm.Default,
-    *acts.examples.itk.itkSeedingAlgConfig("PixelSpacePoints"),
+    *acts.examples.itk.itkSeedingAlgConfig(acts.examples.itk.InputSpacePointsType.PixelSpacePoints),
     geoSelectionConfigFile=geo_dir / "itk-hgtd/geoSelection-ITk.json",
     outputDirRoot=outputDir,
 )

--- a/Examples/Scripts/Python/full_chain_itk.py
+++ b/Examples/Scripts/Python/full_chain_itk.py
@@ -86,7 +86,9 @@ addSeeding(
     if ttbar_pu200
     else TruthSeedRanges(),
     seedingAlgorithm=SeedingAlgorithm.Default,
-    *acts.examples.itk.itkSeedingAlgConfig(acts.examples.itk.InputSpacePointsType.PixelSpacePoints),
+    *acts.examples.itk.itkSeedingAlgConfig(
+        acts.examples.itk.InputSpacePointsType.PixelSpacePoints
+    ),
     geoSelectionConfigFile=geo_dir / "itk-hgtd/geoSelection-ITk.json",
     outputDirRoot=outputDir,
 )

--- a/Examples/Scripts/Python/itk_seeding.py
+++ b/Examples/Scripts/Python/itk_seeding.py
@@ -57,7 +57,9 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
         inputSeeds = addStandardSeeding(
             s,
             spacePoints,
-            *acts.examples.itk.itkSeedingAlgConfig(InputSpacePointsType.PixelSpacePoints),
+            *acts.examples.itk.itkSeedingAlgConfig(
+                InputSpacePointsType.PixelSpacePoints
+            ),
         )
 
         prototracks = "seed-prototracks"
@@ -68,7 +70,7 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
                 outputProtoTracks=prototracks,
             )
         )
-        
+
         # estimate seeding performance
         parEstimateAlg = TrackParamsEstimationAlgorithm(
             level=acts.logging.INFO,
@@ -114,7 +116,9 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
         inputSeeds = addStandardSeeding(
             s,
             spacePoints,
-            *acts.examples.itk.itkSeedingAlgConfig(InputSpacePointsType.StripSpacePoints),
+            *acts.examples.itk.itkSeedingAlgConfig(
+                InputSpacePointsType.StripSpacePoints
+            ),
         )
 
         prototracks = "seed-prototracks"
@@ -125,14 +129,14 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
                 outputProtoTracks=prototracks,
             )
         )
-        
+
         # estimate seeding performance
         parEstimateAlg = TrackParamsEstimationAlgorithm(
             level=acts.logging.INFO,
             inputSeeds=inputSeeds,
             outputTrackParameters="estimatedparameters",
             trackingGeometry=trackingGeometry,
-            magneticField=field
+            magneticField=field,
         )
         s.addAlgorithm(parEstimateAlg)
 

--- a/Examples/Scripts/Python/itk_seeding.py
+++ b/Examples/Scripts/Python/itk_seeding.py
@@ -16,7 +16,7 @@ from acts.examples.reconstruction import (
     SeedingAlgorithm,
 )
 
-from acts.examples.itk import itkSeedingAlgConfig
+from acts.examples.itk import itkSeedingAlgConfig, InputSpacePointsType
 
 u = acts.UnitConstants
 rnd = acts.examples.RandomNumbers(seed=42)
@@ -54,21 +54,26 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
         spacePoints = evReader.config.outputSpacePoints
 
         # run seeding
-        inputProtoTracks, inputSeeds = addStandardSeeding(
+        inputSeeds = addStandardSeeding(
             s,
             spacePoints,
-            *acts.examples.itk.itkSeedingAlgConfig("PixelSpacePoint"),
+            *acts.examples.itk.itkSeedingAlgConfig(InputSpacePointsType.PixelSpacePoints),
         )
 
+        prototracks = "seed-prototracks"
+        s.addAlgorithm(
+            acts.examples.SeedsToPrototracks(
+                level=acts.logging.INFO,
+                inputSeeds=inputSeeds,
+                outputProtoTracks=prototracks,
+            )
+        )
+        
         # estimate seeding performance
         parEstimateAlg = TrackParamsEstimationAlgorithm(
             level=acts.logging.INFO,
             inputSeeds=inputSeeds,
-            inputProtoTracks=inputProtoTracks,
-            inputSpacePoints=[spacePoints],
-            inputSourceLinks="sourcelinks",
             outputTrackParameters="estimatedparameters",
-            outputProtoTracks="prototracks_estimated",
             trackingGeometry=trackingGeometry,
             magneticField=field,
         )
@@ -106,23 +111,28 @@ def runITkSeedingFromCsv(detector, trackingGeometry, field, outputDir):
         spacePoints = evReader.config.outputSpacePoints
 
         # run seeding
-        inputProtoTracks, inputSeeds = addStandardSeeding(
+        inputSeeds = addStandardSeeding(
             s,
             spacePoints,
-            *acts.examples.itk.itkSeedingAlgConfig("StripSpacePoint"),
+            *acts.examples.itk.itkSeedingAlgConfig(InputSpacePointsType.StripSpacePoints),
         )
 
+        prototracks = "seed-prototracks"
+        s.addAlgorithm(
+            acts.examples.SeedsToPrototracks(
+                level=acts.logging.INFO,
+                inputSeeds=inputSeeds,
+                outputProtoTracks=prototracks,
+            )
+        )
+        
         # estimate seeding performance
         parEstimateAlg = TrackParamsEstimationAlgorithm(
             level=acts.logging.INFO,
             inputSeeds=inputSeeds,
-            inputProtoTracks=inputProtoTracks,
-            inputSpacePoints=[spacePoints],
-            inputSourceLinks="sourcelinks",
             outputTrackParameters="estimatedparameters",
-            outputProtoTracks="prototracks_estimated",
             trackingGeometry=trackingGeometry,
-            magneticField=field,
+            magneticField=field
         )
         s.addAlgorithm(parEstimateAlg)
 


### PR DESCRIPTION
As a result of recent PRs and a Typo, the `itk_seeding.py` script was not running. 

Here are the changes:
- using an enum to specify the type of the input space points instead of relying on strings (typo-prones)
- scheduling of `SeedsToPrototracks` since now the seeding algorithm does not produce anymore prototracks

/cc @LuisFelipeCoelho 