### PR TITLE
fix: Switch off the MultiStepper step counter if necessary

### DIFF
--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
@@ -684,6 +684,15 @@ class MultiEigenStepperLoop
       ACTS_VERBOSE("started stepCounterAfterFirstComponentOnSurface");
     }
 
+    // If there are no components onSurface, but the counter is switched on
+    // (e.g., if the navigator changes the target surface), we need to switch it
+    // of again
+    if (state.stepCounterAfterFirstComponentOnSurface &&
+        counts[static_cast<std::size_t>(Status::onSurface)] == 0) {
+      state.stepCounterAfterFirstComponentOnSurface.reset();
+      ACTS_VERBOSE("switch off stepCounterAfterFirstComponentOnSurface");
+    }
+
     // This is a 'any_of' criterium. As long as any of the components has a
     // certain state, this determines the total state (in the order of a
     // somewhat importance)


### PR DESCRIPTION
This could lead to very rare situations with 0 components remaining in the GSF.