### PR TITLE
fix: GSF handles another case of empty components correctly

### DIFF
--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -300,7 +300,7 @@ struct GsfActor {
         ACTS_WARNING(
             "No components left after applying energy loss. "
             "Is the weight cutoff too high?");
-        ACTS_VERBOSE("Return to propagator");
+        ACTS_WARNING("Return to propagator without applying energy loss");
         return;
       }
 

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -296,6 +296,14 @@ struct GsfActor {
       std::vector<ComponentCache> componentCache;
       convoluteComponents(state, stepper, tmpStates, componentCache);
 
+      if (componentCache.empty()) {
+        ACTS_WARNING(
+            "No components left after applying energy loss. "
+            "Is the weight cutoff too high?");
+        ACTS_VERBOSE("Return to propagator");
+        return;
+      }
+
       reduceComponents(stepper, surface, componentCache);
 
       removeLowWeightComponents(componentCache);

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -299,7 +299,8 @@ struct GsfActor {
       if (componentCache.empty()) {
         ACTS_WARNING(
             "No components left after applying energy loss. "
-            "Is the weight cutoff too high?");
+            "Is the weight cutoff "
+            << m_cfg.weightCutoff << " too high?");
         ACTS_WARNING("Return to propagator without applying energy loss");
         return;
       }


### PR DESCRIPTION
If the weight cutoff is very high, it could happen that components are empty after applying the energy loss, and an assertion triggers. This fixes this and prints out a warning.