### PR TITLE
perf: Reduce memory consumption

### DIFF
--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -481,8 +481,8 @@ def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
         numSeedIncrement = 1
         seedWeightIncrement = 10100
         useDetailedDoubleMeasurementInfo = True
-        maxSeedsPerSpMConf = 1000000000
-        maxQualitySeedsPerSpMConf = 1000000000
+        maxSeedsPerSpMConf = 100
+        maxQualitySeedsPerSpMConf = 100
         useDeltaRorTopRadius = False
 
     # fill namedtuples

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -485,7 +485,6 @@ def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
         maxQualitySeedsPerSpMConf = 100
         useDeltaRorTopRadius = False
 
-        
     # fill namedtuples
     seedFinderConfigArg = SeedFinderConfigArg(
         maxSeedsPerSpM=maxSeedsPerSpM,

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -485,6 +485,7 @@ def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
         maxQualitySeedsPerSpMConf = 100
         useDeltaRorTopRadius = False
 
+        
     # fill namedtuples
     seedFinderConfigArg = SeedFinderConfigArg(
         maxSeedsPerSpM=maxSeedsPerSpM,


### PR DESCRIPTION
We have three vectors (of `std::size_t`) that call a reserve of these values. Reduce the number to 100 since it makes no sense we have 1000000000 seed candidates for a single middle SP ... not even for ITk at PU200

/cc @LuisFelipeCoelho 