### PR TITLE
fix: Track state range is invalid if tip index is

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -1016,6 +1016,7 @@ class TrackStateRange {
   };
 
   TrackStateRange(ProxyType _begin) : m_begin{_begin} {}
+  TrackStateRange() : m_begin{std::nullopt} {}
 
   Iterator begin() { return m_begin; }
   Iterator end() { return Iterator{std::nullopt}; }
@@ -1132,7 +1133,13 @@ class MultiTrajectory {
   /// @return Iterator pair to iterate over
   /// @note Const version
   auto trackStateRange(IndexType iendpoint) const {
-    return detail_lt::TrackStateRange{getTrackState(iendpoint)};
+    using range_t =
+        decltype(detail_lt::TrackStateRange{getTrackState(iendpoint)});
+    if (iendpoint == kInvalid) {
+      return range_t{};
+    }
+
+    return range_t{getTrackState(iendpoint)};
   }
 
   /// Range for the track states from @p iendpoint to the trajectory start
@@ -1141,7 +1148,13 @@ class MultiTrajectory {
   /// @note Mutable version
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
   auto trackStateRange(IndexType iendpoint) {
-    return detail_lt::TrackStateRange{getTrackState(iendpoint)};
+    using range_t =
+        decltype(detail_lt::TrackStateRange{getTrackState(iendpoint)});
+    if (iendpoint == kInvalid) {
+      return range_t{};
+    }
+
+    return range_t{getTrackState(iendpoint)};
   }
 
   /// Apply a function to all previous states starting at a given endpoint.

--- a/Core/include/Acts/EventData/Track.hpp
+++ b/Core/include/Acts/EventData/Track.hpp
@@ -286,6 +286,10 @@ class TrackProxy {
   unsigned int nTrackStates() const {
     // @TODO: This should probably be cached, distance is expensive
     //        without random access
+    if (tipIndex() == kInvalid) {
+      // no tip index -> no track states
+      return 0;
+    }
     auto tsRange = trackStates();
     return std::distance(tsRange.begin(), tsRange.end());
   }
@@ -569,7 +573,9 @@ class TrackContainer {
   /// @return the index to the newly added track
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
   IndexType addTrack() {
-    return m_container->addTrack_impl();
+    auto track = getTrack(m_container->addTrack_impl());
+    track.tipIndex() = kInvalid;
+    return track.index();
   }
 
   /// Remove a track at index @p itrack from the container

--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -30,7 +30,7 @@ VectorTrackContainerBase::VectorTrackContainerBase(
 VectorTrackContainer::IndexType VectorTrackContainer::addTrack_impl() {
   assert(checkConsistency());
 
-  m_tipIndex.emplace_back();
+  m_tipIndex.emplace_back(kInvalid);
 
   m_params.emplace_back();
   m_cov.emplace_back();

--- a/Tests/UnitTests/Core/EventData/TrackTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTests.cpp
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackStateAccess, factory_t, holder_types) {
   BOOST_CHECK(tsRange.begin() == tsRange.end());
 
   size_t i = 0;
-  for (auto state : tNone.trackStates()) {
+  for (const auto& state : tNone.trackStates()) {
     (void)state;
     i++;
   }

--- a/Tests/UnitTests/Core/EventData/TrackTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTests.cpp
@@ -295,6 +295,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackStateAccess, factory_t, holder_types) {
   }
 
   BOOST_CHECK_EQUAL(t.nTrackStates(), 5);
+
+  auto tNone = tc.getTrack(tc.addTrack());
+  BOOST_CHECK_EQUAL(tNone.nTrackStates(), 0);
+
+  auto tsRange = tNone.trackStates();
+  BOOST_CHECK(tsRange.begin() == tsRange.end());
+
+  size_t i = 0;
+  for (auto state : tNone.trackStates()) {
+    (void)state;
+    i++;
+  }
+  BOOST_CHECK_EQUAL(i, 0);
 }
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TrackIterator, factory_t, holder_types) {


### PR DESCRIPTION
This changes the track state ranges to return zero-length ranges in case the tip index is kInvalid. The VectorTrackContainer backend initializes the `tipIndex` to kInvalid, and so does the `addTrack`, so in principle this should always be consistent by default.

Fixes #1994