### PR TITLE
refactor: Ambiguity solvers now use Track containers

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/AmbiguityResolutionAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/AmbiguityResolutionAlgorithm.hpp
@@ -29,9 +29,9 @@ class AmbiguityResolutionAlgorithm final : public IAlgorithm {
  public:
   struct Config {
     /// Input trajectories collection.
-    std::string inputTrajectories;
+    std::string inputTracks;
     /// Output trajectories collection.
-    std::string outputTrajectories;
+    std::string outputTracks;
 
     /// Maximum amount of shared hits per track.
     std::uint32_t maximumSharedHits = 1;
@@ -59,6 +59,8 @@ class AmbiguityResolutionAlgorithm final : public IAlgorithm {
 
  private:
   Config m_cfg;
+  ReadDataHandle<ConstTrackContainer> m_inputTracks{this, "InputTracks"};
+  WriteDataHandle<ConstTrackContainer> m_outputTracks{this, "OutputTracks"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/AmbiguityResolutionAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/AmbiguityResolutionAlgorithm.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
+#include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/EventData/Trajectories.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"

--- a/Examples/Algorithms/TrackFindingML/include/ActsExamples/TrackFindingML/AmbiguityResolutionMLAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFindingML/include/ActsExamples/TrackFindingML/AmbiguityResolutionMLAlgorithm.hpp
@@ -9,6 +9,10 @@
 #pragma once
 
 #include "Acts/Plugins/Onnx/OnnxRuntimeBase.hpp"
+
+#include "ActsExamples/EventData/Track.hpp"
+#include "ActsExamples/EventData/Trajectories.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 
 #include <string>
@@ -26,11 +30,11 @@ class AmbiguityResolutionMLAlgorithm final : public IAlgorithm {
  public:
   struct Config {
     /// Input trajectories collection.
-    std::string inputTrajectories;
+    std::string inputTracks;
     /// path to the ONNX model for the duplicate neural network
     std::string inputDuplicateNN;
     /// Output trajectories collection.
-    std::string outputTrajectories;
+    std::string outputTracks;
     /// Minumum number of measurement to form a track.
     int nMeasurementsMin = 7;
   };
@@ -56,6 +60,8 @@ class AmbiguityResolutionMLAlgorithm final : public IAlgorithm {
   Ort::Env m_env;
   // ONNX model for the duplicate neural network
   Acts::OnnxRuntimeBase m_duplicateClassifier;
+  ReadDataHandle<ConstTrackContainer> m_inputTracks{this, "InputTracks"};
+  WriteDataHandle<ConstTrackContainer> m_outputTracks{this, "OutputTracks"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFindingML/include/ActsExamples/TrackFindingML/AmbiguityResolutionMLAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFindingML/include/ActsExamples/TrackFindingML/AmbiguityResolutionMLAlgorithm.hpp
@@ -9,11 +9,7 @@
 #pragma once
 
 #include "Acts/Plugins/Onnx/OnnxRuntimeBase.hpp"
-<<<<<<< HEAD
-
 #include "ActsExamples/EventData/Track.hpp"
-=======
->>>>>>> upstream/main
 #include "ActsExamples/EventData/Trajectories.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -770,7 +770,6 @@ def addKalmanTracks(
     energyLoss: bool = True,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     if directNavigation:
@@ -827,7 +826,6 @@ def addTruthTrackingGsf(
     inputProtoTracks: str = "truth_particle_tracks",
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     gsfOptions = {
@@ -1097,7 +1095,6 @@ def addTrackSelection(
     outputTracks: str,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> acts.examples.TrackSelector:
-
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     trackSelector = acts.examples.TrackSelector(
@@ -1139,7 +1136,6 @@ def addExaTrkX(
     backend: Optional[ExaTrkXBackend] = ExaTrkXBackend.Torch,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
 
     # Run the particle selection
@@ -1224,7 +1220,6 @@ def addAmbiguityResolution(
     writeTrajectories: bool = True,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     from acts.examples import AmbiguityResolutionAlgorithm
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
@@ -1281,7 +1276,6 @@ def addAmbiguityResolutionML(
     writeTrajectories: bool = True,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     from acts.examples import AmbiguityResolutionMLAlgorithm
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
@@ -1337,7 +1331,6 @@ def addVertexFitting(
     trackSelectorRanges: Optional[TrackSelectorRanges] = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
-
     """This function steers the vertex fitting
 
     Parameters

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1232,8 +1232,8 @@ def addAmbiguityResolution(
 
     alg = AmbiguityResolutionAlgorithm(
         level=customLogLevel(),
-        inputTrajectories="trajectories",
-        outputTrajectories="filteredTrajectories",
+        inputTracks="trajectories",
+        outputTracks="filteredTrajectories",
         **acts.examples.defaultKWArgs(
             maximumSharedHits=config.maximumSharedHits,
             nMeasurementsMin=config.nMeasurementsMin,
@@ -1282,9 +1282,9 @@ def addAmbiguityResolutionML(
 
     alg = AmbiguityResolutionMLAlgorithm(
         level=customLogLevel(),
-        inputTrajectories="trajectories",
+        inputTracks="selectedTracks",
         inputDuplicateNN=onnxModelFile,
-        outputTrajectories="filteredTrajectoriesML",
+        outputTracks="filteredTrajectoriesML",
         **acts.examples.defaultKWArgs(
             nMeasurementsMin=config.nMeasurementsMin,
         ),

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -134,8 +134,8 @@ CKFPerformanceConfig = namedtuple(
 
 AmbiguityResolutionConfig = namedtuple(
     "AmbiguityResolutionConfig",
-    ["maximumSharedHits", "nMeasurementsMin"],
-    defaults=[None] * 2,
+    ["maximumSharedHits", "nMeasurementsMin", "maximumIterations"],
+    defaults=[None] * 3,
 )
 
 AmbiguityResolutionMLConfig = namedtuple(
@@ -1231,21 +1231,28 @@ def addAmbiguityResolution(
 
     alg = AmbiguityResolutionAlgorithm(
         level=customLogLevel(),
-        inputTracks="trajectories",
+        inputTracks="selectedTracks",
         outputTracks="filteredTrajectories",
         **acts.examples.defaultKWArgs(
             maximumSharedHits=config.maximumSharedHits,
             nMeasurementsMin=config.nMeasurementsMin,
+            maximumIterations=config.maximumIterations,
         ),
     )
     s.addAlgorithm(alg)
 
-    s.addWhiteboardAlias("trajectories", alg.config.outputTrajectories)
+    trackConverter = acts.examples.TracksToTrajectories(
+        level=customLogLevel(),
+        inputTracks=alg.config.outputTracks,
+        outputTrajectories="trajectories-from-solved-tracks",
+    )
+    s.addAlgorithm(trackConverter)
+    s.addWhiteboardAlias("trajectories", trackConverter.config.outputTrajectories)
 
     addTrajectoryWriters(
         s,
         name="ambi",
-        trajectories=alg.config.outputTrajectories,
+        trajectories="trajectories",
         ckfPerformanceConfig=ckfPerformanceConfig,
         outputDirCsv=outputDirCsv,
         outputDirRoot=outputDirRoot,
@@ -1290,12 +1297,18 @@ def addAmbiguityResolutionML(
     )
     s.addAlgorithm(alg)
 
-    s.addWhiteboardAlias("trajectories", alg.config.outputTrajectories)
+    trackConverter = acts.examples.TracksToTrajectories(
+        level=customLogLevel(),
+        inputTracks=alg.config.outputTracks,
+        outputTrajectories="trajectories-from-solved-tracks",
+    )
+    s.addAlgorithm(trackConverter)
+    s.addWhiteboardAlias("trajectories", trackConverter.config.outputTrajectories)
 
     addTrajectoryWriters(
         s,
         name="ambiML",
-        trajectories=alg.config.outputTrajectories,
+        trajectories="trajectories",
         ckfPerformanceConfig=ckfPerformanceConfig,
         outputDirCsv=outputDirCsv,
         outputDirRoot=outputDirRoot,

--- a/Examples/Python/src/MLTrackFinding.cpp
+++ b/Examples/Python/src/MLTrackFinding.cpp
@@ -24,8 +24,8 @@ void addMLTrackFinding(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::AmbiguityResolutionMLAlgorithm,
                                 mex, "AmbiguityResolutionMLAlgorithm",
-                                inputTracks, inputDuplicateNN,
-                                outputTracks, nMeasurementsMin);
+                                inputTracks, inputDuplicateNN, outputTracks,
+                                nMeasurementsMin);
 }
 
 }  // namespace Acts::Python

--- a/Examples/Python/src/MLTrackFinding.cpp
+++ b/Examples/Python/src/MLTrackFinding.cpp
@@ -24,8 +24,8 @@ void addMLTrackFinding(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::AmbiguityResolutionMLAlgorithm,
                                 mex, "AmbiguityResolutionMLAlgorithm",
-                                inputTrajectories, inputDuplicateNN,
-                                outputTrajectories, nMeasurementsMin);
+                                inputTracks, inputDuplicateNN,
+                                outputTracks, nMeasurementsMin);
 }
 
 }  // namespace Acts::Python

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -309,7 +309,7 @@ void addTrackFinding(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::AmbiguityResolutionAlgorithm, mex,
                                 "AmbiguityResolutionAlgorithm",
-                                inputTrajectories, outputTrajectories,
+                                inputTracks, outputTracks,
                                 maximumSharedHits, nMeasurementsMin);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SeedsToPrototracks, mex,

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -308,9 +308,9 @@ void addTrackFinding(Context& ctx) {
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::AmbiguityResolutionAlgorithm, mex,
-                                "AmbiguityResolutionAlgorithm",
-                                inputTracks, outputTracks,
-                                maximumSharedHits, nMeasurementsMin);
+                                "AmbiguityResolutionAlgorithm", inputTracks,
+                                outputTracks, maximumSharedHits,
+                                maximumIterations, nMeasurementsMin);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SeedsToPrototracks, mex,
                                 "SeedsToPrototracks", inputSeeds,

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -100,7 +100,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
                 mean=acts.Vector4(0, 0, 0, 0),
             ),
             rnd=rnd,
-            #outputDirRoot=outputDir,
+            outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
         )
     if g4_simulation:
@@ -122,7 +122,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
                 pt=(150 * u.MeV, None),
                 removeNeutral=True,
             ),
-            #outputDirRoot=outputDir,
+            outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
             rnd=rnd,
         )
@@ -138,7 +138,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             )
             if ttbar_pu200
             else ParticleSelectorConfig(),
-            #outputDirRoot=outputDir,
+            outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
             rnd=rnd,
         )
@@ -148,8 +148,8 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
         trackingGeometry,
         field,
         digiConfigFile=oddDigiConfig,
-        #outputDirRoot=outputDir,
-        # outputDirCsv=outputDir,
+        outputDirRoot=outputDir,
+        outputDirCsv=outputDir,
         rnd=rnd,
     )
 
@@ -161,7 +161,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
         if ttbar_pu200
         else TruthSeedRanges(),
         geoSelectionConfigFile=oddSeedingSel,
-        #outputDirRoot=outputDir,
+        outputDirRoot=outputDir,
     )
 
     addCKFTracks(
@@ -177,8 +177,8 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             absEta=(None, 3.0),
             loc0=(-4.0 * u.mm, 4.0 * u.mm),
         ),
-        #outputDirRoot=outputDir,
-        outputDirCsv=outputDir,
+        outputDirRoot=outputDir,
+        # outputDirCsv=outputDir,
     )
 
     if ambiguity_MLSolver:
@@ -188,28 +188,30 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             CKFPerformanceConfig(
                 ptMin=1.0 * u.GeV if ttbar_pu200 else 0.0, nMeasurementsMin=7
             ),
-            #outputDirRoot=outputDir,
-            outputDirCsv=outputDir,
+            outputDirRoot=outputDir,
+            # outputDirCsv=outputDir,
             onnxModelFile=os.path.dirname(__file__)
             + "/MLAmbiguityResolution/duplicateClassifier.onnx",
         )
     else:
         addAmbiguityResolution(
             s,
-            AmbiguityResolutionConfig(maximumSharedHits=3, maximumIterations=10000, nMeasurementsMin=7),
+            AmbiguityResolutionConfig(
+                maximumSharedHits=3, maximumIterations=10000, nMeasurementsMin=7
+            ),
             CKFPerformanceConfig(
                 ptMin=1.0 * u.GeV if ttbar_pu200 else 0.0,
                 nMeasurementsMin=7,
             ),
-            #outputDirRoot=outputDir,
-            outputDirCsv=outputDir,
+            outputDirRoot=outputDir,
+            # outputDirCsv=outputDir,
         )
 
     addVertexFitting(
         s,
         field,
         vertexFinder=VertexFinder.Iterative,
-        #outputDirRoot=outputDir,
+        outputDirRoot=outputDir,
     )
 
     s.run()

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -100,7 +100,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
                 mean=acts.Vector4(0, 0, 0, 0),
             ),
             rnd=rnd,
-            outputDirRoot=outputDir,
+            #outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
         )
     if g4_simulation:
@@ -122,7 +122,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
                 pt=(150 * u.MeV, None),
                 removeNeutral=True,
             ),
-            outputDirRoot=outputDir,
+            #outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
             rnd=rnd,
         )
@@ -138,7 +138,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             )
             if ttbar_pu200
             else ParticleSelectorConfig(),
-            outputDirRoot=outputDir,
+            #outputDirRoot=outputDir,
             # outputDirCsv=outputDir,
             rnd=rnd,
         )
@@ -148,7 +148,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
         trackingGeometry,
         field,
         digiConfigFile=oddDigiConfig,
-        outputDirRoot=outputDir,
+        #outputDirRoot=outputDir,
         # outputDirCsv=outputDir,
         rnd=rnd,
     )
@@ -161,7 +161,7 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
         if ttbar_pu200
         else TruthSeedRanges(),
         geoSelectionConfigFile=oddSeedingSel,
-        outputDirRoot=outputDir,
+        #outputDirRoot=outputDir,
     )
 
     addCKFTracks(
@@ -177,8 +177,8 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             absEta=(None, 3.0),
             loc0=(-4.0 * u.mm, 4.0 * u.mm),
         ),
-        outputDirRoot=outputDir,
-        # outputDirCsv=outputDir,
+        #outputDirRoot=outputDir,
+        outputDirCsv=outputDir,
     )
 
     if ambiguity_MLSolver:
@@ -188,28 +188,28 @@ with acts.FpeMonitor() if not g4_simulation else contextlib.nullcontext():
             CKFPerformanceConfig(
                 ptMin=1.0 * u.GeV if ttbar_pu200 else 0.0, nMeasurementsMin=7
             ),
-            outputDirRoot=outputDir,
-            # outputDirCsv=outputDir,
+            #outputDirRoot=outputDir,
+            outputDirCsv=outputDir,
             onnxModelFile=os.path.dirname(__file__)
             + "/MLAmbiguityResolution/duplicateClassifier.onnx",
         )
     else:
         addAmbiguityResolution(
             s,
-            AmbiguityResolutionConfig(maximumSharedHits=3, nMeasurementsMin=7),
+            AmbiguityResolutionConfig(maximumSharedHits=3, maximumIterations=10000, nMeasurementsMin=7),
             CKFPerformanceConfig(
                 ptMin=1.0 * u.GeV if ttbar_pu200 else 0.0,
                 nMeasurementsMin=7,
             ),
-            outputDirRoot=outputDir,
-            # outputDirCsv=outputDir,
+            #outputDirRoot=outputDir,
+            outputDirCsv=outputDir,
         )
 
     addVertexFitting(
         s,
         field,
         vertexFinder=VertexFinder.Iterative,
-        outputDirRoot=outputDir,
+        #outputDirRoot=outputDir,
     )
 
     s.run()


### PR DESCRIPTION
This PR change both Ambiguity solvers to use the Track container instead of the Trajectory ones.
