### PR TITLE
refactor: LinCircle constructor and no use of fill function

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -296,8 +296,7 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
             iDeltaR2;
 
         // fill output vectors
-        linCircleVec.push_back(fillLineCircle(
-            {deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame}));
+        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
         spacePointData.setDeltaR(otherSP->index(),
                                  std::sqrt(deltaR2 + (deltaZ * deltaZ)));
         outVec.push_back(otherSP.get());
@@ -315,8 +314,7 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
             iDeltaR2;
 
         // fill output vectors
-        linCircleVec.push_back(fillLineCircle(
-            {deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame}));
+        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
         spacePointData.setDeltaR(otherSP->index(),
                                  std::sqrt(deltaR2 + (deltaZ * deltaZ)));
         outVec.push_back(otherSP.get());
@@ -349,8 +347,7 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
           iDeltaR2;
 
       // fill output vectors
-      linCircleVec.push_back(fillLineCircle(
-          {deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame}));
+      linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
       spacePointData.setDeltaR(otherSP->index(),
                                std::sqrt(deltaR2 + (deltaZ * deltaZ)));
       outVec.push_back(otherSP.get());

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -296,7 +296,8 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
             iDeltaR2;
 
         // fill output vectors
-        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
+        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT,
+                                  xNewFrame, yNewFrame);
         spacePointData.setDeltaR(otherSP->index(),
                                  std::sqrt(deltaR2 + (deltaZ * deltaZ)));
         outVec.push_back(otherSP.get());
@@ -314,7 +315,8 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
             iDeltaR2;
 
         // fill output vectors
-        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
+        linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT,
+                                  xNewFrame, yNewFrame);
         spacePointData.setDeltaR(otherSP->index(),
                                  std::sqrt(deltaR2 + (deltaZ * deltaZ)));
         outVec.push_back(otherSP.get());
@@ -347,7 +349,8 @@ SeedFinder<external_spacepoint_t, platform_t>::getCompatibleDoublets(
           iDeltaR2;
 
       // fill output vectors
-      linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT, xNewFrame, yNewFrame);
+      linCircleVec.emplace_back(deltaZ * iDeltaR, iDeltaR, Er, uT, vT,
+                                xNewFrame, yNewFrame);
       spacePointData.setDeltaR(otherSP->index(),
                                std::sqrt(deltaR2 + (deltaZ * deltaZ)));
       outVec.push_back(otherSP.get());

--- a/Core/include/Acts/Seeding/SeedFinderUtils.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.hpp
@@ -16,13 +16,25 @@
 namespace Acts {
 /// @brief A partial description of a circle in u-v space.
 struct LinCircle {
-  float cotTheta;
-  float iDeltaR;
-  float Er;
-  float U;
-  float V;
-  float x;
-  float y;
+  LinCircle() = default;
+  LinCircle(float ct, float idr, float er,
+	    float u, float v, float X, float Y)
+    : cotTheta(ct),
+      iDeltaR(idr),
+      Er(er),
+      U(u),
+      V(v),
+      x(X),
+      y(Y)
+  {}
+   
+  float cotTheta{0.};
+  float iDeltaR{0.};
+  float Er{0.};
+  float U{0.};
+  float V{0.};
+  float x{0.};
+  float y{0.};
 };
 
 /// @brief Transform two spacepoints to a u-v space circle.
@@ -67,12 +79,6 @@ void transformCoordinates(Acts::SpacePointData& spacePointData,
                           const external_spacepoint_t& spM, bool bottom,
                           std::vector<LinCircle>& linCircleVec,
                           callable_t&& extractFunction);
-
-/// @brief Fills LineCircle object for a SP dublet in u-v frame.
-///
-/// @param[in] lineCircleVariables Vector contaning LineCircle variables
-inline LinCircle fillLineCircle(
-    const std::array<float, 7>& lineCircleVariables);
 
 /// @brief Check the compatibility of spacepoint coordinates in xyz assuming the Bottom-Middle direction with the strip meassument details
 ///

--- a/Core/include/Acts/Seeding/SeedFinderUtils.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.hpp
@@ -17,17 +17,9 @@ namespace Acts {
 /// @brief A partial description of a circle in u-v space.
 struct LinCircle {
   LinCircle() = default;
-  LinCircle(float ct, float idr, float er,
-	    float u, float v, float X, float Y)
-    : cotTheta(ct),
-      iDeltaR(idr),
-      Er(er),
-      U(u),
-      V(v),
-      x(X),
-      y(Y)
-  {}
-   
+  LinCircle(float ct, float idr, float er, float u, float v, float X, float Y)
+      : cotTheta(ct), iDeltaR(idr), Er(er), U(u), V(v), x(X), y(Y) {}
+
   float cotTheta{0.};
   float iDeltaR{0.};
   float Er{0.};

--- a/Core/include/Acts/Seeding/SeedFinderUtils.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.ipp
@@ -62,8 +62,7 @@ inline LinCircle transformCoordinates(const external_spacepoint_t& sp,
                    iDeltaR2;
 
   sp.setDeltaR(std::sqrt(deltaR2 + (deltaZ * deltaZ)));
-
-  return fillLineCircle({cotTheta, iDeltaR, Er, U, V, xNewFrame, yNewFrame});
+  return LinCircle(cotTheta, iDeltaR, Er, U, V, xNewFrame, yNewFrame);
 }
 
 template <typename external_spacepoint_t>
@@ -138,29 +137,18 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
                 (cotTheta * cotTheta) * (varianceRM + sp->varianceR())) *
                iDeltaR2;
 
-    linCircleVec[idx] =
-        fillLineCircle({cotTheta, iDeltaR, Er, U, V, xNewFrame, yNewFrame});
+    // Fill Line Circle
+    linCircleVec[idx].cotTheta = cotTheta;
+    linCircleVec[idx].iDeltaR = iDeltaR;
+    linCircleVec[idx].Er = Er;
+    linCircleVec[idx].U = U;
+    linCircleVec[idx].V = V;
+    linCircleVec[idx].x = xNewFrame;
+    linCircleVec[idx].y = yNewFrame;
+
     spacePointData.setDeltaR(sp->index(),
                              std::sqrt(deltaR2 + (deltaZ * deltaZ)));
   }
-}
-
-inline LinCircle fillLineCircle(
-    const std::array<float, 7>& lineCircleVariables) {
-  auto [cotTheta, iDeltaR, Er, U, V, xNewFrame, yNewFrame] =
-      lineCircleVariables;
-
-  // VERY frequent (SP^3) access
-  LinCircle l{};
-  l.cotTheta = cotTheta;
-  l.iDeltaR = iDeltaR;
-  l.U = U;
-  l.V = V;
-  l.Er = Er;
-  l.x = xNewFrame;
-  l.y = yNewFrame;
-
-  return l;
 }
 
 template <typename external_spacepoint_t>

--- a/Core/include/Acts/Seeding/SeedFinderUtils.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.ipp
@@ -90,11 +90,6 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
                                  const external_spacepoint_t& spM, bool bottom,
                                  std::vector<LinCircle>& linCircleVec,
                                  callable_t&& extractFunction) {
-  std::vector<std::size_t> indexes(vec.size());
-  for (unsigned int i(0); i < indexes.size(); i++) {
-    indexes[i] = i;
-  }
-
   auto [xM, yM, zM, rM, varianceRM, varianceZM] = extractFunction(spM);
 
   // resize + operator[] is faster then reserve and push_back

--- a/Core/include/Acts/Seeding/SeedFinderUtils.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.ipp
@@ -99,7 +99,7 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
   float sinPhiM = yM / rM;
 
   int bottomFactor = bottom ? -1 : 1;
-    
+
   for (std::size_t idx(0); idx < vec.size(); ++idx) {
     auto& sp = vec[idx];
     auto [xSP, ySP, zSP, rSP, varianceRSP, varianceZSP] = extractFunction(*sp);

--- a/Core/include/Acts/Seeding/SeedFinderUtils.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderUtils.ipp
@@ -46,7 +46,7 @@ inline LinCircle transformCoordinates(const external_spacepoint_t& sp,
   float deltaR2 = (xNewFrame * xNewFrame + yNewFrame * yNewFrame);
   float iDeltaR2 = 1. / (deltaX * deltaX + deltaY * deltaY);
   float iDeltaR = std::sqrt(iDeltaR2);
-  int bottomFactor = 1 * (int(!bottom)) - 1 * (int(bottom));
+  int bottomFactor = bottom ? -1 : 1;
   float cotTheta = deltaZ * iDeltaR * bottomFactor;
 
   // conformal transformation u=x/(x²+y²) v=y/(x²+y²) transform the
@@ -98,6 +98,8 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
   float cosPhiM = xM / rM;
   float sinPhiM = yM / rM;
 
+  int bottomFactor = bottom ? -1 : 1;
+    
   for (std::size_t idx(0); idx < vec.size(); ++idx) {
     auto& sp = vec[idx];
     auto [xSP, ySP, zSP, rSP, varianceRSP, varianceZSP] = extractFunction(*sp);
@@ -116,7 +118,6 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
     float iDeltaR2 = 1. / deltaR2;
     float iDeltaR = std::sqrt(iDeltaR2);
     //
-    int bottomFactor = 1 * (int(!bottom)) - 1 * (int(bottom));
     // cot_theta = (deltaZ/deltaR)
     float cotTheta = deltaZ * iDeltaR * bottomFactor;
     // transformation of circle equation (x,y) into linear equation (u,v)
@@ -128,8 +129,8 @@ inline void transformCoordinates(Acts::SpacePointData& spacePointData,
     float U = xNewFrame * iDeltaR2;
     float V = yNewFrame * iDeltaR2;
     // error term for sp-pair without correlation of middle space point
-    float Er = ((varianceZM + sp->varianceZ()) +
-                (cotTheta * cotTheta) * (varianceRM + sp->varianceR())) *
+    float Er = ((varianceZM + varianceZSP) +
+                (cotTheta * cotTheta) * (varianceRM + varianceRSP)) *
                iDeltaR2;
 
     // Fill Line Circle


### PR DESCRIPTION
Defining a constructor makes the fillLineCircle function redundant