### PR TITLE
refactor: move multipleScattering2 to seeding options

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -428,9 +428,7 @@ inline void SeedFinder<external_spacepoint_t, platform_t>::filterCandidates(
     // resolving with pT to p scaling --> only divide by sin^2(theta)
     // max approximation error for allowed scattering angles of 0.04 rad at
     // eta=infinity: ~8.5%
-    float scatteringInRegion2 = m_config.maxScatteringAngle2 * iSinTheta2;
-    // multiply the squared sigma onto the squared scattering
-    scatteringInRegion2 *= m_config.sigmaScattering * m_config.sigmaScattering;
+    float scatteringInRegion2 = options.multipleScattering2 * iSinTheta2;
 
     float sinTheta = 1 / std::sqrt(iSinTheta2);
     float cosTheta = cotThetaB * sinTheta;

--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -228,6 +228,7 @@ struct SeedFinderOptions {
   float minHelixDiameter2 = std::numeric_limits<float>::quiet_NaN();
   float pT2perRadius = std::numeric_limits<float>::quiet_NaN();
   float sigmapT2perRadius = std::numeric_limits<float>::quiet_NaN();
+  float multipleScattering2 = std::numeric_limits<float>::quiet_NaN();
 
   bool isInInternalUnits = false;
 
@@ -264,6 +265,8 @@ struct SeedFinderOptions {
         std::pow(config.highland / options.pTPerHelixRadius, 2);
     options.sigmapT2perRadius =
         options.pT2perRadius * std::pow(2 * config.sigmaScattering, 2);
+    options.multipleScattering2 =
+        config.maxScatteringAngle2 * std::pow(config.sigmaScattering, 2);
     return options;
   }
 };

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -353,9 +353,7 @@ void SeedFinderOrthogonal<external_spacepoint_t>::filterCandidates(
     // resolving with pT to p scaling --> only divide by sin^2(theta)
     // max approximation error for allowed scattering angles of 0.04 rad at
     // eta=infinity: ~8.5%
-    float scatteringInRegion2 = m_config.maxScatteringAngle2 * iSinTheta2;
-    // multiply the squared sigma onto the squared scattering
-    scatteringInRegion2 *= m_config.sigmaScattering * m_config.sigmaScattering;
+    float scatteringInRegion2 = options.multipleScattering2 * iSinTheta2;
 
     // minimum number of compatible top SPs to trigger the filter for a certain
     // middle bottom pair if seedConfirmation is false we always ask for at


### PR DESCRIPTION
This PR moves the calculation of `m_config.maxScatteringAngle2 * m_config.sigmaScattering * m_config.sigmaScattering` to the seeding option since it can be done only once 