### PR TITLE
refactor: navigator volume material handling

### DIFF
--- a/Core/include/Acts/Navigation/NextNavigator.hpp
+++ b/Core/include/Acts/Navigation/NextNavigator.hpp
@@ -30,7 +30,6 @@
 #include <boost/container/small_vector.hpp>
 
 namespace Acts {
-
 namespace Experimental {
 
 class NextNavigator {
@@ -102,6 +101,10 @@ class NextNavigator {
 
   const TrackingVolume* currentVolume(const State& /*state*/) const {
     return nullptr;  // TODO we do not have a tracking volume
+  }
+
+  const IVolumeMaterial* currentVolumeMaterial(const State& state) const {
+    return state.currentVolume->volumeMaterial();
   }
 
   const Surface* startSurface(const State& state) const {
@@ -425,5 +428,4 @@ class NextNavigator {
 };
 
 }  // namespace Experimental
-
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -16,12 +16,10 @@
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
-#include <iomanip>
+#include <algorithm>
 #include <iterator>
-#include <sstream>
-#include <string>
-
-#include <boost/algorithm/string.hpp>
+#include <memory>
+#include <vector>
 
 namespace Acts {
 
@@ -156,6 +154,13 @@ class DirectNavigator {
 
   const TrackingVolume* currentVolume(const State& state) const {
     return state.currentVolume;
+  }
+
+  const IVolumeMaterial* currentVolumeMaterial(const State& state) const {
+    if (state.currentVolume == nullptr) {
+      return nullptr;
+    }
+    return state.currentVolume->volumeMaterial();
   }
 
   const Surface* startSurface(const State& state) const {

--- a/Core/include/Acts/Propagator/MaterialInteractor.hpp
+++ b/Core/include/Acts/Propagator/MaterialInteractor.hpp
@@ -59,7 +59,7 @@ struct MaterialInteractor {
     if (recordInteractions && !result.materialInteractions.empty() &&
         result.materialInteractions.back().volume != nullptr &&
         result.materialInteractions.back().updatedVolumeStep == false) {
-      UpdateResult(state, stepper, result);
+      updateResult(state, stepper, result);
     }
 
     // If we are on target, everything should have been done
@@ -177,7 +177,7 @@ struct MaterialInteractor {
   /// @param [in] stepper The stepper instance
   /// @param [in, out] result Result storage
   template <typename propagator_state_t, typename stepper_t>
-  void UpdateResult(propagator_state_t& state, const stepper_t& stepper,
+  void updateResult(propagator_state_t& state, const stepper_t& stepper,
                     result_type& result) const {
     // Update the previous interaction
     Vector3 shift = stepper.position(state.stepping) -
@@ -193,6 +193,6 @@ struct MaterialInteractor {
     result.materialInL0 +=
         result.materialInteractions.back().materialSlab.thicknessInL0();
   }
-};  // namespace Acts
+};
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -287,6 +287,13 @@ class Navigator {
     return state.currentVolume;
   }
 
+  const IVolumeMaterial* currentVolumeMaterial(const State& state) const {
+    if (state.currentVolume == nullptr) {
+      return nullptr;
+    }
+    return state.currentVolume->volumeMaterial();
+  }
+
   const Surface* startSurface(const State& state) const {
     return state.startSurface;
   }

--- a/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
+++ b/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
@@ -84,10 +84,10 @@ struct GenericDenseEnvironmentExtension {
     }
 
     // Check existence of a volume with material
-    if (!navigator.currentVolume(state.navigation) ||
-        !navigator.currentVolume(state.navigation)->volumeMaterial()) {
+    if (!navigator.currentVolumeMaterial(state.navigation)) {
       return 0;
     }
+
     return 2;
   }
 
@@ -118,8 +118,7 @@ struct GenericDenseEnvironmentExtension {
     // i = 0 is used for setup and evaluation of k
     if (i == 0) {
       // Set up container for energy loss
-      auto volumeMaterial =
-          navigator.currentVolume(state.navigation)->volumeMaterial();
+      auto volumeMaterial = navigator.currentVolumeMaterial(state.navigation);
       ThisVector3 position = stepper.position(state.stepping);
       material = (volumeMaterial->material(position.template cast<double>()));
       initialMomentum = stepper.momentum(state.stepping);


### PR DESCRIPTION
split off changes from my [calorimeter demo](https://github.com/acts-project/acts/compare/main...andiwand:tmp-calorimeter-demo?expand=1). this adds a shortcut for getting the current volume material from the navigator. since the new geometry has a different volume class we cannot reach the material in a generic way out of the box