### PR TITLE
chore: alias tracks in python examples

### DIFF
--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -855,6 +855,7 @@ def addKalmanTracks(
         ),
     )
     s.addAlgorithm(fitAlg)
+    s.addWhiteboardAlias("tracks", fitAlg.config.outputTracks)
 
     trackConverter = acts.examples.TracksToTrajectories(
         level=customLogLevel(),
@@ -862,7 +863,6 @@ def addKalmanTracks(
         outputTrajectories="kfTrajectories",
     )
     s.addAlgorithm(trackConverter)
-
     s.addWhiteboardAlias("trajectories", trackConverter.config.outputTrajectories)
 
     return s
@@ -965,6 +965,7 @@ def addCKFTracks(
         ),
     )
     s.addAlgorithm(trackFinder)
+    s.addWhiteboardAlias("tracks", trackFinder.config.outputTracks)
 
     trackConverter = acts.examples.TracksToTrajectories(
         level=customLogLevel(),
@@ -1273,7 +1274,7 @@ def addAmbiguityResolution(
 
     alg = AmbiguityResolutionAlgorithm(
         level=customLogLevel(),
-        inputTracks="selectedTracks",
+        inputTracks="tracks",
         outputTracks="filteredTrajectories",
         **acts.examples.defaultKWArgs(
             maximumSharedHits=config.maximumSharedHits,
@@ -1329,7 +1330,7 @@ def addAmbiguityResolutionML(
 
     alg = AmbiguityResolutionMLAlgorithm(
         level=customLogLevel(),
-        inputTracks="selectedTracks",
+        inputTracks="tracks",
         inputDuplicateNN=onnxModelFile,
         outputTracks="filteredTrajectoriesML",
         **acts.examples.defaultKWArgs(
@@ -1384,7 +1385,7 @@ def addAmbiguityResolutionMLDBScan(
 
     alg = AmbiguityResolutionMLDBScanAlgorithm(
         level=customLogLevel(),
-        inputTracks="selectedTracks",
+        inputTracks="tracks",
         inputDuplicateNN=onnxModelFile,
         outputTracks="filteredTrajectoriesMLDBScan",
         **acts.examples.defaultKWArgs(


### PR DESCRIPTION
after trajectories -> tracks changes we did not alias the tracks like we do it for the trajectories. therefore we relied on `selectedTracks` to exist which is not always the case. this PR is adding the alias