### PR TITLE
refactor: replace warning for unmatched particles with info

### DIFF
--- a/Examples/Io/Root/src/RootTrackParameterWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackParameterWriter.cpp
@@ -192,9 +192,8 @@ ActsExamples::ProcessCode ActsExamples::RootTrackParameterWriter::writeT(
         m_t_charge = static_cast<int>(particle.charge());
         m_t_qop = m_t_charge / p;
       } else {
-        ACTS_WARNING("Truth particle with barcode " << particleId << "="
-                                                    << particleId.value()
-                                                    << " not found!");
+        ACTS_INFO("Truth particle with barcode "
+                  << particleId << "=" << particleId.value() << " not found!");
       }
     }
 

--- a/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectoryStatesWriter.cpp
@@ -303,8 +303,8 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectoryStatesWriter::writeT(
           // Get the truth particle charge
           truthQ = static_cast<int>(particle.charge());
         } else {
-          ACTS_WARNING("Truth particle with barcode "
-                       << barcode << "=" << barcode.value() << " not found!");
+          ACTS_INFO("Truth particle with barcode "
+                    << barcode << "=" << barcode.value() << " not found!");
         }
       }
 

--- a/Examples/Io/Root/src/RootTrajectorySummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrajectorySummaryWriter.cpp
@@ -285,10 +285,9 @@ ActsExamples::ProcessCode ActsExamples::RootTrajectorySummaryWriter::writeT(
             }
           }
         } else {
-          ACTS_WARNING("Truth particle with barcode "
-                       << majorityParticleId << "="
-                       << majorityParticleId.value()
-                       << " not found in the input collection!");
+          ACTS_INFO("Truth particle with barcode "
+                    << majorityParticleId << "=" << majorityParticleId.value()
+                    << " not found in the input collection!");
         }
       }
       if (not foundMajorityParticle) {


### PR DESCRIPTION
after https://github.com/acts-project/acts/pull/2049 we see a lot of warnings like
```
RootTrajecto   WARNING   Truth particle with barcode 124|0|7|1|8=558446353911447560
```

I believe they are cause by filtered truth particles which now produce hits and get reconstructed. the root writers then find the tracks with particles which are not in the list of selected ones

after discussion with @Corentin-Allaire and @benjaminhuth it makes most sense to me to just level down the log and guarantee that those tracks are flagged as fake