### PR TITLE
feat!: add non-cost access to Surface

### DIFF
--- a/Core/include/Acts/Geometry/detail/DefaultDetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/detail/DefaultDetectorElementBase.hpp
@@ -35,8 +35,11 @@ class DetectorElementBase {
   /// @param gctx The current geometry context object, e.g. alignment
   virtual const Transform3& transform(const GeometryContext& gctx) const = 0;
 
-  /// Return surface representation
+  /// Return surface representation - const return pattern
   virtual const Surface& surface() const = 0;
+
+  /// Non-const return pattern
+  virtual Surface& surface() = 0;
 
   /// Returns the thickness of the module
   /// @return double that indicates the thickness of the module

--- a/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/GenericDetectorElement.hpp
+++ b/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/GenericDetectorElement.hpp
@@ -83,6 +83,9 @@ class GenericDetectorElement : public Acts::IdentifiedDetectorElement {
   /// Return surface associated with this detector element
   const Acts::Surface& surface() const override;
 
+  /// Non-cost access to surface associated with this detector element
+  Acts::Surface& surface() override;
+
   /// Set the identifier after construction (sometimes needed)
   void assignIdentifier(const Identifier& identifier);
 
@@ -100,7 +103,7 @@ class GenericDetectorElement : public Acts::IdentifiedDetectorElement {
   /// the transform for positioning in 3D space
   std::shared_ptr<const Acts::Transform3> m_elementTransform;
   /// the surface represented by it
-  std::shared_ptr<const Acts::Surface> m_elementSurface;
+  std::shared_ptr<Acts::Surface> m_elementSurface;
   /// the element thickness
   double m_elementThickness;
   /// store either
@@ -129,6 +132,10 @@ ActsExamples::Generic::GenericDetectorElement::transform(
 
 inline const Acts::Surface&
 ActsExamples::Generic::GenericDetectorElement::surface() const {
+  return *m_elementSurface;
+}
+
+inline Acts::Surface& ActsExamples::Generic::GenericDetectorElement::surface() {
   return *m_elementSurface;
 }
 

--- a/Examples/Detectors/GenericDetector/src/GenericDetectorElement.cpp
+++ b/Examples/Detectors/GenericDetector/src/GenericDetectorElement.cpp
@@ -28,9 +28,7 @@ ActsExamples::Generic::GenericDetectorElement::GenericDetectorElement(
       m_elementPlanarBounds(std::move(pBounds)),
       m_elementDiscBounds(nullptr),
       m_digitizationModule(std::move(digitizationModule)) {
-  auto mutableSurface =
-      std::const_pointer_cast<Acts::Surface>(m_elementSurface);
-  mutableSurface->assignSurfaceMaterial(std::move(material));
+  m_elementSurface->assignSurfaceMaterial(std::move(material));
 }
 
 ActsExamples::Generic::GenericDetectorElement::GenericDetectorElement(
@@ -48,7 +46,5 @@ ActsExamples::Generic::GenericDetectorElement::GenericDetectorElement(
       m_elementPlanarBounds(nullptr),
       m_elementDiscBounds(std::move(dBounds)),
       m_digitizationModule(std::move(digitizationModule)) {
-  auto mutableSurface =
-      std::const_pointer_cast<Acts::Surface>(m_elementSurface);
-  mutableSurface->assignSurfaceMaterial(std::move(material));
+  m_elementSurface->assignSurfaceMaterial(std::move(material));
 }

--- a/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
+++ b/Examples/Detectors/TelescopeDetector/include/ActsExamples/TelescopeDetector/TelescopeDetectorElement.hpp
@@ -63,6 +63,9 @@ class TelescopeDetectorElement : public Acts::DetectorElementBase {
   /// Return surface associated with this detector element
   const Acts::Surface& surface() const final;
 
+  /// Non-const access to the surface associated with this detector element
+  Acts::Surface& surface() final;
+
   /// The maximal thickness of the detector element wrt normal axis
   double thickness() const final;
 
@@ -97,7 +100,7 @@ class TelescopeDetectorElement : public Acts::DetectorElementBase {
   // the aligned transforms
   std::vector<std::unique_ptr<Acts::Transform3>> m_alignedTransforms = {};
   /// the surface represented by it
-  std::shared_ptr<const Acts::Surface> m_elementSurface = nullptr;
+  std::shared_ptr<Acts::Surface> m_elementSurface = nullptr;
   /// the element thickness
   double m_elementThickness = 0.;
   /// the planar bounds
@@ -107,6 +110,10 @@ class TelescopeDetectorElement : public Acts::DetectorElementBase {
 };
 
 inline const Acts::Surface& TelescopeDetectorElement::surface() const {
+  return *m_elementSurface;
+}
+
+inline Acts::Surface& TelescopeDetectorElement::surface() {
   return *m_elementSurface;
 }
 

--- a/Examples/Detectors/TelescopeDetector/src/TelescopeDetectorElement.cpp
+++ b/Examples/Detectors/TelescopeDetector/src/TelescopeDetectorElement.cpp
@@ -40,7 +40,5 @@ ActsExamples::Telescope::TelescopeDetectorElement::TelescopeDetectorElement(
       m_elementThickness(thickness),
       m_elementPlanarBounds(nullptr),
       m_elementDiscBounds(std::move(dBounds)) {
-  auto mutableSurface =
-      std::const_pointer_cast<Acts::Surface>(m_elementSurface);
-  mutableSurface->assignSurfaceMaterial(std::move(material));
+  m_elementSurface->assignSurfaceMaterial(std::move(material));
 }

--- a/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4DetectorElement.hpp
+++ b/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4DetectorElement.hpp
@@ -43,6 +43,9 @@ class Geant4DetectorElement : public DetectorElementBase {
   /// Return surface associated with this detector element
   const Surface& surface() const override;
 
+  /// Non-const access to surface associated with this detector element
+  Surface& surface() override;
+
   /// Return the thickness of this detector element
   ActsScalar thickness() const override;
 

--- a/Plugins/Geant4/src/Geant4DetectorElement.cpp
+++ b/Plugins/Geant4/src/Geant4DetectorElement.cpp
@@ -25,6 +25,10 @@ const Acts::Surface& Acts::Geant4DetectorElement::surface() const {
   return *m_surface;
 }
 
+Acts::Surface& Acts::Geant4DetectorElement::surface() {
+  return *m_surface;
+}
+
 Acts::ActsScalar Acts::Geant4DetectorElement::thickness() const {
   return m_thickness;
 }

--- a/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
+++ b/Plugins/TGeo/include/Acts/Plugins/TGeo/TGeoDetectorElement.hpp
@@ -114,6 +114,11 @@ class TGeoDetectorElement : public IdentifiedDetectorElement {
   /// Return surface associated with this detector element
   const Surface& surface() const override;
 
+  /// Return surface associated with this detector element
+  ///
+  /// @note this is the non-const access
+  Surface& surface() override;
+
   /// Retrieve the DigitizationModule
   const std::shared_ptr<const DigitizationModule> digitizationModule()
       const final {
@@ -151,6 +156,10 @@ inline const Transform3& TGeoDetectorElement::transform(
 }
 
 inline const Surface& TGeoDetectorElement::surface() const {
+  return (*m_surface);
+}
+
+inline Surface& TGeoDetectorElement::surface() {
   return (*m_surface);
 }
 

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DetectorElementStub.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/DetectorElementStub.hpp
@@ -52,9 +52,8 @@ class DetectorElementStub : public DetectorElementBase {
       : DetectorElementBase(),
         m_elementTransform(transform),
         m_elementThickness(thickness) {
-    auto mutableSurface = Surface::makeShared<PlaneSurface>(pBounds, *this);
-    mutableSurface->assignSurfaceMaterial(std::move(material));
-    m_elementSurface = mutableSurface;
+    m_elementSurface = Surface::makeShared<PlaneSurface>(pBounds, *this);
+    m_elementSurface->assignSurfaceMaterial(std::move(material));
   }
 
   /// Constructor for single sided detector element
@@ -71,9 +70,8 @@ class DetectorElementStub : public DetectorElementBase {
       : DetectorElementBase(),
         m_elementTransform(transform),
         m_elementThickness(thickness) {
-    auto mutableSurface = Surface::makeShared<LineSurfaceStub>(lBounds, *this);
-    mutableSurface->assignSurfaceMaterial(std::move(material));
-    m_elementSurface = mutableSurface;
+    m_elementSurface = Surface::makeShared<LineSurfaceStub>(lBounds, *this);
+    m_elementSurface->assignSurfaceMaterial(std::move(material));
   }
 
   ///  Destructor
@@ -89,6 +87,9 @@ class DetectorElementStub : public DetectorElementBase {
   /// Return surface associated with this detector element
   const Surface& surface() const override;
 
+  /// Non-const access to surface associated with this detector element
+  Surface& surface() override;
+
   /// The maximal thickness of the detector element wrt normal axis
   double thickness() const override;
 
@@ -96,7 +97,7 @@ class DetectorElementStub : public DetectorElementBase {
   /// the transform for positioning in 3D space
   Transform3 m_elementTransform;
   /// the surface represented by it
-  std::shared_ptr<const Surface> m_elementSurface{nullptr};
+  std::shared_ptr<Surface> m_elementSurface{nullptr};
   /// the element thickness
   double m_elementThickness{0.};
 };
@@ -107,6 +108,10 @@ inline const Transform3& DetectorElementStub::transform(
 }
 
 inline const Surface& DetectorElementStub::surface() const {
+  return *m_elementSurface;
+}
+
+inline Surface& DetectorElementStub::surface() {
   return *m_elementSurface;
 }
 

--- a/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/AlignmentContextTests.cpp
@@ -62,8 +62,7 @@ class AlignableDetectorElement : public DetectorElementBase {
       : DetectorElementBase(),
         m_elementTransform(std::move(transform)),
         m_elementThickness(thickness) {
-    auto mutableSurface = Surface::makeShared<PlaneSurface>(pBounds, *this);
-    m_elementSurface = mutableSurface;
+    m_elementSurface = Surface::makeShared<PlaneSurface>(pBounds, *this);
   }
 
   ///  Destructor
@@ -79,6 +78,9 @@ class AlignableDetectorElement : public DetectorElementBase {
   /// Return surface associated with this detector element
   const Surface& surface() const override;
 
+  /// Non-const access to the surface associated with this detector element
+  Surface& surface() override;
+
   /// The maximal thickness of the detector element wrt normal axis
   double thickness() const override;
 
@@ -86,7 +88,7 @@ class AlignableDetectorElement : public DetectorElementBase {
   /// the transform for positioning in 3D space
   std::shared_ptr<const Transform3> m_elementTransform;
   /// the surface represented by it
-  std::shared_ptr<const Surface> m_elementSurface{nullptr};
+  std::shared_ptr<Surface> m_elementSurface{nullptr};
   /// the element thickness
   double m_elementThickness{0.};
 };
@@ -102,6 +104,10 @@ inline const Transform3& AlignableDetectorElement::transform(
 }
 
 inline const Surface& AlignableDetectorElement::surface() const {
+  return *m_elementSurface;
+}
+
+inline Surface& AlignableDetectorElement::surface() {
   return *m_elementSurface;
 }
 


### PR DESCRIPTION
This PR adds a non-const access to the associated `Surface` to the detector element interface and all derivates.

```c++
virtual Surface& surface() = 0;
```

Is now required to be implemented. It will allow for full const correctness of the new `Detector` geometry, having `non-const` object while detector creation (which will in turn allow for loading of material and setting of `GeometryID` and other associations, but require strict `const correctness` after geometry construction.

It removes already some now unnecessary `const_pointer_cast` or diversions via `MutableSurfacePtr` in the examples.