### PR TITLE
feat: Add support for passing clusters to calibrator

### DIFF
--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFittingAlgorithm.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
@@ -33,6 +34,8 @@ class TrackFittingAlgorithm final : public IAlgorithm {
     std::string inputProtoTracks;
     /// Input initial track parameter estimates for for each proto track.
     std::string inputInitialTrackParameters;
+    /// (optional) Input clusters for each measurement
+    std::string inputClusters;
     /// Output fitted tracks collection.
     std::string outputTracks;
     /// Type erased fitter function.
@@ -69,6 +72,8 @@ class TrackFittingAlgorithm final : public IAlgorithm {
                                                          "InputProtoTracks"};
   ReadDataHandle<TrackParametersContainer> m_inputInitialTrackParameters{
       this, "InputInitialTrackParameters"};
+
+  ReadDataHandle<ClusterContainer> m_inputClusters{this, "InputClusters"};
 
   WriteDataHandle<ConstTrackContainer> m_outputTracks{this, "OutputTracks"};
 };

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
@@ -41,11 +41,15 @@ ActsExamples::TrackFittingAlgorithm::TrackFittingAlgorithm(
   if (!m_cfg.calibrator) {
     throw std::invalid_argument("Missing calibrator");
   }
+  if (m_cfg.inputClusters.empty() && m_cfg.calibrator->needsClusters()) {
+    throw std::invalid_argument("The configured calibrator needs clusters");
+  }
 
   m_inputMeasurements.initialize(m_cfg.inputMeasurements);
   m_inputSourceLinks.initialize(m_cfg.inputSourceLinks);
   m_inputProtoTracks.initialize(m_cfg.inputProtoTracks);
   m_inputInitialTrackParameters.initialize(m_cfg.inputInitialTrackParameters);
+  m_inputClusters.maybeInitialize(m_cfg.inputClusters);
   m_outputTracks.initialize(m_cfg.outputTracks);
 }
 
@@ -56,6 +60,11 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
   const auto& sourceLinks = m_inputSourceLinks(ctx);
   const auto& protoTracks = m_inputProtoTracks(ctx);
   const auto& initialParameters = m_inputInitialTrackParameters(ctx);
+
+  std::optional<std::reference_wrapper<const ClusterContainer>> clusters;
+  if (m_inputClusters.isInitialized()) {
+    clusters = m_inputClusters(ctx);
+  }
 
   // Consistency cross checks
   if (protoTracks.size() != initialParameters.size()) {
@@ -72,7 +81,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
   // measurements to construct it. The other extensions are hold by the
   // fit-function-object
   ActsExamples::MeasurementCalibratorAdapter calibrator(*(m_cfg.calibrator),
-                                                        measurements);
+                                                        measurements, clusters);
 
   TrackFitterFunction::GeneralFitterOptions options{
       ctx.geoContext, ctx.magFieldContext, ctx.calibContext, pSurface.get(),

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
@@ -61,10 +61,8 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
   const auto& protoTracks = m_inputProtoTracks(ctx);
   const auto& initialParameters = m_inputInitialTrackParameters(ctx);
 
-  std::optional<std::reference_wrapper<const ClusterContainer>> clusters;
-  if (m_inputClusters.isInitialized()) {
-    clusters = m_inputClusters(ctx);
-  }
+  const ClusterContainer* clusters =
+      m_inputClusters.isInitialized() ? &m_inputClusters(ctx) : nullptr;
 
   // Consistency cross checks
   if (protoTracks.size() != initialParameters.size()) {

--- a/Examples/Framework/include/ActsExamples/EventData/MeasurementCalibration.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/MeasurementCalibration.hpp
@@ -11,6 +11,7 @@
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/SourceLink.hpp"
 #include "Acts/EventData/VectorMultiTrajectory.hpp"
+#include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include <ActsExamples/EventData/Measurement.hpp>
 
@@ -23,11 +24,14 @@ class MeasurementCalibrator {
  public:
   virtual void calibrate(
       const MeasurementContainer& measurements,
+      const std::optional<std::reference_wrapper<const ClusterContainer>>
+          clusters,
       const Acts::GeometryContext& gctx,
       Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
           trackState) const = 0;
 
   virtual ~MeasurementCalibrator() = default;
+  virtual bool needsClusters() { return false; }
 };
 
 // Calibrator to convert an index source link to a measurement as-is
@@ -40,6 +44,8 @@ class PassThroughCalibrator : public MeasurementCalibrator {
   /// @param trackState The track state to calibrate
   void calibrate(
       const MeasurementContainer& measurements,
+      const std::optional<
+          std::reference_wrapper<const ClusterContainer>> /*clusters*/,
       const Acts::GeometryContext& /*gctx*/,
       Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
           trackState) const override;
@@ -49,8 +55,13 @@ class PassThroughCalibrator : public MeasurementCalibrator {
 // core ACTS calibration interface
 class MeasurementCalibratorAdapter {
  public:
-  MeasurementCalibratorAdapter(const MeasurementCalibrator& calibrator,
-                               const MeasurementContainer& measurements);
+  MeasurementCalibratorAdapter(
+      const MeasurementCalibrator& calibrator,
+      const MeasurementContainer& measurements,
+      const std::optional<std::reference_wrapper<const ClusterContainer>>
+          clusters = {});
+
+  MeasurementCalibratorAdapter() = delete;
 
   void calibrate(
       const Acts::GeometryContext& gctx,
@@ -60,6 +71,8 @@ class MeasurementCalibratorAdapter {
  private:
   const MeasurementCalibrator& m_calibrator;
   const MeasurementContainer& m_measurements;
+  const std::optional<std::reference_wrapper<const ClusterContainer>>
+      m_clusters;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/include/ActsExamples/EventData/MeasurementCalibration.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/MeasurementCalibration.hpp
@@ -24,9 +24,7 @@ class MeasurementCalibrator {
  public:
   virtual void calibrate(
       const MeasurementContainer& measurements,
-      const std::optional<std::reference_wrapper<const ClusterContainer>>
-          clusters,
-      const Acts::GeometryContext& gctx,
+      const ClusterContainer* clusters, const Acts::GeometryContext& gctx,
       Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
           trackState) const = 0;
 
@@ -44,8 +42,7 @@ class PassThroughCalibrator : public MeasurementCalibrator {
   /// @param trackState The track state to calibrate
   void calibrate(
       const MeasurementContainer& measurements,
-      const std::optional<
-          std::reference_wrapper<const ClusterContainer>> /*clusters*/,
+      const ClusterContainer* /*clusters*/,
       const Acts::GeometryContext& /*gctx*/,
       Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
           trackState) const override;
@@ -55,11 +52,9 @@ class PassThroughCalibrator : public MeasurementCalibrator {
 // core ACTS calibration interface
 class MeasurementCalibratorAdapter {
  public:
-  MeasurementCalibratorAdapter(
-      const MeasurementCalibrator& calibrator,
-      const MeasurementContainer& measurements,
-      const std::optional<std::reference_wrapper<const ClusterContainer>>
-          clusters = {});
+  MeasurementCalibratorAdapter(const MeasurementCalibrator& calibrator,
+                               const MeasurementContainer& measurements,
+                               const ClusterContainer* clusters = nullptr);
 
   MeasurementCalibratorAdapter() = delete;
 
@@ -71,8 +66,7 @@ class MeasurementCalibratorAdapter {
  private:
   const MeasurementCalibrator& m_calibrator;
   const MeasurementContainer& m_measurements;
-  const std::optional<std::reference_wrapper<const ClusterContainer>>
-      m_clusters;
+  const ClusterContainer* m_clusters;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/src/EventData/MeasurementCalibration.cpp
+++ b/Examples/Framework/src/EventData/MeasurementCalibration.cpp
@@ -10,6 +10,8 @@
 
 void ActsExamples::PassThroughCalibrator::calibrate(
     const MeasurementContainer& measurements,
+    const std::optional<
+        std::reference_wrapper<const ClusterContainer>> /*clusters*/,
     const Acts::GeometryContext& /*gctx*/,
     Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
         trackState) const {
@@ -28,12 +30,16 @@ void ActsExamples::PassThroughCalibrator::calibrate(
 
 ActsExamples::MeasurementCalibratorAdapter::MeasurementCalibratorAdapter(
     const MeasurementCalibrator& calibrator,
-    const MeasurementContainer& measurements)
-    : m_calibrator{calibrator}, m_measurements{measurements} {}
+    const MeasurementContainer& measurements,
+    const std::optional<std::reference_wrapper<const ClusterContainer>>
+        clusters)
+    : m_calibrator{calibrator},
+      m_measurements{measurements},
+      m_clusters{std::move(clusters)} {}
 
 void ActsExamples::MeasurementCalibratorAdapter::calibrate(
     const Acts::GeometryContext& gctx,
     Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy
         trackState) const {
-  return m_calibrator.calibrate(m_measurements, gctx, trackState);
+  return m_calibrator.calibrate(m_measurements, m_clusters, gctx, trackState);
 }

--- a/Examples/Framework/src/EventData/MeasurementCalibration.cpp
+++ b/Examples/Framework/src/EventData/MeasurementCalibration.cpp
@@ -10,9 +10,7 @@
 
 void ActsExamples::PassThroughCalibrator::calibrate(
     const MeasurementContainer& measurements,
-    const std::optional<
-        std::reference_wrapper<const ClusterContainer>> /*clusters*/,
-    const Acts::GeometryContext& /*gctx*/,
+    const ClusterContainer* /*clusters*/, const Acts::GeometryContext& /*gctx*/,
     Acts::MultiTrajectory<Acts::VectorMultiTrajectory>::TrackStateProxy&
         trackState) const {
   const IndexSourceLink& sourceLink =
@@ -30,12 +28,10 @@ void ActsExamples::PassThroughCalibrator::calibrate(
 
 ActsExamples::MeasurementCalibratorAdapter::MeasurementCalibratorAdapter(
     const MeasurementCalibrator& calibrator,
-    const MeasurementContainer& measurements,
-    const std::optional<std::reference_wrapper<const ClusterContainer>>
-        clusters)
+    const MeasurementContainer& measurements, const ClusterContainer* clusters)
     : m_calibrator{calibrator},
       m_measurements{measurements},
-      m_clusters{std::move(clusters)} {}
+      m_clusters{clusters} {}
 
 void ActsExamples::MeasurementCalibratorAdapter::calibrate(
     const Acts::GeometryContext& gctx,

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -819,6 +819,7 @@ def addKalmanTracks(
     inputProtoTracks: str = "truth_particle_tracks",
     multipleScattering: bool = True,
     energyLoss: bool = True,
+    clusters: str = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
@@ -848,6 +849,7 @@ def addKalmanTracks(
         inputSourceLinks="sourcelinks",
         inputProtoTracks=inputProtoTracks,
         inputInitialTrackParameters="estimatedparameters",
+        inputClusters=clusters if clusters is not None else "",
         outputTracks="kfTracks",
         pickTrack=-1,
         fit=acts.examples.makeKalmanFitterFunction(

--- a/Examples/Python/src/TrackFitting.cpp
+++ b/Examples/Python/src/TrackFitting.cpp
@@ -35,10 +35,11 @@ void addTrackFitting(Context& ctx) {
                                 inputSimHits, inputMeasurementSimHitsMap,
                                 outputProtoTracks);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackFittingAlgorithm, mex, "TrackFittingAlgorithm",
-      inputMeasurements, inputSourceLinks, inputProtoTracks,
-      inputInitialTrackParameters, outputTracks, fit, pickTrack, calibrator);
+  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrackFittingAlgorithm, mex,
+                                "TrackFittingAlgorithm", inputMeasurements,
+                                inputSourceLinks, inputProtoTracks,
+                                inputInitialTrackParameters, inputClusters,
+                                outputTracks, fit, pickTrack, calibrator);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::RefittingAlgorithm, mex,
                                 "RefittingAlgorithm", inputTracks, outputTracks,


### PR DESCRIPTION
Currently, the measurement calibrators in TrackFittingAlgorithm do not have access to cluster-level information. One widely-used pattern in the real world is to apply different calibrations depending on the cluster dimensions for instance, so this information is useful. This PR adds an optional input to the TrackFittingAlgorithm which is handed down through the MeasurementCalibrator interface. The reference to the cluster collection is boxed in a `std::optional<std::reference_wrapper>` to simplify the interface.

Ping @benjaminhuth for comments