### PR TITLE
refactor: replace error with debug message in TracksToTrajectories

### DIFF
--- a/Examples/Algorithms/Utilities/src/TracksToTrajectories.cpp
+++ b/Examples/Algorithms/Utilities/src/TracksToTrajectories.cpp
@@ -61,7 +61,7 @@ ProcessCode TracksToTrajectories::execute(const AlgorithmContext& ctx) const {
     }
 
     if (tips.empty()) {
-      ACTS_ERROR("Last trajectory is empty");
+      ACTS_DEBUG("Last trajectory is empty");
     }
 
     // last entry: move vectors


### PR DESCRIPTION
this pops up quite frequently while using CKF on single muons because if we miss the muon the track container will be empty and therefore the trajectory too