### PR TITLE
fix: Make Exa.TrkX example work with CUDA 12

### DIFF
--- a/Plugins/ExaTrkX/src/ExaTrkXTrackFindingTorch.cpp
+++ b/Plugins/ExaTrkX/src/ExaTrkXTrackFindingTorch.cpp
@@ -137,7 +137,7 @@ std::optional<ExaTrkXTime> ExaTrkXTrackFindingTorch::getTracks(
 
   // At this point, buildEdgesBruteForce could be used instead
   std::optional<torch::Tensor> edgeList = buildEdges(
-      *eOutput, numSpacepoints, m_cfg.embeddingDim, m_cfg.rVal, m_cfg.knnVal);
+      *eOutput, numSpacepoints, m_cfg.embeddingDim, m_cfg.rVal, m_cfg.knnVal).to(device);
   eOutput.reset();
 
   ACTS_VERBOSE("Shape of built edges: (" << edgeList->size(0) << ", "


### PR DESCRIPTION
There seems to be some change in the default device of tensors, this makes it explicit.