### PR TITLE
refactor: Use uint64_t explicitly in MultiTrajectory

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -50,7 +50,7 @@ class ConstTrackStateType;
 /// This view allows modifications.
 class TrackStateType {
  public:
-  using raw_type = unsigned long long;
+  using raw_type = std::uint64_t;
   /// Constructor from a reference to the underlying value container
   /// @param raw the value container
   TrackStateType(raw_type& raw) : m_raw{&raw} {}
@@ -97,7 +97,7 @@ class TrackStateType {
 /// This view does not allow modifications
 class ConstTrackStateType {
  public:
-  using raw_type = unsigned long long;
+  using raw_type = std::uint64_t;
 
   /// Constructor from a reference to the underlying value container
   /// @param raw the value container
@@ -129,7 +129,7 @@ template <typename derived_t>
 class MultiTrajectory;
 class Surface;
 
-using ProjectorBitset = unsigned long long;
+using ProjectorBitset = uint64_t;
 
 namespace detail_lt {
 /// Either type T or const T depending on the boolean.


### PR DESCRIPTION
Was using `unsigned long long` before, but that's not actually guaranteed to be `uint64_t` on all platforms