### PR TITLE
feat: push and pop for FPE monitor

### DIFF
--- a/Core/include/Acts/Utilities/FpeMonitor.hpp
+++ b/Core/include/Acts/Utilities/FpeMonitor.hpp
@@ -21,8 +21,13 @@ class FpeMonitor {
   static void enable(int excepts);
   static void disable(int excepts);
 
+  static void push();
+  static void pop();
+
  private:
-  int m_excepts;
+  int m_excepts{0};
+
+  static std::vector<int>& stack();
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/FpeMonitor.hpp
+++ b/Core/include/Acts/Utilities/FpeMonitor.hpp
@@ -10,6 +10,9 @@
 
 #include "Acts/Utilities/Helpers.hpp"
 
+#include <stack>
+#include <vector>
+
 namespace Acts {
 
 class FpeMonitor {
@@ -27,7 +30,9 @@ class FpeMonitor {
  private:
   int m_excepts{0};
 
-  static std::vector<int>& stack();
+  using Stack = std::stack<int, std::vector<int>>;
+
+  static Stack& stack();
 };
 
 }  // namespace Acts

--- a/Core/src/Utilities/FpeMonitor.cpp
+++ b/Core/src/Utilities/FpeMonitor.cpp
@@ -87,8 +87,8 @@ void FpeMonitor::disable(int excepts) {
 #endif
 }
 
-std::vector<int>& FpeMonitor::stack() {
-  static thread_local std::vector<int> stack;
+FpeMonitor::Stack& FpeMonitor::stack() {
+  static thread_local Stack stack;
   return stack;
 }
 
@@ -96,7 +96,7 @@ void FpeMonitor::push() {
 #if defined(__APPLE__)
   std::cerr << "FPE monitoring currently not supported on Apple" << std::endl;
 #else
-  stack().push_back(fegetexcept());
+  stack().push(fegetexcept());
   disable(FE_ALL_EXCEPT);
 #endif
 }
@@ -107,8 +107,8 @@ void FpeMonitor::pop() {
 #else
   disable(FE_ALL_EXCEPT);
   if (!stack().empty()) {
-    enable(stack().back());
-    stack().pop_back();
+    enable(stack().top());
+    stack().pop();
   }
 #endif
 }

--- a/Core/src/Utilities/FpeMonitor.cpp
+++ b/Core/src/Utilities/FpeMonitor.cpp
@@ -87,4 +87,32 @@ void FpeMonitor::disable(int excepts) {
 #endif
 }
 
+std::vector<int>& FpeMonitor::stack() {
+  static thread_local std::vector<int> stack;
+  return stack;
+}
+
+void FpeMonitor::push() {
+#if defined(__APPLE__)
+  std::cerr << "FPE monitoring currently not supported on Apple" << std::endl;
+  (void)excepts;
+#else
+  stack().push_back(fegetexcept());
+  disable(FE_ALL_EXCEPT);
+#endif
+}
+
+void FpeMonitor::pop() {
+#if defined(__APPLE__)
+  std::cerr << "FPE monitoring currently not supported on Apple" << std::endl;
+  (void)excepts;
+#else
+  disable(FE_ALL_EXCEPT);
+  if (!stack().empty()) {
+    enable(stack().back());
+    stack().pop_back();
+  }
+#endif
+}
+
 }  // namespace Acts

--- a/Core/src/Utilities/FpeMonitor.cpp
+++ b/Core/src/Utilities/FpeMonitor.cpp
@@ -95,7 +95,6 @@ std::vector<int>& FpeMonitor::stack() {
 void FpeMonitor::push() {
 #if defined(__APPLE__)
   std::cerr << "FPE monitoring currently not supported on Apple" << std::endl;
-  (void)excepts;
 #else
   stack().push_back(fegetexcept());
   disable(FE_ALL_EXCEPT);
@@ -105,7 +104,6 @@ void FpeMonitor::push() {
 void FpeMonitor::pop() {
 #if defined(__APPLE__)
   std::cerr << "FPE monitoring currently not supported on Apple" << std::endl;
-  (void)excepts;
 #else
   disable(FE_ALL_EXCEPT);
   if (!stack().empty()) {

--- a/Examples/Python/src/ModuleEntry.cpp
+++ b/Examples/Python/src/ModuleEntry.cpp
@@ -239,7 +239,9 @@ PYBIND11_MODULE(ActsPythonBindings, m) {
                           py::object /*exc_value*/,
                           py::object /*traceback*/) { fm.mon.reset(); })
       .def_static("enable", &Acts::FpeMonitor::enable)
-      .def_static("disable", &Acts::FpeMonitor::disable);
+      .def_static("disable", &Acts::FpeMonitor::disable)
+      .def_static("push", &Acts::FpeMonitor::push)
+      .def_static("pop", &Acts::FpeMonitor::pop);
 
   using ActsExamples::RandomNumbers;
   auto randomNumbers =


### PR DESCRIPTION
with https://github.com/acts-project/acts/pull/2086 I am running into FPEs which seem to come from special input data configurations. one of them popped up in Eigen inverse and this is something out of our control.

my proposal is to disable the FPEs for sections that may throw one and we cannot fix them or cannot fix them right away.

I am not sure how big the performance impact of this is but I also don't really see an alternative