### PR TITLE
refactor: Add tolerance to transformFreeToBoundParameters

### DIFF
--- a/Core/include/Acts/EventData/detail/TransformationFreeToBound.hpp
+++ b/Core/include/Acts/EventData/detail/TransformationFreeToBound.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Definitions/Tolerance.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -24,10 +25,12 @@ namespace detail {
 /// @param freeParams Free track parameters vector
 /// @param surface Surface onto which the parameters are bound
 /// @param geoCtx Geometry context for the global-to-local transformation
+/// @param tolerance Tolerance used for globalToLocal
+///
 /// @return Bound track parameters vector on the given surface
 Result<BoundVector> transformFreeToBoundParameters(
     const FreeVector& freeParams, const Surface& surface,
-    const GeometryContext& geoCtx);
+    const GeometryContext& geoCtx, ActsScalar tolerance = s_onSurfaceTolerance);
 
 /// Convert position and direction to bound track parameters.
 ///
@@ -37,10 +40,13 @@ Result<BoundVector> transformFreeToBoundParameters(
 /// @param qOverP Charge-over-momentum-like parameter
 /// @param surface Surface onto which the parameters are bound
 /// @param geoCtx Geometry context for the global-to-local transformation
+/// @param tolerance Tolerance used for globalToLocal
+///
 /// @return Equivalent bound parameters vector on the given surface
 Result<BoundVector> transformFreeToBoundParameters(
     const Vector3& position, ActsScalar time, const Vector3& direction,
-    ActsScalar qOverP, const Surface& surface, const GeometryContext& geoCtx);
+    ActsScalar qOverP, const Surface& surface, const GeometryContext& geoCtx,
+    ActsScalar tolerance = s_onSurfaceTolerance);
 
 /// Convert direction to curvilinear track parameters.
 ///

--- a/Core/src/EventData/TransformationFreeToBound.cpp
+++ b/Core/src/EventData/TransformationFreeToBound.cpp
@@ -15,13 +15,13 @@
 
 Acts::Result<Acts::BoundVector> Acts::detail::transformFreeToBoundParameters(
     const FreeVector& freeParams, const Surface& surface,
-    const GeometryContext& geoCtx) {
+    const GeometryContext& geoCtx, ActsScalar tolerance) {
   // initialize the bound vector
   BoundVector bp = BoundVector::Zero();
   // convert global to local position on the surface
   auto position = freeParams.segment<3>(eFreePos0);
   auto direction = freeParams.segment<3>(eFreeDir0);
-  auto result = surface.globalToLocal(geoCtx, position, direction);
+  auto result = surface.globalToLocal(geoCtx, position, direction, tolerance);
   if (!result.ok()) {
     return Result<Acts::BoundVector>::failure(result.error());
   }
@@ -40,11 +40,12 @@ Acts::Result<Acts::BoundVector> Acts::detail::transformFreeToBoundParameters(
 Acts::Result<Acts::BoundVector> Acts::detail::transformFreeToBoundParameters(
     const Acts::Vector3& position, ActsScalar time,
     const Acts::Vector3& direction, ActsScalar qOverP,
-    const Acts::Surface& surface, const Acts::GeometryContext& geoCtx) {
+    const Acts::Surface& surface, const Acts::GeometryContext& geoCtx,
+    ActsScalar tolerance) {
   // initialize the bound vector
   BoundVector bp = BoundVector::Zero();
   // convert global to local position on the surface
-  auto result = surface.globalToLocal(geoCtx, position, direction);
+  auto result = surface.globalToLocal(geoCtx, position, direction, tolerance);
   if (!result.ok()) {
     return Result<Acts::BoundVector>::failure(result.error());
   }


### PR DESCRIPTION
configurable tolerance for `transformFreeToBoundParameters` which is otherwise defaulted by the surface