### PR TITLE
fix: Protection against wrong configuration of Seed finder config

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -181,13 +181,15 @@ struct SeedFinderConfig {
     // And make sure the seed filter config is in internal units as well
     if (not seedFilter) {
       throw std::runtime_error(
-	   "Invalid values for the seed filter inside the seed filter config: nullptr");
+          "Invalid values for the seed filter inside the seed filter config: "
+          "nullptr");
     }
     if (not seedFilter->getSeedFilterConfig().isInInternalUnits) {
       throw std::runtime_error(
-           "The internal Seed Filter configuration, contained in the seed finder config, is not in internal units.");
+          "The internal Seed Filter configuration, contained in the seed "
+          "finder config, is not in internal units.");
     }
-    
+
     using namespace Acts::UnitLiterals;
     SeedFinderConfig config = *this;
     config.isInInternalUnits = true;

--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -177,6 +177,17 @@ struct SeedFinderConfig {
       throw std::runtime_error(
           "Repeated conversion to internal units for SeedFinderConfig");
     }
+    // Make sure the shared ptr to the seed filter is not a nullptr
+    // And make sure the seed filter config is in internal units as well
+    if (not seedFilter) {
+      throw std::runtime_error(
+	   "Invalid values for the seed filter inside the seed filter config: nullptr");
+    }
+    if (not seedFilter->getSeedFilterConfig().isInInternalUnits) {
+      throw std::runtime_error(
+           "The internal Seed Filter configuration, contained in the seed finder config, is not in internal units.");
+    }
+    
     using namespace Acts::UnitLiterals;
     SeedFinderConfig config = *this;
     config.isInInternalUnits = true;

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -25,12 +25,17 @@
 ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
     ActsExamples::SeedingAlgorithm::Config cfg, Acts::Logging::Level lvl)
     : ActsExamples::IAlgorithm("SeedingAlgorithm", lvl), m_cfg(std::move(cfg)) {
+
+  // Seed Finder config requires Seed Filter object before convertion to internal units
+  m_cfg.seedFilterConfig = m_cfg.seedFilterConfig.toInternalUnits();
+  m_cfg.seedFinderConfig.seedFilter =
+    std::make_unique<Acts::SeedFilter<SimSpacePoint>>(m_cfg.seedFilterConfig);
+  
   m_cfg.seedFinderConfig =
       m_cfg.seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
   m_cfg.seedFinderOptions =
       m_cfg.seedFinderOptions.toInternalUnits().calculateDerivedQuantities(
           m_cfg.seedFinderConfig);
-  m_cfg.seedFilterConfig = m_cfg.seedFilterConfig.toInternalUnits();
   m_cfg.gridConfig = m_cfg.gridConfig.toInternalUnits();
   m_cfg.gridOptions = m_cfg.gridOptions.toInternalUnits();
   if (m_cfg.inputSpacePoints.empty()) {

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -25,12 +25,12 @@
 ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
     ActsExamples::SeedingAlgorithm::Config cfg, Acts::Logging::Level lvl)
     : ActsExamples::IAlgorithm("SeedingAlgorithm", lvl), m_cfg(std::move(cfg)) {
-
-  // Seed Finder config requires Seed Filter object before convertion to internal units
+  // Seed Finder config requires Seed Filter object before convertion to
+  // internal units
   m_cfg.seedFilterConfig = m_cfg.seedFilterConfig.toInternalUnits();
   m_cfg.seedFinderConfig.seedFilter =
-    std::make_unique<Acts::SeedFilter<SimSpacePoint>>(m_cfg.seedFilterConfig);
-  
+      std::make_unique<Acts::SeedFilter<SimSpacePoint>>(m_cfg.seedFilterConfig);
+
   m_cfg.seedFinderConfig =
       m_cfg.seedFinderConfig.toInternalUnits().calculateDerivedQuantities();
   m_cfg.seedFinderOptions =


### PR DESCRIPTION
In case a misconfiguration of the `SeedFinderConfig`  happens, and the `seedFilter` is a nullptr, the code crashes.

This PR adds a protection against this eventuality. This happens in the `toInternalUnits` function, that now takes responsibility for checking the validity of its parameters.

It checks that the seedFilter is not a `nullptr` and that its config is already in internal units.