### PR TITLE
chore: Update physmon comment after vertexing monitoring changes

### DIFF
--- a/CI/physmon/comment_template.md
+++ b/CI/physmon/comment_template.md
@@ -9,16 +9,21 @@
 Seeding: {{ make_url("seeded", "seeding_seeded.html") }}, {{ make_url("truth estimated", "seeding_truth_estimated.html") }}, {{ make_url("orthogonal", "seeding_orthogonal.html") }}
 CKF: {{ make_url("seeded", "ckf_seeded.html") }}, {{ make_url("truth smeared", "ckf_truth_smeared.html") }}, {{ make_url("truth estimated", "ckf_truth_estimated.html") }}, {{ make_url("orthogonal", "ckf_orthogonal.html") }}
 IVF: {{ make_url("seeded", "ivf_seeded.html") }}, {{ make_url("truth smeared", "ivf_truth_smeared.html") }}, {{ make_url("truth estimated", "ivf_truth_estimated.html") }}, {{ make_url("orthogonal", "ivf_orthogonal.html") }}
+AMVF: {{ make_url("seeded", "amvf_seeded.html") }}, {{ make_url("truth smeared", "amvf_truth_smeared.html") }}, {{ make_url("truth estimated", "amvf_truth_estimated.html") }}, {{ make_url("orthogonal", "amvf_orthogonal.html") }}
 Ambiguity resolution: {{ make_url("seeded", "ambi_seeded.html") }}, {{ make_url("orthogonal", "ambi_orthogonal.html") }}
 {{ make_url("Truth tracking", "truth_tracking.html") }}
 {{ make_url("Truth tracking (GSF)", "gsf.html")}}
 
 ### Vertexing {{ "" if all_exist(
-    "vertexing_mu_scan.pdf", 
+    "vertexing_mu_scan.pdf",
     "ivf_seeded_plots",
     "ivf_truth_smeared_plots",
     "ivf_truth_estimated_plots",
     "ivf_orthogonal_plots",
+    "amvf_seeded_plots",
+    "amvf_truth_smeared_plots",
+    "amvf_truth_estimated_plots",
+    "amvf_orthogonal_plots",
 ) else ":x: "}}
 
 {% call detail_block("Vertexing vs. mu", "vertexing_mu_scan.pdf") %}
@@ -32,12 +37,29 @@ Ambiguity resolution: {{ make_url("seeded", "ambi_seeded.html") }}, {{ make_url(
 {% for url in [
     "covXX.pdf",
     "covYY.pdf",
-    "diffx.pdf",
-    "diffy.pdf",
-    "diffz.pdf",
+    "covZZ.pdf",
+    "resX.pdf",
+    "resY.pdf",
+    "resZ.pdf",
     "recoOverTrue.pdf",
 ] -%}
 {{- make_image("ivf_"+mode+"_plots/"+url, "50%") -}}
+{%- endfor %}
+
+{% for mode in ["seeded", "truth_smeared", "truth_estimated", "orthogonal"] %}
+
+{% call detail_block("AMVF "+mode, "amvf_"+mode+"_plots") %}
+    
+{% for url in [
+    "covXX.pdf",
+    "covYY.pdf",
+    "covZZ.pdf",
+    "resX.pdf",
+    "resY.pdf",
+    "resZ.pdf",
+    "recoOverTrue.pdf",
+] -%}
+{{- make_image("amvf_"+mode+"_plots/"+url, "50%") -}}
 {%- endfor %}
 
 {% endcall %}


### PR DESCRIPTION
after merging a bunch of vertexing monitoring improvements the physmon comment should also catch up