### PR TITLE
refactor: move initialisation of vector in seedFilter

### DIFF
--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -73,13 +73,16 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
               });
   }
 
+  // -> weaker requirement for a good seed
+  std::vector<float> compatibleSeedR;
+  compatibleSeedR.reserve(m_cfg.compatSeedLimit);
+
   size_t beginCompTopIndex = 0;
   // loop over top SPs and other compatible top SP candidates
   for (const std::size_t topSPIndex : topSPIndexVec) {
     // if two compatible seeds with high distance in r are found, compatible
     // seeds span 5 layers
-    // -> weaker requirement for a good seed
-    std::vector<float> compatibleSeedR;
+    compatibleSeedR.clear();
 
     float invHelixDiameter = invHelixDiameterVec[topSPIndex];
     float lowerLimitCurv = invHelixDiameter - m_cfg.deltaInvHelixDiameter;
@@ -93,6 +96,7 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
 
     float weight = -(impact * m_cfg.impactWeightFactor);
 
+    // loop over compatible top SP candidates
     for (size_t variableCompTopIndex = beginCompTopIndex;
          variableCompTopIndex < topSPIndexVec.size(); variableCompTopIndex++) {
       size_t compatibleTopSPIndex = topSPIndexVec[variableCompTopIndex];

--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -73,7 +73,7 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_2SpFixed(
               });
   }
 
-  // -> weaker requirement for a good seed
+  // vector containing the radius of all compatible seeds
   std::vector<float> compatibleSeedR;
   compatibleSeedR.reserve(m_cfg.compatSeedLimit);
 

--- a/Examples/Python/python/acts/examples/itk.py
+++ b/Examples/Python/python/acts/examples/itk.py
@@ -434,7 +434,7 @@ def itkSeedingAlgConfig(inputSpacePointsType: InputSpacePointsType):
         seedConfirmationFilter = True
         impactWeightFactor = 100
         compatSeedLimit = 3
-        numSeedIncrement = float("inf")
+        numSeedIncrement = 100
         seedWeightIncrement = 0
         useDetailedDoubleMeasurementInfo = False
         maxSeedsPerSpMConf = 5


### PR DESCRIPTION
This PR moves the initialisation of `compatibleSeedR` in seedFilter to reduce memory allocation 