### PR TITLE
feat: Safe inverse

### DIFF
--- a/Core/include/Acts/Utilities/Helpers.hpp
+++ b/Core/include/Acts/Utilities/Helpers.hpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -626,6 +627,35 @@ std::tuple<typename T::value_type, ActsScalar> range_medium(const T& tseries) {
   typename T::value_type range = (max - min);
   ActsScalar medium = static_cast<ActsScalar>((max + min) * 0.5);
   return std::tie(range, medium);
+}
+
+/// Calculate the inverse of an Eigen matrix after checking if it can be
+/// numerically inverted. This allows to catch potential FPEs before they occur.
+///
+/// Our main motivation for this is that Athena has a very strict FPE policy
+/// which would flag every single occurrence as a failure and then sombody has
+/// to investigate. Since we are processing a high number of events and floating
+/// point numbers sometimes work in mysterious ways the caller of this function
+/// might want to hide FPEs and handle them in a more controlled way.
+///
+/// @tparam Derived Eigen derived concrete type
+/// @tparam Result Eigen result type defaulted to input type
+///
+/// @param m Eigen matrix to invert
+///
+/// @return The theta value
+template <typename MatrixType, typename ResultType = MatrixType>
+std::optional<ResultType> safeInverse(const MatrixType& m) noexcept {
+  ResultType result;
+  bool invertible = false;
+
+  m.computeInverseWithCheck(result, invertible);
+
+  if (invertible) {
+    return result;
+  }
+
+  return {};
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -530,11 +530,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
     } else {
       // Use full 3d information for significance
       SymMatrix4 sumCov = candidateCov + otherCov;
-      SymMatrix4 sumCovInverse;
-      bool invertible = false;
-      sumCov.computeInverseWithCheck(sumCovInverse, invertible);
-      if (invertible) {
-        significance = std::sqrt(deltaPos.dot(sumCovInverse * deltaPos));
+      if (auto sumCovInverse = safeInverse(sumCov); sumCovInverse) {
+        significance = std::sqrt(deltaPos.dot(*sumCovInverse * deltaPos));
       } else {
         return true;
       }

--- a/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/HelpersTests.cpp
@@ -210,6 +210,19 @@ BOOST_AUTO_TEST_CASE(range_medium) {
   CHECK_CLOSE_ABS(medium1, 0., std::numeric_limits<ActsScalar>::epsilon());
 }
 
+BOOST_AUTO_TEST_CASE(safeInverse) {
+  {
+    auto m = Eigen::Matrix3d::Zero().eval();
+    BOOST_CHECK(!Acts::safeInverse(m));
+  }
+
+  {
+    auto m = Eigen::Matrix3d::Identity().eval();
+    BOOST_CHECK(Acts::safeInverse(m));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
+
 }  // namespace Test
 }  // namespace Acts


### PR DESCRIPTION
After discussion in https://github.com/acts-project/acts/pull/2122 and offline we decided to add a safe inverse that can be used in special occasions to avoid FPEs being thrown in order to handle them in a different, more controlled way.

The main motivation for this is that Athena has a very strict FPE policy which marks every occurrence as a job failure. Since we are dealing with a high number of events a certain number of inverse failures would be acceptable and should not be treated as a fatality.