### PR TITLE
fix: missing include in Examples/IO/Svg

### DIFF
--- a/Examples/Io/Svg/include/ActsExamples/Io/Svg/SvgPointWriter.hpp
+++ b/Examples/Io/Svg/include/ActsExamples/Io/Svg/SvgPointWriter.hpp
@@ -8,13 +8,14 @@
 
 #pragma once
 
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/Plugins/ActSVG/EventDataSvgConverter.hpp"
+#include "Acts/Plugins/ActSVG/SvgUtils.hpp"
+#include "Acts/Utilities/StringHelpers.hpp"
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/Framework/WriterT.hpp"
 #include "ActsExamples/Io/Svg/SvgTrackingGeometryWriter.hpp"
 #include "ActsExamples/Utilities/Paths.hpp"
-#include <Acts/Geometry/TrackingGeometry.hpp>
-#include <Acts/Plugins/ActSVG/EventDataSvgConverter.hpp>
-#include <Acts/Plugins/ActSVG/SvgUtils.hpp>
 
 #include <fstream>
 #include <mutex>


### PR DESCRIPTION
Description says it all