### PR TITLE
fix: unused value appearing only in assert

### DIFF
--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -66,7 +66,7 @@ void ActsExamples::ParticleTrackingAction::PostUserTrackingAction(
                  eventData.particleHitCount.at(barcode) > 0;
 
   if (not m_cfg.keepParticlesWithoutHits and not hasHits) {
-    auto n = eventData.particlesInitial.erase(
+    [[maybe_unused]] auto n = eventData.particlesInitial.erase(
         ActsExamples::SimParticle{barcode, Acts::PdgParticle::eInvalid});
     assert(n == 1);
     return;


### PR DESCRIPTION
One line change introducing `[[maybe_unused]]` for a value that is only checked in assert. 
This removes an `unused variable` warning with clang and MacOS.