### PR TITLE
refactor: Shorten long demangled names in sequencer

### DIFF
--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -22,6 +22,7 @@
 #include <exception>
 #include <limits>
 #include <numeric>
+#include <regex>
 #include <stdexcept>
 #include <typeinfo>
 
@@ -55,6 +56,31 @@ size_t saturatedAdd(size_t a, size_t b) {
   size_t res = a + b;
   res |= -static_cast<int>(res < a);
   return res;
+}
+
+/// Shorten some common but lengthy C++ constructs
+std::string demangleAndShorten(std::string name) {
+  name = boost::core::demangle(name.c_str());
+
+  // Remove std::allocator from vector
+  const static std::regex vector_pattern(
+      R"??(std::vector<(.*), std::allocator<(\1\s*)>\s*>)??");
+  name = std::regex_replace(name, vector_pattern, "std::vector<$1>");
+
+  // Shorten Acts::BoundVariantMeasurement
+  const static std::regex variant_pattern(
+      R"??(std::variant<(Acts::Measurement<Acts::BoundIndices, [0-9]ul>(,|)\s+)+>)??");
+  name = std::regex_replace(name, variant_pattern,
+                            "Acts::BoundVariantMeasurement");
+
+  // strip namespaces
+  boost::algorithm::replace_all(name, "std::", "");
+  boost::algorithm::replace_all(name, "boost::container::", "");
+  boost::algorithm::replace_all(name, "Acts::", "");
+  boost::algorithm::replace_all(name, "ActsExamples::", "");
+  boost::algorithm::replace_all(name, "ActsFatras::", "");
+
+  return name;
 }
 
 }  // namespace
@@ -125,7 +151,7 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
   }
 
   auto symbol = [&](const char* in) {
-    std::string s = boost::core::demangle(in);
+    std::string s = demangleAndShorten(in);
     size_t pos = 0;
     while (pos + 80 < s.size()) {
       ACTS_INFO("   " + s.substr(pos, pos + 80));
@@ -155,10 +181,9 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
                    << "\nat this point in the sequence (source: "
                    << source.fullName() << "),"
                    << "\nbut the type will be\n"
-                   << "'" << boost::core::demangle(source.typeInfo().name())
-                   << "'"
+                   << "'" << demangleAndShorten(source.typeInfo().name()) << "'"
                    << "\nand not\n"
-                   << "'" << boost::core::demangle(handle->typeInfo().name())
+                   << "'" << demangleAndShorten(handle->typeInfo().name())
                    << "'");
         valid = false;
       }


### PR DESCRIPTION
This PR adds some simple name-shortening filters to the printouts of the demangled typenames of inputs/outputs in the Sequencer (remove `std::allocator` from `std::vector` if redundant, shorten `std::variant`s of measurements, strip namespaces, ...)
The aim is to not substantially reduce the information but avoid multi-line typenames, which works fairly well for me now.