### PR TITLE
fix: include array in VectorHelpers.hpp

### DIFF
--- a/Core/include/Acts/Utilities/VectorHelpers.hpp
+++ b/Core/include/Acts/Utilities/VectorHelpers.hpp
@@ -14,9 +14,9 @@
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/TypeTraits.hpp"
 
-#include "Eigen/Dense"
-
 #include <array>
+
+#include "Eigen/Dense"
 
 namespace Acts {
 namespace VectorHelpers {

--- a/Core/include/Acts/Utilities/VectorHelpers.hpp
+++ b/Core/include/Acts/Utilities/VectorHelpers.hpp
@@ -16,6 +16,8 @@
 
 #include "Eigen/Dense"
 
+#include <array>
+
 namespace Acts {
 namespace VectorHelpers {
 


### PR DESCRIPTION
missing include causing compilation issues