### PR TITLE
fix: cmake IN_LIST does not work on LCG_97

### DIFF
--- a/cmake/ActsConfig.cmake.in
+++ b/cmake/ActsConfig.cmake.in
@@ -11,6 +11,9 @@
 #   - Acts_COMMIT_HASH
 #   - Acts_COMMIT_HASH_SHORT
 
+# IN_LIST seems not to work on LCG_97. This forces the right behaviour
+cmake_policy(SET CMP0057 NEW)
+
 @PACKAGE_INIT@
 
 set(Acts_COMPONENTS @_components@)


### PR DESCRIPTION
As noted in https://mattermost.web.cern.ch/acts/pl/1zjgmh3swjnzfnwxy53n3ckuqo :
cmake error on the key word `IN_LIST`. lcg env: `/cvmfs/sft.cern.ch/lcg/views/LCG_97rc4python3/x86_64-centos7-gcc9-opt`, cmake version 3.14.3. lcg cmake doesn't think `if(NOT _component IN_LIST Acts_COMPONENTS)` satisfies the key word policy added in 3.3 and I have to edit `ActsConfig.cmake.in`, adding `cmake_policy(SET CMP0057 NEW)`.

More on `IN_LIST` and `NEW` in general: https://cmake.org/cmake/help/latest/policy/CMP0057.html