### PR TITLE
fix: FPE in FATRAS hit direction

### DIFF
--- a/Fatras/include/ActsFatras/EventData/Hit.hpp
+++ b/Fatras/include/ActsFatras/EventData/Hit.hpp
@@ -88,9 +88,9 @@ class Hit {
   }
   /// Average normalized particle direction vector through the surface.
   Vector3 unitDirection() const {
-    auto dir0 = m_before4 / (2 * m_before4.segment<3>(Acts::eMom0).norm());
-    auto dir1 = m_after4 / (2 * m_after4.segment<3>(Acts::eMom0).norm());
-    return (dir0 + dir1).segment<3>(Acts::eMom0).normalized();
+    auto dir0 = m_before4.segment<3>(Acts::eMom0).normalized();
+    auto dir1 = m_after4.segment<3>(Acts::eMom0).normalized();
+    return ((dir0 + dir1) / 2.).segment<3>(Acts::eMom0).normalized();
   }
   /// Energy deposited by the hit.
   ///


### PR DESCRIPTION
I've encountered FPEs in the calculation of the average direction of FATRAS hits.

Currently we do this:
- Divide four-momenta before and after divide by 2x the norm of the three-momentum vector
- Add both four-vectors, then take only the three-momentum out, then normalize thos

This fails if the norm of either of the three momenta is invalid or zero. I think Eigen has checks against this but we do the division manually.

I think this is equivalent to:
- Getting the normalized three-momenta
- Adding them and dividing by 2, then normalize again

Thoughts?