### PR TITLE
ci: Save ccache always right after build step

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -39,8 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-${{ matrix.image }}_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -92,6 +93,13 @@ jobs:
       - name: ccache stats
         run: ${SETUP} && ccache -s
 
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
       - name: Unit tests
         run: ${SETUP} && cmake --build build --target test
 
@@ -138,8 +146,9 @@ jobs:
           submodules: true
           lfs: true
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-linux_ubuntu_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -175,6 +184,13 @@ jobs:
 
       - name: ccache stats
         run: ccache -s
+
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
       - name: Unit tests
         run: ctest --test-dir build -j$(nproc)
@@ -323,8 +339,9 @@ jobs:
           submodules: true
           lfs: true
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-linux_${{ matrix.image }}_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -359,6 +376,13 @@ jobs:
 
       - name: ccache stats
         run: ccache -s
+
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
       - name: Unit tests
         run: cmake --build build --target test
@@ -411,8 +435,9 @@ jobs:
           dnf -y install ninja-build tbb-devel ccache
           && ln -s $(find / -type f -name 'ccache') /usr/local/bin/ccache
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-linux-nodeps_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -441,6 +466,12 @@ jobs:
       # the build fails for technical reasons.
       - name: ccache stats
         run: ccache -s
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
       - name: Unit tests
         run: ${SETUP} && cmake --build build --target test
       - name: Integration tests
@@ -504,8 +535,9 @@ jobs:
           && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.gz https://acts.web.cern.ch/ACTS/ci/macOS/deps.67dd08d.tar.gz
           && tar -xf deps.tar.gz -C /usr/local/acts
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -536,6 +568,12 @@ jobs:
         run: cmake --build build
       - name: ccache stats
         run: ccache -s
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
       - name: Unit tests
         run: cmake --build build --target test
       - name: Integration tests
@@ -565,8 +603,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-cuda_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -588,6 +627,12 @@ jobs:
         run: cmake --build build
       - name: ccache stats
         run: ccache -s
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   sycl:
     runs-on: ubuntu-latest
@@ -598,8 +643,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache build
-        uses: actions/cache@v3
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        id: ccache-restore
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-sycl_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -625,3 +671,9 @@ jobs:
           && cmake --build build
       - name: ccache stats
         run: ccache -s
+      - name: Save ccache
+        uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}


### PR DESCRIPTION
This should speed up subsequent builds even if there was a problem.