### PR TITLE
feat: pythia event info printing & particle selection with mass

### DIFF
--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
@@ -61,6 +61,13 @@ ActsExamples::SimParticleContainer ActsExamples::Pythia8Generator::operator()(
   m_pythia8->rndm.rndmEnginePtr(&rndmEngine);
   m_pythia8->next();
 
+  if (m_cfg.printShortEventListing) {
+    m_pythia8->process.list();
+  }
+  if (m_cfg.printLongEventListing) {
+    m_pythia8->event.list();
+  }
+
   // convert generated final state particles into internal format
   for (int ip = 0; ip < m_pythia8->event.size(); ++ip) {
     const auto& genParticle = m_pythia8->event[ip];

--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.hpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.hpp
@@ -35,6 +35,10 @@ class Pythia8Generator : public EventGenerator::ParticlesGenerator {
     double cmsEnergy = 14 * Acts::UnitConstants::TeV;
     /// Additional Pythia8 settings.
     std::vector<std::string> settings = {{"HardQCD:all = on"}};
+    /// Let pythia print summarized event info
+    bool printShortEventListing = false;
+    /// Let pythia print detailed event info
+    bool printLongEventListing = false;
   };
 
   Pythia8Generator(const Config& cfg, Acts::Logging::Level lvl);

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
@@ -44,6 +44,8 @@ ActsExamples::ParticleSelector::ParticleSelector(const Config& config,
                                           << m_cfg.absEtaMax << ")");
   ACTS_DEBUG("selection particle pt [" << m_cfg.ptMin << "," << m_cfg.ptMax
                                        << ")");
+  ACTS_DEBUG("selection particle m [" << m_cfg.mMin << "," << m_cfg.mMax
+                                      << ")");
   ACTS_DEBUG("remove charged particles " << m_cfg.removeCharged);
   ACTS_DEBUG("remove neutral particles " << m_cfg.removeNeutral);
 }
@@ -70,7 +72,8 @@ ActsExamples::ProcessCode ActsExamples::ParticleSelector::execute(
            within(std::abs(p.position()[Acts::ePos2]), m_cfg.absZMin,
                   m_cfg.absZMax) and
            within(rho, m_cfg.rhoMin, m_cfg.rhoMax) and
-           within(p.time(), m_cfg.timeMin, m_cfg.timeMax);
+           within(p.time(), m_cfg.timeMin, m_cfg.timeMax) and
+           within(p.mass(), m_cfg.mMin, m_cfg.mMax);
   };
 
   // prepare input/ output types

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
@@ -47,6 +47,9 @@ class ParticleSelector final : public IAlgorithm {
     // Momentum cuts.
     double ptMin = 0;
     double ptMax = std::numeric_limits<double>::infinity();
+    // Rest mass cuts
+    double mMin = 0;
+    double mMax = std::numeric_limits<double>::infinity();
     /// Remove charged particles.
     bool removeCharged = false;
     /// Remove neutral particles.

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -39,10 +39,11 @@ ParticleSelectorConfig = namedtuple(
         "eta",  # (min,max)
         "absEta",  # (min,max)
         "pt",  # (min,max)
+        "m",  # (min,max)
         "removeCharged",  # bool
         "removeNeutral",  # bool
     ],
-    defaults=[(None, None)] * 7 + [None] * 2,
+    defaults=[(None, None)] * 8 + [None] * 2,
 )
 
 
@@ -187,6 +188,7 @@ def addPythia8(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     printParticles: bool = False,
+    printPythiaEventListing: Optional[Union[None, str]] = None,
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """This function steers the particle generation using Pythia8
@@ -213,6 +215,8 @@ def addPythia8(
         the output folder for the Root output, None triggers no output
     printParticles : bool, False
         print generated particles
+    printPythiaEventListing
+        None or "short" or "long"
     """
 
     customLogLevel = acts.examples.defaultLogging(s, logLevel)
@@ -224,6 +228,18 @@ def addPythia8(
     )
     if not isinstance(beam, Iterable):
         beam = (beam, beam)
+
+    if printPythiaEventListing is None:
+        printShortEventListing = False
+        printLongEventListing = False
+    elif printPythiaEventListing == "short":
+        printShortEventListing = True
+        printLongEventListing = False
+    elif printPythiaEventListing == "long":
+        printShortEventListing = False
+        printLongEventListing = True
+    else:
+        raise RuntimeError("Invalid pythia config")
 
     generators = []
     if nhard is not None and nhard > 0:
@@ -238,6 +254,8 @@ def addPythia8(
                         pdgBeam1=beam[1],
                         cmsEnergy=cmsEnergy,
                         settings=hardProcess,
+                        printLongEventListing=printLongEventListing,
+                        printShortEventListing=printShortEventListing,
                     ),
                 ),
             )
@@ -349,6 +367,8 @@ def addParticleSelection(
                 absEtaMax=config.absEta[1],
                 ptMin=config.pt[0],
                 ptMax=config.pt[1],
+                mMin=config.m[0],
+                mMax=config.m[1],
                 removeCharged=config.removeCharged,
                 removeNeutral=config.removeNeutral,
             ),

--- a/Examples/Python/src/Pythia8.cpp
+++ b/Examples/Python/src/Pythia8.cpp
@@ -36,7 +36,11 @@ void addPythia8(Context& ctx) {
       .def_readwrite("pdgBeam0", &Gen::Config::pdgBeam0)
       .def_readwrite("pdgBeam1", &Gen::Config::pdgBeam1)
       .def_readwrite("cmsEnergy", &Gen::Config::cmsEnergy)
-      .def_readwrite("settings", &Gen::Config::settings);
+      .def_readwrite("settings", &Gen::Config::settings)
+      .def_readwrite("printShortEventListing",
+                     &Gen::Config::printShortEventListing)
+      .def_readwrite("printLongEventListing",
+                     &Gen::Config::printLongEventListing);
 
   patchClassesWithConfig(p8);
 }

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -111,6 +111,8 @@ void addTruthTracking(Context& ctx) {
     ACTS_PYTHON_MEMBER(etaMax);
     ACTS_PYTHON_MEMBER(absEtaMin);
     ACTS_PYTHON_MEMBER(absEtaMax);
+    ACTS_PYTHON_MEMBER(mMin);
+    ACTS_PYTHON_MEMBER(mMax);
     ACTS_PYTHON_MEMBER(ptMin);
     ACTS_PYTHON_MEMBER(ptMax);
     ACTS_PYTHON_MEMBER(removeCharged);
@@ -123,6 +125,7 @@ void addTruthTracking(Context& ctx) {
     pythonRangeProperty(c, "phi", &Config::phiMin, &Config::phiMax);
     pythonRangeProperty(c, "eta", &Config::etaMin, &Config::etaMax);
     pythonRangeProperty(c, "absEta", &Config::absEtaMin, &Config::absEtaMax);
+    pythonRangeProperty(c, "m", &Config::mMin, &Config::mMax);
     pythonRangeProperty(c, "pt", &Config::ptMin, &Config::ptMax);
   }
 


### PR DESCRIPTION
This allows to switch on detailed or short event info printing with Pythia8. The possibility to select particles by masses is added to the particle selection algorithm.  