### PR TITLE
ci: Delete unit test and integration test binaries

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -201,8 +201,9 @@ jobs:
       - name: Install
         run: cmake --build build --target install
 
+
       - name: Package build
-        run: tar czf build.tar.gz -C build --exclude="*.o" .
+        run: tar czf build.tar.gz -C build . --exclude "*.o" --exclude "bin/ActsUnitTest*" --exclude "bin/ActsIntegrationTest*"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -203,7 +203,7 @@ jobs:
 
 
       - name: Package build
-        run: tar czf build.tar.gz -C build . --exclude "*.o" --exclude "bin/ActsUnitTest*" --exclude "bin/ActsIntegrationTest*"
+        run: tar czf build.tar.gz -C build --exclude "*.o" --exclude "bin/ActsUnitTest*" --exclude "bin/ActsIntegrationTest*" .
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,6 +74,8 @@ build_exatrkx:
       - build/
     exclude:
       - build/**/*.o
+      - build/bin/ActsUnitTest*
+      - build/bin/ActsIntegrationTest*
 
   script:
     - export PATH=/usr/local/sbin:/usr/sbin:/sbin:$PATH


### PR DESCRIPTION
This further reduces the artifact size we have to pass between jobs