### PR TITLE
refactor: TrackStateType safety, bitsize, conversion

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -74,7 +74,7 @@ class TrackStateType {
   /// @param pos the bit position
   /// @return if the bit at @p pos is one or not
   bool test(std::size_t pos) const {
-    std::bitset<sizeof(raw_type)> bs{*m_raw};
+    std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     return bs.test(pos);
   }
 
@@ -82,7 +82,7 @@ class TrackStateType {
   /// @param pos the position of the bit to change
   /// @param value the value to change the bit to
   void set(std::size_t pos, bool value = true) {
-    std::bitset<sizeof(raw_type)> bs{*m_raw};
+    std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     bs.set(pos, value);
     *m_raw = bs.to_ullong();
   }
@@ -109,7 +109,7 @@ class ConstTrackStateType {
   /// @param pos the bit position
   /// @return if the bit at @p pos is one or not
   bool test(std::size_t pos) const {
-    std::bitset<sizeof(raw_type)> bs{*m_raw};
+    std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     return bs.test(pos);
   }
 

--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -61,6 +61,7 @@ class TrackStateType {
   /// @param other the other set of flags to assign
   /// @return this object
   TrackStateType& operator=(const TrackStateType& other) {
+    assert(other.m_raw != nullptr);
     *m_raw = *other.m_raw;
     return *this;
   }
@@ -70,10 +71,14 @@ class TrackStateType {
   /// @return this object
   TrackStateType& operator=(const ConstTrackStateType& other);
 
+  /// Automatically convert to const track state type
+  operator ConstTrackStateType();
+
   /// Return if the bit at position @p pos is 1
   /// @param pos the bit position
   /// @return if the bit at @p pos is one or not
   bool test(std::size_t pos) const {
+    assert(m_raw != nullptr);
     std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     return bs.test(pos);
   }
@@ -82,6 +87,7 @@ class TrackStateType {
   /// @param pos the position of the bit to change
   /// @param value the value to change the bit to
   void set(std::size_t pos, bool value = true) {
+    assert(m_raw != nullptr);
     std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     bs.set(pos, value);
     *m_raw = bs.to_ullong();
@@ -109,8 +115,20 @@ class ConstTrackStateType {
   /// @param pos the bit position
   /// @return if the bit at @p pos is one or not
   bool test(std::size_t pos) const {
+    assert(m_raw != nullptr);
     std::bitset<sizeof(raw_type) * 8> bs{*m_raw};
     return bs.test(pos);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, ConstTrackStateType t) {
+    assert(t.m_raw != nullptr);
+    std::bitset<sizeof(raw_type) * 8> bs{*t.m_raw};
+    std::bitset<TrackStateFlag::NumTrackStateFlags> trunc;
+    for (size_t i = 0; i < TrackStateFlag::NumTrackStateFlags; i++) {
+      trunc[i] = bs[i];
+    }
+    os << "MPOHMS=" << trunc;
+    return os;
   }
 
  private:
@@ -120,8 +138,12 @@ class ConstTrackStateType {
 
 inline TrackStateType& TrackStateType::operator=(
     const ConstTrackStateType& other) {
+  assert(other.m_raw != nullptr);
   *m_raw = *other.m_raw;
   return *this;
+}
+inline TrackStateType::operator ConstTrackStateType() {
+  return {*m_raw};
 }
 
 // using TrackStateType = std::bitset<TrackStateFlag::NumTrackStateFlags>;


### PR DESCRIPTION
This makes TrackStateType check it's internal pointer, fixes the size of the bitset used for manipulation, and allow auto-conversion from mutable to const.