### PR TITLE
ci: Add more labels to the labeler bot

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,3 +12,21 @@
   - Plugins/**
 'Component - Documentation':
   - docs/**
+'Changes Performance':
+  - CI/physmon/reference/**
+'Event Data Model':
+  - '**/*EventData*/**'
+'Clustering':
+  - '**/*Clusterization*/**'
+'SP formation':
+  - '**/*SpacePointFormation*/**'
+'Seeding':
+  - '**/*Seeding*/**'
+'Track Finding':
+  - '**/*TrackFinding*/**'
+'Track Fitting':
+  - '**/*TrackFitting*/**'
+'Vertexing':
+  - '**/*Vertexing*/**'
+'Ambiguity Resolution':
+  - '**/*AmbiguityResolution*/**'


### PR DESCRIPTION
This adds new labels to the labeler plot. We introduce labels for identifying which state of the reconstruction sequence the PR is affecting, as well a label to check if a reference file has been changed (i.e. a change of performance)