### PR TITLE
refactor: remove duplicate function in `CI/release.py` and add print-outs

### DIFF
--- a/CI/release.py
+++ b/CI/release.py
@@ -153,13 +153,6 @@ def update_zenodo(zenodo_file: Path, repo: str, next_version):
     zenodo_file.write_text(json.dumps(data, indent=2))
 
 
-def update_zenodo(zenodo_file: Path, repo: str, next_version):
-    data = json.loads(zenodo_file.read_text())
-    data["title"] = f"{repo}: v{next_version}"
-    data["version"] = f"v{next_version}"
-    zenodo_file.write_text(json.dumps(data, indent=2))
-
-
 def update_citation(citation_file: Path, next_version):
     with citation_file.open() as fh:
         data = yaml.safe_load(fh)

--- a/CI/release.py
+++ b/CI/release.py
@@ -88,8 +88,8 @@ def evaluate_version_bump(
         try:
             message = commit_parser(commit.message)
             changes.append(message.bump)
-        except UnknownCommitMessageStyleError as err:
-            pass
+        except UnknownCommitMessageStyleError:
+            print("Unknown commit message style!")
 
     if changes:
         level = max(changes)
@@ -126,8 +126,8 @@ def generate_changelog(commits, commit_parser=_default_parser) -> dict:
                     (commit.sha, message.descriptions[0], commit.author)
                 )
 
-        except UnknownCommitMessageStyleError as err:
-            pass
+        except UnknownCommitMessageStyleError:
+            print("Unknown commit message style!")
 
     return changes
 
@@ -193,7 +193,7 @@ async def get_parsed_commit_range(
             try:
                 _default_parser(commit_message)
                 # if this succeeds, do nothing
-            except UnknownCommitMessageStyleError as err:
+            except UnknownCommitMessageStyleError:
                 print("Unknown commit message style!")
                 if not commit_message.startswith("Merge"):
                     invalid_message = True
@@ -291,7 +291,7 @@ async def make_release(
                     await gh.getitem(url)
                     commit_ok = True
                     break
-                except InvalidField as e:
+                except InvalidField:
                     print("Commit", target_hash[:8], "not received yet")
                     pass  # this is what we want
                 await asyncio.sleep(RETRY_INTERVAL)


### PR DESCRIPTION
clean the `CI/release.py` up a bit and add print-outs to the exceptions.