### PR TITLE
fix: GCC segfault in TrackTests.cpp

### DIFF
--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -3,14 +3,16 @@
 # the common libraries which are linked to every unittest can be
 # extended by setting the `unittest_extra_libraries` variables before
 # calling the macro.
-macro(add_unittest _name)
+macro(add_unittest _name _source)
   # automatically prefix the target name
   set(_target "ActsUnitTest${_name}")
-  add_executable(${_target} ${ARGN})
+  add_executable(${_target} ${_source})
   # define required BOOST_TEST_... macros here to ensure consistent names
   target_compile_definitions(
     ${_target}
-    PRIVATE "-DBOOST_TEST_DYN_LINK" "-DBOOST_TEST_MODULE=${_target}")
+    PRIVATE "-DBOOST_TEST_DYN_LINK")
+  set_source_files_properties(${_source} PROPERTIES 
+    COMPILE_DEFINITIONS "BOOST_TEST_MODULE=${_target}")
   target_include_directories(
     ${_target}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Tests/UnitTests/Core/EventData/CMakeLists.txt
+++ b/Tests/UnitTests/Core/EventData/CMakeLists.txt
@@ -10,6 +10,7 @@ add_unittest(TransformBoundToFree TransformBoundToFreeTests.cpp)
 add_unittest(TransformFreeToBound TransformFreeToBoundTests.cpp)
 add_unittest(CorrectedTransformFreeToBound CorrectedTransformFreeToBoundTests.cpp)
 add_unittest(Track TrackTests.cpp)
+target_sources(ActsUnitTestTrack PUBLIC TrackTestsExtra.cpp)
 add_unittest(SourceLink SourceLinkTests.cpp)
 
 add_unittest(TrackStatePropMask TrackStatePropMaskTests.cpp)

--- a/Tests/UnitTests/Core/EventData/TrackTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTests.cpp
@@ -7,7 +7,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <boost/test/data/test_case.hpp>
-#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
@@ -568,92 +567,6 @@ BOOST_AUTO_TEST_CASE(ReverseTrackStates) {
                  std::back_inserter(act),
                  [](const auto& ts) { return ts.index(); });
   BOOST_CHECK_EQUAL_COLLECTIONS(exp.begin(), exp.end(), act.begin(), act.end());
-}
-
-BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
-  // mutable source
-  VectorTrackContainer vtc{};
-  VectorMultiTrajectory mtj{};
-  TrackContainer tc{vtc, mtj};
-  tc.addColumn<size_t>("counter");
-  tc.addColumn<bool>("odd");
-
-  TrackContainer tc2{VectorTrackContainer{}, VectorMultiTrajectory{}};
-  // doesn't have the dynamic column
-
-  TrackContainer tc3{VectorTrackContainer{}, VectorMultiTrajectory{}};
-  tc3.addColumn<size_t>("counter");
-  tc3.addColumn<bool>("odd");
-
-  for (size_t i = 0; i < 10; i++) {
-    auto t = tc.getTrack(tc.addTrack());
-    auto ts = t.appendTrackState();
-    ts.predicted() = BoundVector::Ones();
-    ts = t.appendTrackState();
-    ts.predicted().setOnes();
-    ts.predicted() *= 2;
-
-    ts = t.appendTrackState();
-    ts.predicted().setOnes();
-    ts.predicted() *= 3;
-
-    t.template component<size_t>("counter") = i;
-    t.template component<bool>("odd") = i % 2 == 0;
-
-    auto t2 = tc2.getTrack(tc2.addTrack());
-    BOOST_CHECK_THROW(t2.copyFrom(t),
-                      std::invalid_argument);  // this should fail
-
-    auto t3 = tc3.getTrack(tc3.addTrack());
-    t3.copyFrom(t);  // this should work
-
-    BOOST_CHECK_NE(t3.tipIndex(), MultiTrajectoryTraits::kInvalid);
-    BOOST_CHECK(t3.nTrackStates() > 0);
-    BOOST_REQUIRE_EQUAL(t.nTrackStates(), t3.nTrackStates());
-
-    for (auto [tsa, tsb] : zip(t.trackStates(), t3.trackStates())) {
-      BOOST_CHECK_EQUAL(tsa.predicted(), tsb.predicted());
-    }
-
-    BOOST_CHECK_EQUAL(t.template component<size_t>("counter"),
-                      t3.template component<size_t>("counter"));
-    BOOST_CHECK_EQUAL(t.template component<bool>("odd"),
-                      t3.template component<bool>("odd"));
-  }
-
-  size_t before = mtj.size();
-  TrackContainer tc4{ConstVectorTrackContainer{vtc},
-                     ConstVectorMultiTrajectory{mtj}};
-
-  BOOST_REQUIRE_EQUAL(tc4.trackStateContainer().size(), before);
-
-  TrackContainer tc5{VectorTrackContainer{}, VectorMultiTrajectory{}};
-  tc5.addColumn<size_t>("counter");
-  tc5.addColumn<bool>("odd");
-
-  for (size_t i = 0; i < 10; i++) {
-    auto t4 = tc4.getTrack(i);  // const source!
-    BOOST_CHECK_NE(t4.nTrackStates(), 0);
-
-    auto t5 = tc5.getTrack(tc5.addTrack());
-    t5.copyFrom(t4);  // this should work
-
-    BOOST_CHECK_NE(t5.tipIndex(), MultiTrajectoryTraits::kInvalid);
-    BOOST_CHECK(t5.nTrackStates() > 0);
-    BOOST_REQUIRE_EQUAL(t4.nTrackStates(), t5.nTrackStates());
-
-    auto ita = t4.trackStates().begin();
-    auto itb = t5.trackStates().begin();
-    for (; ita != t4.trackStates().end() && itb != t5.trackStates().end();
-         ++ita, ++itb) {
-      BOOST_CHECK((*ita).predicted() == (*itb).predicted());
-    }
-
-    BOOST_CHECK_EQUAL(t4.template component<size_t>("counter"),
-                      t5.template component<size_t>("counter"));
-    BOOST_CHECK_EQUAL(t4.template component<bool>("odd"),
-                      t5.template component<bool>("odd"));
-  }
 }
 
 BOOST_AUTO_TEST_CASE(EnsureDynamicColumns) {

--- a/Tests/UnitTests/Core/EventData/TrackTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTests.cpp
@@ -587,9 +587,15 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
 
   for (size_t i = 0; i < 10; i++) {
     auto t = tc.getTrack(tc.addTrack());
-    t.appendTrackState().predicted() = BoundVector::Ones();
-    t.appendTrackState().predicted() = BoundVector::Ones() * 2;
-    t.appendTrackState().predicted() = BoundVector::Ones() * 3;
+    auto ts = t.appendTrackState();
+    ts.predicted() = BoundVector::Ones();
+    ts = t.appendTrackState();
+    ts.predicted().setOnes();
+    ts.predicted() *= 2;
+
+    ts = t.appendTrackState();
+    ts.predicted().setOnes();
+    ts.predicted() *= 3;
 
     t.template component<size_t>("counter") = i;
     t.template component<bool>("odd") = i % 2 == 0;
@@ -636,8 +642,11 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
     BOOST_CHECK(t5.nTrackStates() > 0);
     BOOST_REQUIRE_EQUAL(t4.nTrackStates(), t5.nTrackStates());
 
-    for (auto [tsa, tsb] : zip(t4.trackStates(), t5.trackStates())) {
-      BOOST_CHECK_EQUAL(tsa.predicted(), tsb.predicted());
+    auto ita = t4.trackStates().begin();
+    auto itb = t5.trackStates().begin();
+    for (; ita != t4.trackStates().end() && itb != t5.trackStates().end();
+         ++ita, ++itb) {
+      BOOST_CHECK((*ita).predicted() == (*itb).predicted());
     }
 
     BOOST_CHECK_EQUAL(t4.template component<size_t>("counter"),

--- a/Tests/UnitTests/Core/EventData/TrackTestsExtra.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTestsExtra.cpp
@@ -1,0 +1,100 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/EventData/VectorMultiTrajectory.hpp"
+#include "Acts/EventData/VectorTrackContainer.hpp"
+#include "Acts/Utilities/Zip.hpp"
+
+using namespace Acts;
+
+BOOST_AUTO_TEST_SUITE(EventDataTrack)
+
+BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
+  // mutable source
+  VectorTrackContainer vtc{};
+  VectorMultiTrajectory mtj{};
+  TrackContainer tc{vtc, mtj};
+  tc.addColumn<size_t>("counter");
+  tc.addColumn<bool>("odd");
+
+  TrackContainer tc2{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  // doesn't have the dynamic column
+
+  TrackContainer tc3{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  tc3.addColumn<size_t>("counter");
+  tc3.addColumn<bool>("odd");
+
+  for (size_t i = 0; i < 10; i++) {
+    auto t = tc.getTrack(tc.addTrack());
+    auto ts = t.appendTrackState();
+    ts.predicted() = BoundVector::Ones();
+    ts = t.appendTrackState();
+    ts.predicted().setOnes();
+    ts.predicted() *= 2;
+
+    ts = t.appendTrackState();
+    ts.predicted().setOnes();
+    ts.predicted() *= 3;
+
+    t.template component<size_t>("counter") = i;
+    t.template component<bool>("odd") = i % 2 == 0;
+
+    auto t2 = tc2.getTrack(tc2.addTrack());
+    BOOST_CHECK_THROW(t2.copyFrom(t),
+                      std::invalid_argument);  // this should fail
+
+    auto t3 = tc3.getTrack(tc3.addTrack());
+    t3.copyFrom(t);  // this should work
+
+    BOOST_CHECK_NE(t3.tipIndex(), MultiTrajectoryTraits::kInvalid);
+    BOOST_CHECK(t3.nTrackStates() > 0);
+    BOOST_REQUIRE_EQUAL(t.nTrackStates(), t3.nTrackStates());
+
+    for (auto [tsa, tsb] : zip(t.trackStates(), t3.trackStates())) {
+      BOOST_CHECK_EQUAL(tsa.predicted(), tsb.predicted());
+    }
+
+    BOOST_CHECK_EQUAL(t.template component<size_t>("counter"),
+                      t3.template component<size_t>("counter"));
+    BOOST_CHECK_EQUAL(t.template component<bool>("odd"),
+                      t3.template component<bool>("odd"));
+  }
+
+  size_t before = mtj.size();
+  TrackContainer tc4{ConstVectorTrackContainer{vtc},
+                     ConstVectorMultiTrajectory{mtj}};
+
+  BOOST_REQUIRE_EQUAL(tc4.trackStateContainer().size(), before);
+
+  TrackContainer tc5{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  tc5.addColumn<size_t>("counter");
+  tc5.addColumn<bool>("odd");
+
+  for (size_t i = 0; i < 10; i++) {
+    auto t4 = tc4.getTrack(i);  // const source!
+    BOOST_CHECK_NE(t4.nTrackStates(), 0);
+
+    auto t5 = tc5.getTrack(tc5.addTrack());
+    t5.copyFrom(t4);  // this should work
+
+    BOOST_CHECK_NE(t5.tipIndex(), MultiTrajectoryTraits::kInvalid);
+    BOOST_CHECK(t5.nTrackStates() > 0);
+    BOOST_REQUIRE_EQUAL(t4.nTrackStates(), t5.nTrackStates());
+
+    for (auto [tsa, tsb] : zip(t4.trackStates(), t5.trackStates())) {
+      BOOST_CHECK_EQUAL(tsa.predicted(), tsb.predicted());
+    }
+
+    BOOST_CHECK_EQUAL(t4.template component<size_t>("counter"),
+                      t5.template component<size_t>("counter"));
+    BOOST_CHECK_EQUAL(t4.template component<bool>("odd"),
+                      t5.template component<bool>("odd"));
+  }
+}
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
We've observed the Track unit test executable to SEGFAULT during compilation. 
This seems to be a combination of different things in this compilation unit. I haven't been able to fully figure out if there's a single reason it gets triggered, but in local testing I've found that the problem goes away when I split out this test function into a separate compilation unit. I'm doing that here, and I need to make a small change to our CMake config to make that work.