### PR TITLE
fix: missing include of array in FpeMonitor.hpp

### DIFF
--- a/Plugins/FpeMonitoring/include/Acts/Plugins/FpeMonitoring/FpeMonitor.hpp
+++ b/Plugins/FpeMonitoring/include/Acts/Plugins/FpeMonitoring/FpeMonitor.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Utilities/Helpers.hpp"
 
+#include <array>
 #include <atomic>
 #include <csignal>
 #include <cstddef>


### PR DESCRIPTION
I keep finding this kind of compilation issues... 