### PR TITLE
feat: `TrackingGeometry` gains `shared_ptr` world volume accessor

### DIFF
--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -64,6 +64,11 @@ class TrackingGeometry {
   /// @return plain pointer to the world volume
   const TrackingVolume* highestTrackingVolume() const;
 
+  /// Access to the world volume
+  /// @return shared pointer to the world volume
+  const std::shared_ptr<const TrackingVolume>& highestTrackingVolumeShared()
+      const;
+
   /// return the lowest tracking Volume
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -53,7 +53,12 @@ const Acts::TrackingVolume* Acts::TrackingGeometry::lowestTrackingVolume(
 
 const Acts::TrackingVolume* Acts::TrackingGeometry::highestTrackingVolume()
     const {
-  return (m_world.get());
+  return m_world.get();
+}
+
+const std::shared_ptr<const Acts::TrackingVolume>&
+Acts::TrackingGeometry::highestTrackingVolumeShared() const {
+  return m_world;
 }
 
 const Acts::Layer* Acts::TrackingGeometry::associatedLayer(


### PR DESCRIPTION
This is necessary to forward the `shared_ptr` of the world volume to other modules like Geant4 particle killer