### PR TITLE
feat: Remove secondary particles in Geant4 simulation

### DIFF
--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
@@ -135,8 +135,8 @@ class Geant4Simulation final : public Geant4SimulationBase {
     std::vector<std::string> materialMappings = {"Silicon"};
 
     std::shared_ptr<const Acts::Volume> killVolume;
-
     double killAfterTime = std::numeric_limits<double>::infinity();
+    bool killSecondaries = false;
 
     bool recordHitsOfSecondaries = true;
 

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleKillAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleKillAction.hpp
@@ -25,15 +25,16 @@ namespace ActsExamples {
 
 /// A G4SteppingAction that is called for every step in
 /// the simulation process.
-///
-/// It checks whether the particle can be killed according when its position
-/// exceeds the configured values for |z| or r.
 class ParticleKillAction : public G4UserSteppingAction {
  public:
   /// Configuration of the Stepping action
   struct Config {
+    /// particles outside this volume will be terminated
     std::shared_ptr<const Acts::Volume> volume;
+    /// particles that exceed this global time limit will be terminated
     double maxTime = std::numeric_limits<double>::infinity();
+    /// secondary particles will be terminated
+    bool secondaries = false;
   };
 
   /// Construct the stepping action

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleKillAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/ParticleKillAction.hpp
@@ -23,8 +23,10 @@ class Volume;
 
 namespace ActsExamples {
 
-/// A G4SteppingAction that is called for every step in
-/// the simulation process.
+/// A G4SteppingAction that is called for every step in the simulation process.
+///
+/// It checks whether the particle can be killed according to the user settings
+/// e.g. if its position exceeds the configured values for |z| or r.
 class ParticleKillAction : public G4UserSteppingAction {
  public:
   /// Configuration of the Stepping action

--- a/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
@@ -225,6 +225,10 @@ ActsExamples::Geant4Simulation::Geant4Simulation(const Config& cfg,
       delete runManager().GetUserSteppingAction();
     }
 
+    ParticleKillAction::Config particleKillCfg;
+    particleKillCfg.volume = cfg.killVolume;
+    particleKillCfg.maxTime = cfg.killAfterTime;
+
     SensitiveSteppingAction::Config stepCfg;
     stepCfg.eventStore = m_eventStore;
     stepCfg.charged = true;
@@ -232,15 +236,11 @@ ActsExamples::Geant4Simulation::Geant4Simulation(const Config& cfg,
     stepCfg.primary = true;
     stepCfg.secondary = cfg.recordHitsOfSecondaries;
 
-    ParticleKillAction::Config particleKillCfg;
-    particleKillCfg.volume = cfg.killVolume;
-    particleKillCfg.maxTime = cfg.killAfterTime;
-
     SteppingActionList::Config steppingCfg;
-    steppingCfg.actions.push_back(std::make_unique<SensitiveSteppingAction>(
-        stepCfg, m_logger->cloneWithSuffix("SensitiveStepping")));
     steppingCfg.actions.push_back(std::make_unique<ParticleKillAction>(
         particleKillCfg, m_logger->cloneWithSuffix("Killer")));
+    steppingCfg.actions.push_back(std::make_unique<SensitiveSteppingAction>(
+        stepCfg, m_logger->cloneWithSuffix("SensitiveStepping")));
 
     // G4RunManager will take care of deletion
     auto steppingAction = new SteppingActionList(steppingCfg);

--- a/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
@@ -34,7 +34,7 @@ void ActsExamples::ParticleKillAction::UserSteppingAction(const G4Step* step) {
 
   const auto pos = convertLength * track->GetPosition();
   const auto time = convertTime * track->GetGlobalTime();
-  const bool secondary =
+  const bool isSecondary =
       track->GetDynamicParticle()->GetPrimaryParticle() == nullptr;
 
   const bool outOfVolume =

--- a/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
@@ -41,13 +41,13 @@ void ActsExamples::ParticleKillAction::UserSteppingAction(const G4Step* step) {
       m_cfg.volume and
       not m_cfg.volume->inside(Acts::Vector3{pos.x(), pos.y(), pos.z()});
   const bool outOfTime = time > m_cfg.maxTime;
-  const bool invalidSecondary = m_cfg.secondaries && secondary;
+  const bool invalidSecondary = m_cfg.secondaries && isSecondary;
 
   if (outOfVolume or outOfTime or invalidSecondary) {
     ACTS_DEBUG("Kill track with internal track ID "
                << track->GetTrackID() << " at " << pos << " and global time "
-               << time / Acts::UnitConstants::ns << "ns and secondary "
-               << secondary);
+               << time / Acts::UnitConstants::ns << "ns and isSecondary "
+               << isSecondary);
     track->SetTrackStatus(G4TrackStatus::fStopAndKill);
   }
 }

--- a/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleKillAction.cpp
@@ -34,16 +34,20 @@ void ActsExamples::ParticleKillAction::UserSteppingAction(const G4Step* step) {
 
   const auto pos = convertLength * track->GetPosition();
   const auto time = convertTime * track->GetGlobalTime();
+  const bool secondary =
+      track->GetDynamicParticle()->GetPrimaryParticle() == nullptr;
 
   const bool outOfVolume =
       m_cfg.volume and
       not m_cfg.volume->inside(Acts::Vector3{pos.x(), pos.y(), pos.z()});
   const bool outOfTime = time > m_cfg.maxTime;
+  const bool invalidSecondary = m_cfg.secondaries && secondary;
 
-  if (outOfVolume or outOfTime) {
+  if (outOfVolume or outOfTime or invalidSecondary) {
     ACTS_DEBUG("Kill track with internal track ID "
                << track->GetTrackID() << " at " << pos << " and global time "
-               << time / Acts::UnitConstants::ns << "ns");
+               << time / Acts::UnitConstants::ns << "ns and secondary "
+               << secondary);
     track->SetTrackStatus(G4TrackStatus::fStopAndKill);
   }
 }

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -606,7 +606,7 @@ def addGeant4(
     logLevel: Optional[acts.logging.Level] = None,
     killVolume: Optional[acts.Volume] = None,
     killAfterTime: float = float("inf"),
-    killSecondaries: float = False,
+    killSecondaries: bool = False,
     physicsList: str = "FTFP_BERT",
 ) -> None:
     """This function steers the detector simulation using Geant4
@@ -633,7 +633,7 @@ def addGeant4(
         if given, particles are killed when going outside of this volume.
     killAfterTime: float
         if given, particle are killed after the global time since event creation exceeds the given value
-    killSecondaries: float
+    killSecondaries: bool
         if given, secondary particles are removed from simulation
     """
 

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -606,6 +606,7 @@ def addGeant4(
     logLevel: Optional[acts.logging.Level] = None,
     killVolume: Optional[acts.Volume] = None,
     killAfterTime: float = float("inf"),
+    killSecondaries: float = False,
     physicsList: str = "FTFP_BERT",
 ) -> None:
     """This function steers the detector simulation using Geant4
@@ -630,8 +631,10 @@ def addGeant4(
         the output folder for the Root output, None triggers no output
     killVolume: acts.Volume, None
         if given, particles are killed when going outside of this volume.
-    killAfterTime: float, None
+    killAfterTime: float
         if given, particle are killed after the global time since event creation exceeds the given value
+    killSecondaries: float
+        if given, secondary particles are removed from simulation
     """
 
     from acts.examples.geant4 import Geant4Simulation
@@ -674,6 +677,7 @@ def addGeant4(
         materialMappings=materialMappings,
         killVolume=killVolume,
         killAfterTime=killAfterTime,
+        killSecondaries=killSecondaries,
         recordHitsOfSecondaries=recordHitsOfSecondaries,
         keepParticlesWithoutHits=keepParticlesWithoutHits,
     )

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -112,6 +112,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     ACTS_PYTHON_MEMBER(materialMappings);
     ACTS_PYTHON_MEMBER(killVolume);
     ACTS_PYTHON_MEMBER(killAfterTime);
+    ACTS_PYTHON_MEMBER(killSecondaries);
     ACTS_PYTHON_MEMBER(recordHitsOfSecondaries);
     ACTS_PYTHON_MEMBER(keepParticlesWithoutHits);
     ACTS_PYTHON_STRUCT_END();


### PR DESCRIPTION
This allows us to ignore secondary particles in the Geant4 simulation which should speed things up and remove noise when unnecessary