### PR TITLE
refactor: Drop bool conversion in favor of `isAlive` method in `Fatras::Particle`

### DIFF
--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -189,9 +189,12 @@ class Particle {
   Scalar energy() const { return std::hypot(m_mass, m_absMomentum); }
 
   /// Check if the particle is alive, i.e. is not at rest.
-  constexpr operator bool() const { return Scalar(0) < m_absMomentum; }
-  /// Check if the particle is dead, i.e is at rest.
-  constexpr bool operator!() const { return m_absMomentum <= Scalar(0); }
+  constexpr bool isAlive() const { return Scalar(0) < m_absMomentum; }
+
+  constexpr bool isSecondary() const {
+    return particleId().vertexSecondary() != 0 ||
+           particleId().generation() != 0 || particleId().subParticle() != 0;
+  }
 
   // simulation specific properties
 

--- a/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/ParticleTests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(Construct) {
   BOOST_CHECK_EQUAL(particle.transverseMomentum(), Particle::Scalar(0));
   BOOST_CHECK_EQUAL(particle.absoluteMomentum(), Particle::Scalar(0));
   // particle is created at rest and thus not alive
-  BOOST_CHECK(not particle);
+  BOOST_CHECK(not particle.isAlive());
 }
 
 BOOST_AUTO_TEST_CASE(CorrectEnergy) {
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
                     Particle::Scalar(std::hypot(1_GeV, 2_GeV) - 100_MeV));
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // particle is still alive
-  BOOST_CHECK(particle);
+  BOOST_CHECK(particle.isAlive());
 
   // loose some more energy
   particle.correctEnergy(-200_MeV);
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
                     Particle::Scalar(std::hypot(1_GeV, 2_GeV) - 300_MeV));
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // particle is still alive
-  BOOST_CHECK(particle);
+  BOOST_CHECK(particle.isAlive());
 
   // loose a lot of energy
   particle.correctEnergy(-3_GeV);
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
   BOOST_CHECK_EQUAL(particle.energy(), particle.mass());
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // particle is not alive anymore
-  BOOST_CHECK(not particle);
+  BOOST_CHECK(not particle.isAlive());
 
   // lossing even more energy does nothing
   particle.correctEnergy(-10_GeV);
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(CorrectEnergy) {
   BOOST_CHECK_EQUAL(particle.energy(), particle.mass());
   CHECK_CLOSE_REL(particle.unitDirection().norm(), 1, eps);
   // particle is still not alive
-  BOOST_CHECK(not particle);
+  BOOST_CHECK(not particle.isAlive());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Fatras/Kernel/SimulationActorTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/SimulationActorTests.cpp
@@ -76,7 +76,7 @@ struct MockInteractionList {
     generated.push_back(particle);
     particle.correctEnergy(-energyLoss);
     // break if particle is not alive anymore
-    return !particle;
+    return !particle.isAlive();
   }
 
   template <typename generator_t>


### PR DESCRIPTION
Makes the state check for the particle more explicit