### PR TITLE
refactor: use grid density seeding

### DIFF
--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -15,8 +15,9 @@
 #include "Acts/Vertexing/Vertex.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
-#include "DummyVertexFitter.hpp"
 #include <map>
+
+#include "DummyVertexFitter.hpp"
 
 namespace Acts {
 

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
 #include "DummyVertexFitter.hpp"
+#include <map>
 
 namespace Acts {
 

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
@@ -22,7 +22,8 @@
 #include "Acts/Vertexing/HelicalTrackLinearizer.hpp"
 #include "Acts/Vertexing/ImpactPointEstimator.hpp"
 #include "Acts/Vertexing/IterativeVertexFinder.hpp"
-#include "Acts/Vertexing/TrackDensityVertexFinder.hpp"
+//#include "Acts/Vertexing/TrackDensityVertexFinder.hpp"
+#include "Acts/Vertexing/GridDensityVertexFinder.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
 #include "ActsExamples/EventData/ProtoVertex.hpp"
@@ -57,8 +58,7 @@ class IterativeVertexFinderAlgorithm final : public IAlgorithm {
   using Linearizer = Acts::HelicalTrackLinearizer<Propagator>;
   using Fitter =
       Acts::FullBilloirVertexFitter<Acts::BoundTrackParameters, Linearizer>;
-  using Seeder = Acts::TrackDensityVertexFinder<
-      Fitter, Acts::GaussianTrackDensity<Acts::BoundTrackParameters>>;
+  using Seeder = Acts::GridDensityVertexFinder<2000, 15, Fitter>;
   using Finder = Acts::IterativeVertexFinder<Fitter, Seeder>;
   using Options = Acts::VertexingOptions<Acts::BoundTrackParameters>;
 


### PR DESCRIPTION
Replace gaussian vertex seeding (Sec. 5.4.2 in Bastian Schlag's thesis) with grid vertex seeding (Sec. 5.4.3 in Bastian Schlag's thesis)