### PR TITLE
refactor: Separate Surface base class without "obvious" normals

### DIFF
--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Navigation/NavigationDelegates.hpp"
 #include "Acts/Navigation/NavigationState.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
 #include <array>
@@ -45,7 +46,7 @@ class Portal : public std::enable_shared_from_this<Portal> {
   /// Constructor from surface w/o portal links
   ///
   /// @param surface is the representing surface
-  Portal(std::shared_ptr<Surface> surface);
+  Portal(std::shared_ptr<RegularSurface> surface);
 
  public:
   /// The volume links forward/backward with respect to the surface normal
@@ -60,7 +61,8 @@ class Portal : public std::enable_shared_from_this<Portal> {
   friend class DetectorVolume;
 
   /// Factory for producing memory managed instances of Portal.
-  static std::shared_ptr<Portal> makeShared(std::shared_ptr<Surface> surface);
+  static std::shared_ptr<Portal> makeShared(
+      std::shared_ptr<RegularSurface> surface);
 
   /// Retrieve a @c std::shared_ptr for this surface (non-const version)
   ///
@@ -88,10 +90,10 @@ class Portal : public std::enable_shared_from_this<Portal> {
   virtual ~Portal() = default;
 
   /// Const access to the surface representation
-  const Surface& surface() const;
+  const RegularSurface& surface() const;
 
   /// Non-const access to the surface reference
-  Surface& surface();
+  RegularSurface& surface();
 
   /// Update the current volume
   ///
@@ -147,7 +149,7 @@ class Portal : public std::enable_shared_from_this<Portal> {
 
  private:
   /// The surface representation of this portal
-  std::shared_ptr<Surface> m_surface;
+  std::shared_ptr<RegularSurface> m_surface;
 
   /// The portal targets along/opposite the normal vector
   DetectorVolumeUpdators m_volumeUpdators = {unconnectedUpdator(),

--- a/Core/include/Acts/Digitization/DigitizationModule.hpp
+++ b/Core/include/Acts/Digitization/DigitizationModule.hpp
@@ -10,6 +10,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Digitization/DigitizationCell.hpp"
 #include "Acts/Digitization/Segmentation.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <memory>
 #include <vector>
@@ -18,7 +19,7 @@ namespace Acts {
 
 class Surface;
 
-using SurfacePtr = std::shared_ptr<const Surface>;
+using SurfacePtr = std::shared_ptr<const RegularSurface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
 
 /// @class DigitizationModule

--- a/Core/include/Acts/Digitization/Segmentation.hpp
+++ b/Core/include/Acts/Digitization/Segmentation.hpp
@@ -9,6 +9,7 @@
 #pragma once
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Digitization/DigitizationCell.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <memory>
 #include <vector>
@@ -18,7 +19,7 @@ namespace Acts {
 class SurfaceBounds;
 class Surface;
 class BinUtility;
-using SurfacePtr = std::shared_ptr<const Surface>;
+using SurfacePtr = std::shared_ptr<const RegularSurface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
 
 /// @brief Segmentation Base class

--- a/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
@@ -235,7 +235,7 @@ class GenericBoundTrackParameters {
   /// rotation matrix. For non-planar surfaces, it is the local-to-global
   /// rotation matrix of the tangential plane at the track position.
   RotationMatrix3 referenceFrame(const GeometryContext& geoCtx) const {
-    return m_surface->referenceFrame(geoCtx, position(geoCtx), momentum());
+    return m_surface->referenceFrame(geoCtx, localPosition(), momentum());
   }
 
  private:

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 
@@ -57,7 +58,7 @@ class BoundarySurfaceT {
   /// @param surface The unique surface the boundary represents
   /// @param inside The inside volume the boundary surface points to
   /// @param outside The outside volume the boundary surface points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface,
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
                    const volume_t* inside, const volume_t* outside)
       : m_surface(std::move(surface)),
         m_oppositeVolume(inside),
@@ -71,8 +72,8 @@ class BoundarySurfaceT {
   /// @param surface The unique surface the boundary represents
   /// @param inside The inside volume the boundary surface points to
   /// @param outside The outside volume the boundary surface points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface, VolumePtr inside,
-                   VolumePtr outside)
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
+                   VolumePtr inside, VolumePtr outside)
       : m_surface(std::move(surface)),
         m_oppositeVolume(inside.get()),
         m_alongVolume(outside.get()),
@@ -86,7 +87,7 @@ class BoundarySurfaceT {
   /// @param insideArray The inside volume array the boundary surface points to
   /// @param outsideArray The outside volume array the boundary surface
   /// points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface,
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
                    std::shared_ptr<const VolumeArray> insideArray,
                    std::shared_ptr<const VolumeArray> outsideArray)
       : m_surface(std::move(surface)),
@@ -122,7 +123,7 @@ class BoundarySurfaceT {
   }
 
   /// The Surface Representation of this
-  virtual const Surface& surfaceRepresentation() const;
+  virtual const RegularSurface& surfaceRepresentation() const;
 
   /// Helper method: attach a Volume to this BoundarySurfaceT
   /// this is done during the geometry construction.
@@ -141,7 +142,7 @@ class BoundarySurfaceT {
 
  protected:
   /// the represented surface by this
-  std::shared_ptr<const Surface> m_surface;
+  std::shared_ptr<const RegularSurface> m_surface;
   /// the inside (w.r.t. normal vector) volume to point to if only one exists
   const volume_t* m_oppositeVolume;
   /// the outside (w.r.t. normal vector) volume to point to if only one exists
@@ -153,7 +154,7 @@ class BoundarySurfaceT {
 };
 
 template <class volume_t>
-inline const Surface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
+inline const RegularSurface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
     const {
   return (*(m_surface.get()));
 }

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -184,8 +184,18 @@ const volume_t* BoundarySurfaceT<volume_t>::attachedVolume(
     const GeometryContext& gctx, const Vector3& pos, const Vector3& mom,
     Direction dir) const {
   const volume_t* attVolume = nullptr;
+
+  auto localPositionRes =
+      surfaceRepresentation().globalToLocal(gctx, pos, dir * mom.normalized());
+  if (!localPositionRes.ok()) {
+    throw std::runtime_error(
+        "BoundarySurfaceT::attachedVolume: "
+        "surfaceRepresentation().localToGlobal failed");
+  }
+
   // dot product with normal vector to distinguish inside/outside
-  if ((surfaceRepresentation().normal(gctx, pos)).dot(dir * mom) > 0.) {
+  if ((surfaceRepresentation().normal(gctx, *localPositionRes)).dot(dir * mom) >
+      0.) {
     attVolume = m_alongVolumeArray ? m_alongVolumeArray->object(pos).get()
                                    : m_alongVolume;
   } else {

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Direction.hpp"
 #include "Acts/Geometry/Volume.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 
 #include <cmath>
@@ -27,7 +28,7 @@ class Direction;
 
 using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;
 
-using OrientedSurface = std::pair<std::shared_ptr<Surface>, Direction>;
+using OrientedSurface = std::pair<std::shared_ptr<RegularSurface>, Direction>;
 using OrientedSurfaces = std::vector<OrientedSurface>;
 
 // Planar definitions to help construct the boundary surfaces

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -100,8 +100,9 @@ class AtlasStepper {
         covariance = new BoundSymMatrix(*pars.covariance());
         covTransport = true;
         useJacobian = true;
+
         const auto transform = pars.referenceSurface().referenceFrame(
-            geoContext, pos, pars.unitDirection());
+            geoContext, pars.localPosition(), pars.unitDirection());
 
         pVector[8] = transform(0, eBoundLoc0);
         pVector[16] = transform(0, eBoundLoc1);
@@ -575,7 +576,10 @@ class AtlasStepper {
     double Se = std::sin(boundParams[eBoundTheta]);
     double Ce = std::cos(boundParams[eBoundTheta]);
 
-    const auto transform = surface.referenceFrame(state.geoContext, pos, mom);
+    auto locPos = surface.globalToLocal(state.geoContext, pos, mom.normalized())
+                      .value("Bound state on surface is not on surface");
+    const auto transform =
+        surface.referenceFrame(state.geoContext, locPos, mom);
 
     state.pVector[8] = transform(0, eBoundLoc0);
     state.pVector[16] = transform(0, eBoundLoc1);
@@ -905,7 +909,9 @@ class AtlasStepper {
     P[45] *= p;
     P[46] *= p;
 
-    const auto fFrame = surface.referenceFrame(state.geoContext, gp, mom);
+    auto locPos = surface.globalToLocal(state.geoContext, gp, mom.normalized())
+                      .value("Bound state on surface is not on surface");
+    const auto fFrame = surface.referenceFrame(state.geoContext, locPos, mom);
 
     double Ax[3] = {fFrame(0, 0), fFrame(1, 0), fFrame(2, 0)};
     double Ay[3] = {fFrame(0, 1), fFrame(1, 1), fFrame(2, 1)};

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/ConeBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -39,7 +40,7 @@ namespace Acts {
 /// Propagations to a cone surface will be returned in
 /// curvilinear coordinates.
 
-class ConeSurface : public Surface {
+class ConeSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -135,7 +136,7 @@ class ConeSurface : public Surface {
                  const Vector3& position) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   // Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -105,18 +105,17 @@ class ConeSurface : public RegularSurface {
   /// Return the surface type
   SurfaceType type() const override;
 
-  /// Return the measurement frame - this is needed for alignment, in particular
-  ///  for StraightLine and Perigee Surface
-  ///  - the default implementation is the RotationMatrix3 of the transform
+  /// Return the measurement frame.
+  /// @TODO: Add description of the reference frame
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the global position where the measurement frame is
+  /// @param position is the local position where the measurement frame is
   /// constructed
   /// @param direction is the momentum direction used for the measurement frame
   /// construction
   /// @return matrix that indicates the measurement frame
   RotationMatrix3 referenceFrame(const GeometryContext& gctx,
-                                 const Vector3& position,
+                                 const Vector2& position,
                                  const Vector3& direction) const final;
 
   /// Return method for surface normal information
@@ -126,14 +125,6 @@ class ConeSurface : public RegularSurface {
   /// @return Vector3 normal vector in global frame
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
-
-  /// Return method for surface normal information
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the global position as normal vector base
-  /// @return Vector3 normal vector in global frame
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector3& position) const final;
 
   /// Normal vector return without argument
   using RegularSurface::normal;
@@ -148,6 +139,8 @@ class ConeSurface : public RegularSurface {
   /// This method returns the ConeBounds by reference
   const ConeBounds& bounds() const final;
 
+  using RegularSurface::localToGlobal;
+
   /// Local to global transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -155,21 +148,21 @@ class ConeSurface : public RegularSurface {
   /// @param direction is the global momentum direction (ignored in this operation)
   ///
   /// @return The global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
+
+  using RegularSurface::globalToLocal;
 
   /// Global to local transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -40,7 +41,7 @@ class DetectorElementBase;
 ///
 /// @image html figures/CylinderSurface.png
 
-class CylinderSurface : public Surface {
+class CylinderSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -145,7 +146,7 @@ class CylinderSurface : public Surface {
                  const Vector3& position) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -115,7 +115,7 @@ class CylinderSurface : public RegularSurface {
   /// @param direction is the momentum direction vector (ignored)
   /// @return rotation matrix that defines the measurement frame
   RotationMatrix3 referenceFrame(const GeometryContext& gctx,
-                                 const Vector3& position,
+                                 const Vector2& position,
                                  const Vector3& direction) const final;
 
   /// Return the surface type
@@ -133,18 +133,6 @@ class CylinderSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
 
-  /// Return method for surface normal information
-  /// @note for a Cylinder a local position is always required for the normal
-  /// vector
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the global position for which the normal vector is
-  /// requested
-  ///
-  /// @return normal vector at the global position by value
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector3& position) const final;
-
   /// Normal vector return without argument
   using RegularSurface::normal;
 
@@ -158,6 +146,8 @@ class CylinderSurface : public RegularSurface {
   /// This method returns the CylinderBounds by reference
   const CylinderBounds& bounds() const final;
 
+  using RegularSurface::localToGlobal;
+
   /// Local to global transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -165,21 +155,21 @@ class CylinderSurface : public RegularSurface {
   /// @param direction is the global momentum direction (ignored in this operation)
   ///
   /// @return The global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
+
+  using RegularSurface::globalToLocal;
 
   /// Global to local transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Surfaces/InfiniteBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -51,7 +52,7 @@ class SurfaceBounds;
 ///
 /// @image html figures/DiscSurface.png
 ///
-class DiscSurface : public Surface {
+class DiscSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -130,7 +131,7 @@ class DiscSurface : public Surface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// The binning position The position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -121,6 +121,8 @@ class DiscSurface : public RegularSurface {
   /// Return the surface type
   SurfaceType type() const override;
 
+  using RegularSurface::normal;
+
   /// Normal vector return
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -131,7 +133,9 @@ class DiscSurface : public RegularSurface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using RegularSurface::normal;
+  Vector3 normal(const GeometryContext& gctx) const {
+    return normal(gctx, Vector2::Zero());
+  }
 
   /// The binning position The position calculated
   /// for a certain binning type
@@ -146,6 +150,8 @@ class DiscSurface : public RegularSurface {
   /// This method returns the bounds by reference
   const SurfaceBounds& bounds() const final;
 
+  using RegularSurface::localToGlobal;
+
   /// Local to global transformation
   /// For planar surfaces the momentum direction is ignored in the local to
   /// global transformation
@@ -155,23 +161,22 @@ class DiscSurface : public RegularSurface {
   /// @param direction global 3D momentum direction (optionally ignored)
   ///
   /// @return global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
+
+  using RegularSurface::globalToLocal;
 
   /// Global to local transformation
-  /// @note the direction is ignored for Disc surfaces in this calculateion
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
-  /// @param direction global 3D momentum direction (optionally ignored)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Special method for DiscSurface : local<->local transformations polar <->

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -90,17 +90,8 @@ class LineSurface : public Surface {
   /// @param other is the source surface dor copying
   LineSurface& operator=(const LineSurface& other);
 
-  /// The normal vector is undefined if we do not know the momentum.
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param lposition is the local position is ignored
-  ///
-  /// @return a zero vector
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector2& lposition) const final;
-
-  /// Normal vector return without argument
-  using Surface::normal;
+  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                 const Vector3& direction) const override;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -90,7 +90,7 @@ class LineSurface : public Surface {
   /// @param other is the source surface dor copying
   LineSurface& operator=(const LineSurface& other);
 
-  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+  Vector3 normal(const GeometryContext& gctx, const Vector2& pos,
                  const Vector3& direction) const override;
 
   /// The binning position is the position calculated
@@ -103,21 +103,24 @@ class LineSurface : public Surface {
   Vector3 binningPosition(const GeometryContext& gctx,
                           BinningValue bValue) const final;
 
-  /// Return the measurement frame - this is needed for alignment, in particular
-  ///
-  /// for StraightLine and Perigee Surface
-  ///  - the default implementation is the RotationMatrix3 of the transform
+  /// Return the measurement frame
+  /// @TODO: Add description of the reference frame
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the global position where the measurement frame is
+  /// @param position is the local position where the measurement frame is
   /// constructed
   /// @param direction is the momentum direction used for the measurement frame
   /// construction
   ///
   /// @return is a rotation matrix that indicates the measurement frame
   RotationMatrix3 referenceFrame(const GeometryContext& gctx,
-                                 const Vector3& position,
-                                 const Vector3& direction) const final;
+                                 const Vector2& /*position*/,
+                                 const Vector3& direction) const final {
+    return referenceFrame(gctx, direction);
+  }
+
+  RotationMatrix3 referenceFrame(const GeometryContext& gctx,
+                                 const Vector3& direction) const;
 
   /// Calculate the jacobian from local to global which the surface knows best,
   /// hence the calculation is done here.

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/InfiniteBounds.hpp"
 #include "Acts/Surfaces/PlanarBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -39,7 +40,7 @@ class SurfaceBounds;
 ///
 /// @image html figures/PlaneSurface.png
 ///
-class PlaneSurface : public Surface {
+class PlaneSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -98,7 +99,7 @@ class PlaneSurface : public Surface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -89,6 +89,8 @@ class PlaneSurface : public RegularSurface {
   /// @param other The source PlaneSurface for assignment
   PlaneSurface& operator=(const PlaneSurface& other);
 
+  using RegularSurface::normal;
+
   /// Normal vector return
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -99,7 +101,9 @@ class PlaneSurface : public RegularSurface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using RegularSurface::normal;
+  Vector3 normal(const GeometryContext& gctx) const {
+    return normal(gctx, Vector2::Zero());
+  }
 
   /// The binning position is the position calculated
   /// for a certain binning type
@@ -117,6 +121,8 @@ class PlaneSurface : public RegularSurface {
   /// Return method for bounds object of this surfrace
   const SurfaceBounds& bounds() const override;
 
+  using RegularSurface::localToGlobal;
+
   /// Local to global transformation
   ///
   /// @note For planar surfaces the momentum direction is ignored in the local to global
@@ -127,26 +133,22 @@ class PlaneSurface : public RegularSurface {
   /// @param direction global 3D momentum direction (optionally ignored)
   ///
   /// @return the global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const override;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const override;
+
+  using RegularSurface::globalToLocal;
 
   /// Global to local transformation
-  ///
-  /// @note For planar surfaces the momentum direction is ignored in the global to local
-  /// transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
-  /// @param direction global 3D momentum direction (optionally ignored)
-  /// method symmetry)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const override;
 
   /// Method that calculates the correction due to incident angle

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -1,0 +1,63 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Surfaces/Surface.hpp"
+
+namespace Acts {
+
+class RegularSurface : public Surface {
+ public:
+  using Surface::Surface;
+
+  /// Return method for the normal vector of the surface
+  /// The normal vector can only be generally defined at a given local position
+  /// It requires a local position to be given (in general)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param lposition is the local position where the normal vector is
+  /// constructed
+  ///
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx,
+                         const Vector2& lposition) const = 0;
+
+  /// Return method for the normal vector of the surface
+  /// The normal vector can only be generally defined at a given local position
+  /// It requires a local position to be given (in general)
+  ///
+  /// @param position is the global position where the normal vector is
+  /// constructed
+  /// @param gctx The current geometry context object, e.g. alignment
+
+  ///
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx,
+                         const Vector3& /*position*/) const {
+    return normal(gctx, Vector2{Vector2::Zero()});
+  }
+
+  /// Return method for the normal vector of the surface
+  ///
+  /// It will return a normal vector at the center() position
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  //
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx) const {
+    return normal(gctx, center(gctx));
+  }
+
+  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                 const Vector3& /*direction*/) const override {
+    return normal(gctx, pos);
+  };
+};
+
+}  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -28,36 +28,29 @@ class RegularSurface : public Surface {
   virtual Vector3 normal(const GeometryContext& gctx,
                          const Vector2& lposition) const = 0;
 
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
-  ///
-  /// @param position is the global position where the normal vector is
-  /// constructed
-  /// @param gctx The current geometry context object, e.g. alignment
-
-  ///
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& /*position*/) const {
-    return normal(gctx, Vector2{Vector2::Zero()});
-  }
-
-  /// Return method for the normal vector of the surface
-  ///
-  /// It will return a normal vector at the center() position
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  //
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx) const {
-    return normal(gctx, center(gctx));
-  }
-
-  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+  Vector3 normal(const GeometryContext& gctx, const Vector2& pos,
                  const Vector3& /*direction*/) const override {
     return normal(gctx, pos);
   };
+
+  Result<Vector2> globalToLocal(
+      const GeometryContext& gctx, const Vector3& position,
+      const Vector3& /*direction*/,
+      double tolerance = s_onSurfaceTolerance) const override {
+    return globalToLocal(gctx, position, tolerance);
+  }
+
+  virtual Result<Vector2> globalToLocal(
+      const GeometryContext& gctx, const Vector3& position,
+      double tolerance = s_onSurfaceTolerance) const = 0;
+
+  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
+                        const Vector3& /*direction*/) const override {
+    return localToGlobal(gctx, lposition);
+  }
+
+  virtual Vector3 localToGlobal(const GeometryContext& gctx,
+                                const Vector2& lposition) const = 0;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -187,41 +187,8 @@ class Surface : public virtual GeometryObject,
   /// @return center position by value
   virtual Vector3 center(const GeometryContext& gctx) const;
 
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param lposition is the local position where the normal vector is
-  /// constructed
-  ///
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector2& lposition) const = 0;
-
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
-  ///
-  /// @param position is the global position where the normal vector is
-  /// constructed
-  /// @param gctx The current geometry context object, e.g. alignment
-
-  ///
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& position) const;
-
-  /// Return method for the normal vector of the surface
-  ///
-  /// It will return a normal vector at the center() position
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  //
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx) const {
-    return normal(gctx, center(gctx));
-  }
+  virtual Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                         const Vector3& direction) const = 0;
 
   /// Return method for SurfaceBounds
   /// @return SurfaceBounds by reference

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -187,7 +187,7 @@ class Surface : public virtual GeometryObject,
   /// @return center position by value
   virtual Vector3 center(const GeometryContext& gctx) const;
 
-  virtual Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+  virtual Vector3 normal(const GeometryContext& gctx, const Vector2& pos,
                          const Vector3& direction) const = 0;
 
   /// Return method for SurfaceBounds
@@ -291,14 +291,14 @@ class Surface : public virtual GeometryObject,
   /// by all surfaces)
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position global 3D position - considered to be on surface but not
+  /// @param position local position- considered to be on surface but not
   /// inside bounds (check is done)
   /// @param direction global 3D momentum direction (optionally ignored)
   ///
   /// @return RotationMatrix3 which defines the three axes of the measurement
   /// frame
   virtual Acts::RotationMatrix3 referenceFrame(const GeometryContext& gctx,
-                                               const Vector3& position,
+                                               const Vector2& position,
                                                const Vector3& direction) const;
 
   /// Calculate the jacobian from local to global which the surface knows best,

--- a/Core/include/Acts/Utilities/Result.hpp
+++ b/Core/include/Acts/Utilities/Result.hpp
@@ -136,16 +136,16 @@ class Result {
   /// Retrieves the valid value from the result object.
   /// @note This is the lvalue version, returns a reference to the value
   /// @return The valid value as a reference
-  T& value() & {
+  T& value(std::string_view msg = "Value called on error value") & {
     if (m_var.index() != 0) {
       if constexpr (std::is_same_v<E, std::error_code>) {
         std::stringstream ss;
         const auto& e = std::get<E>(m_var);
-        ss << "Value called on error value: " << e.category().name() << ": "
-           << e.message() << " [" << e.value() << "]";
+        ss << msg << ": " << e.category().name() << ": " << e.message() << " ["
+           << e.value() << "]";
         throw std::runtime_error(ss.str());
       } else {
-        throw std::runtime_error("Value called on error value");
+        throw std::runtime_error(msg.data());
       }
     }
 
@@ -156,16 +156,16 @@ class Result {
   /// @note This is the rvalue version, returns the value
   /// by-value and moves out of the variant.
   /// @return The valid value by value, moved out of the variant.
-  T value() && {
+  T value(std::string_view msg = "Value called on error value") && {
     if (m_var.index() != 0) {
       if constexpr (std::is_same_v<E, std::error_code>) {
         std::stringstream ss;
         const auto& e = std::get<E>(m_var);
-        ss << "Value called on error value: " << e.category().name() << ": "
-           << e.message() << " [" << e.value() << "]";
+        ss << msg << ": " << e.category().name() << ": " << e.message() << " ["
+           << e.value() << "]";
         throw std::runtime_error(ss.str());
       } else {
-        throw std::runtime_error("Value called on error value");
+        throw std::runtime_error(msg.data());
       }
     }
 

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -24,21 +24,22 @@ class DetectorVolume;
 }  // namespace Experimental
 }  // namespace Acts
 
-Acts::Experimental::Portal::Portal(std::shared_ptr<Surface> surface)
+Acts::Experimental::Portal::Portal(std::shared_ptr<RegularSurface> surface)
     : m_surface(std::move(surface)) {
   throw_assert(m_surface, "Portal surface is nullptr");
 }
 
 std::shared_ptr<Acts::Experimental::Portal>
-Acts::Experimental::Portal::makeShared(std::shared_ptr<Surface> surface) {
+Acts::Experimental::Portal::makeShared(
+    std::shared_ptr<RegularSurface> surface) {
   return std::shared_ptr<Portal>(new Portal(std::move(surface)));
 }
 
-const Acts::Surface& Acts::Experimental::Portal::surface() const {
+const Acts::RegularSurface& Acts::Experimental::Portal::surface() const {
   return *m_surface.get();
 }
 
-Acts::Surface& Acts::Experimental::Portal::surface() {
+Acts::RegularSurface& Acts::Experimental::Portal::surface() {
   return *m_surface.get();
 }
 

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -12,6 +12,7 @@
 #include "Acts/Navigation/NavigationState.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Delegate.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <cstddef>
 #include <stdexcept>
@@ -24,7 +25,9 @@ class DetectorVolume;
 }  // namespace Acts
 
 Acts::Experimental::Portal::Portal(std::shared_ptr<Surface> surface)
-    : m_surface(std::move(surface)) {}
+    : m_surface(std::move(surface)) {
+  throw_assert(m_surface, "Portal surface is nullptr");
+}
 
 std::shared_ptr<Acts::Experimental::Portal>
 Acts::Experimental::Portal::makeShared(std::shared_ptr<Surface> surface) {

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -122,7 +122,14 @@ void Acts::Experimental::Portal::updateDetectorVolume(
     const GeometryContext& gctx, NavigationState& nState) const {
   const auto& position = nState.position;
   const auto& direction = nState.direction;
-  const Vector3 normal = surface().normal(gctx, position);
+
+  auto localPositionRes = surface().globalToLocal(gctx, position, direction);
+  if (!localPositionRes.ok()) {
+    throw std::runtime_error(
+        "Portal: cannot convert global position to local.");
+  }
+
+  const Vector3 normal = surface().normal(gctx, *localPositionRes);
   Direction dir = Direction::fromScalar(normal.dot(direction));
   const auto& vUpdator = m_volumeUpdators[dir.index()];
   if (vUpdator.connected()) {

--- a/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
+++ b/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
@@ -8,10 +8,13 @@
 
 #include "Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp"
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/detail/TransformationFreeToBound.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -58,7 +61,8 @@ Acts::detail::CorrectedFreeToBoundTransformer::operator()(
     const Logger& logger) const {
   // Get the incidence angle
   Vector3 dir = freeParams.segment<3>(eFreeDir0);
-  Vector3 normal = surface.normal(geoContext);
+  Vector3 normal =
+      surface.normal(geoContext, freeParams.segment<3>(eFreePos0), dir);
   ActsScalar absCosIncidenceAng = std::abs(dir.dot(normal));
   // No correction if the incidentAngle is small enough (not necessary ) or too
   // large (correction could be invalid). Fall back to nominal free to bound

--- a/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
+++ b/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
@@ -61,8 +61,18 @@ Acts::detail::CorrectedFreeToBoundTransformer::operator()(
     const Logger& logger) const {
   // Get the incidence angle
   Vector3 dir = freeParams.segment<3>(eFreeDir0);
-  Vector3 normal =
-      surface.normal(geoContext, freeParams.segment<3>(eFreePos0), dir);
+
+  auto localPositionRes =
+      surface.globalToLocal(geoContext, freeParams.segment<3>(eFreePos0), dir);
+  if (!localPositionRes.ok()) {
+    ACTS_VERBOSE(
+        "Could not transform free to bound: " << localPositionRes.error());
+    return std::nullopt;
+  }
+
+  const Vector2& localPosition = *localPositionRes;
+
+  Vector3 normal = surface.normal(geoContext, localPosition, dir);
   ActsScalar absCosIncidenceAng = std::abs(dir.dot(normal));
   // No correction if the incidentAngle is small enough (not necessary ) or too
   // large (correction could be invalid). Fall back to nominal free to bound

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -24,6 +24,7 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
@@ -842,7 +843,7 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
       // (1) create the Boundary CylinderSurface
       auto cBounds =
           std::make_shared<CylinderBounds>(rGlueMin, 0.5 * (zMax - zMin));
-      std::shared_ptr<const Surface> cSurface =
+      std::shared_ptr<const RegularSurface> cSurface =
           Surface::makeShared<CylinderSurface>(transform, cBounds);
       ACTS_VERBOSE(
           "             creating a new cylindrical boundary surface "
@@ -867,7 +868,7 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
 
       // (2) create the BoundaryDiscSurface, in that case the zMin/zMax provided
       // are both the position of the disk in question
-      std::shared_ptr<const Surface> dSurface =
+      std::shared_ptr<const RegularSurface> dSurface =
           Surface::makeShared<DiscSurface>(transform, rMin, rMax);
       ACTS_VERBOSE(
           "             creating a new disc-like boundary surface "
@@ -922,8 +923,8 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
       // Adapt the boundary material
       ACTS_VERBOSE("- the new boundary surface has boundary material: ");
       ACTS_VERBOSE("    " << *boundaryMaterial);
-      Surface* newSurface =
-          const_cast<Surface*>(&(boundarySurface->surfaceRepresentation()));
+      RegularSurface* newSurface = const_cast<RegularSurface*>(
+          &(boundarySurface->surfaceRepresentation()));
       newSurface->assignSurfaceMaterial(boundaryMaterial);
     }
 

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
 #include <algorithm>
@@ -56,7 +57,7 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   const Transform3& lTransform = PlaneSurface::transform(GeometryContext());
   RotationMatrix3 lRotation = lTransform.rotation();
   const Vector3& lCenter = PlaneSurface::center(GeometryContext());
-  const Vector3& lVector = Surface::normal(GeometryContext(), lCenter);
+  const Vector3& lVector = RegularSurface::normal(GeometryContext(), lCenter);
   // create new surfaces
   const Transform3 apnTransform = Transform3(
       Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector) *

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
@@ -57,7 +58,7 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   const Transform3& lTransform = PlaneSurface::transform(GeometryContext());
   RotationMatrix3 lRotation = lTransform.rotation();
   const Vector3& lCenter = PlaneSurface::center(GeometryContext());
-  const Vector3& lVector = RegularSurface::normal(GeometryContext(), lCenter);
+  const Vector3& lVector = PlaneSurface::normal(GeometryContext());
   // create new surfaces
   const Transform3 apnTransform = Transform3(
       Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector) *

--- a/Core/src/Geometry/ProtoLayer.cpp
+++ b/Core/src/Geometry/ProtoLayer.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Geometry/detail/DefaultDetectorElementBase.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
 #include <algorithm>
@@ -69,11 +70,12 @@ void ProtoLayer::measure(const GeometryContext& gctx,
   for (const auto& sf : surfaces) {
     auto sfPolyhedron = sf->polyhedronRepresentation(gctx, 1);
     const DetectorElementBase* element = sf->associatedDetectorElement();
-    if (element != nullptr) {
+    const auto* regSurface = dynamic_cast<const RegularSurface*>(sf);
+    if (element != nullptr && regSurface != nullptr) {
       // Take the thickness in account if necessary
       double thickness = element->thickness();
       // We need a translation along and opposite half thickness
-      Vector3 sfNormal = sf->normal(gctx, sf->center(gctx));
+      Vector3 sfNormal = regSurface->normal(gctx, sf->center(gctx));
       std::vector<double> deltaT = {-0.5 * thickness, 0.5 * thickness};
       for (const auto& dT : deltaT) {
         Transform3 dtransform = Transform3::Identity();

--- a/Core/src/Geometry/ProtoLayer.cpp
+++ b/Core/src/Geometry/ProtoLayer.cpp
@@ -75,7 +75,10 @@ void ProtoLayer::measure(const GeometryContext& gctx,
       // Take the thickness in account if necessary
       double thickness = element->thickness();
       // We need a translation along and opposite half thickness
-      Vector3 sfNormal = regSurface->normal(gctx, sf->center(gctx));
+      // We assume the normal at (0,0) is ok. For CyinderSurfaces, the normal
+      // depends on the local position, but any normal is ok since we determine
+      // the extent along the radial direction anyway.
+      Vector3 sfNormal = regSurface->normal(gctx, Vector2::Zero());
       std::vector<double> deltaT = {-0.5 * thickness, 0.5 * thickness};
       for (const auto& dT : deltaT) {
         Transform3 dtransform = Transform3::Identity();

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -17,6 +17,7 @@
 #include "Acts/Material/IVolumeMaterial.hpp"
 #include "Acts/Material/ProtoVolumeMaterial.hpp"
 #include "Acts/Propagator/Navigator.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Frustum.hpp"
@@ -263,7 +264,8 @@ void Acts::TrackingVolume::assignBoundaryMaterial(
     std::shared_ptr<const ISurfaceMaterial> surfaceMaterial,
     BoundarySurfaceFace bsFace) {
   auto bSurface = m_boundarySurfaces.at(bsFace);
-  Surface* surface = const_cast<Surface*>(&bSurface->surfaceRepresentation());
+  RegularSurface* surface =
+      const_cast<RegularSurface*>(&bSurface->surfaceRepresentation());
   surface->assignSurfaceMaterial(std::move(surfaceMaterial));
 }
 
@@ -277,7 +279,8 @@ void Acts::TrackingVolume::updateBoundarySurface(
                             .surfaceMaterialSharedPtr();
     auto bsMaterial = bs->surfaceRepresentation().surfaceMaterial();
     if (cMaterialPtr != nullptr && bsMaterial == nullptr) {
-      Surface* surface = const_cast<Surface*>(&bs->surfaceRepresentation());
+      RegularSurface* surface =
+          const_cast<RegularSurface*>(&bs->surfaceRepresentation());
       surface->assignSurfaceMaterial(cMaterialPtr);
     }
   }
@@ -399,7 +402,7 @@ void Acts::TrackingVolume::closeGeometry(
     // create the boundary surface id
     auto boundaryID = GeometryIdentifier(volumeID).setBoundary(++iboundary);
     // now assign to the boundary surface
-    auto& mutableBSurface = *(const_cast<Surface*>(&bSurface));
+    auto& mutableBSurface = *(const_cast<RegularSurface*>(&bSurface));
     mutableBSurface.assignGeometryId(boundaryID);
     // Assign material if you have a decorator
     if (materialDecorator != nullptr) {
@@ -431,7 +434,8 @@ void Acts::TrackingVolume::closeGeometry(
           const auto& bndSrf = avol->boundarySurfaces();
           for (const auto& bnd : bndSrf) {
             const auto& srf = bnd->surfaceRepresentation();
-            Surface* mutableSurfcePtr = const_cast<Surface*>(&srf);
+            RegularSurface* mutableSurfcePtr =
+                const_cast<RegularSurface*>(&srf);
             auto geoID = GeometryIdentifier(volumeID).setSensitive(++isurface);
             mutableSurfcePtr->assignGeometryId(geoID);
           }

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -29,29 +29,33 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::ConeSurface::ConeSurface(const ConeSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::ConeSurface::ConeSurface(const GeometryContext& gctx,
                                const ConeSurface& other,
                                const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform, double alpha,
                                bool symmetric)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, symmetric)) {}
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform, double alpha,
                                double zmin, double zmax, double halfPhi)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, zmin, zmax, halfPhi)) {
 }
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform,
                                std::shared_ptr<const ConeBounds> cbounds)
-    : GeometryObject(), Surface(transform), m_bounds(std::move(cbounds)) {
+    : GeometryObject(),
+      RegularSurface(transform),
+      m_bounds(std::move(cbounds)) {
   throw_assert(m_bounds, "ConeBounds must not be nullptr");
 }
 

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -30,25 +30,27 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::CylinderSurface::CylinderSurface(const CylinderSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::CylinderSurface::CylinderSurface(const GeometryContext& gctx,
                                        const CylinderSurface& other,
                                        const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::CylinderSurface::CylinderSurface(const Transform3& transform,
                                        double radius, double halfz,
                                        double halfphi, double avphi,
                                        double bevelMinZ, double bevelMaxZ)
-    : Surface(transform),
+    : RegularSurface(transform),
       m_bounds(std::make_shared<const CylinderBounds>(
           radius, halfz, halfphi, avphi, bevelMinZ, bevelMaxZ)) {}
 
 Acts::CylinderSurface::CylinderSurface(
     std::shared_ptr<const CylinderBounds> cbounds,
     const Acts::DetectorElementBase& detelement)
-    : Surface(detelement), m_bounds(std::move(cbounds)) {
+    : RegularSurface(detelement), m_bounds(std::move(cbounds)) {
   /// surfaces representing a detector element must have bounds
   assert(cbounds);
 }
@@ -56,7 +58,7 @@ Acts::CylinderSurface::CylinderSurface(
 Acts::CylinderSurface::CylinderSurface(
     const Transform3& transform,
     const std::shared_ptr<const CylinderBounds>& cbounds)
-    : Surface(transform), m_bounds(cbounds) {
+    : RegularSurface(transform), m_bounds(cbounds) {
   throw_assert(cbounds, "CylinderBounds must not be nullptr");
 }
 

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -33,34 +33,38 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::DiscSurface::DiscSurface(const DiscSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::DiscSurface::DiscSurface(const GeometryContext& gctx,
                                const DiscSurface& other,
                                const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform, double rmin,
                                double rmax, double hphisec)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const RadialBounds>(rmin, rmax, hphisec)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform, double minhalfx,
                                double maxhalfx, double minR, double maxR,
                                double avephi, double stereo)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const DiscTrapezoidBounds>(
           minhalfx, maxhalfx, minR, maxR, avephi, stereo)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform,
                                std::shared_ptr<const DiscBounds> dbounds)
-    : GeometryObject(), Surface(transform), m_bounds(std::move(dbounds)) {}
+    : GeometryObject(),
+      RegularSurface(transform),
+      m_bounds(std::move(dbounds)) {}
 
 Acts::DiscSurface::DiscSurface(const std::shared_ptr<const DiscBounds>& dbounds,
                                const DetectorElementBase& detelement)
-    : GeometryObject(), Surface(detelement), m_bounds(dbounds) {
+    : GeometryObject(), RegularSurface(detelement), m_bounds(dbounds) {
   throw_assert(dbounds, "nullptr as DiscBounds");
 }
 
@@ -374,5 +378,5 @@ double Acts::DiscSurface::pathCorrection(const GeometryContext& gctx,
                                          const Vector3& position,
                                          const Vector3& direction) const {
   /// we can ignore the global position here
-  return 1. / std::abs(Surface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
 }

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -132,10 +132,11 @@ Acts::Vector3 Acts::LineSurface::binningPosition(
   return center(gctx);
 }
 
-Acts::Vector3 Acts::LineSurface::normal(const GeometryContext& /*gctx*/,
-                                        const Vector2& /*lpos*/) const {
-  throw std::runtime_error(
-      "LineSurface: normal is undefined without known direction");
+Acts::Vector3 Acts::LineSurface::normal(const GeometryContext& gctx,
+                                        const Vector3& pos,
+                                        const Vector3& direction) const {
+  auto ref = referenceFrame(gctx, pos, direction);
+  return ref.col(2);
 }
 
 const Acts::SurfaceBounds& Acts::LineSurface::bounds() const {

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -83,7 +83,7 @@ Acts::Result<Acts::Vector2> Acts::LineSurface::globalToLocal(
 
   // Bring the global position into the local frame. First remove the
   // translation then the rotation.
-  Vector3 localPosition = referenceFrame(gctx, position, direction).inverse() *
+  Vector3 localPosition = referenceFrame(gctx, direction).inverse() *
                           (position - transform(gctx).translation());
 
   // `localPosition.z()` is not the distance to the PCA but the smallest
@@ -107,8 +107,7 @@ std::string Acts::LineSurface::name() const {
 }
 
 Acts::RotationMatrix3 Acts::LineSurface::referenceFrame(
-    const GeometryContext& gctx, const Vector3& /*position*/,
-    const Vector3& direction) const {
+    const GeometryContext& gctx, const Vector3& direction) const {
   Vector3 unitZ0 = transform(gctx).rotation() * Vector3::UnitZ();
   Vector3 unitD0 = unitZ0.cross(direction).normalized();
   Vector3 unitDistance = unitD0.cross(unitZ0);
@@ -133,7 +132,7 @@ Acts::Vector3 Acts::LineSurface::binningPosition(
 }
 
 Acts::Vector3 Acts::LineSurface::normal(const GeometryContext& gctx,
-                                        const Vector3& pos,
+                                        const Vector2& pos,
                                         const Vector3& direction) const {
   auto ref = referenceFrame(gctx, pos, direction);
   return ref.col(2);
@@ -202,8 +201,6 @@ Acts::BoundToFreeMatrix Acts::LineSurface::boundToFreeJacobian(
   // Transform from bound to free parameters
   FreeVector freeParams =
       detail::transformBoundToFreeParameters(*this, gctx, boundParams);
-  // The global position
-  Vector3 position = freeParams.segment<3>(eFreePos0);
   // The direction
   Vector3 direction = freeParams.segment<3>(eFreeDir0);
   // Get the sines and cosines directly
@@ -212,8 +209,7 @@ Acts::BoundToFreeMatrix Acts::LineSurface::boundToFreeJacobian(
   double cosPhi = std::cos(boundParams[eBoundPhi]);
   double sinPhi = std::sin(boundParams[eBoundPhi]);
   // retrieve the reference frame
-  auto rframe = referenceFrame(gctx, position, direction);
-
+  const auto rframe = referenceFrame(gctx, direction);
   // Initialize the jacobian from local to global
   BoundToFreeMatrix jacToGlobal = BoundToFreeMatrix::Zero();
 

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -26,17 +26,17 @@
 #include <vector>
 
 Acts::PlaneSurface::PlaneSurface(const PlaneSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::PlaneSurface::PlaneSurface(const GeometryContext& gctx,
                                  const PlaneSurface& other,
                                  const Transform3& transform)
     : GeometryObject(),
-      Surface(gctx, other, transform),
+      RegularSurface(gctx, other, transform),
       m_bounds(other.m_bounds) {}
 
 Acts::PlaneSurface::PlaneSurface(const Vector3& center, const Vector3& normal)
-    : Surface(), m_bounds(nullptr) {
+    : RegularSurface(), m_bounds(nullptr) {
   /// the right-handed coordinate system is defined as
   /// T = normal
   /// U = Z x T if T not parallel to Z otherwise U = X x T
@@ -59,14 +59,14 @@ Acts::PlaneSurface::PlaneSurface(const Vector3& center, const Vector3& normal)
 Acts::PlaneSurface::PlaneSurface(
     const std::shared_ptr<const PlanarBounds>& pbounds,
     const Acts::DetectorElementBase& detelement)
-    : Surface(detelement), m_bounds(pbounds) {
+    : RegularSurface(detelement), m_bounds(pbounds) {
   /// surfaces representing a detector element must have bounds
   throw_assert(pbounds, "PlaneBounds must not be nullptr");
 }
 
 Acts::PlaneSurface::PlaneSurface(const Transform3& transform,
                                  std::shared_ptr<const PlanarBounds> pbounds)
-    : Surface(transform), m_bounds(std::move(pbounds)) {}
+    : RegularSurface(transform), m_bounds(std::move(pbounds)) {}
 
 Acts::PlaneSurface& Acts::PlaneSurface::operator=(const PlaneSurface& other) {
   if (this != &other) {
@@ -171,7 +171,7 @@ double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
                                           const Vector3& position,
                                           const Vector3& direction) const {
   // We can ignore the global position here
-  return 1. / std::abs(Surface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
 }
 
 Acts::SurfaceIntersection Acts::PlaneSurface::intersect(

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -81,15 +81,14 @@ Acts::Surface::SurfaceType Acts::PlaneSurface::type() const {
 }
 
 Acts::Vector3 Acts::PlaneSurface::localToGlobal(
-    const GeometryContext& gctx, const Vector2& lposition,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector2& lposition) const {
   return transform(gctx) *
          Vector3(lposition[Acts::eBoundLoc0], lposition[Acts::eBoundLoc1], 0.);
 }
 
 Acts::Result<Acts::Vector2> Acts::PlaneSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/, double tolerance) const {
+    double tolerance) const {
   Vector3 loc3Dframe = transform(gctx).inverse() * position;
   if (std::abs(loc3Dframe.z()) > std::abs(tolerance)) {
     return Result<Vector2>::failure(SurfaceError::GlobalPositionNotOnSurface);
@@ -168,10 +167,10 @@ Acts::Vector3 Acts::PlaneSurface::binningPosition(
 }
 
 double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
-                                          const Vector3& position,
+                                          const Vector3& /*position*/,
                                           const Vector3& direction) const {
   // We can ignore the global position here
-  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(normal(gctx).dot(direction));
 }
 
 Acts::SurfaceIntersection Acts::PlaneSurface::intersect(

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -233,11 +233,6 @@ Acts::Vector3 Acts::Surface::center(const GeometryContext& gctx) const {
   return Vector3(tMatrix(0, 3), tMatrix(1, 3), tMatrix(2, 3));
 }
 
-Acts::Vector3 Acts::Surface::normal(const GeometryContext& gctx,
-                                    const Vector3& /*position*/) const {
-  return normal(gctx, Vector2(Vector2::Zero()));
-}
-
 const Acts::Transform3& Acts::Surface::transform(
     const GeometryContext& gctx) const {
   if (m_associatedDetElement != nullptr) {

--- a/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
@@ -167,7 +167,8 @@ struct SimulationActor {
         // again: interact only if there is valid material to interact with
         if (slab) {
           // adapt material for non-zero incidence
-          auto normal = surface.normal(state.geoContext, local);
+          auto normal = surface.normal(state.geoContext, before.position(),
+                                       before.direction());
           // dot-product(unit normal, direction) = cos(incidence angle)
           // particle direction is normalized, not sure about surface normal
           auto cosIncidenceInv = normal.norm() / normal.dot(before.direction());

--- a/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
@@ -167,8 +167,8 @@ struct SimulationActor {
         // again: interact only if there is valid material to interact with
         if (slab) {
           // adapt material for non-zero incidence
-          auto normal = surface.normal(state.geoContext, before.position(),
-                                       before.direction());
+          auto normal =
+              surface.normal(state.geoContext, local, before.direction());
           // dot-product(unit normal, direction) = cos(incidence angle)
           // particle direction is normalized, not sure about surface normal
           auto cosIncidenceInv = normal.norm() / normal.dot(before.direction());

--- a/Plugins/Json/include/Acts/Plugins/Json/SurfaceJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/SurfaceJsonConverter.hpp
@@ -73,9 +73,13 @@ template <typename surface_t, typename bounds_t>
 std::shared_ptr<surface_t> surfaceFromJsonT(const nlohmann::json& j) {
   nlohmann::json jTransform = j["transform"];
   Transform3 sTransform = Transform3JsonConverter::fromJson(jTransform);
-  nlohmann::json jBounds = j["bounds"];
-  auto sBounds = SurfaceBoundsJsonConverter::fromJson<bounds_t>(jBounds);
-  return Surface::makeShared<surface_t>(sTransform, std::move(sBounds));
+  if constexpr (std::is_same_v<bounds_t, void>) {
+    return Surface::makeShared<surface_t>(sTransform);
+  } else {
+    nlohmann::json jBounds = j["bounds"];
+    auto sBounds = SurfaceBoundsJsonConverter::fromJson<bounds_t>(jBounds);
+    return Surface::makeShared<surface_t>(sTransform, std::move(sBounds));
+  }
 }
 
 namespace SurfaceJsonConverter {

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -87,7 +87,7 @@ std::vector<nlohmann::json> Acts::PortalJsonConverter::toJsonDetray(
     // Get the two volume center
     const auto volumeCenter = volume.transform(gctx).translation();
     const auto surfaceCenter = surface.center(gctx);
-    const auto surfaceNormal = surface.normal(gctx);
+    const auto surfaceNormal = surface.normal(gctx, Vector2::Zero());
     // Get the direction from the volume to the surface, correct link
     const auto volumeToSurface = surfaceCenter - volumeCenter;
     if (volumeToSurface.dot(surfaceNormal) < 0) {

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -18,11 +18,13 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Enumerate.hpp"
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <vector>
 
 namespace {
@@ -73,7 +75,7 @@ std::vector<nlohmann::json> Acts::PortalJsonConverter::toJsonDetray(
     const Options& option) {
   // The overall return object
   std::vector<nlohmann::json> jPortals = {};
-  const Surface& surface = portal.surface();
+  const RegularSurface& surface = portal.surface();
   const auto& volumeLinks = portal.detectorVolumeUpdators();
 
   // First assumption for outside link (along direction)
@@ -297,7 +299,12 @@ std::shared_ptr<Acts::Experimental::Portal> Acts::PortalJsonConverter::fromJson(
         detectorVolumes) {
   // The surface re-creation is trivial
   auto surface = SurfaceJsonConverter::fromJson(jPortal["surface"]);
-  auto portal = Experimental::Portal::makeShared(surface);
+  auto regSurface = std::dynamic_pointer_cast<RegularSurface>(surface);
+  if (!regSurface) {
+    throw std::runtime_error(
+        "PortalJsonConverter: surface is not a regular surface.");
+  }
+  auto portal = Experimental::Portal::makeShared(regSurface);
 
   std::array<Acts::Direction, 2> normalDirs = {Direction::Backward,
                                                Direction::Forward};

--- a/Tests/UnitTests/Core/Digitization/CartesianSegmentationTests.cpp
+++ b/Tests/UnitTests/Core/Digitization/CartesianSegmentationTests.cpp
@@ -14,6 +14,7 @@
 #include "Acts/Digitization/CartesianSegmentation.hpp"
 #include "Acts/Digitization/Segmentation.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
@@ -117,7 +118,10 @@ BOOST_AUTO_TEST_CASE(cartesian_segmentation) {
   CHECK_CLOSE_REL(thicknessPL, 2 * hThickness, 10e-6);
 
   // check the lorentz angle - let's take the second one
-  auto nLorentzPlane = segSurfacesXPL[2]->normal(tgContext);
+  const auto* pSurface =
+      dynamic_cast<const Acts::PlaneSurface*>(segSurfacesXPL[2].get());
+  BOOST_REQUIRE(pSurface != nullptr);
+  auto nLorentzPlane = pSurface->normal(tgContext);
 
   Vector3 nNominal(1., 0., 0.);
   double tAngle = acos(nLorentzPlane.dot(nNominal));

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
@@ -48,10 +49,9 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   const auto pos = pos4.segment<3>(ePos0);
 
   const auto* referenceSurface =
-      dynamic_cast<const RegularSurface*>(&params.referenceSurface());
-  if (referenceSurface == nullptr) {
-    BOOST_FAIL("Reference surface is not a regular surface");
-  }
+      dynamic_cast<const PlaneSurface*>(&params.referenceSurface());
+  BOOST_REQUIRE_MESSAGE(referenceSurface != nullptr,
+                        "Reference surface is not a plane");
 
   // native values
   CHECK_SMALL(params.template get<eBoundLoc0>(), eps);

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
@@ -46,6 +47,12 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   const auto qOverP = (q != 0) ? (q / p) : (1 / p);
   const auto pos = pos4.segment<3>(ePos0);
 
+  const auto* referenceSurface =
+      dynamic_cast<const RegularSurface*>(&params.referenceSurface());
+  if (referenceSurface == nullptr) {
+    BOOST_FAIL("Reference surface is not a regular surface");
+  }
+
   // native values
   CHECK_SMALL(params.template get<eBoundLoc0>(), eps);
   CHECK_SMALL(params.template get<eBoundLoc1>(), eps);
@@ -66,9 +73,8 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   CHECK_CLOSE_OR_SMALL(params.momentum(), p * unitDir, eps, eps);
   BOOST_CHECK_EQUAL(params.charge(), q);
   // curvilinear reference surface
-  CHECK_CLOSE_OR_SMALL(params.referenceSurface().center(geoCtx), pos, eps, eps);
-  CHECK_CLOSE_OR_SMALL(params.referenceSurface().normal(geoCtx), unitDir, eps,
-                       eps);
+  CHECK_CLOSE_OR_SMALL(referenceSurface->center(geoCtx), pos, eps, eps);
+  CHECK_CLOSE_OR_SMALL(referenceSurface->normal(geoCtx), unitDir, eps, eps);
   // TODO verify reference frame
 }
 

--- a/Tests/UnitTests/Core/EventData/TrackParametersDatasets.hpp
+++ b/Tests/UnitTests/Core/EventData/TrackParametersDatasets.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <cmath>
 #include <vector>
@@ -27,15 +28,16 @@ using namespace Acts;
 // reference surfaces
 // this includes only those surfaces that can take unbounded local positions as
 // inputs, i.e. no angles or strictly positive radii.
-const auto surfaces = bdata::make(std::vector<std::shared_ptr<const Surface>>{
-    Surface::makeShared<CylinderSurface>(
-        Transform3::Identity(), 10 /* radius */, 100 /* half-length z */),
-    // TODO perigee roundtrip local->global->local does not seem to work
-    // Surface::makeShared<PerigeeSurface>(Vector3(0, 0, -1.5)),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitX()),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitY()),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitZ()),
-});
+const auto surfaces =
+    bdata::make(std::vector<std::shared_ptr<const RegularSurface>>{
+        Surface::makeShared<CylinderSurface>(
+            Transform3::Identity(), 10 /* radius */, 100 /* half-length z */),
+        // TODO perigee roundtrip local->global->local does not seem to work
+        // Surface::makeShared<PerigeeSurface>(Vector3(0, 0, -1.5)),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitX()),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitY()),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitZ()),
+    });
 // positions
 const auto posAngle = bdata::xrange(-M_PI, M_PI, 0.25);
 const auto posPositiveNonzero = bdata::xrange(0.25, 1.0, 0.25);

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 
@@ -114,7 +115,11 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
 
   for (auto& os : cvbOrientedSurfaces) {
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideBox = osCenter + os.second * osNormal;
     Vector3 outsideBox = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -196,7 +196,8 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
 
   for (auto& os : ccvbOrientedSurfaces) {
     auto onSurface = os.first->binningPosition(geoCtx, binR);
-    auto osNormal = os.first->normal(geoCtx, onSurface);
+    auto locPos = os.first->globalToLocal(geoCtx, onSurface).value();
+    auto osNormal = os.first->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideCcvb = onSurface + os.second * osNormal;
     Vector3 outsideCCvb = onSurface - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -292,7 +292,8 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeOrientedBoundaries) {
 
   for (auto& os : cvbOrientedSurfaces) {
     auto onSurface = os.first->binningPosition(geoCtx, binR);
-    auto osNormal = os.first->normal(geoCtx, onSurface);
+    auto locPos = os.first->globalToLocal(geoCtx, onSurface).value();
+    auto osNormal = os.first->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideCvb = onSurface + os.second * osNormal;
     Vector3 outsideCvb = onSurface - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GenericCuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/PlanarBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
@@ -225,7 +226,11 @@ BOOST_AUTO_TEST_CASE(GenericCuboidVolumeBoundarySurfaces) {
   for (auto& os : gcvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideGcvb = osCenter + os.second * osNormal;
     Vector3 outsideGcvb = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -218,7 +218,7 @@ struct SurfaceArrayCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-        std::shared_ptr<RegularSurface> srfA =
+        std::shared_ptr<PlaneSurface> srfA =
             Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3 nrm = srfA->normal(tgContext);

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -218,7 +218,7 @@ struct SurfaceArrayCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-        std::shared_ptr<Surface> srfA =
+        std::shared_ptr<RegularSurface> srfA =
             Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3 nrm = srfA->normal(tgContext);

--- a/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/TrapezoidVolumeBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
@@ -63,7 +64,11 @@ BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
 
   for (auto& os : tvbOrientedSurfaces) {
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx, osCenter);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideTvb = osCenter + os.second * osNormal;
     Vector3 outsideTvb = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -113,20 +113,19 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceProperties) {
       binningPosition, 1e-6);
   //
   /// Test referenceFrame
-  Vector3 globalPosition{2.0, 2.0, 2.0};
   Vector3 momentum{1.e6, 1.e6, 1.e6};
   double rootHalf = std::sqrt(0.5);
   RotationMatrix3 expectedFrame;
   expectedFrame << -rootHalf, 0., rootHalf, rootHalf, 0., rootHalf, 0., 1., 0.;
-  CHECK_CLOSE_OR_SMALL(
-      coneSurfaceObject->referenceFrame(tgContext, globalPosition, momentum),
-      expectedFrame, 1e-6, 1e-9);
-  //
-  /// Test normal, given 3D position
-  Vector3 origin{0., 0., 0.};
-  Vector3 normal3D = {0., -1., 0.};
-  CHECK_CLOSE_ABS(coneSurfaceObject->normal(tgContext, origin), normal3D, 1e-6);
-  //
+  CHECK_CLOSE_OR_SMALL(coneSurfaceObject->referenceFrame(
+                           tgContext,
+                           Vector2{
+                               0.0,
+                               3.07387 * M_PI / 4.  // magic number!
+                           },
+                           momentum),
+                       expectedFrame, 1e-6, 1e-9);
+
   /// Test normal given 2D rphi position
   Vector2 positionPiBy2(1.0, M_PI / 2.);
   Vector3 normalAtPiBy2{0.0312768, 0.92335, -0.382683};
@@ -143,8 +142,8 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceProperties) {
   BOOST_CHECK_EQUAL(coneSurfaceObject->bounds().type(), SurfaceBounds::eCone);
   //
   /// Test localToGlobal
-  Vector2 localPosition{1.0, M_PI / 2.0};
-  globalPosition =
+  Vector2 localPosition = {1.0, M_PI / 2.0};
+  Vector3 globalPosition =
       coneSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
   // std::cout<<globalPosition<<std::endl;
   Vector3 expectedPosition{0.0220268, 1.65027, 3.5708};

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -169,22 +169,25 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{1, 0, 0};
-    Vector3 normalVector{0., 1., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction = Vector3{1, 0, 0.1}.normalized();
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction),
+                    Vector3::UnitX(), 1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{-1, 0, 0};
-    Vector3 normalVector{0., -1., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{0, 1, 0};
-    Vector3 normalVector{1., 0., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   //

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -118,15 +118,18 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   CHECK_CLOSE_ABS(expectedResult, localPosition, 1e-6);
   //
   // intersection
-  const Vector3 direction{0., 1., 2.};
-  BoundaryCheck bcheck(false);
-  auto sfIntersection =
-      line.intersect(tgContext, {0., 0., 0.}, direction.normalized(), bcheck);
-  BOOST_CHECK(bool(sfIntersection));
-  Vector3 expectedIntersection(0, 1., 2.);
-  CHECK_CLOSE_ABS(sfIntersection.intersection.position, expectedIntersection,
-                  1e-6);  // need more tests..
-  BOOST_CHECK_EQUAL(sfIntersection.object, &line);
+  {
+    const Vector3 direction{0., 1., 2.};
+    BoundaryCheck bcheck(false);
+    auto sfIntersection =
+        line.intersect(tgContext, {0., 0., 0.}, direction.normalized(), bcheck);
+    BOOST_CHECK(bool(sfIntersection));
+    Vector3 expectedIntersection(0, 1., 2.);
+    CHECK_CLOSE_ABS(sfIntersection.intersection.position, expectedIntersection,
+                    1e-6);  // need more tests..
+    BOOST_CHECK_EQUAL(sfIntersection.object, &line);
+  }
+
   //
   // isOnSurface
   const Vector3 insidePosition{0., 2.5, 0.};
@@ -162,13 +165,33 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   output << line.name();
   BOOST_CHECK(output.is_equal("Acts::LineSurface"));
   //
-  // normal does not exist without known momentum direction for line surface
-  BOOST_CHECK_THROW(line.normal(tgContext), std::runtime_error);
+  // normal
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{1, 0, 0};
+    Vector3 normalVector{0., 1., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{-1, 0, 0};
+    Vector3 normalVector{0., -1., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{0, 1, 0};
+    Vector3 normalVector{1., 0., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
   //
-  // pathCorrection is always 1 for the line surface
-  CHECK_CLOSE_ABS(
-      line.pathCorrection(tgContext, Vector3::Zero(), Vector3::UnitX()), 1,
-      1e-6);
+  // pathCorrection
+  Vector3 any3DVector = Vector3::Random();
+  CHECK_CLOSE_REL(line.pathCorrection(tgContext, any3DVector, any3DVector), 1.,
+                  1e-6);
 }
 
 /// Unit test for testing LineSurface assignment

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -146,11 +146,14 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
       line.localToGlobal(tgContext, localPosition, momentum.normalized());
   const Vector3 expectedGlobalPosition{0, 1, 0};
   CHECK_CLOSE_ABS(returnedGlobalPosition, expectedGlobalPosition, 1e-6);
-  //
+
   // referenceFrame
-  Vector3 globalPosition{0., 0., 0.};
-  auto returnedRotationMatrix =
-      line.referenceFrame(tgContext, globalPosition, momentum.normalized());
+  Vector3 globalPosition{0., 1., 2.};
+  auto returnedRotationMatrix = line.referenceFrame(
+      tgContext,
+      line.globalToLocal(tgContext, globalPosition, momentum.normalized())
+          .value(),
+      momentum.normalized());
   double v0 = std::cos(std::atan(2. / 3.));
   double v1 = std::sin(std::atan(2. / 3.));
   RotationMatrix3 expectedRotationMatrix;
@@ -167,25 +170,25 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   //
   // normal
   {
-    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector2 position{5, 5};  // should be irrelevant
     Vector3 direction{1, 0, 0};
     CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
-    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector2 position{5, 5};  // should be irrelevant
     Vector3 direction = Vector3{1, 0, 0.1}.normalized();
     CHECK_CLOSE_ABS(line.normal(tgContext, position, direction),
                     Vector3::UnitX(), 1e-6);
   }
   {
-    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector2 position{5, 5};  // should be irrelevant
     Vector3 direction{-1, 0, 0};
     CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
-    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector2 position{5, 5};  // should be irrelevant
     Vector3 direction{0, 1, 0};
     CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -101,14 +101,14 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
       binningPosition);
   //
   /// Test referenceFrame
-  Vector3 globalPosition{2.0, 2.0, 0.0};
+  Vector2 arbitraryLocalPosition{2.0, 2.0};
   Vector3 momentum{1.e6, 1.e6, 1.e6};
   RotationMatrix3 expectedFrame;
   expectedFrame << 1., 0., 0., 0., 1., 0., 0., 0., 1.;
 
-  CHECK_CLOSE_OR_SMALL(
-      planeSurfaceObject->referenceFrame(tgContext, globalPosition, momentum),
-      expectedFrame, 1e-6, 1e-9);
+  CHECK_CLOSE_OR_SMALL(planeSurfaceObject->referenceFrame(
+                           tgContext, arbitraryLocalPosition, momentum),
+                       expectedFrame, 1e-6, 1e-9);
   //
   /// Test normal, given 3D position
   Vector3 normal3D(0., 0., 1.);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
 
   /// Test localToGlobal
   Vector2 localPosition{1.5, 1.7};
-  globalPosition =
+  Vector3 globalPosition =
       planeSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
   //
   // expected position is the translated one

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -32,17 +32,8 @@ class SurfaceStub : public Surface {
   SurfaceType type() const final { return Surface::Other; }
 
   /// Return method for the normal vector of the surface
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector2& /*lpos*/) const final {
-    return normal(gctx);
-  }
-
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector3& /*position*/) const final {
-    return normal(gctx);
-  }
-
-  Vector3 normal(const GeometryContext& /*gctx*/) const final {
+  Vector3 normal(const GeometryContext& /*gctx*/, const Vector3& /*position*/,
+                 const Vector3& /*direction*/) const final {
     return Vector3{0., 0., 0.};
   }
 

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -32,7 +32,7 @@ class SurfaceStub : public Surface {
   SurfaceType type() const final { return Surface::Other; }
 
   /// Return method for the normal vector of the surface
-  Vector3 normal(const GeometryContext& /*gctx*/, const Vector3& /*position*/,
+  Vector3 normal(const GeometryContext& /*gctx*/, const Vector2& /*position*/,
                  const Vector3& /*direction*/) const final {
     return Vector3{0., 0., 0.};
   }

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -114,9 +114,9 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties) {
       tgContext, reference, mom);  // need more complex case to test
   BOOST_CHECK_EQUAL(referenceFrame, unitary);
   // normal()
-  auto normal = surface.Surface::normal(tgContext,
-                                        reference);  // needs more complex
-                                                     // test
+  auto normal = surface.normal(tgContext, reference,
+                               Vector3::UnitZ());  // needs more
+                                                   // complex test
   Vector3 zero{0., 0., 0.};
   BOOST_CHECK_EQUAL(zero, normal);
   // pathCorrection is pure virtual

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -111,10 +111,10 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties) {
   RotationMatrix3 unitary;
   unitary << 1, 0, 0, 0, 1, 0, 0, 0, 1;
   auto referenceFrame = surface.referenceFrame(
-      tgContext, reference, mom);  // need more complex case to test
+      tgContext, Vector2{1, 2}, mom);  // need more complex case to test
   BOOST_CHECK_EQUAL(referenceFrame, unitary);
   // normal()
-  auto normal = surface.normal(tgContext, reference,
+  auto normal = surface.normal(tgContext, Vector2{1, 2},
                                Vector3::UnitZ());  // needs more
                                                    // complex test
   Vector3 zero{0., 0., 0.};

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -264,10 +264,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     // find vertices
     auto res = finder.find(tracksPtr, vertexingOptions, state);
 
-    BOOST_CHECK(res.ok());
-
     if (!res.ok()) {
-      std::cout << res.error().message() << std::endl;
+      BOOST_FAIL(res.error().message());
     }
 
     // Retrieve vertices found by vertex finder
@@ -482,10 +480,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     // find vertices
     auto res = finder.find(tracksPtr, vertexingOptionsUT, state);
 
-    BOOST_CHECK(res.ok());
-
     if (!res.ok()) {
-      std::cout << res.error().message() << std::endl;
+      BOOST_FAIL(res.error().message());
     }
 
     // Retrieve vertices found by vertex finder

--- a/Tests/UnitTests/Plugins/Json/PortalJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/PortalJsonConverterTests.cpp
@@ -40,6 +40,8 @@ BOOST_AUTO_TEST_CASE(PortalUnconnected) {
 
   auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
 
+  BOOST_CHECK_NE(portal, nullptr);
+
   auto jPortal = Acts::PortalJsonConverter::toJson(tContext, *portal, {});
 
   out.open("portal.json");
@@ -55,6 +57,8 @@ BOOST_AUTO_TEST_CASE(PortalUnconnected) {
   in.close();
 
   auto portalIn = Acts::PortalJsonConverter::fromJson(tContext, jPortalIn, {});
+
+  BOOST_CHECK_NE(portalIn, nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(PortalSingleConnected) {
@@ -67,6 +71,7 @@ BOOST_AUTO_TEST_CASE(PortalSingleConnected) {
       Acts::Vector3(0., 0., 0.), Acts::Vector3(0., 1., 0.));
 
   auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
+  BOOST_CHECK_NE(portal, nullptr);
   // Attaching the portals
   Acts::Experimental::detail::PortalHelper::attachDetectorVolumeUpdator(
       *portal, forwardVolume, Acts::Direction::Forward);
@@ -75,7 +80,7 @@ BOOST_AUTO_TEST_CASE(PortalSingleConnected) {
 
   std::vector<const Acts::Experimental::DetectorVolume*> detectorVolumes = {
       forwardVolume.get(), backwardVolume.get()};
-  // No voluems provided, must bail
+  // No volumes provided, must bail
   BOOST_CHECK_THROW(Acts::PortalJsonConverter::toJson(tContext, *portal, {}),
                     std::runtime_error);
   auto jPortal =
@@ -95,6 +100,7 @@ BOOST_AUTO_TEST_CASE(PortalSingleConnected) {
 
   auto portalIn = Acts::PortalJsonConverter::fromJson(
       tContext, jPortalIn, {forwardVolume, backwardVolume});
+  BOOST_CHECK_NE(portalIn, nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(PortalMultiConnected) {
@@ -110,6 +116,7 @@ BOOST_AUTO_TEST_CASE(PortalMultiConnected) {
       Acts::Vector3(0., 0., 0.), Acts::Vector3(0., 1., 0.));
 
   auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
+  BOOST_CHECK_NE(portal, nullptr);
 
   // Attaching the portals
   Acts::Experimental::detail::PortalHelper::attachDetectorVolumeUpdator(


### PR DESCRIPTION
So far we assume the normal logic for all surfaces is the same, which is not the case for line surfaces. This PR tries to express this via the type system.
This adds a new intermediate class

```cpp
class RegularSurface : public Surface {};
```

that gets the previous `normal` methods.

The base class `Surface` now only has

```cpp
virtual Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
                                      const Vector3& direction) const = 0;
```

which is valid also for `LineSurface`s.

Another option would be to additionally remove the global position arguments, since (I think) they're not actually relevant, other than for some default calculations.