### PR TITLE
fix: Update to Pythia 8.310 API for random engines

### DIFF
--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
@@ -62,9 +62,13 @@ ActsExamples::SimParticleContainer ActsExamples::Pythia8Generator::operator()(
 
   // pythia8 is not thread safe and generation needs to be protected
   std::lock_guard<std::mutex> lock(m_pythia8Mutex);
-  // use per-thread random engine also in pythia
+// use per-thread random engine also in pythia
+#if PYTHIA_VERSION_INTEGER >= 8310
+  m_pythia8->rndm.rndmEnginePtr(std::make_shared<FrameworkRndmEngine>(rng));
+#else
   FrameworkRndmEngine rndmEngine(rng);
   m_pythia8->rndm.rndmEnginePtr(&rndmEngine);
+#endif
   {
     Acts::FpeMonitor mon{0};  // disable all FPEs while we're in Pythia8
     m_pythia8->next();


### PR DESCRIPTION
For some odd reason, Pythia 8.310 introduces a new API for the `rndmEnginePtr` method. It now requires a shared pointer rather than a raw pointer. This commit adds support for this behaviour if ACTS is being compiled against a recent version of Pythia.