### PR TITLE
fix: Fix cylinder intersection order

### DIFF
--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -581,21 +581,10 @@ Acts::TrackingVolume::compatibleBoundaries(
     processBoundaries(bSurfacesConfined);
   }
 
-  auto comparator = [](double a, double b) {
-    // sign function would be nice but ...
-    if ((a > 0 && b > 0) || (a < 0 && b < 0)) {
-      return a < b;
-    }
-    if (a > 0) {  // b < 0
-      return true;
-    }
-    return false;
-  };
-
   std::sort(bIntersections.begin(), bIntersections.end(),
             [&](const auto& a, const auto& b) {
-              return comparator(a.intersection.pathLength,
-                                b.intersection.pathLength);
+              return Intersection3D::navigationOrder(a.intersection.pathLength,
+                                                     b.intersection.pathLength);
             });
   return bIntersections;
 }

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -582,9 +582,9 @@ Acts::TrackingVolume::compatibleBoundaries(
   }
 
   std::sort(bIntersections.begin(), bIntersections.end(),
-            [&](const auto& a, const auto& b) {
-              return Intersection3D::navigationOrder(a.intersection.pathLength,
-                                                     b.intersection.pathLength);
+            [](const auto& a, const auto& b) {
+              return Intersection3D::navigationOrder(a.intersection,
+                                                     b.intersection);
             });
   return bIntersections;
 }

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -279,20 +279,8 @@ Acts::SurfaceIntersection Acts::CylinderSurface::intersect(
   // Check first solution for boundary compatibility
   status2 = boundaryCheck(solution2, status2);
   Intersection3D second(solution2, qe.second, status2);
-  // Check one if its valid or neither is valid
-  bool check1 = status1 != Intersection3D::Status::missed or
-                (status1 == Intersection3D::Status::missed and
-                 status2 == Intersection3D::Status::missed);
-  // Check and (eventually) go with the first solution
-  if ((check1 and (std::abs(qe.first) < std::abs(qe.second))) or
-      status2 == Intersection3D::Status::missed) {
-    // And add the alternative
-    cIntersection.alternative = second;
-  } else {
-    // And add the alternative
-    cIntersection.alternative = first;
-    cIntersection.intersection = second;
-  }
+  cIntersection.alternative = second;
+  cIntersection.applyNavigationOrder();
   return cIntersection;
 }
 


### PR DESCRIPTION
In rare cases we need to propagate through a cylinder volume and only traverse the cylinder surface and not the discs. In this case we need to consider both solutions of the intersection correctly or we end up with faulty surface order or looping navigation.

I experienced this issue in the ITk geometry given a ttbar event and possibly a particle not originating from the IP but from a conversion which can result in such a special case for the navigation.

The proposed fix is to use the navigation order implemented here https://github.com/acts-project/acts/pull/2332 to order the intersections accordingly before they will be picked up by the navigation.

blocked by
- https://github.com/acts-project/acts/pull/2332