### PR TITLE
refactor: Require position for normal calculation to be on-surface

### DIFF
--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Navigation/NavigationDelegates.hpp"
 #include "Acts/Navigation/NavigationState.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
 #include <array>
@@ -45,7 +46,7 @@ class Portal : public std::enable_shared_from_this<Portal> {
   /// Constructor from surface w/o portal links
   ///
   /// @param surface is the representing surface
-  Portal(std::shared_ptr<Surface> surface);
+  Portal(std::shared_ptr<RegularSurface> surface);
 
  public:
   /// The volume links forward/backward with respect to the surface normal
@@ -60,7 +61,8 @@ class Portal : public std::enable_shared_from_this<Portal> {
   friend class DetectorVolume;
 
   /// Factory for producing memory managed instances of Portal.
-  static std::shared_ptr<Portal> makeShared(std::shared_ptr<Surface> surface);
+  static std::shared_ptr<Portal> makeShared(
+      std::shared_ptr<RegularSurface> surface);
 
   /// Retrieve a @c std::shared_ptr for this surface (non-const version)
   ///
@@ -88,10 +90,10 @@ class Portal : public std::enable_shared_from_this<Portal> {
   virtual ~Portal() = default;
 
   /// Const access to the surface representation
-  const Surface& surface() const;
+  const RegularSurface& surface() const;
 
   /// Non-const access to the surface reference
-  Surface& surface();
+  RegularSurface& surface();
 
   /// Update the current volume
   ///
@@ -147,7 +149,7 @@ class Portal : public std::enable_shared_from_this<Portal> {
 
  private:
   /// The surface representation of this portal
-  std::shared_ptr<Surface> m_surface;
+  std::shared_ptr<RegularSurface> m_surface;
 
   /// The portal targets along/opposite the normal vector
   DetectorVolumeUpdators m_volumeUpdators = {unconnectedUpdator(),

--- a/Core/include/Acts/Digitization/DigitizationModule.hpp
+++ b/Core/include/Acts/Digitization/DigitizationModule.hpp
@@ -10,6 +10,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Digitization/DigitizationCell.hpp"
 #include "Acts/Digitization/Segmentation.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <memory>
 #include <vector>
@@ -18,7 +19,7 @@ namespace Acts {
 
 class Surface;
 
-using SurfacePtr = std::shared_ptr<const Surface>;
+using SurfacePtr = std::shared_ptr<const RegularSurface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
 
 /// @class DigitizationModule

--- a/Core/include/Acts/Digitization/Segmentation.hpp
+++ b/Core/include/Acts/Digitization/Segmentation.hpp
@@ -9,6 +9,7 @@
 #pragma once
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Digitization/DigitizationCell.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <memory>
 #include <vector>
@@ -18,7 +19,7 @@ namespace Acts {
 class SurfaceBounds;
 class Surface;
 class BinUtility;
-using SurfacePtr = std::shared_ptr<const Surface>;
+using SurfacePtr = std::shared_ptr<const RegularSurface>;
 using SurfacePtrVector = std::vector<SurfacePtr>;
 
 /// @brief Segmentation Base class

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/Volume.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinnedArray.hpp"
 
@@ -57,7 +58,7 @@ class BoundarySurfaceT {
   /// @param surface The unique surface the boundary represents
   /// @param inside The inside volume the boundary surface points to
   /// @param outside The outside volume the boundary surface points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface,
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
                    const volume_t* inside, const volume_t* outside)
       : m_surface(std::move(surface)),
         m_oppositeVolume(inside),
@@ -71,8 +72,8 @@ class BoundarySurfaceT {
   /// @param surface The unique surface the boundary represents
   /// @param inside The inside volume the boundary surface points to
   /// @param outside The outside volume the boundary surface points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface, VolumePtr inside,
-                   VolumePtr outside)
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
+                   VolumePtr inside, VolumePtr outside)
       : m_surface(std::move(surface)),
         m_oppositeVolume(inside.get()),
         m_alongVolume(outside.get()),
@@ -86,7 +87,7 @@ class BoundarySurfaceT {
   /// @param insideArray The inside volume array the boundary surface points to
   /// @param outsideArray The outside volume array the boundary surface
   /// points to
-  BoundarySurfaceT(std::shared_ptr<const Surface> surface,
+  BoundarySurfaceT(std::shared_ptr<const RegularSurface> surface,
                    std::shared_ptr<const VolumeArray> insideArray,
                    std::shared_ptr<const VolumeArray> outsideArray)
       : m_surface(std::move(surface)),
@@ -122,7 +123,7 @@ class BoundarySurfaceT {
   }
 
   /// The Surface Representation of this
-  virtual const Surface& surfaceRepresentation() const;
+  virtual const RegularSurface& surfaceRepresentation() const;
 
   /// Helper method: attach a Volume to this BoundarySurfaceT
   /// this is done during the geometry construction.
@@ -141,7 +142,7 @@ class BoundarySurfaceT {
 
  protected:
   /// the represented surface by this
-  std::shared_ptr<const Surface> m_surface;
+  std::shared_ptr<const RegularSurface> m_surface;
   /// the inside (w.r.t. normal vector) volume to point to if only one exists
   const volume_t* m_oppositeVolume;
   /// the outside (w.r.t. normal vector) volume to point to if only one exists
@@ -153,7 +154,7 @@ class BoundarySurfaceT {
 };
 
 template <class volume_t>
-inline const Surface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
+inline const RegularSurface& BoundarySurfaceT<volume_t>::surfaceRepresentation()
     const {
   return (*(m_surface.get()));
 }

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -185,7 +185,8 @@ const volume_t* BoundarySurfaceT<volume_t>::attachedVolume(
     Direction dir) const {
   const volume_t* attVolume = nullptr;
   // dot product with normal vector to distinguish inside/outside
-  if ((surfaceRepresentation().normal(gctx, pos)).dot(dir * mom) > 0.) {
+  Vector3 coerced = surfaceRepresentation().coerceToSurface(gctx, pos);
+  if ((surfaceRepresentation().normal(gctx, coerced)).dot(dir * mom) > 0.) {
     attVolume = m_alongVolumeArray ? m_alongVolumeArray->object(pos).get()
                                    : m_alongVolume;
   } else {

--- a/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
+++ b/Core/include/Acts/Geometry/BoundarySurfaceT.hpp
@@ -185,8 +185,7 @@ const volume_t* BoundarySurfaceT<volume_t>::attachedVolume(
     Direction dir) const {
   const volume_t* attVolume = nullptr;
   // dot product with normal vector to distinguish inside/outside
-  Vector3 coerced = surfaceRepresentation().coerceToSurface(gctx, pos);
-  if ((surfaceRepresentation().normal(gctx, coerced)).dot(dir * mom) > 0.) {
+  if ((surfaceRepresentation().normal(gctx, pos)).dot(dir * mom) > 0.) {
     attVolume = m_alongVolumeArray ? m_alongVolumeArray->object(pos).get()
                                    : m_alongVolume;
   } else {

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Direction.hpp"
 #include "Acts/Geometry/Volume.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 
 #include <cmath>
@@ -27,7 +28,7 @@ class Direction;
 
 using VolumeBoundsPtr = std::shared_ptr<const VolumeBounds>;
 
-using OrientedSurface = std::pair<std::shared_ptr<Surface>, Direction>;
+using OrientedSurface = std::pair<std::shared_ptr<RegularSurface>, Direction>;
 using OrientedSurfaces = std::vector<OrientedSurface>;
 
 // Planar definitions to help construct the boundary surfaces

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -41,9 +41,7 @@ namespace Acts {
 /// curvilinear coordinates.
 
 class ConeSurface : public RegularSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor form HepTransform and an opening angle

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -171,7 +171,6 @@ class ConeSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -133,6 +133,15 @@ class ConeSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
+  /// Force a global position to a 3D position that is on surface
+  /// For Cone surfaces, the @c r value expected for the given @c z position is
+  /// used along with the @f$ \phi @f$ value
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global position to be coerced
+  /// @return The coerced global position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
+
   // Return method for the rotational symmetry axis
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -153,6 +162,7 @@ class ConeSurface : public RegularSurface {
                         const Vector2& lposition) const final;
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -138,10 +138,9 @@ class ConeSurface : public RegularSurface {
   /// used along with the @f$ \phi @f$ value
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be coerced
-  /// @param direction is the global momentum direction
   /// @return The coerced global position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   // Return method for the rotational symmetry axis
   ///
@@ -157,14 +156,15 @@ class ConeSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition is the local position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   ///
   /// @return The global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
+  using RegularSurface::localToGlobal;
   using RegularSurface::normal;
 
   /// Global to local transformation

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/ConeBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -39,7 +40,7 @@ namespace Acts {
 /// Propagations to a cone surface will be returned in
 /// curvilinear coordinates.
 
-class ConeSurface : public Surface {
+class ConeSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -135,7 +136,7 @@ class ConeSurface : public Surface {
                  const Vector3& position) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   // Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -135,9 +135,6 @@ class ConeSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
-  /// Normal vector return without argument
-  using RegularSurface::normal;
-
   /// Force a global position to a 3D position that is on surface
   /// For Cone surfaces, the @c r value expected for the given @c z position is
   /// used along with the @f$ \phi @f$ value
@@ -168,6 +165,10 @@ class ConeSurface : public RegularSurface {
   Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
                         const Vector3& direction) const final;
 
+  // Use overloads from `RegularSurface`
+  using RegularSurface::globalToLocal;
+  using RegularSurface::normal;
+
   /// Global to local transformation
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -179,7 +180,6 @@ class ConeSurface : public RegularSurface {
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -133,15 +133,6 @@ class ConeSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
-  /// Force a global position to a 3D position that is on surface
-  /// For Cone surfaces, the @c r value expected for the given @c z position is
-  /// used along with the @f$ \phi @f$ value
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position is the global position to be coerced
-  /// @return The coerced global position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx,
-                          const Vector3& position) const final;
-
   // Return method for the rotational symmetry axis
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -162,7 +153,6 @@ class ConeSurface : public RegularSurface {
                         const Vector2& lposition) const final;
 
   // Use overloads from `RegularSurface`
-  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;

--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -138,6 +138,16 @@ class ConeSurface : public RegularSurface {
   /// Normal vector return without argument
   using RegularSurface::normal;
 
+  /// Force a global position to a 3D position that is on surface
+  /// For Cone surfaces, the @c r value expected for the given @c z position is
+  /// used along with the @f$ \phi @f$ value
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global position to be coerced
+  /// @param direction is the global momentum direction
+  /// @return The coerced global position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   // Return method for the rotational symmetry axis
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -144,17 +144,18 @@ class CylinderSurface : public RegularSurface {
                  const Vector3& position) const final;
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
+  using RegularSurface::localToGlobal;
   using RegularSurface::normal;
 
   /// Forces a global position to be on the cylinder surface
   /// For cylinder surface, the normal is defined to only depend on the @f$ \phi @f$ coordinate
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position Is the global position to be coerced
-  /// @param direction Is the global momentum direction (ignored for cylinder surface)
   /// @return The coerced global position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// Return method for the rotational symmetry axis
   ///
@@ -170,11 +171,10 @@ class CylinderSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition is the local position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   ///
   /// @return The global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
 
   /// Global to local transformation
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -144,9 +144,18 @@ class CylinderSurface : public RegularSurface {
                  const Vector3& position) const final;
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
+
+  /// Forces a global position to be on the cylinder surface
+  /// For cylinder surface, the normal is defined to only depend on the @f$ \phi @f$ coordinate
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position Is the global position to be coerced
+  /// @return The coerced global position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -144,18 +144,9 @@ class CylinderSurface : public RegularSurface {
                  const Vector3& position) const final;
 
   // Use overloads from `RegularSurface`
-  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
-
-  /// Forces a global position to be on the cylinder surface
-  /// For cylinder surface, the normal is defined to only depend on the @f$ \phi @f$ coordinate
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position Is the global position to be coerced
-  /// @return The coerced global position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx,
-                          const Vector3& position) const final;
 
   /// Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -148,6 +148,15 @@ class CylinderSurface : public RegularSurface {
   /// Normal vector return without argument
   using RegularSurface::normal;
 
+  /// Forces a global position to be on the cylinder surface
+  /// For cylinder surface, the normal is defined to only depend on the @f$ \phi @f$ coordinate
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position Is the global position to be coerced
+  /// @param direction Is the global momentum direction (ignored for cylinder surface)
+  /// @return The coerced global position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   /// Return method for the rotational symmetry axis
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -42,9 +42,7 @@ class DetectorElementBase;
 /// @image html figures/CylinderSurface.png
 
 class CylinderSurface : public RegularSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor from DetectorElementBase: Element proxy

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -145,7 +145,8 @@ class CylinderSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
-  /// Normal vector return without argument
+  // Use overloads from `RegularSurface`
+  using RegularSurface::globalToLocal;
   using RegularSurface::normal;
 
   /// Forces a global position to be on the cylinder surface
@@ -188,7 +189,6 @@ class CylinderSurface : public RegularSurface {
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Straight line intersection schema from position/direction

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -40,7 +41,7 @@ class DetectorElementBase;
 ///
 /// @image html figures/CylinderSurface.png
 
-class CylinderSurface : public Surface {
+class CylinderSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -145,7 +146,7 @@ class CylinderSurface : public Surface {
                  const Vector3& position) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// Return method for the rotational symmetry axis
   ///

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -180,7 +180,6 @@ class CylinderSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position is the global position to be transformed
-  /// @param direction is the global momentum direction (ignored in this operation)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -142,7 +142,7 @@ class DiscSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
-  /// Get the normal vector, indepdendent of the location
+  /// Get the normal vector, independent of the location
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -120,7 +120,9 @@ class DiscSurface : public RegularSurface {
   SurfaceType type() const override;
 
   // User overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
+  using RegularSurface::localToGlobal;
   using RegularSurface::normal;
 
   /// Normal vector return
@@ -150,10 +152,9 @@ class DiscSurface : public RegularSurface {
   /// distance to the surface.
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position The global position to be projected
-  /// @param direction The global direction (ignored for disc surfaces)
   /// @return The projected position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// The binning position The position calculated
   /// for a certain binning type
@@ -174,11 +175,10 @@ class DiscSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition local 2D position in specialized surface frame
-  /// @param direction global 3D momentum direction (optionally ignored)
   ///
   /// @return global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const final;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const final;
 
   /// Global to local transformation
   /// @note the direction is ignored for Disc surfaces in this calculateion

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -120,6 +120,7 @@ class DiscSurface : public RegularSurface {
   SurfaceType type() const override;
 
   // User overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
@@ -145,6 +146,15 @@ class DiscSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
+
+  /// Force a global position to be on the disc surface.
+  /// This is done by projecting the position onto the disc, and discarding the
+  /// distance to the surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The global position to be projected
+  /// @return The projected position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// The binning position The position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -186,7 +186,6 @@ class DiscSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
-  /// @param direction global 3D momentum direction (optionally ignored)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -120,7 +120,6 @@ class DiscSurface : public RegularSurface {
   SurfaceType type() const override;
 
   // User overloads from `RegularSurface`
-  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
@@ -146,15 +145,6 @@ class DiscSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
-
-  /// Force a global position to be on the disc surface.
-  /// This is done by projecting the position onto the disc, and discarding the
-  /// distance to the surface.
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The global position to be projected
-  /// @return The projected position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx,
-                          const Vector3& position) const final;
 
   /// The binning position The position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -53,9 +53,7 @@ class SurfaceBounds;
 /// @image html figures/DiscSurface.png
 ///
 class DiscSurface : public RegularSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor for Discs from Transform3, \f$ r_{min}, r_{max} \f$

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -133,6 +133,16 @@ class DiscSurface : public RegularSurface {
   /// Normal vector return without argument
   using RegularSurface::normal;
 
+  /// Force a global position to be on the disc surface.
+  /// This is done by projecting the position onto the disc, and discarding the
+  /// distance to the surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The global position to be projected
+  /// @param direction The global direction (ignored for disc surfaces)
+  /// @return The projected position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   /// The binning position The position calculated
   /// for a certain binning type
   ///

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -16,6 +16,7 @@
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Surfaces/InfiniteBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -51,7 +52,7 @@ class SurfaceBounds;
 ///
 /// @image html figures/DiscSurface.png
 ///
-class DiscSurface : public Surface {
+class DiscSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -130,7 +131,7 @@ class DiscSurface : public Surface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// The binning position The position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -130,6 +130,11 @@ class DiscSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
 
+  /// Get the normal vector, indepdendent of the location
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @return The normal vector
+  Vector3 normal(const GeometryContext& gctx) const;
+
   /// Normal vector return without argument
   using RegularSurface::normal;
 

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -121,6 +121,10 @@ class DiscSurface : public RegularSurface {
   /// Return the surface type
   SurfaceType type() const override;
 
+  // User overloads from `RegularSurface`
+  using RegularSurface::globalToLocal;
+  using RegularSurface::normal;
+
   /// Normal vector return
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -130,13 +134,18 @@ class DiscSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
 
+  /// Get the normal vector of this surface at a given global position
+  /// @note The @p position is required to be on-surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global positiono (for @ref DiscSurface this is ignored)
+  /// @return The normal vector
+  Vector3 normal(const GeometryContext& gctx,
+                 const Vector3& position) const final;
+
   /// Get the normal vector, indepdendent of the location
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
-
-  /// Normal vector return without argument
-  using RegularSurface::normal;
 
   /// Force a global position to be on the disc surface.
   /// This is done by projecting the position onto the disc, and discarding the
@@ -186,7 +195,6 @@ class DiscSurface : public RegularSurface {
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const final;
 
   /// Special method for DiscSurface : local<->local transformations polar <->

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -39,9 +39,7 @@ class SurfaceBounds;
 ///
 /// @image html figures/LineSurface.png
 class LineSurface : public Surface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor from Transform3 and bounds

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -117,6 +117,16 @@ class LineSurface : public Surface {
                                  const Vector3& position,
                                  const Vector3& direction) const final;
 
+  /// Force a global position to be on the line surface
+  /// This function calculates the PCA plane for the given @p direction and then
+  /// projects the given @p position onto this plane.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position Is the global position to be projected
+  /// @param direction Is the direction that defines the PCA plane
+  /// @return The projected position
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   /// Calculate the jacobian from local to global which the surface knows best,
   /// hence the calculation is done here.
   ///

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -90,17 +90,8 @@ class LineSurface : public Surface {
   /// @param other is the source surface dor copying
   LineSurface& operator=(const LineSurface& other);
 
-  /// The normal vector is undefined if we do not know the momentum.
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param lposition is the local position is ignored
-  ///
-  /// @return a zero vector
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector2& lposition) const final;
-
-  /// Normal vector return without argument
-  using Surface::normal;
+  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                 const Vector3& direction) const override;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -119,6 +119,16 @@ class LineSurface : public Surface {
                                  const Vector3& position,
                                  const Vector3& direction) const final;
 
+  /// Force a global position to be on the line surface
+  /// This function calculates the PCA plane for the given @p direction and then
+  /// projects the given @p position onto this plane.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position Is the global position to be projected
+  /// @param direction Is the direction that defines the PCA plane
+  /// @return The projected position
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   /// Calculate the jacobian from local to global which the surface knows best,
   /// hence the calculation is done here.
   ///

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -117,16 +117,6 @@ class LineSurface : public Surface {
                                  const Vector3& position,
                                  const Vector3& direction) const final;
 
-  /// Force a global position to be on the line surface
-  /// This function calculates the PCA plane for the given @p direction and then
-  /// projects the given @p position onto this plane.
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position Is the global position to be projected
-  /// @param direction Is the direction that defines the PCA plane
-  /// @return The projected position
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
-
   /// Calculate the jacobian from local to global which the surface knows best,
   /// hence the calculation is done here.
   ///

--- a/Core/include/Acts/Surfaces/PerigeeSurface.hpp
+++ b/Core/include/Acts/Surfaces/PerigeeSurface.hpp
@@ -28,9 +28,7 @@ namespace Acts {
 ///
 /// @image html figures/LineSurface.png
 class PerigeeSurface : public LineSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor from GlobalPosition

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/BoundaryCheck.hpp"
 #include "Acts/Surfaces/InfiniteBounds.hpp"
 #include "Acts/Surfaces/PlanarBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -39,7 +40,7 @@ class SurfaceBounds;
 ///
 /// @image html figures/PlaneSurface.png
 ///
-class PlaneSurface : public Surface {
+class PlaneSurface : public RegularSurface {
 #ifndef DOXYGEN
   friend Surface;
 #endif
@@ -98,7 +99,7 @@ class PlaneSurface : public Surface {
                  const Vector2& lposition) const final;
 
   /// Normal vector return without argument
-  using Surface::normal;
+  using RegularSurface::normal;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -88,7 +88,9 @@ class PlaneSurface : public RegularSurface {
   PlaneSurface& operator=(const PlaneSurface& other);
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
+  using RegularSurface::localToGlobal;
   using RegularSurface::normal;
 
   /// Get the normal vector of this surface at a given local position
@@ -118,10 +120,9 @@ class PlaneSurface : public RegularSurface {
   /// distance to the surface.
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position The global position to be projected
-  /// @param direction The global direction (ignored for plane surfaces)
   /// @return The projected position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// The binning position is the position calculated
   /// for a certain binning type
@@ -146,11 +147,10 @@ class PlaneSurface : public RegularSurface {
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition local 2D position in specialized surface frame
-  /// @param direction global 3D momentum direction (optionally ignored)
   ///
   /// @return the global position by value
-  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
-                        const Vector3& direction) const override;
+  Vector3 localToGlobal(const GeometryContext& gctx,
+                        const Vector2& lposition) const override;
 
   /// Global to local transformation
   ///

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -160,8 +160,6 @@ class PlaneSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position global 3D position - considered to be on surface but not
   /// inside bounds (check is done)
-  /// @param direction global 3D momentum direction (optionally ignored)
-  /// method symmetry)
   /// @param tolerance optional tolerance within which a point is considered
   /// valid on surface
   ///

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -98,6 +98,11 @@ class PlaneSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
 
+  /// Get the normal vector, indepdendent of the location
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @return The normal vector
+  Vector3 normal(const GeometryContext& gctx) const;
+
   /// Normal vector return without argument
   using RegularSurface::normal;
 

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -89,7 +89,11 @@ class PlaneSurface : public RegularSurface {
   /// @param other The source PlaneSurface for assignment
   PlaneSurface& operator=(const PlaneSurface& other);
 
-  /// Normal vector return
+  // Use overloads from `RegularSurface`
+  using RegularSurface::globalToLocal;
+  using RegularSurface::normal;
+
+  /// Get the normal vector of this surface at a given local position
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition is the local position is ignored
@@ -98,13 +102,18 @@ class PlaneSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector2& lposition) const final;
 
+  /// Get the normal vector of this surface at a given global position
+  /// @note The @p position is required to be on-surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global positiono (for @ref PlaneSurface this is ignored)
+  /// @return The normal vector
+  Vector3 normal(const GeometryContext& gctx,
+                 const Vector3& position) const final;
+
   /// Get the normal vector, indepdendent of the location
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
-
-  /// Normal vector return without argument
-  using RegularSurface::normal;
 
   /// Force a global position to be on the plane surface.
   /// This is done by projecting the position onto the plane, and discarding the
@@ -161,17 +170,13 @@ class PlaneSurface : public RegularSurface {
   /// @return a Result<Vector2> which can be !ok() if the operation fails
   Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
-      const Vector3& direction,
       double tolerance = s_onSurfaceTolerance) const override;
 
   /// Method that calculates the correction due to incident angle
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position global 3D position - considered to be on surface but not
-  /// inside bounds (check is done)
-  /// @param direction global 3D momentum direction (ignored for PlaneSurface)
-  /// @note this is the final implementation of the pathCorrection function
-  ///
+  /// @param position global 3D position (ignored for @ref PlaneSurface)
+  /// @param direction global 3D momentum direction (ignored for @ref PlaneSurface)
   /// @return a double representing the scaling factor
   double pathCorrection(const GeometryContext& gctx, const Vector3& position,
                         const Vector3& direction) const final;

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -88,6 +88,7 @@ class PlaneSurface : public RegularSurface {
   PlaneSurface& operator=(const PlaneSurface& other);
 
   // Use overloads from `RegularSurface`
+  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
@@ -113,6 +114,15 @@ class PlaneSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
+
+  /// Force a global position to be on the plane surface.
+  /// This is done by projecting the position onto the plane, and discarding the
+  /// distance to the surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The global position to be projected
+  /// @return The projected position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx,
+                          const Vector3& position) const final;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -41,9 +41,7 @@ class SurfaceBounds;
 /// @image html figures/PlaneSurface.png
 ///
 class PlaneSurface : public RegularSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Copy Constructor

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -88,7 +88,6 @@ class PlaneSurface : public RegularSurface {
   PlaneSurface& operator=(const PlaneSurface& other);
 
   // Use overloads from `RegularSurface`
-  using RegularSurface::coerceToSurface;
   using RegularSurface::globalToLocal;
   using RegularSurface::localToGlobal;
   using RegularSurface::normal;
@@ -114,15 +113,6 @@ class PlaneSurface : public RegularSurface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;
-
-  /// Force a global position to be on the plane surface.
-  /// This is done by projecting the position onto the plane, and discarding the
-  /// distance to the surface.
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The global position to be projected
-  /// @return The projected position by value
-  Vector3 coerceToSurface(const GeometryContext& gctx,
-                          const Vector3& position) const final;
 
   /// The binning position is the position calculated
   /// for a certain binning type

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -110,7 +110,7 @@ class PlaneSurface : public RegularSurface {
   Vector3 normal(const GeometryContext& gctx,
                  const Vector3& position) const final;
 
-  /// Get the normal vector, indepdendent of the location
+  /// Get the normal vector, independent of the location
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return The normal vector
   Vector3 normal(const GeometryContext& gctx) const;

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -101,6 +101,16 @@ class PlaneSurface : public RegularSurface {
   /// Normal vector return without argument
   using RegularSurface::normal;
 
+  /// Force a global position to be on the plane surface.
+  /// This is done by projecting the position onto the plane, and discarding the
+  /// distance to the surface.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The global position to be projected
+  /// @param direction The global direction (ignored for plane surfaces)
+  /// @return The projected position by value
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
   /// The binning position is the position calculated
   /// for a certain binning type
   ///

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -76,5 +76,43 @@ class RegularSurface : public Surface {
   virtual Result<Vector2> globalToLocal(
       const GeometryContext& gctx, const Vector3& position,
       double tolerance = s_onSurfaceTolerance) const = 0;
+
+  /// Local to global transformation. This is the most generic interface,
+  /// which is implemented by all surfaces.
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param lposition local 2D position in specialized surface frame
+  /// @param direction global 3D momentum direction (ignored for @c RegularSurface)
+  ///
+  /// @return The global position by value
+  Vector3 localToGlobal(const GeometryContext& gctx, const Vector2& lposition,
+                        const Vector3& direction) const final;
+
+  /// Local to global transformation.
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param lposition local 2D position in specialized surface frame
+  ///
+  /// @return The global position by value
+  virtual Vector3 localToGlobal(const GeometryContext& gctx,
+                                const Vector2& lposition) const = 0;
+
+  /// Force a position to be on the surface. This is the most generic overload
+  /// which is implemented by all surfaces.
+  /// @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @param direction The direction to use for the coercion (ignored for @c RegularSurface)
+  /// @return The coerced position
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
+  /// Force a position to be on the surface.
+  /// @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @return The coerced position
+  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
+                                  const Vector3& position) const = 0;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -39,7 +39,7 @@ class RegularSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& position) const;
+                         const Vector3& position) const = 0;
 
   /// Calculate the normal vector of the surface
   /// This overload is fully generic, fulfills the @ref Surface interface and
@@ -50,6 +50,31 @@ class RegularSurface : public Surface {
   /// @param pos is the global position where the normal vector is constructed
   /// @param direction is the direction of the normal vector (ignored for @c RegularSurface)
   Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
-                 const Vector3& direction) const override;
+                 const Vector3& direction) const final;
+
+  /// Convert a global position to a local one this is the most generic
+  /// interface, which is implemented by all surfaces
+  /// @note The @p position is required to be on-surface, which is indicated by
+  ///       the `Result` return value.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global position to be converted
+  /// @param direction is the direction of the local position (ignored for @c RegularSurface)
+  /// @param tolerance is the tolerance for the on-surface check
+  /// @return Result type containing local position by value
+  Result<Vector2> globalToLocal(
+      const GeometryContext& gctx, const Vector3& position,
+      const Vector3& direction,
+      double tolerance = s_onSurfaceTolerance) const final;
+
+  /// Convert a global position to a local one.
+  /// @note The @p position is required to be on-surface, which is indicated by
+  ///       the `Result` return value.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position is the global position to be converted
+  /// @param tolerance is the tolerance for the on-surface check
+  /// @return Result type containing local position by value
+  virtual Result<Vector2> globalToLocal(
+      const GeometryContext& gctx, const Vector3& position,
+      double tolerance = s_onSurfaceTolerance) const = 0;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -34,6 +34,8 @@ class RegularSurface : public Surface {
   ///
   /// @param position is the global position where the normal vector is
   /// constructed
+  /// @note The @p position is required to be on-surface.
+  /// 			Use @ref Surface::coerceToSurface
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
@@ -94,5 +96,23 @@ class RegularSurface : public Surface {
   /// @return The global position by value
   virtual Vector3 localToGlobal(const GeometryContext& gctx,
                                 const Vector2& lposition) const = 0;
+
+  /// Force a position to be on the surface. This is the most generic overload
+  /// which is implemented by all surfaces.
+  /// @ref Surface::coerceToSurface
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @param direction The direction to use for the coercion (ignored for @c RegularSurface)
+  /// @return The coerced position
+  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
+                          const Vector3& direction) const final;
+
+  /// Force a position to be on the surface.
+  /// @ref Surface::coerceToSurface
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @return The coerced position
+  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
+                                  const Vector3& position) const = 0;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -1,0 +1,63 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2016-2020 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Surfaces/Surface.hpp"
+
+namespace Acts {
+
+class RegularSurface : public Surface {
+ public:
+  using Surface::Surface;
+
+  /// Return method for the normal vector of the surface
+  /// The normal vector can only be generally defined at a given local position
+  /// It requires a local position to be given (in general)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param lposition is the local position where the normal vector is
+  /// constructed
+  ///
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx,
+                         const Vector2& lposition) const = 0;
+
+  /// Return method for the normal vector of the surface
+  /// The normal vector can only be generally defined at a given local position
+  /// It requires a local position to be given (in general)
+  ///
+  /// @param position is the global position where the normal vector is
+  /// constructed
+  /// @param gctx The current geometry context object, e.g. alignment
+
+  ///
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx,
+                         const Vector3& /*position*/) const {
+    return normal(gctx, Vector2{Vector2::Zero()});
+  }
+
+  /// Return method for the normal vector of the surface
+  ///
+  /// It will return a normal vector at the center() position
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  //
+  /// @return normal vector by value
+  virtual Vector3 normal(const GeometryContext& gctx) const {
+    return normal(gctx, center(gctx));
+  }
+
+  Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                 const Vector3& /*direction*/) const override {
+    return normal(gctx, pos);
+  };
+};
+
+}  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -34,8 +34,6 @@ class RegularSurface : public Surface {
   ///
   /// @param position is the global position where the normal vector is
   /// constructed
-  /// @note The @p position is required to be on-surface.
-  /// 			Use @ref Surface::coerceToSurface
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
@@ -96,23 +94,5 @@ class RegularSurface : public Surface {
   /// @return The global position by value
   virtual Vector3 localToGlobal(const GeometryContext& gctx,
                                 const Vector2& lposition) const = 0;
-
-  /// Force a position to be on the surface. This is the most generic overload
-  /// which is implemented by all surfaces.
-  /// @ref Surface::coerceToSurface
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position to coerce onto the surface
-  /// @param direction The direction to use for the coercion (ignored for @c RegularSurface)
-  /// @return The coerced position
-  Vector3 coerceToSurface(const GeometryContext& gctx, const Vector3& position,
-                          const Vector3& direction) const final;
-
-  /// Force a position to be on the surface.
-  /// @ref Surface::coerceToSurface
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position to coerce onto the surface
-  /// @return The coerced position
-  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
-                                  const Vector3& position) const = 0;
 };
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -15,11 +15,11 @@ namespace Acts {
 
 class RegularSurface : public Surface {
  public:
+  // Reuse all constructors from the base class
   using Surface::Surface;
 
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
+  /// Calculate the normal vector of the surface
+  /// This overload requires an on-surface local position
   ///
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param lposition is the local position where the normal vector is
@@ -29,28 +29,26 @@ class RegularSurface : public Surface {
   virtual Vector3 normal(const GeometryContext& gctx,
                          const Vector2& lposition) const = 0;
 
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
+  /// Calculate the normal vector of the surface
+  /// This overload accepts a global position
   ///
   /// @param position is the global position where the normal vector is
   /// constructed
+  /// @note The @p position is required to be on-surface.
+  /// 			Use @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
   /// @param gctx The current geometry context object, e.g. alignment
-
-  ///
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
                          const Vector3& position) const;
 
-  /// Return method for the normal vector of the surface
-  ///
-  /// It will return a normal vector at the center() position
-  ///
+  /// Calculate the normal vector of the surface
+  /// This overload is fully generic, fulfills the @ref Surface interface and
+  /// accepts a global position and a direction. For @c RegularSurface this is
+  /// equivalent to the @ref normal(const GeometryContext&, const Vector3&)
+  /// overload, ignoring the @p direction
   /// @param gctx The current geometry context object, e.g. alignment
-  //
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx) const;
-
+  /// @param pos is the global position where the normal vector is constructed
+  /// @param direction is the direction of the normal vector (ignored for @c RegularSurface)
   Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
                  const Vector3& direction) const override;
 };

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 namespace Acts {
 
@@ -39,7 +40,9 @@ class RegularSurface : public Surface {
   ///
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& /*position*/) const {
+                         const Vector3& position) const {
+    throw_assert(isOnSurface(gctx, position, Vector3::Zero(), false),
+                 "Not on surface");
     return normal(gctx, Vector2{Vector2::Zero()});
   }
 
@@ -55,7 +58,8 @@ class RegularSurface : public Surface {
   }
 
   Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
-                 const Vector3& /*direction*/) const override {
+                 const Vector3& direction) const override {
+    throw_assert(isOnSurface(gctx, pos, direction, false), "Not on surface");
     return normal(gctx, pos);
   };
 };

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -40,11 +40,7 @@ class RegularSurface : public Surface {
   ///
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& position) const {
-    throw_assert(isOnSurface(gctx, position, Vector3::Zero(), false),
-                 "Not on surface");
-    return normal(gctx, Vector2{Vector2::Zero()});
-  }
+                         const Vector3& position) const;
 
   /// Return method for the normal vector of the surface
   ///
@@ -53,15 +49,9 @@ class RegularSurface : public Surface {
   /// @param gctx The current geometry context object, e.g. alignment
   //
   /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx) const {
-    return normal(gctx, center(gctx));
-  }
+  virtual Vector3 normal(const GeometryContext& gctx) const;
 
   Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
-                 const Vector3& direction) const override {
-    throw_assert(isOnSurface(gctx, pos, direction, false), "Not on surface");
-    return normal(gctx, pos);
-  };
+                 const Vector3& direction) const override;
 };
-
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/RegularSurface.hpp
+++ b/Core/include/Acts/Surfaces/RegularSurface.hpp
@@ -35,7 +35,7 @@ class RegularSurface : public Surface {
   /// @param position is the global position where the normal vector is
   /// constructed
   /// @note The @p position is required to be on-surface.
-  /// 			Use @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
+  /// 			Use @ref Surface::coerceToSurface
   /// @param gctx The current geometry context object, e.g. alignment
   /// @return normal vector by value
   virtual Vector3 normal(const GeometryContext& gctx,
@@ -44,7 +44,7 @@ class RegularSurface : public Surface {
   /// Calculate the normal vector of the surface
   /// This overload is fully generic, fulfills the @ref Surface interface and
   /// accepts a global position and a direction. For @c RegularSurface this is
-  /// equivalent to the @ref normal(const GeometryContext&, const Vector3&)
+  /// equivalent to the @ref normal
   /// overload, ignoring the @p direction
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param pos is the global position where the normal vector is constructed
@@ -99,7 +99,7 @@ class RegularSurface : public Surface {
 
   /// Force a position to be on the surface. This is the most generic overload
   /// which is implemented by all surfaces.
-  /// @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
+  /// @ref Surface::coerceToSurface
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position The position to coerce onto the surface
   /// @param direction The direction to use for the coercion (ignored for @c RegularSurface)
@@ -108,7 +108,7 @@ class RegularSurface : public Surface {
                           const Vector3& direction) const final;
 
   /// Force a position to be on the surface.
-  /// @ref Surface::coerceToSurface(const GeometryContext&, const Vector3&, const Vector3&)
+  /// @ref Surface::coerceToSurface
   /// @param gctx The current geometry context object, e.g. alignment
   /// @param position The position to coerce onto the surface
   /// @return The coerced position

--- a/Core/include/Acts/Surfaces/StrawSurface.hpp
+++ b/Core/include/Acts/Surfaces/StrawSurface.hpp
@@ -32,9 +32,7 @@ class LineBounds;
 /// @image html figures/LineSurface.png
 ///
 class StrawSurface : public LineSurface {
-#ifndef DOXYGEN
-  friend Surface;
-#endif
+  friend class Surface;
 
  protected:
   /// Constructor from Transform3 and bounds

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -369,8 +369,9 @@ class Surface : public virtual GeometryObject,
   /// Calucation of the path correction for incident
   ///
   /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position global 3D position - considered to be on surface but not
-  /// inside bounds (check is done)
+  /// @param position global 3D position
+  /// @note The @p position is either ignored, or it is coerced to be on the surface,
+  ///       depending on the surface type.
   /// @param direction global 3D momentum direction
   ///
   /// @return Path correction with respect to the nominal incident.

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -254,6 +254,13 @@ class Surface : public virtual GeometryObject,
                    const Vector3& direction,
                    const BoundaryCheck& bcheck = true) const;
 
+  /// Force a position to be on the surface. The exact way this is done
+  /// depends on the surface type. For example, for a plane, the position
+  /// is simply projected onto the plane.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @param direction The direction to use for the coercion
+  /// @return The coerced position
   virtual Vector3 coerceToSurface(const GeometryContext& gctx,
                                   const Vector3& position,
                                   const Vector3& direction) const = 0;

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -254,6 +254,17 @@ class Surface : public virtual GeometryObject,
                    const Vector3& direction,
                    const BoundaryCheck& bcheck = true) const;
 
+  /// Force a position to be on the surface. The exact way this is done
+  /// depends on the surface type. For example, for a plane, the position
+  /// is simply projected onto the plane.
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param position The position to coerce onto the surface
+  /// @param direction The direction to use for the coercion
+  /// @return The coerced position
+  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
+                                  const Vector3& position,
+                                  const Vector3& direction) const = 0;
+
   /// The insideBounds method for local positions
   ///
   /// @param lposition The local position to check

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -187,41 +187,8 @@ class Surface : public virtual GeometryObject,
   /// @return center position by value
   virtual Vector3 center(const GeometryContext& gctx) const;
 
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param lposition is the local position where the normal vector is
-  /// constructed
-  ///
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector2& lposition) const = 0;
-
-  /// Return method for the normal vector of the surface
-  /// The normal vector can only be generally defined at a given local position
-  /// It requires a local position to be given (in general)
-  ///
-  /// @param position is the global position where the normal vector is
-  /// constructed
-  /// @param gctx The current geometry context object, e.g. alignment
-
-  ///
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx,
-                         const Vector3& position) const;
-
-  /// Return method for the normal vector of the surface
-  ///
-  /// It will return a normal vector at the center() position
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  //
-  /// @return normal vector by value
-  virtual Vector3 normal(const GeometryContext& gctx) const {
-    return normal(gctx, center(gctx));
-  }
+  virtual Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
+                         const Vector3& direction) const = 0;
 
   /// Return method for SurfaceBounds
   /// @return SurfaceBounds by reference

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -246,6 +246,10 @@ class Surface : public virtual GeometryObject,
                    const Vector3& direction,
                    const BoundaryCheck& bcheck = true) const;
 
+  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
+                                  const Vector3& position,
+                                  const Vector3& direction) const = 0;
+
   /// The insideBounds method for local positions
   ///
   /// @param lposition The local position to check

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -187,6 +187,14 @@ class Surface : public virtual GeometryObject,
   /// @return center position by value
   virtual Vector3 center(const GeometryContext& gctx) const;
 
+  /// Return the surface normal at a given @p position and @p direction.
+  /// This method is fully generic, and valid for all surface types.
+  /// @note For some surface types, the @p direction is ignored, but
+  ///       it is **not safe** to pass in a zero vector!
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param pos The position at which to calculate the normal
+  /// @param direction The direction at which to calculate the normal
+  /// @return The normal vector at the given position and direction
   virtual Vector3 normal(const GeometryContext& gctx, const Vector3& pos,
                          const Vector3& direction) const = 0;
 

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -254,17 +254,6 @@ class Surface : public virtual GeometryObject,
                    const Vector3& direction,
                    const BoundaryCheck& bcheck = true) const;
 
-  /// Force a position to be on the surface. The exact way this is done
-  /// depends on the surface type. For example, for a plane, the position
-  /// is simply projected onto the plane.
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param position The position to coerce onto the surface
-  /// @param direction The direction to use for the coercion
-  /// @return The coerced position
-  virtual Vector3 coerceToSurface(const GeometryContext& gctx,
-                                  const Vector3& position,
-                                  const Vector3& direction) const = 0;
-
   /// The insideBounds method for local positions
   ///
   /// @param lposition The local position to check

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -24,21 +24,22 @@ class DetectorVolume;
 }  // namespace Experimental
 }  // namespace Acts
 
-Acts::Experimental::Portal::Portal(std::shared_ptr<Surface> surface)
+Acts::Experimental::Portal::Portal(std::shared_ptr<RegularSurface> surface)
     : m_surface(std::move(surface)) {
   throw_assert(m_surface, "Portal surface is nullptr");
 }
 
 std::shared_ptr<Acts::Experimental::Portal>
-Acts::Experimental::Portal::makeShared(std::shared_ptr<Surface> surface) {
+Acts::Experimental::Portal::makeShared(
+    std::shared_ptr<RegularSurface> surface) {
   return std::shared_ptr<Portal>(new Portal(std::move(surface)));
 }
 
-const Acts::Surface& Acts::Experimental::Portal::surface() const {
+const Acts::RegularSurface& Acts::Experimental::Portal::surface() const {
   return *m_surface.get();
 }
 
-Acts::Surface& Acts::Experimental::Portal::surface() {
+Acts::RegularSurface& Acts::Experimental::Portal::surface() {
   return *m_surface.get();
 }
 

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -122,8 +122,7 @@ void Acts::Experimental::Portal::updateDetectorVolume(
     const GeometryContext& gctx, NavigationState& nState) const {
   const auto& position = nState.position;
   const auto& direction = nState.direction;
-  auto coercedPosition = surface().coerceToSurface(gctx, position, direction);
-  const Vector3 normal = surface().normal(gctx, coercedPosition);
+  const Vector3 normal = surface().normal(gctx, position);
   Direction dir = Direction::fromScalar(normal.dot(direction));
   const auto& vUpdator = m_volumeUpdators[dir.index()];
   if (vUpdator.connected()) {

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -122,7 +122,8 @@ void Acts::Experimental::Portal::updateDetectorVolume(
     const GeometryContext& gctx, NavigationState& nState) const {
   const auto& position = nState.position;
   const auto& direction = nState.direction;
-  const Vector3 normal = surface().normal(gctx, position);
+  auto coercedPosition = surface().coerceToSurface(gctx, position, direction);
+  const Vector3 normal = surface().normal(gctx, coercedPosition);
   Direction dir = Direction::fromScalar(normal.dot(direction));
   const auto& vUpdator = m_volumeUpdators[dir.index()];
   if (vUpdator.connected()) {

--- a/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
+++ b/Core/src/EventData/CorrectedTransformationFreeToBound.cpp
@@ -8,10 +8,13 @@
 
 #include "Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp"
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/detail/TransformationFreeToBound.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -58,7 +61,8 @@ Acts::detail::CorrectedFreeToBoundTransformer::operator()(
     const Logger& logger) const {
   // Get the incidence angle
   Vector3 dir = freeParams.segment<3>(eFreeDir0);
-  Vector3 normal = surface.normal(geoContext);
+  Vector3 normal =
+      surface.normal(geoContext, freeParams.segment<3>(eFreePos0), dir);
   ActsScalar absCosIncidenceAng = std::abs(dir.dot(normal));
   // No correction if the incidentAngle is small enough (not necessary ) or too
   // large (correction could be invalid). Fall back to nominal free to bound

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -24,6 +24,7 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
@@ -842,7 +843,7 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
       // (1) create the Boundary CylinderSurface
       auto cBounds =
           std::make_shared<CylinderBounds>(rGlueMin, 0.5 * (zMax - zMin));
-      std::shared_ptr<const Surface> cSurface =
+      std::shared_ptr<const RegularSurface> cSurface =
           Surface::makeShared<CylinderSurface>(transform, cBounds);
       ACTS_VERBOSE(
           "             creating a new cylindrical boundary surface "
@@ -867,7 +868,7 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
 
       // (2) create the BoundaryDiscSurface, in that case the zMin/zMax provided
       // are both the position of the disk in question
-      std::shared_ptr<const Surface> dSurface =
+      std::shared_ptr<const RegularSurface> dSurface =
           Surface::makeShared<DiscSurface>(transform, rMin, rMax);
       ACTS_VERBOSE(
           "             creating a new disc-like boundary surface "
@@ -922,8 +923,8 @@ void Acts::CylinderVolumeHelper::glueTrackingVolumes(
       // Adapt the boundary material
       ACTS_VERBOSE("- the new boundary surface has boundary material: ");
       ACTS_VERBOSE("    " << *boundaryMaterial);
-      Surface* newSurface =
-          const_cast<Surface*>(&(boundarySurface->surfaceRepresentation()));
+      RegularSurface* newSurface = const_cast<RegularSurface*>(
+          &(boundarySurface->surfaceRepresentation()));
       newSurface->assignSurfaceMaterial(boundaryMaterial);
     }
 

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -146,10 +146,8 @@ Acts::Layer::compatibleSurfaces(
     // i.e. the maximum path limit is given by the layer thickness times
     // path correction, we take a safety factor of 1.5
     // -> this avoids punch through for cylinders
-    Vector3 coercedPosition =
-        surfaceRepresentation().coerceToSurface(gctx, position, direction);
-    double pCorrection = surfaceRepresentation().pathCorrection(
-        gctx, coercedPosition, direction);
+    double pCorrection =
+        surfaceRepresentation().pathCorrection(gctx, position, direction);
     pathLimit = 1.5 * thickness() * pCorrection * options.navDir;
   }
 

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -146,8 +146,10 @@ Acts::Layer::compatibleSurfaces(
     // i.e. the maximum path limit is given by the layer thickness times
     // path correction, we take a safety factor of 1.5
     // -> this avoids punch through for cylinders
-    double pCorrection =
-        surfaceRepresentation().pathCorrection(gctx, position, direction);
+    Vector3 coercedPosition =
+        surfaceRepresentation().coerceToSurface(gctx, position, direction);
+    double pCorrection = surfaceRepresentation().pathCorrection(
+        gctx, coercedPosition, direction);
     pathLimit = 1.5 * thickness() * pCorrection * options.navDir;
   }
 

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -54,10 +54,10 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   // get the appropriate transform, the center and the normal vector
 
   //@todo fix with representing volume
-  const Transform3& lTransform = PlaneSurface::transform(GeometryContext());
+  const Transform3& lTransform = transform(GeometryContext());
   RotationMatrix3 lRotation = lTransform.rotation();
-  const Vector3& lCenter = PlaneSurface::center(GeometryContext());
-  const Vector3& lVector = RegularSurface::normal(GeometryContext(), lCenter);
+  const Vector3& lCenter = center(GeometryContext());
+  const Vector3& lVector = normal(GeometryContext(), lCenter);
   // create new surfaces
   const Transform3 apnTransform = Transform3(
       Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector) *

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GenericApproachDescriptor.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
 #include <algorithm>
@@ -56,7 +57,7 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   const Transform3& lTransform = PlaneSurface::transform(GeometryContext());
   RotationMatrix3 lRotation = lTransform.rotation();
   const Vector3& lCenter = PlaneSurface::center(GeometryContext());
-  const Vector3& lVector = Surface::normal(GeometryContext(), lCenter);
+  const Vector3& lVector = RegularSurface::normal(GeometryContext(), lCenter);
   // create new surfaces
   const Transform3 apnTransform = Transform3(
       Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector) *

--- a/Core/src/Geometry/ProtoLayer.cpp
+++ b/Core/src/Geometry/ProtoLayer.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/Polyhedron.hpp"
 #include "Acts/Geometry/detail/DefaultDetectorElementBase.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 
 #include <algorithm>
@@ -69,11 +70,12 @@ void ProtoLayer::measure(const GeometryContext& gctx,
   for (const auto& sf : surfaces) {
     auto sfPolyhedron = sf->polyhedronRepresentation(gctx, 1);
     const DetectorElementBase* element = sf->associatedDetectorElement();
-    if (element != nullptr) {
+    const auto* regSurface = dynamic_cast<const RegularSurface*>(sf);
+    if (element != nullptr && regSurface != nullptr) {
       // Take the thickness in account if necessary
       double thickness = element->thickness();
       // We need a translation along and opposite half thickness
-      Vector3 sfNormal = sf->normal(gctx, sf->center(gctx));
+      Vector3 sfNormal = regSurface->normal(gctx, sf->center(gctx));
       std::vector<double> deltaT = {-0.5 * thickness, 0.5 * thickness};
       for (const auto& dT : deltaT) {
         Transform3 dtransform = Transform3::Identity();

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -197,6 +197,8 @@ void Acts::TrackingVolume::glueTrackingVolume(const GeometryContext& gctx,
   // normal vector
   // Coerce the arbitrary position bPosition to be on the surface repr so we can
   // get a normal
+  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
+      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation
@@ -244,6 +246,8 @@ void Acts::TrackingVolume::glueTrackingVolumes(
   // normal vector
   // Coerce the arbitrary position bPosition to be on the surface repr so we can
   // get a normal
+  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
+      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -197,8 +197,6 @@ void Acts::TrackingVolume::glueTrackingVolume(const GeometryContext& gctx,
   // normal vector
   // Coerce the arbitrary position bPosition to be on the surface repr so we can
   // get a normal
-  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
-      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation
@@ -246,8 +244,6 @@ void Acts::TrackingVolume::glueTrackingVolumes(
   // normal vector
   // Coerce the arbitrary position bPosition to be on the surface repr so we can
   // get a normal
-  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
-      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -195,6 +195,10 @@ void Acts::TrackingVolume::glueTrackingVolume(const GeometryContext& gctx,
       boundarySurfaces().at(bsfMine);
   // @todo - complex glueing could be possible with actual intersection for the
   // normal vector
+  // Coerce the arbitrary position bPosition to be on the surface repr so we can
+  // get a normal
+  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
+      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation
@@ -240,6 +244,10 @@ void Acts::TrackingVolume::glueTrackingVolumes(
       boundarySurfaces().at(bsfMine);
   // @todo - complex glueing could be possible with actual intersection for the
   // normal vector
+  // Coerce the arbitrary position bPosition to be on the surface repr so we can
+  // get a normal
+  bPosition = bSurfaceMine->surfaceRepresentation().coerceToSurface(
+      gctx, bPosition, distance.normalized());
   Vector3 nvector =
       bSurfaceMine->surfaceRepresentation().normal(gctx, bPosition);
   // estimate the orientation

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -17,6 +17,7 @@
 #include "Acts/Material/IVolumeMaterial.hpp"
 #include "Acts/Material/ProtoVolumeMaterial.hpp"
 #include "Acts/Propagator/Navigator.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Frustum.hpp"
@@ -263,7 +264,8 @@ void Acts::TrackingVolume::assignBoundaryMaterial(
     std::shared_ptr<const ISurfaceMaterial> surfaceMaterial,
     BoundarySurfaceFace bsFace) {
   auto bSurface = m_boundarySurfaces.at(bsFace);
-  Surface* surface = const_cast<Surface*>(&bSurface->surfaceRepresentation());
+  RegularSurface* surface =
+      const_cast<RegularSurface*>(&bSurface->surfaceRepresentation());
   surface->assignSurfaceMaterial(std::move(surfaceMaterial));
 }
 
@@ -277,7 +279,8 @@ void Acts::TrackingVolume::updateBoundarySurface(
                             .surfaceMaterialSharedPtr();
     auto bsMaterial = bs->surfaceRepresentation().surfaceMaterial();
     if (cMaterialPtr != nullptr && bsMaterial == nullptr) {
-      Surface* surface = const_cast<Surface*>(&bs->surfaceRepresentation());
+      RegularSurface* surface =
+          const_cast<RegularSurface*>(&bs->surfaceRepresentation());
       surface->assignSurfaceMaterial(cMaterialPtr);
     }
   }
@@ -399,7 +402,7 @@ void Acts::TrackingVolume::closeGeometry(
     // create the boundary surface id
     auto boundaryID = GeometryIdentifier(volumeID).setBoundary(++iboundary);
     // now assign to the boundary surface
-    auto& mutableBSurface = *(const_cast<Surface*>(&bSurface));
+    auto& mutableBSurface = *(const_cast<RegularSurface*>(&bSurface));
     mutableBSurface.assignGeometryId(boundaryID);
     // Assign material if you have a decorator
     if (materialDecorator != nullptr) {
@@ -431,7 +434,8 @@ void Acts::TrackingVolume::closeGeometry(
           const auto& bndSrf = avol->boundarySurfaces();
           for (const auto& bnd : bndSrf) {
             const auto& srf = bnd->surfaceRepresentation();
-            Surface* mutableSurfcePtr = const_cast<Surface*>(&srf);
+            RegularSurface* mutableSurfcePtr =
+                const_cast<RegularSurface*>(&srf);
             auto geoID = GeometryIdentifier(volumeID).setSensitive(++isurface);
             mutableSurfcePtr->assignGeometryId(geoID);
           }

--- a/Core/src/Surfaces/CMakeLists.txt
+++ b/Core/src/Surfaces/CMakeLists.txt
@@ -25,4 +25,5 @@ target_sources(
     TrapezoidBounds.cpp
     detail/AlignmentHelper.cpp
     VerticesHelper.cpp
+    RegularSurface.cpp
 )

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -90,6 +90,17 @@ Acts::Vector3 Acts::ConeSurface::rotSymmetryAxis(
   return transform(gctx).matrix().block<3, 1>(0, 2);
 }
 
+Acts::Vector3 Acts::ConeSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position) const {
+  Vector3 loc3Dframe = transform(gctx).inverse() * position;
+
+  // calculate what the radius should be based on the z position
+  double r = loc3Dframe.z() * bounds().tanAlpha();
+
+  Vector2 local{r * VectorHelpers::phi(loc3Dframe), loc3Dframe.z()};
+  return localToGlobal(gctx, local);
+}
+
 Acts::RotationMatrix3 Acts::ConeSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3& position,
     const Vector3& /*direction*/) const {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -90,6 +90,18 @@ Acts::Vector3 Acts::ConeSurface::rotSymmetryAxis(
   return transform(gctx).matrix().block<3, 1>(0, 2);
 }
 
+Acts::Vector3 Acts::ConeSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position,
+    const Vector3& direction) const {
+  Vector3 loc3Dframe = transform(gctx).inverse() * position;
+
+  // calculate what the radius should be based on the z position
+  double r = loc3Dframe.z() * bounds().tanAlpha();
+
+  Vector2 local{r * VectorHelpers::phi(loc3Dframe), loc3Dframe.z()};
+  return localToGlobal(gctx, local, direction);
+}
+
 Acts::RotationMatrix3 Acts::ConeSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3& position,
     const Vector3& /*direction*/) const {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -91,15 +91,14 @@ Acts::Vector3 Acts::ConeSurface::rotSymmetryAxis(
 }
 
 Acts::Vector3 Acts::ConeSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position,
-    const Vector3& direction) const {
+    const GeometryContext& gctx, const Vector3& position) const {
   Vector3 loc3Dframe = transform(gctx).inverse() * position;
 
   // calculate what the radius should be based on the z position
   double r = loc3Dframe.z() * bounds().tanAlpha();
 
   Vector2 local{r * VectorHelpers::phi(loc3Dframe), loc3Dframe.z()};
-  return localToGlobal(gctx, local, direction);
+  return localToGlobal(gctx, local);
 }
 
 Acts::RotationMatrix3 Acts::ConeSurface::referenceFrame(
@@ -123,9 +122,8 @@ Acts::RotationMatrix3 Acts::ConeSurface::referenceFrame(
   return mFrame;
 }
 
-Acts::Vector3 Acts::ConeSurface::localToGlobal(
-    const GeometryContext& gctx, const Vector2& lposition,
-    const Vector3& /*direction*/) const {
+Acts::Vector3 Acts::ConeSurface::localToGlobal(const GeometryContext& gctx,
+                                               const Vector2& lposition) const {
   // create the position in the local 3d frame
   double r = lposition[Acts::eBoundLoc1] * bounds().tanAlpha();
   double phi = lposition[Acts::eBoundLoc0] / r;

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -135,7 +135,7 @@ Acts::Vector3 Acts::ConeSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2> Acts::ConeSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/, double tolerance) const {
+    double tolerance) const {
   Vector3 loc3Dframe = transform(gctx).inverse() * position;
   double r = loc3Dframe.z() * bounds().tanAlpha();
   if (std::abs(perp(loc3Dframe) - r) > tolerance) {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -90,17 +90,6 @@ Acts::Vector3 Acts::ConeSurface::rotSymmetryAxis(
   return transform(gctx).matrix().block<3, 1>(0, 2);
 }
 
-Acts::Vector3 Acts::ConeSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position) const {
-  Vector3 loc3Dframe = transform(gctx).inverse() * position;
-
-  // calculate what the radius should be based on the z position
-  double r = loc3Dframe.z() * bounds().tanAlpha();
-
-  Vector2 local{r * VectorHelpers::phi(loc3Dframe), loc3Dframe.z()};
-  return localToGlobal(gctx, local);
-}
-
 Acts::RotationMatrix3 Acts::ConeSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3& position,
     const Vector3& /*direction*/) const {

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -29,29 +29,33 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::ConeSurface::ConeSurface(const ConeSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::ConeSurface::ConeSurface(const GeometryContext& gctx,
                                const ConeSurface& other,
                                const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform, double alpha,
                                bool symmetric)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, symmetric)) {}
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform, double alpha,
                                double zmin, double zmax, double halfPhi)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const ConeBounds>(alpha, zmin, zmax, halfPhi)) {
 }
 
 Acts::ConeSurface::ConeSurface(const Transform3& transform,
                                std::shared_ptr<const ConeBounds> cbounds)
-    : GeometryObject(), Surface(transform), m_bounds(std::move(cbounds)) {
+    : GeometryObject(),
+      RegularSurface(transform),
+      m_bounds(std::move(cbounds)) {
   throw_assert(m_bounds, "ConeBounds must not be nullptr");
 }
 

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -86,8 +86,7 @@ Acts::Vector3 Acts::CylinderSurface::binningPosition(
 }
 
 Acts::Vector3 Acts::CylinderSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector3& position) const {
   Vector3 local = transform(gctx).inverse() * position;
 
   double phi = VectorHelpers::phi(local);
@@ -125,8 +124,7 @@ Acts::Surface::SurfaceType Acts::CylinderSurface::type() const {
 }
 
 Acts::Vector3 Acts::CylinderSurface::localToGlobal(
-    const GeometryContext& gctx, const Vector2& lposition,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector2& lposition) const {
   // create the position in the local 3d frame
   double r = bounds().get(CylinderBounds::eR);
   double phi = lposition[Acts::eBoundLoc0] / r;

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -85,20 +85,6 @@ Acts::Vector3 Acts::CylinderSurface::binningPosition(
   return center(gctx);
 }
 
-Acts::Vector3 Acts::CylinderSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position) const {
-  Vector3 local = transform(gctx).inverse() * position;
-
-  double phi = VectorHelpers::phi(local);
-  const double r = bounds().get(CylinderBounds::eR);
-
-  // reset x/y so that they are on surface, but keep z
-  local[eFreePos0] = r * std::cos(phi);
-  local[eFreePos1] = r * std::sin(phi);
-
-  return transform(gctx) * local;
-}
-
 // return the measurement frame: it's the tangential plane
 Acts::RotationMatrix3 Acts::CylinderSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3& position,
@@ -167,9 +153,6 @@ Acts::Vector3 Acts::CylinderSurface::normal(
 
 Acts::Vector3 Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector3& position) const {
-  assert(isOnSurface(gctx, position, Vector3::Zero(), false) &&
-         "Not on surface");
-
   const Transform3& sfTransform = transform(gctx);
   // get it into the cylinder frame
   Vector3 pos3D = sfTransform.inverse() * position;
@@ -182,8 +165,7 @@ Acts::Vector3 Acts::CylinderSurface::normal(
 double Acts::CylinderSurface::pathCorrection(
     const GeometryContext& gctx, const Acts::Vector3& position,
     const Acts::Vector3& direction) const {
-  Vector3 coercedPosition = coerceToSurface(gctx, position, direction);
-  Vector3 normalT = normal(gctx, coercedPosition);
+  Vector3 normalT = normal(gctx, position);
   double cosAlpha = normalT.dot(direction);
   return std::fabs(1. / cosAlpha);
 }

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -185,7 +185,8 @@ Acts::Vector3 Acts::CylinderSurface::normal(
 double Acts::CylinderSurface::pathCorrection(
     const GeometryContext& gctx, const Acts::Vector3& position,
     const Acts::Vector3& direction) const {
-  Vector3 normalT = normal(gctx, position);
+  Vector3 coercedPosition = coerceToSurface(gctx, position, direction);
+  Vector3 normalT = normal(gctx, coercedPosition);
   double cosAlpha = normalT.dot(direction);
   return std::fabs(1. / cosAlpha);
 }

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -85,6 +85,20 @@ Acts::Vector3 Acts::CylinderSurface::binningPosition(
   return center(gctx);
 }
 
+Acts::Vector3 Acts::CylinderSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position) const {
+  Vector3 local = transform(gctx).inverse() * position;
+
+  double phi = VectorHelpers::phi(local);
+  const double r = bounds().get(CylinderBounds::eR);
+
+  // reset x/y so that they are on surface, but keep z
+  local[eFreePos0] = r * std::cos(phi);
+  local[eFreePos1] = r * std::sin(phi);
+
+  return transform(gctx) * local;
+}
+
 // return the measurement frame: it's the tangential plane
 Acts::RotationMatrix3 Acts::CylinderSurface::referenceFrame(
     const GeometryContext& gctx, const Vector3& position,
@@ -153,6 +167,9 @@ Acts::Vector3 Acts::CylinderSurface::normal(
 
 Acts::Vector3 Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector3& position) const {
+  assert(isOnSurface(gctx, position, Vector3::Zero(), false) &&
+         "Not on surface");
+
   const Transform3& sfTransform = transform(gctx);
   // get it into the cylinder frame
   Vector3 pos3D = sfTransform.inverse() * position;
@@ -165,7 +182,8 @@ Acts::Vector3 Acts::CylinderSurface::normal(
 double Acts::CylinderSurface::pathCorrection(
     const GeometryContext& gctx, const Acts::Vector3& position,
     const Acts::Vector3& direction) const {
-  Vector3 normalT = normal(gctx, position);
+  Vector3 coercedPosition = coerceToSurface(gctx, position, direction);
+  Vector3 normalT = normal(gctx, coercedPosition);
   double cosAlpha = normalT.dot(direction);
   return std::fabs(1. / cosAlpha);
 }

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -30,25 +30,27 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::CylinderSurface::CylinderSurface(const CylinderSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::CylinderSurface::CylinderSurface(const GeometryContext& gctx,
                                        const CylinderSurface& other,
                                        const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::CylinderSurface::CylinderSurface(const Transform3& transform,
                                        double radius, double halfz,
                                        double halfphi, double avphi,
                                        double bevelMinZ, double bevelMaxZ)
-    : Surface(transform),
+    : RegularSurface(transform),
       m_bounds(std::make_shared<const CylinderBounds>(
           radius, halfz, halfphi, avphi, bevelMinZ, bevelMaxZ)) {}
 
 Acts::CylinderSurface::CylinderSurface(
     std::shared_ptr<const CylinderBounds> cbounds,
     const Acts::DetectorElementBase& detelement)
-    : Surface(detelement), m_bounds(std::move(cbounds)) {
+    : RegularSurface(detelement), m_bounds(std::move(cbounds)) {
   /// surfaces representing a detector element must have bounds
   assert(cbounds);
 }
@@ -56,7 +58,7 @@ Acts::CylinderSurface::CylinderSurface(
 Acts::CylinderSurface::CylinderSurface(
     const Transform3& transform,
     const std::shared_ptr<const CylinderBounds>& cbounds)
-    : Surface(transform), m_bounds(cbounds) {
+    : RegularSurface(transform), m_bounds(cbounds) {
   throw_assert(cbounds, "CylinderBounds must not be nullptr");
 }
 

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -136,7 +136,7 @@ Acts::Vector3 Acts::CylinderSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2> Acts::CylinderSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/, double tolerance) const {
+    double tolerance) const {
   double inttol = tolerance;
   if (tolerance == s_onSurfaceTolerance) {
     // transform default value!
@@ -164,21 +164,20 @@ Acts::Vector3 Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector2& lposition) const {
   double phi = lposition[Acts::eBoundLoc0] / m_bounds->get(CylinderBounds::eR);
   Vector3 localNormal(cos(phi), sin(phi), 0.);
-  return Vector3(transform(gctx).matrix().block<3, 3>(0, 0) * localNormal);
+  return transform(gctx).linear() * localNormal;
 }
 
 Acts::Vector3 Acts::CylinderSurface::normal(
     const GeometryContext& gctx, const Acts::Vector3& position) const {
-  if (!isOnSurface(gctx, position, Vector3::Zero(), false)) {
-    throw std::runtime_error("Not on surface");
-  }
+  assert(isOnSurface(gctx, position, Vector3::Zero(), false) &&
+         "Not on surface");
 
   const Transform3& sfTransform = transform(gctx);
   // get it into the cylinder frame
   Vector3 pos3D = sfTransform.inverse() * position;
   // set the z coordinate to 0
   pos3D.z() = 0.;
-  // normalize and rotate back into global if needed
+  // normalize and rotate back into global
   return sfTransform.linear() * pos3D.normalized();
 }
 

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -347,6 +347,10 @@ Acts::ActsMatrix<2, 3> Acts::DiscSurface::localCartesianToBoundLocalDerivative(
 
 Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx,
                                         const Vector2& /*lposition*/) const {
+  return normal(gctx);
+}
+
+Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx) const {
   // fast access via transform matrix (and not rotation())
   const auto& tMatrix = transform(gctx).matrix();
   return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -81,8 +81,7 @@ Acts::Surface::SurfaceType Acts::DiscSurface::type() const {
 }
 
 Acts::Vector3 Acts::DiscSurface::localToGlobal(const GeometryContext& gctx,
-                                               const Vector2& lposition,
-                                               const Vector3& /*gmom*/) const {
+                                               const Vector2& lposition) const {
   // create the position in the local 3d frame
   Vector3 loc3Dframe(
       lposition[Acts::eBoundLoc0] * cos(lposition[Acts::eBoundLoc1]),
@@ -362,8 +361,7 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx) const {
 }
 
 Acts::Vector3 Acts::DiscSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector3& position) const {
   // @TODO: Bypass the transform matrix multiplication
   Vector3 local = transform(gctx).inverse() * position;
   local[eFreePos2] = 0;

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -360,14 +360,6 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx) const {
   return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
 
-Acts::Vector3 Acts::DiscSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position) const {
-  // @TODO: Bypass the transform matrix multiplication
-  Vector3 local = transform(gctx).inverse() * position;
-  local[eFreePos2] = 0;
-  return transform(gctx) * local;
-}
-
 Acts::Vector3 Acts::DiscSurface::binningPosition(const GeometryContext& gctx,
                                                  BinningValue bValue) const {
   if (bValue == binR || bValue == binPhi) {

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -93,7 +93,7 @@ Acts::Vector3 Acts::DiscSurface::localToGlobal(const GeometryContext& gctx,
 
 Acts::Result<Acts::Vector2> Acts::DiscSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*gmom*/, double tolerance) const {
+    double tolerance) const {
   // transport it to the globalframe
   Vector3 loc3Dframe = (transform(gctx).inverse()) * position;
   if (std::abs(loc3Dframe.z()) > std::abs(tolerance)) {
@@ -350,6 +350,11 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx,
   return normal(gctx);
 }
 
+Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx,
+                                        const Vector3& /*position*/) const {
+  return normal(gctx);
+}
+
 Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx) const {
   // fast access via transform matrix (and not rotation())
   const auto& tMatrix = transform(gctx).matrix();
@@ -388,8 +393,8 @@ double Acts::DiscSurface::binningPositionValue(const GeometryContext& gctx,
 }
 
 double Acts::DiscSurface::pathCorrection(const GeometryContext& gctx,
-                                         const Vector3& position,
+                                         const Vector3& /*position*/,
                                          const Vector3& direction) const {
   /// we can ignore the global position here
-  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(normal(gctx).dot(direction));
 }

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -33,34 +33,38 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 
 Acts::DiscSurface::DiscSurface(const DiscSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::DiscSurface::DiscSurface(const GeometryContext& gctx,
                                const DiscSurface& other,
                                const Transform3& shift)
-    : GeometryObject(), Surface(gctx, other, shift), m_bounds(other.m_bounds) {}
+    : GeometryObject(),
+      RegularSurface(gctx, other, shift),
+      m_bounds(other.m_bounds) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform, double rmin,
                                double rmax, double hphisec)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const RadialBounds>(rmin, rmax, hphisec)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform, double minhalfx,
                                double maxhalfx, double minR, double maxR,
                                double avephi, double stereo)
     : GeometryObject(),
-      Surface(transform),
+      RegularSurface(transform),
       m_bounds(std::make_shared<const DiscTrapezoidBounds>(
           minhalfx, maxhalfx, minR, maxR, avephi, stereo)) {}
 
 Acts::DiscSurface::DiscSurface(const Transform3& transform,
                                std::shared_ptr<const DiscBounds> dbounds)
-    : GeometryObject(), Surface(transform), m_bounds(std::move(dbounds)) {}
+    : GeometryObject(),
+      RegularSurface(transform),
+      m_bounds(std::move(dbounds)) {}
 
 Acts::DiscSurface::DiscSurface(const std::shared_ptr<const DiscBounds>& dbounds,
                                const DetectorElementBase& detelement)
-    : GeometryObject(), Surface(detelement), m_bounds(dbounds) {
+    : GeometryObject(), RegularSurface(detelement), m_bounds(dbounds) {
   throw_assert(dbounds, "nullptr as DiscBounds");
 }
 
@@ -374,5 +378,5 @@ double Acts::DiscSurface::pathCorrection(const GeometryContext& gctx,
                                          const Vector3& position,
                                          const Vector3& direction) const {
   /// we can ignore the global position here
-  return 1. / std::abs(Surface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
 }

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -352,6 +352,15 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx,
   return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
 
+Acts::Vector3 Acts::DiscSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position,
+    const Vector3& /*direction*/) const {
+  // @TODO: Bypass the transform matrix multiplication
+  Vector3 local = transform(gctx).inverse() * position;
+  local[eFreePos2] = 0;
+  return transform(gctx) * local;
+}
+
 Acts::Vector3 Acts::DiscSurface::binningPosition(const GeometryContext& gctx,
                                                  BinningValue bValue) const {
   if (bValue == binR || bValue == binPhi) {

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -360,6 +360,14 @@ Acts::Vector3 Acts::DiscSurface::normal(const GeometryContext& gctx) const {
   return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
 }
 
+Acts::Vector3 Acts::DiscSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position) const {
+  // @TODO: Bypass the transform matrix multiplication
+  Vector3 local = transform(gctx).inverse() * position;
+  local[eFreePos2] = 0;
+  return transform(gctx) * local;
+}
+
 Acts::Vector3 Acts::DiscSurface::binningPosition(const GeometryContext& gctx,
                                                  BinningValue bValue) const {
   if (bValue == binR || bValue == binPhi) {

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -132,10 +132,11 @@ Acts::Vector3 Acts::LineSurface::binningPosition(
   return center(gctx);
 }
 
-Acts::Vector3 Acts::LineSurface::normal(const GeometryContext& /*gctx*/,
-                                        const Vector2& /*lpos*/) const {
-  throw std::runtime_error(
-      "LineSurface: normal is undefined without known direction");
+Acts::Vector3 Acts::LineSurface::normal(const GeometryContext& gctx,
+                                        const Vector3& pos,
+                                        const Vector3& direction) const {
+  auto ref = referenceFrame(gctx, pos, direction);
+  return ref.col(2);
 }
 
 const Acts::SurfaceBounds& Acts::LineSurface::bounds() const {

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -102,6 +102,19 @@ Acts::Result<Acts::Vector2> Acts::LineSurface::globalToLocal(
   return Result<Vector2>::success(localXY);
 }
 
+Acts::Vector3 Acts::LineSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position,
+    const Vector3& direction) const {
+  // Bring the global position into the local frame. First remove the
+  // translation then the rotation.
+  Vector3 localPosition = referenceFrame(gctx, position, direction).inverse() *
+                          (position - transform(gctx).translation());
+  // force position to be on the PCA surface
+  localPosition.z() = 0;
+  return (referenceFrame(gctx, position, direction) * localPosition) +
+         transform(gctx).translation();
+}
+
 std::string Acts::LineSurface::name() const {
   return "Acts::LineSurface";
 }

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -102,19 +102,6 @@ Acts::Result<Acts::Vector2> Acts::LineSurface::globalToLocal(
   return Result<Vector2>::success(localXY);
 }
 
-Acts::Vector3 Acts::LineSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position,
-    const Vector3& direction) const {
-  // Bring the global position into the local frame. First remove the
-  // translation then the rotation.
-  Vector3 localPosition = referenceFrame(gctx, position, direction).inverse() *
-                          (position - transform(gctx).translation());
-  // force position to be on the PCA surface
-  localPosition.z() = 0;
-  return (referenceFrame(gctx, position, direction) * localPosition) +
-         transform(gctx).translation();
-}
-
 std::string Acts::LineSurface::name() const {
   return "Acts::LineSurface";
 }

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -173,14 +173,6 @@ Acts::Vector3 Acts::PlaneSurface::binningPosition(
   return center(gctx);
 }
 
-Acts::Vector3 Acts::PlaneSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position) const {
-  // @TODO: Bypass the transform matrix multiplication
-  Vector3 local = transform(gctx).inverse() * position;
-  local.z() = 0;
-  return transform(gctx) * local;
-}
-
 double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
                                           const Vector3& /*position*/,
                                           const Vector3& direction) const {

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -81,8 +81,7 @@ Acts::Surface::SurfaceType Acts::PlaneSurface::type() const {
 }
 
 Acts::Vector3 Acts::PlaneSurface::localToGlobal(
-    const GeometryContext& gctx, const Vector2& lposition,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector2& lposition) const {
   return transform(gctx) *
          Vector3(lposition[Acts::eBoundLoc0], lposition[Acts::eBoundLoc1], 0.);
 }
@@ -175,8 +174,7 @@ Acts::Vector3 Acts::PlaneSurface::binningPosition(
 }
 
 Acts::Vector3 Acts::PlaneSurface::coerceToSurface(
-    const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/) const {
+    const GeometryContext& gctx, const Vector3& position) const {
   // @TODO: Bypass the transform matrix multiplication
   Vector3 local = transform(gctx).inverse() * position;
   local.z() = 0;

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -89,7 +89,7 @@ Acts::Vector3 Acts::PlaneSurface::localToGlobal(
 
 Acts::Result<Acts::Vector2> Acts::PlaneSurface::globalToLocal(
     const GeometryContext& gctx, const Vector3& position,
-    const Vector3& /*direction*/, double tolerance) const {
+    double tolerance) const {
   Vector3 loc3Dframe = transform(gctx).inverse() * position;
   if (std::abs(loc3Dframe.z()) > std::abs(tolerance)) {
     return Result<Vector2>::failure(SurfaceError::GlobalPositionNotOnSurface);
@@ -160,10 +160,13 @@ Acts::Vector3 Acts::PlaneSurface::normal(const GeometryContext& gctx,
   return normal(gctx);
 }
 
+Acts::Vector3 Acts::PlaneSurface::normal(const GeometryContext& gctx,
+                                         const Vector3& /*pos*/) const {
+  return normal(gctx);
+}
+
 Acts::Vector3 Acts::PlaneSurface::normal(const GeometryContext& gctx) const {
-  // fast access via transform matrix (and not rotation())
-  const auto& tMatrix = transform(gctx).matrix();
-  return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
+  return transform(gctx).linear().col(2);
 }
 
 Acts::Vector3 Acts::PlaneSurface::binningPosition(

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -26,17 +26,17 @@
 #include <vector>
 
 Acts::PlaneSurface::PlaneSurface(const PlaneSurface& other)
-    : GeometryObject(), Surface(other), m_bounds(other.m_bounds) {}
+    : GeometryObject(), RegularSurface(other), m_bounds(other.m_bounds) {}
 
 Acts::PlaneSurface::PlaneSurface(const GeometryContext& gctx,
                                  const PlaneSurface& other,
                                  const Transform3& transform)
     : GeometryObject(),
-      Surface(gctx, other, transform),
+      RegularSurface(gctx, other, transform),
       m_bounds(other.m_bounds) {}
 
 Acts::PlaneSurface::PlaneSurface(const Vector3& center, const Vector3& normal)
-    : Surface(), m_bounds(nullptr) {
+    : RegularSurface(), m_bounds(nullptr) {
   /// the right-handed coordinate system is defined as
   /// T = normal
   /// U = Z x T if T not parallel to Z otherwise U = X x T
@@ -59,14 +59,14 @@ Acts::PlaneSurface::PlaneSurface(const Vector3& center, const Vector3& normal)
 Acts::PlaneSurface::PlaneSurface(
     const std::shared_ptr<const PlanarBounds>& pbounds,
     const Acts::DetectorElementBase& detelement)
-    : Surface(detelement), m_bounds(pbounds) {
+    : RegularSurface(detelement), m_bounds(pbounds) {
   /// surfaces representing a detector element must have bounds
   throw_assert(pbounds, "PlaneBounds must not be nullptr");
 }
 
 Acts::PlaneSurface::PlaneSurface(const Transform3& transform,
                                  std::shared_ptr<const PlanarBounds> pbounds)
-    : Surface(transform), m_bounds(std::move(pbounds)) {}
+    : RegularSurface(transform), m_bounds(std::move(pbounds)) {}
 
 Acts::PlaneSurface& Acts::PlaneSurface::operator=(const PlaneSurface& other) {
   if (this != &other) {
@@ -171,7 +171,7 @@ double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
                                           const Vector3& position,
                                           const Vector3& direction) const {
   // We can ignore the global position here
-  return 1. / std::abs(Surface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
 }
 
 Acts::SurfaceIntersection Acts::PlaneSurface::intersect(

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -173,6 +173,14 @@ Acts::Vector3 Acts::PlaneSurface::binningPosition(
   return center(gctx);
 }
 
+Acts::Vector3 Acts::PlaneSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position) const {
+  // @TODO: Bypass the transform matrix multiplication
+  Vector3 local = transform(gctx).inverse() * position;
+  local.z() = 0;
+  return transform(gctx) * local;
+}
+
 double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
                                           const Vector3& /*position*/,
                                           const Vector3& direction) const {

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -167,6 +167,15 @@ Acts::Vector3 Acts::PlaneSurface::binningPosition(
   return center(gctx);
 }
 
+Acts::Vector3 Acts::PlaneSurface::coerceToSurface(
+    const GeometryContext& gctx, const Vector3& position,
+    const Vector3& /*direction*/) const {
+  // @TODO: Bypass the transform matrix multiplication
+  Vector3 local = transform(gctx).inverse() * position;
+  local.z() = 0;
+  return transform(gctx) * local;
+}
+
 double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
                                           const Vector3& position,
                                           const Vector3& direction) const {

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -157,6 +157,10 @@ Acts::Polyhedron Acts::PlaneSurface::polyhedronRepresentation(
 
 Acts::Vector3 Acts::PlaneSurface::normal(const GeometryContext& gctx,
                                          const Vector2& /*lpos*/) const {
+  return normal(gctx);
+}
+
+Acts::Vector3 Acts::PlaneSurface::normal(const GeometryContext& gctx) const {
   // fast access via transform matrix (and not rotation())
   const auto& tMatrix = transform(gctx).matrix();
   return Vector3(tMatrix(0, 2), tMatrix(1, 2), tMatrix(2, 2));
@@ -177,10 +181,10 @@ Acts::Vector3 Acts::PlaneSurface::coerceToSurface(
 }
 
 double Acts::PlaneSurface::pathCorrection(const GeometryContext& gctx,
-                                          const Vector3& position,
+                                          const Vector3& /*position*/,
                                           const Vector3& direction) const {
   // We can ignore the global position here
-  return 1. / std::abs(RegularSurface::normal(gctx, position).dot(direction));
+  return 1. / std::abs(normal(gctx).dot(direction));
 }
 
 Acts::SurfaceIntersection Acts::PlaneSurface::intersect(

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -21,9 +21,6 @@ Vector3 RegularSurface::normal(const GeometryContext& gctx,
   return normal(gctx, Vector2{Vector2::Zero()});
 }
 
-Vector3 RegularSurface::normal(const GeometryContext& gctx) const {
-  return normal(gctx, center(gctx));
-}
 
 Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
                                const Vector3& direction) const {

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -14,9 +14,7 @@
 namespace Acts {
 
 Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
-                               const Vector3& direction) const {
-  assert(isOnSurface(gctx, pos, direction, false) && "Not on surface");
-  (void)direction;
+                               const Vector3& /*direction*/) const {
   return normal(gctx, pos);
 }
 
@@ -33,9 +31,4 @@ Vector3 RegularSurface::localToGlobal(const GeometryContext& gctx,
   return localToGlobal(gctx, lposition);
 }
 
-Vector3 RegularSurface::coerceToSurface(const GeometryContext& gctx,
-                                        const Vector3& position,
-                                        const Vector3& /*direction*/) const {
-  return coerceToSurface(gctx, position);
-}
 }  // namespace Acts

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -26,4 +26,16 @@ Result<Vector2> RegularSurface::globalToLocal(const GeometryContext& gctx,
                                               double tolerance) const {
   return globalToLocal(gctx, position, tolerance);
 }
+
+Vector3 RegularSurface::localToGlobal(const GeometryContext& gctx,
+                                      const Vector2& lposition,
+                                      const Vector3& /*direction*/) const {
+  return localToGlobal(gctx, lposition);
+}
+
+Vector3 RegularSurface::coerceToSurface(const GeometryContext& gctx,
+                                        const Vector3& position,
+                                        const Vector3& /*direction*/) const {
+  return coerceToSurface(gctx, position);
+}
 }  // namespace Acts

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -14,7 +14,9 @@
 namespace Acts {
 
 Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
-                               const Vector3& /*direction*/) const {
+                               const Vector3& direction) const {
+  assert(isOnSurface(gctx, pos, direction, false) && "Not on surface");
+  (void)direction;
   return normal(gctx, pos);
 }
 
@@ -31,4 +33,9 @@ Vector3 RegularSurface::localToGlobal(const GeometryContext& gctx,
   return localToGlobal(gctx, lposition);
 }
 
+Vector3 RegularSurface::coerceToSurface(const GeometryContext& gctx,
+                                        const Vector3& position,
+                                        const Vector3& /*direction*/) const {
+  return coerceToSurface(gctx, position);
+}
 }  // namespace Acts

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -1,0 +1,33 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Surfaces/RegularSurface.hpp"
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+
+namespace Acts {
+
+Vector3 RegularSurface::normal(const GeometryContext& gctx,
+                               const Vector3& position) const {
+  if (!isOnSurface(gctx, position, Vector3::Zero(), false)) {
+    throw std::runtime_error("Not on surface");
+  }
+  return normal(gctx, Vector2{Vector2::Zero()});
+}
+
+Vector3 RegularSurface::normal(const GeometryContext& gctx) const {
+  return normal(gctx, center(gctx));
+}
+
+Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
+                               const Vector3& direction) const {
+  throw_assert(isOnSurface(gctx, pos, direction, false), "Not on surface");
+  return normal(gctx, pos);
+};
+}  // namespace Acts

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -13,18 +13,16 @@
 
 namespace Acts {
 
-Vector3 RegularSurface::normal(const GeometryContext& gctx,
-                               const Vector3& position) const {
-  if (!isOnSurface(gctx, position, Vector3::Zero(), false)) {
-    throw std::runtime_error("Not on surface");
-  }
-  return normal(gctx, Vector2{Vector2::Zero()});
-}
-
-
 Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
                                const Vector3& direction) const {
-  throw_assert(isOnSurface(gctx, pos, direction, false), "Not on surface");
+  assert(isOnSurface(gctx, pos, direction, false) && "Not on surface");
   return normal(gctx, pos);
-};
+}
+
+Result<Vector2> RegularSurface::globalToLocal(const GeometryContext& gctx,
+                                              const Vector3& position,
+                                              const Vector3& /*direction*/,
+                                              double tolerance) const {
+  return globalToLocal(gctx, position, tolerance);
+}
 }  // namespace Acts

--- a/Core/src/Surfaces/RegularSurface.cpp
+++ b/Core/src/Surfaces/RegularSurface.cpp
@@ -16,6 +16,7 @@ namespace Acts {
 Vector3 RegularSurface::normal(const GeometryContext& gctx, const Vector3& pos,
                                const Vector3& direction) const {
   assert(isOnSurface(gctx, pos, direction, false) && "Not on surface");
+  (void)direction;
   return normal(gctx, pos);
 }
 

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -233,11 +233,6 @@ Acts::Vector3 Acts::Surface::center(const GeometryContext& gctx) const {
   return Vector3(tMatrix(0, 3), tMatrix(1, 3), tMatrix(2, 3));
 }
 
-Acts::Vector3 Acts::Surface::normal(const GeometryContext& gctx,
-                                    const Vector3& /*position*/) const {
-  return normal(gctx, Vector2(Vector2::Zero()));
-}
-
 const Acts::Transform3& Acts::Surface::transform(
     const GeometryContext& gctx) const {
   if (m_associatedDetElement != nullptr) {

--- a/Examples/Python/python/acts/examples/__init__.py
+++ b/Examples/Python/python/acts/examples/__init__.py
@@ -358,7 +358,7 @@ class Sequencer(ActsPythonBindings._examples._Sequencer):
                     n.append(self.FpeMask(loc, t, count))
                 kwargs["fpeMasks"] = n
 
-            kwargs["fpeMasks"] = kwargs.get("fpeMasks", []) + self._getAutoFpeMasks()
+        kwargs["fpeMasks"] = kwargs.get("fpeMasks", []) + self._getAutoFpeMasks()
 
         cfg = self.Config()
         if len(args) == 1 and isinstance(args[0], self.Config):

--- a/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
@@ -167,7 +167,8 @@ struct SimulationActor {
         // again: interact only if there is valid material to interact with
         if (slab) {
           // adapt material for non-zero incidence
-          auto normal = surface.normal(state.geoContext, local);
+          auto normal = surface.normal(state.geoContext, before.position(),
+                                       before.direction());
           // dot-product(unit normal, direction) = cos(incidence angle)
           // particle direction is normalized, not sure about surface normal
           auto cosIncidenceInv = normal.norm() / normal.dot(before.direction());

--- a/Plugins/ActSVG/src/PortalSvgConverter.cpp
+++ b/Plugins/ActSVG/src/PortalSvgConverter.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Detector/Portal.hpp"
 #include "Acts/Navigation/DetectorVolumeUpdators.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 namespace {
 
@@ -52,6 +53,11 @@ std::vector<Acts::Svg::ProtoLink> convertMultiLink(
     const Acts::Surface& surface, const Acts::Vector3& refPosition,
     const Acts::Svg::PortalConverter::Options& portalOptions,
     int sign) noexcept(false) {
+  const auto* regSurface = dynamic_cast<const Acts::RegularSurface*>(&surface);
+  if (regSurface == nullptr) {
+    throw std::invalid_argument(
+        "convertMultiLink: surface is not RegularSurface.");
+  }
   // The return links
   std::vector<Acts::Svg::ProtoLink> pLinks;
   const auto& volumes = multiLink.indexedUpdator.extractor.dVolumes;
@@ -82,7 +88,7 @@ std::vector<Acts::Svg::ProtoLink> convertMultiLink(
       } else {
         throw std::invalid_argument("convertMultiLink: incorrect binning.");
       }
-      Acts::Vector3 direction = surface.normal(gctx, position);
+      Acts::Vector3 direction = regSurface->normal(gctx, position);
       pLinks.push_back(makeProtoLink(portalOptions, position,
                                      Acts::Vector3(sign * direction), v));
     }

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -88,7 +88,7 @@ std::vector<nlohmann::json> Acts::PortalJsonConverter::toJsonDetray(
     // Get the two volume center
     const auto volumeCenter = volume.transform(gctx).translation();
     const auto surfaceCenter = surface.center(gctx);
-    const auto surfaceNormal = surface.normal(gctx);
+    const auto surfaceNormal = surface.normal(gctx, surfaceCenter);
     // Get the direction from the volume to the surface, correct link
     const auto volumeToSurface = surfaceCenter - volumeCenter;
     if (volumeToSurface.dot(surfaceNormal) < 0) {

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -19,11 +19,13 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Enumerate.hpp"
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <vector>
 
 namespace {
@@ -74,7 +76,7 @@ std::vector<nlohmann::json> Acts::PortalJsonConverter::toJsonDetray(
     const Options& option) {
   // The overall return object
   std::vector<nlohmann::json> jPortals = {};
-  const Surface& surface = portal.surface();
+  const RegularSurface& surface = portal.surface();
   const auto& volumeLinks = portal.detectorVolumeUpdators();
 
   // First assumption for outside link (along direction)
@@ -298,7 +300,12 @@ std::shared_ptr<Acts::Experimental::Portal> Acts::PortalJsonConverter::fromJson(
         detectorVolumes) {
   // The surface re-creation is trivial
   auto surface = SurfaceJsonConverter::fromJson(jPortal["surface"]);
-  auto portal = Experimental::Portal::makeShared(surface);
+  auto regSurface = std::dynamic_pointer_cast<RegularSurface>(surface);
+  if (!regSurface) {
+    throw std::runtime_error(
+        "PortalJsonConverter: surface is not a regular surface.");
+  }
+  auto portal = Experimental::Portal::makeShared(regSurface);
 
   std::array<Acts::Direction, 2> normalDirs = {Direction::Backward,
                                                Direction::Forward};

--- a/Tests/UnitTests/Core/Digitization/CartesianSegmentationTests.cpp
+++ b/Tests/UnitTests/Core/Digitization/CartesianSegmentationTests.cpp
@@ -14,6 +14,7 @@
 #include "Acts/Digitization/CartesianSegmentation.hpp"
 #include "Acts/Digitization/Segmentation.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
@@ -117,7 +118,10 @@ BOOST_AUTO_TEST_CASE(cartesian_segmentation) {
   CHECK_CLOSE_REL(thicknessPL, 2 * hThickness, 10e-6);
 
   // check the lorentz angle - let's take the second one
-  auto nLorentzPlane = segSurfacesXPL[2]->normal(tgContext);
+  const auto* pSurface =
+      dynamic_cast<const Acts::PlaneSurface*>(segSurfacesXPL[2].get());
+  BOOST_REQUIRE(pSurface != nullptr);
+  auto nLorentzPlane = pSurface->normal(tgContext);
 
   Vector3 nNominal(1., 0., 0.);
   double tAngle = acos(nLorentzPlane.dot(nNominal));

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
@@ -48,10 +49,9 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   const auto pos = pos4.segment<3>(ePos0);
 
   const auto* referenceSurface =
-      dynamic_cast<const RegularSurface*>(&params.referenceSurface());
-  if (referenceSurface == nullptr) {
-    BOOST_FAIL("Reference surface is not a regular surface");
-  }
+      dynamic_cast<const PlaneSurface*>(&params.referenceSurface());
+  BOOST_REQUIRE_MESSAGE(referenceSurface != nullptr,
+                        "Reference surface is not a plane");
 
   // native values
   CHECK_SMALL(params.template get<eBoundLoc0>(), eps);

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -16,6 +16,7 @@
 #include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
@@ -46,6 +47,12 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   const auto qOverP = (q != 0) ? (q / p) : (1 / p);
   const auto pos = pos4.segment<3>(ePos0);
 
+  const auto* referenceSurface =
+      dynamic_cast<const RegularSurface*>(&params.referenceSurface());
+  if (referenceSurface == nullptr) {
+    BOOST_FAIL("Reference surface is not a regular surface");
+  }
+
   // native values
   CHECK_SMALL(params.template get<eBoundLoc0>(), eps);
   CHECK_SMALL(params.template get<eBoundLoc1>(), eps);
@@ -66,9 +73,8 @@ void checkParameters(const GenericCurvilinearTrackParameters<charge_t>& params,
   CHECK_CLOSE_OR_SMALL(params.momentum(), p * unitDir, eps, eps);
   BOOST_CHECK_EQUAL(params.charge(), q);
   // curvilinear reference surface
-  CHECK_CLOSE_OR_SMALL(params.referenceSurface().center(geoCtx), pos, eps, eps);
-  CHECK_CLOSE_OR_SMALL(params.referenceSurface().normal(geoCtx), unitDir, eps,
-                       eps);
+  CHECK_CLOSE_OR_SMALL(referenceSurface->center(geoCtx), pos, eps, eps);
+  CHECK_CLOSE_OR_SMALL(referenceSurface->normal(geoCtx), unitDir, eps, eps);
   // TODO verify reference frame
 }
 

--- a/Tests/UnitTests/Core/EventData/TrackParametersDatasets.hpp
+++ b/Tests/UnitTests/Core/EventData/TrackParametersDatasets.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 
 #include <cmath>
 #include <vector>
@@ -27,15 +28,16 @@ using namespace Acts;
 // reference surfaces
 // this includes only those surfaces that can take unbounded local positions as
 // inputs, i.e. no angles or strictly positive radii.
-const auto surfaces = bdata::make(std::vector<std::shared_ptr<const Surface>>{
-    Surface::makeShared<CylinderSurface>(
-        Transform3::Identity(), 10 /* radius */, 100 /* half-length z */),
-    // TODO perigee roundtrip local->global->local does not seem to work
-    // Surface::makeShared<PerigeeSurface>(Vector3(0, 0, -1.5)),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitX()),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitY()),
-    Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitZ()),
-});
+const auto surfaces =
+    bdata::make(std::vector<std::shared_ptr<const RegularSurface>>{
+        Surface::makeShared<CylinderSurface>(
+            Transform3::Identity(), 10 /* radius */, 100 /* half-length z */),
+        // TODO perigee roundtrip local->global->local does not seem to work
+        // Surface::makeShared<PerigeeSurface>(Vector3(0, 0, -1.5)),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitX()),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitY()),
+        Surface::makeShared<PlaneSurface>(Vector3::Zero(), Vector3::UnitZ()),
+    });
 // positions
 const auto posAngle = bdata::xrange(-M_PI, M_PI, 0.25);
 const auto posPositiveNonzero = bdata::xrange(0.25, 1.0, 0.25);

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 
@@ -114,7 +115,11 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
 
   for (auto& os : cvbOrientedSurfaces) {
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideBox = osCenter + os.second * osNormal;
     Vector3 outsideBox = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -196,7 +196,9 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
 
   for (auto& os : ccvbOrientedSurfaces) {
     auto onSurface = os.first->binningPosition(geoCtx, binR);
-    auto osNormal = os.first->normal(geoCtx, onSurface);
+    auto locPos =
+        os.first->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
+    auto osNormal = os.first->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideCcvb = onSurface + os.second * osNormal;
     Vector3 outsideCCvb = onSurface - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -292,7 +292,9 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeOrientedBoundaries) {
 
   for (auto& os : cvbOrientedSurfaces) {
     auto onSurface = os.first->binningPosition(geoCtx, binR);
-    auto osNormal = os.first->normal(geoCtx, onSurface);
+    auto locPos =
+        os.first->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
+    auto osNormal = os.first->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideCvb = onSurface + os.second * osNormal;
     Vector3 outsideCvb = onSurface - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GenericCuboidVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/PlanarBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
@@ -225,7 +226,11 @@ BOOST_AUTO_TEST_CASE(GenericCuboidVolumeBoundarySurfaces) {
   for (auto& os : gcvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideGcvb = osCenter + os.second * osNormal;
     Vector3 outsideGcvb = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -218,7 +218,7 @@ struct SurfaceArrayCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-        std::shared_ptr<RegularSurface> srfA =
+        std::shared_ptr<PlaneSurface> srfA =
             Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3 nrm = srfA->normal(tgContext);

--- a/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SurfaceArrayCreatorTests.cpp
@@ -218,7 +218,7 @@ struct SurfaceArrayCreatorFixture {
         trans.rotate(Eigen::AngleAxisd(M_PI / 2., Vector3(0, 1, 0)));
 
         auto bounds = std::make_shared<const RectangleBounds>(w, h);
-        std::shared_ptr<Surface> srfA =
+        std::shared_ptr<RegularSurface> srfA =
             Surface::makeShared<PlaneSurface>(trans, bounds);
 
         Vector3 nrm = srfA->normal(tgContext);

--- a/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/TrapezoidVolumeBounds.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
@@ -63,7 +64,11 @@ BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
 
   for (auto& os : tvbOrientedSurfaces) {
     auto osCenter = os.first->center(geoCtx);
-    auto osNormal = os.first->normal(geoCtx, osCenter);
+    const auto* pSurface =
+        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+    BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
+                          "The surface is not a plane surface");
+    auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
     Vector3 insideTvb = osCenter + os.second * osNormal;
     Vector3 outsideTvb = osCenter - os.second * osNormal;

--- a/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
@@ -48,6 +48,7 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Tests/CommonHelpers/PredefinedMaterials.hpp"
+#include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
 
@@ -681,7 +682,9 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
       tgb.trackingGeometry(tgContext);
 
   // Build navigator
-  Navigator naviMat({material, true, true, true});
+  Navigator naviMat(
+      {material, true, true, true},
+      Acts::getDefaultLogger("Navigator", Acts::Logging::VERBOSE));
 
   // Set initial parameters for the particle track
   Covariance cov = Covariance::Identity();
@@ -713,7 +716,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
                                                DenseEnvironmentExtension>,
                           detail::HighestValidAuctioneer>,
              Navigator>
-      prop(es, naviMat);
+      prop(es, naviMat,
+           Acts::getDefaultLogger("Propagator", Acts::Logging::VERBOSE));
 
   // Launch and collect results
   const auto& result = prop.propagate(sbtp, propOpts).value();

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -31,6 +31,7 @@
 #include <initializer_list>
 #include <memory>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -204,9 +205,9 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
 
   //
   /// Test pathCorrection
-  CHECK_CLOSE_REL(cylinderSurfaceObject->pathCorrection(testContext, offSurface,
-                                                        momentum.normalized()),
-                  std::sqrt(3.), 0.01);
+  BOOST_CHECK_THROW(cylinderSurfaceObject->pathCorrection(
+                        testContext, offSurface, momentum.normalized()),
+                    std::runtime_error);
   //
   /// Test name
   BOOST_CHECK_EQUAL(cylinderSurfaceObject->name(),

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -31,7 +31,6 @@
 #include <initializer_list>
 #include <memory>
 #include <ostream>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -205,9 +204,9 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
 
   //
   /// Test pathCorrection
-  BOOST_CHECK_THROW(cylinderSurfaceObject->pathCorrection(
-                        testContext, offSurface, momentum.normalized()),
-                    std::runtime_error);
+  CHECK_CLOSE_REL(cylinderSurfaceObject->pathCorrection(testContext, offSurface,
+                                                        momentum.normalized()),
+                  std::sqrt(3.), 0.01);
   //
   /// Test name
   BOOST_CHECK_EQUAL(cylinderSurfaceObject->name(),

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceProperties) {
   double projected3DMomentum = std::sqrt(3.) * 1.e6;
   Vector3 momentum{projected3DMomentum, projected3DMomentum,
                    projected3DMomentum};
-  Vector3 ignoredPosition{1.1, 2.2, 3.3};
+  Vector3 ignoredPosition = discSurfaceObject->center(tgContext);
   CHECK_CLOSE_REL(discSurfaceObject->pathCorrection(tgContext, ignoredPosition,
                                                     momentum.normalized()),
                   std::sqrt(3), 0.01);

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -169,22 +169,25 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{1, 0, 0};
-    Vector3 normalVector{0., 1., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction = Vector3{1, 0, 0.1}.normalized();
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction),
+                    Vector3::UnitX(), 1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{-1, 0, 0};
-    Vector3 normalVector{0., -1., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   {
     Vector3 position{5, 5, 5};  // should be irrelevant
     Vector3 direction{0, 1, 0};
-    Vector3 normalVector{1., 0., 0.};
-    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), direction,
                     1e-6);
   }
   //

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -118,15 +118,18 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   CHECK_CLOSE_ABS(expectedResult, localPosition, 1e-6);
   //
   // intersection
-  const Vector3 direction{0., 1., 2.};
-  BoundaryCheck bcheck(false);
-  auto sfIntersection =
-      line.intersect(tgContext, {0., 0., 0.}, direction.normalized(), bcheck);
-  BOOST_CHECK(bool(sfIntersection));
-  Vector3 expectedIntersection(0, 1., 2.);
-  CHECK_CLOSE_ABS(sfIntersection.intersection.position, expectedIntersection,
-                  1e-6);  // need more tests..
-  BOOST_CHECK_EQUAL(sfIntersection.object, &line);
+  {
+    const Vector3 direction{0., 1., 2.};
+    BoundaryCheck bcheck(false);
+    auto sfIntersection =
+        line.intersect(tgContext, {0., 0., 0.}, direction.normalized(), bcheck);
+    BOOST_CHECK(bool(sfIntersection));
+    Vector3 expectedIntersection(0, 1., 2.);
+    CHECK_CLOSE_ABS(sfIntersection.intersection.position, expectedIntersection,
+                    1e-6);  // need more tests..
+    BOOST_CHECK_EQUAL(sfIntersection.object, &line);
+  }
+
   //
   // isOnSurface
   const Vector3 insidePosition{0., 2.5, 0.};
@@ -162,13 +165,33 @@ BOOST_AUTO_TEST_CASE(LineSurface_allNamedMethods_test) {
   output << line.name();
   BOOST_CHECK(output.is_equal("Acts::LineSurface"));
   //
-  // normal does not exist without known momentum direction for line surface
-  BOOST_CHECK_THROW(line.normal(tgContext), std::runtime_error);
+  // normal
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{1, 0, 0};
+    Vector3 normalVector{0., 1., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{-1, 0, 0};
+    Vector3 normalVector{0., -1., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
+  {
+    Vector3 position{5, 5, 5};  // should be irrelevant
+    Vector3 direction{0, 1, 0};
+    Vector3 normalVector{1., 0., 0.};
+    CHECK_CLOSE_ABS(line.normal(tgContext, position, direction), normalVector,
+                    1e-6);
+  }
   //
-  // pathCorrection is always 1 for the line surface
-  CHECK_CLOSE_ABS(
-      line.pathCorrection(tgContext, Vector3::Zero(), Vector3::UnitX()), 1,
-      1e-6);
+  // pathCorrection
+  Vector3 any3DVector = Vector3::Random();
+  CHECK_CLOSE_REL(line.pathCorrection(tgContext, any3DVector, any3DVector), 1.,
+                  1e-6);
 }
 
 /// Unit test for testing LineSurface assignment

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -101,14 +101,14 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
       binningPosition);
   //
   /// Test referenceFrame
-  Vector3 globalPosition{2.0, 2.0, 0.0};
+  Vector3 arbitraryGlobalPosition{2.0, 2.0, 2.0};
   Vector3 momentum{1.e6, 1.e6, 1.e6};
   RotationMatrix3 expectedFrame;
   expectedFrame << 1., 0., 0., 0., 1., 0., 0., 0., 1.;
 
-  CHECK_CLOSE_OR_SMALL(
-      planeSurfaceObject->referenceFrame(tgContext, globalPosition, momentum),
-      expectedFrame, 1e-6, 1e-9);
+  CHECK_CLOSE_OR_SMALL(planeSurfaceObject->referenceFrame(
+                           tgContext, arbitraryGlobalPosition, momentum),
+                       expectedFrame, 1e-6, 1e-9);
   //
   /// Test normal, given 3D position
   Vector3 normal3D(0., 0., 1.);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
 
   /// Test localToGlobal
   Vector2 localPosition{1.5, 1.7};
-  globalPosition =
+  Vector3 globalPosition =
       planeSurfaceObject->localToGlobal(tgContext, localPosition, momentum);
   //
   // expected position is the translated one

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -30,7 +30,6 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -174,14 +173,8 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
   //
 
   /// Test pathCorrection
-  BOOST_CHECK_THROW(planeSurfaceObject->pathCorrection(tgContext, offSurface,
-                                                       momentum.normalized()),
-                    std::runtime_error);
-  CHECK_CLOSE_REL(planeSurfaceObject->pathCorrection(
-                      tgContext,
-                      planeSurfaceObject->coerceToSurface(
-                          tgContext, offSurface, momentum.normalized()),
-                      momentum.normalized()),
+  CHECK_CLOSE_REL(planeSurfaceObject->pathCorrection(tgContext, offSurface,
+                                                     momentum.normalized()),
                   std::sqrt(3), 0.01);
   //
   /// Test name

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -173,8 +174,14 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
   //
 
   /// Test pathCorrection
-  CHECK_CLOSE_REL(planeSurfaceObject->pathCorrection(tgContext, offSurface,
-                                                     momentum.normalized()),
+  BOOST_CHECK_THROW(planeSurfaceObject->pathCorrection(tgContext, offSurface,
+                                                       momentum.normalized()),
+                    std::runtime_error);
+  CHECK_CLOSE_REL(planeSurfaceObject->pathCorrection(
+                      tgContext,
+                      planeSurfaceObject->coerceToSurface(
+                          tgContext, offSurface, momentum.normalized()),
+                      momentum.normalized()),
                   std::sqrt(3), 0.01);
   //
   /// Test name

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -57,12 +57,6 @@ class SurfaceStub : public Surface {
     return Result<Vector2>::success(Vector2{20., 20.});
   }
 
-  Vector3 coerceToSurface(const GeometryContext& /*gctx*/,
-                          const Vector3& /*position*/,
-                          const Vector3& /*direction*/) const final {
-    return Vector3{20., 20., 0.0};
-  }
-
   /// Calculation of the path correction for incident
   double pathCorrection(const GeometryContext& /*cxt*/, const Vector3& /*gpos*/,
                         const Vector3& /*gmom*/) const final {

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -32,17 +32,8 @@ class SurfaceStub : public Surface {
   SurfaceType type() const final { return Surface::Other; }
 
   /// Return method for the normal vector of the surface
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector2& /*lpos*/) const final {
-    return normal(gctx);
-  }
-
-  Vector3 normal(const GeometryContext& gctx,
-                 const Vector3& /*position*/) const final {
-    return normal(gctx);
-  }
-
-  Vector3 normal(const GeometryContext& /*gctx*/) const final {
+  Vector3 normal(const GeometryContext& /*gctx*/, const Vector3& /*position*/,
+                 const Vector3& /*direction*/) const final {
     return Vector3{0., 0., 0.};
   }
 

--- a/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceStub.hpp
@@ -57,6 +57,12 @@ class SurfaceStub : public Surface {
     return Result<Vector2>::success(Vector2{20., 20.});
   }
 
+  Vector3 coerceToSurface(const GeometryContext& /*gctx*/,
+                          const Vector3& /*position*/,
+                          const Vector3& /*direction*/) const final {
+    return Vector3{20., 20., 0.0};
+  }
+
   /// Calculation of the path correction for incident
   double pathCorrection(const GeometryContext& /*cxt*/, const Vector3& /*gpos*/,
                         const Vector3& /*gmom*/) const final {

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -114,9 +114,9 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties) {
       tgContext, reference, mom);  // need more complex case to test
   BOOST_CHECK_EQUAL(referenceFrame, unitary);
   // normal()
-  auto normal = surface.Surface::normal(tgContext,
-                                        reference);  // needs more complex
-                                                     // test
+  auto normal = surface.normal(tgContext, reference,
+                               Vector3::UnitZ());  // needs more
+                                                   // complex test
   Vector3 zero{0., 0., 0.};
   BOOST_CHECK_EQUAL(zero, normal);
   // pathCorrection is pure virtual

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -111,10 +111,10 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties) {
   RotationMatrix3 unitary;
   unitary << 1, 0, 0, 0, 1, 0, 0, 0, 1;
   auto referenceFrame = surface.referenceFrame(
-      tgContext, reference, mom);  // need more complex case to test
+      tgContext, Vector3{1, 2, 3}, mom);  // need more complex case to test
   BOOST_CHECK_EQUAL(referenceFrame, unitary);
   // normal()
-  auto normal = surface.normal(tgContext, reference,
+  auto normal = surface.normal(tgContext, Vector3{1, 2, 3},
                                Vector3::UnitZ());  // needs more
                                                    // complex test
   Vector3 zero{0., 0., 0.};

--- a/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
+++ b/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
@@ -26,6 +26,7 @@
 #include "Acts/Tests/CommonHelpers/TestSourceLink.hpp"
 #include "Acts/TrackFitting/detail/KalmanGlobalCovariance.hpp"
 #include "Acts/Utilities/CalibrationContext.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <iterator>
 
@@ -86,7 +87,8 @@ auto makeStraightPropagator(std::shared_ptr<const Acts::TrackingGeometry> geo) {
   cfg.resolvePassive = false;
   cfg.resolveMaterial = true;
   cfg.resolveSensitive = true;
-  Acts::Navigator navigator(cfg);
+  Acts::Navigator navigator(
+      cfg, Acts::getDefaultLogger("Navigator", Acts::Logging::VERBOSE));
   Acts::StraightLineStepper stepper;
   return Acts::Propagator<Acts::StraightLineStepper, Acts::Navigator>(
       stepper, std::move(navigator));
@@ -100,7 +102,8 @@ auto makeConstantFieldPropagator(
   cfg.resolvePassive = false;
   cfg.resolveMaterial = true;
   cfg.resolveSensitive = true;
-  Acts::Navigator navigator(cfg);
+  Acts::Navigator navigator(
+      cfg, Acts::getDefaultLogger("Navigator", Acts::Logging::VERBOSE));
   auto field =
       std::make_shared<Acts::ConstantBField>(Acts::Vector3(0.0, 0.0, bz));
   stepper_t stepper(std::move(field));

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -264,10 +264,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     // find vertices
     auto res = finder.find(tracksPtr, vertexingOptions, state);
 
-    BOOST_CHECK(res.ok());
-
     if (!res.ok()) {
-      std::cout << res.error().message() << std::endl;
+      BOOST_FAIL(res.error().message());
     }
 
     // Retrieve vertices found by vertex finder
@@ -482,10 +480,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     // find vertices
     auto res = finder.find(tracksPtr, vertexingOptionsUT, state);
 
-    BOOST_CHECK(res.ok());
-
     if (!res.ok()) {
-      std::cout << res.error().message() << std::endl;
+      BOOST_FAIL(res.error().message());
     }
 
     // Retrieve vertices found by vertex finder


### PR DESCRIPTION
We currently internally project / coerce to the respective surface, but I feel like this is non obvious, and the caller has no control over this. Here, I propose to make this explicit by having another function `coerceToSurface` which projects a global position onto a surface, where the details of how that is done are depending on the surface.

Blocked by 
- #2340