### PR TITLE
fix: Reset navigation state correctly in KF reverse pass

### DIFF
--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -538,7 +538,7 @@ class KalmanFitter {
       navigator.resetState(
           state.navigation, state.geoContext, stepper.position(state.stepping),
           state.options.direction * stepper.direction(state.stepping),
-          &st.referenceSurface(), targetSurface);
+          &st.referenceSurface(), nullptr);
 
       // Update material effects for last measurement state in reversed
       // direction


### PR DESCRIPTION
We use a different abort mechanism in the KF and do not need to tell the navigator about the target surface

Pulled this out of https://github.com/acts-project/acts/pull/2336 where it fixed a bug