### PR TITLE
ci: Hotfix `test_exatrkx_python`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,6 +120,7 @@ test_exatrkx_python:
   tags:
     - docker-gpu-nvidia
   script:
+    - apt-get update -y || true # TODO revert
     - apt-get install -y python3 libxxhash0
     - source /usr/local/bin/thisroot.sh
     - source build/python/setup.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,6 @@ test_exatrkx_python:
   tags:
     - docker-gpu-nvidia
   script:
-    - apt-get update -y
     - apt-get install -y python3 libxxhash0
     - source /usr/local/bin/thisroot.sh
     - source build/python/setup.sh


### PR DESCRIPTION
workaround nvida apt repo error

```
Err:7 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64  Packages
  File has unexpected size (1127072 != 1126689). Mirror sync in progress? [IP: 152.199.20.126 443]
  Hashes of expected file:
   - Filesize:1126689 [weak]
   - SHA256:7cee2584ca6d97b2f07018ba4f9c3c473fb4e299ed170968a1f8c99c090cc59f
   - SHA1:4ee24fac5518a3fcc3702590a0dab32c95484c54 [weak]
   - MD5Sum:593faff511765d11055c9919bf2e3bf8 [weak]
  Release file created at: Thu, 17 Aug 2023 19:03:05 +0000
```

this should be reverted as soon as possible