### PR TITLE
refactor: improve python error messages

### DIFF
--- a/Examples/Python/python/acts/_adapter.py
+++ b/Examples/Python/python/acts/_adapter.py
@@ -31,7 +31,9 @@ def _make_config_adapter(fn):
                 try:
                     setattr(cfg, k, v)
                 except TypeError as e:
-                    raise RuntimeError("{}: Failed to set {}={}".format(type(cfg), k, v)) from e
+                    raise RuntimeError(
+                        "{}: Failed to set {}={}".format(type(cfg), k, v)
+                    ) from e
             else:
                 _kwargs[k] = v
         try:

--- a/Examples/Python/python/acts/_adapter.py
+++ b/Examples/Python/python/acts/_adapter.py
@@ -28,7 +28,10 @@ def _make_config_adapter(fn):
                 v = str(v)
 
             if hasattr(cfg, k):
-                setattr(cfg, k, v)
+                try:
+                    setattr(cfg, k, v)
+                except TypeError as e:
+                    raise RuntimeError("{}: Failed to set {}={}".format(type(cfg), k, v)) from e
             else:
                 _kwargs[k] = v
         try:


### PR DESCRIPTION
Sometimes, the `setattr` in our special python constructor fails, and its not so easy to find out why. This should help by printing the key and the value that did not work together.