### PR TITLE
feat: GlobalChiSquareFitterError framework for Gx2f

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -32,6 +32,7 @@
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Propagator/StraightLineStepper.hpp"
 #include "Acts/Propagator/detail/PointwiseMaterialInteraction.hpp"
+#include "Acts/TrackFitting/GlobalChiSquareFitterError.hpp"
 #include "Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp"
 #include "Acts/TrackFitting/detail/VoidFitterComponents.hpp"
 #include "Acts/Utilities/CalibrationContext.hpp"
@@ -602,9 +603,8 @@ class Gx2Fitter {
           aMatrix.topLeftCorner<reducedMatrixSize, reducedMatrixSize>()
               .inverse();
     } else if (gx2fOptions.nUpdateMax > 0) {
-      // TODO
-      std::cout << "det(a) == 0. This shouldn't happen. Implement real ERROR"
-                << std::endl;
+      ACTS_ERROR("det(a) == 0. This should not happen ever.");
+      return Experimental::GlobalChiSquareFitterError::DetAIsZero;
     }
 
     // Prepare track for return

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitterError.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitterError.hpp
@@ -1,0 +1,33 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <system_error>
+#include <type_traits>
+
+namespace Acts {
+namespace Experimental {
+
+enum class GlobalChiSquareFitterError {
+  // ensure all values are non-zero
+  DetAIsZero = 1,
+};
+
+std::error_code make_error_code(
+    Acts::Experimental::GlobalChiSquareFitterError e);
+
+}  // namespace Experimental
+}  // namespace Acts
+
+namespace std {
+// register with STL
+template <>
+struct is_error_code_enum<Acts::Experimental::GlobalChiSquareFitterError>
+    : std::true_type {};
+}  // namespace std

--- a/Core/src/TrackFitting/CMakeLists.txt
+++ b/Core/src/TrackFitting/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     KalmanFitterError.cpp
     GainMatrixUpdater.cpp
     GainMatrixSmoother.cpp
+    GlobalChiSquareFitterError.cpp
     GsfError.cpp
     GsfUtils.cpp
     BetheHeitlerApprox.cpp

--- a/Core/src/TrackFitting/GlobalChiSquareFitterError.cpp
+++ b/Core/src/TrackFitting/GlobalChiSquareFitterError.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-class KalmanFitterErrorCategory : public std::error_category {
+class GlobalChiSquareFitterErrorCategory : public std::error_category {
  public:
   // Return a short descriptive name for the category.
   const char* name() const noexcept final {
@@ -36,6 +36,6 @@ class KalmanFitterErrorCategory : public std::error_category {
 
 std::error_code Acts::Experimental::make_error_code(
     Acts::Experimental::GlobalChiSquareFitterError e) {
-  static KalmanFitterErrorCategory c;
+  static GlobalChiSquareFitterErrorCategory c;
   return {static_cast<int>(e), c};
 }

--- a/Core/src/TrackFitting/GlobalChiSquareFitterError.cpp
+++ b/Core/src/TrackFitting/GlobalChiSquareFitterError.cpp
@@ -1,0 +1,41 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/TrackFitting/GlobalChiSquareFitterError.hpp"
+
+#include <string>
+
+namespace {
+
+class KalmanFitterErrorCategory : public std::error_category {
+ public:
+  // Return a short descriptive name for the category.
+  const char* name() const noexcept final {
+    return "GlobalChiSquareFitterError";
+  }
+
+  // Return what each enum means in text.
+  std::string message(int c) const final {
+    using Acts::Experimental::GlobalChiSquareFitterError;
+
+    switch (static_cast<GlobalChiSquareFitterError>(c)) {
+      case GlobalChiSquareFitterError::DetAIsZero:
+        return "Gx2f has det(a) == 0 during update.";
+      default:
+        return "unknown";
+    }
+  }
+};
+
+}  // namespace
+
+std::error_code Acts::Experimental::make_error_code(
+    Acts::Experimental::GlobalChiSquareFitterError e) {
+  static KalmanFitterErrorCategory c;
+  return {static_cast<int>(e), c};
+}


### PR DESCRIPTION
This mostly adds the framework for the fitter specific error handling. Currently it only contains a single error case. During the next steps in development we can figure out which other errors might occur and they can be added easily. 