### PR TITLE
fix: Make eta-dependent TrackSelector backwards compatible

### DIFF
--- a/Core/include/Acts/TrackFinding/TrackSelector.hpp
+++ b/Core/include/Acts/TrackFinding/TrackSelector.hpp
@@ -25,7 +25,7 @@ class TrackSelector {
  public:
   /// Configuration of a set of cuts for a single eta bin
   /// Default construction yields a set of cuts that accepts everything.
-  struct CutConfig {
+  struct Config {
     // Minimum/maximum local positions.
     double loc0Min = -inf;
     double loc0Max = inf;
@@ -54,56 +54,56 @@ class TrackSelector {
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& loc0(double min, double max);
+    Config& loc0(double min, double max);
 
     /// Set loc1 acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& loc1(double min, double max);
+    Config& loc1(double min, double max);
 
     /// Set time acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& time(double min, double max);
+    Config& time(double min, double max);
 
     /// Set phi acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& phi(double min, double max);
+    Config& phi(double min, double max);
 
     /// Set the eta acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& eta(double min, double max);
+    Config& eta(double min, double max);
 
     /// Set the absolute eta acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& absEta(double min, double max);
+    Config& absEta(double min, double max);
 
     /// Set the pt acceptance range
     /// @param min Minimum value
     /// @param max Maximum value
     /// @return Reference to this object
-    CutConfig& pt(double min, double max);
+    Config& pt(double min, double max);
 
     /// Print this set of cuts to an output stream
     /// @param os Output stream
     /// @param cuts Cuts to print
     /// @return Reference to the output stream
-    friend std::ostream& operator<<(std::ostream& os, const CutConfig& cuts);
+    friend std::ostream& operator<<(std::ostream& os, const Config& cuts);
   };
 
   /// Main config object for the track selector. Combines a set of cut
   /// configurations and corresponding eta bins
-  struct Config {
+  struct EtaBinnedConfig {
     /// Cut sets for each eta bin
-    std::vector<CutConfig> cutSets = {};
+    std::vector<Config> cutSets = {};
 
     /// Eta bin edges for varying cuts by eta
     std::vector<double> absEtaEdges = {};
@@ -114,37 +114,37 @@ class TrackSelector {
 
     /// Construct an empty (accepts everything) configuration.
     /// Results in a single cut set and one abs eta bin from 0 to infinity.
-    Config() : cutSets{{}}, absEtaEdges{{0, inf}} {};
+    EtaBinnedConfig() : cutSets{{}}, absEtaEdges{{0, inf}} {};
 
     /// Constructor to create a config object that is not upper-bounded.
     /// This is useful to use the "fluent" API to populate the configuration.
     /// @param etaMin Minimum eta bin edge
-    Config(double etaMin) : cutSets{}, absEtaEdges{etaMin} {}
+    EtaBinnedConfig(double etaMin) : cutSets{}, absEtaEdges{etaMin} {}
 
     /// Constructor from a vector of eta bin edges. This automatically
     /// initializes all the cuts to be the same for all eta and be essentially
     /// no-op.
     /// @param absEtaEdgesIn is the vector of eta bin edges
-    Config(std::vector<double> absEtaEdgesIn)
+    EtaBinnedConfig(std::vector<double> absEtaEdgesIn)
         : absEtaEdges{std::move(absEtaEdgesIn)} {
       cutSets.resize(absEtaEdges.size() - 1);
     }
 
     /// Auto-converting constructor from a single cut configuration.
     /// Results in a single absolute eta bin from 0 to infinity.
-    Config(CutConfig cutSet) : cutSets{cutSet}, absEtaEdges{{0, inf}} {}
+    EtaBinnedConfig(Config cutSet) : cutSets{cutSet}, absEtaEdges{{0, inf}} {}
 
     /// Add a new eta bin with the given upper bound.
     /// @param etaMax Upper bound of the new eta bin
     /// @param callback Callback to configure the cuts for this eta bin
     /// @return Reference to this object
-    Config& addCuts(double etaMax,
-                    const std::function<void(CutConfig&)>& callback = {});
+    EtaBinnedConfig& addCuts(double etaMax,
+                             const std::function<void(Config&)>& callback = {});
 
     /// Add a new eta bin with an upper bound of +infinity.
     /// @param callback Callback to configure the cuts for this eta bin
     /// @return Reference to this object
-    Config& addCuts(const std::function<void(CutConfig&)>& callback = {});
+    EtaBinnedConfig& addCuts(const std::function<void(Config&)>& callback = {});
 
     /// Print this configuration to an output stream
     /// @param os Output stream
@@ -160,12 +160,16 @@ class TrackSelector {
     /// Get the cuts for a given eta
     /// @param eta Eta value
     /// @return Cuts for the given eta
-    const CutConfig& getCuts(double eta) const;
+    const Config& getCuts(double eta) const;
   };
 
-  /// Constructor from a config object
+  /// Constructor from a single cut config object
   /// @param config is the configuration object
   TrackSelector(const Config& config);
+
+  /// Constructor from a multi-eta
+  /// @param config is the configuration object
+  TrackSelector(const EtaBinnedConfig& config);
 
   /// Select tracks from an input container and copy them into an output
   /// container
@@ -186,42 +190,42 @@ class TrackSelector {
 
   /// Get readonly access to the config parameters
   /// @return the config object
-  const Config& config() const { return m_cfg; }
+  const EtaBinnedConfig& config() const { return m_cfg; }
 
  private:
-  Config m_cfg;
+  EtaBinnedConfig m_cfg;
 };
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::loc0(double min,
-                                                                double max) {
+inline TrackSelector::Config& TrackSelector::Config::loc0(double min,
+                                                          double max) {
   loc0Min = min;
   loc0Max = max;
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::loc1(double min,
-                                                                double max) {
+inline TrackSelector::Config& TrackSelector::Config::loc1(double min,
+                                                          double max) {
   loc1Min = min;
   loc1Max = max;
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::time(double min,
-                                                                double max) {
+inline TrackSelector::Config& TrackSelector::Config::time(double min,
+                                                          double max) {
   timeMin = min;
   timeMax = max;
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::phi(double min,
-                                                               double max) {
+inline TrackSelector::Config& TrackSelector::Config::phi(double min,
+                                                         double max) {
   phiMin = min;
   phiMax = max;
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::eta(double min,
-                                                               double max) {
+inline TrackSelector::Config& TrackSelector::Config::eta(double min,
+                                                         double max) {
   if (absEtaMin != 0.0 || absEtaMax != inf) {
     throw std::invalid_argument(
         "Cannot set both eta and absEta cuts in the same cut set");
@@ -231,8 +235,8 @@ inline TrackSelector::CutConfig& TrackSelector::CutConfig::eta(double min,
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::absEta(double min,
-                                                                  double max) {
+inline TrackSelector::Config& TrackSelector::Config::absEta(double min,
+                                                            double max) {
   if (etaMin != -inf || etaMax != inf) {
     throw std::invalid_argument(
         "Cannot set both eta and absEta cuts in the same cut set");
@@ -242,15 +246,15 @@ inline TrackSelector::CutConfig& TrackSelector::CutConfig::absEta(double min,
   return *this;
 }
 
-inline TrackSelector::CutConfig& TrackSelector::CutConfig::pt(double min,
-                                                              double max) {
+inline TrackSelector::Config& TrackSelector::Config::pt(double min,
+                                                        double max) {
   ptMin = min;
   ptMax = max;
   return *this;
 }
 
 inline std::ostream& operator<<(std::ostream& os,
-                                const TrackSelector::CutConfig& cuts) {
+                                const TrackSelector::Config& cuts) {
   auto print = [&](const char* name, const auto& min, const auto& max) {
     os << " - " << min << " <= " << name << " < " << max << "\n";
   };
@@ -267,8 +271,8 @@ inline std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-inline TrackSelector::Config& TrackSelector::Config::addCuts(
-    double etaMax, const std::function<void(CutConfig&)>& callback) {
+inline TrackSelector::EtaBinnedConfig& TrackSelector::EtaBinnedConfig::addCuts(
+    double etaMax, const std::function<void(Config&)>& callback) {
   if (etaMax <= absEtaEdges.back()) {
     throw std::invalid_argument{
         "Abs Eta bin edges must be in increasing order"};
@@ -286,12 +290,12 @@ inline TrackSelector::Config& TrackSelector::Config::addCuts(
   return *this;
 }
 
-inline TrackSelector::Config& TrackSelector::Config::addCuts(
-    const std::function<void(CutConfig&)>& callback) {
+inline TrackSelector::EtaBinnedConfig& TrackSelector::EtaBinnedConfig::addCuts(
+    const std::function<void(Config&)>& callback) {
   return addCuts(inf, callback);
 }
 
-inline std::size_t TrackSelector::Config::binIndex(double eta) const {
+inline std::size_t TrackSelector::EtaBinnedConfig::binIndex(double eta) const {
   if (std::abs(eta) >= absEtaEdges.back()) {
     throw std::invalid_argument{"Eta is outside the abs eta bin edges"};
   }
@@ -302,14 +306,14 @@ inline std::size_t TrackSelector::Config::binIndex(double eta) const {
   return index;
 }
 
-inline const TrackSelector::CutConfig& TrackSelector::Config::getCuts(
+inline const TrackSelector::Config& TrackSelector::EtaBinnedConfig::getCuts(
     double eta) const {
   return nEtaBins() == 1 ? cutSets[0] : cutSets[binIndex(eta)];
 }
 
 inline std::ostream& operator<<(std::ostream& os,
-                                const TrackSelector::Config& cfg) {
-  os << "TrackSelector::Config:\n";
+                                const TrackSelector::EtaBinnedConfig& cfg) {
+  os << "TrackSelector::EtaBinnedConfig:\n";
 
   for (std::size_t i = 1; i < cfg.absEtaEdges.size(); i++) {
     os << cfg.absEtaEdges[i - 1] << " <= eta < " << cfg.absEtaEdges[i] << "\n";
@@ -348,7 +352,7 @@ bool TrackSelector::isValidTrack(const track_proxy_t& track) const {
     return false;
   }
 
-  const CutConfig& cuts = m_cfg.getCuts(eta);
+  const Config& cuts = m_cfg.getCuts(eta);
 
   return within(track.transverseMomentum(), cuts.ptMin, cuts.ptMax) and
          within(std::abs(eta), cuts.absEtaMin, cuts.absEtaMax) and
@@ -360,7 +364,8 @@ bool TrackSelector::isValidTrack(const track_proxy_t& track) const {
          checkMin(track.nMeasurements(), cuts.minMeasurements);
 }
 
-inline TrackSelector::TrackSelector(const TrackSelector::Config& config)
+inline TrackSelector::TrackSelector(
+    const TrackSelector::EtaBinnedConfig& config)
     : m_cfg(config) {
   if (m_cfg.cutSets.size() != m_cfg.nEtaBins()) {
     throw std::invalid_argument{
@@ -371,7 +376,7 @@ inline TrackSelector::TrackSelector(const TrackSelector::Config& config)
     static const std::vector<double> infVec = {0, inf};
     bool limitEta = m_cfg.absEtaEdges != infVec;
 
-    const CutConfig& cuts = m_cfg.cutSets[0];
+    const Config& cuts = m_cfg.cutSets[0];
 
     if (limitEta && (cuts.etaMin != -inf || cuts.etaMax != inf ||
                      cuts.absEtaMin != 0.0 || cuts.absEtaMax != inf)) {
@@ -380,5 +385,8 @@ inline TrackSelector::TrackSelector(const TrackSelector::Config& config)
     }
   }
 }
+
+inline TrackSelector::TrackSelector(const Config& config)
+    : TrackSelector{EtaBinnedConfig{config}} {}
 
 }  // namespace Acts

--- a/Examples/Python/src/ExampleAlgorithms.cpp
+++ b/Examples/Python/src/ExampleAlgorithms.cpp
@@ -73,18 +73,19 @@ void addExampleAlgorithms(Context& ctx) {
   }
 
   {
+    using EtaBinnedConfig = Acts::TrackSelector::EtaBinnedConfig;
     using Config = Acts::TrackSelector::Config;
-    using CutConfig = Acts::TrackSelector::CutConfig;
 
     auto tool = py::class_<Acts::TrackSelector>(m, "TrackSelector")
-                    .def(py::init<const Config&>(), py::arg("config"));
+                    .def(py::init<const Config&>(), py::arg("config"))
+                    .def(py::init<const EtaBinnedConfig&>(), py::arg("config"));
 
     {
-      auto c = py::class_<CutConfig>(tool, "CutConfig").def(py::init<>());
+      auto c = py::class_<Config>(tool, "Config").def(py::init<>());
 
       patchKwargsConstructor(c);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c, CutConfig);
+      ACTS_PYTHON_STRUCT_BEGIN(c, Config);
       ACTS_PYTHON_MEMBER(loc0Min);
       ACTS_PYTHON_MEMBER(loc0Max);
       ACTS_PYTHON_MEMBER(loc1Min);
@@ -102,24 +103,23 @@ void addExampleAlgorithms(Context& ctx) {
       ACTS_PYTHON_MEMBER(minMeasurements);
       ACTS_PYTHON_STRUCT_END();
 
-      pythonRangeProperty(c, "loc0", &CutConfig::loc0Min, &CutConfig::loc0Max);
-      pythonRangeProperty(c, "loc1", &CutConfig::loc1Min, &CutConfig::loc1Max);
-      pythonRangeProperty(c, "time", &CutConfig::timeMin, &CutConfig::timeMax);
-      pythonRangeProperty(c, "phi", &CutConfig::phiMin, &CutConfig::phiMax);
-      pythonRangeProperty(c, "eta", &CutConfig::etaMin, &CutConfig::etaMax);
-      pythonRangeProperty(c, "absEta", &CutConfig::absEtaMin,
-                          &CutConfig::absEtaMax);
-      pythonRangeProperty(c, "pt", &CutConfig::ptMin, &CutConfig::ptMax);
+      pythonRangeProperty(c, "loc0", &Config::loc0Min, &Config::loc0Max);
+      pythonRangeProperty(c, "loc1", &Config::loc1Min, &Config::loc1Max);
+      pythonRangeProperty(c, "time", &Config::timeMin, &Config::timeMax);
+      pythonRangeProperty(c, "phi", &Config::phiMin, &Config::phiMax);
+      pythonRangeProperty(c, "eta", &Config::etaMin, &Config::etaMax);
+      pythonRangeProperty(c, "absEta", &Config::absEtaMin, &Config::absEtaMax);
+      pythonRangeProperty(c, "pt", &Config::ptMin, &Config::ptMax);
     }
 
     {
-      auto c = py::class_<Config>(tool, "Config")
+      auto c = py::class_<EtaBinnedConfig>(tool, "EtaBinnedConfig")
                    .def(py::init<>())
-                   .def(py::init<const CutConfig&>());
+                   .def(py::init<const Config&>());
 
-      c.def_property_readonly("nEtaBins", &Config::nEtaBins);
+      c.def_property_readonly("nEtaBins", &EtaBinnedConfig::nEtaBins);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+      ACTS_PYTHON_STRUCT_BEGIN(c, EtaBinnedConfig);
       ACTS_PYTHON_MEMBER(cutSets);
       ACTS_PYTHON_MEMBER(absEtaEdges);
       ACTS_PYTHON_STRUCT_END();


### PR DESCRIPTION
I noticed that the eta-dependent cuts introduced in #2405 are a not actually backwards compatible. This should hoopefully fix that.