### PR TITLE
refactor: Use `qOverP` in dense environment

### DIFF
--- a/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
+++ b/Core/include/Acts/Propagator/detail/GenericDenseEnvironmentExtension.hpp
@@ -126,7 +126,7 @@ struct GenericDenseEnvironmentExtension {
       material = (volumeMaterial->material(position.template cast<double>()));
       initialMomentum = stepper.absoluteMomentum(state.stepping);
       currentMomentum = initialMomentum;
-      qop[0] = q / initialMomentum;
+      qop[0] = stepper.qOverP(state.stepping);
       initializeEnergyLoss(state);
       // Evaluate k
       knew = qop[0] * stepper.direction(state.stepping).cross(bField);


### PR DESCRIPTION
`qOverP` accessor should be preferred over manual calculation

Pulled out from https://github.com/acts-project/acts/pull/2341