### PR TITLE
features: Add optional output seeds to param estimation algorithm

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
@@ -54,6 +54,8 @@ class TrackParamsEstimationAlgorithm final : public IAlgorithm {
     std::string inputSeeds;
     /// Output estimated track parameters collection.
     std::string outputTrackParameters;
+    /// Output seed collection (optional)
+    std::string outputSeeds;
     /// Tracking geometry for surface lookup.
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
     /// Magnetic field variant.
@@ -102,6 +104,7 @@ class TrackParamsEstimationAlgorithm final : public IAlgorithm {
 
   WriteDataHandle<TrackParametersContainer> m_outputTrackParameters{
       this, "OutputTrackParameters"};
+  WriteDataHandle<SimSeedContainer> m_outputSeeds{this, "OutputSeeds"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
@@ -52,10 +52,16 @@ class TrackParamsEstimationAlgorithm final : public IAlgorithm {
   struct Config {
     /// Input seeds collection.
     std::string inputSeeds;
+    /// Input prototracks (optional)
+    std::string inputProtoTracks;
     /// Output estimated track parameters collection.
     std::string outputTrackParameters;
-    /// Output seed collection (optional)
+    /// Output seed collection - only seeds with successful parameter estimation
+    /// are propagated (optional)
     std::string outputSeeds;
+    /// Output prototrack collection - only tracks with successful parameter
+    /// estimation are propagated (optional)
+    std::string outputProtoTracks;
     /// Tracking geometry for surface lookup.
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
     /// Magnetic field variant.
@@ -101,10 +107,12 @@ class TrackParamsEstimationAlgorithm final : public IAlgorithm {
   Acts::BoundSquareMatrix m_covariance = Acts::BoundSquareMatrix::Zero();
 
   ReadDataHandle<SimSeedContainer> m_inputSeeds{this, "InputSeeds"};
+  ReadDataHandle<ProtoTrackContainer> m_inputTracks{this, "InputTracks"};
 
   WriteDataHandle<TrackParametersContainer> m_outputTrackParameters{
       this, "OutputTrackParameters"};
   WriteDataHandle<SimSeedContainer> m_outputSeeds{this, "OutputSeeds"};
+  WriteDataHandle<ProtoTrackContainer> m_outputTracks{this, "OutputTracks"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -257,12 +257,12 @@ void addTrackFinding(Context& ctx) {
       yMin, yMax, houghHistSize_x, houghHistSize_y, hitExtend_x, threshold,
       localMaxWindowSize, kA);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrackParamsEstimationAlgorithm,
-                                mex, "TrackParamsEstimationAlgorithm",
-                                inputSeeds, outputTrackParameters, outputSeeds,
-                                trackingGeometry, magneticField, bFieldMin,
-                                sigmaLoc0, sigmaLoc1, sigmaPhi, sigmaTheta,
-                                sigmaQOverP, sigmaT0, initialVarInflation);
+  ACTS_PYTHON_DECLARE_ALGORITHM(
+      ActsExamples::TrackParamsEstimationAlgorithm, mex,
+      "TrackParamsEstimationAlgorithm", inputSeeds, inputProtoTracks,
+      outputTrackParameters, outputSeeds, outputProtoTracks, trackingGeometry,
+      magneticField, bFieldMin, sigmaLoc0, sigmaLoc1, sigmaPhi, sigmaTheta,
+      sigmaQOverP, sigmaT0, initialVarInflation);
 
   {
     using Alg = ActsExamples::TrackFindingAlgorithm;

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -257,11 +257,12 @@ void addTrackFinding(Context& ctx) {
       yMin, yMax, houghHistSize_x, houghHistSize_y, hitExtend_x, threshold,
       localMaxWindowSize, kA);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackParamsEstimationAlgorithm, mex,
-      "TrackParamsEstimationAlgorithm", inputSeeds, outputTrackParameters,
-      trackingGeometry, magneticField, bFieldMin, sigmaLoc0, sigmaLoc1,
-      sigmaPhi, sigmaTheta, sigmaQOverP, sigmaT0, initialVarInflation);
+  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrackParamsEstimationAlgorithm,
+                                mex, "TrackParamsEstimationAlgorithm",
+                                inputSeeds, outputTrackParameters, outputSeeds,
+                                trackingGeometry, magneticField, bFieldMin,
+                                sigmaLoc0, sigmaLoc1, sigmaPhi, sigmaTheta,
+                                sigmaQOverP, sigmaT0, initialVarInflation);
 
   {
     using Alg = ActsExamples::TrackFindingAlgorithm;


### PR DESCRIPTION
In the case the param estimation fails, the number of parameters /seeds/prototracks does not match, which makes e.g., downstream track fitting impossible.
This allows to pass-through a prototrack collection through the algorithm, in order to ensure they match always.