### PR TITLE
feat: propagation end of world

### DIFF
--- a/Core/include/Acts/Navigation/DetectorNavigator.hpp
+++ b/Core/include/Acts/Navigation/DetectorNavigator.hpp
@@ -114,6 +114,10 @@ class DetectorNavigator {
 
   bool targetReached(const State& state) const { return state.targetReached; }
 
+  bool endOfWorldReached(State& state) const {
+    return state.currentVolume == nullptr;
+  }
+
   bool navigationBreak(const State& state) const {
     return state.navigationBreak;
   }

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -168,6 +168,10 @@ class DirectNavigator {
 
   bool targetReached(const State& state) const { return state.targetReached; }
 
+  bool endOfWorldReached(State& state) const {
+    return state.currentVolume == nullptr;
+  }
+
   bool navigationBreak(const State& state) const {
     return state.navigationBreak;
   }

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -274,6 +274,10 @@ class Navigator {
 
   bool targetReached(const State& state) const { return state.targetReached; }
 
+  bool endOfWorldReached(State& state) const {
+    return state.currentVolume == nullptr;
+  }
+
   bool navigationBreak(const State& state) const {
     return state.navigationBreak;
   }

--- a/Core/include/Acts/Propagator/StandardAborters.hpp
+++ b/Core/include/Acts/Propagator/StandardAborters.hpp
@@ -198,11 +198,9 @@ struct EndOfWorldReached {
   bool operator()(propagator_state_t& state, const stepper_t& /*stepper*/,
                   const navigator_t& navigator,
                   const Logger& /*logger*/) const {
-    if (navigator.currentVolume(state.navigation) != nullptr) {
-      return false;
-    }
-    navigator.targetReached(state.navigation, true);
-    return true;
+    bool endOfWorld = navigator.endOfWorldReached(state.navigation);
+    navigator.targetReached(state.navigation, endOfWorld);
+    return endOfWorld;
   }
 };
 

--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -26,6 +26,7 @@ if (
     else:
         warnings.warn(error + "\nThe compile-time threshold will be used in this case!")
 
+
 def Propagator(stepper, navigator):
     for prefix in ("Eigen", "Atlas", "StraightLine"):
         _stepper = getattr(ActsPythonBindings, f"{prefix}Stepper")

--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -26,7 +26,6 @@ if (
     else:
         warnings.warn(error + "\nThe compile-time threshold will be used in this case!")
 
-
 def Propagator(stepper, navigator):
     for prefix in ("Eigen", "Atlas", "StraightLine"):
         _stepper = getattr(ActsPythonBindings, f"{prefix}Stepper")

--- a/Tests/UnitTests/Fatras/Kernel/SimulationActorTests.cpp
+++ b/Tests/UnitTests/Fatras/Kernel/SimulationActorTests.cpp
@@ -132,6 +132,7 @@ struct MockNavigator {
   bool targetReached(const MockNavigatorState &state) const {
     return state.targetReached;
   }
+
   const Acts::Surface *currentSurface(const MockNavigatorState &state) const {
     return state.currentSurface;
   }


### PR DESCRIPTION
Change the standard `EndOfWorldApproached` aborter to ask the `Navigator` and do not access directly the `currentVolume`.

