### PR TITLE
ci: Bump build procs in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ build_exatrkx:
       -DACTS_EXATRKX_ENABLE_ONNX=ON
       -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
       -DACTS_ENABLE_LOG_FAILURE_THRESHOLD=ON
-    - cmake --build build -- -j3
+    - cmake --build build -- -j$(nproc)
 
 test_exatrkx_unittests:
   stage: test
@@ -179,7 +179,7 @@ build_linux_ubuntu:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j3
+    - cmake --build build -- -j$(nproc)
     - ccache -s
 
 linux_test_examples:
@@ -290,7 +290,7 @@ linux_physmon:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j3
+    - cmake --build build -- -j$(nproc)
     - ccache -s
 
     - ctest --test-dir build -j$(nproc)
@@ -407,7 +407,7 @@ linux_ubuntu_2204_clang:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j3
+    - cmake --build build -- -j$(nproc)
     - ccache -s
 
     - ctest --test-dir build -j$(nproc)


### PR DESCRIPTION
We currently limit to `-j3`, presumably because we were running into memory consumption issues.

I'm playing with the sizing of the GitLab CI build VMs at the moment, and I'd like to see if we can go to the full core count at this point.