### PR TITLE
fix: Fix units in `RootParticleReader`

### DIFF
--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -147,12 +147,16 @@ ActsExamples::ProcessCode ActsExamples::RootParticleReader::read(
 
       p.setProcess(static_cast<ActsFatras::ProcessType>((*m_process)[i]));
       p.setPdg(static_cast<Acts::PdgParticle>((*m_particleType)[i]));
-      p.setCharge((*m_q)[i]);
-      p.setMass((*m_m)[i]);
+      p.setCharge((*m_q)[i] * Acts::UnitConstants::e);
+      p.setMass((*m_m)[i] * Acts::UnitConstants::GeV);
       p.setParticleId((*m_particleId)[i]);
-      p.setPosition4((*m_vx)[i], (*m_vy)[i], (*m_vz)[i], (*m_vt)[i]);
+      p.setPosition4((*m_vx)[i] * Acts::UnitConstants::mm,
+                     (*m_vy)[i] * Acts::UnitConstants::mm,
+                     (*m_vz)[i] * Acts::UnitConstants::mm,
+                     (*m_vt)[i] * Acts::UnitConstants::ns);
+      // NOTE: depends on the normalization done in setDirection
       p.setDirection((*m_px)[i], (*m_py)[i], (*m_pz)[i]);
-      p.setAbsoluteMomentum((*m_p)[i]);
+      p.setAbsoluteMomentum((*m_p)[i] * Acts::UnitConstants::GeV);
 
       particleContainer.insert(particleContainer.end(), p);
       priVtxCollection.push_back((*m_vertexPrimary)[i]);


### PR DESCRIPTION
Effectively only time was broken but I made the other units also explicit.