### PR TITLE
revert: Bump build procs in GitLab CI (#2474)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ build_exatrkx:
       -DACTS_EXATRKX_ENABLE_ONNX=ON
       -DACTS_BUILD_EXAMPLES_PYTHON_BINDINGS=ON
       -DACTS_ENABLE_LOG_FAILURE_THRESHOLD=ON
-    - cmake --build build -- -j$(nproc)
+    - cmake --build build -- -j3
 
 test_exatrkx_unittests:
   stage: test
@@ -179,7 +179,7 @@ build_linux_ubuntu:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j$(nproc)
+    - cmake --build build -- -j3
     - ccache -s
 
 linux_test_examples:
@@ -290,7 +290,7 @@ linux_physmon:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j$(nproc)
+    - cmake --build build -- -j3
     - ccache -s
 
     - ctest --test-dir build -j$(nproc)
@@ -407,7 +407,7 @@ linux_ubuntu_2204_clang:
       -DACTS_BUILD_PLUGIN_ACTSVG=ON
 
     - ccache -z
-    - cmake --build build -- -j$(nproc)
+    - cmake --build build -- -j3
     - ccache -s
 
     - ctest --test-dir build -j$(nproc)


### PR DESCRIPTION
This reverts commit f6d9c0ae629320b9ccc8241634b7655a42b42875. We go back to -j3 to reduce OOM issues.