### PR TITLE
fix: Fix and refactor `PathLimitReached`

### DIFF
--- a/Core/include/Acts/Propagator/StandardAborters.hpp
+++ b/Core/include/Acts/Propagator/StandardAborters.hpp
@@ -68,21 +68,20 @@ struct PathLimitReached {
     double distance =
         std::abs(internalLimit) - std::abs(state.stepping.pathAccumulated);
     double tolerance = state.options.targetTolerance;
-    stepper.setStepSize(state.stepping, distance, ConstrainedStep::aborter,
-                        false);
     bool limitReached = (std::abs(distance) < std::abs(tolerance));
     if (limitReached) {
       ACTS_VERBOSE("Target: x | "
                    << "Path limit reached at distance " << distance);
       // reaching the target means navigation break
       navigator.targetReached(state.navigation, true);
-    } else {
-      ACTS_VERBOSE("Target: 0 | "
-                   << "Target stepSize (path limit) updated to "
-                   << stepper.outputStepSize(state.stepping));
+      return true;
     }
-    // path limit check
-    return limitReached;
+    stepper.setStepSize(state.stepping, distance, ConstrainedStep::aborter,
+                        false);
+    ACTS_VERBOSE("Target: 0 | "
+                 << "Target stepSize (path limit) updated to "
+                 << stepper.outputStepSize(state.stepping));
+    return false;
   }
 };
 


### PR DESCRIPTION
`PathLimitReached` should not update the step length if it already reached its target

Pulled this out of https://github.com/acts-project/acts/pull/2518