### PR TITLE
refactor: revert "remove division of vertex covariance with weight"

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -81,6 +81,9 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fitImpl(
       } else if (currentVtx->fullCovariance() == SquareMatrix4::Zero()) {
         return VertexingError::NoCovariance;
       }
+      double weight =
+          1. / m_cfg.annealingTool.getWeight(state.annealingState, 1.);
+      currentVtx->setFullCovariance(currentVtx->fullCovariance() * weight);
 
       // Set vertexCompatibility for all TrackAtVertex objects
       // at current vertex

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -189,19 +189,15 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
 
   BOOST_CHECK_EQUAL(allVertices.size(), expNRecoVertices);
 
-  double relTol = 1e-2;
-  double small = 1e-3;
   for (int i = 0; i < expNRecoVertices; i++) {
     auto recoVtx = allVertices[i];
     auto expVtx = verticesInfo[i];
-    CHECK_CLOSE_OR_SMALL(recoVtx.position(), expVtx.position, relTol, small);
-    CHECK_CLOSE_OR_SMALL(recoVtx.covariance(), expVtx.covariance, relTol,
-                         small);
+    CHECK_CLOSE_ABS(recoVtx.position(), expVtx.position, 0.001_mm);
+    CHECK_CLOSE_ABS(recoVtx.covariance(), expVtx.covariance, 0.001_mm);
     BOOST_CHECK_EQUAL(recoVtx.tracks().size(), expVtx.nTracks);
-    CHECK_CLOSE_OR_SMALL(recoVtx.tracks()[0].trackWeight, expVtx.trk1Weight,
-                         relTol, small);
-    CHECK_CLOSE_OR_SMALL(recoVtx.tracks()[0].vertexCompatibility,
-                         expVtx.trk1Comp, relTol, small);
+    CHECK_CLOSE_ABS(recoVtx.tracks()[0].trackWeight, expVtx.trk1Weight, 0.003);
+    CHECK_CLOSE_ABS(recoVtx.tracks()[0].vertexCompatibility, expVtx.trk1Comp,
+                    0.003);
   }
 }
 
@@ -351,19 +347,15 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
 
   BOOST_CHECK_EQUAL(allVertices.size(), expNRecoVertices);
 
-  double relTol = 1e-2;
-  double small = 1e-3;
   for (int i = 0; i < expNRecoVertices; i++) {
     auto recoVtx = allVertices[i];
     auto expVtx = verticesInfo[i];
-    CHECK_CLOSE_OR_SMALL(recoVtx.position(), expVtx.position, relTol, small);
-    CHECK_CLOSE_OR_SMALL(recoVtx.covariance(), expVtx.covariance, relTol,
-                         small);
+    CHECK_CLOSE_ABS(recoVtx.position(), expVtx.position, 0.001_mm);
+    CHECK_CLOSE_ABS(recoVtx.covariance(), expVtx.covariance, 0.001_mm);
     BOOST_CHECK_EQUAL(recoVtx.tracks().size(), expVtx.nTracks);
-    CHECK_CLOSE_OR_SMALL(recoVtx.tracks()[0].trackWeight, expVtx.trk1Weight,
-                         relTol, small);
-    CHECK_CLOSE_OR_SMALL(recoVtx.tracks()[0].vertexCompatibility,
-                         expVtx.trk1Comp, relTol, small);
+    CHECK_CLOSE_ABS(recoVtx.tracks()[0].trackWeight, expVtx.trk1Weight, 0.003);
+    CHECK_CLOSE_ABS(recoVtx.tracks()[0].vertexCompatibility, expVtx.trk1Comp,
+                    0.003);
   }
 }
 


### PR DESCRIPTION
reverts #2522 due to changes in Athena output