### PR TITLE
feat: Add option for double-matching in CKF performance writer

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -66,6 +66,9 @@ class CKFPerformanceWriter final : public WriterT<TrajectoriesContainer> {
     DuplicationPlotTool::Config duplicationPlotToolConfig;
     TrackSummaryPlotTool::Config trackSummaryPlotToolConfig;
 
+    /// Whether to do double matching or not
+    bool doubleMatching = false;
+
     /// Min reco-truth matching probability
     double truthMatchProbMin = 0.5;
 


### PR DESCRIPTION
So far we do single-matching in the `CkfPerformanceWriter`, i.e., we associate to matched and fake based on the track purity of the reconstructed track. This is not always reliable.
This adds an option for double matching, which checks also the efficiency of the truth track.