### PR TITLE
refactor: remove `effectiveProjector()` from `collector()` in GX2F

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -228,19 +228,6 @@ struct Gx2FitterResult {
 /// @param trackStateProxy is the current track state
 /// @param result is the mutable result/cache object
 /// @param logger a logger instance
-///
-/// @note This function uses the effectiveProjector(). This is not very
-/// efficient, because Eigen puts the memory on the heap. A better solution can
-/// be found in the GainMatrixUpdater.cpp, where the projector is created
-/// manually. In our case it could be created like
-/// auto projJacobian = result.jacobianFromStart
-///                     .template topLeftCorner<measDim, eBoundSize>().eval();
-/// , and similar for `projPredicted`. However, this doesn't work for the GX2F
-/// when using a measurement like `loc1` which would need a projector like
-/// [0 1 0 0 0 0] (no identity matrix in the top left corner). To properly
-/// construct the correct projector, we would need to know what kind of
-/// measurement we are looking at, but currently, we have that information only
-/// implicitly in the effectiveProjector().
 template <size_t measDim, typename traj_t>
 void collector(typename traj_t::TrackStateProxy& trackStateProxy,
                Gx2FitterResult<traj_t>& result, const Logger& logger) {
@@ -249,10 +236,14 @@ void collector(typename traj_t::TrackStateProxy& trackStateProxy,
   auto covarianceMeasurement =
       trackStateProxy.template calibratedCovariance<measDim>();
   // Project Jacobian and predicted measurements into the measurement dimensions
-  auto projJacobian =
-      (trackStateProxy.effectiveProjector() * result.jacobianFromStart).eval();
-  auto projPredicted =
-      (trackStateProxy.effectiveProjector() * predicted).eval();
+  auto projJacobian = (trackStateProxy.projector()
+                           .template topLeftCorner<measDim, eBoundSize>() *
+                       result.jacobianFromStart)
+                          .eval();
+  auto projPredicted = (trackStateProxy.projector()
+                            .template topLeftCorner<measDim, eBoundSize>() *
+                        predicted)
+                           .eval();
 
   ACTS_VERBOSE("Processing and collecting measurements in Actor:\n"
                << "\tMeasurement:\t" << measurement.transpose()


### PR DESCRIPTION
We were discussing a bit (starting from #2511 ) if we can remove `effectiveProjector` from the collector in the GlobalChiSquareFitter, since it is not very efficient. This PR now removes it.