### PR TITLE
feat: Proposal for required config parameters in Examples

### DIFF
--- a/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/ParametricParticleGenerator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2023 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,6 +12,7 @@
 #include "Acts/Definitions/Units.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
+#include "ActsExamples/Framework/Required.hpp"
 #include "ActsExamples/Generators/EventGenerator.hpp"
 
 #include <array>
@@ -34,27 +35,28 @@ class ParametricParticleGenerator : public EventGenerator::ParticlesGenerator {
     /// Low, high (exclusive) for the transverse direction angle.
     double phiMin = -M_PI;
     double phiMax = M_PI;
-    /// Low, high (inclusive) for  the longitudinal direction angle.
-    ///
-    /// This intentionally uses theta instead of eta so it can represent the
-    /// full direction space with finite values.
+
+    /// Low, high (exclusive) for the pseudo rapidity.
     ///
     /// @note This is the standard generation, for detector performance
     /// classification, where a flat distribution in eta can be useful,
     /// this can be set by the etaUniform flag;
     ///
-    double thetaMin = std::numeric_limits<double>::min();
-    double thetaMax = M_PI - std::numeric_limits<double>::epsilon();
-    bool etaUniform = false;
+    Required<double> etaMin;
+    Required<double> etaMax;
+    Required<bool> etaUniform;
+
     /// Low, high (exclusive) for absolute/transverse momentum.
-    double pMin = 1 * Acts::UnitConstants::GeV;
-    double pMax = 10 * Acts::UnitConstants::GeV;
-    /// Indicate if the momentum referse to transverse momentum
-    bool pTransverse = false;
+    Required<double> pMin;
+    Required<double> pMax;
+    /// Indicate if the momentum referse to transverse momentum.
+    Required<bool> pTransverse;
+
     /// (Absolute) PDG particle number to identify the particle type.
-    Acts::PdgParticle pdg = Acts::PdgParticle::eMuon;
+    Required<Acts::PdgParticle> pdg;
     /// Randomize the charge and flip the PDG particle number sign accordingly.
-    bool randomizeCharge = false;
+    Required<bool> randomizeCharge;
+
     /// Number of particles.
     size_t numParticles = 1;
 
@@ -71,13 +73,12 @@ class ParametricParticleGenerator : public EventGenerator::ParticlesGenerator {
 
  private:
   Config m_cfg;
-  // will be automatically set from PDG data tables
-  double m_charge;
-  double m_mass;
-  double m_cosThetaMin;
-  double m_cosThetaMax;
-  double m_etaMin;
-  double m_etaMax;
+
+  double m_cosThetaMin{};
+  double m_cosThetaMax{};
+
+  double m_charge{};
+  double m_mass{};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/include/ActsExamples/Framework/Required.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Required.hpp
@@ -1,0 +1,86 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+
+namespace ActsExamples {
+
+/// A simple std::optional like container which can only be overwritten by a
+/// defined value.
+template <typename T>
+class Required {
+ public:
+  using value_type = T;
+
+  constexpr Required() = default;
+
+  constexpr Required(const T& data) : m_data(data) {}
+  constexpr Required(T&& data) : m_data(std::move(data)) {}
+
+  constexpr Required(const Required& other) {
+    std::cout << "copy construct" << std::endl;
+    check(other.m_data);
+    m_data = other.m_data;
+  }
+  constexpr Required(Required&& other) {
+    std::cout << "move construct" << std::endl;
+    check(other.m_data);
+    m_data = std::move(other.m_data);
+  }
+
+  Required& operator=(const Required& other) {
+    std::cout << "copy assignment" << std::endl;
+    check(other.m_data);
+    m_data = other.m_data;
+    return *this;
+  }
+  Required& operator=(Required&& other) {
+    std::cout << "move assignment" << std::endl;
+    check(other.m_data);
+    m_data = std::move(other.m_data);
+    return *this;
+  }
+
+  T& operator*() noexcept { return get(); }
+  const T& operator*() const noexcept { return get(); }
+  T* operator->() noexcept { return &get(); }
+  const T* operator->() const noexcept { return &get(); }
+
+  constexpr explicit operator bool() const noexcept { return has(); }
+
+  constexpr bool has() const noexcept { return m_data.has_value(); }
+
+  constexpr T& get() & { return m_data.value(); }
+  constexpr const T& get() const& { return m_data.value(); }
+  constexpr T get() && { return m_data.value(); }
+
+  template <class... Args>
+  constexpr T& emplace(Args&&... args) {
+    return m_data.emplace(std::forward<Args>(args)...);
+  }
+
+  template <class U, class... Args>
+  constexpr T& emplace(std::initializer_list<U> ilist, Args&&... args) {
+    return m_data.emplace(ilist, std::forward<Args>(args)...);
+  }
+
+ private:
+  std::optional<T> m_data;
+
+  static void check(const std::optional<T>& data) {
+    if (!data) {
+      throw std::runtime_error("data required");
+    }
+  }
+};
+
+}  // namespace ActsExamples

--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Utilities/TypeTraits.hpp"
+#include "ActsExamples/Framework/Required.hpp"
 
 #include <string>
 #include <unordered_map>
@@ -16,6 +17,15 @@
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace PYBIND11_NAMESPACE {
+namespace detail {
+template <typename T>
+struct type_caster<ActsExamples::Required<T>>
+    : optional_caster<ActsExamples::Required<T>> {};
+}  // namespace detail
+}  // namespace PYBIND11_NAMESPACE
 
 namespace Acts::Python {
 

--- a/Examples/Python/src/Generators.cpp
+++ b/Examples/Python/src/Generators.cpp
@@ -12,6 +12,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/RandomNumbers.hpp"
+#include "ActsExamples/Framework/Required.hpp"
 #include "ActsExamples/Generators/EventGenerator.hpp"
 #include "ActsExamples/Generators/MultiplicityGenerators.hpp"
 #include "ActsExamples/Generators/ParametricParticleGenerator.hpp"
@@ -35,16 +36,6 @@ class IReader;
 }  // namespace ActsExamples
 
 namespace py = pybind11;
-
-namespace {
-double thetaToEta(double theta) {
-  assert(theta != 0);
-  return -1 * std::log(std::tan(theta / 2.));
-}
-double etaToTheta(double eta) {
-  return 2 * std::atan(std::exp(-eta));
-}
-}  // namespace
 
 namespace Acts::Python {
 
@@ -135,8 +126,8 @@ void addGenerators(Context& ctx) {
         .def(py::init<>())
         .def_readwrite("phiMin", &Config::phiMin)
         .def_readwrite("phiMax", &Config::phiMax)
-        .def_readwrite("thetaMin", &Config::thetaMin)
-        .def_readwrite("thetaMax", &Config::thetaMax)
+        .def_readwrite("etaMin", &Config::etaMin)
+        .def_readwrite("etaMax", &Config::etaMax)
         .def_readwrite("etaUniform", &Config::etaUniform)
         .def_readwrite("pMin", &Config::pMin)
         .def_readwrite("pMax", &Config::pMax)
@@ -147,41 +138,26 @@ void addGenerators(Context& ctx) {
         .def_readwrite("mass", &Config::mass)
         .def_readwrite("charge", &Config::charge)
         .def_property(
-            "p",
-            [](Config& cfg) {
-              return std::pair{cfg.pMin, cfg.pMax};
-            },
-            [](Config& cfg, std::pair<double, double> value) {
+            "p", [](Config& cfg) { return std::tie(cfg.pMin, cfg.pMax); },
+            [](Config& cfg, std::pair<ActsExamples::Required<double>,
+                                      ActsExamples::Required<double>>
+                                value) {
               cfg.pMin = value.first;
               cfg.pMax = value.second;
             })
         .def_property(
-            "phi",
-            [](Config& cfg) {
-              return std::pair{cfg.phiMin, cfg.phiMax};
-            },
+            "phi", [](Config& cfg) { return std::tie(cfg.phiMin, cfg.phiMax); },
             [](Config& cfg, std::pair<double, double> value) {
               cfg.phiMin = value.first;
               cfg.phiMax = value.second;
             })
         .def_property(
-            "theta",
-            [](Config& cfg) {
-              return std::pair{cfg.thetaMin, cfg.thetaMax};
-            },
-            [](Config& cfg, std::pair<double, double> value) {
-              cfg.thetaMin = value.first;
-              cfg.thetaMax = value.second;
-            })
-        .def_property(
-            "eta",
-            [](Config& cfg) {
-              return std::pair{thetaToEta(cfg.thetaMin),
-                               thetaToEta(cfg.thetaMax)};
-            },
-            [](Config& cfg, std::pair<double, double> value) {
-              cfg.thetaMin = etaToTheta(value.first);
-              cfg.thetaMax = etaToTheta(value.second);
+            "eta", [](Config& cfg) { return std::tie(cfg.etaMin, cfg.etaMax); },
+            [](Config& cfg, std::pair<ActsExamples::Required<double>,
+                                      ActsExamples::Required<double>>
+                                value) {
+              cfg.etaMin = value.first;
+              cfg.etaMax = value.second;
             });
   }
 
@@ -211,4 +187,5 @@ void addGenerators(Context& ctx) {
            py::arg("mean"))
       .def_readwrite("mean", &ActsExamples::PoissonMultiplicityGenerator::mean);
 }
+
 }  // namespace Acts::Python

--- a/Examples/Run/Common/src/ParticleGunOptions.cpp
+++ b/Examples/Run/Common/src/ParticleGunOptions.cpp
@@ -77,8 +77,8 @@ ActsExamples::Options::readParticleGunOptions(const Variables& vars) {
   getRange("gen-eta", 1.0, etaMin, etaMax);
 
   pgCfg.etaUniform = vars["gen-eta-uniform"].template as<bool>();
-  pgCfg.thetaMin = 2 * std::atan(std::exp(-etaMin));
-  pgCfg.thetaMax = 2 * std::atan(std::exp(-etaMax));
+  pgCfg.etaMin = etaMin;
+  pgCfg.etaMax = etaMax;
   getRange("gen-mom-gev", 1_GeV, pgCfg.pMin, pgCfg.pMax);
   pgCfg.pTransverse = vars["gen-mom-transverse"].template as<bool>();
   pgCfg.pdg =

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -75,7 +75,7 @@ if not ttbar:
     addParticleGun(
         s,
         MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
-        EtaConfig(-3.0, 3.0),
+        EtaConfig(-3.0, 3.0, uniform=True),
         PhiConfig(0.0, 360.0 * u.degree),
         ParticleConfig(4, acts.PdgParticle.eMuon, randomizeCharge=True),
         vtxGen=acts.examples.GaussianVertexGenerator(


### PR DESCRIPTION
A common pitfall with our Examples is that all the config parameters have and must have a default value. Many of these parameters are experiment dependent and users end up using parameters they didn't know about in the first place.

I propose to improve this situation by boxing these parameters into a `Required` type which acts like a `std::optional`. The config object is still default constructible and the boxing type is wired to Python.

My current implementation is asserting on copies of uninitialized `Required` objects. In Python this will throw an error directly at the algorithm construction because we copy the config into the algorithm which will fail if an uninitialized value was encountered. 

That interface might be unintuitive. Another idea was to validate the config in the algorithms constructor. This requires more code but provides opportunity for better error messages.

I exercised this only on the `ParametricParticleGenerator` for now.