### PR TITLE
refactor: Physmon in pytest

### DIFF
--- a/CI/physmon/tests/conftest.py
+++ b/CI/physmon/tests/conftest.py
@@ -1,0 +1,163 @@
+from pathlib import Path
+import collections
+from typing import List, IO, Tuple
+import threading
+import csv
+from datetime import datetime
+import time
+
+import pytest
+import psutil
+
+import acts
+import acts.examples
+from common import getOpenDataDetectorDirectory
+from acts.examples.odd import getOpenDataDetector
+
+
+@pytest.fixture()
+def output_path(request):
+    path: Path = request.config.getoption("--physmon-output-path").resolve()
+    path.mkdir(parents=True, exist_ok=True)
+
+    return path
+
+
+PhysmonSetup = collections.namedtuple(
+    "Setup",
+    [
+        "detector",
+        "trackingGeometry",
+        "decorators",
+        "field",
+        "digiConfig",
+        "geoSel",
+    ],
+)
+
+
+@pytest.fixture(scope="session")
+def setup():
+    u = acts.UnitConstants
+    srcdir = Path(__file__).resolve().parent.parent.parent.parent
+
+    matDeco = acts.IMaterialDecorator.fromFile(
+        srcdir / "thirdparty/OpenDataDetector/data/odd-material-maps.root",
+        level=acts.logging.INFO,
+    )
+
+    detector, trackingGeometry, decorators = getOpenDataDetector(
+        getOpenDataDetectorDirectory(), matDeco
+    )
+    setup = PhysmonSetup(
+        detector=detector,
+        trackingGeometry=trackingGeometry,
+        decorators=decorators,
+        digiConfig=srcdir
+        / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json",
+        geoSel=srcdir / "thirdparty/OpenDataDetector/config/odd-seeding-config.json",
+        field=acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T)),
+    )
+    return setup
+
+
+# @TODO: try using spyral directly
+
+
+class Monitor:
+    interval: float
+
+    max_rss: float = 0
+    max_vms: float = 0
+
+    terminate: bool = False
+
+    exception = None
+
+    def __init__(
+        self,
+        output: IO[str],
+        interval: float = 0.5,
+    ):
+        self.interval = interval
+        self.writer = csv.writer(output)
+        self.writer.writerow(("time", "rss", "vms"))
+
+
+        self.time: List[float] = [0]
+        self.rss: List[float] = [0]
+        self.vms: List[float] = [0]
+
+    @staticmethod
+    def _get_memory(p: psutil.Process) -> Tuple[float, float]:
+        rss = p.memory_info().rss
+        vms = p.memory_info().vms
+        for subp in p.children(recursive=True):
+            try:
+                rss += subp.memory_info().rss
+                vms += subp.memory_info().vms
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return rss, vms
+
+    def run(self, p: psutil.Process):
+
+        rss_offset, vms_offset = self._get_memory(p)
+        self.writer.writerow((0, 0, 0))
+
+        try:
+            start = datetime.now()
+            while p.is_running() and p.status() in (
+                psutil.STATUS_RUNNING,
+                psutil.STATUS_SLEEPING,
+            ):
+                if self.terminate:
+                    return
+
+                delta = (datetime.now() - start).total_seconds()
+
+                rss, vms = self._get_memory(p)
+                rss -= rss_offset
+                vms -= vms_offset
+
+                self.rss.append(rss / 1e6)
+                self.vms.append(vms / 1e6)
+                self.time.append(delta)
+                self.max_rss = max(rss, self.max_rss)
+                self.max_vms = max(vms, self.max_vms)
+
+                self.writer.writerow((delta, rss, vms))
+
+                time.sleep(self.interval)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return
+        except Exception as e:
+            self.exception = e
+            raise e
+
+
+@pytest.fixture(autouse=True)
+def monitor(output_path: Path, request, capsys):
+    import psutil
+
+    p = psutil.Process()
+
+    memory = output_path / "memory"
+    memory.mkdir(exist_ok=True)
+    with (memory / f"mem_{request.node.name}.csv").open("w") as fh:
+        mon = Monitor(output=fh, interval=0.1)
+
+        t = threading.Thread(target=mon.run, args=(p,))
+        t.start()
+
+        yield
+
+        mon.terminate = True
+        t.join()
+
+        # @TODO: Add plotting
+
+        with capsys.disabled():
+            print("MONITORING")
+
+

--- a/CI/physmon/tests/test_ckf_tracking.py
+++ b/CI/physmon/tests/test_ckf_tracking.py
@@ -35,19 +35,6 @@ from helpers import failure_threshold
 u = acts.UnitConstants
 
 
-#  def run_ckf_tracking(truthSmearedSeeded, truthEstimatedSeeded, label):
-#  with tempfile.TemporaryDirectory() as temp:
-
-
-#  for truthSmearedSeeded, truthEstimatedSeeded, label in [
-#  (True, False, "truth_smeared"),  # if first is true, second is ignored
-#  (False, True, "truth_estimated"),
-#  (False, False, "seeded"),
-#  (False, False, "orthogonal"),
-#  ]:
-#  run_ckf_tracking(truthSmearedSeeded, truthEstimatedSeeded, label)
-
-
 @pytest.mark.parametrize(
     "seeding_algorithm",
     [

--- a/CI/physmon/tests/test_ckf_tracking.py
+++ b/CI/physmon/tests/test_ckf_tracking.py
@@ -1,0 +1,210 @@
+from pathlib import Path
+
+import pytest
+
+import acts.examples
+
+from acts.examples.simulation import (
+    addParticleGun,
+    MomentumConfig,
+    EtaConfig,
+    PhiConfig,
+    ParticleConfig,
+    addFatras,
+    addDigitization,
+)
+
+from acts.examples.reconstruction import (
+    addSeeding,
+    TruthSeedRanges,
+    ParticleSmearingSigmas,
+    SeedFinderConfigArg,
+    SeedFinderOptionsArg,
+    SeedingAlgorithm,
+    TruthEstimatedSeedingAlgorithmConfigArg,
+    addCKFTracks,
+    addAmbiguityResolution,
+    AmbiguityResolutionConfig,
+    addVertexFitting,
+    VertexFinder,
+    TrackSelectorConfig,
+)
+
+from helpers import failure_threshold
+
+u = acts.UnitConstants
+
+
+#  def run_ckf_tracking(truthSmearedSeeded, truthEstimatedSeeded, label):
+#  with tempfile.TemporaryDirectory() as temp:
+
+
+#  for truthSmearedSeeded, truthEstimatedSeeded, label in [
+#  (True, False, "truth_smeared"),  # if first is true, second is ignored
+#  (False, True, "truth_estimated"),
+#  (False, False, "seeded"),
+#  (False, False, "orthogonal"),
+#  ]:
+#  run_ckf_tracking(truthSmearedSeeded, truthEstimatedSeeded, label)
+
+
+@pytest.mark.parametrize(
+    "seeding_algorithm",
+    [
+        SeedingAlgorithm.Default,
+        SeedingAlgorithm.TruthSmeared,
+        SeedingAlgorithm.TruthEstimated,
+        SeedingAlgorithm.Orthogonal,
+    ],
+)
+def test_ckf_tracking(seeding_algorithm, physmon: "Physmon"):
+    s = acts.examples.Sequencer(
+        events=10,
+        numThreads=-1,
+        logLevel=acts.logging.INFO,
+        fpeMasks=acts.examples.Sequencer.FpeMask.fromFile(
+            Path(__file__).parent.parent / "fpe_masks.yml"
+        ),
+    )
+
+    for d in physmon.decorators:
+        s.addContextDecorator(d)
+
+    rnd = acts.examples.RandomNumbers(seed=42)
+
+    addParticleGun(
+        s,
+        MomentumConfig(1.0 * u.GeV, 10.0 * u.GeV, transverse=True),
+        EtaConfig(-3.0, 3.0),
+        PhiConfig(0.0, 360.0 * u.degree),
+        ParticleConfig(4, acts.PdgParticle.eMuon, randomizeCharge=True),
+        vtxGen=acts.examples.GaussianVertexGenerator(
+            mean=acts.Vector4(0, 0, 0, 0),
+            stddev=acts.Vector4(0.0125 * u.mm, 0.0125 * u.mm, 55.5 * u.mm, 1.0 * u.ns),
+        ),
+        multiplicity=50,
+        rnd=rnd,
+    )
+
+    addFatras(
+        s,
+        physmon.trackingGeometry,
+        physmon.field,
+        enableInteractions=True,
+        rnd=rnd,
+    )
+
+    addDigitization(
+        s,
+        physmon.trackingGeometry,
+        physmon.field,
+        digiConfigFile=physmon.digiConfig,
+        rnd=rnd,
+    )
+
+    addSeeding(
+        s,
+        physmon.trackingGeometry,
+        physmon.field,
+        TruthSeedRanges(pt=(500 * u.MeV, None), nHits=(9, None)),
+        ParticleSmearingSigmas(pRel=0.01),  # only used by SeedingAlgorithm.TruthSmeared
+        SeedFinderConfigArg(
+            r=(33 * u.mm, 200 * u.mm),
+            deltaR=(1 * u.mm, 60 * u.mm),
+            collisionRegion=(-250 * u.mm, 250 * u.mm),
+            z=(-2000 * u.mm, 2000 * u.mm),
+            maxSeedsPerSpM=1,
+            sigmaScattering=5,
+            radLengthPerSeed=0.1,
+            minPt=500 * u.MeV,
+            impactMax=3 * u.mm,
+        ),
+        SeedFinderOptionsArg(bFieldInZ=2 * u.T),
+        TruthEstimatedSeedingAlgorithmConfigArg(deltaR=(10.0 * u.mm, None)),
+        seedingAlgorithm=seeding_algorithm,
+        geoSelectionConfigFile=physmon.geoSel,
+        rnd=rnd,  # only used by SeedingAlgorithm.TruthSmeared
+        outputDirRoot=physmon.tmp_path,
+    )
+
+    addCKFTracks(
+        s,
+        physmon.trackingGeometry,
+        physmon.field,
+        TrackSelectorConfig(
+            pt=(500 * u.MeV, None),
+            loc0=(-4.0 * u.mm, 4.0 * u.mm),
+            nMeasurementsMin=6,
+        ),
+        outputDirRoot=physmon.tmp_path,
+    )
+
+    stems = [
+        "performance_ckf",
+        "tracksummary_ckf",
+        "performance_ivf",
+        "performance_amvf",
+    ]
+
+    associatedParticles = "particles_input"
+    if seeding_algorithm in [SeedingAlgorithm.Default, SeedingAlgorithm.Orthogonal]:
+        addAmbiguityResolution(
+            s,
+            AmbiguityResolutionConfig(maximumSharedHits=3),
+            outputDirRoot=physmon.tmp_path,
+        )
+
+        associatedParticles = None
+
+        stems += ["performance_ambi"]
+
+    addVertexFitting(
+        s,
+        physmon.field,
+        associatedParticles=associatedParticles,
+        outputProtoVertices="ivf_protovertices",
+        outputVertices="ivf_fittedVertices",
+        vertexFinder=VertexFinder.Iterative,
+        outputDirRoot=physmon.tmp_path / "ivf",
+    )
+
+    addVertexFitting(
+        s,
+        physmon.field,
+        associatedParticles=associatedParticles,
+        outputProtoVertices="amvf_protovertices",
+        outputVertices="amvf_fittedVertices",
+        vertexFinder=VertexFinder.AMVF,
+        outputDirRoot=physmon.tmp_path / "amvf",
+    )
+
+    with failure_threshold(acts.logging.FATAL):
+        s.run()
+    del s
+
+    for vertexing in ["ivf", "amvf"]:
+        physmon.add_output_file(
+            f"{vertexing}/performance_vertexing.root",
+            rename=f"performance_{vertexing}.root",
+        )
+
+    if seeding_algorithm in [
+        SeedingAlgorithm.Default,
+        SeedingAlgorithm.Orthogonal,
+        SeedingAlgorithm.TruthEstimated,
+    ]:
+        stems += ["performance_seeding"]
+
+    for stem in stems:
+        physmon.add_output_file(f"{stem}.root", rename=f"{stem}_{physmon.name}.root")
+
+    #  ] + (
+    #  ["performance_seeding", "performance_ambi"]
+    #  if label in ["seeded", "orthogonal"]
+    #  else ["performance_seeding"]
+    #  if label == "truth_estimated"
+    #  else []
+    #  ):
+    #  perf_file = physmon.tmp_path / f"{stem}.root"
+    #  assert perf_file.exists(), "Performance file not found"
+    #  shutil.copy(perf_file, physmon.outdir / f"{stem}_{label}.root")

--- a/CI/physmon/tests/test_ckf_tracking.py
+++ b/CI/physmon/tests/test_ckf_tracking.py
@@ -142,8 +142,6 @@ def test_ckf_tracking(seeding_algorithm, physmon: "Physmon"):
     stems = [
         "performance_ckf",
         "tracksummary_ckf",
-        "performance_ivf",
-        "performance_amvf",
     ]
 
     associatedParticles = "particles_input"
@@ -182,11 +180,15 @@ def test_ckf_tracking(seeding_algorithm, physmon: "Physmon"):
         s.run()
     del s
 
+    # @TODO: Add plotting into ROOT file for vertexing and ckf tracksummary
+
     for vertexing in ["ivf", "amvf"]:
+        target = f"performance_{vertexing}.root"
         physmon.add_output_file(
             f"{vertexing}/performance_vertexing.root",
-            rename=f"performance_{vertexing}.root",
+            rename=target,
         )
+        physmon.histogram_comparison(target, f"Performance {vertexing}")
 
     if seeding_algorithm in [
         SeedingAlgorithm.Default,
@@ -196,7 +198,9 @@ def test_ckf_tracking(seeding_algorithm, physmon: "Physmon"):
         stems += ["performance_seeding"]
 
     for stem in stems:
-        physmon.add_output_file(f"{stem}.root", rename=f"{stem}_{physmon.name}.root")
+        target = f"{stem}.root"
+        physmon.add_output_file(f"{stem}.root", rename=target)
+        physmon.histogram_comparison(target, f"Performance {physmon.name} {stem}")
 
     #  ] + (
     #  ["performance_seeding", "performance_ambi"]

--- a/CI/physmon/tests/test_truth_tracking.py
+++ b/CI/physmon/tests/test_truth_tracking.py
@@ -3,6 +3,9 @@ from pathlib import Path
 import acts.examples
 
 from truth_tracking_kalman import runTruthTrackingKalman
+from truth_tracking_gsf import runTruthTrackingGsf
+
+from helpers import failure_threshold
 
 
 def test_truth_tracking_kalman(physmon: "Physmon"):
@@ -32,3 +35,29 @@ def test_truth_tracking_kalman(physmon: "Physmon"):
     physmon.histogram_comparison(
         "performance_truth_tracking.root", title="Truth tracking KF"
     )
+
+
+def test_truth_tracking_gsf(physmon: "Physmon"):
+    s = acts.examples.Sequencer(
+        events=500,
+        numThreads=-1,
+        logLevel=acts.logging.INFO,
+        fpeMasks=acts.examples.Sequencer.FpeMask.fromFile(
+            Path(__file__).parent.parent / "fpe_masks.yml"
+        ),
+    )
+
+    runTruthTrackingGsf(
+        physmon.trackingGeometry,
+        physmon.digiConfig,
+        physmon.field,
+        outputDir=physmon.tmp_path,
+        s=s,
+    )
+
+    with failure_threshold(acts.logging.FATAL):
+        s.run()
+    del s
+
+    physmon.add_output_file("performance_gsf.root", rename="performance_gsf.root")
+    physmon.histogram_comparison("performance_gsf.root", title="Truth tracking GSF")

--- a/CI/physmon/tests/test_truth_tracking_kalman.py
+++ b/CI/physmon/tests/test_truth_tracking_kalman.py
@@ -5,8 +5,7 @@ import acts.examples
 from truth_tracking_kalman import runTruthTrackingKalman
 
 
-def test_truth_tracking_kalman(output_path: Path, tmp_path: Path, setup):
-    print(setup)
+def test_truth_tracking_kalman(physmon: "Physmon"):
     s = acts.examples.Sequencer(
         events=100,
         numThreads=-1,
@@ -17,16 +16,19 @@ def test_truth_tracking_kalman(output_path: Path, tmp_path: Path, setup):
     )
 
     runTruthTrackingKalman(
-        setup.trackingGeometry,
-        setup.field,
-        digiConfigFile=setup.digiConfig,
-        outputDir=tmp_path,
+        physmon.trackingGeometry,
+        physmon.field,
+        digiConfigFile=physmon.digiConfig,
+        outputDir=physmon.tmp_path,
         s=s,
     )
 
     s.run()
     del s
 
-    perf_file = tmp_path / "performance_track_fitter.root"
-    assert perf_file.exists(), "Performance file not found"
-    #  shutil.copy(perf_file, setup.outdir / "performance_truth_tracking.root")
+    physmon.add_output_file(
+        "performance_track_fitter.root", rename="performance_truth_tracking.root"
+    )
+    physmon.histogram_comparison(
+        "performance_truth_tracking.root", title="Truth tracking KF"
+    )

--- a/CI/physmon/tests/test_truth_tracking_kalman.py
+++ b/CI/physmon/tests/test_truth_tracking_kalman.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import acts.examples
+
+from truth_tracking_kalman import runTruthTrackingKalman
+
+
+def test_truth_tracking_kalman(output_path: Path, tmp_path: Path, setup):
+    print(setup)
+    s = acts.examples.Sequencer(
+        events=100,
+        numThreads=-1,
+        logLevel=acts.logging.INFO,
+        fpeMasks=acts.examples.Sequencer.FpeMask.fromFile(
+            Path(__file__).parent.parent / "fpe_masks.yml"
+        ),
+    )
+
+    runTruthTrackingKalman(
+        setup.trackingGeometry,
+        setup.field,
+        digiConfigFile=setup.digiConfig,
+        outputDir=tmp_path,
+        s=s,
+    )
+
+    s.run()
+    del s
+
+    perf_file = tmp_path / "performance_track_fitter.root"
+    assert perf_file.exists(), "Performance file not found"
+    #  shutil.copy(perf_file, setup.outdir / "performance_truth_tracking.root")

--- a/Examples/Python/python/acts/examples/odd.py
+++ b/Examples/Python/python/acts/examples/odd.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from math import sqrt
 import sys, os
+from typing import Tuple, List
+
 import acts
 import acts.examples
 
@@ -9,8 +11,11 @@ def getOpenDataDetector(
     odd_dir: Path,
     mdecorator=None,
     logLevel=acts.logging.INFO,
-):
-
+) -> Tuple[
+    "acts.examples.dd4hep.DD4hepDetector",
+    acts.TrackingGeometry,
+    List[acts.IMaterialDecorator],
+]:
     import acts.examples.dd4hep
 
     customLogLevel = acts.examples.defaultLogging(logLevel=logLevel)

--- a/Examples/Python/setup.sh.in
+++ b/Examples/Python/setup.sh.in
@@ -27,11 +27,11 @@ export PYTHONPATH=$python_dir:$PYTHONPATH
 # This seems to be only reliable on Linux for now, not on MacOS
 odd_dir=$python_dir/../thirdparty/OpenDataDetector/factory
 if [ -d "$odd_dir" ]; then
-    if [[ "$(uname -s)" -eq "Linux" ]]; then
+    if [[ "$(uname -s)" == "Linux" ]]; then
         echo "INFO:    Found OpenDataDetector and set it up"
         export LD_LIBRARY_PATH=$odd_dir:$LD_LIBRARY_PATH
     fi
-    if [[ "$(uname -s)" -eq "Darwin" ]]; then
+    if [[ "$(uname -s)" == "Darwin" ]]; then
         echo "INFO:    Found OpenDataDetector and set it up"
         export DYLD_LIBRARY_PATH=$odd_dir:$DYLD_LIBRARY_PATH
     fi

--- a/Examples/Python/setup.sh.in
+++ b/Examples/Python/setup.sh.in
@@ -26,9 +26,15 @@ export PYTHONPATH=$python_dir:$PYTHONPATH
 # Make ODD available if possible
 # This seems to be only reliable on Linux for now, not on MacOS
 odd_dir=$python_dir/../thirdparty/OpenDataDetector/factory
-if [ -d "$odd_dir" ] && [[ "$(uname -s)" -eq "Linux" ]]; then
-    echo "INFO:    Found OpenDataDetector and set it up"
-    export LD_LIBRARY_PATH=$odd_dir:$LD_LIBRARY_PATH
+if [ -d "$odd_dir" ]; then
+    if [[ "$(uname -s)" -eq "Linux" ]]; then
+        echo "INFO:    Found OpenDataDetector and set it up"
+        export LD_LIBRARY_PATH=$odd_dir:$LD_LIBRARY_PATH
+    fi
+    if [[ "$(uname -s)" -eq "Darwin" ]]; then
+        echo "INFO:    Found OpenDataDetector and set it up"
+        export DYLD_LIBRARY_PATH=$odd_dir:$DYLD_LIBRARY_PATH
+    fi
 fi
 
 # This message might seem excessive, but the Acts bindings are only installed

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -1,59 +1,22 @@
-import multiprocessing
 from pathlib import Path
-import sys
-import os
-import tempfile
-import shutil
 from typing import Dict
-import warnings
-import pytest_check as check
+import shutil
+import tempfile
+import os
+import multiprocessing
 from collections import namedtuple
 
-
-sys.path += [
-    str(Path(__file__).parent.parent.parent.parent / "Examples/Scripts/Python/"),
-    str(Path(__file__).parent),
-]
-
+import pytest
 
 import helpers
 import helpers.hash_root
 from common import getOpenDataDetectorDirectory
 from acts.examples.odd import getOpenDataDetector
 
-import pytest
-
 import acts
 import acts.examples
 
-try:
-    import ROOT
-
-    ROOT.gSystem.ResetSignals()
-except ImportError:
-    pass
-
-try:
-    if acts.logging.getFailureThreshold() != acts.logging.WARNING:
-        acts.logging.setFailureThreshold(acts.logging.WARNING)
-except RuntimeError:
-    # Repackage with different error string
-    errtype = (
-        "negative"
-        if acts.logging.getFailureThreshold() < acts.logging.WARNING
-        else "positive"
-    )
-    warnings.warn(
-        "Runtime log failure threshold could not be set. "
-        "Compile-time value is probably set via CMake, i.e. "
-        f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set, "
-        "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`. "
-        f"The pytest test-suite can produce false-{errtype} results in this configuration"
-    )
-
-
 u = acts.UnitConstants
-
 
 class RootHashAssertionError(AssertionError):
     def __init__(

--- a/Examples/Python/tests/test_examples_vertexing.py
+++ b/Examples/Python/tests/test_examples_vertexing.py
@@ -1,0 +1,133 @@
+if False:
+    from pathlib import Path
+
+    import pytest
+
+    import acts
+    import acts.examples
+    from acts.examples import Sequencer, GenericDetector, RootParticleWriter
+
+    from helpers import (
+        dd4hepEnabled,
+        pythia8Enabled,
+        AssertCollectionExistsAlg,
+        assert_csv_output,
+        assert_entries,
+        assert_has_entries,
+    )
+
+    from acts.examples.odd import getOpenDataDetector
+    from common import getOpenDataDetectorDirectory
+
+    u = acts.UnitConstants
+
+    @pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
+    @pytest.mark.skipif(not pythia8Enabled, reason="Pythia8 not set up")
+    @pytest.mark.slow
+    @pytest.mark.odd
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_vertex_fitting(tmp_path):
+        detector, trackingGeometry, decorators = getOpenDataDetector(
+            getOpenDataDetectorDirectory()
+        )
+
+        field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
+
+        from vertex_fitting import runVertexFitting, VertexFinder
+
+        s = Sequencer(events=100)
+
+        runVertexFitting(
+            field,
+            vertexFinder=VertexFinder.Truth,
+            outputDir=tmp_path,
+            s=s,
+        )
+
+        alg = AssertCollectionExistsAlg(["fittedVertices"], name="check_alg")
+        s.addAlgorithm(alg)
+
+        s.run()
+        assert alg.events_seen == s.config.events
+
+    @pytest.mark.parametrize(
+        "finder,inputTracks,entries",
+        [
+            ("Truth", False, 100),
+            # ("Truth", True, 0), # this combination seems to be not working
+            ("Iterative", False, 100),
+            ("Iterative", True, 100),
+            ("AMVF", False, 100),
+            ("AMVF", True, 100),
+        ],
+    )
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    @pytest.mark.flaky(reruns=2)
+    def test_vertex_fitting_reading(
+        tmp_path, ptcl_gun, rng, finder, inputTracks, entries, assert_root_hash
+    ):
+        ptcl_file = tmp_path / "particles.root"
+
+        detector, trackingGeometry, decorators = GenericDetector.create()
+        field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
+
+        from vertex_fitting import runVertexFitting, VertexFinder
+
+        inputTrackSummary = None
+        if inputTracks:
+            from truth_tracking_kalman import runTruthTrackingKalman
+
+            s2 = Sequencer(numThreads=1, events=100)
+            runTruthTrackingKalman(
+                trackingGeometry,
+                field,
+                digiConfigFile=Path(
+                    Path(__file__).parent.parent.parent.parent
+                    / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+                ),
+                outputDir=tmp_path,
+                s=s2,
+            )
+            s2.run()
+            del s2
+            inputTrackSummary = tmp_path / "tracksummary_fitter.root"
+            assert inputTrackSummary.exists()
+            assert ptcl_file.exists()
+        else:
+            s0 = Sequencer(events=100, numThreads=1)
+            evGen = ptcl_gun(s0)
+            s0.addWriter(
+                RootParticleWriter(
+                    level=acts.logging.INFO,
+                    inputParticles=evGen.config.outputParticles,
+                    filePath=str(ptcl_file),
+                )
+            )
+            s0.run()
+            del s0
+
+            assert ptcl_file.exists()
+
+        finder = VertexFinder[finder]
+
+        s3 = Sequencer(numThreads=1)
+
+        runVertexFitting(
+            field,
+            inputParticlePath=ptcl_file,
+            inputTrackSummary=inputTrackSummary,
+            outputDir=tmp_path,
+            vertexFinder=finder,
+            s=s3,
+        )
+
+        alg = AssertCollectionExistsAlg(["fittedVertices"], name="check_alg")
+        s3.addAlgorithm(alg)
+
+        s3.run()
+
+        vertexing_file = tmp_path / "performance_vertexing.root"
+        assert vertexing_file.exists()
+
+        assert_entries(vertexing_file, "vertexing", entries)
+        assert_root_hash(vertexing_file.name, vertexing_file)

--- a/conftest.py
+++ b/conftest.py
@@ -5,8 +5,9 @@ import pytest_check as check
 
 
 sys.path += [
+    str(Path(__file__).parent / "Examples/Scripts"),
     str(Path(__file__).parent / "Examples/Scripts/Python"),
-    str(Path(__file__).parent / "Examples/Python/tests" ),
+    str(Path(__file__).parent / "Examples/Python/tests"),
 ]
 
 
@@ -18,6 +19,7 @@ try:
     import ROOT
 
     ROOT.gSystem.ResetSignals()
+    ROOT.gROOT.SetBatch(ROOT.kTRUE)
 except ImportError:
     pass
 
@@ -41,4 +43,9 @@ except RuntimeError:
 
 
 def pytest_addoption(parser):
-    parser.addoption("--physmon-output-path", action="store", default=Path.cwd()/"physmon", type=Path)
+    parser.addoption(
+        "--physmon-output-path",
+        action="store",
+        default=Path.cwd() / "physmon",
+        type=Path,
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import sys
+import warnings
+import pytest_check as check
+
+
+sys.path += [
+    str(Path(__file__).parent / "Examples/Scripts/Python"),
+    str(Path(__file__).parent / "Examples/Python/tests" ),
+]
+
+
+import pytest
+
+import acts
+
+try:
+    import ROOT
+
+    ROOT.gSystem.ResetSignals()
+except ImportError:
+    pass
+
+try:
+    if acts.logging.getFailureThreshold() != acts.logging.WARNING:
+        acts.logging.setFailureThreshold(acts.logging.WARNING)
+except RuntimeError:
+    # Repackage with different error string
+    errtype = (
+        "negative"
+        if acts.logging.getFailureThreshold() < acts.logging.WARNING
+        else "positive"
+    )
+    warnings.warn(
+        "Runtime log failure threshold could not be set. "
+        "Compile-time value is probably set via CMake, i.e. "
+        f"`ACTS_LOG_FAILURE_THRESHOLD={acts.logging.getFailureThreshold().name}` is set, "
+        "or `ACTS_ENABLE_LOG_FAILURE_THRESHOLD=OFF`. "
+        f"The pytest test-suite can produce false-{errtype} results in this configuration"
+    )
+
+
+def pytest_addoption(parser):
+    parser.addoption("--physmon-output-path", action="store", default=Path.cwd()/"physmon", type=Path)

--- a/conftest.py
+++ b/conftest.py
@@ -49,3 +49,11 @@ def pytest_addoption(parser):
         default=Path.cwd() / "physmon",
         type=Path,
     )
+    parser.addoption(
+        "--physmon-reference-path",
+        action="store",
+        default=Path(__file__).parent / "CI/physmon/reference",
+        type=Path,
+    )
+
+    parser.addoption("--physmon-update-references", action="store_true")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 testpaths =
     Examples/Python/tests
+    CI/physmon/tests
+addopts = --import-mode=importlib
 norecursedirs=Examples/Python/tests/helpers
 markers =
     csv


### PR DESCRIPTION
This PR proposes reimplementing the physmon workflows inside pytest, where tests are defined to run the workflows.
This also allows me to define most of the extra steps, like file output comparisons and file existence checks can be orchestrated via python functions. This also allows me to provide a unified way to provide a local reference directory like

```
pytest -k "physmon" -v --physmon-reference-path local_references
```

and also to automatically update the references like

```
pytest -k "physmon" -v --physmon-update-references
```

The two can also be combined, which is nice!
