### PR TITLE
fix: Set Current Surface as first surface for direct navigator

### DIFF
--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -314,7 +314,7 @@ class DirectNavigator {
                 : "No Volume") +
            " | ";
   }
-  
+
   const Logger& logger() const { return *m_logger; }
 
   std::unique_ptr<const Logger> m_logger;

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -197,8 +197,18 @@ class DirectNavigator {
   /// @param [in] stepper Stepper in use
   template <typename propagator_state_t, typename stepper_t>
   void initialize(propagator_state_t& state, const stepper_t& stepper) const {
-    state.navigation.currentSurface = state.navigation.startSurface;
     (void)stepper;
+
+    // Call the navigation helper prior to actual navigation                                                                                                    
+    ACTS_VERBOSE(volInfo(state) << "Initialization.");
+
+    // We set the current surface to the start surface                                                                                                          
+    state.navigation.currentSurface = state.navigation.startSurface;
+    if (state.navigation.currentSurface) {
+      ACTS_VERBOSE(volInfo(state)
+                   << "Current surface set to start surface "
+                   << state.navigation.currentSurface->geometryId());
+    }
   }
 
   /// @brief Navigator pre step call

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -72,7 +72,6 @@ class DirectNavigator {
       if (not r.initialized) {
         // Initialize the surface sequence
         state.navigation.navSurfaces = navSurfaces;
-        state.navigation.currentSurface = navSurfaces.front();
         state.navigation.navSurfaceIter = state.navigation.navSurfaces.begin();
         r.initialized = true;
       }
@@ -198,7 +197,7 @@ class DirectNavigator {
   /// @param [in] stepper Stepper in use
   template <typename propagator_state_t, typename stepper_t>
   void initialize(propagator_state_t& state, const stepper_t& stepper) const {
-    (void)state;
+    state.navigation.currentSurface = state.navigation.startSurface;
     (void)stepper;
   }
 

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
+#include "Acts/Navigation/DetectorNavigator.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -12,7 +12,6 @@
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
-#include "Acts/Navigation/DetectorNavigator.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
@@ -308,6 +307,14 @@ class DirectNavigator {
   }
 
  private:
+  template <typename propagator_state_t>
+  std::string volInfo(const propagator_state_t& state) const {
+    return (state.navigation.currentVolume
+                ? state.navigation.currentVolume->volumeName()
+                : "No Volume") +
+           " | ";
+  }
+  
   const Logger& logger() const { return *m_logger; }
 
   std::unique_ptr<const Logger> m_logger;

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -72,6 +72,7 @@ class DirectNavigator {
       if (not r.initialized) {
         // Initialize the surface sequence
         state.navigation.navSurfaces = navSurfaces;
+        state.navigation.currentSurface = navSurfaces.front();
         state.navigation.navSurfaceIter = state.navigation.navSurfaces.begin();
         r.initialized = true;
       }

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -200,10 +200,10 @@ class DirectNavigator {
   void initialize(propagator_state_t& state, const stepper_t& stepper) const {
     (void)stepper;
 
-    // Call the navigation helper prior to actual navigation                                                                                                    
+    // Call the navigation helper prior to actual navigation
     ACTS_VERBOSE(volInfo(state) << "Initialization.");
 
-    // We set the current surface to the start surface                                                                                                          
+    // We set the current surface to the start surface
     state.navigation.currentSurface = state.navigation.startSurface;
     if (state.navigation.currentSurface) {
       ACTS_VERBOSE(volInfo(state)


### PR DESCRIPTION
For a direct navigator we set the current surface to be the first surface in the surface sequence. This is done in the `DirectNavigator:Initializer::operator()`