### PR TITLE
fix: Direct Navigator: Set surface iterator to next surface in case start surface is in the list

### DIFF
--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -73,7 +73,21 @@ class DirectNavigator {
         // Initialize the surface sequence
         state.navigation.navSurfaces = navSurfaces;
         state.navigation.navSurfaceIter = state.navigation.navSurfaces.begin();
-        r.initialized = true;
+
+	// In case the start surface is in the list of nav surfaces
+	// we need to correct the iterator to point to the next surface
+	// in the vector
+	if (state.navigation.startSurface) {
+	  auto surfaceIter = std::find(state.navigation.navSurfaces.begin(),
+                                       state.navigation.navSurfaces.end(),
+                                       state.navigation.startSurface);
+	  // if current surface in the list, point to the next surface
+          if (surfaceIter != state.navigation.navSurfaces.end()) {	   
+            state.navigation.navSurfaceIter = ++surfaceIter;
+          }
+	}
+	
+	r.initialized = true;
       }
     }
   };

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -74,20 +74,20 @@ class DirectNavigator {
         state.navigation.navSurfaces = navSurfaces;
         state.navigation.navSurfaceIter = state.navigation.navSurfaces.begin();
 
-	// In case the start surface is in the list of nav surfaces
-	// we need to correct the iterator to point to the next surface
-	// in the vector
-	if (state.navigation.startSurface) {
-	  auto surfaceIter = std::find(state.navigation.navSurfaces.begin(),
+        // In case the start surface is in the list of nav surfaces
+        // we need to correct the iterator to point to the next surface
+        // in the vector
+        if (state.navigation.startSurface) {
+          auto surfaceIter = std::find(state.navigation.navSurfaces.begin(),
                                        state.navigation.navSurfaces.end(),
                                        state.navigation.startSurface);
-	  // if current surface in the list, point to the next surface
-          if (surfaceIter != state.navigation.navSurfaces.end()) {	   
+          // if current surface in the list, point to the next surface
+          if (surfaceIter != state.navigation.navSurfaces.end()) {
             state.navigation.navSurfaceIter = ++surfaceIter;
           }
-	}
-	
-	r.initialized = true;
+        }
+
+        r.initialized = true;
       }
     }
   };


### PR DESCRIPTION
As the title says ... 

Point is that I noticed the when I was setting the start surface to be the first surface in `navSurfaces` the KF was correctly processing it doing its computations, but then it was stepping ahead and still searching for the first surface realizing it was behind and thus unreachable. With this the KF knows that surface has already been processed.