### PR TITLE
fix: pdg: eGamma for `<<` was incorrect

### DIFF
--- a/Core/src/Definitions/ParticleData.cpp
+++ b/Core/src/Definitions/ParticleData.cpp
@@ -117,7 +117,7 @@ std::optional<std::string_view> Acts::pdgToShortAbsString(PdgParticle pdg) {
   if (pdg == eTau) {
     return "t";
   }
-  if (pdg == eTau) {
+  if (pdg == eGamma) {
     return "g";
   }
   if (pdg == ePionZero) {


### PR DESCRIPTION
Previous ParticleHypothesis outputs couldn't display `eGamma` as supposed.