### PR TITLE
refactor: Use `__cpp_concepts` directly

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -15,10 +15,6 @@ target_compile_features(
   ActsCore
   PUBLIC ${ACTS_CXX_STANDARD_FEATURE})
 
-if(ACTS_CONCEPTS_SUPPORTED)
-  target_compile_definitions(ActsCore PUBLIC ACTS_CONCEPTS_SUPPORTED)
-endif()
-
 target_include_directories(
   ActsCore
   PUBLIC

--- a/Core/include/Acts/EventData/ChargeConcept.hpp
+++ b/Core/include/Acts/EventData/ChargeConcept.hpp
@@ -16,7 +16,7 @@
 #include <any>
 #include <type_traits>
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 #include <concepts>
 
 namespace Acts {

--- a/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
@@ -19,7 +19,7 @@
 #include <any>
 #include <type_traits>
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 #include <concepts>
 
 namespace Acts {

--- a/Core/include/Acts/EventData/TrackContainerBackendConcept.hpp
+++ b/Core/include/Acts/EventData/TrackContainerBackendConcept.hpp
@@ -16,7 +16,7 @@
 #include <any>
 #include <type_traits>
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 #include <concepts>
 
 namespace Acts {

--- a/Core/include/Acts/EventData/TrackStateProxyConcept.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxyConcept.hpp
@@ -20,7 +20,7 @@
 
 #include <utility>
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 #include <concepts>
 
 namespace Acts {

--- a/Core/include/Acts/Geometry/SurfaceVisitorConcept.hpp
+++ b/Core/include/Acts/Geometry/SurfaceVisitorConcept.hpp
@@ -10,7 +10,7 @@
 
 #include "Acts/Surfaces/Surface.hpp"
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 #include <concepts>
 
 namespace Acts {

--- a/Core/include/Acts/Utilities/Concepts.hpp
+++ b/Core/include/Acts/Utilities/Concepts.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if defined(ACTS_CONCEPTS_SUPPORTED)
+#if defined(__cpp_concepts)
 
 #define ACTS_REQUIRES(x) requires(x)
 #define ACTS_CONCEPT(x) x

--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -55,25 +55,3 @@ set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # set relative library path for ACTS libraries
 set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
-
-if(${ACTS_CXX_STANDARD} GREATER_EQUAL 20)
-  file(WRITE
-    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/concepts.cpp"
-    "#include <concepts>\n"
-    "template<class T, class U>\n"
-    "concept Derived = std::is_base_of<U, T>::value;\n"
-    "struct A {}; struct B : public A {};"
-    "int main() { static_assert(Derived<B, A>, \"works\");  }\n" )
-
-  message(CHECK_START "Are C++20 concepts supported")
-  try_compile(ACTS_CONCEPTS_SUPPORTED "${CMAKE_BINARY_DIR}"
-      "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/concepts.cpp"
-      CXX_STANDARD 20
-      OUTPUT_VARIABLE __OUTPUT)
-
-  if(ACTS_CONCEPTS_SUPPORTED)
-    message(CHECK_PASS "yes")
-  else()
-    message(CHECK_FAIL "no")
-  endif()
-endif()


### PR DESCRIPTION
This replaces the custom C++20 concepts detection mechanism at CMake level with the corresponding feature preprocessor define.