### PR TITLE
ci: Update to gcovr=6.0 and remove bundled-version support

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -65,7 +65,7 @@ jobs:
         run: >
           pip3 install gcovr==6.0
           && cd build
-          && /usr/bin/python3 ../CI/test_coverage --exclude-noncode-lines
+          && /usr/bin/python3 ../CI/test_coverage
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -65,7 +65,7 @@ jobs:
         run: >
           pip3 install gcovr==6.0
           && cd build
-          && /usr/bin/python3 ../CI/test_coverage
+          && /usr/bin/python3 ../CI/test_coverage --exclude-noncode-lines
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -63,7 +63,7 @@ jobs:
           && du -sh build
       - name: Coverage
         run: >
-          pip3 install gcovr==5.0
+          pip3 install gcovr==6.0
           && cd build
           && /usr/bin/python3 ../CI/test_coverage
       - name: Upload coverage

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -65,7 +65,7 @@ jobs:
         run: >
           pip3 install gcovr==6.0
           && cd build
-          && /usr/bin/python3 ../CI/test_coverage
+          && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:

--- a/CI/test_coverage
+++ b/CI/test_coverage
@@ -6,89 +6,86 @@ import os
 import subprocess
 import argparse
 import multiprocessing as mp
+import re
 
 
 if not os.path.exists("CMakeCache.txt"):
-  print("Not in CMake build dir. Not executing")
-  sys.exit(1)
+    print("Not in CMake build dir. Not executing")
+    sys.exit(1)
+
 
 def check_output(*args, **kwargs):
-  p = subprocess.Popen(*args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
-  p.wait()
-  stdout, stderr = p.communicate()
-  if sys.version_info > (2,):
+    p = subprocess.Popen(
+        *args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
+    )
+    p.wait()
+    stdout, stderr = p.communicate()
     stdout = stdout.decode("utf-8")
-  return (p.returncode, stdout.strip())
+    return (p.returncode, stdout.strip())
+
 
 # call helper function
 def call(cmd):
-  print(" ".join(cmd))
-  try:
-    subprocess.check_call(cmd)
-  except subprocess.CalledProcessError as e:
-    print("Failed, output: ", e.output)
-    raise e
+    print(" ".join(cmd))
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as e:
+        print("Failed, output: ", e.output)
+        raise e
+
 
 p = argparse.ArgumentParser()
 p.add_argument("--gcov", default=check_output(["which", "gcov"])[1])
 args = p.parse_args()
 
-
-bundled_gcovr = os.path.abspath(os.path.join(os.getcwd(), "../cmake/gcovr"))
-
 ret, gcovr_exe = check_output(["which", "gcovr"])
-if ret != 0:
-  # gcovr not in path
-  # bundled version needs python2
-  if sys.version_info < (3,):
-    # this python is v2, use it
-    gcovr = [sys.executable, bundled_gcovr]
-  else:
-    # this is not python2, see if installed
-    ret, python_exe = check_output(["which", "python2"])
-    if ret == 0:
-      gcovr = [python_exe, bundled_gcovr]
-    else:
-      # check if python executable is v2
-      ret, python_exe = check_output(["which", "python"])
-      if ret != 0:
-        # on python3, no python2 installed but also no gcovr, nothing we can do
-        print("Cannot run coverage in this configuration")
-        sys.exit(1)
-      ret, python_ver = check_output(["python", "--version"])
-      assert ret == 0, "Error checking python version"
-      import re
-      version = tuple(map(int, re.match("^Python (\d\.\d\.\d)", python_ver).group(1).split(".")))
-      if version > (2,):
-        # version ok, use it
-        gcovr = [python_exe, bundled_gcovr]
-else:
-  # gcovr in path, use directry
-  gcovr = [gcovr_exe] # will have correct python version
+assert ret == 0, "gcovr not installed. Use 'pip install gcovr'."
+
+ret, gcovr_version_text = check_output(["gcovr", "--version"])
+gcovr_version = re.match("gcovr (\d+)\.(\d+)", gcovr_version_text)
+gcovr_version_major, gcovr_version_minor = gcovr_version.groups()
+gcovr_version_major = int(gcovr_version_major)
+gcovr_version_minor = int(gcovr_version_minor)
+
+extra_flags = []
+
+print(f"Found gcovr version {gcovr_version_major}.{gcovr_version_minor}")
+if gcovr_version_major < 5:
+    print("Consider upgrading to a newer gcovr version.")
+elif gcovr_version_major == 5 and gcovr_version_minor == 1:
+    assert False and "Version 5.1 does not support parallel processing of gcov data"
+elif gcovr_version_major >= 6:
+    extra_flags += ["--exclude-noncode-lines"]
+
+gcovr = [gcovr_exe]
 
 script_dir = os.path.dirname(__file__)
 source_dir = os.path.abspath(os.path.join(script_dir, ".."))
 coverage_dir = os.path.abspath("coverage")
 
 if not os.path.exists(coverage_dir):
-  os.makedirs(coverage_dir)
+    os.makedirs(coverage_dir)
 
-excludes = ["-e", "../Tests/", "-e", "../Legacy", "-e", ".*json\.hpp"]
+excludes = ["-e", "../Tests/", "-e", ".*json\.hpp"]
 
 # create the html report
-call(gcovr
-     + ["-r", source_dir]
-     + ["--gcov-executable", args.gcov]
-     + ["-j", str(mp.cpu_count())]
-     + excludes +
-     ["--xml", "-o", "coverage/cov.xml"])
-     #  ["--html", "--html-details",
-     #  "-o", os.path.join(coverage_dir, "index.html")])
+call(
+    gcovr
+    + ["-r", source_dir]
+    + ["--gcov-executable", args.gcov]
+    + ["-j", str(mp.cpu_count())]
+    + excludes
+    + extra_flags
+    + ["--xml", "-o", "coverage/cov.xml"]
+)
+#  ["--html", "--html-details",
+#  "-o", os.path.join(coverage_dir, "index.html")])
 
-call(gcovr
-     + ["-r", source_dir]
-     + ["-j", str(mp.cpu_count())]
-     + ["--gcov-executable", args.gcov]
-     + excludes)
-
-
+call(
+    gcovr
+    + ["-r", source_dir]
+    + ["-j", str(mp.cpu_count())]
+    + ["--gcov-executable", args.gcov]
+    + excludes
+    + extra_flags
+)

--- a/CI/test_coverage.py
+++ b/CI/test_coverage.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# vi:syntax=python
-from __future__ import print_function
 import sys
 import os
 import subprocess
@@ -42,19 +40,18 @@ ret, gcovr_exe = check_output(["which", "gcovr"])
 assert ret == 0, "gcovr not installed. Use 'pip install gcovr'."
 
 ret, gcovr_version_text = check_output(["gcovr", "--version"])
-gcovr_version = re.match("gcovr (\d+)\.(\d+)", gcovr_version_text)
-gcovr_version_major, gcovr_version_minor = gcovr_version.groups()
-gcovr_version_major = int(gcovr_version_major)
-gcovr_version_minor = int(gcovr_version_minor)
+gcovr_version = tuple(
+    map(int, re.match("gcovr (\d+\.\d+)", gcovr_version_text).group(1).split("."))
+)
 
 extra_flags = []
 
-print(f"Found gcovr version {gcovr_version_major}.{gcovr_version_minor}")
-if gcovr_version_major < 5:
+print(f"Found gcovr version {gcovr_version[0]}.{gcovr_version[1]}")
+if gcovr_version < (5,):
     print("Consider upgrading to a newer gcovr version.")
-elif gcovr_version_major == 5 and gcovr_version_minor == 1:
+elif gcovr_version == (5, 1):
     assert False and "Version 5.1 does not support parallel processing of gcov data"
-elif gcovr_version_major >= 6:
+elif gcovr_version >= (6,):
     extra_flags += ["--exclude-noncode-lines"]
 
 gcovr = [gcovr_exe]
@@ -78,8 +75,6 @@ call(
     + extra_flags
     + ["--xml", "-o", "coverage/cov.xml"]
 )
-#  ["--html", "--html-details",
-#  "-o", os.path.join(coverage_dir, "index.html")])
 
 call(
     gcovr


### PR DESCRIPTION
Addresses and closes Issue #1211 
----------------------------------
The supposed problem was "Parallel processing of gcov data. ([#%s592](https://github.com/gcovr/gcovr/issues/592))" in gcov 5.1. This was already fixed in 5.2.

We need to add `--exclude-noncode-lines` due to a breaking change in gcovr 6.0, otherwise our coverage would change a lot (-0.33%):
New [--exclude-noncode-lines](https://gcovr.com/en/stable/manpage.html#cmdoption-gcovr-exclude-noncode-lines) to exclude noncode lines. Noncode lines are not excluded by default anymore. ([#%s704](https://github.com/gcovr/gcovr/issues/704), [#%s705](https://github.com/gcovr/gcovr/issues/705))

Closes #1211

Update the gcovr-call
----------------------
- remove use of local bundled version (files were removed some years ago)
- remove outdated exclude of folder `/Legacy/`
- remind user to update gcovr to at least `v5.0`
- assert if `v5.1` is used
- black