### PR TITLE
feat: Add GSF component momentum cut to stabilize fit

### DIFF
--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
@@ -25,7 +25,6 @@
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/detail/LoopStepperUtils.hpp"
 #include "Acts/Surfaces/Surface.hpp"
-#include "Acts/Utilities/GaussianMixtureReduction.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -449,9 +449,9 @@ struct GaussianSumFitter {
     if (options.referenceSurface) {
       const auto& params = *bwdResult->endParameters;
 
-      const auto [finalPars, finalCov] = Acts::reduceGaussianMixture(
+      const auto [finalPars, finalCov] = detail::mergeGaussianMixture(
           params.components(), params.referenceSurface(),
-          options.stateReductionMethod, [](auto& t) {
+          options.componentMergeMethod, [](auto& t) {
             return std::tie(std::get<0>(t), std::get<1>(t), *std::get<2>(t));
           });
 

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -76,6 +76,20 @@ struct GaussianSumFitter {
   /// The actor type
   using GsfActor = detail::GsfActor<bethe_heitler_approx_t, traj_t>;
 
+  /// This allows to break the propagation by setting the navigationBreak
+  /// TODO refactor once we can do this more elegantly
+  struct NavigationBreakAborter {
+    NavigationBreakAborter() = default;
+
+    template <typename propagator_state_t, typename stepper_t,
+              typename navigator_t>
+    bool operator()(propagator_state_t& state, const stepper_t& /*stepper*/,
+                    const navigator_t& navigator,
+                    const Logger& /*logger*/) const {
+      return navigator.navigationBreak(state.navigation);
+    }
+  };
+
   /// @brief The fit function for the Direct navigator
   template <typename source_link_it_t, typename start_parameters_t,
             typename track_container_t, template <typename> class holder_t>
@@ -92,7 +106,7 @@ struct GaussianSumFitter {
     // Initialize the forward propagation with the DirectNavigator
     auto fwdPropInitializer = [&sSequence, this](const auto& opts) {
       using Actors = ActionList<GsfActor, DirectNavigator::Initializer>;
-      using Aborters = AbortList<>;
+      using Aborters = AbortList<NavigationBreakAborter>;
 
       PropagatorOptions<Actors, Aborters> propOptions(opts.geoContext,
                                                       opts.magFieldContext);
@@ -147,7 +161,7 @@ struct GaussianSumFitter {
     // Initialize the forward propagation with the DirectNavigator
     auto fwdPropInitializer = [this](const auto& opts) {
       using Actors = ActionList<GsfActor>;
-      using Aborters = AbortList<EndOfWorldReached>;
+      using Aborters = AbortList<EndOfWorldReached, NavigationBreakAborter>;
 
       PropagatorOptions<Actors, Aborters> propOptions(opts.geoContext,
                                                       opts.magFieldContext);

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -384,7 +384,12 @@ struct GaussianSumFitter {
       r.measurementStates++;
       r.processedStates++;
 
-      const auto& params = *fwdGsfResult.lastMeasurementState;
+      assert(!fwdGsfResult.lastMeasurementComponents.empty());
+      assert(fwdGsfResult.lastMeasurementSurface != nullptr);
+      MultiComponentBoundTrackParameters params(
+          fwdGsfResult.lastMeasurementSurface->getSharedPtr(),
+          fwdGsfResult.lastMeasurementComponents,
+          sParameters.particleHypothesis());
 
       return m_propagator.template propagate<std::decay_t<decltype(params)>,
                                              decltype(bwdPropOptions),

--- a/Core/include/Acts/TrackFitting/GsfMixtureReduction.hpp
+++ b/Core/include/Acts/TrackFitting/GsfMixtureReduction.hpp
@@ -13,8 +13,14 @@
 
 namespace Acts {
 
+/// Greedy component reduction algorithm. Reduces the components with the
+/// minimal symmetric KL-distance (applied only to the q/p-dimension) until the
+/// required number of components is reached.
+/// @param cmpCache the component collection
+/// @param maxCmpsAfterMerge the number of components we want to reach
+/// @param surface the surface type on which the components are
 void reduceMixtureWithKLDistance(std::vector<GsfComponent> &cmpCache,
                                  std::size_t maxCmpsAfterMerge,
                                  const Surface &surface);
 
-}
+}  // namespace Acts

--- a/Core/include/Acts/TrackFitting/GsfOptions.hpp
+++ b/Core/include/Acts/TrackFitting/GsfOptions.hpp
@@ -20,6 +20,14 @@
 
 namespace Acts {
 
+/// @enum ComponentMergeMethod
+///
+/// Available reduction methods for the reduction of a Gaussian mixture
+enum class ComponentMergeMethod { eMean, eMaxWeight };
+
+/// @struct GsfComponent
+///
+/// Encapsulates a component of a Gaussian mixture as used by the GSF
 struct GsfComponent {
   ActsScalar weight = 0;
   BoundVector boundPars = BoundVector::Zero();
@@ -99,8 +107,7 @@ struct GsfOptions {
 
   std::string_view finalMultiComponentStateColumn = "";
 
-  MixtureReductionMethod stateReductionMethod =
-      MixtureReductionMethod::eMaxWeight;
+  ComponentMergeMethod componentMergeMethod = ComponentMergeMethod::eMaxWeight;
 
 #if __cplusplus < 202002L
   GsfOptions() = delete;

--- a/Core/include/Acts/TrackFitting/GsfOptions.hpp
+++ b/Core/include/Acts/TrackFitting/GsfOptions.hpp
@@ -101,6 +101,8 @@ struct GsfOptions {
 
   double weightCutoff = 1.e-4;
 
+  double momentumCutoff = 500_MeV;
+
   bool abortOnError = false;
 
   bool disableAllMaterialHandling = false;

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -20,6 +20,7 @@
 #include "Acts/TrackFitting/GsfError.hpp"
 #include "Acts/TrackFitting/GsfOptions.hpp"
 #include "Acts/TrackFitting/KalmanFitter.hpp"
+#include "Acts/TrackFitting/detail/GsfComponentMerging.hpp"
 #include "Acts/TrackFitting/detail/GsfUtils.hpp"
 #include "Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp"
 #include "Acts/Utilities/Zip.hpp"
@@ -114,7 +115,7 @@ struct GsfActor {
     bool inReversePass = false;
 
     /// How to reduce the states that are stored in the multi trajectory
-    MixtureReductionMethod reductionMethod = MixtureReductionMethod::eMaxWeight;
+    ComponentMergeMethod mergeMethod = ComponentMergeMethod::eMaxWeight;
 
     const Logger* logger{nullptr};
 
@@ -714,15 +715,15 @@ struct GsfActor {
       proxy.setReferenceSurface(surface.getSharedPtr());
       proxy.copyFrom(firstCmpProxy, mask);
 
-      auto [prtMean, prtCov] = reduceGaussianMixture(
-          tmpStates.tips, surface, m_cfg.reductionMethod,
-          PrtProjector{tmpStates.traj, tmpStates.weights});
+      auto [prtMean, prtCov] =
+          mergeGaussianMixture(tmpStates.tips, surface, m_cfg.mergeMethod,
+                               PrtProjector{tmpStates.traj, tmpStates.weights});
       proxy.predicted() = prtMean;
       proxy.predictedCovariance() = prtCov;
 
       if (isMeasurement) {
-        auto [fltMean, fltCov] = reduceGaussianMixture(
-            tmpStates.tips, surface, m_cfg.reductionMethod,
+        auto [fltMean, fltCov] = mergeGaussianMixture(
+            tmpStates.tips, surface, m_cfg.mergeMethod,
             FltProjector{tmpStates.traj, tmpStates.weights});
         proxy.filtered() = fltMean;
         proxy.filteredCovariance() = fltCov;
@@ -744,8 +745,8 @@ struct GsfActor {
               result.surfacesVisitedBwdAgain.push_back(&surface);
 
               if (trackState.hasSmoothed()) {
-                const auto [smtMean, smtCov] = reduceGaussianMixture(
-                    tmpStates.tips, surface, m_cfg.reductionMethod,
+                const auto [smtMean, smtCov] = mergeGaussianMixture(
+                    tmpStates.tips, surface, m_cfg.mergeMethod,
                     FltProjector{tmpStates.traj, tmpStates.weights});
 
                 trackState.smoothed() = smtMean;
@@ -766,7 +767,7 @@ struct GsfActor {
     m_cfg.abortOnError = options.abortOnError;
     m_cfg.disableAllMaterialHandling = options.disableAllMaterialHandling;
     m_cfg.weightCutoff = options.weightCutoff;
-    m_cfg.reductionMethod = options.stateReductionMethod;
+    m_cfg.mergeMethod = options.componentMergeMethod;
     m_cfg.calibrationContext = &options.calibrationContext.get();
   }
 };

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -317,7 +317,8 @@ struct GsfActor {
     // Break the navigation if we found all measurements
     if (m_cfg.numberMeasurements &&
         result.measurementStates == m_cfg.numberMeasurements) {
-      navigator.targetReached(state.navigation, true);
+      ACTS_VERBOSE("Stop navigation because all measurements are found");
+      navigator.navigationBreak(state.navigation, true);
     }
   }
 

--- a/Core/include/Acts/TrackFitting/detail/GsfComponentMerging.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfComponentMerging.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/TrackFitting/GsfOptions.hpp"
 #include "Acts/Utilities/Identity.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
@@ -18,8 +19,7 @@
 #include <optional>
 #include <tuple>
 
-namespace Acts {
-namespace detail {
+namespace Acts::detail {
 
 /// Angle descriptions for the combineBoundGaussianMixture function
 template <BoundIndices Idx>
@@ -203,13 +203,6 @@ auto gaussianMixtureMeanCov(const components_t components,
   return RetType{mean, cov};
 }
 
-}  // namespace detail
-
-/// @enum MixtureReductionMethod
-///
-/// Available reduction methods for the reduction of a Gaussian mixture
-enum class MixtureReductionMethod { eMean, eMaxWeight };
-
 /// Reduce Gaussian mixture
 ///
 /// @param mixture The mixture iterable
@@ -220,16 +213,16 @@ enum class MixtureReductionMethod { eMean, eMaxWeight };
 ///
 /// @return parameters and covariance as std::tuple< BoundVector, BoundMatrix >
 template <typename mixture_t, typename projector_t = Acts::Identity>
-auto reduceGaussianMixture(const mixture_t &mixture, const Surface &surface,
-                           MixtureReductionMethod method,
-                           projector_t &&projector = projector_t{}) {
+auto mergeGaussianMixture(const mixture_t &mixture, const Surface &surface,
+                          ComponentMergeMethod method,
+                          projector_t &&projector = projector_t{}) {
   using R = std::tuple<Acts::BoundVector, Acts::BoundSquareMatrix>;
   const auto [mean, cov] =
       detail::angleDescriptionSwitch(surface, [&](const auto &desc) {
         return detail::gaussianMixtureMeanCov(mixture, projector, desc);
       });
 
-  if (method == MixtureReductionMethod::eMean) {
+  if (method == ComponentMergeMethod::eMean) {
     return R{mean, cov};
   } else {
     const auto maxWeightIt = std::max_element(
@@ -242,4 +235,4 @@ auto reduceGaussianMixture(const mixture_t &mixture, const Surface &surface,
   }
 }
 
-}  // namespace Acts
+}  // namespace Acts::detail

--- a/Core/include/Acts/TrackFitting/detail/SymmetricKlDistanceMatrix.hpp
+++ b/Core/include/Acts/TrackFitting/detail/SymmetricKlDistanceMatrix.hpp
@@ -11,8 +11,8 @@
 #include "Acts/EventData/MultiComponentTrackParameters.hpp"
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/TrackFitting/detail/GsfComponentMerging.hpp"
 #include "Acts/TrackFitting/detail/GsfUtils.hpp"
-#include "Acts/Utilities/GaussianMixtureReduction.hpp"
 
 namespace Acts::detail {
 

--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFitterFunction.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFitterFunction.hpp
@@ -16,9 +16,9 @@
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
-#include "Acts/Propagator/MultiEigenStepperLoop.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/TrackFitting/BetheHeitlerApprox.hpp"
+#include "Acts/TrackFitting/GsfOptions.hpp"
 #include "Acts/Utilities/CalibrationContext.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/MeasurementCalibration.hpp"
@@ -74,22 +74,27 @@ std::shared_ptr<TrackFitterFunction> makeKalmanFitterFunction(
 /// approximation
 using BetheHeitlerApprox = Acts::AtlasBetheHeitlerApprox<6, 5>;
 
+/// Available algorithms for the mixture reduction
+enum class MixtureReductionAlgorithm { KLDistance };
+
 /// Makes a fitter function object for the GSF
 ///
 /// @param trackingGeometry the trackingGeometry for the propagator
 /// @param magneticField the magnetic field for the propagator
 /// @param betheHeitlerApprox The object that encapsulates the approximation.
 /// @param maxComponents number of maximum components in the track state
-/// @param abortOnError whether to call std::abort on an error
-/// @param disableAllMaterialHandling run the GSF like a KF (no energy loss,
-/// always 1 component, ...)
+/// @param weightCutoff when to drop components
+/// @param componentMergeMethod How to merge a mixture to a single set of
+/// parameters and covariance
+/// @param mixtureReductionAlgorithm How to reduce the number of components
+/// in a mixture
 /// @param logger a logger instance
 std::shared_ptr<TrackFitterFunction> makeGsfFitterFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
-    BetheHeitlerApprox betheHeitlerApprox, size_t maxComponents,
-    double weightCutoff, Acts::MixtureReductionMethod finalReductionMethod,
-    bool abortOnError, bool disableAllMaterialHandling,
+    BetheHeitlerApprox betheHeitlerApprox, std::size_t maxComponents,
+    double weightCutoff, Acts::ComponentMergeMethod componentMergeMethod,
+    MixtureReductionAlgorithm mixtureReductionAlgorithm,
     const Acts::Logger& logger);
 
 /// Makes a fitter function object for the Global Chi Square Fitter (GX2F)

--- a/Examples/Algorithms/TrackFitting/src/GsfFitterFunction.cpp
+++ b/Examples/Algorithms/TrackFitting/src/GsfFitterFunction.cpp
@@ -54,6 +54,7 @@ class TrackingGeometry;
 }  // namespace Acts
 
 using namespace ActsExamples;
+using namespace Acts::UnitLiterals;
 
 namespace {
 
@@ -101,6 +102,7 @@ struct GsfFitterFunctionImpl final : public ActsExamples::TrackFitterFunction {
         &Acts::GainMatrixUpdater::operator()<Acts::VectorMultiTrajectory>>(
         &updater);
 
+    const double momentumCutoff = 500_MeV;
     Acts::GsfOptions<Acts::VectorMultiTrajectory> gsfOptions{
         options.geoContext,
         options.magFieldContext,
@@ -110,6 +112,7 @@ struct GsfFitterFunctionImpl final : public ActsExamples::TrackFitterFunction {
         &(*options.referenceSurface),
         maxComponents,
         weightCutoff,
+        momentumCutoff,
         abortOnError,
         disableAllMaterialHandling};
     gsfOptions.componentMergeMethod = mergeMethod;

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -981,9 +981,8 @@ def addTruthTrackingGsf(
     gsfOptions = {
         "betheHeitlerApprox": acts.examples.AtlasBetheHeitlerApprox.makeDefault(),
         "maxComponents": 12,
-        "abortOnError": False,
-        "disableAllMaterialHandling": False,
-        "finalReductionMethod": acts.examples.FinalReductionMethod.maxWeight,
+        "componentMergeMethod": acts.examples.ComponentMergeMethod.maxWeight,
+        "mixtureReductionAlgorithm": acts.examples.MixtureReductionAlgorithm.KLDistance,
         "weightCutoff": 1.0e-4,
         "level": customLogLevel(),
     }

--- a/Examples/Python/src/TrackFitting.cpp
+++ b/Examples/Python/src/TrackFitting.cpp
@@ -10,7 +10,7 @@
 #include "Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp"
 #include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/TrackFitting/BetheHeitlerApprox.hpp"
-#include "Acts/Utilities/GaussianMixtureReduction.hpp"
+#include "Acts/TrackFitting/GsfOptions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/MeasurementCalibration.hpp"
@@ -97,9 +97,13 @@ void addTrackFitting(Context& ctx) {
         },
         py::arg("path"));
 
-    py::enum_<Acts::MixtureReductionMethod>(mex, "FinalReductionMethod")
-        .value("mean", Acts::MixtureReductionMethod::eMean)
-        .value("maxWeight", Acts::MixtureReductionMethod::eMaxWeight);
+    py::enum_<Acts::ComponentMergeMethod>(mex, "ComponentMergeMethod")
+        .value("mean", Acts::ComponentMergeMethod::eMean)
+        .value("maxWeight", Acts::ComponentMergeMethod::eMaxWeight);
+
+    py::enum_<ActsExamples::MixtureReductionAlgorithm>(
+        mex, "MixtureReductionAlgorithm")
+        .value("KLDistance", MixtureReductionAlgorithm::KLDistance);
 
     py::class_<ActsExamples::BetheHeitlerApprox>(mex, "AtlasBetheHeitlerApprox")
         .def_static("loadFromFiles",
@@ -107,26 +111,24 @@ void addTrackFitting(Context& ctx) {
                     py::arg("lowParametersPath"), py::arg("lowParametersPath"))
         .def_static("makeDefault",
                     []() { return Acts::makeDefaultBetheHeitlerApprox(); });
-
     mex.def(
         "makeGsfFitterFunction",
         [](std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
            std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
-           BetheHeitlerApprox betheHeitlerApprox, size_t maxComponents,
-           double weightCutoff,
-           Acts::MixtureReductionMethod finalReductionMethod, bool abortOnError,
-           bool disableAllMaterialHandling, Logging::Level level) {
+           BetheHeitlerApprox betheHeitlerApprox, std::size_t maxComponents,
+           double weightCutoff, Acts::ComponentMergeMethod componentMergeMethod,
+           ActsExamples::MixtureReductionAlgorithm mixtureReductionAlgorithm,
+           Logging::Level level) {
           return ActsExamples::makeGsfFitterFunction(
               trackingGeometry, magneticField, betheHeitlerApprox,
-              maxComponents, weightCutoff, finalReductionMethod, abortOnError,
-              disableAllMaterialHandling,
+              maxComponents, weightCutoff, componentMergeMethod,
+              mixtureReductionAlgorithm,
               *Acts::getDefaultLogger("GSFFunc", level));
         },
         py::arg("trackingGeometry"), py::arg("magneticField"),
         py::arg("betheHeitlerApprox"), py::arg("maxComponents"),
-        py::arg("weightCutoff"), py::arg("finalReductionMethod"),
-        py::arg("abortOnError"), py::arg("disableAllMaterialHandling"),
-        py::arg("level"));
+        py::arg("weightCutoff"), py::arg("componentMergeMethod"),
+        py::arg("mixtureReductionAlgorithm"), py::arg("level"));
 
     mex.def(
         "makeGlobalChiSquareFitterFunction",

--- a/Tests/UnitTests/Core/TrackFitting/GsfComponentMergingTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfComponentMergingTests.cpp
@@ -21,7 +21,7 @@
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
-#include "Acts/Utilities/GaussianMixtureReduction.hpp"
+#include "Acts/TrackFitting/detail/GsfComponentMerging.hpp"
 #include "Acts/Utilities/Identity.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"

--- a/docs/core/reconstruction/track_fitting.md
+++ b/docs/core/reconstruction/track_fitting.md
@@ -67,12 +67,6 @@ Simplified overview of the GSF algorithm.
 ### The Multi-Stepper
 To implement the GSF, a special stepper is needed, that can handle a multi-component state internally: The {class}`Acts::MultiEigenStepperLoop`, which is based on the {class}`Acts::EigenStepper` and thus shares a lot of code with it. It interfaces to the navigation as one aggregate state to limit the navigation overhead, but internally processes a multi-component state. How this aggregation is performed can be configured via a template parameter, by default weighted average is used ({struct}`Acts::WeightedComponentReducerLoop`).
 
-At the end of the fit the multi-component state must be reduced to a single set of parameters with a corresponding covariance matrix. This is supported by the {class}`Acts::MultiEigenStepperLoop` in two different ways currently: The *mean* method computes the mean and the covariance matrix of the multi-component state, whereas the *maximum weight* method just returns the component with the maximum weight. This can be configured in the constructor of the {class}`Acts::MultiEigenStepperLoop` with the {enum}`Acts::MixtureReductionMethod`. In the future there is planned to add a *mode* finding method as well.
-
-:::{note}
-In practice it turned out that the *maximum weight* method leads to better results so far.
-:::
-
 Even though the multi-stepper interface exposes only one aggregate state and thus is compatible with most standard tools, there is a special aborter is required to stop the navigation when the surface is reached, the {struct}`Acts::MultiStepperSurfaceReached`. It checks if all components have reached the target surface already and updates their state accordingly. Optionally, it also can stop the propagation when the aggregate state reaches the surface.
 
 
@@ -87,9 +81,24 @@ outline:
 ---
 ```
 
-The fit can be customized with several options, e.g., the maximum number of components. All options can be found in the {struct}`Acts::GsfOptions`.
+The fit can be customized with several options. Important ones are:
+* *maximum components*: How many components at maximum should be kept.
+* *weight cut*: When to drop components.
+* *component merging*: How a multi-component state is reduced to a single set of parameters and covariance. The method can be chosen with the enum {enum}`Acts::ComponentMergeMethod`. Two methods are supported currently:
+    * The *mean* computes the mean and the covariance of the mean.
+    * *max weight* takes the parameters of component with the maximum weight and computes the variance around these. This is a cheap approximation of the mode, which is not implemented currently.
 
-To simplify integration, the GSF returns an {struct}`Acts::KalmanFitterResult` object, the same as the {class}`Acts::KalmanFitter`. This allows to use the same analysis tools for both fitters.
+:::{note}
+A good starting configuration is to use 12 components, the *max weight* merging and the *KL distance* reduction.
+:::
+
+All options can be found in the {struct}`Acts::GsfOptions`:
+
+```{doxygenstruct} Acts::GsfOptions
+---
+outline:
+---
+```
 
 If the GSF finds the column with the string identifier *"gsf-final-multi-component-state"* (defined in `Acts::GsfConstants::kFinalMultiComponentStateColumn`) in the track container, it adds the final multi-component state to the track as a `std::optional<Acts::MultiComponentBoundTrackParameters<SinglyCharged>>` object.
 

--- a/docs/core/reconstruction/track_fitting.md
+++ b/docs/core/reconstruction/track_fitting.md
@@ -83,7 +83,8 @@ outline:
 
 The fit can be customized with several options. Important ones are:
 * *maximum components*: How many components at maximum should be kept.
-* *weight cut*: When to drop components.
+* *weight cut*: When to drop components because of too little weight.
+* *momentum cut*: When to drop components because of too low momentum. This can help stabilizing the fit, as low momenta tend to disturb the navigation.
 * *component merging*: How a multi-component state is reduced to a single set of parameters and covariance. The method can be chosen with the enum {enum}`Acts::ComponentMergeMethod`. Two methods are supported currently:
     * The *mean* computes the mean and the covariance of the mean.
     * *max weight* takes the parameters of component with the maximum weight and computes the variance around these. This is a cheap approximation of the mode, which is not implemented currently.


### PR DESCRIPTION
Adds an optional momentum cut, which drops low weight component. This can stabilize the fit and the navigation.

Should go in after #2658 