### PR TITLE
refactor: No error in GSF if start pars are out of bounds

### DIFF
--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -230,9 +230,9 @@ struct GaussianSumFitter {
             .status();
 
     if (intersectionStatusStartSurface != Intersection3D::Status::onSurface) {
-      ACTS_ERROR(
-          "Surface intersection of start parameters with bound-check failed");
-      return GsfError::StartParametersNotOnStartSurface;
+      ACTS_DEBUG(
+          "Surface intersection of start parameters WITH bound-check failed");
+      // return GsfError::StartParametersNotOnStartSurface;
     }
 
     // To be able to find measurements later, we put them into a map

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -232,7 +232,6 @@ struct GaussianSumFitter {
     if (intersectionStatusStartSurface != Intersection3D::Status::onSurface) {
       ACTS_DEBUG(
           "Surface intersection of start parameters WITH bound-check failed");
-      // return GsfError::StartParametersNotOnStartSurface;
     }
 
     // To be able to find measurements later, we put them into a map

--- a/Core/include/Acts/TrackFitting/GsfError.hpp
+++ b/Core/include/Acts/TrackFitting/GsfError.hpp
@@ -14,7 +14,6 @@
 namespace Acts {
 
 enum class GsfError {
-  StartParametersNotOnStartSurface = 1,
   StartParametersHaveNoCovariance,
   NoMeasurementStatesCreatedForward,
   NoMeasurementStatesCreatedBackward,

--- a/Core/src/TrackFitting/GsfError.cpp
+++ b/Core/src/TrackFitting/GsfError.cpp
@@ -24,8 +24,6 @@ class GsfErrorCategory : public std::error_category {
     switch (static_cast<GsfError>(c)) {
       case GsfError::StartParametersHaveNoCovariance:
         return "Start parameters have no Covariance";
-      case GsfError::StartParametersNotOnStartSurface:
-        return "Start parameters don't lie in the start surface";
       case GsfError::NoMeasurementStatesCreatedForward:
         return "No measurement states found in the forward pass";
       case GsfError::NoMeasurementStatesCreatedBackward:


### PR DESCRIPTION
I'm actually not sure why I introduced this error type. Presumably, this happens when the smeared digitization smeares hits out-of-bounds...
Maybe we should prevent this in the future, but it should not fail in the GSF.