### PR TITLE
refactor: Disable FPE mask printing if FPEMON  is disabled by envvar

### DIFF
--- a/Examples/Python/python/acts/examples/__init__.py
+++ b/Examples/Python/python/acts/examples/__init__.py
@@ -527,7 +527,7 @@ class Sequencer(ActsPythonBindings._examples._Sequencer):
 
     @classmethod
     def _printFpeSummary(cls, masks: List[FpeMask]):
-        if len(masks) == 0:
+        if len(masks) == 0 or "ACTS_SEQUENCER_DISABLE_FPEMON" in os.environ:
             return
 
         # Try to make a nice summary with rich, or fallback to a plain text one


### PR DESCRIPTION
The summary of the FPE masks is quite verbose, and if the environment variable `ACTS_SEQUENCER_DISABLE_FPEMON` is set, one is probably not interested in this output.