### PR TITLE
docs: Doc fix for Gx2FitterOptions and 1 link

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -104,6 +104,7 @@ struct Gx2FitterOptions {
   /// @param freeToBoundCorrection_ Correction for non-linearity effect during transform from free to bound
   /// @param nUpdateMax_ Max number of iterations for updating the parameters
   /// @param zeroField_ Disables the QoP fit in case of missing B-field
+  /// @param relChi2changeCutOff_ Check for convergence (abort condition)
   Gx2FitterOptions(const GeometryContext& gctx,
                    const MagneticFieldContext& mctx,
                    std::reference_wrapper<const CalibrationContext> cctx,

--- a/docs/contribution/profiling.md
+++ b/docs/contribution/profiling.md
@@ -5,7 +5,7 @@ gperftools is a software profiling package. It contains a CPU profiler, thread-c
 
 ## Install gperftools
 
-It is strongly recommended to install [libunwind](http://download.savannah.gnu.org/releases/libunwind/libunwind-0.99-beta.tar.gz) before trying to configure or install gperftools.
+It is strongly recommended to install [libunwind](https://github.com/libunwind/libunwind) before trying to configure or install gperftools.
 
 ### Ubuntu
 


### PR DESCRIPTION
Fixes one undocumented parameter in the GX2F and a broken link.