### PR TITLE
feat: improve DD4hep based detector building and add tests

### DIFF
--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -26,6 +26,7 @@ if (
     else:
         warnings.warn(error + "\nThe compile-time threshold will be used in this case!")
 
+
 def Propagator(stepper, navigator):
     for prefix in ("Eigen", "Atlas", "StraightLine"):
         _stepper = getattr(ActsPythonBindings, f"{prefix}Stepper")

--- a/Examples/Python/python/acts/__init__.py
+++ b/Examples/Python/python/acts/__init__.py
@@ -26,7 +26,6 @@ if (
     else:
         warnings.warn(error + "\nThe compile-time threshold will be used in this case!")
 
-
 def Propagator(stepper, navigator):
     for prefix in ("Eigen", "Atlas", "StraightLine"):
         _stepper = getattr(ActsPythonBindings, f"{prefix}Stepper")

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
@@ -14,6 +14,7 @@
 #include "Acts/Utilities/BinningData.hpp"
 #include "Acts/Utilities/detail/AxisFwd.hpp"
 
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -52,6 +53,26 @@ inline BinningValue stringToBinningValue(const std::string &binningString) {
   }
 }
 
+/// Helper method to cenvert a binning list string to a vector of binning values
+/// e.g. "r,z" -> {binR, binZ}
+///
+/// @param binningString
+///
+/// @return a vector of binninng values
+inline std::vector<BinningValue> stringToBinningValues(
+    const std::string &binningString, const char &del = ',') {
+  if (binningString.empty()) {
+    return {};
+  }
+  std::vector<BinningValue> bBinning;
+  std::stringstream s(binningString);
+  std::string b = "";
+  while (getline(s, b, del)) {
+    bBinning.push_back(stringToBinningValue(b));
+  }
+  return bBinning;
+}
+
 /// Helper method to decode the binning from what would appear in the
 /// xml into variant parameters, such that it can be understood in the
 /// downstream processing.
@@ -64,10 +85,10 @@ inline BinningValue stringToBinningValue(const std::string &binningString) {
 /// Example for e.g. bname = \"surface_binning\":
 ///
 /// - Equidistant binning in r and phi:
-///   \< surface_binning nr=\"2\" rmin=\"25\" rmax=\"100\" nphi=\"22\"
+///   \<acts_surface_binning nr=\"2\" rmin=\"25\" rmax=\"100\" nphi=\"22\"
 ///   phimin=\"-3.1415\" phimax=\"3.1415\" \/ \>
 /// - Variable binning in z:
-///   \< surface_binning zboundaries=\"-100,-90,90,100\" \/ \>
+///   \<acts_surface_binning zboundaries=\"-100,-90,90,100\" \/ \>
 ///
 /// And 2D combinations of this are allowed.
 ///
@@ -88,6 +109,10 @@ inline void decodeBinning(dd4hep::rec::VariantParameters &variantParams,
     // Gather the bin expansion parameter, expansion of 0 is default
     int nExpansion =
         Acts::getAttrValueOr<int>(xmlBinning, std::string(bv + "expansion"), 0);
+    // Auto-range detection
+    bool autoRange =
+        Acts::getAttrValueOr<int>(xmlBinning, std::string(bv + "autorange"), 0);
+    variantParams.set<bool>(bname + "_" + bv + "_autorange", autoRange);
     variantParams.set<int>(bname + "_" + bv + "_exp", nExpansion);
     // Equidistant binning detected
     if (nBins > 0) {
@@ -96,12 +121,14 @@ inline void decodeBinning(dd4hep::rec::VariantParameters &variantParams,
       // Set the number of bins
       variantParams.set<int>(bname + "_" + bv + "_n", nBins);
       // Set min/max paraeter
-      variantParams.set<double>(
-          bname + "_" + bv + "_min",
-          xmlBinning.attr<double>(std::string(bv + "min").c_str()));
-      variantParams.set<double>(
-          bname + "_" + bv + "_max",
-          xmlBinning.attr<double>(std::string(bv + "max").c_str()));
+      if (!autoRange) {
+        variantParams.set<double>(
+            bname + "_" + bv + "_min",
+            xmlBinning.attr<double>(std::string(bv + "min").c_str()));
+        variantParams.set<double>(
+            bname + "_" + bv + "_max",
+            xmlBinning.attr<double>(std::string(bv + "max").c_str()));
+      }
     } else {
       // Variable binning detected
       variantParams.set<std::string>(bname + "_" + bv + "_type", "variable");

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
@@ -110,8 +110,8 @@ inline void decodeBinning(dd4hep::rec::VariantParameters &variantParams,
     int nExpansion =
         Acts::getAttrValueOr<int>(xmlBinning, std::string(bv + "expansion"), 0);
     // Auto-range detection
-    bool autoRange =
-        Acts::getAttrValueOr<int>(xmlBinning, std::string(bv + "autorange"), 0);
+    bool autoRange = Acts::getAttrValueOr<bool>(
+        xmlBinning, std::string(bv + "autorange"), false);
     variantParams.set<bool>(bname + "_" + bv + "_autorange", autoRange);
     variantParams.set<int>(bname + "_" + bv + "_exp", nExpansion);
     // Equidistant binning detected

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBlueprint.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBlueprint.hpp
@@ -13,12 +13,15 @@
 #include "Acts/Detector/interface/IGeometryIdGenerator.hpp"
 #include "Acts/Detector/interface/IInternalStructureBuilder.hpp"
 #include "Acts/Detector/interface/IRootVolumeFinderBuilder.hpp"
+#include "Acts/Geometry/Extent.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <vector>
 
@@ -52,11 +55,13 @@ class DD4hepBlueprint {
   /// @brief Create a blueprint from a DD4hep detector element
   ///
   /// @param cache the cache object for the detector store
+  /// @param gctx the geometry context
   /// @param dd4hepElement the dd4hep detector element tree
   ///
   /// @return a new blueprint top node
   std::unique_ptr<Blueprint::Node> create(
-      Cache& cache, const dd4hep::DetElement& dd4hepElement) const;
+      Cache& cache, const GeometryContext& gctx,
+      const dd4hep::DetElement& dd4hepElement) const;
 
  private:
   /// @brief auto-calculate the unit length conversion
@@ -76,22 +81,28 @@ class DD4hepBlueprint {
   ///
   /// @param cache the cache object
   /// @param mother the mother node
+  /// @param gctx the geometry context
   /// @param dd4hepElement the detector element at current level
   /// @param hiearchyLevel the current hierarchy level
   void recursiveParse(Cache& cache, Blueprint::Node& mother,
+                      const GeometryContext& gctx,
                       const dd4hep::DetElement& dd4hepElement,
                       unsigned int hiearchyLevel = 0) const;
 
   /// @brief Extract the bounds type, values and binning from a DD4hep element
   ///
+  /// @param gctx the geometry context
   /// @param dd4hepElement the DD4hep element
   /// @param baseName the base name of the acts type, e.g. "acts_volume", "acts_container", ...
+  /// @param extOpt the optional extent as output from the internal parsing
   ///
   /// @return a tuple of the bounds type, values and binning, auxiliary data
   std::tuple<Transform3, VolumeBounds::BoundsType, std::vector<ActsScalar>,
              std::vector<BinningValue>, std::string>
-  extractExternals(const dd4hep::DetElement& dd4hepElement,
-                   const std::string& baseName) const;
+  extractExternals([[maybe_unused]] const GeometryContext& gctx,
+                   const dd4hep::DetElement& dd4hepElement,
+                   const std::string& baseName,
+                   const std::optional<Extent>& extOpt = std::nullopt) const;
 
   /// @brief Extract the internals from a DD4hep element
   ///
@@ -101,6 +112,7 @@ class DD4hepBlueprint {
   /// If any of the elements is not found, a nullptr is returned.
   ///
   /// @param dd4hepStore the store for the created dd4hep detector elements
+  /// @param gctx the geometry context
   /// @param dd4hepElement the DD4hep element
   /// @param baseName the base name of the acts type, e.g. "acts_volume", "acts_container", ...
   ///
@@ -110,8 +122,9 @@ class DD4hepBlueprint {
   std::tuple<std::shared_ptr<const IInternalStructureBuilder>,
              std::shared_ptr<const IRootVolumeFinderBuilder>,
              std::shared_ptr<const IGeometryIdGenerator>,
-             std::array<std::string, 3u>>
+             std::array<std::string, 3u>, std::optional<Extent>>
   extractInternals(DD4hepDetectorElement::Store& dd4hepStore,
+                   const GeometryContext& gctx,
                    const dd4hep::DetElement& dd4hepElement,
                    const std::string& baseName) const;
 };

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
@@ -72,7 +72,7 @@ class DD4hepDetectorSurfaceFactory {
     /// Optionally provide an Extent constraints to measure the layers
     std::vector<BinningValue> extentContraints = {};
     /// The approximination for extent measuring
-    size_t nExtentSegments = 1u;
+    std::size_t nExtentSegments = 1u;
   };
 
   /// Nested options struct to steer the conversion
@@ -139,7 +139,7 @@ class DD4hepDetectorSurfaceFactory {
   /// @param dd4hepElement the detector element
   /// @param options to steer the conversion
   ///
-  /// @note the cache is handed through in order to opionally measure the
+  /// @note the cache is handed through in order to optionally measure the
   /// extent of the sensitive surface and register it
   ///
   /// @return a created detector element and surface
@@ -166,7 +166,7 @@ class DD4hepDetectorSurfaceFactory {
   /// @param thickness the thickness of the condensed component
   /// @param options to steer the conversion
   ///
-  /// @note the cache is handed through in order to opionally measure the
+  /// @note the cache is handed through in order to optionally measure the
   /// extent of the sensitive surface and register it
   ///
   /// @note void function that also checks the options if the attachment should be applied

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
@@ -8,12 +8,16 @@
 
 #pragma once
 
+#include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
+
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Common.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Detector/LayerStructureBuilder.hpp"
 #include "Acts/Detector/ProtoBinning.hpp"
+#include "Acts/Geometry/Extent.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/BinningData.hpp"
 
 #include <tuple>
 #include <vector>
@@ -61,6 +65,14 @@ class DD4hepDetectorSurfaceFactory {
     std::vector<Experimental::ProtoBinning> binnings = {};
     /// The collected supports
     std::vector<Experimental::ProtoSupport> supports = {};
+    /// Optionally provide an Extent object to measure the sensitives
+    std::optional<Extent> sExtent = std::nullopt;
+    /// Optionally provide an Extent object to measure the passive
+    std::optional<Extent> pExtent = std::nullopt;
+    /// Optionally provide an Extent constraints to measure the layers
+    std::vector<BinningValue> extentContraints = {};
+    /// The approximination for extent measuring
+    size_t nExtentSegments = 1u;
   };
 
   /// Nested options struct to steer the conversion
@@ -87,11 +99,13 @@ class DD4hepDetectorSurfaceFactory {
   /// Construction method of the detector elements
   ///
   /// @param cache [in,out] into which the Elements are filled
+  /// @param gctx the geometry context
   /// @param dd4hepElement the detector element representing the super structure
   /// @param options to steer the conversion
   ///
   /// @note this method will call the recursive construction
-  void construct(Cache& cache, const dd4hep::DetElement& dd4hepElement,
+  void construct(Cache& cache, const GeometryContext& gctx,
+                 const dd4hep::DetElement& dd4hepElement,
                  const Options& options);
 
  private:
@@ -108,30 +122,41 @@ class DD4hepDetectorSurfaceFactory {
   /// Construction method of the detector elements - recursive walk down
   ///
   /// @param cache [in,out] into which the Elements are filled
+  /// @param gctx the geometry context
   /// @param dd4hepElement the detector element representing the super structure
   /// @param options to steer the conversion
   /// @param level the current level of the tree, used for log message output
   ///
   /// @note this method is called recursively
-  void recursiveConstruct(Cache& cache, const dd4hep::DetElement& dd4hepElement,
+  void recursiveConstruct(Cache& cache, const GeometryContext& gctx,
+                          const dd4hep::DetElement& dd4hepElement,
                           const Options& options, int level);
 
   /// Method to convert a single sensitive detector element
   ///
+  /// @param cache [in,out] into which the Elements are filled
+  /// @param gctx the geometry context
   /// @param dd4hepElement the detector element
   /// @param options to steer the conversion
   ///
+  /// @note the cache is handed through in order to opionally measure the
+  /// extent of the sensitive surface and register it
+  ///
   /// @return a created detector element and surface
   DD4hepSensitiveSurface constructSensitiveComponents(
+      Cache& cache, const GeometryContext& gctx,
       const dd4hep::DetElement& dd4hepElement, const Options& options) const;
 
   /// Method to convert a single sensitive detector element
   ///
+  /// @param cache [in,out] into which the Elements are filled
+  /// @param gctx the geometry context
   /// @param dd4hepElement the detector element
   /// @param options to steer the conversion
   ///
   /// @return a created surface
   DD4hepPassiveSurface constructPassiveComponents(
+      Cache& cache, const GeometryContext& gctx,
       const dd4hep::DetElement& dd4hepElement, const Options& options) const;
 
   /// Attach surface material if present
@@ -140,6 +165,9 @@ class DD4hepDetectorSurfaceFactory {
   /// @param surface the surface to attach the material to
   /// @param thickness the thickness of the condensed component
   /// @param options to steer the conversion
+  ///
+  /// @note the cache is handed through in order to opionally measure the
+  /// extent of the sensitive surface and register it
   ///
   /// @note void function that also checks the options if the attachment should be applied
   void attachSurfaceMaterial(const dd4hep::DetElement& dd4hepElement,

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp
@@ -11,12 +11,16 @@
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Detector/LayerStructureBuilder.hpp"
 #include "Acts/Detector/ProtoBinning.hpp"
+#include "Acts/Geometry/Extent.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp"
+#include "Acts/Utilities/BinningData.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
+#include <optional>
 #include <string>
+#include <tuple>
 
 namespace dd4hep {
 class DetElement;
@@ -59,8 +63,14 @@ class DD4hepLayerStructure {
     std::string name = "";
     /// An out put log level
     Logging::Level logLevel = Logging::INFO;
+    // The extent structure - optionally
+    std::optional<Extent> extent = std::nullopt;
+    /// The extent constraints - optionally
+    std::vector<BinningValue> extentContraints = {};
     /// Approximation for the polyhedron binning nSegments
     unsigned int nSegments = 1u;
+    /// Patch the binning with the extent if possible
+    bool patchBinningWithExtent = true;
     /// Conversion options
     DD4hepDetectorSurfaceFactory::Options conversionOptions;
   };
@@ -72,13 +82,15 @@ class DD4hepLayerStructure {
   /// It takes the detector element from DD4hep and some optional parameters
   ///
   /// @param dd4hepStore [in, out] the detector store for the built elements
+  /// @param gcxt the geometry context
   /// @param dd4hepElement the dd4hep detector element
   /// @param options containing the optional descriptions
   ///
-  /// @return a LayerStructureBuilder
-  std::shared_ptr<LayerStructureBuilder> builder(
-      DD4hepDetectorElement::Store& dd4hepStore,
-      const dd4hep::DetElement& dd4hepElement, const Options& options) const;
+  /// @return a LayerStructureBuilder, and an optional extent
+  std::tuple<std::shared_ptr<LayerStructureBuilder>, std::optional<Extent>>
+  builder(DD4hepDetectorElement::Store& dd4hepStore,
+          const GeometryContext& gctx, const dd4hep::DetElement& dd4hepElement,
+          const Options& options) const;
 
  private:
   /// The workorse: the surface factory

--- a/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
+++ b/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<const TrackingGeometry> convertDD4hepDetector(
     auto volBuilder = volumeBuilder_dd4hep(
         subDetector, logger, bTypePhi, bTypeR, bTypeZ, layerEnvelopeR,
         layerEnvelopeZ, defaultLayerThickness);
-    if (volBuilder) {
+    if (volBuilder != nullptr) {
       // distinguish beam pipe
       if (volBuilder->getConfiguration().buildToRadiusZero) {
         // check if beam pipe is already present
@@ -122,7 +122,7 @@ std::unique_ptr<const TrackingGeometry> convertDD4hepDetector(
     }
   }
   // Finally add the beam pipe
-  if (beamPipeVolumeBuilder) {
+  if (beamPipeVolumeBuilder != nullptr) {
     volumeBuilders.push_back(beamPipeVolumeBuilder);
   }
 

--- a/Plugins/DD4hep/src/DD4hepDetectorStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepDetectorStructure.cpp
@@ -49,7 +49,8 @@ Acts::Experimental::DD4hepDetectorStructure::construct(
 
   DD4hepBlueprint dd4hepBlueprintDrawer(
       bpdCfg, getDefaultLogger("DD4hepBlueprint", options.logLevel));
-  auto dd4hepBlueprint = dd4hepBlueprintDrawer.create(bpdCache, dd4hepElement);
+  auto dd4hepBlueprint =
+      dd4hepBlueprintDrawer.create(bpdCache, gctx, dd4hepElement);
   detectorStore = bpdCache.dd4hepStore;
 
   // Draw the raw graph
@@ -85,7 +86,9 @@ Acts::Experimental::DD4hepDetectorStructure::construct(
     dCfg.name = "Cylindrical detector from DD4hep blueprint";
     dCfg.builder = detectorBuilder;
     dCfg.geoIdGenerator = dd4hepBlueprint->geoIdGenerator;
-    detector = DetectorBuilder(dCfg).construct(gctx);
+    detector = DetectorBuilder(dCfg, getDefaultLogger("DD4hepDetectorBuilder",
+                                                      options.logLevel))
+                   .construct(gctx);
   } else {
     throw std::invalid_argument(
         "DD4hepDetectorStructure: Only cylindrical detectors are (currently) "

--- a/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
@@ -8,6 +8,8 @@
 
 #include "Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp"
 
+#include "Acts/Utilities/BinningType.hpp"
+
 Acts::Experimental::DD4hepLayerStructure::DD4hepLayerStructure(
     std::shared_ptr<DD4hepDetectorSurfaceFactory> surfaceFactory,
     std::unique_ptr<const Logger> logger)
@@ -18,9 +20,10 @@ Acts::Experimental::DD4hepLayerStructure::DD4hepLayerStructure(
   }
 }
 
-std::shared_ptr<Acts::Experimental::LayerStructureBuilder>
+std::tuple<std::shared_ptr<Acts::Experimental::LayerStructureBuilder>,
+           std::optional<Acts::Extent>>
 Acts::Experimental::DD4hepLayerStructure::builder(
-    DD4hepDetectorElement::Store& dd4hepStore,
+    DD4hepDetectorElement::Store& dd4hepStore, const GeometryContext& gctx,
     const dd4hep::DetElement& dd4hepElement, const Options& options) const {
   // Check for misconfiguration with double naming
   if (dd4hepStore.find(options.name) != dd4hepStore.end()) {
@@ -32,7 +35,12 @@ Acts::Experimental::DD4hepLayerStructure::builder(
 
   // This object is going to be filled with the created surfaces
   DD4hepDetectorSurfaceFactory::Cache fCache;
-  m_surfaceFactory->construct(fCache, dd4hepElement, options.conversionOptions);
+  fCache.sExtent = options.extent;
+  fCache.pExtent = options.extent;
+  fCache.extentContraints = options.extentContraints;
+  fCache.nExtentSegments = options.nSegments;
+  m_surfaceFactory->construct(fCache, gctx, dd4hepElement,
+                              options.conversionOptions);
 
   ACTS_DEBUG("Conversion from DD4Hep : " << fCache.sensitiveSurfaces.size()
                                          << " sensitive surfaces");
@@ -50,8 +58,28 @@ Acts::Experimental::DD4hepLayerStructure::builder(
 
   // Surfaces are prepared for creating the builder
   LayerStructureBuilder::Config lsbConfig;
-  lsbConfig.auxiliary = "*** DD4hep driven builder for: ";
+  lsbConfig.auxiliary = "*** DD4hep auto-generated builder for: ";
   lsbConfig.auxiliary += options.name;
+
+  // Patch the binning to the extent parameters
+  if (fCache.sExtent.has_value() && options.patchBinningWithExtent) {
+    const auto& extent = fCache.sExtent.value();
+    // Check if the binning
+    ACTS_VERBOSE("Checking if surface binning ranges can be patched.");
+    for (auto& b : fCache.binnings) {
+      if (extent.constrains(b.binValue)) {
+        ACTS_VERBOSE("Binning '" << binningValueNames()[b.binValue]
+                                 << "' is patched.");
+        ACTS_VERBOSE(" <- from : [" << b.edges.front() << ", " << b.edges.back()
+                                    << "]");
+        b.edges.front() = extent.min(b.binValue);
+        b.edges.back() = extent.max(b.binValue);
+        ACTS_VERBOSE(" -> to   : [" << b.edges.front() << ", " << b.edges.back()
+                                    << "]");
+      }
+    }
+  }
+
   // Translate binings and supports
   lsbConfig.binnings = fCache.binnings;
   lsbConfig.supports = fCache.supports;
@@ -84,6 +112,7 @@ Acts::Experimental::DD4hepLayerStructure::builder(
     }
   }
 
+  // Create the surface provider from the layer structure
   lsbConfig.surfacesProvider =
       std::make_shared<Experimental::LayerStructureBuilder::SurfacesHolder>(
           lSurfaces);
@@ -92,7 +121,17 @@ Acts::Experimental::DD4hepLayerStructure::builder(
   ACTS_DEBUG("Configured to build " << lsbConfig.supports.size()
                                     << " supports.");
 
+  // Make one common extent
+  if (fCache.sExtent.has_value() && fCache.pExtent.has_value()) {
+    ACTS_DEBUG(
+        "Sensitive extent determinded: " << fCache.sExtent.value().toString());
+    ACTS_DEBUG(
+        "Passive   extent determinded: " << fCache.pExtent.value().toString());
+    fCache.sExtent.value().extend(fCache.pExtent.value());
+  }
+
   // Return the structure builder
-  return std::make_shared<LayerStructureBuilder>(
-      lsbConfig, getDefaultLogger(options.name, options.logLevel));
+  return {std::make_shared<LayerStructureBuilder>(
+              lsbConfig, getDefaultLogger(options.name, options.logLevel)),
+          fCache.sExtent};
 }

--- a/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
@@ -124,9 +124,9 @@ Acts::Experimental::DD4hepLayerStructure::builder(
   // Make one common extent
   if (fCache.sExtent.has_value() && fCache.pExtent.has_value()) {
     ACTS_DEBUG(
-        "Sensitive extent determinded: " << fCache.sExtent.value().toString());
+        "Sensitive extent determined: " << fCache.sExtent.value().toString());
     ACTS_DEBUG(
-        "Passive   extent determinded: " << fCache.pExtent.value().toString());
+        "Passive   extent determined: " << fCache.pExtent.value().toString());
     fCache.sExtent.value().extend(fCache.pExtent.value());
   }
 

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepCylinderLayerStructureTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepCylinderLayerStructureTests.cpp
@@ -103,8 +103,11 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginBeampipeStructure) {
   lsOptions.name = "BeamPipe";
   lsOptions.logLevel = Acts::Logging::VERBOSE;
 
-  auto beamPipeInternalsBuilder =
-      beamPipeStructure.builder(dd4hepStore, world, lsOptions);
+  auto [beamPipeInternalsBuilder, beamPipeExt] =
+      beamPipeStructure.builder(dd4hepStore, tContext, world, lsOptions);
+
+  // Not configured to have the beam pipe Extent measured
+  BOOST_CHECK(beamPipeExt == std::nullopt);
 
   // Build the internal volume structure
   auto [surfaces, volumes, surfacesUpdator, volumeUpdator] =
@@ -161,6 +164,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructure) {
     cxml << segmentation_xml;
     cxml << cylinder_layer_head_xml;
 
+    // Test binning
     if (nz * nphi > 1u) {
       cxml << indent_12_xml << "<acts_surface_binning";
       cxml << " ztype=\"equidistant\"";
@@ -189,15 +193,6 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructure) {
            << "    <tubs rmin=\"122*mm\" rmax=\"124*mm\" dz=\"500*mm\" "
               "material=\"Air\"/>"
            << '\n';
-      cxml << indent_12_xml << "  </acts_passive_surface>" << '\n';
-      passiveAddon = 1u;
-    } else if (itest == 2u) {
-      cxml << indent_12_xml << "  <acts_passive_surface>" << '\n';
-      cxml << indent_12_xml
-           << "    <tubs rmin=\"122*mm\" rmax=\"124*mm\" dz=\"500*mm\" "
-              "material=\"Air\"/>"
-           << '\n';
-      cxml << "    <acts_proto_material/>" << '\n';
       cxml << indent_12_xml << "  </acts_passive_surface>" << '\n';
       passiveAddon = 1u;
     }
@@ -229,8 +224,8 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructure) {
     lsOptions.name = "BarrelLayer";
     lsOptions.logLevel = Acts::Logging::VERBOSE;
 
-    auto barrelInternalsBuilder =
-        barrelStructure.builder(dd4hepStore, world, lsOptions);
+    auto [barrelInternalsBuilder, barrelExt] =
+        barrelStructure.builder(dd4hepStore, tContext, world, lsOptions);
 
     // Build the internal volume structure
     auto [surfaces, volumes, surfacesUpdator, volumeUpdator] =
@@ -248,6 +243,67 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructure) {
     // Kill that instance before going into the next test
     lcdd->destroyInstance();
   }
+}
+
+// Test the auto-range determination
+BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructureAutoRange) {
+  // First create some test surfaces
+  Acts::Test::CylindricalTrackingGeometry::DetectorStore dStore;
+  auto cSurfaces = cGeometry.surfacesCylinder(dStore, 8.4, 36., 0.15, 0.145,
+                                              116., 3., 2., {52, 14});
+
+  // Create an XML from it
+  std::ofstream cxml;
+  std::string fName = "CylinderLayer_auto_range.xml";
+
+  cxml.open(fName);
+  cxml << head_xml;
+  cxml << segmentation_xml;
+  cxml << cylinder_layer_head_xml;
+
+  cxml << "<modules>" << '\n';
+  for (const auto& s : cSurfaces) {
+    cxml << indent_12_xml
+         << DD4hepTestsHelper::surfaceToXML(tContext, *s,
+                                            Acts::Transform3::Identity())
+         << "\n";
+  }
+  cxml << "</modules>" << '\n';
+  cxml << tail_xml;
+  cxml << end_xml;
+  cxml.close();
+
+  auto lcdd = &(dd4hep::Detector::getInstance());
+  lcdd->fromCompact(fName);
+  lcdd->volumeManager();
+  lcdd->apply("DD4hepVolumeManager", 0, nullptr);
+
+  auto world = lcdd->world();
+
+  // Now the test starts ...
+  auto sFactory = std::make_shared<Acts::DD4hepDetectorSurfaceFactory>(
+      Acts::getDefaultLogger("DD4hepDetectorSurfaceFactory",
+                             Acts::Logging::VERBOSE));
+
+  Acts::Experimental::DD4hepLayerStructure barrelStructure(
+      std::move(sFactory),
+      Acts::getDefaultLogger("DD4hepLayerStructure", Acts::Logging::VERBOSE));
+
+  Acts::DD4hepDetectorElement::Store dd4hepStore;
+
+  Acts::Experimental::DD4hepLayerStructure::Options lsOptions;
+  lsOptions.name = "AutoRangeLayer";
+  auto extent = Acts::Extent();
+  lsOptions.extent = extent;
+  lsOptions.extentContraints = {Acts::binZ, Acts::binR};
+  lsOptions.logLevel = Acts::Logging::VERBOSE;
+
+  auto [barrelInternalsBuilder, barrelExt] =
+      barrelStructure.builder(dd4hepStore, tContext, world, lsOptions);
+
+  BOOST_CHECK(barrelExt != std::nullopt);
+  BOOST_CHECK(barrelExt.value().constrains(Acts::binZ));
+  BOOST_CHECK(barrelExt.value().constrains(Acts::binR));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepCylindricalDetectorTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepCylindricalDetectorTests.cpp
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(DD4hepCylidricalDetectorExplicit) {
 
   Acts::Experimental::DD4hepBlueprint bp(
       bpCfg, Acts::getDefaultLogger("DD4hepBlueprint", Acts::Logging::VERBOSE));
-  auto dd4hepBlueprint = bp.create(bpCache, world);
+  auto dd4hepBlueprint = bp.create(bpCache, tContext, world);
 
   // We should have 6 store entries now
   // 1 : beam pipe (empty)

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepDiscLayerStructureTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepDiscLayerStructureTests.cpp
@@ -155,8 +155,8 @@ BOOST_AUTO_TEST_CASE(DD4hepDiscLayerStructure) {
     lsOptions.name = "DiscLayer";
     lsOptions.logLevel = Acts::Logging::VERBOSE;
 
-    auto discInternalsBuilder =
-        discStructure.builder(dd4hepStore, world, lsOptions);
+    auto [discInternalsBuilder, discExt] =
+        discStructure.builder(dd4hepStore, tContext, world, lsOptions);
 
     // Build the internal volume structure
     auto [surfaces, volumes, surfacesUpdator, volumeUpdator] =


### PR DESCRIPTION
This PR adds the possibility that the internal layer structure, i.e. the contained surfaces - drive the dimension of the external volume shape.

E.g. in DD4hep, one could then write
```xml
      <argument value="acts_volume_internals_measure: str = z,r"/>
      <argument value="acts_volume_internals_clearance: double = pix_b_clear"/>
```

Which will trigger measuring the internal surface dimensions in z & r and add a clearance around it.
