### PR TITLE
fix: Fix trapezoid accelerated inside check

### DIFF
--- a/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
@@ -30,7 +30,6 @@ namespace Acts {
 /// @image html TrapezoidBounds.gif
 ///
 /// @todo can be speed optimized by calculating kappa/delta and caching it
-
 class TrapezoidBounds : public PlanarBounds {
  public:
   enum BoundValues {

--- a/Core/src/Surfaces/TrapezoidBounds.cpp
+++ b/Core/src/Surfaces/TrapezoidBounds.cpp
@@ -32,18 +32,25 @@ bool Acts::TrapezoidBounds::inside(const Acts::Vector2& lposition,
     double tolX = bcheck.tolerance()[eBoundLoc0];
     double tolY = bcheck.tolerance()[eBoundLoc1];
 
-    if (std::abs(y) - hlY > tolY) {
-      // outside y range
-      return false;
-    }
-
+    // check outside x range + tolerance
     if (std::abs(x) - std::max(hlXnY, hlXpY) > tolX) {
-      // outside x range
       return false;
     }
 
-    if (std::abs(x) - std::min(hlXnY, hlXpY) <= tolX) {
-      // inside x range
+    // check outside y range + tolerance
+    if (std::abs(y) - hlY > tolY) {
+      return false;
+    }
+
+    // check inside x range + tolerance, inside y range
+    if ((std::abs(x) - std::min(hlXnY, hlXpY) <= tolX) &&
+        (std::abs(y) - hlY <= 0)) {
+      return true;
+    }
+
+    // check inside x range, inside y range + tolerance
+    if ((std::abs(x) - std::min(hlXnY, hlXpY) <= 0) &&
+        (std::abs(y) - hlY <= tolY)) {
       return true;
     }
   }

--- a/Core/src/Surfaces/TrapezoidBounds.cpp
+++ b/Core/src/Surfaces/TrapezoidBounds.cpp
@@ -32,25 +32,31 @@ bool Acts::TrapezoidBounds::inside(const Acts::Vector2& lposition,
     double tolX = bcheck.tolerance()[eBoundLoc0];
     double tolY = bcheck.tolerance()[eBoundLoc1];
 
-    // check outside x range + tolerance
-    if (std::abs(x) - std::max(hlXnY, hlXpY) > tolX) {
-      return false;
-    }
+    double distY = std::abs(y) - hlY;
 
     // check outside y range + tolerance
-    if (std::abs(y) - hlY > tolY) {
+    if (distY > tolY) {
       return false;
     }
 
-    // check inside x range + tolerance, inside y range
-    if ((std::abs(x) - std::min(hlXnY, hlXpY) <= tolX) &&
-        (std::abs(y) - hlY <= 0)) {
+    // distance x to outer rectangle
+    double distOuterX = std::abs(x) - std::max(hlXnY, hlXpY);
+
+    // check outside x range + tolerance
+    if (distOuterX > tolX) {
+      return false;
+    }
+
+    // distance x to inner rectangle
+    double distInnerX = std::abs(x) - std::min(hlXnY, hlXpY);
+
+    // check inside x range, inside y range + tolerance (already checked above)
+    if (distInnerX <= 0) {
       return true;
     }
 
-    // check inside x range, inside y range + tolerance
-    if ((std::abs(x) - std::min(hlXnY, hlXpY) <= 0) &&
-        (std::abs(y) - hlY <= tolY)) {
+    // check inside x range + tolerance, inside y range
+    if ((distInnerX <= tolX) && (distY <= 0)) {
       return true;
     }
   }


### PR DESCRIPTION
This bug flagged some points to be inside while they are not. I fixed this by checking against two rectangles instead of just one which is too big.

discovered in https://github.com/acts-project/acts/pull/2694