### PR TITLE
ci: monitor annealing in AMVFitter

### DIFF
--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -97,7 +97,6 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::executeAfterSeederChoice(
 
   // Set up deterministic annealing with user-defined temperatures
   Acts::AnnealingUtility::Config annealingConfig;
-  annealingConfig.setOfTemperatures = {1.};
   Acts::AnnealingUtility annealingUtility(annealingConfig);
 
   // Set up the vertex fitter with user-defined annealing


### PR DESCRIPTION
Annealing was removed here #1723 for alignment with ATHENA.

I would argue that we should monitor changes in the annealing as it is one of the primary features of the adaptive vertex fit.