### PR TITLE
ci: reduce spatialTrkGridSize

### DIFF
--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -61,7 +61,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::execute(
     Seeder seedFinder;
     return executeAfterSeederChoice<Seeder, Finder>(ctx, seedFinder);
   } else if (m_cfg.seedFinder == SeedFinder::AdaptiveGridSeeder) {
-    using Seeder = Acts::AdaptiveGridDensityVertexFinder<109, 1, Fitter>;
+    using Seeder = Acts::AdaptiveGridDensityVertexFinder<19, 1, Fitter>;
     using Finder = Acts::AdaptiveMultiVertexFinder<Fitter, Seeder>;
     // The seeder config argument corresponds to the bin size in mm
     Seeder::Config seederConfig(0.05);

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -61,7 +61,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::execute(
     Seeder seedFinder;
     return executeAfterSeederChoice<Seeder, Finder>(ctx, seedFinder);
   } else if (m_cfg.seedFinder == SeedFinder::AdaptiveGridSeeder) {
-    using Seeder = Acts::AdaptiveGridDensityVertexFinder<19, 1, Fitter>;
+    using Seeder = Acts::AdaptiveGridDensityVertexFinder<9, 1, Fitter>;
     using Finder = Acts::AdaptiveMultiVertexFinder<Fitter, Seeder>;
     // The seeder config argument corresponds to the bin size in mm
     Seeder::Config seederConfig(0.05);


### PR DESCRIPTION
Tracks are modelled by too many bins in z in our CI's `AdaptiveGridTrackDensity`; their number can be reduced while maintaining physics performance.