### PR TITLE
feat: Optional write out detailed matching infos in CKFPerformanceWriter

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -27,9 +27,9 @@
 #include <utility>
 
 #include <TFile.h>
+#include <TTree.h>
 #include <TVectorFfwd.h>
 #include <TVectorT.h>
-#include <TTree.h>
 
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::phi;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -68,6 +68,10 @@ ActsExamples::CKFPerformanceWriter::CKFPerformanceWriter(
     throw std::invalid_argument("Could not open '" + m_cfg.filePath + "'");
   }
 
+  if (m_cfg.writeMatchingDetails) {
+    m_matchingTree = new TTree("matchingdetails", "matchingdetails");
+  }
+
   // initialize the plot tools
   m_effPlotTool.book(m_effPlotCache);
   m_fakeRatePlotTool.book(m_fakeRatePlotCache);
@@ -133,6 +137,11 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::finalize() {
     write_float(eff_particle, "eff_particles");
     write_float(fakeRate_particle, "fakerate_particles");
     write_float(duplicationRate_particle, "duplicaterate_particles");
+
+    if (m_matchingTree != nullptr) {
+      m_matchingTree->Write();
+    }
+
     ACTS_INFO("Wrote performance plots to '" << m_outputFile->GetPath() << "'");
   }
   return ProcessCode::SUCCESS;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -29,6 +29,7 @@
 #include <TFile.h>
 #include <TVectorFfwd.h>
 #include <TVectorT.h>
+#include <TTree.h>
 
 using Acts::VectorHelpers::eta;
 using Acts::VectorHelpers::phi;
@@ -323,6 +324,25 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
                             nFakeTracks);
     m_nTotalParticles += 1;
   }  // end all truth particles
+
+  // Write additional stuff to TTree
+  if (m_cfg.writeMatchingDetails && m_matchingTree != nullptr) {
+    uint32_t eventNr{};
+    uint64_t particleId{};
+    bool isMatched{};
+
+    m_matchingTree->Branch("event_nr", &eventNr);
+    m_matchingTree->Branch("particleId", &particleId);
+    m_matchingTree->Branch("matched", &isMatched);
+
+    for (const auto& p : particles) {
+      eventNr = ctx.eventNumber;
+      particleId = p.particleId().value();
+      isMatched = (matched.find(p.particleId()) != matched.end());
+
+      m_matchingTree->Fill();
+    }
+  }
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -70,6 +70,10 @@ ActsExamples::CKFPerformanceWriter::CKFPerformanceWriter(
 
   if (m_cfg.writeMatchingDetails) {
     m_matchingTree = new TTree("matchingdetails", "matchingdetails");
+
+    m_matchingTree->Branch("event_nr", &m_treeEventNr);
+    m_matchingTree->Branch("particleId", &m_treeParticleId);
+    m_matchingTree->Branch("matched", &m_treeIsMatched);
   }
 
   // initialize the plot tools
@@ -336,18 +340,10 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
 
   // Write additional stuff to TTree
   if (m_cfg.writeMatchingDetails && m_matchingTree != nullptr) {
-    uint32_t eventNr{};
-    uint64_t particleId{};
-    bool isMatched{};
-
-    m_matchingTree->Branch("event_nr", &eventNr);
-    m_matchingTree->Branch("particleId", &particleId);
-    m_matchingTree->Branch("matched", &isMatched);
-
     for (const auto& p : particles) {
-      eventNr = ctx.eventNumber;
-      particleId = p.particleId().value();
-      isMatched = (matched.find(p.particleId()) != matched.end());
+      m_treeEventNr = ctx.eventNumber;
+      m_treeParticleId = p.particleId().value();
+      m_treeIsMatched = (matched.find(p.particleId()) != matched.end());
 
       m_matchingTree->Fill();
     }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -72,7 +72,7 @@ ActsExamples::CKFPerformanceWriter::CKFPerformanceWriter(
     m_matchingTree = new TTree("matchingdetails", "matchingdetails");
 
     m_matchingTree->Branch("event_nr", &m_treeEventNr);
-    m_matchingTree->Branch("particleId", &m_treeParticleId);
+    m_matchingTree->Branch("particle_id", &m_treeParticleId);
     m_matchingTree->Branch("matched", &m_treeIsMatched);
   }
 

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -115,6 +115,11 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
   /// For optional output of the matching details
   TTree* m_matchingTree{nullptr};
 
+  /// Variables to fill in the TTree
+  uint32_t m_treeEventNr{};
+  uint64_t m_treeParticleId{};
+  bool m_treeIsMatched{};
+
   // Adding numbers for efficiency, fake, duplicate calculations
   std::size_t m_nTotalTracks = 0;
   std::size_t m_nTotalMatchedTracks = 0;

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -74,12 +74,11 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
     double truthMatchProbMin = 0.5;
 
     /// Write additional matching details to a TTree
-    bool writeMatchingDetails
+    bool writeMatchingDetails = false;
 
-        /// function to check if neural network predicted track label is
-        /// duplicate
-        std::function<bool(std::vector<float>&)>
-            duplicatedPredictor = nullptr;
+    /// function to check if neural network predicted track label is
+    /// duplicate
+    std::function<bool(std::vector<float>&)> duplicatedPredictor = nullptr;
   };
 
   /// Construct from configuration and log level.
@@ -117,14 +116,14 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
   TTree* m_matchingTree{nullptr};
 
   // Adding numbers for efficiency, fake, duplicate calculations
-  size_t m_nTotalTracks = 0;
-  size_t m_nTotalMatchedTracks = 0;
-  size_t m_nTotalFakeTracks = 0;
-  size_t m_nTotalDuplicateTracks = 0;
-  size_t m_nTotalParticles = 0;
-  size_t m_nTotalMatchedParticles = 0;
-  size_t m_nTotalDuplicateParticles = 0;
-  size_t m_nTotalFakeParticles = 0;
+  std::size_t m_nTotalTracks = 0;
+  std::size_t m_nTotalMatchedTracks = 0;
+  std::size_t m_nTotalFakeTracks = 0;
+  std::size_t m_nTotalDuplicateTracks = 0;
+  std::size_t m_nTotalParticles = 0;
+  std::size_t m_nTotalMatchedParticles = 0;
+  std::size_t m_nTotalDuplicateParticles = 0;
+  std::size_t m_nTotalFakeParticles = 0;
 
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
   ReadDataHandle<HitParticlesMap> m_inputMeasurementParticlesMap{

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -78,8 +78,8 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
 
         /// function to check if neural network predicted track label is
         /// duplicate
-            std::function<bool(std::vector<float>&)>
-                duplicatedPredictor = nullptr;
+        std::function<bool(std::vector<float>&)>
+            duplicatedPredictor = nullptr;
   };
 
   /// Construct from configuration and log level.

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.hpp
@@ -73,8 +73,13 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
     /// Min reco-truth matching probability
     double truthMatchProbMin = 0.5;
 
-    /// function to check if neural network predicted track label is duplicate
-    std::function<bool(std::vector<float>&)> duplicatedPredictor = nullptr;
+    /// Write additional matching details to a TTree
+    bool writeMatchingDetails
+
+        /// function to check if neural network predicted track label is
+        /// duplicate
+            std::function<bool(std::vector<float>&)>
+                duplicatedPredictor = nullptr;
   };
 
   /// Construct from configuration and log level.
@@ -108,15 +113,18 @@ class CKFPerformanceWriter final : public WriterT<ConstTrackContainer> {
   TrackSummaryPlotTool m_trackSummaryPlotTool;
   TrackSummaryPlotTool::TrackSummaryPlotCache m_trackSummaryPlotCache{};
 
+  /// For optional output of the matching details
+  TTree* m_matchingTree{nullptr};
+
   // Adding numbers for efficiency, fake, duplicate calculations
-  std::size_t m_nTotalTracks = 0;
-  std::size_t m_nTotalMatchedTracks = 0;
-  std::size_t m_nTotalFakeTracks = 0;
-  std::size_t m_nTotalDuplicateTracks = 0;
-  std::size_t m_nTotalParticles = 0;
-  std::size_t m_nTotalMatchedParticles = 0;
-  std::size_t m_nTotalDuplicateParticles = 0;
-  std::size_t m_nTotalFakeParticles = 0;
+  size_t m_nTotalTracks = 0;
+  size_t m_nTotalMatchedTracks = 0;
+  size_t m_nTotalFakeTracks = 0;
+  size_t m_nTotalDuplicateTracks = 0;
+  size_t m_nTotalParticles = 0;
+  size_t m_nTotalMatchedParticles = 0;
+  size_t m_nTotalDuplicateParticles = 0;
+  size_t m_nTotalFakeParticles = 0;
 
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
   ReadDataHandle<HitParticlesMap> m_inputMeasurementParticlesMap{

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -379,7 +379,8 @@ void addOutput(Context& ctx) {
       inputTracks, inputParticles, inputMeasurementParticlesMap, filePath,
       fileMode, effPlotToolConfig, fakeRatePlotToolConfig,
       duplicationPlotToolConfig, trackSummaryPlotToolConfig,
-      duplicatedPredictor, truthMatchProbMin, doubleMatching);
+      duplicatedPredictor, truthMatchProbMin, doubleMatching,
+      writeMatchingDetails);
 
   ACTS_PYTHON_DECLARE_WRITER(
       ActsExamples::RootNuclearInteractionParametersWriter, mex,

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -379,7 +379,7 @@ void addOutput(Context& ctx) {
                              inputParticles, inputMeasurementParticlesMap,
                              filePath, fileMode, effPlotToolConfig,
                              fakeRatePlotToolConfig, duplicationPlotToolConfig,
-                             trackSummaryPlotToolConfig, duplicatedPredictor);
+                             trackSummaryPlotToolConfig, duplicatedPredictor, truthMatchProbMin, doubleMatching);
 
   ACTS_PYTHON_DECLARE_WRITER(
       ActsExamples::RootNuclearInteractionParametersWriter, mex,

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -374,12 +374,12 @@ void addOutput(Context& ctx) {
       trackingGeometry, outputDir, outputPrecision, writeSensitive,
       writeBoundary, writeSurfaceGrid, writeLayerVolume, writePerEvent);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CKFPerformanceWriter, mex,
-                             "CKFPerformanceWriter", inputTracks,
-                             inputParticles, inputMeasurementParticlesMap,
-                             filePath, fileMode, effPlotToolConfig,
-                             fakeRatePlotToolConfig, duplicationPlotToolConfig,
-                             trackSummaryPlotToolConfig, duplicatedPredictor, truthMatchProbMin, doubleMatching);
+  ACTS_PYTHON_DECLARE_WRITER(
+      ActsExamples::CKFPerformanceWriter, mex, "CKFPerformanceWriter",
+      inputTracks, inputParticles, inputMeasurementParticlesMap, filePath,
+      fileMode, effPlotToolConfig, fakeRatePlotToolConfig,
+      duplicationPlotToolConfig, trackSummaryPlotToolConfig,
+      duplicatedPredictor, truthMatchProbMin, doubleMatching);
 
   ACTS_PYTHON_DECLARE_WRITER(
       ActsExamples::RootNuclearInteractionParametersWriter, mex,


### PR DESCRIPTION
Needed for GNN+CKF workflow.
Optionally writes additional info to a `TTree` like this:
```
      event_nr         particle_id  matched
0            2    4503599677702144     True
1            2    4503599862251520     True
2            2    4503599929360384     True
3            2    4503599946137600    False
...
```