### PR TITLE
refactor: Portal fusing and remove shared-from-this

### DIFF
--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -41,14 +41,13 @@ struct NavigationState;
 /// The surface can carry material to allow mapping onto
 /// portal positions if required.
 ///
-class Portal : public std::enable_shared_from_this<Portal> {
- protected:
+class Portal {
+ public:
   /// Constructor from surface w/o portal links
   ///
   /// @param surface is the representing surface
   Portal(std::shared_ptr<RegularSurface> surface);
 
- public:
   /// The volume links forward/backward with respect to the surface normal
   using DetectorVolumeUpdaters = std::array<DetectorVolumeUpdater, 2u>;
 
@@ -59,32 +58,6 @@ class Portal : public std::enable_shared_from_this<Portal> {
 
   /// Declare the DetectorVolume friend for portal setting
   friend class DetectorVolume;
-
-  /// Factory for producing memory managed instances of Portal.
-  static std::shared_ptr<Portal> makeShared(
-      std::shared_ptr<RegularSurface> surface);
-
-  /// Retrieve a @c std::shared_ptr for this surface (non-const version)
-  ///
-  /// @note Will error if this was not created through the @c makeShared factory
-  ///       since it needs access to the original reference. In C++14 this is
-  ///       undefined behavior (but most likely implemented as a @c bad_weak_ptr
-  ///       exception), in C++17 it is defined as that exception.
-  /// @note Only call this if you need shared ownership of this object.
-  ///
-  /// @return The shared pointer
-  std::shared_ptr<Portal> getSharedPtr();
-
-  /// Retrieve a @c std::shared_ptr for this surface (const version)
-  ///
-  /// @note Will error if this was not created through the @c makeShared factory
-  ///       since it needs access to the original reference. In C++14 this is
-  ///       undefined behavior, but most likely implemented as a @c bad_weak_ptr
-  ///       exception, in C++17 it is defined as that exception.
-  /// @note Only call this if you need shared ownership of this object.
-  ///
-  /// @return The shared pointer
-  std::shared_ptr<const Portal> getSharedPtr() const;
 
   Portal() = delete;
   virtual ~Portal() = default;

--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -110,7 +110,8 @@ class Portal : public std::enable_shared_from_this<Portal> {
 
   /// Fuse with another portal, this one is kept
   ///
-  /// @param other is the portal that will be fused
+  /// @param keep is the portal that will be kept
+  /// @param discard is the portal that will be fused
   ///
   /// @note this will move the portal links from the other
   /// into this volume, it will throw an exception if the
@@ -121,7 +122,9 @@ class Portal : public std::enable_shared_from_this<Portal> {
   /// will be thrown and the portals are not fusable
   ///
   /// @note that other will be overwritten to point to this
-  void fuse(std::shared_ptr<Portal>& other) noexcept(false);
+  static std::shared_ptr<Portal> fuse(
+      std::shared_ptr<Portal>& keep,
+      std::shared_ptr<Portal>& discard) noexcept(false);
 
   /// Update the volume link
   ///

--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -83,8 +83,8 @@ class Portal {
 
   /// Fuse with another portal, this one is kept
   ///
-  /// @param keep is the portal that will be kept
-  /// @param discard is the portal that will be fused
+  /// @param aPortal is the first portal to fuse
+  /// @param bPortal is the second portal to fuse
   ///
   /// @note this will combine the portal links from the both
   /// portals into a new one, it will throw an exception if the
@@ -97,8 +97,8 @@ class Portal {
   /// @note Both input portals become invalid, in that their update
   /// delegates and attached volumes are reset
   static std::shared_ptr<Portal> fuse(
-      std::shared_ptr<Portal>& keep,
-      std::shared_ptr<Portal>& discard) noexcept(false);
+      std::shared_ptr<Portal>& aPortal,
+      std::shared_ptr<Portal>& bPortal) noexcept(false);
 
   /// Update the volume link
   ///

--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -86,15 +86,16 @@ class Portal {
   /// @param keep is the portal that will be kept
   /// @param discard is the portal that will be fused
   ///
-  /// @note this will move the portal links from the other
-  /// into this volume, it will throw an exception if the
+  /// @note this will combine the portal links from the both
+  /// portals into a new one, it will throw an exception if the
   /// portals are not fusable
   ///
   /// @note if one portal carries material, it will be kept,
   /// however, if both portals carry material, an exception
   /// will be thrown and the portals are not fusable
   ///
-  /// @note that other will be overwritten to point to this
+  /// @note Both input portals become invalid, in that their update
+  /// delegates and attached volumes are reset
   static std::shared_ptr<Portal> fuse(
       std::shared_ptr<Portal>& keep,
       std::shared_ptr<Portal>& discard) noexcept(false);

--- a/Core/include/Acts/Detector/Portal.hpp
+++ b/Core/include/Acts/Detector/Portal.hpp
@@ -60,7 +60,6 @@ class Portal {
   friend class DetectorVolume;
 
   Portal() = delete;
-  virtual ~Portal() = default;
 
   /// Const access to the surface representation
   const RegularSurface& surface() const;

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -25,11 +25,6 @@ Portal::Portal(std::shared_ptr<RegularSurface> surface)
   throw_assert(m_surface, "Portal surface is nullptr");
 }
 
-std::shared_ptr<Portal> Portal::makeShared(
-    std::shared_ptr<RegularSurface> surface) {
-  return std::shared_ptr<Portal>(new Portal(std::move(surface)));
-}
-
 const Acts::RegularSurface& Portal::surface() const {
   return *m_surface.get();
 }
@@ -44,14 +39,6 @@ const Portal::DetectorVolumeUpdaters& Portal::detectorVolumeUpdaters() const {
 
 Portal::AttachedDetectorVolumes& Portal::attachedDetectorVolumes() {
   return m_attachedVolumes;
-}
-
-std::shared_ptr<Portal> Portal::getSharedPtr() {
-  return shared_from_this();
-}
-
-std::shared_ptr<const Portal> Portal::getSharedPtr() const {
-  return shared_from_this();
 }
 
 void Portal::assignGeometryId(const GeometryIdentifier& geometryId) {
@@ -101,7 +88,7 @@ std::shared_ptr<Portal> Portal::fuse(std::shared_ptr<Portal>& aPortal,
   const auto& bSurface = bPortal->surface();
 
   // @TODO: There's no safety against fusing portals with different surfaces
-  std::shared_ptr<Portal> fused = Portal::makeShared(aPortal->m_surface);
+  std::shared_ptr<Portal> fused = std::make_shared<Portal>(aPortal->m_surface);
 
   if (aSurface.surfaceMaterial() != nullptr &&
       bSurface.surfaceMaterial() != nullptr) {

--- a/Core/src/Detector/Portal.cpp
+++ b/Core/src/Detector/Portal.cpp
@@ -18,57 +18,47 @@
 #include <stdexcept>
 #include <utility>
 
-namespace Acts {
-namespace Experimental {
-class DetectorVolume;
-}  // namespace Experimental
-}  // namespace Acts
+namespace Acts::Experimental {
 
-Acts::Experimental::Portal::Portal(std::shared_ptr<RegularSurface> surface)
+Portal::Portal(std::shared_ptr<RegularSurface> surface)
     : m_surface(std::move(surface)) {
   throw_assert(m_surface, "Portal surface is nullptr");
 }
 
-std::shared_ptr<Acts::Experimental::Portal>
-Acts::Experimental::Portal::makeShared(
+std::shared_ptr<Portal> Portal::makeShared(
     std::shared_ptr<RegularSurface> surface) {
   return std::shared_ptr<Portal>(new Portal(std::move(surface)));
 }
 
-const Acts::RegularSurface& Acts::Experimental::Portal::surface() const {
+const Acts::RegularSurface& Portal::surface() const {
   return *m_surface.get();
 }
 
-Acts::RegularSurface& Acts::Experimental::Portal::surface() {
+Acts::RegularSurface& Portal::surface() {
   return *m_surface.get();
 }
 
-const Acts::Experimental::Portal::DetectorVolumeUpdaters&
-Acts::Experimental::Portal::detectorVolumeUpdaters() const {
+const Portal::DetectorVolumeUpdaters& Portal::detectorVolumeUpdaters() const {
   return m_volumeUpdaters;
 }
 
-Acts::Experimental::Portal::AttachedDetectorVolumes&
-Acts::Experimental::Portal::attachedDetectorVolumes() {
+Portal::AttachedDetectorVolumes& Portal::attachedDetectorVolumes() {
   return m_attachedVolumes;
 }
 
-std::shared_ptr<Acts::Experimental::Portal>
-Acts::Experimental::Portal::getSharedPtr() {
+std::shared_ptr<Portal> Portal::getSharedPtr() {
   return shared_from_this();
 }
 
-std::shared_ptr<const Acts::Experimental::Portal>
-Acts::Experimental::Portal::getSharedPtr() const {
+std::shared_ptr<const Portal> Portal::getSharedPtr() const {
   return shared_from_this();
 }
 
-void Acts::Experimental::Portal::assignGeometryId(
-    const GeometryIdentifier& geometryId) {
+void Portal::assignGeometryId(const GeometryIdentifier& geometryId) {
   m_surface->assignGeometryId(geometryId);
 }
 
-void Acts::Experimental::Portal::fuse(std::shared_ptr<Portal>& other) {
+void Portal::fuse(std::shared_ptr<Portal>& other) {
   Direction bDir = Direction::Backward;
 
   // Determine this directioon
@@ -104,7 +94,7 @@ void Acts::Experimental::Portal::fuse(std::shared_ptr<Portal>& other) {
   other = getSharedPtr();
 }
 
-void Acts::Experimental::Portal::assignDetectorVolumeUpdater(
+void Portal::assignDetectorVolumeUpdater(
     Direction dir, DetectorVolumeUpdater dVolumeUpdater,
     std::vector<std::shared_ptr<DetectorVolume>> attachedVolumes) {
   auto idx = dir.index();
@@ -112,7 +102,7 @@ void Acts::Experimental::Portal::assignDetectorVolumeUpdater(
   m_attachedVolumes[idx] = std::move(attachedVolumes);
 }
 
-void Acts::Experimental::Portal::assignDetectorVolumeUpdater(
+void Portal::assignDetectorVolumeUpdater(
     DetectorVolumeUpdater dVolumeUpdater,
     std::vector<std::shared_ptr<DetectorVolume>> attachedVolumes) {
   // Check and throw exceptions
@@ -127,8 +117,8 @@ void Acts::Experimental::Portal::assignDetectorVolumeUpdater(
   m_attachedVolumes[idx] = std::move(attachedVolumes);
 }
 
-void Acts::Experimental::Portal::updateDetectorVolume(
-    const GeometryContext& gctx, NavigationState& nState) const {
+void Portal::updateDetectorVolume(const GeometryContext& gctx,
+                                  NavigationState& nState) const {
   const auto& position = nState.position;
   const auto& direction = nState.direction;
   const Vector3 normal = surface().normal(gctx, position);
@@ -140,3 +130,5 @@ void Acts::Experimental::Portal::updateDetectorVolume(
     nState.currentVolume = nullptr;
   }
 }
+
+}  // namespace Acts::Experimental

--- a/Core/src/Detector/PortalGenerators.cpp
+++ b/Core/src/Detector/PortalGenerators.cpp
@@ -33,7 +33,7 @@ Acts::Experimental::generatePortals(
   std::vector<std::shared_ptr<Portal>> portals;
   for (auto [i, oSurface] : enumerate(orientedSurfaces)) {
     // Create a portal from the surface
-    auto portal = Portal::makeShared(oSurface.first);
+    auto portal = std::make_shared<Portal>(oSurface.first);
     // Create a shared link instance & delegate
     auto singleLinkImpl =
         std::make_unique<const SingleDetectorVolumeImpl>(dVolume.get());

--- a/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
+++ b/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
@@ -99,7 +99,7 @@ Acts::Experimental::PortalReplacement createDiscReplacement(
   const auto& stitchBoundaries =
       (stitchValue == Acts::binR) ? rBoundaries : phiBoundaries;
   return Acts::Experimental::PortalReplacement(
-      Acts::Experimental::Portal::makeShared(surface), index, dir,
+      std::make_shared<Acts::Experimental::Portal>(surface), index, dir,
       stitchBoundaries, stitchValue);
 }
 
@@ -135,7 +135,7 @@ Acts::Experimental::PortalReplacement createCylinderReplacement(
   const auto& stitchBoundaries =
       (stitchValue == Acts::binZ) ? zBoundaries : phiBoundaries;
   return Acts::Experimental::PortalReplacement(
-      Acts::Experimental::Portal::makeShared(surface), index, dir,
+      std::make_shared<Acts::Experimental::Portal>(surface), index, dir,
       stitchBoundaries, stitchValue);
 }
 
@@ -200,8 +200,8 @@ Acts::Experimental::PortalReplacement createSectorReplacement(
       transform, std::move(bounds));
   // A make a portal and indicate the new link direction
   Acts::Experimental::PortalReplacement pRep = {
-      Acts::Experimental::Portal::makeShared(surface), index, dir, boundaries,
-      binning};
+      std::make_shared<Acts::Experimental::Portal>(surface), index, dir,
+      boundaries, binning};
   return pRep;
 }
 

--- a/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
+++ b/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
@@ -430,7 +430,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
       // the inner cylinder of the outer portal goes to waste
       auto& keepCylinder = volumes[iv - 1]->portalPtrs()[2u];
       auto& wasteCylinder = volumes[iv]->portalPtrs()[3u];
-      keepCylinder->fuse(wasteCylinder);
+      keepCylinder = Portal::fuse(keepCylinder, wasteCylinder);
       volumes[iv]->updatePortal(keepCylinder, 3u);
     }
   }
@@ -605,7 +605,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInZ(
         message += " / " + Acts::toString(wastePosition);
         throw std::runtime_error(message.c_str());
       }
-      keepDisc->fuse(wasteDisc);
+      keepDisc = Portal::fuse(keepDisc, wasteDisc);
       volumes[iv]->updatePortal(keepDisc, 0u);
     }
   }
@@ -766,7 +766,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInPhi(
     // Fuse and swap
     auto& keepSector = volumes[iv - 1]->portalPtrs()[iSecOffset + 1u];
     auto& wasteSector = volumes[iv]->portalPtrs()[iSecOffset];
-    keepSector->fuse(wasteSector);
+    keepSector = Portal::fuse(keepSector, wasteSector);
     volumes[iv]->updatePortal(keepSector, iSecOffset);
     // The current values
     auto curValues = volumes[iv]->volumeBounds().values();
@@ -877,19 +877,19 @@ Acts::Experimental::detail::CylindricalDetectorHelper::wrapInZR(
   // Fuse outer cover of first with inner cylinder of wrapping volume
   auto& keepCover = volumes[0u]->portalPtrs()[2u];
   auto& wasteCover = volumes[1u]->portalPtrs()[3u];
-  keepCover->fuse(wasteCover);
+  keepCover = Portal::fuse(keepCover, wasteCover);
   volumes[1u]->updatePortal(keepCover, 3u);
 
   // Stitch sides - negative
   auto& keepDiscN = volumes[1u]->portalPtrs()[4u];
   auto& wasteDiscN = volumes[0u]->portalPtrs()[0u];
-  keepDiscN->fuse(wasteDiscN);
+  keepDiscN = Portal::fuse(keepDiscN, wasteDiscN);
   volumes[0u]->updatePortal(keepDiscN, 0u);
 
   // Stich sides - positive
   auto& keepDiscP = volumes[0u]->portalPtrs()[1u];
   auto& wasteDiscP = volumes[1u]->portalPtrs()[5u];
-  keepDiscP->fuse(wasteDiscP);
+  keepDiscP = Portal::fuse(keepDiscP, wasteDiscP);
   volumes[1u]->updatePortal(keepDiscP, 5u);
 
   // If needed, insert new cylinder
@@ -963,7 +963,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
     // Fuse and swap
     std::shared_ptr<Portal> keepCylinder = containers[ic - 1].find(2u)->second;
     std::shared_ptr<Portal> wasteCylinder = containers[ic].find(3u)->second;
-    keepCylinder->fuse(wasteCylinder);
+    keepCylinder = Portal::fuse(keepCylinder, wasteCylinder);
     for (auto& av : wasteCylinder->attachedDetectorVolumes()[1u]) {
       av->updatePortal(keepCylinder, 3u);
     }
@@ -1019,7 +1019,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInZ(
     }
     std::shared_ptr<Portal> keepDisc = formerContainer.find(1u)->second;
     std::shared_ptr<Portal> wasteDisc = currentContainer.find(0u)->second;
-    keepDisc->fuse(wasteDisc);
+    keepDisc = Portal::fuse(keepDisc, wasteDisc);
     for (auto& av : wasteDisc->attachedDetectorVolumes()[1u]) {
       ACTS_VERBOSE("Update portal of detector volume '" << av->name() << "'.");
       av->updatePortal(keepDisc, 0u);
@@ -1121,19 +1121,19 @@ Acts::Experimental::detail::CylindricalDetectorHelper::wrapInZR(
   // Fuse outer cover of first with inner cylinder of wrapping volume
   auto& keepCover = innerContainer[2u];
   auto& wasteCover = wrappingVolume->portalPtrs()[3u];
-  keepCover->fuse(wasteCover);
+  keepCover = Portal::fuse(keepCover, wasteCover);
   wrappingVolume->updatePortal(keepCover, 3u);
 
   // Stitch sides - negative
   auto& keepDiscN = innerContainer[0u];
   auto& wasteDiscN = wrappingVolume->portalPtrs()[4u];
-  keepDiscN->fuse(wasteDiscN);
+  keepDiscN = Portal::fuse(keepDiscN, wasteDiscN);
   wrappingVolume->updatePortal(keepDiscN, 4u);
 
   // Stich sides - positive
   auto& keepDiscP = innerContainer[1u];
   auto& wasteDiscP = wrappingVolume->portalPtrs()[5u];
-  keepDiscP->fuse(wasteDiscP);
+  keepDiscP = Portal::fuse(keepDiscP, wasteDiscP);
   wrappingVolume->updatePortal(keepDiscP, 5u);
 
   // If inner stitching is necessary

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -305,7 +305,7 @@ std::shared_ptr<Acts::Experimental::Portal> Acts::PortalJsonConverter::fromJson(
     throw std::runtime_error(
         "PortalJsonConverter: surface is not a regular surface.");
   }
-  auto portal = Experimental::Portal::makeShared(regSurface);
+  auto portal = std::make_shared<Experimental::Portal>(regSurface);
 
   std::array<Acts::Direction, 2> normalDirs = {Direction::Backward,
                                                Direction::Forward};

--- a/Tests/UnitTests/Core/Detector/DetectorVolumeTests.cpp
+++ b/Tests/UnitTests/Core/Detector/DetectorVolumeTests.cpp
@@ -131,7 +131,8 @@ BOOST_AUTO_TEST_CASE(UpdatePortal) {
   auto cylinderSurface =
       Acts::Surface::makeShared<Acts::CylinderSurface>(nominal, 10., 100.);
 
-  auto cylinderPortal = Acts::Experimental::Portal::makeShared(cylinderSurface);
+  auto cylinderPortal =
+      std::make_shared<Acts::Experimental::Portal>(cylinderSurface);
 
   fullCylinderVolume->updatePortal(cylinderPortal, 2u);
 

--- a/Tests/UnitTests/Core/Detector/PortalTests.cpp
+++ b/Tests/UnitTests/Core/Detector/PortalTests.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(PortalTest) {
   portalA->updateDetectorVolume(tContext, nState);
   BOOST_CHECK_EQUAL(nState.currentVolume, volumeB.get());
 
-  // Portal A retains identical posotion to B
+  // Portal A retains identical position to B
   BOOST_CHECK_EQUAL(portalA->surface().center(gctx),
                     portalB->surface().center(gctx));
 

--- a/Tests/UnitTests/Core/Detector/PortalTests.cpp
+++ b/Tests/UnitTests/Core/Detector/PortalTests.cpp
@@ -53,18 +53,6 @@ class LinkToVolumeImpl : public INavigationDelegate {
 }  // namespace Experimental
 }  // namespace Acts
 
-/// Unpack to shared - simply to test the getSharedPtr mechanism
-///
-/// @tparam referenced_type is the type of the referenced object
-///
-/// @param rt is the referenced object
-///
-/// @returns a shared pointer
-template <typename referenced_type>
-std::shared_ptr<referenced_type> unpackToShared(referenced_type& rt) {
-  return rt.getSharedPtr();
-}
-
 using namespace Acts::Experimental;
 
 // A test context
@@ -90,16 +78,13 @@ BOOST_AUTO_TEST_CASE(PortalTest) {
       Acts::Surface::makeShared<Acts::PlaneSurface>(dTransform, rectangle);
 
   // Create a portal out of it
-  auto portalA = Portal::makeShared(surface);
+  auto portalA = std::make_shared<Portal>(surface);
 
   BOOST_CHECK_EQUAL(&(portalA->surface()), surface.get());
 
   portalA->assignGeometryId(Acts::GeometryIdentifier{5});
   BOOST_CHECK_EQUAL(portalA->surface().geometryId(),
                     Acts::GeometryIdentifier{5});
-
-  BOOST_CHECK_EQUAL(portalA, unpackToShared<Portal>(*portalA));
-  BOOST_CHECK_EQUAL(portalA, unpackToShared<const Portal>(*portalA));
 
   // Create a links to volumes
   auto linkToAImpl = std::make_unique<const LinkToVolumeImpl>(volumeA);
@@ -124,7 +109,7 @@ BOOST_AUTO_TEST_CASE(PortalTest) {
   portalA->updateDetectorVolume(tContext, nState);
   BOOST_CHECK_EQUAL(nState.currentVolume, nullptr);
 
-  auto portalB = Portal::makeShared(surface);
+  auto portalB = std::make_shared<Portal>(surface);
   DetectorVolumeUpdater linkToB;
   auto linkToBImpl = std::make_unique<const LinkToVolumeImpl>(volumeB);
   linkToB.connect<&LinkToVolumeImpl::link>(std::move(linkToBImpl));
@@ -164,13 +149,13 @@ BOOST_AUTO_TEST_CASE(PortalTest) {
   auto linkToAIImpl = std::make_unique<const LinkToVolumeImpl>(volumeA);
   auto linkToBIImpl = std::make_unique<const LinkToVolumeImpl>(volumeB);
 
-  auto portalAI = Portal::makeShared(surface);
+  auto portalAI = std::make_shared<Portal>(surface);
   DetectorVolumeUpdater linkToAI;
   linkToAI.connect<&LinkToVolumeImpl::link>(std::move(linkToAIImpl));
   portalAI->assignDetectorVolumeUpdater(Acts::Direction::Positive,
                                         std::move(linkToAI), {volumeA});
 
-  auto portalBI = Portal::makeShared(surface);
+  auto portalBI = std::make_shared<Portal>(surface);
   DetectorVolumeUpdater linkToBI;
   linkToBI.connect<&LinkToVolumeImpl::link>(std::move(linkToBIImpl));
   portalBI->assignDetectorVolumeUpdater(Acts::Direction::Positive,
@@ -207,7 +192,7 @@ BOOST_AUTO_TEST_CASE(PortalMaterialTest) {
   auto surfaceA = Acts::Surface::makeShared<Acts::PlaneSurface>(
       Acts::Transform3::Identity(), rectangle);
   surfaceA->assignSurfaceMaterial(materialA);
-  auto portalA = Acts::Experimental::Portal::makeShared(surfaceA);
+  auto portalA = std::make_shared<Portal>(surfaceA);
 
   DetectorVolumeUpdater linkToA;
   auto linkToAImpl = std::make_unique<const LinkToVolumeImpl>(volumeA);
@@ -217,7 +202,7 @@ BOOST_AUTO_TEST_CASE(PortalMaterialTest) {
 
   auto surfaceB = Acts::Surface::makeShared<Acts::PlaneSurface>(
       Acts::Transform3::Identity(), rectangle);
-  auto portalB = Acts::Experimental::Portal::makeShared(surfaceB);
+  auto portalB = std::make_shared<Portal>(surfaceB);
   DetectorVolumeUpdater linkToB;
   auto linkToBImpl = std::make_unique<const LinkToVolumeImpl>(volumeB);
   linkToB.connect<&LinkToVolumeImpl::link>(std::move(linkToBImpl));
@@ -230,7 +215,7 @@ BOOST_AUTO_TEST_CASE(PortalMaterialTest) {
   BOOST_CHECK_EQUAL(portalA->surface().surfaceMaterial(), materialA.get());
 
   // Remake portal B
-  portalB = Acts::Experimental::Portal::makeShared(surfaceB);
+  portalB = std::make_shared<Portal>(surfaceB);
   DetectorVolumeUpdater linkToB2;
   auto linkToB2Impl = std::make_unique<const LinkToVolumeImpl>(volumeB);
   linkToB2.connect<&LinkToVolumeImpl::link>(std::move(linkToB2Impl));
@@ -244,14 +229,14 @@ BOOST_AUTO_TEST_CASE(PortalMaterialTest) {
   // This fails because A has accumulated volumes on both sides through fusing
   BOOST_CHECK_THROW(Portal::fuse(portalB, portalA), std::invalid_argument);
   // Remove Negative volume on A
-  portalA->assignDetectorVolumeUpdator(Acts::Direction::Negative,
-                                       DetectorVolumeUpdator{}, {});
+  portalA->assignDetectorVolumeUpdater(Acts::Direction::Negative,
+                                       DetectorVolumeUpdater{}, {});
 
   portalB = Portal::fuse(portalB, portalA);
   BOOST_CHECK_EQUAL(portalB->surface().surfaceMaterial(), materialA.get());
 
   // Remake portal A and B, this time both with material
-  portalA = Acts::Experimental::Portal::makeShared(surfaceA);
+  portalA = std::make_shared<Portal>(surfaceA);
   DetectorVolumeUpdater linkToA2;
   auto linkToA2Impl = std::make_unique<const LinkToVolumeImpl>(volumeA);
   linkToA2.connect<&LinkToVolumeImpl::link>(std::move(linkToA2Impl));
@@ -259,7 +244,7 @@ BOOST_AUTO_TEST_CASE(PortalMaterialTest) {
                                        std::move(linkToA2), {volumeA});
 
   surfaceB->assignSurfaceMaterial(materialB);
-  portalB = Acts::Experimental::Portal::makeShared(surfaceB);
+  portalB = std::make_shared<Portal>(surfaceB);
   DetectorVolumeUpdater linkToB3;
   auto linkToB3Impl = std::make_unique<const LinkToVolumeImpl>(volumeB);
   linkToB3.connect<&LinkToVolumeImpl::link>(std::move(linkToB3Impl));

--- a/Tests/UnitTests/Core/Navigation/NavigationStateTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/NavigationStateTests.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE(NavigationState) {
       Acts::Surface::makeShared<Acts::PlaneSurface>(dTransform, rectangle);
 
   // Create a few fake portals out of it
-  auto portalA = Acts::Experimental::Portal::makeShared(pSurfaceA);
-  auto portalB = Acts::Experimental::Portal::makeShared(pSurfaceB);
+  auto portalA = std::make_shared<Acts::Experimental::Portal>(pSurfaceA);
+  auto portalB = std::make_shared<Acts::Experimental::Portal>(pSurfaceB);
 
   std::vector<const Acts::Surface*> surfaces = {surfaceA.get(), surfaceB.get(),
                                                 surfaceC.get()};

--- a/Tests/UnitTests/Core/Navigation/NavigationStateUpdatersTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/NavigationStateUpdatersTests.cpp
@@ -176,8 +176,8 @@ auto surfaceC = Acts::Surface::makeShared<Acts::SurfaceStub>();
 
 auto pSurfaceA = Acts::Surface::makeShared<Acts::SurfaceStub>();
 auto pSurfaceB = Acts::Surface::makeShared<Acts::SurfaceStub>();
-auto portalA = Acts::Experimental::Portal::makeShared(pSurfaceA);
-auto portalB = Acts::Experimental::Portal::makeShared(pSurfaceB);
+auto portalA = std::make_shared<Acts::Experimental::Portal>(pSurfaceA);
+auto portalB = std::make_shared<Acts::Experimental::Portal>(pSurfaceB);
 
 BOOST_AUTO_TEST_SUITE(Experimental)
 

--- a/Tests/UnitTests/Plugins/Json/PortalJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/PortalJsonConverterTests.cpp
@@ -38,7 +38,8 @@ BOOST_AUTO_TEST_CASE(PortalUnconnected) {
   auto surface = Acts::Surface::makeShared<Acts::PlaneSurface>(
       Acts::Vector3(0., 0., 0.), Acts::Vector3(0., 1., 0.));
 
-  auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
+  auto portal =
+      std::make_shared<Acts::Experimental::Portal>(std::move(surface));
 
   BOOST_CHECK_NE(portal, nullptr);
 
@@ -70,7 +71,8 @@ BOOST_AUTO_TEST_CASE(PortalSingleConnected) {
   auto surface = Acts::Surface::makeShared<Acts::PlaneSurface>(
       Acts::Vector3(0., 0., 0.), Acts::Vector3(0., 1., 0.));
 
-  auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
+  auto portal =
+      std::make_shared<Acts::Experimental::Portal>(std::move(surface));
   BOOST_CHECK_NE(portal, nullptr);
   // Attaching the portals
   Acts::Experimental::detail::PortalHelper::attachDetectorVolumeUpdater(
@@ -115,7 +117,8 @@ BOOST_AUTO_TEST_CASE(PortalMultiConnected) {
   auto surface = Acts::Surface::makeShared<Acts::PlaneSurface>(
       Acts::Vector3(0., 0., 0.), Acts::Vector3(0., 1., 0.));
 
-  auto portal = Acts::Experimental::Portal::makeShared(std::move(surface));
+  auto portal =
+      std::make_shared<Acts::Experimental::Portal>(std::move(surface));
   BOOST_CHECK_NE(portal, nullptr);
 
   // Attaching the portals


### PR DESCRIPTION
The shared-from-this functionality in `Portal` is only needed because `Portal::fuse` uses it to reset the other fuse partner to itself. This PR changes `Portal::fuse` into a static symmetric function which returns a new merged portal.

The input portals are invalidated.

It then removes the shared-from-this functionality from portal, as it is no longer needed.