### PR TITLE
fix: set fused portals correctly to former keep volume

### DIFF
--- a/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
+++ b/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
@@ -959,7 +959,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
 
     // Fuse containers, and update the attached volumes
     std::shared_ptr<Portal> innerCylinder = containers[ic - 1].find(2u)->second;
-    // Direction is explicitely up
+    // Direction is explicitly addressed with a direction index
     auto innerAttachedVolumes =
         innerCylinder
             ->attachedDetectorVolumes()[Direction(Direction::Backward).index()];


### PR DESCRIPTION
This PR sets the fused portals correctly back to the former keep volumes that relied on keeping the same shared pointer.

This is an update after #2746 which omitted that.