### PR TITLE
chore: Add pre-commit config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v14.0.0'
+    hooks:
+      - id: clang-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-added-large-files


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a framework for managing git-supported pre-commit hooks. It uses a plugin system and auto-installs plugins when run. By default, this does nothing for developers, but if you install pre-commit and run

```console
$ pre-commit install
```

it will register itself as a pre-commit hook with git. It will then yell at you before committing if files are not formatted correctly (I'm also adding a few other things like and end-of-file checker). It only runs on files that are staged, so it should be fast.

One neat thing is that it can run clang-format, and that it installs the correct version of clang-tidy from PIP! So theoretically, with this, you should get portable automatically correctly formatted commits.