### PR TITLE
revert: Remove `volumeSignature` from geometry building

### DIFF
--- a/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBuilder.hpp
@@ -503,6 +503,9 @@ class CylinderVolumeBuilder : public ITrackingVolumeBuilder {
     /// -------------------- MB (inner [0]) ---------------
     std::array<std::shared_ptr<const ISurfaceMaterial>, 6> boundaryMaterial{
         nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+
+    /// Volume signature
+    int volumeSignature = -1;
   };
 
   /// Constructor

--- a/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/BuildGenericDetector.hpp
+++ b/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/BuildGenericDetector.hpp
@@ -205,6 +205,7 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
   bpvConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
                               1. * Acts::UnitConstants::mm};
   bpvConfig.buildToRadiusZero = true;
+  bpvConfig.volumeSignature = 0;
   auto beamPipeVolumeBuilder =
       std::make_shared<const Acts::CylinderVolumeBuilder>(
           bpvConfig,
@@ -392,6 +393,7 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
   pvbConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
                               5. * Acts::UnitConstants::mm};
   pvbConfig.layerBuilder = pixelLayerBuilder;
+  pvbConfig.volumeSignature = 0;
   auto pixelVolumeBuilder = std::make_shared<const Acts::CylinderVolumeBuilder>(
       pvbConfig, Acts::getDefaultLogger("PixelVolumeBuilder", volumeLLevel));
   // add to the list of builders
@@ -425,6 +427,7 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
     pstvolConfig.volumeName = "PST";
     pstvolConfig.buildToRadiusZero = false;
     pstvolConfig.layerBuilder = pstBuilder;
+    pstvolConfig.volumeSignature = 0;
     auto pstVolumeBuilder = std::make_shared<const Acts::CylinderVolumeBuilder>(
         pstvolConfig, Acts::getDefaultLogger("PSTVolumeBuilder", volumeLLevel));
     // add to the detector builds
@@ -620,6 +623,7 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
     ssvbConfig.volumeName = "SStrip";
     ssvbConfig.buildToRadiusZero = false;
     ssvbConfig.layerBuilder = sstripLayerBuilder;
+    ssvbConfig.volumeSignature = 0;
     auto sstripVolumeBuilder =
         std::make_shared<const Acts::CylinderVolumeBuilder>(
             ssvbConfig,
@@ -805,6 +809,7 @@ std::unique_ptr<const Acts::TrackingGeometry> buildDetector(
     lsvbConfig.volumeName = "LStrip";
     lsvbConfig.buildToRadiusZero = false;
     lsvbConfig.layerBuilder = lstripLayerBuilder;
+    lsvbConfig.volumeSignature = 0;
     auto lstripVolumeBuilder =
         std::make_shared<const Acts::CylinderVolumeBuilder>(
             lsvbConfig,

--- a/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
@@ -295,6 +295,7 @@ std::shared_ptr<const Acts::TrackingGeometry> buildTGeoDetector(
     ringLayoutConfiguration(lbc.layerConfigurations[0]);
     ringLayoutConfiguration(lbc.layerConfigurations[2]);
     volumeConfig.layerBuilder = layerBuilder;
+    volumeConfig.volumeSignature = 0;
     auto volumeBuilder = std::make_shared<const Acts::CylinderVolumeBuilder>(
         volumeConfig, logger.clone(lbc.configurationName + "VolumeBuilder",
                                    config.volumeLogLevel));

--- a/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
+++ b/Plugins/DD4hep/src/ConvertDD4hepDetector.cpp
@@ -382,6 +382,7 @@ std::shared_ptr<const CylinderVolumeBuilder> volumeBuilder_dd4hep(
     cvbConfig.layerEnvelopeR = std::make_pair(layerEnvelopeR, layerEnvelopeR);
     cvbConfig.layerEnvelopeZ = layerEnvelopeZ;
     cvbConfig.trackingVolumeHelper = volumeHelper;
+    cvbConfig.volumeSignature = 0;
     cvbConfig.volumeName = subDetector.name();
     cvbConfig.layerBuilder = dd4hepLayerBuilder;
     auto cylinderVolumeBuilder =
@@ -437,6 +438,7 @@ std::shared_ptr<const CylinderVolumeBuilder> volumeBuilder_dd4hep(
     // the configuration object of the volume builder
     Acts::CylinderVolumeBuilder::Config cvbConfig;
     cvbConfig.trackingVolumeHelper = volumeHelper;
+    cvbConfig.volumeSignature = 0;
     cvbConfig.volumeName = subDetector.name();
     cvbConfig.layerBuilder = pcLayerBuilder;
     cvbConfig.layerEnvelopeR = {layerEnvelopeR, layerEnvelopeR};
@@ -520,6 +522,7 @@ std::shared_ptr<const CylinderVolumeBuilder> volumeBuilder_dd4hep(
     cvbConfig.layerEnvelopeR = std::make_pair(layerEnvelopeR, layerEnvelopeR);
     cvbConfig.layerEnvelopeZ = layerEnvelopeZ;
     cvbConfig.trackingVolumeHelper = volumeHelper;
+    cvbConfig.volumeSignature = 0;
     cvbConfig.volumeName = subDetector.name();
     cvbConfig.layerBuilder = dd4hepLayerBuilder;
     cvbConfig.ctVolumeBuilder = dd4hepVolumeBuilder;

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
@@ -259,6 +259,7 @@ struct CylindricalTrackingGeometry {
     bpvConfig.layerBuilder = beamPipeBuilder;
     bpvConfig.layerEnvelopeR = {1_mm, 1_mm};
     bpvConfig.buildToRadiusZero = true;
+    bpvConfig.volumeSignature = 0;
     auto beamPipeVolumeBuilder = std::make_shared<const CylinderVolumeBuilder>(
         bpvConfig, getDefaultLogger("BeamPipeVolumeBuilder", volumeLLevel));
 

--- a/Tests/UnitTests/Core/Geometry/SimpleGeometryTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/SimpleGeometryTests.cpp
@@ -83,6 +83,7 @@ BOOST_AUTO_TEST_CASE(SimpleGeometryTest) {
   bpvConfig.layerBuilder = beamPipeBuilder;
   bpvConfig.layerEnvelopeR = {1_mm, 1_mm};
   bpvConfig.buildToRadiusZero = true;
+  bpvConfig.volumeSignature = 0;
   auto beamPipeVolumeBuilder = std::make_shared<const CylinderVolumeBuilder>(
       bpvConfig, getDefaultLogger("BeamPipeVolumeBuilder", volumeLLevel));
 
@@ -101,6 +102,7 @@ BOOST_AUTO_TEST_CASE(SimpleGeometryTest) {
   cvbConfig.layerBuilder = layerBuilder;
   cvbConfig.layerEnvelopeR = {1_mm, 1_mm};
   cvbConfig.buildToRadiusZero = false;
+  cvbConfig.volumeSignature = 0;
   auto centralVolumeBuilder = std::make_shared<const CylinderVolumeBuilder>(
       cvbConfig, getDefaultLogger("CentralVolumeBuilder", volumeLLevel));
 

--- a/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/SurfaceMaterialMapperTests.cpp
@@ -87,6 +87,7 @@ std::shared_ptr<const TrackingGeometry> trackingGeometry() {
   cvbConfig.layerBuilder = layerBuilder;
   cvbConfig.layerEnvelopeR = {1_mm, 1_mm};
   cvbConfig.buildToRadiusZero = true;
+  cvbConfig.volumeSignature = 0;
   auto centralVolumeBuilder = std::make_shared<const CylinderVolumeBuilder>(
       cvbConfig, getDefaultLogger("CentralVolumeBuilder", volumeLLevel));
 


### PR DESCRIPTION
This reverts commit 34bd984f66029ebe93697aab76e84c56a16f10c0 from #2759 as it breaks Athena compilation.