### PR TITLE
fix: bump svg version (fix) and display bin centers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.35)
+set(_acts_actsvg_version 0.4.37)
 set(_acts_autodiff_version 0.6)
 set(_acts_boost_version 1.71.0)
 set(_acts_dd4hep_version 1.21)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.37)
+set(_acts_actsvg_version 0.4.38)
 set(_acts_autodiff_version 0.6)
 set(_acts_boost_version 1.71.0)
 set(_acts_dd4hep_version 1.21)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.38)
+set(_acts_actsvg_version 0.4.39)
 set(_acts_autodiff_version 0.6)
 set(_acts_boost_version 1.71.0)
 set(_acts_dd4hep_version 1.21)

--- a/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
+++ b/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
@@ -95,6 +95,19 @@ ProtoIndexedSurfaceGrid convertImpl(const GeometryContext& gctx,
       }
       constrain.extend(sExtent, {binR});
     }
+    // Add center info
+    std::string centerInfo = " - center = (";
+    const Vector3& center = s->center(gctx);
+    centerInfo +=
+        std::to_string(VectorHelpers::cast(center, indexGrid.casts[0u]));
+    if (indexGrid.casts.size() > 1u) {
+      centerInfo += ", ";
+      centerInfo +=
+          std::to_string(VectorHelpers::cast(center, indexGrid.casts[1u]));
+      centerInfo += ")";
+    }
+    pSurface._aux_info["center"] = {centerInfo};
+    // Add the center info
     pSurfaces.push_back(pSurface);
   }
 
@@ -118,17 +131,23 @@ ProtoIndexedSurfaceGrid convertImpl(const GeometryContext& gctx,
 
   // 1D connections
   if constexpr (index_grid::grid_type::DIM == 1u) {
+    const auto& binEdges = axes[0u]->getBinEdges();
     for (unsigned int ib0 = 1u; ib0 <= axes[0u]->getNBins(); ++ib0) {
       typename index_grid::grid_type::index_t lbin;
       lbin[0u] = ib0;
       highlightIndices.push_back(indexGrid.grid.atLocalBins(lbin));
       // Register the bin naming
-      pGrid._bin_ids.push_back(std::string("- bin : [") + std::to_string(ib0) +
-                               std::string("]"));
+      std::string binInfo =
+          std::string("- bin : [") + std::to_string(ib0) + std::string("]");
+      ActsScalar binCenter = 0.5 * (binEdges[ib0] + binEdges[ib0 - 1u]);
+      binInfo += "\n - center : (" + std::to_string(binCenter) + ")";
+      pGrid._bin_ids.push_back(binInfo);
     }
   }
   // 2D connections
   if constexpr (index_grid::grid_type::DIM == 2u) {
+    const auto& binEdges0 = axes[0u]->getBinEdges();
+    const auto& binEdges1 = axes[1u]->getBinEdges();
     for (unsigned int ib0 = 1u; ib0 <= axes[0u]->getNBins(); ++ib0) {
       for (unsigned int ib1 = 1u; ib1 <= axes[1u]->getNBins(); ++ib1) {
         typename index_grid::grid_type::index_t lbin;
@@ -136,9 +155,14 @@ ProtoIndexedSurfaceGrid convertImpl(const GeometryContext& gctx,
         lbin[1u] = ib1;
         highlightIndices.push_back(indexGrid.grid.atLocalBins(lbin));
         // Register the bin naming
-        pGrid._bin_ids.push_back(std::string("- bin : [") +
-                                 std::to_string(ib0) + std::string(", ") +
-                                 std::to_string(ib1) + std::string("]"));
+        std::string binInfo = std::string("- bin : [") + std::to_string(ib0) +
+                              std::string(", ") + std::to_string(ib1) +
+                              std::string("]");
+        ActsScalar binCenter0 = 0.5 * (binEdges0[ib0] + binEdges0[ib0 - 1u]);
+        ActsScalar binCenter1 = 0.5 * (binEdges1[ib1] + binEdges1[ib1 - 1u]);
+        binInfo += "\n - center : (" + std::to_string(binCenter0) + ", " +
+                   std::to_string(binCenter1) + ")";
+        pGrid._bin_ids.push_back(binInfo);
         if (estimateR) {
           pGrid._reference_r = constrain.medium(binR);
         }
@@ -256,7 +280,7 @@ static inline actsvg::svg::object xy(const ProtoIndexedSurfaceGrid& pIndexGrid,
     }
   }
 
-  // The grid
+  // The grid as provided
   auto gOb =
       actsvg::display::grid(identification + std::string("_grid"), pGrid);
 
@@ -274,14 +298,21 @@ static inline actsvg::svg::object xy(const ProtoIndexedSurfaceGrid& pIndexGrid,
     binText.push_back("Source:");
     binText.push_back(pGrid._bin_ids[ig]);
     binText.push_back("Target:");
-    for (const auto& sis : pIndices[ig]) {
-      binText.push_back(std::string("- object: ") + std::to_string(sis));
+    for (const auto [is, sis] : enumerate(pIndices[ig])) {
+      const auto& ps = pSurfaces[sis];
+      std::string oInfo = std::string("- object: ") + std::to_string(sis);
+      if (ps._aux_info.find("center") != ps._aux_info.end()) {
+        for (const auto& ci : ps._aux_info.at("center")) {
+          oInfo += ci;
+        }
+      }
+      binText.push_back(oInfo);
     }
     // Make the connected text
     std::string cTextId =
         identification + std::string("_ct_") + std::to_string(ig);
     auto cText = actsvg::draw::connected_text(
-        "bla", {static_cast<actsvg::scalar>(1.1 * xmax), 0}, binText,
+        cTextId, {static_cast<actsvg::scalar>(1.1 * xmax), 0}, binText,
         actsvg::style::font{}, actsvg::style::transform{}, gTile);
     xyIndexedGrid.add_object(cText);
   }


### PR DESCRIPTION
This is a mini fix:
- updating the `ActsSVG` version to `v0.4.38` removes the warning:

```sh
z-rphi view detected!
z-rphi view detected!
z-rphi view detected!
z-rphi view detected!
z-rphi view detected!
z-rphi view detected!
```

caused by a `cout` in the `v0.4.35` version.

It also adds bin center displays.
