### PR TITLE
refactor!: Remove navigator layer bounds check option

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -113,10 +113,6 @@ class Navigator {
     bool resolveMaterial = true;
     /// stop at every surface regardless what it is
     bool resolvePassive = false;
-
-    /// Whether to perform boundary checks for layer resolving (improves
-    /// navigation for bended tracks)
-    BoundaryCheck boundaryCheckLayerResolving = BoundaryCheck(true);
   };
 
   /// @brief Nested State struct
@@ -1187,7 +1183,6 @@ class Navigator {
     // Create the navigation options
     // - and get the compatible layers, start layer will be excluded
     NavigationOptions<Layer> navOpts;
-    navOpts.boundaryCheck = m_cfg.boundaryCheckLayerResolving;
     navOpts.resolveSensitive = m_cfg.resolveSensitive;
     navOpts.resolveMaterial = m_cfg.resolveMaterial;
     navOpts.resolvePassive = m_cfg.resolvePassive;

--- a/Tests/IntegrationTests/PropagationBentTracks.cpp
+++ b/Tests/IntegrationTests/PropagationBentTracks.cpp
@@ -89,25 +89,6 @@ BOOST_AUTO_TEST_CASE(with_boundary_check_no_bfield) {
                     0);
 }
 
-BOOST_AUTO_TEST_CASE(without_boundary_check_no_bfield) {
-  auto navCfg = Acts::Navigator::Config{};
-  navCfg.boundaryCheckLayerResolving = Acts::BoundaryCheck(false);
-  const auto xPositions = xPositionsOfPassedSurfaces(navCfg, 0.0_T);
-
-  // without bField we exit at the side so we don't hit the surfaces at x ~
-  // 2000 and also not the boundary surface at x = 3000, regardless of the
-  // boundary checking
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 999.0), 1);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 1001.0),
-                    1);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 1999.0),
-                    0);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 2001.0),
-                    0);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 3000.0),
-                    0);
-}
-
 BOOST_AUTO_TEST_CASE(with_boundary_check_with_bfield) {
   auto navCfg = Acts::Navigator::Config{};
   const auto xPositions = xPositionsOfPassedSurfaces(navCfg, 0.5_T);
@@ -121,24 +102,6 @@ BOOST_AUTO_TEST_CASE(with_boundary_check_with_bfield) {
                     0);
   BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 2001.0),
                     0);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 3000.0),
-                    1);
-}
-
-BOOST_AUTO_TEST_CASE(no_boundary_check_with_bfield) {
-  auto navCfg = Acts::Navigator::Config{};
-  navCfg.boundaryCheckLayerResolving = Acts::BoundaryCheck(false);
-  const auto xPositions = xPositionsOfPassedSurfaces(navCfg, 0.5_T);
-
-  // Without boundary check at layer resolving, we also hit the surfaces at x ~
-  // 2000
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 999.0), 1);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 1001.0),
-                    1);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 1999.0),
-                    1);
-  BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 2001.0),
-                    1);
   BOOST_CHECK_EQUAL(std::count(xPositions.begin(), xPositions.end(), 3000.0),
                     1);
 }


### PR DESCRIPTION
This option is supposed to improve the navigation but can also cause regressions. Layers without bounds overlap with boundaries therefore we might end up outside the current tracking volume while targeting a layer. I propose that this should be rather fixed by the used with proper layer bounds that extend to the volume boundaries.