### PR TITLE
fix: documentation - missing/extra parameters

### DIFF
--- a/Core/include/Acts/Detector/GeometryIdGenerator.hpp
+++ b/Core/include/Acts/Detector/GeometryIdGenerator.hpp
@@ -197,7 +197,7 @@ class ChainedGeometryIdGenerator : public IGeometryIdGenerator {
   ///
   /// @tparam gometry_object_t the geometry object type
   ///
-  /// @param the cache object with the array of sub caches
+  /// @param cache object with the array of sub caches
   /// @param object the object to assign the geometry id to
   template <typename gometry_object_t>
   void assign(IGeometryIdGenerator::GeoIdCache& cache,

--- a/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
+++ b/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
@@ -66,9 +66,8 @@ class ProtoSurfaceMaterialT : public ISurfaceMaterial {
   ProtoSurfaceMaterialT<BinningType>& operator=(
       ProtoSurfaceMaterialT<BinningType>&& smproxy) = default;
 
-  /// Scale operator
+  /// Scale operator - dummy implementation
   ///
-  /// @param scale The value to scale this material by
   ProtoSurfaceMaterialT<BinningType>& operator*=(double /*unused*/) final {
     return (*this);
   }

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -132,6 +132,7 @@ struct CombinatorialKalmanFilterExtensions {
 
   /// Default branch stopper which will never stop
   /// @param tipState The tip state to decide whether to stop (unused)
+  /// @param trackState The track state to decide whether to stop (unused)
   /// @return false
   static bool voidBranchStopper(
       const CombinatorialKalmanFilterTipState& tipState,

--- a/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridTrackDensity.hpp
@@ -197,6 +197,10 @@ class AdaptiveGridTrackDensity {
   /// @param centralBin Central z and t bin of the track (where its
   /// density is the highest)
   /// @param cov 3x3 impact parameter covariance matrix
+  /// @param spatialTrkGridSize Number of bins in z direction
+  /// @param temporalTrkGridSize Number of bins in time direction
+  ///
+  /// @return The track density map
   DensityMap createTrackGrid(const Acts::Vector3& impactParams,
                              const Bin& centralBin,
                              const Acts::SquareMatrix3& cov,

--- a/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexTrackUpdater.hpp
@@ -31,21 +31,16 @@ namespace KalmanVertexTrackUpdater {
 /// @brief Refits a single track with the knowledge of
 /// the vertex it has originated from
 ///
-/// @tparam input_track_t Track object type
-/// @tparam nDimVertex number of dimensions of the vertex. Can be 3 (if we only
-/// fit its spatial coordinates) or 4 (if we also fit time).
-///
 /// @param track Track to update
-/// @param vtx Vertex `track` belongs to
+/// @param vtxPosFull full vertex position
+/// @param vtxCovFull full vertex covariance matrix
+/// @param nDimVertex number of dimensions of the vertex
 void update(TrackAtVertexRef track, const Vector4& vtxPosFull,
             const SquareMatrix4& vtxCovFull, unsigned int nDimVertex);
 
 namespace detail {
 
 /// @brief Calculates a covariance matrix for the refitted track parameters
-///
-/// @tparam nDimVertex number of dimensions of the vertex. Can be 3 (if we only
-/// fit its spatial coordinates) or 4 (if we also fit time).
 ///
 /// @param wMat W_k matrix from Ref. (1)
 /// @param crossCovVP Cross-covariance matrix between vertex position and track

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
@@ -92,17 +92,17 @@ void calculateUpdate4(const Vector4& vtxPos, const SquareMatrix4& vtxCov,
 /// updated track momentum when adding/removing linTrack. Saves the result in
 /// cache.
 ///
-/// @tparam input_track_t Track object type
 /// @tparam nDimVertex number of dimensions of the vertex. Can be 3 (if we only
 /// fit its spatial coordinates) or 4 (if we also fit time).
 ///
-/// @param vtx Vertex
+/// @param vtxPos Vertex position
+/// @param vtxCov Vertex covariance matrix
 /// @param linTrack Linearized track to be added or removed
 /// @param trackWeight Track weight
 /// @param sign +1 (add track) or -1 (remove track)
 /// @note Tracks are removed during the smoothing procedure to compute
 /// the chi2 of the track wrt the updated vertex position
-/// @param[out] cache A cache to store the results of this function
+/// @param[in,out] cache A cache to store the results of this function
 template <unsigned int nDimVertex>
 void calculateUpdate(const Vector4& vtxPos, const SquareMatrix4& vtxCov,
                      const Acts::LinearizedTrack& linTrack,


### PR DESCRIPTION
This PR collects a few fixes of missing documented parameters in various packages that makes the doc build break (albeit not reproducibly).