### PR TITLE
refactor!: Vertex InputTrack becomes concrete type

### DIFF
--- a/Core/include/Acts/Vertexing/AMVFInfo.hpp
+++ b/Core/include/Acts/Vertexing/AMVFInfo.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Vertexing/TrackAtVertex.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
 
 #include <map>
@@ -46,9 +47,9 @@ struct VertexInfo {
   bool relinearize = true;
 
   // Vector of all tracks that are currently assigned to vertex
-  std::vector<const input_track_t*> trackLinks;
+  std::vector<InputTrack> trackLinks;
 
-  std::map<const input_track_t*, const BoundTrackParameters> impactParams3D;
+  std::map<InputTrack, const BoundTrackParameters> impactParams3D;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -72,11 +72,11 @@ class AdaptiveGridDensityVertexFinder {
     DensityMap mainDensityMap;
 
     // Map from input track to corresponding track density map
-    std::unordered_map<const InputTrack_t*, DensityMap> trackDensities;
+    std::unordered_map<InputTrack, DensityMap> trackDensities;
 
     // Store tracks that have been removed from track collection. These
     // tracks will be removed from the main grid
-    std::vector<const InputTrack_t*> tracksToRemove;
+    std::vector<InputTrack> tracksToRemove;
 
     bool isInitialized = false;
   };
@@ -92,7 +92,7 @@ class AdaptiveGridDensityVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -103,7 +103,9 @@ class AdaptiveGridDensityVertexFinder {
       typename T = InputTrack_t,
       std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
   AdaptiveGridDensityVertexFinder(const Config& cfg)
-      : m_cfg(cfg), m_extractParameters([](T params) { return params; }) {}
+      : m_cfg(cfg), m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }) {}
 
   /// @brief Default constructor used if InputTrack_t type ==
   /// BoundTrackParameters
@@ -121,7 +123,7 @@ class AdaptiveGridDensityVertexFinder {
   /// object
   AdaptiveGridDensityVertexFinder(
       const Config& cfg,
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_cfg(cfg), m_extractParameters(func) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
@@ -130,7 +132,7 @@ class AdaptiveGridDensityVertexFinder {
   /// @param func Function extracting BoundTrackParameters from InputTrack_t
   /// object
   AdaptiveGridDensityVertexFinder(
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_extractParameters(func) {}
 
  private:
@@ -147,7 +149,7 @@ class AdaptiveGridDensityVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
@@ -8,7 +8,7 @@
 
 template <typename vfitter_t>
 auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
-    const std::vector<const InputTrack_t*>& trackVector,
+    const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
     -> Result<std::vector<Vertex<InputTrack_t>>> {
   // Remove density contributions from tracks removed from track collection
@@ -26,7 +26,7 @@ auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
     state.mainDensityMap = DensityMap();
     // Fill with track densities
     for (auto trk : trackVector) {
-      const BoundTrackParameters& trkParams = m_extractParameters(*trk);
+      const BoundTrackParameters& trkParams = m_extractParameters(trk);
       // Take only tracks that fulfill selection criteria
       if (!doesPassTrackSelection(trkParams)) {
         continue;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -197,7 +197,7 @@ class AdaptiveMultiVertexFinder {
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("AdaptiveMultiVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters(func),
+        m_extractParameters(std::move(func)),
         m_logger(std::move(logger)) {}
 
   AdaptiveMultiVertexFinder(AdaptiveMultiVertexFinder&&) = default;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -180,7 +180,9 @@ class AdaptiveMultiVertexFinder {
                                 getDefaultLogger("AdaptiveMultiVertexFinder",
                                                  Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters([](T params) { return params; }),
+        m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }),
         m_logger(std::move(logger)) {}
 
   /// @brief Constructor for user-defined InputTrack_t type !=
@@ -191,7 +193,7 @@ class AdaptiveMultiVertexFinder {
   /// object
   /// @param logger The logging instance
   AdaptiveMultiVertexFinder(
-      Config cfg, std::function<BoundTrackParameters(InputTrack_t)> func,
+      Config cfg, std::function<BoundTrackParameters(const InputTrack&)> func,
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("AdaptiveMultiVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
@@ -209,7 +211,7 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return Vector of all reconstructed vertices
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& allTracks,
+      const std::vector<InputTrack>& allTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -220,7 +222,7 @@ class AdaptiveMultiVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger;
@@ -242,11 +244,11 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return The seed vertex
   Result<Vertex<InputTrack_t>> doSeeding(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       Vertex<InputTrack_t>& currentConstraint,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       SeedFinderState_t& seedFinderState,
-      const std::vector<const InputTrack_t*>& removedSeedTracks) const;
+      const std::vector<InputTrack>& removedSeedTracks) const;
 
   /// @brief Sets constraint vertex after seeding
   ///
@@ -265,7 +267,7 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return The IP significance
   Result<double> getIPSignificance(
-      const InputTrack_t* track, const Vertex<InputTrack_t>& vtx,
+      const InputTrack& track, const Vertex<InputTrack_t>& vtx,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Adds compatible track to vertex candidate
@@ -275,7 +277,7 @@ class AdaptiveMultiVertexFinder {
   /// @param[out] fitterState The vertex fitter state
   /// @param vertexingOptions Vertexing options
   Result<void> addCompatibleTracksToVertex(
-      const std::vector<const InputTrack_t*>& tracks, Vertex<InputTrack_t>& vtx,
+      const std::vector<InputTrack>& tracks, Vertex<InputTrack_t>& vtx,
       FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
@@ -292,10 +294,9 @@ class AdaptiveMultiVertexFinder {
   ///
   /// return True if recovery was successful, false otherwise
   Result<bool> canRecoverFromNoCompatibleTracks(
-      const std::vector<const InputTrack_t*>& allTracks,
-      const std::vector<const InputTrack_t*>& seedTracks,
-      Vertex<InputTrack_t>& vtx, const Vertex<InputTrack_t>& currentConstraint,
-      FitterState_t& fitterState,
+      const std::vector<InputTrack>& allTracks,
+      const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
+      const Vertex<InputTrack_t>& currentConstraint, FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Method that tries to prepare the vertex for the fit
@@ -310,10 +311,9 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return True if preparation was successful, false otherwise
   Result<bool> canPrepareVertexForFit(
-      const std::vector<const InputTrack_t*>& allTracks,
-      const std::vector<const InputTrack_t*>& seedTracks,
-      Vertex<InputTrack_t>& vtx, const Vertex<InputTrack_t>& currentConstraint,
-      FitterState_t& fitterState,
+      const std::vector<InputTrack>& allTracks,
+      const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
+      const Vertex<InputTrack_t>& currentConstraint, FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Method that checks if vertex is a good vertex and if
@@ -326,8 +326,7 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return pair(nCompatibleTracks, isGoodVertex)
   std::pair<int, bool> checkVertexAndCompatibleTracks(
-      Vertex<InputTrack_t>& vtx,
-      const std::vector<const InputTrack_t*>& seedTracks,
+      Vertex<InputTrack_t>& vtx, const std::vector<InputTrack>& seedTracks,
       FitterState_t& fitterState, bool useVertexConstraintInFit) const;
 
   /// @brief Method that removes all tracks that are compatible with
@@ -339,9 +338,9 @@ class AdaptiveMultiVertexFinder {
   /// @param[out] removedSeedTracks Collection of seed track that will be
   /// removed
   void removeCompatibleTracksFromSeedTracks(
-      Vertex<InputTrack_t>& vtx, std::vector<const InputTrack_t*>& seedTracks,
+      Vertex<InputTrack_t>& vtx, std::vector<InputTrack>& seedTracks,
       FitterState_t& fitterState,
-      std::vector<const InputTrack_t*>& removedSeedTracks) const;
+      std::vector<InputTrack>& removedSeedTracks) const;
 
   /// @brief Method that tries to remove an incompatible track
   /// from seed tracks after removing a compatible track failed.
@@ -354,11 +353,11 @@ class AdaptiveMultiVertexFinder {
   /// @param[in] geoCtx The geometry context to access global positions
   ///
   /// @return Incompatible track was removed
-  bool removeTrackIfIncompatible(
-      Vertex<InputTrack_t>& vtx, std::vector<const InputTrack_t*>& seedTracks,
-      FitterState_t& fitterState,
-      std::vector<const InputTrack_t*>& removedSeedTracks,
-      const GeometryContext& geoCtx) const;
+  bool removeTrackIfIncompatible(Vertex<InputTrack_t>& vtx,
+                                 std::vector<InputTrack>& seedTracks,
+                                 FitterState_t& fitterState,
+                                 std::vector<InputTrack>& removedSeedTracks,
+                                 const GeometryContext& geoCtx) const;
 
   /// @brief Method that evaluates if the new vertex candidate should
   /// be kept, i.e. saved, or not

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -234,8 +234,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getIPSignificance(
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     addCompatibleTracksToVertex(
-        const std::vector<InputTrack>& tracks,
-        Vertex<InputTrack_t>& vtx, FitterState_t& fitterState,
+        const std::vector<InputTrack>& tracks, Vertex<InputTrack_t>& vtx,
+        FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<void> {
   for (const auto& trk : tracks) {
@@ -267,8 +267,7 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     canRecoverFromNoCompatibleTracks(
         const std::vector<InputTrack>& allTracks,
-        const std::vector<InputTrack>& seedTracks,
-        Vertex<InputTrack_t>& vtx,
+        const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
         const Vertex<InputTrack_t>& currentConstraint,
         FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
@@ -283,8 +282,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     double newZ = 0;
     bool nearTrackFound = false;
     for (const auto& trk : seedTracks) {
-      auto pos =
-          m_extractParameters(trk).position(vertexingOptions.geoContext);
+      auto pos = m_extractParameters(trk).position(vertexingOptions.geoContext);
       auto zDistance = std::abs(pos[eZ] - vtx.position()[eZ]);
       if (zDistance < smallestDeltaZ) {
         smallestDeltaZ = zDistance;
@@ -326,8 +324,7 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     canPrepareVertexForFit(
         const std::vector<InputTrack>& allTracks,
-        const std::vector<InputTrack>& seedTracks,
-        Vertex<InputTrack_t>& vtx,
+        const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
         const Vertex<InputTrack_t>& currentConstraint,
         FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
@@ -356,10 +353,10 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
-    checkVertexAndCompatibleTracks(
-        Vertex<InputTrack_t>& vtx,
-        const std::vector<InputTrack>& seedTracks,
-        FitterState_t& fitterState, bool useVertexConstraintInFit) const
+    checkVertexAndCompatibleTracks(Vertex<InputTrack_t>& vtx,
+                                   const std::vector<InputTrack>& seedTracks,
+                                   FitterState_t& fitterState,
+                                   bool useVertexConstraintInFit) const
     -> std::pair<int, bool> {
   bool isGoodVertex = false;
   int nCompatibleTracks = 0;
@@ -423,11 +420,11 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
-    removeTrackIfIncompatible(
-        Vertex<InputTrack_t>& vtx, std::vector<InputTrack>& seedTracks,
-        FitterState_t& fitterState,
-        std::vector<InputTrack>& removedSeedTracks,
-        const GeometryContext& geoCtx) const -> bool {
+    removeTrackIfIncompatible(Vertex<InputTrack_t>& vtx,
+                              std::vector<InputTrack>& seedTracks,
+                              FitterState_t& fitterState,
+                              std::vector<InputTrack>& removedSeedTracks,
+                              const GeometryContext& geoCtx) const -> bool {
   // Try to find the track with highest compatibility
   double maxCompatibility = 0;
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -183,7 +183,7 @@ class AdaptiveMultiVertexFitter {
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("AdaptiveMultiVertexFitter", Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters(func),
+        m_extractParameters(std::move(func)),
         m_logger(std::move(logger)) {}
 
   /// @brief Adds a new vertex to an existing multi-vertex fit.

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -69,13 +69,12 @@ class AdaptiveMultiVertexFitter {
     typename Linearizer_t::State linearizerState;
 
     // Map to store vertices information
+    // @TODO Does this have to be a mutable pointer?
     std::map<Vertex<InputTrack_t>*, VertexInfo<InputTrack_t>> vtxInfoMap;
 
-    std::multimap<const InputTrack_t*, Vertex<InputTrack_t>*>
-        trackToVerticesMultiMap;
+    std::multimap<InputTrack, Vertex<InputTrack_t>*> trackToVerticesMultiMap;
 
-    std::map<std::pair<const InputTrack_t*, Vertex<InputTrack_t>*>,
-             TrackAtVertex<InputTrack_t>>
+    std::map<std::pair<InputTrack, Vertex<InputTrack_t>*>, TrackAtVertex>
         tracksAtVerticesMap;
 
     /// @brief Default State constructor
@@ -167,7 +166,9 @@ class AdaptiveMultiVertexFitter {
                                 getDefaultLogger("AdaptiveMultiVertexFitter",
                                                  Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters([](T params) { return params; }),
+        m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }),
         m_logger(std::move(logger)) {}
 
   /// @brief Constructor for user-defined InputTrack_t type !=
@@ -178,7 +179,7 @@ class AdaptiveMultiVertexFitter {
   /// object
   /// @param logger The logging instance
   AdaptiveMultiVertexFitter(
-      Config cfg, std::function<BoundTrackParameters(InputTrack_t)> func,
+      Config cfg, std::function<BoundTrackParameters(const InputTrack&)> func,
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("AdaptiveMultiVertexFitter", Logging::INFO))
       : m_cfg(std::move(cfg)),
@@ -224,7 +225,7 @@ class AdaptiveMultiVertexFitter {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger;
@@ -282,7 +283,7 @@ class AdaptiveMultiVertexFitter {
   ///
   /// @return Vector of compatibility values
   std::vector<double> collectTrackToVertexCompatibilities(
-      State& state, const InputTrack_t* trk) const;
+      State& state, const InputTrack& trk) const;
 
   /// @brief Determines if any vertex position has shifted more than
   /// m_cfg.maxRelativeShift in the last iteration

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -83,7 +83,9 @@ class FullBilloirVertexFitter {
                               getDefaultLogger("FullBilloirVertexFitter",
                                                Logging::INFO))
       : m_cfg(cfg),
-        extractParameters([](T params) { return params; }),
+        extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }),
         m_logger(std::move(logger)) {}
 
   /// @brief Constructor for user-defined input_track_t type =!
@@ -95,7 +97,7 @@ class FullBilloirVertexFitter {
   /// @param logger Logging instance
   FullBilloirVertexFitter(
       const Config& cfg,
-      std::function<BoundTrackParameters(input_track_t)> func,
+      std::function<BoundTrackParameters(const InputTrack&)> func,
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("FullBilloirVertexFitter", Logging::INFO))
       : m_cfg(cfg), extractParameters(func), m_logger(std::move(logger)) {}
@@ -109,7 +111,7 @@ class FullBilloirVertexFitter {
   ///
   /// @return Fitted vertex
   Result<Vertex<input_track_t>> fit(
-      const std::vector<const input_track_t*>& paramVector,
+      const std::vector<InputTrack>& paramVector,
       const linearizer_t& linearizer,
       const VertexingOptions<input_track_t>& vertexingOptions,
       State& state) const;
@@ -122,7 +124,7 @@ class FullBilloirVertexFitter {
   /// input_track_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other input_track_t
   /// objects.
-  std::function<BoundTrackParameters(input_track_t)> extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> extractParameters;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger;

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -100,7 +100,9 @@ class FullBilloirVertexFitter {
       std::function<BoundTrackParameters(const InputTrack&)> func,
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("FullBilloirVertexFitter", Logging::INFO))
-      : m_cfg(cfg), extractParameters(func), m_logger(std::move(logger)) {}
+      : m_cfg(cfg),
+        extractParameters(std::move(func)),
+        m_logger(std::move(logger)) {}
 
   /// @brief Fit method, fitting vertex for provided tracks with constraint
   ///

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -13,18 +13,17 @@
 #include "Acts/Vertexing/TrackAtVertex.hpp"
 #include "Acts/Vertexing/VertexingError.hpp"
 
-namespace {
+namespace Acts::detail {
 
 /// @struct BilloirTrack
 ///
 /// @brief Struct to cache track-specific matrix operations in Billoir fitter
-template <typename input_track_t>
 struct BilloirTrack {
-  BilloirTrack(const input_track_t* params) : originalTrack(params) {}
+  BilloirTrack(const InputTrack& params) : originalTrack(params) {}
 
   BilloirTrack(const BilloirTrack& arg) = default;
 
-  const input_track_t* originalTrack;
+  InputTrack originalTrack;
   double chi2 = 0;
 
   // We drop the summation index i from Ref. (1) for better readability
@@ -53,13 +52,12 @@ struct BilloirVertex {
   Acts::Vector4 sumBCinvU = Acts::Vector4::Zero();
 };
 
-}  // end anonymous namespace
+}  // namespace Acts::detail
 
 template <typename input_track_t, typename linearizer_t>
 Acts::Result<Acts::Vertex<input_track_t>>
 Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
-    const std::vector<const input_track_t*>& paramVector,
-    const linearizer_t& linearizer,
+    const std::vector<InputTrack>& paramVector, const linearizer_t& linearizer,
     const VertexingOptions<input_track_t>& vertexingOptions,
     State& state) const {
   unsigned int nTracks = paramVector.size();
@@ -90,7 +88,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     ndf += 3;
   }
 
-  std::vector<BilloirTrack<input_track_t>> billoirTracks;
+  std::vector<detail::BilloirTrack> billoirTracks;
   std::vector<Vector3> trackMomenta;
   // Initial guess of the 4D vertex position
   Vector4 linPoint = vertexingOptions.constraint.fullPosition();
@@ -99,7 +97,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
   for (int nIter = 0; nIter < m_cfg.maxIterations; ++nIter) {
     billoirTracks.clear();
     double newChi2 = 0;
-    BilloirVertex billoirVertex;
+    detail::BilloirVertex billoirVertex;
 
     Vector3 linPointPos = VectorHelpers::position(linPoint);
     // Make Perigee surface at linPointPos, transverse plane of Perigee
@@ -109,9 +107,9 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
 
     // iterate over all tracks
     for (std::size_t iTrack = 0; iTrack < nTracks; ++iTrack) {
-      const input_track_t* trackContainer = paramVector[iTrack];
+      const InputTrack& trackContainer = paramVector[iTrack];
 
-      const auto& trackParams = extractParameters(*trackContainer);
+      const auto& trackParams = extractParameters(trackContainer);
 
       auto result = linearizer.linearizeTrack(
           trackParams, linPoint[3], *perigeeSurface,
@@ -143,7 +141,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
       double fTheta = trackMomenta[iTrack][1];
       double fQOvP = trackMomenta[iTrack][2];
       double fTime = linPoint[FreeIndices::eFreeTime];
-      BilloirTrack<input_track_t> billoirTrack(trackContainer);
+      detail::BilloirTrack billoirTrack(trackContainer);
 
       billoirTrack.deltaQ << d0, z0, phi - fPhi, theta - fTheta, qOverP - fQOvP,
           t0 - fTime;
@@ -307,7 +305,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
       fittedVertex.setFullCovariance(covV);
       fittedVertex.setFitQuality(chi2, ndf);
 
-      std::vector<TrackAtVertex<input_track_t>> tracksAtVertex;
+      std::vector<TrackAtVertex> tracksAtVertex;
 
       std::shared_ptr<PerigeeSurface> perigee =
           Surface::makeShared<PerigeeSurface>(
@@ -328,14 +326,13 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
         paramVec[eBoundTime] = linPoint[FreeIndices::eFreeTime];
         BoundTrackParameters refittedParams(
             perigee, paramVec, covDeltaP[iTrack],
-            extractParameters(*billoirTrack.originalTrack)
-                .particleHypothesis());
-        TrackAtVertex<input_track_t> trackAtVertex(
-            billoirTrack.chi2, refittedParams, billoirTrack.originalTrack);
+            extractParameters(billoirTrack.originalTrack).particleHypothesis());
+        TrackAtVertex trackAtVertex(billoirTrack.chi2, refittedParams,
+                                    billoirTrack.originalTrack);
         tracksAtVertex.push_back(std::move(trackAtVertex));
       }
 
-      fittedVertex.setTracksAtVertex(tracksAtVertex);
+      fittedVertex.setTracksAtVertex(std::move(tracksAtVertex));
     }
   }  // end loop iterations
 

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Vertexing/TrackAtVertex.hpp"
 
 #include <map>
 #include <set>
@@ -22,6 +23,7 @@ namespace Acts {
 /// matrices (determining the width of the function)
 template <typename input_track_t>
 class GaussianTrackDensity {
+  // @TODO: Remove template
  public:
   /// @brief Struct to store information for a single track
   struct TrackEntry {
@@ -112,8 +114,8 @@ class GaussianTrackDensity {
   ///
   /// @return Pair of position of global maximum and Gaussian width
   std::pair<double, double> globalMaximumWithWidth(
-      State& state, const std::vector<const input_track_t*>& trackList,
-      const std::function<BoundTrackParameters(input_track_t)>&
+      State& state, const std::vector<InputTrack>& trackList,
+      const std::function<BoundTrackParameters(const InputTrack&)>&
           extractParameters) const;
 
   /// @brief Calculates the z position of the global maximum
@@ -124,10 +126,10 @@ class GaussianTrackDensity {
   /// InputTrack
   ///
   /// @return z position of the global maximum
-  double globalMaximum(State& state,
-                       const std::vector<const input_track_t*>& trackList,
-                       const std::function<BoundTrackParameters(input_track_t)>&
-                           extractParameters) const;
+  double globalMaximum(
+      State& state, const std::vector<InputTrack>& trackList,
+      const std::function<BoundTrackParameters(const InputTrack&)>&
+          extractParameters) const;
 
  private:
   /// The configuration
@@ -140,8 +142,8 @@ class GaussianTrackDensity {
   /// @param extractParameters Function extracting BoundTrackParameters from
   /// InputTrack
   Result<void> addTracks(
-      State& state, const std::vector<const input_track_t*>& trackList,
-      const std::function<BoundTrackParameters(input_track_t)>&
+      State& state, const std::vector<InputTrack>& trackList,
+      const std::function<BoundTrackParameters(const InputTrack&)>&
           extractParameters) const;
 
   /// @brief Evaluate the density function and its two first

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -15,8 +15,8 @@ namespace Acts {
 template <typename input_track_t>
 std::pair<double, double>
 Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
-    State& state, const std::vector<const input_track_t*>& trackList,
-    const std::function<BoundTrackParameters(input_track_t)>& extractParameters)
+    State& state, const std::vector<InputTrack>& trackList,
+    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
     const {
   auto result = addTracks(state, trackList, extractParameters);
   if (!result.ok()) {
@@ -68,19 +68,19 @@ Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
 
 template <typename input_track_t>
 double Acts::GaussianTrackDensity<input_track_t>::globalMaximum(
-    State& state, const std::vector<const input_track_t*>& trackList,
-    const std::function<BoundTrackParameters(input_track_t)>& extractParameters)
+    State& state, const std::vector<InputTrack>& trackList,
+    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
     const {
   return globalMaximumWithWidth(state, trackList, extractParameters).first;
 }
 
 template <typename input_track_t>
 Result<void> Acts::GaussianTrackDensity<input_track_t>::addTracks(
-    State& state, const std::vector<const input_track_t*>& trackList,
-    const std::function<BoundTrackParameters(input_track_t)>& extractParameters)
+    State& state, const std::vector<InputTrack>& trackList,
+    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
     const {
   for (auto trk : trackList) {
-    const BoundTrackParameters& boundParams = extractParameters(*trk);
+    const BoundTrackParameters& boundParams = extractParameters(trk);
     // Get required track parameters
     const double d0 = boundParams.parameters()[BoundIndices::eBoundLoc0];
     const double z0 = boundParams.parameters()[BoundIndices::eBoundLoc1];

--- a/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
+++ b/Core/include/Acts/Vertexing/GaussianTrackDensity.ipp
@@ -16,8 +16,8 @@ template <typename input_track_t>
 std::pair<double, double>
 Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
     State& state, const std::vector<InputTrack>& trackList,
-    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
-    const {
+    const std::function<BoundTrackParameters(const InputTrack&)>&
+        extractParameters) const {
   auto result = addTracks(state, trackList, extractParameters);
   if (!result.ok()) {
     return std::make_pair(0., 0.);
@@ -69,16 +69,16 @@ Acts::GaussianTrackDensity<input_track_t>::globalMaximumWithWidth(
 template <typename input_track_t>
 double Acts::GaussianTrackDensity<input_track_t>::globalMaximum(
     State& state, const std::vector<InputTrack>& trackList,
-    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
-    const {
+    const std::function<BoundTrackParameters(const InputTrack&)>&
+        extractParameters) const {
   return globalMaximumWithWidth(state, trackList, extractParameters).first;
 }
 
 template <typename input_track_t>
 Result<void> Acts::GaussianTrackDensity<input_track_t>::addTracks(
     State& state, const std::vector<InputTrack>& trackList,
-    const std::function<BoundTrackParameters(const InputTrack&)>& extractParameters)
-    const {
+    const std::function<BoundTrackParameters(const InputTrack&)>&
+        extractParameters) const {
   for (auto trk : trackList) {
     const BoundTrackParameters& boundParams = extractParameters(trk);
     // Get required track parameters

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -83,15 +83,14 @@ class GridDensityVertexFinder {
     MainGridVector mainGrid = MainGridVector::Zero();
     // Map to store z-bin and track grid (i.e. the density contribution of
     // a single track to the main grid) for every single track
-    std::map<const InputTrack_t*, std::pair<int, TrackGridVector>>
-        binAndTrackGridMap;
+    std::map<InputTrack, std::pair<int, TrackGridVector>> binAndTrackGridMap;
 
     // Map to store bool if track has passed track selection or not
-    std::map<const InputTrack_t*, bool> trackSelectionMap;
+    std::map<InputTrack, bool> trackSelectionMap;
 
     // Store tracks that have been removed from track collection. These
     // track will be removed from the main grid
-    std::vector<const InputTrack_t*> tracksToRemove;
+    std::vector<InputTrack> tracksToRemove;
 
     bool isInitialized = false;
   };
@@ -107,7 +106,7 @@ class GridDensityVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -118,7 +117,9 @@ class GridDensityVertexFinder {
       typename T = InputTrack_t,
       std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
   GridDensityVertexFinder(const Config& cfg)
-      : m_cfg(cfg), m_extractParameters([](T params) { return params; }) {}
+      : m_cfg(cfg), m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }) {}
 
   /// @brief Default constructor used if InputTrack_t type ==
   /// BoundTrackParameters
@@ -136,7 +137,7 @@ class GridDensityVertexFinder {
   /// object
   GridDensityVertexFinder(
       const Config& cfg,
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_cfg(cfg), m_extractParameters(func) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
@@ -145,7 +146,7 @@ class GridDensityVertexFinder {
   /// @param func Function extracting BoundTrackParameters from InputTrack_t
   /// object
   GridDensityVertexFinder(
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_extractParameters(func) {}
 
  private:
@@ -162,7 +163,7 @@ class GridDensityVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -8,7 +8,7 @@
 
 template <int mainGridSize, int trkGridSize, typename vfitter_t>
 auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
-    const std::vector<const InputTrack_t*>& trackVector,
+    const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
     -> Result<std::vector<Vertex<InputTrack_t>>> {
   // Remove density contributions from tracks removed from track collection
@@ -37,7 +37,7 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
     state.mainGrid = MainGridVector::Zero();
     // Fill with track densities
     for (auto trk : trackVector) {
-      const BoundTrackParameters& trkParams = m_extractParameters(*trk);
+      const BoundTrackParameters& trkParams = m_extractParameters(trk);
       // Take only tracks that fulfill selection criteria
       if (!doesPassTrackSelection(trkParams)) {
         if (m_cfg.cacheGridStateForTrackRemoval) {

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -146,7 +146,9 @@ class IterativeVertexFinder {
                         std::unique_ptr<const Logger> logger = getDefaultLogger(
                             "IterativeVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters([](T params) { return params; }),
+        m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }),
         m_logger(std::move(logger)) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
@@ -156,10 +158,10 @@ class IterativeVertexFinder {
   /// @param func Function extracting BoundTrackParameters from InputTrack_t
   /// object
   /// @param logger The logging instance
-  IterativeVertexFinder(Config cfg,
-                        std::function<BoundTrackParameters(InputTrack_t)> func,
-                        std::unique_ptr<const Logger> logger = getDefaultLogger(
-                            "IterativeVertexFinder", Logging::INFO))
+  IterativeVertexFinder(
+      Config cfg, std::function<BoundTrackParameters(const InputTrack&)> func,
+      std::unique_ptr<const Logger> logger =
+          getDefaultLogger("IterativeVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
         m_extractParameters(func),
         m_logger(std::move(logger)) {}
@@ -172,7 +174,7 @@ class IterativeVertexFinder {
   ///
   /// @return Collection of vertices found by finder
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -183,7 +185,7 @@ class IterativeVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger;
@@ -196,15 +198,15 @@ class IterativeVertexFinder {
   /// @param seedTracks Seeding tracks
   /// @param vertexingOptions Vertexing options
   Result<Vertex<InputTrack_t>> getVertexSeed(
-      const std::vector<const InputTrack_t*>& seedTracks,
+      const std::vector<InputTrack>& seedTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Removes all tracks in tracksToRemove from seedTracks
   ///
   /// @param tracksToRemove Tracks to be removed from seedTracks
   /// @param seedTracks List to remove tracks from
-  void removeTracks(const std::vector<const InputTrack_t*>& tracksToRemove,
-                    std::vector<const InputTrack_t*>& seedTracks) const;
+  void removeTracks(const std::vector<InputTrack>& tracksToRemove,
+                    std::vector<InputTrack>& seedTracks) const;
 
   /// @brief Function for calculating how compatible
   /// a given track is to a given vertex
@@ -230,9 +232,8 @@ class IterativeVertexFinder {
   /// @param vertexingOptions Vertexing options
   /// @param state The state object
   Result<void> removeUsedCompatibleTracks(
-      Vertex<InputTrack_t>& vertex,
-      std::vector<const InputTrack_t*>& tracksToFit,
-      std::vector<const InputTrack_t*>& seedTracks,
+      Vertex<InputTrack_t>& vertex, std::vector<InputTrack>& tracksToFit,
+      std::vector<InputTrack>& seedTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -245,10 +246,10 @@ class IterativeVertexFinder {
   /// @param vertexingOptions Vertexing options
   /// @param state The state object
   Result<void> fillTracksToFit(
-      const std::vector<const InputTrack_t*>& seedTracks,
+      const std::vector<InputTrack>& seedTracks,
       const Vertex<InputTrack_t>& seedVertex,
-      std::vector<const InputTrack_t*>& tracksToFitOut,
-      std::vector<const InputTrack_t*>& tracksToFitSplitVertexOut,
+      std::vector<InputTrack>& tracksToFitOut,
+      std::vector<InputTrack>& tracksToFitSplitVertexOut,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -266,10 +267,9 @@ class IterativeVertexFinder {
   /// @return Bool if currentVertex is still a good vertex
   Result<bool> reassignTracksToNewVertex(
       std::vector<Vertex<InputTrack_t>>& vertexCollection,
-      Vertex<InputTrack_t>& currentVertex,
-      std::vector<const InputTrack_t*>& tracksToFit,
-      std::vector<const InputTrack_t*>& seedTracks,
-      const std::vector<const InputTrack_t*>& origTracks,
+      Vertex<InputTrack_t>& currentVertex, std::vector<InputTrack>& tracksToFit,
+      std::vector<InputTrack>& seedTracks,
+      const std::vector<InputTrack>& origTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -163,7 +163,7 @@ class IterativeVertexFinder {
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("IterativeVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters(func),
+        m_extractParameters(std::move(func)),
         m_logger(std::move(logger)) {}
 
   /// @brief Finds vertices corresponding to input trackVector

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -558,7 +558,7 @@ template <typename vfitter_t, typename sfinder_t>
 int Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::countSignificantTracks(
     const Vertex<InputTrack_t>& vtx) const {
   return std::count_if(vtx.tracks().begin(), vtx.tracks().end(),
-                       [this](TrackAtVertex trk) {
+                       [this](const TrackAtVertex& trk) {
                          return trk.trackWeight > m_cfg.cutOffTrackWeight;
                        });
 }

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -8,13 +8,13 @@
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
-    const std::vector<const InputTrack_t*>& trackVector,
+    const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
     -> Result<std::vector<Vertex<InputTrack_t>>> {
   // Original tracks
-  const std::vector<const InputTrack_t*>& origTracks = trackVector;
+  const std::vector<InputTrack>& origTracks = trackVector;
   // Tracks for seeding
-  std::vector<const InputTrack_t*> seedTracks = trackVector;
+  std::vector<InputTrack> seedTracks = trackVector;
 
   // List of vertices to be filled below
   std::vector<Vertex<InputTrack_t>> vertexCollection;
@@ -40,8 +40,8 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     /// End seeding
     /// Now take only tracks compatible with current seed
     // Tracks used for the fit in this iteration
-    std::vector<const InputTrack_t*> tracksToFit;
-    std::vector<const InputTrack_t*> tracksToFitSplitVertex;
+    std::vector<InputTrack> tracksToFit;
+    std::vector<InputTrack> tracksToFitSplitVertex;
 
     // Fill vector with tracks to fit, only compatible with seed:
     auto res = fillTracksToFit(seedTracks, seedVertex, tracksToFit,
@@ -157,7 +157,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getVertexSeed(
-    const std::vector<const InputTrack_t*>& seedTracks,
+    const std::vector<InputTrack>& seedTracks,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<Vertex<InputTrack_t>> {
   typename sfinder_t::State finderState;
@@ -192,15 +192,15 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getVertexSeed(
 
 template <typename vfitter_t, typename sfinder_t>
 void Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeTracks(
-    const std::vector<const InputTrack_t*>& tracksToRemove,
-    std::vector<const InputTrack_t*>& seedTracks) const {
+    const std::vector<InputTrack>& tracksToRemove,
+    std::vector<InputTrack>& seedTracks) const {
   for (const auto& trk : tracksToRemove) {
-    const BoundTrackParameters& params = m_extractParameters(*trk);
+    const BoundTrackParameters& params = m_extractParameters(trk);
     // Find track in seedTracks
     auto foundIter =
         std::find_if(seedTracks.begin(), seedTracks.end(),
                      [&params, this](const auto seedTrk) {
-                       return params == m_extractParameters(*seedTrk);
+                       return params == m_extractParameters(seedTrk);
                      });
     if (foundIter != seedTracks.end()) {
       // Remove track from seed tracks
@@ -252,11 +252,11 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getCompatibility(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<void>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
-    Vertex<InputTrack_t>& vertex, std::vector<const InputTrack_t*>& tracksToFit,
-    std::vector<const InputTrack_t*>& seedTracks,
+    Vertex<InputTrack_t>& vertex, std::vector<InputTrack>& tracksToFit,
+    std::vector<InputTrack>& seedTracks,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {
-  std::vector<TrackAtVertex<InputTrack_t>> tracksAtVertex = vertex.tracks();
+  std::vector<TrackAtVertex> tracksAtVertex = vertex.tracks();
 
   for (const auto& trackAtVtx : tracksAtVertex) {
     // Check compatibility
@@ -267,7 +267,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
     // Find and remove track from seedTracks
     auto foundSeedIter =
         std::find_if(seedTracks.begin(), seedTracks.end(),
-                     [&trackAtVtx](const auto seedTrk) {
+                     [&trackAtVtx](const auto& seedTrk) {
                        return trackAtVtx.originalParams == seedTrk;
                      });
     if (foundSeedIter != seedTracks.end()) {
@@ -279,7 +279,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
     // Find and remove track from tracksToFit
     auto foundFitIter =
         std::find_if(tracksToFit.begin(), tracksToFit.end(),
-                     [&trackAtVtx](const auto fitTrk) {
+                     [&trackAtVtx](const auto& fitTrk) {
                        return trackAtVtx.originalParams == fitTrk;
                      });
     if (foundFitIter != tracksToFit.end()) {
@@ -304,7 +304,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
   for (const auto& trk : tracksToFit) {
     // calculate chi2 w.r.t. last fitted vertex
     auto result =
-        getCompatibility(m_extractParameters(*trk), vertex,
+        getCompatibility(m_extractParameters(trk), vertex,
                          *vertexPerigeeSurface, vertexingOptions, state);
 
     if (!result.ok()) {
@@ -318,7 +318,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
     if (chi2 < m_cfg.maximumChi2cutForSeeding) {
       auto foundIter =
           std::find_if(seedTracks.begin(), seedTracks.end(),
-                       [&trk](const auto seedTrk) { return trk == seedTrk; });
+                       [&trk](const auto& seedTrk) { return trk == seedTrk; });
       if (foundIter != seedTracks.end()) {
         // Remove track from seed tracks
         seedTracks.erase(foundIter);
@@ -346,10 +346,10 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<void>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
-    const std::vector<const InputTrack_t*>& seedTracks,
+    const std::vector<InputTrack>& seedTracks,
     const Vertex<InputTrack_t>& seedVertex,
-    std::vector<const InputTrack_t*>& tracksToFitOut,
-    std::vector<const InputTrack_t*>& tracksToFitSplitVertexOut,
+    std::vector<InputTrack>& tracksToFitOut,
+    std::vector<InputTrack>& tracksToFitSplitVertexOut,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {
   int numberOfTracks = seedTracks.size();
@@ -379,7 +379,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
     // If a large amount of tracks is available, we check their compatibility
     // with the vertex before adding them to the fit:
     else {
-      const BoundTrackParameters& sTrackParams = m_extractParameters(*sTrack);
+      const BoundTrackParameters& sTrackParams = m_extractParameters(sTrack);
       auto distanceRes = m_cfg.ipEst.calculateDistance(
           vertexingOptions.geoContext, sTrackParams, seedVertex.position(),
           state.ipState);
@@ -423,9 +423,9 @@ Acts::Result<bool>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
     std::vector<Vertex<InputTrack_t>>& vertexCollection,
     Vertex<InputTrack_t>& currentVertex,
-    std::vector<const InputTrack_t*>& tracksToFit,
-    std::vector<const InputTrack_t*>& seedTracks,
-    const std::vector<const InputTrack_t*>& /* origTracks */,
+    std::vector<InputTrack>& tracksToFit,
+    std::vector<InputTrack>& seedTracks,
+    const std::vector<InputTrack>& /* origTracks */,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {
   int numberOfAddedTracks = 0;
@@ -438,7 +438,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
   // to new (current) vertex
   for (auto& vertexIt : vertexCollection) {
     // tracks at vertexIt
-    std::vector<TrackAtVertex<InputTrack_t>> tracksAtVertex = vertexIt.tracks();
+    std::vector<TrackAtVertex> tracksAtVertex = vertexIt.tracks();
     auto tracksBegin = tracksAtVertex.begin();
     auto tracksEnd = tracksAtVertex.end();
 
@@ -455,7 +455,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
       }
       // use original perigee parameters
       BoundTrackParameters origParams =
-          m_extractParameters(*(tracksIter->originalParams));
+          m_extractParameters(tracksIter->originalParams);
 
       // compute compatibility
       auto resultNew = getCompatibility(origParams, currentVertex,
@@ -559,7 +559,7 @@ template <typename vfitter_t, typename sfinder_t>
 int Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::countSignificantTracks(
     const Vertex<InputTrack_t>& vtx) const {
   return std::count_if(vtx.tracks().begin(), vtx.tracks().end(),
-                       [this](TrackAtVertex<InputTrack_t> trk) {
+                       [this](TrackAtVertex trk) {
                          return trk.trackWeight > m_cfg.cutOffTrackWeight;
                        });
 }

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -422,8 +422,7 @@ template <typename vfitter_t, typename sfinder_t>
 Acts::Result<bool>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
     std::vector<Vertex<InputTrack_t>>& vertexCollection,
-    Vertex<InputTrack_t>& currentVertex,
-    std::vector<InputTrack>& tracksToFit,
+    Vertex<InputTrack_t>& currentVertex, std::vector<InputTrack>& tracksToFit,
     std::vector<InputTrack>& seedTracks,
     const std::vector<InputTrack>& /* origTracks */,
     const VertexingOptions<InputTrack_t>& vertexingOptions,

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
@@ -66,8 +66,7 @@ struct Cache {
 /// @param vtx Vertex to be updated
 /// @param trk Track to be used for updating the vertex
 template <typename input_track_t, unsigned int nDimVertex>
-void updateVertexWithTrack(Vertex<input_track_t>& vtx,
-                           TrackAtVertex<input_track_t>& trk);
+void updateVertexWithTrack(Vertex<input_track_t>& vtx, TrackAtVertex& trk);
 
 namespace detail {
 void updateVertexWithTrack(Vector4& vtxPos, SquareMatrix4& vtxCov,

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
@@ -6,13 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "Acts/Vertexing/VertexingError.hpp"
-
 #include <algorithm>
 
 template <typename input_track_t, unsigned int nDimVertex>
 void Acts::KalmanVertexUpdater::updateVertexWithTrack(
-    Vertex<input_track_t>& vtx, TrackAtVertex<input_track_t>& trk) {
+    Vertex<input_track_t>& vtx, TrackAtVertex& trk) {
   std::pair<double, double> fitQuality = vtx.fitQuality();
   detail::updateVertexWithTrack(vtx.fullPosition(), vtx.fullCovariance(),
                                 fitQuality, trk, 1, nDimVertex);

--- a/Core/include/Acts/Vertexing/TrackAtVertex.hpp
+++ b/Core/include/Acts/Vertexing/TrackAtVertex.hpp
@@ -77,7 +77,7 @@ struct TrackAtVertex {
   TrackAtVertex(double chi2perTrack, const BoundTrackParameters& paramsAtVertex,
                 InputTrack originalTrack)
       : fittedParams(paramsAtVertex),
-        originalParams(std::move(originalTrack)),
+        originalParams(originalTrack),
         chi2Track(chi2perTrack) {}
 
   /// @brief Constructor with default chi2
@@ -86,8 +86,7 @@ struct TrackAtVertex {
   /// @param originalTrack Original perigee parameter
   TrackAtVertex(const BoundTrackParameters& paramsAtVertex,
                 InputTrack originalTrack)
-      : fittedParams(paramsAtVertex),
-        originalParams(std::move(originalTrack)) {}
+      : fittedParams(paramsAtVertex), originalParams(originalTrack) {}
 
   /// Fitted perigee
   BoundTrackParameters fittedParams;

--- a/Core/include/Acts/Vertexing/TrackAtVertex.hpp
+++ b/Core/include/Acts/Vertexing/TrackAtVertex.hpp
@@ -15,18 +15,12 @@
 #include <functional>
 #include <typeindex>
 
-// @TODO REMOVE!
-#include <boost/core/demangle.hpp>
-
 namespace Acts {
 
 struct InputTrack {
   template <typename input_track_t>
   explicit InputTrack(const input_track_t* inputTrack)
       : m_type{typeid(inputTrack)}, m_ptr{inputTrack} {}
-
-  // template <typename input_track_t>
-  // InputTrack(const input_track_t* inputTrack) : InputTrack{*inputTrack} {}
 
   InputTrack() = delete;
   InputTrack(const InputTrack&) = default;
@@ -47,8 +41,6 @@ struct InputTrack {
   const T* as() const {
     using ptr_t = const T*;
     if (m_type != typeid(ptr_t)) {
-      std::cout << boost::core::demangle(m_type.name()) << " vs. "
-                << boost::core::demangle(typeid(ptr_t).name()) << std::endl;
       throw std::bad_any_cast();
     }
     return static_cast<ptr_t>(m_ptr);

--- a/Core/include/Acts/Vertexing/TrackAtVertex.hpp
+++ b/Core/include/Acts/Vertexing/TrackAtVertex.hpp
@@ -11,17 +11,68 @@
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Vertexing/LinearizedTrack.hpp"
 
+#include <any>
 #include <functional>
+#include <typeindex>
+
+// @TODO REMOVE!
+#include <boost/core/demangle.hpp>
 
 namespace Acts {
+
+struct InputTrack {
+  template <typename input_track_t>
+  explicit InputTrack(const input_track_t* inputTrack)
+      : m_type{typeid(inputTrack)}, m_ptr{inputTrack} {}
+
+  // template <typename input_track_t>
+  // InputTrack(const input_track_t* inputTrack) : InputTrack{*inputTrack} {}
+
+  InputTrack() = delete;
+  InputTrack(const InputTrack&) = default;
+  InputTrack(InputTrack&&) = default;
+  InputTrack& operator=(const InputTrack&) = default;
+  InputTrack& operator=(InputTrack&&) = default;
+
+  bool operator==(const InputTrack& other) const {
+    return m_ptr == other.m_ptr;
+  }
+
+  template <typename input_track_t>
+  bool operator==(const input_track_t* other) const {
+    return m_ptr == other;
+  }
+
+  template <typename T>
+  const T* as() const {
+    using ptr_t = const T*;
+    if (m_type != typeid(ptr_t)) {
+      std::cout << boost::core::demangle(m_type.name()) << " vs. "
+                << boost::core::demangle(typeid(ptr_t).name()) << std::endl;
+      throw std::bad_any_cast();
+    }
+    return static_cast<ptr_t>(m_ptr);
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const InputTrack& track) {
+    os << track.m_ptr;
+    return os;
+  }
+
+  friend bool operator<(const InputTrack& lhs, const InputTrack& rhs) {
+    return lhs.m_ptr < rhs.m_ptr;
+  }
+
+  friend struct std::hash<Acts::InputTrack>;
+
+ private:
+  std::type_index m_type;
+  const void* m_ptr;
+};
 
 /// @class TrackAtVertex
 ///
 /// @brief Defines a track at vertex object
-///
-/// @tparam input_track_t Track object type
-
-template <typename input_track_t>
 struct TrackAtVertex {
   /// Deleted default constructor
   TrackAtVertex() = delete;
@@ -32,9 +83,9 @@ struct TrackAtVertex {
   /// @param paramsAtVertex Fitted perigee parameter
   /// @param originalTrack Original perigee parameter
   TrackAtVertex(double chi2perTrack, const BoundTrackParameters& paramsAtVertex,
-                const input_track_t* originalTrack)
+                InputTrack originalTrack)
       : fittedParams(paramsAtVertex),
-        originalParams(originalTrack),
+        originalParams(std::move(originalTrack)),
         chi2Track(chi2perTrack) {}
 
   /// @brief Constructor with default chi2
@@ -42,14 +93,15 @@ struct TrackAtVertex {
   /// @param paramsAtVertex Fitted perigee parameter
   /// @param originalTrack Original perigee parameter
   TrackAtVertex(const BoundTrackParameters& paramsAtVertex,
-                const input_track_t* originalTrack)
-      : fittedParams(paramsAtVertex), originalParams(originalTrack) {}
+                InputTrack originalTrack)
+      : fittedParams(paramsAtVertex),
+        originalParams(std::move(originalTrack)) {}
 
   /// Fitted perigee
   BoundTrackParameters fittedParams;
 
   /// Original input parameters
-  const input_track_t* originalParams;
+  InputTrack originalParams;
 
   /// Chi2 of track
   double chi2Track = 0;
@@ -83,8 +135,7 @@ struct TrackAtVertexRef {
   LinearizedTrack& linearizedState;
   bool isLinearized;
 
-  template <typename input_track_t>
-  TrackAtVertexRef(TrackAtVertex<input_track_t>& track)
+  TrackAtVertexRef(TrackAtVertex& track)
       : fittedParams(track.fittedParams),
         chi2Track(track.chi2Track),
         ndf(track.ndf),
@@ -95,3 +146,10 @@ struct TrackAtVertexRef {
 };
 
 }  // namespace Acts
+
+template <>
+struct std::hash<Acts::InputTrack> {
+  std::size_t operator()(const Acts::InputTrack& track) const noexcept {
+    return std::hash<const void*>{}(track.m_ptr);
+  }
+};

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
@@ -62,7 +62,7 @@ class TrackDensityVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -73,7 +73,9 @@ class TrackDensityVertexFinder {
       typename T = InputTrack_t,
       std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
   TrackDensityVertexFinder(const Config& cfg)
-      : m_cfg(cfg), m_extractParameters([](T params) { return params; }) {}
+      : m_cfg(cfg), m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }) {}
 
   /// @brief Default constructor used if InputTrack_t type ==
   /// BoundTrackParameters
@@ -81,7 +83,9 @@ class TrackDensityVertexFinder {
       typename T = InputTrack_t,
       std::enable_if_t<std::is_same<T, BoundTrackParameters>::value, int> = 0>
   TrackDensityVertexFinder()
-      : m_extractParameters([](T params) { return params; }) {}
+      : m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
   /// BoundTrackParameters
@@ -91,7 +95,7 @@ class TrackDensityVertexFinder {
   /// object
   TrackDensityVertexFinder(
       const Config& cfg,
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_cfg(cfg), m_extractParameters(func) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
@@ -100,7 +104,7 @@ class TrackDensityVertexFinder {
   /// @param func Function extracting BoundTrackParameters from InputTrack_t
   /// object
   TrackDensityVertexFinder(
-      const std::function<BoundTrackParameters(InputTrack_t)>& func)
+      const std::function<BoundTrackParameters(const InputTrack&)>& func)
       : m_extractParameters(func) {}
 
  private:
@@ -109,7 +113,7 @@ class TrackDensityVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
@@ -8,7 +8,7 @@
 
 template <typename vfitter_t, typename track_density_t>
 auto Acts::TrackDensityVertexFinder<vfitter_t, track_density_t>::find(
-    const std::vector<const InputTrack_t*>& trackVector,
+    const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& /*state*/) const -> Result<std::vector<Vertex<InputTrack_t>>> {
   typename track_density_t::State densityState(trackVector.size());

--- a/Core/include/Acts/Vertexing/Vertex.hpp
+++ b/Core/include/Acts/Vertexing/Vertex.hpp
@@ -41,7 +41,7 @@ class Vertex {
   /// @param covariance Position covariance matrix
   /// @param tracks Vector of tracks associated with the vertex
   Vertex(const Vector3& position, const SquareMatrix3& covariance,
-         const std::vector<TrackAtVertex<input_track_t>>& tracks);
+         std::vector<TrackAtVertex> tracks);
 
   /// @brief Vertex constructor
   ///
@@ -49,7 +49,7 @@ class Vertex {
   /// @param covariance 4x4 covariance matrix
   /// @param tracks Vector of tracks associated with the vertex
   Vertex(const Vector4& position, const SquareMatrix4& covariance,
-         const std::vector<TrackAtVertex<input_track_t>>& tracks);
+         std::vector<TrackAtVertex> tracks);
 
   /// @return Returns 3-position
   Vector3 position() const;
@@ -69,7 +69,7 @@ class Vertex {
   SquareMatrix4& fullCovariance();
 
   /// @return Returns vector of tracks associated with the vertex
-  const std::vector<TrackAtVertex<input_track_t>>& tracks() const;
+  const std::vector<TrackAtVertex>& tracks() const;
 
   /// @return Returns pair of (chi2, numberDoF)
   std::pair<double, double> fitQuality() const;
@@ -101,8 +101,7 @@ class Vertex {
   void setFullCovariance(const SquareMatrix4& covariance);
 
   /// @param tracks Vector of tracks at vertex
-  void setTracksAtVertex(
-      const std::vector<TrackAtVertex<input_track_t>>& tracks);
+  void setTracksAtVertex(std::vector<TrackAtVertex> tracks);
 
   /// @param chiSquared Chi2 of fit
   /// @param numberDoF Number of degrees of freedom
@@ -114,7 +113,7 @@ class Vertex {
  private:
   Vector4 m_position = Vector4::Zero();
   SquareMatrix4 m_covariance = SquareMatrix4::Zero();
-  std::vector<TrackAtVertex<input_track_t>> m_tracksAtVertex;
+  std::vector<TrackAtVertex> m_tracksAtVertex;
   double m_chiSquared = 0.;  // chi2 of the fit
   double m_numberDoF = 0.;   // number of degrees of freedom
 };

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -18,10 +18,10 @@ Acts::Vertex<input_track_t>::Vertex(const Vector4& position)
     : m_position(position) {}
 
 template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(
-    const Vector3& position, const SquareMatrix3& covariance,
-    const std::vector<TrackAtVertex<input_track_t>>& tracks)
-    : m_tracksAtVertex(tracks) {
+Acts::Vertex<input_track_t>::Vertex(const Vector3& position,
+                                    const SquareMatrix3& covariance,
+                                    std::vector<TrackAtVertex> tracks)
+    : m_tracksAtVertex(std::move(tracks)) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
   m_position[ePos2] = position[ePos2];
@@ -29,12 +29,12 @@ Acts::Vertex<input_track_t>::Vertex(
 }
 
 template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(
-    const Vector4& position, const SquareMatrix4& covariance,
-    const std::vector<TrackAtVertex<input_track_t>>& tracks)
+Acts::Vertex<input_track_t>::Vertex(const Vector4& position,
+                                    const SquareMatrix4& covariance,
+                                    std::vector<TrackAtVertex> tracks)
     : m_position(position),
       m_covariance(covariance),
-      m_tracksAtVertex(tracks) {}
+      m_tracksAtVertex(std::move(tracks)) {}
 
 template <typename input_track_t>
 Acts::Vector3 Acts::Vertex<input_track_t>::position() const {
@@ -72,8 +72,8 @@ Acts::SquareMatrix4& Acts::Vertex<input_track_t>::fullCovariance() {
 }
 
 template <typename input_track_t>
-const std::vector<Acts::TrackAtVertex<input_track_t>>&
-Acts::Vertex<input_track_t>::tracks() const {
+const std::vector<Acts::TrackAtVertex>& Acts::Vertex<input_track_t>::tracks()
+    const {
   return m_tracksAtVertex;
 }
 
@@ -116,8 +116,8 @@ void Acts::Vertex<input_track_t>::setFullCovariance(
 
 template <typename input_track_t>
 void Acts::Vertex<input_track_t>::setTracksAtVertex(
-    const std::vector<TrackAtVertex<input_track_t>>& tracks) {
-  m_tracksAtVertex = tracks;
+    std::vector<TrackAtVertex> tracks) {
+  m_tracksAtVertex = std::move(tracks);
 }
 
 template <typename input_track_t>

--- a/Core/include/Acts/Vertexing/VertexFinderConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFinderConcept.hpp
@@ -29,9 +29,9 @@ METHOD_TRAIT(find_t, find);
       struct VertexFinderConcept {
         constexpr static bool state_exists = exists<state_t, S>;
         static_assert(state_exists, "State type not found");
-        
+
         constexpr static bool find_exists = has_method<const S, Result<std::vector<Vertex<typename S::InputTrack_t>>>,
-         find_t, const std::vector<const typename S::InputTrack_t*>&, 
+         find_t, const std::vector<InputTrack>&,
          const VertexingOptions<typename S::InputTrack_t>&, typename S::State&>;
         static_assert(find_exists, "find method not found");
 

--- a/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
@@ -34,8 +34,8 @@ METHOD_TRAIT(fit_t, fit);
     template <typename S>
       struct VertexFitterConcept {
         constexpr static bool fit_exists = has_method<const S, Result<Vertex<typename S::InputTrack_t>>,
-         fit_t, 
-         const std::vector<const typename S::InputTrack_t*>&, 
+         fit_t,
+         const std::vector<InputTrack>&,
          const typename S::Linearizer_t&,
          const VertexingOptions<typename S::InputTrack_t>&,
          typename S::State&>;

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
@@ -85,7 +85,9 @@ class ZScanVertexFinder {
                     std::unique_ptr<const Logger> logger =
                         getDefaultLogger("ZScanVertexFinder", Logging::INFO))
       : m_cfg(std::move(cfg)),
-        m_extractParameters([](T params) { return params; }),
+        m_extractParameters([](const InputTrack& params) {
+          return *params.as<BoundTrackParameters>();
+        }),
         m_logger(std::move(logger)) {}
 
   /// @brief Constructor for user-defined InputTrack_t type =!
@@ -96,7 +98,7 @@ class ZScanVertexFinder {
   /// object
   /// @param logger Logging instance
   ZScanVertexFinder(const Config& cfg,
-                    std::function<BoundTrackParameters(InputTrack_t)> func,
+                    std::function<BoundTrackParameters(const InputTrack&)> func,
                     std::unique_ptr<const Logger> logger =
                         getDefaultLogger("ZScanVertexFinder", Logging::INFO))
       : m_cfg(cfg), m_extractParameters(func), m_logger(std::move(logger)) {}
@@ -112,7 +114,7 @@ class ZScanVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex<InputTrack_t>>> find(
-      const std::vector<const InputTrack_t*>& trackVector,
+      const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
 
@@ -122,7 +124,7 @@ class ZScanVertexFinder {
   /// @brief Function to extract track parameters,
   /// InputTrack_t objects are BoundTrackParameters by default, function to be
   /// overwritten to return BoundTrackParameters for other InputTrack_t objects.
-  std::function<BoundTrackParameters(InputTrack_t)> m_extractParameters;
+  std::function<BoundTrackParameters(const InputTrack&)> m_extractParameters;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger;

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
@@ -101,7 +101,9 @@ class ZScanVertexFinder {
                     std::function<BoundTrackParameters(const InputTrack&)> func,
                     std::unique_ptr<const Logger> logger =
                         getDefaultLogger("ZScanVertexFinder", Logging::INFO))
-      : m_cfg(cfg), m_extractParameters(func), m_logger(std::move(logger)) {}
+      : m_cfg(cfg),
+        m_extractParameters(std::move(func)),
+        m_logger(std::move(logger)) {}
 
   /// @brief Function that determines single vertex,
   /// based on z0 values of input tracks,

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
@@ -8,7 +8,7 @@
 
 template <typename vfitter_t>
 auto Acts::ZScanVertexFinder<vfitter_t>::find(
-    const std::vector<const InputTrack_t*>& trackVector,
+    const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& /*state*/) const -> Result<std::vector<Vertex<InputTrack_t>>> {
   double ZResult = 0.;
@@ -18,7 +18,7 @@ auto Acts::ZScanVertexFinder<vfitter_t>::find(
 
   for (const auto& iTrk : trackVector) {
     // Extract BoundTrackParameters from InputTrack_t object
-    const BoundTrackParameters& params = m_extractParameters(*iTrk);
+    const BoundTrackParameters& params = m_extractParameters(iTrk);
 
     std::pair<double, double> z0AndWeight;
     ImpactParametersAndSigma ipas;

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -151,21 +151,19 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::executeAfterSeederChoice(
 
   const auto& inputTrackParameters = m_inputTrackParameters(ctx);
   // TODO change this from pointers to tracks parameters to actual tracks
-  auto inputTrackPointers =
-      makeTrackParametersPointerContainer(inputTrackParameters);
+  auto inputTracks = makeInputTracks(inputTrackParameters);
 
-  if (inputTrackParameters.size() != inputTrackPointers.size()) {
+  if (inputTrackParameters.size() != inputTracks.size()) {
     ACTS_ERROR("Input track containers do not align: "
-               << inputTrackParameters.size()
-               << " != " << inputTrackPointers.size());
+               << inputTrackParameters.size() << " != " << inputTracks.size());
   }
 
-  for (const auto trk : inputTrackPointers) {
-    if (trk->covariance() && trk->covariance()->determinant() <= 0) {
+  for (const auto& trk : inputTrackParameters) {
+    if (trk.covariance() && trk.covariance()->determinant() <= 0) {
       // actually we should consider this as an error but I do not want the CI
       // to fail
-      ACTS_WARNING("input track " << *trk << " has det(cov) = "
-                                  << trk->covariance()->determinant());
+      ACTS_WARNING("input track " << trk << " has det(cov) = "
+                                  << trk.covariance()->determinant());
     }
   }
 
@@ -187,7 +185,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::executeAfterSeederChoice(
     ACTS_DEBUG("Have " << inputTrackParameters.size()
                        << " input track parameters, running vertexing");
     // find vertices
-    auto result = finder.find(inputTrackPointers, finderOpts, state);
+    auto result = finder.find(inputTracks, finderOpts, state);
 
     if (result.ok()) {
       vertices = std::move(result.value());
@@ -204,7 +202,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::executeAfterSeederChoice(
   }
 
   // store proto vertices extracted from the found vertices
-  m_outputProtoVertices(ctx, makeProtoVertices(inputTrackPointers, vertices));
+  m_outputProtoVertices(ctx, makeProtoVertices(inputTracks, vertices));
 
   // store found vertices
   m_outputVertices(ctx, std::move(vertices));

--- a/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
@@ -49,21 +49,19 @@ ActsExamples::ProcessCode ActsExamples::IterativeVertexFinderAlgorithm::execute(
 
   const auto& inputTrackParameters = m_inputTrackParameters(ctx);
   // TODO change this from pointers to tracks parameters to actual tracks
-  auto inputTrackPointers =
-      makeTrackParametersPointerContainer(inputTrackParameters);
+  auto inputTracks = makeInputTracks(inputTrackParameters);
 
-  if (inputTrackParameters.size() != inputTrackPointers.size()) {
+  if (inputTrackParameters.size() != inputTracks.size()) {
     ACTS_ERROR("Input track containers do not align: "
-               << inputTrackParameters.size()
-               << " != " << inputTrackPointers.size());
+               << inputTrackParameters.size() << " != " << inputTracks.size());
   }
 
-  for (const auto trk : inputTrackPointers) {
-    if (trk->covariance() && trk->covariance()->determinant() <= 0) {
+  for (const auto& trk : inputTrackParameters) {
+    if (trk.covariance() && trk.covariance()->determinant() <= 0) {
       // actually we should consider this as an error but I do not want the CI
       // to fail
-      ACTS_WARNING("input track " << *trk << " has det(cov) = "
-                                  << trk->covariance()->determinant());
+      ACTS_WARNING("input track " << trk << " has det(cov) = "
+                                  << trk.covariance()->determinant());
     }
   }
 
@@ -95,7 +93,7 @@ ActsExamples::ProcessCode ActsExamples::IterativeVertexFinderAlgorithm::execute(
   Options finderOpts(ctx.geoContext, ctx.magFieldContext);
 
   // find vertices
-  auto result = finder.find(inputTrackPointers, finderOpts, state);
+  auto result = finder.find(inputTracks, finderOpts, state);
 
   VertexCollection vertices;
   if (result.ok()) {
@@ -112,7 +110,7 @@ ActsExamples::ProcessCode ActsExamples::IterativeVertexFinderAlgorithm::execute(
   }
 
   // store proto vertices extracted from the found vertices
-  m_outputProtoVertices(ctx, makeProtoVertices(inputTrackPointers, vertices));
+  m_outputProtoVertices(ctx, makeProtoVertices(inputTracks, vertices));
 
   // store found vertices
   m_outputVertices(ctx, std::move(vertices));

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -59,20 +59,11 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
   ACTS_VERBOSE("Read from '" << m_cfg.inputProtoVertices << "'");
 
   const auto& inputTrackParameters = m_inputTrackParameters(ctx);
-  auto inputTrackPointers =
-      makeTrackParametersPointerContainer(inputTrackParameters);
-
-  if (inputTrackParameters.size() != inputTrackPointers.size()) {
-    ACTS_ERROR("Input track containers do not align: "
-               << inputTrackParameters.size()
-               << " != " << inputTrackPointers.size());
-  }
-
   ACTS_VERBOSE("Have " << inputTrackParameters.size() << " track parameters");
   const auto& protoVertices = m_inputProtoVertices(ctx);
   ACTS_VERBOSE("Have " << protoVertices.size() << " proto vertices");
 
-  std::vector<const Acts::BoundTrackParameters*> inputTrackPtrCollection;
+  std::vector<Acts::InputTrack> inputTracks;
 
   VertexCollection fittedVertices;
 
@@ -86,22 +77,21 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
     }
 
     // select input tracks for the input proto vertex
-    inputTrackPtrCollection.clear();
-    inputTrackPtrCollection.reserve(protoVertex.size());
+    inputTracks.clear();
+    inputTracks.reserve(protoVertex.size());
     for (const auto& trackIdx : protoVertex) {
       if (trackIdx >= inputTrackParameters.size()) {
         ACTS_ERROR("track parameters " << trackIdx << " does not exist");
         continue;
       }
 
-      inputTrackPtrCollection.push_back(inputTrackPointers[trackIdx]);
+      inputTracks.emplace_back(&inputTrackParameters[trackIdx]);
     }
 
     if (!m_cfg.doConstrainedFit) {
       VertexFitterOptions vfOptions(ctx.geoContext, ctx.magFieldContext);
 
-      auto fitRes = vertexFitter.fit(inputTrackPtrCollection, linearizer,
-                                     vfOptions, state);
+      auto fitRes = vertexFitter.fit(inputTracks, linearizer, vfOptions, state);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {
@@ -118,8 +108,8 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
       VertexFitterOptions vfOptionsConstr(ctx.geoContext, ctx.magFieldContext,
                                           theConstraint);
 
-      auto fitRes = vertexFitter.fit(inputTrackPtrCollection, linearizer,
-                                     vfOptionsConstr, state);
+      auto fitRes =
+          vertexFitter.fit(inputTracks, linearizer, vfOptionsConstr, state);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {

--- a/Examples/Algorithms/Vertexing/src/VertexingHelpers.hpp
+++ b/Examples/Algorithms/Vertexing/src/VertexingHelpers.hpp
@@ -24,21 +24,20 @@ namespace ActsExamples {
 ///
 /// @param trackParameters input examples track parameters container
 /// @return track parameters pointer container referencing the input tracks
-inline std::vector<const Acts::BoundTrackParameters*>
-makeTrackParametersPointerContainer(
+inline std::vector<Acts::InputTrack> makeInputTracks(
     const TrackParametersContainer& trackParameters) {
-  std::vector<const Acts::BoundTrackParameters*> trackParametersPointers;
-  trackParametersPointers.reserve(trackParameters.size());
+  std::vector<Acts::InputTrack> inputTracks;
+  inputTracks.reserve(trackParameters.size());
 
   for (const auto& trackParam : trackParameters) {
-    trackParametersPointers.push_back(&trackParam);
+    inputTracks.emplace_back(&trackParam);
   }
-  return trackParametersPointers;
+  return inputTracks;
 }
 
 /// Create proto vertices from reconstructed vertices.
 ///
-/// @param trackParameters input track parameters container
+/// @param inputTracks input track parameters container
 /// @param vertices reconstructed vertices
 /// @return proto vertices corresponding to the reconstructed vertices
 ///
@@ -46,7 +45,7 @@ makeTrackParametersPointerContainer(
 /// elements in the given input track parameters container. If that is not the
 /// case the behaviour is undefined.
 inline ProtoVertexContainer makeProtoVertices(
-    const std::vector<const Acts::BoundTrackParameters*>& trackParameters,
+    const std::vector<Acts::InputTrack>& inputTracks,
     const std::vector<Acts::Vertex<Acts::BoundTrackParameters>>& vertices) {
   ProtoVertexContainer protoVertices;
   protoVertices.reserve(vertices.size());
@@ -56,10 +55,10 @@ inline ProtoVertexContainer makeProtoVertices(
     protoVertex.reserve(vertex.tracks().size());
 
     for (const auto& track : vertex.tracks()) {
-      auto it = std::find(trackParameters.begin(), trackParameters.end(),
+      auto it = std::find(inputTracks.begin(), inputTracks.end(),
                           track.originalParams);
-      if (it != trackParameters.end()) {
-        protoVertex.push_back(std::distance(trackParameters.begin(), it));
+      if (it != inputTracks.end()) {
+        protoVertex.push_back(std::distance(inputTracks.begin(), it));
       } else {
         protoVertex.push_back(-1);
       }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -400,7 +400,8 @@ ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
     if (m_cfg.useTracks) {
       for (const auto& trk : tracksAtVtx) {
         // Track parameters before the vertex fit
-        Acts::BoundTrackParameters origTrack = *(trk.originalParams);
+        const Acts::BoundTrackParameters& origTrack =
+            *trk.originalParams.as<Acts::BoundTrackParameters>();
 
         // Finding the matching parameters in the container of all track
         // parameters. This allows us to identify the corresponding particle,
@@ -634,7 +635,9 @@ ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
           // Check if they correspond to a track that contributed to the vertex.
           // We save the momenta if we find a match.
           for (const auto& trk : tracksAtVtx) {
-            if (trk.originalParams->parameters() == params) {
+            const auto& boundParams =
+                *trk.originalParams.as<Acts::BoundTrackParameters>();
+            if (boundParams.parameters() == params) {
               innerTrkWeight.push_back(trk.trackWeight);
               const auto& trueUnitDir = particle.direction();
               Acts::ActsVector<3> trueMom;
@@ -645,7 +648,7 @@ ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
               innerTruthQOverP.push_back(trueMom[2]);
 
               // Save track parameters before the vertex fit
-              const auto paramsAtVtx = propagateToVtx(*(trk.originalParams));
+              const auto paramsAtVtx = propagateToVtx(boundParams);
               if (paramsAtVtx != std::nullopt) {
                 Acts::ActsVector<3> recoMom =
                     paramsAtVtx->parameters().segment(Acts::eBoundPhi, 3);

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -213,22 +213,21 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
        iTrack++) {
     // Index of current vertex
     int vtxIdx = (int)(iTrack / nTracksPerVtx);
-    state.vtxInfoMap[&(vtxList[vtxIdx])].trackLinks.push_back(
-        &(allTracks[iTrack]));
+
+    InputTrack inputTrack{&allTracks[iTrack]};
+
+    state.vtxInfoMap[&(vtxList[vtxIdx])].trackLinks.push_back(inputTrack);
     state.tracksAtVerticesMap.insert(
-        std::make_pair(std::make_pair(&(allTracks[iTrack]), &(vtxList[vtxIdx])),
-                       TrackAtVertex<BoundTrackParameters>(
-                           1., allTracks[iTrack], &(allTracks[iTrack]))));
+        std::make_pair(std::make_pair(inputTrack, &(vtxList[vtxIdx])),
+                       TrackAtVertex(1., allTracks[iTrack], inputTrack)));
 
     // Use first track also for second vertex to let vtx1 and vtx2
     // share this track
     if (iTrack == 0) {
-      state.vtxInfoMap[&(vtxList.at(1))].trackLinks.push_back(
-          &(allTracks[iTrack]));
+      state.vtxInfoMap[&(vtxList.at(1))].trackLinks.push_back(inputTrack);
       state.tracksAtVerticesMap.insert(
-          std::make_pair(std::make_pair(&(allTracks[iTrack]), &(vtxList.at(1))),
-                         TrackAtVertex<BoundTrackParameters>(
-                             1., allTracks[iTrack], &(allTracks[iTrack]))));
+          std::make_pair(std::make_pair(inputTrack, &(vtxList.at(1))),
+                         TrackAtVertex(1., allTracks[iTrack], inputTrack)));
     }
   }
 
@@ -243,7 +242,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   ACTS_DEBUG("Checking all vertices linked to a single track:");
   for (auto& trk : allTracks) {
     ACTS_DEBUG("Track with ptr: " << &trk);
-    auto range = state.trackToVerticesMultiMap.equal_range(&trk);
+    auto range = state.trackToVerticesMultiMap.equal_range(InputTrack{&trk});
     for (auto vtxIter = range.first; vtxIter != range.second; ++vtxIter) {
       ACTS_DEBUG("\t used by vertex: " << vtxIter->second);
     }
@@ -260,7 +259,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   for (auto& vtx : vtxPtrList) {
     c++;
     ACTS_DEBUG(c << ". vertex, with ptr: " << vtx);
-    for (auto& trk : state.vtxInfoMap[vtx].trackLinks) {
+    for (const auto& trk : state.vtxInfoMap[vtx].trackLinks) {
       ACTS_DEBUG("\t track ptr: " << trk);
     }
   }
@@ -268,7 +267,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   ACTS_DEBUG("Checking all vertices linked to a single track AFTER fit:");
   for (auto& trk : allTracks) {
     ACTS_DEBUG("Track with ptr: " << &trk);
-    auto range = state.trackToVerticesMultiMap.equal_range(&trk);
+    auto range = state.trackToVerticesMultiMap.equal_range(InputTrack{&trk});
     for (auto vtxIter = range.first; vtxIter != range.second; ++vtxIter) {
       ACTS_DEBUG("\t used by vertex: " << vtxIter->second);
     }
@@ -425,10 +424,10 @@ BOOST_AUTO_TEST_CASE(time_fitting) {
   for (const auto& trk : trks) {
     ACTS_DEBUG("Track parameters:\n" << trk);
     // Index of current vertex
-    state.vtxInfoMap[&vtx].trackLinks.push_back(&trk);
+    state.vtxInfoMap[&vtx].trackLinks.push_back(InputTrack{&trk});
     state.tracksAtVerticesMap.insert(
-        std::make_pair(std::make_pair(&trk, &vtx),
-                       TrackAtVertex<BoundTrackParameters>(1., trk, &trk)));
+        std::make_pair(std::make_pair(InputTrack{&trk}, &vtx),
+                       TrackAtVertex(1., trk, InputTrack{&trk})));
   }
 
   state.addVertexToMultiMap(vtx);
@@ -609,17 +608,17 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
 
   // Prepare vtx info for fitter
   VertexInfo<BoundTrackParameters> vtxInfo1;
+  vtxInfo1.seedPosition = vtxInfo1.linPoint;
   vtxInfo1.linPoint.setZero();
   vtxInfo1.linPoint.head<3>() = vtxPos1;
-  vtxInfo1.constraint = vtx1Constr;
+  vtxInfo1.constraint = std::move(vtx1Constr);
   vtxInfo1.oldPosition = vtxInfo1.linPoint;
-  vtxInfo1.seedPosition = vtxInfo1.linPoint;
 
   for (const auto& trk : params1) {
-    vtxInfo1.trackLinks.push_back(&trk);
+    vtxInfo1.trackLinks.push_back(InputTrack{&trk});
     state.tracksAtVerticesMap.insert(
-        std::make_pair(std::make_pair(&trk, &vtx1),
-                       TrackAtVertex<BoundTrackParameters>(1.5, trk, &trk)));
+        std::make_pair(std::make_pair(InputTrack{&trk}, &vtx1),
+                       TrackAtVertex(1.5, trk, InputTrack{&trk})));
   }
 
   // Prepare second vertex
@@ -638,15 +637,15 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
   VertexInfo<BoundTrackParameters> vtxInfo2;
   vtxInfo2.linPoint.setZero();
   vtxInfo2.linPoint.head<3>() = vtxPos2;
-  vtxInfo2.constraint = vtx2Constr;
+  vtxInfo2.constraint = std::move(vtx2Constr);
   vtxInfo2.oldPosition = vtxInfo2.linPoint;
   vtxInfo2.seedPosition = vtxInfo2.linPoint;
 
   for (const auto& trk : params2) {
-    vtxInfo2.trackLinks.push_back(&trk);
+    vtxInfo2.trackLinks.push_back(InputTrack{&trk});
     state.tracksAtVerticesMap.insert(
-        std::make_pair(std::make_pair(&trk, &vtx2),
-                       TrackAtVertex<BoundTrackParameters>(1.5, trk, &trk)));
+        std::make_pair(std::make_pair(InputTrack{&trk}, &vtx2),
+                       TrackAtVertex(1.5, trk, InputTrack{&trk})));
   }
 
   state.vtxInfoMap[&vtx1] = std::move(vtxInfo1);

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -28,6 +28,7 @@
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/FullBilloirVertexFitter.hpp"
 #include "Acts/Vertexing/HelicalTrackLinearizer.hpp"
+#include "Acts/Vertexing/TrackAtVertex.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
@@ -95,8 +96,8 @@ std::uniform_real_distribution<double> resTDist(0.1_ns, 0.2_ns);
 std::uniform_int_distribution<std::uint32_t> nTracksDist(3, 10);
 
 // Dummy user-defined InputTrack type
-struct InputTrack {
-  InputTrack(const BoundTrackParameters& params) : m_parameters(params) {}
+struct InputTrackStub {
+  InputTrackStub(const BoundTrackParameters& params) : m_parameters(params) {}
 
   const BoundTrackParameters& parameters() const { return m_parameters; }
 
@@ -127,7 +128,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
   // Constraint for vertex fit
   Vertex<BoundTrackParameters> constraint;
-  Vertex<InputTrack> customConstraint;
+  Vertex<InputTrackStub> customConstraint;
   // Some arbitrary values
   SquareMatrix4 covMatVtx = SquareMatrix4::Zero();
   double ns2 = Acts::UnitConstants::ns * Acts::UnitConstants::ns;
@@ -153,27 +154,32 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
   // Create a custom std::function to extract BoundTrackParameters from
   // user-defined InputTrack
-  std::function<BoundTrackParameters(InputTrack)> extractParameters =
-      [](const InputTrack& params) { return params.parameters(); };
+  std::function<BoundTrackParameters(const InputTrack&)> extractParameters =
+      [](const InputTrack& params) {
+        return params.as<InputTrackStub>()->parameters();
+      };
 
   // Set up Billoir vertex fitter with user-defined input tracks
-  using CustomVertexFitter = FullBilloirVertexFitter<InputTrack, Linearizer>;
+  using CustomVertexFitter =
+      FullBilloirVertexFitter<InputTrackStub, Linearizer>;
   CustomVertexFitter::Config customVertexFitterCfg;
   CustomVertexFitter customBilloirFitter(customVertexFitterCfg,
                                          extractParameters);
   CustomVertexFitter::State customState(bField->makeCache(magFieldContext));
   // Vertexing options for custom tracks
-  VertexingOptions<InputTrack> customVfOptions(geoContext, magFieldContext);
-  VertexingOptions<InputTrack> customVfOptionsConstr(
+  VertexingOptions<InputTrackStub> customVfOptions(geoContext, magFieldContext);
+  VertexingOptions<InputTrackStub> customVfOptionsConstr(
       geoContext, magFieldContext, customConstraint);
 
   BOOST_TEST_CONTEXT(
       "Testing FullBilloirVertexFitter when input track vector is empty.") {
     const std::vector<const BoundTrackParameters*> emptyVector;
+    const std::vector<InputTrack> emptyVectorInput;
 
     // Without constraint
     Vertex<BoundTrackParameters> fittedVertex =
-        billoirFitter.fit(emptyVector, linearizer, vfOptions, state).value();
+        billoirFitter.fit(emptyVectorInput, linearizer, vfOptions, state)
+            .value();
 
     Vector3 origin(0., 0., 0.);
     SquareMatrix4 zeroMat = SquareMatrix4::Zero();
@@ -182,7 +188,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // With constraint
     fittedVertex =
-        billoirFitter.fit(emptyVector, linearizer, vfOptionsConstr, state)
+        billoirFitter.fit(emptyVectorInput, linearizer, vfOptionsConstr, state)
             .value();
 
     BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
@@ -211,7 +217,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // Vector to store track objects used for vertex fit
     std::vector<BoundTrackParameters> tracks;
-    std::vector<InputTrack> customTracks;
+    std::vector<InputTrackStub> customTracks;
 
     // Calculate random track emerging from vicinity of vertex position
     for (std::uint32_t iTrack = 0; iTrack < nTracks; iTrack++) {
@@ -245,14 +251,14 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
                                ParticleHypothesis::pion()));
     }
 
-    std::vector<const BoundTrackParameters*> tracksPtr;
+    std::vector<InputTrack> inputTracks;
     for (const auto& trk : tracks) {
-      tracksPtr.push_back(&trk);
+      inputTracks.push_back(InputTrack{&trk});
     }
 
-    std::vector<const InputTrack*> customTracksPtr;
+    std::vector<InputTrack> customInputTracks;
     for (const auto& trk : customTracks) {
-      customTracksPtr.push_back(&trk);
+      customInputTracks.push_back(InputTrack{&trk});
     }
 
     auto fit = [&trueVertex, &nTracks](const auto& fitter, const auto& trksPtr,
@@ -274,22 +280,22 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter without vertex constraint.") {
-      fit(billoirFitter, tracksPtr, linearizer, vfOptions, state);
+      fit(billoirFitter, inputTracks, linearizer, vfOptions, state);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with vertex constraint.") {
-      fit(billoirFitter, tracksPtr, linearizer, vfOptionsConstr, state);
+      fit(billoirFitter, inputTracks, linearizer, vfOptionsConstr, state);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with custom tracks (no vertex "
         "constraint).") {
-      fit(customBilloirFitter, customTracksPtr, linearizer, customVfOptions,
+      fit(customBilloirFitter, customInputTracks, linearizer, customVfOptions,
           customState);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with custom tracks (with vertex "
         "constraint).") {
-      fit(customBilloirFitter, customTracksPtr, linearizer,
+      fit(customBilloirFitter, customInputTracks, linearizer,
           customVfOptionsConstr, customState);
     }
   }

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -150,17 +150,17 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
                            .value());
   }
 
-  std::vector<const BoundTrackParameters*> trackPtrVec;
+  std::vector<InputTrack> inputTracks;
   for (const auto& trk : trackVec) {
-    trackPtrVec.push_back(&trk);
+    inputTracks.emplace_back(&trk);
   }
 
-  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
 
-  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }
@@ -268,9 +268,9 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
                            .value());
   }
 
-  std::vector<const BoundTrackParameters*> trackPtrVec;
+  std::vector<InputTrack> inputTracks;
   for (const auto& trk : trackVec) {
-    trackPtrVec.push_back(&trk);
+    inputTracks.emplace_back(&trk);
   }
 
   Finder1::State state1;
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   double zResult1 = 0;
   double zResult2 = 0;
 
-  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     zResult1 = result[eZ];
   }
 
-  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }
@@ -312,10 +312,10 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   CHECK_CLOSE_REL(zResult1, zResult2, 1e-5);
 
   int trkCount = 0;
-  std::vector<const BoundTrackParameters*> removedTracks;
+  std::vector<InputTrack> removedTracks;
   for (const auto& trk : trackVec) {
     if ((trkCount % 4) != 0) {
-      removedTracks.push_back(&trk);
+      removedTracks.emplace_back(&trk);
     }
     trkCount++;
   }
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   state1.tracksToRemove = removedTracks;
   state2.tracksToRemove = removedTracks;
 
-  auto res3 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  auto res3 = finder1.find(inputTracks, vertexingOptions, state1);
   if (!res3.ok()) {
     std::cout << res3.error().message() << std::endl;
   }
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     zResult1 = result[eZ];
   }
 
-  auto res4 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  auto res4 = finder2.find(inputTracks, vertexingOptions, state2);
   if (!res4.ok()) {
     std::cout << res4.error().message() << std::endl;
   }
@@ -433,13 +433,13 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
                            .value());
   }
 
-  std::vector<const BoundTrackParameters*> trackPtrVec;
+  std::vector<InputTrack> inputTracks;
   for (const auto& trk : trackVec) {
-    trackPtrVec.push_back(&trk);
+    inputTracks.emplace_back(&trk);
   }
 
   // Test finder 1
-  auto res1 = finder1.find(trackPtrVec, vertexingOptions, state1);
+  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
@@ -457,7 +457,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   }
 
   // Test finder 2
-  auto res2 = finder2.find(trackPtrVec, vertexingOptions, state2);
+  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -100,8 +100,8 @@ std::uniform_int_distribution<std::uint32_t> nVertexDist(1, 6);
 std::uniform_int_distribution<std::uint32_t> nTracksDist(5, 15);
 
 // Dummy user-defined InputTrack type
-struct InputTrack {
-  InputTrack(const BoundTrackParameters& params) : m_parameters(params) {}
+struct InputTrackStub {
+  InputTrackStub(const BoundTrackParameters& params) : m_parameters(params) {}
 
   const BoundTrackParameters& parameters() const { return m_parameters; }
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     // Vector to be filled with all tracks in current event
     std::vector<std::unique_ptr<const BoundTrackParameters>> tracks;
 
-    std::vector<const BoundTrackParameters*> tracksPtr;
+    std::vector<InputTrack> inputTracks;
 
     // Vector to be filled with truth vertices for later comparison
     std::vector<Vertex<BoundTrackParameters>> trueVertices;
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
 
       // True vertex
       Vertex<BoundTrackParameters> trueV(Vector3(x, y, z));
-      std::vector<TrackAtVertex<BoundTrackParameters>> tracksAtTrueVtx;
+      std::vector<TrackAtVertex> tracksAtTrueVtx;
 
       // Calculate d0 and z0 corresponding to vertex position
       double d0_v = std::hypot(x, y);
@@ -242,8 +242,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
 
         tracks.push_back(std::make_unique<BoundTrackParameters>(params));
 
-        TrackAtVertex<BoundTrackParameters> trAtVt(0., params,
-                                                   tracks.back().get());
+        TrackAtVertex trAtVt(0., params, InputTrack{tracks.back().get()});
         tracksAtTrueVtx.push_back(trAtVt);
       }
 
@@ -256,14 +255,14 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     std::shuffle(std::begin(tracks), std::end(tracks), gen);
 
     for (const auto& trk : tracks) {
-      tracksPtr.push_back(trk.get());
+      inputTracks.emplace_back(trk.get());
     }
 
     VertexingOptions<BoundTrackParameters> vertexingOptions(geoContext,
                                                             magFieldContext);
 
     // find vertices
-    auto res = finder.find(tracksPtr, vertexingOptions, state);
+    auto res = finder.find(inputTracks, vertexingOptions, state);
 
     if (!res.ok()) {
       BOOST_FAIL(res.error().message());
@@ -353,17 +352,19 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     // Set up propagator with void navigator
     auto propagator = std::make_shared<Propagator>(stepper);
 
-    // Linearizer for user defined InputTrack type test
+    // Linearizer for user defined InputTrackStub type test
     Linearizer::Config ltConfigUT(bField, propagator);
     Linearizer linearizer(ltConfigUT);
 
     // Set up vertex fitter for user track type
-    using BilloirFitter = FullBilloirVertexFitter<InputTrack, Linearizer>;
+    using BilloirFitter = FullBilloirVertexFitter<InputTrackStub, Linearizer>;
 
     // Create a custom std::function to extract BoundTrackParameters from
     // user-defined InputTrack
-    std::function<BoundTrackParameters(InputTrack)> extractParameters =
-        [](const InputTrack& params) { return params.parameters(); };
+    std::function<BoundTrackParameters(const InputTrack&)> extractParameters =
+        [](const InputTrack& params) {
+          return params.as<InputTrackStub>()->parameters();
+        };
 
     // Set up Billoir Vertex Fitter
     BilloirFitter::Config vertexFitterCfg;
@@ -371,7 +372,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     BilloirFitter bFitter(vertexFitterCfg, extractParameters);
 
     // IP Estimator
-    using IPEstimator = ImpactPointEstimator<InputTrack, Propagator>;
+    using IPEstimator = ImpactPointEstimator<InputTrackStub, Propagator>;
 
     IPEstimator::Config ipEstimatorCfg(bField, propagator);
     IPEstimator ipEstimator(ipEstimatorCfg);
@@ -391,9 +392,9 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     VertexFinder::State state(*bField, magFieldContext);
 
     // Same for user track type tracks
-    std::vector<std::unique_ptr<const InputTrack>> tracks;
+    std::vector<std::unique_ptr<const InputTrackStub>> tracks;
 
-    std::vector<const InputTrack*> tracksPtr;
+    std::vector<InputTrack> inputTracks;
 
     // Vector to be filled with truth vertices for later comparison
     std::vector<Vertex<InputTrack>> trueVertices;
@@ -420,7 +421,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
 
       // True vertex
       Vertex<InputTrack> trueV(Vector3(x, y, z));
-      std::vector<TrackAtVertex<InputTrack>> tracksAtTrueVtx;
+      std::vector<TrackAtVertex> tracksAtTrueVtx;
 
       // Calculate d0 and z0 corresponding to vertex position
       double d0_v = std::hypot(x, y);
@@ -452,15 +453,13 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
             0., 0., 0., 0., 0., res_ph * res_ph, 0., 0., 0., 0., 0., 0.,
             res_th * res_th, 0., 0., 0., 0., 0., 0., res_qp * res_qp, 0., 0.,
             0., 0., 0., 0., 1.;
-        auto paramsUT = InputTrack(
+        auto params =
             BoundTrackParameters(perigeeSurface, paramVec, std::move(covMat),
-                                 ParticleHypothesis::pion()));
+                                 ParticleHypothesis::pion());
 
-        tracks.push_back(std::make_unique<InputTrack>(paramsUT));
+        tracks.push_back(std::make_unique<InputTrackStub>(params));
 
-        auto params = extractParameters(paramsUT);
-
-        TrackAtVertex<InputTrack> trAtVt(0., params, tracks.back().get());
+        TrackAtVertex trAtVt(0., params, InputTrack{tracks.back().get()});
         tracksAtTrueVtx.push_back(trAtVt);
       }
 
@@ -473,14 +472,14 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     std::shuffle(std::begin(tracks), std::end(tracks), gen);
 
     for (const auto& trk : tracks) {
-      tracksPtr.push_back(trk.get());
+      inputTracks.emplace_back(trk.get());
     }
 
-    VertexingOptions<InputTrack> vertexingOptionsUT(geoContext,
-                                                    magFieldContext);
+    VertexingOptions<InputTrackStub> vertexingOptionsUT(geoContext,
+                                                        magFieldContext);
 
     // find vertices
-    auto res = finder.find(tracksPtr, vertexingOptionsUT, state);
+    auto res = finder.find(inputTracks, vertexingOptionsUT, state);
 
     if (!res.ok()) {
       BOOST_FAIL(res.error().message());
@@ -604,9 +603,9 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   auto csvData = readTracksAndVertexCSV(toolString);
   auto tracks = std::get<TracksData>(csvData);
 
-  std::vector<const BoundTrackParameters*> tracksPtr;
+  std::vector<InputTrack> inputTracks;
   for (const auto& trk : tracks) {
-    tracksPtr.push_back(&trk);
+    inputTracks.emplace_back(&trk);
   }
 
   Vertex<BoundTrackParameters> beamSpot = std::get<BeamSpotData>(csvData);
@@ -619,7 +618,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
       geoContext, magFieldContext, beamSpot);
 
   // find vertices
-  auto findResult = finder.find(tracksPtr, vertexingOptions, state);
+  auto findResult = finder.find(inputTracks, vertexingOptions, state);
 
   BOOST_CHECK(findResult.ok());
 

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
             .value();
 
     // Create TrackAtVertex
-    TrackAtVertex<BoundTrackParameters> trkAtVtx(0., params, &params);
+    TrackAtVertex trkAtVtx(0., params, InputTrack{&params});
 
     // Set linearized state of trackAtVertex
     trkAtVtx.linearizedState = linTrack;

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
             .value();
 
     // Create TrackAtVertex
-    TrackAtVertex<BoundTrackParameters> trkAtVtx(0., params, &params);
+    TrackAtVertex trkAtVtx(0., params, InputTrack{&params});
 
     // Set linearized state of trackAtVertex
     trkAtVtx.linearizedState = linTrack;


### PR DESCRIPTION
This PR changes the input track type given to most of the vertex components from a templated pointer type to a type-erased pointer-like object. Comparison with the original pointer are still permitted, and you can get the pointer back out if you know the type.

The pointer is internally stored as a `void*` but is private and access is made type safe with an additional stored type index.

This PR leaves a number of functions / downstream types templated on a `input_track_t`, but it now only ever gets the concrete `InputType`. I have a PRs in the pipeline that remove these template parameters.

Part of:
- #2842 

Blocked by:
- #2875 
- #2874