### PR TITLE
refactor!: Untemplate `Vertex`

### DIFF
--- a/Core/include/Acts/Vertexing/AMVFInfo.hpp
+++ b/Core/include/Acts/Vertexing/AMVFInfo.hpp
@@ -22,15 +22,14 @@ template <typename input_track_t>
 struct VertexInfo {
   VertexInfo() = default;
 
-  VertexInfo(const Acts::Vertex<input_track_t>& constr,
-             const Acts::Vector4& pos)
+  VertexInfo(const Acts::Vertex& constr, const Acts::Vector4& pos)
       : constraint(constr),
         linPoint(pos),
         oldPosition(pos),
         seedPosition(pos) {}
 
   // Vertex constraint
-  Acts::Vertex<input_track_t> constraint;
+  Acts::Vertex constraint;
 
   // Point where all associated tracks are linearized
   Acts::Vector4 linPoint{Acts::Vector4::Zero()};

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -91,7 +91,7 @@ class AdaptiveGridDensityVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.ipp
@@ -10,7 +10,7 @@ template <typename vfitter_t>
 auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
-    -> Result<std::vector<Vertex<InputTrack_t>>> {
+    -> Result<std::vector<Vertex>> {
   // Remove density contributions from tracks removed from track collection
   if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&
       !state.tracksToRemove.empty()) {
@@ -45,7 +45,7 @@ auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
     // No tracks passed selection
     // Return empty seed, i.e. vertex at constraint position
     // (Note: Upstream finder should check for this break condition)
-    std::vector<Vertex<InputTrack_t>> seedVec{vertexingOptions.constraint};
+    std::vector<Vertex> seedVec{vertexingOptions.constraint};
     return seedVec;
   }
 
@@ -79,7 +79,7 @@ auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
   Vector4 seedPos =
       vertexingOptions.constraint.fullPosition() + Vector4(0., 0., z, t);
 
-  Vertex<InputTrack_t> returnVertex = Vertex<InputTrack_t>(seedPos);
+  Vertex returnVertex = Vertex(seedPos);
 
   SquareMatrix4 seedCov = vertexingOptions.constraint.fullCovariance();
 
@@ -90,7 +90,7 @@ auto Acts::AdaptiveGridDensityVertexFinder<vfitter_t>::find(
 
   returnVertex.setFullCovariance(seedCov);
 
-  std::vector<Vertex<InputTrack_t>> seedVec{returnVertex};
+  std::vector<Vertex> seedVec{returnVertex};
 
   return seedVec;
 }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -210,7 +210,7 @@ class AdaptiveMultiVertexFinder {
   /// @param state State for fulfilling interfaces
   ///
   /// @return Vector of all reconstructed vertices
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& allTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
@@ -243,9 +243,8 @@ class AdaptiveMultiVertexFinder {
   /// from seed track collection in last iteration
   ///
   /// @return The seed vertex
-  Result<Vertex<InputTrack_t>> doSeeding(
-      const std::vector<InputTrack>& trackVector,
-      Vertex<InputTrack_t>& currentConstraint,
+  Result<Vertex> doSeeding(
+      const std::vector<InputTrack>& trackVector, Vertex& currentConstraint,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       SeedFinderState_t& seedFinderState,
       const std::vector<InputTrack>& removedSeedTracks) const;
@@ -255,9 +254,9 @@ class AdaptiveMultiVertexFinder {
   /// @param currentConstraint Vertex constraint
   /// @param useVertexConstraintInFit Indicates whether constraint is used during vertex fit
   /// @param seedVertex Seed vertex
-  void setConstraintAfterSeeding(Vertex<InputTrack_t>& currentConstraint,
+  void setConstraintAfterSeeding(Vertex& currentConstraint,
                                  bool useVertexConstraintInFit,
-                                 Vertex<InputTrack_t>& seedVertex) const;
+                                 Vertex& seedVertex) const;
 
   /// @brief Calculates the IP significance of a track to a given vertex
   ///
@@ -267,7 +266,7 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return The IP significance
   Result<double> getIPSignificance(
-      const InputTrack& track, const Vertex<InputTrack_t>& vtx,
+      const InputTrack& track, const Vertex& vtx,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Adds compatible track to vertex candidate
@@ -277,7 +276,7 @@ class AdaptiveMultiVertexFinder {
   /// @param[out] fitterState The vertex fitter state
   /// @param vertexingOptions Vertexing options
   Result<void> addCompatibleTracksToVertex(
-      const std::vector<InputTrack>& tracks, Vertex<InputTrack_t>& vtx,
+      const std::vector<InputTrack>& tracks, Vertex& vtx,
       FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
@@ -295,8 +294,8 @@ class AdaptiveMultiVertexFinder {
   /// return True if recovery was successful, false otherwise
   Result<bool> canRecoverFromNoCompatibleTracks(
       const std::vector<InputTrack>& allTracks,
-      const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
-      const Vertex<InputTrack_t>& currentConstraint, FitterState_t& fitterState,
+      const std::vector<InputTrack>& seedTracks, Vertex& vtx,
+      const Vertex& currentConstraint, FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Method that tries to prepare the vertex for the fit
@@ -312,8 +311,8 @@ class AdaptiveMultiVertexFinder {
   /// @return True if preparation was successful, false otherwise
   Result<bool> canPrepareVertexForFit(
       const std::vector<InputTrack>& allTracks,
-      const std::vector<InputTrack>& seedTracks, Vertex<InputTrack_t>& vtx,
-      const Vertex<InputTrack_t>& currentConstraint, FitterState_t& fitterState,
+      const std::vector<InputTrack>& seedTracks, Vertex& vtx,
+      const Vertex& currentConstraint, FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Method that checks if vertex is a good vertex and if
@@ -326,7 +325,7 @@ class AdaptiveMultiVertexFinder {
   ///
   /// @return pair(nCompatibleTracks, isGoodVertex)
   std::pair<int, bool> checkVertexAndCompatibleTracks(
-      Vertex<InputTrack_t>& vtx, const std::vector<InputTrack>& seedTracks,
+      Vertex& vtx, const std::vector<InputTrack>& seedTracks,
       FitterState_t& fitterState, bool useVertexConstraintInFit) const;
 
   /// @brief Method that removes all tracks that are compatible with
@@ -338,7 +337,7 @@ class AdaptiveMultiVertexFinder {
   /// @param[out] removedSeedTracks Collection of seed track that will be
   /// removed
   void removeCompatibleTracksFromSeedTracks(
-      Vertex<InputTrack_t>& vtx, std::vector<InputTrack>& seedTracks,
+      Vertex& vtx, std::vector<InputTrack>& seedTracks,
       FitterState_t& fitterState,
       std::vector<InputTrack>& removedSeedTracks) const;
 
@@ -353,7 +352,7 @@ class AdaptiveMultiVertexFinder {
   /// @param[in] geoCtx The geometry context to access global positions
   ///
   /// @return Incompatible track was removed
-  bool removeTrackIfIncompatible(Vertex<InputTrack_t>& vtx,
+  bool removeTrackIfIncompatible(Vertex& vtx,
                                  std::vector<InputTrack>& seedTracks,
                                  FitterState_t& fitterState,
                                  std::vector<InputTrack>& removedSeedTracks,
@@ -367,8 +366,7 @@ class AdaptiveMultiVertexFinder {
   /// @param fitterState The vertex fitter state
   ///
   /// @return Keep new vertex
-  bool keepNewVertex(Vertex<InputTrack_t>& vtx,
-                     const std::vector<Vertex<InputTrack_t>*>& allVertices,
+  bool keepNewVertex(Vertex& vtx, const std::vector<Vertex*>& allVertices,
                      FitterState_t& fitterState) const;
 
   /// @brief Method that evaluates if the new vertex candidate is
@@ -378,9 +376,8 @@ class AdaptiveMultiVertexFinder {
   /// @param allVertices All so far found vertices
   ///
   /// @return Vertex is merged
-  bool isMergedVertex(
-      const Vertex<InputTrack_t>& vtx,
-      const std::vector<Vertex<InputTrack_t>*>& allVertices) const;
+  bool isMergedVertex(const Vertex& vtx,
+                      const std::vector<Vertex*>& allVertices) const;
 
   /// @brief Method that deletes last vertex from list of all vertices
   /// and refits all vertices afterwards
@@ -391,10 +388,8 @@ class AdaptiveMultiVertexFinder {
   /// @param fitterState The current vertex fitter state
   /// @param vertexingOptions Vertexing options
   Result<void> deleteLastVertex(
-      Vertex<InputTrack_t>& vtx,
-      std::vector<std::unique_ptr<Vertex<InputTrack_t>>>& allVertices,
-      std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
-      FitterState_t& fitterState,
+      Vertex& vtx, std::vector<std::unique_ptr<Vertex>>& allVertices,
+      std::vector<Vertex*>& allVerticesPtr, FitterState_t& fitterState,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Prepares the output vector of vertices
@@ -403,8 +398,8 @@ class AdaptiveMultiVertexFinder {
   /// @param fitterState The vertex fitter state
   ///
   /// @return The output vertex collection
-  Result<std::vector<Vertex<InputTrack_t>>> getVertexOutputList(
-      const std::vector<Vertex<InputTrack_t>*>& allVerticesPtr,
+  Result<std::vector<Vertex>> getVertexOutputList(
+      const std::vector<Vertex*>& allVerticesPtr,
       FitterState_t& fitterState) const;
 };
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -140,12 +140,10 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::doSeeding(
-    const std::vector<InputTrack>& trackVector,
-    Vertex& currentConstraint,
+    const std::vector<InputTrack>& trackVector, Vertex& currentConstraint,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     SeedFinderState_t& seedFinderState,
-    const std::vector<InputTrack>& removedSeedTracks) const
-    -> Result<Vertex> {
+    const std::vector<InputTrack>& removedSeedTracks) const -> Result<Vertex> {
   VertexingOptions<InputTrack_t> seedOptions = vertexingOptions;
   seedOptions.constraint = currentConstraint;
 
@@ -234,8 +232,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getIPSignificance(
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     addCompatibleTracksToVertex(
-        const std::vector<InputTrack>& tracks,
-        Vertex& vtx, FitterState_t& fitterState,
+        const std::vector<InputTrack>& tracks, Vertex& vtx,
+        FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<void> {
   for (const auto& trk : tracks) {
@@ -267,10 +265,8 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     canRecoverFromNoCompatibleTracks(
         const std::vector<InputTrack>& allTracks,
-        const std::vector<InputTrack>& seedTracks,
-        Vertex& vtx,
-        const Vertex& currentConstraint,
-        FitterState_t& fitterState,
+        const std::vector<InputTrack>& seedTracks, Vertex& vtx,
+        const Vertex& currentConstraint, FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<bool> {
   // Recover from cases where no compatible tracks to vertex
@@ -325,10 +321,8 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
     canPrepareVertexForFit(
         const std::vector<InputTrack>& allTracks,
-        const std::vector<InputTrack>& seedTracks,
-        Vertex& vtx,
-        const Vertex& currentConstraint,
-        FitterState_t& fitterState,
+        const std::vector<InputTrack>& seedTracks, Vertex& vtx,
+        const Vertex& currentConstraint, FitterState_t& fitterState,
         const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<bool> {
   // Add vertex info to fitter state
@@ -355,10 +349,10 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
-    checkVertexAndCompatibleTracks(
-        Vertex& vtx,
-        const std::vector<InputTrack>& seedTracks,
-        FitterState_t& fitterState, bool useVertexConstraintInFit) const
+    checkVertexAndCompatibleTracks(Vertex& vtx,
+                                   const std::vector<InputTrack>& seedTracks,
+                                   FitterState_t& fitterState,
+                                   bool useVertexConstraintInFit) const
     -> std::pair<int, bool> {
   bool isGoodVertex = false;
   int nCompatibleTracks = 0;
@@ -422,11 +416,10 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
-    removeTrackIfIncompatible(
-        Vertex& vtx, std::vector<InputTrack>& seedTracks,
-        FitterState_t& fitterState,
-        std::vector<InputTrack>& removedSeedTracks,
-        const GeometryContext& geoCtx) const -> bool {
+    removeTrackIfIncompatible(Vertex& vtx, std::vector<InputTrack>& seedTracks,
+                              FitterState_t& fitterState,
+                              std::vector<InputTrack>& removedSeedTracks,
+                              const GeometryContext& geoCtx) const -> bool {
   // Try to find the track with highest compatibility
   double maxCompatibility = 0;
 
@@ -480,8 +473,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::keepNewVertex(
-    Vertex& vtx,
-    const std::vector<Vertex*>& allVertices,
+    Vertex& vtx, const std::vector<Vertex*>& allVertices,
     FitterState_t& fitterState) const -> bool {
   double contamination = 0.;
   double contaminationNum = 0;
@@ -509,8 +501,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::keepNewVertex(
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
-    const Vertex& vtx,
-    const std::vector<Vertex*>& allVertices) const -> bool {
+    const Vertex& vtx, const std::vector<Vertex*>& allVertices) const -> bool {
   const Vector4& candidatePos = vtx.fullPosition();
   const SquareMatrix4& candidateCov = vtx.fullCovariance();
 
@@ -564,10 +555,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::isMergedVertex(
 
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
-    Vertex& vtx,
-    std::vector<std::unique_ptr<Vertex>>& allVertices,
-    std::vector<Vertex*>& allVerticesPtr,
-    FitterState_t& fitterState,
+    Vertex& vtx, std::vector<std::unique_ptr<Vertex>>& allVertices,
+    std::vector<Vertex*>& allVerticesPtr, FitterState_t& fitterState,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
     -> Result<void> {
   allVertices.pop_back();
@@ -609,8 +598,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
 template <typename vfitter_t, typename sfinder_t>
 auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::getVertexOutputList(
     const std::vector<Vertex*>& allVerticesPtr,
-    FitterState_t& fitterState) const
-    -> Acts::Result<std::vector<Vertex>> {
+    FitterState_t& fitterState) const -> Acts::Result<std::vector<Vertex>> {
   std::vector<Vertex> outputVec;
   for (auto vtx : allVerticesPtr) {
     auto& outVtx = *vtx;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -57,7 +57,7 @@ class AdaptiveMultiVertexFitter {
         : ipState(field.makeCache(magContext)),
           linearizerState(field.makeCache(magContext)) {}
     // Vertex collection to be fitted
-    std::vector<Vertex<InputTrack_t>*> vertexCollection;
+    std::vector<Vertex*> vertexCollection;
 
     // Annealing state
     AnnealingUtility::State annealingState;
@@ -70,25 +70,24 @@ class AdaptiveMultiVertexFitter {
 
     // Map to store vertices information
     // @TODO Does this have to be a mutable pointer?
-    std::map<Vertex<InputTrack_t>*, VertexInfo<InputTrack_t>> vtxInfoMap;
+    std::map<Vertex*, VertexInfo<InputTrack_t>> vtxInfoMap;
 
-    std::multimap<InputTrack, Vertex<InputTrack_t>*> trackToVerticesMultiMap;
+    std::multimap<InputTrack, Vertex*> trackToVerticesMultiMap;
 
-    std::map<std::pair<InputTrack, Vertex<InputTrack_t>*>, TrackAtVertex>
-        tracksAtVerticesMap;
+    std::map<std::pair<InputTrack, Vertex*>, TrackAtVertex> tracksAtVerticesMap;
 
     /// @brief Default State constructor
     State() = default;
 
     // Adds a vertex to trackToVerticesMultiMap
-    void addVertexToMultiMap(Vertex<InputTrack_t>& vtx) {
+    void addVertexToMultiMap(Vertex& vtx) {
       for (auto trk : vtxInfoMap[&vtx].trackLinks) {
         trackToVerticesMultiMap.emplace(trk, &vtx);
       }
     }
 
     // Removes a vertex from trackToVerticesMultiMap
-    void removeVertexFromMultiMap(Vertex<InputTrack_t>& vtx) {
+    void removeVertexFromMultiMap(Vertex& vtx) {
       for (auto iter = trackToVerticesMultiMap.begin();
            iter != trackToVerticesMultiMap.end();) {
         if (iter->second == &vtx) {
@@ -99,7 +98,7 @@ class AdaptiveMultiVertexFitter {
       }
     }
 
-    Result<void> removeVertexFromCollection(Vertex<InputTrack_t>& vtxToRemove,
+    Result<void> removeVertexFromCollection(Vertex& vtxToRemove,
                                             const Logger& logger) {
       auto it = std::find(vertexCollection.begin(), vertexCollection.end(),
                           &vtxToRemove);
@@ -202,8 +201,7 @@ class AdaptiveMultiVertexFitter {
   ///
   /// @return Result<void> object
   Result<void> addVtxToFit(
-      State& state, Vertex<InputTrack_t>& newVertex,
-      const Linearizer_t& linearizer,
+      State& state, Vertex& newVertex, const Linearizer_t& linearizer,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Performs a simultaneous fit of all vertices in
@@ -239,9 +237,8 @@ class AdaptiveMultiVertexFitter {
   /// @param verticesVec Vector of vertices to search
   ///
   /// @return True if vtx is already in verticesVec
-  bool isAlreadyInList(
-      Vertex<InputTrack_t>* vtx,
-      const std::vector<Vertex<InputTrack_t>*>& verticesVec) const;
+  bool isAlreadyInList(Vertex* vtx,
+                       const std::vector<Vertex*>& verticesVec) const;
 
   /// @brief 1) Calls ImpactPointEstimator::estimate3DImpactParameters
   /// for all tracks that are associated with vtx (i.e., all elements
@@ -252,7 +249,7 @@ class AdaptiveMultiVertexFitter {
   /// @param vtx Vertex object
   /// @param vertexingOptions Vertexing options
   Result<void> prepareVertexForFit(
-      State& state, Vertex<InputTrack_t>* vtx,
+      State& state, Vertex* vtx,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
   /// @brief Sets the vertexCompatibility for all TrackAtVertex objects
@@ -262,7 +259,7 @@ class AdaptiveMultiVertexFitter {
   /// @param currentVtx Current vertex
   /// @param vertexingOptions Vertexing options
   Result<void> setAllVertexCompatibilities(
-      State& state, Vertex<InputTrack_t>* currentVtx,
+      State& state, Vertex* currentVtx,
       const VertexingOptions<input_track_t>& vertexingOptions) const;
 
   /// @brief Sets weights to the track according to Eq.(5.46) in Ref.(1)

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -65,7 +65,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fit(
       // Check if we use the constraint during the vertex fit
       if (state.vtxInfoMap[vtx].constraint.fullCovariance() !=
           SquareMatrix4::Zero()) {
-        const Acts::Vertex<input_track_t>& constraint =
+        const Acts::Vertex& constraint =
             state.vtxInfoMap[vtx].constraint;
         vtx->setFullPosition(constraint.fullPosition());
         vtx->setFitQuality(constraint.fitQuality());
@@ -120,7 +120,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fit(
 template <typename input_track_t, typename linearizer_t>
 Acts::Result<void>
 Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::addVtxToFit(
-    State& state, Vertex<input_track_t>& newVertex,
+    State& state, Vertex& newVertex,
     const linearizer_t& linearizer,
     const VertexingOptions<input_track_t>& vertexingOptions) const {
   if (state.vtxInfoMap[&newVertex].trackLinks.empty()) {
@@ -130,12 +130,12 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::addVtxToFit(
     return VertexingError::EmptyInput;
   }
 
-  std::vector<Vertex<input_track_t>*> verticesToFit = {&newVertex};
+  std::vector<Vertex*> verticesToFit = {&newVertex};
 
   // List of vertices added in last iteration
-  std::vector<Vertex<input_track_t>*> lastIterAddedVertices = {&newVertex};
+  std::vector<Vertex*> lastIterAddedVertices = {&newVertex};
   // List of vertices added in current iteration
-  std::vector<Vertex<input_track_t>*> currentIterAddedVertices;
+  std::vector<Vertex*> currentIterAddedVertices;
 
   // Fill verticesToFit with vertices that are connected to newVertex (via
   // tracks and/or other vertices).
@@ -195,15 +195,15 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::addVtxToFit(
 
 template <typename input_track_t, typename linearizer_t>
 bool Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::
-    isAlreadyInList(Vertex<input_track_t>* vtx,
-                    const std::vector<Vertex<input_track_t>*>& vertices) const {
+    isAlreadyInList(Vertex* vtx,
+                    const std::vector<Vertex*>& vertices) const {
   return std::find(vertices.begin(), vertices.end(), vtx) != vertices.end();
 }
 
 template <typename input_track_t, typename linearizer_t>
 Acts::Result<void> Acts::
     AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::prepareVertexForFit(
-        State& state, Vertex<input_track_t>* vtx,
+        State& state, Vertex* vtx,
         const VertexingOptions<input_track_t>& vertexingOptions) const {
   // Vertex info object
   auto& vtxInfo = state.vtxInfoMap[vtx];
@@ -228,7 +228,7 @@ template <typename input_track_t, typename linearizer_t>
 Acts::Result<void>
 Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::
     setAllVertexCompatibilities(
-        State& state, Vertex<input_track_t>* vtx,
+        State& state, Vertex* vtx,
         const VertexingOptions<input_track_t>& vertexingOptions) const {
   VertexInfo<input_track_t>& vtxInfo = state.vtxInfoMap[vtx];
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -65,8 +65,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fit(
       // Check if we use the constraint during the vertex fit
       if (state.vtxInfoMap[vtx].constraint.fullCovariance() !=
           SquareMatrix4::Zero()) {
-        const Acts::Vertex& constraint =
-            state.vtxInfoMap[vtx].constraint;
+        const Acts::Vertex& constraint = state.vtxInfoMap[vtx].constraint;
         vtx->setFullPosition(constraint.fullPosition());
         vtx->setFitQuality(constraint.fitQuality());
         vtx->setFullCovariance(constraint.fullCovariance());
@@ -120,8 +119,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::fit(
 template <typename input_track_t, typename linearizer_t>
 Acts::Result<void>
 Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::addVtxToFit(
-    State& state, Vertex& newVertex,
-    const linearizer_t& linearizer,
+    State& state, Vertex& newVertex, const linearizer_t& linearizer,
     const VertexingOptions<input_track_t>& vertexingOptions) const {
   if (state.vtxInfoMap[&newVertex].trackLinks.empty()) {
     ACTS_ERROR(
@@ -195,8 +193,7 @@ Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::addVtxToFit(
 
 template <typename input_track_t, typename linearizer_t>
 bool Acts::AdaptiveMultiVertexFitter<input_track_t, linearizer_t>::
-    isAlreadyInList(Vertex* vtx,
-                    const std::vector<Vertex*>& vertices) const {
+    isAlreadyInList(Vertex* vtx, const std::vector<Vertex*>& vertices) const {
   return std::find(vertices.begin(), vertices.end(), vtx) != vertices.end();
 }
 

--- a/Core/include/Acts/Vertexing/DummyVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/DummyVertexFitter.hpp
@@ -34,9 +34,8 @@ class DummyVertexFitter {
   DummyVertexFitter() = delete;
 
   /// @brief Dummy fit method
-  Result<Vertex<input_track_t>> fit(
-      const std::vector<input_track_t>&, const linearizer_t&,
-      const VertexingOptions<input_track_t>&) const;
+  Result<Vertex> fit(const std::vector<input_track_t>&, const linearizer_t&,
+                     const VertexingOptions<input_track_t>&) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -112,11 +112,10 @@ class FullBilloirVertexFitter {
   /// @param state The state object
   ///
   /// @return Fitted vertex
-  Result<Vertex<input_track_t>> fit(
-      const std::vector<InputTrack>& paramVector,
-      const linearizer_t& linearizer,
-      const VertexingOptions<input_track_t>& vertexingOptions,
-      State& state) const;
+  Result<Vertex> fit(const std::vector<InputTrack>& paramVector,
+                     const linearizer_t& linearizer,
+                     const VertexingOptions<input_track_t>& vertexingOptions,
+                     State& state) const;
 
  private:
   /// Configuration object

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -55,7 +55,7 @@ struct BilloirVertex {
 }  // namespace Acts::detail
 
 template <typename input_track_t, typename linearizer_t>
-Acts::Result<Acts::Vertex<input_track_t>>
+Acts::Result<Acts::Vertex>
 Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
     const std::vector<InputTrack>& paramVector, const linearizer_t& linearizer,
     const VertexingOptions<input_track_t>& vertexingOptions,
@@ -64,7 +64,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
   double chi2 = std::numeric_limits<double>::max();
 
   if (nTracks == 0) {
-    return Vertex<input_track_t>(Vector3(0., 0., 0.));
+    return Vertex(Vector3(0., 0., 0.));
   }
 
   // Set number of degrees of freedom following Eq. 8.28 from Ref. (2):
@@ -92,7 +92,7 @@ Acts::FullBilloirVertexFitter<input_track_t, linearizer_t>::fit(
   std::vector<Vector3> trackMomenta;
   // Initial guess of the 4D vertex position
   Vector4 linPoint = vertexingOptions.constraint.fullPosition();
-  Vertex<input_track_t> fittedVertex;
+  Vertex fittedVertex;
 
   for (int nIter = 0; nIter < m_cfg.maxIterations; ++nIter) {
     billoirTracks.clear();

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -105,7 +105,7 @@ class GridDensityVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.ipp
@@ -10,7 +10,7 @@ template <int mainGridSize, int trkGridSize, typename vfitter_t>
 auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
-    -> Result<std::vector<Vertex<InputTrack_t>>> {
+    -> Result<std::vector<Vertex>> {
   // Remove density contributions from tracks removed from track collection
   if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&
       !state.tracksToRemove.empty()) {
@@ -30,7 +30,7 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
       // No tracks were removed anymore
       // Return empty seed, i.e. vertex at constraint position
       // (Note: Upstream finder should check for this break condition)
-      std::vector<Vertex<InputTrack_t>> seedVec{vertexingOptions.constraint};
+      std::vector<Vertex> seedVec{vertexingOptions.constraint};
       return seedVec;
     }
   } else {
@@ -82,7 +82,7 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
   // Construct output vertex
   Vector3 seedPos = vertexingOptions.constraint.position() + Vector3(0., 0., z);
 
-  Vertex<InputTrack_t> returnVertex = Vertex<InputTrack_t>(seedPos);
+  Vertex returnVertex = Vertex(seedPos);
 
   SquareMatrix4 seedCov = vertexingOptions.constraint.fullCovariance();
 
@@ -93,7 +93,7 @@ auto Acts::GridDensityVertexFinder<mainGridSize, trkGridSize, vfitter_t>::find(
 
   returnVertex.setFullCovariance(seedCov);
 
-  std::vector<Vertex<InputTrack_t>> seedVec{returnVertex};
+  std::vector<Vertex> seedVec{returnVertex};
 
   return seedVec;
 }

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -181,7 +181,7 @@ class ImpactPointEstimator {
   /// @param mctx The magnetic field context
   /// @param calculateTimeIP If true, the difference in time is computed
   Result<ImpactParametersAndSigma> getImpactParameters(
-      const BoundTrackParameters& track, const Vertex<input_track_t>& vtx,
+      const BoundTrackParameters& track, const Vertex& vtx,
       const GeometryContext& gctx, const MagneticFieldContext& mctx,
       bool calculateTimeIP = false) const;
 
@@ -198,7 +198,7 @@ class ImpactPointEstimator {
   ///
   /// @return A pair holding the sign for the 2D and Z lifetimes
   Result<std::pair<double, double>> getLifetimeSignOfTrack(
-      const BoundTrackParameters& track, const Vertex<input_track_t>& vtx,
+      const BoundTrackParameters& track, const Vertex& vtx,
       const Acts::Vector3& direction, const GeometryContext& gctx,
       const MagneticFieldContext& mctx) const;
 
@@ -213,7 +213,7 @@ class ImpactPointEstimator {
   ///
   /// @return The value of the 3D lifetime
   Result<double> get3DLifetimeSignOfTrack(
-      const BoundTrackParameters& track, const Vertex<input_track_t>& vtx,
+      const BoundTrackParameters& track, const Vertex& vtx,
       const Acts::Vector3& direction, const GeometryContext& gctx,
       const MagneticFieldContext& mctx) const;
 

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -377,7 +377,7 @@ template <typename input_track_t, typename propagator_t,
 Acts::Result<Acts::ImpactParametersAndSigma>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     getImpactParameters(const BoundTrackParameters& track,
-                        const Vertex<input_track_t>& vtx,
+                        const Vertex& vtx,
                         const GeometryContext& gctx,
                         const Acts::MagneticFieldContext& mctx,
                         bool calculateTimeIP) const {
@@ -464,7 +464,7 @@ template <typename input_track_t, typename propagator_t,
 Acts::Result<std::pair<double, double>>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     getLifetimeSignOfTrack(const BoundTrackParameters& track,
-                           const Vertex<input_track_t>& vtx,
+                           const Vertex& vtx,
                            const Acts::Vector3& direction,
                            const GeometryContext& gctx,
                            const MagneticFieldContext& mctx) const {
@@ -508,7 +508,7 @@ template <typename input_track_t, typename propagator_t,
 Acts::Result<double>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     get3DLifetimeSignOfTrack(const BoundTrackParameters& track,
-                             const Vertex<input_track_t>& vtx,
+                             const Vertex& vtx,
                              const Acts::Vector3& direction,
                              const GeometryContext& gctx,
                              const MagneticFieldContext& mctx) const {

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.ipp
@@ -376,8 +376,7 @@ template <typename input_track_t, typename propagator_t,
           typename propagator_options_t>
 Acts::Result<Acts::ImpactParametersAndSigma>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
-    getImpactParameters(const BoundTrackParameters& track,
-                        const Vertex& vtx,
+    getImpactParameters(const BoundTrackParameters& track, const Vertex& vtx,
                         const GeometryContext& gctx,
                         const Acts::MagneticFieldContext& mctx,
                         bool calculateTimeIP) const {
@@ -463,8 +462,7 @@ template <typename input_track_t, typename propagator_t,
           typename propagator_options_t>
 Acts::Result<std::pair<double, double>>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
-    getLifetimeSignOfTrack(const BoundTrackParameters& track,
-                           const Vertex& vtx,
+    getLifetimeSignOfTrack(const BoundTrackParameters& track, const Vertex& vtx,
                            const Acts::Vector3& direction,
                            const GeometryContext& gctx,
                            const MagneticFieldContext& mctx) const {
@@ -508,8 +506,7 @@ template <typename input_track_t, typename propagator_t,
 Acts::Result<double>
 Acts::ImpactPointEstimator<input_track_t, propagator_t, propagator_options_t>::
     get3DLifetimeSignOfTrack(const BoundTrackParameters& track,
-                             const Vertex& vtx,
-                             const Acts::Vector3& direction,
+                             const Vertex& vtx, const Acts::Vector3& direction,
                              const GeometryContext& gctx,
                              const MagneticFieldContext& mctx) const {
   const std::shared_ptr<PerigeeSurface> perigeeSurface =

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -173,7 +173,7 @@ class IterativeVertexFinder {
   /// @param state State for fulfilling interfaces
   ///
   /// @return Collection of vertices found by finder
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
@@ -197,7 +197,7 @@ class IterativeVertexFinder {
   ///
   /// @param seedTracks Seeding tracks
   /// @param vertexingOptions Vertexing options
-  Result<Vertex<InputTrack_t>> getVertexSeed(
+  Result<Vertex> getVertexSeed(
       const std::vector<InputTrack>& seedTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions) const;
 
@@ -217,7 +217,7 @@ class IterativeVertexFinder {
   /// @param vertexingOptions Vertexing options
   /// @param state The state object
   Result<double> getCompatibility(
-      const BoundTrackParameters& params, const Vertex<InputTrack_t>& vertex,
+      const BoundTrackParameters& params, const Vertex& vertex,
       const Surface& perigeeSurface,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
@@ -232,7 +232,7 @@ class IterativeVertexFinder {
   /// @param vertexingOptions Vertexing options
   /// @param state The state object
   Result<void> removeUsedCompatibleTracks(
-      Vertex<InputTrack_t>& vertex, std::vector<InputTrack>& tracksToFit,
+      Vertex& vertex, std::vector<InputTrack>& tracksToFit,
       std::vector<InputTrack>& seedTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
@@ -246,8 +246,7 @@ class IterativeVertexFinder {
   /// @param vertexingOptions Vertexing options
   /// @param state The state object
   Result<void> fillTracksToFit(
-      const std::vector<InputTrack>& seedTracks,
-      const Vertex<InputTrack_t>& seedVertex,
+      const std::vector<InputTrack>& seedTracks, const Vertex& seedVertex,
       std::vector<InputTrack>& tracksToFitOut,
       std::vector<InputTrack>& tracksToFitSplitVertexOut,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
@@ -266,9 +265,8 @@ class IterativeVertexFinder {
   ///
   /// @return Bool if currentVertex is still a good vertex
   Result<bool> reassignTracksToNewVertex(
-      std::vector<Vertex<InputTrack_t>>& vertexCollection,
-      Vertex<InputTrack_t>& currentVertex, std::vector<InputTrack>& tracksToFit,
-      std::vector<InputTrack>& seedTracks,
+      std::vector<Vertex>& vertexCollection, Vertex& currentVertex,
+      std::vector<InputTrack>& tracksToFit, std::vector<InputTrack>& seedTracks,
       const std::vector<InputTrack>& origTracks,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;
@@ -278,7 +276,7 @@ class IterativeVertexFinder {
   /// @param vtx The vertex
   ///
   /// @return Number of significant tracks
-  int countSignificantTracks(const Vertex<InputTrack_t>& vtx) const;
+  int countSignificantTracks(const Vertex& vtx) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -10,14 +10,14 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions, State& state) const
-    -> Result<std::vector<Vertex<InputTrack_t>>> {
+    -> Result<std::vector<Vertex>> {
   // Original tracks
   const std::vector<InputTrack>& origTracks = trackVector;
   // Tracks for seeding
   std::vector<InputTrack> seedTracks = trackVector;
 
   // List of vertices to be filled below
-  std::vector<Vertex<InputTrack_t>> vertexCollection;
+  std::vector<Vertex> vertexCollection;
 
   int nInterations = 0;
   // begin iterating
@@ -54,8 +54,8 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     ACTS_DEBUG("Number of tracks used for fit: " << tracksToFit.size());
 
     /// Begin vertex fit
-    Vertex<InputTrack_t> currentVertex;
-    Vertex<InputTrack_t> currentSplitVertex;
+    Vertex currentVertex;
+    Vertex currentSplitVertex;
 
     if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
       auto fitResult = m_cfg.vertexFitter.fit(
@@ -159,7 +159,7 @@ template <typename vfitter_t, typename sfinder_t>
 auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getVertexSeed(
     const std::vector<InputTrack>& seedTracks,
     const VertexingOptions<InputTrack_t>& vertexingOptions) const
-    -> Result<Vertex<InputTrack_t>> {
+    -> Result<Vertex> {
   typename sfinder_t::State finderState;
   auto res = m_cfg.seedFinder.find(seedTracks, vertexingOptions, finderState);
 
@@ -181,7 +181,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getVertexSeed(
 
   // retrieve the seed vertex as the last element in
   // the seed vertexCollection
-  Vertex<InputTrack_t> seedVertex = vertexCollection.back();
+  Vertex seedVertex = vertexCollection.back();
 
   ACTS_DEBUG("Use " << seedTracks.size() << " tracks for vertex seed finding.")
   ACTS_DEBUG(
@@ -214,7 +214,7 @@ void Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeTracks(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<double>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getCompatibility(
-    const BoundTrackParameters& params, const Vertex<InputTrack_t>& vertex,
+    const BoundTrackParameters& params, const Vertex& vertex,
     const Surface& perigeeSurface,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {
@@ -252,7 +252,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getCompatibility(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<void>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
-    Vertex<InputTrack_t>& vertex, std::vector<InputTrack>& tracksToFit,
+    Vertex& vertex, std::vector<InputTrack>& tracksToFit,
     std::vector<InputTrack>& seedTracks,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {
@@ -347,7 +347,7 @@ template <typename vfitter_t, typename sfinder_t>
 Acts::Result<void>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
     const std::vector<InputTrack>& seedTracks,
-    const Vertex<InputTrack_t>& seedVertex,
+    const Vertex& seedVertex,
     std::vector<InputTrack>& tracksToFitOut,
     std::vector<InputTrack>& tracksToFitSplitVertexOut,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
@@ -421,8 +421,9 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<bool>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
-    std::vector<Vertex<InputTrack_t>>& vertexCollection,
-    Vertex<InputTrack_t>& currentVertex, std::vector<InputTrack>& tracksToFit,
+    std::vector<Vertex>& vertexCollection,
+    Vertex& currentVertex,
+    std::vector<InputTrack>& tracksToFit,
     std::vector<InputTrack>& seedTracks,
     const std::vector<InputTrack>& /* origTracks */,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
@@ -514,7 +515,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
   // override current vertex with new fit
   // set first to default vertex to be able to check if still good vertex
   // later
-  currentVertex = Vertex<InputTrack_t>();
+  currentVertex = Vertex();
   if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
     auto fitResult = m_cfg.vertexFitter.fit(
         tracksToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
@@ -556,7 +557,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
 
 template <typename vfitter_t, typename sfinder_t>
 int Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::countSignificantTracks(
-    const Vertex<InputTrack_t>& vtx) const {
+    const Vertex& vtx) const {
   return std::count_if(vtx.tracks().begin(), vtx.tracks().end(),
                        [this](const TrackAtVertex& trk) {
                          return trk.trackWeight > m_cfg.cutOffTrackWeight;

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -346,8 +346,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::removeUsedCompatibleTracks(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<void>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
-    const std::vector<InputTrack>& seedTracks,
-    const Vertex& seedVertex,
+    const std::vector<InputTrack>& seedTracks, const Vertex& seedVertex,
     std::vector<InputTrack>& tracksToFitOut,
     std::vector<InputTrack>& tracksToFitSplitVertexOut,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
@@ -421,10 +420,8 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::fillTracksToFit(
 template <typename vfitter_t, typename sfinder_t>
 Acts::Result<bool>
 Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
-    std::vector<Vertex>& vertexCollection,
-    Vertex& currentVertex,
-    std::vector<InputTrack>& tracksToFit,
-    std::vector<InputTrack>& seedTracks,
+    std::vector<Vertex>& vertexCollection, Vertex& currentVertex,
+    std::vector<InputTrack>& tracksToFit, std::vector<InputTrack>& seedTracks,
     const std::vector<InputTrack>& /* origTracks */,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
     State& state) const {

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.hpp
@@ -66,7 +66,7 @@ struct Cache {
 /// @param vtx Vertex to be updated
 /// @param trk Track to be used for updating the vertex
 template <typename input_track_t, unsigned int nDimVertex>
-void updateVertexWithTrack(Vertex<input_track_t>& vtx, TrackAtVertex& trk);
+void updateVertexWithTrack(Vertex& vtx, TrackAtVertex& trk);
 
 namespace detail {
 void updateVertexWithTrack(Vector4& vtxPos, SquareMatrix4& vtxCov,

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
@@ -10,7 +10,7 @@
 
 template <typename input_track_t, unsigned int nDimVertex>
 void Acts::KalmanVertexUpdater::updateVertexWithTrack(
-    Vertex<input_track_t>& vtx, TrackAtVertex& trk) {
+    Vertex& vtx, TrackAtVertex& trk) {
   std::pair<double, double> fitQuality = vtx.fitQuality();
   detail::updateVertexWithTrack(vtx.fullPosition(), vtx.fullCovariance(),
                                 fitQuality, trk, 1, nDimVertex);

--- a/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
+++ b/Core/include/Acts/Vertexing/KalmanVertexUpdater.ipp
@@ -9,8 +9,8 @@
 #include <algorithm>
 
 template <typename input_track_t, unsigned int nDimVertex>
-void Acts::KalmanVertexUpdater::updateVertexWithTrack(
-    Vertex& vtx, TrackAtVertex& trk) {
+void Acts::KalmanVertexUpdater::updateVertexWithTrack(Vertex& vtx,
+                                                      TrackAtVertex& trk) {
   std::pair<double, double> fitQuality = vtx.fitQuality();
   detail::updateVertexWithTrack(vtx.fullPosition(), vtx.fullCovariance(),
                                 fitQuality, trk, 1, nDimVertex);

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
@@ -61,7 +61,7 @@ class TrackDensityVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.ipp
@@ -10,7 +10,7 @@ template <typename vfitter_t, typename track_density_t>
 auto Acts::TrackDensityVertexFinder<vfitter_t, track_density_t>::find(
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
-    State& /*state*/) const -> Result<std::vector<Vertex<InputTrack_t>>> {
+    State& /*state*/) const -> Result<std::vector<Vertex>> {
   typename track_density_t::State densityState(trackVector.size());
 
   // Calculate z seed position
@@ -25,7 +25,7 @@ auto Acts::TrackDensityVertexFinder<vfitter_t, track_density_t>::find(
   Vector4 seedPos =
       vertexingOptions.constraint.fullPosition() + Vector4(0., 0., z, 0.);
 
-  Vertex<InputTrack_t> returnVertex = Vertex<InputTrack_t>(seedPos);
+  Vertex returnVertex = Vertex(seedPos);
 
   SquareMatrix4 seedCov = vertexingOptions.constraint.fullCovariance();
 
@@ -36,7 +36,7 @@ auto Acts::TrackDensityVertexFinder<vfitter_t, track_density_t>::find(
 
   returnVertex.setFullCovariance(seedCov);
 
-  std::vector<Vertex<InputTrack_t>> seedVec{returnVertex};
+  std::vector<Vertex> seedVec{returnVertex};
 
   return seedVec;
 }

--- a/Core/include/Acts/Vertexing/Vertex.hpp
+++ b/Core/include/Acts/Vertexing/Vertex.hpp
@@ -14,12 +14,7 @@
 namespace Acts {
 
 /// @class Vertex
-///
 /// @brief Class for storing vertex objects
-///
-/// @tparam input_track_t Track object type
-///
-template <typename input_track_t>
 class Vertex {
  public:
   /// @brief Default constructor

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -6,21 +6,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-inline
-Acts::Vertex::Vertex(const Vector3& position) {
+inline Acts::Vertex::Vertex(const Vector3& position) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
   m_position[ePos2] = position[ePos2];
 }
 
-inline
-Acts::Vertex::Vertex(const Vector4& position)
-    : m_position(position) {}
+inline Acts::Vertex::Vertex(const Vector4& position) : m_position(position) {}
 
-inline
-Acts::Vertex::Vertex(const Vector3& position,
-                                    const SquareMatrix3& covariance,
-                                    std::vector<TrackAtVertex> tracks)
+inline Acts::Vertex::Vertex(const Vector3& position,
+                            const SquareMatrix3& covariance,
+                            std::vector<TrackAtVertex> tracks)
     : m_tracksAtVertex(std::move(tracks)) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
@@ -28,108 +24,84 @@ Acts::Vertex::Vertex(const Vector3& position,
   m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
-inline
-Acts::Vertex::Vertex(const Vector4& position,
-                                    const SquareMatrix4& covariance,
-                                    std::vector<TrackAtVertex> tracks)
+inline Acts::Vertex::Vertex(const Vector4& position,
+                            const SquareMatrix4& covariance,
+                            std::vector<TrackAtVertex> tracks)
     : m_position(position),
       m_covariance(covariance),
       m_tracksAtVertex(std::move(tracks)) {}
 
-inline
-Acts::Vector3 Acts::Vertex::position() const {
+inline Acts::Vector3 Acts::Vertex::position() const {
   return VectorHelpers::position(m_position);
 }
 
-inline
-Acts::ActsScalar Acts::Vertex::time() const {
+inline Acts::ActsScalar Acts::Vertex::time() const {
   return m_position[eTime];
 }
 
-inline
-const Acts::Vector4& Acts::Vertex::fullPosition() const {
+inline const Acts::Vector4& Acts::Vertex::fullPosition() const {
   return m_position;
 }
 
-inline
-Acts::Vector4& Acts::Vertex::fullPosition() {
+inline Acts::Vector4& Acts::Vertex::fullPosition() {
   return m_position;
 }
 
-inline
-Acts::SquareMatrix3 Acts::Vertex::covariance() const {
+inline Acts::SquareMatrix3 Acts::Vertex::covariance() const {
   return m_covariance.block<3, 3>(ePos0, ePos0);
 }
 
-inline
-const Acts::SquareMatrix4& Acts::Vertex::fullCovariance() const {
+inline const Acts::SquareMatrix4& Acts::Vertex::fullCovariance() const {
   return m_covariance;
 }
 
-inline
-Acts::SquareMatrix4& Acts::Vertex::fullCovariance() {
+inline Acts::SquareMatrix4& Acts::Vertex::fullCovariance() {
   return m_covariance;
 }
 
-inline
-const std::vector<Acts::TrackAtVertex>& Acts::Vertex::tracks()
-    const {
+inline const std::vector<Acts::TrackAtVertex>& Acts::Vertex::tracks() const {
   return m_tracksAtVertex;
 }
 
-inline
-std::pair<double, double> Acts::Vertex::fitQuality() const {
+inline std::pair<double, double> Acts::Vertex::fitQuality() const {
   return std::pair<double, double>(m_chiSquared, m_numberDoF);
 }
 
-inline
-void Acts::Vertex::setPosition(const Vector3& position,
-                                              ActsScalar time) {
+inline void Acts::Vertex::setPosition(const Vector3& position,
+                                      ActsScalar time) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
   m_position[ePos2] = position[ePos2];
   m_position[eTime] = time;
 }
 
-inline
-void Acts::Vertex::setFullPosition(const Vector4& fullPosition) {
+inline void Acts::Vertex::setFullPosition(const Vector4& fullPosition) {
   m_position = fullPosition;
 }
 
-inline
-void Acts::Vertex::setTime(ActsScalar time) {
+inline void Acts::Vertex::setTime(ActsScalar time) {
   m_position[eTime] = time;
 }
 
-inline
-void Acts::Vertex::setCovariance(
-    const SquareMatrix3& covariance) {
+inline void Acts::Vertex::setCovariance(const SquareMatrix3& covariance) {
   m_covariance.setZero();
   m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
-inline
-void Acts::Vertex::setFullCovariance(
-    const SquareMatrix4& covariance) {
+inline void Acts::Vertex::setFullCovariance(const SquareMatrix4& covariance) {
   m_covariance = covariance;
 }
 
-inline
-void Acts::Vertex::setTracksAtVertex(
-    std::vector<TrackAtVertex> tracks) {
+inline void Acts::Vertex::setTracksAtVertex(std::vector<TrackAtVertex> tracks) {
   m_tracksAtVertex = std::move(tracks);
 }
 
-inline
-void Acts::Vertex::setFitQuality(double chiSquared,
-                                                double numberDoF) {
+inline void Acts::Vertex::setFitQuality(double chiSquared, double numberDoF) {
   m_chiSquared = chiSquared;
   m_numberDoF = numberDoF;
 }
 
-inline
-void Acts::Vertex::setFitQuality(
-    std::pair<double, double> fitQuality) {
+inline void Acts::Vertex::setFitQuality(std::pair<double, double> fitQuality) {
   m_chiSquared = fitQuality.first;
   m_numberDoF = fitQuality.second;
 }

--- a/Core/include/Acts/Vertexing/Vertex.ipp
+++ b/Core/include/Acts/Vertexing/Vertex.ipp
@@ -6,19 +6,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const Vector3& position) {
+inline
+Acts::Vertex::Vertex(const Vector3& position) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
   m_position[ePos2] = position[ePos2];
 }
 
-template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const Vector4& position)
+inline
+Acts::Vertex::Vertex(const Vector4& position)
     : m_position(position) {}
 
-template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const Vector3& position,
+inline
+Acts::Vertex::Vertex(const Vector3& position,
                                     const SquareMatrix3& covariance,
                                     std::vector<TrackAtVertex> tracks)
     : m_tracksAtVertex(std::move(tracks)) {
@@ -28,62 +28,62 @@ Acts::Vertex<input_track_t>::Vertex(const Vector3& position,
   m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
-template <typename input_track_t>
-Acts::Vertex<input_track_t>::Vertex(const Vector4& position,
+inline
+Acts::Vertex::Vertex(const Vector4& position,
                                     const SquareMatrix4& covariance,
                                     std::vector<TrackAtVertex> tracks)
     : m_position(position),
       m_covariance(covariance),
       m_tracksAtVertex(std::move(tracks)) {}
 
-template <typename input_track_t>
-Acts::Vector3 Acts::Vertex<input_track_t>::position() const {
+inline
+Acts::Vector3 Acts::Vertex::position() const {
   return VectorHelpers::position(m_position);
 }
 
-template <typename input_track_t>
-Acts::ActsScalar Acts::Vertex<input_track_t>::time() const {
+inline
+Acts::ActsScalar Acts::Vertex::time() const {
   return m_position[eTime];
 }
 
-template <typename input_track_t>
-const Acts::Vector4& Acts::Vertex<input_track_t>::fullPosition() const {
+inline
+const Acts::Vector4& Acts::Vertex::fullPosition() const {
   return m_position;
 }
 
-template <typename input_track_t>
-Acts::Vector4& Acts::Vertex<input_track_t>::fullPosition() {
+inline
+Acts::Vector4& Acts::Vertex::fullPosition() {
   return m_position;
 }
 
-template <typename input_track_t>
-Acts::SquareMatrix3 Acts::Vertex<input_track_t>::covariance() const {
+inline
+Acts::SquareMatrix3 Acts::Vertex::covariance() const {
   return m_covariance.block<3, 3>(ePos0, ePos0);
 }
 
-template <typename input_track_t>
-const Acts::SquareMatrix4& Acts::Vertex<input_track_t>::fullCovariance() const {
+inline
+const Acts::SquareMatrix4& Acts::Vertex::fullCovariance() const {
   return m_covariance;
 }
 
-template <typename input_track_t>
-Acts::SquareMatrix4& Acts::Vertex<input_track_t>::fullCovariance() {
+inline
+Acts::SquareMatrix4& Acts::Vertex::fullCovariance() {
   return m_covariance;
 }
 
-template <typename input_track_t>
-const std::vector<Acts::TrackAtVertex>& Acts::Vertex<input_track_t>::tracks()
+inline
+const std::vector<Acts::TrackAtVertex>& Acts::Vertex::tracks()
     const {
   return m_tracksAtVertex;
 }
 
-template <typename input_track_t>
-std::pair<double, double> Acts::Vertex<input_track_t>::fitQuality() const {
+inline
+std::pair<double, double> Acts::Vertex::fitQuality() const {
   return std::pair<double, double>(m_chiSquared, m_numberDoF);
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setPosition(const Vector3& position,
+inline
+void Acts::Vertex::setPosition(const Vector3& position,
                                               ActsScalar time) {
   m_position[ePos0] = position[ePos0];
   m_position[ePos1] = position[ePos1];
@@ -91,44 +91,44 @@ void Acts::Vertex<input_track_t>::setPosition(const Vector3& position,
   m_position[eTime] = time;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setFullPosition(const Vector4& fullPosition) {
+inline
+void Acts::Vertex::setFullPosition(const Vector4& fullPosition) {
   m_position = fullPosition;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setTime(ActsScalar time) {
+inline
+void Acts::Vertex::setTime(ActsScalar time) {
   m_position[eTime] = time;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setCovariance(
+inline
+void Acts::Vertex::setCovariance(
     const SquareMatrix3& covariance) {
   m_covariance.setZero();
   m_covariance.block<3, 3>(ePos0, ePos0) = covariance;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setFullCovariance(
+inline
+void Acts::Vertex::setFullCovariance(
     const SquareMatrix4& covariance) {
   m_covariance = covariance;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setTracksAtVertex(
+inline
+void Acts::Vertex::setTracksAtVertex(
     std::vector<TrackAtVertex> tracks) {
   m_tracksAtVertex = std::move(tracks);
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setFitQuality(double chiSquared,
+inline
+void Acts::Vertex::setFitQuality(double chiSquared,
                                                 double numberDoF) {
   m_chiSquared = chiSquared;
   m_numberDoF = numberDoF;
 }
 
-template <typename input_track_t>
-void Acts::Vertex<input_track_t>::setFitQuality(
+inline
+void Acts::Vertex::setFitQuality(
     std::pair<double, double> fitQuality) {
   m_chiSquared = fitQuality.first;
   m_numberDoF = fitQuality.second;

--- a/Core/include/Acts/Vertexing/VertexFinderConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFinderConcept.hpp
@@ -30,7 +30,7 @@ METHOD_TRAIT(find_t, find);
         constexpr static bool state_exists = exists<state_t, S>;
         static_assert(state_exists, "State type not found");
 
-        constexpr static bool find_exists = has_method<const S, Result<std::vector<Vertex<typename S::InputTrack_t>>>,
+        constexpr static bool find_exists = has_method<const S, Result<std::vector<Vertex>>,
          find_t, const std::vector<InputTrack>&,
          const VertexingOptions<typename S::InputTrack_t>&, typename S::State&>;
         static_assert(find_exists, "find method not found");

--- a/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
@@ -33,7 +33,7 @@ METHOD_TRAIT(fit_t, fit);
 // clang-format off
     template <typename S>
       struct VertexFitterConcept {
-        constexpr static bool fit_exists = has_method<const S, Result<Vertex<typename S::InputTrack_t>>,
+        constexpr static bool fit_exists = has_method<const S, Result<Vertex>,
          fit_t,
          const std::vector<InputTrack>&,
          const typename S::Linearizer_t&,

--- a/Core/include/Acts/Vertexing/VertexingOptions.hpp
+++ b/Core/include/Acts/Vertexing/VertexingOptions.hpp
@@ -31,8 +31,7 @@ struct VertexingOptions {
   /// @param constr Vertex constraint
   /// @param useConstr Boolean indicating whether vertex constraint should be used during the vertex fit
   VertexingOptions(const GeometryContext& gctx,
-                   const MagneticFieldContext& mctx,
-                   const Vertex<input_track_t>& constr,
+                   const MagneticFieldContext& mctx, const Vertex& constr,
                    const bool useConstr = true)
       : geoContext(gctx),
         magFieldContext(mctx),
@@ -51,7 +50,7 @@ struct VertexingOptions {
   VertexingOptions(const GeometryContext& gctx,
                    const MagneticFieldContext& mctx)
       : geoContext(gctx), magFieldContext(mctx) {
-    constraint = Vertex<input_track_t>();
+    constraint = Vertex();
     useConstraintInFit = false;
   }
 
@@ -62,7 +61,7 @@ struct VertexingOptions {
   /// Vertex constraint. Important note: While this variable is not used during
   /// the vertex fit if useConstraintInFit is set to false, it is always used
   /// during vertex finding.
-  Vertex<input_track_t> constraint;
+  Vertex constraint;
   /// Boolean indicating whether we use the constraint information during
   /// the vertex fit. If set to true, the covariance matrix of constraint must
   /// be invertible.

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
@@ -115,7 +115,7 @@ class ZScanVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex<InputTrack_t>>> find(
+  Result<std::vector<Vertex>> find(
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions<InputTrack_t>& vertexingOptions,
       State& state) const;

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.ipp
@@ -10,7 +10,7 @@ template <typename vfitter_t>
 auto Acts::ZScanVertexFinder<vfitter_t>::find(
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions<InputTrack_t>& vertexingOptions,
-    State& /*state*/) const -> Result<std::vector<Vertex<InputTrack_t>>> {
+    State& /*state*/) const -> Result<std::vector<Vertex>> {
   double ZResult = 0.;
   // Prepare the vector of points, on which the 3d mode has later to be
   // calculated
@@ -94,10 +94,10 @@ auto Acts::ZScanVertexFinder<vfitter_t>::find(
   Vector4 output(vertexingOptions.constraint.position().x(),
                  vertexingOptions.constraint.position().y(), ZResult,
                  vertexingOptions.constraint.time());
-  Vertex<InputTrack_t> vtxResult = Vertex<InputTrack_t>(output);
+  Vertex vtxResult = Vertex(output);
 
   // Vector to be filled with one single vertex
-  std::vector<Vertex<InputTrack_t>> vertexCollection;
+  std::vector<Vertex> vertexCollection;
 
   // Add vertex to vertexCollection
   vertexCollection.push_back(vtxResult);

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -59,8 +59,7 @@ class AdaptiveMultiVertexFinderAlgorithm final : public IAlgorithm {
       Acts::AdaptiveMultiVertexFitter<Acts::BoundTrackParameters, Linearizer>;
   using Options = Acts::VertexingOptions<Acts::BoundTrackParameters>;
 
-  using VertexCollection =
-      std::vector<Acts::Vertex<Acts::BoundTrackParameters>>;
+  using VertexCollection = std::vector<Acts::Vertex>;
 
   enum class SeedFinder { GaussianSeeder, AdaptiveGridSeeder };
 

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
@@ -62,8 +62,7 @@ class IterativeVertexFinderAlgorithm final : public IAlgorithm {
   using Finder = Acts::IterativeVertexFinder<Fitter, Seeder>;
   using Options = Acts::VertexingOptions<Acts::BoundTrackParameters>;
 
-  using VertexCollection =
-      std::vector<Acts::Vertex<Acts::BoundTrackParameters>>;
+  using VertexCollection = std::vector<Acts::Vertex>;
 
   struct Config {
     /// Optional. Input track parameters collection

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/SingleSeedVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/SingleSeedVertexFinderAlgorithm.hpp
@@ -43,8 +43,8 @@ class SingleSeedVertexFinderAlgorithm final : public IAlgorithm {
 
   ReadDataHandle<SimSpacePointContainer> m_inputSpacepoints{this,
                                                             "spacepoints"};
-  WriteDataHandle<std::vector<Acts::Vertex<Acts::BoundTrackParameters>>>
-      m_outputVertices{this, "fittedVertices"};
+  WriteDataHandle<std::vector<Acts::Vertex>> m_outputVertices{this,
+                                                              "fittedVertices"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -53,8 +53,7 @@ class VertexFitterAlgorithm final : public IAlgorithm {
   using VertexFitterOptions =
       Acts::VertexingOptions<Acts::BoundTrackParameters>;
 
-  using VertexCollection =
-      std::vector<Acts::Vertex<Acts::BoundTrackParameters>>;
+  using VertexCollection = std::vector<Acts::Vertex>;
 
   struct Config {
     /// Optional. Input track parameters collection

--- a/Examples/Algorithms/Vertexing/src/SingleSeedVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/SingleSeedVertexFinderAlgorithm.cpp
@@ -51,7 +51,7 @@ ActsExamples::SingleSeedVertexFinderAlgorithm::execute(
                                      << "mm, y = " << vtx.value()[1]
                                      << "mm, z = " << vtx.value()[2] << "mm");
 
-    std::vector<Acts::Vertex<Acts::BoundTrackParameters>> vertexCollection;
+    std::vector<Acts::Vertex> vertexCollection;
     vertexCollection.emplace_back(vtx.value());
 
     // store found vertices

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -99,7 +99,7 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
       }
     } else {
       // Vertex constraint
-      Acts::Vertex<Acts::BoundTrackParameters> theConstraint;
+      Acts::Vertex theConstraint;
 
       theConstraint.setFullCovariance(m_cfg.constraintCov);
       theConstraint.setFullPosition(m_cfg.constraintPos);

--- a/Examples/Algorithms/Vertexing/src/VertexingHelpers.hpp
+++ b/Examples/Algorithms/Vertexing/src/VertexingHelpers.hpp
@@ -46,7 +46,7 @@ inline std::vector<Acts::InputTrack> makeInputTracks(
 /// case the behaviour is undefined.
 inline ProtoVertexContainer makeProtoVertices(
     const std::vector<Acts::InputTrack>& inputTracks,
-    const std::vector<Acts::Vertex<Acts::BoundTrackParameters>>& vertices) {
+    const std::vector<Acts::Vertex>& vertices) {
   ProtoVertexContainer protoVertices;
   protoVertices.reserve(vertices.size());
 

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -232,8 +232,7 @@ int ActsExamples::VertexPerformanceWriter::getNumberOfTruePriVertices(
 }
 
 ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
-    const AlgorithmContext& ctx,
-    const std::vector<Acts::Vertex<Acts::BoundTrackParameters>>& vertices) {
+    const AlgorithmContext& ctx, const std::vector<Acts::Vertex>& vertices) {
   // Exclusive access to the tree while writing
   std::lock_guard<std::mutex> lock(m_writeMutex);
 

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.hpp
@@ -40,7 +40,7 @@ struct AlgorithmContext;
 /// Additionally it matches the reco vertices to their truth vertices
 /// and write out the difference in x,y and z position.
 class VertexPerformanceWriter final
-    : public WriterT<std::vector<Acts::Vertex<Acts::BoundTrackParameters>>> {
+    : public WriterT<std::vector<Acts::Vertex>> {
  public:
   using HitParticlesMap = IndexMultimap<ActsFatras::Barcode>;
 
@@ -95,10 +95,8 @@ class VertexPerformanceWriter final
  protected:
   /// @brief Write method called by the base class
   /// @param [in] ctx is the algorithm context for event information
-  ProcessCode writeT(
-      const AlgorithmContext& ctx,
-      const std::vector<Acts::Vertex<Acts::BoundTrackParameters>>& vertices)
-      override;
+  ProcessCode writeT(const AlgorithmContext& ctx,
+                     const std::vector<Acts::Vertex>& vertices) override;
 
  private:
   Config m_cfg;             ///< The config class

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootAthenaNTupleReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootAthenaNTupleReader.hpp
@@ -228,8 +228,8 @@ class RootAthenaNTupleReader : public ActsExamples::IReader {
   WriteDataHandle<std::vector<Acts::Vector4>> m_outputRecoVtxParameters{
       this, "OutputRecoVertices"};
 
-  WriteDataHandle<Acts::Vertex<Acts::BoundTrackParameters>>
-      m_outputBeamspotConstraint{this, "OutputBeamsspotConstraint"};
+  WriteDataHandle<Acts::Vertex> m_outputBeamspotConstraint{
+      this, "OutputBeamsspotConstraint"};
 };
 
 }  // namespace ActsExamples

--- a/Examples/Io/Root/src/RootAthenaNTupleReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaNTupleReader.cpp
@@ -245,7 +245,7 @@ ActsExamples::ProcessCode ActsExamples::RootAthenaNTupleReader::read(
     recoVertexContainer.push_back(vtx);
   }
 
-  Acts::Vertex<Acts::BoundTrackParameters> beamspotConstraint;
+  Acts::Vertex beamspotConstraint;
   Acts::Vector3 beamspotPos;
   Acts::SquareMatrix3 beamspotCov;
 

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
   }
 
   // TODO: test without using beam spot constraint
-  Vertex<BoundTrackParameters> bsConstr = std::get<BeamSpotData>(csvData);
+  Vertex bsConstr = std::get<BeamSpotData>(csvData);
   VertexingOptions<BoundTrackParameters> vertexingOptions(
       geoContext, magFieldContext, bsConstr);
 
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
 
   BOOST_CHECK(findResult.ok());
 
-  std::vector<Vertex<BoundTrackParameters>> allVertices = *findResult;
+  std::vector<Vertex> allVertices = *findResult;
 
   if (debugMode) {
     std::cout << "Time needed: " << timediff << " ms." << std::endl;
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
     userInputTracks.emplace_back(&trk);
   }
 
-  Vertex<InputTrackStub> constraintVtx;
+  Vertex constraintVtx;
   constraintVtx.setPosition(std::get<BeamSpotData>(csvData).position());
   constraintVtx.setCovariance(std::get<BeamSpotData>(csvData).covariance());
 
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
 
   BOOST_CHECK(findResult.ok());
 
-  std::vector<Vertex<InputTrackStub>> allVertices = *findResult;
+  std::vector<Vertex> allVertices = *findResult;
 
   if (debugMode) {
     std::cout << "Number of vertices reconstructed: " << allVertices.size()
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   }
 
   // TODO: test using beam spot constraint
-  Vertex<BoundTrackParameters> bsConstr = std::get<BeamSpotData>(csvData);
+  Vertex bsConstr = std::get<BeamSpotData>(csvData);
   VertexingOptions<BoundTrackParameters> vertexingOptions(
       geoContext, magFieldContext, bsConstr);
 
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
 
   BOOST_CHECK(findResult.ok());
 
-  std::vector<Vertex<BoundTrackParameters>> allVertices = *findResult;
+  std::vector<Vertex> allVertices = *findResult;
 
   if (debugMode) {
     std::cout << "Time needed: " << timediff << " ms." << std::endl;
@@ -604,7 +604,7 @@ BOOST_AUTO_TEST_CASE(
     inputTracks.emplace_back(&trk);
   }
 
-  Vertex<BoundTrackParameters> bsConstr = std::get<BeamSpotData>(csvData);
+  Vertex bsConstr = std::get<BeamSpotData>(csvData);
   VertexingOptions<BoundTrackParameters> vertexingOptions(
       geoContext, magFieldContext, bsConstr);
 
@@ -621,7 +621,7 @@ BOOST_AUTO_TEST_CASE(
 
   BOOST_CHECK(findResult.ok());
 
-  std::vector<Vertex<BoundTrackParameters>> allVertices = *findResult;
+  std::vector<Vertex> allVertices = *findResult;
 
   if (debugMode) {
     std::cout << "Time needed: " << timediff << " ms." << std::endl;

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -148,9 +148,9 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   double resTh = resAngDist(gen);
   double resQp = resQoPDist(gen);
 
-  std::vector<Vertex<BoundTrackParameters>> vtxList;
+  std::vector<Vertex> vtxList;
   for (auto& vtxPos : vtxPosVec) {
-    Vertex<BoundTrackParameters> vtx(vtxPos);
+    Vertex vtx(vtxPos);
     // Set some vertex covariance
     SquareMatrix4 posCovariance(SquareMatrix4::Identity());
     vtx.setFullCovariance(posCovariance);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
     vtxList.push_back(vtx);
   }
 
-  std::vector<Vertex<BoundTrackParameters>*> vtxPtrList;
+  std::vector<Vertex*> vtxPtrList;
   ACTS_DEBUG("All vertices in test case:");
   int cv = 0;
   for (auto& vtx : vtxList) {
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
 
   // Copy vertex seeds from state.vertexCollection to new
   // list in order to be able to compare later
-  std::vector<Vertex<BoundTrackParameters>> seedListCopy = vtxList;
+  std::vector<Vertex> seedListCopy = vtxList;
 
   auto res1 =
       fitter.addVtxToFit(state, vtxList.at(0), linearizer, vertexingOptions);
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(time_fitting) {
   // Seed position of the vertex
   Vector4 vtxSeedPos(0.0_mm, 0.0_mm, -1.4_mm, 0.0_ps);
 
-  Vertex<BoundTrackParameters> vtx(vtxSeedPos);
+  Vertex vtx(vtxSeedPos);
   // Set initial covariance matrix to a large value
   SquareMatrix4 initialCovariance(SquareMatrix4::Identity() * 1e+8);
   vtx.setFullCovariance(initialCovariance);
@@ -596,13 +596,13 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
 
   // Prepare first vertex
   Vector3 vtxPos1(0.15_mm, 0.15_mm, 2.9_mm);
-  Vertex<BoundTrackParameters> vtx1(vtxPos1);
+  Vertex vtx1(vtxPos1);
 
   // Add to vertex list
   state.vertexCollection.push_back(&vtx1);
 
   // The constraint vtx for vtx1
-  Vertex<BoundTrackParameters> vtx1Constr(vtxPos1);
+  Vertex vtx1Constr(vtxPos1);
   vtx1Constr.setFullCovariance(covConstr);
   vtx1Constr.setFitQuality(0, -3);
 
@@ -623,13 +623,13 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
 
   // Prepare second vertex
   Vector3 vtxPos2(0.3_mm, -0.2_mm, -4.8_mm);
-  Vertex<BoundTrackParameters> vtx2(vtxPos2);
+  Vertex vtx2(vtxPos2);
 
   // Add to vertex list
   state.vertexCollection.push_back(&vtx2);
 
   // The constraint vtx for vtx2
-  Vertex<BoundTrackParameters> vtx2Constr(vtxPos2);
+  Vertex vtx2Constr(vtxPos2);
   vtx2Constr.setFullCovariance(covConstr);
   vtx2Constr.setFitQuality(0, -3);
 

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -127,8 +127,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
   Linearizer linearizer(ltConfig);
 
   // Constraint for vertex fit
-  Vertex<BoundTrackParameters> constraint;
-  Vertex<InputTrackStub> customConstraint;
+  Vertex constraint;
+  Vertex customConstraint;
   // Some arbitrary values
   SquareMatrix4 covMatVtx = SquareMatrix4::Zero();
   double ns2 = Acts::UnitConstants::ns * Acts::UnitConstants::ns;
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
     const std::vector<InputTrack> emptyVectorInput;
 
     // Without constraint
-    Vertex<BoundTrackParameters> fittedVertex =
+    Vertex fittedVertex =
         billoirFitter.fit(emptyVectorInput, linearizer, vfOptions, state)
             .value();
 

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
 
   VertexingOptions<BoundTrackParameters> vertexingOptions(geoContext,
                                                           magFieldContext);
-  Vertex<BoundTrackParameters> constraintVtx;
+  Vertex constraintVtx;
   constraintVtx.setCovariance(SquareMatrix3::Identity());
   vertexingOptions.constraint = constraintVtx;
 

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -218,7 +218,7 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
 
   // Vertex position and vertex object
   Vector4 vtxPos(vx0, vy0, vz0, vt0);
-  Vertex<BoundTrackParameters> vtx(vtxPos, makeVertexCovariance(), {});
+  Vertex vtx(vtxPos, makeVertexCovariance(), {});
 
   // Perigee surface at vertex position
   auto vtxPerigeeSurface =
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(Lifetimes2d3d) {
   trk_par[eBoundQOverP] = 1_e / 10_GeV;
 
   Vector4 ip_pos{0., 0., 0., 0.};
-  Vertex<BoundTrackParameters> ip_vtx(ip_pos, makeVertexCovariance(), {});
+  Vertex ip_vtx(ip_pos, makeVertexCovariance(), {});
 
   // Form the bound track parameters at the ip
   auto perigeeSurface = Surface::makeShared<PerigeeSurface>(ip_pos.head<3>());
@@ -525,7 +525,7 @@ BOOST_DATA_TEST_CASE(SingeTrackImpactParameters, tracks* vertices, d0, l0, t0,
   BoundTrackParameters track(perigeeSurface, par,
                              makeBoundParametersCovariance(),
                              ParticleHypothesis::pionLike(std::abs(q)));
-  Vertex<BoundTrackParameters> myConstraint(vtxPos, makeVertexCovariance(), {});
+  Vertex myConstraint(vtxPos, makeVertexCovariance(), {});
 
   // check that computed impact parameters are meaningful
   ImpactParametersAndSigma output =

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     std::vector<InputTrack> inputTracks;
 
     // Vector to be filled with truth vertices for later comparison
-    std::vector<Vertex<BoundTrackParameters>> trueVertices;
+    std::vector<Vertex> trueVertices;
 
     // start creating event with nVertices vertices
     std::uint32_t nVertices = nVertexDist(gen);
@@ -204,7 +204,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
       double z = vZDist(gen);
 
       // True vertex
-      Vertex<BoundTrackParameters> trueV(Vector3(x, y, z));
+      Vertex trueV(Vector3(x, y, z));
       std::vector<TrackAtVertex> tracksAtTrueVtx;
 
       // Calculate d0 and z0 corresponding to vertex position
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     std::vector<InputTrack> inputTracks;
 
     // Vector to be filled with truth vertices for later comparison
-    std::vector<Vertex<InputTrack>> trueVertices;
+    std::vector<Vertex> trueVertices;
 
     // start creating event with nVertices vertices
     std::uint32_t nVertices = nVertexDist(gen);
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
       double z = vZDist(gen);
 
       // True vertex
-      Vertex<InputTrack> trueV(Vector3(x, y, z));
+      Vertex trueV(Vector3(x, y, z));
       std::vector<TrackAtVertex> tracksAtTrueVtx;
 
       // Calculate d0 and z0 corresponding to vertex position
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
     inputTracks.emplace_back(&trk);
   }
 
-  Vertex<BoundTrackParameters> beamSpot = std::get<BeamSpotData>(csvData);
+  Vertex beamSpot = std::get<BeamSpotData>(csvData);
   // Set time covariance
   SquareMatrix4 fullCovariance = SquareMatrix4::Zero();
   fullCovariance.topLeftCorner<3, 3>() = beamSpot.covariance();
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   }
 
   // Retrieve vertices found by vertex finder
-  // std::vector<Vertex<BoundTrackParameters>> allVertices = *findResult;
+  // std::vector<Vertex> allVertices = *findResult;
 
   // Test expected outcomes from athena implementation
   // Number of reconstructed vertices

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexTrackUpdaterTests.cpp
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
 
     // Create a vertex
     Vector3 vtxPos(vXYDist(gen), vXYDist(gen), vZDist(gen));
-    Vertex<BoundTrackParameters> vtx(vtxPos);
+    Vertex vtx(vtxPos);
 
     // Update trkAtVertex with assumption of originating from vtx
     KalmanVertexTrackUpdater::update(trkAtVtx, vtx.fullPosition(),

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_Updater) {
 
     // Create a vertex
     Vector3 vtxPos(vXYDist(gen), vXYDist(gen), vZDist(gen));
-    Vertex<BoundTrackParameters> vtx(vtxPos);
+    Vertex vtx(vtxPos);
     vtx.setFullCovariance(SquareMatrix4::Identity() * 0.01);
 
     // Update trkAtVertex with assumption of originating from vtx

--- a/Tests/UnitTests/Core/Vertexing/TrackDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/TrackDensityVertexFinderTests.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_constr_test) {
   Vector3 constraintPos{1.7_mm, 1.3_mm, -6_mm};
   SquareMatrix3 constrCov = ActsSquareMatrix<3>::Identity();
 
-  Vertex<BoundTrackParameters> constraint(constraintPos);
+  Vertex constraint(constraintPos);
   constraint.setCovariance(constrCov);
 
   // Finder options
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_usertrack_test) {
   Vector3 constraintPos{1.7_mm, 1.3_mm, -6_mm};
   SquareMatrix3 constrCov = SquareMatrix3::Identity();
 
-  Vertex<InputTrackStub> constraint(constraintPos);
+  Vertex constraint(constraintPos);
   constraint.setCovariance(constrCov);
 
   // Finder options

--- a/Tests/UnitTests/Core/Vertexing/VertexingDataHelper.hpp
+++ b/Tests/UnitTests/Core/Vertexing/VertexingDataHelper.hpp
@@ -40,7 +40,7 @@ struct VertexInfo {
   double trk1Chi2 = 0;
 };
 
-inline std::tuple<Vertex<BoundTrackParameters>, std::vector<VertexInfo>,
+inline std::tuple<Vertex, std::vector<VertexInfo>,
                   std::vector<BoundTrackParameters>>
 readTracksAndVertexCSV(const std::string& toolString,
                        const std::string& fileBase = "vertexing_event_mu20") {
@@ -63,7 +63,7 @@ readTracksAndVertexCSV(const std::string& toolString,
   std::shared_ptr<PerigeeSurface> perigeeSurface;
   std::vector<BoundTrackParameters> tracks;
   std::vector<VertexInfo> vertices;
-  Vertex<BoundTrackParameters> beamspotConstraint;
+  Vertex beamspotConstraint;
 
   // Read in beamspot data
   std::getline(beamspotData, line);  // skip header


### PR DESCRIPTION
This PR makes `Vertex` a concrete type, which is possible after moving input track to be a concrete type erased type.

Part of:
- #2842 

Blocked by:
- #2876