### PR TITLE
fix: typo fixes and name change

### DIFF
--- a/Core/include/Acts/Material/GridSurfaceMaterial.hpp
+++ b/Core/include/Acts/Material/GridSurfaceMaterial.hpp
@@ -79,7 +79,7 @@ struct IndexedMaterialAccessor {
   }
 };
 
-/// @brief GridSurfaceMaterialBase
+/// @brief GridSurfaceMaterialT
 ///
 /// It extends the @c ISurfaceMaterial base class and allows to create
 /// material maps associated to a grid structure
@@ -90,7 +90,7 @@ struct IndexedMaterialAccessor {
 /// It is templated on the material type and a slab accessor type in order
 /// to allow it to be used in the material recording as well.
 template <typename grid_t, typename material_accessor_t = GridMaterialAccessor>
-class GridSurfaceMaterialBase : public ISurfaceMaterial {
+class GridSurfaceMaterialT : public ISurfaceMaterial {
  public:
   /// Broadcast grid type
   using grid_type = grid_t;
@@ -104,11 +104,11 @@ class GridSurfaceMaterialBase : public ISurfaceMaterial {
   /// @param gcasts global casts -> casts a grid position from global
   /// @param laccessors local accessors -> accessors to the local grid
   /// @param transform  transform from global frame into map frame
-  GridSurfaceMaterialBase(grid_type&& grid,
-                          material_accessor_type&& materialAccessor,
-                          const std::vector<BinningValue>& gcasts,
-                          const std::vector<std::size_t>& laccessors,
-                          const Transform3& transform = Transform3::Identity())
+  GridSurfaceMaterialT(grid_type&& grid,
+                       material_accessor_type&& materialAccessor,
+                       const std::vector<BinningValue>& gcasts,
+                       const std::vector<std::size_t>& laccessors,
+                       const Transform3& transform = Transform3::Identity())
       : m_grid(std::move(grid)),
         m_materialAccessor(std::move(materialAccessor)),
         m_globalCasts(gcasts),
@@ -186,10 +186,10 @@ class GridSurfaceMaterialBase : public ISurfaceMaterial {
 // Indexed Surface material
 template <typename grid_type>
 using IndexedSurfaceMaterial =
-    GridSurfaceMaterialBase<grid_type, IndexedMaterialAccessor>;
+    GridSurfaceMaterialT<grid_type, IndexedMaterialAccessor>;
 
 // Grid Surface material
 template <typename grid_type>
-using GridSurfaceMaterial = GridSurfaceMaterialBase<grid_type>;
+using GridSurfaceMaterial = GridSurfaceMaterialT<grid_type>;
 
 }  // namespace Acts

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
@@ -70,7 +70,7 @@ class DD4hepDetectorSurfaceFactory {
     /// Optionally provide an Extent object to measure the passive
     std::optional<Extent> pExtent = std::nullopt;
     /// Optionally provide an Extent constraints to measure the layers
-    std::vector<BinningValue> extentContraints = {};
+    std::vector<BinningValue> extentConstraints = {};
     /// The approximination for extent measuring
     std::size_t nExtentSegments = 1u;
   };

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepLayerStructure.hpp
@@ -66,7 +66,7 @@ class DD4hepLayerStructure {
     // The extent structure - optionally
     std::optional<Extent> extent = std::nullopt;
     /// The extent constraints - optionally
-    std::vector<BinningValue> extentContraints = {};
+    std::vector<BinningValue> extentConstraints = {};
     /// Approximation for the polyhedron binning nSegments
     unsigned int nSegments = 1u;
     /// Patch the binning with the extent if possible

--- a/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
@@ -245,7 +245,7 @@ Acts::Experimental::DD4hepBlueprintFactory::extractInternals(
         }
         internalsExtent.setEnvelope(clearance);
         lOptions.extent = internalsExtent;
-        lOptions.extentContraints = internalBinningValues;
+        lOptions.extentConstraints = internalBinningValues;
       }
       // Create the builder from the dd4hep element
       auto [ib, extOpt] = m_cfg.layerStructure->builder(

--- a/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
@@ -109,7 +109,7 @@ Acts::DD4hepDetectorSurfaceFactory::constructSensitiveComponents(
     auto sExtent =
         sSurface->polyhedronRepresentation(gctx, cache.nExtentSegments)
             .extent();
-    cache.sExtent.value().extend(sExtent, cache.extentContraints);
+    cache.sExtent.value().extend(sExtent, cache.extentConstraints);
   }
 
   attachSurfaceMaterial(dd4hepElement, *sSurface.get(),
@@ -137,7 +137,7 @@ Acts::DD4hepDetectorSurfaceFactory::constructPassiveComponents(
     auto sExtent =
         pSurface->polyhedronRepresentation(gctx, cache.nExtentSegments)
             .extent();
-    cache.pExtent.value().extend(sExtent, cache.extentContraints);
+    cache.pExtent.value().extend(sExtent, cache.extentConstraints);
   }
   attachSurfaceMaterial(dd4hepElement, *pSurface.get(), thickness, options);
   // Return a passive surface

--- a/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
@@ -37,7 +37,7 @@ Acts::Experimental::DD4hepLayerStructure::builder(
   DD4hepDetectorSurfaceFactory::Cache fCache;
   fCache.sExtent = options.extent;
   fCache.pExtent = options.extent;
-  fCache.extentContraints = options.extentContraints;
+  fCache.extentConstraints = options.extentConstraints;
   fCache.nExtentSegments = options.nSegments;
   m_surfaceFactory->construct(fCache, gctx, dd4hepElement,
                               options.conversionOptions);

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepCylinderLayerStructureTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepCylinderLayerStructureTests.cpp
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginCylinderLayerStructureAutoRange) {
   lsOptions.name = "AutoRangeLayer";
   auto extent = Acts::Extent();
   lsOptions.extent = extent;
-  lsOptions.extentContraints = {Acts::binZ, Acts::binR};
+  lsOptions.extentConstraints = {Acts::binZ, Acts::binR};
   lsOptions.logLevel = Acts::Logging::VERBOSE;
 
   auto [barrelInternalsBuilder, barrelExt] =

--- a/docs/known-warnings.txt
+++ b/docs/known-warnings.txt
@@ -6,4 +6,4 @@
 .*doxygenfile: Found multiple matches for file \"SeedFinder.hpp.*
 .*Duplicate explicit target name: .*class_acts_1_1_axis_aligned_bounding_box_.*
 .*undefined label: .*class_acts_1_1_convex_polygon_bounds_3_01_polygon_dynamic_01_4.*
-.*undefined label: .*class_acts_1_1_grid_surface_material_base.*
+.*undefined label: .*class_acts_1_1_grid_surface_material_t.*


### PR DESCRIPTION
This mini-PR fixes a type in 6 files & changes the name of the `GridSurfaceMaterial` frame class.