### PR TITLE
build: Add cvmfs setup for LCG105 on centos7/8 and RHEL9 lxplus

### DIFF
--- a/CI/setup_cvmfs_lcg105.sh
+++ b/CI/setup_cvmfs_lcg105.sh
@@ -1,0 +1,23 @@
+# setup appropriate LCG release via cvmfs
+
+if test -e /etc/centos-release && grep 'CentOS Linux release 7' /etc/centos-release; then
+  lcg_os=centos7
+elif test -e /etc/centos-release && grep 'CentOS Stream release 8' /etc/centos-release; then
+  lcg_os=centos8
+# not centos. Check for RHEL  
+elif test -e /etc/redhat-release && grep 'Red Hat Enterprise Linux release 9' /etc/redhat-release; then
+  lcg_os=el9
+else
+  echo "Unsupported system" 1>&2
+  return
+fi
+
+lcg_release=LCG_105
+lcg_compiler=gcc11-opt
+lcg_platform=x86_64-${lcg_os}-${lcg_compiler}
+lcg_view=/cvmfs/sft.cern.ch/lcg/views/${lcg_release}/${lcg_platform}
+
+source ${lcg_view}/setup.sh
+# extra variables required to build acts
+export DD4hep_DIR=${lcg_view}
+

--- a/CI/setup_cvmfs_lcg105.sh
+++ b/CI/setup_cvmfs_lcg105.sh
@@ -5,7 +5,7 @@ if test -e /etc/centos-release && grep 'CentOS Linux release 7' /etc/centos-rele
 elif test -e /etc/centos-release && grep 'CentOS Stream release 8' /etc/centos-release; then
   lcg_os=centos8
 # not centos. Check for RHEL  
-elif test -e /etc/redhat-release && grep 'Red Hat Enterprise Linux release 9' /etc/redhat-release; then
+elif test -e /etc/redhat-release && grep 'Linux release 9' /etc/redhat-release; then
   lcg_os=el9
 else
   echo "Unsupported system" 1>&2


### PR DESCRIPTION
The LXPLUS machines are slowly moving to [RHEL9](https://linux.web.cern.ch/rhel/). 
I use LCG cmvfs setup often to compile acts on lxplus. I've added a setup script to extend the setup of the correct environment on rhel9 machines and keeps the support for centos7/8 using LCG105. 
I successfully compiled and ran the odd full chain on RHEL9. 
In the future deprecated LCG setups should be cleaned.