### PR TITLE
fix: DirectNavigator causes incorrect propagation finalization

### DIFF
--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -562,7 +562,17 @@ class KalmanFitter {
       // Reset navigation state
       // We do not need to specify a target here since this will be handled
       // separately in the KF actor
-      state.navigation = navigator.makeState(&st.referenceSurface(), nullptr);
+      auto newState = navigator.makeState(&st.referenceSurface(), nullptr);
+
+      if constexpr (isDirectNavigator) {
+        // reinitialize navigation surfaces
+        newState.navSurfaces = state.navigation.navSurfaces;
+        newState.navSurfaceIter =
+          std::find(newState.navSurfaces.begin(), newState.navSurfaces.end(), 
+                    &st.referenceSurface());
+      }
+
+      state.navigation = std::move(newState);
       navigator.initialize(state, stepper);
 
       // Update material effects for last measurement state in reversed
@@ -1039,7 +1049,17 @@ class KalmanFitter {
       // Reset the navigation state to enable propagation towards the target
       // surface
       // Set targetSurface to nullptr as it is handled manually in the actor
-      state.navigation = navigator.makeState(&surface, nullptr);
+      auto newState = navigator.makeState(&surface, nullptr);
+
+      if constexpr (isDirectNavigator) {
+        // reinitialize navigation surfaces
+        newState.navSurfaces = state.navigation.navSurfaces;
+        newState.navSurfaceIter =
+          std::find(newState.navSurfaces.begin(), newState.navSurfaces.end(), 
+                    &surface);
+      }
+
+      state.navigation = std::move(newState);
       navigator.initialize(state, stepper);
 
       return Result<void>::success();

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -568,8 +568,8 @@ class KalmanFitter {
         // reinitialize navigation surfaces
         newState.navSurfaces = state.navigation.navSurfaces;
         newState.navSurfaceIter =
-          std::find(newState.navSurfaces.begin(), newState.navSurfaces.end(), 
-                    &st.referenceSurface());
+            std::find(newState.navSurfaces.begin(), newState.navSurfaces.end(),
+                      &st.referenceSurface());
       }
 
       state.navigation = std::move(newState);
@@ -1054,9 +1054,8 @@ class KalmanFitter {
       if constexpr (isDirectNavigator) {
         // reinitialize navigation surfaces
         newState.navSurfaces = state.navigation.navSurfaces;
-        newState.navSurfaceIter =
-          std::find(newState.navSurfaces.begin(), newState.navSurfaces.end(), 
-                    &surface);
+        newState.navSurfaceIter = std::find(
+            newState.navSurfaces.begin(), newState.navSurfaces.end(), &surface);
       }
 
       state.navigation = std::move(newState);


### PR DESCRIPTION
This is observed to break the KalmanFitter if run with the direct navigator, at least in some cases. To be followed up with a more robust solution.