### PR TITLE
chore: Change policy for regular reviews to include develop branches

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -16,7 +16,7 @@ approval_rules:
     ignore_update_merges: true
   if:
     targets_branch:
-      pattern: "^main$"
+      pattern: "^(main|develop\/.+)$"
 
 - name: Is a backport
   requires:


### PR DESCRIPTION
This now applies the main review policy also to the `develop/v*` branches in addition to `main`.
