### PR TITLE
feat: Write `sumPt2` in `VertexPerformanceWriter`

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -128,6 +128,8 @@ ActsExamples::VertexPerformanceWriter::VertexPerformanceWriter(
     m_outputTree->Branch("covYT", &m_covYT);
     m_outputTree->Branch("covZT", &m_covZT);
 
+    m_outputTree->Branch("sumPt2", &m_sumPt2);
+
     // Branches related to track momenta at vertex
     m_outputTree->Branch("trk_truthPhi", &m_truthPhi);
     m_outputTree->Branch("trk_truthTheta", &m_truthTheta);
@@ -592,6 +594,16 @@ ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
                 Acts::FreeIndices::eFreePos1, Acts::FreeIndices::eFreeTime));
             m_covZT.push_back(vtx.fullCovariance()(
                 Acts::FreeIndices::eFreePos2, Acts::FreeIndices::eFreeTime));
+
+            double sumPt2 = 0;
+            for (const auto& trk : tracksAtVtx) {
+              if (trk.trackWeight > m_cfg.minTrkWeight) {
+                double pt = trk.originalParams.as<Acts::BoundTrackParameters>()
+                                ->transverseMomentum();
+                sumPt2 += pt * pt;
+              }
+            }
+            m_sumPt2.push_back(sumPt2);
 
             m_nTracksOnTruthVertex.push_back(nTracksOnTruthVertex);
             m_nTracksOnRecoVertex.push_back(nTracksOnRecoVertex);

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.hpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.hpp
@@ -119,7 +119,7 @@ class VertexPerformanceWriter final
   std::vector<double> m_recoZ;
   std::vector<double> m_recoT;
 
-  /// Difference of reconstructed and true vertex 4D position
+  // Difference of reconstructed and true vertex 4D position
   std::vector<double> m_resX;
   std::vector<double> m_resY;
   std::vector<double> m_resZ;
@@ -142,6 +142,9 @@ class VertexPerformanceWriter final
   std::vector<double> m_covYZ;
   std::vector<double> m_covYT;
   std::vector<double> m_covZT;
+
+  // Sum pT^2 of all tracks associated with the vertex
+  std::vector<double> m_sumPt2;
 
   //--------------------------------------------------------------
   // Track-related variables are contained in a vector of vectors: The inner


### PR DESCRIPTION
This can be used to disambiguate multiple reco vertices assigned to the same truth vertex