### PR TITLE
refactor!: Use `Delegate` for track linearizers

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/AMVFInfo.hpp"
 #include "Acts/Vertexing/ImpactPointEstimator.hpp"
+#include "Acts/Vertexing/TrackLinearizer.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
 #include <type_traits>
@@ -33,7 +34,6 @@ namespace Acts {
 /// @tparam sfinder_t Seed finder type
 template <typename vfitter_t, typename sfinder_t>
 class AdaptiveMultiVertexFinder {
-  using Linearizer_t = typename vfitter_t::Linearizer_t;
   using FitterState_t = typename vfitter_t::State;
   using SeedFinderState_t = typename sfinder_t::State;
 
@@ -54,14 +54,12 @@ class AdaptiveMultiVertexFinder {
     /// @param fitter The vertex fitter
     /// @param sfinder The seed finder
     /// @param ipEst ImpactPointEstimator
-    /// @param lin Track linearizer
     /// @param bIn Input magnetic field
     Config(vfitter_t fitter, sfinder_t sfinder, ImpactPointEstimator ipEst,
-           Linearizer_t lin, std::shared_ptr<const MagneticFieldProvider> bIn)
+           std::shared_ptr<const MagneticFieldProvider> bIn)
         : vertexFitter(std::move(fitter)),
           seedFinder(std::move(sfinder)),
           ipEstimator(std::move(ipEst)),
-          linearizer(std::move(lin)),
           bField{std::move(bIn)} {}
 
     // Vertex fitter
@@ -72,9 +70,6 @@ class AdaptiveMultiVertexFinder {
 
     // ImpactPointEstimator
     ImpactPointEstimator ipEstimator;
-
-    // Track linearizer
-    Linearizer_t linearizer;
 
     std::shared_ptr<const MagneticFieldProvider> bField;
 

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -88,8 +88,8 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
     fitterState.addVertexToMultiMap(vtxCandidate);
 
     // Perform the fit
-    auto fitResult = m_cfg.vertexFitter.addVtxToFit(
-        fitterState, vtxCandidate,  vertexingOptions);
+    auto fitResult = m_cfg.vertexFitter.addVtxToFit(fitterState, vtxCandidate,
+                                                    vertexingOptions);
     if (!fitResult.ok()) {
       return fitResult.error();
     }
@@ -582,8 +582,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
   }
 
   // Do the fit with removed vertex
-  auto fitResult =
-      m_cfg.vertexFitter.fit(fitterState,  vertexingOptions);
+  auto fitResult = m_cfg.vertexFitter.fit(fitterState, vertexingOptions);
   if (!fitResult.ok()) {
     return fitResult.error();
   }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFinder.ipp
@@ -89,7 +89,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::find(
 
     // Perform the fit
     auto fitResult = m_cfg.vertexFitter.addVtxToFit(
-        fitterState, vtxCandidate, m_cfg.linearizer, vertexingOptions);
+        fitterState, vtxCandidate,  vertexingOptions);
     if (!fitResult.ok()) {
       return fitResult.error();
     }
@@ -583,7 +583,7 @@ auto Acts::AdaptiveMultiVertexFinder<vfitter_t, sfinder_t>::deleteLastVertex(
 
   // Do the fit with removed vertex
   auto fitResult =
-      m_cfg.vertexFitter.fit(fitterState, m_cfg.linearizer, vertexingOptions);
+      m_cfg.vertexFitter.fit(fitterState,  vertexingOptions);
   if (!fitResult.ok()) {
     return fitResult.error();
   }

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -18,6 +18,7 @@
 #include "Acts/Vertexing/ImpactPointEstimator.hpp"
 #include "Acts/Vertexing/LinearizerConcept.hpp"
 #include "Acts/Vertexing/TrackAtVertex.hpp"
+#include "Acts/Vertexing/TrackLinearizer.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
 #include "Acts/Vertexing/VertexingError.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
@@ -33,17 +34,8 @@ namespace Acts {
 ///   `Identification of b-jets and investigation of the discovery potential
 ///   of a Higgs boson in the WH−−>lvbb¯ channel with the ATLAS experiment`
 ///
-///////////////////////////////////////////////////////////////////////////
-///
-/// @tparam linearizer_t Track linearizer type
-template <typename linearizer_t>
 class AdaptiveMultiVertexFitter {
-  static_assert(LinearizerConcept<linearizer_t>,
-                "Linearizer does not fulfill linearizer concept.");
-
  public:
-  using Linearizer_t = linearizer_t;
-
   /// @brief The fitter state
   struct State {
     State(const MagneticFieldProvider& field,
@@ -67,9 +59,6 @@ class AdaptiveMultiVertexFitter {
     std::multimap<InputTrack, Vertex*> trackToVerticesMultiMap;
 
     std::map<std::pair<InputTrack, Vertex*>, TrackAtVertex> tracksAtVerticesMap;
-
-    /// @brief Default State constructor
-    State() = default;
 
     // Adds a vertex to trackToVerticesMultiMap
     void addVertexToMultiMap(Vertex& vtx) {
@@ -146,6 +135,8 @@ class AdaptiveMultiVertexFitter {
 
     // Function to extract parameters from InputTrack
     InputTrack::Extractor extractParameters;
+
+    TrackLinearizer trackLinearizer;
   };
 
   /// @brief Constructor for user-defined InputTrack_t type !=
@@ -164,6 +155,11 @@ class AdaptiveMultiVertexFitter {
           "AdaptiveMultiVertexFitter: No function to extract parameters "
           "from InputTrack_t provided.");
     }
+
+    if (!m_cfg.trackLinearizer.connected()) {
+      throw std::invalid_argument(
+          "AdaptiveMultiVertexFitter: No track linearizer provided.");
+    }
   }
 
   /// @brief Adds a new vertex to an existing multi-vertex fit.
@@ -177,23 +173,20 @@ class AdaptiveMultiVertexFitter {
   ///
   /// @param state Fitter state
   /// @param newVertex Vertex to be added to fit
-  /// @param linearizer Track linearizer
   /// @param vertexingOptions Vertexing options
   ///
   /// @return Result<void> object
   Result<void> addVtxToFit(State& state, Vertex& newVertex,
-                           const Linearizer_t& linearizer,
                            const VertexingOptions& vertexingOptions) const;
 
   /// @brief Performs a simultaneous fit of all vertices in
   /// state.vertexCollection
   ///
   /// @param state Fitter state
-  /// @param linearizer Track linearizer
   /// @param vertexingOptions Vertexing options
   ///
   /// @return Result<void> object
-  Result<void> fit(State& state, const Linearizer_t& linearizer,
+  Result<void> fit(State& state,
                    const VertexingOptions& vertexingOptions) const;
 
  private:
@@ -241,11 +234,9 @@ class AdaptiveMultiVertexFitter {
   ///  and updates the vertices by calling the VertexUpdater
   ///
   /// @param state Fitter state
-  /// @param linearizer The track linearizer
   /// @param vertexingOptions Vertexing options
   Result<void> setWeightsAndUpdate(
-      State& state, const Linearizer_t& linearizer,
-      const VertexingOptions& vertexingOptions) const;
+      State& state, const VertexingOptions& vertexingOptions) const;
 
   /// @brief Collects the compatibility values of the track `trk`
   /// wrt to all of its associated vertices

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.ipp
@@ -10,10 +10,8 @@
 #include "Acts/Vertexing/KalmanVertexUpdater.hpp"
 #include "Acts/Vertexing/VertexingError.hpp"
 
-template <typename linearizer_t>
-Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::fit(
-    State& state, const linearizer_t& linearizer,
-    const VertexingOptions& vertexingOptions) const {
+inline Acts::Result<void> Acts::AdaptiveMultiVertexFitter::fit(
+    State& state, const VertexingOptions& vertexingOptions) const {
   // Reset annealing tool
   state.annealingState = AnnealingUtility::State();
 
@@ -86,8 +84,7 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::fit(
     }  // End loop over vertex collection
 
     // Recalculate all track weights and update vertices
-    auto setWeightsResult =
-        setWeightsAndUpdate(state, linearizer, vertexingOptions);
+    auto setWeightsResult = setWeightsAndUpdate(state, vertexingOptions);
     if (!setWeightsResult.ok()) {
       // Print vertices and associated tracks if logger is in debug mode
       if (logger().doPrint(Logging::DEBUG)) {
@@ -115,9 +112,8 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::fit(
   return {};
 }
 
-template <typename linearizer_t>
-Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::addVtxToFit(
-    State& state, Vertex& newVertex, const linearizer_t& linearizer,
+inline Acts::Result<void> Acts::AdaptiveMultiVertexFitter::addVtxToFit(
+    State& state, Vertex& newVertex,
     const VertexingOptions& vertexingOptions) const {
   if (state.vtxInfoMap[&newVertex].trackLinks.empty()) {
     ACTS_ERROR(
@@ -181,7 +177,7 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::addVtxToFit(
   }
 
   // Perform fit on all added vertices
-  auto fitRes = fit(state, linearizer, vertexingOptions);
+  auto fitRes = fit(state, vertexingOptions);
   if (!fitRes.ok()) {
     return fitRes.error();
   }
@@ -189,15 +185,12 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter<linearizer_t>::addVtxToFit(
   return {};
 }
 
-template <typename linearizer_t>
-bool Acts::AdaptiveMultiVertexFitter<linearizer_t>::isAlreadyInList(
+inline bool Acts::AdaptiveMultiVertexFitter::isAlreadyInList(
     Vertex* vtx, const std::vector<Vertex*>& vertices) const {
   return std::find(vertices.begin(), vertices.end(), vtx) != vertices.end();
 }
 
-template <typename linearizer_t>
-Acts::Result<void>
-Acts::AdaptiveMultiVertexFitter<linearizer_t>::prepareVertexForFit(
+inline Acts::Result<void> Acts::AdaptiveMultiVertexFitter::prepareVertexForFit(
     State& state, Vertex* vtx, const VertexingOptions& vertexingOptions) const {
   // Vertex info object
   auto& vtxInfo = state.vtxInfoMap[vtx];
@@ -218,9 +211,8 @@ Acts::AdaptiveMultiVertexFitter<linearizer_t>::prepareVertexForFit(
   return {};
 }
 
-template <typename linearizer_t>
-Acts::Result<void>
-Acts::AdaptiveMultiVertexFitter<linearizer_t>::setAllVertexCompatibilities(
+inline Acts::Result<void>
+Acts::AdaptiveMultiVertexFitter::setAllVertexCompatibilities(
     State& state, Vertex* vtx, const VertexingOptions& vertexingOptions) const {
   VertexInfo& vtxInfo = state.vtxInfoMap[vtx];
 
@@ -260,11 +252,8 @@ Acts::AdaptiveMultiVertexFitter<linearizer_t>::setAllVertexCompatibilities(
   return {};
 }
 
-template <typename linearizer_t>
-Acts::Result<void>
-Acts::AdaptiveMultiVertexFitter<linearizer_t>::setWeightsAndUpdate(
-    State& state, const linearizer_t& linearizer,
-    const VertexingOptions& vertexingOptions) const {
+inline Acts::Result<void> Acts::AdaptiveMultiVertexFitter::setWeightsAndUpdate(
+    State& state, const VertexingOptions& vertexingOptions) const {
   for (auto vtx : state.vertexCollection) {
     VertexInfo& vtxInfo = state.vtxInfoMap[vtx];
 
@@ -288,7 +277,7 @@ Acts::AdaptiveMultiVertexFitter<linearizer_t>::setWeightsAndUpdate(
         // Check if track is already linearized and whether we need to
         // relinearize
         if (!trkAtVtx.isLinearized || vtxInfo.relinearize) {
-          auto result = linearizer.linearizeTrack(
+          auto result = m_cfg.trackLinearizer(
               m_cfg.extractParameters(trk), vtxInfo.linPoint[3],
               *vtxPerigeeSurface, vertexingOptions.geoContext,
               vertexingOptions.magFieldContext, state.fieldCache);
@@ -317,10 +306,9 @@ Acts::AdaptiveMultiVertexFitter<linearizer_t>::setWeightsAndUpdate(
   return {};
 }
 
-template <typename linearizer_t>
-std::vector<double> Acts::AdaptiveMultiVertexFitter<linearizer_t>::
-    collectTrackToVertexCompatibilities(State& state,
-                                        const InputTrack& trk) const {
+inline std::vector<double>
+Acts::AdaptiveMultiVertexFitter::collectTrackToVertexCompatibilities(
+    State& state, const InputTrack& trk) const {
   // Compatibilities of trk wrt all of its associated vertices
   std::vector<double> trkToVtxCompatibilities;
 
@@ -342,8 +330,7 @@ std::vector<double> Acts::AdaptiveMultiVertexFitter<linearizer_t>::
   return trkToVtxCompatibilities;
 }
 
-template <typename linearizer_t>
-bool Acts::AdaptiveMultiVertexFitter<linearizer_t>::checkSmallShift(
+inline bool Acts::AdaptiveMultiVertexFitter::checkSmallShift(
     State& state) const {
   for (auto* vtx : state.vertexCollection) {
     Vector3 diff =
@@ -357,8 +344,7 @@ bool Acts::AdaptiveMultiVertexFitter<linearizer_t>::checkSmallShift(
   return true;
 }
 
-template <typename linearizer_t>
-void Acts::AdaptiveMultiVertexFitter<linearizer_t>::doVertexSmoothing(
+inline void Acts::AdaptiveMultiVertexFitter::doVertexSmoothing(
     State& state) const {
   for (const auto vtx : state.vertexCollection) {
     for (const auto& trk : state.vtxInfoMap[vtx].trackLinks) {
@@ -376,8 +362,7 @@ void Acts::AdaptiveMultiVertexFitter<linearizer_t>::doVertexSmoothing(
   }
 }
 
-template <typename linearizer_t>
-void Acts::AdaptiveMultiVertexFitter<linearizer_t>::logDebugData(
+inline void Acts::AdaptiveMultiVertexFitter::logDebugData(
     const State& state, const Acts::GeometryContext& geoContext) const {
   ACTS_DEBUG("Encountered an error when fitting the following "
              << state.vertexCollection.size() << " vertices:");

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/HelicalTrackLinearizer.hpp"
 #include "Acts/Vertexing/LinearizerConcept.hpp"
+#include "Acts/Vertexing/TrackLinearizer.hpp"
 #include "Acts/Vertexing/Vertex.hpp"
 #include "Acts/Vertexing/VertexingOptions.hpp"
 
@@ -44,16 +45,8 @@ namespace Acts {
 /// ACTS White Paper: Cross-Covariance Matrices in the Billoir Vertex Fit
 /// https://acts.readthedocs.io/en/latest/white_papers/billoir-covariances.html
 /// Author(s) Russo, F
-///
-/// @tparam linearizer_t Track linearizer type
-template <typename linearizer_t>
 class FullBilloirVertexFitter {
-  static_assert(LinearizerConcept<linearizer_t>,
-                "Linearizer does not fulfill linearizer concept.");
-
  public:
-  using Linearizer_t = linearizer_t;
-
   struct State {
     /// @brief The state constructor
     ///
@@ -70,6 +63,8 @@ class FullBilloirVertexFitter {
 
     // Function to extract parameters from InputTrack
     InputTrack::Extractor extractParameters;
+
+    TrackLinearizer trackLinearizer;
   };
 
   /// @brief Constructor for user-defined InputTrack type
@@ -87,6 +82,12 @@ class FullBilloirVertexFitter {
           "No function to extract parameters "
           "provided.");
     }
+
+    if (!m_cfg.trackLinearizer.connected()) {
+      throw std::invalid_argument(
+          "FullBilloirVertexFitter: "
+          "No track linearizer provided.");
+    }
   }
 
   /// @brief Fit method, fitting vertex for provided tracks with constraint
@@ -98,7 +99,6 @@ class FullBilloirVertexFitter {
   ///
   /// @return Fitted vertex
   Result<Vertex> fit(const std::vector<InputTrack>& paramVector,
-                     const linearizer_t& linearizer,
                      const VertexingOptions& vertexingOptions,
                      State& state) const;
 

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.ipp
@@ -54,9 +54,8 @@ struct BilloirVertex {
 
 }  // namespace Acts::detail
 
-template <typename linearizer_t>
-Acts::Result<Acts::Vertex> Acts::FullBilloirVertexFitter<linearizer_t>::fit(
-    const std::vector<InputTrack>& paramVector, const linearizer_t& linearizer,
+inline Acts::Result<Acts::Vertex> Acts::FullBilloirVertexFitter::fit(
+    const std::vector<InputTrack>& paramVector,
     const VertexingOptions& vertexingOptions, State& state) const {
   unsigned int nTracks = paramVector.size();
   double chi2 = std::numeric_limits<double>::max();
@@ -109,7 +108,7 @@ Acts::Result<Acts::Vertex> Acts::FullBilloirVertexFitter<linearizer_t>::fit(
 
       const auto& trackParams = m_cfg.extractParameters(trackContainer);
 
-      auto result = linearizer.linearizeTrack(
+      auto result = m_cfg.trackLinearizer(
           trackParams, linPoint[3], *perigeeSurface,
           vertexingOptions.geoContext, vertexingOptions.magFieldContext,
           state.fieldCache);

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -58,16 +58,16 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     Vertex currentSplitVertex;
 
     if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
-      auto fitResult = m_cfg.vertexFitter.fit(
-          tracksToFit, vertexingOptions, state.fitterState);
+      auto fitResult = m_cfg.vertexFitter.fit(tracksToFit, vertexingOptions,
+                                              state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
         return fitResult.error();
       }
     } else if (!vertexingOptions.useConstraintInFit && tracksToFit.size() > 1) {
-      auto fitResult = m_cfg.vertexFitter.fit(
-          tracksToFit,  vertexingOptions, state.fitterState);
+      auto fitResult = m_cfg.vertexFitter.fit(tracksToFit, vertexingOptions,
+                                              state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
@@ -75,9 +75,8 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
       }
     }
     if (m_cfg.createSplitVertices && tracksToFitSplitVertex.size() > 1) {
-      auto fitResult =
-          m_cfg.vertexFitter.fit(tracksToFitSplitVertex,
-                                 vertexingOptions, state.fitterState);
+      auto fitResult = m_cfg.vertexFitter.fit(
+          tracksToFitSplitVertex, vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentSplitVertex = std::move(*fitResult);
       } else {
@@ -217,10 +216,10 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getCompatibility(
     const Surface& perigeeSurface, const VertexingOptions& vertexingOptions,
     State& state) const {
   // Linearize track
-  auto result = m_cfg.trackLinearizer(
-      params, vertex.fullPosition()[3], perigeeSurface,
-      vertexingOptions.geoContext, vertexingOptions.magFieldContext,
-      state.fieldCache);
+  auto result =
+      m_cfg.trackLinearizer(params, vertex.fullPosition()[3], perigeeSurface,
+                            vertexingOptions.geoContext,
+                            vertexingOptions.magFieldContext, state.fieldCache);
   if (!result.ok()) {
     return result.error();
   }
@@ -510,16 +509,16 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
   // later
   currentVertex = Vertex();
   if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
-    auto fitResult = m_cfg.vertexFitter.fit(
-        tracksToFit,  vertexingOptions, state.fitterState);
+    auto fitResult = m_cfg.vertexFitter.fit(tracksToFit, vertexingOptions,
+                                            state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {
       return Result<bool>::success(false);
     }
   } else if (!vertexingOptions.useConstraintInFit && tracksToFit.size() > 1) {
-    auto fitResult = m_cfg.vertexFitter.fit(
-        tracksToFit,  vertexingOptions, state.fitterState);
+    auto fitResult = m_cfg.vertexFitter.fit(tracksToFit, vertexingOptions,
+                                            state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.ipp
@@ -59,7 +59,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
 
     if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
       auto fitResult = m_cfg.vertexFitter.fit(
-          tracksToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
+          tracksToFit, vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
@@ -67,7 +67,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
       }
     } else if (!vertexingOptions.useConstraintInFit && tracksToFit.size() > 1) {
       auto fitResult = m_cfg.vertexFitter.fit(
-          tracksToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
+          tracksToFit,  vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentVertex = std::move(*fitResult);
       } else {
@@ -76,7 +76,7 @@ auto Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::find(
     }
     if (m_cfg.createSplitVertices && tracksToFitSplitVertex.size() > 1) {
       auto fitResult =
-          m_cfg.vertexFitter.fit(tracksToFitSplitVertex, m_cfg.linearizer,
+          m_cfg.vertexFitter.fit(tracksToFitSplitVertex,
                                  vertexingOptions, state.fitterState);
       if (fitResult.ok()) {
         currentSplitVertex = std::move(*fitResult);
@@ -217,7 +217,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::getCompatibility(
     const Surface& perigeeSurface, const VertexingOptions& vertexingOptions,
     State& state) const {
   // Linearize track
-  auto result = m_cfg.linearizer.linearizeTrack(
+  auto result = m_cfg.trackLinearizer(
       params, vertex.fullPosition()[3], perigeeSurface,
       vertexingOptions.geoContext, vertexingOptions.magFieldContext,
       state.fieldCache);
@@ -511,7 +511,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
   currentVertex = Vertex();
   if (vertexingOptions.useConstraintInFit && !tracksToFit.empty()) {
     auto fitResult = m_cfg.vertexFitter.fit(
-        tracksToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
+        tracksToFit,  vertexingOptions, state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {
@@ -519,7 +519,7 @@ Acts::IterativeVertexFinder<vfitter_t, sfinder_t>::reassignTracksToNewVertex(
     }
   } else if (!vertexingOptions.useConstraintInFit && tracksToFit.size() > 1) {
     auto fitResult = m_cfg.vertexFitter.fit(
-        tracksToFit, m_cfg.linearizer, vertexingOptions, state.fitterState);
+        tracksToFit,  vertexingOptions, state.fitterState);
     if (fitResult.ok()) {
       currentVertex = std::move(*fitResult);
     } else {

--- a/Core/include/Acts/Vertexing/TrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/TrackLinearizer.hpp
@@ -1,0 +1,25 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2023 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
+#include "Acts/MagneticField/MagneticFieldProvider.hpp"
+#include "Acts/Utilities/Delegate.hpp"
+
+namespace Acts {
+struct LinearizedTrack;
+class Surface;
+
+using TrackLinearizer = Acts::Delegate<Result<LinearizedTrack>(
+    const BoundTrackParameters&, double, const Surface& perigeeSurface,
+    const Acts::GeometryContext&, const Acts::MagneticFieldContext&,
+    MagneticFieldProvider::Cache&)>;
+};  // namespace Acts

--- a/Core/include/Acts/Vertexing/TrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/TrackLinearizer.hpp
@@ -19,7 +19,8 @@ struct LinearizedTrack;
 class Surface;
 
 using TrackLinearizer = Acts::Delegate<Result<LinearizedTrack>(
-    const BoundTrackParameters&, double, const Surface& perigeeSurface,
-    const Acts::GeometryContext&, const Acts::MagneticFieldContext&,
-    MagneticFieldProvider::Cache&)>;
+    const BoundTrackParameters& params, double linPointTime,
+    const Surface& perigeeSurface, const Acts::GeometryContext& gctx,
+    const Acts::MagneticFieldContext& mctx,
+    MagneticFieldProvider::Cache& fieldCache)>;
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/TrackLinearizer.hpp
+++ b/Core/include/Acts/Vertexing/TrackLinearizer.hpp
@@ -22,4 +22,4 @@ using TrackLinearizer = Acts::Delegate<Result<LinearizedTrack>(
     const BoundTrackParameters&, double, const Surface& perigeeSurface,
     const Acts::GeometryContext&, const Acts::MagneticFieldContext&,
     MagneticFieldProvider::Cache&)>;
-};  // namespace Acts
+}  // namespace Acts

--- a/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
+++ b/Core/include/Acts/Vertexing/VertexFitterConcept.hpp
@@ -20,8 +20,6 @@ namespace Concepts {
 namespace VertexFitter {
 
 template <typename T>
-using linearizer_t = typename T::Linearizer_t;
-template <typename T>
 using state_t = typename T::State;
 
 METHOD_TRAIT(fit_t, fit);
@@ -32,18 +30,14 @@ METHOD_TRAIT(fit_t, fit);
         constexpr static bool fit_exists = has_method<const S, Result<Vertex>,
          fit_t,
          const std::vector<InputTrack>&,
-         const typename S::Linearizer_t&,
          const VertexingOptions&,
          typename S::State&>;
         static_assert(fit_exists, "fit method not found");
 
-        constexpr static bool linearizer_exists = exists<linearizer_t, S>;
-        static_assert(linearizer_exists, "Linearizer type not found");
         constexpr static bool state_exists = exists<state_t, S>;
         static_assert(state_exists, "State type not found");
 
         constexpr static bool value = require<fit_exists,
-                                              linearizer_exists,
                                               state_exists>;
       };
 // clang-format on

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -53,7 +53,7 @@ class AdaptiveMultiVertexFinderAlgorithm final : public IAlgorithm {
  public:
   using Propagator = Acts::Propagator<Acts::EigenStepper<>>;
   using Linearizer = Acts::HelicalTrackLinearizer;
-  using Fitter = Acts::AdaptiveMultiVertexFitter<Linearizer>;
+  using Fitter = Acts::AdaptiveMultiVertexFitter;
   using Options = Acts::VertexingOptions;
 
   using VertexCollection = std::vector<Acts::Vertex>;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp
@@ -53,7 +53,7 @@ class IterativeVertexFinderAlgorithm final : public IAlgorithm {
  public:
   using Propagator = Acts::Propagator<Acts::EigenStepper<>>;
   using Linearizer = Acts::HelicalTrackLinearizer;
-  using Fitter = Acts::FullBilloirVertexFitter<Linearizer>;
+  using Fitter = Acts::FullBilloirVertexFitter;
   using Seeder =
       Acts::TrackDensityVertexFinder<Fitter, Acts::GaussianTrackDensity>;
   using Finder = Acts::IterativeVertexFinder<Fitter, Seeder>;

--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/VertexFitterAlgorithm.hpp
@@ -48,7 +48,7 @@ class VertexFitterAlgorithm final : public IAlgorithm {
   using Propagator = Acts::Propagator<Acts::EigenStepper<>>;
   using PropagatorOptions = Acts::PropagatorOptions<>;
   using Linearizer = Acts::HelicalTrackLinearizer;
-  using VertexFitter = Acts::FullBilloirVertexFitter<Linearizer>;
+  using VertexFitter = Acts::FullBilloirVertexFitter;
   using VertexFitterOptions = Acts::VertexingOptions;
 
   using VertexCollection = std::vector<Acts::Vertex>;

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -128,12 +128,12 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::executeAfterSeederChoice(
   fitterCfg.doSmoothing = true;
   fitterCfg.useTime = m_cfg.useTime;
   fitterCfg.extractParameters.connect<&Acts::InputTrack::extractParameters>();
+  fitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
   Fitter fitter(std::move(fitterCfg),
                 logger().cloneWithSuffix("AdaptiveMultiVertexFitter"));
 
   typename Finder::Config finderConfig(std::move(fitter), std::move(seedFinder),
-                                       ipEstimator, std::move(linearizer),
-                                       m_cfg.bField);
+                                       ipEstimator, m_cfg.bField);
   // Set the initial variance of the 4D vertex position. Since time is on a
   // numerical scale, we have to provide a greater value in the corresponding
   // dimension.

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -47,18 +47,22 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
   // Setup the propagator with void navigator
   auto propagator = std::make_shared<Propagator>(
       stepper, Acts::VoidNavigator{}, logger().cloneWithSuffix("Prop"));
-  PropagatorOptions propagatorOpts(ctx.geoContext, ctx.magFieldContext);
-  // Setup the vertex fitter
-  VertexFitter::Config vertexFitterCfg;
-  vertexFitterCfg.extractParameters
-      .connect<&Acts::InputTrack::extractParameters>();
-  VertexFitter vertexFitter(vertexFitterCfg);
-  VertexFitter::State state(m_cfg.bField->makeCache(ctx.magFieldContext));
+
   // Setup the linearizer
   Linearizer::Config ltConfig;
   ltConfig.bField = m_cfg.bField;
   ltConfig.propagator = propagator;
   Linearizer linearizer(ltConfig, logger().cloneWithSuffix("HelLin"));
+
+  PropagatorOptions propagatorOpts(ctx.geoContext, ctx.magFieldContext);
+  // Setup the vertex fitter
+  VertexFitter::Config vertexFitterCfg;
+  vertexFitterCfg.extractParameters
+      .connect<&Acts::InputTrack::extractParameters>();
+  vertexFitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(
+      &linearizer);
+  VertexFitter vertexFitter(vertexFitterCfg);
+  VertexFitter::State state(m_cfg.bField->makeCache(ctx.magFieldContext));
 
   ACTS_VERBOSE("Read from '" << m_cfg.inputTrackParameters << "'");
   ACTS_VERBOSE("Read from '" << m_cfg.inputProtoVertices << "'");
@@ -96,7 +100,7 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
     if (!m_cfg.doConstrainedFit) {
       VertexFitterOptions vfOptions(ctx.geoContext, ctx.magFieldContext);
 
-      auto fitRes = vertexFitter.fit(inputTracks, linearizer, vfOptions, state);
+      auto fitRes = vertexFitter.fit(inputTracks, vfOptions, state);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {
@@ -113,8 +117,7 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
       VertexFitterOptions vfOptionsConstr(ctx.geoContext, ctx.magFieldContext,
                                           theConstraint);
 
-      auto fitRes =
-          vertexFitter.fit(inputTracks, linearizer, vfOptionsConstr, state);
+      auto fitRes = vertexFitter.fit(inputTracks, vfOptionsConstr, state);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
   annealingConfig.setOfTemperatures = temperatures;
   AnnealingUtility annealingUtility(annealingConfig);
 
-  using Fitter = AdaptiveMultiVertexFitter<Linearizer>;
+  using Fitter = AdaptiveMultiVertexFitter;
 
   Fitter::Config fitterCfg(ipEstimator);
 
@@ -107,6 +107,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
   // Test smoothing
   fitterCfg.doSmoothing = true;
   fitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+  fitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
   Fitter fitter(fitterCfg);
 
@@ -119,7 +120,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
   using Finder = AdaptiveMultiVertexFinder<Fitter, SeedFinder>;
 
   Finder::Config finderConfig(std::move(fitter), seedFinder, ipEstimator,
-                              std::move(linearizer), bField);
+                              bField);
   finderConfig.extractParameters.connect<&InputTrack::extractParameters>();
 
   Finder finder(std::move(finderConfig));
@@ -252,7 +253,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
   annealingConfig.setOfTemperatures = temperatures;
   AnnealingUtility annealingUtility(annealingConfig);
 
-  using Fitter = AdaptiveMultiVertexFitter<Linearizer>;
+  using Fitter = AdaptiveMultiVertexFitter;
 
   Fitter::Config fitterCfg(ipEstimator);
 
@@ -267,6 +268,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
   // Test smoothing
   fitterCfg.doSmoothing = true;
   fitterCfg.extractParameters.connect(extractParameters);
+  fitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
   Fitter fitter(fitterCfg);
 
@@ -279,7 +281,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
   using Finder = AdaptiveMultiVertexFinder<Fitter, SeedFinder>;
 
   Finder::Config finderConfig(std::move(fitter), seedFinder, ipEstimator,
-                              std::move(linearizer), bField);
+                              bField);
   finderConfig.extractParameters.connect(extractParameters);
   Finder::State state;
 
@@ -397,7 +399,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   annealingConfig.setOfTemperatures = temperatures;
   AnnealingUtility annealingUtility(annealingConfig);
 
-  using Fitter = AdaptiveMultiVertexFitter<Linearizer>;
+  using Fitter = AdaptiveMultiVertexFitter;
 
   Fitter::Config fitterCfg(ipEst);
 
@@ -412,6 +414,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   // Test smoothing
   fitterCfg.doSmoothing = true;
   fitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+  fitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
   Fitter fitter(fitterCfg);
 
@@ -425,7 +428,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   using Finder = AdaptiveMultiVertexFinder<Fitter, SeedFinder>;
 
   Finder::Config finderConfig(std::move(fitter), std::move(seedFinder), ipEst,
-                              std::move(linearizer), bField);
+                              bField);
   finderConfig.extractParameters.connect<&InputTrack::extractParameters>();
 
   Finder finder(std::move(finderConfig));
@@ -547,7 +550,7 @@ BOOST_AUTO_TEST_CASE(
   annealingConfig.setOfTemperatures = temperatures;
   AnnealingUtility annealingUtility(annealingConfig);
 
-  using Fitter = AdaptiveMultiVertexFitter<Linearizer>;
+  using Fitter = AdaptiveMultiVertexFitter;
 
   Fitter::Config fitterCfg(ipEst);
 
@@ -562,6 +565,7 @@ BOOST_AUTO_TEST_CASE(
   // Test smoothing
   fitterCfg.doSmoothing = true;
   fitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+  fitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
   Fitter fitter(fitterCfg);
 
@@ -583,7 +587,7 @@ BOOST_AUTO_TEST_CASE(
   using Finder = AdaptiveMultiVertexFinder<Fitter, SeedFinder>;
 
   Finder::Config finderConfig(std::move(fitter), std::move(seedFinder), ipEst,
-                              std::move(linearizer), bField);
+                              bField);
   finderConfig.extractParameters.connect<&InputTrack::extractParameters>();
 
   Finder finder(std::move(finderConfig));

--- a/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/FullBilloirVertexFitterTests.cpp
@@ -52,7 +52,6 @@ namespace Acts {
 namespace Test {
 
 using Covariance = BoundSquareMatrix;
-using Linearizer = HelicalTrackLinearizer;
 
 // Create a test context
 GeometryContext geoContext = GeometryContext();
@@ -123,10 +122,10 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
   // Set up propagator with void navigator
   auto propagator = std::make_shared<Propagator<EigenStepper<>>>(stepper);
 
-  Linearizer::Config ltConfig;
+  HelicalTrackLinearizer::Config ltConfig;
   ltConfig.bField = bField;
   ltConfig.propagator = propagator;
-  Linearizer linearizer(ltConfig);
+  HelicalTrackLinearizer linearizer(ltConfig);
 
   // Constraint for vertex fit
   Vertex constraint;
@@ -144,9 +143,11 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
   customConstraint.setFullPosition(Vector4(0, 0, 0, 0));
 
   // Set up Billoir vertex fitter with default tracks
-  using VertexFitter = FullBilloirVertexFitter<Linearizer>;
+  using VertexFitter = FullBilloirVertexFitter;
   VertexFitter::Config vertexFitterCfg;
   vertexFitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+  vertexFitterCfg.trackLinearizer
+      .connect<&HelicalTrackLinearizer::linearizeTrack>(&linearizer);
   VertexFitter billoirFitter(vertexFitterCfg);
   VertexFitter::State state(bField->makeCache(magFieldContext));
   // Vertexing options for default tracks
@@ -162,6 +163,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
   // Set up Billoir vertex fitter with user-defined input tracks
   VertexFitter::Config customVertexFitterCfg;
   customVertexFitterCfg.extractParameters.connect(extractParameters);
+  customVertexFitterCfg.trackLinearizer
+      .connect<&HelicalTrackLinearizer::linearizeTrack>(&linearizer);
   VertexFitter customBilloirFitter(customVertexFitterCfg);
   VertexFitter::State customState(bField->makeCache(magFieldContext));
   // Vertexing options for custom tracks
@@ -176,8 +179,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // Without constraint
     Vertex fittedVertex =
-        billoirFitter.fit(emptyVectorInput, linearizer, vfOptions, state)
-            .value();
+        billoirFitter.fit(emptyVectorInput, vfOptions, state).value();
 
     Vector3 origin(0., 0., 0.);
     SquareMatrix4 zeroMat = SquareMatrix4::Zero();
@@ -186,8 +188,7 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     // With constraint
     fittedVertex =
-        billoirFitter.fit(emptyVectorInput, linearizer, vfOptionsConstr, state)
-            .value();
+        billoirFitter.fit(emptyVectorInput, vfOptionsConstr, state).value();
 
     BOOST_CHECK_EQUAL(fittedVertex.position(), origin);
     BOOST_CHECK_EQUAL(fittedVertex.fullCovariance(), zeroMat);
@@ -260,9 +261,8 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
     }
 
     auto fit = [&trueVertex, &nTracks](const auto& fitter, const auto& trksPtr,
-                                       const auto& lin, const auto& vfOpts,
-                                       auto& vfState) {
-      auto fittedVertex = fitter.fit(trksPtr, lin, vfOpts, vfState).value();
+                                       const auto& vfOpts, auto& vfState) {
+      auto fittedVertex = fitter.fit(trksPtr, vfOpts, vfState).value();
       if (!fittedVertex.tracks().empty()) {
         CHECK_CLOSE_ABS(fittedVertex.position(), trueVertex.head(3), 1_mm);
         auto tracksAtVtx = fittedVertex.tracks();
@@ -278,23 +278,22 @@ BOOST_AUTO_TEST_CASE(billoir_vertex_fitter_defaulttrack_test) {
 
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter without vertex constraint.") {
-      fit(billoirFitter, inputTracks, linearizer, vfOptions, state);
+      fit(billoirFitter, inputTracks, vfOptions, state);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with vertex constraint.") {
-      fit(billoirFitter, inputTracks, linearizer, vfOptionsConstr, state);
+      fit(billoirFitter, inputTracks, vfOptionsConstr, state);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with custom tracks (no vertex "
         "constraint).") {
-      fit(customBilloirFitter, customInputTracks, linearizer, customVfOptions,
-          customState);
+      fit(customBilloirFitter, customInputTracks, customVfOptions, customState);
     }
     BOOST_TEST_CONTEXT(
         "Testing FullBilloirVertexFitter with custom tracks (with vertex "
         "constraint).") {
-      fit(customBilloirFitter, customInputTracks, linearizer,
-          customVfOptionsConstr, customState);
+      fit(customBilloirFitter, customInputTracks, customVfOptionsConstr,
+          customState);
     }
   }
 }

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -140,11 +140,13 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     ltConfig.propagator = propagator;
     Linearizer linearizer(ltConfig);
 
-    using BilloirFitter = FullBilloirVertexFitter<Linearizer>;
+    using BilloirFitter = FullBilloirVertexFitter;
 
     // Set up Billoir Vertex Fitter
     BilloirFitter::Config vertexFitterCfg;
     vertexFitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+    vertexFitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(
+        &linearizer);
 
     BilloirFitter bFitter(vertexFitterCfg);
 
@@ -167,8 +169,9 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
     static_assert(VertexFinderConcept<VertexFinder>,
                   "Vertex finder does not fulfill vertex finder concept.");
 
-    VertexFinder::Config cfg(std::move(bFitter), std::move(linearizer),
-                             std::move(sFinder), ipEstimator);
+    VertexFinder::Config cfg(std::move(bFitter), std::move(sFinder),
+                             ipEstimator);
+    cfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
     cfg.reassignTracksAfterFirstFit = true;
     cfg.extractParameters.connect<&InputTrack::extractParameters>();
@@ -359,7 +362,7 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     Linearizer linearizer(ltConfigUT);
 
     // Set up vertex fitter for user track type
-    using BilloirFitter = FullBilloirVertexFitter<Linearizer>;
+    using BilloirFitter = FullBilloirVertexFitter;
 
     // Create a custom std::function to extract BoundTrackParameters from
     // user-defined InputTrack
@@ -370,6 +373,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
     // Set up Billoir Vertex Fitter
     BilloirFitter::Config vertexFitterCfg;
     vertexFitterCfg.extractParameters.connect(extractParameters);
+    vertexFitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(
+        &linearizer);
 
     BilloirFitter bFitter(vertexFitterCfg);
 
@@ -384,10 +389,11 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
 
     // Vertex Finder
     using VertexFinder = IterativeVertexFinder<BilloirFitter, ZScanSeedFinder>;
-    VertexFinder::Config cfg(std::move(bFitter), std::move(linearizer),
-                             std::move(sFinder), ipEstimator);
+    VertexFinder::Config cfg(std::move(bFitter), std::move(sFinder),
+                             ipEstimator);
     cfg.reassignTracksAfterFirstFit = true;
     cfg.extractParameters.connect(extractParameters);
+    cfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
     VertexFinder finder(std::move(cfg));
     VertexFinder::State state(*bField, magFieldContext);
@@ -564,11 +570,13 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   ltConfig.propagator = propagator;
   Linearizer linearizer(ltConfig);
 
-  using BilloirFitter = FullBilloirVertexFitter<Linearizer>;
+  using BilloirFitter = FullBilloirVertexFitter;
 
   // Set up Billoir Vertex Fitter
   BilloirFitter::Config vertexFitterCfg;
   vertexFitterCfg.extractParameters.connect<&InputTrack::extractParameters>();
+  vertexFitterCfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(
+      &linearizer);
 
   BilloirFitter bFitter(vertexFitterCfg);
 
@@ -591,12 +599,12 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   static_assert(VertexFinderConcept<VertexFinder>,
                 "Vertex finder does not fulfill vertex finder concept.");
 
-  VertexFinder::Config cfg(std::move(bFitter), std::move(linearizer),
-                           std::move(sFinder), ipEstimator);
+  VertexFinder::Config cfg(std::move(bFitter), std::move(sFinder), ipEstimator);
   cfg.maxVertices = 200;
   cfg.maximumChi2cutForSeeding = 49;
   cfg.significanceCutSeeding = 12;
   cfg.extractParameters.connect<&InputTrack::extractParameters>();
+  cfg.trackLinearizer.connect<&Linearizer::linearizeTrack>(&linearizer);
 
   VertexFinder finder(std::move(cfg));
   VertexFinder::State state(*bField, magFieldContext);

--- a/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(zscan_finder_test) {
     // Set up propagator with void navigator
     auto propagator = std::make_shared<Propagator>(stepper);
 
-    using BilloirFitter = FullBilloirVertexFitter<Linearizer_t>;
+    using BilloirFitter = FullBilloirVertexFitter;
 
     // Create perigee surface
     std::shared_ptr<PerigeeSurface> perigeeSurface =
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(zscan_finder_usertrack_test) {
     // Set up propagator with void navigator
     auto propagator = std::make_shared<Propagator>(stepper);
 
-    using BilloirFitter = FullBilloirVertexFitter<Linearizer_t>;
+    using BilloirFitter = FullBilloirVertexFitter;
 
     // Create perigee surface
     std::shared_ptr<PerigeeSurface> perigeeSurface =


### PR DESCRIPTION
This allows removing the linearizer template from: 
- Billoir fitter
- ZScan finder
- IVF
- AMVFitter

Part of:
- #2842 

Blocked by:
- #2886