### PR TITLE
ci: Reduce build job count to 2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ build_exatrkx:
       -DACTS_ENABLE_LOG_FAILURE_THRESHOLD=ON
 
     - ccache -z
-    - cmake --build build -- -j3
+    - cmake --build build -- -j2
     - ccache -s
 
 test_exatrkx_unittests:


### PR DESCRIPTION
We've been getting OOM errors in the build again. This works around that.