### PR TITLE
fix: Geant4SurfaceProvider gdml schema validation fix

### DIFF
--- a/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4SurfaceProvider.hpp
+++ b/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4SurfaceProvider.hpp
@@ -87,7 +87,7 @@ class Geant4SurfaceProvider : public Acts::Experimental::ISurfacesProvider {
   ///@param options The optional configuration for KDTree
   Geant4SurfaceProvider(const Config& config,
                         const kdtOptions& options = kdtOptions(),
-                        bool validateGDMLschema = false) {
+                        bool validateGDMLschema = true) {
     if (config.gdmlPath.empty()) {
       throw std::invalid_argument(
           "Geant4SurfaceProvider: no gdml file provided");

--- a/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4SurfaceProvider.hpp
+++ b/Plugins/Geant4/include/Acts/Plugins/Geant4/Geant4SurfaceProvider.hpp
@@ -86,7 +86,8 @@ class Geant4SurfaceProvider : public Acts::Experimental::ISurfacesProvider {
   ///@param config The configuration struct
   ///@param options The optional configuration for KDTree
   Geant4SurfaceProvider(const Config& config,
-                        const kdtOptions& options = kdtOptions()) {
+                        const kdtOptions& options = kdtOptions(),
+                        bool validateGDMLschema = false) {
     if (config.gdmlPath.empty()) {
       throw std::invalid_argument(
           "Geant4SurfaceProvider: no gdml file provided");
@@ -101,7 +102,7 @@ class Geant4SurfaceProvider : public Acts::Experimental::ISurfacesProvider {
 
     /// Read the gdml file and get the world volume
     G4GDMLParser parser;
-    parser.Read(m_cfg.gdmlPath);
+    parser.Read(m_cfg.gdmlPath, validateGDMLschema);
     m_g4World = parser.GetWorldVolume();
 
     if (m_g4World == nullptr) {

--- a/Tests/UnitTests/Plugins/Geant4/Geant4SurfaceProviderTests.cpp
+++ b/Tests/UnitTests/Plugins/Geant4/Geant4SurfaceProviderTests.cpp
@@ -119,9 +119,8 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderNames) {
       std::make_shared<Acts::Geant4PhysicalVolumeSelectors::NameSelector>(names,
                                                                           true);
 
-  auto spFull =
-      std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(spFullCfg,
-      Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(), 
+  auto spFull = std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(
+      spFullCfg, Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(),
       false);
 
   auto lbFullCfg = Acts::Experimental::LayerStructureBuilder::Config();
@@ -164,9 +163,7 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderNames) {
   auto spLeftArm =
       std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(
           spLeftArmCfg,
-                Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(), 
-      false);
-
+          Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(), false);
 
   auto lbCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lbCfg.surfacesProvider = spLeftArm;

--- a/Tests/UnitTests/Plugins/Geant4/Geant4SurfaceProviderTests.cpp
+++ b/Tests/UnitTests/Plugins/Geant4/Geant4SurfaceProviderTests.cpp
@@ -120,7 +120,9 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderNames) {
                                                                           true);
 
   auto spFull =
-      std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(spFullCfg);
+      std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(spFullCfg,
+      Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(), 
+      false);
 
   auto lbFullCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lbFullCfg.surfacesProvider = spFull;
@@ -161,7 +163,10 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderNames) {
 
   auto spLeftArm =
       std::make_shared<Acts::Experimental::Geant4SurfaceProvider<>>(
-          spLeftArmCfg);
+          spLeftArmCfg,
+                Acts::Experimental::Geant4SurfaceProvider<>::kdtOptions(), 
+      false);
+
 
   auto lbCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lbCfg.surfacesProvider = spLeftArm;
@@ -196,7 +201,7 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderRanges) {
   kdt1DOpt.binningValues = {Acts::BinningValue::binZ};
 
   auto sp1D = std::make_shared<Acts::Experimental::Geant4SurfaceProvider<1>>(
-      sp1DCfg, kdt1DOpt);
+      sp1DCfg, kdt1DOpt, false);
 
   auto lb1DCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lb1DCfg.surfacesProvider = sp1D;
@@ -231,7 +236,7 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderRanges) {
   kdt2DOpt.binningValues = {Acts::BinningValue::binZ};
 
   auto sp2D = std::make_shared<Acts::Experimental::Geant4SurfaceProvider<2>>(
-      sp2DCfg, kdt2DOpt);
+      sp2DCfg, kdt2DOpt, false);
 
   auto lb2DCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lb2DCfg.surfacesProvider = sp2D;
@@ -270,7 +275,7 @@ BOOST_AUTO_TEST_CASE(Geant4SurfaceProviderRanges) {
           ranges);
 
   auto sp2DPos = std::make_shared<Acts::Experimental::Geant4SurfaceProvider<1>>(
-      sp2DPosCfg, kdt1DOpt);
+      sp2DPosCfg, kdt1DOpt, false);
 
   auto lb2DPosCfg = Acts::Experimental::LayerStructureBuilder::Config();
   lb2DPosCfg.surfacesProvider = sp2DPos;


### PR DESCRIPTION
Making the validation of the GDML file schema optional when parsing the files. 

Mainly added so that the tests could be decoupled from the state of the servers with the .xsd files. 