### PR TITLE
fix(ci): default arguments definition in physmon

### DIFF
--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -4,14 +4,13 @@ set -e
 set -x
 
 
-mode=${1:all}
+mode=${1:-all}
 if ! [[ $mode = @(all|kalman|gsf|fullchains|vertexing|simulation) ]]; then
     echo "Usage: $0 <all|kalman|gsf|fullchains|vertexing|simulation> (outdir)"
     exit 1
 fi
 
-outdir=${2:physmon}
-[ -z "$outdir" ] && outdir=physmon
+outdir=${2:-physmon}
 mkdir -p $outdir
 
 refdir=CI/physmon/reference


### PR DESCRIPTION
Bash needs for the defaults the following syntax `VAR=${[number]:-default}` (`-` was missing). Now the variable `outdir` cannot be empty anymore and we don't need to check.

This does not change anything in the current setup, since we are always specifying both additional arguments.