### PR TITLE
refactor: Remove `deltaR` from performance writers in Examples

### DIFF
--- a/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
@@ -33,8 +33,7 @@ class EffPlotTool {
     std::map<std::string, PlotHelpers::Binning> varBinning = {
         {"Eta", PlotHelpers::Binning("#eta", 40, -4, 4)},
         {"Phi", PlotHelpers::Binning("#phi", 100, -3.15, 3.15)},
-        {"Pt", PlotHelpers::Binning("pT [GeV/c]", 40, 0, 100)},
-        {"DeltaR", PlotHelpers::Binning("#Delta R", 100, 0, 0.3)}};
+        {"Pt", PlotHelpers::Binning("pT [GeV/c]", 40, 0, 100)}};
   };
 
   /// @brief Nested Cache struct
@@ -42,9 +41,6 @@ class EffPlotTool {
     TEfficiency* trackEff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
     TEfficiency* trackEff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
     TEfficiency* trackEff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
-    TEfficiency* trackEff_vs_DeltaR{
-        nullptr};  ///< Tracking efficiency vs distance to the closest truth
-                   ///< particle
   };
 
   /// Constructor
@@ -62,11 +58,9 @@ class EffPlotTool {
   ///
   /// @param effPlotCache cache object for efficiency plots
   /// @param truthParticle the truth Particle
-  /// @param deltaR the distance to the closest truth particle
   /// @param status the reconstruction status
   void fill(EffPlotCache& effPlotCache,
-            const ActsFatras::Particle& truthParticle, double deltaR,
-            bool status) const;
+            const ActsFatras::Particle& truthParticle, bool status) const;
 
   /// @brief write the efficiency plots to file
   ///

--- a/Examples/Framework/include/ActsExamples/Validation/TrackClassification.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/TrackClassification.hpp
@@ -10,7 +10,7 @@
 
 #include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
-#include "ActsExamples/EventData/Trajectories.hpp"
+#include "ActsExamples/EventData/Track.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
 
 #include <cstddef>

--- a/Examples/Framework/src/Validation/EffPlotTool.cpp
+++ b/Examples/Framework/src/Validation/EffPlotTool.cpp
@@ -26,7 +26,6 @@ void ActsExamples::EffPlotTool::book(
   PlotHelpers::Binning bPhi = m_cfg.varBinning.at("Phi");
   PlotHelpers::Binning bEta = m_cfg.varBinning.at("Eta");
   PlotHelpers::Binning bPt = m_cfg.varBinning.at("Pt");
-  PlotHelpers::Binning bDeltaR = m_cfg.varBinning.at("DeltaR");
   ACTS_DEBUG("Initialize the histograms for efficiency plots");
   // efficiency vs pT
   effPlotCache.trackEff_vs_pT = PlotHelpers::bookEff(
@@ -37,17 +36,12 @@ void ActsExamples::EffPlotTool::book(
   // efficiency vs phi
   effPlotCache.trackEff_vs_phi = PlotHelpers::bookEff(
       "trackeff_vs_phi", "Tracking efficiency;Truth #phi;Efficiency", bPhi);
-  // efficiancy vs distance to the closest truth particle
-  effPlotCache.trackEff_vs_DeltaR = PlotHelpers::bookEff(
-      "trackeff_vs_DeltaR",
-      "Tracking efficiency;Closest track #Delta R;Efficiency", bDeltaR);
 }
 
 void ActsExamples::EffPlotTool::clear(EffPlotCache& effPlotCache) const {
   delete effPlotCache.trackEff_vs_pT;
   delete effPlotCache.trackEff_vs_eta;
   delete effPlotCache.trackEff_vs_phi;
-  delete effPlotCache.trackEff_vs_DeltaR;
 }
 
 void ActsExamples::EffPlotTool::write(
@@ -56,19 +50,16 @@ void ActsExamples::EffPlotTool::write(
   effPlotCache.trackEff_vs_pT->Write();
   effPlotCache.trackEff_vs_eta->Write();
   effPlotCache.trackEff_vs_phi->Write();
-  effPlotCache.trackEff_vs_DeltaR->Write();
 }
 
 void ActsExamples::EffPlotTool::fill(EffPlotTool::EffPlotCache& effPlotCache,
                                      const ActsFatras::Particle& truthParticle,
-                                     double deltaR, bool status) const {
+                                     bool status) const {
   const auto t_phi = phi(truthParticle.direction());
   const auto t_eta = eta(truthParticle.direction());
   const auto t_pT = truthParticle.transverseMomentum();
-  const auto t_deltaR = deltaR;
 
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_pT, t_pT, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_eta, t_eta, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_phi, t_phi, status);
-  PlotHelpers::fillEff(effPlotCache.trackEff_vs_DeltaR, t_deltaR, status);
 }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/CKFPerformanceWriter.cpp
@@ -317,7 +317,7 @@ ActsExamples::ProcessCode ActsExamples::CKFPerformanceWriter::writeT(
       }
     }
     // Fill efficiency plots
-    m_effPlotTool.fill(m_effPlotCache, particle, minDeltaR, isReconstructed);
+    m_effPlotTool.fill(m_effPlotCache, particle, isReconstructed);
     // Fill number of duplicated tracks for this particle
     m_duplicationPlotTool.fill(m_duplicationPlotCache, particle,
                                nMatchedTracks - 1);

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/SeedingPerformanceWriter.cpp
@@ -175,7 +175,7 @@ ActsExamples::ProcessCode ActsExamples::SeedingPerformanceWriter::writeT(
         minDeltaR = distance;
       }
     }
-    m_effPlotTool.fill(m_effPlotCache, particle, minDeltaR, isMatched);
+    m_effPlotTool.fill(m_effPlotCache, particle, isMatched);
     m_duplicationPlotTool.fill(m_duplicationPlotCache, particle,
                                nMatchedSeedsForParticle - 1);
   }

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/TrackFitterPerformanceWriter.cpp
@@ -171,7 +171,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFitterPerformanceWriter::writeT(
         minDeltaR = distance;
       }
     }
-    m_effPlotTool.fill(m_effPlotCache, particle, minDeltaR, isReconstructed);
+    m_effPlotTool.fill(m_effPlotCache, particle, isReconstructed);
   }
 
   return ProcessCode::SUCCESS;


### PR DESCRIPTION
While working on a centralized truth matching (https://github.com/acts-project/acts/pull/2904) I stumbled over `deltaR` in the performance writers which seems to be a measure of how close truth and reco are and based on that we match them.

To me that measure seems very arbitrary as we use an unweighted euclidean distance of phi and eta to calculate it. In https://github.com/acts-project/acts/pull/2904 I do not use this measure for truth tracking but only the association between measurements and truth particles.

In preparation of getting https://github.com/acts-project/acts/pull/2904 merged soon I split this change out so we can have a separate discussion and keep the physmon diff to a minimum.