### PR TITLE
refactor!: `ImpactPointEstimator` moves to cpp file

### DIFF
--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -40,7 +40,7 @@ class AdaptiveMultiVertexFitter {
   struct State {
     State(const MagneticFieldProvider& field,
           const Acts::MagneticFieldContext& magContext)
-        : ipState(field.makeCache(magContext)),
+        : ipState{field.makeCache(magContext)},
           fieldCache(field.makeCache(magContext)) {}
     // Vertex collection to be fitted
     std::vector<Vertex*> vertexCollection;

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -48,11 +48,6 @@ class ImpactPointEstimator {
  public:
   /// State struct
   struct State {
-    /// @brief The state constructor
-    ///
-    /// @param fieldCacheIn The magnetic field cache
-    State(MagneticFieldProvider::Cache fieldCacheIn)
-        : fieldCache(std::move(fieldCacheIn)) {}
     /// Magnetic field cache
     MagneticFieldProvider::Cache fieldCache;
   };

--- a/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
+++ b/Core/include/Acts/Vertexing/ImpactPointEstimator.hpp
@@ -134,7 +134,8 @@ class ImpactPointEstimator {
   /// @note Confusingly, a *smaller* compatibility means that a track is *more*
   /// compatible.
   ///
-  /// @note If @p vertexPos has dimension 3 we only consider spatial dimensions; if is 4, we
+  /// @tparam nDim Number of dimensions used to compute compatibility
+  /// @note If @p nDim = 3 we only consider spatial dimensions; if nDim = 4, we
   ///       also consider time. Other values are not allowed.
   /// @param gctx The Geometry context
   /// @param trkParams Track parameters at point of closest
@@ -142,9 +143,14 @@ class ImpactPointEstimator {
   /// @param vertexPos The vertex position
   ///
   /// @return The compatibility value
+  template <int nDim>
   Result<double> getVertexCompatibility(
       const GeometryContext& gctx, const BoundTrackParameters* trkParams,
-      const ActsDynamicVector& vertexPos) const;
+      const ActsVector<nDim>& vertexPos) const {
+    static_assert(nDim == 3 || nDim == 4,
+                  "Only 3D and 4D vertex positions allowed");
+    return getVertexCompatibility(gctx, trkParams, {vertexPos.data(), nDim});
+  }
 
   /// @brief Calculate the distance between a track and a vertex by finding the
   /// corresponding 3D PCA. Returns also the momentum direction at the 3D PCA.
@@ -154,17 +160,19 @@ class ImpactPointEstimator {
   /// tracks we use the Newton method.
   ///
   /// @tparam nDim Number of dimensions used to compute compatibility
-  /// @note If nDim = 3 we only consider spatial dimensions; if nDim = 4, we
-  /// also consider time. Other values are not allowed.
+  /// @note If @p nDim = 3 we only consider spatial dimensions; if nDim = 4, we
+  ///       also consider time. Other values are not allowed.
   /// @param gctx Geometry context
   /// @param trkParams Track parameters
   /// @param vtxPos Vertex position
   /// @param state The state object
-  template <unsigned int nDim>
+  template <int nDim>
   Result<std::pair<Acts::ActsVector<nDim>, Acts::Vector3>>
   getDistanceAndMomentum(const GeometryContext& gctx,
                          const BoundTrackParameters& trkParams,
                          const ActsVector<nDim>& vtxPos, State& state) const {
+    static_assert(nDim == 3 || nDim == 4,
+                  "Only 3D and 4D vertex positions allowed");
     auto res =
         getDistanceAndMomentum(gctx, trkParams, {vtxPos.data(), nDim}, state);
     if (!res.ok()) {
@@ -224,6 +232,10 @@ class ImpactPointEstimator {
   Result<std::pair<Acts::Vector4, Acts::Vector3>> getDistanceAndMomentum(
       const GeometryContext& gctx, const BoundTrackParameters& trkParams,
       Eigen::Map<const ActsDynamicVector> vtxPos, State& state) const;
+
+  Result<double> getVertexCompatibility(
+      const GeometryContext& gctx, const BoundTrackParameters* trkParams,
+      Eigen::Map<const ActsDynamicVector> vertexPos) const;
 
   /// Configuration object
   const Config m_cfg;

--- a/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IterativeVertexFinder.hpp
@@ -121,7 +121,7 @@ class IterativeVertexFinder final : public IVertexFinder {
     State(const MagneticFieldProvider& field,
           const Acts::MagneticFieldContext& _magContext)
         : magContext(_magContext),
-          ipState(field.makeCache(magContext)),
+          ipState{field.makeCache(magContext)},
           fieldCache(field.makeCache(magContext)) {}
 
     std::reference_wrapper<const Acts::MagneticFieldContext> magContext;

--- a/Core/include/Acts/Vertexing/VertexingError.hpp
+++ b/Core/include/Acts/Vertexing/VertexingError.hpp
@@ -21,6 +21,7 @@ enum class VertexingError {
   NotConverged,
   ElementNotFound,
   NoCovariance,
+  InvalidInput,
 };
 
 std::error_code make_error_code(Acts::VertexingError e);

--- a/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
@@ -236,16 +236,17 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter::setAllVertexCompatibilities(
     }
     // Set compatibility with current vertex
     Acts::Result<double> compatibilityResult(0.);
-    ActsDynamicVector vertexPos;
     if (m_cfg.useTime) {
-      vertexPos = vtxInfo.oldPosition;
+      compatibilityResult = m_cfg.ipEst.getVertexCompatibility(
+          vertexingOptions.geoContext, &(vtxInfo.impactParams3D.at(trk)),
+          vtxInfo.oldPosition);
     } else {
-      vertexPos = VectorHelpers::position(vtxInfo.oldPosition);
+      Acts::Vector3 vertexPosOnly =
+          VectorHelpers::position(vtxInfo.oldPosition);
+      compatibilityResult = m_cfg.ipEst.getVertexCompatibility(
+          vertexingOptions.geoContext, &(vtxInfo.impactParams3D.at(trk)),
+          vertexPosOnly);
     }
-
-    compatibilityResult = m_cfg.ipEst.getVertexCompatibility(
-        vertexingOptions.geoContext, &(vtxInfo.impactParams3D.at(trk)),
-        vertexPos);
 
     if (!compatibilityResult.ok()) {
       return compatibilityResult.error();

--- a/Core/src/Vertexing/CMakeLists.txt
+++ b/Core/src/Vertexing/CMakeLists.txt
@@ -16,4 +16,5 @@ target_sources(
     NumericalTrackLinearizer.cpp
     TrackDensityVertexFinder.cpp
     GaussianTrackDensity.cpp
+    ImpactPointEstimator.cpp
 )

--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -17,10 +17,11 @@
 namespace Acts {
 
 namespace {
-template <int nDim, typename vector_t>
+template <typename vector_t>
 Result<double> getVertexCompatibilityImpl(const GeometryContext& gctx,
                                           const BoundTrackParameters* trkParams,
                                           vector_t vertexPos) {
+  static constexpr int nDim = vector_t::RowsAtCompileTime;
   static_assert(nDim == 3 || nDim == 4,
                 "The number of dimensions nDim must be either 3 or 4.");
 
@@ -153,11 +154,12 @@ Result<double> performNewtonOptimization(
 }
 
 // Note: always return Vector4, we'll chop off the last component if needed
-template <int nDim, typename vector_t>
+template <typename vector_t>
 Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
     const GeometryContext& gctx, const BoundTrackParameters& trkParams,
     vector_t vtxPos, const ImpactPointEstimator::Config& cfg,
     ImpactPointEstimator::State& state, const Logger& logger) {
+  static constexpr int nDim = vector_t::RowsAtCompileTime;
   static_assert(nDim == 3 || nDim == 4,
                 "The number of dimensions nDim must be either 3 or 4.");
 
@@ -295,8 +297,8 @@ Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
 Result<double> ImpactPointEstimator::calculateDistance(
     const GeometryContext& gctx, const BoundTrackParameters& trkParams,
     const Vector3& vtxPos, State& state) const {
-  auto res = getDistanceAndMomentumImpl<3>(gctx, trkParams, vtxPos, m_cfg,
-                                           state, *m_logger);
+  auto res = getDistanceAndMomentumImpl(gctx, trkParams, vtxPos, m_cfg, state,
+                                        *m_logger);
 
   if (!res.ok()) {
     return res.error();
@@ -311,8 +313,8 @@ Result<BoundTrackParameters> ImpactPointEstimator::estimate3DImpactParameters(
     const GeometryContext& gctx, const MagneticFieldContext& mctx,
     const BoundTrackParameters& trkParams, const Vector3& vtxPos,
     State& state) const {
-  auto res = getDistanceAndMomentumImpl<3>(gctx, trkParams, vtxPos, m_cfg,
-                                           state, *m_logger);
+  auto res = getDistanceAndMomentumImpl(gctx, trkParams, vtxPos, m_cfg, state,
+                                        *m_logger);
 
   if (!res.ok()) {
     return res.error();
@@ -387,11 +389,11 @@ Result<double> ImpactPointEstimator::getVertexCompatibility(
     const GeometryContext& gctx, const BoundTrackParameters* trkParams,
     Eigen::Map<const ActsDynamicVector> vertexPos) const {
   if (vertexPos.size() == 3) {
-    return getVertexCompatibilityImpl<3>(gctx, trkParams,
-                                         vertexPos.template head<3>());
+    return getVertexCompatibilityImpl(gctx, trkParams,
+                                      vertexPos.template head<3>());
   } else if (vertexPos.size() == 4) {
-    return getVertexCompatibilityImpl<4>(gctx, trkParams,
-                                         vertexPos.template head<4>());
+    return getVertexCompatibilityImpl(gctx, trkParams,
+                                      vertexPos.template head<4>());
   } else {
     return VertexingError::InvalidInput;
   }
@@ -402,10 +404,10 @@ ImpactPointEstimator::getDistanceAndMomentum(
     const GeometryContext& gctx, const BoundTrackParameters& trkParams,
     Eigen::Map<const ActsDynamicVector> vtxPos, State& state) const {
   if (vtxPos.size() == 3) {
-    return getDistanceAndMomentumImpl<3>(
+    return getDistanceAndMomentumImpl(
         gctx, trkParams, vtxPos.template head<3>(), m_cfg, state, *m_logger);
   } else if (vtxPos.size() == 4) {
-    return getDistanceAndMomentumImpl<4>(
+    return getDistanceAndMomentumImpl(
         gctx, trkParams, vtxPos.template head<4>(), m_cfg, state, *m_logger);
   } else {
     return VertexingError::InvalidInput;

--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -161,8 +161,6 @@ Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
   static_assert(nDim == 3 || nDim == 4,
                 "The number of dimensions nDim must be either 3 or 4.");
 
-  // Eigen::Map<const ActsVector<nDim>> vtxPos{vtxPosDyn.data()};
-
   // Reference point R
   Vector3 refPoint = trkParams.referenceSurface().center(gctx);
 
@@ -212,7 +210,7 @@ Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
     }
 
     // Vector pointing from the vertex position to the 3D PCA
-    Vector4 deltaRStraightTrack;
+    Vector4 deltaRStraightTrack{Vector4::Zero()};
     deltaRStraightTrack.head<nDim>() = pcaStraightTrack - vtxPos;
 
     return std::make_pair(deltaRStraightTrack, momDirStraightTrack);
@@ -286,7 +284,7 @@ Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
     pca[3] = tP - rho / (beta * sinTheta) * (phi - phiP);
   }
   // Vector pointing from the vertex position to the 3D PCA
-  Vector4 deltaR;
+  Vector4 deltaR{Vector4::Zero()};
   deltaR.head<nDim>() = pca - vtxPos;
 
   return std::make_pair(deltaR, momDir);
@@ -304,8 +302,9 @@ Result<double> ImpactPointEstimator::calculateDistance(
     return res.error();
   }
 
-  // Return distance
-  return res.value().first.norm();
+  // Return distance (we get a 4D vector in all cases, but we only need the
+  // position norm)
+  return res.value().first.template head<3>().norm();
 }
 
 Result<BoundTrackParameters> ImpactPointEstimator::estimate3DImpactParameters(

--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -20,7 +20,7 @@ namespace {
 template <typename vector_t>
 Result<double> getVertexCompatibilityImpl(const GeometryContext& gctx,
                                           const BoundTrackParameters* trkParams,
-                                          vector_t vertexPos) {
+                                          const vector_t& vertexPos) {
   static constexpr int nDim = vector_t::RowsAtCompileTime;
   static_assert(nDim == 3 || nDim == 4,
                 "The number of dimensions nDim must be either 3 or 4.");
@@ -157,7 +157,7 @@ Result<double> performNewtonOptimization(
 template <typename vector_t>
 Result<std::pair<Vector4, Vector3>> getDistanceAndMomentumImpl(
     const GeometryContext& gctx, const BoundTrackParameters& trkParams,
-    vector_t vtxPos, const ImpactPointEstimator::Config& cfg,
+    const vector_t& vtxPos, const ImpactPointEstimator::Config& cfg,
     ImpactPointEstimator::State& state, const Logger& logger) {
   static constexpr int nDim = vector_t::RowsAtCompileTime;
   static_assert(nDim == 3 || nDim == 4,

--- a/Core/src/Vertexing/VertexingError.cpp
+++ b/Core/src/Vertexing/VertexingError.cpp
@@ -34,6 +34,8 @@ class VertexingErrorCategory : public std::error_category {
         return "Unable to find element.";
       case VertexingError::NoCovariance:
         return "No covariance provided.";
+      case VertexingError::InvalidInput:
+        return "Invalid input provided.";
       default:
         return "unknown";
     }

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -186,8 +186,7 @@ BOOST_DATA_TEST_CASE(SingleTrackDistanceParametersCompatibility3D, tracks, d0,
   // check that we get sensible compatibility scores
   // this is a chi2-like value and should always be positive
   auto compatibility =
-      ipEstimator
-          .getVertexCompatibility<3>(geoContext, &trackAtIP3d, refPosition)
+      ipEstimator.getVertexCompatibility(geoContext, &trackAtIP3d, refPosition)
           .value();
   BOOST_CHECK_GT(compatibility, 0);
 }
@@ -391,14 +390,14 @@ BOOST_DATA_TEST_CASE(VertexCompatibility4D, IPs* vertices, d0, l0, vx0, vy0,
 
   // Calculate the 4D vertex compatibilities of the three tracks
   double compatibilityClose =
-      ipEstimator.getVertexCompatibility<4>(geoContext, &paramsClose, vtxPos)
+      ipEstimator.getVertexCompatibility(geoContext, &paramsClose, vtxPos)
           .value();
   double compatibilityCloseLargerCov =
       ipEstimator
-          .getVertexCompatibility<4>(geoContext, &paramsCloseLargerCov, vtxPos)
+          .getVertexCompatibility(geoContext, &paramsCloseLargerCov, vtxPos)
           .value();
   double compatibilityFar =
-      ipEstimator.getVertexCompatibility<4>(geoContext, &paramsFar, vtxPos)
+      ipEstimator.getVertexCompatibility(geoContext, &paramsFar, vtxPos)
           .value();
 
   // The track who is closer in time must have a better (i.e., smaller)

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -147,7 +147,7 @@ BOOST_DATA_TEST_CASE(SingleTrackDistanceParametersCompatibility3D, tracks, d0,
   par[eBoundQOverP] = particleHypothesis.qOverP(p, q);
 
   Estimator ipEstimator = makeEstimator(2_T);
-  Estimator::State state(magFieldCache());
+  Estimator::State state{magFieldCache()};
   // reference position and corresponding perigee surface
   Vector3 refPosition(0., 0., 0.);
   auto perigeeSurface = Surface::makeShared<PerigeeSurface>(refPosition);
@@ -202,7 +202,7 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
   auto propagator = std::make_shared<Propagator>(std::move(stepper));
   Estimator::Config cfg(field, propagator);
   Estimator ipEstimator(cfg);
-  Estimator::State ipState(magFieldCache());
+  Estimator::State ipState{magFieldCache()};
 
   // Set up quantities for B = 0
   auto zeroField = std::make_shared<MagneticField>(Vector3(0, 0, 0));
@@ -211,7 +211,7 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
       std::make_shared<StraightPropagator>(straightLineStepper);
   StraightLineEstimator::Config zeroFieldCfg(zeroField, straightLinePropagator);
   StraightLineEstimator zeroFieldIPEstimator(zeroFieldCfg);
-  StraightLineEstimator::State zeroFieldIPState(magFieldCache());
+  StraightLineEstimator::State zeroFieldIPState{magFieldCache()};
 
   // Vertex position and vertex object
   Vector4 vtxPos(vx0, vy0, vz0, vt0);
@@ -416,7 +416,7 @@ BOOST_DATA_TEST_CASE(VertexCompatibility4D, IPs* vertices, d0, l0, vx0, vy0,
 //
 BOOST_AUTO_TEST_CASE(SingleTrackDistanceParametersAthenaRegression) {
   Estimator ipEstimator = makeEstimator(1.9971546939_T);
-  Estimator::State state(magFieldCache());
+  Estimator::State state{magFieldCache()};
 
   // Use same values as in Athena unit test
   Vector4 pos1(2_mm, 1_mm, -10_mm, 0_ns);
@@ -513,7 +513,7 @@ BOOST_DATA_TEST_CASE(SingeTrackImpactParameters, tracks* vertices, d0, l0, t0,
   vtxPos[eTime] = vt0;
 
   Estimator ipEstimator = makeEstimator(1_T);
-  Estimator::State state(magFieldCache());
+  Estimator::State state{magFieldCache()};
 
   // reference position and corresponding perigee surface
   Vector3 refPosition(0., 0., 0.);

--- a/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/KalmanVertexUpdaterTests.cpp
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(Kalman_Vertex_TrackUpdater) {
   // Set up ImpactPointEstimator, used for comparisons later
   ImpactPointEstimator::Config ip3dEstConfig(bField, propagator);
   ImpactPointEstimator ip3dEst(ip3dEstConfig);
-  ImpactPointEstimator::State state(bField->makeCache(magFieldContext));
+  ImpactPointEstimator::State state{bField->makeCache(magFieldContext)};
 
   // Set up HelicalTrackLinearizer, needed for linearizing the tracks
   // Linearizer for BoundTrackParameters type test


### PR DESCRIPTION
This PR moves the code of the `ImpactPointEstimator` from the header into a compiled file. To allow this, I have to make some changes to the interface to remove templates.

In the process, I introduced `Eigen::Map<ActsDynamicVector>` as an argument to `getDistanceAndMomentum` and `getVertexCompatibility`.
Part of:
- #2842 

Blocked by:
- #2953 