### PR TITLE
refactor!: Move and Grid Density finders to cpp

### DIFF
--- a/Core/include/Acts/Vertexing/GaussianGridTrackDensity.hpp
+++ b/Core/include/Acts/Vertexing/GaussianGridTrackDensity.hpp
@@ -21,32 +21,43 @@ namespace Acts {
 /// The position of the highest track density (of either a single
 /// bin or the sum of a certain region) can be determined.
 /// Single tracks can be cached and removed from the overall density.
-///
-/// @tparam mainGridSize The size of the z-axis 1-dim main density grid
-/// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
-/// a single track is modelled as a (trkGridSize x trkGridSize) grid
-/// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
-template <int mainGridSize = 2000, int trkGridSize = 15>
 class GaussianGridTrackDensity {
-  // Assert odd trkGridSize
-  static_assert(trkGridSize % 2);
-  // Assert bigger main grid than track grid
-  static_assert(mainGridSize > trkGridSize);
-
  public:
-  using MainGridVector = Eigen::Matrix<float, mainGridSize, 1>;
-  using TrackGridVector = Eigen::Matrix<float, trkGridSize, 1>;
+  using MainGridVector = Eigen::Matrix<float, Eigen::Dynamic, 1>;
+  using TrackGridVector = Eigen::Matrix<float, Eigen::Dynamic, 1>;
 
   /// The configuration struct
   struct Config {
     /// @param zMinMax_ The minimum and maximum z-values (in mm) that
     ///                 should be covered by the main 1-dim density grid along
     ///                 the z-axis
+    /// @tparam mainGridSize The size of the z-axis 1-dim main density grid
+    /// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
+    /// a single track is modelled as a (trkGridSize x trkGridSize) grid
+    /// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
     /// @note The value of @p zMinMax_ together with @p mainGridSize determines the
     /// overall bin size to be used as seen below
-    Config(float zMinMax_ = 100) : zMinMax(zMinMax_) {
+    Config(float zMinMax_ = 100, int mainGridSize_ = 2000,
+           int trkGridSize_ = 15)
+        : mainGridSize(mainGridSize_),
+          trkGridSize(trkGridSize_),
+          zMinMax(zMinMax_) {
       binSize = 2. * zMinMax / mainGridSize;
+
+      if (trkGridSize % 2 == 0) {
+        throw std::runtime_error(
+            "GaussianGridTrackDensity: trkGridSize has to be an odd value!");
+      }
+      if (mainGridSize < trkGridSize) {
+        throw std::runtime_error(
+            "GaussianGridTrackDensity: mainGridSize has to be bigger than "
+            "trkGridSize!");
+      }
     }
+
+    int mainGridSize;
+    int trkGridSize;
+
     // Min and max z value of big grid
     float zMinMax;  // mm
 
@@ -104,6 +115,8 @@ class GaussianGridTrackDensity {
   /// @param mainGrid The main 1-dim density grid along the z-axis
   void removeTrackGridFromMainGrid(int zBin, const TrackGridVector& trkGrid,
                                    MainGridVector& mainGrid) const;
+
+  const Config& config() const { return m_cfg; }
 
  private:
   /// @brief Helper function that actually adds the track to the
@@ -176,5 +189,3 @@ class GaussianGridTrackDensity {
 };
 
 }  // namespace Acts
-
-#include "Acts/Vertexing/GaussianGridTrackDensity.ipp"

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -36,11 +36,6 @@ class GridDensityVertexFinder final : public IVertexFinder {
 
   /// @brief The Config struct
   struct Config {
-    Config(float zMinMax_ = 100, int mainGridSize_ = 2000,
-           int trkGridSize_ = 15)
-        : Config{GaussianGridTrackDensity::Config{zMinMax_, mainGridSize_,
-                                                  trkGridSize_}} {}
-
     ///@param gDensity The grid density
     Config(GaussianGridTrackDensity gDensity) : gridDensity(gDensity) {}
 

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -29,33 +29,23 @@ namespace Acts {
 /// density vector) needs to be calculated. All track contributions along the
 /// beam axis (main density grid) a superimposed and the z-value of the bin
 /// with the highest track density is returned as a vertex candidate.
-/// @tparam mainGridSize The size of the z-axis 1-dim main density grid
-/// @tparam trkGridSize The 2(!)-dim grid size of a single track, i.e.
-/// a single track is modelled as a (trkGridSize x trkGridSize) grid
-/// in the d0-z0 plane. Note: trkGridSize has to be an odd value.
-template <int mainGridSize = 2000, int trkGridSize = 15>
 class GridDensityVertexFinder final : public IVertexFinder {
-  // Assert odd trkGridSize
-  static_assert(trkGridSize % 2);
-  // Assert bigger main grid than track grid
-  static_assert(mainGridSize > trkGridSize);
-
-  using GridDensity = GaussianGridTrackDensity<mainGridSize, trkGridSize>;
-
  public:
-  using MainGridVector = typename GridDensity::MainGridVector;
-  using TrackGridVector = typename GridDensity::TrackGridVector;
+  using MainGridVector = GaussianGridTrackDensity::MainGridVector;
+  using TrackGridVector = GaussianGridTrackDensity::TrackGridVector;
 
   /// @brief The Config struct
   struct Config {
-    ///@param zMinMax min and max z value of big z-axis grid
-    Config(float zMinMax = 100)
-        : gridDensity(typename GridDensity::Config(zMinMax)) {}
+    Config(float zMinMax_ = 100, int mainGridSize_ = 2000,
+           int trkGridSize_ = 15)
+        : Config{GaussianGridTrackDensity::Config{zMinMax_, mainGridSize_,
+                                                  trkGridSize_}} {}
+
     ///@param gDensity The grid density
-    Config(const GridDensity& gDensity) : gridDensity(gDensity) {}
+    Config(GaussianGridTrackDensity gDensity) : gridDensity(gDensity) {}
 
     // The grid density object
-    GridDensity gridDensity;
+    GaussianGridTrackDensity gridDensity;
 
     // Cache the main grid and the density contributions (trackGrid and z-bin)
     // for every single track.
@@ -82,8 +72,10 @@ class GridDensityVertexFinder final : public IVertexFinder {
   ///
   /// Only needed if cacheGridStateForTrackRemoval == true
   struct State {
+    State(MainGridVector mainGrid_) : mainGrid(std::move(mainGrid_)) {}
+
     // The main density grid
-    MainGridVector mainGrid = MainGridVector::Zero();
+    MainGridVector mainGrid;
     // Map to store z-bin and track grid (i.e. the density contribution of
     // a single track to the main grid) for every single track
     std::map<InputTrack, std::pair<int, TrackGridVector>> binAndTrackGridMap;
@@ -115,7 +107,9 @@ class GridDensityVertexFinder final : public IVertexFinder {
 
   IVertexFinder::State makeState(
       const Acts::MagneticFieldContext& /*mctx*/) const override {
-    return IVertexFinder::State{State{}};
+    return IVertexFinder::State{
+        std::in_place_type<State>,
+        MainGridVector{m_cfg.gridDensity.config().mainGridSize}};
   }
 
   void setTracksToRemove(
@@ -151,5 +145,3 @@ class GridDensityVertexFinder final : public IVertexFinder {
 };
 
 }  // namespace Acts
-
-#include "GridDensityVertexFinder.ipp"

--- a/Core/src/Vertexing/CMakeLists.txt
+++ b/Core/src/Vertexing/CMakeLists.txt
@@ -17,4 +17,6 @@ target_sources(
     TrackDensityVertexFinder.cpp
     GaussianTrackDensity.cpp
     ImpactPointEstimator.cpp
+    GaussianGridTrackDensity.cpp
+    GridDensityVertexFinder.cpp
 )

--- a/Core/src/Vertexing/GaussianGridTrackDensity.cpp
+++ b/Core/src/Vertexing/GaussianGridTrackDensity.cpp
@@ -12,6 +12,7 @@
 #include "Acts/Vertexing/VertexingError.hpp"
 
 #include <algorithm>
+
 namespace Acts {
 
 Result<float> GaussianGridTrackDensity::getMaxZPosition(

--- a/Core/src/Vertexing/GaussianGridTrackDensity.cpp
+++ b/Core/src/Vertexing/GaussianGridTrackDensity.cpp
@@ -16,7 +16,7 @@ namespace Acts {
 
 Result<float> GaussianGridTrackDensity::getMaxZPosition(
     MainGridVector& mainGrid) const {
-  if (mainGrid.isZero(0)) {
+  if (mainGrid.isZero()) {
     return VertexingError::EmptyInput;
   }
 
@@ -142,7 +142,7 @@ GaussianGridTrackDensity::createTrackGrid(float d0, float distCtrZ,
 
 Result<float> GaussianGridTrackDensity::estimateSeedWidth(
     MainGridVector& mainGrid, float maxZ) const {
-  if (mainGrid.isZero(0)) {
+  if (mainGrid.isZero()) {
     return VertexingError::EmptyInput;
   }
   // Get z bin of max density z value

--- a/Core/src/Vertexing/GridDensityVertexFinder.cpp
+++ b/Core/src/Vertexing/GridDensityVertexFinder.cpp
@@ -61,7 +61,7 @@ auto GridDensityVertexFinder::find(const std::vector<InputTrack>& trackVector,
 
   double z = 0;
   double width = 0;
-  if (!state.mainGrid.isZero(0)) {
+  if (!state.mainGrid.isZero()) {
     if (!m_cfg.estimateSeedWidth) {
       // Get z value of highest density bin
       auto maxZres = m_cfg.gridDensity.getMaxZPosition(state.mainGrid);

--- a/Core/src/Vertexing/GridDensityVertexFinder.cpp
+++ b/Core/src/Vertexing/GridDensityVertexFinder.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Vertexing/GridDensityVertexFinder.hpp"
 
 namespace Acts {
+
 auto GridDensityVertexFinder::find(const std::vector<InputTrack>& trackVector,
                                    const VertexingOptions& vertexingOptions,
                                    IVertexFinder::State& anyState) const

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -413,8 +413,8 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
 
   Fitter fitter(fitterCfg);
 
-  using SeedFinder = GridDensityVertexFinder<4000, 55>;
-  SeedFinder::Config seedFinderCfg(250);
+  using SeedFinder = GridDensityVertexFinder;
+  SeedFinder::Config seedFinderCfg(250, 4000, 55);
   seedFinderCfg.cacheGridStateForTrackRemoval = true;
   seedFinderCfg.extractParameters.connect<&InputTrack::extractParameters>();
 

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
   Fitter fitter(fitterCfg);
 
   using SeedFinder = GridDensityVertexFinder;
-  SeedFinder::Config seedFinderCfg(250, 4000, 55);
+  SeedFinder::Config seedFinderCfg{{{250, 4000, 55}}};
   seedFinderCfg.cacheGridStateForTrackRemoval = true;
   seedFinderCfg.extractParameters.connect<&InputTrack::extractParameters>();
 

--- a/Tests/UnitTests/Core/Vertexing/GaussianGridTrackDensityTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GaussianGridTrackDensityTests.cpp
@@ -43,13 +43,13 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_density_test) {
   constexpr std::size_t mainGridSize = 400;
   constexpr std::size_t trkGridSize = 15;
 
-  using Grid = GaussianGridTrackDensity<mainGridSize, trkGridSize>;
+  using Grid = GaussianGridTrackDensity;
 
   double binSize = 0.1;  // mm
   double zMinMax = mainGridSize / 2 * binSize;
 
   // Set up grid density with zMinMax
-  Grid::Config cfg(zMinMax);
+  Grid::Config cfg(zMinMax, mainGridSize, trkGridSize);
   Grid grid(cfg);
 
   // Create some test tracks
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_density_test) {
                                ParticleHypothesis::pion());
 
   // The grid to be filled
-  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero();
+  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero(mainGridSize);
 
   // addTrack method returns the central z bin where the track density
   // grid was added and the track density grid itself for caching
@@ -118,14 +118,14 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_density_test) {
 
   // Tracks are far away from z-axis (or not in region of interest) and
   // should not have contributed to density grid
-  auto zeroGrid = Grid::MainGridVector::Zero();
+  auto zeroGrid = Grid::MainGridVector::Zero(mainGridSize);
   BOOST_CHECK_EQUAL(mainGrid, zeroGrid);
 
   // Now add track 1 and 2 to grid, separately.
   binAndTrackGrid = grid.addTrack(params1, mainGrid);
   auto gridCopy = mainGrid;
 
-  mainGrid = Grid::MainGridVector::Zero();
+  mainGrid = Grid::MainGridVector::Zero(mainGridSize);
   binAndTrackGrid = grid.addTrack(params2, mainGrid);
 
   // Track 1 is closer to z-axis and should thus yield higher
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_density_test) {
   BOOST_CHECK_EQUAL(maxBin, 0);
 
   // Check if error is thrown for empty grid
-  mainGrid = Grid::MainGridVector::Zero();
+  mainGrid = Grid::MainGridVector::Zero(mainGridSize);
   auto maxResErr = grid.getMaxZPosition(mainGrid);
   BOOST_CHECK(!maxResErr.ok());
 
@@ -183,13 +183,13 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_sum_max_densitytest) {
   constexpr int mainGridSize = 50;
   constexpr int trkGridSize = 11;
 
-  using Grid = Acts::GaussianGridTrackDensity<mainGridSize, trkGridSize>;
+  using Grid = Acts::GaussianGridTrackDensity;
 
   double binSize = 0.1;  // mm
   double zMinMax = mainGridSize / 2 * binSize;
 
   // Set up grid density with zMinMax
-  Grid::Config cfg(zMinMax);
+  Grid::Config cfg(zMinMax, mainGridSize, trkGridSize);
   cfg.useHighestSumZPosition = true;
   Grid grid(cfg);
 
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_sum_max_densitytest) {
                                ParticleHypothesis::pion());
 
   // The grid to be filled
-  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero();
+  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero(mainGridSize);
 
   // addTrack method returns the central z bin where the track density
   // grid was added and the track density grid itself for caching
@@ -246,13 +246,13 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_seed_width_test) {
   constexpr int mainGridSize = 50;
   constexpr int trkGridSize = 11;
 
-  using Grid = Acts::GaussianGridTrackDensity<mainGridSize, trkGridSize>;
+  using Grid = Acts::GaussianGridTrackDensity;
 
   double binSize = 0.1;  // mm
   double zMinMax = mainGridSize / 2 * binSize;
 
   // Set up grid density with zMinMax
-  Grid::Config cfg(zMinMax);
+  Grid::Config cfg(zMinMax, mainGridSize, trkGridSize);
   cfg.useHighestSumZPosition = true;
   Grid grid(cfg);
 
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(gaussian_grid_seed_width_test) {
                                ParticleHypothesis::pion());
 
   // The grid to be filled
-  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero();
+  Grid::MainGridVector mainGrid = Grid::MainGridVector::Zero(mainGridSize);
 
   // addTrack method returns the central z bin where the track density
   // grid was added and the track density grid itself for caching

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
 
   VertexingOptions vertexingOptions(geoContext, magFieldContext);
 
-  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
-  Finder1::Config cfg1;
+  using Finder1 = GridDensityVertexFinder;
+  Finder1::Config cfg1{100, mainGridSize, trkGridSize};
   cfg1.cacheGridStateForTrackRemoval = false;
   cfg1.extractParameters.connect<&InputTrack::extractParameters>();
   Finder1 finder1(cfg1);
@@ -210,11 +210,11 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
 
   VertexingOptions vertexingOptions(geoContext, magFieldContext);
 
-  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
-  using GridDensity = GaussianGridTrackDensity<mainGridSize, trkGridSize>;
+  using Finder1 = GridDensityVertexFinder;
+  using GridDensity = GaussianGridTrackDensity;
 
   // Use custom grid density here
-  GridDensity::Config densityConfig(100_mm);
+  GridDensity::Config densityConfig(100_mm, mainGridSize, trkGridSize);
   densityConfig.useHighestSumZPosition = true;
   GridDensity density(densityConfig);
 
@@ -382,8 +382,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   constraintVtx.setCovariance(SquareMatrix3::Identity());
   vertexingOptions.constraint = constraintVtx;
 
-  using Finder1 = GridDensityVertexFinder<mainGridSize, trkGridSize>;
-  Finder1::Config cfg1;
+  using Finder1 = GridDensityVertexFinder;
+  Finder1::Config cfg1{100, mainGridSize, trkGridSize};
   cfg1.cacheGridStateForTrackRemoval = false;
   cfg1.estimateSeedWidth = true;
   cfg1.extractParameters.connect<&InputTrack::extractParameters>();

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -98,7 +98,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
   VertexingOptions vertexingOptions(geoContext, magFieldContext);
 
   using Finder1 = GridDensityVertexFinder;
-  Finder1::Config cfg1{100, mainGridSize, trkGridSize};
+  Finder1::Config cfg1{{{100, mainGridSize, trkGridSize}}};
   cfg1.cacheGridStateForTrackRemoval = false;
   cfg1.extractParameters.connect<&InputTrack::extractParameters>();
   Finder1 finder1(cfg1);
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   vertexingOptions.constraint = constraintVtx;
 
   using Finder1 = GridDensityVertexFinder;
-  Finder1::Config cfg1{100, mainGridSize, trkGridSize};
+  Finder1::Config cfg1{{{100, mainGridSize, trkGridSize}}};
   cfg1.cacheGridStateForTrackRemoval = false;
   cfg1.estimateSeedWidth = true;
   cfg1.extractParameters.connect<&InputTrack::extractParameters>();


### PR DESCRIPTION
This PR moves 

- `GaussianGridTrackDensity`
- `GridDensityVertexFinder`

to cpp files. It has to refactor the interface a bit to make this possible, mostly, the grid sizes become runtime arguments instead of compile-time parameters. This then also changes the internal grid eigen objects to be dynamic, which I think should be fine because we essentially only do lookups on them.

Part of:
- #2842

Blocked by:
- #2971