### PR TITLE
fix: Match particles without cutting on track weight in `VertexPerformanceWriter`

### DIFF
--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -412,8 +412,7 @@ ActsExamples::ProcessCode ActsExamples::VertexPerformanceWriter::writeT(
         for (std::size_t i = 0; i < trackParameters.size(); ++i) {
           const auto& params = trackParameters[i].parameters();
 
-          if (origTrack.parameters() == params &&
-              trk.trackWeight > m_cfg.minTrkWeight) {
+          if (origTrack.parameters() == params) {
             // We expect that the i-th associated truth particle corresponds to
             // the i-th track parameters
             const auto& particle = associatedTruthParticles[i];


### PR DESCRIPTION
Removed `trk.trackWeight > m_cfg.minTrkWeight` from the matching code as this is checked later anyways and the log afterwards is fired in cases where we can actually match the track.