### PR TITLE
feat(gx2f): Add new error `NotEnoughMeasurements`

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -684,7 +684,7 @@ class Gx2Fitter {
       // We might encounter the case, where we cannot use some (parts of a)
       // measurements, maybe if we do not support that kind of measurement. This
       // is also taken into account here.
-      // `ndf = 4` is choosen, since this a minimum that makes sense for us, but
+      // `ndf = 4` is chosen, since this a minimum that makes sense for us, but
       // a more general approach is desired.
       // TODO genernalize for n-dimensional fit
       constexpr std::size_t ndf = 4;

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitterError.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitterError.hpp
@@ -18,6 +18,7 @@ enum class GlobalChiSquareFitterError {
   // ensure all values are non-zero
   AIsNotInvertible = 1,
   DidNotConverge = 2,
+  NotEnoughMeasurements = 3,
 };
 
 std::error_code make_error_code(

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -735,6 +735,74 @@ BOOST_AUTO_TEST_CASE(DidNotConverge) {
 
   ACTS_INFO("*** Test: DidNotConverge -- Finish");
 }
+
+BOOST_AUTO_TEST_CASE(NotEnoughMeasurements) {
+  ACTS_INFO("*** Test: NotEnoughMeasurements -- Start");
+
+  std::default_random_engine rng(42);
+
+  ACTS_DEBUG("Create the detector");
+  const std::size_t nSurfaces = 2;
+  Detector detector;
+  detector.geometry = makeToyDetector(geoCtx, nSurfaces);
+
+  ACTS_DEBUG("Set the start parameters for measurement creation and fit");
+  const auto parametersMeasurements = makeParameters();
+  const auto startParametersFit = makeParameters(
+      7_mm, 11_mm, 15_mm, 42_ns, 10_degree, 80_degree, 1_GeV, 1_e);
+
+  ACTS_DEBUG("Create the measurements");
+  // simulation propagator
+  using SimPropagator =
+      Acts::Propagator<Acts::StraightLineStepper, Acts::Navigator>;
+  const SimPropagator simPropagator = makeStraightPropagator(detector.geometry);
+  const auto measurements =
+      createMeasurements(simPropagator, geoCtx, magCtx, parametersMeasurements,
+                         resMapAllPixel, rng);
+  const auto sourceLinks = prepareSourceLinks(measurements.sourceLinks);
+  ACTS_VERBOSE("sourceLinks.size() = " << sourceLinks.size());
+
+  BOOST_REQUIRE_EQUAL(sourceLinks.size(), nSurfaces);
+
+  ACTS_DEBUG("Set up the fitter");
+  const Surface* rSurface = &parametersMeasurements.referenceSurface();
+
+  using RecoStepper = EigenStepper<>;
+  const auto recoPropagator =
+      makeConstantFieldPropagator<RecoStepper>(detector.geometry, 0_T);
+
+  using RecoPropagator = decltype(recoPropagator);
+  using Gx2Fitter =
+      Experimental::Gx2Fitter<RecoPropagator, VectorMultiTrajectory>;
+  const Gx2Fitter fitter(recoPropagator, gx2fLogger->clone());
+
+  Experimental::Gx2FitterExtensions<VectorMultiTrajectory> extensions;
+  extensions.calibrator
+      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+  TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
+  extensions.surfaceAccessor
+      .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
+
+  const Experimental::Gx2FitterOptions gx2fOptions(
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 6, true, 0);
+
+  Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
+                              Acts::VectorMultiTrajectory{}};
+
+  ACTS_DEBUG("Fit the track");
+  ACTS_VERBOSE("startParameter unsmeared:\n" << parametersMeasurements);
+  ACTS_VERBOSE("startParameter fit:\n" << startParametersFit);
+  const auto res = fitter.fit(sourceLinks.begin(), sourceLinks.end(),
+                              startParametersFit, gx2fOptions, tracks);
+
+  BOOST_REQUIRE(!res.ok());
+  BOOST_CHECK_EQUAL(
+      res.error(),
+      Acts::Experimental::GlobalChiSquareFitterError::NotEnoughMeasurements);
+
+  ACTS_INFO("*** Test: NotEnoughMeasurements -- Finish");
+}
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace Test
 }  // namespace Acts


### PR DESCRIPTION
## What?
Returns an error, in case the number of measurements is too low for a fit.

This check takes into account the evaluated dimensions of the measurements. To fit, we need at least NDF+1 measurements. However, we n-dimensional measurements count for n measurements, reducing the effective number of needed measurements.

 We might encounter the case, where we cannot use some (parts of a) measurements, maybe if we do not support that kind of measurement. This is also taken into account here.

`ndf = 4` is chosen, since this a minimum that makes sense for us, but a more general approach is desired.

## Why?
We had in PR #2966 FPE Problems due to a division by zero in:
https://github.com/acts-project/acts/blob/a42f23b96876a0fdfba5a8ab1b6c90a9b1f2dc30/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp#L716
This happened, when no measurements were evaluated by the collector. It could happen that we didn't collect any measurements, since the ODD uses also some 3-dimensional measurements. Currently, the GX2F can only handle 1- and 2-dimensional measurements.

## Future TODO
Make `ndf` dependent on the problem. For this we need to find a way to deduce, how many parameters we want to fit.