### PR TITLE
fix: Tweak AMVF config `tracksMaxSignificance` with time in Examples

### DIFF
--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -133,6 +133,7 @@ auto ActsExamples::AdaptiveMultiVertexFinderAlgorithm::makeVertexFinder() const
   finderConfig.tracksMaxZinterval = 1. * Acts::UnitConstants::mm;
   finderConfig.maxIterations = 200;
   finderConfig.useTime = m_cfg.useTime;
+  finderConfig.tracksMaxSignificance = 5;
   if (m_cfg.useTime) {
     // Check if vertices are merged in space and time
     // TODO rename do3dSplitting -> doFullSplitting

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -134,10 +134,6 @@ auto ActsExamples::AdaptiveMultiVertexFinderAlgorithm::makeVertexFinder() const
   finderConfig.maxIterations = 200;
   finderConfig.useTime = m_cfg.useTime;
   if (m_cfg.useTime) {
-    // When using time, we have an extra contribution to the chi2 by the time
-    // coordinate. We thus need to increase tracksMaxSignificance (i.e., the
-    // maximum chi2 that a track can have to be associated with a vertex).
-    finderConfig.tracksMaxSignificance = 7.5;
     // Check if vertices are merged in space and time
     // TODO rename do3dSplitting -> doFullSplitting
     finderConfig.do3dSplitting = true;


### PR DESCRIPTION
Similar to https://github.com/acts-project/acts/pull/2985 we would like to see how this drives the performance.