### PR TITLE
fix: AMVF merge significance with Z and T

### DIFF
--- a/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
@@ -516,19 +516,17 @@ bool AdaptiveMultiVertexFinder::isMergedVertex(
         // Use only z significance
         significance = std::abs(deltaZPos) / std::sqrt(sumVarZ);
       } else {
-        Vector2 candidateZtPos =
-            (Vector2() << candidatePos[eZ], candidatePos[eTime]).finished();
-        Vector2 otherZtPos =
-            (Vector2() << otherPos[eZ], otherPos[eTime]).finished();
+        Vector2 candidateZtPos;
+        candidateZtPos << candidatePos[eZ], candidatePos[eTime];
+        Vector2 otherZtPos;
+        otherZtPos << otherPos[eZ], otherPos[eTime];
 
-        SquareMatrix2 candidateZtCov =
-            (SquareMatrix2() << candidateCov(eZ, eZ), candidateCov(eZ, eTime),
-             candidateCov(eTime, eZ), candidateCov(eTime, eTime))
-                .finished();
-        SquareMatrix2 otherZtCov =
-            (SquareMatrix2() << otherCov(eZ, eZ), otherCov(eZ, eTime),
-             otherCov(eTime, eZ), otherCov(eTime, eTime))
-                .finished();
+        SquareMatrix2 candidateZtCov;
+        candidateZtCov << candidateCov(eZ, eZ), candidateCov(eZ, eTime),
+            candidateCov(eTime, eZ), candidateCov(eTime, eTime);
+        SquareMatrix2 otherZtCov;
+        otherZtCov << otherCov(eZ, eZ), otherCov(eZ, eTime),
+            otherCov(eTime, eZ), otherCov(eTime, eTime);
 
         // Use 2D (z,t) information for significance
         const Vector2 deltaPos = otherZtPos - candidateZtPos;

--- a/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFinder.cpp
@@ -516,22 +516,22 @@ bool AdaptiveMultiVertexFinder::isMergedVertex(
         // Use only z significance
         significance = std::abs(deltaZPos) / std::sqrt(sumVarZ);
       } else {
-        auto candidateZtPos =
+        Vector2 candidateZtPos =
             (Vector2() << candidatePos[eZ], candidatePos[eTime]).finished();
-        auto otherZtPos =
+        Vector2 otherZtPos =
             (Vector2() << otherPos[eZ], otherPos[eTime]).finished();
 
-        auto candidateZtCov =
+        SquareMatrix2 candidateZtCov =
             (SquareMatrix2() << candidateCov(eZ, eZ), candidateCov(eZ, eTime),
              candidateCov(eTime, eZ), candidateCov(eTime, eTime))
                 .finished();
-        auto otherZtCov =
+        SquareMatrix2 otherZtCov =
             (SquareMatrix2() << otherCov(eZ, eZ), otherCov(eZ, eTime),
              otherCov(eTime, eZ), otherCov(eTime, eTime))
                 .finished();
 
         // Use 2D (z,t) information for significance
-        const Vector3 deltaPos = otherZtPos - candidateZtPos;
+        const Vector2 deltaPos = otherZtPos - candidateZtPos;
         SquareMatrix2 sumCov = candidateZtCov + otherZtCov;
         auto sumCovInverse = safeInverse(sumCov);
         if (!sumCovInverse) {

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -138,9 +138,6 @@ auto ActsExamples::AdaptiveMultiVertexFinderAlgorithm::makeVertexFinder() const
     // coordinate. We thus need to increase tracksMaxSignificance (i.e., the
     // maximum chi2 that a track can have to be associated with a vertex).
     finderConfig.tracksMaxSignificance = 7.5;
-    // Check if vertices are merged in space and time
-    // TODO rename do3dSplitting -> doFullSplitting
-    finderConfig.do3dSplitting = true;
     // Reset the maximum significance that two vertices can have before they
     // are considered as merged. The default value 3 is tuned for comparing
     // the vertices' z-coordinates. Since we consider 4 dimensions here, we


### PR DESCRIPTION
We realized that switching on time with the AMVF will also cause the merging significance calculation to change from Z to XYZT.