### PR TITLE
Feat: add kaon hypothesis

### DIFF
--- a/Core/include/Acts/Definitions/PdgParticle.hpp
+++ b/Core/include/Acts/Definitions/PdgParticle.hpp
@@ -25,6 +25,8 @@ enum PdgParticle : std::int32_t {
   eGamma = 22,
   ePionZero = 111,
   ePionPlus = 211,
+  eKaon = 321,
+  eAntiKaon = -eKaon,
   ePionMinus = -ePionPlus,
   eNeutron = 2112,
   eAntiNeutron = -eNeutron,

--- a/Core/include/Acts/EventData/ParticleHypothesis.hpp
+++ b/Core/include/Acts/EventData/ParticleHypothesis.hpp
@@ -44,10 +44,12 @@ class SinglyChargedParticleHypothesis
   static SinglyChargedParticleHypothesis electron() {
     return SinglyChargedParticleHypothesis(PdgParticle::eElectron);
   }
+  static SinglyChargedParticleHypothesis kaon() {
+    return SinglyChargedParticleHypothesis(PdgParticle::eKaon);
+  }
   static SinglyChargedParticleHypothesis proton() {
     return SinglyChargedParticleHypothesis(PdgParticle::eProton);
   }
-
   static SinglyChargedParticleHypothesis chargedGeantino() {
     return SinglyChargedParticleHypothesis(PdgParticle::eInvalid, 0);
   }
@@ -106,6 +108,9 @@ class NonNeutralChargedParticleHypothesis
   static NonNeutralChargedParticleHypothesis electron() {
     return SinglyChargedParticleHypothesis::electron();
   }
+  static NonNeutralChargedParticleHypothesis kaon() {
+    return SinglyChargedParticleHypothesis::kaon();
+  }
   static NonNeutralChargedParticleHypothesis proton() {
     return SinglyChargedParticleHypothesis::proton();
   }
@@ -146,6 +151,9 @@ class ParticleHypothesis : public GenericParticleHypothesis<AnyCharge> {
   }
   static ParticleHypothesis electron() {
     return SinglyChargedParticleHypothesis::electron();
+  }
+  static ParticleHypothesis kaon() {
+    return SinglyChargedParticleHypothesis::kaon();
   }
   static ParticleHypothesis proton() {
     return SinglyChargedParticleHypothesis::proton();

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -228,6 +228,8 @@ void addPdgParticle(Acts::Python::Context& ctx) {
       .value("ePionZero", Acts::PdgParticle::ePionZero)
       .value("ePionPlus", Acts::PdgParticle::ePionPlus)
       .value("ePionMinus", Acts::PdgParticle::ePionMinus)
+      .value("eKaon", Acts::PdgParticle::eKaon)
+      .value("eAntiKaon", Acts::PdgParticle::eAntiKaon)
       .value("eNeutron", Acts::PdgParticle::eNeutron)
       .value("eAntiNeutron", Acts::PdgParticle::eAntiNeutron)
       .value("eProton", Acts::PdgParticle::eProton)

--- a/Examples/Python/src/EventData.cpp
+++ b/Examples/Python/src/EventData.cpp
@@ -57,6 +57,10 @@ void addEventData(Context& ctx) {
           [](py::object /* self */) {
             return Acts::ParticleHypothesis::electron();
           })
+      .def_property_readonly_static("kaon",
+                                    [](py::object /* self */) {
+                                      return Acts::ParticleHypothesis::kaon();
+                                    })
       .def_property_readonly_static("proton",
                                     [](py::object /* self */) {
                                       return Acts::ParticleHypothesis::proton();

--- a/Examples/Python/tests/test_event_data.py
+++ b/Examples/Python/tests/test_event_data.py
@@ -6,20 +6,20 @@ def test_particle_hypothesis():
     pion = acts.ParticleHypothesis.pion
     electron = acts.ParticleHypothesis.electron
     proton = acts.ParticleHypothesis.proton
+    kaon = acts.ParticleHypothesis.kaon
     geantino = acts.ParticleHypothesis.geantino
     chargedGeantino = acts.ParticleHypothesis.chargedGeantino
 
     # create new particle hypothesis
-    kaon = acts.ParticleHypothesis(321, 0.493677, 1)
 
     # check pdg
     assert muon.absolutePdg() == acts.PdgParticle.eMuon
     assert pion.absolutePdg() == acts.PdgParticle.ePionPlus
     assert electron.absolutePdg() == acts.PdgParticle.eElectron
+    assert kaon.absolutePdg() == acts.PdgParticle.eKaon
     assert proton.absolutePdg() == acts.PdgParticle.eProton
     assert geantino.absolutePdg() == acts.PdgParticle.eInvalid
     assert chargedGeantino.absolutePdg() == acts.PdgParticle.eInvalid
-    assert kaon.absolutePdg() == 321
 
     # check mass
     assert electron.mass() != 0
@@ -45,6 +45,7 @@ def test_particle_hypothesis():
     assert (
         str(electron) == "ParticleHypothesis{absPdg=e, mass=0.000510999, absCharge=1}"
     )
+    assert str(kaon) == "ParticleHypothesis{absPdg=K, mass=0.493677, absCharge=1}"
     assert str(proton) == "ParticleHypothesis{absPdg=p, mass=0.938272, absCharge=1}"
     assert str(geantino) == "ParticleHypothesis{absPdg=0, mass=0, absCharge=0}"
     assert str(chargedGeantino) == "ParticleHypothesis{absPdg=0, mass=0, absCharge=1}"


### PR DESCRIPTION
This adds the kaon hypothesis such that there's no need to define it by hand.

Currently:
```
kaon = acts.ParticleHypothesis(321, 0.493677, 1)
```

```
>>> import acts
>>> kaon = acts.ParticleHypothesis(321, 0.493677, 1)
>>> kaon.absolutePdg()
<PdgParticle.???: 321>
>>> 
```

Tagging @andiwand for a review.