### PR TITLE
refactor: OrientedSurface improvements

### DIFF
--- a/Core/include/Acts/Definitions/Direction.hpp
+++ b/Core/include/Acts/Definitions/Direction.hpp
@@ -33,6 +33,9 @@ class Direction final {
   static constexpr auto Backward = Value::Negative;
   static constexpr auto Forward = Value::Positive;
 
+  static constexpr auto OppositeNormal = Value::Negative;
+  static constexpr auto AlongNormal = Value::Positive;
+
   /// This turns a signed value into a direction. Will assert on zero.
   ///
   /// @param scalar is the signed value

--- a/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConeVolumeBounds.hpp
@@ -113,7 +113,7 @@ class ConeVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const final;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CuboidVolumeBounds.hpp
@@ -112,7 +112,7 @@ class CuboidVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const override;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CutoutCylinderVolumeBounds.hpp
@@ -101,7 +101,7 @@ class CutoutCylinderVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const override;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -161,7 +161,7 @@ class CylinderVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const override;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/GenericCuboidVolumeBounds.hpp
@@ -77,7 +77,7 @@ class GenericCuboidVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const override;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/TrapezoidVolumeBounds.hpp
@@ -124,7 +124,7 @@ class TrapezoidVolumeBounds : public VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  OrientedSurfaces orientedSurfaces(
+  std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const override;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -31,8 +31,6 @@ struct OrientedSurface {
   Direction direction;
 };
 
-using OrientedSurfaces = std::vector<OrientedSurface>;
-
 // Planar definitions to help construct the boundary surfaces
 static const Transform3 s_planeXY = Transform3::Identity();
 static const Transform3 s_planeYZ = AngleAxis3(0.5 * M_PI, Vector3::UnitY()) *
@@ -105,7 +103,7 @@ class VolumeBounds {
   /// It will throw an exception if the orientation prescription is not adequate
   ///
   /// @return a vector of surfaces bounding this volume
-  virtual OrientedSurfaces orientedSurfaces(
+  virtual std::vector<OrientedSurface> orientedSurfaces(
       const Transform3& transform = Transform3::Identity()) const = 0;
 
   /// Construct bounding box for this shape

--- a/Core/include/Acts/Geometry/VolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/VolumeBounds.hpp
@@ -26,7 +26,11 @@ class Surface;
 class VolumeBounds;
 class Direction;
 
-using OrientedSurface = std::pair<std::shared_ptr<RegularSurface>, Direction>;
+struct OrientedSurface {
+  std::shared_ptr<RegularSurface> surface;
+  Direction direction;
+};
+
 using OrientedSurfaces = std::vector<OrientedSurface>;
 
 // Planar definitions to help construct the boundary surfaces

--- a/Core/src/Detector/PortalGenerators.cpp
+++ b/Core/src/Detector/PortalGenerators.cpp
@@ -33,7 +33,7 @@ Acts::Experimental::generatePortals(
   std::vector<std::shared_ptr<Portal>> portals;
   for (auto [i, oSurface] : enumerate(orientedSurfaces)) {
     // Create a portal from the surface
-    auto portal = std::make_shared<Portal>(oSurface.first);
+    auto portal = std::make_shared<Portal>(oSurface.surface);
     // Create a shared link instance & delegate
     auto singleLinkImpl =
         std::make_unique<const SingleDetectorVolumeImpl>(dVolume.get());
@@ -41,8 +41,8 @@ Acts::Experimental::generatePortals(
     singleLink.connect<&SingleDetectorVolumeImpl::update>(
         std::move(singleLinkImpl));
     // Update the volume link and the store
-    portal->assignDetectorVolumeUpdater(oSurface.second, std::move(singleLink),
-                                        {dVolume});
+    portal->assignDetectorVolumeUpdater(oSurface.direction,
+                                        std::move(singleLink), {dVolume});
     // Portal is prepared
     portals.push_back(std::move(portal));
   }

--- a/Core/src/Geometry/AbstractVolume.cpp
+++ b/Core/src/Geometry/AbstractVolume.cpp
@@ -35,12 +35,12 @@ void Acts::AbstractVolume::createBoundarySurfaces() {
   for (auto& osf : orientedSurfaces) {
     AbstractVolume* opposite = nullptr;
     AbstractVolume* along = nullptr;
-    if (osf.second == Direction::Negative) {
+    if (osf.direction == Direction::Negative) {
       opposite = this;
     } else {
       along = this;
     }
     m_boundarySurfaces.push_back(std::make_shared<const Boundary>(
-        std::move(osf.first), opposite, along));
+        std::move(osf.surface), opposite, along));
   }
 }

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -102,13 +102,13 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     auto innerCone =
         Surface::makeShared<ConeSurface>(innerConeTrans, m_innerConeBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(innerCone), Direction::Forward));
+        OrientedSurface{std::move(innerCone), Direction::Forward});
   } else if (m_innerCylinderBounds != nullptr) {
     // Or alternatively the inner Cylinder
     auto innerCylinder =
         Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(innerCylinder), Direction::Forward));
+        OrientedSurface{std::move(innerCylinder), Direction::Forward});
   }
 
   // Create an outer Cone
@@ -117,13 +117,13 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     auto outerCone =
         Surface::makeShared<ConeSurface>(outerConeTrans, m_outerConeBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(outerCone), Direction::Backward));
+        OrientedSurface{std::move(outerCone), Direction::Backward});
   } else if (m_outerCylinderBounds != nullptr) {
     // or alternatively an outer Cylinder
     auto outerCylinder =
         Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(outerCylinder), Direction::Backward));
+        OrientedSurface{std::move(outerCylinder), Direction::Backward});
   }
 
   // Set a disc at Zmin
@@ -133,7 +133,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     auto negativeDisc = Surface::makeShared<DiscSurface>(negativeDiscTrans,
                                                          m_negativeDiscBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(negativeDisc), Direction::Forward));
+        OrientedSurface{std::move(negativeDisc), Direction::Forward});
   }
 
   // Set a disc at Zmax
@@ -141,7 +141,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
   auto positiveDisc =
       Surface::makeShared<DiscSurface>(positiveDiscTrans, m_positiveDiscBounds);
   oSurfaces.push_back(
-      OrientedSurface(std::move(positiveDisc), Direction::Backward));
+      OrientedSurface{std::move(positiveDisc), Direction::Backward});
 
   if (m_sectorBounds) {
     RotationMatrix3 sectorRotation;
@@ -156,7 +156,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
     auto negSectorPlane =
         Surface::makeShared<PlaneSurface>(negSectorAbsTrans, m_sectorBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(negSectorPlane), Direction::Positive));
+        OrientedSurface{std::move(negSectorPlane), Direction::Positive});
 
     Transform3 posSectorRelTrans{sectorRotation};
     posSectorRelTrans.prerotate(
@@ -166,7 +166,7 @@ Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
         Surface::makeShared<PlaneSurface>(posSectorAbsTrans, m_sectorBounds);
 
     oSurfaces.push_back(
-        OrientedSurface(std::move(posSectorPlane), Direction::Negative));
+        OrientedSurface{std::move(posSectorPlane), Direction::Negative});
   }
   return oSurfaces;
 }

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -156,7 +156,7 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     auto negSectorPlane =
         Surface::makeShared<PlaneSurface>(negSectorAbsTrans, m_sectorBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(negSectorPlane), Direction::Positive});
+        OrientedSurface{std::move(negSectorPlane), Direction::AlongNormal});
 
     Transform3 posSectorRelTrans{sectorRotation};
     posSectorRelTrans.prerotate(
@@ -166,7 +166,7 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
         Surface::makeShared<PlaneSurface>(posSectorAbsTrans, m_sectorBounds);
 
     oSurfaces.push_back(
-        OrientedSurface{std::move(posSectorPlane), Direction::Negative});
+        OrientedSurface{std::move(posSectorPlane), Direction::OppositeNormal});
   }
   return oSurfaces;
 }

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -102,13 +102,13 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     auto innerCone =
         Surface::makeShared<ConeSurface>(innerConeTrans, m_innerConeBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(innerCone), Direction::Forward});
+        OrientedSurface{std::move(innerCone), Direction:: AlongNormal});
   } else if (m_innerCylinderBounds != nullptr) {
     // Or alternatively the inner Cylinder
     auto innerCylinder =
         Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(innerCylinder), Direction::Forward});
+        OrientedSurface{std::move(innerCylinder), Direction:: AlongNormal});
   }
 
   // Create an outer Cone
@@ -117,13 +117,13 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     auto outerCone =
         Surface::makeShared<ConeSurface>(outerConeTrans, m_outerConeBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(outerCone), Direction::Backward});
+        OrientedSurface{std::move(outerCone), Direction::OppositeNormal});
   } else if (m_outerCylinderBounds != nullptr) {
     // or alternatively an outer Cylinder
     auto outerCylinder =
         Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(outerCylinder), Direction::Backward});
+        OrientedSurface{std::move(outerCylinder), Direction::OppositeNormal});
   }
 
   // Set a disc at Zmin
@@ -133,7 +133,7 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     auto negativeDisc = Surface::makeShared<DiscSurface>(negativeDiscTrans,
                                                          m_negativeDiscBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(negativeDisc), Direction::Forward});
+        OrientedSurface{std::move(negativeDisc), Direction::AlongNormal});
   }
 
   // Set a disc at Zmax
@@ -141,7 +141,7 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
   auto positiveDisc =
       Surface::makeShared<DiscSurface>(positiveDiscTrans, m_positiveDiscBounds);
   oSurfaces.push_back(
-      OrientedSurface{std::move(positiveDisc), Direction::Backward});
+      OrientedSurface{std::move(positiveDisc), Direction::OppositeNormal});
 
   if (m_sectorBounds) {
     RotationMatrix3 sectorRotation;

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -102,13 +102,13 @@ std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     auto innerCone =
         Surface::makeShared<ConeSurface>(innerConeTrans, m_innerConeBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(innerCone), Direction:: AlongNormal});
+        OrientedSurface{std::move(innerCone), Direction::AlongNormal});
   } else if (m_innerCylinderBounds != nullptr) {
     // Or alternatively the inner Cylinder
     auto innerCylinder =
         Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(innerCylinder), Direction:: AlongNormal});
+        OrientedSurface{std::move(innerCylinder), Direction::AlongNormal});
   }
 
   // Create an outer Cone

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -91,9 +91,9 @@ ConeVolumeBounds::ConeVolumeBounds(ActsScalar cylinderR, ActsScalar alpha,
   checkConsistency();
 }
 
-Acts::OrientedSurfaces Acts::ConeVolumeBounds::orientedSurfaces(
+std::vector<Acts::OrientedSurface> Acts::ConeVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
   oSurfaces.reserve(6);
 
   // Create an inner Cone

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -44,9 +44,9 @@ CuboidVolumeBounds& CuboidVolumeBounds::operator=(
   return *this;
 }
 
-Acts::OrientedSurfaces Acts::CuboidVolumeBounds::orientedSurfaces(
+std::vector<Acts::OrientedSurface> Acts::CuboidVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
   oSurfaces.reserve(6);
   // Face surfaces xy -------------------------------------
   //   (1) - at negative local z

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -52,33 +52,33 @@ Acts::OrientedSurfaces Acts::CuboidVolumeBounds::orientedSurfaces(
   //   (1) - at negative local z
   auto sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., 0., -get(eHalfLengthZ)), m_xyBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
   //   (2) - at positive local z
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., 0., get(eHalfLengthZ)), m_xyBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
   // Face surfaces yz -------------------------------------
   //   (3) - at negative local x
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(-get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
   //   (4) - at positive local x
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
   // Face surfaces zx -------------------------------------
   //   (5) - at negative local y
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., -get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
   //   (6) - at positive local y
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
 
   return oSurfaces;
 }

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -52,33 +52,36 @@ std::vector<Acts::OrientedSurface> Acts::CuboidVolumeBounds::orientedSurfaces(
   //   (1) - at negative local z
   auto sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., 0., -get(eHalfLengthZ)), m_xyBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
   //   (2) - at positive local z
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., 0., get(eHalfLengthZ)), m_xyBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
   // Face surfaces yz -------------------------------------
   //   (3) - at negative local x
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(-get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
   //   (4) - at positive local x
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(get(eHalfLengthX), 0., 0.) * s_planeYZ,
       m_yzBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
   // Face surfaces zx -------------------------------------
   //   (5) - at negative local y
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., -get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
   //   (6) - at positive local y
   sf = Surface::makeShared<PlaneSurface>(
       transform * Translation3(0., get(eHalfLengthY), 0.) * s_planeZX,
       m_zxBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
 
   return oSurfaces;
 }

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -63,13 +63,13 @@ Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto outer =
       Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.at(tubeOuterCover) =
-      OrientedSurface{std::move(outer), Direction::Negative};
+      OrientedSurface{std::move(outer), Direction::OppositeNormal};
 
   // Inner (cutout) cylinder envelope
   auto cutoutInner =
       Surface::makeShared<CylinderSurface>(transform, m_cutoutCylinderBounds);
   oSurfaces.at(tubeInnerCover) =
-      OrientedSurface{std::move(cutoutInner), Direction::Positive};
+      OrientedSurface{std::move(cutoutInner), Direction::AlongNormal};
 
   // z position of the pos and neg choke points
   double hlChoke = (get(eHalfLengthZ) - get(eHalfLengthZcutout)) * 0.5;
@@ -80,13 +80,13 @@ Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
     auto posInner = Surface::makeShared<CylinderSurface>(posChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index7) =
-        OrientedSurface{std::move(posInner), Direction::Positive};
+        OrientedSurface{std::move(posInner), Direction::AlongNormal};
 
     auto negChokeTrf = transform * Translation3(Vector3(0, 0, -zChoke));
     auto negInner = Surface::makeShared<CylinderSurface>(negChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index6) =
-        OrientedSurface{std::move(negInner), Direction::Positive};
+        OrientedSurface{std::move(negInner), Direction::AlongNormal};
   }
 
   // Two Outer disks
@@ -95,14 +95,14 @@ Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto posOutDisc =
       Surface::makeShared<DiscSurface>(posOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(positiveFaceXY) =
-      OrientedSurface{std::move(posOutDisc), Direction::Negative};
+      OrientedSurface{std::move(posOutDisc), Direction::OppositeNormal};
 
   auto negOutDiscTrf =
       transform * Translation3(Vector3(0, 0, -get(eHalfLengthZ)));
   auto negOutDisc =
       Surface::makeShared<DiscSurface>(negOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(negativeFaceXY) =
-      OrientedSurface{std::move(negOutDisc), Direction::Positive};
+      OrientedSurface{std::move(negOutDisc), Direction::AlongNormal};
 
   // Two Inner disks
   auto posInDiscTrf =
@@ -110,14 +110,14 @@ Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto posInDisc =
       Surface::makeShared<DiscSurface>(posInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index5) =
-      OrientedSurface{std::move(posInDisc), Direction::Positive};
+      OrientedSurface{std::move(posInDisc), Direction::AlongNormal};
 
   auto negInDiscTrf =
       transform * Translation3(Vector3(0, 0, -get(eHalfLengthZcutout)));
   auto negInDisc =
       Surface::makeShared<DiscSurface>(negInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index4) =
-      OrientedSurface{std::move(negInDisc), Direction::Negative};
+      OrientedSurface{std::move(negInDisc), Direction::OppositeNormal};
 
   return oSurfaces;
 }

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -48,9 +48,10 @@ bool Acts::CutoutCylinderVolumeBounds::inside(const Acts::Vector3& gpos,
   return !insideRInner || !insideZInner;  // we are not, inside bounds
 }
 
-Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
+std::vector<Acts::OrientedSurface>
+Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
 
   if (get(eMinR) == 0.) {
     oSurfaces.resize(6);  // exactly six surfaces (no choke inner cover)

--- a/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CutoutCylinderVolumeBounds.cpp
@@ -62,13 +62,13 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto outer =
       Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.at(tubeOuterCover) =
-      OrientedSurface(std::move(outer), Direction::Negative);
+      OrientedSurface{std::move(outer), Direction::Negative};
 
   // Inner (cutout) cylinder envelope
   auto cutoutInner =
       Surface::makeShared<CylinderSurface>(transform, m_cutoutCylinderBounds);
   oSurfaces.at(tubeInnerCover) =
-      OrientedSurface(std::move(cutoutInner), Direction::Positive);
+      OrientedSurface{std::move(cutoutInner), Direction::Positive};
 
   // z position of the pos and neg choke points
   double hlChoke = (get(eHalfLengthZ) - get(eHalfLengthZcutout)) * 0.5;
@@ -79,13 +79,13 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
     auto posInner = Surface::makeShared<CylinderSurface>(posChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index7) =
-        OrientedSurface(std::move(posInner), Direction::Positive);
+        OrientedSurface{std::move(posInner), Direction::Positive};
 
     auto negChokeTrf = transform * Translation3(Vector3(0, 0, -zChoke));
     auto negInner = Surface::makeShared<CylinderSurface>(negChokeTrf,
                                                          m_innerCylinderBounds);
     oSurfaces.at(index6) =
-        OrientedSurface(std::move(negInner), Direction::Positive);
+        OrientedSurface{std::move(negInner), Direction::Positive};
   }
 
   // Two Outer disks
@@ -94,14 +94,14 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto posOutDisc =
       Surface::makeShared<DiscSurface>(posOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(positiveFaceXY) =
-      OrientedSurface(std::move(posOutDisc), Direction::Negative);
+      OrientedSurface{std::move(posOutDisc), Direction::Negative};
 
   auto negOutDiscTrf =
       transform * Translation3(Vector3(0, 0, -get(eHalfLengthZ)));
   auto negOutDisc =
       Surface::makeShared<DiscSurface>(negOutDiscTrf, m_outerDiscBounds);
   oSurfaces.at(negativeFaceXY) =
-      OrientedSurface(std::move(negOutDisc), Direction::Positive);
+      OrientedSurface{std::move(negOutDisc), Direction::Positive};
 
   // Two Inner disks
   auto posInDiscTrf =
@@ -109,14 +109,14 @@ Acts::OrientedSurfaces Acts::CutoutCylinderVolumeBounds::orientedSurfaces(
   auto posInDisc =
       Surface::makeShared<DiscSurface>(posInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index5) =
-      OrientedSurface(std::move(posInDisc), Direction::Positive);
+      OrientedSurface{std::move(posInDisc), Direction::Positive};
 
   auto negInDiscTrf =
       transform * Translation3(Vector3(0, 0, -get(eHalfLengthZcutout)));
   auto negInDisc =
       Surface::makeShared<DiscSurface>(negInDiscTrf, m_innerDiscBounds);
   oSurfaces.at(index4) =
-      OrientedSurface(std::move(negInDisc), Direction::Negative);
+      OrientedSurface{std::move(negInDisc), Direction::Negative};
 
   return oSurfaces;
 }

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -90,24 +90,24 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
   // [0] Bottom Disc (negative z)
   auto dSurface = Surface::makeShared<DiscSurface>(transMinZ, m_discBounds);
   oSurfaces.push_back(
-      OrientedSurface(std::move(dSurface), Direction::Positive));
+      OrientedSurface{std::move(dSurface), Direction::Positive});
   // [1] Top Disc (positive z)
   dSurface = Surface::makeShared<DiscSurface>(transMaxZ, m_discBounds);
   oSurfaces.push_back(
-      OrientedSurface(std::move(dSurface), Direction::Negative));
+      OrientedSurface{std::move(dSurface), Direction::Negative});
 
   // [2] Outer Cylinder
   auto cSurface =
       Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.push_back(
-      OrientedSurface(std::move(cSurface), Direction::Negative));
+      OrientedSurface{std::move(cSurface), Direction::Negative});
 
   // [3] Inner Cylinder (optional)
   if (m_innerCylinderBounds != nullptr) {
     cSurface =
         Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(cSurface), Direction::Positive));
+        OrientedSurface{std::move(cSurface), Direction::Positive});
   }
 
   // [4] & [5] - Sectoral planes (optional)
@@ -122,7 +122,7 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
     auto pSurface =
         Surface::makeShared<PlaneSurface>(sp1Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(pSurface), Direction::Positive));
+        OrientedSurface{std::move(pSurface), Direction::Positive});
     // sectorPlane 2 (positive phi)
     const Transform3 sp2Transform =
         Transform3(transform *
@@ -133,7 +133,7 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
     pSurface =
         Surface::makeShared<PlaneSurface>(sp2Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(
-        OrientedSurface(std::move(pSurface), Direction::Negative));
+        OrientedSurface{std::move(pSurface), Direction::Negative});
   }
   return oSurfaces;
 }

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -62,7 +62,7 @@ CylinderVolumeBounds::CylinderVolumeBounds(const RadialBounds& rBounds,
 
 std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
   oSurfaces.reserve(6);
 
   Translation3 vMinZ(0., 0., -get(eHalfLengthZ));

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -90,24 +90,24 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
   // [0] Bottom Disc (negative z)
   auto dSurface = Surface::makeShared<DiscSurface>(transMinZ, m_discBounds);
   oSurfaces.push_back(
-      OrientedSurface{std::move(dSurface), Direction::Positive});
+      OrientedSurface{std::move(dSurface), Direction::AlongNormal});
   // [1] Top Disc (positive z)
   dSurface = Surface::makeShared<DiscSurface>(transMaxZ, m_discBounds);
   oSurfaces.push_back(
-      OrientedSurface{std::move(dSurface), Direction::Negative});
+      OrientedSurface{std::move(dSurface), Direction::OppositeNormal});
 
   // [2] Outer Cylinder
   auto cSurface =
       Surface::makeShared<CylinderSurface>(transform, m_outerCylinderBounds);
   oSurfaces.push_back(
-      OrientedSurface{std::move(cSurface), Direction::Negative});
+      OrientedSurface{std::move(cSurface), Direction::OppositeNormal});
 
   // [3] Inner Cylinder (optional)
   if (m_innerCylinderBounds != nullptr) {
     cSurface =
         Surface::makeShared<CylinderSurface>(transform, m_innerCylinderBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(cSurface), Direction::Positive});
+        OrientedSurface{std::move(cSurface), Direction::AlongNormal});
   }
 
   // [4] & [5] - Sectoral planes (optional)
@@ -122,7 +122,7 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
     auto pSurface =
         Surface::makeShared<PlaneSurface>(sp1Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(pSurface), Direction::Positive});
+        OrientedSurface{std::move(pSurface), Direction::AlongNormal});
     // sectorPlane 2 (positive phi)
     const Transform3 sp2Transform =
         Transform3(transform *
@@ -133,7 +133,7 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
     pSurface =
         Surface::makeShared<PlaneSurface>(sp2Transform, m_sectorPlaneBounds);
     oSurfaces.push_back(
-        OrientedSurface{std::move(pSurface), Direction::Negative});
+        OrientedSurface{std::move(pSurface), Direction::OppositeNormal});
   }
   return oSurfaces;
 }

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -63,9 +63,10 @@ bool Acts::GenericCuboidVolumeBounds::inside(const Acts::Vector3& gpos,
   return true;
 }
 
-Acts::OrientedSurfaces Acts::GenericCuboidVolumeBounds::orientedSurfaces(
+std::vector<Acts::OrientedSurface>
+Acts::GenericCuboidVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
 
   // approximate cog of the volume
   Vector3 cog(0, 0, 0);

--- a/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/GenericCuboidVolumeBounds.cpp
@@ -115,7 +115,7 @@ Acts::OrientedSurfaces Acts::GenericCuboidVolumeBounds::orientedSurfaces(
     auto srfTrf = transform * vol2srf.inverse();
     auto srf = Surface::makeShared<PlaneSurface>(srfTrf, polyBounds);
 
-    oSurfaces.push_back(OrientedSurface(std::move(srf), dir));
+    oSurfaces.push_back(OrientedSurface{std::move(srf), dir});
   };
 
   make_surface(m_vertices[0], m_vertices[1], m_vertices[2], m_vertices[3]);

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -151,7 +151,7 @@ void Acts::TrackingVolume::createBoundarySurfaces() {
   for (auto& osf : orientedSurfaces) {
     TrackingVolume* opposite = nullptr;
     TrackingVolume* along = nullptr;
-    if (osf.direction == Direction::Negative) {
+    if (osf.direction == Direction:: OppositeNormal) {
       opposite = this;
     } else {
       along = this;

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -151,13 +151,13 @@ void Acts::TrackingVolume::createBoundarySurfaces() {
   for (auto& osf : orientedSurfaces) {
     TrackingVolume* opposite = nullptr;
     TrackingVolume* along = nullptr;
-    if (osf.second == Direction::Negative) {
+    if (osf.direction == Direction::Negative) {
       opposite = this;
     } else {
       along = this;
     }
     m_boundarySurfaces.push_back(std::make_shared<const Boundary>(
-        std::move(osf.first), opposite, along));
+        std::move(osf.surface), opposite, along));
   }
 }
 

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -151,7 +151,7 @@ void Acts::TrackingVolume::createBoundarySurfaces() {
   for (auto& osf : orientedSurfaces) {
     TrackingVolume* opposite = nullptr;
     TrackingVolume* along = nullptr;
-    if (osf.direction == Direction:: OppositeNormal) {
+    if (osf.direction == Direction::OppositeNormal) {
       opposite = this;
     } else {
       along = this;

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -70,11 +70,12 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
   auto nzTransform = transform * Translation3(0., 0., -get(eHalfLengthZ));
   auto sf =
       Surface::makeShared<PlaneSurface>(nzTransform, m_faceXYTrapezoidBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
   //   (2) - At positive local z
   auto pzTransform = transform * Translation3(0., 0., get(eHalfLengthZ));
   sf = Surface::makeShared<PlaneSurface>(pzTransform, m_faceXYTrapezoidBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
 
   ActsScalar poshOffset = get(eHalfLengthY) / std::tan(get(eAlpha));
   ActsScalar neghOffset = get(eHalfLengthY) / std::tan(get(eBeta));
@@ -88,7 +89,7 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
                      s_planeYZ;
   sf =
       Surface::makeShared<PlaneSurface>(fbTransform, m_faceBetaRectangleBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
 
   // (4) - At point A, attached to alpha opening angle
   Vector3 faPosition(get(eHalfLengthXnegY) + poshOffset, 0., 0.);
@@ -97,7 +98,8 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
       AngleAxis3(-0.5 * M_PI + get(eAlpha), Vector3(0., 0., 1.)) * s_planeYZ;
   sf = Surface::makeShared<PlaneSurface>(faTransform,
                                          m_faceAlphaRectangleBounds);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
 
   // Face surfaces zx
   //   (5) - At negative local y
@@ -105,13 +107,14 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
       transform * Translation3(0., -get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(nxTransform,
                                          m_faceZXRectangleBoundsBottom);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::AlongNormal});
   //   (6) - At positive local y
   auto pxTransform =
       transform * Translation3(topShift, get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(pxTransform,
                                          m_faceZXRectangleBoundsTop);
-  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
+  oSurfaces.push_back(
+      OrientedSurface{std::move(sf), Direction::OppositeNormal});
 
   return oSurfaces;
 }

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -56,7 +56,7 @@ TrapezoidVolumeBounds::TrapezoidVolumeBounds(ActsScalar minhalex,
 
 std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
     const Transform3& transform) const {
-  OrientedSurfaces oSurfaces;
+  std::vector<OrientedSurface> oSurfaces;
   oSurfaces.reserve(6);
 
   // Face surfaces xy

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -70,11 +70,11 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
   auto nzTransform = transform * Translation3(0., 0., -get(eHalfLengthZ));
   auto sf =
       Surface::makeShared<PlaneSurface>(nzTransform, m_faceXYTrapezoidBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
   //   (2) - At positive local z
   auto pzTransform = transform * Translation3(0., 0., get(eHalfLengthZ));
   sf = Surface::makeShared<PlaneSurface>(pzTransform, m_faceXYTrapezoidBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
 
   ActsScalar poshOffset = get(eHalfLengthY) / std::tan(get(eAlpha));
   ActsScalar neghOffset = get(eHalfLengthY) / std::tan(get(eBeta));
@@ -88,7 +88,7 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
                      s_planeYZ;
   sf =
       Surface::makeShared<PlaneSurface>(fbTransform, m_faceBetaRectangleBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
 
   // (4) - At point A, attached to alpha opening angle
   Vector3 faPosition(get(eHalfLengthXnegY) + poshOffset, 0., 0.);
@@ -97,7 +97,7 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
       AngleAxis3(-0.5 * M_PI + get(eAlpha), Vector3(0., 0., 1.)) * s_planeYZ;
   sf = Surface::makeShared<PlaneSurface>(faTransform,
                                          m_faceAlphaRectangleBounds);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
 
   // Face surfaces zx
   //   (5) - At negative local y
@@ -105,13 +105,13 @@ std::vector<OrientedSurface> TrapezoidVolumeBounds::orientedSurfaces(
       transform * Translation3(0., -get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(nxTransform,
                                          m_faceZXRectangleBoundsBottom);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Positive));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Positive});
   //   (6) - At positive local y
   auto pxTransform =
       transform * Translation3(topShift, get(eHalfLengthY), 0.) * s_planeZX;
   sf = Surface::makeShared<PlaneSurface>(pxTransform,
                                          m_faceZXRectangleBoundsTop);
-  oSurfaces.push_back(OrientedSurface(std::move(sf), Direction::Negative));
+  oSurfaces.push_back(OrientedSurface{std::move(sf), Direction::Negative});
 
   return oSurfaces;
 }

--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -148,7 +148,7 @@ void Acts::GeometryView3D::drawSurfaceArray(
       auto cvbOrientedSurfaces = cvb.orientedSurfaces();
       for (auto z : zValues) {
         for (const auto& cvbSf : cvbOrientedSurfaces) {
-          drawSurface(helper, *cvbSf.first, gctx,
+          drawSurface(helper, *cvbSf.surface, gctx,
                       Translation3(0., 0., z) * transform, gridRadConfig);
         }
       }
@@ -164,7 +164,7 @@ void Acts::GeometryView3D::drawSurfaceArray(
                                  0.5 * thickness);
         auto cvbOrientedSurfaces = cvb.orientedSurfaces();
         for (const auto& cvbSf : cvbOrientedSurfaces) {
-          drawSurface(helper, *cvbSf.first, gctx,
+          drawSurface(helper, *cvbSf.surface, gctx,
                       Translation3(0., 0., z) * transform, gridRadConfig);
         }
       }

--- a/Plugins/Json/include/Acts/Plugins/Json/PortalJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/PortalJsonConverter.hpp
@@ -64,7 +64,7 @@ nlohmann::json toJson(
 std::vector<nlohmann::json> toJsonDetray(
     const GeometryContext& gctx, const Experimental::Portal& portal,
     std::size_t ip, const Experimental::DetectorVolume& volume,
-    const OrientedSurfaces& orientedSurfaces,
+    const std::vector<OrientedSurface>& orientedSurfaces,
     const std::vector<const Experimental::DetectorVolume*>& detectorVolumes,
     const Options& options = Options{});
 

--- a/Plugins/Json/src/PortalJsonConverter.cpp
+++ b/Plugins/Json/src/PortalJsonConverter.cpp
@@ -72,7 +72,7 @@ nlohmann::json Acts::PortalJsonConverter::toJson(
 std::vector<nlohmann::json> Acts::PortalJsonConverter::toJsonDetray(
     const GeometryContext& gctx, const Experimental::Portal& portal,
     std::size_t ip, const Experimental::DetectorVolume& volume,
-    const OrientedSurfaces& orientedSurfaces,
+    const std::vector<OrientedSurface>& orientedSurfaces,
     const std::vector<const Experimental::DetectorVolume*>& detectorVolumes,
     const Options& option) {
   // The overall return object

--- a/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeVolumeBoundsTests.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(ConeVolumeBoundsSurfaceOrientation) {
 
   for (auto& os : cvbOrientedSurfaces) {
     // Test the orientation of the boundary surfaces
-    auto rot = os.first->transform(geoCtx).rotation();
+    auto rot = os.surface->transform(geoCtx).rotation();
     BOOST_CHECK(rot.col(0).isApprox(xaxis));
     BOOST_CHECK(rot.col(1).isApprox(yaxis));
     BOOST_CHECK(rot.col(2).isApprox(zaxis));

--- a/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CuboidVolumeBoundsTests.cpp
@@ -121,15 +121,15 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
   auto geoCtx = GeometryContext();
 
   for (auto& os : cvbOrientedSurfaces) {
-    auto osCenter = os.first->center(geoCtx);
+    auto osCenter = os.surface->center(geoCtx);
     const auto* pSurface =
-        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+        dynamic_cast<const Acts::PlaneSurface*>(os.surface.get());
     BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
                           "The surface is not a plane surface");
     auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
-    Vector3 insideBox = osCenter + os.second * osNormal;
-    Vector3 outsideBox = osCenter - os.second * osNormal;
+    Vector3 insideBox = osCenter + os.direction * osNormal;
+    Vector3 outsideBox = osCenter - os.direction * osNormal;
     BOOST_CHECK(box.inside(insideBox));
     BOOST_CHECK(!box.inside(outsideBox));
   }
@@ -140,37 +140,37 @@ BOOST_AUTO_TEST_CASE(CuboidVolumeBoundarySurfaces) {
 
   // Test the orientation of the boundary surfaces
   auto nFaceXY =
-      cvbOrientedSurfaces[negativeFaceXY].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[negativeFaceXY].surface->transform(geoCtx).rotation();
   BOOST_CHECK(nFaceXY.col(0).isApprox(xaxis));
   BOOST_CHECK(nFaceXY.col(1).isApprox(yaxis));
   BOOST_CHECK(nFaceXY.col(2).isApprox(zaxis));
 
   auto pFaceXY =
-      cvbOrientedSurfaces[positiveFaceXY].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[positiveFaceXY].surface->transform(geoCtx).rotation();
   BOOST_CHECK(pFaceXY.col(0).isApprox(xaxis));
   BOOST_CHECK(pFaceXY.col(1).isApprox(yaxis));
   BOOST_CHECK(pFaceXY.col(2).isApprox(zaxis));
 
   auto nFaceYZ =
-      cvbOrientedSurfaces[negativeFaceYZ].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[negativeFaceYZ].surface->transform(geoCtx).rotation();
   BOOST_CHECK(nFaceYZ.col(0).isApprox(yaxis));
   BOOST_CHECK(nFaceYZ.col(1).isApprox(zaxis));
   BOOST_CHECK(nFaceYZ.col(2).isApprox(xaxis));
 
   auto pFaceYZ =
-      cvbOrientedSurfaces[positiveFaceYZ].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[positiveFaceYZ].surface->transform(geoCtx).rotation();
   BOOST_CHECK(pFaceYZ.col(0).isApprox(yaxis));
   BOOST_CHECK(pFaceYZ.col(1).isApprox(zaxis));
   BOOST_CHECK(pFaceYZ.col(2).isApprox(xaxis));
 
   auto nFaceZX =
-      cvbOrientedSurfaces[negativeFaceZX].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[negativeFaceZX].surface->transform(geoCtx).rotation();
   BOOST_CHECK(nFaceZX.col(0).isApprox(zaxis));
   BOOST_CHECK(nFaceZX.col(1).isApprox(xaxis));
   BOOST_CHECK(nFaceZX.col(2).isApprox(yaxis));
 
   auto pFaceZX =
-      cvbOrientedSurfaces[positiveFaceZX].first->transform(geoCtx).rotation();
+      cvbOrientedSurfaces[positiveFaceZX].surface->transform(geoCtx).rotation();
   BOOST_CHECK(pFaceZX.col(0).isApprox(zaxis));
   BOOST_CHECK(pFaceZX.col(1).isApprox(xaxis));
   BOOST_CHECK(pFaceZX.col(2).isApprox(yaxis));

--- a/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CutoutCylinderVolumeBoundsTests.cpp
@@ -195,19 +195,19 @@ BOOST_AUTO_TEST_CASE(CutoutCylinderVolumeOrientedBoundaries) {
   Vector3 zaxis(0., 0., 1.);
 
   for (auto& os : ccvbOrientedSurfaces) {
-    auto onSurface = os.first->binningPosition(geoCtx, binR);
+    auto onSurface = os.surface->binningPosition(geoCtx, binR);
     auto locPos =
-        os.first->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
-    auto osNormal = os.first->normal(geoCtx, locPos);
+        os.surface->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
+    auto osNormal = os.surface->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
-    Vector3 insideCcvb = onSurface + os.second * osNormal;
-    Vector3 outsideCCvb = onSurface - os.second * osNormal;
+    Vector3 insideCcvb = onSurface + os.direction * osNormal;
+    Vector3 outsideCCvb = onSurface - os.direction * osNormal;
 
     BOOST_CHECK(ccvb.inside(insideCcvb));
     BOOST_CHECK(!ccvb.inside(outsideCCvb));
 
     // Test the orientation of the boundary surfaces
-    auto rot = os.first->transform(geoCtx).rotation();
+    auto rot = os.surface->transform(geoCtx).rotation();
     BOOST_CHECK(rot.col(0).isApprox(xaxis));
     BOOST_CHECK(rot.col(1).isApprox(yaxis));
     BOOST_CHECK(rot.col(2).isApprox(zaxis));

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeBoundsTests.cpp
@@ -202,18 +202,18 @@ BOOST_DATA_TEST_CASE(
 
   // check if difference is halfZ - sign and direction independent
   CHECK_CLOSE_REL(
-      (pos - boundarySurfaces.at(0).first->center(tgContext)).norm(),
+      (pos - boundarySurfaces.at(0).surface->center(tgContext)).norm(),
       cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
   CHECK_CLOSE_REL(
-      (pos - boundarySurfaces.at(1).first->center(tgContext)).norm(),
+      (pos - boundarySurfaces.at(1).surface->center(tgContext)).norm(),
       cylBounds.get(CylinderVolumeBounds::eHalfLengthZ), 1e-12);
   // transform to local
   double posDiscPosZ =
-      (transform.inverse() * boundarySurfaces.at(1).first->center(tgContext))
+      (transform.inverse() * boundarySurfaces.at(1).surface->center(tgContext))
           .z();
   double centerPosZ = (transform.inverse() * pos).z();
   double negDiscPosZ =
-      (transform.inverse() * boundarySurfaces.at(0).first->center(tgContext))
+      (transform.inverse() * boundarySurfaces.at(0).surface->center(tgContext))
           .z();
   // check if center of disc boundaries lies in the middle in z
   BOOST_CHECK_LT(centerPosZ, posDiscPosZ);
@@ -230,18 +230,20 @@ BOOST_DATA_TEST_CASE(
   // positive disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transform.rotation().col(2).dot(boundarySurfaces.at(1).first->normal(
+      transform.rotation().col(2).dot(boundarySurfaces.at(1).surface->normal(
           tgContext, Acts::Vector2(0., 0.))),
       1., 1e-12);
   // negative disc durface should point in positive direction in the frame of
   // the volume
   CHECK_CLOSE_REL(
-      transform.rotation().col(2).dot(boundarySurfaces.at(0).first->normal(
+      transform.rotation().col(2).dot(boundarySurfaces.at(0).surface->normal(
           tgContext, Acts::Vector2(0., 0.))),
       1., 1e-12);
   // test in r
-  CHECK_CLOSE_REL(boundarySurfaces.at(3).first->center(tgContext), pos, 1e-12);
-  CHECK_CLOSE_REL(boundarySurfaces.at(2).first->center(tgContext), pos, 1e-12);
+  CHECK_CLOSE_REL(boundarySurfaces.at(3).surface->center(tgContext), pos,
+                  1e-12);
+  CHECK_CLOSE_REL(boundarySurfaces.at(2).surface->center(tgContext), pos,
+                  1e-12);
 }
 
 BOOST_AUTO_TEST_CASE(CylinderVolumeBoundsBoundingBox) {
@@ -306,19 +308,19 @@ BOOST_AUTO_TEST_CASE(CylinderVolumeOrientedBoundaries) {
   Vector3 zaxis(0., 0., 1.);
 
   for (auto& os : cvbOrientedSurfaces) {
-    auto onSurface = os.first->binningPosition(geoCtx, binR);
+    auto onSurface = os.surface->binningPosition(geoCtx, binR);
     auto locPos =
-        os.first->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
-    auto osNormal = os.first->normal(geoCtx, locPos);
+        os.surface->globalToLocal(geoCtx, onSurface, Vector3::Zero()).value();
+    auto osNormal = os.surface->normal(geoCtx, locPos);
     // Check if you step inside the volume with the oriented normal
-    Vector3 insideCvb = onSurface + os.second * osNormal;
-    Vector3 outsideCvb = onSurface - os.second * osNormal;
+    Vector3 insideCvb = onSurface + os.direction * osNormal;
+    Vector3 outsideCvb = onSurface - os.direction * osNormal;
 
     BOOST_CHECK(cvb.inside(insideCvb));
     BOOST_CHECK(!cvb.inside(outsideCvb));
 
     // Test the orientation of the boundary surfaces
-    auto rot = os.first->transform(geoCtx).rotation();
+    auto rot = os.surface->transform(geoCtx).rotation();
     BOOST_CHECK(rot.col(0).isApprox(xaxis));
     BOOST_CHECK(rot.col(1).isApprox(yaxis));
     BOOST_CHECK(rot.col(2).isApprox(zaxis));

--- a/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GenericCuboidVolumeBoundsTests.cpp
@@ -83,9 +83,9 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
 
   auto surfaces = cubo.orientedSurfaces(Transform3::Identity());
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.surface->bounds());
     for (const auto& vtx : pbounds->vertices()) {
-      Vector3 glob = srf.first->localToGlobal(gctx, vtx, {});
+      Vector3 glob = srf.surface->localToGlobal(gctx, vtx, {});
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(glob, vertices));
     }
@@ -103,9 +103,9 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
 
   surfaces = cubo.orientedSurfaces(Transform3::Identity());
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.surface->bounds());
     for (const auto& vtx : pbounds->vertices()) {
-      Vector3 glob = srf.first->localToGlobal(gctx, vtx, {});
+      Vector3 glob = srf.surface->localToGlobal(gctx, vtx, {});
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(glob, vertices));
     }
@@ -117,9 +117,9 @@ BOOST_AUTO_TEST_CASE(GenericCuboidBoundsOrientedSurfaces) {
 
   surfaces = cubo.orientedSurfaces(trf);
   for (const auto& srf : surfaces) {
-    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.first->bounds());
+    auto pbounds = dynamic_cast<const PlanarBounds*>(&srf.surface->bounds());
     for (const auto& vtx : pbounds->vertices()) {
-      Vector3 glob = srf.first->localToGlobal(gctx, vtx, {});
+      Vector3 glob = srf.surface->localToGlobal(gctx, vtx, {});
       // check if glob is in actual vertex list
       BOOST_CHECK(is_in(trf.inverse() * glob, vertices));
     }
@@ -225,15 +225,15 @@ BOOST_AUTO_TEST_CASE(GenericCuboidVolumeBoundarySurfaces) {
 
   for (auto& os : gcvbOrientedSurfaces) {
     auto geoCtx = GeometryContext();
-    auto osCenter = os.first->center(geoCtx);
+    auto osCenter = os.surface->center(geoCtx);
     const auto* pSurface =
-        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+        dynamic_cast<const Acts::PlaneSurface*>(os.surface.get());
     BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
                           "The surface is not a plane surface");
     auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
-    Vector3 insideGcvb = osCenter + os.second * osNormal;
-    Vector3 outsideGcvb = osCenter - os.second * osNormal;
+    Vector3 insideGcvb = osCenter + os.direction * osNormal;
+    Vector3 outsideGcvb = osCenter - os.direction * osNormal;
     BOOST_CHECK(cubo.inside(insideGcvb));
     BOOST_CHECK(!cubo.inside(outsideGcvb));
   }

--- a/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/TrapezoidVolumeBoundsTests.cpp
@@ -60,15 +60,15 @@ BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
   auto geoCtx = GeometryContext();
 
   for (auto& os : tvbOrientedSurfaces) {
-    auto osCenter = os.first->center(geoCtx);
+    auto osCenter = os.surface->center(geoCtx);
     const auto* pSurface =
-        dynamic_cast<const Acts::PlaneSurface*>(os.first.get());
+        dynamic_cast<const Acts::PlaneSurface*>(os.surface.get());
     BOOST_REQUIRE_MESSAGE(pSurface != nullptr,
                           "The surface is not a plane surface");
     auto osNormal = pSurface->normal(geoCtx);
     // Check if you step inside the volume with the oriented normal
-    Vector3 insideTvb = osCenter + os.second * osNormal;
-    Vector3 outsideTvb = osCenter - os.second * osNormal;
+    Vector3 insideTvb = osCenter + os.direction * osNormal;
+    Vector3 outsideTvb = osCenter - os.direction * osNormal;
     BOOST_CHECK(tvb.inside(insideTvb));
     BOOST_CHECK(!tvb.inside(outsideTvb));
   }
@@ -79,25 +79,25 @@ BOOST_AUTO_TEST_CASE(TrapezoidVolumeBoundarySurfaces) {
 
   // Test the orientation of the boundary surfaces
   auto nFaceXY =
-      tvbOrientedSurfaces[negativeFaceXY].first->transform(geoCtx).rotation();
+      tvbOrientedSurfaces[negativeFaceXY].surface->transform(geoCtx).rotation();
   BOOST_CHECK(nFaceXY.col(0).isApprox(xaxis));
   BOOST_CHECK(nFaceXY.col(1).isApprox(yaxis));
   BOOST_CHECK(nFaceXY.col(2).isApprox(zaxis));
 
   auto pFaceXY =
-      tvbOrientedSurfaces[positiveFaceXY].first->transform(geoCtx).rotation();
+      tvbOrientedSurfaces[positiveFaceXY].surface->transform(geoCtx).rotation();
   BOOST_CHECK(pFaceXY.col(0).isApprox(xaxis));
   BOOST_CHECK(pFaceXY.col(1).isApprox(yaxis));
   BOOST_CHECK(pFaceXY.col(2).isApprox(zaxis));
 
   auto nFaceZX =
-      tvbOrientedSurfaces[negativeFaceZX].first->transform(geoCtx).rotation();
+      tvbOrientedSurfaces[negativeFaceZX].surface->transform(geoCtx).rotation();
   BOOST_CHECK(nFaceZX.col(0).isApprox(zaxis));
   BOOST_CHECK(nFaceZX.col(1).isApprox(xaxis));
   BOOST_CHECK(nFaceZX.col(2).isApprox(yaxis));
 
   auto pFaceZX =
-      tvbOrientedSurfaces[positiveFaceZX].first->transform(geoCtx).rotation();
+      tvbOrientedSurfaces[positiveFaceZX].surface->transform(geoCtx).rotation();
   BOOST_CHECK(pFaceZX.col(0).isApprox(zaxis));
   BOOST_CHECK(pFaceZX.col(1).isApprox(xaxis));
   BOOST_CHECK(pFaceZX.col(2).isApprox(yaxis));

--- a/docs/_extensions/lazy_autodoc.py
+++ b/docs/_extensions/lazy_autodoc.py
@@ -67,7 +67,6 @@ def run() -> None:
         "Acts::SurfaceVector",
         "Acts::Intersection3D",
         "Acts::OrientedSurface",
-        "Acts::OrientedSurfaces",
         "Acts::BoundToFreeMatrix",
         "Acts::FreeToBoundMatrix",
         "Acts::FreeSquareMatrix",

--- a/docs/_extensions/lazy_autodoc.py
+++ b/docs/_extensions/lazy_autodoc.py
@@ -66,7 +66,6 @@ def run() -> None:
         "Acts::FreeMatrix",
         "Acts::SurfaceVector",
         "Acts::Intersection3D",
-        "Acts::OrientedSurface",
         "Acts::BoundToFreeMatrix",
         "Acts::FreeToBoundMatrix",
         "Acts::FreeSquareMatrix",
@@ -80,6 +79,7 @@ def run() -> None:
         "Acts::Geant4PhysicalVolumeSelectors::AllSelector",
         "Acts::Geant4PhysicalVolumeSelectors::NameSelector",
         "Acts::Geant4PhysicalVolumeSelectors::PositionSelector",
+        "Acts::OrientedSurface",
     }
 
     role_instances["class"] |= {


### PR DESCRIPTION
This PR:

1. Makes `OrientedSurface` a struct with member names
2. Remove the `OrientedSurfaces` typedef over a vector
3. Add aliases `AlongNormal` and `OppositeNormal` to the `Direction` type

I don't think this is breaking.