### PR TITLE
refactor: Change the MultiLayerSurfacesUpdater to use the local position and direction

### DIFF
--- a/Core/src/Detector/MultiWireStructureBuilder.cpp
+++ b/Core/src/Detector/MultiWireStructureBuilder.cpp
@@ -72,7 +72,8 @@ class MultiWireInternalStructureBuilder
         isg{internalSurfaces,
             {},
             {m_cfg.binning[0u].binValue, m_cfg.binning[1u].binValue},
-            {m_cfg.binning[0u].expansion, m_cfg.binning[1u].expansion}};
+            {m_cfg.binning[0u].expansion, m_cfg.binning[1u].expansion},
+            m_cfg.transform};
     Acts::Experimental::detail::CenterReferenceGenerator rGenerator;
     Acts::GridAxisGenerators::EqBoundEqBound aGenerator{
         {m_cfg.binning[0u].edges.front(), m_cfg.binning[0u].edges.back()},
@@ -127,6 +128,7 @@ Acts::Experimental::MultiWireStructureBuilder::construct(
   MultiWireInternalStructureBuilder::Config iConfig;
   iConfig.iSurfaces = mCfg.mlSurfaces;
   iConfig.binning = mCfg.mlBinning;
+  iConfig.transform = mCfg.transform;
   iConfig.auxiliary = "Construct Internal Structure";
 
   Acts::Experimental::DetectorVolumeBuilder::Config dvConfig;


### PR DESCRIPTION
This PR introduces some changes in the `MultiLayerSurfacesUpdater` in order to consider the local position and direction from the navigation state and generates the path in the grid based on them. Also, since this Navigation Delegate is used in the `MultiWireStructureBuilder` I pass the transform of the multiLayer in the delegate, in order to be taken into account for the global->local transformations. 

(I deleted a previous branch that I have created for this and created a new one, because I had messed up with some files from main)