### PR TITLE
fix: change the order in geant4 converters transform

### DIFF
--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -59,8 +59,8 @@ Acts::Transform3 Acts::Geant4AlgebraConverter::transform(
   rotation << g4Rot.xx(), g4Rot.yx(), g4Rot.zx(), g4Rot.xy(), g4Rot.yy(),
       g4Rot.zy(), g4Rot.xz(), g4Rot.yz(), g4Rot.zz();
   Transform3 transform = Transform3::Identity();
-  transform.pretranslate(translation);
   transform.prerotate(rotation);
+  transform.pretranslate(translation);  
   return transform;
 }
 

--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -60,7 +60,7 @@ Acts::Transform3 Acts::Geant4AlgebraConverter::transform(
       g4Rot.zy(), g4Rot.xz(), g4Rot.yz(), g4Rot.zz();
   Transform3 transform = Transform3::Identity();
   transform.prerotate(rotation);
-  transform.pretranslate(translation);  
+  transform.pretranslate(translation);
   return transform;
 }
 


### PR DESCRIPTION
I think in the `Geant4Converters` when we apply the transform, the rotation should be first in the code and then the translation. Also, I noticed that the opposite breaks the transform of the straw surfaces of the muon mockup detector.
@asalzburger @ssdetlab 

