### PR TITLE
docs: remove empty style guide and fix gender neutral language

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -154,7 +154,7 @@ familiar with development process in the Acts project.
 #. **Prefer git pull --rebase!**
 
    If you work with a colleague on a new
-   development, you may want to include his latest changes. This is
+   development, you may want to include their latest changes. This is
    usually done by calling ``git pull`` which will synchronise your
    local working copy with the remote repository (which may have been
    updated by your colleague). By default, this action creates a merge

--- a/docs/contribution/contribution.md
+++ b/docs/contribution/contribution.md
@@ -12,5 +12,4 @@ physmon
 root_hash_checks
 release
 profiling
-style_guide
 :::

--- a/docs/contribution/style_guide.md
+++ b/docs/contribution/style_guide.md
@@ -1,1 +1,0 @@
-# Style guide


### PR DESCRIPTION
The (empty) style guide seems to be unnecessary, since we already have a separate section [Code guidelines](https://acts.readthedocs.io/en/v33.0.0/codeguide.html) and also talk about formatting in the [Contribution guidelines](https://acts.readthedocs.io/en/v33.0.0/contribution/guide.html#contribution-guidelines).