### PR TITLE
feat: Add basic regions support to G4 example

### DIFF
--- a/Examples/Algorithms/Geant4/CMakeLists.txt
+++ b/Examples/Algorithms/Geant4/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ACTS_EXAMPLES_G4SOURCES
     src/MaterialPhysicsList.cpp
     src/MaterialSteppingAction.cpp
     src/ParticleTrackingAction.cpp
+    src/RegionCreator.cpp
     src/SensitiveSurfaceMapper.cpp
     src/SensitiveSteppingAction.cpp
     src/SimParticleTranslation.cpp

--- a/Examples/Algorithms/Geant4/include/ActsExamples/DDG4/DDG4DetectorConstruction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/DDG4/DDG4DetectorConstruction.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2021 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ActsExamples/Geant4/DetectorConstructionFactory.hpp"
+#include "ActsExamples/Geant4/RegionCreator.hpp"
 
 #include <memory>
 
@@ -28,7 +29,9 @@ struct DD4hepDetector;
 /// Construct the Geant4 detector from a DD4hep description.
 class DDG4DetectorConstruction final : public G4VUserDetectorConstruction {
  public:
-  DDG4DetectorConstruction(std::shared_ptr<DD4hep::DD4hepDetector> detector);
+  DDG4DetectorConstruction(
+      std::shared_ptr<DD4hep::DD4hepDetector> detector,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
   ~DDG4DetectorConstruction() final;
 
   /// Convert the stored DD4hep detector to a Geant4 description.
@@ -43,6 +46,8 @@ class DDG4DetectorConstruction final : public G4VUserDetectorConstruction {
  private:
   /// The Acts DD4hep detector instance
   std::shared_ptr<DD4hep::DD4hepDetector> m_detector;
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
   /// The world volume
   G4VPhysicalVolume* m_world = nullptr;
 
@@ -54,7 +59,8 @@ class DDG4DetectorConstructionFactory final
     : public DetectorConstructionFactory {
  public:
   DDG4DetectorConstructionFactory(
-      std::shared_ptr<DD4hep::DD4hepDetector> detector);
+      std::shared_ptr<DD4hep::DD4hepDetector> detector,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
   ~DDG4DetectorConstructionFactory() final;
 
   std::unique_ptr<G4VUserDetectorConstruction> factorize() const override;
@@ -62,6 +68,8 @@ class DDG4DetectorConstructionFactory final
  private:
   /// The Acts DD4hep detector instance
   std::shared_ptr<DD4hep::DD4hepDetector> m_detector;
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GdmlDetectorConstruction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/GdmlDetectorConstruction.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ActsExamples/Geant4/DetectorConstructionFactory.hpp"
+#include "ActsExamples/Geant4/RegionCreator.hpp"
 
 #include <string>
 
@@ -22,7 +23,10 @@ namespace ActsExamples {
 class GdmlDetectorConstruction final : public G4VUserDetectorConstruction {
  public:
   /// @param path is the path to the Gdml file
-  GdmlDetectorConstruction(std::string path);
+  /// @param regionCreators are the region creators
+  GdmlDetectorConstruction(
+      std::string path,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
 
   /// Read the file and parse it to construct the Geant4 description
   ///
@@ -33,20 +37,26 @@ class GdmlDetectorConstruction final : public G4VUserDetectorConstruction {
  private:
   /// Path to the Gdml file
   std::string m_path;
-  /// Cached worled volume
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
+  /// Cached world volume
   G4VPhysicalVolume* m_world = nullptr;
 };
 
 class GdmlDetectorConstructionFactory final
     : public DetectorConstructionFactory {
  public:
-  GdmlDetectorConstructionFactory(std::string path);
+  GdmlDetectorConstructionFactory(
+      std::string path,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
 
   std::unique_ptr<G4VUserDetectorConstruction> factorize() const override;
 
  private:
   /// Path to the Gdml file
   std::string m_path;
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/RegionCreator.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/RegionCreator.hpp
@@ -1,0 +1,71 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+
+#include <string>
+#include <vector>
+
+namespace ActsExamples {
+
+/// Geant4 Region Creator
+///
+/// Used to set process cuts in specified volumes.
+/// Particles will not be created if their energy is below the cut in length
+/// units.
+class RegionCreator {
+ public:
+  /// Nested configuration struct for the Geant4 region creator
+  struct Config {
+    /// Process cut to be applied for gammas, in mm
+    double gammaCut{};
+
+    /// Process cut to be applied for electrons, in mm
+    double electronCut{};
+
+    /// Process cut to be applied for positrons, in mm
+    double positronCut{};
+
+    /// Process cut to be applied for protons, in mm
+    double protonCut{};
+
+    /// Volume list to be included in this region
+    std::vector<std::string> volumes{};
+  };
+
+  /// Region creator constructor
+  ///
+  /// @param cfg is the configuration struct
+  /// @param name is the region name
+  /// @param level is the logging level to be used
+  RegionCreator(const Config& cfg, std::string name,
+                Acts::Logging::Level level);
+
+  /// Construct the region
+  void Construct();
+
+  /// Readonly access to the configuration
+  const Config& config() const { return m_cfg; }
+
+ private:
+  /// Region name
+  std::string m_name;
+
+  /// Config instance
+  Config m_cfg;
+
+  /// Private access method to the logging instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+  /// The looging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Geant4/include/ActsExamples/TelescopeDetector/TelescopeG4DetectorConstruction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/TelescopeDetector/TelescopeG4DetectorConstruction.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2022 CERN for the benefit of the Acts project
+// Copyright (C) 2022-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ActsExamples/Geant4/DetectorConstructionFactory.hpp"
+#include "ActsExamples/Geant4/RegionCreator.hpp"
 #include "ActsExamples/TelescopeDetector/TelescopeDetector.hpp"
 
 #include "G4VUserDetectorConstruction.hh"
@@ -21,25 +22,35 @@ namespace ActsExamples::Telescope {
 class TelescopeG4DetectorConstruction final
     : public G4VUserDetectorConstruction {
  public:
-  TelescopeG4DetectorConstruction(const TelescopeDetector::Config& cfg);
+  TelescopeG4DetectorConstruction(
+      const TelescopeDetector::Config& cfg,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
 
   G4VPhysicalVolume* Construct() final;
 
  private:
+  /// The configuration of the telescope detector
   TelescopeDetector::Config m_cfg;
-
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
+  /// The world volume
   G4VPhysicalVolume* m_world{};
 };
 
 class TelescopeG4DetectorConstructionFactory final
     : public DetectorConstructionFactory {
  public:
-  TelescopeG4DetectorConstructionFactory(const TelescopeDetector::Config& cfg);
+  TelescopeG4DetectorConstructionFactory(
+      const TelescopeDetector::Config& cfg,
+      std::vector<std::shared_ptr<RegionCreator>> regionCreators = {});
 
   std::unique_ptr<G4VUserDetectorConstruction> factorize() const override;
 
  private:
+  /// The configuration of the telescope detector
   TelescopeDetector::Config m_cfg;
+  /// Region creators
+  std::vector<std::shared_ptr<RegionCreator>> m_regionCreators;
 };
 
 }  // namespace ActsExamples::Telescope

--- a/Examples/Algorithms/Geant4/src/GdmlDetectorConstruction.cpp
+++ b/Examples/Algorithms/Geant4/src/GdmlDetectorConstruction.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2020 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,12 @@ class G4VPhysicalVolume;
 
 using namespace ActsExamples;
 
-GdmlDetectorConstruction::GdmlDetectorConstruction(std::string path)
-    : G4VUserDetectorConstruction(), m_path(std::move(path)) {}
+GdmlDetectorConstruction::GdmlDetectorConstruction(
+    std::string path,
+    std::vector<std::shared_ptr<RegionCreator>> regionCreators)
+    : G4VUserDetectorConstruction(),
+      m_path(std::move(path)),
+      m_regionCreators(std::move(regionCreators)) {}
 
 G4VPhysicalVolume* GdmlDetectorConstruction::Construct() {
   if (m_world == nullptr) {
@@ -25,15 +29,21 @@ G4VPhysicalVolume* GdmlDetectorConstruction::Construct() {
     // TODO how to handle errors
     parser.Read(m_path);
     m_world = parser.GetWorldVolume();
+
+    // Create regions
+    for (const auto& regionCreator : m_regionCreators) {
+      regionCreator->Construct();
+    }
   }
   return m_world;
 }
 
 GdmlDetectorConstructionFactory::GdmlDetectorConstructionFactory(
-    std::string path)
-    : m_path(std::move(path)) {}
+    std::string path,
+    std::vector<std::shared_ptr<RegionCreator>> regionCreators)
+    : m_path(std::move(path)), m_regionCreators(std::move(regionCreators)) {}
 
 std::unique_ptr<G4VUserDetectorConstruction>
 GdmlDetectorConstructionFactory::factorize() const {
-  return std::make_unique<GdmlDetectorConstruction>(m_path);
+  return std::make_unique<GdmlDetectorConstruction>(m_path, m_regionCreators);
 }

--- a/Examples/Algorithms/Geant4/src/RegionCreator.cpp
+++ b/Examples/Algorithms/Geant4/src/RegionCreator.cpp
@@ -1,0 +1,71 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/RegionCreator.hpp"
+
+#include <G4LogicalVolume.hh>
+#include <G4LogicalVolumeStore.hh>
+#include <G4ProductionCuts.hh>
+#include <G4Region.hh>
+
+namespace ActsExamples {
+
+RegionCreator::RegionCreator(const Config& cfg, std::string name,
+                             Acts::Logging::Level level)
+    : m_name(std::move(name)),
+      m_cfg(cfg),
+      m_logger(Acts::getDefaultLogger(m_name, level)) {}
+
+void RegionCreator::Construct() {
+  // create a new G4Region
+  G4Region* region = new G4Region(m_name);
+
+  // loop over volumes and find the ones in the list
+  std::size_t nVolumes{0};
+  G4LogicalVolumeStore* logStore = G4LogicalVolumeStore::GetInstance();
+  for (const std::string& volumeName : m_cfg.volumes) {
+    std::size_t nVolumesCurrent{0};
+    for (auto* it : *logStore) {
+      ACTS_DEBUG("Checking volume " << it->GetName() << " against "
+                                    << volumeName);
+      if (volumeName == static_cast<const std::string&>(it->GetName())) {
+        nVolumesCurrent++;
+        it->SetRegion(region);
+        region->AddRootLogicalVolume(it);
+        ACTS_DEBUG("Volume " << it->GetName() << " added to region");
+      }
+    }
+    if (nVolumesCurrent == 0) {
+      ACTS_WARNING("No volumes matching \""
+                   << volumeName << "\" found in G4 LogicalVolumeStore. "
+                   << m_name << " G4PhysicsRegion may not behave as intended.");
+    }
+    nVolumes += nVolumesCurrent;
+  }
+
+  ACTS_INFO("Created region " << m_name);
+  ACTS_INFO("A total of " << nVolumes << " volumes were assigned");
+
+  // create a G4ProductionCuts object and set appropriate values
+  G4ProductionCuts* cuts = new G4ProductionCuts();
+  cuts->SetProductionCut(m_cfg.gammaCut, "gamma");
+  cuts->SetProductionCut(m_cfg.electronCut, "e-");
+  cuts->SetProductionCut(m_cfg.positronCut, "e+");
+  cuts->SetProductionCut(m_cfg.protonCut, "proton");
+
+  ACTS_INFO("Setting production cuts to");
+  ACTS_INFO("    gamma: " << m_cfg.gammaCut);
+  ACTS_INFO("    e-: " << m_cfg.electronCut);
+  ACTS_INFO("    e+: " << m_cfg.positronCut);
+  ACTS_INFO("    proton: " << m_cfg.protonCut);
+
+  // assign cuts to the region
+  region->SetProductionCuts(cuts);
+}
+
+}  // namespace ActsExamples

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -586,13 +586,14 @@ def addSimWriters(
 
 def getG4DetectorConstructionFactory(
     detector: Any,
+    regionList: List[Any] = [],
 ) -> Any:
     try:
         from acts.examples import TelescopeDetector
         from acts.examples.geant4 import TelescopeG4DetectorConstructionFactory
 
         if type(detector) is TelescopeDetector:
-            return TelescopeG4DetectorConstructionFactory(detector)
+            return TelescopeG4DetectorConstructionFactory(detector, regionList)
     except Exception as e:
         print(e)
 
@@ -601,7 +602,7 @@ def getG4DetectorConstructionFactory(
         from acts.examples.geant4.dd4hep import DDG4DetectorConstructionFactory
 
         if type(detector) is DD4hepDetector:
-            return DDG4DetectorConstructionFactory(detector)
+            return DDG4DetectorConstructionFactory(detector, regionList)
     except Exception as e:
         print(e)
 
@@ -636,6 +637,7 @@ def addGeant4(
     killAfterTime: float = float("inf"),
     killSecondaries: bool = False,
     physicsList: str = "FTFP_BERT",
+    regionList: List[Any] = [],
 ) -> None:
     """This function steers the detector simulation using Geant4
 
@@ -684,7 +686,9 @@ def addGeant4(
     if g4DetectorConstructionFactory is None:
         if detector is None:
             raise AttributeError("detector not given")
-        g4DetectorConstructionFactory = getG4DetectorConstructionFactory(detector)
+        g4DetectorConstructionFactory = getG4DetectorConstructionFactory(
+            detector, regionList
+        )
 
     global __geant4Handle
 

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2021 CERN for the benefit of the Acts project
+// Copyright (C) 2021-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,6 +21,7 @@
 #include "ActsExamples/Geant4/GdmlDetectorConstruction.hpp"
 #include "ActsExamples/Geant4/Geant4Manager.hpp"
 #include "ActsExamples/Geant4/Geant4Simulation.hpp"
+#include "ActsExamples/Geant4/RegionCreator.hpp"
 #include "ActsExamples/Geant4Detector/Geant4Detector.hpp"
 #include "ActsExamples/MuonSpectrometerMockupDetector/MockupSectorBuilder.hpp"
 #include "ActsExamples/TelescopeDetector/TelescopeDetector.hpp"
@@ -149,7 +150,11 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     py::class_<GdmlDetectorConstructionFactory, DetectorConstructionFactory,
                std::shared_ptr<GdmlDetectorConstructionFactory>>(
         mod, "GdmlDetectorConstructionFactory")
-        .def(py::init<std::string>());
+        .def(py::init<std::string,
+                      std::vector<std::shared_ptr<RegionCreator>>>(),
+             py::arg("path"),
+             py::arg("regionCreators") =
+                 std::vector<std::shared_ptr<RegionCreator>>());
   }
 
   {
@@ -158,7 +163,11 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
         DetectorConstructionFactory,
         std::shared_ptr<Telescope::TelescopeG4DetectorConstructionFactory>>(
         mod, "TelescopeG4DetectorConstructionFactory")
-        .def(py::init<const Telescope::TelescopeDetector::Config&>());
+        .def(py::init<const Telescope::TelescopeDetector::Config&,
+                      std::vector<std::shared_ptr<RegionCreator>>>(),
+             py::arg("cfg"),
+             py::arg("regionCreators") =
+                 std::vector<std::shared_ptr<RegionCreator>>());
   }
 
   {
@@ -223,7 +232,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
   }
 
   {
-    /// Helper function to test if the autmotaic geometry conversion works
+    /// Helper function to test if the automatic geometry conversion works
     ///
     /// @param gdmlFileName is the name of the GDML file
     /// @param sensitiveMatches is a list of strings to match sensitive volumes
@@ -307,6 +316,25 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(SensitiveNames);
     ACTS_PYTHON_MEMBER(PassiveNames);
+    ACTS_PYTHON_STRUCT_END();
+  }
+
+  {
+    using Tool = RegionCreator;
+    using Config = Tool::Config;
+    auto tool = py::class_<Tool, std::shared_ptr<Tool>>(mod, "RegionCreator")
+                    .def(py::init<const Config&, std::string, Logging::Level>(),
+                         py::arg("config"), py::arg("name"),
+                         py::arg("logLevel") = Logging::INFO)
+                    .def_property_readonly("config", &Tool::config);
+
+    auto c = py::class_<Config>(tool, "Config").def(py::init<>());
+    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_MEMBER(gammaCut);
+    ACTS_PYTHON_MEMBER(electronCut);
+    ACTS_PYTHON_MEMBER(positronCut);
+    ACTS_PYTHON_MEMBER(protonCut);
+    ACTS_PYTHON_MEMBER(volumes);
     ACTS_PYTHON_STRUCT_END();
   }
 

--- a/Examples/Python/src/Geant4DD4hepComponent.cpp
+++ b/Examples/Python/src/Geant4DD4hepComponent.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2021 CERN for the benefit of the Acts project
+// Copyright (C) 2021-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,6 +10,7 @@
 #include "ActsExamples/DD4hepDetector/DD4hepDetector.hpp"
 #include "ActsExamples/DDG4/DDG4DetectorConstruction.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
+#include "ActsExamples/Geant4/RegionCreator.hpp"
 
 #include <G4VUserDetectorConstruction.hh>
 #include <pybind11/pybind11.h>
@@ -28,5 +29,9 @@ PYBIND11_MODULE(ActsPythonBindingsDDG4, m) {
   py::class_<DDG4DetectorConstructionFactory, DetectorConstructionFactory,
              std::shared_ptr<DDG4DetectorConstructionFactory>>(
       m, "DDG4DetectorConstructionFactory")
-      .def(py::init<std::shared_ptr<DD4hep::DD4hepDetector>>());
+      .def(py::init<std::shared_ptr<DD4hep::DD4hepDetector>,
+                    std::vector<std::shared_ptr<RegionCreator>>>(),
+           py::arg("detector"),
+           py::arg("regionCreators") =
+               std::vector<std::shared_ptr<RegionCreator>>());
 }


### PR DESCRIPTION
I work with fast simulation for silicon detectors and I was interested to see how `G4ProductionCuts` affect the number of secondary particles. This may be useful also for other people so adding it here.

/cc @andiwand @paulgessinger 