### PR TITLE
docs: missing white papers section in RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,7 +167,7 @@ if tags.has("lazy_autodoc") or on_readthedocs:
     extensions += ["lazy_autodoc"]
 
 
-if tags.has("white_papers"):
+if on_readthedocs or tags.has("white_papers"):
     import white_papers
 
     white_papers.render()


### PR DESCRIPTION
After #2797 the white papers were missing in the read the docs build. Thanks @beomki-yeo for noticing.
https://acts--3067.org.readthedocs.build/en/3067/white_papers/index.html