### PR TITLE
fix: Wrong network size written to onnx

### DIFF
--- a/Examples/Scripts/Python/MLAmbiguityResolution/train_ambiguity_solver.py
+++ b/Examples/Scripts/Python/MLAmbiguityResolution/train_ambiguity_solver.py
@@ -273,7 +273,7 @@ input_test = torch.tensor(x_train, dtype=torch.float32)
 torch.save(duplicateClassifier, "duplicateClassifier.pt")
 torch.onnx.export(
     duplicateClassifier,
-    input_test,
+    input_test[0:1],
     "duplicateClassifier.onnx",
     input_names=["x"],
     output_names=["y"],

--- a/Examples/Scripts/Python/MLAmbiguityResolution/train_seed_solver.py
+++ b/Examples/Scripts/Python/MLAmbiguityResolution/train_seed_solver.py
@@ -322,7 +322,7 @@ input_test = torch.tensor(x_train, dtype=torch.float32)
 torch.save(duplicateClassifier, "seedduplicateClassifier.pt")
 torch.onnx.export(
     duplicateClassifier,
-    input_test[0],
+    input_test[0:1],
     "seedduplicateClassifier.onnx",
     input_names=["x"],
     output_names=["y"],


### PR DESCRIPTION
This PR fix an issue for the seed selection NN where the wrong network size would be written to the onnx file. The default network are unaffected as they where written before this mistake was introduced.