### PR TITLE
refactor: Use makeX for tracks and track states

### DIFF
--- a/Core/include/Acts/EventData/TrackProxy.hpp
+++ b/Core/include/Acts/EventData/TrackProxy.hpp
@@ -352,39 +352,27 @@ class TrackProxy {
 
   /// Access the theta parameter of the track at the reference surface
   /// @return The theta parameter
-  ActsScalar theta() const {
-    return parameters()[eBoundTheta];
-  }
+  ActsScalar theta() const { return parameters()[eBoundTheta]; }
 
   /// Access the phi parameter of the track at the reference surface
   /// @return The phi parameter
-  ActsScalar phi() const {
-    return parameters()[eBoundPhi];
-  }
+  ActsScalar phi() const { return parameters()[eBoundPhi]; }
 
   /// Access the loc0 parameter of the track at the reference surface
   /// @return The loc0 parameter
-  ActsScalar loc0() const {
-    return parameters()[eBoundLoc0];
-  }
+  ActsScalar loc0() const { return parameters()[eBoundLoc0]; }
 
   /// Access the loc1 parameter of the track at the reference surface
   /// @return The loc1 parameter
-  ActsScalar loc1() const {
-    return parameters()[eBoundLoc1];
-  }
+  ActsScalar loc1() const { return parameters()[eBoundLoc1]; }
 
   /// Access the time parameter of the track at the reference surface
   /// @return The time parameter
-  ActsScalar time() const {
-    return parameters()[eBoundTime];
-  }
+  ActsScalar time() const { return parameters()[eBoundTime]; }
 
   /// Access the q/p (curvature) parameter of the track at the reference surface
   /// @return The q/p parameter
-  ActsScalar qOverP() const {
-    return parameters()[eBoundQOverP];
-  }
+  ActsScalar qOverP() const { return parameters()[eBoundQOverP]; }
 
   /// Get the particle hypothesis
   /// @return the particle hypothesis
@@ -404,9 +392,7 @@ class TrackProxy {
   /// Get the charge of the tack
   /// @note this depends on the charge hypothesis
   /// @return The absolute track momentum
-  ActsScalar charge() const {
-    return particleHypothesis().qFromQOP(qOverP());
-  }
+  ActsScalar charge() const { return particleHypothesis().qFromQOP(qOverP()); }
 
   /// Get the absolute momentum of the tack
   /// @return The absolute track momentum
@@ -428,9 +414,7 @@ class TrackProxy {
 
   /// Get the global momentum vector
   /// @return the global momentum vector
-  Vector3 momentum() const {
-    return absoluteMomentum() * direction();
-  }
+  Vector3 momentum() const { return absoluteMomentum() * direction(); }
 
   /// Return the number of track states associated to this track
   /// @note This is calculated by iterating over the track states which is
@@ -519,9 +503,7 @@ class TrackProxy {
 
   /// Return the chi squared for the track. Const version
   /// @return The chi squared
-  float chi2() const {
-    return component<float, hashString("chi2")>();
-  }
+  float chi2() const { return component<float, hashString("chi2")>(); }
 
   /// Return a mutable reference to the number of degrees of freedom for the
   /// track. Mutable version
@@ -541,9 +523,7 @@ class TrackProxy {
   /// Return the index of this track in the track container
   /// @note This is separate from the tip index
   /// @return the track index
-  IndexType index() const {
-    return m_index;
-  }
+  IndexType index() const { return m_index; }
 
   /// @}
 
@@ -659,7 +639,7 @@ class TrackProxy {
   template <bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
   auto appendTrackState(TrackStatePropMask mask = TrackStatePropMask::All) {
     auto& tsc = m_container->trackStateContainer();
-    auto ts = tsc.getTrackState(tsc.addTrackState(mask, tipIndex()));
+    auto ts = tsc.makeTrackState(mask, tipIndex());
     tipIndex() = ts.index();
     return ts;
   }
@@ -850,9 +830,7 @@ class TrackProxy {
 
   /// Return a reference to the track container backend, const version.
   /// @return reference to the track container backend
-  const auto& container() const {
-    return *m_container;
-  }
+  const auto& container() const { return *m_container; }
 
  private:
   TrackProxy(detail_tc::ConstIf<TrackContainer<Container, Trajectory, holder_t>,

--- a/Core/include/Acts/TrackFinding/TrackSelector.hpp
+++ b/Core/include/Acts/TrackFinding/TrackSelector.hpp
@@ -372,7 +372,7 @@ void TrackSelector::selectTracks(const input_tracks_t& inputTracks,
     if (!isValidTrack(track)) {
       continue;
     }
-    auto destProxy = outputTracks.getTrack(outputTracks.addTrack());
+    auto destProxy = outputTracks.makeTrack();
     destProxy.copyFrom(track, false);
     destProxy.tipIndex() = track.tipIndex();
   }

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -450,7 +450,7 @@ struct GaussianSumFitter {
       return return_error_or_abort(GsfError::NoMeasurementStatesCreatedFinal);
     }
 
-    auto track = trackContainer.getTrack(trackContainer.addTrack());
+    auto track = trackContainer.makeTrack();
     track.tipIndex() = fwdGsfResult.lastMeasurementTip;
 
     if (options.referenceSurface) {

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -433,12 +433,9 @@ class Gx2Fitter {
 
           // Add a <mask> TrackState entry multi trajectory. This allocates
           // storage for all components, which we will set later.
-          std::size_t currentTrackIndex =
-              fittedStates.addTrackState(mask, result.lastTrackIndex);
-
-          // now get track state proxy back
           typename traj_t::TrackStateProxy trackStateProxy =
-              fittedStates.getTrackState(currentTrackIndex);
+              fittedStates.makeTrackState(mask, result.lastTrackIndex);
+          std::size_t currentTrackIndex = trackStateProxy.index();
 
           // Set the trackStateProxy components with the state from the ongoing
           // propagation
@@ -826,7 +823,7 @@ class Gx2Fitter {
     }
 
     // Prepare track for return
-    auto track = trackContainer.getTrack(trackContainer.addTrack());
+    auto track = trackContainer.makeTrack();
     track.tipIndex() = tipIndex;
     track.parameters() = params.parameters();
     track.covariance() = fullCovariancePredicted;

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1281,7 +1281,7 @@ class KalmanFitter {
       return kalmanResult.result.error();
     }
 
-    auto track = trackContainer.getTrack(trackContainer.addTrack());
+    auto track = trackContainer.makeTrack();
     track.tipIndex() = kalmanResult.lastMeasurementIndex;
     if (kalmanResult.fittedParameters) {
       const auto& params = kalmanResult.fittedParameters.value();

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -735,9 +735,8 @@ struct GsfActor {
                     TrackStatePropMask::Filtered | TrackStatePropMask::Smoothed
               : TrackStatePropMask::Calibrated | TrackStatePropMask::Predicted;
 
-      result.currentTip =
-          result.fittedStates->addTrackState(mask, result.currentTip);
-      auto proxy = result.fittedStates->getTrackState(result.currentTip);
+      auto proxy = result.fittedStates->makeTrackState(mask, result.currentTip);
+      result.currentTip = proxy.index();
 
       proxy.setReferenceSurface(surface.getSharedPtr());
       proxy.copyFrom(firstCmpProxy, mask);

--- a/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
+++ b/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
@@ -45,12 +45,8 @@ auto kalmanHandleMeasurement(
   // Add a <mask> TrackState entry multi trajectory. This allocates storage for
   // all components, which we will set later.
   TrackStatePropMask mask = TrackStatePropMask::All;
-  const std::size_t currentTrackIndex =
-      fittedStates.addTrackState(mask, lastTrackIndex);
-
-  // now get track state proxy back
   typename traj_t::TrackStateProxy trackStateProxy =
-      fittedStates.getTrackState(currentTrackIndex);
+      fittedStates.makeTrackState(mask, lastTrackIndex);
 
   // Set the trackStateProxy components with the state from the ongoing
   // propagation
@@ -146,12 +142,8 @@ auto kalmanHandleNoMeasurement(
   // all components, which we will set later.
   TrackStatePropMask mask =
       ~(TrackStatePropMask::Calibrated | TrackStatePropMask::Filtered);
-  const std::size_t currentTrackIndex =
-      fittedStates.addTrackState(mask, lastTrackIndex);
-
-  // now get track state proxy back
   typename traj_t::TrackStateProxy trackStateProxy =
-      fittedStates.getTrackState(currentTrackIndex);
+      fittedStates.makeTrackState(mask, lastTrackIndex);
 
   // Set the trackStateProxy components with the state from the ongoing
   // propagation

--- a/Examples/Algorithms/AmbiguityResolution/src/GreedyAmbiguityResolutionAlgorithm.cpp
+++ b/Examples/Algorithms/AmbiguityResolution/src/GreedyAmbiguityResolutionAlgorithm.cpp
@@ -87,7 +87,7 @@ ActsExamples::GreedyAmbiguityResolutionAlgorithm::execute(
   solvedTracks.ensureDynamicColumns(tracks);
 
   for (auto iTrack : state.selectedTracks) {
-    auto destProxy = solvedTracks.getTrack(solvedTracks.addTrack());
+    auto destProxy = solvedTracks.makeTrack();
     auto srcProxy = tracks.getTrack(state.trackTips.at(iTrack));
     destProxy.copyFrom(srcProxy, false);
     destProxy.tipIndex() = srcProxy.tipIndex();

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -195,7 +195,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithm::execute(
 
       if (!m_trackSelector.has_value() ||
           m_trackSelector->isValidTrack(track)) {
-        auto destProxy = tracks.getTrack(tracks.addTrack());
+        auto destProxy = tracks.makeTrack();
         destProxy.copyFrom(track, true);  // make sure we copy track states!
       }
     }

--- a/Examples/Algorithms/TrackFindingML/src/AmbiguityResolutionML.cpp
+++ b/Examples/Algorithms/TrackFindingML/src/AmbiguityResolutionML.cpp
@@ -62,7 +62,7 @@ ActsExamples::AmbiguityResolutionML::prepareOutputTrack(
   solvedTracks.ensureDynamicColumns(tracks);
 
   for (auto&& iTrack : goodTracks) {
-    auto destProxy = solvedTracks.getTrack(solvedTracks.addTrack());
+    auto destProxy = solvedTracks.makeTrack();
     auto srcProxy = tracks.getTrack(iTrack);
     destProxy.copyFrom(srcProxy, false);
     destProxy.tipIndex() = srcProxy.tipIndex();

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackModifier.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackModifier.cpp
@@ -64,7 +64,7 @@ ProcessCode TrackModifier::execute(
   outputTracks.ensureDynamicColumns(inputTracks);
 
   for (const auto& inputTrack : inputTracks) {
-    auto outputTrack = outputTracks.getTrack(outputTracks.addTrack());
+    auto outputTrack = outputTracks.makeTrack();
     outputTrack.copyFrom(inputTrack);
     modifyTrack(outputTrack);
   }

--- a/Examples/Io/EDM4hep/src/EDM4hepTrackReader.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepTrackReader.cpp
@@ -51,7 +51,7 @@ ProcessCode EDM4hepTrackReader::read(const AlgorithmContext& ctx) {
   TrackContainer tracks(trackContainer, trackStateContainer);
 
   for (const auto& inputTrack : trackCollection) {
-    auto track = tracks.getTrack(tracks.addTrack());
+    auto track = tracks.makeTrack();
     Acts::EDM4hepUtil::readTrack(inputTrack, track, m_cfg.Bz);
   }
 

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(MemoryStats) {
   }
 
   TestTrackState pc(rng, 2u);
-  auto ts = mt.getTrackState(mt.addTrackState());
+  auto ts = mt.makeTrackState();
   fillTrackState<VectorMultiTrajectory>(pc, TrackStatePropMask::All, ts);
 
   stats = mt.statistics();
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(Accessors) {
   mtj.addColumn<unsigned int>("ndof");
   mtj.addColumn<double>("super_chi2");
 
-  auto ts = mtj.getTrackState(mtj.addTrackState());
+  auto ts = mtj.makeTrackState();
 
   ProxyAccessor<unsigned int> ndof("ndof");
   ConstProxyAccessor<unsigned int> ndofConst("ndof");

--- a/Tests/UnitTests/Core/EventData/TrackContainerComplianceTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackContainerComplianceTests.cpp
@@ -25,11 +25,11 @@ ACTS_DOES_NOT_COMPILE_SUITE_BEGIN(BuildFromConstRef)
   TrackContainer mutTc{mutVtc, mutMtj};
   static_assert(!mutTc.ReadOnly, "Unexpectedly read only");
 
-  auto t = mutTc.getTrack(mutTc.addTrack());
+  auto t = mutTc.makeTrack();
   t.appendTrackState();
   t.appendTrackState();
   t.appendTrackState();
-  t = mutTc.getTrack(mutTc.addTrack());
+  t = mutTc.makeTrack();
   t.appendTrackState();
 
   ConstVectorTrackContainer vtc{std::move(mutVtc)};
@@ -71,7 +71,7 @@ ACTS_DOES_NOT_COMPILE_SUITE_BEGIN(BuildFromConstRef)
   VectorTrackContainer vtc;
   VectorMultiTrajectory mtj;
   TrackContainer tc{vtc, mtj};
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
   (void)t;
 
   ConstProxyAccessor<unsigned int> caccNMeasuements("nMeasurements");

--- a/Tests/UnitTests/Core/EventData/TrackTests.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTests.cpp
@@ -304,14 +304,12 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackStateAccess, factory_t, holder_types) {
 
   auto mkts = [&](auto prev) {
     if constexpr (std::is_same_v<decltype(prev), IndexType>) {
-      auto ts =
-          traj.getTrackState(traj.addTrackState(TrackStatePropMask::All, prev));
+      auto ts = traj.makeTrackState(TrackStatePropMask::All, prev);
       TestTrackState pc(rng, 2u);
       fillTrackState<VectorMultiTrajectory>(pc, TrackStatePropMask::All, ts);
       return ts;
     } else {
-      auto ts = traj.getTrackState(
-          traj.addTrackState(TrackStatePropMask::All, prev.index()));
+      auto ts = traj.makeTrackState(TrackStatePropMask::All, prev.index());
       TestTrackState pc(rng, 2u);
       fillTrackState<VectorMultiTrajectory>(pc, TrackStatePropMask::All, ts);
       return ts;
@@ -324,7 +322,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackStateAccess, factory_t, holder_types) {
   auto ts4 = mkts(ts3);
   auto ts5 = mkts(ts4);
 
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
   t.tipIndex() = ts5.index();
 
   std::vector<IndexType> act;
@@ -345,7 +343,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackStateAccess, factory_t, holder_types) {
 
   BOOST_CHECK_EQUAL(t.nTrackStates(), 5);
 
-  auto tNone = tc.getTrack(tc.addTrack());
+  auto tNone = tc.makeTrack();
   BOOST_CHECK_EQUAL(tNone.nTrackStates(), 0);
 
   auto tsRange = tNone.trackStatesReversed();
@@ -364,7 +362,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TrackIterator, factory_t, holder_types) {
   auto& tc = factory.trackContainer();
 
   for (unsigned int i = 0; i < 10; i++) {
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     t.tipIndex() = i;
   }
   BOOST_CHECK_EQUAL(tc.size(), 10);
@@ -385,7 +383,7 @@ BOOST_AUTO_TEST_CASE(IteratorConcept) {
   TrackContainer tc{vtc, mtj};
 
   for (unsigned int i = 0; i < 10; i++) {
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     t.tipIndex() = i;
   }
   BOOST_CHECK_EQUAL(tc.size(), 10);
@@ -447,7 +445,7 @@ BOOST_AUTO_TEST_CASE(ConstCorrectness) {
     TrackContainer tc{vtc, mtj};
 
     for (unsigned int i = 0; i < 10; i++) {
-      auto t = tc.getTrack(tc.addTrack());
+      auto t = tc.makeTrack();
       t.tipIndex() = i;
     }
 
@@ -487,11 +485,11 @@ BOOST_AUTO_TEST_CASE(BuildFromConstRef) {
   TrackContainer mutTc{mutVtc, mutMtj};
   static_assert(!mutTc.ReadOnly, "Unexpectedly read only");
 
-  auto t = mutTc.getTrack(mutTc.addTrack());
+  auto t = mutTc.makeTrack();
   t.appendTrackState();
   t.appendTrackState();
   t.appendTrackState();
-  t = mutTc.getTrack(mutTc.addTrack());
+  t = mutTc.makeTrack();
   t.appendTrackState();
 
   BOOST_CHECK_EQUAL(mutTc.size(), 2);
@@ -549,7 +547,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(DynamicColumns, factory_t, holder_types) {
   tc.template addColumn<float>("col_a");
   BOOST_CHECK(tc.hasColumn("col_a"_hash));
 
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
   t.template component<float>("col_a") = 5.6f;
   BOOST_CHECK_EQUAL((t.template component<float, "col_a"_hash>()), 5.6f);
 }
@@ -575,7 +573,7 @@ BOOST_AUTO_TEST_CASE(EnsureDynamicColumns) {
 
 BOOST_AUTO_TEST_CASE(AppendTrackState) {
   TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
 
   std::vector<VectorMultiTrajectory::TrackStateProxy> trackStates;
   trackStates.push_back(t.appendTrackState());
@@ -596,13 +594,13 @@ BOOST_AUTO_TEST_CASE(ForwardIteration) {
   TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
   {
     // let's create an unrelated track first
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     for (std::size_t i = 0; i < 10; i++) {
       t.appendTrackState();
     }
   }
 
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
 
   auto stem = t.appendTrackState();
   t.appendTrackState();
@@ -650,7 +648,7 @@ BOOST_AUTO_TEST_CASE(ForwardIteration) {
 
 BOOST_AUTO_TEST_CASE(CalculateQuantities) {
   TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
 
   auto ts = t.appendTrackState();
   ts.typeFlags().set(MeasurementFlag);

--- a/Tests/UnitTests/Core/EventData/TrackTestsExtra.cpp
+++ b/Tests/UnitTests/Core/EventData/TrackTestsExtra.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
   tc3.addColumn<bool>("odd");
 
   for (std::size_t i = 0; i < 10; i++) {
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     auto ts = t.appendTrackState();
     ts.predicted() = BoundVector::Ones();
     ts.component<std::size_t, "ts_counter"_hash>() = i;
@@ -61,11 +61,11 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
     t.template component<std::size_t>("counter") = i;
     t.template component<bool>("odd") = i % 2 == 0;
 
-    auto t2 = tc2.getTrack(tc2.addTrack());
+    auto t2 = tc2.makeTrack();
     BOOST_CHECK_THROW(t2.copyFrom(t),
                       std::invalid_argument);  // this should fail
 
-    auto t3 = tc3.getTrack(tc3.addTrack());
+    auto t3 = tc3.makeTrack();
     t3.copyFrom(t);  // this should work
 
     BOOST_CHECK_NE(t3.tipIndex(), MultiTrajectoryTraits::kInvalid);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumns) {
     auto t4 = tc4.getTrack(i);  // const source!
     BOOST_CHECK_NE(t4.nTrackStates(), 0);
 
-    auto t5 = tc5.getTrack(tc5.addTrack());
+    auto t5 = tc5.makeTrack();
     t5.copyFrom(t4);  // this should work
 
     BOOST_CHECK_NE(t5.tipIndex(), MultiTrajectoryTraits::kInvalid);
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(ReverseTrackStates) {
   VectorMultiTrajectory mtj{};
   TrackContainer tc{vtc, mtj};
 
-  auto t = tc.getTrack(tc.addTrack());
+  auto t = tc.makeTrack();
 
   for (std::size_t i = 0; i < 4; i++) {
     auto ts = t.appendTrackState();

--- a/Tests/UnitTests/Plugins/EDM4hep/ConvertTrackEDM4hepTest.cpp
+++ b/Tests/UnitTests/Plugins/EDM4hep/ConvertTrackEDM4hepTest.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(RoundTripTests) {
 
   std::uint32_t numT = nTracks(rng);
   for (std::uint32_t t = 0; t < numT; t++) {
-    auto track = tracks.getTrack(tracks.addTrack());
+    auto track = tracks.makeTrack();
     {
       auto [par, cov] = genParams();
       track.parameters() = par;
@@ -372,7 +372,7 @@ BOOST_AUTO_TEST_CASE(RoundTripTests) {
 
   for (const auto edm4hepTrack : edm4hepTracksConst) {
     EDM4hepUtil::readTrack(
-        edm4hepTrack, readTracks.getTrack(readTracks.addTrack()), Bz, *logger);
+        edm4hepTrack, readTracks.makeTrack(), Bz, *logger);
   }
 
   BOOST_CHECK_EQUAL(tracks.size(), readTracks.size());

--- a/Tests/UnitTests/Plugins/Podio/PodioTrackContainerTest.cpp
+++ b/Tests/UnitTests/Plugins/Podio/PodioTrackContainerTest.cpp
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(ConvertTrack) {
 
     BOOST_CHECK_EQUAL(tc.size(), 0);
 
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     BOOST_CHECK_EQUAL(t.tipIndex(), MultiTrajectoryTraits::kInvalid);
 
     t.setParticleHypothesis(pHypo);
@@ -225,8 +225,8 @@ BOOST_AUTO_TEST_CASE(ConvertTrack) {
     BOOST_CHECK_EQUAL(pTrack.getReferenceSurface().identifier,
                       PodioUtil::kNoIdentifier);
 
-    auto t2 = tc.getTrack(tc.addTrack());
-    auto t3 = tc.getTrack(tc.addTrack());
+    auto t2 = tc.makeTrack();
+    auto t3 = tc.makeTrack();
     BOOST_CHECK_EQUAL(tc.size(), 3);
 
     // Register surface "with the detector"
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumnsDifferentBackends) {
   tsc3.addColumn<uint8_t>("ts_odd");
 
   for (std::size_t i = 0; i < 10; i++) {
-    auto t = tc.getTrack(tc.addTrack());
+    auto t = tc.makeTrack();
     auto ts = t.appendTrackState();
     ts.predicted() = BoundVector::Ones();
     ts.component<uint64_t, "ts_counter"_hash>() = i;
@@ -358,11 +358,11 @@ BOOST_AUTO_TEST_CASE(CopyTracksIncludingDynamicColumnsDifferentBackends) {
     t.template component<uint64_t>("counter") = i;
     t.template component<uint8_t>("odd") = static_cast<uint8_t>(i % 2 == 0);
 
-    auto t2 = tc2.getTrack(tc2.addTrack());
+    auto t2 = tc2.makeTrack();
     BOOST_CHECK_THROW(t2.copyFrom(t),
                       std::invalid_argument);  // this should fail
 
-    auto t3 = tc3.getTrack(tc3.addTrack());
+    auto t3 = tc3.makeTrack();
     t3.copyFrom(t);  // this should work
 
     BOOST_CHECK_NE(t3.tipIndex(), MultiTrajectoryTraits::kInvalid);

--- a/Tests/UnitTests/Plugins/Podio/PodioTrackStateContainerTest.cpp
+++ b/Tests/UnitTests/Plugins/Podio/PodioTrackStateContainerTest.cpp
@@ -240,14 +240,13 @@ BOOST_AUTO_TEST_CASE(WriteToPodioFrame) {
   BOOST_CHECK(c.hasColumn("float_column"_hash));
 
   {
-    auto t1 = c.getTrackState(c.addTrackState(TrackStatePropMask::Predicted));
+    auto t1 = c.makeTrackState(TrackStatePropMask::Predicted);
     t1.predicted() = tv1;
     t1.predictedCovariance() = cov1;
 
     t1.setReferenceSurface(free);
 
-    auto t2 =
-        c.getTrackState(c.addTrackState(TrackStatePropMask::All, t1.index()));
+    auto t2 = c.makeTrackState(TrackStatePropMask::All, t1.index());
     t2.predicted() = tv2;
     t2.predictedCovariance() = cov2;
 
@@ -259,7 +258,7 @@ BOOST_AUTO_TEST_CASE(WriteToPodioFrame) {
 
     t2.jacobian() = cov2;
 
-    auto t3 = c.getTrackState(c.addTrackState());
+    auto t3 = c.makeTrackState();
     t3.setReferenceSurface(reg);
 
     t1.component<int32_t, "int_column"_hash>() = -11;

--- a/docs/core/eventdata/tracks.md
+++ b/docs/core/eventdata/tracks.md
@@ -372,7 +372,7 @@ With these dynamic columns registered, it is now possible to set and get values 
 
 ```cpp
 using namespace Acts::HashedStringLiterals;
-auto track = tc.getTrack(tc.addTrack());
+auto track = tc.makeTrack();
 
 // these two are equivalent
 track.component<float, "col_a"_hash>() = 42.42;


### PR DESCRIPTION
Replaces `getX(addX())` with the helper `makeX()`