### PR TITLE
refactor: Reserve memory in advance and move object instead of copying

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -1190,6 +1190,7 @@ class CombinatorialKalmanFilter {
     }
 
     std::vector<typename TrackContainer::TrackProxy> tracks;
+    tracks.reserve(combKalmanResult.lastMeasurementIndices.size());
 
     for (auto tip : combKalmanResult.lastMeasurementIndices) {
       auto track = trackContainer.makeTrack();
@@ -1209,7 +1210,7 @@ class CombinatorialKalmanFilter {
 
       calculateTrackQuantities(track);
 
-      tracks.push_back(track);
+      tracks.push_back(std::move(track));
     }
 
     return tracks;


### PR DESCRIPTION
as the title says. 

Most likely the second is not an issue since it's just a proxy ... but still it does not hurt