### PR TITLE
perf: Remove covariance from material states and holes in CKF

### DIFF
--- a/Core/include/Acts/EventData/TrackProxy.hpp
+++ b/Core/include/Acts/EventData/TrackProxy.hpp
@@ -730,7 +730,7 @@ class TrackProxy {
       prev = ts.previous();
       ts.template component<IndexType>(hashString("next")) = prev;
       ts.previous() = next;
-      if (invertJacobians) {
+      if (invertJacobians && ts.hasJacobian()) {
         if (next != kInvalid) {
           BoundMatrix curJacobian = ts.jacobian();
           ts.jacobian() = nextJacobian.inverse();

--- a/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixSmoother.hpp
@@ -85,6 +85,7 @@ class GainMatrixSmoother {
     // ensure the track state has a smoothed component
     prev_ts.addComponents(TrackStatePropMask::Smoothed);
 
+    // TODO state component could also be shared
     prev_ts.smoothed() = prev_ts.filtered();
     prev_ts.smoothedCovariance() = prev_ts.filteredCovariance();
 
@@ -100,6 +101,11 @@ class GainMatrixSmoother {
     // default-constructed error represents success, i.e. an invalid error code
     std::error_code error;
     trajectory.applyBackwards(prev_ts.previous(), [&, this](auto ts) {
+      // skip over track states without a filtered component
+      if (!ts.hasFiltered()) {
+        return true;  // continue execution
+      }
+
       // should have filtered and predicted, this should also include the
       // covariances.
       assert(ts.hasFiltered());

--- a/Core/src/Propagator/detail/CovarianceEngine.cpp
+++ b/Core/src/Propagator/detail/CovarianceEngine.cpp
@@ -60,6 +60,7 @@ Result<BoundState> detail::boundState(
                                freeToPathDerivatives, boundToFreeJacobian,
                                freeParameters, freeToBoundCorrection);
   }
+  // TODO this looks a bit like a hack and expensive
   if (boundCovariance != BoundSquareMatrix::Zero()) {
     cov = boundCovariance;
   }


### PR DESCRIPTION
I briefly looked at some flamegraphs of the CKF and realized that `boundState` is one of the major contributors to the CPU time. Most of the `boundState` calculation is done for covariance transport. The transport is essential for the KF formalism and correctly treating measurements but I don't think it is necessary to transport the covariance to material states.

As a consequence I also remove the jacobian from the material states which will be compensated by having the accumulated transport jacobian on the next measurement state.

I imagine that this can make a big difference especially at the end of the detector where all the sensitives are processed already.