### PR TITLE
docs: remove old-style file comments

### DIFF
--- a/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/EventGenerator.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2018-03-13
-/// @author Moritz Kiehn <msmk@cern.ch>
-
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/MultiplicityGenerators.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/MultiplicityGenerators.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2018-03-13
-/// @author Moritz Kiehn <msmk@cern.ch>
-
 #pragma once
 
 #include "ActsExamples/Framework/RandomNumbers.hpp"

--- a/Examples/Algorithms/Generators/ActsExamples/Generators/VertexGenerators.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/VertexGenerators.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2018-03-13
-/// @author Moritz Kiehn <msmk@cern.ch>
-
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2018-03-14
-/// @author Moritz Kiehn <msmk@cern.ch>
-
 #pragma once
 
 #include "Acts/Geometry/GeometryIdentifier.hpp"

--- a/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IAlgorithm.hpp
@@ -6,12 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2016-05-11 Initial version
-/// @date 2017-07-27 Simplify interface
-/// @author Andreas Salzburger
-/// @author Moritz Kiehn <msmk@cern.ch>
-
 #pragma once
 
 #include "ActsExamples/Framework/ProcessCode.hpp"

--- a/Examples/Framework/include/ActsExamples/Framework/IWriter.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IWriter.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2017-07-25
-/// @author Moritz Kiehnn <msmk@cern.ch>
-
 #pragma once
 
 #include "ActsExamples/Framework/AlgorithmContext.hpp"

--- a/Examples/Framework/include/ActsExamples/Framework/WriterT.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/WriterT.hpp
@@ -6,10 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @date 2017-08-07
-/// @author Moritz Kiehnn <msmk@cern.ch>
-
 #pragma once
 
 #include "ActsExamples/Framework/DataHandle.hpp"

--- a/Examples/HelloWorld/HelloWorld.cpp
+++ b/Examples/HelloWorld/HelloWorld.cpp
@@ -6,9 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @brief An example tools that shows the sequencer functionality
-
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 

--- a/Examples/Io/Csv/src/CsvOutputData.hpp
+++ b/Examples/Io/Csv/src/CsvOutputData.hpp
@@ -6,9 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @brief Plain structs that each define one row in a TrackML csv file
-
 #pragma once
 
 #include <ActsExamples/EventData/Index.hpp>

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/PredefinedMaterials.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/PredefinedMaterials.hpp
@@ -6,9 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file
-/// @brief Predefined materials for test
-
 #pragma once
 
 #include "Acts/Definitions/Units.hpp"

--- a/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/ConstantBFieldTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file ConstantBField_tests.cpp
-
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/InterpolatedBFieldMapTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file InterpolatedBFieldMap_tests.cpp
-
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/MagneticFieldInterfaceConsistencyTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file MagneticFieldInterfaceConsistencyTests.cpp
-
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/tools/floating_point_comparison.hpp>
 #include <boost/test/unit_test.hpp>

--- a/Tests/UnitTests/Core/MagneticField/SolenoidBFieldTests.cpp
+++ b/Tests/UnitTests/Core/MagneticField/SolenoidBFieldTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file SolenoidBFieldTests.cpp
-
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/Tests/UnitTests/Core/Material/InterpolatedMaterialMapTests.cpp
+++ b/Tests/UnitTests/Core/Material/InterpolatedMaterialMapTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file InterpolatedMaterialdMapTests.cpp
-
 #include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/Tests/UnitTests/Core/Utilities/LoggerTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/LoggerTests.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-/// @file Logger_tests.cpp
-
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Utilities/Logger.hpp"


### PR DESCRIPTION
We do not really do this kind of comments in ACTS. Especially date and author is clear from git.