### PR TITLE
feat: Bind version info to Python

### DIFF
--- a/Examples/Python/src/ModuleEntry.cpp
+++ b/Examples/Python/src/ModuleEntry.cpp
@@ -91,6 +91,17 @@ PYBIND11_MODULE(ActsPythonBindings, m) {
   m.attr("__version__") =
       std::tuple{Acts::VersionMajor, Acts::VersionMinor, Acts::VersionPatch};
 
+  {
+    auto mv = m.def_submodule("version");
+
+    mv.attr("major") = Acts::VersionMajor;
+    mv.attr("minor") = Acts::VersionMinor;
+    mv.attr("patch") = Acts::VersionPatch;
+
+    mv.attr("commit_hash") = Acts::CommitHash;
+    mv.attr("commit_hash_short") = Acts::CommitHashShort;
+  }
+
   addUnits(ctx);
   addFramework(ctx);
   addLogging(ctx);

--- a/Examples/Python/tests/test_base.py
+++ b/Examples/Python/tests/test_base.py
@@ -5,6 +5,16 @@ import acts
 import acts.examples
 
 
+def test_version():
+    assert hasattr(acts, "__version__")
+    assert hasattr(acts, "version")
+    assert hasattr(acts.version, "major")
+    assert hasattr(acts.version, "minor")
+    assert hasattr(acts.version, "patch")
+    assert hasattr(acts.version, "commit_hash")
+    assert hasattr(acts.version, "commit_hash_short")
+
+
 def test_logging():
     for l in ("VERBOSE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"):
         assert hasattr(acts.logging, l)


### PR DESCRIPTION
Binds more version information to Python which can be used to differentiate between acts builds / installs.