### PR TITLE
fix(ci): conventionalcommits.org SSL_ERROR_BAD_CERT_DOMAIN

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ linkcheck_ignore = [
     r"https://pythia.org.*",
     r"https://lcginfo.cern.ch/.*",
     r"https://.*\.?intel.com/.*",
-    r"https://conventionalcommits.org/.*",
+    r"https://www.conventionalcommits.org/.*",
 ]
 
 # -- Options for HTML output --------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ linkcheck_ignore = [
     r"https://pythia.org.*",
     r"https://lcginfo.cern.ch/.*",
     r"https://.*\.?intel.com/.*",
-    r"https://conventionalcommits.org/.*"
+    r"https://conventionalcommits.org/.*",
 ]
 
 # -- Options for HTML output --------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,7 @@ linkcheck_ignore = [
     r"https://pythia.org.*",
     r"https://lcginfo.cern.ch/.*",
     r"https://.*\.?intel.com/.*",
+    r"https://conventionalcommits.org/.*"
 ]
 
 # -- Options for HTML output --------------------------------------------------

--- a/docs/contribution/release.md
+++ b/docs/contribution/release.md
@@ -1,6 +1,6 @@
 # How to make a release
 
-We use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
+We use conventional commits for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
 
 The next version number for a release is automatically determined from the PRs (commits) that have been merged since the last release, following semantic versioning. On top of that, release notes are automatically generated from the PR titles, using the prefixes as groups.
 

--- a/docs/contribution/release.md
+++ b/docs/contribution/release.md
@@ -1,6 +1,6 @@
 # How to make a release
 
-We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
+We use conventional commits (https://www.conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
 
 The next version number for a release is automatically determined from the PRs (commits) that have been merged since the last release, following semantic versioning. On top of that, release notes are automatically generated from the PR titles, using the prefixes as groups.
 

--- a/docs/contribution/release.md
+++ b/docs/contribution/release.md
@@ -1,6 +1,6 @@
 # How to make a release
 
-We use conventional commits for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
+We use [conventional commits](https://conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
 
 The next version number for a release is automatically determined from the PRs (commits) that have been merged since the last release, following semantic versioning. On top of that, release notes are automatically generated from the PR titles, using the prefixes as groups.
 

--- a/docs/contribution/release.md
+++ b/docs/contribution/release.md
@@ -1,6 +1,6 @@
 # How to make a release
 
-We use [conventional commits](https://conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
+We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) for all of our PRs. We use the common prefixes: `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.
 
 The next version number for a release is automatically determined from the PRs (commits) that have been merged since the last release, following semantic versioning. On top of that, release notes are automatically generated from the PR titles, using the prefixes as groups.
 


### PR DESCRIPTION
This stops us from merging, because the docs-build fails. We can revert this, when their certificate works again.