### PR TITLE
fix: add schema_version to podio edm.yml

### DIFF
--- a/Plugins/Podio/edm.yml
+++ b/Plugins/Podio/edm.yml
@@ -1,4 +1,5 @@
 ---
+schema_version: 1
 options:
   getSyntax: True
   exposePODMembers: False


### PR DESCRIPTION
Since https://github.com/AIDASoft/podio/pull/556/ the mandatory schema_version does not just generate a warning anymore, but fails with an error. This will prevent CMake from configuring correctly with newer podio versions, in particular version 1 coming up.

This PR adds a schema_version of 1 to edm.yml.