### PR TITLE
refactor!: Seed filter container policy

### DIFF
--- a/Core/include/Acts/Seeding/ContainerPolicy.hpp
+++ b/Core/include/Acts/Seeding/ContainerPolicy.hpp
@@ -11,8 +11,6 @@
 #include <iterator>
 #include <vector>
 
-#include <stdlib.h>
-
 template <typename T>
 class ContainerPolicy {
  public:

--- a/Core/include/Acts/Seeding/ContainerPolicy.hpp
+++ b/Core/include/Acts/Seeding/ContainerPolicy.hpp
@@ -1,0 +1,45 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <iterator>
+#include <vector>
+
+#include <stdlib.h>
+
+template <typename T>
+class ContainerPolicy {
+ public:
+  virtual void policyInsert(T value) = 0;
+};
+
+template <typename T>
+class GenericBackInserter {
+  ContainerPolicy<T>& policy;
+
+ public:
+  using value_type = T;
+  using iterator_category = std::output_iterator_tag;
+  GenericBackInserter(ContainerPolicy<T>& p) : policy(p) {}
+
+  GenericBackInserter& operator=(const T& value) {
+    policy.policyInsert(value);
+    return *this;
+  }
+};
+
+template <typename T>
+class VectorPolicy : public ContainerPolicy<T> {
+  std::vector<T>& container;
+
+ public:
+  VectorPolicy(std::vector<T>& vec) : container(vec) {}
+
+  void policyInsert(T value) override { container.push_back(value); }
+};

--- a/Core/include/Acts/Seeding/SeedFilter.hpp
+++ b/Core/include/Acts/Seeding/SeedFilter.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/EventData/SpacePointData.hpp"
 #include "Acts/Seeding/CandidatesForMiddleSp.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 #include "Acts/Seeding/IExperimentCuts.hpp"
 #include "Acts/Seeding/InternalSeed.hpp"
 #include "Acts/Seeding/Seed.hpp"
@@ -84,8 +85,7 @@ class SeedFilter {
       CandidatesForMiddleSp<const InternalSpacePoint<external_spacepoint_t>>&
           candidates_collector,
       const std::size_t numQualitySeeds,
-      std::back_insert_iterator<std::vector<Seed<external_spacepoint_t>>> outIt)
-      const;
+      GenericBackInserter<Seed<external_spacepoint_t>> outIt) const;
 
   /// Filter seeds once all seeds for one middle space point have been created
   /// @param spacePointData Auxiliary variables used by the seeding
@@ -99,8 +99,7 @@ class SeedFilter {
           const InternalSpacePoint<external_spacepoint_t>>::value_type>&
           candidates,
       const std::size_t numQualitySeeds,
-      std::back_insert_iterator<std::vector<Seed<external_spacepoint_t>>> outIt)
-      const;
+      GenericBackInserter<Seed<external_spacepoint_t>> outIt) const;
 
   const SeedFilterConfig getSeedFilterConfig() const { return m_cfg; }
   const IExperimentCuts<external_spacepoint_t>* getExperimentCuts() const {

--- a/Core/include/Acts/Seeding/SeedFilter.ipp
+++ b/Core/include/Acts/Seeding/SeedFilter.ipp
@@ -250,8 +250,7 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_1SpFixed(
     CandidatesForMiddleSp<const InternalSpacePoint<external_spacepoint_t>>&
         candidates_collector,
     const std::size_t numQualitySeeds,
-    std::back_insert_iterator<std::vector<Seed<external_spacepoint_t>>> outIt)
-    const {
+    GenericBackInserter<Seed<external_spacepoint_t>> outIt) const {
   // retrieve all candidates
   // this collection is already sorted
   // higher weights first
@@ -267,8 +266,7 @@ void SeedFilter<external_spacepoint_t>::filterSeeds_1SpFixed(
         const InternalSpacePoint<external_spacepoint_t>>::value_type>&
         candidates,
     const std::size_t numQualitySeeds,
-    std::back_insert_iterator<std::vector<Seed<external_spacepoint_t>>> outIt)
-    const {
+    GenericBackInserter<Seed<external_spacepoint_t>> outIt) const {
   if (m_experimentCuts != nullptr) {
     candidates = m_experimentCuts->cutPerMiddleSP(std::move(candidates));
   }

--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -99,11 +99,11 @@ class SeedFinder {
   /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain z bin.
   /// @note Ranges must return pointers.
   /// @note Ranges must be separate objects for each parallel call.
-  template <template <typename...> typename container_t, typename sp_range_t>
+  template <typename sp_range_t>
   void createSeedsForGroup(
       const Acts::SeedFinderOptions& options, SeedingState& state,
       const grid_t& grid,
-      std::back_insert_iterator<container_t<Seed<external_spacepoint_t>>> outIt,
+      GenericBackInserter<Seed<external_spacepoint_t>> outIt,
       const sp_range_t& bottomSPs, const std::size_t middleSPs,
       const sp_range_t& topSPs,
       const Acts::Range1D<float>& rMiddleSPRange) const;

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -36,11 +36,10 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::SeedFinder(
 }
 
 template <typename external_spacepoint_t, typename grid_t, typename platform_t>
-template <template <typename...> typename container_t, typename sp_range_t>
+template <typename sp_range_t>
 void SeedFinder<external_spacepoint_t, grid_t, platform_t>::createSeedsForGroup(
     const Acts::SeedFinderOptions& options, SeedingState& state,
-    const grid_t& grid,
-    std::back_insert_iterator<container_t<Seed<external_spacepoint_t>>> outIt,
+    const grid_t& grid, GenericBackInserter<Seed<external_spacepoint_t>> outIt,
     const sp_range_t& bottomSPsIdx, const std::size_t middleSPsIdx,
     const sp_range_t& topSPsIdx,
     const Acts::Range1D<float>& rMiddleSPRange) const {
@@ -837,8 +836,11 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::createSeedsForGroup(
   const Acts::Range1D<float> rMiddleSPRange;
   std::vector<Seed<external_spacepoint_t>> ret;
 
-  createSeedsForGroup(options, state, grid, std::back_inserter(ret), bottomSPs,
-                      middleSPs, topSPs, rMiddleSPRange);
+  VectorPolicy outPolicyContainer(ret);
+  GenericBackInserter backInserter(outPolicyContainer);
+
+  createSeedsForGroup(options, state, grid, backInserter, bottomSPs, middleSPs,
+                      topSPs, rMiddleSPRange);
 
   return ret;
 }

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -676,9 +676,11 @@ void SeedFinderOrthogonal<external_spacepoint_t>::processFromMiddleSP(
    */
   if ((!bottom_lh_v.empty() && !top_lh_v.empty()) ||
       (!bottom_hl_v.empty() && !top_hl_v.empty())) {
+    VectorPolicy outPolicyContainer(out_cont);
+    GenericBackInserter backInserter(outPolicyContainer);
     m_config.seedFilter->filterSeeds_1SpFixed(
         spacePointData, candidates_collector, seedFilterState.numQualitySeeds,
-        std::back_inserter(out_cont));
+        backInserter);
   }
 }
 

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -312,9 +312,11 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
   }
 
   for (const auto [bottom, middle, top] : spacePointsGrouping) {
-    m_seedFinder.createSeedsForGroup(
-        m_cfg.seedFinderOptions, state, spacePointsGrouping.grid(),
-        std::back_inserter(seeds), bottom, middle, top, rMiddleSPRange);
+    VectorPolicy outPolicyContainer(seeds);
+    GenericBackInserter backInserter(outPolicyContainer);
+    m_seedFinder.createSeedsForGroup(m_cfg.seedFinderOptions, state,
+                                     spacePointsGrouping.grid(), backInserter,
+                                     bottom, middle, top, rMiddleSPRange);
   }
 
   ACTS_DEBUG("Created " << seeds.size() << " track seeds from "

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding/SeedFinder.ipp
@@ -7,6 +7,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include "Acts/Seeding/CandidatesForMiddleSp.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -310,9 +311,10 @@ SeedFinder<external_spacepoint_t, Acts::Cuda>::createSeedsForGroup(
                 CandidatesForMiddleSp<const InternalSpacePoint<
                     external_spacepoint_t>>::descendingByQuality);
       std::size_t numQualitySeeds = 0;  // not used but needs to be fixed
+      VectorPolicy seedPolicyContainer(outputVec);
+      GenericBackInserter backInserter(seedPolicyContainer);
       m_config.seedFilter->filterSeeds_1SpFixed(spacePointData, candidates,
-                                                numQualitySeeds,
-                                                std::back_inserter(outputVec));
+                                                numQualitySeeds, backInserter);
     }
   }
   ACTS_CUDA_ERROR_CHECK(cudaStreamDestroy(cuStream));

--- a/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
+++ b/Plugins/Cuda/include/Acts/Plugins/Cuda/Seeding2/SeedFinder.ipp
@@ -19,6 +19,7 @@
 
 // Acts include(s).
 #include "Acts/Seeding/CandidatesForMiddleSp.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 #include "Acts/Seeding/InternalSeed.hpp"
 #include "Acts/Seeding/InternalSpacePoint.hpp"
 
@@ -231,9 +232,10 @@ SeedFinder<external_spacepoint_t>::createSeedsForGroup(
         CandidatesForMiddleSp<const InternalSpacePoint<external_spacepoint_t>>::
             descendingByQuality);
     std::size_t numQualitySeeds = 0;  // not used but needs to be fixed
+    VectorPolicy seedPolicyContainer(outputVec);
+    GenericBackInserter backInserter(seedPolicyContainer);
     m_commonConfig.seedFilter->filterSeeds_1SpFixed(
-        spacePointData, candidates, numQualitySeeds,
-        std::back_inserter(outputVec));
+        spacePointData, candidates, numQualitySeeds, backInserter);
   }
 
   // Free up all allocated device memory.

--- a/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
@@ -10,6 +10,7 @@
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Geometry/Extent.hpp"
 #include "Acts/Seeding/BinnedGroup.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 #include "Acts/Seeding/Seed.hpp"
 #include "Acts/Seeding/SeedFilter.hpp"
 #include "Acts/Seeding/SeedFilterConfig.hpp"
@@ -211,8 +212,10 @@ int main(int argc, char** argv) {
   auto start = std::chrono::system_clock::now();
   for (auto [bottom, middle, top] : spGroup) {
     auto& v = seedVector.emplace_back();
-    a.createSeedsForGroup(options, state, spGroup.grid(), std::back_inserter(v),
-                          bottom, middle, top, rMiddleSPRange);
+    VectorPolicy seedPolicyContainer(v);
+    GenericBackInserter backInserter(seedPolicyContainer);
+    a.createSeedsForGroup(options, state, spGroup.grid(), backInserter, bottom,
+                          middle, top, rMiddleSPRange);
   }
   auto end = std::chrono::system_clock::now();
   std::chrono::duration<double> elapsed_seconds = end - start;

--- a/Tests/UnitTests/Plugins/Cuda/Seeding/SeedFinderCudaTest.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding/SeedFinderCudaTest.cpp
@@ -8,6 +8,7 @@
 
 #include "Acts/Plugins/Cuda/Seeding/SeedFinder.hpp"
 #include "Acts/Seeding/BinnedGroup.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 #include "Acts/Seeding/InternalSeed.hpp"
 #include "Acts/Seeding/InternalSpacePoint.hpp"
 #include "Acts/Seeding/Seed.hpp"
@@ -288,10 +289,11 @@ int main(int argc, char** argv) {
     state.spacePointData.resize(spVec.size());
     for (; groupIt != spGroup.end(); ++groupIt) {
       const auto [bottom, middle, top] = *groupIt;
-      seedFinder_cpu.createSeedsForGroup(
-          options, state, spGroup.grid(),
-          std::back_inserter(seedVector_cpu.emplace_back()), bottom, middle,
-          top, rMiddleSPRange);
+      VectorPolicy seedPolicyContainer(seedVector_cpu.emplace_back());
+      GenericBackInserter backInserter(seedPolicyContainer);
+      seedFinder_cpu.createSeedsForGroup(options, state, spGroup.grid(),
+                                         backInserter, bottom, middle, top,
+                                         rMiddleSPRange);
       group_count++;
       if (allgroup == false) {
         if (group_count >= nGroupToIterate)

--- a/Tests/UnitTests/Plugins/Cuda/Seeding2/main.cpp
+++ b/Tests/UnitTests/Plugins/Cuda/Seeding2/main.cpp
@@ -21,6 +21,7 @@
 // Acts include(s).
 #include "Acts/EventData/SpacePointData.hpp"
 #include "Acts/Seeding/BinnedGroup.hpp"
+#include "Acts/Seeding/ContainerPolicy.hpp"
 #include "Acts/Seeding/SeedFilterConfig.hpp"
 #include "Acts/Seeding/SeedFinder.hpp"
 #include "Acts/Seeding/SeedFinderConfig.hpp"
@@ -200,9 +201,11 @@ int main(int argc, char* argv[]) {
       auto& group = seeds_host.emplace_back();
       auto [bottom, middle, top] = *spGroup_itr;
 
+      VectorPolicy seedPolicyContainer(group);
+      GenericBackInserter backInserter(seedPolicyContainer);
       seedFinder_host.createSeedsForGroup(sfOptions, state, spGroup.grid(),
-                                          std::back_inserter(group), bottom,
-                                          middle, top, rMiddleSPRange);
+                                          backInserter, bottom, middle, top,
+                                          rMiddleSPRange);
     }
   }
 

--- a/docs/core/reconstruction/pattern_recognition/seeding.md
+++ b/docs/core/reconstruction/pattern_recognition/seeding.md
@@ -68,7 +68,7 @@ compatibility by applying a set of configurable cuts that can be tested with
 two SP only (pseudorapidity, origin along $z$-axis, distance in $r$ between SP,
 compatibility with interaction point).
 
-:::{doxygenfunction} Acts::SeedFinder::createSeedsForGroup(const Acts::SeedFinderOptions &options, SeedingState &state, const grid_t &grid, std::back_insert_iterator<container_t<Seed<external_spacepoint_t>>> outIt, const sp_range_t &bottomSPs, const std::size_t middleSPs, const sp_range_t &topSPs, const Acts::Range1D<float> &rMiddleSPRange) const
+:::{doxygenfunction} Acts::SeedFinder::createSeedsForGroup(const Acts::SeedFinderOptions &options, SeedingState &state, const grid_t &grid, GenericBackInserter<Seed<external_spacepoint_t>> outIt, const sp_range_t &bottomSPs, const std::size_t middleSPs, const sp_range_t &topSPs, const Acts::Range1D<float> &rMiddleSPRange) const
 :::
 
 
@@ -228,7 +228,7 @@ The seed confirmation also sets a limit on the number of seeds produced for each
 which retains only the higher quality seeds. If this limit is exceeded, the algorithm
 checks if there is any low-quality seed in the seed container of this middle SP that can be removed.
 
-:::{doxygenfunction} Acts::SeedFilter::filterSeeds_1SpFixed (Acts::SpacePointData &spacePointData, CandidatesForMiddleSp<const InternalSpacePoint<external_spacepoint_t>>&,const std::size_t,std::back_insert_iterator<std::vector<Seed<external_spacepoint_t>>>) const
+:::{doxygenfunction} Acts::SeedFilter::filterSeeds_1SpFixed (Acts::SpacePointData &spacePointData, CandidatesForMiddleSp<const InternalSpacePoint<external_spacepoint_t>>&,const std::size_t,GenericBackInserter<Seed<external_spacepoint_t>>) const
 :outline:
 :::
 


### PR DESCRIPTION
Refactor the seed filter to allow other container types than std::vector.
Using a container policy allows to keep the functions virtual.