### PR TITLE
fix(ci): exclude unreachable cds.cern.ch from docs check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ linkcheck_ignore = [
     r"https://lcginfo.cern.ch/.*",
     r"https://.*\.?intel.com/.*",
     r"https://www.conventionalcommits.org/.*",
+    r"https://cds.cern.ch/record/.*",
 ]
 
 # -- Options for HTML output --------------------------------------------------


### PR DESCRIPTION
[CERN Document Server](https://cds.cern.ch/) is currently only reachable from within CERN:

> We're currently experiencing a surge in traffic to our systems. As a mitigation, the CDS website is temporarly available only from inside the CERN network. More information [here](https://cern.service-now.com/service-portal?id=outage&n=OTG0149709).