### PR TITLE
fix: MaterialInteractionAssignment empty intersections safety check

### DIFF
--- a/Core/src/Material/MaterialInteractionAssignment.cpp
+++ b/Core/src/Material/MaterialInteractionAssignment.cpp
@@ -21,6 +21,11 @@ Acts::MaterialInteractionAssignment::assign(
   // Return container: The unassigned materials
   std::vector<MaterialInteraction> unassignedMaterialInteractions;
 
+  if (intersectedSurfaces.empty()) {
+    unassignedMaterialInteractions = materialInteractions;
+    return {assignedMaterialInteractions, unassignedMaterialInteractions, {}};
+  }
+
   /// Simple matching of material interactions to surfaces - no pre/post
   /// matching
   // -----------------------------------------------------------------------------
@@ -40,8 +45,6 @@ Acts::MaterialInteractionAssignment::assign(
     if (veto) {
       continue;
     }
-
-    // Walk along the sorted intersections
     auto [cSurface, cPosition, cDirection] = intersectedSurfaces[is];
     ActsScalar cDistance = (cPosition - materialInteraction.position).norm();
 


### PR DESCRIPTION
Adding a small fix that checks for no intersections condition during the material interaction assignment. Previously the code could've segfaulted when accessing `intersectedSurfaces` in the `materialInteractions` loop. 

 