### PR TITLE
fix: Fix my local build after #3139

### DIFF
--- a/Examples/Algorithms/AmbiguityResolution/src/ScoreBasedAmbiguityResolutionAlgorithm.cpp
+++ b/Examples/Algorithms/AmbiguityResolution/src/ScoreBasedAmbiguityResolutionAlgorithm.cpp
@@ -36,7 +36,7 @@ Acts::ScoreBasedAmbiguityResolution::Config transformConfig(
   file >> json_file;
   file.close();
 
-  from_json(json_file, configPair);
+  Acts::from_json(json_file, configPair);
 
   result.volumeMap = configPair.first;
   result.detectorConfigs = configPair.second;
@@ -90,6 +90,7 @@ bool doubleHolesFilter(const Acts::TrackProxy<Acts::ConstVectorTrackContainer,
     return false;
   }
 }
+
 }  // namespace
 
 ActsExamples::ScoreBasedAmbiguityResolutionAlgorithm::

--- a/Plugins/Json/include/Acts/Plugins/Json/AmbiguityConfigJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/AmbiguityConfigJsonConverter.hpp
@@ -9,7 +9,12 @@
 #pragma once
 
 #include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
-#include "Acts/Plugins/Json/ActsJson.hpp"
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
 
 namespace Acts {
 


### PR DESCRIPTION
My local builds fails after https://github.com/acts-project/acts/pull/3139 which I think is caused by a more recent json version that includes `std::pair` `from_json` implementations which clash with win the overload resolution.