### PR TITLE
refactor!: Use `std::string_view` for `addColumn` in track EDM

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -31,6 +31,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
@@ -383,11 +384,12 @@ class MultiTrajectory {
 
   /// Add a column to the @c MultiTrajectory
   /// @tparam T Type of the column values to add
+  /// @param key the name of the column to be added
   /// @note This takes a string argument rather than a hashed string to maintain
   ///       compatibility with backends.
   /// @note Only available if the MultiTrajectory is not read-only
   template <typename T, bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
-  void addColumn(const std::string& key) {
+  void addColumn(std::string_view key) {
     self().template addColumn_impl<T>(key);
   }
 

--- a/Core/include/Acts/EventData/TrackContainer.hpp
+++ b/Core/include/Acts/EventData/TrackContainer.hpp
@@ -220,7 +220,7 @@ class TrackContainer {
   /// @note Only available if the track container is not read-only
   /// @param key the name of the column to be added
   template <typename T, bool RO = ReadOnly, typename = std::enable_if_t<!RO>>
-  constexpr void addColumn(const std::string& key) {
+  constexpr void addColumn(std::string_view key) {
     m_container->template addColumn_impl<T>(key);
   }
 

--- a/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
@@ -455,7 +455,7 @@ class VectorMultiTrajectory final
   }
 
   template <typename T>
-  void addColumn_impl(const std::string& key) {
+  void addColumn_impl(std::string_view key) {
     Acts::HashedString hashedKey = hashString(key);
     m_dynamic.insert({hashedKey, std::make_unique<detail::DynamicColumn<T>>()});
   }

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -224,7 +224,7 @@ class VectorTrackContainer final : public detail_vtc::VectorTrackContainerBase {
   void removeTrack_impl(IndexType itrack);
 
   template <typename T>
-  constexpr void addColumn_impl(const std::string& key) {
+  constexpr void addColumn_impl(std::string_view key) {
     Acts::HashedString hashedKey = hashString(key);
     m_dynamic.insert({hashedKey, std::make_unique<detail::DynamicColumn<T>>()});
   }

--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioDynamicColumns.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioDynamicColumns.hpp
@@ -10,6 +10,7 @@
 
 #include <any>
 #include <string>
+#include <string_view>
 
 #include <podio/Frame.h>
 #include <podio/UserDataCollection.h>
@@ -17,7 +18,7 @@
 namespace Acts::podio_detail {
 
 struct ConstDynamicColumnBase {
-  ConstDynamicColumnBase(const std::string& name) : m_name{name} {}
+  ConstDynamicColumnBase(std::string_view name) : m_name{name} {}
 
   virtual ~ConstDynamicColumnBase() = default;
 
@@ -31,7 +32,7 @@ struct ConstDynamicColumnBase {
 
 template <typename T>
 struct ConstDynamicColumn : public ConstDynamicColumnBase {
-  ConstDynamicColumn(const std::string& name,
+  ConstDynamicColumn(std::string_view name,
                      const podio::UserDataCollection<T>& collection)
       : ConstDynamicColumnBase(name), m_collection{collection} {}
 
@@ -44,7 +45,7 @@ struct ConstDynamicColumn : public ConstDynamicColumnBase {
 };
 
 struct DynamicColumnBase : public ConstDynamicColumnBase {
-  DynamicColumnBase(const std::string& name) : ConstDynamicColumnBase{name} {}
+  DynamicColumnBase(std::string_view name) : ConstDynamicColumnBase{name} {}
 
   virtual std::any get(std::size_t i) = 0;
   std::any get(std::size_t i) const override = 0;
@@ -66,7 +67,7 @@ struct DynamicColumnBase : public ConstDynamicColumnBase {
 
 template <typename T>
 struct DynamicColumn : public DynamicColumnBase {
-  DynamicColumn(const std::string& name,
+  DynamicColumn(std::string_view name,
                 podio::UserDataCollection<T> collection = {})
       : DynamicColumnBase(name), m_collection{std::move(collection)} {}
 

--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackContainer.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackContainer.hpp
@@ -223,7 +223,7 @@ class MutablePodioTrackContainer : public PodioTrackContainerBase {
   void removeTrack_impl(IndexType itrack);
 
   template <typename T>
-  constexpr void addColumn_impl(const std::string& key) {
+  constexpr void addColumn_impl(std::string_view key) {
     Acts::HashedString hashedKey = hashString(key);
     m_dynamic.insert(
         {hashedKey, std::make_unique<podio_detail::DynamicColumn<T>>(key)});

--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
@@ -603,7 +603,7 @@ class MutablePodioTrackStateContainer final
   }
 
   template <typename T>
-  constexpr void addColumn_impl(const std::string& key) {
+  constexpr void addColumn_impl(std::string_view key) {
     HashedString hashedKey = hashString(key);
     m_dynamic.insert(
         {hashedKey, std::make_unique<podio_detail::DynamicColumn<T>>(key)});


### PR DESCRIPTION
This makes it easier for compile time known dynamic columns to add. Pulled out of https://github.com/acts-project/acts/pull/3161