### PR TITLE
refactor: Simplify layer handling in `Navigator`

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -838,7 +838,7 @@ class Navigator {
       NavigationOptions<Surface> navOpts;
       // Exclude the current surface in case it's a boundary
       navOpts.startObject = state.navigation.currentSurface;
-      navOpts.nearLimit = stepper.overstepLimit(state.stepping);
+      navOpts.nearLimit = state.options.surfaceTolerance;
       navOpts.farLimit =
           stepper.getStepSize(state.stepping, ConstrainedStep::aborter);
       navOpts.forceIntersectBoundaries =
@@ -1044,11 +1044,7 @@ class Navigator {
         navOpts.externalSurfaces.push_back(itSurface->second);
       }
     }
-    // No overstepping on start layer, otherwise ask the stepper
-    navOpts.nearLimit = (currentLayer == state.navigation.startLayer)
-                            ? state.options.surfaceTolerance
-                            : stepper.overstepLimit(state.stepping);
-    // Check the limit
+    navOpts.nearLimit = state.options.surfaceTolerance;
     navOpts.farLimit =
         stepper.getStepSize(state.stepping, ConstrainedStep::aborter);
 
@@ -1113,7 +1109,7 @@ class Navigator {
     navOpts.resolveMaterial = m_cfg.resolveMaterial;
     navOpts.resolvePassive = m_cfg.resolvePassive;
     navOpts.startObject = startLayer;
-    navOpts.nearLimit = stepper.overstepLimit(state.stepping);
+    navOpts.nearLimit = state.options.surfaceTolerance;
     navOpts.farLimit =
         stepper.getStepSize(state.stepping, ConstrainedStep::aborter);
     // Request the compatible layers

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -191,6 +191,8 @@ class Navigator {
 
   State makeState(const Surface* startSurface,
                   const Surface* targetSurface) const {
+    assert(startSurface != nullptr && "Start surface must be set");
+
     State result;
     result.startSurface = startSurface;
     result.targetSurface = targetSurface;
@@ -1016,12 +1018,14 @@ class Navigator {
   bool resolveSurfaces(propagator_state_t& state, const stepper_t& stepper,
                        const Layer* cLayer = nullptr) const {
     // get the layer and layer surface
-    auto layerSurface = cLayer ? state.navigation.startSurface
-                               : state.navigation.navLayer().first.object();
-    auto navLayer = cLayer ? cLayer : state.navigation.navLayer().second;
+    const Layer* navLayer =
+        cLayer ? cLayer : state.navigation.navLayer().second;
+    assert(navLayer != nullptr && "Current layer is not set.");
+    const Surface* layerSurface = &navLayer->surfaceRepresentation();
     // are we on the start layer
-    bool onStart = (navLayer == state.navigation.startLayer);
-    auto startSurface = onStart ? state.navigation.startSurface : layerSurface;
+    const Surface* startSurface = (navLayer == state.navigation.startLayer)
+                                      ? state.navigation.startSurface
+                                      : layerSurface;
     // Use navigation parameters and NavigationOptions
     NavigationOptions<Surface> navOpts;
     navOpts.resolveSensitive = m_cfg.resolveSensitive;

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -1011,7 +1011,6 @@ class Navigator {
   ///
   /// @param [in,out] state is the propagation state object
   /// @param [in] stepper Stepper in use
-  /// @param [in] cLayer is the already assigned current layer, e.g. start layer
   ///
   /// boolean return triggers exit to stepper
   template <typename propagator_state_t, typename stepper_t>


### PR DESCRIPTION
The `startSurface` should never be null which is checked and protected against now