### PR TITLE
feat: type safe navigation delegates

### DIFF
--- a/Core/include/Acts/Navigation/DetectorVolumeFinders.hpp
+++ b/Core/include/Acts/Navigation/DetectorVolumeFinders.hpp
@@ -22,12 +22,12 @@
 
 namespace Acts::Experimental {
 
-struct NoopFinder : public INavigationDelegate {
+struct NoopFinder : public IExternalNavigationDelegate {
   inline void update(const GeometryContext& /*gctx*/,
                      NavigationState& /*nState*/) const {}
 };
 
-struct RootVolumeFinder : public INavigationDelegate {
+struct RootVolumeFinder : public IExternalNavigationDelegate {
   inline void update(const GeometryContext& gctx,
                      NavigationState& nState) const {
     if (nState.currentDetector == nullptr) {
@@ -47,7 +47,7 @@ struct RootVolumeFinder : public INavigationDelegate {
   }
 };
 
-struct TrialAndErrorVolumeFinder : public INavigationDelegate {
+struct TrialAndErrorVolumeFinder : public IExternalNavigationDelegate {
   inline void update(const GeometryContext& gctx,
                      NavigationState& nState) const {
     if (nState.currentVolume == nullptr) {
@@ -116,7 +116,7 @@ struct IndexedDetectorVolumeExtractor {
 /// @tparam grid_type is the grid type used for this
 template <typename grid_type>
 using IndexedDetectorVolumesImpl =
-    IndexedUpdaterImpl<grid_type, IndexedDetectorVolumeExtractor,
-                       DetectorVolumeFiller>;
+    IndexedUpdaterImpl<IExternalNavigationDelegate, grid_type,
+                       IndexedDetectorVolumeExtractor, DetectorVolumeFiller>;
 
 }  // namespace Acts::Experimental

--- a/Core/include/Acts/Navigation/DetectorVolumeUpdaters.hpp
+++ b/Core/include/Acts/Navigation/DetectorVolumeUpdaters.hpp
@@ -25,7 +25,7 @@ class DetectorVolume;
 /// @brief  The end of world sets the volume pointer of the
 /// navigation state to nullptr, usually indicates the end of
 /// the known world, hence the name
-struct EndOfWorldImpl : public INavigationDelegate {
+struct EndOfWorldImpl : public IExternalNavigationDelegate {
   /// @brief a null volume link - explicitly
   ///
   /// @note the method parameters are ignored
@@ -38,7 +38,7 @@ struct EndOfWorldImpl : public INavigationDelegate {
 /// @brief Single volume updator, it sets the current navigation
 /// volume to the volume in question
 ///
-struct SingleDetectorVolumeImpl : public INavigationDelegate {
+struct SingleDetectorVolumeImpl : public IExternalNavigationDelegate {
   const DetectorVolume* dVolume = nullptr;
 
   /// @brief Allowed constructor
@@ -96,10 +96,10 @@ struct DetectorVolumesCollection {
 /// 1-dimensional grid, e.g. a z-spaced array, or an r-spaced array
 /// of volumes.
 ///
-struct BoundVolumesGrid1Impl : public INavigationDelegate {
+struct BoundVolumesGrid1Impl : public IExternalNavigationDelegate {
   using IndexedUpdater =
-      IndexedUpdaterImpl<VariableBoundIndexGrid1, DetectorVolumesCollection,
-                         DetectorVolumeFiller>;
+      IndexedUpdaterImpl<IExternalNavigationDelegate, VariableBoundIndexGrid1,
+                         DetectorVolumesCollection, DetectorVolumeFiller>;
   // The indexed updator
   IndexedUpdater indexedUpdater;
 

--- a/Core/include/Acts/Navigation/MultiLayerSurfacesUpdater.hpp
+++ b/Core/include/Acts/Navigation/MultiLayerSurfacesUpdater.hpp
@@ -20,7 +20,7 @@
 namespace Acts::Experimental {
 
 template <typename grid_t, typename path_generator>
-class MultiLayerSurfacesUpdaterImpl : public INavigationDelegate {
+class MultiLayerSurfacesUpdaterImpl : public IInternalNavigationDelegate {
  public:
   /// Broadcast the grid type
   using grid_type = grid_t;

--- a/Core/include/Acts/Navigation/NavigationDelegates.hpp
+++ b/Core/include/Acts/Navigation/NavigationDelegates.hpp
@@ -18,13 +18,11 @@ class Surface;
 
 namespace Experimental {
 
-/// Base class for navigation delegates
-/// This allows to define a common Owning delegate
-/// schema, which in turn allows for accessing the holder
-/// of the delegate implementation for e.g. I/O or display
-class INavigationDelegate {
+/// Base class for navigation delegates that handle internal
+/// volume navigation updates
+class IInternalNavigationDelegate {
  public:
-  virtual ~INavigationDelegate() = default;
+  virtual ~IInternalNavigationDelegate() = default;
 };
 
 /// Declare an updator for the local navigation, i.e. the
@@ -43,7 +41,14 @@ class INavigationDelegate {
 /// Memory  managed navigation state updator
 using SurfaceCandidatesUpdater =
     OwningDelegate<void(const GeometryContext& gctx, NavigationState& nState),
-                   INavigationDelegate>;
+                   IInternalNavigationDelegate>;
+
+/// Base class for external navigation delegates that handle external
+/// volume navigation updates
+class IExternalNavigationDelegate {
+ public:
+  virtual ~IExternalNavigationDelegate() = default;
+};
 
 /// Declare a Detctor Volume finding or switching delegate
 ///
@@ -53,7 +58,7 @@ using SurfaceCandidatesUpdater =
 /// @return the new DetectorVolume into which one changes at this switch
 using DetectorVolumeUpdater =
     OwningDelegate<void(const GeometryContext& gctx, NavigationState& nState),
-                   INavigationDelegate>;
+                   IExternalNavigationDelegate>;
 
 }  // namespace Experimental
 }  // namespace Acts

--- a/Core/include/Acts/Navigation/NavigationStateUpdaters.hpp
+++ b/Core/include/Acts/Navigation/NavigationStateUpdaters.hpp
@@ -66,7 +66,7 @@ inline void updateCandidates(const GeometryContext& gctx,
 /// @tparam object_type the type of the object to be filled
 /// @tparam filler_type is the helper to fill the object into nState
 template <typename object_type, typename filler_type>
-class SingleObjectImpl : public INavigationDelegate {
+class SingleObjectImpl : public IInternalNavigationDelegate {
  public:
   /// Convenience constructor
   /// @param so the single object
@@ -94,7 +94,7 @@ class SingleObjectImpl : public INavigationDelegate {
 /// @tparam extractor_type the helper to extract the objects from
 /// @tparam filler_type is the helper to fill the object into nState
 template <typename extractor_type, typename filler_type>
-class StaticUpdaterImpl : public INavigationDelegate {
+class StaticUpdaterImpl : public IInternalNavigationDelegate {
  public:
   /// @brief updates the navigation state with a single object that is filled in
   ///
@@ -120,8 +120,9 @@ class StaticUpdaterImpl : public INavigationDelegate {
 /// @tparam grid_t is the type of the grid
 /// @tparam extractor_type is the helper to extract the object
 /// @tparam filler_type is the helper to fill the object into the nState
-template <typename grid_t, typename extractor_type, typename filler_type>
-class IndexedUpdaterImpl : public INavigationDelegate {
+template <typename delegate_type, typename grid_t, typename extractor_type,
+          typename filler_type>
+class IndexedUpdaterImpl : public delegate_type {
  public:
   /// Broadcast the grid type
   using grid_type = grid_t;
@@ -173,8 +174,8 @@ class IndexedUpdaterImpl : public INavigationDelegate {
 /// payload extractor, these have to be provided by a tuple
 ///
 /// @tparam updators_t the updators that will be called in sequence
-template <typename... updators_t>
-class ChainedUpdaterImpl : public INavigationDelegate {
+template <typename delegate_type, typename... updators_t>
+class ChainedUpdaterImpl : public delegate_type {
  public:
   /// The stored updators
   std::tuple<updators_t...> updators;

--- a/Core/include/Acts/Navigation/SurfaceCandidatesUpdaters.hpp
+++ b/Core/include/Acts/Navigation/SurfaceCandidatesUpdaters.hpp
@@ -24,7 +24,7 @@
 
 namespace Acts::Experimental {
 
-struct AllPortalsImpl : public INavigationDelegate {
+struct AllPortalsImpl : public IInternalNavigationDelegate {
   /// A ordered portal provider
   ///
   /// @param gctx is the Geometry context of this call
@@ -56,7 +56,7 @@ struct AllPortalsImpl : public INavigationDelegate {
   }
 };
 
-struct AllPortalsAndSurfacesImpl : public INavigationDelegate {
+struct AllPortalsAndSurfacesImpl : public IInternalNavigationDelegate {
   /// An ordered list of portals and surfaces provider
   ///
   /// @param gctx is the Geometry context of this call
@@ -118,7 +118,7 @@ inline static SurfaceCandidatesUpdater tryAllPortalsAndSurfaces() {
 /// checking, this could be e.g. support surfaces for layer structures,
 /// e.g.
 ///
-struct AdditionalSurfacesImpl : public INavigationDelegate {
+struct AdditionalSurfacesImpl : public IInternalNavigationDelegate {
   /// The volumes held by this collection
   std::vector<const Surface*> surfaces = {};
 
@@ -138,7 +138,8 @@ struct AdditionalSurfacesImpl : public INavigationDelegate {
 /// @tparam grid_type is the grid type used for this indexed lookup
 template <typename grid_type>
 using IndexedSurfacesImpl =
-    IndexedUpdaterImpl<grid_type, IndexedSurfacesExtractor, SurfacesFiller>;
+    IndexedUpdaterImpl<IInternalNavigationDelegate, grid_type,
+                       IndexedSurfacesExtractor, SurfacesFiller>;
 
 /// @brief  An indexed multi layer surface implementation access
 ///
@@ -152,6 +153,7 @@ using MultiLayerSurfacesImpl =
 ///@tparam inexed_updator is the updator for the indexed surfaces
 template <typename grid_type, template <typename> class indexed_updator>
 using IndexedSurfacesAllPortalsImpl =
-    ChainedUpdaterImpl<AllPortalsImpl, indexed_updator<grid_type>>;
+    ChainedUpdaterImpl<IInternalNavigationDelegate, AllPortalsImpl,
+                       indexed_updator<grid_type>>;
 
 }  // namespace Acts::Experimental

--- a/Core/src/Detector/IndexedRootVolumeFinderBuilder.cpp
+++ b/Core/src/Detector/IndexedRootVolumeFinderBuilder.cpp
@@ -77,8 +77,8 @@ Acts::Experimental::IndexedRootVolumeFinderBuilder::construct(
   fillGridIndices2D(gctx, grid, rootVolumes, boundaries, casts);
 
   using IndexedDetectorVolumesImpl =
-      IndexedUpdaterImpl<GridType, IndexedDetectorVolumeExtractor,
-                         DetectorVolumeFiller>;
+      IndexedUpdaterImpl<IExternalNavigationDelegate, GridType,
+                         IndexedDetectorVolumeExtractor, DetectorVolumeFiller>;
 
   auto indexedDetectorVolumeImpl =
       std::make_unique<const IndexedDetectorVolumesImpl>(std::move(grid),

--- a/Plugins/Json/include/Acts/Plugins/Json/DetectorVolumeFinderJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/DetectorVolumeFinderJsonConverter.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Navigation/DetectorVolumeFinders.hpp"
 #include "Acts/Navigation/DetectorVolumeUpdaters.hpp"
+#include "Acts/Navigation/NavigationDelegates.hpp"
 #include "Acts/Plugins/Json/DetrayJsonHelper.hpp"
 #include "Acts/Plugins/Json/IndexedGridJsonHelper.hpp"
 #include "Acts/Utilities/Grid.hpp"
@@ -34,8 +35,9 @@ void convert(nlohmann::json& jIndexedVolumes,
   using GridType = typename instance_type::template grid_type<std::size_t>;
   // Defining a Delegate type
   using DelegateType = Experimental::IndexedUpdaterImpl<
-      GridType, Acts::Experimental::IndexedDetectorVolumeExtractor,
-      Acts::Experimental::DetectorVolumeFiller>;
+      Experimental::IExternalNavigationDelegate, GridType,
+      Experimental::IndexedDetectorVolumeExtractor,
+      Experimental::DetectorVolumeFiller>;
   // Get the instance
   const auto* instance = delegate.instance();
   auto castedDelegate = dynamic_cast<const DelegateType*>(instance);

--- a/Plugins/Json/src/DetectorVolumeFinderJsonConverter.cpp
+++ b/Plugins/Json/src/DetectorVolumeFinderJsonConverter.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Navigation/DetectorVolumeFinders.hpp"
 #include "Acts/Navigation/DetectorVolumeUpdaters.hpp"
+#include "Acts/Navigation/NavigationDelegates.hpp"
 #include "Acts/Plugins/Json/GridJsonConverter.hpp"
 #include "Acts/Plugins/Json/UtilitiesJsonConverter.hpp"
 #include "Acts/Utilities/GridAxisGenerators.hpp"
@@ -39,7 +40,8 @@ struct IndexedVolumesGenerator {
       const std::array<Acts::BinningValue, grid_type::DIM>& bv,
       const Acts::Transform3& transform) {
     using IndexedDetectorVolumesImpl = Acts::Experimental::IndexedUpdaterImpl<
-        grid_type, Acts::Experimental::IndexedDetectorVolumeExtractor,
+        Acts::Experimental::IExternalNavigationDelegate, grid_type,
+        Acts::Experimental::IndexedDetectorVolumeExtractor,
         Acts::Experimental::DetectorVolumeFiller>;
 
     auto indexedDetectorVolumeImpl =
@@ -56,7 +58,7 @@ struct IndexedVolumesGenerator {
 
 }  // namespace
 
-Acts::Experimental::SurfaceCandidatesUpdater
+Acts::Experimental::DetectorVolumeUpdater
 Acts::DetectorVolumeFinderJsonConverter::fromJson(
     const nlohmann::json& jVolumeFinder) {
   // The return object

--- a/Tests/UnitTests/Core/Detector/PortalTests.cpp
+++ b/Tests/UnitTests/Core/Detector/PortalTests.cpp
@@ -34,7 +34,7 @@
 namespace Acts::Experimental {
 
 /// a simple link to volume struct
-class LinkToVolumeImpl : public INavigationDelegate {
+class LinkToVolumeImpl : public IExternalNavigationDelegate {
  public:
   std::shared_ptr<DetectorVolume> dVolume = nullptr;
 

--- a/Tests/UnitTests/Core/Navigation/NavigationStateUpdatersTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/NavigationStateUpdatersTests.cpp
@@ -237,10 +237,9 @@ BOOST_AUTO_TEST_CASE(AllPortalsAllSurfaces) {
 
   AllPortalsProvider allPortals;
   AllSurfacesProvider allSurfaces;
-  auto allPortalsAllSurfaces =
-      Acts::Experimental::ChainedUpdaterImpl<AllPortalsProvider,
-                                             AllSurfacesProvider>(
-          std::tie(allPortals, allSurfaces));
+  auto allPortalsAllSurfaces = Acts::Experimental::ChainedUpdaterImpl<
+      Acts::Experimental::IInternalNavigationDelegate, AllPortalsProvider,
+      AllSurfacesProvider>(std::tie(allPortals, allSurfaces));
 
   allPortalsAllSurfaces.update(tContext, nState);
   BOOST_CHECK_EQUAL(nState.surfaceCandidates.size(), 5u);
@@ -259,14 +258,14 @@ BOOST_AUTO_TEST_CASE(AllPortalsGrid1DSurfaces) {
   AllPortalsProvider allPortals;
   Acts::MultiGrid1D grid;
   using Grid1DSurfacesProvider = Acts::Experimental::IndexedUpdaterImpl<
-      decltype(grid), Acts::Experimental::IndexedSurfacesExtractor,
+      Acts::Experimental::IInternalNavigationDelegate, decltype(grid),
+      Acts::Experimental::IndexedSurfacesExtractor,
       Acts::Experimental::SurfacesFiller>;
   auto grid1DSurfaces = Grid1DSurfacesProvider(std::move(grid), {Acts::binR});
 
-  auto allPortalsGrid1DSurfaces =
-      Acts::Experimental::ChainedUpdaterImpl<AllPortalsProvider,
-                                             Grid1DSurfacesProvider>(
-          std::tie(allPortals, grid1DSurfaces));
+  auto allPortalsGrid1DSurfaces = Acts::Experimental::ChainedUpdaterImpl<
+      Acts::Experimental::IInternalNavigationDelegate, AllPortalsProvider,
+      Grid1DSurfacesProvider>(std::tie(allPortals, grid1DSurfaces));
 
   allPortalsGrid1DSurfaces.update(tContext, nState);
   BOOST_CHECK_EQUAL(nState.surfaceCandidates.size(), 4u);
@@ -285,15 +284,15 @@ BOOST_AUTO_TEST_CASE(AllPortalsGrid2DSurfaces) {
   AllPortalsProvider allPortals;
   Acts::MultiGrid2D grid;
   using Grid2DSurfacesProvider = Acts::Experimental::IndexedUpdaterImpl<
-      decltype(grid), Acts::Experimental::IndexedSurfacesExtractor,
+      Acts::Experimental::IInternalNavigationDelegate, decltype(grid),
+      Acts::Experimental::IndexedSurfacesExtractor,
       Acts::Experimental::SurfacesFiller>;
   auto grid2DSurfaces =
       Grid2DSurfacesProvider(std::move(grid), {Acts::binR, Acts::binZ});
 
-  auto allPortalsGrid2DSurfaces =
-      Acts::Experimental::ChainedUpdaterImpl<AllPortalsProvider,
-                                             Grid2DSurfacesProvider>(
-          std::tie(allPortals, grid2DSurfaces));
+  auto allPortalsGrid2DSurfaces = Acts::Experimental::ChainedUpdaterImpl<
+      Acts::Experimental::IInternalNavigationDelegate, AllPortalsProvider,
+      Grid2DSurfacesProvider>(std::tie(allPortals, grid2DSurfaces));
 
   allPortalsGrid2DSurfaces.update(tContext, nState);
   BOOST_CHECK_EQUAL(nState.surfaceCandidates.size(), 3u);

--- a/Tests/UnitTests/Plugins/Json/DetectorVolumeFinderJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/DetectorVolumeFinderJsonConverterTests.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE(RzVolumes) {
   auto casts = std::array<Acts::BinningValue, 2u>{Acts::binZ, Acts::binR};
 
   using IndexedDetectorVolumesImpl = Acts::Experimental::IndexedUpdaterImpl<
-      GridType, Acts::Experimental::IndexedDetectorVolumeExtractor,
+      Acts::Experimental::IExternalNavigationDelegate, GridType,
+      Acts::Experimental::IndexedDetectorVolumeExtractor,
       Acts::Experimental::DetectorVolumeFiller>;
 
   auto indexedDetectorVolumesImpl =


### PR DESCRIPTION
This was already done once, and it's only a first step in ironing out some inconsistencies.

This splits the navigation delegates into 
* `IInternalNavigationDelegate` - for everything within the volumes
* `IExternalNavigationDelegate` - for everything between and into the volumes

This PR only introduces the new interfaces, it will be followed by renaming PRs.
