### PR TITLE
feat: introduce delegate for the sourcelink creation and the measurement selection

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -133,6 +133,12 @@ using SourceLinkAccessorDelegate =
     Delegate<std::pair<source_link_iterator_t, source_link_iterator_t>(
         const Surface&)>;
 
+/// expected max number of track states that are expected to be added by
+/// stateCandidateCreator
+/// @note if the number of states exceeds this number dynamic memory allocation will occur.
+//.       the number is chosen to yield a container size of 64 bytes.
+static constexpr std::size_t s_maxBranchesPerSurface = 10;
+
 /// Combined options for the combinatorial Kalman filter.
 ///
 /// @tparam source_link_iterator_t Type of the source link iterator
@@ -197,7 +203,8 @@ struct CombinatorialKalmanFilterOptions {
   /// Delegate definition to create track states for selected measurements
   /// @note expected to iterator over the given sourcelink range,
   ///       select measurements, and create track states for
-  ///       which new tips are to be created.
+  ///       which new tips are to be created, more over the outlier
+  ///       flag should be set for states that are outlier.
   ///
   /// @param geoContext The current geometry context
   /// @param calibrationContext pointer to the current calibration context
@@ -206,19 +213,21 @@ struct CombinatorialKalmanFilterOptions {
   /// @param slBegin Begin iterator for sourcelinks
   /// @param slEnd End iterator for sourcelinks
   /// @param prevTip Index pointing at previous trajectory state (i.e. tip)
+  /// @param bufferTrajectory a temporary trajectory which can be used to create temporary track states
+  /// @param trackStateCandidates a temporary buffer that can be used to collect track states
   /// @param trajectory the trajectory to which the new states are to be added
-  /// @param trackStateCandidates list to be filled with the new states
-  /// @param isOutlier flag to be set to true of the states are outliers
   /// @param logger a logger for messages
-  using TrackStateCandidateCreator = Delegate<Result<std::pair<
-      typename std::vector<typename traj_t::TrackStateProxy>::iterator,
-      typename std::vector<typename traj_t::TrackStateProxy>::iterator>>(
-      const GeometryContext& geoContext,
-      const CalibrationContext& calibrationContext, const Surface& surface,
-      const BoundState& boundState, source_link_iterator_t slBegin,
-      source_link_iterator_t slEnd, std::size_t prevTip, traj_t& trajectory,
-      std::vector<typename traj_t::TrackStateProxy>& trackStateCandidates,
-      bool& isOutlier, const Logger& logger)>;
+  using TrackStateCandidateCreator =
+      Delegate<Result<boost::container::small_vector<
+          typename traj_t::TrackStateProxy::IndexType,
+          s_maxBranchesPerSurface>>(
+          const GeometryContext& geoContext,
+          const CalibrationContext& calibrationContext, const Surface& surface,
+          const BoundState& boundState, source_link_iterator_t slBegin,
+          source_link_iterator_t slEnd, std::size_t prevTip,
+          traj_t& bufferTrajectory,
+          std::vector<typename traj_t::TrackStateProxy>& trackStateCandidates,
+          traj_t& trajectory, const Logger& logger)>;
 
   /// The delegate to create new track states.
   TrackStateCandidateCreator trackStateCandidateCreator;
@@ -324,26 +333,37 @@ class CombinatorialKalmanFilter {
     typename CombinatorialKalmanFilterExtensions<traj_t>::Calibrator calibrator;
     typename CombinatorialKalmanFilterExtensions<traj_t>::MeasurementSelector
         measurementSelector;
-    /// Create and fill track states for all source links
+
+    /// Create track states for selected measurements given by the source links
     ///
     /// @param gctx The current geometry context
-    /// @param result Reference to the result struct of the actor
+    /// @param calibrationContext pointer to the current calibration context
+    /// @param surface the surface the sourceLinks are associated to
     /// @param boundState Bound state from the propagation on this surface
-    /// @param prevTip Index pointing at previous trajectory state (i.e. tip)
     /// @param slBegin Begin iterator for sourcelinks
     /// @param slEnd End iterator for sourcelinks
+    /// @param prevTip Index pointing at previous trajectory state (i.e. tip)
+    /// @param bufferTrajectory a buffer for temporary candidate track states
+    /// @param trackStateCandidates a buffer for temporary track state proxies for candidates
+    /// @param trajectory the trajectory to which new track states for selected measurements will be added
+    /// @param logger the logger for messages.
     template <typename source_link_iterator_t>
-    Result<std::pair<
-        typename std::vector<typename traj_t::TrackStateProxy>::iterator,
-        typename std::vector<typename traj_t::TrackStateProxy>::iterator>>
+    Result<boost::container::small_vector<
+        typename traj_t::TrackStateProxy::IndexType, s_maxBranchesPerSurface>>
     createSourceLinkTrackStates(
         const GeometryContext& gctx,
         const CalibrationContext& calibrationContext,
         [[maybe_unused]] const Surface& surface, const BoundState& boundState,
         source_link_iterator_t slBegin, source_link_iterator_t slEnd,
-        std::size_t prevTip, traj_t& trajectory,
+        std::size_t prevTip, traj_t& bufferTrajectory,
         std::vector<typename traj_t::TrackStateProxy>& trackStateCandidates,
-        bool& isOutlier, const Logger& logger) const {
+        traj_t& trajectory, const Logger& logger) const {
+      using ResultTrackStateList = Acts::Result<boost::container::small_vector<
+          typename traj_t::TrackStateProxy::IndexType,
+          s_maxBranchesPerSurface>>;
+      ResultTrackStateList resultTrackStateList{boost::container::small_vector<
+          typename traj_t::TrackStateProxy::IndexType,
+          s_maxBranchesPerSurface>()};
       const auto& [boundParams, jacobian, pathLength] = boundState;
 
       trackStateCandidates.clear();
@@ -354,7 +374,7 @@ class CombinatorialKalmanFilter {
         trackStateCandidates.reserve(std::distance(slBegin, slEnd));
       }
 
-      trajectory.clear();
+      bufferTrajectory.clear();
 
       using PM = TrackStatePropMask;
 
@@ -376,7 +396,7 @@ class CombinatorialKalmanFilter {
         // CAREFUL! This trackstate has a previous index that is not in this
         // MultiTrajectory Visiting brackwards from this track state will
         // fail!
-        auto ts = trajectory.makeTrackState(mask, prevTip);
+        auto ts = bufferTrajectory.makeTrackState(mask, prevTip);
 
         if (it == slBegin) {
           // only set these for first
@@ -401,7 +421,107 @@ class CombinatorialKalmanFilter {
 
         trackStateCandidates.push_back(ts);
       }
-      return measurementSelector(trackStateCandidates, isOutlier, logger);
+      bool isOutlier = false;
+      Result<std::pair<
+          typename std::vector<typename traj_t::TrackStateProxy>::iterator,
+          typename std::vector<typename traj_t::TrackStateProxy>::iterator>>
+          selectorResult =
+              measurementSelector(trackStateCandidates, isOutlier, logger);
+      if (!selectorResult.ok()) {
+        ACTS_ERROR("Selection of calibrated measurements failed: "
+                   << selectorResult.error());
+        resultTrackStateList =
+            ResultTrackStateList::failure(selectorResult.error());
+      } else {
+        auto selectedTrackStateRange = *selectorResult;
+
+        resultTrackStateList = processSelectedTrackStates(
+            selectedTrackStateRange.first, selectedTrackStateRange.second,
+            trajectory, isOutlier, logger);
+      }
+
+      return resultTrackStateList;
+    }
+
+    /// Create track states for the given trajectory from candidate track states
+    ///
+    /// @param begin begin iterator of the list of candidate track states
+    /// @param end end iterator of the list of candidate track states
+    /// @param fittedStates the trajectory to which the new track states are added
+    /// @param isOutlier true if the candidate(s) is(are) an outlier(s).
+    /// @param logger the logger for messages
+    Result<boost::container::small_vector<
+        typename traj_t::TrackStateProxy::IndexType, s_maxBranchesPerSurface>>
+    processSelectedTrackStates(
+        typename std::vector<typename traj_t::TrackStateProxy>::const_iterator
+            begin,
+        typename std::vector<typename traj_t::TrackStateProxy>::const_iterator
+            end,
+        traj_t& fittedStates, bool isOutlier, const Logger& logger) const {
+      Acts::Result<boost::container::small_vector<
+          typename traj_t::TrackStateProxy::IndexType, s_maxBranchesPerSurface>>
+          resultTrackStateList{boost::container::small_vector<
+              typename traj_t::TrackStateProxy::IndexType,
+              s_maxBranchesPerSurface>()};
+      boost::container::small_vector<
+          typename traj_t::TrackStateProxy::IndexType, s_maxBranchesPerSurface>&
+          trackStateList = *resultTrackStateList;
+      trackStateList.reserve(end - begin);
+      using PM = TrackStatePropMask;
+
+      std::optional<typename traj_t::TrackStateProxy> firstTrackState{
+          std::nullopt};
+      for (auto it = begin; it != end; ++it) {
+        auto& candidateTrackState = *it;
+
+        PM mask = PM::Predicted | PM::Filtered | PM::Jacobian | PM::Calibrated;
+
+        if (it != begin) {
+          // subsequent track states don't need storage for these as they will
+          // be shared
+          mask &= ~PM::Predicted & ~PM::Jacobian;
+        }
+
+        if (isOutlier) {
+          // outlier won't have separate filtered parameters
+          mask &= ~PM::Filtered;
+        }
+
+        // copy this trackstate into fitted states MultiTrajectory
+        typename traj_t::TrackStateProxy trackState =
+            fittedStates.makeTrackState(mask, candidateTrackState.previous());
+        ACTS_VERBOSE("Create SourceLink output track state #"
+                     << trackState.index() << " with mask: " << mask);
+
+        if (it != begin) {
+          // assign indices pointing to first track state
+          trackState.shareFrom(*firstTrackState, PM::Predicted);
+          trackState.shareFrom(*firstTrackState, PM::Jacobian);
+        } else {
+          firstTrackState = trackState;
+        }
+
+        // either copy ALL or everything except for predicted and jacobian
+        trackState.allocateCalibrated(candidateTrackState.calibratedSize());
+        trackState.copyFrom(candidateTrackState, mask, false);
+
+        auto typeFlags = trackState.typeFlags();
+        if (trackState.referenceSurface().surfaceMaterial() != nullptr) {
+          typeFlags.set(TrackStateFlag::MaterialFlag);
+        }
+        typeFlags.set(TrackStateFlag::ParameterFlag);
+
+        if (isOutlier) {
+          // propagate information that this is an outlier state
+          ACTS_VERBOSE(
+              "Creating outlier track state with tip = " << trackState.index());
+          // Set the outlier flag needed by the next step to identify outlier
+          // states
+          typeFlags.set(TrackStateFlag::OutlierFlag);
+        }
+        trackStateList.push_back(trackState.index());
+      }
+      return resultTrackStateList;
     }
   };
 
@@ -599,9 +719,7 @@ class CombinatorialKalmanFilter {
     Result<void> filter(const Surface* surface, propagator_state_t& state,
                         const stepper_t& stepper, const navigator_t& navigator,
                         result_type& result) const {
-      // Initialize the number of branches on current surface
       std::size_t nBranchesOnSurface = 0;
-
       // Count the number of source links on the surface
       auto [slBegin, slEnd] = m_sourcelinkAccessor(*surface);
       if (slBegin != slEnd) {
@@ -639,33 +757,30 @@ class CombinatorialKalmanFilter {
 
         // Create trackstates for all source links (will be filtered later)
         // Results are stored in result => no return value
-        using TrackStateRangeResult = Result<std::pair<
-            typename std::vector<typename traj_t::TrackStateProxy>::iterator,
-            typename std::vector<typename traj_t::TrackStateProxy>::iterator>>;
 
-        bool isOutlier = false;
-        TrackStateRangeResult selectorResult = trackStateCandidateCreator(
+        using TrackStatesResult = Acts::Result<boost::container::small_vector<
+            typename traj_t::TrackStateProxy::IndexType,
+            s_maxBranchesPerSurface>>;
+
+        TrackStatesResult tsRes = trackStateCandidateCreator(
             state.geoContext, *calibrationContextPtr, *surface, boundState,
             slBegin, slEnd, prevTip, *result.stateBuffer,
-            result.trackStateCandidates, isOutlier, logger());
+            result.trackStateCandidates, *result.fittedStates, logger());
 
-        if (!selectorResult.ok()) {
-          ACTS_ERROR("Selection of calibrated measurements failed: "
-                     << selectorResult.error());
-          return selectorResult.error();
+        if (!tsRes.ok()) {
+          ACTS_ERROR(
+              "Processing of selected track states failed: " << tsRes.error())
+          return tsRes.error();
         }
-        auto selectedTrackStateRange = *selectorResult;
-
-        auto procRes = processSelectedTrackStates(
-            state.geoContext, selectedTrackStateRange.first,
-            selectedTrackStateRange.second, result, isOutlier, prevTipState,
-            nBranchesOnSurface);
-
+        Result<std::tuple<unsigned int, bool>> procRes = processNewTrackStates(
+            state.geoContext, prevTipState, *tsRes, result);
         if (!procRes.ok()) {
           ACTS_ERROR(
               "Processing of selected track states failed: " << procRes.error())
           return procRes.error();
         }
+        auto [nNewBranchesOnSurface, isOutlier] = *procRes;
+        nBranchesOnSurface = nNewBranchesOnSurface;
 
         if (nBranchesOnSurface > 0 && !isOutlier) {
           // If there are measurement track states on this surface
@@ -804,83 +919,41 @@ class CombinatorialKalmanFilter {
       return Result<void>::success();
     }
 
-    /// Handle the list of selected track states
+    /// process new, incompomplete track states and set the filtered state
+    /// @note will process the given list of new states, run the updater
+    ///     or share the predicted state for states flagged as outliers
+    ///     and add them to the list of active tips
     ///
-    /// @param gctx The current geometry context
-    /// @param begin The start iterator for selected track states
-    /// @param end The end iterator for selected track states
-    /// @param result Reference to the actor result struct
-    /// @param isOutlier If this track state is a single outlier one
-    /// @param prevTipState Tip state prior to this surface
-    /// @param [in,out] nBranchesOnSurface Number of branches on surface, will be updated
-    Result<void> processSelectedTrackStates(
-        const Acts::GeometryContext& gctx,
-        typename std::vector<typename traj_t::TrackStateProxy>::const_iterator
-            begin,
-        typename std::vector<typename traj_t::TrackStateProxy>::const_iterator
-            end,
-        result_type& result, bool isOutlier, const TipState& prevTipState,
-        std::size_t& nBranchesOnSurface) const {
-      using PM = TrackStatePropMask;
-
-      std::optional<typename traj_t::TrackStateProxy> firstTrackState{
-          std::nullopt};
-      for (auto it = begin; it != end; ++it) {
-        auto& candidateTrackState = *it;
-
-        PM mask = PM::Predicted | PM::Filtered | PM::Jacobian | PM::Calibrated;
-
-        if (it != begin) {
-          // subsequent track states don't need storage for these as they will
-          // be shared
-          mask &= ~PM::Predicted & ~PM::Jacobian;
-        }
-
-        if (isOutlier) {
-          // outlier won't have separate filtered parameters
-          mask &= ~PM::Filtered;
-        }
-
-        // copy this trackstate into fitted states MultiTrajectory
-        typename traj_t::TrackStateProxy trackState =
-            result.fittedStates->makeTrackState(mask,
-                                                candidateTrackState.previous());
-        ACTS_VERBOSE("Create SourceLink output track state #"
-                     << trackState.index() << " with mask: " << mask);
-
-        if (it != begin) {
-          // assign indices pointing to first track state
-          trackState.shareFrom(*firstTrackState, PM::Predicted);
-          trackState.shareFrom(*firstTrackState, PM::Jacobian);
-        } else {
-          firstTrackState = trackState;
-        }
-
-        // either copy ALL or everything except for predicted and jacobian
-        trackState.allocateCalibrated(candidateTrackState.calibratedSize());
-        trackState.copyFrom(candidateTrackState, mask, false);
-
-        auto typeFlags = trackState.typeFlags();
-        if (trackState.referenceSurface().surfaceMaterial() != nullptr) {
-          typeFlags.set(TrackStateFlag::MaterialFlag);
-        }
-        typeFlags.set(TrackStateFlag::ParameterFlag);
-
+    /// @param gctx The geometry context for this track finding/fitting
+    /// @param prevTipState the previous tip state
+    /// @param newTrackStateList index list of new track states
+    /// @param result which contains among others the new states, and the list of active tips
+    /// @return tuple of the number of newly added tips and outlier flag or an error
+    Result<std::tuple<unsigned int, bool>> processNewTrackStates(
+        const Acts::GeometryContext& gctx, const TipState& prevTipState,
+        const boost::container::small_vector<
+            typename traj_t::TrackStateProxy::IndexType,
+            s_maxBranchesPerSurface>& newTrackStateList,
+        result_type& result) const {
+      unsigned int nBranchesOnSurface = 0;
+      bool isOutlier = false;
+      for (typename traj_t::TrackStateProxy::IndexType tipIndex :
+           newTrackStateList) {
         // Inherit the tip state from the previous and will be updated
         // later
+        typename traj_t::TrackStateProxy trackState(
+            result.fittedStates->getTrackState(tipIndex));
         TipState tipState = prevTipState;
-        std::size_t currentTip = trackState.index();
 
         // Increment of number of processedState and passed sensitive surfaces
         tipState.nSensitiveSurfaces++;
         tipState.nStates++;
 
-        if (isOutlier) {
-          ACTS_VERBOSE(
-              "Creating outlier track state with tip = " << currentTip);
-          // Set the outlier flag
-          typeFlags.set(TrackStateFlag::OutlierFlag);
+        using PM = Acts::TrackStatePropMask;
+        TrackStateType typeFlags(trackState.typeFlags());
+        if (typeFlags.test(TrackStateFlag::OutlierFlag)) {
           // Increment number of outliers
+          isOutlier = true;
           tipState.nOutliers++;
           // No Kalman update for outlier
           // Set the filtered parameter index to be the same with predicted
@@ -895,7 +968,7 @@ class CombinatorialKalmanFilter {
             return updateRes.error();
           }
           ACTS_VERBOSE(
-              "Creating measurement track state with tip = " << currentTip);
+              "Creating measurement track state with tip = " << tipIndex);
           // Set the measurement flag
           typeFlags.set(TrackStateFlag::MeasurementFlag);
           // Increment number of measurements
@@ -903,7 +976,7 @@ class CombinatorialKalmanFilter {
         }
 
         // Put tipstate back into active tips to continue with it
-        result.activeTips.emplace_back(currentTip, tipState);
+        result.activeTips.emplace_back(tipIndex, tipState);
 
         using BranchStopperResult =
             CombinatorialKalmanFilterBranchStopperResult;
@@ -923,8 +996,7 @@ class CombinatorialKalmanFilter {
           result.activeTips.erase(result.activeTips.end() - 1);
         }
       }
-
-      return Result<void>::success();
+      return std::make_tuple(nBranchesOnSurface, isOutlier);
     }
 
     /// @brief CombinatorialKalmanFilter actor operation: add a hole or material track state


### PR DESCRIPTION
This PR adds a delegate to the  CKF extensions. If this delegate is not set a default 
delegate will be used which behaves as the version without these commits.  

The delegate allows to provide a different implement for source link creation and 
measurement selection which is better suited for a particular use case. 

An example 
can be seen here: [goetzgaycken/acts:MeasurementSelector2.hpp:L501](https://github.com/goetzgaycken/acts/blob/34c37ac31bbe27d8bb776c1ba249f5c722bd5d84/Core/include/Acts/TrackFinding/MeasurementSelector2.hpp#L501)
It only creates track states for the finally selected measurements and simplifies the computations for the chi2 and uses
a more suitable interface for the calibrator. This allowed to reduce the time for the source link creation and measurement selection by a factor 2, when used within athena for ITK inputs. 