### PR TITLE
fix: Add missing header for compilation with GCC 14

### DIFF
--- a/Core/include/Acts/Seeding/HoughTransformUtils.ipp
+++ b/Core/include/Acts/Seeding/HoughTransformUtils.ipp
@@ -6,6 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <algorithm>
+
 template <class identifier_t>
 template <class PointType>
 void Acts::HoughTransformUtils::HoughPlane<identifier_t>::fill(


### PR DESCRIPTION
In my version of GCC `std::sort` could not be resolved with the provided headers anymore.