### PR TITLE
refactor: Early exit for `AnnulusBounds::inside`

### DIFF
--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -178,158 +178,156 @@ bool Acts::AnnulusBounds::inside(const Vector2& lposition,
   if (bcheck.type() == BoundaryCheck::Type::eAbsolute) {
     return inside(lposition, bcheck.tolerance()[eBoundLoc0],
                   bcheck.tolerance()[eBoundLoc1]);
-  } else {
-    // first check if inside. We don't need to look into the covariance if
-    // inside
-    if (inside(lposition, 0., 0.)) {
-      return true;
-    }
-
-    // we need to rotate the locpo
-    Vector2 locpo_rotated = m_rotationStripPC * lposition;
-
-    // covariance is given in STRIP SYSTEM in PC
-    // we need to convert the covariance to the MODULE SYSTEM in PC
-    // via jacobian.
-    // The following transforms into STRIP XY, does the shift into MODULE XY,
-    // and then transforms into MODULE PC
-    double dphi = get(eAveragePhi);
-    double phi_strip = locpo_rotated[eBoundLoc1];
-    double r_strip = locpo_rotated[eBoundLoc0];
-    double O_x = m_shiftXY[eBoundLoc0];
-    double O_y = m_shiftXY[eBoundLoc1];
-
-    // For a transformation from cartesian into polar coordinates
-    //
-    //              [         _________      ]
-    //              [        /  2    2       ]
-    //              [      \/  x  + y        ]
-    //     [ r' ]   [                        ]
-    // v = [    ] = [      /       y        \]
-    //     [phi']   [2*atan|----------------|]
-    //              [      |       _________|]
-    //              [      |      /  2    2 |]
-    //              [      \x + \/  x  + y  /]
-    //
-    // Where x, y are polar coordinates that can be rotated by dPhi
-    //
-    // [x]   [O_x + r*cos(dPhi - phi)]
-    // [ ] = [                       ]
-    // [y]   [O_y - r*sin(dPhi - phi)]
-    //
-    // The general jacobian is:
-    //
-    //        [d        d      ]
-    //        [--(f_x)  --(f_x)]
-    //        [dx       dy     ]
-    // Jgen = [                ]
-    //        [d        d      ]
-    //        [--(f_y)  --(f_y)]
-    //        [dx       dy     ]
-    //
-    // which means in this case:
-    //
-    //     [     d                   d           ]
-    //     [ ----------(rMod)    ---------(rMod) ]
-    //     [ dr_{strip}          dphiStrip       ]
-    // J = [                                     ]
-    //     [    d                   d            ]
-    //     [----------(phiMod)  ---------(phiMod)]
-    //     [dr_{strip}          dphiStrip        ]
-    //
-    // Performing the derivative one gets:
-    //
-    //     [B*O_x + C*O_y + rStrip  rStrip*(B*O_y + O_x*sin(dPhi - phiStrip))]
-    //     [----------------------  -----------------------------------------]
-    //     [          ___                               ___                  ]
-    //     [        \/ A                              \/ A                   ]
-    // J = [                                                                 ]
-    //     [  -(B*O_y - C*O_x)           rStrip*(B*O_x + C*O_y + rStrip)     ]
-    //     [  -----------------          -------------------------------     ]
-    //     [          A                                 A                    ]
-    //
-    // where
-    //        2                                          2 2
-    // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y  -
-    // 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip B = cos(dPhi - phiStrip) C =
-    // -sin(dPhi - phiStrip)
-
-    double cosDPhiPhiStrip = std::cos(dphi - phi_strip);
-    double sinDPhiPhiStrip = std::sin(dphi - phi_strip);
-
-    double A = O_x * O_x + 2 * O_x * r_strip * cosDPhiPhiStrip + O_y * O_y -
-               2 * O_y * r_strip * sinDPhiPhiStrip + r_strip * r_strip;
-    double sqrtA = std::sqrt(A);
-
-    double B = cosDPhiPhiStrip;
-    double C = -sinDPhiPhiStrip;
-    ActsMatrix<2, 2> jacobianStripPCToModulePC;
-    jacobianStripPCToModulePC(0, 0) = (B * O_x + C * O_y + r_strip) / sqrtA;
-    jacobianStripPCToModulePC(0, 1) =
-        r_strip * (B * O_y + O_x * sinDPhiPhiStrip) / sqrtA;
-    jacobianStripPCToModulePC(1, 0) = -(B * O_y - C * O_x) / A;
-    jacobianStripPCToModulePC(1, 1) =
-        r_strip * (B * O_x + C * O_y + r_strip) / A;
-
-    // covariance is given in STRIP PC
-    auto covStripPC = bcheck.covariance();
-    // calculate covariance in MODULE PC using jacobian from above
-    auto covModulePC = jacobianStripPCToModulePC * covStripPC *
-                       jacobianStripPCToModulePC.transpose();
-
-    // Mahalanobis distance uses inverse covariance as weights
-    auto weightStripPC = covStripPC.inverse();
-    auto weightModulePC = covModulePC.inverse();
-
-    double minDist = std::numeric_limits<double>::max();
-
-    Vector2 currentClosest;
-    double currentDist = 0;
-
-    // do projection in STRIP PC
-
-    // first: STRIP system. locpo is in STRIP PC already
-    currentClosest = closestOnSegment(m_inLeftStripPC, m_outLeftStripPC,
-                                      locpo_rotated, weightStripPC);
-    currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
-    minDist = currentDist;
-
-    currentClosest = closestOnSegment(m_inRightStripPC, m_outRightStripPC,
-                                      locpo_rotated, weightStripPC);
-    currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
-    if (currentDist < minDist) {
-      minDist = currentDist;
-    }
-
-    // now: MODULE system. Need to transform locpo to MODULE PC
-    //  transform is STRIP PC -> STRIP XY -> MODULE XY -> MODULE PC
-    Vector2 locpoStripXY(
-        locpo_rotated[eBoundLoc0] * std::cos(locpo_rotated[eBoundLoc1]),
-        locpo_rotated[eBoundLoc0] * std::sin(locpo_rotated[eBoundLoc1]));
-    Vector2 locpoModulePC = stripXYToModulePC(locpoStripXY);
-
-    // now check edges in MODULE PC (inner and outer circle)
-    // assuming Mahalanobis distances are of same unit if covariance
-    // is correctly transformed
-    currentClosest = closestOnSegment(m_inLeftModulePC, m_inRightModulePC,
-                                      locpoModulePC, weightModulePC);
-    currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
-    if (currentDist < minDist) {
-      minDist = currentDist;
-    }
-
-    currentClosest = closestOnSegment(m_outLeftModulePC, m_outRightModulePC,
-                                      locpoModulePC, weightModulePC);
-    currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
-    if (currentDist < minDist) {
-      minDist = currentDist;
-    }
-
-    // compare resulting Mahalanobis distance to configured
-    // "number of sigmas"
-    // we square it b/c we never took the square root of the distance
-    return minDist < bcheck.tolerance()[0] * bcheck.tolerance()[0];
   }
+
+  // first check if inside. We don't need to look into the covariance if inside
+  if (inside(lposition, 0., 0.)) {
+    return true;
+  }
+
+  // we need to rotate the locpo
+  Vector2 locpo_rotated = m_rotationStripPC * lposition;
+
+  // covariance is given in STRIP SYSTEM in PC
+  // we need to convert the covariance to the MODULE SYSTEM in PC
+  // via jacobian.
+  // The following transforms into STRIP XY, does the shift into MODULE XY,
+  // and then transforms into MODULE PC
+  double dphi = get(eAveragePhi);
+  double phi_strip = locpo_rotated[eBoundLoc1];
+  double r_strip = locpo_rotated[eBoundLoc0];
+  double O_x = m_shiftXY[eBoundLoc0];
+  double O_y = m_shiftXY[eBoundLoc1];
+
+  // For a transformation from cartesian into polar coordinates
+  //
+  //              [         _________      ]
+  //              [        /  2    2       ]
+  //              [      \/  x  + y        ]
+  //     [ r' ]   [                        ]
+  // v = [    ] = [      /       y        \]
+  //     [phi']   [2*atan|----------------|]
+  //              [      |       _________|]
+  //              [      |      /  2    2 |]
+  //              [      \x + \/  x  + y  /]
+  //
+  // Where x, y are polar coordinates that can be rotated by dPhi
+  //
+  // [x]   [O_x + r*cos(dPhi - phi)]
+  // [ ] = [                       ]
+  // [y]   [O_y - r*sin(dPhi - phi)]
+  //
+  // The general jacobian is:
+  //
+  //        [d        d      ]
+  //        [--(f_x)  --(f_x)]
+  //        [dx       dy     ]
+  // Jgen = [                ]
+  //        [d        d      ]
+  //        [--(f_y)  --(f_y)]
+  //        [dx       dy     ]
+  //
+  // which means in this case:
+  //
+  //     [     d                   d           ]
+  //     [ ----------(rMod)    ---------(rMod) ]
+  //     [ dr_{strip}          dphiStrip       ]
+  // J = [                                     ]
+  //     [    d                   d            ]
+  //     [----------(phiMod)  ---------(phiMod)]
+  //     [dr_{strip}          dphiStrip        ]
+  //
+  // Performing the derivative one gets:
+  //
+  //     [B*O_x + C*O_y + rStrip  rStrip*(B*O_y + O_x*sin(dPhi - phiStrip))]
+  //     [----------------------  -----------------------------------------]
+  //     [          ___                               ___                  ]
+  //     [        \/ A                              \/ A                   ]
+  // J = [                                                                 ]
+  //     [  -(B*O_y - C*O_x)           rStrip*(B*O_x + C*O_y + rStrip)     ]
+  //     [  -----------------          -------------------------------     ]
+  //     [          A                                 A                    ]
+  //
+  // where
+  //        2                                          2 2
+  // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y  -
+  // 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip B = cos(dPhi - phiStrip) C =
+  // -sin(dPhi - phiStrip)
+
+  double cosDPhiPhiStrip = std::cos(dphi - phi_strip);
+  double sinDPhiPhiStrip = std::sin(dphi - phi_strip);
+
+  double A = O_x * O_x + 2 * O_x * r_strip * cosDPhiPhiStrip + O_y * O_y -
+             2 * O_y * r_strip * sinDPhiPhiStrip + r_strip * r_strip;
+  double sqrtA = std::sqrt(A);
+
+  double B = cosDPhiPhiStrip;
+  double C = -sinDPhiPhiStrip;
+  ActsMatrix<2, 2> jacobianStripPCToModulePC;
+  jacobianStripPCToModulePC(0, 0) = (B * O_x + C * O_y + r_strip) / sqrtA;
+  jacobianStripPCToModulePC(0, 1) =
+      r_strip * (B * O_y + O_x * sinDPhiPhiStrip) / sqrtA;
+  jacobianStripPCToModulePC(1, 0) = -(B * O_y - C * O_x) / A;
+  jacobianStripPCToModulePC(1, 1) = r_strip * (B * O_x + C * O_y + r_strip) / A;
+
+  // covariance is given in STRIP PC
+  auto covStripPC = bcheck.covariance();
+  // calculate covariance in MODULE PC using jacobian from above
+  auto covModulePC = jacobianStripPCToModulePC * covStripPC *
+                     jacobianStripPCToModulePC.transpose();
+
+  // Mahalanobis distance uses inverse covariance as weights
+  auto weightStripPC = covStripPC.inverse();
+  auto weightModulePC = covModulePC.inverse();
+
+  double minDist = std::numeric_limits<double>::max();
+
+  Vector2 currentClosest;
+  double currentDist = 0;
+
+  // do projection in STRIP PC
+
+  // first: STRIP system. locpo is in STRIP PC already
+  currentClosest = closestOnSegment(m_inLeftStripPC, m_outLeftStripPC,
+                                    locpo_rotated, weightStripPC);
+  currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
+  minDist = currentDist;
+
+  currentClosest = closestOnSegment(m_inRightStripPC, m_outRightStripPC,
+                                    locpo_rotated, weightStripPC);
+  currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
+  if (currentDist < minDist) {
+    minDist = currentDist;
+  }
+
+  // now: MODULE system. Need to transform locpo to MODULE PC
+  //  transform is STRIP PC -> STRIP XY -> MODULE XY -> MODULE PC
+  Vector2 locpoStripXY(
+      locpo_rotated[eBoundLoc0] * std::cos(locpo_rotated[eBoundLoc1]),
+      locpo_rotated[eBoundLoc0] * std::sin(locpo_rotated[eBoundLoc1]));
+  Vector2 locpoModulePC = stripXYToModulePC(locpoStripXY);
+
+  // now check edges in MODULE PC (inner and outer circle)
+  // assuming Mahalanobis distances are of same unit if covariance
+  // is correctly transformed
+  currentClosest = closestOnSegment(m_inLeftModulePC, m_inRightModulePC,
+                                    locpoModulePC, weightModulePC);
+  currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
+  if (currentDist < minDist) {
+    minDist = currentDist;
+  }
+
+  currentClosest = closestOnSegment(m_outLeftModulePC, m_outRightModulePC,
+                                    locpoModulePC, weightModulePC);
+  currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
+  if (currentDist < minDist) {
+    minDist = currentDist;
+  }
+
+  // compare resulting Mahalanobis distance to configured
+  // "number of sigmas"
+  // we square it b/c we never took the square root of the distance
+  return minDist < bcheck.tolerance()[0] * bcheck.tolerance()[0];
 }
 
 Acts::Vector2 Acts::AnnulusBounds::stripXYToModulePC(

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -188,11 +188,9 @@ bool Acts::AnnulusBounds::inside(const Vector2& lposition,
   // we need to rotate the locpo
   Vector2 locpo_rotated = m_rotationStripPC * lposition;
 
-  // covariance is given in STRIP SYSTEM in PC
-  // we need to convert the covariance to the MODULE SYSTEM in PC
-  // via jacobian.
-  // The following transforms into STRIP XY, does the shift into MODULE XY,
-  // and then transforms into MODULE PC
+  // covariance is given in STRIP SYSTEM in PC we need to convert the covariance
+  // to the MODULE SYSTEM in PC via jacobian. The following transforms into
+  // STRIP XY, does the shift into MODULE XY, and then transforms into MODULE PC
   double dphi = get(eAveragePhi);
   double phi_strip = locpo_rotated[eBoundLoc1];
   double r_strip = locpo_rotated[eBoundLoc0];
@@ -249,10 +247,12 @@ bool Acts::AnnulusBounds::inside(const Vector2& lposition,
   //     [          A                                 A                    ]
   //
   // where
-  //        2                                          2 2
-  // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y  -
-  // 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip B = cos(dPhi - phiStrip) C =
-  // -sin(dPhi - phiStrip)
+  //        2                                          2
+  // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y
+  //                                                 2
+  //     - 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip
+  // B = cos(dPhi - phiStrip)
+  // C = -sin(dPhi - phiStrip)
 
   double cosDPhiPhiStrip = std::cos(dphi - phi_strip);
   double sinDPhiPhiStrip = std::sin(dphi - phi_strip);
@@ -307,9 +307,8 @@ bool Acts::AnnulusBounds::inside(const Vector2& lposition,
       locpo_rotated[eBoundLoc0] * std::sin(locpo_rotated[eBoundLoc1]));
   Vector2 locpoModulePC = stripXYToModulePC(locpoStripXY);
 
-  // now check edges in MODULE PC (inner and outer circle)
-  // assuming Mahalanobis distances are of same unit if covariance
-  // is correctly transformed
+  // now check edges in MODULE PC (inner and outer circle) assuming Mahalanobis
+  // distances are of same unit if covariance is correctly transformed
   currentClosest = closestOnSegment(m_inLeftModulePC, m_inRightModulePC,
                                     locpoModulePC, weightModulePC);
   currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
@@ -324,9 +323,8 @@ bool Acts::AnnulusBounds::inside(const Vector2& lposition,
     minDist = currentDist;
   }
 
-  // compare resulting Mahalanobis distance to configured
-  // "number of sigmas"
-  // we square it b/c we never took the square root of the distance
+  // compare resulting Mahalanobis distance to configured "number of sigmas" we
+  // square it b/c we never took the square root of the distance
   return minDist < bcheck.tolerance()[0] * bcheck.tolerance()[0];
 }
 


### PR DESCRIPTION
Move code to the left and by leveraging early return statements. Have a clear unconditional return statement at the end of the function.

Pulled out of https://github.com/acts-project/acts/pull/3170