### PR TITLE
ci: bump codecov-action to v4

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -67,9 +67,10 @@ jobs:
           && cd build
           && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage/cov.xml
+          disable_search: true
 
   build_performance:
     runs-on: ubuntu-latest

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - "docs/**"
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-linux_ubuntu_debug_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -63,7 +63,7 @@ jobs:
           && du -sh build
       - name: Coverage
         run: >
-          pip3 install gcovr==6.0
+          pip3 install gcovr==7.2
           && cd build
           && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage
@@ -95,7 +95,7 @@ jobs:
         with:
           name: cmakeperf
           path: perf.csv
-  
+
   metric_tracking:
     runs-on: ubuntu-latest
     needs: build_performance

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -67,7 +67,7 @@ jobs:
           && cd build
           && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./build/coverage/cov.xml
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -67,7 +67,7 @@ jobs:
           && cd build
           && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage/cov.xml
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ runner.os  }}-ccache-linux_ubuntu_debug_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
@@ -63,7 +63,7 @@ jobs:
           && du -sh build
       - name: Coverage
         run: >
-          pip3 install gcovr==7.2
+          pip3 install gcovr==6.0
           && cd build
           && /usr/bin/python3 ../CI/test_coverage.py
       - name: Upload coverage


### PR DESCRIPTION
## Issue
For about a week, we did not get any coverage reports added to PRs.
Reason was a failing upload, due to the codecov rate limit.
`[2024-05-24T09:08:19.271Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 429 - {'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 2453s.', code='throttled')}`

## Solution - Update from `codecov-action@v3` to `codecov-action@v4`.
To keep the same coverage, we need to add the flag `disable_search: true`. Otherwise, around 1500 coverage files would be uploaded and increase our coverage from 50% to 85%. This solution was suggested in:
- https://github.com/codecov/codecov-action/issues/1354

Maybe we need to add the token as `token: ${{ secrets.CODECOV_TOKEN }}`, when we run into the rate-limit again. But it might not necessary, since they enabled token-free uploads for forks of open-source repositories.

## Coverage Change -1.63%
The change seems to be due to 2 reasons:
- The old HEAD lies 14 commits in the past
- Ending `}` are not counted as "covered" and just ignored. Therefore the relative amount of uncovered parts is increased.