### PR TITLE
fix: Adding another parameter in the json configuration 

### DIFF
--- a/Examples/Io/Json/src/JsonDigitizationConfig.cpp
+++ b/Examples/Io/Json/src/JsonDigitizationConfig.cpp
@@ -114,7 +114,7 @@ void from_json(
 void ActsExamples::to_json(nlohmann::json& j,
                            const ActsExamples::ParameterSmearingConfig& psc) {
   j["index"] = psc.index;
-  j["forcePositiveValues"] = psc.forcePositiveValues;   
+  j["forcePositiveValues"] = psc.forcePositiveValues;
   to_json(j, psc.smearFunction);
 }
 

--- a/Examples/Io/Json/src/JsonDigitizationConfig.cpp
+++ b/Examples/Io/Json/src/JsonDigitizationConfig.cpp
@@ -114,12 +114,16 @@ void from_json(
 void ActsExamples::to_json(nlohmann::json& j,
                            const ActsExamples::ParameterSmearingConfig& psc) {
   j["index"] = psc.index;
+  j["forcePositiveValues"] = psc.forcePositiveValues;   
   to_json(j, psc.smearFunction);
 }
 
 void ActsExamples::from_json(const nlohmann::json& j,
                              ActsExamples::ParameterSmearingConfig& psc) {
   psc.index = static_cast<Acts::BoundIndices>(j["index"]);
+  if (j.find("forcePositiveValues") != j.end()) {
+    psc.forcePositiveValues = j["forcePositiveValues"];
+  }
   from_json(j, psc.smearFunction);
 }
 

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -332,6 +332,8 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
 
   for (auto& el : digiConfig) {
     for (auto& smearing : el.smearingDigiConfig) {
+      //check if the forcePositiveValue parameter is successfully parsed
+      BOOST_CHECK(smearing.forcePositiveValues);
       std::fill(std::begin(s.indices), std::end(s.indices),
                 static_cast<Acts::BoundIndices>(smearing.index));
       std::fill(std::begin(s.smearFunctions), std::end(s.smearFunctions),

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
 
   for (auto& el : digiConfig) {
     for (auto& smearing : el.smearingDigiConfig) {
-      //check if the forcePositiveValue parameter is successfully parsed
+      // check if the forcePositiveValue parameter is successfully parsed
       BOOST_CHECK(smearing.forcePositiveValues);
       std::fill(std::begin(s.indices), std::end(s.indices),
                 static_cast<Acts::BoundIndices>(smearing.index));

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -332,9 +332,6 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
 
   for (auto& el : digiConfig) {
     for (auto& smearing : el.smearingDigiConfig) {
-      // check if the forcePositiveValues is parsed successfully
-      BOOST_CHECK(smearing.forcePositiveValues);
-
       std::fill(std::begin(s.indices), std::end(s.indices),
                 static_cast<Acts::BoundIndices>(smearing.index));
       std::fill(std::begin(s.smearFunctions), std::end(s.smearFunctions),
@@ -352,7 +349,11 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
     BOOST_TEST_INFO("Comparing smeared measurement "
                     << i << " originating from bound parameter "
                     << s.indices[i]);
-    CHECK_CLOSE_REL(par[i], f.boundParams[s.indices[i]], 0.15);
+    double ref = f.boundParams[s.indices[i]];
+    if (s.forcePositive[i]) {
+      ref = std::abs(ref);
+    }
+    CHECK_CLOSE_REL(par[i], ref, 0.15);
   }
 }
 

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -332,6 +332,9 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
 
   for (auto& el : digiConfig) {
     for (auto& smearing : el.smearingDigiConfig) {
+      //check if the forcePositiveValues is parsed successfully 
+      BOOST_CHECK(smearing.forcePositiveValues);
+      
       std::fill(std::begin(s.indices), std::end(s.indices),
                 static_cast<Acts::BoundIndices>(smearing.index));
       std::fill(std::begin(s.smearFunctions), std::end(s.smearFunctions),

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -332,9 +332,9 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
 
   for (auto& el : digiConfig) {
     for (auto& smearing : el.smearingDigiConfig) {
-      //check if the forcePositiveValues is parsed successfully 
+      // check if the forcePositiveValues is parsed successfully
       BOOST_CHECK(smearing.forcePositiveValues);
-      
+
       std::fill(std::begin(s.indices), std::end(s.indices),
                 static_cast<Acts::BoundIndices>(smearing.index));
       std::fill(std::begin(s.smearFunctions), std::end(s.smearFunctions),


### PR DESCRIPTION
This PR fixes the previous PR I opened with the straw surfaces smearing https://github.com/acts-project/acts/pull/3197 because I realized that the` forcePositiveValues` parameter from json is not parsed successfully, since I did not add them in the `JsonConfiguration`. I am fixing with this PR (hopefully). 