### PR TITLE
fix: Fix breaking `EigenStepper` change

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -162,7 +162,9 @@ class EigenStepper {
   };
 
   /// Constructor requires knowledge of the detector's magnetic field
-  /// @deprecated `overstepLimit` will be removed in a future release
+  /// @param bField The magnetic field provider
+  /// @param overstepLimit The limit for the overstep check
+  /// @note `overstepLimit` will be removed in a future release
   explicit EigenStepper(std::shared_ptr<const MagneticFieldProvider> bField,
                         double overstepLimit = 100 * UnitConstants::um);
 

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -162,7 +162,9 @@ class EigenStepper {
   };
 
   /// Constructor requires knowledge of the detector's magnetic field
-  EigenStepper(std::shared_ptr<const MagneticFieldProvider> bField);
+  /// @deprecated `overstepLimit` will be removed in a future release
+  explicit EigenStepper(std::shared_ptr<const MagneticFieldProvider> bField,
+                        double overstepLimit = 100 * UnitConstants::um);
 
   State makeState(std::reference_wrapper<const GeometryContext> gctx,
                   std::reference_wrapper<const MagneticFieldContext> mctx,

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -15,7 +15,8 @@
 
 template <typename E, typename A>
 Acts::EigenStepper<E, A>::EigenStepper(
-    std::shared_ptr<const MagneticFieldProvider> bField)
+    std::shared_ptr<const MagneticFieldProvider> bField,
+    double /*overstepLimit*/)
     : m_bField(std::move(bField)) {}
 
 template <typename E, typename A>


### PR DESCRIPTION
In https://github.com/acts-project/acts/pull/2846 I removed a constructor parameter which was used by Athena and maybe other clients. This would classify as a breaking change. To work around that I reintroduced the parameter and marked the constructor as deprecated.