### PR TITLE
fix: material loading to portals, forwarding of volumes in detector building

### DIFF
--- a/Core/src/Detector/CylindricalContainerBuilder.cpp
+++ b/Core/src/Detector/CylindricalContainerBuilder.cpp
@@ -267,8 +267,7 @@ Acts::Experimental::CylindricalContainerBuilder::construct(
   if (m_cfg.rootVolumeFinderBuilder) {
     // Return the container
     return Acts::Experimental::DetectorComponent{
-        {},
-        portalContainer,
+        volumes, portalContainer,
         RootDetectorVolumes{
             rootVolumes,
             m_cfg.rootVolumeFinderBuilder->construct(gctx, rootVolumes)}};
@@ -276,5 +275,6 @@ Acts::Experimental::CylindricalContainerBuilder::construct(
 
   // Return the container
   return Acts::Experimental::DetectorComponent{
-      {}, portalContainer, RootDetectorVolumes{rootVolumes, tryRootVolumes()}};
+      volumes, portalContainer,
+      RootDetectorVolumes{rootVolumes, tryRootVolumes()}};
 }

--- a/Core/src/Detector/DetectorBuilder.cpp
+++ b/Core/src/Detector/DetectorBuilder.cpp
@@ -51,8 +51,13 @@ Acts::Experimental::DetectorBuilder::construct(
   if (m_cfg.materialDecorator != nullptr) {
     ACTS_DEBUG("Decorating the detector with material");
     std::for_each(volumes.begin(), volumes.end(), [&](auto& v) {
+      // Assign to surfaces
       for (auto& sf : v->surfacePtrs()) {
         m_cfg.materialDecorator->decorate(*sf);
+      }
+      // Assign to portals
+      for (auto& p : v->portalPtrs()) {
+        m_cfg.materialDecorator->decorate(p->surface());
       }
     });
   }


### PR DESCRIPTION
These are two fixes in the Detector building:
 - volumes were not handed forward in the cylindrical building
 - material was loaded only onto the surfaces but not portals