### PR TITLE
fix: codecov coverage badge - correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ or *A Common Tracking Software* if you do not like recursive acronyms
 
 [![10.5281/zenodo.5141418](https://zenodo.org/badge/DOI/10.5281/zenodo.5141418.svg)](https://doi.org/10.5281/zenodo.5141418)
 [![Chat on Mattermost](https://badgen.net/badge/chat/on%20mattermost/cyan)](https://mattermost.web.cern.ch/acts/)
-[![codecov](https://codecov.io/gh/acts-project/acts/branch/master/graph/badge.svg)](https://codecov.io/gh/acts-project/acts)
+[![codecov](https://codecov.io/gh/acts-project/acts/graph/badge.svg)](https://codecov.io/gh/acts-project/acts)
 [![Latest release](https://badgen.net/github/release/acts-project/acts)](https://github.com/acts-project/acts/releases)
 [![Status](https://badgen.net/github/checks/acts-project/acts/main)](https://github.com/acts-project/acts/actions)
 [![Metrics](https://badgen.net/badge/metric/tracker/purple)](https://acts-project.github.io/metrics/)


### PR DESCRIPTION
After
- https://github.com/acts-project/acts/pull/3108

the badge did not update anymore. This was due to the wrong branch setting, after copying the suggestion from codecov. This removes any branch-specification and takes the default branch from ACTS.

Since the documentation of codecov is not super clear, it might be necessary also to add a token in the future like this:
```
[![codecov](https://codecov.io/gh/acts-project/acts/graph/badge.svg?token=INSERT_TOKEN_HERE)](https://codecov.io/gh/acts-project/acts)
```
The token (different from the upload token) can be found at https://app.codecov.io/gh/acts-project/acts/settings/badge (login required). It seems to work without token for now, so no reason to expose it to the public.