### PR TITLE
ci: Disable metric tracking for now

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -98,28 +98,28 @@ jobs:
           name: cmakeperf
           path: perf.csv
 
-  metric_tracking:
-    runs-on: ubuntu-latest
-    needs: build_performance
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: pip3 install git+https://github.com/paulgessinger/headwind.git@eeeaa80
-      - uses: actions/download-artifact@v4
-        with:
-          name: cmakeperf
-      - name: Run collection
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-        run: |
-          ssh-agent -a $SSH_AUTH_SOCK > /dev/null
-          ssh-add - <<< "${{ secrets.METRIC_DEPLOY_SSH_KEY }}"
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-          git clone git@github.com:acts-project/metrics.git
-          hdw collect CI/headwind.yml --commit $(git log --pretty=format:'%H' -1)
-          cd metrics
-          git add -A
-          git commit -m"update metrics"
-          git push
+  # metric_tracking:
+  #   runs-on: ubuntu-latest
+  #   needs: build_performance
+  #   if: github.ref == 'refs/heads/main'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Install dependencies
+  #       run: pip3 install git+https://github.com/paulgessinger/headwind.git@eeeaa80
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         name: cmakeperf
+  #     - name: Run collection
+  #       env:
+  #         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+  #       run: |
+  #         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+  #         ssh-add - <<< "${{ secrets.METRIC_DEPLOY_SSH_KEY }}"
+  #         git config --global user.email "action@github.com"
+  #         git config --global user.name "GitHub Action"
+  #         git clone git@github.com:acts-project/metrics.git
+  #         hdw collect CI/headwind.yml --commit $(git log --pretty=format:'%H' -1)
+  #         cd metrics
+  #         git add -A
+  #         git commit -m"update metrics"
+  #         git push


### PR DESCRIPTION
This is currently failing because the tracker tool is failing to parse some commit date. I was planning to rework this job anyway, so I'm just disabling it for now.