### PR TITLE
revert: Remove target volume estimation from `Navigator` #3217

### DIFF
--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -345,6 +345,12 @@ class Navigator {
     // Call the navigation helper prior to actual navigation
     ACTS_VERBOSE(volInfo(state) << "Entering navigator::preStep.");
 
+    // Initialize the target and target volume
+    if (state.navigation.targetSurface != nullptr &&
+        state.navigation.targetVolume == nullptr) {
+      // Find out about the target as much as you can
+      initializeTarget(state, stepper);
+    }
     // Try targeting the surfaces - then layers - then boundaries
     if (state.navigation.navigationStage <= Stage::surfaceTarget &&
         targetSurfaces(state, stepper)) {
@@ -752,6 +758,11 @@ class Navigator {
       ++state.navigation.navLayerIndex;
     }
 
+    // Re-initialize target at last layer, only in case it is the target volume
+    // This avoids a wrong target volume estimation
+    if (state.navigation.currentVolume == state.navigation.targetVolume) {
+      initializeTarget(state, stepper);
+    }
     // Screen output
     if (logger().doPrint(Logging::VERBOSE)) {
       std::ostringstream os;
@@ -816,6 +827,9 @@ class Navigator {
       stepper.releaseStepSize(state.stepping, ConstrainedStep::actor);
       return true;
     }
+
+    // Re-initialize target at volume boundary
+    initializeTarget(state, stepper);
 
     // Helper function to find boundaries
     auto findBoundaries = [&]() -> bool {
@@ -916,6 +930,85 @@ class Navigator {
 
     // Tried our best, but couldn't do anything
     return false;
+  }
+
+  /// @brief Navigation (re-)initialisation for the target
+  ///
+  /// @note This is only called a few times every propagation/extrapolation
+  ///
+  /// As a straight line estimate can lead you to the wrong destination
+  /// Volume, this will be called at:
+  /// - initialization
+  /// - attempted volume switch
+  /// Target finding by association will not be done again
+  ///
+  /// @tparam propagator_state_t The state type of the propagator
+  /// @tparam stepper_t The type of stepper used for the propagation
+  ///
+  /// @param [in,out] state is the propagation state object
+  /// @param [in] stepper Stepper in use
+  ///
+  /// boolean return triggers exit to stepper
+  template <typename propagator_state_t, typename stepper_t>
+  void initializeTarget(propagator_state_t& state,
+                        const stepper_t& stepper) const {
+    if (state.navigation.targetVolume != nullptr &&
+        state.stepping.pathAccumulated == 0.) {
+      ACTS_VERBOSE(volInfo(state)
+                   << "Re-initialzing cancelled as it is the first step.");
+      return;
+    }
+    // Fast Navigation initialization for target:
+    if (state.navigation.targetSurface != nullptr &&
+        state.navigation.targetSurface->associatedLayer() &&
+        state.navigation.targetVolume == nullptr) {
+      ACTS_VERBOSE(volInfo(state)
+                   << "Fast target initialization through association.");
+      ACTS_VERBOSE(volInfo(state)
+                   << "Target surface set to "
+                   << state.navigation.targetSurface->geometryId());
+      state.navigation.targetLayer =
+          state.navigation.targetSurface->associatedLayer();
+      state.navigation.targetVolume =
+          state.navigation.targetLayer->trackingVolume();
+    } else if (state.navigation.targetSurface != nullptr) {
+      // screen output that you do a re-initialization
+      if (state.navigation.targetVolume != nullptr) {
+        ACTS_VERBOSE(volInfo(state)
+                     << "Re-initialization of target volume triggered.");
+      }
+      // Slow navigation initialization for target:
+      // target volume and layer search through global search
+      auto targetIntersection =
+          state.navigation.targetSurface
+              ->intersect(
+                  state.geoContext, stepper.position(state.stepping),
+                  state.options.direction * stepper.direction(state.stepping),
+                  BoundaryCheck(false), state.options.surfaceTolerance)
+              .closest();
+      if (targetIntersection) {
+        ACTS_VERBOSE(volInfo(state)
+                     << "Target estimate position ("
+                     << targetIntersection.position().x() << ", "
+                     << targetIntersection.position().y() << ", "
+                     << targetIntersection.position().z() << ")");
+        /// get the target volume from the intersection
+        auto tPosition = targetIntersection.position();
+        state.navigation.targetVolume =
+            m_cfg.trackingGeometry->lowestTrackingVolume(state.geoContext,
+                                                         tPosition);
+        state.navigation.targetLayer =
+            state.navigation.targetVolume != nullptr
+                ? state.navigation.targetVolume->associatedLayer(
+                      state.geoContext, tPosition)
+                : nullptr;
+        if (state.navigation.targetVolume != nullptr) {
+          ACTS_VERBOSE(volInfo(state)
+                       << "Target volume estimated : "
+                       << state.navigation.targetVolume->volumeName());
+        }
+      }
+    }
   }
 
   /// @brief Resolve the surfaces of this layer


### PR DESCRIPTION
Reverting #3217 as this has bigger implications in Athena than expected. The point where this fails at the moment is in a special extrapolation where the whole tracking geometry is "cut" by a cylinder after the first pixel barrel layer. Somehow the previous version of the code was able to handle this case, I am not sure how, since we are also violating our navigation concepts with overlaps there.

I would like to follow up on this on at a later stage where I will try to make the change sound with Athena before we bring it in. One idea is to make the `SurfaceReached` aborter more robust by giving it a state (if this is possible) about the intersections we are targeting. This should make it possible to remove the overstepping condition and to safely target cylinders with that aborter even if there are overlaps in the geometry.