### PR TITLE
fix: add missing gx2f mode to physmon

### DIFF
--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -20,8 +20,8 @@ shopt -s extglob
 
 
 mode=${1:-all}
-if ! [[ $mode = @(all|kalman|gsf|fullchains|vertexing|simulation) ]]; then
-    echo "Usage: $0 <all|kalman|gsf|fullchains|vertexing|simulation> (outdir)"
+if ! [[ $mode = @(all|kalman|gsf|gx2f|fullchains|vertexing|simulation) ]]; then
+    echo "Usage: $0 <all|kalman|gsf|gx2f|fullchains|vertexing|simulation> (outdir)"
     exit 1
 fi
 


### PR DESCRIPTION
We already have everything in place to just run the GX2F tests alone, but we could not use the mode.