### PR TITLE
fix: correct first, then draw for SVG portals

### DIFF
--- a/Plugins/ActSVG/src/PortalSvgConverter.cpp
+++ b/Plugins/ActSVG/src/PortalSvgConverter.cpp
@@ -80,9 +80,9 @@ std::vector<Acts::Svg::ProtoLink> convertMultiLink(
         position = Acts::Vector3(refC * std::cos(phi), refC * std::sin(phi),
                                  refPosition.z());
       } else if (bValue == Acts::binZ) {
-        position[2] = refC;
         // correct to global
         refC += surface.transform(gctx).translation().z();
+        position[2] = refC;
       } else if (bValue == Acts::binPhi) {
         Acts::ActsScalar r = Acts::VectorHelpers::perp(refPosition);
         position = Acts::Vector3(r * std::cos(refC), r * std::sin(refC),


### PR DESCRIPTION
One-line swapping change.

correcting, after assigning does not make sense, you man!