### PR TITLE
refactor: Use unique_ptr for GlueVolumeDescriptor

### DIFF
--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/BoundarySurfaceT.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Geometry/GlueVolumesDescriptor.hpp"
 #include "Acts/Geometry/Layer.hpp"
 #include "Acts/Geometry/TrackingVolumeVisitorConcept.hpp"
 #include "Acts/Geometry/Volume.hpp"

--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -428,8 +428,7 @@ class TrackingVolume : public Volume {
   ///  - positiveFaceXY
   ///
   /// @param gvd register a new GlueVolumeDescriptor
-  /// @todo update to shared/unique ptr
-  void registerGlueVolumeDescriptor(GlueVolumesDescriptor* gvd);
+  void registerGlueVolumeDescriptor(std::unique_ptr<GlueVolumesDescriptor> gvd);
 
   /// Register the outside glue volumes -
   /// ordering is in the TrackingVolume Frame:
@@ -468,7 +467,7 @@ class TrackingVolume : public Volume {
   MutableTrackingVolumeVector m_confinedDenseVolumes;
 
   /// Volumes to glue Volumes from the outside
-  GlueVolumesDescriptor* m_glueVolumeDescriptor{nullptr};
+  std::unique_ptr<GlueVolumesDescriptor> m_glueVolumeDescriptor{nullptr};
 
   /// @}
 

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -60,9 +60,7 @@ TrackingVolume::TrackingVolume(
     : TrackingVolume(transform, std::move(volbounds), nullptr, nullptr,
                      containedVolumeArray, {}, volumeName) {}
 
-TrackingVolume::~TrackingVolume() {
-  delete m_glueVolumeDescriptor;
-}
+TrackingVolume::~TrackingVolume() = default;
 
 const TrackingVolume* TrackingVolume::lowestTrackingVolume(
     const GeometryContext& /*gctx*/, const Vector3& position,
@@ -260,16 +258,16 @@ void TrackingVolume::updateBoundarySurface(
   m_boundarySurfaces.at(bsf) = std::move(bs);
 }
 
-void TrackingVolume::registerGlueVolumeDescriptor(GlueVolumesDescriptor* gvd) {
-  delete m_glueVolumeDescriptor;
-  m_glueVolumeDescriptor = gvd;
+void TrackingVolume::registerGlueVolumeDescriptor(
+    std::unique_ptr<GlueVolumesDescriptor> gvd) {
+  m_glueVolumeDescriptor = std::move(gvd);
 }
 
 GlueVolumesDescriptor& TrackingVolume::glueVolumesDescriptor() {
   if (m_glueVolumeDescriptor == nullptr) {
-    m_glueVolumeDescriptor = new GlueVolumesDescriptor;
+    m_glueVolumeDescriptor = std::make_unique<GlueVolumesDescriptor>();
   }
-  return (*m_glueVolumeDescriptor);
+  return *m_glueVolumeDescriptor;
 }
 
 void TrackingVolume::synchronizeLayers(double envelope) const {


### PR DESCRIPTION
We'll get rid of the glue volume descriptor entirely anyway, but it doesn't hurt to switch to smart pointers regardless.
