### PR TITLE
feat: safe divide

### DIFF
--- a/Core/include/Acts/Utilities/AlgebraHelpers.hpp
+++ b/Core/include/Acts/Utilities/AlgebraHelpers.hpp
@@ -272,7 +272,8 @@ struct SafeDivideEpsilon<long double> {
 /// @param denominator the denominator of the division.
 ///
 /// @return numerator / denominator if denominator is not zero or near-zero.
-/// Throws a runtime_error if the denominator is zero or near-zero.
+/// Otherwise it will round the denominator towards +-epsilon to ensure a proper
+/// result. Zero will be rounded up.
 template <typename T>
 constexpr T safeDivide(T numerator, T denominator) {
   static_assert(std::is_floating_point<T>::value,
@@ -281,7 +282,11 @@ constexpr T safeDivide(T numerator, T denominator) {
   constexpr T epsilon = SafeDivideEpsilon<T>::value;
 
   if (std::abs(denominator) < epsilon) {
-    throw std::runtime_error("Division by zero or near-zero value.");
+    if (denominator >= 0) {
+      return numerator / epsilon;
+    } else {
+      return -numerator / epsilon;
+    }
   }
 
   return numerator / denominator;

--- a/Core/include/Acts/Utilities/AlgebraHelpers.hpp
+++ b/Core/include/Acts/Utilities/AlgebraHelpers.hpp
@@ -249,4 +249,42 @@ constexpr T safeExp(T val) noexcept {
   return std::exp(val);
 }
 
+/// Specialisation of the save divide epsilon to be used for safe division,
+/// depending on the floating point type.
+template <typename T>
+struct SafeDivideEpsilon {};
+template <>
+struct SafeDivideEpsilon<float> {
+  static constexpr float value = 1e-7f;
+};
+template <>
+struct SafeDivideEpsilon<double> {
+  static constexpr double value = 1e-15;
+};
+template <>
+struct SafeDivideEpsilon<long double> {
+  static constexpr long double value = 1e-19L;
+};
+
+/// Perform safe division while avoiding division by zero or near-zero values.
+///
+/// @param numerator the numerator of the division.
+/// @param denominator the denominator of the division.
+///
+/// @return numerator / denominator if denominator is not zero or near-zero.
+/// Throws a runtime_error if the denominator is zero or near-zero.
+template <typename T>
+constexpr T safeDivide(T numerator, T denominator) {
+  static_assert(std::is_floating_point<T>::value,
+                "safeDivide requires floating-point types");
+
+  constexpr T epsilon = SafeDivideEpsilon<T>::value;
+
+  if (std::abs(denominator) < epsilon) {
+    throw std::runtime_error("Division by zero or near-zero value.");
+  }
+
+  return numerator / denominator;
+}
+
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
@@ -134,38 +134,49 @@ BOOST_AUTO_TEST_CASE(SafeDivideFloat) {
 
   const FloatType zero = 0.;
   const FloatType a = 2.;
-  const FloatType b = 5.;
 
   {
-    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+    const FloatType denom = 5.;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = largerThanEpsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = epsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = smallerThanEpsilon;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = zero;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
   }
 }
 
@@ -178,38 +189,49 @@ BOOST_AUTO_TEST_CASE(SafeDivideDouble) {
 
   const FloatType zero = 0.;
   const FloatType a = 2.;
-  const FloatType b = 5.;
 
   {
-    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+    const FloatType denom = 5.;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = largerThanEpsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = epsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = smallerThanEpsilon;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = zero;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
   }
 }
 
@@ -222,38 +244,49 @@ BOOST_AUTO_TEST_CASE(SafeDivideLongDouble) {
 
   const FloatType zero = 0.;
   const FloatType a = 2.;
-  const FloatType b = 5.;
 
   {
-    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+    const FloatType denom = 5.;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = largerThanEpsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = epsilon;
     BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
-    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / denom);
     BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = smallerThanEpsilon;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, -denom), -a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, -denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, -denom), zero);
   }
   {
     const FloatType denom = zero;
-    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
-    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / epsilon);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(-a, denom), -a / epsilon);
+
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
   }
 }
 

--- a/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
@@ -20,6 +20,8 @@ namespace Acts::Test {
 
 BOOST_AUTO_TEST_SUITE(AlgebraHelpers)
 
+BOOST_AUTO_TEST_SUITE(SafeInverse)
+
 ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("SafeInverse", logLevel))
 
 BOOST_AUTO_TEST_CASE(SafeInverseSmallMatrix) {
@@ -116,6 +118,146 @@ BOOST_AUTO_TEST_CASE(SafeInverseFPELargeMatrix) {
 //
 //   auto mInv = Acts::safeInverse(m);
 // }
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(SafeDivide)
+
+ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("SafeDivide", logLevel))
+
+BOOST_AUTO_TEST_CASE(SafeDivideFloat) {
+  using FloatType = float;
+
+  const FloatType largerThanEpsilon = 1e-6f;
+  const FloatType epsilon = 1e-7f;
+  const FloatType smallerThanEpsilon = 1e-8f;
+
+  const FloatType zero = 0.;
+  const FloatType a = 2.;
+  const FloatType b = 5.;
+
+  {
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+  }
+  {
+    const FloatType denom = largerThanEpsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = epsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = smallerThanEpsilon;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+  {
+    const FloatType denom = zero;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SafeDivideDouble) {
+  using FloatType = double;
+
+  const FloatType largerThanEpsilon = 1e-14;
+  const FloatType epsilon = 1e-15;
+  const FloatType smallerThanEpsilon = 1e-16;
+
+  const FloatType zero = 0.;
+  const FloatType a = 2.;
+  const FloatType b = 5.;
+
+  {
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+  }
+  {
+    const FloatType denom = largerThanEpsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = epsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = smallerThanEpsilon;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+  {
+    const FloatType denom = zero;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SafeDivideLongDouble) {
+  using FloatType = long double;
+
+  const FloatType largerThanEpsilon = 1e-18L;
+  const FloatType epsilon = 1e-19L;
+  const FloatType smallerThanEpsilon = 1e-20L;
+
+  const FloatType zero = 0.;
+  const FloatType a = 2.;
+  const FloatType b = 5.;
+
+  {
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, b), a / b);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, a), b / a);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, a), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, b), zero);
+  }
+  {
+    const FloatType denom = largerThanEpsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = epsilon;
+    BOOST_CHECK_EQUAL(Acts::safeDivide(a, denom), a / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(b, denom), b / denom);
+    BOOST_CHECK_EQUAL(Acts::safeDivide(zero, denom), zero);
+  }
+  {
+    const FloatType denom = smallerThanEpsilon;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+  {
+    const FloatType denom = zero;
+    BOOST_CHECK_THROW(Acts::safeDivide(a, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(b, denom), std::runtime_error);
+    BOOST_CHECK_THROW(Acts::safeDivide(zero, denom), std::runtime_error);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Prevents FPEs by giving a good estimate, when i comes to a potentially dangerous division.

Example use case is the `pathCorrection` calculation for the `cylinderSurface`. We do not want to fail the navigation, and instead give an good estimate for the correction:
- https://github.com/acts-project/acts/pull/3254