### PR TITLE
fix: limit cylinderSurface pathCorrection

### DIFF
--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -168,7 +168,7 @@ double Acts::CylinderSurface::pathCorrection(
   double cosAlpha = normalT.dot(direction);
   // We constrain cosAlpha in the division, for cases where we encounter a 90°
   // incline.
-  return std::fabs(1. / std::max(cosAlpha, 1e-15));
+  return 1. / std::max(std::fabs(cosAlpha), 1e-15);
 }
 
 const Acts::CylinderBounds& Acts::CylinderSurface::bounds() const {

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -166,7 +166,9 @@ double Acts::CylinderSurface::pathCorrection(
     const Acts::Vector3& direction) const {
   Vector3 normalT = normal(gctx, position);
   double cosAlpha = normalT.dot(direction);
-  return std::fabs(1. / cosAlpha);
+  // We constrain cosAlpha in the division, for cases where we encounter a 90°
+  // incline.
+  return std::fabs(1. / std::max(cosAlpha, 1e-15));
 }
 
 const Acts::CylinderBounds& Acts::CylinderSurface::bounds() const {


### PR DESCRIPTION
To follow-up on the path correction bug, which I tried to fix in
- https://github.com/acts-project/acts/pull/3254

(first fix was not so well received, since it was not clear enough what values to expect)