### PR TITLE
fix: Add some missing headers for GCC 14

### DIFF
--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/ExaTrkXPipeline.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/ExaTrkXPipeline.hpp
@@ -32,8 +32,9 @@ struct ExaTrkXTiming {
 class ExaTrkXHook {
  public:
   virtual ~ExaTrkXHook() {}
-  virtual void operator()(const std::any &nodes, const std::any &edges,
-                          const std::any &weights) const {};
+  virtual void operator()(const std::any & /*nodes*/,
+                          const std::any & /*edges*/,
+                          const std::any & /*weights*/) const {};
 };
 
 class ExaTrkXPipeline {

--- a/Plugins/ExaTrkX/src/ExaTrkXPipeline.cpp
+++ b/Plugins/ExaTrkX/src/ExaTrkXPipeline.cpp
@@ -8,6 +8,8 @@
 
 #include "Acts/Plugins/ExaTrkX/ExaTrkXPipeline.hpp"
 
+#include <algorithm>
+
 namespace Acts {
 
 ExaTrkXPipeline::ExaTrkXPipeline(

--- a/Plugins/GeoModel/include/Acts/Plugins/GeoModel/GeoModelTree.hpp
+++ b/Plugins/GeoModel/include/Acts/Plugins/GeoModel/GeoModelTree.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <GeoModelRead/ReadGeoModel.h>
 
 class GeoVPhysVol;


### PR DESCRIPTION
These headers need to be included to build with GCC 14. Additional fixed a unused variable warning.