### PR TITLE
feat: Add method for currentPortal in DetectorNavigator

### DIFF
--- a/Core/include/Acts/Navigation/DetectorNavigator.hpp
+++ b/Core/include/Acts/Navigation/DetectorNavigator.hpp
@@ -86,6 +86,10 @@ class DetectorNavigator {
     return state.currentSurface;
   }
 
+  const Portal* currentPortal(const State& state) const {
+    return state.currentPortal;
+  }
+
   const DetectorVolume* currentVolume(const State& state) const {
     return state.currentVolume;
   }


### PR DESCRIPTION
This PR just adds a simple method to retrieve the current portal in the navigation.

@junggjo9 