### PR TITLE
refactor: truth tracking examples: fix ODD setup and make default

### DIFF
--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -167,7 +167,7 @@ if "__main__" == __name__:
     )
 
     ## GenericDetector
-    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # detector, trackingGeometry, _ = acts.examples.GenericDetector.create()
     # digiConfigFile = (
     #     srcdir
     #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -156,21 +156,51 @@ def runTruthTrackingGsf(
 
 
 if "__main__" == __name__:
+    import argparse
+
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # Parse the command line arguments
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-d",
+        "--detector",
+        type=str,
+        choices=["GenericDetector", "ODD"],
+        default="GenericDetector",
+        help="Select Detector: GenericDetector (default) or ODD",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path.cwd(),
+        help="Output directory. Default `Path.cwd()`",
+    )
+    args = p.parse_args()
+
+    if args.detector == "ODD":
+        from acts.examples.odd import getOpenDataDetector
+
+        detector, trackingGeometry, _ = getOpenDataDetector()
+        digiConfigFile = (
+            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        )
+    else:
+        # GenericDetector
+        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+        digiConfigFile = (
+            srcdir
+            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+        )
+
+    outputDir = args.output
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
-
-    inputParticlePath = Path("particles.root")
-    if not inputParticlePath.exists():
-        inputParticlePath = None
 
     runTruthTrackingGsf(
         trackingGeometry=trackingGeometry,
         field=field,
-        digiConfigFile=srcdir
-        / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json",
-        inputParticlePath=inputParticlePath,
-        outputDir=Path.cwd(),
+        digiConfigFile=digiConfigFile,
+        outputDir=outputDir,
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -156,45 +156,22 @@ def runTruthTrackingGsf(
 
 
 if "__main__" == __name__:
-    import argparse
-
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    # Parse the command line arguments
-    p = argparse.ArgumentParser()
-    p.add_argument(
-        "-d",
-        "--detector",
-        type=str,
-        choices=["GenericDetector", "ODD"],
-        default="GenericDetector",
-        help="Select Detector: GenericDetector (default) or ODD",
+    # ODD
+    from acts.examples.odd import getOpenDataDetector
+
+    detector, trackingGeometry, _ = getOpenDataDetector()
+    digiConfigFile = (
+        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
     )
-    p.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        default=Path.cwd(),
-        help="Output directory. Default `Path.cwd()`",
-    )
-    args = p.parse_args()
 
-    if args.detector == "ODD":
-        from acts.examples.odd import getOpenDataDetector
-
-        detector, trackingGeometry, _ = getOpenDataDetector()
-        digiConfigFile = (
-            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
-        )
-    else:
-        # GenericDetector
-        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
-        digiConfigFile = (
-            srcdir
-            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
-        )
-
-    outputDir = args.output
+    ## GenericDetector
+    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # digiConfigFile = (
+    #     srcdir
+    #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+    # )
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
 
@@ -202,5 +179,5 @@ if "__main__" == __name__:
         trackingGeometry=trackingGeometry,
         field=field,
         digiConfigFile=digiConfigFile,
-        outputDir=outputDir,
+        outputDir=Path.cwd(),
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -166,7 +166,7 @@ if "__main__" == __name__:
     )
 
     ## GenericDetector
-    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # detector, trackingGeometry, _ = acts.examples.GenericDetector.create()
     # digiConfigFile = (
     #     srcdir
     #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -155,18 +155,51 @@ def runTruthTrackingGx2f(
 
 
 if "__main__" == __name__:
+    import argparse
+
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    # detector, trackingGeometry, _ = getOpenDataDetector()
-    detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # Parse the command line arguments
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-d",
+        "--detector",
+        type=str,
+        choices=["GenericDetector", "ODD"],
+        default="GenericDetector",
+        help="Select Detector: GenericDetector (default) or ODD",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path.cwd(),
+        help="Output directory. Default `Path.cwd()`",
+    )
+    args = p.parse_args()
+
+    if args.detector == "ODD":
+        from acts.examples.odd import getOpenDataDetector
+
+        detector, trackingGeometry, _ = getOpenDataDetector()
+        digiConfigFile = (
+            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        )
+    else:
+        # GenericDetector
+        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+        digiConfigFile = (
+            srcdir
+            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+        )
+
+    outputDir = args.output
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
 
     runTruthTrackingGx2f(
         trackingGeometry=trackingGeometry,
         field=field,
-        digiConfigFile=srcdir
-        / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json",
-        # "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json",
-        outputDir=Path.cwd(),
+        digiConfigFile=digiConfigFile,
+        outputDir=outputDir,
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -155,45 +155,22 @@ def runTruthTrackingGx2f(
 
 
 if "__main__" == __name__:
-    import argparse
-
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    # Parse the command line arguments
-    p = argparse.ArgumentParser()
-    p.add_argument(
-        "-d",
-        "--detector",
-        type=str,
-        choices=["GenericDetector", "ODD"],
-        default="GenericDetector",
-        help="Select Detector: GenericDetector (default) or ODD",
+    # ODD
+    from acts.examples.odd import getOpenDataDetector
+
+    detector, trackingGeometry, _ = getOpenDataDetector()
+    digiConfigFile = (
+        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
     )
-    p.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        default=Path.cwd(),
-        help="Output directory. Default `Path.cwd()`",
-    )
-    args = p.parse_args()
 
-    if args.detector == "ODD":
-        from acts.examples.odd import getOpenDataDetector
-
-        detector, trackingGeometry, _ = getOpenDataDetector()
-        digiConfigFile = (
-            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
-        )
-    else:
-        # GenericDetector
-        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
-        digiConfigFile = (
-            srcdir
-            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
-        )
-
-    outputDir = args.output
+    ## GenericDetector
+    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # digiConfigFile = (
+    #     srcdir
+    #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+    # )
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
 
@@ -201,5 +178,5 @@ if "__main__" == __name__:
         trackingGeometry=trackingGeometry,
         field=field,
         digiConfigFile=digiConfigFile,
-        outputDir=outputDir,
+        outputDir=Path.cwd(),
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -159,45 +159,22 @@ def runTruthTrackingKalman(
 
 
 if "__main__" == __name__:
-    import argparse
-
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    # Parse the command line arguments
-    p = argparse.ArgumentParser()
-    p.add_argument(
-        "-d",
-        "--detector",
-        type=str,
-        choices=["GenericDetector", "ODD"],
-        default="GenericDetector",
-        help="Select Detector: GenericDetector (default) or ODD",
+    # ODD
+    from acts.examples.odd import getOpenDataDetector
+
+    detector, trackingGeometry, _ = getOpenDataDetector()
+    digiConfigFile = (
+        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
     )
-    p.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        default=Path.cwd(),
-        help="Output directory. Default `Path.cwd()`",
-    )
-    args = p.parse_args()
 
-    if args.detector == "ODD":
-        from acts.examples.odd import getOpenDataDetector
-
-        detector, trackingGeometry, _ = getOpenDataDetector()
-        digiConfigFile = (
-            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
-        )
-    else:
-        # GenericDetector
-        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
-        digiConfigFile = (
-            srcdir
-            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
-        )
-
-    outputDir = args.output
+    ## GenericDetector
+    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # digiConfigFile = (
+    #     srcdir
+    #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+    # )
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
 
@@ -205,5 +182,5 @@ if "__main__" == __name__:
         trackingGeometry=trackingGeometry,
         field=field,
         digiConfigFile=digiConfigFile,
-        outputDir=outputDir,
+        outputDir=Path.cwd(),
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -159,18 +159,51 @@ def runTruthTrackingKalman(
 
 
 if "__main__" == __name__:
+    import argparse
+
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
 
-    # detector, trackingGeometry, _ = getOpenDataDetector()
-    detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # Parse the command line arguments
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-d",
+        "--detector",
+        type=str,
+        choices=["GenericDetector", "ODD"],
+        default="GenericDetector",
+        help="Select Detector: GenericDetector (default) or ODD",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path.cwd(),
+        help="Output directory. Default `Path.cwd()`",
+    )
+    args = p.parse_args()
+
+    if args.detector == "ODD":
+        from acts.examples.odd import getOpenDataDetector
+
+        detector, trackingGeometry, _ = getOpenDataDetector()
+        digiConfigFile = (
+            srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        )
+    else:
+        # GenericDetector
+        detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+        digiConfigFile = (
+            srcdir
+            / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
+        )
+
+    outputDir = args.output
 
     field = acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T))
 
     runTruthTrackingKalman(
         trackingGeometry=trackingGeometry,
         field=field,
-        digiConfigFile=srcdir
-        / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json",
-        # "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json",
-        outputDir=Path.cwd(),
+        digiConfigFile=digiConfigFile,
+        outputDir=outputDir,
     ).run()

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -170,7 +170,7 @@ if "__main__" == __name__:
     )
 
     ## GenericDetector
-    # detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
+    # detector, trackingGeometry, _ = acts.examples.GenericDetector.create()
     # digiConfigFile = (
     #     srcdir
     #     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"


### PR DESCRIPTION
## Why?
- The ODD was never set correctly
- We usually want to run on the ODD and only have the generic for quick checks.

## Note
I put the import `from acts.examples.odd import getOpenDataDetector` under main, since usually, we want to call the `runTruthTrackingFITTERNAME()` from outside.