### PR TITLE
fix(gx2f): forward propagation error

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -767,6 +767,11 @@ class Gx2Fitter {
                                                      propagationResult,
                                                      propagatorOptions, false);
 
+      if (!result.ok()) {
+        ACTS_ERROR("Propagation failed: " << result.error());
+        return result.error();
+      }
+
       // TODO Improve Propagator + Actor [allocate before loop], rewrite
       // makeMeasurements
       auto& propRes = *result;


### PR DESCRIPTION
Somehow the GX2F was so perfect, that no errors occurred until I got today
```
terminate called after throwing an instance of 'std::bad_variant_access'
 what():  std::get: wrong index for variant
```