### PR TITLE
docs: update links to avoid redirects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ Bug reports and feature requests
 --------------------------------
 
 To report an issue and before starting work, please create an issue in the
-`GitHub issue tracker <https://github.com/acts-project/acts-core/issues>`_. A
+`GitHub issue tracker <https://github.com/acts-project/acts/issues>`_. A
 comprehensive explanation will help the development team to respond in a timely
 manner. Verbalising the issue before starting work allows the other contributors
 to chime in and avoids disagreements how to progress.
@@ -76,10 +76,10 @@ be merged in, request a review from the `reviewers team
 request is reviewed, it can be merged in.
 
 To get started with git, please refer to the `short introduction
-<http://git-scm.com/docs/gittutorial>`_ as well as the `full git documentation
+<https://git-scm.com/docs/gittutorial>`_ as well as the `full git documentation
 <https://git-scm.com/doc>`_. Tutorials as well as explanations of concepts and
 workflows with git can also be found on `Atlassian
-<http://www.atlassian.com/git/>`_.
+<https://www.atlassian.com/git/>`_.
 
 Checklist for pull requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -138,8 +138,8 @@ familiar with development process in the Acts project.
    Well-written commit messages are key
    to understand your changes. There are many guidelines available on
    how to write proper commit logs (e.g.
-   `here <http://alistapart.com/article/the-art-of-the-commit>`__,
-   `here <http://chris.beams.io/posts/git-commit/>`__, or
+   `here <https://alistapart.com/article/the-art-of-the-commit>`__,
+   `here <https://cbea.ms/git-commit/>`__, or
    `here <https://wiki.openstack.org/wiki/GitCommitMessages#Information_in_commit_messages>`__).
    As a short summary:
 
@@ -162,9 +162,9 @@ familiar with development process in the Acts project.
    remote repository. These merge commits are considered to contribute
    little information to the development process of the feature and they
    clutter the history (read more e.g.
-   `here <https://developer.atlassian.com/blog/2016/04/stop-foxtrots-now/>`__
+   `here <https://www.atlassian.com/blog/it-teams/stop-foxtrots-now>`__
    or
-   `here <http://victorlin.me/posts/2013/09/30/keep-a-readable-git-history>`__).
+   `here <https://fangpenlin.com/posts/2013/09/30/keep-a-readable-git-history/>`__).
    This problem can be avoided by using ``git pull --rebase`` which
    replays your local (un-pushed) commits on the tip of the remote
    branch. You can make this the default behaviour by running
@@ -182,7 +182,7 @@ Coding style and guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Acts project uses
-`clang-format <http://clang.llvm.org/docs/ClangFormat.html>`_ for
+`clang-format <https://clang.llvm.org/docs/ClangFormat.html>`_ for
 formatting its source code. A ``.clang-format`` configuration file comes
 with the project and should be used to automatically format the code.
 Developers can use the provided Docker image to format their project or
@@ -192,7 +192,7 @@ installing `the same clang version as used in the
 CI <https://github.com/acts-project/machines/blob/master/format10/Dockerfile>`_
 is recommended. There are several instructions available on how to
 integrate clang-format with your favourite IDE (e.g. `Xcode <https://github.com/travisjeffery/ClangFormat-Xcode>`_,
-`emacs <http://clang.llvm.org/docs/ClangFormat.html#emacs-integration>`_).
+`emacs <https://clang.llvm.org/docs/ClangFormat.html#emacs-integration>`_).
 The Acts CI system will automatically check code formatting using the
 provided clang-format configuration and will notify incompatible formatting.
 
@@ -269,7 +269,7 @@ member of the reviewers team before being merged but anyone is welcome
 to contribute by commenting on code changes. You can help reviewing
 proposed contributions by going to `the "pull requests" section of the
 Acts (core) GitHub
-repository <https://github.com/acts-project/acts-core/pulls>`_.
+repository <https://github.com/acts-project/acts/pulls>`_.
 
 As some of the guidelines recommended here require rights granted to the
 reviewers team, this guide specifically addresses the people in this

--- a/Core/include/Acts/Utilities/BoundingBox.hpp
+++ b/Core/include/Acts/Utilities/BoundingBox.hpp
@@ -182,7 +182,7 @@ class AxisAlignedBoundingBox {
    *
    * @note This implementation may treat parallel rays on any of the slabs
    *       as **outside** due to how @c NaNs are handled by Eigen.
-   *       See http://eigen.tuxfamily.org/bz/show_bug.cgi?id=564
+   *       See https://eigen.tuxfamily.org/bz/show_bug.cgi?id=564
    * @param ray The ray to intersect with
    * @return Whether the ray intersects this AABB
    */

--- a/Core/include/Acts/Utilities/BoundingBox.ipp
+++ b/Core/include/Acts/Utilities/BoundingBox.ipp
@@ -128,7 +128,7 @@ bool Acts::AxisAlignedBoundingBox<entity_t, value_t, DIM>::intersect(
 
   // Calculate the component wise min/max between the t0s and t1s
   // this is non-compliant with IEEE-754-2008, NaN gets propagated through
-  // http://eigen.tuxfamily.org/bz/show_bug.cgi?id=564
+  // https://eigen.tuxfamily.org/bz/show_bug.cgi?id=564
   // this means that rays parallel to boundaries might not be considered
   // to intersect.
   vertex_array_type tsmaller = t0s.min(t1s);

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ More information can be found in the [Acts documentation](https://acts.readthedo
 
 Acts is developed in C++ and is build using [CMake](https://cmake.org). Building
 the core library requires a C++17 compatible compiler,
-[Boost](https://www.boost.org), and [Eigen](http://eigen.tuxfamily.org). The
+[Boost](https://www.boost.org), and [Eigen](https://eigen.tuxfamily.org). The
 following commands will clone the repository, configure, and build the core
 library
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ More information can be found in the [Acts documentation](https://acts.readthedo
 
 Acts is developed in C++ and is build using [CMake](https://cmake.org). Building
 the core library requires a C++17 compatible compiler,
-[Boost](http://boost.org), and [Eigen](http://eigen.tuxfamily.org). The
+[Boost](https://www.boost.org), and [Eigen](http://eigen.tuxfamily.org). The
 following commands will clone the repository, configure, and build the core
 library
 

--- a/docs/acts_project.md
+++ b/docs/acts_project.md
@@ -1,6 +1,6 @@
 # The ACTS project
 
-The *A Common Tracking Software (ACTS)* project is an attempt to preserve and evolve the track reconstruction software of the LHC era towards HL-LHC and beyond. It has been initiated in 2016 starting from the [ATLAS Common Tracking Software](https://gitlab.cern.ch/atlas/athena/-/tree/master/Tracking). Given the changing computing landscape, dedicated care of parallel code execution is taken, and is written in `C++17`.
+The *A Common Tracking Software (ACTS)* project is an attempt to preserve and evolve the track reconstruction software of the LHC era towards HL-LHC and beyond. It has been initiated in 2016 starting from the [ATLAS Common Tracking Software](https://gitlab.cern.ch/atlas/athena/-/tree/main/Tracking). Given the changing computing landscape, dedicated care of parallel code execution is taken, and is written in `C++17`.
 
 A [coherent write-up of the project](https://link.springer.com/article/10.1007/s41781-021-00078-8) has been published in 2022 in Springer's CSBS.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ linkcheck_retries = 5
 linkcheck_ignore = [
     r"https://doi.org/.*",
     r"https://cernvm.cern.ch/.*",
-    r"http://eigen.tuxfamily.org.*",
+    r"https://eigen.tuxfamily.org.*",
     r"https://pythia.org.*",
     r"https://lcginfo.cern.ch/.*",
     r"https://.*\.?intel.com/.*",

--- a/docs/contribution/profiling.md
+++ b/docs/contribution/profiling.md
@@ -43,7 +43,7 @@ An older version of pprof comes bundled with gperftools but using the newer Go v
 ### Install Go pprof (Optional)
 
 First, you must install Go. Instructions to do so are available [here](https://go.dev/doc/install).
-Optionally, you can install [Graphviz](http://www.graphviz.org/download/) to produce visualisations of profiles.
+Optionally, you can install [Graphviz](https://www.graphviz.org/download/) to produce visualisations of profiles.
 
 Then, run the following command to install pprof itself:
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@
 
 ACTS is developed in C++ and is built using [CMake](https://cmake.org). Building
 the core library requires a C++17 compatible compiler,
-[Boost](https://www.boost.org), and [Eigen](http://eigen.tuxfamily.org). The
+[Boost](https://www.boost.org), and [Eigen](https://eigen.tuxfamily.org). The
 following commands will clone the repository, configure, and build the core
 library:
 
@@ -26,7 +26,7 @@ The following dependencies are required to build the ACTS core library:
 -   A C++17 compatible compiler (recent versions of either gcc and clang should work)
 -   [CMake](https://cmake.org) >= 3.14
 -   [Boost](https://www.boost.org) >= 1.71 with `filesystem`, `program_options`, and `unit_test_framework`
--   [Eigen](http://eigen.tuxfamily.org) >= 3.3.7
+-   [Eigen](https://eigen.tuxfamily.org) >= 3.3.7
 
 The following dependencies are optional and are needed to build additional
 components:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@
 
 ACTS is developed in C++ and is built using [CMake](https://cmake.org). Building
 the core library requires a C++17 compatible compiler,
-[Boost](http://boost.org), and [Eigen](http://eigen.tuxfamily.org). The
+[Boost](https://www.boost.org), and [Eigen](http://eigen.tuxfamily.org). The
 following commands will clone the repository, configure, and build the core
 library:
 
@@ -25,7 +25,7 @@ The following dependencies are required to build the ACTS core library:
 
 -   A C++17 compatible compiler (recent versions of either gcc and clang should work)
 -   [CMake](https://cmake.org) >= 3.14
--   [Boost](http://boost.org) >= 1.71 with `filesystem`, `program_options`, and `unit_test_framework`
+-   [Boost](https://www.boost.org) >= 1.71 with `filesystem`, `program_options`, and `unit_test_framework`
 -   [Eigen](http://eigen.tuxfamily.org) >= 3.3.7
 
 The following dependencies are optional and are needed to build additional
@@ -34,7 +34,7 @@ components:
 -   [CUDA](https://developer.nvidia.com/cuda-zone) for the CUDA plugin and the Exa.TrkX plugin and its examples
 -   [DD4hep](http://dd4hep.cern.ch) >= 1.11 for the DD4hep plugin and some examples
 -   [Doxygen](http://doxygen.org) >= 1.8.15 for the documentation
--   [Geant4](http://geant4.org/) for some examples
+-   [Geant4](https://geant4.org/) for some examples
 -   [HepMC](https://gitlab.cern.ch/hepmc/HepMC3) >= 3.2.1 for some examples
 -   [Intel Threading Building Blocks](https://github.com/oneapi-src/oneTBB) >= 2020.1 for the examples
 -   [ONNX Runtime](https://onnxruntime.ai/) >= 1.12.0 for the ONNX plugin, the Exa.TrkX plugin and some examples
@@ -336,7 +336,7 @@ want and it will figure out the rest.
 In addition to the ACTS-specific options, many generic options are available
 that modify various aspects of the build. The following options are some of the
 most common ones. For more details, have a look at the annotated list of [useful
-CMake variables](https://cmake.org/Wiki/CMake_Useful_Variables) or at the [CMake
+CMake variables](https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/Useful-Variables) or at the [CMake
 documentation](https://cmake.org/documentation/).
 
 | Option               | Description                                                                                                                       |
@@ -363,7 +363,7 @@ The following environment variables might be useful.
 ## The OpenDataDetector
 
 ACTS comes packaged with a detector modeled using DD4hep that can be used to test your algorithms. It comes equipped with a magnetic field file as well as an already built material map.
-It is available via the git submodule feature by performing the following steps ([`git lfs`](https://git-lfs.github.com/) need to be installed on your machine):
+It is available via the git submodule feature by performing the following steps ([`git lfs`](https://git-lfs.com/) need to be installed on your machine):
 
 ```console
 $ git submodule init

--- a/docs/white_papers.toml
+++ b/docs/white_papers.toml
@@ -17,7 +17,7 @@ authors = [ "Felix Russo",]
 title = "Gaussian Track Densities"
 description = "Given the impact parameters $(d_0, z_0, t_0)$ of a track in Perigee parametrization, one can model the probability of the particle passing exactly through a point $(d, z, t)$ using a multivariate Gaussian distribution. In this white paper, we derive the maximum and the width of such a distribution for $d = 0$. This is useful in vertex seed finding, where we only consider the track density along the beam axis. We use the analytical results from this white paper in the unit test of the Acts module AdaptiveGridTrackDensity."
 [[white_papers]]
-repository = "https://github.com/beomki-yeo/path-correction-term-from-momentum-variation"
+repository = "https://github.com/acts-project/path-correction-term-from-momentum-variation"
 slug = "correction-for-transport-jacobian"
 pdf_url = "https://github.com/acts-project/path-correction-term-from-momentum-variation/releases/download/v2.0/main.pdf"
 

--- a/docs/white_papers/how_to_add.md
+++ b/docs/white_papers/how_to_add.md
@@ -41,7 +41,7 @@ LaTeX installations. `latexmk` is configured to use LuaLatex by default.
 
 ## Integrate with Overleaf
 
-[Overleaf](https://overleaf.com) is a convenient web-based LaTeX authoring tool. It has GitHub integration 🎉!
+[Overleaf](https://www.overleaf.com) is a convenient web-based LaTeX authoring tool. It has GitHub integration 🎉!
 
 :::{image} figures/overleaf_import_github.png
 :align: center


### PR DESCRIPTION
I didn't update
- doxygen.org -> doxygen.nl, because the org page is their official intention
- http://mozilla.org/MPL/2.0/ -> https://www.mozilla.org/en-US/MPL/2.0/, because we have it in all headers like this.

## From Docs Build
- (contribution/guide: line  138) redirect  http://alistapart.com/article/the-art-of-the-commit - permanently to https://alistapart.com/article/the-art-of-the-commit/
- (contribution/guide: line   78) redirect  http://git-scm.com/docs/gittutorial - permanently to https://git-scm.com/docs/gittutorial
- (contribution/guide: line  138) redirect  http://chris.beams.io/posts/git-commit/ - permanently to https://cbea.ms/git-commit/
- ( getting_started: line    5) redirect  http://boost.org - permanently to https://www.boost.org/
- ( getting_started: line   37) redirect  http://geant4.org/ - permanently to https://geant4.org:443/
- (contribution/guide: line  156) redirect  http://victorlin.me/posts/2013/09/30/keep-a-readable-git-history - permanently to https://fangpenlin.com/posts/2013/09/30/keep-a-readable-git-history/
- (contribution/guide: line   78) redirect  http://www.atlassian.com/git/ - permanently to https://www.atlassian.com/git
- (contribution/profiling: line   45) redirect  http://www.graphviz.org/download/ - permanently to https://www.graphviz.org/download/
- (contribution/guide: line  184) redirect  http://clang.llvm.org/docs/ClangFormat.html - with Found to https://clang.llvm.org/docs/ClangFormat.html
- (contribution/guide: line  184) redirect  http://clang.llvm.org/docs/ClangFormat.html#emacs-integration - with Found to https://clang.llvm.org/docs/ClangFormat.html
- ( getting_started: line  336) redirect  https://cmake.org/Wiki/CMake_Useful_Variables - permanently to https://cmake.org/rdrctcm.php?old_link=CMake_Useful_Variables
- (contribution/guide: line  156) redirect  https://developer.atlassian.com/blog/2016/04/stop-foxtrots-now/ - permanently to https://www.atlassian.com/blog/developer
- ( getting_started: line  365) redirect  https://git-lfs.github.com/ - permanently to https://git-lfs.com/
- (contribution/guide: line   25) redirect  https://github.com/acts-project/acts-core/issues - permanently to https://github.com/acts-project/acts/issues
- (contribution/guide: line  267) redirect  https://github.com/acts-project/acts-core/pulls - permanently to https://github.com/acts-project/acts/pulls
- (white_papers/correction-for-transport-jacobian: line    7) redirect  https://github.com/beomki-yeo/path-correction-term-from-momentum-variation - permanently to https://github.com/acts-project/path-correction-term-from-momentum-variation
- (    acts_project: line    3) redirect  https://gitlab.cern.ch/atlas/athena/-/tree/master/Tracking - with Found to https://gitlab.cern.ch/atlas/athena/-/tree/main/Tracking
- (white_papers/how_to_add: line   44) redirect  https://overleaf.com - permanently to https://www.overleaf.com/
