### PR TITLE
docs: update linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,14 +60,8 @@ myst_dmath_allow_labels = True
 
 linkcheck_retries = 5
 linkcheck_ignore = [
-    r"https://doi.org/.*",
-    r"https://cernvm.cern.ch/.*",
+    r"https://cbea.ms/.*",
     r"https://eigen.tuxfamily.org.*",
-    r"https://pythia.org.*",
-    r"https://lcginfo.cern.ch/.*",
-    r"https://.*\.?intel.com/.*",
-    r"https://www.conventionalcommits.org/.*",
-    r"https://cds.cern.ch/record/.*",
 ]
 
 # -- Options for HTML output --------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,6 @@ myst_dmath_allow_labels = True
 
 linkcheck_retries = 5
 linkcheck_ignore = [
-    r"https://cbea.ms/.*",  # no certificate on 2024-06-18
     r"https://eigen.tuxfamily.org.*",  # frequently down
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,8 +60,8 @@ myst_dmath_allow_labels = True
 
 linkcheck_retries = 5
 linkcheck_ignore = [
-    r"https://cbea.ms/.*",
-    r"https://eigen.tuxfamily.org.*",
+    r"https://cbea.ms/.*",  # no certificate on 2024-06-18
+    r"https://eigen.tuxfamily.org.*",  # frequently down
 ]
 
 # -- Options for HTML output --------------------------------------------------


### PR DESCRIPTION
- `eigen.tuxfamily.org` proofed itself to be quite unstable. Let's keep it in.

The rest seems to have fixed their issues with the certificates or we don't link to their pages anymore.

## Edit 1
Thanks to @benjaminhuth on the idea with the extra comments, since git blame is annoying, when there is a refactoring.

## Edit 2
- `cbea.ms` had a certificate problem [MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT](about:certerror?e=nssBadCert&u=https%3A//cbea.ms/&s=badStsCert&c=UTF-8&d=%20#certificateErrorDebugInformation). They fixed it apparently in the meantime (^.^)