### PR TITLE
style: Update clang-format to v18

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   format:
     runs-on: ubuntu-latest
-    container: ghcr.io/acts-project/format14:v41
+    container: ghcr.io/acts-project/format18:48
     steps:
       - uses: actions/checkout@v4
       - name: Check

--- a/Alignment/include/ActsAlignment/Kernel/Alignment.ipp
+++ b/Alignment/include/ActsAlignment/Kernel/Alignment.ipp
@@ -262,11 +262,11 @@ ActsAlignment::Alignment<fitter_t>::align(
         alignOptions.deltaAverageChi2ONdfCutOff.first) {
       if (std::abs(recentChi2ONdf.front() - alignResult.averageChi2ONdf) <=
           alignOptions.deltaAverageChi2ONdfCutOff.second) {
-        ACTS_INFO(
-            "Alignment has converged with change of chi2/ndf < "
-            << alignOptions.deltaAverageChi2ONdfCutOff.second << " in the last "
-            << alignOptions.deltaAverageChi2ONdfCutOff.first << " iterations"
-            << " after " << iIter << " iteration(s)");
+        ACTS_INFO("Alignment has converged with change of chi2/ndf < "
+                  << alignOptions.deltaAverageChi2ONdfCutOff.second
+                  << " in the last "
+                  << alignOptions.deltaAverageChi2ONdfCutOff.first
+                  << " iterations" << " after " << iIter << " iteration(s)");
         converged = true;
         break;
       }

--- a/Core/include/Acts/Detector/DetectorVolumeVisitorConcept.hpp
+++ b/Core/include/Acts/Detector/DetectorVolumeVisitorConcept.hpp
@@ -19,12 +19,12 @@ class DetectorVolume;
 
 template <typename T>
 concept DetectorVolumeVisitor = requires(T v) {
-  {v(std::declval<const Experimental::DetectorVolume*>())};
+  { v(std::declval<const Experimental::DetectorVolume*>()) };
 };
 
 template <typename T>
 concept MutableDetectorVolumeVisitor = requires(T v) {
-  {v(std::declval<Experimental::DetectorVolume*>())};
+  { v(std::declval<Experimental::DetectorVolume*>()) };
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/ChargeConcept.hpp
+++ b/Core/include/Acts/EventData/ChargeConcept.hpp
@@ -23,7 +23,7 @@ namespace Acts {
 
 template <typename C>
 concept ChargeConcept = requires(C c, float f, double d) {
-  {C{f}};
+  { C{f} };
 
   { c == c } -> std::same_as<bool>;
   { c != c } -> std::same_as<bool>;

--- a/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
@@ -34,8 +34,8 @@ using ConstCovariance = Eigen::Map<const BoundMatrix>;
 
 template <typename R>
 concept RangeLike = requires(R r) {
-  {r.begin()};
-  {r.end()};
+  { r.begin() };
+  { r.end() };
 
   requires std::forward_iterator<decltype(r.begin())>;
   requires std::forward_iterator<decltype(r.end())>;
@@ -44,102 +44,104 @@ concept RangeLike = requires(R r) {
 }  // namespace detail
 
 template <typename T>
-concept CommonMultiTrajectoryBackend = requires(const T& cv, HashedString key,
-                                                TrackIndexType istate) {
-  { cv.calibratedSize_impl(istate) } -> std::same_as<TrackIndexType>;
+concept CommonMultiTrajectoryBackend =
+    requires(const T& cv, HashedString key, TrackIndexType istate) {
+      { cv.calibratedSize_impl(istate) } -> std::same_as<TrackIndexType>;
 
-  { cv.getUncalibratedSourceLink_impl(istate) } -> std::same_as<SourceLink>;
+      { cv.getUncalibratedSourceLink_impl(istate) } -> std::same_as<SourceLink>;
 
-  { cv.referenceSurface_impl(istate) } -> std::same_as<const Surface*>;
+      { cv.referenceSurface_impl(istate) } -> std::same_as<const Surface*>;
 
-  { cv.parameters_impl(istate) } -> std::same_as<detail::ConstParameters>;
+      { cv.parameters_impl(istate) } -> std::same_as<detail::ConstParameters>;
 
-  { cv.covariance_impl(istate) } -> std::same_as<detail::ConstCovariance>;
+      { cv.covariance_impl(istate) } -> std::same_as<detail::ConstCovariance>;
 
-  { cv.jacobian_impl(istate) } -> std::same_as<detail::ConstCovariance>;
+      { cv.jacobian_impl(istate) } -> std::same_as<detail::ConstCovariance>;
 
-  {
-    cv.template measurement_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<const ActsVector<2>>>;
+      {
+        cv.template measurement_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<const ActsVector<2>>>;
 
-  {
-    cv.template measurementCovariance_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<const ActsSquareMatrix<2>>>;
+      {
+        cv.template measurementCovariance_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<const ActsSquareMatrix<2>>>;
 
-  { cv.has_impl(key, istate) } -> std::same_as<bool>;
+      { cv.has_impl(key, istate) } -> std::same_as<bool>;
 
-  { cv.size_impl() } -> std::same_as<TrackIndexType>;
+      { cv.size_impl() } -> std::same_as<TrackIndexType>;
 
-  { cv.component_impl(key, istate) } -> std::same_as<std::any>;
+      { cv.component_impl(key, istate) } -> std::same_as<std::any>;
 
-  { cv.hasColumn_impl(key) } -> std::same_as<bool>;
+      { cv.hasColumn_impl(key) } -> std::same_as<bool>;
 
-  {cv.dynamicKeys_impl()};
-  requires detail::RangeLike<decltype(cv.dynamicKeys_impl())>;
-};
+      { cv.dynamicKeys_impl() };
+      requires detail::RangeLike<decltype(cv.dynamicKeys_impl())>;
+    };
 
 template <typename T>
-concept ConstMultiTrajectoryBackend = CommonMultiTrajectoryBackend<T> &&
+concept ConstMultiTrajectoryBackend =
+    CommonMultiTrajectoryBackend<T> &&
     requires(T v, HashedString key, TrackIndexType istate) {
-  { v.parameters_impl(istate) } -> std::same_as<detail::ConstParameters>;
+      { v.parameters_impl(istate) } -> std::same_as<detail::ConstParameters>;
 
-  { v.covariance_impl(istate) } -> std::same_as<detail::ConstCovariance>;
+      { v.covariance_impl(istate) } -> std::same_as<detail::ConstCovariance>;
 
-  { v.jacobian_impl(istate) } -> std::same_as<detail::ConstCovariance>;
+      { v.jacobian_impl(istate) } -> std::same_as<detail::ConstCovariance>;
 
-  {
-    v.template measurement_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<const ActsVector<2>>>;
+      {
+        v.template measurement_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<const ActsVector<2>>>;
 
-  {
-    v.template measurementCovariance_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<const ActsSquareMatrix<2>>>;
-};
+      {
+        v.template measurementCovariance_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<const ActsSquareMatrix<2>>>;
+    };
 
 template <typename T>
-concept MutableMultiTrajectoryBackend = CommonMultiTrajectoryBackend<T> &&
+concept MutableMultiTrajectoryBackend =
+    CommonMultiTrajectoryBackend<T> &&
     requires(T v, HashedString key, TrackIndexType istate,
              TrackStatePropMask mask, std::string col, std::size_t dim,
              SourceLink sl, std::shared_ptr<const Surface> surface) {
-  { v.parameters_impl(istate) } -> std::same_as<detail::Parameters>;
+      { v.parameters_impl(istate) } -> std::same_as<detail::Parameters>;
 
-  { v.covariance_impl(istate) } -> std::same_as<detail::Covariance>;
+      { v.covariance_impl(istate) } -> std::same_as<detail::Covariance>;
 
-  { v.jacobian_impl(istate) } -> std::same_as<detail::Covariance>;
+      { v.jacobian_impl(istate) } -> std::same_as<detail::Covariance>;
 
-  {
-    v.template measurement_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<ActsVector<2>>>;
+      {
+        v.template measurement_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<ActsVector<2>>>;
 
-  {
-    v.template measurementCovariance_impl<2>(istate)
-    } -> std::same_as<Eigen::Map<ActsSquareMatrix<2>>>;
+      {
+        v.template measurementCovariance_impl<2>(istate)
+      } -> std::same_as<Eigen::Map<ActsSquareMatrix<2>>>;
 
-  { v.addTrackState_impl() } -> std::same_as<TrackIndexType>;
+      { v.addTrackState_impl() } -> std::same_as<TrackIndexType>;
 
-  {v.shareFrom_impl(istate, istate, mask, mask)};
+      { v.shareFrom_impl(istate, istate, mask, mask) };
 
-  {v.unset_impl(mask, istate)};
+      { v.unset_impl(mask, istate) };
 
-  {v.clear_impl()};
+      { v.clear_impl() };
 
-  // As far as I know there's no good way to assert that there's a generic
-  // template function
-  {v.template addColumn_impl<std::uint32_t>(col)};
-  {v.template addColumn_impl<std::uint64_t>(col)};
-  {v.template addColumn_impl<std::int32_t>(col)};
-  {v.template addColumn_impl<std::int64_t>(col)};
-  {v.template addColumn_impl<float>(col)};
-  {v.template addColumn_impl<double>(col)};
+      // As far as I know there's no good way to assert that there's a generic
+      // template function
+      { v.template addColumn_impl<std::uint32_t>(col) };
+      { v.template addColumn_impl<std::uint64_t>(col) };
+      { v.template addColumn_impl<std::int32_t>(col) };
+      { v.template addColumn_impl<std::int64_t>(col) };
+      { v.template addColumn_impl<float>(col) };
+      { v.template addColumn_impl<double>(col) };
 
-  {v.allocateCalibrated_impl(istate, dim)};
+      { v.allocateCalibrated_impl(istate, dim) };
 
-  {v.setUncalibratedSourceLink_impl(istate, sl)};
+      { v.setUncalibratedSourceLink_impl(istate, sl) };
 
-  {v.setReferenceSurface_impl(istate, surface)};
+      { v.setReferenceSurface_impl(istate, surface) };
 
-  {v.copyDynamicFrom_impl(istate, key, std::declval<const std::any&>())};
-};
+      { v.copyDynamicFrom_impl(istate, key, std::declval<const std::any&>()) };
+    };
 
 }  // namespace Acts
 #endif

--- a/Core/include/Acts/EventData/ProxyAccessor.hpp
+++ b/Core/include/Acts/EventData/ProxyAccessor.hpp
@@ -25,7 +25,7 @@ concept MutableProxyType = requires(T t, HashedString key) {
 
   {
     t.template component<int>(key)
-    } -> std::same_as<std::conditional_t<T::ReadOnly, const int&, int&>>;
+  } -> std::same_as<std::conditional_t<T::ReadOnly, const int&, int&>>;
 };
 
 template <typename T>
@@ -35,7 +35,7 @@ concept ConstProxyType = requires(T t, HashedString key) {
 };
 
 template <typename T>
-concept ProxyType = (MutableProxyType<T> || ConstProxyType<T>)&&requires {
+concept ProxyType = (MutableProxyType<T> || ConstProxyType<T>) && requires {
   typename T::ConstProxyType;
 
   requires ConstProxyType<typename T::ConstProxyType>;

--- a/Core/include/Acts/EventData/TrackContainer.hpp
+++ b/Core/include/Acts/EventData/TrackContainer.hpp
@@ -132,9 +132,7 @@ class TrackContainer {
   /// Get a const track proxy for a track index
   /// @param itrack the track index in the container
   /// @return A const track proxy for the index
-  ConstTrackProxy getTrack(IndexType itrack) const {
-    return {*this, itrack};
-  }
+  ConstTrackProxy getTrack(IndexType itrack) const { return {*this, itrack}; }
 
   /// Get a mutable track proxy for a track index
   /// @note Only available if the track container is not read-only
@@ -267,9 +265,7 @@ class TrackContainer {
 
   /// Get a const reference to the track container backend
   /// @return a const reference to the backend
-  const auto& container() const {
-    return *m_container;
-  }
+  const auto& container() const { return *m_container; }
 
   /// Get a mutable reference to the track state container backend
   /// @note Only available if the track container is not read-only
@@ -289,23 +285,17 @@ class TrackContainer {
 
   /// Get a const reference to the track state container backend
   /// @return a const reference to the backend
-  const auto& trackStateContainer() const {
-    return *m_traj;
-  }
+  const auto& trackStateContainer() const { return *m_traj; }
 
   /// Retrieve the holder of the track state container
   /// @return The track state container including it's holder
-  const auto& trackStateContainerHolder() const {
-    return m_traj;
-  }
+  const auto& trackStateContainerHolder() const { return m_traj; }
 
   /// @}
 
   /// Get the size (number of tracks) of the track container
   /// @return the sixe
-  constexpr IndexType size() const {
-    return m_container->size_impl();
-  }
+  constexpr IndexType size() const { return m_container->size_impl(); }
 
   /// Clear the content of the track container
   /// @note Only available if the track container is not read-only

--- a/Core/include/Acts/EventData/TrackContainerBackendConcept.hpp
+++ b/Core/include/Acts/EventData/TrackContainerBackendConcept.hpp
@@ -32,66 +32,72 @@ using ConstCovariance = Eigen::Map<const BoundMatrix>;
 }  // namespace detail
 
 template <typename T>
-concept ConstTrackContainerBackend = requires(const T& cv, HashedString key,
-                                              TrackIndexType itrack) {
-  { cv.size_impl() } -> std::same_as<std::size_t>;
+concept ConstTrackContainerBackend =
+    requires(const T& cv, HashedString key, TrackIndexType itrack) {
+      { cv.size_impl() } -> std::same_as<std::size_t>;
 
-  { cv.component_impl(key, itrack) } -> std::same_as<std::any>;
+      { cv.component_impl(key, itrack) } -> std::same_as<std::any>;
 
-  { cv.parameters(itrack) } -> std::same_as<detail::ConstParameters>;
+      { cv.parameters(itrack) } -> std::same_as<detail::ConstParameters>;
 
-  { cv.covariance(itrack) } -> std::same_as<detail::ConstCovariance>;
+      { cv.covariance(itrack) } -> std::same_as<detail::ConstCovariance>;
 
-  { cv.hasColumn_impl(key) } -> std::same_as<bool>;
+      { cv.hasColumn_impl(key) } -> std::same_as<bool>;
 
-  { cv.referenceSurface_impl(itrack) } -> std::same_as<const Surface*>;
+      { cv.referenceSurface_impl(itrack) } -> std::same_as<const Surface*>;
 
-  { cv.particleHypothesis_impl(itrack) } -> std::same_as<ParticleHypothesis>;
+      {
+        cv.particleHypothesis_impl(itrack)
+      } -> std::same_as<ParticleHypothesis>;
 
-  {cv.dynamicKeys_impl()};
-  requires detail::RangeLike<decltype(cv.dynamicKeys_impl())>;
-};
+      { cv.dynamicKeys_impl() };
+      requires detail::RangeLike<decltype(cv.dynamicKeys_impl())>;
+    };
 
 template <typename T>
-concept MutableTrackContainerBackend = ConstTrackContainerBackend<T> &&
+concept MutableTrackContainerBackend =
+    ConstTrackContainerBackend<T> &&
     requires(T v, HashedString key, TrackIndexType itrack, std::string col,
              const T& other, std::shared_ptr<const Surface> sharedSurface) {
-  { v.parameters(itrack) } -> std::same_as<detail::Parameters>;
+      { v.parameters(itrack) } -> std::same_as<detail::Parameters>;
 
-  { v.covariance(itrack) } -> std::same_as<detail::Covariance>;
+      { v.covariance(itrack) } -> std::same_as<detail::Covariance>;
 
-  { v.addTrack_impl() } -> std::same_as<TrackIndexType>;
+      { v.addTrack_impl() } -> std::same_as<TrackIndexType>;
 
-  {v.removeTrack_impl(itrack)};
+      { v.removeTrack_impl(itrack) };
 
-  // As far as I know there's no good way to assert that there's a
-  // generic template function
-  {v.template addColumn_impl<std::uint32_t>(col)};
-  {v.template addColumn_impl<std::uint64_t>(col)};
-  {v.template addColumn_impl<std::int32_t>(col)};
-  {v.template addColumn_impl<std::int64_t>(col)};
-  {v.template addColumn_impl<float>(col)};
-  {v.template addColumn_impl<double>(col)};
+      // As far as I know there's no good way to assert that there's a
+      // generic template function
+      { v.template addColumn_impl<std::uint32_t>(col) };
+      { v.template addColumn_impl<std::uint64_t>(col) };
+      { v.template addColumn_impl<std::int32_t>(col) };
+      { v.template addColumn_impl<std::int64_t>(col) };
+      { v.template addColumn_impl<float>(col) };
+      { v.template addColumn_impl<double>(col) };
 
-  {v.copyDynamicFrom_impl(itrack, key, std::declval<const std::any&>())};
+      { v.copyDynamicFrom_impl(itrack, key, std::declval<const std::any&>()) };
 
-  {v.ensureDynamicColumns_impl(other)};
+      { v.ensureDynamicColumns_impl(other) };
 
-  {v.reserve(itrack)};
+      { v.reserve(itrack) };
 
-  {v.setReferenceSurface_impl(itrack, sharedSurface)};
+      { v.setReferenceSurface_impl(itrack, sharedSurface) };
 
-  {v.setParticleHypothesis_impl(
-      itrack, std::declval<const Acts::ParticleHypothesis&>())};
+      {
+        v.setParticleHypothesis_impl(
+            itrack, std::declval<const Acts::ParticleHypothesis&>())
+      };
 
-  {v.clear()};
-};
+      { v.clear() };
+    };
 
 template <typename T>
 struct IsReadOnlyTrackContainer;
 
 template <typename T>
-concept TrackContainerBackend = ConstTrackContainerBackend<T> &&
+concept TrackContainerBackend =
+    ConstTrackContainerBackend<T> &&
     (IsReadOnlyTrackContainer<T>::value || MutableTrackContainerBackend<T>);
 }  // namespace Acts
 

--- a/Core/include/Acts/EventData/TrackProxy.hpp
+++ b/Core/include/Acts/EventData/TrackProxy.hpp
@@ -352,39 +352,27 @@ class TrackProxy {
 
   /// Access the theta parameter of the track at the reference surface
   /// @return The theta parameter
-  ActsScalar theta() const {
-    return parameters()[eBoundTheta];
-  }
+  ActsScalar theta() const { return parameters()[eBoundTheta]; }
 
   /// Access the phi parameter of the track at the reference surface
   /// @return The phi parameter
-  ActsScalar phi() const {
-    return parameters()[eBoundPhi];
-  }
+  ActsScalar phi() const { return parameters()[eBoundPhi]; }
 
   /// Access the loc0 parameter of the track at the reference surface
   /// @return The loc0 parameter
-  ActsScalar loc0() const {
-    return parameters()[eBoundLoc0];
-  }
+  ActsScalar loc0() const { return parameters()[eBoundLoc0]; }
 
   /// Access the loc1 parameter of the track at the reference surface
   /// @return The loc1 parameter
-  ActsScalar loc1() const {
-    return parameters()[eBoundLoc1];
-  }
+  ActsScalar loc1() const { return parameters()[eBoundLoc1]; }
 
   /// Access the time parameter of the track at the reference surface
   /// @return The time parameter
-  ActsScalar time() const {
-    return parameters()[eBoundTime];
-  }
+  ActsScalar time() const { return parameters()[eBoundTime]; }
 
   /// Access the q/p (curvature) parameter of the track at the reference surface
   /// @return The q/p parameter
-  ActsScalar qOverP() const {
-    return parameters()[eBoundQOverP];
-  }
+  ActsScalar qOverP() const { return parameters()[eBoundQOverP]; }
 
   /// Get the particle hypothesis
   /// @return the particle hypothesis
@@ -404,9 +392,7 @@ class TrackProxy {
   /// Get the charge of the tack
   /// @note this depends on the charge hypothesis
   /// @return The absolute track momentum
-  ActsScalar charge() const {
-    return particleHypothesis().qFromQOP(qOverP());
-  }
+  ActsScalar charge() const { return particleHypothesis().qFromQOP(qOverP()); }
 
   /// Get the absolute momentum of the tack
   /// @return The absolute track momentum
@@ -428,9 +414,7 @@ class TrackProxy {
 
   /// Get the global momentum vector
   /// @return the global momentum vector
-  Vector3 momentum() const {
-    return absoluteMomentum() * direction();
-  }
+  Vector3 momentum() const { return absoluteMomentum() * direction(); }
 
   /// Return the number of track states associated to this track
   /// @note This is calculated by iterating over the track states which is
@@ -519,9 +503,7 @@ class TrackProxy {
 
   /// Return the chi squared for the track. Const version
   /// @return The chi squared
-  float chi2() const {
-    return component<float, hashString("chi2")>();
-  }
+  float chi2() const { return component<float, hashString("chi2")>(); }
 
   /// Return a mutable reference to the number of degrees of freedom for the
   /// track. Mutable version
@@ -541,9 +523,7 @@ class TrackProxy {
   /// Return the index of this track in the track container
   /// @note This is separate from the tip index
   /// @return the track index
-  IndexType index() const {
-    return m_index;
-  }
+  IndexType index() const { return m_index; }
 
   /// @}
 
@@ -850,9 +830,7 @@ class TrackProxy {
 
   /// Return a reference to the track container backend, const version.
   /// @return reference to the track container backend
-  const auto& container() const {
-    return *m_container;
-  }
+  const auto& container() const { return *m_container; }
 
  private:
   TrackProxy(detail_tc::ConstIf<TrackContainer<Container, Trajectory, holder_t>,

--- a/Core/include/Acts/EventData/TrackStateProxyConcept.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxyConcept.hpp
@@ -66,189 +66,200 @@ template <typename T>
 concept TrackStateProxyConcept =
     requires(const T& cv, T v, HashedString key,
              std::shared_ptr<const Surface> surface) {
-  { cv.index() } -> std::same_as<TrackIndexType>;
+      { cv.index() } -> std::same_as<TrackIndexType>;
 
-  { cv.previous() } -> std::same_as<TrackIndexType>;
+      { cv.previous() } -> std::same_as<TrackIndexType>;
 
-  { cv.hasPrevious() } -> std::same_as<bool>;
+      { cv.hasPrevious() } -> std::same_as<bool>;
 
-  { cv.getMask() } -> std::same_as<TrackStatePropMask>;
+      { cv.getMask() } -> std::same_as<TrackStatePropMask>;
 
-  { cv.referenceSurface() } -> std::same_as<const Surface&>;
+      { cv.referenceSurface() } -> std::same_as<const Surface&>;
 
-  { cv.hasReferenceSurface() } -> std::same_as<bool>;
+      { cv.hasReferenceSurface() } -> std::same_as<bool>;
 
-  { cv.template has<hashString("blubb")>() } -> std::same_as<bool>;
+      { cv.template has<hashString("blubb")>() } -> std::same_as<bool>;
 
-  { cv.has(key) } -> std::same_as<bool>;
+      { cv.has(key) } -> std::same_as<bool>;
 
-  { cv.has("blubb") } -> std::same_as<bool>;
+      { cv.has("blubb") } -> std::same_as<bool>;
 
-  // Cannot verify for all types, so just check int
-  {
-    cv.template component<int, hashString("blubb")>()
-    } -> std::same_as<const int&>;
+      // Cannot verify for all types, so just check int
+      {
+        cv.template component<int, hashString("blubb")>()
+      } -> std::same_as<const int&>;
 
-  { cv.template component<int>(key) } -> std::same_as<const int&>;
+      { cv.template component<int>(key) } -> std::same_as<const int&>;
 
-  { cv.parameters() } -> std::same_as<detail::ConstParameters>;
-  { cv.covariance() } -> std::same_as<detail::ConstCovariance>;
+      { cv.parameters() } -> std::same_as<detail::ConstParameters>;
+      { cv.covariance() } -> std::same_as<detail::ConstCovariance>;
 
-  { cv.predicted() } -> std::same_as<detail::ConstParameters>;
-  { cv.predictedCovariance() } -> std::same_as<detail::ConstCovariance>;
-  { cv.hasPredicted() } -> std::same_as<bool>;
-  { v.hasPredicted() } -> std::same_as<bool>;
+      { cv.predicted() } -> std::same_as<detail::ConstParameters>;
+      { cv.predictedCovariance() } -> std::same_as<detail::ConstCovariance>;
+      { cv.hasPredicted() } -> std::same_as<bool>;
+      { v.hasPredicted() } -> std::same_as<bool>;
 
-  { cv.filtered() } -> std::same_as<detail::ConstParameters>;
-  { cv.filteredCovariance() } -> std::same_as<detail::ConstCovariance>;
-  { cv.hasFiltered() } -> std::same_as<bool>;
-  { v.hasFiltered() } -> std::same_as<bool>;
+      { cv.filtered() } -> std::same_as<detail::ConstParameters>;
+      { cv.filteredCovariance() } -> std::same_as<detail::ConstCovariance>;
+      { cv.hasFiltered() } -> std::same_as<bool>;
+      { v.hasFiltered() } -> std::same_as<bool>;
 
-  { cv.smoothed() } -> std::same_as<detail::ConstParameters>;
-  { cv.smoothedCovariance() } -> std::same_as<detail::ConstCovariance>;
-  { cv.hasSmoothed() } -> std::same_as<bool>;
-  { v.hasSmoothed() } -> std::same_as<bool>;
+      { cv.smoothed() } -> std::same_as<detail::ConstParameters>;
+      { cv.smoothedCovariance() } -> std::same_as<detail::ConstCovariance>;
+      { cv.hasSmoothed() } -> std::same_as<bool>;
+      { v.hasSmoothed() } -> std::same_as<bool>;
 
-  { cv.jacobian() } -> std::same_as<detail::ConstCovariance>;
-  { cv.hasJacobian() } -> std::same_as<bool>;
-  { v.hasJacobian() } -> std::same_as<bool>;
+      { cv.jacobian() } -> std::same_as<detail::ConstCovariance>;
+      { cv.hasJacobian() } -> std::same_as<bool>;
+      { v.hasJacobian() } -> std::same_as<bool>;
 
-  { cv.hasProjector() } -> std::same_as<bool>;
-  { v.hasProjector() } -> std::same_as<bool>;
+      { cv.hasProjector() } -> std::same_as<bool>;
+      { v.hasProjector() } -> std::same_as<bool>;
 
-  { cv.effectiveProjector() } -> std::same_as<detail::EffectiveProjector>;
-  { v.effectiveProjector() } -> std::same_as<detail::EffectiveProjector>;
+      { cv.effectiveProjector() } -> std::same_as<detail::EffectiveProjector>;
+      { v.effectiveProjector() } -> std::same_as<detail::EffectiveProjector>;
 
-  { cv.projectorBitset() } -> std::same_as<ProjectorBitset>;
-  { v.projectorBitset() } -> std::same_as<ProjectorBitset>;
+      { cv.projectorBitset() } -> std::same_as<ProjectorBitset>;
+      { v.projectorBitset() } -> std::same_as<ProjectorBitset>;
 
-  { cv.getUncalibratedSourceLink() } -> std::same_as<SourceLink>;
-  { v.getUncalibratedSourceLink() } -> std::same_as<SourceLink>;
+      { cv.getUncalibratedSourceLink() } -> std::same_as<SourceLink>;
+      { v.getUncalibratedSourceLink() } -> std::same_as<SourceLink>;
 
-  { cv.hasCalibrated() } -> std::same_as<bool>;
-  { v.hasCalibrated() } -> std::same_as<bool>;
+      { cv.hasCalibrated() } -> std::same_as<bool>;
+      { v.hasCalibrated() } -> std::same_as<bool>;
 
-  { cv.template calibrated<2>() } -> std::same_as<detail::ConstMeasurement>;
-  {
-    cv.template calibratedCovariance<2>()
-    } -> std::same_as<detail::ConstMeasurementCovariance>;
+      { cv.template calibrated<2>() } -> std::same_as<detail::ConstMeasurement>;
+      {
+        cv.template calibratedCovariance<2>()
+      } -> std::same_as<detail::ConstMeasurementCovariance>;
 
-  { cv.effectiveCalibrated() } -> std::same_as<detail::ConstDynamicMeasurement>;
-  {
-    cv.effectiveCalibratedCovariance()
-    } -> std::same_as<detail::ConstDynamicMeasurementCovariance>;
+      {
+        cv.effectiveCalibrated()
+      } -> std::same_as<detail::ConstDynamicMeasurement>;
+      {
+        cv.effectiveCalibratedCovariance()
+      } -> std::same_as<detail::ConstDynamicMeasurementCovariance>;
 
-  { cv.calibratedSize() } -> std::same_as<TrackIndexType>;
-  { v.calibratedSize() } -> std::same_as<TrackIndexType>;
+      { cv.calibratedSize() } -> std::same_as<TrackIndexType>;
+      { v.calibratedSize() } -> std::same_as<TrackIndexType>;
 
-  { cv.chi2() } -> std::same_as<float>;
+      { cv.chi2() } -> std::same_as<float>;
 
-  { cv.pathLength() } -> std::same_as<double>;
+      { cv.pathLength() } -> std::same_as<double>;
 
-  { cv.typeFlags() } -> std::same_as<ConstTrackStateType>;
-};
-
-template <typename T>
-concept ConstTrackStateProxyConcept = TrackStateProxyConcept<T> &&
-    requires(T v, HashedString key) {
-  // Cannot verify for all types, so just check int
-  {
-    v.template component<int, hashString("blubb")>()
-    } -> std::same_as<const int&>;
-
-  { v.template component<int>(key) } -> std::same_as<const int&>;
-
-  { v.predicted() } -> std::same_as<detail::ConstParameters>;
-  { v.predictedCovariance() } -> std::same_as<detail::ConstCovariance>;
-
-  { v.filtered() } -> std::same_as<detail::ConstParameters>;
-  { v.filteredCovariance() } -> std::same_as<detail::ConstCovariance>;
-
-  { v.smoothed() } -> std::same_as<detail::ConstParameters>;
-  { v.smoothedCovariance() } -> std::same_as<detail::ConstCovariance>;
-
-  { v.jacobian() } -> std::same_as<detail::ConstCovariance>;
-
-  { v.template calibrated<2>() } -> std::same_as<detail::ConstMeasurement>;
-  {
-    v.template calibratedCovariance<2>()
-    } -> std::same_as<detail::ConstMeasurementCovariance>;
-
-  { v.effectiveCalibrated() } -> std::same_as<detail::ConstDynamicMeasurement>;
-  {
-    v.effectiveCalibratedCovariance()
-    } -> std::same_as<detail::ConstDynamicMeasurementCovariance>;
-
-  { v.chi2() } -> std::same_as<double>;
-
-  { v.pathLength() } -> std::same_as<double>;
-
-  { v.typeFlags() } -> std::same_as<ConstTrackStateType>;
-};
+      { cv.typeFlags() } -> std::same_as<ConstTrackStateType>;
+    };
 
 template <typename T>
-concept MutableTrackStateProxyConcept = TrackStateProxyConcept<T> &&
+concept ConstTrackStateProxyConcept =
+    TrackStateProxyConcept<T> && requires(T v, HashedString key) {
+      // Cannot verify for all types, so just check int
+      {
+        v.template component<int, hashString("blubb")>()
+      } -> std::same_as<const int&>;
+
+      { v.template component<int>(key) } -> std::same_as<const int&>;
+
+      { v.predicted() } -> std::same_as<detail::ConstParameters>;
+      { v.predictedCovariance() } -> std::same_as<detail::ConstCovariance>;
+
+      { v.filtered() } -> std::same_as<detail::ConstParameters>;
+      { v.filteredCovariance() } -> std::same_as<detail::ConstCovariance>;
+
+      { v.smoothed() } -> std::same_as<detail::ConstParameters>;
+      { v.smoothedCovariance() } -> std::same_as<detail::ConstCovariance>;
+
+      { v.jacobian() } -> std::same_as<detail::ConstCovariance>;
+
+      { v.template calibrated<2>() } -> std::same_as<detail::ConstMeasurement>;
+      {
+        v.template calibratedCovariance<2>()
+      } -> std::same_as<detail::ConstMeasurementCovariance>;
+
+      {
+        v.effectiveCalibrated()
+      } -> std::same_as<detail::ConstDynamicMeasurement>;
+      {
+        v.effectiveCalibratedCovariance()
+      } -> std::same_as<detail::ConstDynamicMeasurementCovariance>;
+
+      { v.chi2() } -> std::same_as<double>;
+
+      { v.pathLength() } -> std::same_as<double>;
+
+      { v.typeFlags() } -> std::same_as<ConstTrackStateType>;
+    };
+
+template <typename T>
+concept MutableTrackStateProxyConcept =
+    TrackStateProxyConcept<T> &&
     requires(T v, HashedString key, TrackStatePropMask mask,
              TrackIndexType index, std::shared_ptr<const Surface> surface,
              Eigen::Matrix<double, 3, 6> projector,
              ProjectorBitset projectorBitset, SourceLink sl,
              Acts::Measurement<BoundIndices, 2> meas, std::size_t measdim) {
-  {v.shareFrom(mask, mask)};
+      { v.shareFrom(mask, mask) };
 
-  {v.shareFrom(std::declval<typename T::Trajectory::ConstTrackStateProxy>(),
-               mask)};
+      {
+        v.shareFrom(
+            std::declval<typename T::Trajectory::ConstTrackStateProxy>(), mask)
+      };
 
-  {v.shareFrom(std::declval<T>(), mask)};
+      { v.shareFrom(std::declval<T>(), mask) };
 
-  // Cannot verify copyFrom compatibility with other backend proxies
-  {v.copyFrom(std::declval<typename T::Trajectory::ConstTrackStateProxy>(),
-              mask)};
+      // Cannot verify copyFrom compatibility with other backend proxies
+      {
+        v.copyFrom(std::declval<typename T::Trajectory::ConstTrackStateProxy>(),
+                   mask)
+      };
 
-  {v.copyFrom(std::declval<T>(), mask)};
+      { v.copyFrom(std::declval<T>(), mask) };
 
-  {v.unset(mask)};
+      { v.unset(mask) };
 
-  // Cannot verify for all types, so just check int
-  { v.template component<int, hashString("blubb")>() } -> std::same_as<int&>;
+      // Cannot verify for all types, so just check int
+      {
+        v.template component<int, hashString("blubb")>()
+      } -> std::same_as<int&>;
 
-  { v.template component<int>(key) } -> std::same_as<int&>;
+      { v.template component<int>(key) } -> std::same_as<int&>;
 
-  { v.predicted() } -> std::same_as<detail::Parameters>;
-  { v.predictedCovariance() } -> std::same_as<detail::Covariance>;
+      { v.predicted() } -> std::same_as<detail::Parameters>;
+      { v.predictedCovariance() } -> std::same_as<detail::Covariance>;
 
-  { v.filtered() } -> std::same_as<detail::Parameters>;
-  { v.filteredCovariance() } -> std::same_as<detail::Covariance>;
+      { v.filtered() } -> std::same_as<detail::Parameters>;
+      { v.filteredCovariance() } -> std::same_as<detail::Covariance>;
 
-  { v.smoothed() } -> std::same_as<detail::Parameters>;
-  { v.smoothedCovariance() } -> std::same_as<detail::Covariance>;
+      { v.smoothed() } -> std::same_as<detail::Parameters>;
+      { v.smoothedCovariance() } -> std::same_as<detail::Covariance>;
 
-  { v.jacobian() } -> std::same_as<detail::Covariance>;
+      { v.jacobian() } -> std::same_as<detail::Covariance>;
 
-  {v.setProjector(projector)};
+      { v.setProjector(projector) };
 
-  {v.setProjectorBitset(projectorBitset)};
+      { v.setProjectorBitset(projectorBitset) };
 
-  {v.setUncalibratedSourceLink(sl)};
+      { v.setUncalibratedSourceLink(sl) };
 
-  { v.template calibrated<2>() } -> std::same_as<detail::Measurement>;
-  {
-    v.template calibratedCovariance<2>()
-    } -> std::same_as<detail::MeasurementCovariance>;
+      { v.template calibrated<2>() } -> std::same_as<detail::Measurement>;
+      {
+        v.template calibratedCovariance<2>()
+      } -> std::same_as<detail::MeasurementCovariance>;
 
-  { v.effectiveCalibrated() } -> std::same_as<detail::DynamicMeasurement>;
-  {
-    v.effectiveCalibratedCovariance()
-    } -> std::same_as<detail::DynamicMeasurementCovariance>;
+      { v.effectiveCalibrated() } -> std::same_as<detail::DynamicMeasurement>;
+      {
+        v.effectiveCalibratedCovariance()
+      } -> std::same_as<detail::DynamicMeasurementCovariance>;
 
-  {v.setCalibrated(meas)};
+      { v.setCalibrated(meas) };
 
-  {v.allocateCalibrated(measdim)};
+      { v.allocateCalibrated(measdim) };
 
-  { v.chi2() } -> std::same_as<double&>;
+      { v.chi2() } -> std::same_as<double&>;
 
-  { v.pathLength() } -> std::same_as<double&>;
+      { v.pathLength() } -> std::same_as<double&>;
 
-  { v.typeFlags() } -> std::same_as<TrackStateType>;
-};
+      { v.typeFlags() } -> std::same_as<TrackStateType>;
+    };
 }  // namespace Acts
 #endif

--- a/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
@@ -438,9 +438,7 @@ class VectorMultiTrajectory final
     return detail_vmt::VectorMultiTrajectoryBase::has_impl(*this, key, istate);
   }
 
-  IndexType size_impl() const {
-    return m_index.size();
-  }
+  IndexType size_impl() const { return m_index.size(); }
 
   void clear_impl();
 
@@ -565,9 +563,7 @@ class ConstVectorMultiTrajectory final
     return detail_vmt::VectorMultiTrajectoryBase::has_impl(*this, key, istate);
   }
 
-  IndexType size_impl() const {
-    return m_index.size();
-  }
+  IndexType size_impl() const { return m_index.size(); }
 
   std::any component_impl(HashedString key, IndexType istate) const {
     return detail_vmt::VectorMultiTrajectoryBase::component_impl<true>(

--- a/Core/include/Acts/Geometry/TrackingVolumeVisitorConcept.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolumeVisitorConcept.hpp
@@ -17,7 +17,7 @@ class TrackingVolume;
 
 template <typename T>
 concept TrackingVolumeVisitor = requires(T v) {
-  {v(std::declval<const TrackingVolume*>())};
+  { v(std::declval<const TrackingVolume*>()) };
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/EigenStepper.ipp
+++ b/Core/include/Acts/Propagator/EigenStepper.ipp
@@ -100,9 +100,8 @@ bool Acts::EigenStepper<E, A>::prepareCurvilinearState(
 }
 
 template <typename E, typename A>
-auto Acts::EigenStepper<E, A>::curvilinearState(State& state,
-                                                bool transportCov) const
-    -> CurvilinearState {
+auto Acts::EigenStepper<E, A>::curvilinearState(
+    State& state, bool transportCov) const -> CurvilinearState {
   return detail::curvilinearState(
       state.cov, state.jacobian, state.jacTransport, state.derivative,
       state.jacToGlobal, state.pars, state.particleHypothesis,

--- a/Core/include/Acts/Propagator/MaterialInteractor.hpp
+++ b/Core/include/Acts/Propagator/MaterialInteractor.hpp
@@ -81,8 +81,8 @@ struct MaterialInteractor {
 
     // We only have material interactions if there is potential material
     if (surface && surface->surfaceMaterial()) {
-      ACTS_VERBOSE("MaterialInteractor | "
-                   << "Found material on surface " << surface->geometryId());
+      ACTS_VERBOSE("MaterialInteractor | " << "Found material on surface "
+                                           << surface->geometryId());
 
       // Prepare relevant input particle properties
       detail::PointwiseMaterialInteraction interaction(surface, state, stepper);
@@ -129,8 +129,8 @@ struct MaterialInteractor {
 
     // We only have material interactions if there is potential material
     if (volume && volume->volumeMaterial()) {
-      ACTS_VERBOSE("MaterialInteractor | "
-                   << "Found material in volume " << volume->geometryId());
+      ACTS_VERBOSE("MaterialInteractor | " << "Found material in volume "
+                                           << volume->geometryId());
 
       // Prepare relevant input particle properties
       detail::VolumeMaterialInteraction interaction(volume, state, stepper);

--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
@@ -63,9 +63,8 @@ auto MultiEigenStepperLoop<E, R, A>::boundState(
 }
 
 template <typename E, typename R, typename A>
-auto MultiEigenStepperLoop<E, R, A>::curvilinearState(State& state,
-                                                      bool transportCov) const
-    -> CurvilinearState {
+auto MultiEigenStepperLoop<E, R, A>::curvilinearState(
+    State& state, bool transportCov) const -> CurvilinearState {
   assert(!state.components.empty());
 
   std::vector<

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -119,12 +119,12 @@ auto Acts::Propagator<S, N>::propagate(const parameters_t& start,
 template <typename S, typename N>
 template <typename parameters_t, typename propagator_options_t,
           typename target_aborter_t, typename path_aborter_t>
-auto Acts::Propagator<S, N>::propagate(
-    const parameters_t& start, const Surface& target,
-    const propagator_options_t& options) const
-    -> Result<action_list_t_result_t<
-        StepperBoundTrackParameters,
-        typename propagator_options_t::action_list_type>> {
+auto Acts::Propagator<S, N>::propagate(const parameters_t& start,
+                                       const Surface& target,
+                                       const propagator_options_t& options)
+    const -> Result<action_list_t_result_t<
+              StepperBoundTrackParameters,
+              typename propagator_options_t::action_list_type>> {
   static_assert(Concepts::BoundTrackParametersConcept<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
@@ -270,12 +270,13 @@ auto Acts::Propagator<S, N>::makeResult(propagator_state_t state,
 
 template <typename S, typename N>
 template <typename propagator_state_t, typename propagator_options_t>
-auto Acts::Propagator<S, N>::makeResult(
-    propagator_state_t state, Result<void> propagationResult,
-    const Surface& target, const propagator_options_t& /*options*/) const
-    -> Result<action_list_t_result_t<
-        StepperBoundTrackParameters,
-        typename propagator_options_t::action_list_type>> {
+auto Acts::Propagator<S, N>::makeResult(propagator_state_t state,
+                                        Result<void> propagationResult,
+                                        const Surface& target,
+                                        const propagator_options_t& /*options*/)
+    const -> Result<action_list_t_result_t<
+              StepperBoundTrackParameters,
+              typename propagator_options_t::action_list_type>> {
   // Type of track parameters produced at the end of the propagation
   using ReturnParameterType = StepperBoundTrackParameters;
 

--- a/Core/include/Acts/Propagator/StandardAborters.hpp
+++ b/Core/include/Acts/Propagator/StandardAborters.hpp
@@ -51,8 +51,8 @@ struct PathLimitReached {
     double tolerance = state.options.surfaceTolerance;
     bool limitReached = (std::abs(distance) < std::abs(tolerance));
     if (limitReached) {
-      ACTS_VERBOSE("PathLimit aborter | "
-                   << "Path limit reached at distance " << distance);
+      ACTS_VERBOSE("PathLimit aborter | " << "Path limit reached at distance "
+                                          << distance);
       return true;
     }
     stepper.updateStepSize(state.stepping, distance, ConstrainedStep::aborter,

--- a/Core/include/Acts/Seeding/SeedFinderGbts.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderGbts.ipp
@@ -314,12 +314,12 @@ void SeedFinderGbts<external_spacepoint_t>::runGbts_TrackFinder(
                   nEdges++;
                 }
               }  // loop over n2 (outer) nodes
-            }    // loop over n1 (inner) nodes
-          }      // loop over source eta bins
-        }        // loop over dst eta bins
-      }          // loop over L2(L1) layers
-    }            // loop over dst layers
-  }              // loop over the stages of doublet making
+            }  // loop over n1 (inner) nodes
+          }  // loop over source eta bins
+        }  // loop over dst eta bins
+      }  // loop over L2(L1) layers
+    }  // loop over dst layers
+  }  // loop over the stages of doublet making
 
   std::vector<const GbtsNode<external_spacepoint_t>*> vNodes;
 

--- a/Core/include/Acts/Surfaces/SurfaceConcept.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceConcept.hpp
@@ -36,7 +36,7 @@ concept SurfaceConcept = requires(S s, const S cs, S s2, const S cs2,
   { cs.bounds() } -> std::convertible_to<const SurfaceBounds&>;
   {
     cs.associatedDetectorElement()
-    } -> std::same_as<const DetectorElementBase*>;
+  } -> std::same_as<const DetectorElementBase*>;
 
   { cs.associatedLayer() } -> std::same_as<const Layer*>;
   { s.associateLayer(std::declval<const Layer&>()) } -> std::same_as<void>;
@@ -44,51 +44,51 @@ concept SurfaceConcept = requires(S s, const S cs, S s2, const S cs2,
   { cs.surfaceMaterial() } -> std::same_as<const ISurfaceMaterial*>;
   {
     cs.surfaceMaterialSharedPtr()
-    } -> std::same_as<const std::shared_ptr<const ISurfaceMaterial>&>;
+  } -> std::same_as<const std::shared_ptr<const ISurfaceMaterial>&>;
   {
     s.assignSurfaceMaterial(
         std::declval<std::shared_ptr<const ISurfaceMaterial>>())
-    } -> std::same_as<void>;
+  } -> std::same_as<void>;
   {
     cs.isOnSurface(gctx, Vector3{}, Vector3{},
                    std::declval<const BoundaryCheck&>())
-    } -> std::same_as<bool>;
+  } -> std::same_as<bool>;
   {
     cs.insideBounds(Vector2{}, std::declval<const BoundaryCheck&>())
-    } -> std::same_as<bool>;
+  } -> std::same_as<bool>;
 
   { cs.localToGlobal(gctx, Vector2{}, Vector3{}) } -> std::same_as<Vector3>;
 
   {
     cs.globalToLocal(gctx, Vector3{}, Vector3{}, double{5})
-    } -> std::same_as<Result<Vector2>>;
+  } -> std::same_as<Result<Vector2>>;
 
   {
     cs.referenceFrame(gctx, Vector3{}, Vector3{})
-    } -> std::same_as<RotationMatrix3>;
+  } -> std::same_as<RotationMatrix3>;
 
   {
     cs.boundToFreeJacobian(gctx, Vector3{}, Vector3{})
-    } -> std::same_as<BoundToFreeMatrix>;
+  } -> std::same_as<BoundToFreeMatrix>;
 
   {
     cs.freeToBoundJacobian(gctx, Vector3{}, Vector3{})
-    } -> std::same_as<FreeToBoundMatrix>;
+  } -> std::same_as<FreeToBoundMatrix>;
 
   {
     cs.freeToPathDerivative(gctx, Vector3{}, Vector3{})
-    } -> std::same_as<FreeToPathMatrix>;
+  } -> std::same_as<FreeToPathMatrix>;
 
   { cs.pathCorrection(gctx, Vector3{}, Vector3{}) } -> std::same_as<double>;
 
   {
     cs.intersect(gctx, Vector3{}, Vector3{},
                  std::declval<const BoundaryCheck&>(), std::declval<double>())
-    } -> std::same_as<SurfaceMultiIntersection>;
+  } -> std::same_as<SurfaceMultiIntersection>;
 
   {
     cs.toStream(gctx, std::declval<std::ostream&>())
-    } -> std::same_as<std::ostream&>;
+  } -> std::same_as<std::ostream&>;
 
   { cs.toString(gctx) } -> std::same_as<std::string>;
 
@@ -96,34 +96,34 @@ concept SurfaceConcept = requires(S s, const S cs, S s2, const S cs2,
 
   {
     cs.polyhedronRepresentation(gctx, std::declval<std::size_t>())
-    } -> std::same_as<Polyhedron>;
+  } -> std::same_as<Polyhedron>;
 
   {
     cs.alignmentToBoundDerivative(gctx, Vector3{}, Vector3{}, FreeVector{})
-    } -> std::same_as<AlignmentToBoundMatrix>;
+  } -> std::same_as<AlignmentToBoundMatrix>;
 
   {
     cs.alignmentToPathDerivative(gctx, Vector3{}, Vector3{})
-    } -> std::same_as<AlignmentToPathMatrix>;
+  } -> std::same_as<AlignmentToPathMatrix>;
 
   {
     cs.localCartesianToBoundLocalDerivative(gctx, Vector3{})
-    } -> std::same_as<ActsMatrix<2, 3>>;
+  } -> std::same_as<ActsMatrix<2, 3>>;
 };
 
 template <typename S>
-concept RegularSurfaceConcept = SurfaceConcept<S> &&
-    requires(S s, const S cs, GeometryContext gctx) {
-  { cs.normal(gctx, Vector2{}) } -> std::same_as<Vector3>;
+concept RegularSurfaceConcept =
+    SurfaceConcept<S> && requires(S s, const S cs, GeometryContext gctx) {
+      { cs.normal(gctx, Vector2{}) } -> std::same_as<Vector3>;
 
-  { cs.normal(gctx, Vector3{}) } -> std::same_as<Vector3>;
+      { cs.normal(gctx, Vector3{}) } -> std::same_as<Vector3>;
 
-  {
-    cs.globalToLocal(gctx, Vector3{}, Vector3{}, std::declval<double>())
-    } -> std::same_as<Result<Vector2>>;
+      {
+        cs.globalToLocal(gctx, Vector3{}, Vector3{}, std::declval<double>())
+      } -> std::same_as<Result<Vector2>>;
 
-  { cs.localToGlobal(gctx, Vector2{}) } -> std::same_as<Vector3>;
-};
+      { cs.localToGlobal(gctx, Vector2{}) } -> std::same_as<Vector3>;
+    };
 }  // namespace Acts
 
 #endif

--- a/Core/include/Acts/Surfaces/SurfaceVisitorConcept.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceVisitorConcept.hpp
@@ -19,12 +19,12 @@ class Surface;
 
 template <typename T>
 concept SurfaceVisitor = requires(T v) {
-  {v(std::declval<const Surface*>())};
+  { v(std::declval<const Surface*>()) };
 };
 
 template <typename T>
 concept MutableSurfaceVisitor = requires(T v) {
-  {v(std::declval<Surface*>())};
+  { v(std::declval<Surface*>()) };
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -672,8 +672,8 @@ class Gx2Fitter {
            const Gx2FitterOptions<traj_t>& gx2fOptions,
            TrackContainer<track_container_t, traj_t, holder_t>& trackContainer)
       const -> std::enable_if_t<
-          !_isdn, Result<typename TrackContainer<track_container_t, traj_t,
-                                                 holder_t>::TrackProxy>> {
+                !_isdn, Result<typename TrackContainer<
+                            track_container_t, traj_t, holder_t>::TrackProxy>> {
     // Preprocess Measurements (SourceLinks -> map)
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyway, so the map can own them.

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1095,8 +1095,8 @@ class KalmanFitter {
            const KalmanFitterOptions<traj_t>& kfOptions,
            TrackContainer<track_container_t, traj_t, holder_t>& trackContainer)
       const -> std::enable_if_t<
-          !_isdn, Result<typename TrackContainer<track_container_t, traj_t,
-                                                 holder_t>::TrackProxy>> {
+                !_isdn, Result<typename TrackContainer<
+                            track_container_t, traj_t, holder_t>::TrackProxy>> {
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyway, so the map can own them.
     ACTS_VERBOSE("Preparing " << std::distance(it, end)
@@ -1177,8 +1177,8 @@ class KalmanFitter {
            const std::vector<const Surface*>& sSequence,
            TrackContainer<track_container_t, traj_t, holder_t>& trackContainer)
       const -> std::enable_if_t<
-          _isdn, Result<typename TrackContainer<track_container_t, traj_t,
-                                                holder_t>::TrackProxy>> {
+                _isdn, Result<typename TrackContainer<track_container_t, traj_t,
+                                                      holder_t>::TrackProxy>> {
     // To be able to find measurements later, we put them into a map
     // We need to copy input SourceLinks anyway, so the map can own them.
     ACTS_VERBOSE("Preparing " << std::distance(it, end)

--- a/Core/include/Acts/Utilities/Any.hpp
+++ b/Core/include/Acts/Utilities/Any.hpp
@@ -136,9 +136,7 @@ class AnyBase : public AnyBaseAll {
   }
 
 #if defined(_ACTS_ANY_ENABLE_VERBOSE)
-  AnyBase() {
-    _ACTS_ANY_VERBOSE("Default construct this=" << this);
-  };
+  AnyBase() { _ACTS_ANY_VERBOSE("Default construct this=" << this); };
 #else
   AnyBase() = default;
 #endif
@@ -175,9 +173,7 @@ class AnyBase : public AnyBaseAll {
     return *reinterpret_cast<const T*>(dataPtr());
   }
 
-  ~AnyBase() {
-    destroy();
-  }
+  ~AnyBase() { destroy(); }
 
   AnyBase(const AnyBase& other) {
     if (m_handler == nullptr && other.m_handler == nullptr) {
@@ -247,9 +243,7 @@ class AnyBase : public AnyBaseAll {
     return *this;
   }
 
-  operator bool() const {
-    return m_handler != nullptr;
-  }
+  operator bool() const { return m_handler != nullptr; }
 
  private:
   void* dataPtr() {
@@ -260,9 +254,7 @@ class AnyBase : public AnyBaseAll {
     }
   }
 
-  void setDataPtr(void* ptr) {
-    *reinterpret_cast<void**>(m_data.data()) = ptr;
-  }
+  void setDataPtr(void* ptr) { *reinterpret_cast<void**>(m_data.data()) = ptr; }
 
   const void* dataPtr() const {
     if (m_handler->heapAllocated) {

--- a/Core/include/Acts/Utilities/AxisFwd.hpp
+++ b/Core/include/Acts/Utilities/AxisFwd.hpp
@@ -86,18 +86,18 @@ inline std::ostream& operator<<(std::ostream& os, AxisType type) {
 template <AxisType type, AxisBoundaryType bdt = AxisBoundaryType::Open>
 class Axis;
 
-Axis(ActsScalar min, ActsScalar max, std::size_t bins)
-    ->Axis<AxisType::Equidistant, AxisBoundaryType::Open>;
+Axis(ActsScalar min, ActsScalar max,
+     std::size_t bins) -> Axis<AxisType::Equidistant, AxisBoundaryType::Open>;
 
 template <AxisBoundaryType bdt>
 Axis(AxisBoundaryTypeTag<bdt> /*bdt*/, ActsScalar min, ActsScalar max,
      std::size_t bins) -> Axis<AxisType::Equidistant, bdt>;
 
 Axis(std::vector<ActsScalar> bins)
-    ->Axis<AxisType::Variable, AxisBoundaryType::Open>;
+    -> Axis<AxisType::Variable, AxisBoundaryType::Open>;
 
 template <AxisBoundaryType bdt>
-Axis(AxisBoundaryTypeTag<bdt> /*bdt*/, std::vector<ActsScalar> bins)
-    -> Axis<AxisType::Variable, bdt>;
+Axis(AxisBoundaryTypeTag<bdt> /*bdt*/,
+     std::vector<ActsScalar> bins) -> Axis<AxisType::Variable, bdt>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/GridIterator.hpp
+++ b/Core/include/Acts/Utilities/GridIterator.hpp
@@ -300,8 +300,8 @@ class GridLocalIterator {
 };
 
 template <typename T, class... Axes>
-GridGlobalIterator(const Acts::Grid<T, Axes...>& grid, std::size_t idx)
-    -> GridGlobalIterator<T, Axes...>;
+GridGlobalIterator(const Acts::Grid<T, Axes...>& grid,
+                   std::size_t idx) -> GridGlobalIterator<T, Axes...>;
 
 }  // namespace Acts
 

--- a/Core/include/Acts/Utilities/KDTree.hpp
+++ b/Core/include/Acts/Utilities/KDTree.hpp
@@ -180,9 +180,8 @@ class KDTree {
   /// @param i The iterator to write the output to.
   template <typename OutputIt>
   void rangeSearchInserterWithKey(const range_t &r, OutputIt i) const {
-    rangeSearchMapDiscard(r, [i](const coordinate_t &c, const Type &v) mutable {
-      i = {c, v};
-    });
+    rangeSearchMapDiscard(
+        r, [i](const coordinate_t &c, const Type &v) mutable { i = {c, v}; });
   }
 
   /// @brief Perform an orthogonal range search within the k-d tree, applying

--- a/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
+++ b/Core/include/Acts/Utilities/detail/MPL/type_collector.hpp
@@ -70,9 +70,8 @@ constexpr auto type_collector = [](auto t_, auto predicate, auto extractor) {
  * @tparam items The items to filter / collect from.
  */
 template <typename helper, typename... items>
-constexpr auto type_collector_t = type_collector(hana::tuple_t<items...>,
-                                                 helper::predicate,
-                                                 helper::extractor);
+constexpr auto type_collector_t = type_collector(
+    hana::tuple_t<items...>, helper::predicate, helper::extractor);
 
 /**
  * Meta function which returns a compile time bool

--- a/Core/include/Acts/Vertexing/SingleSeedVertexFinder.ipp
+++ b/Core/include/Acts/Vertexing/SingleSeedVertexFinder.ipp
@@ -309,14 +309,14 @@ Acts::SingleSeedVertexFinder<spacepoint_t>::findTriplets(
                       triplets.push_back(tr);
                     }
                   }  // loop over far spacepoints
-                }    // loop over middle spacepoints
-              }      // loop over near spacepoints
-            }        // loop over far phi slices
-          }          // loop over middle phi slices
-        }            // loop over near phi slices
-      }              // loop over far Z slices
-    }                // loop over near Z slices
-  }                  // loop over middle Z slices
+                }  // loop over middle spacepoints
+              }  // loop over near spacepoints
+            }  // loop over far phi slices
+          }  // loop over middle phi slices
+        }  // loop over near phi slices
+      }  // loop over far Z slices
+    }  // loop over near Z slices
+  }  // loop over middle Z slices
 
   return triplets;
 }

--- a/Core/include/Acts/Visualization/detail/ObjVisualization3D.ipp
+++ b/Core/include/Acts/Visualization/detail/ObjVisualization3D.ipp
@@ -109,8 +109,7 @@ void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
       for (const auto& shd : shadings) {
         mos << shd << " " << std::to_string(color[0] / 256.) << " ";
         mos << std::to_string(color[1] / 256.) << " ";
-        mos << std::to_string(color[2] / 256.) << " "
-            << "\n";
+        mos << std::to_string(color[2] / 256.) << " " << "\n";
       }
       mos << "\n";
     }

--- a/Core/src/EventData/VectorMultiTrajectory.cpp
+++ b/Core/src/EventData/VectorMultiTrajectory.cpp
@@ -22,9 +22,8 @@
 
 namespace Acts {
 
-auto VectorMultiTrajectory::addTrackState_impl(TrackStatePropMask mask,
-                                               IndexType iprevious)
-    -> IndexType {
+auto VectorMultiTrajectory::addTrackState_impl(
+    TrackStatePropMask mask, IndexType iprevious) -> IndexType {
   using PropMask = TrackStatePropMask;
 
   m_index.emplace_back();

--- a/Core/src/Geometry/CylinderVolumeStack.cpp
+++ b/Core/src/Geometry/CylinderVolumeStack.cpp
@@ -295,15 +295,15 @@ void CylinderVolumeStack::overlapPrint(
     ss << std::setfill(' ');
     ACTS_VERBOSE("Checking overlap between");
     int w = 9;
-    ss << " - "
-       << " z: [ " << std::setw(w) << a.minZ() << " <- " << std::setw(w)
-       << a.midZ() << " -> " << std::setw(w) << a.maxZ() << " ]";
+    ss << " - " << " z: [ " << std::setw(w) << a.minZ() << " <- "
+       << std::setw(w) << a.midZ() << " -> " << std::setw(w) << a.maxZ()
+       << " ]";
     ACTS_VERBOSE(ss.str());
 
     ss.str("");
-    ss << " - "
-       << " z: [ " << std::setw(w) << b.minZ() << " <- " << std::setw(w)
-       << b.midZ() << " -> " << std::setw(w) << b.maxZ() << " ]";
+    ss << " - " << " z: [ " << std::setw(w) << b.minZ() << " <- "
+       << std::setw(w) << b.midZ() << " -> " << std::setw(w) << b.maxZ()
+       << " ]";
     ACTS_VERBOSE(ss.str());
   }
 }

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -376,9 +376,8 @@ Acts::MutableLayerPtr Acts::LayerCreator::planeLayer(
   Translation3 addTranslation(0., 0., 0.);
   if (transform.isApprox(Transform3::Identity())) {
     addTranslation = Translation3(centerX, centerY, centerZ);
-    ACTS_VERBOSE(" - layer shift  = "
-                 << "(" << centerX << ", " << centerY << ", " << centerZ
-                 << ")");
+    ACTS_VERBOSE(" - layer shift  = " << "(" << centerX << ", " << centerY
+                                      << ", " << centerZ << ")");
   }
 
   std::unique_ptr<SurfaceArray> sArray;

--- a/Core/src/Surfaces/RectangleBounds.cpp
+++ b/Core/src/Surfaces/RectangleBounds.cpp
@@ -30,8 +30,8 @@ const Acts::RectangleBounds& Acts::RectangleBounds::boundingBox() const {
 std::ostream& Acts::RectangleBounds::toStream(std::ostream& sl) const {
   sl << std::setiosflags(std::ios::fixed);
   sl << std::setprecision(7);
-  sl << "Acts::RectangleBounds:  (hlX, hlY) = "
-     << "(" << 0.5 * (get(eMaxX) - get(eMinX)) << ", "
+  sl << "Acts::RectangleBounds:  (hlX, hlY) = " << "("
+     << 0.5 * (get(eMaxX) - get(eMinX)) << ", "
      << 0.5 * (get(eMaxY) - get(eMinY)) << ")";
   sl << "\n(lower left, upper right):\n";
   sl << min().transpose() << "\n" << max().transpose();

--- a/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
@@ -159,8 +159,8 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter::addVtxToFit(
             }
           }
         }  // End for loop over range of associated vertices
-      }    // End loop over trackLinks
-    }      // End loop over lastIterAddedVertices
+      }  // End loop over trackLinks
+    }  // End loop over lastIterAddedVertices
 
     lastIterAddedVertices = currentIterAddedVertices;
     currentIterAddedVertices.clear();

--- a/Examples/Algorithms/Digitization/src/ModuleClusters.cpp
+++ b/Examples/Algorithms/Digitization/src/ModuleClusters.cpp
@@ -219,7 +219,7 @@ std::vector<std::vector<ModuleValue>> ModuleClusters::mergeParameters(
         thisvec.push_back(std::move(values.at(j)));
       }
     }  // Loop on `j'
-  }    // Loop on `i'
+  }  // Loop on `i'
   return retv;
 }
 

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Manager.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Manager.hpp
@@ -82,8 +82,8 @@ class Geant4Manager {
       const std::string &name) const;
 
   /// Get the current list of physics list factories.
-  const std::unordered_map<std::string, std::shared_ptr<PhysicsListFactory>>
-      &getPhysicsListFactories() const;
+  const std::unordered_map<std::string, std::shared_ptr<PhysicsListFactory>> &
+  getPhysicsListFactories() const;
 
  private:
   Geant4Manager();

--- a/Examples/Algorithms/TrackFinding/src/GbtsSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GbtsSeedingAlgorithm.cpp
@@ -106,15 +106,15 @@ ActsExamples::ProcessCode ActsExamples::GbtsSeedingAlgorithm::execute(
   // }
 
   for (auto sp : GbtsSpacePoints) {
-    ACTS_DEBUG("Gbts space points: "
-               << " Gbts_id: " << sp.gbtsID << " z: " << sp.SP->z()
-               << " r: " << sp.SP->r() << " ACTS volume:  "
-               << sp.SP->sourceLinks()
-                      .front()
-                      .get<IndexSourceLink>()
-                      .geometryId()
-                      .volume()
-               << "\n");
+    ACTS_DEBUG("Gbts space points: " << " Gbts_id: " << sp.gbtsID << " z: "
+                                     << sp.SP->z() << " r: " << sp.SP->r()
+                                     << " ACTS volume:  "
+                                     << sp.SP->sourceLinks()
+                                            .front()
+                                            .get<IndexSourceLink>()
+                                            .geometryId()
+                                            .volume()
+                                     << "\n");
   }
 
   // this is now calling on a core algorithm

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -204,10 +204,8 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
         ACTS_ERROR("Adding "
                    << elementType << " " << element->name() << ":"
                    << "\n-> white board will contain key '" << handle->key()
-                   << "'"
-                   << "\nat this point in the sequence (source: "
-                   << source.fullName() << "),"
-                   << "\nbut the type will be\n"
+                   << "'" << "\nat this point in the sequence (source: "
+                   << source.fullName() << ")," << "\nbut the type will be\n"
                    << "'" << demangleAndShorten(source.typeInfo().name()) << "'"
                    << "\nand not\n"
                    << "'" << demangleAndShorten(handle->typeInfo().name())
@@ -216,8 +214,8 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
       }
     } else {
       ACTS_ERROR("Adding " << elementType << " " << element->name() << ":"
-                           << "\n-> white board will not contain key"
-                           << " '" << handle->key()
+                           << "\n-> white board will not contain key" << " '"
+                           << handle->key()
                            << "' at this point in the sequence."
                            << "\n   Needed for read data handle '"
                            << handle->name() << "'")
@@ -627,10 +625,9 @@ void Sequencer::fpeReport() const {
 
     std::vector<std::reference_wrapper<const Acts::FpeMonitor::Result::FpeInfo>>
         sorted;
-    std::transform(
-        merged.stackTraces().begin(), merged.stackTraces().end(),
-        std::back_inserter(sorted),
-        [](const auto& f) -> const auto& { return f; });
+    std::transform(merged.stackTraces().begin(), merged.stackTraces().end(),
+                   std::back_inserter(sorted),
+                   [](const auto& f) -> const auto& { return f; });
     std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
       return a.get().count > b.get().count;
     });

--- a/Examples/Io/Csv/src/CsvSeedWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSeedWriter.cpp
@@ -163,13 +163,8 @@ ActsExamples::ProcessCode ActsExamples::CsvSeedWriter::writeT(
     infoMap[toAdd.seedID] = toAdd;
   }
 
-  mos << "seed_id,particleId,"
-      << "pT,eta,phi,"
-      << "bX,bY,bZ,"
-      << "mX,mY,mZ,"
-      << "tX,tY,tZ,"
-      << "good/duplicate/fake,"
-      << "vertexZ,quality,"
+  mos << "seed_id,particleId," << "pT,eta,phi," << "bX,bY,bZ," << "mX,mY,mZ,"
+      << "tX,tY,tZ," << "good/duplicate/fake," << "vertexZ,quality,"
       << "Hits_ID" << '\n';
 
   for (auto& [id, info] : infoMap) {

--- a/Examples/Io/Csv/src/CsvTrackWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackWriter.cpp
@@ -179,11 +179,8 @@ ProcessCode CsvTrackWriter::writeT(const AlgorithmContext& context,
   // write csv header
   mos << "track_id,seed_id,particleId,"
       << "nStates,nMajorityHits,nMeasurements,nOutliers,nHoles,nSharedHits,"
-      << "chi2,ndf,chi2/ndf,"
-      << "pT,eta,phi,"
-      << "truthMatchProbability,"
-      << "good/duplicate/fake,"
-      << "Hits_ID";
+      << "chi2,ndf,chi2/ndf," << "pT,eta,phi," << "truthMatchProbability,"
+      << "good/duplicate/fake," << "Hits_ID";
 
   mos << '\n';
   mos << std::setprecision(m_cfg.outputPrecision);

--- a/Examples/Io/Root/src/RootBFieldWriter.cpp
+++ b/Examples/Io/Root/src/RootBFieldWriter.cpp
@@ -189,8 +189,8 @@ void RootBFieldWriter::run(const Config& config,
           Bz = bField.z() / Acts::UnitConstants::T;
           outputTree->Fill();
         }  // for z
-      }    // for y
-    }      // for x
+      }  // for y
+    }  // for x
 
   } else {
     ACTS_INFO("Map will be written out in cylinder coordinates (r,z).");
@@ -271,7 +271,7 @@ void RootBFieldWriter::run(const Config& config,
         Br = VectorHelpers::perp(bField) / Acts::UnitConstants::T;
         outputTree->Fill();
       }  // for R
-    }    // for z
+    }  // for z
   }
 
   // Tear down ROOT I/O

--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -34,10 +34,7 @@ template <typename T, typename Ur, typename Ut>
 void pythonRangeProperty(T& obj, const std::string& name, Ur Ut::*begin,
                          Ur Ut::*end) {
   obj.def_property(
-      name.c_str(),
-      [=](Ut& self) {
-        return std::pair{self.*begin, self.*end};
-      },
+      name.c_str(), [=](Ut& self) { return std::pair{self.*begin, self.*end}; },
       [=](Ut& self, std::pair<Ur, Ur> p) {
         self.*begin = p.first;
         self.*end = p.second;

--- a/Examples/Python/src/Generators.cpp
+++ b/Examples/Python/src/Generators.cpp
@@ -159,28 +159,21 @@ void addGenerators(Context& ctx) {
         .def_readwrite("mass", &Config::mass)
         .def_readwrite("charge", &Config::charge)
         .def_property(
-            "p",
-            [](Config& cfg) {
-              return std::pair{cfg.pMin, cfg.pMax};
-            },
+            "p", [](Config& cfg) { return std::pair{cfg.pMin, cfg.pMax}; },
             [](Config& cfg, std::pair<double, double> value) {
               cfg.pMin = value.first;
               cfg.pMax = value.second;
             })
         .def_property(
             "phi",
-            [](Config& cfg) {
-              return std::pair{cfg.phiMin, cfg.phiMax};
-            },
+            [](Config& cfg) { return std::pair{cfg.phiMin, cfg.phiMax}; },
             [](Config& cfg, std::pair<double, double> value) {
               cfg.phiMin = value.first;
               cfg.phiMax = value.second;
             })
         .def_property(
             "theta",
-            [](Config& cfg) {
-              return std::pair{cfg.thetaMin, cfg.thetaMax};
-            },
+            [](Config& cfg) { return std::pair{cfg.thetaMin, cfg.thetaMax}; },
             [](Config& cfg, std::pair<double, double> value) {
               cfg.thetaMin = value.first;
               cfg.thetaMax = value.second;

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -219,18 +219,17 @@ void addJson(Context& ctx) {
   }
 
   {
-    mex.def(
-        "readDetectorFromJson",
-        [](const Acts::GeometryContext& gctx,
-           const std::string& fileName) -> auto{
-          auto in = std::ifstream(fileName,
-                                  std::ifstream::in | std::ifstream::binary);
-          nlohmann::json jDetectorIn;
-          in >> jDetectorIn;
-          in.close();
+    mex.def("readDetectorFromJson",
+            [](const Acts::GeometryContext& gctx,
+               const std::string& fileName) -> auto {
+              auto in = std::ifstream(
+                  fileName, std::ifstream::in | std::ifstream::binary);
+              nlohmann::json jDetectorIn;
+              in >> jDetectorIn;
+              in.close();
 
-          return Acts::DetectorJsonConverter::fromJson(gctx, jDetectorIn);
-        });
+              return Acts::DetectorJsonConverter::fromJson(gctx, jDetectorIn);
+            });
   }
 }
 }  // namespace Acts::Python

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -350,20 +350,21 @@ void addTrackFinding(Context& ctx) {
                                 outputTrackParameters);
 
   {
-    auto constructor = [](const std::vector<std::pair<
-                              GeometryIdentifier,
-                              std::tuple<std::vector<double>,
-                                         std::vector<double>,
-                                         std::vector<std::size_t>>>>& input) {
-      std::vector<std::pair<GeometryIdentifier, MeasurementSelectorCuts>>
-          converted;
-      converted.reserve(input.size());
-      for (const auto& [id, cuts] : input) {
-        const auto& [bins, chi2, num] = cuts;
-        converted.emplace_back(id, MeasurementSelectorCuts{bins, chi2, num});
-      }
-      return std::make_unique<MeasurementSelector::Config>(converted);
-    };
+    auto constructor =
+        [](const std::vector<
+            std::pair<GeometryIdentifier,
+                      std::tuple<std::vector<double>, std::vector<double>,
+                                 std::vector<std::size_t>>>>& input) {
+          std::vector<std::pair<GeometryIdentifier, MeasurementSelectorCuts>>
+              converted;
+          converted.reserve(input.size());
+          for (const auto& [id, cuts] : input) {
+            const auto& [bins, chi2, num] = cuts;
+            converted.emplace_back(id,
+                                   MeasurementSelectorCuts{bins, chi2, num});
+          }
+          return std::make_unique<MeasurementSelector::Config>(converted);
+        };
 
     py::class_<MeasurementSelectorCuts>(m, "MeasurementSelectorCuts")
         .def(py::init<>())

--- a/Plugins/FpeMonitoring/src/FpeMonitor.cpp
+++ b/Plugins/FpeMonitoring/src/FpeMonitor.cpp
@@ -133,8 +133,8 @@ unsigned int FpeMonitor::Result::numStackTraces() const {
   return m_stracktraces.size();
 }
 
-const std::vector<FpeMonitor::Result::FpeInfo>
-    &FpeMonitor::Result::stackTraces() const {
+const std::vector<FpeMonitor::Result::FpeInfo> &
+FpeMonitor::Result::stackTraces() const {
   return m_stracktraces;
 }
 
@@ -167,11 +167,11 @@ void FpeMonitor::Result::deduplicate() {
   m_stracktraces.clear();
 
   for (auto &info : copy) {
-    auto it = std::find_if(
-        m_stracktraces.begin(), m_stracktraces.end(),
-        [&info](const FpeInfo &el) {
-          return areFpesEquivalent({el.type, *el.st}, {info.type, *info.st});
-        });
+    auto it = std::find_if(m_stracktraces.begin(), m_stracktraces.end(),
+                           [&info](const FpeInfo &el) {
+                             return areFpesEquivalent({el.type, *el.st},
+                                                      {info.type, *info.st});
+                           });
     if (it != m_stracktraces.end()) {
       it->count += info.count;
       continue;

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/FloatComparisons.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/FloatComparisons.hpp
@@ -293,8 +293,7 @@ boost::test_tools::predicate_result checkCloseCovariance(
         boost::test_tools::predicate_result res(false);
         res.message() << "The difference between the covariance matrix term "
                       << val(row, col) << " and its reference " << ref(row, col)
-                      << ","
-                      << " at index (" << row << ", " << col << "),"
+                      << "," << " at index (" << row << ", " << col << "),"
                       << " is not within tolerance " << tol * orderOfMagnitude
                       << '.' << " The covariance matrix being tested was\n"
                       << val << '\n'

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/LineSurfaceStub.hpp
@@ -19,32 +19,27 @@ class LineSurfaceStub : public LineSurface {
   LineSurfaceStub() = delete;
   //
   LineSurfaceStub(const Transform3& htrans, double radius, double halfz)
-      : GeometryObject(), LineSurface(htrans, radius, halfz) { /* nop */
-  }
+      : GeometryObject(), LineSurface(htrans, radius, halfz) { /* nop */ }
   //
   LineSurfaceStub(const Transform3& htrans,
                   std::shared_ptr<const LineBounds> lbounds = nullptr)
-      : GeometryObject(), LineSurface(htrans, std::move(lbounds)) { /*nop */
-  }
+      : GeometryObject(), LineSurface(htrans, std::move(lbounds)) { /*nop */ }
   //
   LineSurfaceStub(std::shared_ptr<const LineBounds> lbounds,
                   const DetectorElementBase& detelement)
       : GeometryObject(),
-        LineSurface(std::move(lbounds), detelement) { /* nop */
-  }
+        LineSurface(std::move(lbounds), detelement) { /* nop */ }
 
   //
   LineSurfaceStub(const LineSurfaceStub& ls)
-      : GeometryObject(), LineSurface(ls) { /* nop */
-  }
+      : GeometryObject(), LineSurface(ls) { /* nop */ }
 
   LineSurfaceStub& operator=(const LineSurfaceStub& ls) = default;
 
   //
   LineSurfaceStub(const GeometryContext& gctx, const LineSurfaceStub& ls,
                   const Transform3& t)
-      : GeometryObject(), LineSurface(gctx, ls, t) { /* nop */
-  }
+      : GeometryObject(), LineSurface(gctx, ls, t) { /* nop */ }
 
   /// Return method for the Surface type to avoid dynamic casts
   SurfaceType type() const final { return Surface::Straw; }

--- a/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
@@ -236,9 +236,7 @@ BOOST_AUTO_TEST_CASE(VolumeMaterialMapper_comparison_tests) {
   // Build the material grid
   Grid3D Grid = createGrid(xAxis, yAxis, zAxis);
   std::function<Vector3(Vector3)> transfoGlobalToLocal =
-      [](Vector3 pos) -> Vector3 {
-    return {pos.x(), pos.y(), pos.z()};
-  };
+      [](Vector3 pos) -> Vector3 { return {pos.x(), pos.y(), pos.z()}; };
 
   // Walk over each property
   for (const auto& rm : matRecord) {

--- a/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
@@ -261,9 +261,8 @@ void test_bound_to_curvilinear(const std::vector<TestData> &test_data_list,
         const auto &curvilinear_parameters = result.value().endParameters;
         if (curvilinear_parameters.has_value() &&
             curvilinear_parameters.value().covariance().has_value()) {
-          MSG_DEBUG(i << " | "
-                      << "limit: " << null_propagation_options.pathLimit
-                      << " tolerance: "
+          MSG_DEBUG(i << " | " << "limit: "
+                      << null_propagation_options.pathLimit << " tolerance: "
                       << null_propagation_options.stepTolerance << std::endl);
 
           Acts::BoundSquareMatrix curvi_cov =

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//#include <boost/test/tools/output_test_stream.hpp>
+// #include <boost/test/tools/output_test_stream.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
@@ -38,12 +38,8 @@ class SurfaceBoundsStub : public SurfaceBounds {
 #endif
 
   ~SurfaceBoundsStub() override = default;
-  BoundsType type() const final {
-    return SurfaceBounds::eOther;
-  }
-  std::vector<double> values() const override {
-    return m_values;
-  }
+  BoundsType type() const final { return SurfaceBounds::eOther; }
+  std::vector<double> values() const override { return m_values; }
   bool inside(const Vector2& /*lpos*/,
               const BoundaryCheck& /*bcheck*/) const final {
     return true;

--- a/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
+++ b/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
@@ -210,7 +210,7 @@ struct FitterTester {
 
     if (doDiag) {
       doTest(true);
-    }               // with reversed & smoothed columns
+    }  // with reversed & smoothed columns
     doTest(false);  // without the extra columns
   }
 

--- a/Tests/UnitTests/Core/TrackFitting/GainMatrixUpdaterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GainMatrixUpdaterTests.cpp
@@ -75,8 +75,7 @@ BOOST_AUTO_TEST_CASE(Update) {
 
   // Gain matrix update and filtered state
   BOOST_CHECK(GainMatrixUpdater()
-                  .
-                  operator()<VectorMultiTrajectory>(tgContext, ts)
+                  .operator()<VectorMultiTrajectory>(tgContext, ts)
                   .ok());
 
   // Check for regression. This does NOT test if the math is correct, just that

--- a/Tests/UnitTests/Core/TrackFitting/GsfComponentMergingTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfComponentMergingTests.cpp
@@ -148,8 +148,8 @@ auto circularMean(const std::vector<ActsVector<D>> &samples) -> ActsVector<D> {
 // subtraction object to enable circular behaviour
 template <int D, typename subtract_t = std::minus<ActsVector<D>>>
 auto boundCov(const std::vector<ActsVector<D>> &samples,
-              const ActsVector<D> &mu, const subtract_t &sub = subtract_t{})
-    -> ActsSquareMatrix<D> {
+              const ActsVector<D> &mu,
+              const subtract_t &sub = subtract_t{}) -> ActsSquareMatrix<D> {
   ActsSquareMatrix<D> boundCov = ActsSquareMatrix<D>::Zero();
 
   for (const auto &smpl : samples) {

--- a/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AlgebraHelpersTests.cpp
@@ -78,14 +78,13 @@ BOOST_AUTO_TEST_CASE(SafeInverseFPESmallMatrix) {
   BOOST_CHECK(mInv);
   BOOST_CHECK(!mInvInv);
 
-  ACTS_VERBOSE("Test: SafeInverseFPESmallMatrix"
-               << "\n"
-               << "m:\n"
-               << m << "\n"
-               << "mInv:\n"
-               << *mInv << "\n"
-               << "mInvInv [garbage]:\n"
-               << *mInvInv);
+  ACTS_VERBOSE("Test: SafeInverseFPESmallMatrix" << "\n"
+                                                 << "m:\n"
+                                                 << m << "\n"
+                                                 << "mInv:\n"
+                                                 << *mInv << "\n"
+                                                 << "mInvInv [garbage]:\n"
+                                                 << *mInvInv);
 }
 
 BOOST_AUTO_TEST_CASE(SafeInverseFPELargeMatrix) {
@@ -97,12 +96,11 @@ BOOST_AUTO_TEST_CASE(SafeInverseFPELargeMatrix) {
 
   BOOST_CHECK(!mInv);
 
-  ACTS_VERBOSE("Test: SafeInverseFPELargeMatrix"
-               << "\n"
-               << "m:\n"
-               << m << "\n"
-               << "mInv [garbage]:\n"
-               << *mInv);
+  ACTS_VERBOSE("Test: SafeInverseFPELargeMatrix" << "\n"
+                                                 << "m:\n"
+                                                 << m << "\n"
+                                                 << "mInv [garbage]:\n"
+                                                 << *mInv);
 }
 
 /// This test should not compile

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -279,9 +279,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
       std::cout << "----- True vertices -----" << std::endl;
       for (const auto& vertex : trueVertices) {
         Vector3 pos = vertex.position();
-        std::cout << count << ". True Vertex:\t Position:"
-                  << "(" << pos[eX] << "," << pos[eY] << "," << pos[eZ] << ")"
-                  << std::endl;
+        std::cout << count << ". True Vertex:\t Position:" << "(" << pos[eX]
+                  << "," << pos[eY] << "," << pos[eZ] << ")" << std::endl;
         std::cout << "Number of tracks: " << vertex.tracks().size() << std::endl
                   << std::endl;
         count++;
@@ -290,9 +289,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
       count = 1;
       for (const auto& vertex : vertexCollection) {
         Vector3 pos = vertex.position();
-        std::cout << count << ". Reco Vertex:\t Position:"
-                  << "(" << pos[eX] << "," << pos[eY] << "," << pos[eZ] << ")"
-                  << std::endl;
+        std::cout << count << ". Reco Vertex:\t Position:" << "(" << pos[eX]
+                  << "," << pos[eY] << "," << pos[eZ] << ")" << std::endl;
         std::cout << "Number of tracks: " << vertex.tracks().size() << std::endl
                   << std::endl;
         count++;
@@ -500,9 +498,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
       std::cout << "----- True vertices -----" << std::endl;
       for (const auto& vertex : trueVertices) {
         Vector3 pos = vertex.position();
-        std::cout << count << ". True Vertex:\t Position:"
-                  << "(" << pos[eX] << "," << pos[eY] << "," << pos[eZ] << ")"
-                  << std::endl;
+        std::cout << count << ". True Vertex:\t Position:" << "(" << pos[eX]
+                  << "," << pos[eY] << "," << pos[eZ] << ")" << std::endl;
         std::cout << "Number of tracks: " << vertex.tracks().size() << std::endl
                   << std::endl;
         count++;
@@ -511,9 +508,8 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
       count = 1;
       for (const auto& vertex : vertexCollectionUT) {
         Vector3 pos = vertex.position();
-        std::cout << count << ". Reco Vertex:\t Position:"
-                  << "(" << pos[eX] << "," << pos[eY] << "," << pos[eZ] << ")"
-                  << std::endl;
+        std::cout << count << ". Reco Vertex:\t Position:" << "(" << pos[eX]
+                  << "," << pos[eY] << "," << pos[eZ] << ")" << std::endl;
         std::cout << "Number of tracks: " << vertex.tracks().size() << std::endl
                   << std::endl;
         count++;

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepDiscLayerStructureTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepDiscLayerStructureTests.cpp
@@ -113,15 +113,15 @@ BOOST_AUTO_TEST_CASE(DD4hepDiscLayerStructure) {
     if (itest == 1u) {
       cxml << indent_12_xml << "  <acts_passive_surface>" << '\n';
       cxml << indent_12_xml
-           << "    <tubs rmin=\"20*mm\" rmax=\"120*mm\" dz=\"2*mm\" "
-           << "cz=\"" << rZ + 10. << "\" material=\"Air\"/>" << '\n';
+           << "    <tubs rmin=\"20*mm\" rmax=\"120*mm\" dz=\"2*mm\" " << "cz=\""
+           << rZ + 10. << "\" material=\"Air\"/>" << '\n';
       cxml << indent_12_xml << "  </acts_passive_surface>" << '\n';
       passiveAddon = 1u;
     } else if (itest == 2u) {
       cxml << indent_12_xml << "  <acts_passive_surface>" << '\n';
       cxml << indent_12_xml
-           << "    <tubs rmin=\"20*mm\" rmax=\"120*mm\" dz=\"2*mm\" "
-           << "cz=\"" << rZ + 10. << "\" material=\"Air\"/>" << '\n';
+           << "    <tubs rmin=\"20*mm\" rmax=\"120*mm\" dz=\"2*mm\" " << "cz=\""
+           << rZ + 10. << "\" material=\"Air\"/>" << '\n';
       cxml << "    <acts_proto_material/>" << '\n';
       cxml << indent_12_xml << "  </acts_passive_surface>" << '\n';
       passiveAddon = 1u;

--- a/Tests/UnitTests/Plugins/Json/MaterialMapJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/MaterialMapJsonConverterTests.cpp
@@ -26,10 +26,10 @@ class IVolumeMaterial;
 class DummyDecorator : public Acts::IVolumeMaterialJsonDecorator {
  public:
   void decorate([[maybe_unused]] const Acts::ISurfaceMaterial &material,
-                [[maybe_unused]] nlohmann::json &json) const override{};
+                [[maybe_unused]] nlohmann::json &json) const override {};
 
   void decorate([[maybe_unused]] const Acts::IVolumeMaterial &material,
-                [[maybe_unused]] nlohmann::json &json) const override{};
+                [[maybe_unused]] nlohmann::json &json) const override {};
 };
 
 BOOST_AUTO_TEST_SUITE(MaterialMapJsonConverter)


### PR DESCRIPTION
This commit updates the formatter used in the CI to clang-format 18 and makes the required changes to the source files as well. This affects mostly modern C++20 features like concepts, although some additional style changes are observed as well.