### PR TITLE
chore: Fix a number of SonarQube reliability issues

### DIFF
--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
@@ -413,7 +413,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
       score = score * fac;
       ACTS_DEBUG("Modifier for chi2 = " << chi2 << " and NDF = " << indf
                                         << " is : " << fac
-                                        << "  New score now: " << score)
+                                        << "  New score now: " << score);
     }
     iTrack++;
 

--- a/Core/include/Acts/EventData/SourceLink.hpp
+++ b/Core/include/Acts/EventData/SourceLink.hpp
@@ -44,7 +44,7 @@ class SourceLink final {
                   "Cannot wrap SourceLink in SourceLink");
 
     if constexpr (std::is_same_v<T, std::decay_t<T>>) {
-      m_upstream = any_type{std::forward(upstream)};
+      m_upstream = any_type{std::forward<T>(upstream)};
     } else {
       m_upstream = any_type{static_cast<std::decay_t<T>>(upstream)};
     }

--- a/Core/include/Acts/EventData/SourceLink.hpp
+++ b/Core/include/Acts/EventData/SourceLink.hpp
@@ -44,7 +44,7 @@ class SourceLink final {
                   "Cannot wrap SourceLink in SourceLink");
 
     if constexpr (std::is_same_v<T, std::decay_t<T>>) {
-      m_upstream = any_type{std::move(upstream)};
+      m_upstream = any_type{std::forward(upstream)};
     } else {
       m_upstream = any_type{static_cast<std::decay_t<T>>(upstream)};
     }

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -295,7 +295,7 @@ class DirectNavigator {
         // Set the current surface
         state.navigation.currentSurface = *state.navigation.navSurfaceIter;
         ACTS_VERBOSE("Current surface set to  "
-                     << state.navigation.currentSurface->geometryId())
+                     << state.navigation.currentSurface->geometryId());
         // Move the sequence to the next surface
         ++state.navigation.navSurfaceIter;
         if (state.navigation.navSurfaceIter !=

--- a/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
+++ b/Core/include/Acts/Seeding/EstimateTrackParamsFromSeed.hpp
@@ -55,7 +55,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
   // Check the number of provided space points
   std::size_t numSP = std::distance(spBegin, spEnd);
   if (numSP < 3) {
-    ACTS_ERROR("At least three space points are required.")
+    ACTS_ERROR("At least three space points are required.");
     return std::nullopt;
   }
 
@@ -67,7 +67,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
 
   for (spacepoint_iterator_t it = spBegin; it != spEnd; it++) {
     if (*it == nullptr) {
-      ACTS_ERROR("Empty space point found. This should not happen.")
+      ACTS_ERROR("Empty space point found. This should not happen.");
       return std::nullopt;
     }
     const auto& sp = *it;
@@ -158,7 +158,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
   // Check the number of provided space points
   std::size_t numSP = std::distance(spBegin, spEnd);
   if (numSP != 3) {
-    ACTS_ERROR("There should be exactly three space points provided.")
+    ACTS_ERROR("There should be exactly three space points provided.");
     return std::nullopt;
   }
 
@@ -171,7 +171,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
     // case?
     ACTS_WARNING("The magnetic field at the bottom space point: B = "
                  << bFieldInTesla << " T is smaller than |B|_min = "
-                 << bFieldMinInTesla << " T. Estimation is not performed.")
+                 << bFieldMinInTesla << " T. Estimation is not performed.");
     return std::nullopt;
   }
 
@@ -185,7 +185,7 @@ std::optional<BoundVector> estimateTrackParamsFromSeed(
   for (std::size_t isp = 0; isp < 3; ++isp) {
     spacepoint_iterator_t it = std::next(spBegin, isp);
     if (*it == nullptr) {
-      ACTS_ERROR("Empty space point found. This should not happen.")
+      ACTS_ERROR("Empty space point found. This should not happen.");
       return std::nullopt;
     }
     const auto& sp = *it;

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -768,14 +768,14 @@ class CombinatorialKalmanFilter {
 
         if (!tsRes.ok()) {
           ACTS_ERROR(
-              "Processing of selected track states failed: " << tsRes.error())
+              "Processing of selected track states failed: " << tsRes.error());
           return tsRes.error();
         }
         Result<std::tuple<unsigned int, bool>> procRes = processNewTrackStates(
             state.geoContext, prevTipState, *tsRes, result);
         if (!procRes.ok()) {
-          ACTS_ERROR(
-              "Processing of selected track states failed: " << procRes.error())
+          ACTS_ERROR("Processing of selected track states failed: "
+                     << procRes.error());
           return procRes.error();
         }
         auto [nNewBranchesOnSurface, isOutlier] = *procRes;

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -606,12 +606,14 @@ class Gx2Fitter {
             // MaterialUpdateStage::FullUpdate);
           }
         } else {
-          ACTS_INFO("Surface " << geoId << " has no measurement/material/hole.")
+          ACTS_INFO("Surface " << geoId
+                               << " has no measurement/material/hole.");
         }
       }
       ACTS_VERBOSE("result.processedMeasurements: "
                    << result.processedMeasurements << "\n"
-                   << "inputMeasurements.size(): " << inputMeasurements->size())
+                   << "inputMeasurements.size(): "
+                   << inputMeasurements->size());
       if (result.processedMeasurements >= inputMeasurements->size()) {
         ACTS_INFO("Actor: finish: all measurements found.");
         result.finished = true;
@@ -831,7 +833,7 @@ class Gx2Fitter {
                              trackState, *m_addToSumLogger);
           } else {
             ACTS_ERROR("Can not process state with measurement with "
-                       << measDim << " dimensions.")
+                       << measDim << " dimensions.");
             throw std::domain_error(
                 "Found measurement with less than 1 or more than 6 "
                 "dimension(s).");
@@ -839,9 +841,9 @@ class Gx2Fitter {
         } else if (typeFlags.test(TrackStateFlag::HoleFlag)) {
           // Handle hole
           // TODO: write hole handling
-          ACTS_VERBOSE("Placeholder: Handle hole.")
+          ACTS_VERBOSE("Placeholder: Handle hole.");
         } else {
-          ACTS_WARNING("Unknown state encountered")
+          ACTS_WARNING("Unknown state encountered");
         }
         // TODO: Material handling. Should be there for hole and measurement
       }
@@ -1005,7 +1007,7 @@ class Gx2Fitter {
 
     if (trackContainer.hasColumn(
             Acts::hashString(Gx2fConstants::gx2fnUpdateColumn))) {
-      ACTS_DEBUG("Add nUpdate to track")
+      ACTS_DEBUG("Add nUpdate to track");
       track.template component<std::size_t>("Gx2fnUpdateColumn") = nUpdate;
     }
 

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -1008,7 +1008,8 @@ class Gx2Fitter {
     if (trackContainer.hasColumn(
             Acts::hashString(Gx2fConstants::gx2fnUpdateColumn))) {
       ACTS_DEBUG("Add nUpdate to track");
-      track.template component<std::uint32_t>("Gx2fnUpdateColumn") = nUpdate;
+      track.template component<std::uint32_t>("Gx2fnUpdateColumn") =
+          static_cast<std::uint32_t>(nUpdate);
     }
 
     // TODO write test for calculateTrackQuantities

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -152,7 +152,7 @@ struct GsfActor {
 
     // Return is we found an error earlier
     if (!result.result.ok()) {
-      ACTS_WARNING("result.result not ok, return!")
+      ACTS_WARNING("result.result not ok, return!");
       return;
     }
 

--- a/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
+++ b/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
@@ -105,7 +105,7 @@ auto kalmanHandleMeasurement(
     } else {
       ACTS_VERBOSE(
           "Filtering step successful. But measurement is determined "
-          "to be an outlier. Stepping state is not updated.")
+          "to be an outlier. Stepping state is not updated.");
       // Set the outlier type flag
       typeFlags.set(TrackStateFlag::OutlierFlag);
       trackStateProxy.shareFrom(trackStateProxy, TrackStatePropMask::Predicted,

--- a/Core/include/Acts/Utilities/Axis.hpp
+++ b/Core/include/Acts/Utilities/Axis.hpp
@@ -160,7 +160,8 @@ class Axis<AxisType::Equidistant, bdt> final : public IAxis {
   /// @return Set of neighboring bin indices (global)
   NeighborHoodIndices neighborHoodIndices(std::size_t idx,
                                           std::size_t size = 1) const {
-    return neighborHoodIndices(idx, std::make_pair(-size, size));
+    return neighborHoodIndices(idx,
+                               std::make_pair(-static_cast<int>(size), size));
   }
 
   /// @brief Get #size bins which neighbor the one given
@@ -418,7 +419,8 @@ class Axis<AxisType::Variable, bdt> final : public IAxis {
   /// Create a binning structure with @c nBins variable-sized bins from the
   /// given bin boundaries. @c nBins is given by the number of bin edges
   /// reduced by one.
-  Axis(std::vector<ActsScalar> binEdges) : m_binEdges(std::move(binEdges)) {}
+  explicit Axis(std::vector<ActsScalar> binEdges)
+      : m_binEdges(std::move(binEdges)) {}
 
   /// @param [in] typeTag boundary type tag
   /// @param [in] binEdges vector of bin edges
@@ -461,7 +463,8 @@ class Axis<AxisType::Variable, bdt> final : public IAxis {
   /// @return Set of neighboring bin indices (global)
   NeighborHoodIndices neighborHoodIndices(std::size_t idx,
                                           std::size_t size = 1) const {
-    return neighborHoodIndices(idx, std::make_pair(-size, size));
+    return neighborHoodIndices(idx,
+                               std::make_pair(-static_cast<int>(size), size));
   }
 
   /// @brief Get #size bins which neighbor the one given

--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -122,7 +123,7 @@ class BinUtility {
     m_transform = m_transform * gbu.transform();
     m_itransform = m_transform.inverse();
     if (m_binningData.size() + bData.size() > 3) {
-      throw "BinUtility does not support dim > 3";
+      throw std::runtime_error{"BinUtility does not support dim > 3"};
     }
     m_binningData.insert(m_binningData.end(), bData.begin(), bData.end());
     return (*this);
@@ -268,7 +269,7 @@ class BinUtility {
   /// @return the binning value of the accessor entry
   BinningValue binningValue(std::size_t ba = 0) const {
     if (ba >= m_binningData.size()) {
-      throw "dimension out of bounds";
+      throw std::runtime_error{"Dimension out of bounds"};
     }
     return (m_binningData[ba].binvalue);
   }

--- a/Core/include/Acts/Utilities/BinningData.hpp
+++ b/Core/include/Acts/Utilities/BinningData.hpp
@@ -244,9 +244,6 @@ class BinningData {
         binvalue == binH) {
       return lposition[0];
     }
-    if (binvalue == binPhi) {
-      return lposition[1];
-    }
     return lposition[1];
   }
 

--- a/Core/include/Acts/Utilities/Delegate.hpp
+++ b/Core/include/Acts/Utilities/Delegate.hpp
@@ -74,17 +74,17 @@ class Delegate<R(Args...), H, O> {
  public:
   Delegate() = default;
 
-  Delegate(Delegate &&) = default;
-  Delegate &operator=(Delegate &&) = default;
-  Delegate(const Delegate &) = default;
-  Delegate &operator=(const Delegate &) = default;
+  Delegate(Delegate &&) noexcept = default;
+  Delegate &operator=(Delegate &&) noexcept = default;
+  Delegate(const Delegate &) noexcept = default;
+  Delegate &operator=(const Delegate &) noexcept = default;
 
   /// Constructor with an explicit runtime callable
   /// @param callable The runtime value of the callable
   /// @note The function signature requires the first argument of the callable is `const void*`.
   ///       i.e. if the signature of the delegate is `void(int)`, the
   ///       callable's signature has to be `void(const void*, int)`.
-  Delegate(function_type callable) { connect(callable); }
+  explicit Delegate(function_type callable) { connect(callable); }
 
   /// Constructor with a possibly stateful function object.
   /// @tparam Callable Type of the callable
@@ -92,7 +92,7 @@ class Delegate<R(Args...), H, O> {
   /// @note @c Delegate does not assume owner ship over @p callable. You need to ensure
   ///       it's lifetime is longer than that of @c Delegate.
   template <typename Callable, typename = isNoFunPtr<Callable>>
-  Delegate(Callable &callable) {
+  explicit Delegate(Callable &callable) {
     connect(callable);
   }
 
@@ -100,7 +100,7 @@ class Delegate<R(Args...), H, O> {
   /// @tparam Callable The compile-time free function pointer
   /// @note @c DelegateFuncTag is used to communicate the callable type
   template <auto Callable>
-  Delegate(DelegateFuncTag<Callable> /*tag*/) {
+  explicit Delegate(DelegateFuncTag<Callable> /*tag*/) {
     connect<Callable>();
   }
 
@@ -157,7 +157,7 @@ class Delegate<R(Args...), H, O> {
         "signature");
 
     m_function = [](const holder_type * /*payload*/,
-                    Args... args) -> return_type {
+                    Args &&...args) -> return_type {
       return std::invoke(Callable, std::forward<Args>(args)...);
     };
   }
@@ -223,7 +223,7 @@ class Delegate<R(Args...), H, O> {
   template <auto Callable, typename Type, DelegateType T = kOwnership,
             typename = std::enable_if_t<T == DelegateType::Owning>>
   void connect(std::unique_ptr<const Type> instance) {
-    using member_ptr_type = return_type (Type::*)(Args...) const;
+    using member_ptr_type = return_type (Type::*)(Args && ...) const;
     static_assert(Concepts::is_detected<isSignatureCompatible, member_ptr_type,
                                         decltype(Callable)>::value,
                   "Callable given does not correspond exactly to required call "
@@ -235,7 +235,7 @@ class Delegate<R(Args...), H, O> {
           delete concretePayload;
         });
 
-    m_function = [](const holder_type *payload, Args... args) -> return_type {
+    m_function = [](const holder_type *payload, Args &&...args) -> return_type {
       assert(payload != nullptr && "Payload is required, but not set");
       const auto *concretePayload = static_cast<const Type *>(payload);
       return std::invoke(Callable, concretePayload,
@@ -246,10 +246,10 @@ class Delegate<R(Args...), H, O> {
   /// The call operator that exposes the functionality of the @c Delegate type.
   /// @param args The arguments to call the contained function with
   /// @return Return value of the contained function
-  return_type operator()(Args... args) const {
+  template <typename... Ts>
+  return_type operator()(Ts &&...args) const {
     assert(connected() && "Delegate is not connected");
-    return std::invoke(m_function, m_payload.ptr(),
-                       std::forward<Args>(args)...);
+    return std::invoke(m_function, m_payload.ptr(), std::forward<Ts>(args)...);
   }
 
   /// Return whether this delegate is currently connected
@@ -258,7 +258,7 @@ class Delegate<R(Args...), H, O> {
 
   /// Return whether this delegate is currently connected
   /// @return True if this delegate is connected
-  operator bool() const { return connected(); }
+  explicit operator bool() const { return connected(); }
 
   /// Disconnect this delegate, meaning it cannot be called anymore
   void disconnect() {
@@ -274,7 +274,9 @@ class Delegate<R(Args...), H, O> {
 
  private:
   // Deleter that does not do anything
-  static void noopDeleter(const holder_type * /*unused*/) {}
+  static void noopDeleter(const holder_type * /*unused*/) {
+    // we do not own the payload
+  }
 
   /// @cond
 

--- a/Core/include/Acts/Utilities/Delegate.hpp
+++ b/Core/include/Acts/Utilities/Delegate.hpp
@@ -157,7 +157,7 @@ class Delegate<R(Args...), H, O> {
         "signature");
 
     m_function = [](const holder_type * /*payload*/,
-                    Args &&...args) -> return_type {
+                    Args... args) -> return_type {
       return std::invoke(Callable, std::forward<Args>(args)...);
     };
   }
@@ -223,7 +223,7 @@ class Delegate<R(Args...), H, O> {
   template <auto Callable, typename Type, DelegateType T = kOwnership,
             typename = std::enable_if_t<T == DelegateType::Owning>>
   void connect(std::unique_ptr<const Type> instance) {
-    using member_ptr_type = return_type (Type::*)(Args && ...) const;
+    using member_ptr_type = return_type (Type::*)(Args &&...) const;
     static_assert(Concepts::is_detected<isSignatureCompatible, member_ptr_type,
                                         decltype(Callable)>::value,
                   "Callable given does not correspond exactly to required call "

--- a/Core/include/Acts/Utilities/Delegate.hpp
+++ b/Core/include/Acts/Utilities/Delegate.hpp
@@ -223,7 +223,7 @@ class Delegate<R(Args...), H, O> {
   template <auto Callable, typename Type, DelegateType T = kOwnership,
             typename = std::enable_if_t<T == DelegateType::Owning>>
   void connect(std::unique_ptr<const Type> instance) {
-    using member_ptr_type = return_type (Type::*)(Args &&...) const;
+    using member_ptr_type = return_type (Type::*)(Args && ...) const;
     static_assert(Concepts::is_detected<isSignatureCompatible, member_ptr_type,
                                         decltype(Callable)>::value,
                   "Callable given does not correspond exactly to required call "

--- a/Core/include/Acts/Utilities/GridBinFinder.hpp
+++ b/Core/include/Acts/Utilities/GridBinFinder.hpp
@@ -45,7 +45,9 @@ class GridBinFinder {
                     std::is_same<std::pair<int, int>, std::decay_t<args>>,
                     std::is_same<std::vector<std::pair<int, int>>,
                                  std::decay_t<args>>>...>::value>>
-  explicit GridBinFinder(args&&... vals);
+  explicit GridBinFinder(args&&... vals) {
+    storeValue(std::forward<args>(vals)...);
+  }
 
   /// @brief Retrieve the neighbouring bins given a local position in the grid
   ///

--- a/Core/include/Acts/Utilities/GridBinFinder.hpp
+++ b/Core/include/Acts/Utilities/GridBinFinder.hpp
@@ -37,8 +37,15 @@ class GridBinFinder {
   /// @pre The provided paramers must be of type 'int', 'std::pair<int, int>' or 'std::vector<std::pair<int, int>>'
   /// no other type is allowed. The order of these parameters must correspond to
   /// the same ordering of the axes in the grid
-  template <typename... args>
-  GridBinFinder(args&&... vals);
+  template <typename... args,
+            typename = std::enable_if_t<
+                sizeof...(args) == DIM &&
+                std::conjunction<std::disjunction<
+                    std::is_same<int, std::decay_t<args>>,
+                    std::is_same<std::pair<int, int>, std::decay_t<args>>,
+                    std::is_same<std::vector<std::pair<int, int>>,
+                                 std::decay_t<args>>>...>::value>>
+  explicit GridBinFinder(args&&... vals);
 
   /// @brief Retrieve the neighbouring bins given a local position in the grid
   ///

--- a/Core/include/Acts/Utilities/GridBinFinder.hpp
+++ b/Core/include/Acts/Utilities/GridBinFinder.hpp
@@ -40,11 +40,11 @@ class GridBinFinder {
   template <typename... args,
             typename = std::enable_if_t<
                 sizeof...(args) == DIM &&
-                std::conjunction<std::disjunction<
+                std::conjunction_v<std::disjunction<
                     std::is_same<int, std::decay_t<args>>,
                     std::is_same<std::pair<int, int>, std::decay_t<args>>,
                     std::is_same<std::vector<std::pair<int, int>>,
-                                 std::decay_t<args>>>...>::value>>
+                                 std::decay_t<args>>>...>>>
   explicit GridBinFinder(args&&... vals) {
     storeValue(std::forward<args>(vals)...);
   }

--- a/Core/include/Acts/Utilities/GridBinFinder.ipp
+++ b/Core/include/Acts/Utilities/GridBinFinder.ipp
@@ -7,12 +7,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 template <std::size_t DIM>
-template <typename... args>
-Acts::GridBinFinder<DIM>::GridBinFinder(args&&... vals) {
-  storeValue(std::forward<args>(vals)...);
-}
-
-template <std::size_t DIM>
 template <typename first_value_t, typename... vals>
 void Acts::GridBinFinder<DIM>::storeValue(first_value_t&& fv,
                                           vals&&... others) {

--- a/Core/include/Acts/Utilities/GridBinFinder.ipp
+++ b/Core/include/Acts/Utilities/GridBinFinder.ipp
@@ -9,13 +9,6 @@
 template <std::size_t DIM>
 template <typename... args>
 Acts::GridBinFinder<DIM>::GridBinFinder(args&&... vals) {
-  static_assert(sizeof...(args) == DIM);
-  static_assert(
-      std::conjunction<std::disjunction<
-          std::is_same<int, typename std::decay<args>::type>,
-          std::is_same<std::pair<int, int>, typename std::decay<args>::type>,
-          std::is_same<std::vector<std::pair<int, int>>,
-                       typename std::decay<args>::type>>...>::value);
   storeValue(std::forward<args>(vals)...);
 }
 

--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -242,10 +242,7 @@ class ThresholdFailure : public std::runtime_error {
 /// lifetime.
 class ScopedFailureThreshold {
  public:
-  explicit ScopedFailureThreshold(Level level)
-      : m_previousLevel(getFailureThreshold()) {
-    setFailureThreshold(level);
-  }
+  explicit ScopedFailureThreshold(Level level) { setFailureThreshold(level); }
   ScopedFailureThreshold(const ScopedFailureThreshold&) = delete;
   ScopedFailureThreshold& operator=(const ScopedFailureThreshold&) = delete;
   ScopedFailureThreshold(ScopedFailureThreshold&&) = delete;
@@ -254,7 +251,7 @@ class ScopedFailureThreshold {
   ~ScopedFailureThreshold() noexcept;
 
  private:
-  Level m_previousLevel;
+  Level m_previousLevel{getFailureThreshold()};
 };
 
 /// @brief abstract base class for printing debug output

--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -251,7 +251,7 @@ class ScopedFailureThreshold {
   ScopedFailureThreshold(ScopedFailureThreshold&&) = delete;
   ScopedFailureThreshold& operator=(ScopedFailureThreshold&&) = delete;
 
-  ~ScopedFailureThreshold() noexcept { setFailureThreshold(m_previousLevel); }
+  ~ScopedFailureThreshold() noexcept;
 
  private:
   Level m_previousLevel;

--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -66,11 +66,14 @@
 
 // Debug level agnostic implementation of the ACTS_XYZ logging macros
 #define ACTS_LOG(level, x)                                                     \
-  if (logger().doPrint(level)) {                                               \
-    std::ostringstream os;                                                     \
-    os << x;                                                                   \
-    logger().log(level, os.str());                                             \
-  }
+  do {                                                                         \
+    if (logger().doPrint(level)) {                                             \
+      std::ostringstream os;                                                   \
+      os << x;                                                                 \
+      logger().log(level, os.str());                                           \
+    }                                                                          \
+  }                                                                            \
+  while(0)
 
 /// @brief macro for verbose debug output
 /// @ingroup Logging

--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -239,10 +239,16 @@ class ThresholdFailure : public std::runtime_error {
 /// lifetime.
 class ScopedFailureThreshold {
  public:
-  ScopedFailureThreshold(Level level) : m_previousLevel(getFailureThreshold()) {
+  explicit ScopedFailureThreshold(Level level)
+      : m_previousLevel(getFailureThreshold()) {
     setFailureThreshold(level);
   }
-  ~ScopedFailureThreshold() { setFailureThreshold(m_previousLevel); }
+  ScopedFailureThreshold(const ScopedFailureThreshold&) = delete;
+  ScopedFailureThreshold& operator=(const ScopedFailureThreshold&) = delete;
+  ScopedFailureThreshold(ScopedFailureThreshold&&) = delete;
+  ScopedFailureThreshold& operator=(ScopedFailureThreshold&&) = delete;
+
+  ~ScopedFailureThreshold() noexcept { setFailureThreshold(m_previousLevel); }
 
  private:
   Level m_previousLevel;

--- a/Core/include/Acts/Utilities/ThrowAssert.hpp
+++ b/Core/include/Acts/Utilities/ThrowAssert.hpp
@@ -66,9 +66,11 @@ class AssertionFailureException : public std::exception {
 
 }  // namespace Acts
 
-#define throw_assert(EXPRESSION, MESSAGE)                                 \
-  if (!(EXPRESSION)) {                                                    \
-    throw Acts::AssertionFailureException(                                \
-        #EXPRESSION, __FILE__, __LINE__,                                  \
-        (Acts::AssertionFailureException::StreamFormatter() << MESSAGE)); \
-  }
+#define throw_assert(EXPRESSION, MESSAGE)                                   \
+  do {                                                                      \
+    if (!(EXPRESSION)) {                                                    \
+      throw Acts::AssertionFailureException(                                \
+          #EXPRESSION, __FILE__, __LINE__,                                  \
+          (Acts::AssertionFailureException::StreamFormatter() << MESSAGE)); \
+    }                                                                       \
+  } while (0)

--- a/Core/include/Acts/Utilities/detail/ContextType.hpp
+++ b/Core/include/Acts/Utilities/detail/ContextType.hpp
@@ -30,7 +30,7 @@ class ContextType {
   /// @tparam T The type of the value to construct from
   /// @param value The value to construct from
   template <typename T>
-  explicit ContextType(T&& value) : m_data{std::move(value)} {}
+  explicit ContextType(T&& value) : m_data{std::forward(value)} {}
 
   /// Copy construct a new Context Type object from anything. Must be explicit.
   ///

--- a/Core/include/Acts/Utilities/detail/ContextType.hpp
+++ b/Core/include/Acts/Utilities/detail/ContextType.hpp
@@ -30,7 +30,7 @@ class ContextType {
   /// @tparam T The type of the value to construct from
   /// @param value The value to construct from
   template <typename T>
-  explicit ContextType(T&& value) : m_data{std::forward(value)} {}
+  explicit ContextType(T&& value) : m_data{std::forward<T>(value)} {}
 
   /// Copy construct a new Context Type object from anything. Must be explicit.
   ///

--- a/Core/include/Acts/Utilities/detail/grid_helper.hpp
+++ b/Core/include/Acts/Utilities/detail/grid_helper.hpp
@@ -802,7 +802,7 @@ struct grid_helper {
       const std::array<std::size_t, sizeof...(Axes)>& localIndices,
       std::size_t size, const std::tuple<Axes...>& axes) {
     return neighborHoodIndices(
-        localIndices, std::make_pair(static_cast<int>(-size), size), axes);
+        localIndices, std::make_pair(-static_cast<int>(size), size), axes);
   }
 
   /// @brief get global bin indices for bins in specified neighborhood

--- a/Core/src/Detector/DetectorVolumeBuilder.cpp
+++ b/Core/src/Detector/DetectorVolumeBuilder.cpp
@@ -56,14 +56,14 @@ Acts::Experimental::DetectorVolumeBuilder::construct(
   std::shared_ptr<DetectorVolume> dVolume = nullptr;
   // If there are no internals, the volume is fully defined
   if (m_cfg.internalsBuilder == nullptr) {
-    ACTS_VERBOSE("No internal structure present.")
+    ACTS_VERBOSE("No internal structure present.");
     // Construct the DetectorVolume
     dVolume = DetectorVolumeFactory::construct(
         portalGenerator, gctx, m_cfg.name, transform, std::move(bounds),
         tryAllPortals());
   } else {
     // Internal structure is present
-    ACTS_VERBOSE("Internal structure is being built.")
+    ACTS_VERBOSE("Internal structure is being built.");
     auto [surfaces, volumes, surfacesUpdater, volumeUpdater] =
         m_cfg.internalsBuilder->construct(gctx);
 

--- a/Core/src/Detector/LayerStructureBuilder.cpp
+++ b/Core/src/Detector/LayerStructureBuilder.cpp
@@ -210,7 +210,7 @@ Acts::Experimental::LayerStructureBuilder::construct(
   // collect those that should be assigned to all bins
   std::vector<std::size_t> assignToAll = {};
   if (!m_cfg.supports.empty()) {
-    ACTS_DEBUG("Adding " << m_cfg.supports.size() << " support structures.")
+    ACTS_DEBUG("Adding " << m_cfg.supports.size() << " support structures.");
     // The surface candidate updator
     for (const auto& support : m_cfg.supports) {
       // Check if the supportsurface has already been built

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -212,8 +212,7 @@ Acts::CylinderVolumeHelper::createGapTrackingVolume(
   // create the layer r/z positions
   std::vector<double> layerPositions;
   if (materialLayers > 1) {
-    double step = cylinder ? (max - min) / (materialLayers - 1)
-                           : (max - min) / (materialLayers - 1);
+    double step = (max - min) / (materialLayers - 1);
     for (unsigned int il = 0; il < materialLayers; ++il) {
       layerPositions.push_back(min + il * step);
     }

--- a/Core/src/Geometry/CylinderVolumeStack.cpp
+++ b/Core/src/Geometry/CylinderVolumeStack.cpp
@@ -177,7 +177,7 @@ void CylinderVolumeStack::initializeOuterVolume(BinningValue direction,
     ACTS_VERBOSE("*** Volume configuration after z attachment:");
     printVolumeSequence(volumeTuples, logger, Acts::Logging::VERBOSE);
 
-    ACTS_VERBOSE("Synchronizing bounds in r")
+    ACTS_VERBOSE("Synchronizing bounds in r");
     const auto [minR, maxR] = synchronizeRBounds(volumeTuples, logger);
 
     for (auto& vt : volumeTuples) {
@@ -237,7 +237,7 @@ void CylinderVolumeStack::initializeOuterVolume(BinningValue direction,
     ACTS_VERBOSE("*** Volume configuration after r attachment:");
     printVolumeSequence(volumeTuples, logger, Acts::Logging::VERBOSE);
 
-    ACTS_VERBOSE("Synchronizing bounds in z")
+    ACTS_VERBOSE("Synchronizing bounds in z");
     const auto [minZ, maxZ] = synchronizeZBounds(volumeTuples, logger);
 
     for (auto& vt : volumeTuples) {

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -424,7 +424,7 @@ bool Acts::LayerCreator::checkBinning(const GeometryContext& gctx,
   // through the binning? If not, surfaces get lost and the binning does not
   // work
 
-  ACTS_VERBOSE("Performing consistency check")
+  ACTS_VERBOSE("Performing consistency check");
 
   std::vector<const Surface*> surfaces = sArray.surfaces();
   std::set<const Surface*> sensitiveSurfaces(surfaces.begin(), surfaces.end());

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -38,7 +38,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
       protoLayerOpt ? *protoLayerOpt : ProtoLayer(gctx, surfacesRaw);
 
   ACTS_VERBOSE("Creating a SurfaceArray on a cylinder");
-  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
+  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.");
   ACTS_VERBOSE(" -- with phi x z  = " << binsPhi << " x " << binsZ << " = "
                                       << binsPhi * binsZ << " bins.");
 
@@ -131,7 +131,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnCylinder(
   std::size_t bins1 = axes.at(1)->getNBins();
 
   ACTS_VERBOSE("Creating a SurfaceArray on a cylinder");
-  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
+  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.");
   ACTS_VERBOSE(" -- with phi x z  = " << bins0 << " x " << bins1 << " = "
                                       << bins0 * bins1 << " bins.");
 
@@ -182,7 +182,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
   std::size_t bins0 = axes.at(0)->getNBins();
   std::size_t bins1 = axes.at(1)->getNBins();
 
-  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
+  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.");
   ACTS_VERBOSE(" -- with r x phi  = " << bins0 << " x " << bins1 << " = "
                                       << bins0 * bins1 << " bins.");
   sl->fill(gctx, surfacesRaw);
@@ -289,7 +289,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnDisc(
   std::size_t bins0 = axes.at(0)->getNBins();
   std::size_t bins1 = axes.at(1)->getNBins();
 
-  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
+  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.");
   ACTS_VERBOSE(" -- with r x phi  = " << bins0 << " x " << bins1 << " = "
                                       << bins0 * bins1 << " bins.");
 
@@ -314,7 +314,7 @@ Acts::SurfaceArrayCreator::surfaceArrayOnPlane(
       protoLayerOpt ? *protoLayerOpt : ProtoLayer(gctx, surfacesRaw);
 
   ACTS_VERBOSE("Creating a SurfaceArray on a plance");
-  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.")
+  ACTS_VERBOSE(" -- with " << surfaces.size() << " surfaces.");
   ACTS_VERBOSE(" -- with " << bins1 << " x " << bins2 << " = " << bins1 * bins2
                            << " bins.");
   Transform3 ftransform = transform;

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -73,7 +73,7 @@ Acts::SurfaceMaterialMapper::State Acts::SurfaceMaterialMapper::createState(
 void Acts::SurfaceMaterialMapper::resolveMaterialSurfaces(
     State& mState, const TrackingVolume& tVolume) const {
   ACTS_VERBOSE("Checking volume '" << tVolume.volumeName()
-                                   << "' for material surfaces.")
+                                   << "' for material surfaces.");
 
   ACTS_VERBOSE("- boundary surfaces ...");
   // Check the boundary surfaces
@@ -170,7 +170,7 @@ void Acts::SurfaceMaterialMapper::checkAndInsert(State& mState,
 void Acts::SurfaceMaterialMapper::collectMaterialVolumes(
     State& mState, const TrackingVolume& tVolume) const {
   ACTS_VERBOSE("Checking volume '" << tVolume.volumeName()
-                                   << "' for material surfaces.")
+                                   << "' for material surfaces.");
   ACTS_VERBOSE("- Insert Volume ...");
   if (tVolume.volumeMaterial() != nullptr) {
     mState.volumeMaterial[tVolume.geometryId()] =
@@ -207,7 +207,7 @@ void Acts::SurfaceMaterialMapper::mapMaterialTrack(
   // Retrieve the recorded material from the recorded material track
   auto& rMaterial = mTrack.second.materialInteractions;
   ACTS_VERBOSE("Retrieved " << rMaterial.size()
-                            << " recorded material steps to map.")
+                            << " recorded material steps to map.");
 
   // Check if the material interactions are associated with a surface. If yes we
   // simply need to loop over them and accumulate the material
@@ -258,7 +258,7 @@ void Acts::SurfaceMaterialMapper::mapInteraction(
   // These should be mapped onto the mapping surfaces found
   ACTS_VERBOSE("Found     " << mappingSurfaces.size()
                             << " mapping surfaces for this track.");
-  ACTS_VERBOSE("Mapping surfaces are :")
+  ACTS_VERBOSE("Mapping surfaces are :");
   for (auto& mSurface : mappingSurfaces) {
     ACTS_VERBOSE(" - Surface : " << mSurface.surface->geometryId()
                                  << " at position = (" << mSurface.position.x()
@@ -416,7 +416,7 @@ void Acts::SurfaceMaterialMapper::mapInteraction(
     ++rmIter;
   }
 
-  ACTS_VERBOSE("Surfaces have following number of assigned hits :")
+  ACTS_VERBOSE("Surfaces have following number of assigned hits :");
   for (auto& [key, value] : assignedMaterial) {
     ACTS_VERBOSE(" + Surface : " << key << " has " << value << " hits.");
   }

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -71,7 +71,7 @@ Acts::VolumeMaterialMapper::State Acts::VolumeMaterialMapper::createState(
 void Acts::VolumeMaterialMapper::resolveMaterialVolume(
     State& mState, const TrackingVolume& tVolume) const {
   ACTS_VERBOSE("Checking volume '" << tVolume.volumeName()
-                                   << "' for material surfaces.")
+                                   << "' for material surfaces.");
 
   ACTS_VERBOSE("- Insert Volume ...");
   checkAndInsert(mState, tVolume);
@@ -181,7 +181,7 @@ void Acts::VolumeMaterialMapper::checkAndInsert(
 void Acts::VolumeMaterialMapper::collectMaterialSurfaces(
     State& mState, const TrackingVolume& tVolume) const {
   ACTS_VERBOSE("Checking volume '" << tVolume.volumeName()
-                                   << "' for material surfaces.")
+                                   << "' for material surfaces.");
 
   ACTS_VERBOSE("- boundary surfaces ...");
   // Check the boundary surfaces
@@ -391,12 +391,12 @@ void Acts::VolumeMaterialMapper::mapMaterialTrack(
   // Retrieve the recorded material from the recorded material track
   auto& rMaterial = mTrack.second.materialInteractions;
   ACTS_VERBOSE("Retrieved " << rMaterial.size()
-                            << " recorded material steps to map.")
+                            << " recorded material steps to map.");
 
   // These should be mapped onto the mapping surfaces found
   ACTS_VERBOSE("Found     " << mappingVolumes.size()
                             << " mapping volumes for this track.");
-  ACTS_VERBOSE("Mapping volumes are :")
+  ACTS_VERBOSE("Mapping volumes are :");
   for (auto& mVolumes : mappingVolumes) {
     ACTS_VERBOSE(" - Volume : " << mVolumes.volume->geometryId()
                                 << " at position = (" << mVolumes.position.x()

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -369,7 +369,7 @@ std::shared_ptr<Acts::CylinderSurface> Acts::CylinderSurface::mergedWith(
   using namespace Acts::UnitLiterals;
 
   ACTS_DEBUG("Merging cylinder surfaces in " << binningValueNames()[direction]
-                                             << " direction")
+                                             << " direction");
 
   Transform3 otherLocal = transform(gctx).inverse() * other.transform(gctx);
 

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -383,7 +383,7 @@ std::shared_ptr<Acts::DiscSurface> Acts::DiscSurface::mergedWith(
   using namespace Acts::UnitLiterals;
 
   ACTS_DEBUG("Merging disc surfaces in " << binningValueNames()[direction]
-                                         << " direction")
+                                         << " direction");
 
   Transform3 otherLocal = transform(gctx).inverse() * other.transform(gctx);
 

--- a/Core/src/Utilities/Logger.cpp
+++ b/Core/src/Utilities/Logger.cpp
@@ -26,6 +26,7 @@ Level& getFailureThresholdMutable() {
     if (envvar == nullptr) {
       return level;
     }
+
     std::string slevel = envvar;
     if (slevel == "VERBOSE") {
       level = std::min(level, Level::VERBOSE);
@@ -60,7 +61,14 @@ void setFailureThreshold(Level level) {
 }
 
 ScopedFailureThreshold::~ScopedFailureThreshold() noexcept {
-  setFailureThreshold(m_previousLevel);
+  try {
+    setFailureThreshold(m_previousLevel);
+  } catch (const std::bad_alloc&) {
+    // bad alloc can be thrown when initializing the global static variable
+    std::cerr << "Failed to reset log failure threshold (bad_alloc)"
+              << std::endl;
+    std::terminate();
+  }
 }
 
 #else

--- a/Core/src/Utilities/Logger.cpp
+++ b/Core/src/Utilities/Logger.cpp
@@ -59,6 +59,10 @@ void setFailureThreshold(Level level) {
   getFailureThresholdMutable() = level;
 }
 
+ScopedFailureThreshold::~ScopedFailureThreshold() noexcept {
+  setFailureThreshold(m_previousLevel);
+}
+
 #else
 
 void setFailureThreshold(Level /*lvl*/) {
@@ -69,6 +73,8 @@ void setFailureThreshold(Level /*lvl*/) {
       "https://acts.readthedocs.io/en/latest/core/misc/"
       "logging.html#logging-thresholds"};
 }
+
+ScopedFailureThreshold::~ScopedFailureThreshold() noexcept = default;
 
 #endif
 

--- a/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
@@ -120,7 +120,7 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter::addVtxToFit(
   if (state.vtxInfoMap[&newVertex].trackLinks.empty()) {
     ACTS_ERROR(
         "newVertex does not have any associated tracks (i.e., its trackLinks "
-        "are empty).")
+        "are empty).");
     return VertexingError::EmptyInput;
   }
 

--- a/Core/src/Vertexing/IterativeVertexFinder.cpp
+++ b/Core/src/Vertexing/IterativeVertexFinder.cpp
@@ -208,7 +208,7 @@ auto Acts::IterativeVertexFinder::getVertexSeed(
   }
   const Vertex& seedVertex = seedVector.back();
 
-  ACTS_DEBUG("Use " << seedTracks.size() << " tracks for vertex seed finding.")
+  ACTS_DEBUG("Use " << seedTracks.size() << " tracks for vertex seed finding.");
   ACTS_DEBUG(
       "Found seed at position: " << seedVertex.fullPosition().transpose());
 
@@ -230,7 +230,7 @@ inline void Acts::IterativeVertexFinder::removeTracks(
       // Remove track from seed tracks
       seedTracks.erase(foundIter);
     } else {
-      ACTS_WARNING("Track to be removed not found in seed tracks.")
+      ACTS_WARNING("Track to be removed not found in seed tracks.");
     }
   }
 }

--- a/Core/src/Vertexing/NumericalTrackLinearizer.cpp
+++ b/Core/src/Vertexing/NumericalTrackLinearizer.cpp
@@ -95,7 +95,7 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
   if (paramVec(eLinTheta) + m_cfg.delta > M_PI) {
     ACTS_ERROR(
         "Wiggled theta outside range, choose a smaller wiggle (i.e., delta)! "
-        "You might need to decrease targetTolerance as well.")
+        "You might need to decrease targetTolerance as well.");
   }
 
   // Wiggling each of the parameters at the PCA and computing the Perigee

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -198,7 +198,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
             DigitizedParameters dParameters;
 
             if (simHit.depositedEnergy() < m_cfg.minEnergyDeposit) {
-              ACTS_VERBOSE("Skip hit because energy deposit to small")
+              ACTS_VERBOSE("Skip hit because energy deposit to small");
               continue;
             }
 
@@ -214,7 +214,8 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
                   cfg.segmentation, cfg.thickness);
               if (!channelsRes.ok() || channelsRes->empty()) {
                 ACTS_DEBUG(
-                    "Geometric channelization did not work, skipping this hit.")
+                    "Geometric channelization did not work, skipping this "
+                    "hit.");
                 continue;
               }
               ACTS_VERBOSE("Activated " << channelsRes->size()
@@ -247,7 +248,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
             // Check on success - threshold could have eliminated all channels
             if (dParameters.values.empty()) {
               ACTS_VERBOSE(
-                  "Parameter digitization did not yield a measurement.")
+                  "Parameter digitization did not yield a measurement.");
               continue;
             }
 

--- a/Examples/Algorithms/Printers/ActsExamples/Printers/ParticlesPrinter.cpp
+++ b/Examples/Algorithms/Printers/ActsExamples/Printers/ParticlesPrinter.cpp
@@ -40,7 +40,7 @@ ActsExamples::ProcessCode ActsExamples::ParticlesPrinter::execute(
                      << particles.size() << " particles");
   for (const auto& particle : particles) {
     ACTS_INFO("  particle " << particle);
-    ACTS_INFO("    process_type: " << particle.process())
+    ACTS_INFO("    process_type: " << particle.process());
     ACTS_INFO("    position:     " << particle.position().transpose() / 1_mm
                                    << " mm");
     ACTS_INFO("    direction:    " << particle.direction().transpose());

--- a/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingOrthogonalAlgorithm.cpp
@@ -105,7 +105,7 @@ ActsExamples::ProcessCode ActsExamples::SeedingOrthogonalAlgorithm::execute(
 }
 
 void ActsExamples::SeedingOrthogonalAlgorithm::printOptions() const {
-  ACTS_DEBUG("SeedFinderOptions")
+  ACTS_DEBUG("SeedFinderOptions");
   ACTS_DEBUG("beamPos           " << m_cfg.seedFinderOptions.beamPos);
   // field induction
   ACTS_DEBUG("bFieldInZ         " << m_cfg.seedFinderOptions.bFieldInZ);
@@ -114,12 +114,12 @@ void ActsExamples::SeedingOrthogonalAlgorithm::printOptions() const {
   ACTS_DEBUG("minHelixDiameter2 " << m_cfg.seedFinderOptions.minHelixDiameter2);
   ACTS_DEBUG("pT2perRadius      " << m_cfg.seedFinderOptions.pT2perRadius);
   ACTS_DEBUG("sigmapT2perRadius " << m_cfg.seedFinderOptions.sigmapT2perRadius);
-  ACTS_DEBUG("...\n")
+  ACTS_DEBUG("...\n");
 }
 
 template <typename sp>
 void ActsExamples::SeedingOrthogonalAlgorithm::printConfig() const {
-  ACTS_DEBUG("SeedFinderOrthogonalConfig")
+  ACTS_DEBUG("SeedFinderOrthogonalConfig");
   ACTS_DEBUG("minPt                 " << m_cfg.seedFinderConfig.minPt);
   ACTS_DEBUG("deltaRMinTopSP        " << m_cfg.seedFinderConfig.deltaRMinTopSP);
   ACTS_DEBUG("deltaRMaxTopSP        " << m_cfg.seedFinderConfig.deltaRMaxTopSP);
@@ -141,5 +141,5 @@ void ActsExamples::SeedingOrthogonalAlgorithm::printConfig() const {
   ACTS_DEBUG("highland              " << m_cfg.seedFinderConfig.highland);
   ACTS_DEBUG("maxScatteringAngle2   "
              << m_cfg.seedFinderConfig.maxScatteringAngle2);
-  ACTS_DEBUG("...\n")
+  ACTS_DEBUG("...\n");
 }

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -128,7 +128,7 @@ ActsExamples::ProcessCode ActsExamples::TrackParamsEstimationAlgorithm::execute(
     // Get the bottom space point and its reference surface
     const auto bottomSP = seed.sp().front();
     if (bottomSP->sourceLinks().empty()) {
-      ACTS_WARNING("Missing source link in the space point")
+      ACTS_WARNING("Missing source link in the space point");
       continue;
     }
     const auto& sourceLink = bottomSP->sourceLinks()[0];

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -220,7 +220,7 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
                            << " '" << handle->key()
                            << "' at this point in the sequence."
                            << "\n   Needed for read data handle '"
-                           << handle->name() << "'")
+                           << handle->name() << "'");
       valid = false;
     }
   }

--- a/Examples/Io/Root/src/RootMeasurementWriter.cpp
+++ b/Examples/Io/Root/src/RootMeasurementWriter.cpp
@@ -75,7 +75,7 @@ ActsExamples::RootMeasurementWriter::RootMeasurementWriter(
       dTrees.push_back({geoID, std::move(dTree)});
     }
   } else {
-    ACTS_DEBUG("Bound indices are not declared, no reco setup.")
+    ACTS_DEBUG("Bound indices are not declared, no reco setup.");
   }
 
   m_outputTrees = Acts::GeometryHierarchyMap<std::unique_ptr<DigitizationTree>>(

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Plugins/TGeo/TGeoDetectorElement.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <map>
 #include <memory>
@@ -92,4 +93,19 @@ class DD4hepDetectorElement : public TGeoDetectorElement {
   /// DD4hep segmentation
   dd4hep::Segmentation m_segmentation;
 };
+
+/// This extension holds an ACTS detector element belonging to a DD4hep detector
+/// element, and synchronizes ownership
+struct DD4hepDetectorElementExtension {
+  explicit DD4hepDetectorElementExtension(
+      std::shared_ptr<DD4hepDetectorElement> de)
+      : detectorElement(std::move(de)) {
+    throw_assert(detectorElement != nullptr,
+                 "DD4hepDetectorElement is nullptr");
+  }
+
+ private:
+  std::shared_ptr<DD4hepDetectorElement> detectorElement;
+};
+
 }  // namespace Acts

--- a/Plugins/DD4hep/src/DD4hepDetectorStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepDetectorStructure.cpp
@@ -56,21 +56,21 @@ Acts::Experimental::DD4hepDetectorStructure::construct(
 
   // Draw the raw graph
   if (!options.emulateToGraph.empty()) {
-    ACTS_DEBUG("Writing the initial bluepring to file before gap filling.")
+    ACTS_DEBUG("Writing the initial bluepring to file before gap filling.");
     std::ofstream bpi(options.emulateToGraph + "_initial.dot");
     detail::BlueprintDrawer::dotStream(bpi, *dd4hepBlueprint);
     bpi.close();
   }
 
   if (dd4hepBlueprint->boundsType == VolumeBounds::eCylinder) {
-    ACTS_DEBUG("Cylindrical detector building detected.")
+    ACTS_DEBUG("Cylindrical detector building detected.");
 
     // Now fill the gaps
     detail::BlueprintHelper::fillGaps(*dd4hepBlueprint);
 
     // Draw the synchronized graph
     if (!options.emulateToGraph.empty()) {
-      ACTS_DEBUG("Writing the final bluepring to file.")
+      ACTS_DEBUG("Writing the final bluepring to file.");
       std::ofstream bpf(options.emulateToGraph + "_final.dot");
       detail::BlueprintDrawer::dotStream(bpf, *dd4hepBlueprint);
       bpf.close();

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -197,8 +197,7 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::endcapLayers(
         // Create the sensitive surface
         auto sensitiveSurf = createSensitiveSurface(detElement, true);
         // Create the surfaceArray
-        std::unique_ptr<Acts::SurfaceArray> sArray =
-            std::make_unique<SurfaceArray>(sensitiveSurf);
+        auto sArray = std::make_unique<SurfaceArray>(sensitiveSurf);
 
         // create the share disc bounds
         auto dBounds = std::make_shared<const RadialBounds>(pl.min(Acts::binR),
@@ -342,8 +341,7 @@ const Acts::LayerVector Acts::DD4hepLayerBuilder::centralLayers(
         // create the layer
         double layerR = (pl.min(Acts::binR) + pl.max(Acts::binR)) * 0.5;
         double thickness = std::fabs(pl.max(Acts::binR) - pl.min(Acts::binR));
-        std::shared_ptr<const CylinderBounds> cBounds(
-            new CylinderBounds(layerR, halfZ));
+        auto cBounds = std::make_shared<CylinderBounds>(layerR, halfZ);
         // Create the layer containing the sensitive surface
         centralLayer =
             CylinderLayer::create(transform, cBounds, std::move(sArray),
@@ -390,9 +388,12 @@ Acts::DD4hepLayerBuilder::createSensitiveSurface(
   std::string detAxis =
       getParamOr<std::string>("axis_definitions", detElement, "XYZ");
   // Create the corresponding detector element !- memory leak --!
-  Acts::DD4hepDetectorElement* dd4hepDetElement =
-      new Acts::DD4hepDetectorElement(detElement, detAxis, UnitConstants::cm,
-                                      isDisc, nullptr);
+  auto dd4hepDetElement = std::make_shared<Acts::DD4hepDetectorElement>(
+      detElement, detAxis, UnitConstants::cm, isDisc, nullptr);
+
+  detElement.addExtension<DD4hepDetectorElementExtension>(
+      new dd4hep::rec::StructExtension(
+          DD4hepDetectorElementExtension(dd4hepDetElement)));
 
   // return the surface
   return dd4hepDetElement->surface().getSharedPtr();


### PR DESCRIPTION
This PR 

- Modifies the logging macros so that they require a `;` now
- Modifies the DD4hep conversion to not leak memory, but instead attach the ACTS detector element lifetime to the DD4hep detector element
- Adds an explicit cast from `uint64_t` to `uint32_t`
- Makes a number of constructors `explicit` and/or `noexcept`
- Avoids some problematic integer manipulations
- Avoids throwing `std::string` as an exception
- \+ a few smaller fixes