### PR TITLE
feat: Wire grid size for `AMVF` and `AdaptiveGridSeeder` to Python in Examples

### DIFF
--- a/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
+++ b/Examples/Algorithms/Vertexing/include/ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -67,12 +67,19 @@ class AdaptiveMultiVertexFinderAlgorithm final : public IAlgorithm {
     std::string outputProtoVertices;
     /// Output vertex collection
     std::string outputVertices = "vertices";
+
+    /// The magnetic field
+    std::shared_ptr<Acts::MagneticFieldProvider> bField;
+
     /// Enum member determining the choice of the vertex seed finder
     SeedFinder seedFinder;
     /// Use time information in vertex seeder, finder, and fitter
     bool useTime = false;
-    /// The magnetic field
-    std::shared_ptr<Acts::MagneticFieldProvider> bField;
+    /// Bin extent in z-direction which is only used with `AdaptiveGridSeeder`
+    double spatialBinExtent = 15. * Acts::UnitConstants::um;
+    /// Bin extent in t-direction which is only used with `AdaptiveGridSeeder`
+    /// and `useTime`
+    double temporalBinExtent = 19. * Acts::UnitConstants::mm;
   };
 
   AdaptiveMultiVertexFinderAlgorithm(const Config& config,

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020-2021 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -92,9 +92,9 @@ auto ActsExamples::AdaptiveMultiVertexFinderAlgorithm::makeVertexFinder() const
     // Set up track density used during vertex seeding
     Acts::AdaptiveGridTrackDensity::Config trkDensityCfg;
     // Bin extent in z-direction
-    trkDensityCfg.spatialBinExtent = 15. * Acts::UnitConstants::um;
+    trkDensityCfg.spatialBinExtent = m_cfg.spatialBinExtent;
     // Bin extent in t-direction
-    trkDensityCfg.temporalBinExtent = 19. * Acts::UnitConstants::mm;
+    trkDensityCfg.temporalBinExtent = m_cfg.temporalBinExtent;
     trkDensityCfg.useTime = m_cfg.useTime;
     Acts::AdaptiveGridTrackDensity trkDensity(trkDensityCfg);
 

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1875,6 +1875,8 @@ def addVertexFitting(
     seeder: Optional[acts.VertexSeedFinder] = acts.VertexSeedFinder.GaussianSeeder,
     vertexFinder: VertexFinder = VertexFinder.Truth,
     useTime: Optional[bool] = False,
+    spatialBinExtent: Optional[float] = None,
+    temporalBinExtent: Optional[float] = None,
     trackSelectorConfig: Optional[TrackSelectorConfig] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     logLevel: Optional[acts.logging.Level] = None,
@@ -1894,10 +1896,14 @@ def addVertexFitting(
         acts.seeder.AdaptiveGridSeeder
     vertexFinder : VertexFinder, Truth
         vertexFinder algorithm: one of Truth, AMVF, Iterative
-    useTime : bool
+    useTime : bool, False
         determines whether time information is used in vertex seeder, finder,
         and fitter
         only implemented for the AMVF and the AdaptiveGridSeeder
+    spatialBinExtent : float, None
+        spatial bin extent for the AdaptiveGridSeeder
+    temporalBinExtent : float, None
+        temporal bin extent for the AdaptiveGridSeeder
     logLevel : acts.logging.Level, None
         logging level to override setting given in `s`
     """
@@ -1967,6 +1973,8 @@ def addVertexFitting(
             level=customLogLevel(),
             seedFinder=seeder,
             useTime=useTime,
+            spatialBinExtent=spatialBinExtent,
+            temporalBinExtent=temporalBinExtent,
             bField=field,
             inputTrackParameters=trackParameters,
             outputProtoVertices=outputProtoVertices,

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1972,13 +1972,15 @@ def addVertexFitting(
         findVertices = AdaptiveMultiVertexFinderAlgorithm(
             level=customLogLevel(),
             seedFinder=seeder,
-            useTime=useTime,
-            spatialBinExtent=spatialBinExtent,
-            temporalBinExtent=temporalBinExtent,
             bField=field,
             inputTrackParameters=trackParameters,
             outputProtoVertices=outputProtoVertices,
             outputVertices=outputVertices,
+            **acts.examples.defaultKWArgs(
+                useTime=useTime,
+                spatialBinExtent=spatialBinExtent,
+                temporalBinExtent=temporalBinExtent,
+            ),
         )
         s.addAlgorithm(findVertices)
     else:

--- a/Examples/Python/src/Vertexing.cpp
+++ b/Examples/Python/src/Vertexing.cpp
@@ -38,7 +38,8 @@ void addVertexing(Context& ctx) {
   ACTS_PYTHON_DECLARE_ALGORITHM(
       ActsExamples::AdaptiveMultiVertexFinderAlgorithm, mex,
       "AdaptiveMultiVertexFinderAlgorithm", inputTrackParameters,
-      outputProtoVertices, outputVertices, seedFinder, useTime, bField);
+      outputProtoVertices, outputVertices, seedFinder, bField, useTime,
+      spatialBinExtent, temporalBinExtent);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::IterativeVertexFinderAlgorithm,
                                 mex, "IterativeVertexFinderAlgorithm",

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -403,7 +403,7 @@ if args.reco:
     addVertexFitting(
         s,
         field,
-        vertexFinder=VertexFinder.Iterative,
+        vertexFinder=VertexFinder.AMVF,
         outputDirRoot=outputDir if args.output_root else None,
     )
 

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -403,7 +403,7 @@ if args.reco:
     addVertexFitting(
         s,
         field,
-        vertexFinder=VertexFinder.AMVF,
+        vertexFinder=VertexFinder.Iterative,
         outputDirRoot=outputDir if args.output_root else None,
     )
 


### PR DESCRIPTION
Until now it was not possible to change the grid granularity of the `AdaptiveGridSeeder` for the `AMVF` which makes it hard to study effects of these parameters on the performance (physics and CPU). I am wiring these parameters here.

Example of how to use this
```
addVertexFitting(
    ...
    vertexFinder=VertexFinder.AMVF,
    seeder=acts.VertexSeedFinder.AdaptiveGridSeeder,
    useTime=True,
    spatialBinExtent=15.0 * u.um,
    temporalBinExtent=19.0 * u.mm,
)
```