### PR TITLE
feat: `VariableSizeSubspace`

### DIFF
--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -93,7 +93,8 @@ class FixedSizeSubspace {
   /// @tparam index_t Input index type, must be convertible to std::uint8_t
   /// @param indices Unique, ordered indices
   template <typename index_t>
-  constexpr FixedSizeSubspace(const std::array<index_t, kSize>& indices) {
+  constexpr explicit FixedSizeSubspace(
+      const std::array<index_t, kSize>& indices) {
     for (std::size_t i = 0u; i < kSize; ++i) {
       assert((indices[i] < kFullSize) &&
              "Axis indices must be within the full space");
@@ -138,8 +139,8 @@ class FixedSizeSubspace {
     bool isContained = false;
     // always iterate over all elements to avoid branching and hope the compiler
     // can optimise this for us.
-    for (auto a : m_axes) {
-      isContained |= (a == index);
+    for (std::uint8_t a : m_axes) {
+      isContained = isContained || (a == index);
     }
     return isContained;
   }
@@ -152,12 +153,12 @@ class FixedSizeSubspace {
   ///
   /// @note Always returns a column vector regardless of the input
   template <typename fullspace_vector_t>
-  auto projectVector(const Eigen::MatrixBase<fullspace_vector_t>& full) const
-      -> SubspaceVectorFor<fullspace_vector_t> {
+  SubspaceVectorFor<fullspace_vector_t> projectVector(
+      const Eigen::MatrixBase<fullspace_vector_t>& full) const {
     EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(fullspace_vector_t, kFullSize);
 
     SubspaceVectorFor<fullspace_vector_t> sub;
-    for (auto i = 0u; i < kSize; ++i) {
+    for (std::size_t i = 0u; i < kSize; ++i) {
       sub[i] = full[m_axes[i]];
     }
     return sub;
@@ -171,13 +172,13 @@ class FixedSizeSubspace {
   ///
   /// @note Always returns a column vector regardless of the input
   template <typename subspace_vector_t>
-  auto expandVector(const Eigen::MatrixBase<subspace_vector_t>& sub) const
-      -> FullspaceVectorFor<subspace_vector_t> {
+  FullspaceVectorFor<subspace_vector_t> expandVector(
+      const Eigen::MatrixBase<subspace_vector_t>& sub) const {
     EIGEN_STATIC_ASSERT_VECTOR_SPECIFIC_SIZE(subspace_vector_t, kSize);
 
     FullspaceVectorFor<subspace_vector_t> full;
     full.setZero();
-    for (auto i = 0u; i < kSize; ++i) {
+    for (std::size_t i = 0u; i < kSize; ++i) {
       full[m_axes[i]] = sub[i];
     }
     return full;
@@ -187,10 +188,10 @@ class FixedSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type for the projection matrix
   template <typename scalar_t>
-  auto projector() const -> ProjectionMatrix<scalar_t> {
+  ProjectionMatrix<scalar_t> projector() const {
     ProjectionMatrix<scalar_t> proj;
     proj.setZero();
-    for (auto i = 0u; i < kSize; ++i) {
+    for (std::size_t i = 0u; i < kSize; ++i) {
       proj(i, m_axes[i]) = 1;
     }
     return proj;
@@ -200,10 +201,10 @@ class FixedSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type of the generated expansion matrix
   template <typename scalar_t>
-  auto expander() const -> ExpansionMatrix<scalar_t> {
+  ExpansionMatrix<scalar_t> expander() const {
     ExpansionMatrix<scalar_t> expn;
     expn.setZero();
-    for (auto i = 0u; i < kSize; ++i) {
+    for (std::size_t i = 0u; i < kSize; ++i) {
       expn(m_axes[i], i) = 1;
     }
     return expn;
@@ -246,7 +247,8 @@ class VariableSizeSubspace {
   /// @tparam index_t Input index type, must be convertible to std::uint8_t
   /// @param indices Unique, ordered indices
   template <typename index_t, std::size_t kSize>
-  constexpr VariableSizeSubspace(const std::array<index_t, kSize>& indices) {
+  constexpr explicit VariableSizeSubspace(
+      const std::array<index_t, kSize>& indices) {
     m_size = kSize;
     for (std::size_t i = 0u; i < kSize; ++i) {
       assert((indices[i] < kFullSize) &&
@@ -287,7 +289,7 @@ class VariableSizeSubspace {
     // always iterate over all elements to avoid branching and hope the compiler
     // can optimise this for us.
     for (std::size_t i = 0; i < kFullSize; ++i) {
-      isContained |= ((i < m_size) & (m_axes[i] == index));
+      isContained = isContained || ((i < m_size) & (m_axes[i] == index));
     }
     return isContained;
   }
@@ -296,10 +298,10 @@ class VariableSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type for the projection matrix
   template <typename scalar_t>
-  ProjectionMatrix<scalar_t> projector() const  {
+  ProjectionMatrix<scalar_t> projector() const {
     ProjectionMatrix<scalar_t> proj(m_size, kFullSize);
     proj.setZero();
-    for (auto i = 0u; i < m_size; ++i) {
+    for (std::size_t i = 0u; i < m_size; ++i) {
       proj(i, m_axes[i]) = 1;
     }
     return proj;
@@ -309,10 +311,10 @@ class VariableSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type of the generated expansion matrix
   template <typename scalar_t>
-  auto expander() const -> ExpansionMatrix<scalar_t> {
+  ExpansionMatrix<scalar_t> expander() const {
     ExpansionMatrix<scalar_t> expn(kFullSize, m_size);
     expn.setZero();
-    for (auto i = 0u; i < m_size; ++i) {
+    for (std::size_t i = 0u; i < m_size; ++i) {
       expn(m_axes[i], i) = 1;
     }
     return expn;
@@ -322,10 +324,10 @@ class VariableSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type for the projection matrix
   template <typename scalar_t>
-  auto fullProjector() const -> FullProjectionMatrix<scalar_t> {
+  FullProjectionMatrix<scalar_t> fullProjector() const {
     FullProjectionMatrix<scalar_t> proj;
     proj.setZero();
-    for (auto i = 0u; i < m_size; ++i) {
+    for (std::size_t i = 0u; i < m_size; ++i) {
       proj(i, m_axes[i]) = 1;
     }
     return proj;
@@ -335,10 +337,10 @@ class VariableSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type of the generated expansion matrix
   template <typename scalar_t>
-  auto fullExpander() const -> FullExpansionMatrix<scalar_t> {
+  FullExpansionMatrix<scalar_t> fullExpander() const {
     FullExpansionMatrix<scalar_t> expn;
     expn.setZero();
-    for (auto i = 0u; i < m_size; ++i) {
+    for (std::size_t i = 0u; i < m_size; ++i) {
       expn(m_axes[i], i) = 1;
     }
     return expn;

--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -289,7 +289,7 @@ class VariableSizeSubspace {
     // always iterate over all elements to avoid branching and hope the compiler
     // can optimise this for us.
     for (std::size_t i = 0; i < kFullSize; ++i) {
-      isContained = isContained || ((i < m_size) & (m_axes[i] == index));
+      isContained = isContained || ((i < m_size) && (m_axes[i] == index));
     }
     return isContained;
   }

--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -118,6 +118,12 @@ class FixedSizeSubspace {
   /// Size of the full vector space.
   static constexpr std::size_t fullSize() { return kFullSize; }
 
+  /// Access axis index by position.
+  ///
+  /// @param i Position in the subspace
+  /// @return Axis index in the full space
+  constexpr std::size_t operator[](std::size_t i) const { return m_axes[i]; }
+
   /// Axis indices that comprise the subspace.
   ///
   /// The specific container and index type should be considered an
@@ -133,7 +139,7 @@ class FixedSizeSubspace {
     // always iterate over all elements to avoid branching and hope the compiler
     // can optimise this for us.
     for (auto a : m_axes) {
-      isContained = (isContained || (a == index));
+      isContained |= (a == index);
     }
     return isContained;
   }
@@ -201,6 +207,175 @@ class FixedSizeSubspace {
       expn(m_axes[i], i) = 1;
     }
     return expn;
+  }
+};
+
+/// Variable-size subspace representation.
+///
+/// @tparam kFullSize Size of the full vector space
+/// @tparam kSize Size of the subspace
+template <std::size_t kFullSize>
+class VariableSizeSubspace {
+  static_assert(kFullSize <= static_cast<std::size_t>(UINT8_MAX),
+                "Full vector space size is larger than the supported range");
+
+  template <typename scalar_t>
+  using ProjectionMatrix = Eigen::Matrix<scalar_t, Eigen::Dynamic, kFullSize>;
+  template <typename scalar_t>
+  using ExpansionMatrix = Eigen::Matrix<scalar_t, kFullSize, Eigen::Dynamic>;
+
+  template <typename scalar_t>
+  using FullProjectionMatrix = Eigen::Matrix<scalar_t, kFullSize, kFullSize>;
+  template <typename scalar_t>
+  using FullExpansionMatrix = Eigen::Matrix<scalar_t, kFullSize, kFullSize>;
+
+  std::size_t m_size{};
+
+  // the functionality could also be implemented using a std::bitset where each
+  // bit corresponds to an axis in the fullspace and set bits indicate which
+  // bits make up the subspace. this would be a more compact representation but
+  // complicates the implementation since we can not easily iterate over the
+  // indices of the subspace. storing the subspace indices directly requires a
+  // bit more memory but is easier to work with. for our typical use cases with
+  // n<=8, this still takes only 64bit of memory.
+  std::array<std::uint8_t, kFullSize> m_axes{};
+
+ public:
+  /// Construct from a container of axis indices.
+  ///
+  /// @tparam index_t Input index type, must be convertible to std::uint8_t
+  /// @param indices Unique, ordered indices
+  template <typename index_t, std::size_t kSize>
+  constexpr VariableSizeSubspace(const std::array<index_t, kSize>& indices) {
+    m_size = kSize;
+    for (std::size_t i = 0u; i < kSize; ++i) {
+      assert((indices[i] < kFullSize) &&
+             "Axis indices must be within the full space");
+      if (0u < i) {
+        assert((indices[i - 1u] < indices[i]) &&
+               "Axis indices must be unique and ordered");
+      }
+    }
+    for (std::size_t i = 0; i < kSize; ++i) {
+      m_axes[i] = static_cast<std::uint8_t>(indices[i]);
+    }
+  }
+  // The subset can not be constructed w/o defining its axis indices.
+  VariableSizeSubspace() = delete;
+  VariableSizeSubspace(const VariableSizeSubspace&) = default;
+  VariableSizeSubspace(VariableSizeSubspace&&) = default;
+  VariableSizeSubspace& operator=(const VariableSizeSubspace&) = default;
+  VariableSizeSubspace& operator=(VariableSizeSubspace&&) = default;
+
+  /// Size of the subspace.
+  constexpr std::size_t size() const { return m_size; }
+  /// Size of the full vector space.
+  static constexpr std::size_t fullSize() { return kFullSize; }
+
+  /// Access axis index by position.
+  ///
+  /// @param i Position in the subspace
+  /// @return Axis index in the full space
+  constexpr std::size_t operator[](std::size_t i) const {
+    assert(i < m_size);
+    return m_axes[i];
+  }
+
+  /// Check if the given axis index in the full space is part of the subspace.
+  constexpr bool contains(std::size_t index) const {
+    bool isContained = false;
+    // always iterate over all elements to avoid branching and hope the compiler
+    // can optimise this for us.
+    for (std::size_t i = 0; i < kFullSize; ++i) {
+      isContained |= ((i < m_size) & (m_axes[i] == index));
+    }
+    return isContained;
+  }
+
+  /// Projection matrix that maps from the full space into the subspace.
+  ///
+  /// @tparam scalar_t Scalar type for the projection matrix
+  template <typename scalar_t>
+  auto projector() const -> ProjectionMatrix<scalar_t> {
+    ProjectionMatrix<scalar_t> proj(m_size, kFullSize);
+    proj.setZero();
+    for (auto i = 0u; i < m_size; ++i) {
+      proj(i, m_axes[i]) = 1;
+    }
+    return proj;
+  }
+
+  /// Expansion matrix that maps from the subspace into the full space.
+  ///
+  /// @tparam scalar_t Scalar type of the generated expansion matrix
+  template <typename scalar_t>
+  auto expander() const -> ExpansionMatrix<scalar_t> {
+    ExpansionMatrix<scalar_t> expn(kFullSize, m_size);
+    expn.setZero();
+    for (auto i = 0u; i < m_size; ++i) {
+      expn(m_axes[i], i) = 1;
+    }
+    return expn;
+  }
+
+  /// Projection matrix that maps from the full space into the subspace.
+  ///
+  /// @tparam scalar_t Scalar type for the projection matrix
+  template <typename scalar_t>
+  auto fullProjector() const -> FullProjectionMatrix<scalar_t> {
+    FullProjectionMatrix<scalar_t> proj;
+    proj.setZero();
+    for (auto i = 0u; i < m_size; ++i) {
+      proj(i, m_axes[i]) = 1;
+    }
+    return proj;
+  }
+
+  /// Expansion matrix that maps from the subspace into the full space.
+  ///
+  /// @tparam scalar_t Scalar type of the generated expansion matrix
+  template <typename scalar_t>
+  auto fullExpander() const -> FullExpansionMatrix<scalar_t> {
+    FullExpansionMatrix<scalar_t> expn;
+    expn.setZero();
+    for (auto i = 0u; i < m_size; ++i) {
+      expn(m_axes[i], i) = 1;
+    }
+    return expn;
+  }
+
+  std::uint64_t projectorBits() const {
+    std::uint64_t result = 0;
+
+    for (std::size_t i = 0; i < m_size; ++i) {
+      for (std::size_t j = 0; j < kFullSize; ++j) {
+        // the bit order is defined in `Acts/Utilities/AlgebraHelpers.hpp`
+        // in `matrixToBitset`
+        std::size_t index = m_size * kFullSize - 1 - (i + j * m_size);
+        if (m_axes[i] == j) {
+          result |= (1ull << index);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  std::uint64_t fullProjectorBits() const {
+    std::uint64_t result = 0;
+
+    for (std::size_t i = 0; i < kFullSize; ++i) {
+      for (std::size_t j = 0; j < kFullSize; ++j) {
+        // the bit order is defined in `Acts/Utilities/AlgebraHelpers.hpp`
+        // in `matrixToBitset`
+        std::size_t index = kFullSize * kFullSize - 1 - (i + j * kFullSize);
+        if (i < m_size && m_axes[i] == j) {
+          result |= (1ull << index);
+        }
+      }
+    }
+
+    return result;
   }
 };
 

--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -215,11 +215,6 @@ class VariableSizeSubspace {
                 "Full vector space size is larger than the supported range");
 
   template <typename scalar_t>
-  using ProjectionMatrix = Eigen::Matrix<scalar_t, Eigen::Dynamic, kFullSize>;
-  template <typename scalar_t>
-  using ExpansionMatrix = Eigen::Matrix<scalar_t, kFullSize, Eigen::Dynamic>;
-
-  template <typename scalar_t>
   using FullProjectionMatrix = Eigen::Matrix<scalar_t, kFullSize, kFullSize>;
   template <typename scalar_t>
   using FullExpansionMatrix = Eigen::Matrix<scalar_t, kFullSize, kFullSize>;
@@ -280,32 +275,6 @@ class VariableSizeSubspace {
       isContained = isContained || ((i < m_size) && (m_axes[i] == index));
     }
     return isContained;
-  }
-
-  /// Projection matrix that maps from the full space into the subspace.
-  ///
-  /// @tparam scalar_t Scalar type for the projection matrix
-  template <typename scalar_t>
-  ProjectionMatrix<scalar_t> projector() const {
-    ProjectionMatrix<scalar_t> proj(m_size, kFullSize);
-    proj.setZero();
-    for (std::size_t i = 0u; i < m_size; ++i) {
-      proj(i, m_axes[i]) = 1;
-    }
-    return proj;
-  }
-
-  /// Expansion matrix that maps from the subspace into the full space.
-  ///
-  /// @tparam scalar_t Scalar type of the generated expansion matrix
-  template <typename scalar_t>
-  ExpansionMatrix<scalar_t> expander() const {
-    ExpansionMatrix<scalar_t> expn(kFullSize, m_size);
-    expn.setZero();
-    for (std::size_t i = 0u; i < m_size; ++i) {
-      expn(m_axes[i], i) = 1;
-    }
-    return expn;
   }
 
   /// Projection matrix that maps from the full space into the subspace.

--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -107,12 +107,6 @@ class FixedSizeSubspace {
       m_axes[i] = static_cast<std::uint8_t>(indices[i]);
     }
   }
-  // The subset can not be constructed w/o defining its axis indices.
-  FixedSizeSubspace() = delete;
-  FixedSizeSubspace(const FixedSizeSubspace&) = default;
-  FixedSizeSubspace(FixedSizeSubspace&&) = default;
-  FixedSizeSubspace& operator=(const FixedSizeSubspace&) = default;
-  FixedSizeSubspace& operator=(FixedSizeSubspace&&) = default;
 
   /// Size of the subspace.
   static constexpr std::size_t size() { return kSize; }
@@ -262,12 +256,6 @@ class VariableSizeSubspace {
       m_axes[i] = static_cast<std::uint8_t>(indices[i]);
     }
   }
-  // The subset can not be constructed w/o defining its axis indices.
-  VariableSizeSubspace() = delete;
-  VariableSizeSubspace(const VariableSizeSubspace&) = default;
-  VariableSizeSubspace(VariableSizeSubspace&&) = default;
-  VariableSizeSubspace& operator=(const VariableSizeSubspace&) = default;
-  VariableSizeSubspace& operator=(VariableSizeSubspace&&) = default;
 
   /// Size of the subspace.
   constexpr std::size_t size() const { return m_size; }

--- a/Core/include/Acts/Utilities/detail/Subspace.hpp
+++ b/Core/include/Acts/Utilities/detail/Subspace.hpp
@@ -296,7 +296,7 @@ class VariableSizeSubspace {
   ///
   /// @tparam scalar_t Scalar type for the projection matrix
   template <typename scalar_t>
-  auto projector() const -> ProjectionMatrix<scalar_t> {
+  ProjectionMatrix<scalar_t> projector() const  {
     ProjectionMatrix<scalar_t> proj(m_size, kFullSize);
     proj.setZero();
     for (auto i = 0u; i < m_size; ++i) {


### PR DESCRIPTION
As an alternative to the existing `Acts::detail::FixedSizeSubspace` I implement `VariableSizeSubspace` which is very similar except that the actual size of the subspace can be runtime dependent.

Pulled out of https://github.com/acts-project/acts/pull/3107