### PR TITLE
fix(gx2f): compatible with non-Vector-TrackContainer (e.g. in Athena)

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -709,8 +709,8 @@ class Gx2Fitter {
     // new track and delete it after updating the parameters. However, if we
     // would work on the externally provided track container, it would be
     // difficult to remove the correct track, if it contains more than one.
-    Acts::VectorTrackContainer trackContainerTempBackend;
-    Acts::VectorMultiTrajectory trajectoryTempBackend;
+    track_container_t trackContainerTempBackend;
+    traj_t trajectoryTempBackend;
     TrackContainer trackContainerTemp{trackContainerTempBackend,
                                       trajectoryTempBackend};
 


### PR DESCRIPTION
I stumbled over this during the Athena integration. Athena uses a different track container and track type. This messes up stuff with our templating.

Again a mistake resulting from premature optimisation.