### PR TITLE
refactor(geometry): Surface merging uses custom exception

### DIFF
--- a/Core/include/Acts/Surfaces/SurfaceMergingException.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceMergingException.hpp
@@ -1,0 +1,35 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace Acts {
+class Surface;
+
+/// @brief Exception type failures to merge two surfaces
+class SurfaceMergingException : public std::exception {
+ public:
+  SurfaceMergingException(std::weak_ptr<const Surface> surfaceA,
+                          std::weak_ptr<const Surface> surfaceB,
+                          const std::string& reason)
+      : m_surfaceA(std::move(surfaceA)),
+        m_surfaceB(std::move(surfaceB)),
+        m_message(std::string{"Failure to merge surfaces: "} + reason) {}
+
+  const char* what() const throw() override { return m_message.c_str(); }
+
+ private:
+  std::weak_ptr<const Surface> m_surfaceA;
+  std::weak_ptr<const Surface> m_surfaceB;
+  std::string m_message;
+};
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -20,6 +20,7 @@
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Surfaces/SurfaceMergingException.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Helpers.hpp"
@@ -352,13 +353,13 @@ BOOST_DATA_TEST_CASE(IncompatibleZDirection,
       base * Translation3{Vector3::UnitZ() * 200_mm}, 30_mm, 100_mm);
 
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl2, Acts::binPhi, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   auto cylShiftedXy = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3{1_mm, 2_mm, 200_mm}}, 30_mm, 100_mm);
   BOOST_CHECK_THROW(
       cyl->mergedWith(testContext, *cylShiftedXy, Acts::binZ, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   auto cylRotatedZ = Surface::makeShared<CylinderSurface>(
       base * AngleAxis3{10_degree, Vector3::UnitZ()} *
@@ -366,7 +367,7 @@ BOOST_DATA_TEST_CASE(IncompatibleZDirection,
       30_mm, 100_mm);
   BOOST_CHECK_THROW(
       cyl->mergedWith(testContext, *cylRotatedZ, Acts::binZ, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   auto cylRotatedX = Surface::makeShared<CylinderSurface>(
       base * AngleAxis3{10_degree, Vector3::UnitX()} *
@@ -374,38 +375,38 @@ BOOST_DATA_TEST_CASE(IncompatibleZDirection,
       30_mm, 100_mm);
   BOOST_CHECK_THROW(
       cyl->mergedWith(testContext, *cylRotatedX, Acts::binZ, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Cylinder with different radius
   auto cyl3 = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3::UnitZ() * 200_mm}, 35_mm, 100_mm);
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl3, Acts::binZ, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   // Cylinder with bevel
   auto cyl4 = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3::UnitZ() * 200_mm}, 30_mm, 100_mm, M_PI, 0,
       M_PI / 8.0);
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl4, Acts::binZ, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   auto cyl5 = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3::UnitZ() * 200_mm}, 30_mm, 100_mm, M_PI, 0, 0,
       M_PI / 8.0);
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl5, Acts::binZ, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   // Cylinder with overlap in z
   auto cyl6 = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3::UnitZ() * 150_mm}, 30_mm, 100_mm);
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl6, Acts::binZ, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   // Cylinder with gap in z
   auto cyl7 = Surface::makeShared<CylinderSurface>(
       base * Translation3{Vector3::UnitZ() * 250_mm}, 30_mm, 100_mm);
   BOOST_CHECK_THROW(cyl->mergedWith(testContext, *cyl7, Acts::binZ, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 }
 
 BOOST_DATA_TEST_CASE(ZDirection,
@@ -465,14 +466,14 @@ BOOST_DATA_TEST_CASE(IncompatibleRPhiDirection,
                                                       45_degree, a(85_degree));
   BOOST_CHECK_THROW(
       cylPhi->mergedWith(testContext, *cylPhi2, Acts::binRPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Cylinder with gap in phi
   auto cylPhi3 = Surface::makeShared<CylinderSurface>(base, 30_mm, 100_mm,
                                                       45_degree, a(105_degree));
   BOOST_CHECK_THROW(
       cylPhi->mergedWith(testContext, *cylPhi3, Acts::binRPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Cylinder with a z shift
   auto cylPhi4 = Surface::makeShared<CylinderSurface>(
@@ -480,7 +481,7 @@ BOOST_DATA_TEST_CASE(IncompatibleRPhiDirection,
       a(95_degree));
   BOOST_CHECK_THROW(
       cylPhi->mergedWith(testContext, *cylPhi4, Acts::binRPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 }
 
 BOOST_DATA_TEST_CASE(RPhiDirection,

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -23,6 +23,7 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Surfaces/SurfaceMergingException.hpp"
 #include "Acts/Tests/CommonHelpers/DetectorElementStub.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BinningType.hpp"
@@ -398,10 +399,10 @@ BOOST_AUTO_TEST_CASE(IncompatibleBounds) {
       Surface::makeShared<DiscSurface>(base, 20_mm, 40_mm, 30_mm, 100_mm);
 
   BOOST_CHECK_THROW(discRadial->mergedWith(tgContext, *discTrap, binR, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   BOOST_CHECK_THROW(discTrap2->mergedWith(tgContext, *discTrap, binR, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 }
 
 BOOST_DATA_TEST_CASE(IncompatibleRDirection,
@@ -423,35 +424,35 @@ BOOST_DATA_TEST_CASE(IncompatibleRDirection,
   auto discOverlap = makeDisc(base, 90_mm, 150_mm);
   BOOST_CHECK_THROW(
       disc->mergedWith(tgContext, *discOverlap, Acts::binR, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Disc with gap in r
   auto discGap = makeDisc(base, 110_mm, 150_mm);
   BOOST_CHECK_THROW(disc->mergedWith(tgContext, *discGap, Acts::binR, *logger),
-                    std::invalid_argument);
+                    SurfaceMergingException);
 
   auto discShiftedZ = Surface::makeShared<DiscSurface>(
       base * Translation3{Vector3::UnitZ() * 10_mm}, 100_mm, 150_mm);
   BOOST_CHECK_THROW(
       disc->mergedWith(tgContext, *discShiftedZ, Acts::binR, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   auto discShiftedXy = makeDisc(
       base * Translation3{Vector3{1_mm, 2_mm, 200_mm}}, 100_mm, 150_mm);
   BOOST_CHECK_THROW(
       disc->mergedWith(tgContext, *discShiftedXy, Acts::binZ, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   auto discRotatedZ =
       makeDisc(base * AngleAxis3{10_degree, Vector3::UnitZ()}, 100_mm, 150_mm);
   BOOST_CHECK_THROW(
       disc->mergedWith(tgContext, *discRotatedZ, Acts::binR, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
   auto discRotatedX =
       makeDisc(base * AngleAxis3{10_degree, Vector3::UnitX()}, 100_mm, 150_mm);
   BOOST_CHECK_THROW(
       disc->mergedWith(tgContext, *discRotatedX, Acts::binR, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 }
 
 BOOST_DATA_TEST_CASE(RDirection,
@@ -509,26 +510,26 @@ BOOST_DATA_TEST_CASE(IncompatiblePhiDirection,
   auto discPhi2 = makeDisc(base, 30_mm, 100_mm, 45_degree, a(85_degree));
   BOOST_CHECK_THROW(
       discPhi->mergedWith(tgContext, *discPhi2, Acts::binPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Disc with gap in phi
   auto discPhi3 = makeDisc(base, 30_mm, 100_mm, 45_degree, a(105_degree));
   BOOST_CHECK_THROW(
       discPhi->mergedWith(tgContext, *discPhi3, Acts::binPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Disc with a z shift
   auto discPhi4 = makeDisc(base * Translation3{Vector3::UnitZ() * 20_mm}, 30_mm,
                            100_mm, 45_degree, a(95_degree));
   BOOST_CHECK_THROW(
       discPhi->mergedWith(tgContext, *discPhi4, Acts::binPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 
   // Disc with different r bounds: could be merged in r but not in phi
   auto discPhi5 = makeDisc(base, 100_mm, 150_mm, 45_degree, a(95_degree));
   BOOST_CHECK_THROW(
       discPhi->mergedWith(tgContext, *discPhi5, Acts::binPhi, *logger),
-      std::invalid_argument);
+      SurfaceMergingException);
 }
 
 BOOST_DATA_TEST_CASE(PhiDirection,


### PR DESCRIPTION
This switches the surface merging introduced in #3288 over to a dedicated exception `SurfaceMergingException`.