### PR TITLE
feat: `Surface::toStream` overload without stream argument

### DIFF
--- a/Core/include/Acts/Geometry/GeometryContext.hpp
+++ b/Core/include/Acts/Geometry/GeometryContext.hpp
@@ -25,6 +25,35 @@ namespace Acts {
 
 using GeometryContext = ContextType;
 
+/// Helper struct that stores an object and a context, and will print it to
+/// an outstream.
+/// This allows you to write
+/// ```cpp
+/// std::cout << surface->toStream(geoContext) << std::endl;
+/// ```
+template <typename T>
+struct GeometryContextOstreamWrapper {
+  GeometryContextOstreamWrapper(const T& object, const GeometryContext& gctx)
+      : m_object(object), m_gctx(gctx) {}
+
+  GeometryContextOstreamWrapper(const GeometryContextOstreamWrapper&) = delete;
+  GeometryContextOstreamWrapper(GeometryContextOstreamWrapper&&) = delete;
+  GeometryContextOstreamWrapper& operator=(
+      const GeometryContextOstreamWrapper&) = delete;
+  GeometryContextOstreamWrapper& operator=(GeometryContextOstreamWrapper&&) =
+      delete;
+
+  friend std::ostream& operator<<(
+      std::ostream& os, const GeometryContextOstreamWrapper& osWrapper) {
+    osWrapper.m_object.toStream(osWrapper.m_gctx, os);
+    return os;
+  }
+
+ private:
+  const T& m_object;
+  const GeometryContext& m_gctx;
+};
+
 }  // namespace Acts
 
 #endif

--- a/Core/include/Acts/Geometry/GeometryContext.hpp
+++ b/Core/include/Acts/Geometry/GeometryContext.hpp
@@ -15,6 +15,8 @@
 
 #include "Acts/Utilities/detail/ContextType.hpp"
 
+#include <ostream>
+
 namespace Acts {
 
 /// @brief This is the central definition of the Acts
@@ -45,7 +47,7 @@ struct GeometryContextOstreamWrapper {
 
   friend std::ostream& operator<<(
       std::ostream& os, const GeometryContextOstreamWrapper& osWrapper) {
-    osWrapper.m_object.toStream(osWrapper.m_gctx, os);
+    osWrapper.m_object.toStreamImpl(osWrapper.m_gctx, os);
     return os;
   }
 

--- a/Core/include/Acts/Geometry/GeometryContext.hpp
+++ b/Core/include/Acts/Geometry/GeometryContext.hpp
@@ -47,11 +47,13 @@ struct GeometryContextOstreamWrapper {
 
   friend std::ostream& operator<<(
       std::ostream& os, const GeometryContextOstreamWrapper& osWrapper) {
-    osWrapper.m_object.toStreamImpl(osWrapper.m_gctx, os);
+    osWrapper.toStream(os);
     return os;
   }
 
  private:
+  void toStream(std::ostream& os) const { m_object.toStreamImpl(m_gctx, os); }
+
   const T& m_object;
   const GeometryContext& m_gctx;
 };

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -907,7 +907,7 @@ class Navigator {
                      << " out of " << state.navigation.navBoundaries.size()
                      << " not reachable anymore, switching to next.");
         ACTS_VERBOSE("Targeted boundary surface was: \n"
-                     << std::tie(*boundarySurface, state.geoContext));
+                     << boundarySurface->toStream(state.geoContext));
       }
       // Increase the index to the next one
       ++state.navigation.navBoundaryIndex;

--- a/Core/include/Acts/Surfaces/PerigeeSurface.hpp
+++ b/Core/include/Acts/Surfaces/PerigeeSurface.hpp
@@ -74,15 +74,6 @@ class PerigeeSurface : public LineSurface {
   /// Return properly formatted class name for screen output */
   std::string name() const final;
 
-  /// Output Method for std::ostream
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param sl is the ostream to be dumped into
-  ///
-  /// @return ostreamn object which was streamed into
-  std::ostream& toStream(const GeometryContext& gctx,
-                         std::ostream& sl) const final;
-
   /// Return a Polyhedron for the surfaces
   ///
   /// @param gctx The current geometry context object, e.g. alignment
@@ -91,6 +82,16 @@ class PerigeeSurface : public LineSurface {
   /// @return A list of vertices and a face/facett description of it
   Polyhedron polyhedronRepresentation(const GeometryContext& gctx,
                                       std::size_t lseg) const final;
+
+ protected:
+  /// Output Method for std::ostream
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param sl is the ostream to be dumped into
+  ///
+  /// @return ostreamn object which was streamed into
+  std::ostream& toStreamImpl(const GeometryContext& gctx,
+                             std::ostream& sl) const final;
 };
 
 ACTS_STATIC_CHECK_CONCEPT(SurfaceConcept, PerigeeSurface);

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -406,6 +406,15 @@ class Surface : public virtual GeometryObject,
   virtual std::ostream& toStream(const GeometryContext& gctx,
                                  std::ostream& sl) const;
 
+  /// Helper method for printing: the returned object captures the
+  /// surface and the geometry context and will print the surface
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @return The wrapper object for printing
+  GeometryContextOstreamWrapper<Surface> toStream(
+      const GeometryContext& gctx) const {
+    return {*this, gctx};
+  }
+
   /// Output into a std::string
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -63,6 +63,8 @@ using SurfaceMultiIntersection = ObjectMultiIntersection<Surface>;
 class Surface : public virtual GeometryObject,
                 public std::enable_shared_from_this<Surface> {
  public:
+  friend GeometryContextOstreamWrapper<Surface>;
+
   /// @enum SurfaceType
   ///
   /// This enumerator simplifies the persistency & calculations,
@@ -479,7 +481,6 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const Vector3& position) const = 0;
 
  protected:
-  friend GeometryContextOstreamWrapper<Surface>;
   /// Output Method for std::ostream, to be overloaded by child classes
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -399,13 +399,6 @@ class Surface : public virtual GeometryObject,
       const BoundaryCheck& bcheck = BoundaryCheck(false),
       ActsScalar tolerance = s_onSurfaceTolerance) const = 0;
 
-  /// Output Method for std::ostream, to be overloaded by child classes
-  ///
-  /// @param gctx The current geometry context object, e.g. alignment
-  /// @param sl is the ostream to be dumped into
-  virtual std::ostream& toStream(const GeometryContext& gctx,
-                                 std::ostream& sl) const;
-
   /// Helper method for printing: the returned object captures the
   /// surface and the geometry context and will print the surface
   /// @param gctx The current geometry context object, e.g. alignment
@@ -486,6 +479,14 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const Vector3& position) const = 0;
 
  protected:
+  friend GeometryContextOstreamWrapper<Surface>;
+  /// Output Method for std::ostream, to be overloaded by child classes
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  /// @param sl is the ostream to be dumped into
+  virtual std::ostream& toStreamImpl(const GeometryContext& gctx,
+                                     std::ostream& sl) const;
+
   /// Transform3 definition that positions
   /// (translation, rotation) the surface in global space
   Transform3 m_transform = Transform3::Identity();
@@ -523,16 +524,5 @@ class Surface : public virtual GeometryObject,
       const GeometryContext& gctx, const Vector3& position,
       const Vector3& direction) const;
 };
-
-/// Print surface information to the provided stream. Internally invokes the
-/// `surface.toStream(...)`-method. This can be easily used e.g. like `std::cout
-/// << std::tie(surface, geometryContext);`
-inline std::ostream& operator<<(
-    std::ostream& os,
-    const std::tuple<const Surface&, const GeometryContext&>& tup) {
-  const auto [surface, gctx] = tup;
-  surface.toStream(gctx, os);
-  return os;
-}
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -63,7 +63,7 @@ using SurfaceMultiIntersection = ObjectMultiIntersection<Surface>;
 class Surface : public virtual GeometryObject,
                 public std::enable_shared_from_this<Surface> {
  public:
-  friend GeometryContextOstreamWrapper<Surface>;
+  friend struct GeometryContextOstreamWrapper<Surface>;
 
   /// @enum SurfaceType
   ///

--- a/Core/include/Acts/Surfaces/SurfaceConcept.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceConcept.hpp
@@ -86,9 +86,7 @@ concept SurfaceConcept = requires(S s, const S cs, S s2, const S cs2,
                  std::declval<const BoundaryCheck&>(), std::declval<double>())
     } -> std::same_as<SurfaceMultiIntersection>;
 
-  {
-    cs.toStream(gctx, std::declval<std::ostream&>())
-    } -> std::same_as<std::ostream&>;
+  { cs.toStream(gctx) } -> std::same_as<GeometryContextOstreamWrapper<Surface>>;
 
   { cs.toString(gctx) } -> std::same_as<std::string>;
 

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -45,8 +45,8 @@ std::string Acts::PerigeeSurface::name() const {
   return "Acts::PerigeeSurface";
 }
 
-std::ostream& Acts::PerigeeSurface::toStream(const GeometryContext& gctx,
-                                             std::ostream& sl) const {
+std::ostream& Acts::PerigeeSurface::toStreamImpl(const GeometryContext& gctx,
+                                                 std::ostream& sl) const {
   sl << std::setiosflags(std::ios::fixed);
   sl << std::setprecision(7);
   sl << "Acts::PerigeeSurface:" << std::endl;

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -195,8 +195,8 @@ bool Acts::Surface::operator==(const Surface& other) const {
 }
 
 // overload dump for stream operator
-std::ostream& Acts::Surface::toStream(const GeometryContext& gctx,
-                                      std::ostream& sl) const {
+std::ostream& Acts::Surface::toStreamImpl(const GeometryContext& gctx,
+                                          std::ostream& sl) const {
   sl << std::setiosflags(std::ios::fixed);
   sl << std::setprecision(4);
   sl << name() << std::endl;
@@ -221,7 +221,7 @@ std::ostream& Acts::Surface::toStream(const GeometryContext& gctx,
 
 std::string Acts::Surface::toString(const GeometryContext& gctx) const {
   std::stringstream ss;
-  toStream(gctx, ss);
+  ss << toStream(gctx);
   return ss.str();
 }
 

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -213,15 +213,20 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
                     std::string("Acts::CylinderSurface"));
   //
   /// Test dump
-  boost::test_tools::output_test_stream dumpOuput;
-  cylinderSurfaceObject->toStream(testContext, dumpOuput);
-  BOOST_CHECK(
-      dumpOuput.is_equal("Acts::CylinderSurface\n\
+  boost::test_tools::output_test_stream dumpOutput;
+  cylinderSurfaceObject->toStream(testContext, dumpOutput);
+  std::string expected =
+      "Acts::CylinderSurface\n\
      Center position  (x, y, z) = (0.0000, 1.0000, 2.0000)\n\
      Rotation:             colX = (1.000000, 0.000000, 0.000000)\n\
                            colY = (0.000000, 1.000000, 0.000000)\n\
                            colZ = (0.000000, 0.000000, 1.000000)\n\
-     Bounds  : Acts::CylinderBounds: (radius, halfLengthZ, halfPhiSector, averagePhi, bevelMinZ, bevelMaxZ) = (1.0000000, 10.0000000, 3.1415927, 0.0000000, 0.0000000, 0.0000000)"));
+     Bounds  : Acts::CylinderBounds: (radius, halfLengthZ, halfPhiSector, averagePhi, bevelMinZ, bevelMaxZ) = (1.0000000, 10.0000000, 3.1415927, 0.0000000, 0.0000000, 0.0000000)";
+  BOOST_CHECK(dumpOutput.is_equal(expected));
+
+  dumpOutput.flush();
+  dumpOutput << cylinderSurfaceObject->toStream(testContext);
+  BOOST_CHECK(dumpOutput.is_equal(expected));
 }
 
 BOOST_AUTO_TEST_CASE(CylinderSurfaceEqualityOperators) {

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -214,7 +214,6 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
   //
   /// Test dump
   boost::test_tools::output_test_stream dumpOutput;
-  cylinderSurfaceObject->toStream(testContext, dumpOutput);
   std::string expected =
       "Acts::CylinderSurface\n\
      Center position  (x, y, z) = (0.0000, 1.0000, 2.0000)\n\
@@ -222,9 +221,6 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
                            colY = (0.000000, 1.000000, 0.000000)\n\
                            colZ = (0.000000, 0.000000, 1.000000)\n\
      Bounds  : Acts::CylinderBounds: (radius, halfLengthZ, halfPhiSector, averagePhi, bevelMinZ, bevelMaxZ) = (1.0000000, 10.0000000, 3.1415927, 0.0000000, 0.0000000, 0.0000000)";
-  BOOST_CHECK(dumpOutput.is_equal(expected));
-
-  dumpOutput.flush();
   dumpOutput << cylinderSurfaceObject->toStream(testContext);
   BOOST_CHECK(dumpOutput.is_equal(expected));
 }

--- a/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
@@ -65,10 +65,10 @@ BOOST_AUTO_TEST_CASE(PerigeeSurfaceProperties) {
                     std::string("Acts::PerigeeSurface"));
   //
   /// Test dump
-  boost::test_tools::output_test_stream dumpOuput;
-  perigeeSurfaceObject->toStream(tgContext, dumpOuput);
+  boost::test_tools::output_test_stream dumpOutput;
+  dumpOutput << perigeeSurfaceObject->toStream(tgContext);
   BOOST_CHECK(
-      dumpOuput.is_equal("Acts::PerigeeSurface:\n\
+      dumpOutput.is_equal("Acts::PerigeeSurface:\n\
      Center position  (x, y, z) = (1.0000000, 1.0000000, 1.0000000)"));
 }
 

--- a/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
@@ -91,10 +91,10 @@ BOOST_AUTO_TEST_CASE(StrawSurfaceProperties) {
                     std::string("Acts::StrawSurface"));
   //
   /// Test dump
-  boost::test_tools::output_test_stream dumpOuput;
-  strawSurfaceObject->toStream(tgContext, dumpOuput);
+  boost::test_tools::output_test_stream dumpOutput;
+  dumpOutput << strawSurfaceObject->toStream(tgContext);
   BOOST_CHECK(
-      dumpOuput.is_equal("Acts::StrawSurface\n\
+      dumpOutput.is_equal("Acts::StrawSurface\n\
      Center position  (x, y, z) = (0.0000, 1.0000, 2.0000)\n\
      Rotation:             colX = (1.000000, 0.000000, 0.000000)\n\
                            colY = (0.000000, 1.000000, 0.000000)\n\

--- a/Tests/UnitTests/Plugins/Json/SurfaceJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/SurfaceJsonConverterTests.cpp
@@ -34,9 +34,11 @@
 
 using namespace Acts;
 
+namespace {
 std::ofstream out;
 
 Acts::GeometryContext gctx;
+}  // namespace
 
 BOOST_AUTO_TEST_SUITE(SurfaceJsonConversion)
 


### PR DESCRIPTION
I'm adding a way that allows you to avoid having to write

```cpp
surface->toStream(gctx, std::cout);
std::cout << std::endl;
```

and instead write

```cpp
std::cout << surface->toStream(gctx) << std::endl;
```

This is done by returning a temporary helper struct that implements `operator<<`.
