### PR TITLE
refactor(gx2f): change type of Gx2fnUpdateColumn to uint32_t (athena compatability)

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -993,7 +993,7 @@ class Gx2Fitter {
 
     if (!trackContainer.hasColumn(
             Acts::hashString(Gx2fConstants::gx2fnUpdateColumn))) {
-      trackContainer.template addColumn<std::size_t>("Gx2fnUpdateColumn");
+      trackContainer.template addColumn<std::uint32_t>("Gx2fnUpdateColumn");
     }
 
     // Prepare track for return
@@ -1006,7 +1006,7 @@ class Gx2Fitter {
     if (trackContainer.hasColumn(
             Acts::hashString(Gx2fConstants::gx2fnUpdateColumn))) {
       ACTS_DEBUG("Add nUpdate to track")
-      track.template component<std::size_t>("Gx2fnUpdateColumn") = nUpdate;
+      track.template component<std::uint32_t>("Gx2fnUpdateColumn") = nUpdate;
     }
 
     // TODO write test for calculateTrackQuantities

--- a/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
@@ -526,7 +526,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
     if (m_cfg.writeGx2fSpecific) {
       if (tracks.hasColumn(Acts::hashString("Gx2fnUpdateColumn"))) {
         int nUpdate = static_cast<int>(
-            track.template component<std::size_t,
+            track.template component<std::uint32_t,
                                      Acts::hashString("Gx2fnUpdateColumn")>());
         m_nUpdatesGx2f.push_back(nUpdate);
       } else {

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(NoFit) {
   // Convergence
   BOOST_CHECK_EQUAL(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       0);
 
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(Fit5Iterations) {
   // Convergence
   BOOST_CHECK_EQUAL(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       5);
 
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(MixedDetector) {
   // Convergence
   BOOST_CHECK_EQUAL(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       5);
 
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(FitWithBfield) {
   // Convergence
   BOOST_CHECK_EQUAL(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       5);
 
@@ -664,7 +664,7 @@ BOOST_AUTO_TEST_CASE(relChi2changeCutOff) {
   // Convergence
   BOOST_CHECK_LT(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       10);
 
@@ -1027,7 +1027,7 @@ BOOST_AUTO_TEST_CASE(Material) {
   // Convergence
   BOOST_CHECK_EQUAL(
       (track.template component<
-          std::size_t,
+          std::uint32_t,
           hashString(Experimental::Gx2fConstants::gx2fnUpdateColumn)>()),
       5);
 


### PR DESCRIPTION
`size_t`-columns are not supported in athena. This should be fine for the fitter, since we don't expect values larger than 2000 or so to be in there. Usually we have values around 4-6.