### PR TITLE
fix: fixing macOS (arm64) build by including ostream

### DIFF
--- a/Core/src/Utilities/BinningType.cpp
+++ b/Core/src/Utilities/BinningType.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Utilities/BinningType.hpp"
 
 #include <algorithm>
+#include <ostream>
 #include <stdexcept>
 
 namespace Acts {


### PR DESCRIPTION
Fixes compilation problem with macOS (arm64).
