### PR TITLE
docs: Label as docs changes to rst files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,6 +28,7 @@
   - changed-files:
     - any-glob-to-any-file:
       - docs/**
+      - '**/*.rst'
 'Changes Performance':
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
allow the label bot to label a PR in a rst file has been modified