### PR TITLE
refactor!: Move context from vertexing options to vertexing calls

### DIFF
--- a/Core/include/Acts/Material/PropagatorMaterialAssigner.hpp
+++ b/Core/include/Acts/Material/PropagatorMaterialAssigner.hpp
@@ -137,9 +137,10 @@ class PropagatorMaterialAssigner final : public IAssignmentFinder {
     using PropagatorOptions =
         typename propagator_t::template Options<ActionList, AbortList>;
 
-    PropagatorOptions options(gctx, mctx);
+    PropagatorOptions options;
 
-    const auto& result = m_propagator.propagate(start, options).value();
+    const auto& result =
+        m_propagator.propagate(gctx, mctx, start, options).value();
 
     // The surface collection results
     auto scResult =

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -49,6 +49,8 @@ class BasePropagator {
   using Options = PropagatorPlainOptions;
 
   /// Method to propagate start bound track parameters to a target surface.
+  /// @param geoContext The geometry context.
+  /// @param magFieldContext The magnetic field context.
   /// @param start The start bound track parameters.
   /// @param target The target surface.
   /// @param options The propagation options.
@@ -249,6 +251,8 @@ class Propagator final
   /// @tparam propagator_options_t Type of the propagator options
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start initial track parameters to propagate
   /// @param [in] options Propagation options, type Options<,>
   /// @param [in] makeCurvilinear Produce curvilinear parameters at the end of the propagation
@@ -278,6 +282,8 @@ class Propagator final
   /// @tparam target_aborter_t The target aborter type to be added
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] target Target surface of to propagate to
   /// @param [in] options Propagation options
@@ -306,6 +312,8 @@ class Propagator final
   /// @tparam propagator_options_t Type of the propagator options
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] options Propagation options
   ///
@@ -329,6 +337,8 @@ class Propagator final
   /// @tparam target_aborter_t The target aborter type to be added
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] target Target surface of to propagate to
   /// @param [in] options Propagation options

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -54,6 +54,8 @@ class BasePropagator {
   /// @param options The propagation options.
   /// @return The end bound track parameters.
   virtual Result<BoundTrackParameters> propagateToSurface(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const BoundTrackParameters& start, const Surface& target,
       const Options& options) const = 0;
 
@@ -67,6 +69,8 @@ template <typename derived_t>
 class BasePropagatorHelper : public BasePropagator {
  public:
   Result<BoundTrackParameters> propagateToSurface(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const BoundTrackParameters& start, const Surface& target,
       const Options& options) const override;
 };
@@ -257,7 +261,9 @@ class Propagator final
   Result<
       action_list_t_result_t<StepperCurvilinearTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const propagator_options_t& options,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const propagator_options_t& options,
             bool makeCurvilinear = true) const;
 
   /// @brief Propagate track parameters - User method
@@ -284,7 +290,9 @@ class Propagator final
   Result<
       action_list_t_result_t<StepperBoundTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const Surface& target,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const Surface& target,
             const propagator_options_t& options) const;
 
   /// @brief Builds the propagator state object
@@ -304,7 +312,9 @@ class Propagator final
   /// @return Propagator state object
   template <typename parameters_t, typename propagator_options_t,
             typename path_aborter_t = PathLimitReached>
-  auto makeState(const parameters_t& start,
+  auto makeState(const GeometryContext& geoContext,
+                 const MagneticFieldContext& magFieldContext,
+                 const parameters_t& start,
                  const propagator_options_t& options) const;
 
   /// @brief Builds the propagator state object
@@ -327,7 +337,9 @@ class Propagator final
   template <typename parameters_t, typename propagator_options_t,
             typename target_aborter_t = SurfaceReached,
             typename path_aborter_t = PathLimitReached>
-  auto makeState(const parameters_t& start, const Surface& target,
+  auto makeState(const GeometryContext& geoContext,
+                 const MagneticFieldContext& magFieldContext,
+                 const parameters_t& start, const Surface& target,
                  const propagator_options_t& options) const;
 
   /// @brief Propagate track parameters

--- a/Core/include/Acts/Propagator/PropagatorOptions.hpp
+++ b/Core/include/Acts/Propagator/PropagatorOptions.hpp
@@ -47,17 +47,6 @@ struct PurePropagatorPlainOptions {
 
 /// @brief Holds the generic propagator options
 struct PropagatorPlainOptions : public detail::PurePropagatorPlainOptions {
-  /// PropagatorPlainOptions with context
-  PropagatorPlainOptions(const GeometryContext& gctx,
-                         const MagneticFieldContext& mctx)
-      : geoContext(gctx), magFieldContext(mctx) {}
-
-  /// The context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-
-  /// The context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
-
   /// Stepper plain options
   StepperPlainOptions stepping;
 
@@ -82,21 +71,17 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
   using action_list_type = action_list_t;
   using aborter_list_type = aborter_list_t;
 
-  /// PropagatorOptions with context
-  PropagatorOptions(const GeometryContext& gctx,
-                    const MagneticFieldContext& mctx)
-      : geoContext(gctx), magFieldContext(mctx) {}
+  /// Default constructor
+  PropagatorOptions() = default;
 
   /// PropagatorOptions with context and plain options
-  PropagatorOptions(const PropagatorPlainOptions& pOptions)
-      : geoContext(pOptions.geoContext),
-        magFieldContext(pOptions.magFieldContext) {
+  PropagatorOptions(const PropagatorPlainOptions& pOptions) {
     setPlainOptions(pOptions);
   }
 
   /// @brief Convert to plain options
   operator PropagatorPlainOptions() const {
-    PropagatorPlainOptions pOptions(geoContext, magFieldContext);
+    PropagatorPlainOptions pOptions;
     static_cast<PurePropagatorPlainOptions&>(pOptions) =
         static_cast<const PurePropagatorPlainOptions&>(*this);
     pOptions.stepping = static_cast<const StepperPlainOptions&>(stepping);
@@ -115,7 +100,7 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
   extend(extended_aborter_list_t aborters) const {
     PropagatorOptions<stepper_options_t, navigator_options_t, action_list_t,
                       extended_aborter_list_t>
-        eoptions(geoContext, magFieldContext);
+        eoptions;
 
     // Copy the base options
     static_cast<PurePropagatorPlainOptions&>(eoptions) =
@@ -143,12 +128,6 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
     stepping.setPlainOptions(pOptions.stepping);
     navigation.setPlainOptions(pOptions.navigation);
   }
-
-  /// The context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-
-  /// The context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
 
   /// Stepper options
   stepper_options_t stepping;

--- a/Core/include/Acts/Propagator/PropagatorState.hpp
+++ b/Core/include/Acts/Propagator/PropagatorState.hpp
@@ -39,6 +39,7 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
   ///
   /// @tparam propagator_options_t the type of the propagator options
   ///
+  /// @param gctx The geometry context
   /// @param topts The options handed over by the propagate call
   /// @param steppingIn Stepper state instance to begin with
   /// @param navigationIn Navigator state instance to begin with

--- a/Core/include/Acts/Propagator/PropagatorState.hpp
+++ b/Core/include/Acts/Propagator/PropagatorState.hpp
@@ -42,12 +42,13 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
   /// @param topts The options handed over by the propagate call
   /// @param steppingIn Stepper state instance to begin with
   /// @param navigationIn Navigator state instance to begin with
-  PropagatorState(const propagator_options_t& topts, stepper_state_t steppingIn,
+  PropagatorState(const GeometryContext& gctx,
+                  const propagator_options_t& topts, stepper_state_t steppingIn,
                   navigator_state_t navigationIn)
       : options(topts),
         stepping{std::move(steppingIn)},
         navigation{std::move(navigationIn)},
-        geoContext(topts.geoContext) {}
+        geoContext(gctx) {}
 
   using detail::Extendable<extension_state_t...>::get;
   using detail::Extendable<extension_state_t...>::tuple;

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -120,7 +120,9 @@ class RiddersPropagator {
   Result<
       action_list_t_result_t<CurvilinearTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start,
             const propagator_options_t& options) const;
 
   /// @brief Propagation method targeting bound parameters
@@ -138,7 +140,9 @@ class RiddersPropagator {
   template <typename parameters_t, typename propagator_options_t>
   Result<action_list_t_result_t<
       BoundTrackParameters, typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const Surface& target,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const Surface& target,
             const propagator_options_t& options) const;
 
  private:
@@ -151,9 +155,11 @@ class RiddersPropagator {
   /// @param [in] nominalResult The result of the nominal propagation
   template <typename propagator_options_t, typename parameters_t,
             typename result_t>
-  Jacobian wiggleAndCalculateJacobian(const propagator_options_t& options,
-                                      const parameters_t& start,
-                                      result_t& nominalResult) const;
+  Jacobian wiggleAndCalculateJacobian(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
+      const propagator_options_t& options, const parameters_t& start,
+      result_t& nominalResult) const;
 
   /// @brief This function tests whether the variations on a disc as target
   /// surface lead to results on different sides wrt the center of the disc.
@@ -184,6 +190,8 @@ class RiddersPropagator {
   /// @return Vector containing each slope
   template <typename propagator_options_t, typename parameters_t>
   std::vector<BoundVector> wiggleParameter(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const propagator_options_t& options, const parameters_t& start,
       unsigned int param, const Surface& target, const BoundVector& nominal,
       const std::vector<double>& deviations) const;

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -112,6 +112,8 @@ class RiddersPropagator {
   /// @tparam parameters_t Type of the start parameters
   /// @tparam propagator_options_t Type of the propagator options
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Start parameters
   /// @param [in] options Options of the propagations
   ///
@@ -130,6 +132,8 @@ class RiddersPropagator {
   /// @tparam parameters_t Type of the start parameters
   /// @tparam propagator_options_t Type of the propagator options
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Start parameters
   /// @param [in] target The target surface
   /// @param [in] options Options of the propagations
@@ -150,6 +154,8 @@ class RiddersPropagator {
   /// propagating again. This function is called from the different propagation
   /// overloads in order to deduplicate code.
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] options Options of the propagations
   /// @param [in] start Start parameters
   /// @param [in] nominalResult The result of the nominal propagation
@@ -180,6 +186,8 @@ class RiddersPropagator {
   /// @tparam options_t PropagatorOptions object
   /// @tparam parameters_t Type of the parameters to start the propagation with
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] options Options do define how to wiggle
   /// @param [in] start Start parameters which will be modified
   /// @param [in] param Index to get the parameter that will be modified

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -768,10 +768,10 @@ class CombinatorialKalmanFilter {
           // Update stepping state using filtered parameters of last track
           // state on this surface
           auto ts = result.activeBranches.back().outermostTrackState();
-          stepper.update(state.stepping,
-                         MultiTrajectoryHelpers::freeFiltered(
-                             state.options.geoContext, ts),
-                         ts.filtered(), ts.filteredCovariance(), *surface);
+          stepper.update(
+              state.stepping,
+              MultiTrajectoryHelpers::freeFiltered(state.geoContext, ts),
+              ts.filtered(), ts.filteredCovariance(), *surface);
           ACTS_VERBOSE("Stepping state is updated with filtered parameter:");
           ACTS_VERBOSE("-> " << ts.filtered().transpose()
                              << " of track state with tip = " << ts.index());
@@ -1205,8 +1205,7 @@ class CombinatorialKalmanFilter {
     using Aborters = AbortList<CombinatorialKalmanFilterAborter>;
 
     // Create relevant options for the propagation options
-    typename propagator_t::template Options<Actors, Aborters> propOptions(
-        tfOptions.geoContext, tfOptions.magFieldContext);
+    typename propagator_t::template Options<Actors, Aborters> propOptions;
 
     // Set the trivial propagator options
     propOptions.setPlainOptions(tfOptions.propagatorPlainOptions);
@@ -1238,8 +1237,9 @@ class CombinatorialKalmanFilter {
               source_link_iterator_t>>(&defaultTrackStateCreator);
     }
 
-    auto propState =
-        m_propagator.template makeState(initialParameters, propOptions);
+    auto propState = m_propagator.template makeState(
+        tfOptions.geoContext, tfOptions.magFieldContext, initialParameters,
+        propOptions);
 
     auto& r =
         propState

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -109,7 +109,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -132,7 +132,7 @@ struct GaussianSumFitter {
           std::next(sSequence.rbegin()), sSequence.rend());
       backwardSequence.push_back(opts.referenceSurface);
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -166,7 +166,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -183,7 +183,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -295,7 +295,8 @@ struct GaussianSumFitter {
         params = sParameters;
       }
 
-      auto state = m_propagator.makeState(*params, fwdPropOptions);
+      auto state = m_propagator.makeState(
+          options.geoContext, options.magFieldContext, *params, fwdPropOptions);
 
       auto& r = state.template get<typename GsfActor::result_type>();
       r.fittedStates = &trackContainer.trackStateContainer();
@@ -358,7 +359,8 @@ struct GaussianSumFitter {
           m_propagator.template makeState<MultiComponentBoundTrackParameters,
                                           decltype(bwdPropOptions),
                                           MultiStepperSurfaceReached>(
-              params, target, bwdPropOptions);
+              options.geoContext, options.magFieldContext, params, target,
+              bwdPropOptions);
 
       assert(
           (fwdGsfResult.lastMeasurementTip != MultiTrajectoryTraits::kInvalid &&

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -747,14 +747,15 @@ class Gx2Fitter {
       Acts::GeometryContext geoCtx = gx2fOptions.geoContext;
       Acts::MagneticFieldContext magCtx = gx2fOptions.magFieldContext;
       // Set options for propagator
-      PropagatorOptions propagatorOptions(geoCtx, magCtx);
+      PropagatorOptions propagatorOptions;
       auto& gx2fActor = propagatorOptions.actionList.template get<GX2FActor>();
       gx2fActor.inputMeasurements = &inputMeasurements;
       gx2fActor.extensions = gx2fOptions.extensions;
       gx2fActor.calibrationContext = &gx2fOptions.calibrationContext.get();
       gx2fActor.actorLogger = m_actorLogger.get();
 
-      auto propagatorState = m_propagator.makeState(params, propagatorOptions);
+      auto propagatorState =
+          m_propagator.makeState(geoCtx, magCtx, params, propagatorOptions);
 
       auto& r = propagatorState.template get<Gx2FitterResult<traj_t>>();
       r.fittedStates = &trajectoryTempBackend;
@@ -979,14 +980,15 @@ class Gx2Fitter {
       Acts::GeometryContext geoCtx = gx2fOptions.geoContext;
       Acts::MagneticFieldContext magCtx = gx2fOptions.magFieldContext;
       // Set options for propagator
-      PropagatorOptions propagatorOptions(geoCtx, magCtx);
+      PropagatorOptions propagatorOptions;
       auto& gx2fActor = propagatorOptions.actionList.template get<GX2FActor>();
       gx2fActor.inputMeasurements = &inputMeasurements;
       gx2fActor.extensions = gx2fOptions.extensions;
       gx2fActor.calibrationContext = &gx2fOptions.calibrationContext.get();
       gx2fActor.actorLogger = m_actorLogger.get();
 
-      auto propagatorState = m_propagator.makeState(params, propagatorOptions);
+      auto propagatorState =
+          m_propagator.makeState(geoCtx, magCtx, params, propagatorOptions);
 
       auto& r = propagatorState.template get<Gx2FitterResult<traj_t>>();
       r.fittedStates = &trackContainer.trackStateContainer();

--- a/Core/include/Acts/TrackFitting/GsfOptions.hpp
+++ b/Core/include/Acts/TrackFitting/GsfOptions.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2022 CERN for the benefit of the Acts project
+// Copyright (C) 2022-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -121,8 +121,7 @@ struct GsfOptions {
              const CalibrationContext &calibCtxt)
       : geoContext(geoCtxt),
         magFieldContext(magFieldCtxt),
-        calibrationContext(calibCtxt),
-        propagatorPlainOptions(geoCtxt, magFieldCtxt) {}
+        calibrationContext(calibCtxt) {}
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1246,6 +1246,8 @@ class KalmanFitter {
   /// @tparam track_container_t Type of the track container backend
   /// @tparam holder_t Type defining track container backend ownership
   ///
+  /// @param geoContext The geometry context
+  /// @param magField The magnetic field context
   /// @param sParameters The initial track parameters
   /// @param propagatorOptions The Propagator Options
   /// @param trackContainer Input track container storage to append into

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -490,7 +490,7 @@ struct GsfActor {
       auto proxy = tmpStates.traj.getTrackState(idx);
 
       cmp.pars() =
-          MultiTrajectoryHelpers::freeFiltered(state.options.geoContext, proxy);
+          MultiTrajectoryHelpers::freeFiltered(state.geoContext, proxy);
       cmp.cov() = proxy.filteredCovariance();
       cmp.weight() = tmpStates.weights.at(idx);
     }

--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -275,6 +275,8 @@ findTrackStateForExtrapolation(
 /// @tparam propagator_t The propagator type
 /// @tparam propagator_options_t The propagator options type
 ///
+/// @param geoContext The geometry context
+/// @param magFieldContext The magnetic field context
 /// @param track The track which is modified in-place
 /// @param referenceSurface The reference surface
 /// @param propagator The propagator

--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -13,6 +13,7 @@
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TrackStateType.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/TrackFitting/GainMatrixSmoother.hpp"
@@ -285,13 +286,14 @@ findTrackStateForExtrapolation(
 template <typename track_proxy_t, typename propagator_t,
           typename propagator_options_t>
 Result<void> extrapolateTrackToReferenceSurface(
-    track_proxy_t &track, const Surface &referenceSurface,
-    const propagator_t &propagator, propagator_options_t options,
-    TrackExtrapolationStrategy strategy,
+    const GeometryContext &geoContext,
+    const MagneticFieldContext &magFieldContext, track_proxy_t &track,
+    const Surface &referenceSurface, const propagator_t &propagator,
+    propagator_options_t options, TrackExtrapolationStrategy strategy,
     const Logger &logger = *getDefaultLogger("TrackExtrapolation",
                                              Logging::INFO)) {
   auto findResult = findTrackStateForExtrapolation(
-      options.geoContext, track, referenceSurface, strategy, logger);
+      geoContext, track, referenceSurface, strategy, logger);
 
   if (!findResult.ok()) {
     ACTS_ERROR("failed to find track state for extrapolation");
@@ -310,7 +312,7 @@ Result<void> extrapolateTrackToReferenceSurface(
   auto propagateResult =
       propagator.template propagate<BoundTrackParameters, propagator_options_t,
                                     ForcedSurfaceReached>(
-          parameters, referenceSurface, options);
+          geoContext, magFieldContext, parameters, referenceSurface, options);
 
   if (!propagateResult.ok()) {
     ACTS_ERROR("failed to extrapolate track: " << propagateResult.error());

--- a/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveGridDensityVertexFinder.hpp
@@ -91,6 +91,8 @@ class AdaptiveGridDensityVertexFinder final : public IVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex>> find(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions& vertexingOptions,
       IVertexFinder::State& anyState) const override;

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -175,8 +175,9 @@ class AdaptiveMultiVertexFitter {
   /// @param vertexingOptions Vertexing options
   ///
   /// @return Result<void> object
-  Result<void> addVtxToFit(State& state, Vertex& newVertex,
-                           const VertexingOptions& vertexingOptions) const;
+  Result<void> addVtxToFit(const Acts::GeometryContext& geoContext,
+                           const Acts::MagneticFieldContext& magFieldContext,
+                           State& state, Vertex& newVertex) const;
 
   /// @brief Performs a simultaneous fit of all vertices in
   /// state.vertexCollection
@@ -185,8 +186,9 @@ class AdaptiveMultiVertexFitter {
   /// @param vertexingOptions Vertexing options
   ///
   /// @return Result<void> object
-  Result<void> fit(State& state,
-                   const VertexingOptions& vertexingOptions) const;
+  Result<void> fit(const Acts::GeometryContext& geoContext,
+                   const Acts::MagneticFieldContext& magFieldContext,
+                   State& state) const;
 
  private:
   /// Configuration object
@@ -216,8 +218,9 @@ class AdaptiveMultiVertexFitter {
   /// @param vtx Vertex object
   /// @param vertexingOptions Vertexing options
   Result<void> prepareVertexForFit(
-      State& state, Vertex* vtx,
-      const VertexingOptions& vertexingOptions) const;
+      const Acts::GeometryContext& geoContext,
+      const Acts::MagneticFieldContext& magFieldContext, State& state,
+      Vertex* vtx) const;
 
   /// @brief Sets the vertexCompatibility for all TrackAtVertex objects
   /// at the current vertex
@@ -226,8 +229,9 @@ class AdaptiveMultiVertexFitter {
   /// @param currentVtx Current vertex
   /// @param vertexingOptions Vertexing options
   Result<void> setAllVertexCompatibilities(
-      State& state, Vertex* currentVtx,
-      const VertexingOptions& vertexingOptions) const;
+      const Acts::GeometryContext& geoContext,
+      const Acts::MagneticFieldContext& magFieldContext, State& state,
+      Vertex* currentVtx) const;
 
   /// @brief Sets weights to the track according to Eq.(5.46) in Ref.(1)
   ///  and updates the vertices by calling the VertexUpdater
@@ -235,7 +239,8 @@ class AdaptiveMultiVertexFitter {
   /// @param state Fitter state
   /// @param vertexingOptions Vertexing options
   Result<void> setWeightsAndUpdate(
-      State& state, const VertexingOptions& vertexingOptions) const;
+      const Acts::GeometryContext& geoContext,
+      const Acts::MagneticFieldContext& magFieldContext, State& state) const;
 
   /// @brief Collects the compatibility values of the track `trk`
   /// wrt to all of its associated vertices

--- a/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/FullBilloirVertexFitter.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
@@ -87,7 +88,9 @@ class FullBilloirVertexFitter {
   /// @param fieldCache The magnetic field cache
   ///
   /// @return Fitted vertex
-  Result<Vertex> fit(const std::vector<InputTrack>& paramVector,
+  Result<Vertex> fit(const GeometryContext& geoContext,
+                     const MagneticFieldContext& magFieldContext,
+                     const std::vector<InputTrack>& paramVector,
                      const VertexingOptions& vertexingOptions,
                      MagneticFieldProvider::Cache& fieldCache) const;
 

--- a/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/GridDensityVertexFinder.hpp
@@ -96,12 +96,14 @@ class GridDensityVertexFinder final : public IVertexFinder {
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
   Result<std::vector<Vertex>> find(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions& vertexingOptions,
       IVertexFinder::State& anyState) const override;
 
   IVertexFinder::State makeState(
-      const Acts::MagneticFieldContext& /*mctx*/) const override {
+      const Acts::MagneticFieldContext& /*magFieldContext*/) const override {
     return IVertexFinder::State{
         std::in_place_type<State>,
         MainGridVector{m_cfg.gridDensity.config().mainGridSize}};

--- a/Core/include/Acts/Vertexing/IVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/IVertexFinder.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2023 CERN for the benefit of the Acts project
+// Copyright (C) 2023-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "Acts/Utilities/Any.hpp"
@@ -34,13 +35,16 @@ class IVertexFinder {
   /// @param state The state object (needs to be created via @c makeState)
   /// @return The found vertex candidates
   virtual Result<std::vector<Vertex>> find(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const std::vector<InputTrack>& trackVector,
       const VertexingOptions& vertexingOptions, State& state) const = 0;
 
   /// Function to create a state object for this concrete vertex finder
-  /// @param mctx The magnetic field context
+  /// @param magFieldContext The magnetic field context
   /// @return The state object
-  virtual State makeState(const MagneticFieldContext& mctx) const = 0;
+  virtual State makeState(
+      const MagneticFieldContext& magFieldContext) const = 0;
 
   /// For vertex finders that have an internal state of active tracks, this
   /// method instructs them to mark used tracks for removal

--- a/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/TrackDensityVertexFinder.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/GaussianTrackDensity.hpp"
@@ -48,7 +49,9 @@ class TrackDensityVertexFinder final : public IVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex>> find(const std::vector<InputTrack>& trackVector,
+  Result<std::vector<Vertex>> find(const GeometryContext& geoContext,
+                                   const MagneticFieldContext& magFieldContext,
+                                   const std::vector<InputTrack>& trackVector,
                                    const VertexingOptions& vertexingOptions,
                                    IVertexFinder::State& state) const override;
 

--- a/Core/include/Acts/Vertexing/VertexingOptions.hpp
+++ b/Core/include/Acts/Vertexing/VertexingOptions.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2019-2023 CERN for the benefit of the Acts project
+// Copyright (C) 2019-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,43 +20,20 @@ namespace Acts {
 /// @brief Vertex Finder Options
 ///
 struct VertexingOptions {
-  /// Default constructor is deleted
-  VertexingOptions() = delete;
+  VertexingOptions() = default;
 
-  /// VertexingOptions with context and vertex constraint
+  /// VertexingOptions with vertex constraint
   ///
-  /// @param gctx Geometry context
-  /// @param mctx Magnetic field context
   /// @param constr Vertex constraint
   /// @param useConstr Boolean indicating whether vertex constraint should be used during the vertex fit
-  VertexingOptions(const GeometryContext& gctx,
-                   const MagneticFieldContext& mctx, const Vertex& constr,
-                   const bool useConstr = true)
-      : geoContext(gctx),
-        magFieldContext(mctx),
-        constraint(constr),
-        useConstraintInFit(useConstr) {
+  VertexingOptions(const Vertex& constr, const bool useConstr = true)
+      : constraint(constr), useConstraintInFit(useConstr) {
     if (useConstraintInFit && constraint.covariance().determinant() == 0.) {
       throw std::invalid_argument(
           "Vertex constraint covariance matrix must be invertible.");
     }
   }
 
-  /// VertexingOptions with context and without vertex constraint
-  ///
-  /// @param gctx Geometry context
-  /// @param mctx Magnetic field context
-  VertexingOptions(const GeometryContext& gctx,
-                   const MagneticFieldContext& mctx)
-      : geoContext(gctx), magFieldContext(mctx) {
-    constraint = Vertex();
-    useConstraintInFit = false;
-  }
-
-  /// Context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-  /// Context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
   /// Vertex constraint. Important note: While this variable is not used during
   /// the vertex fit if useConstraintInFit is set to false, it is always used
   /// during vertex finding.
@@ -64,7 +41,7 @@ struct VertexingOptions {
   /// Boolean indicating whether we use the constraint information during
   /// the vertex fit. If set to true, the covariance matrix of constraint must
   /// be invertible.
-  bool useConstraintInFit;
+  bool useConstraintInFit = false;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
+++ b/Core/include/Acts/Vertexing/ZScanVertexFinder.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Vertexing/FsmwMode1dFinder.hpp"
@@ -86,7 +87,9 @@ class ZScanVertexFinder final : public IVertexFinder {
   ///
   /// @return Vector of vertices, filled with a single
   ///         vertex (for consistent interfaces)
-  Result<std::vector<Vertex>> find(const std::vector<InputTrack>& trackVector,
+  Result<std::vector<Vertex>> find(const GeometryContext& geoContext,
+                                   const MagneticFieldContext& magFieldContext,
+                                   const std::vector<InputTrack>& trackVector,
                                    const VertexingOptions& vertexingOptions,
                                    IVertexFinder::State& state) const override;
 

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -244,11 +244,13 @@ void Acts::SurfaceMaterialMapper::mapInteraction(
       ActionList<MaterialSurfaceCollector, MaterialVolumeCollector>;
   using AbortList = AbortList<EndOfWorldReached>;
 
-  StraightLinePropagator::Options<ActionList, AbortList> options(
-      mState.geoContext, mState.magFieldContext);
+  StraightLinePropagator::Options<ActionList, AbortList> options;
 
   // Now collect the material layers by using the straight line propagator
-  const auto& result = m_propagator.propagate(start, options).value();
+  const auto& result =
+      m_propagator
+          .propagate(mState.geoContext, mState.magFieldContext, start, options)
+          .value();
   auto mcResult = result.get<MaterialSurfaceCollector::result_type>();
   auto mvcResult = result.get<MaterialVolumeCollector::result_type>();
 

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -377,11 +377,13 @@ void Acts::VolumeMaterialMapper::mapMaterialTrack(
   using ActionList = ActionList<BoundSurfaceCollector, MaterialVolumeCollector>;
   using AbortList = AbortList<EndOfWorldReached>;
 
-  StraightLinePropagator::Options<ActionList, AbortList> options(
-      mState.geoContext, mState.magFieldContext);
+  StraightLinePropagator::Options<ActionList, AbortList> options;
 
   // Now collect the material volume by using the straight line propagator
-  const auto& result = m_propagator.propagate(start, options).value();
+  const auto& result =
+      m_propagator
+          .propagate(mState.geoContext, mState.magFieldContext, start, options)
+          .value();
   auto mcResult = result.get<BoundSurfaceCollector::result_type>();
   auto mvcResult = result.get<MaterialVolumeCollector::result_type>();
 

--- a/Core/src/Vertexing/AdaptiveGridDensityVertexFinder.cpp
+++ b/Core/src/Vertexing/AdaptiveGridDensityVertexFinder.cpp
@@ -10,6 +10,8 @@
 
 Acts::Result<std::vector<Acts::Vertex>>
 Acts::AdaptiveGridDensityVertexFinder::find(
+    const GeometryContext& /*geoContext*/,
+    const MagneticFieldContext& /*magFieldContext*/,
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions& vertexingOptions,
     IVertexFinder::State& anyState) const {

--- a/Core/src/Vertexing/FullBilloirVertexFitter.cpp
+++ b/Core/src/Vertexing/FullBilloirVertexFitter.cpp
@@ -57,6 +57,8 @@ struct BilloirVertex {
 }  // namespace
 
 Acts::Result<Acts::Vertex> Acts::FullBilloirVertexFitter::fit(
+    const GeometryContext& geoContext,
+    const MagneticFieldContext& magFieldContext,
     const std::vector<InputTrack>& paramVector,
     const VertexingOptions& vertexingOptions,
     MagneticFieldProvider::Cache& fieldCache) const {
@@ -113,8 +115,7 @@ Acts::Result<Acts::Vertex> Acts::FullBilloirVertexFitter::fit(
 
       auto result =
           m_cfg.trackLinearizer(trackParams, linPoint[3], *perigeeSurface,
-                                vertexingOptions.geoContext,
-                                vertexingOptions.magFieldContext, fieldCache);
+                                geoContext, magFieldContext, fieldCache);
       if (!result.ok()) {
         return result.error();
       }

--- a/Core/src/Vertexing/GridDensityVertexFinder.cpp
+++ b/Core/src/Vertexing/GridDensityVertexFinder.cpp
@@ -10,10 +10,12 @@
 
 namespace Acts {
 
-auto GridDensityVertexFinder::find(const std::vector<InputTrack>& trackVector,
-                                   const VertexingOptions& vertexingOptions,
-                                   IVertexFinder::State& anyState) const
-    -> Result<std::vector<Vertex>> {
+auto GridDensityVertexFinder::find(
+    const GeometryContext& /*geoContext*/,
+    const MagneticFieldContext& /*magFieldContext*/,
+    const std::vector<InputTrack>& trackVector,
+    const VertexingOptions& vertexingOptions,
+    IVertexFinder::State& anyState) const -> Result<std::vector<Vertex>> {
   auto& state = anyState.as<State>();
   // Remove density contributions from tracks removed from track collection
   if (m_cfg.cacheGridStateForTrackRemoval && state.isInitialized &&

--- a/Core/src/Vertexing/HelicalTrackLinearizer.cpp
+++ b/Core/src/Vertexing/HelicalTrackLinearizer.cpp
@@ -19,7 +19,7 @@ Acts::HelicalTrackLinearizer::linearizeTrack(
     const Acts::MagneticFieldContext& mctx,
     MagneticFieldProvider::Cache& fieldCache) const {
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
 
   // Length scale at which we consider to be sufficiently close to the Perigee
   // surface to skip the propagation.
@@ -43,8 +43,8 @@ Acts::HelicalTrackLinearizer::linearizeTrack(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the PCA of the reference point
-  const auto res =
-      m_cfg.propagator->propagateToSurface(params, perigeeSurface, pOptions);
+  const auto res = m_cfg.propagator->propagateToSurface(
+      gctx, mctx, params, perigeeSurface, pOptions);
   if (!res.ok()) {
     return res.error();
   }

--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -367,14 +367,14 @@ Result<BoundTrackParameters> ImpactPointEstimator::estimate3DImpactParameters(
           .closest();
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction =
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the surface; intersection corresponds to an estimate of the 3D
   // PCA. If deltaR and momDir were orthogonal the calculation would be exact.
-  auto result =
-      m_cfg.propagator->propagateToSurface(trkParams, *planeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, trkParams,
+                                                     *planeSurface, pOptions);
   if (result.ok()) {
     return *result;
   } else {
@@ -423,7 +423,7 @@ Result<ImpactParametersAndSigma> ImpactPointEstimator::getImpactParameters(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   auto intersection =
       perigeeSurface
           ->intersect(gctx, track.position(gctx), track.direction(),
@@ -433,8 +433,8 @@ Result<ImpactParametersAndSigma> ImpactPointEstimator::getImpactParameters(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Do the propagation to linPoint
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     ACTS_ERROR("Error during propagation in getImpactParameters.");
@@ -507,12 +507,12 @@ Result<std::pair<double, double>> ImpactPointEstimator::getLifetimeSignOfTrack(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction = Direction::Backward;
 
   // Do the propagation to the perigeee
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     return result.error();
@@ -546,12 +546,12 @@ Result<double> ImpactPointEstimator::get3DLifetimeSignOfTrack(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction = Direction::Backward;
 
   // Do the propagation to the perigeee
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     return result.error();

--- a/Core/src/Vertexing/NumericalTrackLinearizer.cpp
+++ b/Core/src/Vertexing/NumericalTrackLinearizer.cpp
@@ -20,7 +20,7 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
     const Acts::MagneticFieldContext& mctx,
     MagneticFieldProvider::Cache& /*fieldCache*/) const {
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
 
   // Length scale at which we consider to be sufficiently close to the Perigee
   // surface to skip the propagation.
@@ -44,8 +44,8 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the PCA of the reference point
-  auto result =
-      m_cfg.propagator->propagateToSurface(params, perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, params,
+                                                     perigeeSurface, pOptions);
   if (!result.ok()) {
     return result.error();
   }
@@ -128,7 +128,7 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
 
     // Propagate to the new PCA and extract Perigee parameters
     auto newResult = m_cfg.propagator->propagateToSurface(
-        wiggledCurvilinearParams, perigeeSurface, pOptions);
+        gctx, mctx, wiggledCurvilinearParams, perigeeSurface, pOptions);
     if (!newResult.ok()) {
       return newResult.error();
     }

--- a/Core/src/Vertexing/TrackDensityVertexFinder.cpp
+++ b/Core/src/Vertexing/TrackDensityVertexFinder.cpp
@@ -9,6 +9,8 @@
 #include "Acts/Vertexing/TrackDensityVertexFinder.hpp"
 
 Acts::Result<std::vector<Acts::Vertex>> Acts::TrackDensityVertexFinder::find(
+    const GeometryContext& /*geoContext*/,
+    const MagneticFieldContext& /*magFieldContext*/,
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions& vertexingOptions,
     IVertexFinder::State& /*state*/) const {

--- a/Core/src/Vertexing/ZScanVertexFinder.cpp
+++ b/Core/src/Vertexing/ZScanVertexFinder.cpp
@@ -19,6 +19,8 @@ Acts::ZScanVertexFinder::ZScanVertexFinder(const Config& cfg,
 }
 
 Acts::Result<std::vector<Acts::Vertex>> Acts::ZScanVertexFinder::find(
+    const GeometryContext& geoContext,
+    const MagneticFieldContext& magFieldContext,
     const std::vector<InputTrack>& trackVector,
     const VertexingOptions& vertexingOptions,
     IVertexFinder::State& /*state*/) const {
@@ -36,8 +38,7 @@ Acts::Result<std::vector<Acts::Vertex>> Acts::ZScanVertexFinder::find(
     if (vertexingOptions.useConstraintInFit &&
         vertexingOptions.constraint.covariance()(0, 0) != 0) {
       auto estRes = m_cfg.ipEstimator.getImpactParameters(
-          params, vertexingOptions.constraint, vertexingOptions.geoContext,
-          vertexingOptions.magFieldContext);
+          params, vertexingOptions.constraint, geoContext, magFieldContext);
       if (estRes.ok()) {
         ipas = *estRes;
       } else {
@@ -68,7 +69,7 @@ Acts::Result<std::vector<Acts::Vertex>> Acts::ZScanVertexFinder::find(
           "Unable to compute IP significance. "
           "Setting IP weight to 1.");
 
-      z0AndWeight.first = params.position(vertexingOptions.geoContext)[eZ];
+      z0AndWeight.first = params.position(geoContext)[eZ];
       z0AndWeight.second = 1.;
     }
 

--- a/Examples/Algorithms/Alignment/src/AlignmentAlgorithm.cpp
+++ b/Examples/Algorithms/Alignment/src/AlignmentAlgorithm.cpp
@@ -113,10 +113,9 @@ ActsExamples::ProcessCode ActsExamples::AlignmentAlgorithm::execute(
       &kfSmoother);
 
   // Set the KalmanFitter options
-  TrackFitterOptions kfOptions(
-      ctx.geoContext, ctx.magFieldContext, ctx.calibContext, extensions,
-      Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext),
-      &(*pSurface));
+  TrackFitterOptions kfOptions(ctx.geoContext, ctx.magFieldContext,
+                               ctx.calibContext, extensions,
+                               Acts::PropagatorPlainOptions(), &(*pSurface));
 
   // Set the alignment options
   ActsAlignment::AlignmentOptions<TrackFitterOptions> alignOptions(

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagatorInterface.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagatorInterface.hpp
@@ -88,7 +88,7 @@ class ConcretePropagator : public PropagatorInterface {
       using PropagatorOptions =
           typename propagator_t::template Options<ActionList, AbortList>;
 
-      PropagatorOptions options(context.geoContext, context.magFieldContext);
+      PropagatorOptions options;
       options.pathLimit = pathLength;
 
       // Activate loop protection at some pt value
@@ -108,7 +108,9 @@ class ConcretePropagator : public PropagatorInterface {
       options.stepping.maxStepSize = cfg.maxStepSize;
 
       // Propagate using the propagator
-      auto result = m_propagator.propagate(startParameters, options);
+      auto result =
+          m_propagator.propagate(context.geoContext, context.magFieldContext,
+                                 startParameters, options);
       if (result.ok()) {
         const auto& resultValue = result.value();
         auto steppingResults =

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -346,13 +346,11 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
       slAccessorDelegate;
   slAccessorDelegate.connect<&IndexSourceLinkAccessor::range>(&slAccessor);
 
-  Acts::PropagatorPlainOptions firstPropOptions(ctx.geoContext,
-                                                ctx.magFieldContext);
+  Acts::PropagatorPlainOptions firstPropOptions;
   firstPropOptions.maxSteps = m_cfg.maxSteps;
   firstPropOptions.direction = Acts::Direction::Forward;
 
-  Acts::PropagatorPlainOptions secondPropOptions(ctx.geoContext,
-                                                 ctx.magFieldContext);
+  Acts::PropagatorPlainOptions secondPropOptions;
   secondPropOptions.maxSteps = m_cfg.maxSteps;
   secondPropOptions.direction = firstPropOptions.direction.invert();
 
@@ -377,7 +375,7 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
                       logger().cloneWithSuffix("Navigator")),
       logger().cloneWithSuffix("Propagator"));
 
-  ExtrapolatorOptions extrapolationOptions(ctx.geoContext, ctx.magFieldContext);
+  ExtrapolatorOptions extrapolationOptions;
 
   // Perform the track finding for all initial parameters
   ACTS_DEBUG("Invoke track finding with " << initialParameters.size()
@@ -568,9 +566,9 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
               //      implementation
               auto secondExtrapolationResult =
                   Acts::extrapolateTrackToReferenceSurface(
-                      trackCandidate, *pSurface, extrapolator,
-                      extrapolationOptions, m_cfg.extrapolationStrategy,
-                      logger());
+                      ctx.geoContext, ctx.magFieldContext, trackCandidate,
+                      *pSurface, extrapolator, extrapolationOptions,
+                      m_cfg.extrapolationStrategy, logger());
               if (!secondExtrapolationResult.ok()) {
                 m_nFailedExtrapolation++;
                 ACTS_ERROR("Second extrapolation for seed "
@@ -597,8 +595,9 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
       if (nSecond == 0) {
         auto firstExtrapolationResult =
             Acts::extrapolateTrackToReferenceSurface(
-                trackCandidate, *pSurface, extrapolator, extrapolationOptions,
-                m_cfg.extrapolationStrategy, logger());
+                ctx.geoContext, ctx.magFieldContext, trackCandidate, *pSurface,
+                extrapolator, extrapolationOptions, m_cfg.extrapolationStrategy,
+                logger());
         if (!firstExtrapolationResult.ok()) {
           m_nFailedExtrapolation++;
           ACTS_ERROR("Extrapolation for seed "

--- a/Examples/Algorithms/TrackFitting/src/RefittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/RefittingAlgorithm.cpp
@@ -69,8 +69,7 @@ ActsExamples::ProcessCode ActsExamples::RefittingAlgorithm::execute(
 
     TrackFitterFunction::GeneralFitterOptions options{
         ctx.geoContext, ctx.magFieldContext, ctx.calibContext,
-        &track.referenceSurface(),
-        Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext)};
+        &track.referenceSurface(), Acts::PropagatorPlainOptions()};
 
     const Acts::BoundTrackParameters initialParams(
         track.referenceSurface().getSharedPtr(), track.parameters(),

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
@@ -96,7 +96,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
 
   TrackFitterFunction::GeneralFitterOptions options{
       ctx.geoContext, ctx.magFieldContext, ctx.calibContext, pSurface.get(),
-      Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext)};
+      Acts::PropagatorPlainOptions()};
 
   auto trackContainer = std::make_shared<Acts::VectorTrackContainer>();
   auto trackStateContainer = std::make_shared<Acts::VectorMultiTrajectory>();

--- a/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/AdaptiveMultiVertexFinderAlgorithm.cpp
@@ -189,7 +189,7 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::execute(
   auto state = m_vertexFinder.makeState(ctx.magFieldContext);
 
   // Default vertexing options, this is where e.g. a constraint could be set
-  Options finderOpts(ctx.geoContext, ctx.magFieldContext);
+  Options finderOpts;
 
   VertexCollection vertices;
 
@@ -199,7 +199,8 @@ ActsExamples::AdaptiveMultiVertexFinderAlgorithm::execute(
     ACTS_DEBUG("Have " << inputTrackParameters.size()
                        << " input track parameters, running vertexing");
     // find vertices
-    auto result = m_vertexFinder.find(inputTracks, finderOpts, state);
+    auto result = m_vertexFinder.find(ctx.geoContext, ctx.magFieldContext,
+                                      inputTracks, finderOpts, state);
 
     if (result.ok()) {
       vertices = std::move(result.value());

--- a/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/IterativeVertexFinderAlgorithm.cpp
@@ -107,10 +107,11 @@ ActsExamples::ProcessCode ActsExamples::IterativeVertexFinderAlgorithm::execute(
   Finder finder(std::move(finderCfg), logger().clone());
   Acts::IVertexFinder::State state{std::in_place_type<Finder::State>,
                                    *m_cfg.bField, ctx.magFieldContext};
-  Options finderOpts(ctx.geoContext, ctx.magFieldContext);
+  Options finderOpts;
 
   // find vertices
-  auto result = finder.find(inputTracks, finderOpts, state);
+  auto result = finder.find(ctx.geoContext, ctx.magFieldContext, inputTracks,
+                            finderOpts, state);
 
   VertexCollection vertices;
   if (result.ok()) {

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -104,9 +104,10 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
     }
 
     if (!m_cfg.doConstrainedFit) {
-      VertexFitterOptions vfOptions(ctx.geoContext, ctx.magFieldContext);
+      VertexFitterOptions vfOptions;
 
-      auto fitRes = vertexFitter.fit(inputTracks, vfOptions, fieldCache);
+      auto fitRes = vertexFitter.fit(ctx.geoContext, ctx.magFieldContext,
+                                     inputTracks, vfOptions, fieldCache);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {
@@ -120,10 +121,10 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
       theConstraint.setFullPosition(m_cfg.constraintPos);
 
       // Vertex fitter options
-      VertexFitterOptions vfOptionsConstr(ctx.geoContext, ctx.magFieldContext,
-                                          theConstraint);
+      VertexFitterOptions vfOptionsConstr(theConstraint);
 
-      auto fitRes = vertexFitter.fit(inputTracks, vfOptionsConstr, fieldCache);
+      auto fitRes = vertexFitter.fit(ctx.geoContext, ctx.magFieldContext,
+                                     inputTracks, vfOptionsConstr, fieldCache);
       if (fitRes.ok()) {
         fittedVertices.push_back(*fitRes);
       } else {

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -61,7 +61,6 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
   ltConfig.propagator = propagator;
   Linearizer linearizer(ltConfig, logger().cloneWithSuffix("HelLin"));
 
-  PropagatorOptions propagatorOpts(ctx.geoContext, ctx.magFieldContext);
   // Setup the vertex fitter
   VertexFitter::Config vertexFitterCfg;
   vertexFitterCfg.extractParameters

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -777,11 +777,12 @@ ProcessCode VertexPerformanceWriter::writeT(
 
       // Setting the geometry/magnetic field context for the event
       using PropagatorOptions = Propagator::Options<>;
-      PropagatorOptions pOptions(ctx.geoContext, ctx.magFieldContext);
+      PropagatorOptions pOptions;
       pOptions.direction =
           Acts::Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
-      auto result = propagator->propagate(params, *perigeeSurface, pOptions);
+      auto result = propagator->propagate(ctx.geoContext, ctx.magFieldContext,
+                                          params, *perigeeSurface, pOptions);
       if (!result.ok()) {
         ACTS_ERROR("Propagation to true vertex position failed.");
         return std::nullopt;

--- a/Fatras/include/ActsFatras/Kernel/Simulation.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulation.hpp
@@ -87,7 +87,7 @@ struct SingleParticleSimulation {
         typename propagator_t::template Options<Actions, Abort>;
 
     // Construct per-call options.
-    PropagatorOptions options(geoCtx, magCtx);
+    PropagatorOptions options;
     options.stepping.maxStepSize = maxStepSize;
     options.pathLimit = pathLimit;
     // setup the interactor as part of the propagator options
@@ -100,7 +100,7 @@ struct SingleParticleSimulation {
 
     if (particle.hasReferenceSurface()) {
       auto result = propagator.propagate(
-          particle.boundParameters(geoCtx).value(), options);
+          geoCtx, magCtx, particle.boundParameters(geoCtx).value(), options);
       if (!result.ok()) {
         return result.error();
       }
@@ -108,8 +108,8 @@ struct SingleParticleSimulation {
       return std::move(value);
     }
 
-    auto result =
-        propagator.propagate(particle.curvilinearParameters(), options);
+    auto result = propagator.propagate(
+        geoCtx, magCtx, particle.curvilinearParameters(), options);
     if (!result.ok()) {
       return result.error();
     }

--- a/Tests/Benchmarks/StepperBenchmarkCommons.hpp
+++ b/Tests/Benchmarks/StepperBenchmarkCommons.hpp
@@ -89,7 +89,7 @@ struct BenchmarkStepper {
 
     Propagator propagator(std::move(stepper));
 
-    PropagatorOptions options(tgContext, mfContext);
+    PropagatorOptions options;
     options.pathLimit = maxPathInM * UnitConstants::m;
 
     Vector4 pos4(0, 0, 0, 0);
@@ -117,7 +117,8 @@ struct BenchmarkStepper {
     std::size_t numIters = 0;
     const auto propagationBenchResult = Acts::Test::microBenchmark(
         [&] {
-          auto state = propagator.makeState(pars, options);
+          auto state =
+              propagator.makeState(tgContext, mfContext, pars, options);
           auto tmp = propagator.propagate(state);
           auto r = propagator.makeResult(state, tmp, options, true).value();
           if (totalPathLength == 0.) {

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/MeasurementsCreator.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/MeasurementsCreator.hpp
@@ -161,14 +161,15 @@ Measurements createMeasurements(const propagator_t& propagator,
       typename propagator_t::template Options<Actions, Aborters>;
 
   // Set options for propagator
-  PropagatorOptions options(geoCtx, magCtx);
+  PropagatorOptions options;
   auto& creator = options.actionList.template get<MeasurementsCreator>();
   creator.resolutions = resolutions;
   creator.rng = &rng;
   creator.sourceId = sourceId;
 
   // Launch and collect the measurements
-  auto result = propagator.propagate(trackParameters, options).value();
+  auto result =
+      propagator.propagate(geoCtx, magCtx, trackParameters, options).value();
   return std::move(result.template get<Measurements>());
 }
 

--- a/Tests/IntegrationTests/NavigatorConsistency.cpp
+++ b/Tests/IntegrationTests/NavigatorConsistency.cpp
@@ -76,7 +76,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
       typename propagator_t::template Options<ActionListType, AbortListType>;
 
   // forward surface test
-  Options fwdOptions(tgContext, mfContext);
+  Options fwdOptions;
   fwdOptions.pathLimit = 25_cm;
 
   // get the surface collector and configure it
@@ -87,7 +87,8 @@ void runSelfConsistencyTest(const propagator_t& prop,
   fwdSurfaceCollector.selector.selectPassive = true;
 
   ACTS_DEBUG(">>> Forward Propagation : start.");
-  auto fwdResult = prop.propagate(start, fwdOptions).value();
+  auto fwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
   auto fwdSurfaceHits =
       fwdResult.template get<SurfaceCollector::result_type>().collected;
   auto fwdSurfaces = collectRelevantGeoIds(
@@ -100,7 +101,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Forward Propagation : end.");
 
   // backward surface test
-  Options bwdOptions(tgContext, mfContext);
+  Options bwdOptions;
   bwdOptions.pathLimit = 25_cm;
   bwdOptions.direction = Direction::Backward;
 
@@ -115,7 +116,8 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   ACTS_DEBUG(">>> Backward Propagation : start.");
   auto bwdResult =
-      prop.propagate(*fwdResult.endParameters, startSurface, bwdOptions)
+      prop.propagate(tgContext, mfContext, *fwdResult.endParameters,
+                     startSurface, bwdOptions)
           .value();
   auto bwdSurfaceHits =
       bwdResult.template get<SurfaceCollector::result_type>().collected;
@@ -137,7 +139,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   // stepping from one surface to the next
   // now go from surface to surface and check
-  Options fwdStepOptions(tgContext, mfContext);
+  Options fwdStepOptions;
 
   // get the surface collector and configure it
   auto& fwdStepSurfaceCollector =
@@ -157,8 +159,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
                << fwdSteps.surface->geometryId());
 
     // make a forward step
-    auto fwdStep =
-        prop.propagate(sParameters, *fwdSteps.surface, fwdStepOptions).value();
+    auto fwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                  *fwdSteps.surface, fwdStepOptions)
+                       .value();
 
     auto fwdStepSurfacesTmp = collectRelevantGeoIds(
         fwdStep.template get<SurfaceCollector::result_type>());
@@ -176,8 +179,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Forward step : "
              << sParameters.referenceSurface().geometryId() << " --> "
              << dSurface.geometryId());
-  auto fwdStepFinal =
-      prop.propagate(sParameters, dSurface, fwdStepOptions).value();
+  auto fwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                     dSurface, fwdStepOptions)
+                          .value();
   auto fwdStepSurfacesTmp = collectRelevantGeoIds(
       fwdStepFinal.template get<SurfaceCollector::result_type>());
   fwdStepSurfaces.insert(fwdStepSurfaces.end(), fwdStepSurfacesTmp.begin(),
@@ -187,7 +191,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   // stepping from one surface to the next : backwards
   // now go from surface to surface and check
-  Options bwdStepOptions(tgContext, mfContext);
+  Options bwdStepOptions;
   bwdStepOptions.direction = Direction::Backward;
 
   // get the surface collector and configure it
@@ -207,8 +211,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
                << bwdSteps.surface->geometryId());
 
     // make a forward step
-    auto bwdStep =
-        prop.propagate(sParameters, *bwdSteps.surface, bwdStepOptions).value();
+    auto bwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                  *bwdSteps.surface, bwdStepOptions)
+                       .value();
 
     auto bwdStepSurfacesTmp = collectRelevantGeoIds(
         bwdStep.template get<SurfaceCollector::result_type>());
@@ -226,8 +231,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Backward step : "
              << sParameters.referenceSurface().geometryId() << " --> "
              << dSurface.geometryId());
-  auto bwdStepFinal =
-      prop.propagate(sParameters, dbSurface, bwdStepOptions).value();
+  auto bwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                     dbSurface, bwdStepOptions)
+                          .value();
   auto bwdStepSurfacesTmp = collectRelevantGeoIds(
       bwdStepFinal.template get<SurfaceCollector::result_type>());
   bwdStepSurfaces.insert(bwdStepSurfaces.end(), bwdStepSurfacesTmp.begin(),
@@ -265,7 +271,7 @@ void runConsistencyTest(const propagator_probe_t& propProbe,
         typename propagator_t::template Options<ActionListType, AbortListType>;
 
     // forward surface test
-    Options fwdOptions(tgContext, mfContext);
+    Options fwdOptions;
     fwdOptions.pathLimit = 25_cm;
     fwdOptions.stepping.maxStepSize = 1_cm;
 
@@ -276,7 +282,8 @@ void runConsistencyTest(const propagator_probe_t& propProbe,
     fwdSurfaceCollector.selector.selectMaterial = true;
     fwdSurfaceCollector.selector.selectPassive = true;
 
-    auto fwdResult = prop.propagate(start, fwdOptions).value();
+    auto fwdResult =
+        prop.propagate(tgContext, mfContext, start, fwdOptions).value();
     auto fwdSurfaces = collectRelevantGeoIds(
         fwdResult.template get<SurfaceCollector::result_type>());
 

--- a/Tests/IntegrationTests/PropagationAtlasConstant.cpp
+++ b/Tests/IntegrationTests/PropagationAtlasConstant.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Tests/IntegrationTests/PropagationBentTracks.cpp
+++ b/Tests/IntegrationTests/PropagationBentTracks.cpp
@@ -58,9 +58,9 @@ std::vector<double> xPositionsOfPassedSurfaces(Acts::Navigator::Config navCfg,
 
   Propagator::Options<Acts::ActionList<Acts::detail::SteppingLogger>,
                       Acts::AbortList<Acts::EndOfWorldReached>>
-      opts(geoCtx, magCtx);
+      opts;
 
-  auto res = propagator.propagate(start, opts);
+  auto res = propagator.propagate(geoCtx, magCtx, start, opts);
 
   BOOST_CHECK(res.ok());
 

--- a/Tests/IntegrationTests/PropagationTests.hpp
+++ b/Tests/IntegrationTests/PropagationTests.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -243,13 +243,13 @@ inline std::pair<Acts::CurvilinearTrackParameters, double> transportFreely(
   using namespace Acts::UnitLiterals;
 
   // setup propagation options
-  options_t options(geoCtx, magCtx);
+  options_t options;
   options.direction = Acts::Direction::fromScalar(pathLength);
   options.pathLimit = pathLength;
   options.surfaceTolerance = 1_nm;
   options.stepping.stepTolerance = 1_nm;
 
-  auto result = propagator.propagate(initialParams, options);
+  auto result = propagator.propagate(geoCtx, magCtx, initialParams, options);
   BOOST_CHECK(result.ok());
   BOOST_CHECK(result.value().endParameters);
 
@@ -267,13 +267,14 @@ inline std::pair<Acts::BoundTrackParameters, double> transportToSurface(
   using namespace Acts::UnitLiterals;
 
   // setup propagation options
-  options_t options(geoCtx, magCtx);
+  options_t options;
   options.direction = Acts::Direction::Forward;
   options.pathLimit = pathLimit;
   options.surfaceTolerance = 1_nm;
   options.stepping.stepTolerance = 1_nm;
 
-  auto result = propagator.propagate(initialParams, targetSurface, options);
+  auto result = propagator.propagate(geoCtx, magCtx, initialParams,
+                                     targetSurface, options);
   BOOST_CHECK(result.ok());
   BOOST_CHECK(result.value().endParameters);
 

--- a/Tests/UnitTests/Alignment/Kernel/AlignmentTests.cpp
+++ b/Tests/UnitTests/Alignment/Kernel/AlignmentTests.cpp
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(ZeroFieldKalmanAlignment) {
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
   KalmanFitterOptions kfOptions(geoCtx, magCtx, calCtx, extensions,
-                                PropagatorPlainOptions(geoCtx, magCtx));
+                                PropagatorPlainOptions());
 
   // Construct a non-updating alignment updater
   AlignedTransformUpdater voidAlignUpdater =

--- a/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
@@ -270,11 +270,11 @@ BOOST_AUTO_TEST_CASE(VolumeMaterialMapper_comparison_tests) {
   // Launch propagation and gather result
   using PropagatorOptions = Propagator<StraightLineStepper, Navigator>::Options<
       ActionList<MaterialCollector>, AbortList<EndOfWorldReached>>;
-  PropagatorOptions po(gc, mc);
+  PropagatorOptions po;
   po.stepping.maxStepSize = 1._mm;
   po.maxSteps = 1e6;
 
-  const auto& result = prop.propagate(sctp, po).value();
+  const auto& result = prop.propagate(gc, mc, sctp, po).value();
   const MaterialCollector::this_result& stepResult =
       result.get<typename MaterialCollector::result_type>();
 

--- a/Tests/UnitTests/Core/Navigation/DetectorNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/DetectorNavigatorTests.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
   using AbortList = Acts::AbortList<>;
   using PropagatorOptions = Propagator::Options<ActionList, AbortList>;
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
 
   Stepper stepper;
 
@@ -99,8 +99,9 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
 
     Propagator propagator(stepper, navigator);
 
-    BOOST_CHECK_THROW(propagator.makeState(start, options),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW(
+        propagator.makeState(geoContext, mfContext, start, options),
+        std::invalid_argument);
   }
 
   // Run with geometry but without resolving
@@ -117,7 +118,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    auto state = propagator.makeState(start, options);
+    auto state = propagator.makeState(geoContext, mfContext, start, options);
 
     navigator.initialize(state, stepper);
 
@@ -151,8 +152,9 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    BOOST_CHECK_THROW(propagator.makeState(startEoW, options),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW(
+        propagator.makeState(geoContext, mfContext, startEoW, options),
+        std::invalid_argument);
   }
 
   // Initialize properly
@@ -166,7 +168,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    auto state = propagator.makeState(start, options);
+    auto state = propagator.makeState(geoContext, mfContext, start, options);
 
     navigator.initialize(state, stepper);
     auto initState = state.navigation;
@@ -281,7 +283,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -295,7 +297,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
       posFwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultFwd = propagator.propagate(startFwd, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, startFwd, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
@@ -305,7 +308,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
       posBwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultBwd = propagator.propagate(startBwd, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, startBwd, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 7 steps to reach the end of world
@@ -436,7 +440,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsAmbiguity) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -452,12 +456,14 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsAmbiguity) {
 
   // Has to properly handle propagation in the
   // forward and backward direction
-  auto resultFwd = propagator.propagate(start, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, start, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
 
-  auto resultBwd = propagator.propagate(start, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, start, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 3 steps to reach the end of world
@@ -550,7 +556,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -566,7 +572,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
       posFwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultFwd = propagator.propagate(startFwd, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, startFwd, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
@@ -575,7 +582,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
       posBwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultBwd = propagator.propagate(startBwd, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, startBwd, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 4 steps to reach the end of world

--- a/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
@@ -240,7 +240,7 @@ void test_bound_to_curvilinear(const std::vector<TestData> &test_data_list,
       using PropagatorOptions = typename Propagator::template Options<>;
 
       // configure propagator for tiny step size
-      PropagatorOptions null_propagation_options(geoCtx, magFieldContext);
+      PropagatorOptions null_propagation_options;
 
       null_propagation_options.pathLimit =
           i == 0 ? 0 : 1e-12 * 1_m * std::pow(10, i - 1);
@@ -258,8 +258,8 @@ void test_bound_to_curvilinear(const std::vector<TestData> &test_data_list,
       // curvilinear parameterisation
       Propagator propagator(std::move(stepper), Acts::VoidNavigator(),
                             Acts::getDefaultLogger("Propagator", log_level));
-      auto result =
-          propagator.propagate(params, null_propagation_options, true);
+      auto result = propagator.propagate(geoCtx, magFieldContext, params,
+                                         null_propagation_options, true);
       {
         const auto &curvilinear_parameters = result.value().endParameters;
         if (curvilinear_parameters.has_value() &&

--- a/Tests/UnitTests/Core/Propagator/CovarianceEngineTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/CovarianceEngineTests.cpp
@@ -199,14 +199,14 @@ using propagator_t = Propagator<EigenStepper<>, VoidNavigator>;
 BoundVector localToLocal(const propagator_t& prop, const BoundVector& local,
                          const Surface& src, const Surface& dst) {
   using PropagatorOptions = typename propagator_t::template Options<>;
-  PropagatorOptions options{gctx, mctx};
+  PropagatorOptions options;
   options.stepping.stepTolerance = 1e-10;
   options.surfaceTolerance = 1e-10;
 
   BoundTrackParameters start{src.getSharedPtr(), local, std::nullopt,
                              ParticleHypothesis::pion()};
 
-  auto res = prop.propagate(start, dst, options).value();
+  auto res = prop.propagate(gctx, mctx, start, dst, options).value();
   auto endParameters = res.endParameters.value();
 
   BOOST_CHECK_EQUAL(&endParameters.referenceSurface(), &dst);

--- a/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
@@ -113,7 +113,7 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
   // Options definition
   using Options = typename rpropagator_t::template Options<RefereceActionList,
                                                            ReferenceAbortList>;
-  Options pOptions(tgContext, mfContext);
+  Options pOptions;
   if (oversteppingTest) {
     pOptions.stepping.maxStepSize = oversteppingMaxStepSize;
   }
@@ -124,7 +124,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
   sCollector.selector.selectMaterial = true;
 
   // Result is immediately used, non-valid result would indicate failure
-  const auto& pResult = rprop.propagate(start, pOptions).value();
+  const auto& pResult =
+      rprop.propagate(tgContext, mfContext, start, pOptions).value();
   auto& cSurfaces = pResult.template get<SurfaceCollector<>::result_type>();
   auto& cMaterial = pResult.template get<MaterialInteractor::result_type>();
   const Surface& destination = pResult.endParameters->referenceSurface();
@@ -147,7 +148,7 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
     // Direct options definition
     using DirectOptions =
         typename dpropagator_t::template Options<DirectActionList, AbortList<>>;
-    DirectOptions dOptions(tgContext, mfContext);
+    DirectOptions dOptions;
     // Set the surface sequence
     auto& dInitializer =
         dOptions.actionList.template get<DirectNavigator::Initializer>();
@@ -159,7 +160,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
 
     // Now redo the propagation with the direct propagator
     const auto& ddResult =
-        dprop.propagate(start, destination, dOptions).value();
+        dprop.propagate(tgContext, mfContext, start, destination, dOptions)
+            .value();
     auto& ddSurfaces = ddResult.template get<SurfaceCollector<>::result_type>();
     auto& ddMaterial = ddResult.template get<MaterialInteractor::result_type>();
 
@@ -168,7 +170,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
     CHECK_CLOSE_REL(cMaterial.materialInX0, ddMaterial.materialInX0, 1e-3);
 
     // Now redo the propagation with the direct propagator - without destination
-    const auto& dwResult = dprop.propagate(start, dOptions).value();
+    const auto& dwResult =
+        dprop.propagate(tgContext, mfContext, start, dOptions).value();
     auto& dwSurfaces = dwResult.template get<SurfaceCollector<>::result_type>();
 
     // CHECK if you have as many surfaces collected as the default navigator

--- a/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.maxSteps = 100;
   propOpts.stepping.maxStepSize = 1.5_m;
 
@@ -603,7 +603,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   Propagator prop(es, naviVac);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -627,7 +628,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  DefPropagatorOptions propOptsDef(tgContext, mfContext);
+  DefPropagatorOptions propOptsDef;
   propOptsDef.maxSteps = 100;
   propOptsDef.stepping.maxStepSize = 1.5_m;
 
@@ -635,7 +636,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   DefPropagator propDef(esDef, naviVac);
 
   // Launch and collect results
-  const auto& resultDef = propDef.propagate(sbtp, propOptsDef).value();
+  const auto& resultDef =
+      propDef.propagate(tgContext, mfContext, sbtp, propOptsDef).value();
   const StepCollector::this_result& stepResultDef =
       resultDef.get<typename StepCollector::result_type>();
 
@@ -692,7 +694,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.maxSteps = 10000;
   propOpts.stepping.maxStepSize = 1.5_m;
 
@@ -703,7 +705,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
                   Acts::getDefaultLogger("Propagator", Acts::Logging::VERBOSE));
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -737,7 +740,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
 
   // Rebuild and check the choice of extension
   // Set options for propagator
-  DensePropagatorOptions propOptsDense(tgContext, mfContext);
+  DensePropagatorOptions propOptsDense;
   propOptsDense.maxSteps = 1000;
   propOptsDense.stepping.maxStepSize = 1.5_m;
 
@@ -746,7 +749,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   DensePropagator propDense(esDense, naviMat);
 
   // Launch and collect results
-  const auto& resultDense = propDense.propagate(sbtp, propOptsDense).value();
+  const auto& resultDense =
+      propDense.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultDense =
       resultDense.get<typename StepCollector::result_type>();
 
@@ -770,7 +774,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   Stepper esB(bField);
   Propagator propB(esB, naviMat);
 
-  const auto& resultB = propB.propagate(sbtp, propOptsDense).value();
+  const auto& resultB =
+      propB.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultB =
       resultB.get<typename StepCollector::result_type>();
 
@@ -842,7 +847,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.abortList.get<EndOfWorld>().maxX = 3_m;
   propOpts.maxSteps = 1000;
   propOpts.stepping.maxStepSize = 1.5_m;
@@ -853,7 +858,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   Propagator prop(es, naviDet);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -895,7 +901,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   using DefPropagatorOptions =
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
-  DefPropagatorOptions propOptsDef(tgContext, mfContext);
+  DefPropagatorOptions propOptsDef;
   propOptsDef.abortList.get<EndOfWorld>().maxX = 3_m;
   propOptsDef.maxSteps = 1000;
   propOptsDef.stepping.maxStepSize = 1.5_m;
@@ -905,7 +911,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   DefPropagator propDef(esDef, naviDet);
 
   // Launch and collect results
-  const auto& resultDef = propDef.propagate(sbtp, propOptsDef).value();
+  const auto& resultDef =
+      propDef.propagate(tgContext, mfContext, sbtp, propOptsDef).value();
   const StepCollector::this_result& stepResultDef =
       resultDef.get<typename StepCollector::result_type>();
 
@@ -948,7 +955,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
                                AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  DensePropagatorOptions propOptsDense(tgContext, mfContext);
+  DensePropagatorOptions propOptsDense;
   propOptsDense.abortList.get<EndOfWorld>().maxX = 3_m;
   propOptsDense.maxSteps = 1000;
   propOptsDense.stepping.maxStepSize = 1.5_m;
@@ -958,7 +965,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   DensePropagator propDense(esDense, naviDet);
 
   // Launch and collect results
-  const auto& resultDense = propDense.propagate(sbtp, propOptsDense).value();
+  const auto& resultDense =
+      propDense.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultDense =
       resultDense.get<typename StepCollector::result_type>();
 
@@ -1080,7 +1088,7 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
                           AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.abortList.get<EndOfWorld>().maxX = 3._m;
   propOpts.maxSteps = 10000;
 
@@ -1090,7 +1098,8 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
   Propagator prop(es, naviVac);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -112,12 +112,13 @@ BOOST_DATA_TEST_CASE(
   CurvilinearTrackParameters start(Vector4(0, 0, 0, 0), phi, theta, q / p, cov,
                                    ParticleHypothesis::pion());
 
-  EigenPropagatorType::Options<> options(tgContext, mfContext);
+  EigenPropagatorType::Options<> options;
   options.stepping.maxStepSize = 10_cm;
   options.pathLimit = 25_cm;
 
-  BOOST_CHECK(
-      epropagator.propagate(start, options).value().endParameters.has_value());
+  BOOST_CHECK(epropagator.propagate(tgContext, mfContext, start, options)
+                  .value()
+                  .endParameters.has_value());
 }
 
 // This test case checks that no segmentation fault appears
@@ -157,17 +158,17 @@ BOOST_DATA_TEST_CASE(
   // A PlaneSelector for the SurfaceCollector
   using PlaneCollector = SurfaceCollector<PlaneSelector>;
 
-  EigenPropagatorType::Options<ActionList<PlaneCollector>> options(tgContext,
-                                                                   mfContext);
+  EigenPropagatorType::Options<ActionList<PlaneCollector>> options;
 
   options.stepping.maxStepSize = 10_cm;
   options.pathLimit = 25_cm;
 
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   auto collector_result = result.get<PlaneCollector::result_type>();
 
   // step through the surfaces and go step by step
-  EigenPropagatorType::Options<> optionsEmpty(tgContext, mfContext);
+  EigenPropagatorType::Options<> optionsEmpty;
 
   optionsEmpty.stepping.maxStepSize = 25_cm;
   // Try propagation from start to each surface
@@ -179,9 +180,11 @@ BOOST_DATA_TEST_CASE(
       continue;
     }
     // Extrapolate & check
-    const auto& cresult = epropagator.propagate(start, *csurface, optionsEmpty)
-                              .value()
-                              .endParameters;
+    const auto& cresult =
+        epropagator
+            .propagate(tgContext, mfContext, start, *csurface, optionsEmpty)
+            .value()
+            .endParameters;
     BOOST_CHECK(cresult.has_value());
   }
 }
@@ -220,12 +223,12 @@ BOOST_DATA_TEST_CASE(
   CurvilinearTrackParameters start(Vector4(0, 0, 0, 0), phi, theta, q / p, cov,
                                    ParticleHypothesis::pion());
 
-  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options(
-      tgContext, mfContext);
+  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options;
   options.stepping.maxStepSize = 25_cm;
   options.pathLimit = 25_cm;
 
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   if (result.endParameters) {
     // test that you actually lost some energy
     BOOST_CHECK_LT(result.endParameters->absoluteMomentum(),
@@ -268,12 +271,12 @@ BOOST_DATA_TEST_CASE(
                                    ParticleHypothesis::pion());
 
   // Action list and abort list
-  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options(
-      tgContext, mfContext);
+  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options;
   options.stepping.maxStepSize = 25_cm;
   options.pathLimit = 1500_mm;
 
-  const auto& status = epropagator.propagate(start, options).value();
+  const auto& status =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   // this test assumes state.options.loopFraction = 0.5
   // maximum momentum allowed
   auto bCache = bField->makeCache(mfContext);

--- a/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
@@ -140,19 +140,21 @@ BOOST_AUTO_TEST_CASE(kalman_extrapolator) {
 
   // Create some options
   using StepWiseOptions = Propagator::Options<StepWiseActors, Aborters>;
-  StepWiseOptions swOptions(tgContext, mfContext);
+  StepWiseOptions swOptions;
 
   using PlainActors = ActionList<>;
   using PlainOptions = Propagator::Options<PlainActors, Aborters>;
-  PlainOptions pOptions(tgContext, mfContext);
+  PlainOptions pOptions;
 
   // Run the standard propagation
-  const auto& pResult = propagator.propagate(start, pOptions).value();
+  const auto& pResult =
+      propagator.propagate(tgContext, mfContext, start, pOptions).value();
   // Let's get the end parameters and jacobian matrix
   const auto& pJacobian = *(pResult.transportJacobian);
 
   // Run the stepwise propagation
-  const auto& swResult = propagator.propagate(start, swOptions).value();
+  const auto& swResult =
+      propagator.propagate(tgContext, mfContext, start, swOptions).value();
   auto swJacobianTest = swResult.template get<StepWiseResult>();
 
   // (1) Path length test

--- a/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
@@ -199,9 +199,10 @@ BOOST_DATA_TEST_CASE(
                                    std::nullopt, ParticleHypothesis::pion());
 
   using PropagatorOptions = EigenPropagator::Options<ActionList<>, AbortList<>>;
-  PropagatorOptions options(tgContext, mfContext);
+  PropagatorOptions options;
   options.maxSteps = 1e6;
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
 
   // this test assumes state.options.loopFraction = 0.5
   CHECK_CLOSE_REL(px, -result.endParameters->momentum().x(), 1e-2);

--- a/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
@@ -91,7 +91,7 @@ void runTest(const propagator_t& prop,
 
   using Options =
       typename propagator_t::template Options<ActionListType, AbortListType>;
-  Options fwdOptions(tgContext, mfContext);
+  Options fwdOptions;
   fwdOptions.stepping.maxStepSize = 25_cm;
   fwdOptions.pathLimit = 25_cm;
 
@@ -106,7 +106,8 @@ void runTest(const propagator_t& prop,
     std::cout << ">>> Forward Propagation : start." << std::endl;
   }
   // forward material test
-  const auto& fwdResult = prop.propagate(start, fwdOptions).value();
+  const auto& fwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
   const auto& fwdMaterial =
       fwdResult.template get<MaterialInteractor::result_type>();
   // check that the collected material is not zero
@@ -134,7 +135,7 @@ void runTest(const propagator_t& prop,
   }
 
   // backward material test
-  Options bwdOptions(tgContext, mfContext);
+  Options bwdOptions;
   bwdOptions.stepping.maxStepSize = 25_cm;
   bwdOptions.pathLimit = -25_cm;
   bwdOptions.direction = Direction::Backward;
@@ -152,7 +153,8 @@ void runTest(const propagator_t& prop,
     std::cout << ">>> Backward Propagation : start." << std::endl;
   }
   const auto& bwdResult =
-      prop.propagate(*fwdResult.endParameters, startSurface, bwdOptions)
+      prop.propagate(tgContext, mfContext, *fwdResult.endParameters,
+                     startSurface, bwdOptions)
           .value();
   if (debugMode) {
     std::cout << ">>> Backward Propagation : end." << std::endl;
@@ -192,7 +194,7 @@ void runTest(const propagator_t& prop,
 
   // stepping from one surface to the next
   // now go from surface to surface and check
-  Options fwdStepOptions(tgContext, mfContext);
+  Options fwdStepOptions;
   fwdStepOptions.stepping.maxStepSize = 25_cm;
   fwdStepOptions.pathLimit = 25_cm;
 
@@ -227,9 +229,9 @@ void runTest(const propagator_t& prop,
     }
 
     // make a forward step
-    const auto& fwdStep =
-        prop.propagate(sParameters, (*fwdSteps.surface), fwdStepOptions)
-            .value();
+    const auto& fwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                         (*fwdSteps.surface), fwdStepOptions)
+                              .value();
 
     auto& fwdStepMaterial =
         fwdStep.template get<typename MaterialInteractor::result_type>();
@@ -251,8 +253,9 @@ void runTest(const propagator_t& prop,
               << dSurface.geometryId() << std::endl;
   }
 
-  const auto& fwdStepFinal =
-      prop.propagate(sParameters, dSurface, fwdStepOptions).value();
+  const auto& fwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                            dSurface, fwdStepOptions)
+                                 .value();
 
   auto& fwdStepMaterial =
       fwdStepFinal.template get<typename MaterialInteractor::result_type>();
@@ -265,7 +268,7 @@ void runTest(const propagator_t& prop,
 
   // stepping from one surface to the next : backwards
   // now go from surface to surface and check
-  Options bwdStepOptions(tgContext, mfContext);
+  Options bwdStepOptions;
   bwdStepOptions.stepping.maxStepSize = 25_cm;
   bwdStepOptions.pathLimit = -25_cm;
   bwdStepOptions.direction = Direction::Backward;
@@ -299,9 +302,9 @@ void runTest(const propagator_t& prop,
                 << bwdSteps.surface->geometryId() << std::endl;
     }
     // make a forward step
-    const auto& bwdStep =
-        prop.propagate(sParameters, (*bwdSteps.surface), bwdStepOptions)
-            .value();
+    const auto& bwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                         (*bwdSteps.surface), bwdStepOptions)
+                              .value();
 
     auto& bwdStepMaterial =
         bwdStep.template get<typename MaterialInteractor::result_type>();
@@ -323,8 +326,9 @@ void runTest(const propagator_t& prop,
               << dSurface.geometryId() << std::endl;
   }
 
-  const auto& bwdStepFinal =
-      prop.propagate(sParameters, dbSurface, bwdStepOptions).value();
+  const auto& bwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                            dbSurface, bwdStepOptions)
+                                 .value();
 
   auto& bwdStepMaterial =
       bwdStepFinal.template get<typename MaterialInteractor::result_type>();
@@ -344,7 +348,8 @@ void runTest(const propagator_t& prop,
   covfwdMaterialInteractor.multipleScattering = true;
 
   // forward material test
-  const auto& covfwdResult = prop.propagate(start, fwdOptions).value();
+  const auto& covfwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
 
   BOOST_CHECK_LE(
       start.covariance()->determinant(),

--- a/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
@@ -736,7 +736,7 @@ void propagator_instatiation_test_function() {
       Vector3::Zero(), Vector3{1.0, 0.0, 0.0});
   using PropagatorOptions =
       typename Propagator<multi_stepper_t, Navigator>::template Options<>;
-  PropagatorOptions options(geoCtx, magCtx);
+  PropagatorOptions options;
 
   std::vector<std::tuple<double, BoundVector, std::optional<BoundSquareMatrix>>>
       cmps(4, {0.25, BoundVector::Ones().eval(),
@@ -750,10 +750,10 @@ void propagator_instatiation_test_function() {
   using type_a =
       decltype(propagator.template propagate<decltype(pars), decltype(options),
                                              MultiStepperSurfaceReached>(
-          pars, *surface, options));
+          geoCtx, magCtx, pars, *surface, options));
 
   // Instantiate without target
-  using tybe_b = decltype(propagator.propagate(pars, options));
+  using tybe_b = decltype(propagator.propagate(geoCtx, magCtx, pars, options));
 }
 
 BOOST_AUTO_TEST_CASE(propagator_instatiation_test) {

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/EventData/ParticleHypothesis.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/StraightLineStepper.hpp"
@@ -50,6 +51,7 @@ namespace Acts::Test {
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();
+MagneticFieldContext mfContext = MagneticFieldContext();
 
 BOOST_AUTO_TEST_SUITE(Surfaces)
 
@@ -321,11 +323,12 @@ BOOST_AUTO_TEST_CASE(LineSurfaceIntersection) {
       Vector4::Zero(), Vector3::Zero(), 1, std::nullopt,
       ParticleHypothesis::pion()};
   {
-    PropagatorOptions options(tgContext, {});
+    PropagatorOptions options;
     options.direction = Acts::Direction::Backward;
     options.pathLimit = pathLimit;
 
-    auto result = propagator.propagate(initialParams, options);
+    auto result =
+        propagator.propagate(tgContext, mfContext, initialParams, options);
     BOOST_CHECK(result.ok());
     BOOST_CHECK(result.value().endParameters);
 
@@ -342,11 +345,12 @@ BOOST_AUTO_TEST_CASE(LineSurfaceIntersection) {
   BoundTrackParameters endParameters{surface, BoundVector::Zero(), std::nullopt,
                                      ParticleHypothesis::pion()};
   {
-    PropagatorOptions options(tgContext, {});
+    PropagatorOptions options;
     options.direction = Acts::Direction::Forward;
     options.stepping.maxStepSize = 1_mm;
 
-    auto result = propagator.propagate(displacedParameters, *surface, options);
+    auto result = propagator.propagate(tgContext, mfContext,
+                                       displacedParameters, *surface, options);
     BOOST_CHECK(result.ok());
     BOOST_CHECK(result.value().endParameters);
     CHECK_CLOSE_ABS(result.value().pathLength, pathLimit, eps);

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -292,7 +292,7 @@ struct Fixture {
     return CombinatorialKalmanFilterOptions(
         geoCtx, magCtx, calCtx,
         Acts::SourceLinkAccessorDelegate<TestSourceLinkAccessor::Iterator>{},
-        getExtensions(), Acts::PropagatorPlainOptions(geoCtx, magCtx));
+        getExtensions(), Acts::PropagatorPlainOptions());
   }
 };
 

--- a/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
@@ -101,8 +101,7 @@ auto makeDefaultGsfOptions() {
   GsfOptions<VectorMultiTrajectory> opts{tester.geoCtx, tester.magCtx,
                                          tester.calCtx};
   opts.extensions = getExtensions();
-  opts.propagatorPlainOptions =
-      PropagatorPlainOptions(tester.geoCtx, tester.magCtx);
+  opts.propagatorPlainOptions = PropagatorPlainOptions();
   return opts;
 }
 

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -239,9 +239,8 @@ BOOST_AUTO_TEST_CASE(NoFit) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 0, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 0, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -327,9 +326,8 @@ BOOST_AUTO_TEST_CASE(Fit5Iterations) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -433,9 +431,8 @@ BOOST_AUTO_TEST_CASE(MixedDetector) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -529,9 +526,8 @@ BOOST_AUTO_TEST_CASE(FitWithBfield) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -627,9 +623,8 @@ BOOST_AUTO_TEST_CASE(relChi2changeCutOff) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 500, 1e-5);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 500, 1e-5);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -728,9 +723,8 @@ BOOST_AUTO_TEST_CASE(DidNotConverge) {
   // Since we didn't break due to convergence, we reach nUpdatesMax and
   // therefore fail the fit.
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 6, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 6, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -797,9 +791,8 @@ BOOST_AUTO_TEST_CASE(NotEnoughMeasurements) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 6, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 6, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -886,9 +879,8 @@ BOOST_AUTO_TEST_CASE(FindHoles) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 20, 1e-5);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 20, 1e-5);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -992,9 +984,8 @@ BOOST_AUTO_TEST_CASE(Material) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};

--- a/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
@@ -102,9 +102,8 @@ auto makeDefaultKalmanFitterOptions() {
       &Acts::detail::Test::TestSourceLink::SurfaceAccessor::operator()>(
       &tester.surfaceAccessor);
 
-  return KalmanFitterOptions(
-      tester.geoCtx, tester.magCtx, tester.calCtx, extensions,
-      PropagatorPlainOptions(tester.geoCtx, tester.magCtx));
+  return KalmanFitterOptions(tester.geoCtx, tester.magCtx, tester.calCtx,
+                             extensions, PropagatorPlainOptions());
 }
 
 }  // namespace

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFinderTests.cpp
@@ -145,10 +145,11 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_test) {
 
   // TODO: test without using beam spot constraint
   Vertex bsConstr = std::get<BeamSpotData>(csvData);
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, bsConstr);
+  VertexingOptions vertexingOptions(bsConstr);
 
   auto t1 = std::chrono::system_clock::now();
-  auto findResult = finder.find(inputTracks, vertexingOptions, state);
+  auto findResult = finder.find(geoContext, magFieldContext, inputTracks,
+                                vertexingOptions, state);
   auto t2 = std::chrono::system_clock::now();
 
   auto timediff =
@@ -312,9 +313,10 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_usertype_test) {
   constraintVtx.setPosition(std::get<BeamSpotData>(csvData).position());
   constraintVtx.setCovariance(std::get<BeamSpotData>(csvData).covariance());
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, constraintVtx);
+  VertexingOptions vertexingOptions(constraintVtx);
 
-  auto findResult = finder.find(userInputTracks, vertexingOptions, state);
+  auto findResult = finder.find(geoContext, magFieldContext, userInputTracks,
+                                vertexingOptions, state);
 
   if (!findResult.ok()) {
     std::cout << findResult.error().message() << std::endl;
@@ -448,10 +450,11 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_finder_grid_seed_finder_test) {
 
   // TODO: test using beam spot constraint
   Vertex bsConstr = std::get<BeamSpotData>(csvData);
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, bsConstr);
+  VertexingOptions vertexingOptions(bsConstr);
 
   auto t1 = std::chrono::system_clock::now();
-  auto findResult = finder.find(inputTracks, vertexingOptions, state);
+  auto findResult = finder.find(geoContext, magFieldContext, inputTracks,
+                                vertexingOptions, state);
   auto t2 = std::chrono::system_clock::now();
 
   auto timediff =
@@ -604,10 +607,11 @@ BOOST_AUTO_TEST_CASE(
   }
 
   Vertex bsConstr = std::get<BeamSpotData>(csvData);
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, bsConstr);
+  VertexingOptions vertexingOptions(bsConstr);
 
   auto t1 = std::chrono::system_clock::now();
-  auto findResult = finder.find(inputTracks, vertexingOptions, state);
+  auto findResult = finder.find(geoContext, magFieldContext, inputTracks,
+                                vertexingOptions, state);
   auto t2 = std::chrono::system_clock::now();
 
   auto timediff =

--- a/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/AdaptiveMultiVertexFitterTests.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   // Set up propagator with void navigator
   auto propagator = std::make_shared<Propagator>(stepper);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
 
   // IP 3D Estimator
   ImpactPointEstimator::Config ip3dEstCfg(bField, propagator);
@@ -248,7 +248,8 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   // list in order to be able to compare later
   std::vector<Vertex> seedListCopy = vtxList;
 
-  auto res1 = fitter.addVtxToFit(state, vtxList.at(0), vertexingOptions);
+  auto res1 =
+      fitter.addVtxToFit(geoContext, magFieldContext, state, vtxList.at(0));
   ACTS_DEBUG("Tracks linked to each vertex AFTER fit:");
   int c = 0;
   for (auto& vtx : vtxPtrList) {
@@ -292,7 +293,8 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test) {
   CHECK_CLOSE_ABS(vtxList.at(1).fullPosition(),
                   seedListCopy.at(1).fullPosition(), 1_mm);
 
-  auto res2 = fitter.addVtxToFit(state, vtxList.at(2), vertexingOptions);
+  auto res2 =
+      fitter.addVtxToFit(geoContext, magFieldContext, state, vtxList.at(2));
   BOOST_CHECK(res2.ok());
 
   // Now also the third vertex should have been modified and fitted
@@ -329,7 +331,7 @@ BOOST_AUTO_TEST_CASE(time_fitting) {
   // Set up propagator with void navigator
   auto propagator = std::make_shared<Propagator>(stepper);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
 
   ImpactPointEstimator::Config ip3dEstCfg(bField, propagator);
   ImpactPointEstimator ip3dEst(ip3dEstCfg);
@@ -423,7 +425,7 @@ BOOST_AUTO_TEST_CASE(time_fitting) {
 
   state.addVertexToMultiMap(vtx);
 
-  auto res = fitter.addVtxToFit(state, vtx, vertexingOptions);
+  auto res = fitter.addVtxToFit(geoContext, magFieldContext, state, vtx);
 
   BOOST_CHECK(res.ok());
 
@@ -464,7 +466,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
   // Set up propagator with void navigator
   auto propagator = std::make_shared<Propagator>(stepper);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
 
   ImpactPointEstimator::Config ip3dEstCfg(bField, propagator);
   ImpactPointEstimator ip3dEst(ip3dEstCfg);
@@ -644,7 +646,7 @@ BOOST_AUTO_TEST_CASE(adaptive_multi_vertex_fitter_test_athena) {
   state.addVertexToMultiMap(vtx2);
 
   // Fit vertices
-  fitter.fit(state, vertexingOptions);
+  fitter.fit(geoContext, magFieldContext, state);
 
   auto vtx1Fitted = state.vertexCollection.at(0);
   auto vtx1PosFitted = vtx1Fitted->position();

--- a/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/GridDensityVertexFinderTests.cpp
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
   std::shared_ptr<PerigeeSurface> perigeeSurface =
       Surface::makeShared<PerigeeSurface>(pos0);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
 
   using Finder1 = GridDensityVertexFinder;
   Finder1::Config cfg1{{{100, mainGridSize, trkGridSize}}};
@@ -153,12 +153,14 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_test) {
     inputTracks.emplace_back(&trk);
   }
 
-  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
+  auto res1 = finder1.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
 
-  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
+  auto res2 = finder2.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }
@@ -204,7 +206,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   std::shared_ptr<PerigeeSurface> perigeeSurface =
       Surface::makeShared<PerigeeSurface>(pos0);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
 
   using Finder1 = GridDensityVertexFinder;
   using GridDensity = GaussianGridTrackDensity;
@@ -278,7 +280,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   double zResult1 = 0;
   double zResult2 = 0;
 
-  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
+  auto res1 = finder1.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
@@ -293,7 +296,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     zResult1 = result[eZ];
   }
 
-  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
+  auto res2 = finder2.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }
@@ -322,7 +326,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
   state1.as<Finder1::State>().tracksToRemove = removedTracks;
   state2.as<Finder2::State>().tracksToRemove = removedTracks;
 
-  auto res3 = finder1.find(inputTracks, vertexingOptions, state1);
+  auto res3 = finder1.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state1);
   if (!res3.ok()) {
     std::cout << res3.error().message() << std::endl;
   }
@@ -338,7 +343,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_track_caching_test) {
     zResult1 = result[eZ];
   }
 
-  auto res4 = finder2.find(inputTracks, vertexingOptions, state2);
+  auto res4 = finder2.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state2);
   if (!res4.ok()) {
     std::cout << res4.error().message() << std::endl;
   }
@@ -373,7 +379,7 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   std::shared_ptr<PerigeeSurface> perigeeSurface =
       Surface::makeShared<PerigeeSurface>(pos0);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
   Vertex constraintVtx;
   constraintVtx.setCovariance(SquareMatrix3::Identity());
   vertexingOptions.constraint = constraintVtx;
@@ -439,7 +445,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   }
 
   // Test finder 1
-  auto res1 = finder1.find(inputTracks, vertexingOptions, state1);
+  auto res1 = finder1.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state1);
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
   }
@@ -457,7 +464,8 @@ BOOST_AUTO_TEST_CASE(grid_density_vertex_finder_seed_width_test) {
   }
 
   // Test finder 2
-  auto res2 = finder2.find(inputTracks, vertexingOptions, state2);
+  auto res2 = finder2.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state2);
   if (!res2.ok()) {
     std::cout << res2.error().message() << std::endl;
   }

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -257,7 +257,7 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
   auto refPerigeeSurface = Surface::makeShared<PerigeeSurface>(refPoint);
 
   // Set up the propagator options (they are the same with and without B field)
-  PropagatorOptions pOptions(geoContext, magFieldContext);
+  PropagatorOptions pOptions;
   auto intersection =
       refPerigeeSurface
           ->intersect(geoContext, params.position(geoContext),
@@ -267,13 +267,14 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the 2D PCA of the reference point in a constant B field
-  auto result = propagator->propagate(params, *refPerigeeSurface, pOptions);
+  auto result = propagator->propagate(geoContext, magFieldContext, params,
+                                      *refPerigeeSurface, pOptions);
   BOOST_CHECK(result.ok());
   const auto& refParams = *result->endParameters;
 
   // Propagate to the 2D PCA of the reference point when B = 0
-  auto zeroFieldResult =
-      straightLinePropagator->propagate(params, *refPerigeeSurface, pOptions);
+  auto zeroFieldResult = straightLinePropagator->propagate(
+      geoContext, magFieldContext, params, *refPerigeeSurface, pOptions);
   BOOST_CHECK(zeroFieldResult.ok());
   const auto& zeroFieldRefParams = *zeroFieldResult->endParameters;
 

--- a/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/IterativeVertexFinderTests.cpp
@@ -253,10 +253,11 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test) {
       inputTracks.emplace_back(trk.get());
     }
 
-    VertexingOptions vertexingOptions(geoContext, magFieldContext);
+    VertexingOptions vertexingOptions;
 
     // find vertices
-    auto res = finder.find(inputTracks, vertexingOptions, state);
+    auto res = finder.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state);
 
     if (!res.ok()) {
       BOOST_FAIL(res.error().message());
@@ -474,10 +475,11 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_user_track_type) {
       inputTracks.emplace_back(trk.get());
     }
 
-    VertexingOptions vertexingOptionsUT(geoContext, magFieldContext);
+    VertexingOptions vertexingOptionsUT;
 
     // find vertices
-    auto res = finder.find(inputTracks, vertexingOptionsUT, state);
+    auto res = finder.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptionsUT, state);
 
     if (!res.ok()) {
       BOOST_FAIL(res.error().message());
@@ -609,10 +611,11 @@ BOOST_AUTO_TEST_CASE(iterative_finder_test_athena_reference) {
   fullCovariance.topLeftCorner<3, 3>() = beamSpot.covariance();
   fullCovariance(eTime, eTime) = 100_ns;
   beamSpot.setFullCovariance(fullCovariance);
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, beamSpot);
+  VertexingOptions vertexingOptions(beamSpot);
 
   // find vertices
-  auto findResult = finder.find(inputTracks, vertexingOptions, state);
+  auto findResult = finder.find(geoContext, magFieldContext, inputTracks,
+                                vertexingOptions, state);
 
   BOOST_CHECK(findResult.ok());
 

--- a/Tests/UnitTests/Core/Vertexing/TrackDensityVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/TrackDensityVertexFinderTests.cpp
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_test) {
   Vector3 pos1c{1.69457_mm, -0.50837_mm, -7_mm};
   Vector3 mom1c{300_MeV, 1000_MeV, 100_MeV};
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
   GaussianTrackDensity::Config densityCfg;
   densityCfg.extractParameters.connect<&InputTrack::extractParameters>();
   TrackDensityVertexFinder finder{{{densityCfg}}};
@@ -99,8 +99,10 @@ BOOST_AUTO_TEST_CASE(track_density_finder_test) {
   std::vector<InputTrack> vec2 = {InputTrack{&params1c}, InputTrack{&params1a},
                                   InputTrack{&params1b}};
 
-  auto res1 = finder.find(vec1, vertexingOptions, state);
-  auto res2 = finder.find(vec2, vertexingOptions, state);
+  auto res1 =
+      finder.find(geoContext, magFieldContext, vec1, vertexingOptions, state);
+  auto res2 =
+      finder.find(geoContext, magFieldContext, vec2, vertexingOptions, state);
 
   if (!res1.ok()) {
     std::cout << res1.error().message() << std::endl;
@@ -144,7 +146,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_constr_test) {
   constraint.setCovariance(constrCov);
 
   // Finder options
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, constraint);
+  VertexingOptions vertexingOptions(constraint);
   GaussianTrackDensity::Config densityCfg;
   densityCfg.extractParameters.connect<&InputTrack::extractParameters>();
   TrackDensityVertexFinder finder{{{densityCfg}}};
@@ -176,7 +178,8 @@ BOOST_AUTO_TEST_CASE(track_density_finder_constr_test) {
   std::vector<InputTrack> vec1 = {InputTrack{&params1a}, InputTrack{&params1b},
                                   InputTrack{&params1c}};
 
-  auto res = finder.find(vec1, vertexingOptions, state);
+  auto res =
+      finder.find(geoContext, magFieldContext, vec1, vertexingOptions, state);
 
   if (!res.ok()) {
     std::cout << res.error().message() << std::endl;
@@ -220,7 +223,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_random_test) {
   std::shared_ptr<PerigeeSurface> perigeeSurface =
       Surface::makeShared<PerigeeSurface>(pos0);
 
-  VertexingOptions vertexingOptions(geoContext, magFieldContext);
+  VertexingOptions vertexingOptions;
   GaussianTrackDensity::Config densityCfg;
   densityCfg.extractParameters.connect<&InputTrack::extractParameters>();
   TrackDensityVertexFinder finder{{{densityCfg}}};
@@ -266,7 +269,8 @@ BOOST_AUTO_TEST_CASE(track_density_finder_random_test) {
     inputTracks.emplace_back(&trk);
   }
 
-  auto res3 = finder.find(inputTracks, vertexingOptions, state);
+  auto res3 = finder.find(geoContext, magFieldContext, inputTracks,
+                          vertexingOptions, state);
   if (!res3.ok()) {
     std::cout << res3.error().message() << std::endl;
   }
@@ -315,7 +319,7 @@ BOOST_AUTO_TEST_CASE(track_density_finder_usertrack_test) {
   constraint.setCovariance(constrCov);
 
   // Finder options
-  VertexingOptions vertexingOptions(geoContext, magFieldContext, constraint);
+  VertexingOptions vertexingOptions(constraint);
 
   auto extractParameters = [](const InputTrack& params) {
     return params.as<InputTrackStub>()->parameters();
@@ -352,7 +356,8 @@ BOOST_AUTO_TEST_CASE(track_density_finder_usertrack_test) {
   std::vector<InputTrack> vec1 = {InputTrack{&params1a}, InputTrack{&params1b},
                                   InputTrack{&params1c}};
 
-  auto res = finder.find(vec1, vertexingOptions, state);
+  auto res =
+      finder.find(geoContext, magFieldContext, vec1, vertexingOptions, state);
 
   if (!res.ok()) {
     std::cout << res.error().message() << std::endl;

--- a/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ZScanVertexFinderTests.cpp
@@ -166,10 +166,11 @@ BOOST_AUTO_TEST_CASE(zscan_finder_test) {
 
     VertexFinder finder(cfg);
 
-    VertexingOptions vertexingOptions(geoContext, magFieldContext);
+    VertexingOptions vertexingOptions;
 
     auto state = finder.makeState(magFieldContext);
-    auto res = finder.find(inputTracks, vertexingOptions, state);
+    auto res = finder.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state);
 
     BOOST_CHECK(res.ok());
 
@@ -291,9 +292,10 @@ BOOST_AUTO_TEST_CASE(zscan_finder_usertrack_test) {
     VertexFinder finder(cfg);
     auto state = finder.makeState(magFieldContext);
 
-    VertexingOptions vertexingOptions(geoContext, magFieldContext);
+    VertexingOptions vertexingOptions;
 
-    auto res = finder.find(inputTracks, vertexingOptions, state);
+    auto res = finder.find(geoContext, magFieldContext, inputTracks,
+                           vertexingOptions, state);
 
     BOOST_CHECK(res.ok());
 

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -357,8 +357,7 @@ static inline std::string testMultiTrajectory(IVisualization3D& helper) {
           &surfaceAccessor);
 
   KalmanFitterOptions kfOptions(tgContext, mfContext, calContext, extensions,
-                                PropagatorPlainOptions(tgContext, mfContext),
-                                rSurface);
+                                PropagatorPlainOptions(), rSurface);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};


### PR DESCRIPTION
Similar to https://github.com/acts-project/acts/pull/3378 the context arguments are moved from vertexing options to vertexing calls.

blocked by:
- https://github.com/acts-project/acts/pull/3378