### PR TITLE
refactor!: Move context from stepper state to stepper calls

### DIFF
--- a/Core/include/Acts/Material/PropagatorMaterialAssigner.hpp
+++ b/Core/include/Acts/Material/PropagatorMaterialAssigner.hpp
@@ -137,9 +137,10 @@ class PropagatorMaterialAssigner final : public IAssignmentFinder {
     using PropagatorOptions =
         typename propagator_t::template Options<ActionList, AbortList>;
 
-    PropagatorOptions options(gctx, mctx);
+    PropagatorOptions options;
 
-    const auto& result = m_propagator.propagate(start, options).value();
+    const auto& result =
+        m_propagator.propagate(gctx, mctx, start, options).value();
 
     // The surface collection results
     auto scResult =

--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -416,12 +416,13 @@ class AtlasStepper {
   /// @param [in] surfaceTolerance Surface tolerance used for intersection
   /// @param [in] logger Logger instance to use
   Intersection3D::Status updateSurfaceStatus(
-      State& state, const Surface& surface, std::uint8_t index,
-      Direction navDir, const BoundaryTolerance& boundaryTolerance,
+      const GeometryContext& geoContext, State& state, const Surface& surface,
+      std::uint8_t index, Direction navDir,
+      const BoundaryTolerance& boundaryTolerance,
       ActsScalar surfaceTolerance = s_onSurfaceTolerance,
       const Logger& logger = getDummyLogger()) const {
     return detail::updateSingleSurfaceStatus<AtlasStepper>(
-        *this, state, surface, index, navDir, boundaryTolerance,
+        geoContext, *this, state, surface, index, navDir, boundaryTolerance,
         surfaceTolerance, logger);
   }
 

--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -241,9 +241,9 @@ class DirectNavigator {
               state.options.surfaceTolerance)
               .index();
       auto surfaceStatus = stepper.updateSurfaceStatus(
-          state.stepping, surface, index, state.options.direction,
-          BoundaryTolerance::Infinite(), state.options.surfaceTolerance,
-          *m_logger);
+          state.geoContext, state.stepping, surface, index,
+          state.options.direction, BoundaryTolerance::Infinite(),
+          state.options.surfaceTolerance, *m_logger);
       if (surfaceStatus == Intersection3D::Status::unreachable) {
         ACTS_VERBOSE(
             "Surface not reachable anymore, switching to next one in "
@@ -299,9 +299,9 @@ class DirectNavigator {
               state.options.surfaceTolerance)
               .index();
       auto surfaceStatus = stepper.updateSurfaceStatus(
-          state.stepping, surface, index, state.options.direction,
-          BoundaryTolerance::Infinite(), state.options.surfaceTolerance,
-          *m_logger);
+          state.geoContext, state.stepping, surface, index,
+          state.options.direction, BoundaryTolerance::Infinite(),
+          state.options.surfaceTolerance, *m_logger);
       if (surfaceStatus == Intersection3D::Status::onSurface) {
         // Set the current surface
         state.navigation.currentSurface = *state.navigation.navSurfaceIter;

--- a/Core/include/Acts/Propagator/Navigator.hpp
+++ b/Core/include/Acts/Propagator/Navigator.hpp
@@ -560,8 +560,9 @@ class Navigator {
     // If we are on the surface pointed at by the index, we can make
     // it the current one to pass it to the other actors
     auto surfaceStatus = stepper.updateSurfaceStatus(
-        state.stepping, *surface, intersection.index(), state.options.direction,
-        BoundaryTolerance::None(), state.options.surfaceTolerance, logger());
+        state.geoContext, state.stepping, *surface, intersection.index(),
+        state.options.direction, BoundaryTolerance::None(),
+        state.options.surfaceTolerance, logger());
     if (surfaceStatus == Intersection3D::Status::onSurface) {
       ACTS_VERBOSE(volInfo(state)
                    << "Status Surface successfully hit, storing it.");
@@ -651,7 +652,7 @@ class Navigator {
         }
       }
       auto surfaceStatus = stepper.updateSurfaceStatus(
-          state.stepping, *surface, intersection.index(),
+          state.geoContext, state.stepping, *surface, intersection.index(),
           state.options.direction, boundaryTolerance,
           state.options.surfaceTolerance, logger());
       if (surfaceStatus == Intersection3D::Status::reachable) {
@@ -746,7 +747,7 @@ class Navigator {
       }
       // Try to step towards it
       auto layerStatus = stepper.updateSurfaceStatus(
-          state.stepping, *layerSurface, intersection.index(),
+          state.geoContext, state.stepping, *layerSurface, intersection.index(),
           state.options.direction, BoundaryTolerance::None(),
           state.options.surfaceTolerance, logger());
       if (layerStatus == Intersection3D::Status::reachable) {
@@ -899,9 +900,9 @@ class Navigator {
       const auto* boundarySurface = intersection.object();
       // Step towards the boundary surfrace
       auto boundaryStatus = stepper.updateSurfaceStatus(
-          state.stepping, *boundarySurface, intersection.index(),
-          state.options.direction, BoundaryTolerance::None(),
-          state.options.surfaceTolerance, logger());
+          state.geoContext, state.stepping, *boundarySurface,
+          intersection.index(), state.options.direction,
+          BoundaryTolerance::None(), state.options.surfaceTolerance, logger());
       if (boundaryStatus == Intersection3D::Status::reachable) {
         ACTS_VERBOSE(volInfo(state)
                      << "Boundary reachable, step size updated to "
@@ -1202,7 +1203,7 @@ class Navigator {
       }
       // TODO we do not know the intersection index - passing 0
       auto targetStatus = stepper.updateSurfaceStatus(
-          state.stepping, *state.navigation.targetSurface, 0,
+          state.geoContext, state.stepping, *state.navigation.targetSurface, 0,
           state.options.direction, BoundaryTolerance::None(),
           state.options.surfaceTolerance, logger());
       // the only advance could have been to the target

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -49,6 +49,8 @@ class BasePropagator {
   using Options = PropagatorPlainOptions;
 
   /// Method to propagate start bound track parameters to a target surface.
+  /// @param geoContext The geometry context.
+  /// @param magFieldContext The magnetic field context.
   /// @param start The start bound track parameters.
   /// @param target The target surface.
   /// @param options The propagation options.
@@ -249,6 +251,8 @@ class Propagator final
   /// @tparam propagator_options_t Type of the propagator options
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start initial track parameters to propagate
   /// @param [in] options Propagation options, type Options<,>
   /// @param [in] makeCurvilinear Produce curvilinear parameters at the end of the propagation
@@ -278,6 +282,8 @@ class Propagator final
   /// @tparam target_aborter_t The target aborter type to be added
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] target Target surface of to propagate to
   /// @param [in] options Propagation options
@@ -306,6 +312,8 @@ class Propagator final
   /// @tparam propagator_options_t Type of the propagator options
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] options Propagation options
   ///
@@ -329,6 +337,8 @@ class Propagator final
   /// @tparam target_aborter_t The target aborter type to be added
   /// @tparam path_aborter_t The path aborter type to be added
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Initial track parameters to propagate
   /// @param [in] target Target surface of to propagate to
   /// @param [in] options Propagation options

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -54,6 +54,8 @@ class BasePropagator {
   /// @param options The propagation options.
   /// @return The end bound track parameters.
   virtual Result<BoundTrackParameters> propagateToSurface(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const BoundTrackParameters& start, const Surface& target,
       const Options& options) const = 0;
 
@@ -67,6 +69,8 @@ template <typename derived_t>
 class BasePropagatorHelper : public BasePropagator {
  public:
   Result<BoundTrackParameters> propagateToSurface(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const BoundTrackParameters& start, const Surface& target,
       const Options& options) const override;
 };
@@ -257,7 +261,9 @@ class Propagator final
   Result<
       action_list_t_result_t<StepperCurvilinearTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const propagator_options_t& options,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const propagator_options_t& options,
             bool makeCurvilinear = true) const;
 
   /// @brief Propagate track parameters - User method
@@ -284,7 +290,9 @@ class Propagator final
   Result<
       action_list_t_result_t<StepperBoundTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const Surface& target,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const Surface& target,
             const propagator_options_t& options) const;
 
   /// @brief Builds the propagator state object
@@ -304,7 +312,9 @@ class Propagator final
   /// @return Propagator state object
   template <typename parameters_t, typename propagator_options_t,
             typename path_aborter_t = PathLimitReached>
-  auto makeState(const parameters_t& start,
+  auto makeState(const GeometryContext& geoContext,
+                 const MagneticFieldContext& magFieldContext,
+                 const parameters_t& start,
                  const propagator_options_t& options) const;
 
   /// @brief Builds the propagator state object
@@ -327,7 +337,9 @@ class Propagator final
   template <typename parameters_t, typename propagator_options_t,
             typename target_aborter_t = SurfaceReached,
             typename path_aborter_t = PathLimitReached>
-  auto makeState(const parameters_t& start, const Surface& target,
+  auto makeState(const GeometryContext& geoContext,
+                 const MagneticFieldContext& magFieldContext,
+                 const parameters_t& start, const Surface& target,
                  const propagator_options_t& options) const;
 
   /// @brief Propagate track parameters

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -297,7 +297,7 @@ auto Acts::Propagator<S, N>::makeResult(
   moveStateToResult(state, result);
 
   // Compute the final results and mark the propagation as successful
-  auto bsRes = m_stepper.boundState(state.stepping, target);
+  auto bsRes = m_stepper.boundState(state.geoContext, state.stepping, target);
   if (!bsRes.ok()) {
     return bsRes.error();
   }

--- a/Core/include/Acts/Propagator/PropagatorOptions.hpp
+++ b/Core/include/Acts/Propagator/PropagatorOptions.hpp
@@ -47,17 +47,6 @@ struct PurePropagatorPlainOptions {
 
 /// @brief Holds the generic propagator options
 struct PropagatorPlainOptions : public detail::PurePropagatorPlainOptions {
-  /// PropagatorPlainOptions with context
-  PropagatorPlainOptions(const GeometryContext& gctx,
-                         const MagneticFieldContext& mctx)
-      : geoContext(gctx), magFieldContext(mctx) {}
-
-  /// The context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-
-  /// The context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
-
   /// Stepper plain options
   StepperPlainOptions stepping;
 
@@ -82,21 +71,17 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
   using action_list_type = action_list_t;
   using aborter_list_type = aborter_list_t;
 
-  /// PropagatorOptions with context
-  PropagatorOptions(const GeometryContext& gctx,
-                    const MagneticFieldContext& mctx)
-      : geoContext(gctx), magFieldContext(mctx) {}
+  /// Default constructor
+  PropagatorOptions() = default;
 
   /// PropagatorOptions with context and plain options
-  PropagatorOptions(const PropagatorPlainOptions& pOptions)
-      : geoContext(pOptions.geoContext),
-        magFieldContext(pOptions.magFieldContext) {
+  PropagatorOptions(const PropagatorPlainOptions& pOptions) {
     setPlainOptions(pOptions);
   }
 
   /// @brief Convert to plain options
   operator PropagatorPlainOptions() const {
-    PropagatorPlainOptions pOptions(geoContext, magFieldContext);
+    PropagatorPlainOptions pOptions;
     static_cast<PurePropagatorPlainOptions&>(pOptions) =
         static_cast<const PurePropagatorPlainOptions&>(*this);
     pOptions.stepping = static_cast<const StepperPlainOptions&>(stepping);
@@ -115,7 +100,7 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
   extend(extended_aborter_list_t aborters) const {
     PropagatorOptions<stepper_options_t, navigator_options_t, action_list_t,
                       extended_aborter_list_t>
-        eoptions(geoContext, magFieldContext);
+        eoptions;
 
     // Copy the base options
     static_cast<PurePropagatorPlainOptions&>(eoptions) =
@@ -143,12 +128,6 @@ struct PropagatorOptions : public detail::PurePropagatorPlainOptions {
     stepping.setPlainOptions(pOptions.stepping);
     navigation.setPlainOptions(pOptions.navigation);
   }
-
-  /// The context object for the geometry
-  std::reference_wrapper<const GeometryContext> geoContext;
-
-  /// The context object for the magnetic field
-  std::reference_wrapper<const MagneticFieldContext> magFieldContext;
 
   /// Stepper options
   stepper_options_t stepping;

--- a/Core/include/Acts/Propagator/PropagatorState.hpp
+++ b/Core/include/Acts/Propagator/PropagatorState.hpp
@@ -39,6 +39,7 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
   ///
   /// @tparam propagator_options_t the type of the propagator options
   ///
+  /// @param gctx The geometry context
   /// @param topts The options handed over by the propagate call
   /// @param steppingIn Stepper state instance to begin with
   /// @param navigationIn Navigator state instance to begin with

--- a/Core/include/Acts/Propagator/PropagatorState.hpp
+++ b/Core/include/Acts/Propagator/PropagatorState.hpp
@@ -42,12 +42,13 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
   /// @param topts The options handed over by the propagate call
   /// @param steppingIn Stepper state instance to begin with
   /// @param navigationIn Navigator state instance to begin with
-  PropagatorState(const propagator_options_t& topts, stepper_state_t steppingIn,
+  PropagatorState(const GeometryContext& gctx,
+                  const propagator_options_t& topts, stepper_state_t steppingIn,
                   navigator_state_t navigationIn)
       : options(topts),
         stepping{std::move(steppingIn)},
         navigation{std::move(navigationIn)},
-        geoContext(topts.geoContext) {}
+        geoContext(gctx) {}
 
   using detail::Extendable<extension_state_t...>::get;
   using detail::Extendable<extension_state_t...>::tuple;

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -120,7 +120,9 @@ class RiddersPropagator {
   Result<
       action_list_t_result_t<CurvilinearTrackParameters,
                              typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start,
             const propagator_options_t& options) const;
 
   /// @brief Propagation method targeting bound parameters
@@ -138,7 +140,9 @@ class RiddersPropagator {
   template <typename parameters_t, typename propagator_options_t>
   Result<action_list_t_result_t<
       BoundTrackParameters, typename propagator_options_t::action_list_type>>
-  propagate(const parameters_t& start, const Surface& target,
+  propagate(const GeometryContext& geoContext,
+            const MagneticFieldContext& magFieldContext,
+            const parameters_t& start, const Surface& target,
             const propagator_options_t& options) const;
 
  private:
@@ -151,9 +155,11 @@ class RiddersPropagator {
   /// @param [in] nominalResult The result of the nominal propagation
   template <typename propagator_options_t, typename parameters_t,
             typename result_t>
-  Jacobian wiggleAndCalculateJacobian(const propagator_options_t& options,
-                                      const parameters_t& start,
-                                      result_t& nominalResult) const;
+  Jacobian wiggleAndCalculateJacobian(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
+      const propagator_options_t& options, const parameters_t& start,
+      result_t& nominalResult) const;
 
   /// @brief This function tests whether the variations on a disc as target
   /// surface lead to results on different sides wrt the center of the disc.
@@ -184,6 +190,8 @@ class RiddersPropagator {
   /// @return Vector containing each slope
   template <typename propagator_options_t, typename parameters_t>
   std::vector<BoundVector> wiggleParameter(
+      const GeometryContext& geoContext,
+      const MagneticFieldContext& magFieldContext,
       const propagator_options_t& options, const parameters_t& start,
       unsigned int param, const Surface& target, const BoundVector& nominal,
       const std::vector<double>& deviations) const;

--- a/Core/include/Acts/Propagator/RiddersPropagator.hpp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2017-2019 CERN for the benefit of the Acts project
+// Copyright (C) 2017-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -112,6 +112,8 @@ class RiddersPropagator {
   /// @tparam parameters_t Type of the start parameters
   /// @tparam propagator_options_t Type of the propagator options
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Start parameters
   /// @param [in] options Options of the propagations
   ///
@@ -130,6 +132,8 @@ class RiddersPropagator {
   /// @tparam parameters_t Type of the start parameters
   /// @tparam propagator_options_t Type of the propagator options
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] start Start parameters
   /// @param [in] target The target surface
   /// @param [in] options Options of the propagations
@@ -150,6 +154,8 @@ class RiddersPropagator {
   /// propagating again. This function is called from the different propagation
   /// overloads in order to deduplicate code.
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] options Options of the propagations
   /// @param [in] start Start parameters
   /// @param [in] nominalResult The result of the nominal propagation
@@ -180,6 +186,8 @@ class RiddersPropagator {
   /// @tparam options_t PropagatorOptions object
   /// @tparam parameters_t Type of the parameters to start the propagation with
   ///
+  /// @param [in] geoContext The geometry context
+  /// @param [in] magFieldContext The magnetic field context
   /// @param [in] options Options do define how to wiggle
   /// @param [in] start Start parameters which will be modified
   /// @param [in] param Index to get the parameter that will be modified

--- a/Core/include/Acts/Propagator/StepperConcept.hpp
+++ b/Core/include/Acts/Propagator/StepperConcept.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
 #include "Acts/Surfaces/Surface.hpp"
@@ -97,7 +98,7 @@ constexpr bool MultiStepperStateConcept= require<
         static_assert(bound_state_exists, "BoundState type not found");
         constexpr static bool curvilinear_state_exists = exists<curvilinear_state_t, S>;
         static_assert(curvilinear_state_exists, "CurvilinearState type not found");
-        constexpr static bool reset_state_exists = has_method<const S, void, reset_state_t, state&, const BoundVector&, const BoundSquareMatrix&, const Surface&, const double>;
+        constexpr static bool reset_state_exists = has_method<const S, void, reset_state_t, const GeometryContext&, state&, const BoundVector&, const BoundSquareMatrix&, const Surface&, const double>;
         static_assert(reset_state_exists, "resetState method not found");
         constexpr static bool position_exists = has_method<const S, Vector3, position_t, const state&>;
         static_assert(position_exists, "position method not found");
@@ -113,14 +114,14 @@ constexpr bool MultiStepperStateConcept= require<
         static_assert(charge_exists, "charge method not found");
         constexpr static bool time_exists = has_method<const S, double, time_t, const state&>;
         static_assert(time_exists, "time method not found");
-        constexpr static bool bound_state_method_exists= has_method<const S, Result<typename S::BoundState>, bound_state_method_t, state&, const Surface&, bool, const FreeToBoundCorrection&>;
+        constexpr static bool bound_state_method_exists= has_method<const S, Result<typename S::BoundState>, bound_state_method_t, const GeometryContext&, state&, const Surface&, bool, const FreeToBoundCorrection&>;
         static_assert(bound_state_method_exists, "boundState method not found");
         constexpr static bool curvilinear_state_method_exists = has_method<const S, typename S::CurvilinearState, curvilinear_state_method_t, state&, bool>;
         static_assert(curvilinear_state_method_exists, "curvilinearState method not found");
         constexpr static bool covariance_transport_exists = require<has_method<const S, void, covariance_transport_curvilinear_t, state&>,
-                                                                    has_method<const S, void, covariance_transport_bound_t, state&, const Surface&, const FreeToBoundCorrection&>>;
+                                                                    has_method<const S, void, covariance_transport_bound_t, const GeometryContext&, state&, const Surface&, const FreeToBoundCorrection&>>;
         static_assert(covariance_transport_exists, "covarianceTransport method not found");
-        constexpr static bool update_surface_exists = has_method<const S, Intersection3D::Status, update_surface_status_t, state&, const Surface&, std::uint8_t, Direction, const BoundaryTolerance&, ActsScalar, const Logger&>;
+        constexpr static bool update_surface_exists = has_method<const S, Intersection3D::Status, update_surface_status_t, const GeometryContext&, state&, const Surface&, std::uint8_t, Direction, const BoundaryTolerance&, ActsScalar, const Logger&>;
         static_assert(update_surface_exists, "updateSurfaceStatus method not found");
         constexpr static bool update_step_size_exists = has_method<const S, void, update_step_size_t, state&, double, ConstrainedStep::Type, bool>;
         static_assert(update_step_size_exists, "updateStepSize method not found");
@@ -160,7 +161,7 @@ constexpr bool MultiStepperStateConcept= require<
       struct SingleStepperConcept {
         constexpr static bool common_stepper_concept_fullfilled = CommonStepperConcept<S, state>::value;
         static_assert(common_stepper_concept_fullfilled, "Stepper does not fulfill common stepper concept");
-        constexpr static bool update_method_exists = require<has_method<const S, void, update_t, state&, const FreeVector&, const BoundVector&, const BoundSquareMatrix&, const Surface&>, has_method<const S, void, update_t, state&, const Vector3&, const Vector3&, double, double>>;
+        constexpr static bool update_method_exists = require<has_method<const S, void, update_t, const GeometryContext&, state&, const FreeVector&, const BoundVector&, const BoundSquareMatrix&, const Surface&>, has_method<const S, void, update_t, state&, const Vector3&, const Vector3&, double, double>>;
         // static_assert(update_method_exists, "update method not found");
         constexpr static bool get_field_exists = has_method<const S, Result<Vector3>, get_field_t, state&, const Vector3&>;
         // static_assert(get_field_exists, "getField method not found");
@@ -220,4 +221,5 @@ template <typename stepper>
 constexpr bool StepperStateConcept =
     Acts::Concepts ::Stepper::StepperStateConcept<stepper> ||
     Acts::Concepts ::Stepper::MultiStepperStateConcept<stepper>;
+
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/detail/ParameterTraits.hpp
+++ b/Core/include/Acts/Propagator/detail/ParameterTraits.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2023 CERN for the benefit of the Acts project
+// Copyright (C) 2023-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,6 +19,7 @@ namespace Acts::detail {
 template <typename stepper_t>
 struct stepper_bound_parameters {
   using result_type = decltype(std::declval<stepper_t>().boundState(
+      std::declval<const GeometryContext&>(),
       std::declval<typename stepper_t::State&>(), std::declval<Acts::Surface>(),
       std::declval<bool>(), std::declval<Acts::FreeToBoundCorrection>()));
   using type =
@@ -39,4 +40,5 @@ struct stepper_curvilinear_parameters {
 template <typename stepper_t>
 using stepper_curvilinear_parameters_type_t =
     typename stepper_curvilinear_parameters<stepper_t>::type;
+
 }  // namespace Acts::detail

--- a/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
+++ b/Core/include/Acts/Propagator/detail/SteppingHelper.hpp
@@ -33,17 +33,17 @@ namespace Acts::detail {
 /// @param boundaryTolerance [in] The boundary check for this status update
 template <typename stepper_t>
 Acts::Intersection3D::Status updateSingleSurfaceStatus(
-    const stepper_t& stepper, typename stepper_t::State& state,
-    const Surface& surface, std::uint8_t index, Direction navDir,
+    const GeometryContext& geoContext, const stepper_t& stepper,
+    typename stepper_t::State& state, const Surface& surface,
+    std::uint8_t index, Direction navDir,
     const BoundaryTolerance& boundaryTolerance, ActsScalar surfaceTolerance,
     const Logger& logger) {
   ACTS_VERBOSE("Update single surface status for surface: "
                << surface.geometryId() << " index " << static_cast<int>(index));
 
-  auto sIntersection =
-      surface.intersect(state.geoContext, stepper.position(state),
-                        navDir * stepper.direction(state), boundaryTolerance,
-                        surfaceTolerance)[index];
+  auto sIntersection = surface.intersect(
+      geoContext, stepper.position(state), navDir * stepper.direction(state),
+      boundaryTolerance, surfaceTolerance)[index];
 
   // The intersection is on surface already
   if (sIntersection.status() == Intersection3D::Status::onSurface) {

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -609,7 +609,8 @@ class CombinatorialKalmanFilter {
           ACTS_VERBOSE("Target surface reached");
 
           // Bind the parameter to the target surface
-          auto res = stepper.boundState(state.stepping, *targetReached.surface);
+          auto res = stepper.boundState(state.geoContext, state.stepping,
+                                        *targetReached.surface);
           if (!res.ok()) {
             ACTS_ERROR("Error while acquiring bound state for target surface: "
                        << res.error() << " " << res.error().message());
@@ -665,10 +666,10 @@ class CombinatorialKalmanFilter {
       auto currentState = result.activeBranches.back().outermostTrackState();
 
       // Reset the stepping state
-      stepper.resetState(state.stepping, currentState.filtered(),
-                         currentState.filteredCovariance(),
-                         currentState.referenceSurface(),
-                         state.options.stepping.maxStepSize);
+      stepper.resetState(
+          state.geoContext, state.stepping, currentState.filtered(),
+          currentState.filteredCovariance(), currentState.referenceSurface(),
+          state.options.stepping.maxStepSize);
 
       // Reset the navigation state
       // Set targetSurface to nullptr for forward filtering; it's only needed
@@ -714,15 +715,16 @@ class CombinatorialKalmanFilter {
                                             << " detected.");
 
         // Transport the covariance to the surface
-        stepper.transportCovarianceToBound(state.stepping, *surface);
+        stepper.transportCovarianceToBound(state.geoContext, state.stepping,
+                                           *surface);
 
         // Update state and stepper with pre material effects
         materialInteractor(surface, state, stepper, navigator,
                            MaterialUpdateStage::PreUpdate);
 
         // Bind the transported state to the current surface
-        auto boundStateRes =
-            stepper.boundState(state.stepping, *surface, false);
+        auto boundStateRes = stepper.boundState(
+            state.geoContext, state.stepping, *surface, false);
         if (!boundStateRes.ok()) {
           return boundStateRes.error();
         }
@@ -769,7 +771,7 @@ class CombinatorialKalmanFilter {
           // state on this surface
           auto ts = result.activeBranches.back().outermostTrackState();
           stepper.update(
-              state.stepping,
+              state.geoContext, state.stepping,
               MultiTrajectoryHelpers::freeFiltered(state.geoContext, ts),
               ts.filtered(), ts.filteredCovariance(), *surface);
           ACTS_VERBOSE("Stepping state is updated with filtered parameter:");
@@ -816,8 +818,8 @@ class CombinatorialKalmanFilter {
                              MaterialUpdateStage::PreUpdate);
 
           // Transport & bind the state to the current surface
-          auto boundStateRes =
-              stepper.boundState(state.stepping, *surface, false);
+          auto boundStateRes = stepper.boundState(
+              state.geoContext, state.stepping, *surface, false);
           if (!boundStateRes.ok()) {
             return boundStateRes.error();
           }

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -768,10 +768,10 @@ class CombinatorialKalmanFilter {
           // Update stepping state using filtered parameters of last track
           // state on this surface
           auto ts = result.activeBranches.back().outermostTrackState();
-          stepper.update(state.stepping,
-                         MultiTrajectoryHelpers::freeFiltered(
-                             state.options.geoContext, ts),
-                         ts.filtered(), ts.filteredCovariance(), *surface);
+          stepper.update(
+              state.stepping,
+              MultiTrajectoryHelpers::freeFiltered(state.geoContext, ts),
+              ts.filtered(), ts.filteredCovariance(), *surface);
           ACTS_VERBOSE("Stepping state is updated with filtered parameter:");
           ACTS_VERBOSE("-> " << ts.filtered().transpose()
                              << " of track state with tip = " << ts.index());
@@ -1205,8 +1205,7 @@ class CombinatorialKalmanFilter {
     using Aborters = AbortList<CombinatorialKalmanFilterAborter>;
 
     // Create relevant options for the propagation options
-    typename propagator_t::template Options<Actors, Aborters> propOptions(
-        tfOptions.geoContext, tfOptions.magFieldContext);
+    typename propagator_t::template Options<Actors, Aborters> propOptions;
 
     // Set the trivial propagator options
     propOptions.setPlainOptions(tfOptions.propagatorPlainOptions);
@@ -1238,8 +1237,9 @@ class CombinatorialKalmanFilter {
               source_link_iterator_t>>(&defaultTrackStateCreator);
     }
 
-    auto propState =
-        m_propagator.template makeState(initialParameters, propOptions);
+    auto propState = m_propagator.template makeState(
+        tfOptions.geoContext, tfOptions.magFieldContext, initialParameters,
+        propOptions);
 
     auto& r =
         propState

--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -109,7 +109,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -132,7 +132,7 @@ struct GaussianSumFitter {
           std::next(sSequence.rbegin()), sSequence.rend());
       backwardSequence.push_back(opts.referenceSurface);
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -166,7 +166,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -183,7 +183,7 @@ struct GaussianSumFitter {
       using PropagatorOptions =
           typename propagator_t::template Options<Actors, Aborters>;
 
-      PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
+      PropagatorOptions propOptions;
 
       propOptions.setPlainOptions(opts.propagatorPlainOptions);
 
@@ -295,7 +295,8 @@ struct GaussianSumFitter {
         params = sParameters;
       }
 
-      auto state = m_propagator.makeState(*params, fwdPropOptions);
+      auto state = m_propagator.makeState(
+          options.geoContext, options.magFieldContext, *params, fwdPropOptions);
 
       auto& r = state.template get<typename GsfActor::result_type>();
       r.fittedStates = &trackContainer.trackStateContainer();
@@ -358,7 +359,8 @@ struct GaussianSumFitter {
           m_propagator.template makeState<MultiComponentBoundTrackParameters,
                                           decltype(bwdPropOptions),
                                           MultiStepperSurfaceReached>(
-              params, target, bwdPropOptions);
+              options.geoContext, options.magFieldContext, params, target,
+              bwdPropOptions);
 
       assert(
           (fwdGsfResult.lastMeasurementTip != MultiTrajectoryTraits::kInvalid &&

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -747,14 +747,15 @@ class Gx2Fitter {
       Acts::GeometryContext geoCtx = gx2fOptions.geoContext;
       Acts::MagneticFieldContext magCtx = gx2fOptions.magFieldContext;
       // Set options for propagator
-      PropagatorOptions propagatorOptions(geoCtx, magCtx);
+      PropagatorOptions propagatorOptions;
       auto& gx2fActor = propagatorOptions.actionList.template get<GX2FActor>();
       gx2fActor.inputMeasurements = &inputMeasurements;
       gx2fActor.extensions = gx2fOptions.extensions;
       gx2fActor.calibrationContext = &gx2fOptions.calibrationContext.get();
       gx2fActor.actorLogger = m_actorLogger.get();
 
-      auto propagatorState = m_propagator.makeState(params, propagatorOptions);
+      auto propagatorState =
+          m_propagator.makeState(geoCtx, magCtx, params, propagatorOptions);
 
       auto& r = propagatorState.template get<Gx2FitterResult<traj_t>>();
       r.fittedStates = &trajectoryTempBackend;
@@ -979,14 +980,15 @@ class Gx2Fitter {
       Acts::GeometryContext geoCtx = gx2fOptions.geoContext;
       Acts::MagneticFieldContext magCtx = gx2fOptions.magFieldContext;
       // Set options for propagator
-      PropagatorOptions propagatorOptions(geoCtx, magCtx);
+      PropagatorOptions propagatorOptions;
       auto& gx2fActor = propagatorOptions.actionList.template get<GX2FActor>();
       gx2fActor.inputMeasurements = &inputMeasurements;
       gx2fActor.extensions = gx2fOptions.extensions;
       gx2fActor.calibrationContext = &gx2fOptions.calibrationContext.get();
       gx2fActor.actorLogger = m_actorLogger.get();
 
-      auto propagatorState = m_propagator.makeState(params, propagatorOptions);
+      auto propagatorState =
+          m_propagator.makeState(geoCtx, magCtx, params, propagatorOptions);
 
       auto& r = propagatorState.template get<Gx2FitterResult<traj_t>>();
       r.fittedStates = &trackContainer.trackStateContainer();

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -480,8 +480,9 @@ class Gx2Fitter {
           {
             trackStateProxy.setReferenceSurface(surface->getSharedPtr());
             // Bind the transported state to the current surface
-            auto res = stepper.boundState(state.stepping, *surface, false,
-                                          freeToBoundCorrection);
+            auto res =
+                stepper.boundState(state.geoContext, state.stepping, *surface,
+                                   false, freeToBoundCorrection);
             if (!res.ok()) {
               result.result = res.error();
               return;
@@ -553,8 +554,9 @@ class Gx2Fitter {
               {
                 trackStateProxy.setReferenceSurface(surface->getSharedPtr());
                 // Bind the transported state to the current surface
-                auto res = stepper.boundState(state.stepping, *surface, false,
-                                              freeToBoundCorrection);
+                auto res =
+                    stepper.boundState(state.geoContext, state.stepping,
+                                       *surface, false, freeToBoundCorrection);
                 if (!res.ok()) {
                   result.result = res.error();
                   return;

--- a/Core/include/Acts/TrackFitting/GsfOptions.hpp
+++ b/Core/include/Acts/TrackFitting/GsfOptions.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2022 CERN for the benefit of the Acts project
+// Copyright (C) 2022-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -121,8 +121,7 @@ struct GsfOptions {
              const CalibrationContext &calibCtxt)
       : geoContext(geoCtxt),
         magFieldContext(magFieldCtxt),
-        calibrationContext(calibCtxt),
-        propagatorPlainOptions(geoCtxt, magFieldCtxt) {}
+        calibrationContext(calibCtxt) {}
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1246,6 +1246,8 @@ class KalmanFitter {
   /// @tparam track_container_t Type of the track container backend
   /// @tparam holder_t Type defining track container backend ownership
   ///
+  /// @param geoContext The geometry context
+  /// @param magField The magnetic field context
   /// @param sParameters The initial track parameters
   /// @param propagatorOptions The Propagator Options
   /// @param trackContainer Input track container storage to append into

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -244,7 +244,7 @@ struct GsfActor {
     for (auto cmp : stepper.componentIterable(state.stepping)) {
       auto singleState = cmp.singleState(state);
       cmp.singleStepper(stepper).transportCovarianceToBound(
-          singleState.stepping, surface);
+          state.geoContext, singleState.stepping, surface);
     }
 
     if (haveMaterial) {
@@ -371,12 +371,12 @@ struct GsfActor {
 
     // Evaluate material slab
     auto slab = surface.surfaceMaterial()->materialSlab(
-        old_bound.position(state.stepping.geoContext), state.options.direction,
+        old_bound.position(state.geoContext), state.options.direction,
         MaterialUpdateStage::FullUpdate);
 
     const auto pathCorrection = surface.pathCorrection(
-        state.stepping.geoContext,
-        old_bound.position(state.stepping.geoContext), old_bound.direction());
+        state.geoContext, old_bound.position(state.geoContext),
+        old_bound.direction());
     slab.scaleThickness(pathCorrection);
 
     const double pathXOverX0 = slab.thicknessInX0();
@@ -520,7 +520,8 @@ struct GsfActor {
       BoundTrackParameters bound(surface.getSharedPtr(), pars, cov,
                                  stepper.particleHypothesis(state.stepping));
 
-      auto res = stepper.addComponent(state.stepping, std::move(bound), weight);
+      auto res = stepper.addComponent(state.geoContext, state.stepping,
+                                      std::move(bound), weight);
 
       if (!res.ok()) {
         ACTS_ERROR("Error adding component to MultiStepper");

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -490,7 +490,7 @@ struct GsfActor {
       auto proxy = tmpStates.traj.getTrackState(idx);
 
       cmp.pars() =
-          MultiTrajectoryHelpers::freeFiltered(state.options.geoContext, proxy);
+          MultiTrajectoryHelpers::freeFiltered(state.geoContext, proxy);
       cmp.cov() = proxy.filteredCovariance();
       cmp.weight() = tmpStates.weights.at(idx);
     }

--- a/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
+++ b/Core/include/Acts/TrackFitting/detail/KalmanUpdateHelpers.hpp
@@ -56,8 +56,8 @@ auto kalmanHandleMeasurement(
   {
     trackStateProxy.setReferenceSurface(surface.getSharedPtr());
     // Bind the transported state to the current surface
-    auto res = stepper.boundState(state.stepping, surface, doCovTransport,
-                                  freeToBoundCorrection);
+    auto res = stepper.boundState(state.geoContext, state.stepping, surface,
+                                  doCovTransport, freeToBoundCorrection);
     if (!res.ok()) {
       ACTS_ERROR("Propagate to surface " << surface.geometryId()
                                          << " failed: " << res.error());
@@ -151,8 +151,8 @@ auto kalmanHandleNoMeasurement(
   {
     trackStateProxy.setReferenceSurface(surface.getSharedPtr());
     // Bind the transported state to the current surface
-    auto res = stepper.boundState(state.stepping, surface, doCovTransport,
-                                  freeToBoundCorrection);
+    auto res = stepper.boundState(state.geoContext, state.stepping, surface,
+                                  doCovTransport, freeToBoundCorrection);
     if (!res.ok()) {
       return res.error();
     }

--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -275,6 +275,8 @@ findTrackStateForExtrapolation(
 /// @tparam propagator_t The propagator type
 /// @tparam propagator_options_t The propagator options type
 ///
+/// @param geoContext The geometry context
+/// @param magFieldContext The magnetic field context
 /// @param track The track which is modified in-place
 /// @param referenceSurface The reference surface
 /// @param propagator The propagator

--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -13,6 +13,7 @@
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TrackStateType.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/TrackFitting/GainMatrixSmoother.hpp"
@@ -285,13 +286,14 @@ findTrackStateForExtrapolation(
 template <typename track_proxy_t, typename propagator_t,
           typename propagator_options_t>
 Result<void> extrapolateTrackToReferenceSurface(
-    track_proxy_t &track, const Surface &referenceSurface,
-    const propagator_t &propagator, propagator_options_t options,
-    TrackExtrapolationStrategy strategy,
+    const GeometryContext &geoContext,
+    const MagneticFieldContext &magFieldContext, track_proxy_t &track,
+    const Surface &referenceSurface, const propagator_t &propagator,
+    propagator_options_t options, TrackExtrapolationStrategy strategy,
     const Logger &logger = *getDefaultLogger("TrackExtrapolation",
                                              Logging::INFO)) {
   auto findResult = findTrackStateForExtrapolation(
-      options.geoContext, track, referenceSurface, strategy, logger);
+      geoContext, track, referenceSurface, strategy, logger);
 
   if (!findResult.ok()) {
     ACTS_ERROR("failed to find track state for extrapolation");
@@ -310,7 +312,7 @@ Result<void> extrapolateTrackToReferenceSurface(
   auto propagateResult =
       propagator.template propagate<BoundTrackParameters, propagator_options_t,
                                     ForcedSurfaceReached>(
-          parameters, referenceSurface, options);
+          geoContext, magFieldContext, parameters, referenceSurface, options);
 
   if (!propagateResult.ok()) {
     ACTS_ERROR("failed to extrapolate track: " << propagateResult.error());

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -244,11 +244,13 @@ void Acts::SurfaceMaterialMapper::mapInteraction(
       ActionList<MaterialSurfaceCollector, MaterialVolumeCollector>;
   using AbortList = AbortList<EndOfWorldReached>;
 
-  StraightLinePropagator::Options<ActionList, AbortList> options(
-      mState.geoContext, mState.magFieldContext);
+  StraightLinePropagator::Options<ActionList, AbortList> options;
 
   // Now collect the material layers by using the straight line propagator
-  const auto& result = m_propagator.propagate(start, options).value();
+  const auto& result =
+      m_propagator
+          .propagate(mState.geoContext, mState.magFieldContext, start, options)
+          .value();
   auto mcResult = result.get<MaterialSurfaceCollector::result_type>();
   auto mvcResult = result.get<MaterialVolumeCollector::result_type>();
 

--- a/Core/src/Material/VolumeMaterialMapper.cpp
+++ b/Core/src/Material/VolumeMaterialMapper.cpp
@@ -377,11 +377,13 @@ void Acts::VolumeMaterialMapper::mapMaterialTrack(
   using ActionList = ActionList<BoundSurfaceCollector, MaterialVolumeCollector>;
   using AbortList = AbortList<EndOfWorldReached>;
 
-  StraightLinePropagator::Options<ActionList, AbortList> options(
-      mState.geoContext, mState.magFieldContext);
+  StraightLinePropagator::Options<ActionList, AbortList> options;
 
   // Now collect the material volume by using the straight line propagator
-  const auto& result = m_propagator.propagate(start, options).value();
+  const auto& result =
+      m_propagator
+          .propagate(mState.geoContext, mState.magFieldContext, start, options)
+          .value();
   auto mcResult = result.get<BoundSurfaceCollector::result_type>();
   auto mvcResult = result.get<MaterialVolumeCollector::result_type>();
 

--- a/Core/src/Vertexing/HelicalTrackLinearizer.cpp
+++ b/Core/src/Vertexing/HelicalTrackLinearizer.cpp
@@ -19,7 +19,7 @@ Acts::HelicalTrackLinearizer::linearizeTrack(
     const Acts::MagneticFieldContext& mctx,
     MagneticFieldProvider::Cache& fieldCache) const {
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
 
   // Length scale at which we consider to be sufficiently close to the Perigee
   // surface to skip the propagation.
@@ -43,8 +43,8 @@ Acts::HelicalTrackLinearizer::linearizeTrack(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the PCA of the reference point
-  const auto res =
-      m_cfg.propagator->propagateToSurface(params, perigeeSurface, pOptions);
+  const auto res = m_cfg.propagator->propagateToSurface(
+      gctx, mctx, params, perigeeSurface, pOptions);
   if (!res.ok()) {
     return res.error();
   }

--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -367,14 +367,14 @@ Result<BoundTrackParameters> ImpactPointEstimator::estimate3DImpactParameters(
           .closest();
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction =
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the surface; intersection corresponds to an estimate of the 3D
   // PCA. If deltaR and momDir were orthogonal the calculation would be exact.
-  auto result =
-      m_cfg.propagator->propagateToSurface(trkParams, *planeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, trkParams,
+                                                     *planeSurface, pOptions);
   if (result.ok()) {
     return *result;
   } else {
@@ -423,7 +423,7 @@ Result<ImpactParametersAndSigma> ImpactPointEstimator::getImpactParameters(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   auto intersection =
       perigeeSurface
           ->intersect(gctx, track.position(gctx), track.direction(),
@@ -433,8 +433,8 @@ Result<ImpactParametersAndSigma> ImpactPointEstimator::getImpactParameters(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Do the propagation to linPoint
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     ACTS_ERROR("Error during propagation in getImpactParameters.");
@@ -507,12 +507,12 @@ Result<std::pair<double, double>> ImpactPointEstimator::getLifetimeSignOfTrack(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction = Direction::Backward;
 
   // Do the propagation to the perigeee
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     return result.error();
@@ -546,12 +546,12 @@ Result<double> ImpactPointEstimator::get3DLifetimeSignOfTrack(
       Surface::makeShared<PerigeeSurface>(vtx.position());
 
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
   pOptions.direction = Direction::Backward;
 
   // Do the propagation to the perigeee
-  auto result =
-      m_cfg.propagator->propagateToSurface(track, *perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, track,
+                                                     *perigeeSurface, pOptions);
 
   if (!result.ok()) {
     return result.error();

--- a/Core/src/Vertexing/NumericalTrackLinearizer.cpp
+++ b/Core/src/Vertexing/NumericalTrackLinearizer.cpp
@@ -20,7 +20,7 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
     const Acts::MagneticFieldContext& mctx,
     MagneticFieldProvider::Cache& /*fieldCache*/) const {
   // Create propagator options
-  PropagatorPlainOptions pOptions(gctx, mctx);
+  PropagatorPlainOptions pOptions;
 
   // Length scale at which we consider to be sufficiently close to the Perigee
   // surface to skip the propagation.
@@ -44,8 +44,8 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the PCA of the reference point
-  auto result =
-      m_cfg.propagator->propagateToSurface(params, perigeeSurface, pOptions);
+  auto result = m_cfg.propagator->propagateToSurface(gctx, mctx, params,
+                                                     perigeeSurface, pOptions);
   if (!result.ok()) {
     return result.error();
   }
@@ -128,7 +128,7 @@ Acts::NumericalTrackLinearizer::linearizeTrack(
 
     // Propagate to the new PCA and extract Perigee parameters
     auto newResult = m_cfg.propagator->propagateToSurface(
-        wiggledCurvilinearParams, perigeeSurface, pOptions);
+        gctx, mctx, wiggledCurvilinearParams, perigeeSurface, pOptions);
     if (!newResult.ok()) {
       return newResult.error();
     }

--- a/Examples/Algorithms/Alignment/src/AlignmentAlgorithm.cpp
+++ b/Examples/Algorithms/Alignment/src/AlignmentAlgorithm.cpp
@@ -113,10 +113,9 @@ ActsExamples::ProcessCode ActsExamples::AlignmentAlgorithm::execute(
       &kfSmoother);
 
   // Set the KalmanFitter options
-  TrackFitterOptions kfOptions(
-      ctx.geoContext, ctx.magFieldContext, ctx.calibContext, extensions,
-      Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext),
-      &(*pSurface));
+  TrackFitterOptions kfOptions(ctx.geoContext, ctx.magFieldContext,
+                               ctx.calibContext, extensions,
+                               Acts::PropagatorPlainOptions(), &(*pSurface));
 
   // Set the alignment options
   ActsAlignment::AlignmentOptions<TrackFitterOptions> alignOptions(

--- a/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagatorInterface.hpp
+++ b/Examples/Algorithms/Propagation/include/ActsExamples/Propagation/PropagatorInterface.hpp
@@ -88,7 +88,7 @@ class ConcretePropagator : public PropagatorInterface {
       using PropagatorOptions =
           typename propagator_t::template Options<ActionList, AbortList>;
 
-      PropagatorOptions options(context.geoContext, context.magFieldContext);
+      PropagatorOptions options;
       options.pathLimit = pathLength;
 
       // Activate loop protection at some pt value
@@ -108,7 +108,9 @@ class ConcretePropagator : public PropagatorInterface {
       options.stepping.maxStepSize = cfg.maxStepSize;
 
       // Propagate using the propagator
-      auto result = m_propagator.propagate(startParameters, options);
+      auto result =
+          m_propagator.propagate(context.geoContext, context.magFieldContext,
+                                 startParameters, options);
       if (result.ok()) {
         const auto& resultValue = result.value();
         auto steppingResults =

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -346,13 +346,11 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
       slAccessorDelegate;
   slAccessorDelegate.connect<&IndexSourceLinkAccessor::range>(&slAccessor);
 
-  Acts::PropagatorPlainOptions firstPropOptions(ctx.geoContext,
-                                                ctx.magFieldContext);
+  Acts::PropagatorPlainOptions firstPropOptions;
   firstPropOptions.maxSteps = m_cfg.maxSteps;
   firstPropOptions.direction = Acts::Direction::Forward;
 
-  Acts::PropagatorPlainOptions secondPropOptions(ctx.geoContext,
-                                                 ctx.magFieldContext);
+  Acts::PropagatorPlainOptions secondPropOptions;
   secondPropOptions.maxSteps = m_cfg.maxSteps;
   secondPropOptions.direction = firstPropOptions.direction.invert();
 
@@ -377,7 +375,7 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
                       logger().cloneWithSuffix("Navigator")),
       logger().cloneWithSuffix("Propagator"));
 
-  ExtrapolatorOptions extrapolationOptions(ctx.geoContext, ctx.magFieldContext);
+  ExtrapolatorOptions extrapolationOptions;
 
   // Perform the track finding for all initial parameters
   ACTS_DEBUG("Invoke track finding with " << initialParameters.size()
@@ -568,9 +566,9 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
               //      implementation
               auto secondExtrapolationResult =
                   Acts::extrapolateTrackToReferenceSurface(
-                      trackCandidate, *pSurface, extrapolator,
-                      extrapolationOptions, m_cfg.extrapolationStrategy,
-                      logger());
+                      ctx.geoContext, ctx.magFieldContext, trackCandidate,
+                      *pSurface, extrapolator, extrapolationOptions,
+                      m_cfg.extrapolationStrategy, logger());
               if (!secondExtrapolationResult.ok()) {
                 m_nFailedExtrapolation++;
                 ACTS_ERROR("Second extrapolation for seed "
@@ -597,8 +595,9 @@ ProcessCode TrackFindingAlgorithm::execute(const AlgorithmContext& ctx) const {
       if (nSecond == 0) {
         auto firstExtrapolationResult =
             Acts::extrapolateTrackToReferenceSurface(
-                trackCandidate, *pSurface, extrapolator, extrapolationOptions,
-                m_cfg.extrapolationStrategy, logger());
+                ctx.geoContext, ctx.magFieldContext, trackCandidate, *pSurface,
+                extrapolator, extrapolationOptions, m_cfg.extrapolationStrategy,
+                logger());
         if (!firstExtrapolationResult.ok()) {
           m_nFailedExtrapolation++;
           ACTS_ERROR("Extrapolation for seed "

--- a/Examples/Algorithms/TrackFitting/src/RefittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/RefittingAlgorithm.cpp
@@ -69,8 +69,7 @@ ActsExamples::ProcessCode ActsExamples::RefittingAlgorithm::execute(
 
     TrackFitterFunction::GeneralFitterOptions options{
         ctx.geoContext, ctx.magFieldContext, ctx.calibContext,
-        &track.referenceSurface(),
-        Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext)};
+        &track.referenceSurface(), Acts::PropagatorPlainOptions()};
 
     const Acts::BoundTrackParameters initialParams(
         track.referenceSurface().getSharedPtr(), track.parameters(),

--- a/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFitting/src/TrackFittingAlgorithm.cpp
@@ -96,7 +96,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFittingAlgorithm::execute(
 
   TrackFitterFunction::GeneralFitterOptions options{
       ctx.geoContext, ctx.magFieldContext, ctx.calibContext, pSurface.get(),
-      Acts::PropagatorPlainOptions(ctx.geoContext, ctx.magFieldContext)};
+      Acts::PropagatorPlainOptions()};
 
   auto trackContainer = std::make_shared<Acts::VectorTrackContainer>();
   auto trackStateContainer = std::make_shared<Acts::VectorMultiTrajectory>();

--- a/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/VertexFitterAlgorithm.cpp
@@ -61,7 +61,6 @@ ActsExamples::ProcessCode ActsExamples::VertexFitterAlgorithm::execute(
   ltConfig.propagator = propagator;
   Linearizer linearizer(ltConfig, logger().cloneWithSuffix("HelLin"));
 
-  PropagatorOptions propagatorOpts(ctx.geoContext, ctx.magFieldContext);
   // Setup the vertex fitter
   VertexFitter::Config vertexFitterCfg;
   vertexFitterCfg.extractParameters

--- a/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
+++ b/Examples/Io/Performance/ActsExamples/Io/Performance/VertexPerformanceWriter.cpp
@@ -777,11 +777,12 @@ ProcessCode VertexPerformanceWriter::writeT(
 
       // Setting the geometry/magnetic field context for the event
       using PropagatorOptions = Propagator::Options<>;
-      PropagatorOptions pOptions(ctx.geoContext, ctx.magFieldContext);
+      PropagatorOptions pOptions;
       pOptions.direction =
           Acts::Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
-      auto result = propagator->propagate(params, *perigeeSurface, pOptions);
+      auto result = propagator->propagate(ctx.geoContext, ctx.magFieldContext,
+                                          params, *perigeeSurface, pOptions);
       if (!result.ok()) {
         ACTS_ERROR("Propagation to true vertex position failed.");
         return std::nullopt;

--- a/Fatras/include/ActsFatras/Kernel/Simulation.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulation.hpp
@@ -87,7 +87,7 @@ struct SingleParticleSimulation {
         typename propagator_t::template Options<Actions, Abort>;
 
     // Construct per-call options.
-    PropagatorOptions options(geoCtx, magCtx);
+    PropagatorOptions options;
     options.stepping.maxStepSize = maxStepSize;
     options.pathLimit = pathLimit;
     // setup the interactor as part of the propagator options
@@ -100,7 +100,7 @@ struct SingleParticleSimulation {
 
     if (particle.hasReferenceSurface()) {
       auto result = propagator.propagate(
-          particle.boundParameters(geoCtx).value(), options);
+          geoCtx, magCtx, particle.boundParameters(geoCtx).value(), options);
       if (!result.ok()) {
         return result.error();
       }
@@ -108,8 +108,8 @@ struct SingleParticleSimulation {
       return std::move(value);
     }
 
-    auto result =
-        propagator.propagate(particle.curvilinearParameters(), options);
+    auto result = propagator.propagate(
+        geoCtx, magCtx, particle.curvilinearParameters(), options);
     if (!result.ok()) {
       return result.error();
     }

--- a/Tests/Benchmarks/StepperBenchmarkCommons.hpp
+++ b/Tests/Benchmarks/StepperBenchmarkCommons.hpp
@@ -89,7 +89,7 @@ struct BenchmarkStepper {
 
     Propagator propagator(std::move(stepper));
 
-    PropagatorOptions options(tgContext, mfContext);
+    PropagatorOptions options;
     options.pathLimit = maxPathInM * UnitConstants::m;
 
     Vector4 pos4(0, 0, 0, 0);
@@ -117,7 +117,8 @@ struct BenchmarkStepper {
     std::size_t numIters = 0;
     const auto propagationBenchResult = Acts::Test::microBenchmark(
         [&] {
-          auto state = propagator.makeState(pars, options);
+          auto state =
+              propagator.makeState(tgContext, mfContext, pars, options);
           auto tmp = propagator.propagate(state);
           auto r = propagator.makeResult(state, tmp, options, true).value();
           if (totalPathLength == 0.) {

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/MeasurementsCreator.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/MeasurementsCreator.hpp
@@ -161,14 +161,15 @@ Measurements createMeasurements(const propagator_t& propagator,
       typename propagator_t::template Options<Actions, Aborters>;
 
   // Set options for propagator
-  PropagatorOptions options(geoCtx, magCtx);
+  PropagatorOptions options;
   auto& creator = options.actionList.template get<MeasurementsCreator>();
   creator.resolutions = resolutions;
   creator.rng = &rng;
   creator.sourceId = sourceId;
 
   // Launch and collect the measurements
-  auto result = propagator.propagate(trackParameters, options).value();
+  auto result =
+      propagator.propagate(geoCtx, magCtx, trackParameters, options).value();
   return std::move(result.template get<Measurements>());
 }
 

--- a/Tests/IntegrationTests/NavigatorConsistency.cpp
+++ b/Tests/IntegrationTests/NavigatorConsistency.cpp
@@ -76,7 +76,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
       typename propagator_t::template Options<ActionListType, AbortListType>;
 
   // forward surface test
-  Options fwdOptions(tgContext, mfContext);
+  Options fwdOptions;
   fwdOptions.pathLimit = 25_cm;
 
   // get the surface collector and configure it
@@ -87,7 +87,8 @@ void runSelfConsistencyTest(const propagator_t& prop,
   fwdSurfaceCollector.selector.selectPassive = true;
 
   ACTS_DEBUG(">>> Forward Propagation : start.");
-  auto fwdResult = prop.propagate(start, fwdOptions).value();
+  auto fwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
   auto fwdSurfaceHits =
       fwdResult.template get<SurfaceCollector::result_type>().collected;
   auto fwdSurfaces = collectRelevantGeoIds(
@@ -100,7 +101,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Forward Propagation : end.");
 
   // backward surface test
-  Options bwdOptions(tgContext, mfContext);
+  Options bwdOptions;
   bwdOptions.pathLimit = 25_cm;
   bwdOptions.direction = Direction::Backward;
 
@@ -115,7 +116,8 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   ACTS_DEBUG(">>> Backward Propagation : start.");
   auto bwdResult =
-      prop.propagate(*fwdResult.endParameters, startSurface, bwdOptions)
+      prop.propagate(tgContext, mfContext, *fwdResult.endParameters,
+                     startSurface, bwdOptions)
           .value();
   auto bwdSurfaceHits =
       bwdResult.template get<SurfaceCollector::result_type>().collected;
@@ -137,7 +139,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   // stepping from one surface to the next
   // now go from surface to surface and check
-  Options fwdStepOptions(tgContext, mfContext);
+  Options fwdStepOptions;
 
   // get the surface collector and configure it
   auto& fwdStepSurfaceCollector =
@@ -157,8 +159,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
                << fwdSteps.surface->geometryId());
 
     // make a forward step
-    auto fwdStep =
-        prop.propagate(sParameters, *fwdSteps.surface, fwdStepOptions).value();
+    auto fwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                  *fwdSteps.surface, fwdStepOptions)
+                       .value();
 
     auto fwdStepSurfacesTmp = collectRelevantGeoIds(
         fwdStep.template get<SurfaceCollector::result_type>());
@@ -176,8 +179,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Forward step : "
              << sParameters.referenceSurface().geometryId() << " --> "
              << dSurface.geometryId());
-  auto fwdStepFinal =
-      prop.propagate(sParameters, dSurface, fwdStepOptions).value();
+  auto fwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                     dSurface, fwdStepOptions)
+                          .value();
   auto fwdStepSurfacesTmp = collectRelevantGeoIds(
       fwdStepFinal.template get<SurfaceCollector::result_type>());
   fwdStepSurfaces.insert(fwdStepSurfaces.end(), fwdStepSurfacesTmp.begin(),
@@ -187,7 +191,7 @@ void runSelfConsistencyTest(const propagator_t& prop,
 
   // stepping from one surface to the next : backwards
   // now go from surface to surface and check
-  Options bwdStepOptions(tgContext, mfContext);
+  Options bwdStepOptions;
   bwdStepOptions.direction = Direction::Backward;
 
   // get the surface collector and configure it
@@ -207,8 +211,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
                << bwdSteps.surface->geometryId());
 
     // make a forward step
-    auto bwdStep =
-        prop.propagate(sParameters, *bwdSteps.surface, bwdStepOptions).value();
+    auto bwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                  *bwdSteps.surface, bwdStepOptions)
+                       .value();
 
     auto bwdStepSurfacesTmp = collectRelevantGeoIds(
         bwdStep.template get<SurfaceCollector::result_type>());
@@ -226,8 +231,9 @@ void runSelfConsistencyTest(const propagator_t& prop,
   ACTS_DEBUG(">>> Backward step : "
              << sParameters.referenceSurface().geometryId() << " --> "
              << dSurface.geometryId());
-  auto bwdStepFinal =
-      prop.propagate(sParameters, dbSurface, bwdStepOptions).value();
+  auto bwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                     dbSurface, bwdStepOptions)
+                          .value();
   auto bwdStepSurfacesTmp = collectRelevantGeoIds(
       bwdStepFinal.template get<SurfaceCollector::result_type>());
   bwdStepSurfaces.insert(bwdStepSurfaces.end(), bwdStepSurfacesTmp.begin(),
@@ -265,7 +271,7 @@ void runConsistencyTest(const propagator_probe_t& propProbe,
         typename propagator_t::template Options<ActionListType, AbortListType>;
 
     // forward surface test
-    Options fwdOptions(tgContext, mfContext);
+    Options fwdOptions;
     fwdOptions.pathLimit = 25_cm;
     fwdOptions.stepping.maxStepSize = 1_cm;
 
@@ -276,7 +282,8 @@ void runConsistencyTest(const propagator_probe_t& propProbe,
     fwdSurfaceCollector.selector.selectMaterial = true;
     fwdSurfaceCollector.selector.selectPassive = true;
 
-    auto fwdResult = prop.propagate(start, fwdOptions).value();
+    auto fwdResult =
+        prop.propagate(tgContext, mfContext, start, fwdOptions).value();
     auto fwdSurfaces = collectRelevantGeoIds(
         fwdResult.template get<SurfaceCollector::result_type>());
 

--- a/Tests/IntegrationTests/PropagationAtlasConstant.cpp
+++ b/Tests/IntegrationTests/PropagationAtlasConstant.cpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/Tests/IntegrationTests/PropagationBentTracks.cpp
+++ b/Tests/IntegrationTests/PropagationBentTracks.cpp
@@ -58,9 +58,9 @@ std::vector<double> xPositionsOfPassedSurfaces(Acts::Navigator::Config navCfg,
 
   Propagator::Options<Acts::ActionList<Acts::detail::SteppingLogger>,
                       Acts::AbortList<Acts::EndOfWorldReached>>
-      opts(geoCtx, magCtx);
+      opts;
 
-  auto res = propagator.propagate(start, opts);
+  auto res = propagator.propagate(geoCtx, magCtx, start, opts);
 
   BOOST_CHECK(res.ok());
 

--- a/Tests/IntegrationTests/PropagationTests.hpp
+++ b/Tests/IntegrationTests/PropagationTests.hpp
@@ -1,6 +1,6 @@
 // This file is part of the Acts project.
 //
-// Copyright (C) 2020 CERN for the benefit of the Acts project
+// Copyright (C) 2020-2024 CERN for the benefit of the Acts project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -243,13 +243,13 @@ inline std::pair<Acts::CurvilinearTrackParameters, double> transportFreely(
   using namespace Acts::UnitLiterals;
 
   // setup propagation options
-  options_t options(geoCtx, magCtx);
+  options_t options;
   options.direction = Acts::Direction::fromScalar(pathLength);
   options.pathLimit = pathLength;
   options.surfaceTolerance = 1_nm;
   options.stepping.stepTolerance = 1_nm;
 
-  auto result = propagator.propagate(initialParams, options);
+  auto result = propagator.propagate(geoCtx, magCtx, initialParams, options);
   BOOST_CHECK(result.ok());
   BOOST_CHECK(result.value().endParameters);
 
@@ -267,13 +267,14 @@ inline std::pair<Acts::BoundTrackParameters, double> transportToSurface(
   using namespace Acts::UnitLiterals;
 
   // setup propagation options
-  options_t options(geoCtx, magCtx);
+  options_t options;
   options.direction = Acts::Direction::Forward;
   options.pathLimit = pathLimit;
   options.surfaceTolerance = 1_nm;
   options.stepping.stepTolerance = 1_nm;
 
-  auto result = propagator.propagate(initialParams, targetSurface, options);
+  auto result = propagator.propagate(geoCtx, magCtx, initialParams,
+                                     targetSurface, options);
   BOOST_CHECK(result.ok());
   BOOST_CHECK(result.value().endParameters);
 

--- a/Tests/UnitTests/Alignment/Kernel/AlignmentTests.cpp
+++ b/Tests/UnitTests/Alignment/Kernel/AlignmentTests.cpp
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(ZeroFieldKalmanAlignment) {
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
   KalmanFitterOptions kfOptions(geoCtx, magCtx, calCtx, extensions,
-                                PropagatorPlainOptions(geoCtx, magCtx));
+                                PropagatorPlainOptions());
 
   // Construct a non-updating alignment updater
   AlignedTransformUpdater voidAlignUpdater =

--- a/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/VolumeMaterialMapperTests.cpp
@@ -270,11 +270,11 @@ BOOST_AUTO_TEST_CASE(VolumeMaterialMapper_comparison_tests) {
   // Launch propagation and gather result
   using PropagatorOptions = Propagator<StraightLineStepper, Navigator>::Options<
       ActionList<MaterialCollector>, AbortList<EndOfWorldReached>>;
-  PropagatorOptions po(gc, mc);
+  PropagatorOptions po;
   po.stepping.maxStepSize = 1._mm;
   po.maxSteps = 1e6;
 
-  const auto& result = prop.propagate(sctp, po).value();
+  const auto& result = prop.propagate(gc, mc, sctp, po).value();
   const MaterialCollector::this_result& stepResult =
       result.get<typename MaterialCollector::result_type>();
 

--- a/Tests/UnitTests/Core/Navigation/DetectorNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/DetectorNavigatorTests.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
   using AbortList = Acts::AbortList<>;
   using PropagatorOptions = Propagator::Options<ActionList, AbortList>;
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
 
   Stepper stepper;
 
@@ -99,8 +99,9 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
 
     Propagator propagator(stepper, navigator);
 
-    BOOST_CHECK_THROW(propagator.makeState(start, options),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW(
+        propagator.makeState(geoContext, mfContext, start, options),
+        std::invalid_argument);
   }
 
   // Run with geometry but without resolving
@@ -117,7 +118,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    auto state = propagator.makeState(start, options);
+    auto state = propagator.makeState(geoContext, mfContext, start, options);
 
     navigator.initialize(state, stepper);
 
@@ -151,8 +152,9 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    BOOST_CHECK_THROW(propagator.makeState(startEoW, options),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW(
+        propagator.makeState(geoContext, mfContext, startEoW, options),
+        std::invalid_argument);
   }
 
   // Initialize properly
@@ -166,7 +168,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsInitialization) {
                      Acts::Experimental::DetectorNavigator>
         propagator(stepper, navigator);
 
-    auto state = propagator.makeState(start, options);
+    auto state = propagator.makeState(geoContext, mfContext, start, options);
 
     navigator.initialize(state, stepper);
     auto initState = state.navigation;
@@ -281,7 +283,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -295,7 +297,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
       posFwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultFwd = propagator.propagate(startFwd, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, startFwd, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
@@ -305,7 +308,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsForwardBackward) {
       posBwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultBwd = propagator.propagate(startBwd, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, startBwd, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 7 steps to reach the end of world
@@ -436,7 +440,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsAmbiguity) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -452,12 +456,14 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsAmbiguity) {
 
   // Has to properly handle propagation in the
   // forward and backward direction
-  auto resultFwd = propagator.propagate(start, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, start, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
 
-  auto resultBwd = propagator.propagate(start, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, start, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 3 steps to reach the end of world
@@ -550,7 +556,7 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
                       Acts::getDefaultLogger("DetectorNavigator",
                                              Acts::Logging::Level::VERBOSE));
 
-  PropagatorOptions options(geoContext, mfContext);
+  PropagatorOptions options;
   options.direction = Acts::Direction::Forward;
 
   Propagator propagator(
@@ -566,7 +572,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
       posFwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultFwd = propagator.propagate(startFwd, options).value();
+  auto resultFwd =
+      propagator.propagate(geoContext, mfContext, startFwd, options).value();
   auto statesFwd = resultFwd.get<StateRecorder::result_type>();
 
   options.direction = Acts::Direction::Backward;
@@ -575,7 +582,8 @@ BOOST_AUTO_TEST_CASE(DetectorNavigatorTestsMultipleIntersection) {
       posBwd, 0_degree, 90_degree, 1_e / 1_GeV, std::nullopt,
       Acts::ParticleHypothesis::electron());
 
-  auto resultBwd = propagator.propagate(startBwd, options).value();
+  auto resultBwd =
+      propagator.propagate(geoContext, mfContext, startBwd, options).value();
   auto statesBwd = resultBwd.get<StateRecorder::result_type>();
 
   // 4 steps to reach the end of world

--- a/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/AtlasStepperTests.cpp
@@ -244,7 +244,8 @@ BOOST_AUTO_TEST_CASE(BuildBound) {
   // example surface at the current state position
   auto plane = Surface::makeShared<PlaneSurface>(pos, unitDir);
 
-  auto&& [pars, jac, pathLength] = stepper.boundState(state, *plane).value();
+  auto&& [pars, jac, pathLength] =
+      stepper.boundState(geoCtx, state, *plane).value();
   // check parameters
   CHECK_CLOSE_ABS(pars.position(geoCtx), pos, eps);
   CHECK_CLOSE_ABS(pars.time(), time, eps);

--- a/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/BoundToCurvilinearConversionTests.cpp
@@ -240,7 +240,7 @@ void test_bound_to_curvilinear(const std::vector<TestData> &test_data_list,
       using PropagatorOptions = typename Propagator::template Options<>;
 
       // configure propagator for tiny step size
-      PropagatorOptions null_propagation_options(geoCtx, magFieldContext);
+      PropagatorOptions null_propagation_options;
 
       null_propagation_options.pathLimit =
           i == 0 ? 0 : 1e-12 * 1_m * std::pow(10, i - 1);
@@ -258,8 +258,8 @@ void test_bound_to_curvilinear(const std::vector<TestData> &test_data_list,
       // curvilinear parameterisation
       Propagator propagator(std::move(stepper), Acts::VoidNavigator(),
                             Acts::getDefaultLogger("Propagator", log_level));
-      auto result =
-          propagator.propagate(params, null_propagation_options, true);
+      auto result = propagator.propagate(geoCtx, magFieldContext, params,
+                                         null_propagation_options, true);
       {
         const auto &curvilinear_parameters = result.value().endParameters;
         if (curvilinear_parameters.has_value() &&

--- a/Tests/UnitTests/Core/Propagator/CovarianceEngineTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/CovarianceEngineTests.cpp
@@ -199,14 +199,14 @@ using propagator_t = Propagator<EigenStepper<>, VoidNavigator>;
 BoundVector localToLocal(const propagator_t& prop, const BoundVector& local,
                          const Surface& src, const Surface& dst) {
   using PropagatorOptions = typename propagator_t::template Options<>;
-  PropagatorOptions options{gctx, mctx};
+  PropagatorOptions options;
   options.stepping.stepTolerance = 1e-10;
   options.surfaceTolerance = 1e-10;
 
   BoundTrackParameters start{src.getSharedPtr(), local, std::nullopt,
                              ParticleHypothesis::pion()};
 
-  auto res = prop.propagate(start, dst, options).value();
+  auto res = prop.propagate(gctx, mctx, start, dst, options).value();
   auto endParameters = res.endParameters.value();
 
   BOOST_CHECK_EQUAL(&endParameters.referenceSurface(), &dst);

--- a/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
@@ -113,7 +113,7 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
   // Options definition
   using Options = typename rpropagator_t::template Options<RefereceActionList,
                                                            ReferenceAbortList>;
-  Options pOptions(tgContext, mfContext);
+  Options pOptions;
   if (oversteppingTest) {
     pOptions.stepping.maxStepSize = oversteppingMaxStepSize;
   }
@@ -124,7 +124,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
   sCollector.selector.selectMaterial = true;
 
   // Result is immediately used, non-valid result would indicate failure
-  const auto& pResult = rprop.propagate(start, pOptions).value();
+  const auto& pResult =
+      rprop.propagate(tgContext, mfContext, start, pOptions).value();
   auto& cSurfaces = pResult.template get<SurfaceCollector<>::result_type>();
   auto& cMaterial = pResult.template get<MaterialInteractor::result_type>();
   const Surface& destination = pResult.endParameters->referenceSurface();
@@ -147,7 +148,7 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
     // Direct options definition
     using DirectOptions =
         typename dpropagator_t::template Options<DirectActionList, AbortList<>>;
-    DirectOptions dOptions(tgContext, mfContext);
+    DirectOptions dOptions;
     // Set the surface sequence
     auto& dInitializer =
         dOptions.actionList.template get<DirectNavigator::Initializer>();
@@ -159,7 +160,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
 
     // Now redo the propagation with the direct propagator
     const auto& ddResult =
-        dprop.propagate(start, destination, dOptions).value();
+        dprop.propagate(tgContext, mfContext, start, destination, dOptions)
+            .value();
     auto& ddSurfaces = ddResult.template get<SurfaceCollector<>::result_type>();
     auto& ddMaterial = ddResult.template get<MaterialInteractor::result_type>();
 
@@ -168,7 +170,8 @@ void runTest(const rpropagator_t& rprop, const dpropagator_t& dprop, double pT,
     CHECK_CLOSE_REL(cMaterial.materialInX0, ddMaterial.materialInX0, 1e-3);
 
     // Now redo the propagation with the direct propagator - without destination
-    const auto& dwResult = dprop.propagate(start, dOptions).value();
+    const auto& dwResult =
+        dprop.propagate(tgContext, mfContext, start, dOptions).value();
     auto& dwSurfaces = dwResult.template get<SurfaceCollector<>::result_type>();
 
     // CHECK if you have as many surfaces collected as the default navigator

--- a/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
@@ -593,7 +593,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.maxSteps = 100;
   propOpts.stepping.maxStepSize = 1.5_m;
 
@@ -603,7 +603,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   Propagator prop(es, naviVac);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -627,7 +628,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  DefPropagatorOptions propOptsDef(tgContext, mfContext);
+  DefPropagatorOptions propOptsDef;
   propOptsDef.maxSteps = 100;
   propOptsDef.stepping.maxStepSize = 1.5_m;
 
@@ -635,7 +636,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   DefPropagator propDef(esDef, naviVac);
 
   // Launch and collect results
-  const auto& resultDef = propDef.propagate(sbtp, propOptsDef).value();
+  const auto& resultDef =
+      propDef.propagate(tgContext, mfContext, sbtp, propOptsDef).value();
   const StepCollector::this_result& stepResultDef =
       resultDef.get<typename StepCollector::result_type>();
 
@@ -692,7 +694,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.maxSteps = 10000;
   propOpts.stepping.maxStepSize = 1.5_m;
 
@@ -703,7 +705,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
                   Acts::getDefaultLogger("Propagator", Acts::Logging::VERBOSE));
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -737,7 +740,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
 
   // Rebuild and check the choice of extension
   // Set options for propagator
-  DensePropagatorOptions propOptsDense(tgContext, mfContext);
+  DensePropagatorOptions propOptsDense;
   propOptsDense.maxSteps = 1000;
   propOptsDense.stepping.maxStepSize = 1.5_m;
 
@@ -746,7 +749,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   DensePropagator propDense(esDense, naviMat);
 
   // Launch and collect results
-  const auto& resultDense = propDense.propagate(sbtp, propOptsDense).value();
+  const auto& resultDense =
+      propDense.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultDense =
       resultDense.get<typename StepCollector::result_type>();
 
@@ -770,7 +774,8 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   Stepper esB(bField);
   Propagator propB(esB, naviMat);
 
-  const auto& resultB = propB.propagate(sbtp, propOptsDense).value();
+  const auto& resultB =
+      propB.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultB =
       resultB.get<typename StepCollector::result_type>();
 
@@ -842,7 +847,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.abortList.get<EndOfWorld>().maxX = 3_m;
   propOpts.maxSteps = 1000;
   propOpts.stepping.maxStepSize = 1.5_m;
@@ -853,7 +858,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   Propagator prop(es, naviDet);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 
@@ -895,7 +901,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   using DefPropagatorOptions =
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
 
-  DefPropagatorOptions propOptsDef(tgContext, mfContext);
+  DefPropagatorOptions propOptsDef;
   propOptsDef.abortList.get<EndOfWorld>().maxX = 3_m;
   propOptsDef.maxSteps = 1000;
   propOptsDef.stepping.maxStepSize = 1.5_m;
@@ -905,7 +911,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   DefPropagator propDef(esDef, naviDet);
 
   // Launch and collect results
-  const auto& resultDef = propDef.propagate(sbtp, propOptsDef).value();
+  const auto& resultDef =
+      propDef.propagate(tgContext, mfContext, sbtp, propOptsDef).value();
   const StepCollector::this_result& stepResultDef =
       resultDef.get<typename StepCollector::result_type>();
 
@@ -948,7 +955,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
                                AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  DensePropagatorOptions propOptsDense(tgContext, mfContext);
+  DensePropagatorOptions propOptsDense;
   propOptsDense.abortList.get<EndOfWorld>().maxX = 3_m;
   propOptsDense.maxSteps = 1000;
   propOptsDense.stepping.maxStepSize = 1.5_m;
@@ -958,7 +965,8 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   DensePropagator propDense(esDense, naviDet);
 
   // Launch and collect results
-  const auto& resultDense = propDense.propagate(sbtp, propOptsDense).value();
+  const auto& resultDense =
+      propDense.propagate(tgContext, mfContext, sbtp, propOptsDense).value();
   const StepCollector::this_result& stepResultDense =
       resultDense.get<typename StepCollector::result_type>();
 
@@ -1080,7 +1088,7 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
                           AbortList<EndOfWorld>>;
 
   // Set options for propagator
-  PropagatorOptions propOpts(tgContext, mfContext);
+  PropagatorOptions propOpts;
   propOpts.abortList.get<EndOfWorld>().maxX = 3._m;
   propOpts.maxSteps = 10000;
 
@@ -1090,7 +1098,8 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
   Propagator prop(es, naviVac);
 
   // Launch and collect results
-  const auto& result = prop.propagate(sbtp, propOpts).value();
+  const auto& result =
+      prop.propagate(tgContext, mfContext, sbtp, propOpts).value();
   const StepCollector::this_result& stepResult =
       result.get<typename StepCollector::result_type>();
 

--- a/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/ExtrapolatorTests.cpp
@@ -112,12 +112,13 @@ BOOST_DATA_TEST_CASE(
   CurvilinearTrackParameters start(Vector4(0, 0, 0, 0), phi, theta, q / p, cov,
                                    ParticleHypothesis::pion());
 
-  EigenPropagatorType::Options<> options(tgContext, mfContext);
+  EigenPropagatorType::Options<> options;
   options.stepping.maxStepSize = 10_cm;
   options.pathLimit = 25_cm;
 
-  BOOST_CHECK(
-      epropagator.propagate(start, options).value().endParameters.has_value());
+  BOOST_CHECK(epropagator.propagate(tgContext, mfContext, start, options)
+                  .value()
+                  .endParameters.has_value());
 }
 
 // This test case checks that no segmentation fault appears
@@ -157,17 +158,17 @@ BOOST_DATA_TEST_CASE(
   // A PlaneSelector for the SurfaceCollector
   using PlaneCollector = SurfaceCollector<PlaneSelector>;
 
-  EigenPropagatorType::Options<ActionList<PlaneCollector>> options(tgContext,
-                                                                   mfContext);
+  EigenPropagatorType::Options<ActionList<PlaneCollector>> options;
 
   options.stepping.maxStepSize = 10_cm;
   options.pathLimit = 25_cm;
 
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   auto collector_result = result.get<PlaneCollector::result_type>();
 
   // step through the surfaces and go step by step
-  EigenPropagatorType::Options<> optionsEmpty(tgContext, mfContext);
+  EigenPropagatorType::Options<> optionsEmpty;
 
   optionsEmpty.stepping.maxStepSize = 25_cm;
   // Try propagation from start to each surface
@@ -179,9 +180,11 @@ BOOST_DATA_TEST_CASE(
       continue;
     }
     // Extrapolate & check
-    const auto& cresult = epropagator.propagate(start, *csurface, optionsEmpty)
-                              .value()
-                              .endParameters;
+    const auto& cresult =
+        epropagator
+            .propagate(tgContext, mfContext, start, *csurface, optionsEmpty)
+            .value()
+            .endParameters;
     BOOST_CHECK(cresult.has_value());
   }
 }
@@ -220,12 +223,12 @@ BOOST_DATA_TEST_CASE(
   CurvilinearTrackParameters start(Vector4(0, 0, 0, 0), phi, theta, q / p, cov,
                                    ParticleHypothesis::pion());
 
-  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options(
-      tgContext, mfContext);
+  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options;
   options.stepping.maxStepSize = 25_cm;
   options.pathLimit = 25_cm;
 
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   if (result.endParameters) {
     // test that you actually lost some energy
     BOOST_CHECK_LT(result.endParameters->absoluteMomentum(),
@@ -268,12 +271,12 @@ BOOST_DATA_TEST_CASE(
                                    ParticleHypothesis::pion());
 
   // Action list and abort list
-  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options(
-      tgContext, mfContext);
+  EigenPropagatorType::Options<ActionList<MaterialInteractor>> options;
   options.stepping.maxStepSize = 25_cm;
   options.pathLimit = 1500_mm;
 
-  const auto& status = epropagator.propagate(start, options).value();
+  const auto& status =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
   // this test assumes state.options.loopFraction = 0.5
   // maximum momentum allowed
   auto bCache = bField->makeCache(mfContext);

--- a/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/KalmanExtrapolatorTests.cpp
@@ -140,19 +140,21 @@ BOOST_AUTO_TEST_CASE(kalman_extrapolator) {
 
   // Create some options
   using StepWiseOptions = Propagator::Options<StepWiseActors, Aborters>;
-  StepWiseOptions swOptions(tgContext, mfContext);
+  StepWiseOptions swOptions;
 
   using PlainActors = ActionList<>;
   using PlainOptions = Propagator::Options<PlainActors, Aborters>;
-  PlainOptions pOptions(tgContext, mfContext);
+  PlainOptions pOptions;
 
   // Run the standard propagation
-  const auto& pResult = propagator.propagate(start, pOptions).value();
+  const auto& pResult =
+      propagator.propagate(tgContext, mfContext, start, pOptions).value();
   // Let's get the end parameters and jacobian matrix
   const auto& pJacobian = *(pResult.transportJacobian);
 
   // Run the stepwise propagation
-  const auto& swResult = propagator.propagate(start, swOptions).value();
+  const auto& swResult =
+      propagator.propagate(tgContext, mfContext, start, swOptions).value();
   auto swJacobianTest = swResult.template get<StepWiseResult>();
 
   // (1) Path length test

--- a/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/LoopProtectionTests.cpp
@@ -199,9 +199,10 @@ BOOST_DATA_TEST_CASE(
                                    std::nullopt, ParticleHypothesis::pion());
 
   using PropagatorOptions = EigenPropagator::Options<ActionList<>, AbortList<>>;
-  PropagatorOptions options(tgContext, mfContext);
+  PropagatorOptions options;
   options.maxSteps = 1e6;
-  const auto& result = epropagator.propagate(start, options).value();
+  const auto& result =
+      epropagator.propagate(tgContext, mfContext, start, options).value();
 
   // this test assumes state.options.loopFraction = 0.5
   CHECK_CLOSE_REL(px, -result.endParameters->momentum().x(), 1e-2);

--- a/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MaterialCollectionTests.cpp
@@ -91,7 +91,7 @@ void runTest(const propagator_t& prop,
 
   using Options =
       typename propagator_t::template Options<ActionListType, AbortListType>;
-  Options fwdOptions(tgContext, mfContext);
+  Options fwdOptions;
   fwdOptions.stepping.maxStepSize = 25_cm;
   fwdOptions.pathLimit = 25_cm;
 
@@ -106,7 +106,8 @@ void runTest(const propagator_t& prop,
     std::cout << ">>> Forward Propagation : start." << std::endl;
   }
   // forward material test
-  const auto& fwdResult = prop.propagate(start, fwdOptions).value();
+  const auto& fwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
   const auto& fwdMaterial =
       fwdResult.template get<MaterialInteractor::result_type>();
   // check that the collected material is not zero
@@ -134,7 +135,7 @@ void runTest(const propagator_t& prop,
   }
 
   // backward material test
-  Options bwdOptions(tgContext, mfContext);
+  Options bwdOptions;
   bwdOptions.stepping.maxStepSize = 25_cm;
   bwdOptions.pathLimit = -25_cm;
   bwdOptions.direction = Direction::Backward;
@@ -152,7 +153,8 @@ void runTest(const propagator_t& prop,
     std::cout << ">>> Backward Propagation : start." << std::endl;
   }
   const auto& bwdResult =
-      prop.propagate(*fwdResult.endParameters, startSurface, bwdOptions)
+      prop.propagate(tgContext, mfContext, *fwdResult.endParameters,
+                     startSurface, bwdOptions)
           .value();
   if (debugMode) {
     std::cout << ">>> Backward Propagation : end." << std::endl;
@@ -192,7 +194,7 @@ void runTest(const propagator_t& prop,
 
   // stepping from one surface to the next
   // now go from surface to surface and check
-  Options fwdStepOptions(tgContext, mfContext);
+  Options fwdStepOptions;
   fwdStepOptions.stepping.maxStepSize = 25_cm;
   fwdStepOptions.pathLimit = 25_cm;
 
@@ -227,9 +229,9 @@ void runTest(const propagator_t& prop,
     }
 
     // make a forward step
-    const auto& fwdStep =
-        prop.propagate(sParameters, (*fwdSteps.surface), fwdStepOptions)
-            .value();
+    const auto& fwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                         (*fwdSteps.surface), fwdStepOptions)
+                              .value();
 
     auto& fwdStepMaterial =
         fwdStep.template get<typename MaterialInteractor::result_type>();
@@ -251,8 +253,9 @@ void runTest(const propagator_t& prop,
               << dSurface.geometryId() << std::endl;
   }
 
-  const auto& fwdStepFinal =
-      prop.propagate(sParameters, dSurface, fwdStepOptions).value();
+  const auto& fwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                            dSurface, fwdStepOptions)
+                                 .value();
 
   auto& fwdStepMaterial =
       fwdStepFinal.template get<typename MaterialInteractor::result_type>();
@@ -265,7 +268,7 @@ void runTest(const propagator_t& prop,
 
   // stepping from one surface to the next : backwards
   // now go from surface to surface and check
-  Options bwdStepOptions(tgContext, mfContext);
+  Options bwdStepOptions;
   bwdStepOptions.stepping.maxStepSize = 25_cm;
   bwdStepOptions.pathLimit = -25_cm;
   bwdStepOptions.direction = Direction::Backward;
@@ -299,9 +302,9 @@ void runTest(const propagator_t& prop,
                 << bwdSteps.surface->geometryId() << std::endl;
     }
     // make a forward step
-    const auto& bwdStep =
-        prop.propagate(sParameters, (*bwdSteps.surface), bwdStepOptions)
-            .value();
+    const auto& bwdStep = prop.propagate(tgContext, mfContext, sParameters,
+                                         (*bwdSteps.surface), bwdStepOptions)
+                              .value();
 
     auto& bwdStepMaterial =
         bwdStep.template get<typename MaterialInteractor::result_type>();
@@ -323,8 +326,9 @@ void runTest(const propagator_t& prop,
               << dSurface.geometryId() << std::endl;
   }
 
-  const auto& bwdStepFinal =
-      prop.propagate(sParameters, dbSurface, bwdStepOptions).value();
+  const auto& bwdStepFinal = prop.propagate(tgContext, mfContext, sParameters,
+                                            dbSurface, bwdStepOptions)
+                                 .value();
 
   auto& bwdStepMaterial =
       bwdStepFinal.template get<typename MaterialInteractor::result_type>();
@@ -344,7 +348,8 @@ void runTest(const propagator_t& prop,
   covfwdMaterialInteractor.multipleScattering = true;
 
   // forward material test
-  const auto& covfwdResult = prop.propagate(start, fwdOptions).value();
+  const auto& covfwdResult =
+      prop.propagate(tgContext, mfContext, start, fwdOptions).value();
 
   BOOST_CHECK_LE(
       start.covariance()->determinant(),

--- a/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
@@ -736,7 +736,7 @@ void propagator_instatiation_test_function() {
       Vector3::Zero(), Vector3{1.0, 0.0, 0.0});
   using PropagatorOptions =
       typename Propagator<multi_stepper_t, Navigator>::template Options<>;
-  PropagatorOptions options(geoCtx, magCtx);
+  PropagatorOptions options;
 
   std::vector<std::tuple<double, BoundVector, std::optional<BoundSquareMatrix>>>
       cmps(4, {0.25, BoundVector::Ones().eval(),
@@ -750,10 +750,10 @@ void propagator_instatiation_test_function() {
   using type_a =
       decltype(propagator.template propagate<decltype(pars), decltype(options),
                                              MultiStepperSurfaceReached>(
-          pars, *surface, options));
+          geoCtx, magCtx, pars, *surface, options));
 
   // Instantiate without target
-  using tybe_b = decltype(propagator.propagate(pars, options));
+  using tybe_b = decltype(propagator.propagate(geoCtx, magCtx, pars, options));
 }
 
 BOOST_AUTO_TEST_CASE(propagator_instatiation_test) {

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -98,12 +98,11 @@ struct PropagatorState {
 
       // Previous step size for overstep estimation (ignored here)
       double previousStepSize = 0.;
-
-      GeometryContext geoContext = GeometryContext();
     };
 
     /// State resetter
-    void resetState(State& /*state*/, const BoundVector& /*boundParams*/,
+    void resetState(const GeometryContext& /*gctx*/, State& /*state*/,
+                    const BoundVector& /*boundParams*/,
                     const BoundSquareMatrix& /*cov*/,
                     const Surface& /*surface*/,
                     const double /*stepSize*/) const {}
@@ -139,11 +138,12 @@ struct PropagatorState {
     }
 
     Intersection3D::Status updateSurfaceStatus(
-        State& state, const Surface& surface, std::uint8_t index,
-        Direction navDir, const BoundaryTolerance& boundaryTolerance,
-        ActsScalar surfaceTolerance, const Logger& logger) const {
+        const GeometryContext& gctx, State& state, const Surface& surface,
+        std::uint8_t index, Direction navDir,
+        const BoundaryTolerance& boundaryTolerance, ActsScalar surfaceTolerance,
+        const Logger& logger) const {
       return detail::updateSingleSurfaceStatus<Stepper>(
-          *this, state, surface, index, navDir, boundaryTolerance,
+          gctx, *this, state, surface, index, navDir, boundaryTolerance,
           surfaceTolerance, logger);
     }
 
@@ -174,11 +174,12 @@ struct PropagatorState {
     }
 
     Result<BoundState> boundState(
-        State& state, const Surface& surface, bool /*transportCov*/,
+        const GeometryContext& gctx, State& state, const Surface& surface,
+        bool /*transportCov*/,
         const FreeToBoundCorrection& /*freeToBoundCorrection*/
     ) const {
       auto bound = BoundTrackParameters::create(
-          surface.getSharedPtr(), tgContext, state.pos4, state.dir,
+          surface.getSharedPtr(), gctx, state.pos4, state.dir,
           state.q / state.p, std::nullopt, state.particleHypothesis);
       if (!bound.ok()) {
         return bound.error();
@@ -188,8 +189,8 @@ struct PropagatorState {
       return bState;
     }
 
-    CurvilinearState curvilinearState(State& state, bool /*transportCov*/
-    ) const {
+    CurvilinearState curvilinearState(State& state,
+                                      bool /*transportCov*/) const {
       CurvilinearTrackParameters parameters(state.pos4, state.dir,
                                             state.q / state.p, std::nullopt,
                                             state.particleHypothesis);
@@ -199,7 +200,8 @@ struct PropagatorState {
       return curvState;
     }
 
-    void update(State& /*state*/, const FreeVector& /*freePars*/,
+    void update(const GeometryContext& /*gctx*/, State& /*state*/,
+                const FreeVector& /*freePars*/,
                 const BoundVector& /*boundPars*/, const Covariance& /*cov*/,
                 const Surface& /*surface*/) const {}
 
@@ -210,7 +212,8 @@ struct PropagatorState {
     void transportCovarianceToCurvilinear(State& /*state*/) const {}
 
     void transportCovarianceToBound(
-        State& /*state*/, const Surface& /*surface*/,
+        const GeometryContext& /*gctx*/, State& /*state*/,
+        const Surface& /*surface*/,
         const FreeToBoundCorrection& /*freeToBoundCorrection*/) const {}
 
     Result<Vector3> getField(State& /*state*/, const Vector3& /*pos*/) const {

--- a/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineSurfaceTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/EventData/ParticleHypothesis.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/StraightLineStepper.hpp"
@@ -50,6 +51,7 @@ namespace Acts::Test {
 
 // Create a test context
 GeometryContext tgContext = GeometryContext();
+MagneticFieldContext mfContext = MagneticFieldContext();
 
 BOOST_AUTO_TEST_SUITE(Surfaces)
 
@@ -321,11 +323,12 @@ BOOST_AUTO_TEST_CASE(LineSurfaceIntersection) {
       Vector4::Zero(), Vector3::Zero(), 1, std::nullopt,
       ParticleHypothesis::pion()};
   {
-    PropagatorOptions options(tgContext, {});
+    PropagatorOptions options;
     options.direction = Acts::Direction::Backward;
     options.pathLimit = pathLimit;
 
-    auto result = propagator.propagate(initialParams, options);
+    auto result =
+        propagator.propagate(tgContext, mfContext, initialParams, options);
     BOOST_CHECK(result.ok());
     BOOST_CHECK(result.value().endParameters);
 
@@ -342,11 +345,12 @@ BOOST_AUTO_TEST_CASE(LineSurfaceIntersection) {
   BoundTrackParameters endParameters{surface, BoundVector::Zero(), std::nullopt,
                                      ParticleHypothesis::pion()};
   {
-    PropagatorOptions options(tgContext, {});
+    PropagatorOptions options;
     options.direction = Acts::Direction::Forward;
     options.stepping.maxStepSize = 1_mm;
 
-    auto result = propagator.propagate(displacedParameters, *surface, options);
+    auto result = propagator.propagate(tgContext, mfContext,
+                                       displacedParameters, *surface, options);
     BOOST_CHECK(result.ok());
     BOOST_CHECK(result.value().endParameters);
     CHECK_CLOSE_ABS(result.value().pathLength, pathLimit, eps);

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -292,7 +292,7 @@ struct Fixture {
     return CombinatorialKalmanFilterOptions(
         geoCtx, magCtx, calCtx,
         Acts::SourceLinkAccessorDelegate<TestSourceLinkAccessor::Iterator>{},
-        getExtensions(), Acts::PropagatorPlainOptions(geoCtx, magCtx));
+        getExtensions(), Acts::PropagatorPlainOptions());
   }
 };
 

--- a/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
@@ -101,8 +101,7 @@ auto makeDefaultGsfOptions() {
   GsfOptions<VectorMultiTrajectory> opts{tester.geoCtx, tester.magCtx,
                                          tester.calCtx};
   opts.extensions = getExtensions();
-  opts.propagatorPlainOptions =
-      PropagatorPlainOptions(tester.geoCtx, tester.magCtx);
+  opts.propagatorPlainOptions = PropagatorPlainOptions();
   return opts;
 }
 

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -239,9 +239,8 @@ BOOST_AUTO_TEST_CASE(NoFit) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 0, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 0, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -327,9 +326,8 @@ BOOST_AUTO_TEST_CASE(Fit5Iterations) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -433,9 +431,8 @@ BOOST_AUTO_TEST_CASE(MixedDetector) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -529,9 +526,8 @@ BOOST_AUTO_TEST_CASE(FitWithBfield) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -627,9 +623,8 @@ BOOST_AUTO_TEST_CASE(relChi2changeCutOff) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 500, 1e-5);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 500, 1e-5);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -728,9 +723,8 @@ BOOST_AUTO_TEST_CASE(DidNotConverge) {
   // Since we didn't break due to convergence, we reach nUpdatesMax and
   // therefore fail the fit.
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 6, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 6, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -797,9 +791,8 @@ BOOST_AUTO_TEST_CASE(NotEnoughMeasurements) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 6, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 6, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -886,9 +879,8 @@ BOOST_AUTO_TEST_CASE(FindHoles) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 20, 1e-5);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 20, 1e-5);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};
@@ -992,9 +984,8 @@ BOOST_AUTO_TEST_CASE(Material) {
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
 
   const Experimental::Gx2FitterOptions gx2fOptions(
-      geoCtx, magCtx, calCtx, extensions,
-      PropagatorPlainOptions(geoCtx, magCtx), rSurface, false, false,
-      FreeToBoundCorrection(false), 5, 0);
+      geoCtx, magCtx, calCtx, extensions, PropagatorPlainOptions(), rSurface,
+      false, false, FreeToBoundCorrection(false), 5, 0);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};

--- a/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
@@ -102,9 +102,8 @@ auto makeDefaultKalmanFitterOptions() {
       &Acts::detail::Test::TestSourceLink::SurfaceAccessor::operator()>(
       &tester.surfaceAccessor);
 
-  return KalmanFitterOptions(
-      tester.geoCtx, tester.magCtx, tester.calCtx, extensions,
-      PropagatorPlainOptions(tester.geoCtx, tester.magCtx));
+  return KalmanFitterOptions(tester.geoCtx, tester.magCtx, tester.calCtx,
+                             extensions, PropagatorPlainOptions());
 }
 
 }  // namespace

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -257,7 +257,7 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
   auto refPerigeeSurface = Surface::makeShared<PerigeeSurface>(refPoint);
 
   // Set up the propagator options (they are the same with and without B field)
-  PropagatorOptions pOptions(geoContext, magFieldContext);
+  PropagatorOptions pOptions;
   auto intersection =
       refPerigeeSurface
           ->intersect(geoContext, params.position(geoContext),
@@ -267,13 +267,14 @@ BOOST_DATA_TEST_CASE(TimeAtPca, tracksWithoutIPs* vertices, t0, phi, theta, p,
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
   // Propagate to the 2D PCA of the reference point in a constant B field
-  auto result = propagator->propagate(params, *refPerigeeSurface, pOptions);
+  auto result = propagator->propagate(geoContext, magFieldContext, params,
+                                      *refPerigeeSurface, pOptions);
   BOOST_CHECK(result.ok());
   const auto& refParams = *result->endParameters;
 
   // Propagate to the 2D PCA of the reference point when B = 0
-  auto zeroFieldResult =
-      straightLinePropagator->propagate(params, *refPerigeeSurface, pOptions);
+  auto zeroFieldResult = straightLinePropagator->propagate(
+      geoContext, magFieldContext, params, *refPerigeeSurface, pOptions);
   BOOST_CHECK(zeroFieldResult.ok());
   const auto& zeroFieldRefParams = *zeroFieldResult->endParameters;
 

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -357,8 +357,7 @@ static inline std::string testMultiTrajectory(IVisualization3D& helper) {
           &surfaceAccessor);
 
   KalmanFitterOptions kfOptions(tgContext, mfContext, calContext, extensions,
-                                PropagatorPlainOptions(tgContext, mfContext),
-                                rSurface);
+                                PropagatorPlainOptions(), rSurface);
 
   Acts::TrackContainer tracks{Acts::VectorTrackContainer{},
                               Acts::VectorMultiTrajectory{}};


### PR DESCRIPTION
Similar to https://github.com/acts-project/acts/pull/3378 the context arguments are moved from vertexing options to vertexing calls.

blocked by:
- https://github.com/acts-project/acts/pull/3378