### PR TITLE
docs: Load linkcheck ignore patterns from URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,9 @@ import subprocess
 from pathlib import Path
 import shutil
 import datetime
+import urllib.request
+import urllib.error
+import json
 
 # check if we are running on readthedocs.org
 on_readthedocs = os.environ.get("READTHEDOCS", None) == "True"
@@ -59,11 +62,22 @@ myst_heading_anchors = 3
 myst_dmath_allow_labels = True
 
 linkcheck_retries = 5
-linkcheck_ignore = [
-    r"https://doi.org/.*",  # frequently unreachable
-    r"https://pythia.org.*",  # frequently unreachable
-    r"https://eigen.tuxfamily.org.*",  # frequently down
-]
+linkcheck_ignore = []
+
+# Linkcheck ignore patterns are loaded from this URL, so we can
+# update without adding pull requests.
+linkcheck_ignore_url = (
+    "https://raw.githubusercontent.com/acts-project/linkcheck-ignore/main/data.json"
+)
+try:
+    response = urllib.request.urlopen(linkcheck_ignore_url)
+    linkcheck_ignore = json.loads(response.read().decode("utf-8"))
+except urllib.error.HTTPError:
+    print("Error getting linkcheck ignore data, using default")
+
+print("Link check ignore patterns")
+print(linkcheck_ignore)
+
 
 # -- Options for HTML output --------------------------------------------------
 


### PR DESCRIPTION
This allows us to fix this without creating pull-requests every time anything goes down.