### PR TITLE
refactor: Move config files from ODD to Acts to ensure compatibility

### DIFF
--- a/CI/physmon/physmon_common.py
+++ b/CI/physmon/physmon_common.py
@@ -22,6 +22,7 @@ PhysmonSetup = collections.namedtuple(
 def makeSetup() -> PhysmonSetup:
     u = acts.UnitConstants
     srcdir = Path(__file__).resolve().parent.parent.parent
+    algdir = srcdir / "Examples/Algorithms"
 
     parser = argparse.ArgumentParser()
     parser.add_argument("outdir")
@@ -38,9 +39,8 @@ def makeSetup() -> PhysmonSetup:
         detector=detector,
         trackingGeometry=trackingGeometry,
         decorators=decorators,
-        digiConfig=srcdir
-        / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json",
-        geoSel=srcdir / "thirdparty/OpenDataDetector/config/odd-seeding-config.json",
+        digiConfig=algdir / "Digitization/share/odd-digi-smearing-config.json",
+        geoSel=algdir / "TrackFinding/share/odd-seeding-config.json",
         field=acts.ConstantBField(acts.Vector3(0, 0, 2 * u.T)),
         outdir=Path(args.outdir),
     )

--- a/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
+++ b/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
@@ -17,6 +17,7 @@
 #include <stdexcept>
 #include <utility>
 #include <vector>
+#include <sstream>
 
 namespace Acts {
 
@@ -220,7 +221,9 @@ inline void GeometryHierarchyMap<value_t>::sortAndCheckDuplicates(
     return lhs.first == rhs.first;
   });
   if (dup != end) {
-    throw std::invalid_argument("Input elements contain duplicates");
+    std::stringstream ss;
+    ss << "Input elements contain duplicates (" << dup->first << ")";
+    throw std::invalid_argument(ss.str());
   }
 }
 

--- a/Examples/Algorithms/Digitization/scripts/gen-odd-geometric.py
+++ b/Examples/Algorithms/Digitization/scripts/gen-odd-geometric.py
@@ -29,30 +29,91 @@ sstrip_cfg = {
 lstrip_cfg = {
     "thickness": 0.250,
     "digital": True,
-    "pitch": [ls_pitchx,],
+    "pitch": [
+        ls_pitchx,
+    ],
 }
 
 # Assemble all simplified configurations of the different geometry hierarchy entries
-cfgs = [{"desc": "pixel barrel", "vol": 17, "size": [16.8, 72.0], **pixel_cfg},]
+cfgs = [
+    {"desc": "pixel barrel", "vol": 17, "size": [16.8, 72.0], **pixel_cfg},
+]
 for ecvol in [16, 18]:
     cfgs += [
-        {"desc": "pixel endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [32.2, 78.0], **pixel_cfg},
-        {"desc": "pixel endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [16.8, 78.0], **pixel_cfg},
+        {
+            "desc": "pixel endcap (ring 0)",
+            "vol": ecvol,
+            "extra": 1,
+            "size": [32.2, 78.0],
+            **pixel_cfg,
+        },
+        {
+            "desc": "pixel endcap (ring 1)",
+            "vol": ecvol,
+            "extra": 2,
+            "size": [16.8, 78.0],
+            **pixel_cfg,
+        },
     ]
 
-cfgs += [{"desc": "sstrip barrel", "vol": 24, "size": [48.0, 108.0], **sstrip_cfg},]
+cfgs += [
+    {"desc": "sstrip barrel", "vol": 24, "size": [48.0, 108.0], **sstrip_cfg},
+]
 for ecvol in [23, 25]:
     cfgs += [
-        {"desc": "sstrip endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [32.2, 78.0], **sstrip_cfg},
-        {"desc": "sstrip endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [44.0, 78.0], **sstrip_cfg},
-        {"desc": "sstrip endcap (ring 2)", "vol": ecvol, "extra": 3, "size": [56.4, 78.0], **sstrip_cfg},
+        {
+            "desc": "sstrip endcap (ring 0)",
+            "vol": ecvol,
+            "extra": 1,
+            "size": [32.2, 78.0],
+            **sstrip_cfg,
+        },
+        {
+            "desc": "sstrip endcap (ring 1)",
+            "vol": ecvol,
+            "extra": 2,
+            "size": [44.0, 78.0],
+            **sstrip_cfg,
+        },
+        {
+            "desc": "sstrip endcap (ring 2)",
+            "vol": ecvol,
+            "extra": 3,
+            "size": [56.4, 78.0],
+            **sstrip_cfg,
+        },
     ]
 
-cfgs += [{"desc": "sstrip barrel", "vol": 29, "size": [96.0,], **lstrip_cfg},]
+cfgs += [
+    {
+        "desc": "sstrip barrel",
+        "vol": 29,
+        "size": [
+            96.0,
+        ],
+        **lstrip_cfg,
+    },
+]
 for ecvol in [28, 30]:
     cfgs += [
-        {"desc": "sstrip endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [58.6,], **lstrip_cfg},
-        {"desc": "sstrip endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [70.0,], **lstrip_cfg},
+        {
+            "desc": "sstrip endcap (ring 0)",
+            "vol": ecvol,
+            "extra": 1,
+            "size": [
+                58.6,
+            ],
+            **lstrip_cfg,
+        },
+        {
+            "desc": "sstrip endcap (ring 1)",
+            "vol": ecvol,
+            "extra": 2,
+            "size": [
+                70.0,
+            ],
+            **lstrip_cfg,
+        },
     ]
 
 # Assemble the entries of the geometry hierarchy map
@@ -61,14 +122,16 @@ entries = []
 for cfg in cfgs:
     binning_data = []
     for pitch, size, binDim in zip(cfg["pitch"], cfg["size"], ["binX", "binY"]):
-        binning_data.append({
-            "bins": int(size / pitch),
-            "max": 0.5*size,
-            "min": -0.5*size,
-            "option": "open",
-            "type": "equidistant",
-            "value": binDim
-        })
+        binning_data.append(
+            {
+                "bins": int(size / pitch),
+                "max": 0.5 * size,
+                "min": -0.5 * size,
+                "option": "open",
+                "type": "equidistant",
+                "value": binDim,
+            }
+        )
 
     segmentation = {}
     segmentation["binningdata"] = binning_data
@@ -95,7 +158,7 @@ for cfg in cfgs:
 
 # Assemble and write the final configuration
 final_json = {}
-final_json["acts-geometry-hierarchy-map"] =  {
+final_json["acts-geometry-hierarchy-map"] = {
     "format-version": 0,
     "value-identifier": "digitization-configuration",
 }

--- a/Examples/Algorithms/Digitization/scripts/gen-odd-geometric.py
+++ b/Examples/Algorithms/Digitization/scripts/gen-odd-geometric.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import json
+import sys
+import os
+
+format_file_version = 0
+
+# Assume charge smearing and threshold to be the same for the full detector
+charge_smearing = {"mean": 0.0, "stddev": 0.001, "type": "Gauss"}
+threshold = 0.001
+
+# Assemble some generic information for detector regions
+p_pitch = 0.05
+ss_pitchx = 0.075
+ss_pitchy = 0.5
+ls_pitchx = 0.15
+
+pixel_cfg = {
+    "thickness": 0.125,
+    "digital": False,
+    "pitch": [p_pitch, p_pitch],
+}
+sstrip_cfg = {
+    "thickness": 0.200,
+    "digital": True,
+    "pitch": [ss_pitchx, ss_pitchy],
+}
+lstrip_cfg = {
+    "thickness": 0.250,
+    "digital": True,
+    "pitch": [ls_pitchx,],
+}
+
+# Assemble all simplified configurations of the different geometry hierarchy entries
+cfgs = [{"desc": "pixel barrel", "vol": 17, "size": [16.8, 72.0], **pixel_cfg},]
+for ecvol in [16, 18]:
+    cfgs += [
+        {"desc": "pixel endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [32.2, 78.0], **pixel_cfg},
+        {"desc": "pixel endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [16.8, 78.0], **pixel_cfg},
+    ]
+
+cfgs += [{"desc": "sstrip barrel", "vol": 24, "size": [48.0, 108.0], **sstrip_cfg},]
+for ecvol in [23, 25]:
+    cfgs += [
+        {"desc": "sstrip endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [32.2, 78.0], **sstrip_cfg},
+        {"desc": "sstrip endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [44.0, 78.0], **sstrip_cfg},
+        {"desc": "sstrip endcap (ring 2)", "vol": ecvol, "extra": 3, "size": [56.4, 78.0], **sstrip_cfg},
+    ]
+
+cfgs += [{"desc": "sstrip barrel", "vol": 29, "size": [96.0,], **lstrip_cfg},]
+for ecvol in [28, 30]:
+    cfgs += [
+        {"desc": "sstrip endcap (ring 0)", "vol": ecvol, "extra": 1, "size": [58.6,], **lstrip_cfg},
+        {"desc": "sstrip endcap (ring 1)", "vol": ecvol, "extra": 2, "size": [70.0,], **lstrip_cfg},
+    ]
+
+# Assemble the entries of the geometry hierarchy map
+entries = []
+
+for cfg in cfgs:
+    binning_data = []
+    for pitch, size, binDim in zip(cfg["pitch"], cfg["size"], ["binX", "binY"]):
+        binning_data.append({
+            "bins": int(size / pitch),
+            "max": 0.5*size,
+            "min": -0.5*size,
+            "option": "open",
+            "type": "equidistant",
+            "value": binDim
+        })
+
+    segmentation = {}
+    segmentation["binningdata"] = binning_data
+
+    geometric = {}
+    geometric["digital"] = cfg["digital"]
+    geometric["indices"] = list(range(len(cfg["pitch"])))
+    geometric["segmentation"] = segmentation
+    geometric["thickness"] = cfg["thickness"]
+    geometric["threshold"] = threshold
+    geometric["charge-smearing"] = charge_smearing
+
+    value = {}
+    value["geometric"] = geometric
+
+    entry = {}
+    entry["description"] = cfg["desc"]
+    entry["volume"] = cfg["vol"]
+    if "extra" in cfg:
+        entry["extra"] = cfg["extra"]
+    entry["value"] = value
+
+    entries.append(entry)
+
+# Assemble and write the final configuration
+final_json = {}
+final_json["acts-geometry-hierarchy-map"] =  {
+    "format-version": 0,
+    "value-identifier": "digitization-configuration",
+}
+final_json["entries"] = entries
+
+try:
+    output_file = sys.argv[1]
+except:
+    output_file = "odd-digi-geometric-config.json"
+
+with open(output_file, "w") as f:
+    json.dump(final_json, f, indent=4)

--- a/Examples/Algorithms/Digitization/share/odd-digi-geometric-config.json
+++ b/Examples/Algorithms/Digitization/share/odd-digi-geometric-config.json
@@ -1,0 +1,657 @@
+{
+    "acts-geometry-hierarchy-map": {
+        "format-version": 0,
+        "value-identifier": "digitization-configuration"
+    },
+    "entries": [
+        {
+            "description": "pixel barrel",
+            "volume": 17,
+            "value": {
+                "geometric": {
+                    "digital": false,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 336,
+                                "max": 8.4,
+                                "min": -8.4,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 1440,
+                                "max": 36.0,
+                                "min": -36.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.125,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "pixel endcap (ring 0)",
+            "volume": 16,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": false,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 644,
+                                "max": 16.1,
+                                "min": -16.1,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 1560,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.125,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "pixel endcap (ring 1)",
+            "volume": 16,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": false,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 336,
+                                "max": 8.4,
+                                "min": -8.4,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 1560,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.125,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "pixel endcap (ring 0)",
+            "volume": 18,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": false,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 644,
+                                "max": 16.1,
+                                "min": -16.1,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 1560,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.125,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "pixel endcap (ring 1)",
+            "volume": 18,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": false,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 336,
+                                "max": 8.4,
+                                "min": -8.4,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 1560,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.125,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip barrel",
+            "volume": 24,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 640,
+                                "max": 24.0,
+                                "min": -24.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 216,
+                                "max": 54.0,
+                                "min": -54.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 0)",
+            "volume": 23,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 429,
+                                "max": 16.1,
+                                "min": -16.1,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 1)",
+            "volume": 23,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 586,
+                                "max": 22.0,
+                                "min": -22.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 2)",
+            "volume": 23,
+            "extra": 3,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 752,
+                                "max": 28.2,
+                                "min": -28.2,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 0)",
+            "volume": 25,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 429,
+                                "max": 16.1,
+                                "min": -16.1,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 1)",
+            "volume": 25,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 586,
+                                "max": 22.0,
+                                "min": -22.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 2)",
+            "volume": 25,
+            "extra": 3,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0,
+                        1
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 752,
+                                "max": 28.2,
+                                "min": -28.2,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            },
+                            {
+                                "bins": 156,
+                                "max": 39.0,
+                                "min": -39.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binY"
+                            }
+                        ]
+                    },
+                    "thickness": 0.2,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip barrel",
+            "volume": 29,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 640,
+                                "max": 48.0,
+                                "min": -48.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            }
+                        ]
+                    },
+                    "thickness": 0.25,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 0)",
+            "volume": 28,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 390,
+                                "max": 29.3,
+                                "min": -29.3,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            }
+                        ]
+                    },
+                    "thickness": 0.25,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 1)",
+            "volume": 28,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 466,
+                                "max": 35.0,
+                                "min": -35.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            }
+                        ]
+                    },
+                    "thickness": 0.25,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 0)",
+            "volume": 30,
+            "extra": 1,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 390,
+                                "max": 29.3,
+                                "min": -29.3,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            }
+                        ]
+                    },
+                    "thickness": 0.25,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        },
+        {
+            "description": "sstrip endcap (ring 1)",
+            "volume": 30,
+            "extra": 2,
+            "value": {
+                "geometric": {
+                    "digital": true,
+                    "indices": [
+                        0
+                    ],
+                    "segmentation": {
+                        "binningdata": [
+                            {
+                                "bins": 466,
+                                "max": 35.0,
+                                "min": -35.0,
+                                "option": "open",
+                                "type": "equidistant",
+                                "value": "binX"
+                            }
+                        ]
+                    },
+                    "thickness": 0.25,
+                    "threshold": 0.001,
+                    "charge-smearing": {
+                        "mean": 0.0,
+                        "stddev": 0.001,
+                        "type": "Gauss"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/Examples/Algorithms/Digitization/share/odd-digi-smearing-config-notime.json
+++ b/Examples/Algorithms/Digitization/share/odd-digi-smearing-config-notime.json
@@ -1,0 +1,80 @@
+{
+  "acts-geometry-hierarchy-map": {
+    "format-version": 0,
+    "value-identifier": "digitization-configuration"
+  },
+  "entries": [
+    {
+      "volume": 16,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 17,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 18,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 23,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 24,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 25,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 28,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    },
+    {
+      "volume": 29,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    },
+    {
+      "volume": 30,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    }
+  ]
+}

--- a/Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json
+++ b/Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json
@@ -1,0 +1,83 @@
+{
+  "acts-geometry-hierarchy-map": {
+    "format-version": 0,
+    "value-identifier": "digitization-configuration"
+  },
+  "entries": [
+    {
+      "volume": 16,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" },
+          { "index": 5, "stddev": 25, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 17,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" },
+          { "index": 5, "stddev": 25, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 18,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.015, "type": "Gauss" },
+          { "index": 1, "stddev": 0.015, "type": "Gauss" },
+          { "index": 5, "stddev": 25, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 23,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 24,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 25,
+      "value": {
+        "smearing": [
+          { "index": 0, "stddev": 0.043, "type": "Gauss" },
+          { "index": 1, "stddev": 1.2, "type": "Gauss" }
+        ]
+      }
+    },
+    {
+      "volume": 28,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    },
+    {
+      "volume": 29,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    },
+    {
+      "volume": 30,
+      "value": {
+        "smearing": [{ "index": 0, "stddev": 0.072, "type": "Gauss" }]
+      }
+    }
+  ]
+}

--- a/Examples/Algorithms/MaterialMapping/share/odd-material-mapping-config.json
+++ b/Examples/Algorithms/MaterialMapping/share/odd-material-mapping-config.json
@@ -1,0 +1,15200 @@
+{
+    "Surfaces": {
+        "acts-geometry-hierarchy-map": {
+            "format-version": 0,
+            "value-identifier": "Material Surface Map"
+        },
+        "entries": [
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            0.0,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 72339069014638592,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 1
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            0.0,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 72620543991349248,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 1
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            4002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 72902018968059904,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4002.0,
+                                    "min": -4002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 1
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            11.3,
+                            4001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 144115256795332608,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4001.0,
+                                    "min": -4001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 2
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            24.0,
+                            4001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 144115325514809344,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 10,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 2
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            27.66212161878084,
+                            4001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 144115394234286080,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4001.0,
+                                    "min": -4001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 2
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            0.0,
+                            29.924243619031408,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 144396663052566528,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 29.924243927001953,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 2
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            0.0,
+                            29.924243619031408,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 144678138029277184,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 29.924243927001953,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 2
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 216454257090494464,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 3
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 216735732067205120,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 3
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            4002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 217017207043915776,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4002.0,
+                                    "min": -4002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 3
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            4002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 217298682020626432,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4002.0,
+                                    "min": -4002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 3
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 288230444871188480,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3760.890625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 4
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 288230513590665216,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3519.28125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 4
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 288230582310141952,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3277.671875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 4
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 288511851128422400,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 4
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            482.71875,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 289074801081843712,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 482.71875,
+                                    "min": -482.71875,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3519.28125
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 4
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 360569445166350336,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 5
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 360850920143060992,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 5
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 361132395119771648,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 5
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 361413870096482304,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 5
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 432627039204278272,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1085.4117431640625,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 6
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 432908514180988928,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1085.4117431640625,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 6
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1085.4117357355483,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 433189989157699584,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 6
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 433471464134410240,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 6
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 504684633242206208,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 7
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 504966108218916864,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 7
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            713.2684387041754,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 505247583195627520,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 7
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 505529058172338176,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 7
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 576460821022900224,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3019.8125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 8
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 576460889742376960,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3002.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 8
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 576460958461853696,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2985.3125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 8
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 648799821318062080,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 9
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 649081296294772736,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 9
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            713.2684387041754,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 649362771271483392,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 9
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 649644246248194048,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 9
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 720857415355990016,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 10
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 721138890332700672,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 10
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            206.00000000000003,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 721420365309411328,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 10
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 721701840286121984,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 10
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 792633603136684032,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2727.171875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 11
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 792633671856160768,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2485.28125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 11
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 792633740575637504,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2243.390625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 11
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 864972603431845888,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 12
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 865254078408556544,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 12
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            206.00000000000003,
+                            2002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 865535553385267200,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2002.0,
+                                    "min": -2002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 12
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            2002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 865817028361977856,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2002.0,
+                                    "min": -2002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 12
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 937030197469773824,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 13
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 937311672446484480,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 13
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            190.00000000000003,
+                            2002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 937593147423195136,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2002.0,
+                                    "min": -2002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 13
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            2002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 937874622399905792,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2002.0,
+                                    "min": -2002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 13
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1008806385250467840,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1989.50000000025
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 14
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1008806453969944576,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1976.5000000005
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 14
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1008806522689421312,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1963.5000000005
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 14
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1081145385545629696,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1951.000000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 15
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1081426860522340352,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1951.000000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 15
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            190.00000000000003,
+                            1951.000000001,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1081708335499051008,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1951.0,
+                                    "min": -1951.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 15
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            1951.000000001,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1081989810475761664,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1951.0,
+                                    "min": -1951.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 15
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            40.0,
+                            189.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921573326323712,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1950.5000000005
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            40.0,
+                            189.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921642045800448,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1950.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921710765277184,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1742.215625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921779484753920,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1520.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921779753189376,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1534.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921780021624832,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1505.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921848204230656,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1419.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921916923707392,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1320.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921917192142848,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1334.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921917460578304,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1305.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152921985643184128,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1219.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922054362660864,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1120.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922054631096320,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1134.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922054899531776,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1105.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922123082137600,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1049.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922191801614336,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -980.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922192070049792,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -994.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922192338485248,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -965.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922260521091072,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -909.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922329240567808,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -840.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922329509003264,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -854.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922329777438720,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -825.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922397960044544,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -779.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922466679521280,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -720.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922466947956736,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -734.43125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922467216392192,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -705.56875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 15,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922535398998016,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -669.9999877929688
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 16,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922604118474752,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -620.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 1,
+                "layer": 16,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922604386910208,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -634.4312500000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "approach": 2,
+                "layer": 16,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922604655345664,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -605.5687499999999
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 17,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1152922672837951488,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -581.4265502929686
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1153202979583557632,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1951.000000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 16
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            30.42424377301668,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979167364251648,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            35.12791650921291,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979236083728384,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            30.924243619031408,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979236352163840,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            39.33158939939441,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979236620599296,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 200,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            52.99847162744389,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979304803205120,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            70.72044657982553,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979373522681856,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            66.6653545097706,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979373791117312,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            74.77553864988047,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979374059552768,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 200,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            93.62140767598103,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979442242158592,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            116.51682213132918,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979510961635328,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            112.46727976846597,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979511230070784,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            120.56636449419238,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979511498506240,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 200,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            144.46873961181018,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979579681112064,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            172.4170177784625,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979648400588800,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            168.371111120593,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979648669024256,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            176.462924436332,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979648937459712,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 200,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            183.23146057128906,
+                            512.25,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1224979717120065536,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 512.25,
+                                    "min": -512.25,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3.2499999999999716
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 17
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1225260573621485568,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -557.2843749999998
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 17
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036761402179584,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            583.5015502929687
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036830121656320,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            620.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036830390091776,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            606.1687499999999
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036830658527232,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            633.8312500000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036898841133056,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            669.9999938964844
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036967560609792,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            720.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036967829045248,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            706.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297036968097480704,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            733.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037036280086528,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            779.9999938964844
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037104999563264,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            840.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037105267998720,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            826.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037105536434176,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            853.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037173719040000,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            909.9999938964844
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037242438516736,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            980.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037242706952192,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            966.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037242975387648,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            993.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037311157993472,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1049.9999938964843
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037379877470208,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1120.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037380145905664,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1106.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037380414341120,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1133.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037448596946944,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1220.0000244140624
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037517316423680,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1320.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037517584859136,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1306.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037517853294592,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1333.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037586035900416,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1420.0000244140624
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037654755377152,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1520.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 1,
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037655023812608,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1506.16875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "approach": 2,
+                "layer": 14,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            32.0,
+                            183.78506840347362,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037655292248064,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 183.78506469726563,
+                                    "min": 32.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1533.83125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 15,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            40.0,
+                            189.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037723474853888,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1741.9156494135625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 16,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            40.0,
+                            189.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037792194330624,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1950.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 17,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            40.0,
+                            189.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297037860913807360,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1950.5000000005
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1297318167659413504,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            560.8343749999999
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 18
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1369094355440107520,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1963.50000000025
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 19
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1369094424159584256,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1976.5000000005
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 19
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1369094492879060992,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1989.5
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 19
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            190.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1369375761697341440,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 190.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1951.000000001
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 19
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            195.5,
+                            2001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1441151949478035456,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2001.0,
+                                    "min": -2001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 20
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            203.00000000000003,
+                            2001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1441152018197512192,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 20
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            205.5,
+                            2001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1441152086916988928,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2001.0,
+                                    "min": -2001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 20
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1441433355735269376,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 20
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            190.00000000000003,
+                            2002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1442277780665401344,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2002.0,
+                                    "min": -2002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 20
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1513209543515963392,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2243.390625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 21
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1513209612235440128,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2485.28125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 21
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1513209680954916864,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2727.171875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 21
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            206.00000000000003,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1513490949773197312,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 206.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 21
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            206.00000000000003,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1585548543811125248,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 206.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 22
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            206.00000000000003,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1585830018787835904,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 206.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 22
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            713.2684387041754,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1586111493764546560,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 22
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            206.00000000000003,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1586392968741257216,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 22
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324731591819264,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2968.0625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324800311296000,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2950.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324800579731456,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2967.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324800848166912,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2932.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324869030772736,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2750.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324937750249472,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2550.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324938018684928,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2567.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657324938287120384,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2532.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325006469726208,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2375.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325075189202944,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2200.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325075457638400,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2217.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325075726073856,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2182.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325143908679680,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2025.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325212628156416,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1850.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325212896591872,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1867.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325213165027328,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1832.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325281347633152,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1700.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325350067109888,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1550.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325350335545344,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1567.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325350603980800,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1532.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325418786586624,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1425.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325487506063360,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1300.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325487774498816,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1317.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325488042934272,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1282.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657325556225540096,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1247.828125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1657606137849053184,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 23
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            226.72966495596796,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382325629747200,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            268.58023960649314,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382394349223936,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            247.45932991193595,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382394617659392,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            289.70114930105035,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382394886094848,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            318.42696596378937,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382463068700672,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            368.2808746399708,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382531788177408,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            347.1527905701569,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382532056612864,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            389.4089587097847,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382532325048320,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            438.1697968924999,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382600507654144,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            508.06249563411995,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382669227130880,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            486.9306277205467,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382669495566336,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            529.1943635476932,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382669764001792,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            587.9934771639404,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382737946607616,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            667.9262255536066,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382806666084352,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            646.7926183903808,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382806934519808,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            689.0598327168325,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382807202955264,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            701.1641265786502,
+                            1149.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729382875385561088,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1149.0,
+                                    "min": -1149.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 24
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            206.00000000000003,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1729663731886981120,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1213.21875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 24
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801439919667675136,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1250.328125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801439988387151872,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1300.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801439988655587328,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1282.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801439988924022784,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1317.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440057106628608,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1425.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440125826105344,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1550.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440126094540800,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1532.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440126362976256,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1567.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440194545582080,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1700.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440263265058816,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1850.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440263533494272,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1832.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440263801929728,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1867.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440331984535552,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2025.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440400704012288,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2200.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440400972447744,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2182.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440401240883200,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2217.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440469423489024,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2375.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440538142965760,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2550.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440538411401216,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2532.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440538679836672,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2567.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440606862442496,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2750.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440675581919232,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2950.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440675850354688,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2932.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440676118790144,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 712.2684326171875,
+                                    "min": 215.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2967.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            214.99999999999997,
+                            712.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801440744301395968,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2968.0625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            206.00000000000003,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1801721325924909056,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1218.21875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 25
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            206.00000000000003,
+                            2968.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1802565750855041024,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 2968.5625,
+                                    "min": -2968.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 25
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1873497513705603072,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2985.3125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 26
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1873497582425079808,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3002.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 26
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1873497651144556544,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3019.8125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 26
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            713.2684387041754,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1873778919962836992,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 713.2684326171875,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2968.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 26
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            713.2684387041754,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1945836514000764928,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1085.4117431640625,
+                                    "min": 713.2684326171875,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 27
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            713.2684387041754,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1946117988977475584,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1085.4117431640625,
+                                    "min": 713.2684326171875,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 27
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1085.4117357355483,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1946399463954186240,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 27
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            713.2684387041754,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 1946680938930896896,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 27
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612701781458944,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.0625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612770500935680,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3000.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612770769371136,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3035.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612771037806592,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2964.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612839220412416,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2800.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612907939889152,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2600.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612908208324608,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2635.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612908476760064,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2564.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017612976659365888,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2425.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613045378842624,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2250.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613045647278080,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2285.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613045915713536,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2214.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613114098319360,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -2075.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613182817796096,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1900.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613183086231552,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1935.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613183354667008,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1864.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613251537272832,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1750.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613320256749568,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1600.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613320525185024,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1635.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613320793620480,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1564.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613388976226304,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1450.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613457695703040,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1300.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613457964138496,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1335.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613458232573952,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1264.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2017613526415179776,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1234.7971984501628
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 28
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            756.9646706456003,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670295819386880,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            828.7426008006108,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670364538863616,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            800.6609086740132,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670364807299072,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 250,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            856.8242929272085,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670365075734528,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            928.5955866397879,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670433258340352,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1028.4670165580287,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670501977817088,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1000.3668934944196,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670502246252544,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 250,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1056.5671396216378,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670502514688000,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1070.9894372037115,
+                            1150.8762938006512,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089670570697293824,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1150.8763427734375,
+                                    "min": -1150.8763427734375,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            5.000000000000114
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 29
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            713.2684387041754,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2089951702076620800,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -1205.1568969003256
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 29
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161727889857314816,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1237.2971801757813
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161727958576791552,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1300.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161727958845227008,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1264.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161727959113662464,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1335.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728027296268288,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1450.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728096015745024,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1600.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728096284180480,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1564.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 4,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728096552615936,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1635.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 5,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728164735221760,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1750.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728233454698496,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1900.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728233723133952,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1864.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 6,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728233991569408,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1935.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 7,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728302174175232,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2075.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728370893651968,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2250.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728371162087424,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2214.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 8,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728371430522880,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2285.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 9,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728439613128704,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2425.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728508332605440,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2600.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728508601040896,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2564.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 10,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728508869476352,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2635.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 11,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728577052082176,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2800.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728645771558912,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3000.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 1,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728646039994368,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            2964.4375
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "approach": 2,
+                "layer": 12,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728646308429824,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1084.4117431640625,
+                                    "min": 716.8359985351563,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3035.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 13,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            716.8360054665936,
+                            1084.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2161728714491035648,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.0625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            713.2684387041754,
+                            1085.4117357355483,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2162009296114548736,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            1210.1568969003256
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 30
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            713.2684387041754,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2162853721044680704,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 72,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 150,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 30
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1122.2058715820313,
+                            3001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2233785483895242752,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3001.0,
+                                    "min": -3001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 31
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1180.0,
+                            3001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2233785552614719488,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 31
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1201.5,
+                            3001.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2233785621334196224,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3001.0,
+                                    "min": -3001.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 31
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2234066890152476672,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            -3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 31
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2234629840105897984,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 3036.5625,
+                                    "min": -3036.5625,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 31
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1085.4117357355483,
+                            3036.5625,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2234911315082608640,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 100,
+                                    "max": 0.0,
+                                    "min": 0.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": true,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 31
+            },
+            {
+                "layer": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2305843077933170688,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3277.671875
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 32
+            },
+            {
+                "layer": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2305843146652647424,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3519.28125
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 32
+            },
+            {
+                "layer": 3,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2305843215372124160,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3760.890625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 32
+            },
+            {
+                "boundary": 1,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2306124484190404608,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3036.5625
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 32
+            },
+            {
+                "boundary": 2,
+                "value": {
+                    "bounds": {
+                        "type": "RadialBounds",
+                        "values": [
+                            29.924243619031408,
+                            1202.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2306405959167115264,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 1202.0,
+                                    "min": 29.924243927001953,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binR"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            4002.0
+                        ]
+                    },
+                    "type": "DiscSurface"
+                },
+                "volume": 32
+            },
+            {
+                "boundary": 3,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            1202.0,
+                            482.71875,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2306687434143825920,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 482.71875,
+                                    "min": -482.71875,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": [
+                            0.0,
+                            0.0,
+                            3519.28125
+                        ]
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 32
+            },
+            {
+                "boundary": 4,
+                "value": {
+                    "bounds": {
+                        "type": "CylinderBounds",
+                        "values": [
+                            29.924243619031408,
+                            4002.0,
+                            3.141592653589793,
+                            0.0
+                        ]
+                    },
+                    "geo_id": 2306968909120536576,
+                    "material": {
+                        "binUtility": {
+                            "binningdata": [
+                                {
+                                    "bins": 1,
+                                    "max": 3.1415927410125732,
+                                    "min": -3.1415927410125732,
+                                    "option": "closed",
+                                    "type": "equidistant",
+                                    "value": "binPhi"
+                                },
+                                {
+                                    "bins": 1,
+                                    "max": 4002.0,
+                                    "min": -4002.0,
+                                    "option": "open",
+                                    "type": "equidistant",
+                                    "value": "binZ"
+                                }
+                            ]
+                        },
+                        "mapMaterial": false,
+                        "type": "proto"
+                    },
+                    "transform": {
+                        "rotation": null,
+                        "translation": null
+                    },
+                    "type": "CylinderSurface"
+                },
+                "volume": 32
+            }
+        ]
+    },
+    "Volumes": {
+        "acts-geometry-hierarchy-map": {
+            "format-version": 0,
+            "value-identifier": "Material Volume Map"
+        },
+        "entries": []
+    }
+}

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -249,8 +249,10 @@ def detector_config(request):
             detector,
             trackingGeometry,
             decorators,
-            geometrySelection= algdir / "TrackFinding/share/geoSelection-genericDetector.json",
-            digiConfigFile=algdir / "Digitization/share/default-smearing-config-generic.json",
+            geometrySelection=algdir
+            / "TrackFinding/share/geoSelection-genericDetector.json",
+            digiConfigFile=algdir
+            / "Digitization/share/default-smearing-config-generic.json",
             name=request.param,
         )
     elif request.param == "odd":

--- a/Examples/Python/tests/conftest.py
+++ b/Examples/Python/tests/conftest.py
@@ -241,6 +241,7 @@ DetectorConfig = namedtuple(
 @pytest.fixture(params=["generic", pytest.param("odd", marks=pytest.mark.odd)])
 def detector_config(request):
     srcdir = Path(__file__).resolve().parent.parent.parent.parent
+    algdir = srcdir / "Examples/Algorithms"
 
     if request.param == "generic":
         detector, trackingGeometry, decorators = acts.examples.GenericDetector.create()
@@ -248,14 +249,8 @@ def detector_config(request):
             detector,
             trackingGeometry,
             decorators,
-            geometrySelection=(
-                srcdir
-                / "Examples/Algorithms/TrackFinding/share/geoSelection-genericDetector.json"
-            ),
-            digiConfigFile=(
-                srcdir
-                / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json"
-            ),
+            geometrySelection= algdir / "TrackFinding/share/geoSelection-genericDetector.json",
+            digiConfigFile=algdir / "Digitization/share/default-smearing-config-generic.json",
             name=request.param,
         )
     elif request.param == "odd":
@@ -271,13 +266,8 @@ def detector_config(request):
             detector,
             trackingGeometry,
             decorators,
-            digiConfigFile=(
-                srcdir
-                / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
-            ),
-            geometrySelection=(
-                srcdir / "thirdparty/OpenDataDetector/config/odd-seeding-config.json"
-            ),
+            digiConfigFile=algdir / "Digitization/share/odd-digi-smearing-config.json",
+            geometrySelection=algdir / "Digitization/share/odd-seeding-config.json",
             name=request.param,
         )
 

--- a/Examples/Python/tests/test_material.py
+++ b/Examples/Python/tests/test_material.py
@@ -27,7 +27,7 @@ def test_json_material_decorator():
         rConfig=config,
         jFileName=str(
             Path(__file__).parent.parent.parent.parent
-            / "thirdparty/OpenDataDetector/config/odd-material-mapping-config.json"
+            / "Examples/Algorithms/MaterialMapping/share/odd-material-mapping-config.json"
         ),
         level=acts.logging.WARNING,
     )

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -163,7 +163,7 @@ if "__main__" == __name__:
 
     detector, trackingGeometry, _ = getOpenDataDetector()
     digiConfigFile = (
-        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        srcdir / "Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json"
     )
 
     ## GenericDetector

--- a/Examples/Scripts/Python/truth_tracking_gsf_refitting.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf_refitting.py
@@ -21,7 +21,7 @@ s = runTruthTrackingKalman(
     field,
     digiConfigFile=srcdir
     / "Examples/Algorithms/Digitization/share/default-smearing-config-generic.json",
-    # "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json",
+    # "Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json",
     outputDir=outputDir,
 )
 

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -162,7 +162,7 @@ if "__main__" == __name__:
 
     detector, trackingGeometry, _ = getOpenDataDetector()
     digiConfigFile = (
-        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        srcdir / "Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json"
     )
 
     ## GenericDetector

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -166,7 +166,7 @@ if "__main__" == __name__:
 
     detector, trackingGeometry, _ = getOpenDataDetector()
     digiConfigFile = (
-        srcdir / "thirdparty/OpenDataDetector/config/odd-digi-smearing-config.json"
+        srcdir / "Examples/Algorithms/Digitization/share/odd-digi-smearing-config.json"
     )
 
     ## GenericDetector


### PR DESCRIPTION
Until now, the config files were in the ODD repo, but the consuming algorithms resided in ACTS. This can (and did) lead to incompatibilities.
Additional provides a generator script for a ODD geometric config, as well as the resulting file.