### PR TITLE
fix: `VectorTrackContainer::removeTrack_impl`

### DIFF
--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -80,6 +80,8 @@ void VectorTrackContainer::removeTrack_impl(IndexType itrack) {
   erase(m_tipIndex);
   erase(m_stemIndex);
 
+  erase(m_particleHypothesis);
+
   erase(m_params);
   erase(m_cov);
   erase(m_referenceSurfaces);


### PR DESCRIPTION
Small fix otherwise `removeTrack` will cause assertions to fire later