### PR TITLE
feat: speed up detector navigator

### DIFF
--- a/Core/include/Acts/Navigation/NavigationStateUpdaters.hpp
+++ b/Core/include/Acts/Navigation/NavigationStateUpdaters.hpp
@@ -39,31 +39,25 @@ inline void updateCandidates(const GeometryContext& gctx,
   const auto& position = nState.position;
   const auto& direction = nState.direction;
 
-  NavigationState::SurfaceCandidates nextSurfaceCandidates;
-
-  for (NavigationState::SurfaceCandidate c : nState.surfaceCandidates) {
+  for (NavigationState::SurfaceCandidate& c : nState.surfaceCandidates) {
     // Get the surface representation: either native surface of portal
-    const Surface& sRep =
+    const Surface& surface =
         c.surface != nullptr ? *c.surface : c.portal->surface();
 
     // Only allow overstepping if it's not a portal
     ActsScalar overstepTolerance =
         c.portal != nullptr ? s_onSurfaceTolerance : nState.overstepTolerance;
 
-    // Get the intersection @todo make a templated intersector
-    // TODO surface tolerance
-    auto sIntersection = sRep.intersect(
+    // Check the surface intersection
+    auto sIntersection = surface.intersect(
         gctx, position, direction, c.boundaryTolerance, s_onSurfaceTolerance);
     for (auto& si : sIntersection.split()) {
-      c.objectIntersection = si;
-      if (c.objectIntersection.isValid() &&
-          c.objectIntersection.pathLength() > overstepTolerance) {
-        nextSurfaceCandidates.emplace_back(c);
+      if (si.isValid() && si.pathLength() > overstepTolerance) {
+        c.objectIntersection = si;
+        break;
       }
     }
   }
-
-  nState.surfaceCandidates = std::move(nextSurfaceCandidates);
 }
 
 /// @brief This sets a single object, e.g. single surface or single volume


### PR DESCRIPTION
With this PR, the Straight line propagation through the OpenDataDetector:
- remains identical regarding the reached sensitive elements
- gets very close in execution speed 

The latter improvement is on the `DetectorNavigator` to change the `surfaceCandidates` of the state in situ and break after the first successfully hit candidate.

The plot shows a comparison of the distribution of number of sensitives hit and positions between Gen1 and Gen2 geometry, showing that this is now identical:

![SteppingComparison](https://github.com/user-attachments/assets/866f5b69-43f1-47ab-873c-fc370a8ff3a3)

The bottom row shows the non-sensitive steps taken, which are obviously different due to the different geometry portals.
