### PR TITLE
ci: Update MacOS dependencies

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -353,7 +353,8 @@ jobs:
           && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.zst ${{ env.DEPENDENCY_URL }}
           && mkdir ${{ env.DEPENDENCY_DIR }}
           && tar -xf deps.tar.zst -C ${{ env.DEPENDENCY_DIR }}
-          && ${{ env.DEPENDENCY_DIR }}/bin/python3 -m pip install pyyaml jinja2
+          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
+          && pip3 install pyyaml jinja2
 
       - name: Restore ccache
         uses: actions/cache/restore@v4
@@ -370,6 +371,7 @@ jobs:
         # versions such as the one installed via homebrew
         run: >
           ccache -z
+          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
           && cmake -B build -S .
           -GNinja
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
@@ -408,7 +410,7 @@ jobs:
           path: ${{ env.INSTALL_DIR }}
       - name: Downstream configure
         run: >
-          source ${{ env.DEPENDENCY_DIR }}/setup.sh
+          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
           && cmake -B build-downstream -S Tests/DownstreamProject
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
@@ -419,6 +421,5 @@ jobs:
         run: cmake --build build-downstream
       - name: Downstream run
         run: |
-          source ${{ env.DEPENDENCY_DIR }}/setup.sh
-          source ${{ env.DEPENDENCY_DIR}}/dd4hep/*/bin/thisdd4hep.sh
+          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
           ./build-downstream/bin/ShowActsVersion

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -379,7 +379,6 @@ jobs:
           -DCMAKE_CXX_FLAGS=-Werror
           -DCMAKE_CXX_STANDARD=20
           -DCMAKE_INSTALL_PREFIX="${{ env.INSTALL_DIR }}"
-          -DCMAKE_PREFIX_PATH=/usr/local/acts
           -DACTS_BUILD_EVERYTHING=ON
           -DACTS_BUILD_EXAMPLES_UNITTESTS=ON
           -DACTS_BUILD_ODD=ON

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -411,7 +411,7 @@ jobs:
           path: ${{ env.INSTALL_DIR }}
       - name: Downstream configure
         run: >
-          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
+          PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
           && cmake -B build-downstream -S Tests/DownstreamProject
           -GNinja
           -DCMAKE_BUILD_TYPE=Release
@@ -421,6 +421,6 @@ jobs:
       - name: Downstream build
         run: cmake --build build-downstream
       - name: Downstream run
-        run: |
-          && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
-          ./build-downstream/bin/ShowActsVersion
+        run: >
+          PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
+          && ./build-downstream/bin/ShowActsVersion

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -354,7 +354,7 @@ jobs:
           && mkdir ${{ env.DEPENDENCY_DIR }}
           && tar -xf deps.tar.zst -C ${{ env.DEPENDENCY_DIR }}
           && PATH="${{ env.DEPENDENCY_DIR }}/bin:$PATH"
-          && pip3 install pyyaml jinja2
+          && python3 -m pip install pyyaml jinja2
 
       - name: Restore ccache
         uses: actions/cache/restore@v4

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -376,6 +376,7 @@ jobs:
           -GNinja
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           -DCMAKE_PREFIX_PATH="${{ env.DEPENDENCY_DIR }}"
+          -DPython_EXECUTABLE=${{ env.DEPENDENCY_DIR }}/bin/python3
           -DDD4HEP_DEBUG_CMAKE=ON
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -370,11 +370,10 @@ jobs:
         # versions such as the one installed via homebrew
         run: >
           ccache -z
-          && source ${{ env.DEPENDENCY_DIR }}/setup.sh
           && cmake -B build -S .
           -GNinja
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-          -DPython_EXECUTABLE=${{ env.DEPENDENCY_DIR }}/python/3.12.2/bin/python3
+          -DCMAKE_PREFIX_PATH="${{ env.DEPENDENCY_DIR }}"
           -DDD4HEP_DEBUG_CMAKE=ON
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS=-Werror

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -335,7 +335,7 @@ jobs:
       INSTALL_DIR: ${{ github.workspace }}/install_acts
       DEPENDENCY_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
-      DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/macOS/cmake/deps.8e12bbf.tar.zst
+      DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/macOS/cmake/deps.8a95213.tar.zst
       # Works around an issue where root's RPATH is wrong for tbb, thus won't find it
       DYLD_LIBRARY_PATH: "${{ github.workspace }}/install/tbb/2021.11.0/lib"
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -352,11 +352,8 @@ jobs:
           brew install cmake ninja ccache xerces-c
           && wget --verbose --progress=dot:giga --continue --retry-connrefused --tries=5 --timeout=2 -O deps.tar.zst ${{ env.DEPENDENCY_URL }}
           && mkdir ${{ env.DEPENDENCY_DIR }}
-          && ls ${{ env.DEPENDENCY_DIR }}
           && tar -xf deps.tar.zst -C ${{ env.DEPENDENCY_DIR }}
-          && ls ${{ env.DEPENDENCY_DIR }}
-          && ls ${{ env.DEPENDENCY_DIR }}/python
-          && ${{ env.DEPENDENCY_DIR }}/python/3.12.2/bin/python3 -m pip install pyyaml jinja2
+          && ${{ env.DEPENDENCY_DIR }}/bin/python3 -m pip install pyyaml jinja2
 
       - name: Restore ccache
         uses: actions/cache/restore@v4


### PR DESCRIPTION
It appears that the MacOS build broke because of a change of the software stack of the runner. We do not have control over that so I rebuilt the dependencies in the hope this resolves the problem.