### PR TITLE
feat(geometry): Allow operator<< on surfaces without detector elements

### DIFF
--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -482,6 +482,14 @@ class Surface : public virtual GeometryObject,
   virtual ActsMatrix<2, 3> localCartesianToBoundLocalDerivative(
       const GeometryContext& gctx, const Vector3& position) const = 0;
 
+  /// Outstream operator for surfaces without an associated detector element
+  /// @note This operator checks if an associated detector element is set
+  ///       and will throws an exception if that's the case.
+  /// @param os The output stream
+  /// @param srf The surface to print
+  /// @return The output stream
+  friend std::ostream& operator<<(std::ostream& os, const Surface& srf);
+
  protected:
   /// Output Method for std::ostream, to be overloaded by child classes
   ///

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -357,3 +357,16 @@ void Acts::Surface::assignSurfaceMaterial(
 void Acts::Surface::associateLayer(const Acts::Layer& lay) {
   m_associatedLayer = (&lay);
 }
+
+std::ostream& Acts::operator<<(std::ostream& os, const Acts::Surface& srf) {
+  if (srf.associatedDetectorElement() != nullptr) {
+    throw std::runtime_error(
+        "Cannot print Surface with associated DetectorElement without geometry "
+        "context");
+  }
+  // Using a default context is ONLY safe, if the surface does not have an
+  // associated detector element, which we ensure right above.
+  Acts::GeometryContext defaultContext;
+  os << srf.toStream(defaultContext);
+  return os;
+}


### PR DESCRIPTION
We previously disallowed this, but this is only necessary if we have a detector element. Arguably, specifically for printing it can sometimes be inconvenient to have to pass around a geometry context just for this.