### PR TITLE
ci: Disable clang-tidy for external dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ clang_tidy:
         clang-tidy/clang-tidy.json
         --exclude "*thirdparty*"
         --exclude "*ActsPodioEdm*"
+        --exclude "*build/_deps/*"
 
     # Check the combined report against the defined limits
     - CI/clang_tidy/check_clang_tidy.py --report clang-tidy/clang-tidy.json --config CI/clang_tidy/limits.yml


### PR DESCRIPTION
When using CMake's FetchContent mechanism, the source code for those dependencies ends up in the `build/_deps/` directory, which was previously subject to analysis by clang-tidy, which can lead to errors rooted in external projects. This commit disables clang-tidy for that directory, resolving the issue.

This commit comes from #3117.