### PR TITLE
refactor: Change track parameter concepts to C++20

### DIFF
--- a/Core/include/Acts/EventData/GenericCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericCurvilinearTrackParameters.hpp
@@ -82,8 +82,7 @@ class GenericCurvilinearTrackParameters
   template <typename other_track_parameter_t>
   static GenericCurvilinearTrackParameters create(
       const other_track_parameter_t& other) {
-    static_assert(
-        Concepts::BoundTrackParametersConcept<other_track_parameter_t>);
+    static_assert(Concepts::BoundTrackParameters<other_track_parameter_t>);
 
     return GenericCurvilinearTrackParameters(
         other.fourPosition(), other.particleHypothesis(), other.covariance());

--- a/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
@@ -91,8 +91,7 @@ class GenericFreeTrackParameters {
   template <typename other_track_parameter_t>
   static GenericFreeTrackParameters create(
       const other_track_parameter_t& other) {
-    static_assert(
-        Concepts::FreeTrackParametersConcept<other_track_parameter_t>);
+    static_assert(Concepts::FreeTrackParameters<other_track_parameter_t>);
 
     return GenericFreeTrackParameters(
         other.parameters(), other.particleHypothesis(), other.covariance());

--- a/Core/include/Acts/EventData/TrackParametersConcept.hpp
+++ b/Core/include/Acts/EventData/TrackParametersConcept.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Utilities/TypeTraits.hpp"
 
+#include <concepts>
 #include <optional>
 #include <type_traits>
 
@@ -22,154 +23,47 @@ class Surface;
 
 namespace Concepts {
 
-// nested types that must be available
-template <typename T>
-using TypeScalar = typename T::Scalar;
-template <typename T>
-using TypeParametersVector = typename T::ParametersVector;
-template <typename T>
-using TypeCovarianceMatrix = typename T::CovarianceMatrix;
+template <typename Parameters>
+concept BasicTrackParameters = requires {
+  typename Parameters::Scalar;
+  typename Parameters::ParametersVector;
+  typename Parameters::CovarianceMatrix;
 
-template <typename T>
-using ReturnTypeParameters = decltype(std::declval<T>().parameters());
-template <typename T>
-using ReturnTypeCovariance = decltype(std::declval<T>().covariance());
-template <typename T>
-using ReturnTypeFourPositionFromContext =
-    decltype(std::declval<T>().fourPosition(std::declval<GeometryContext>()));
-template <typename T>
-using ReturnTypeFourPosition = decltype(std::declval<T>().fourPosition());
-template <typename T>
-using ReturnTypePositionFromContext =
-    decltype(std::declval<T>().position(std::declval<GeometryContext>()));
-template <typename T>
-using ReturnTypePosition = decltype(std::declval<T>().position());
-template <typename T>
-using ReturnTypeTime = decltype(std::declval<T>().time());
-template <typename T>
-using ReturnTypeDirection = decltype(std::declval<T>().direction());
-template <typename T>
-using ReturnTypeAbsoluteMomentum =
-    decltype(std::declval<T>().absoluteMomentum());
-template <typename T>
-using ReturnTypeCharge = decltype(std::declval<T>().charge());
-template <typename T>
-using ReturnTypeReferenceSurface =
-    decltype(std::declval<T>().referenceSurface());
-
-template <typename T>
-struct BoundTrackParametersConceptImpl {
-  // check for required nested types
-  constexpr static bool hasTypeScalar = exists<TypeScalar, const T>;
-  constexpr static bool hasTypeParametersVector =
-      exists<TypeParametersVector, const T>;
-  constexpr static bool hasTypeCovarianceMatrix =
-      exists<TypeCovarianceMatrix, const T>;
-
-  // check for required methods
-  constexpr static bool hasMethodParameters =
-      std::is_convertible_v<ReturnTypeParameters<T>, BoundVector>;
-  constexpr static bool hasMethodCovariance =
-      std::is_convertible_v<ReturnTypeCovariance<T>,
-                            std::optional<BoundSquareMatrix>>;
-  constexpr static bool hasMethodFourPositionFromContext =
-      identical_to<Vector4, ReturnTypeFourPositionFromContext, const T>;
-  constexpr static bool hasMethodPositionFromContext =
-      identical_to<Vector3, ReturnTypePositionFromContext, const T>;
-  constexpr static bool hasMethodTime =
-      identical_to<TypeScalar<T>, ReturnTypeTime, const T>;
-  constexpr static bool hasMethodDirection =
-      identical_to<Vector3, ReturnTypeDirection, const T>;
-  constexpr static bool hasMethodAbsoluteMomentum =
-      identical_to<TypeScalar<T>, ReturnTypeAbsoluteMomentum, const T>;
-  constexpr static bool hasMethodCharge =
-      identical_to<TypeScalar<T>, ReturnTypeCharge, const T>;
-  constexpr static bool hasMethodReferenceSurface =
-      identical_to<const Surface&, ReturnTypeReferenceSurface, const T>;
-
-  // provide meaningful error messages in case of non-compliance
-  static_assert(hasTypeScalar, "Scalar type is missing");
-  static_assert(hasTypeParametersVector, "Parameters vector type is missing");
-  static_assert(hasTypeCovarianceMatrix, "Covariance matrix type is missing");
-  static_assert(hasMethodParameters, "Missing or invalid 'parameters' method");
-  static_assert(hasMethodCovariance, "Missing or invalid 'covariance' method");
-  static_assert(hasMethodFourPositionFromContext,
-                "Missing or invalid 'fourPosition' method");
-  static_assert(hasMethodPositionFromContext,
-                "Missing or invalid 'position' method");
-  static_assert(hasMethodTime, "Missing or invalid 'time' method");
-  static_assert(hasMethodDirection, "Missing or invalid 'direction' method");
-  static_assert(hasMethodAbsoluteMomentum,
-                "Missing or invalid 'absoluteMomentum' method");
-  static_assert(hasMethodCharge, "Missing or invalid 'charge' method");
-  static_assert(hasMethodReferenceSurface,
-                "Missing or invalid 'referenceSurface' method");
-
-  constexpr static bool value =
-      require<hasTypeScalar, hasTypeParametersVector, hasTypeCovarianceMatrix,
-              hasMethodParameters, hasMethodCovariance,
-              hasMethodFourPositionFromContext, hasMethodPositionFromContext,
-              hasMethodTime, hasMethodDirection, hasMethodAbsoluteMomentum,
-              hasMethodCharge, hasMethodReferenceSurface>;
+  requires requires(const Parameters &p) {
+    { p.time() } -> std::floating_point;
+    { p.direction() } -> std::same_as<Vector3>;
+    { p.absoluteMomentum() } -> std::floating_point;
+    { p.charge() } -> std::floating_point;
+  };
 };
 
-template <typename T>
-struct FreeTrackParametersConceptImpl {
-  // check for required nested types
-  constexpr static bool hasTypeScalar = exists<TypeScalar, const T>;
-  constexpr static bool hasTypeParametersVector =
-      exists<TypeParametersVector, const T>;
-  constexpr static bool hasTypeCovarianceMatrix =
-      exists<TypeCovarianceMatrix, const T>;
-
-  // check for required methods
-  constexpr static bool hasMethodParameters =
-      std::is_convertible_v<ReturnTypeParameters<T>, FreeVector>;
-  constexpr static bool hasMethodCovariance =
-      std::is_convertible_v<ReturnTypeCovariance<T>,
-                            std::optional<FreeSquareMatrix>>;
-  constexpr static bool hasMethodFourPosition =
-      identical_to<Vector4, ReturnTypeFourPosition, const T>;
-  constexpr static bool hasMethodPosition =
-      identical_to<Vector3, ReturnTypePosition, const T>;
-  constexpr static bool hasMethodTime =
-      identical_to<TypeScalar<T>, ReturnTypeTime, const T>;
-  constexpr static bool hasMethodDirection =
-      identical_to<Vector3, ReturnTypeDirection, const T>;
-  constexpr static bool hasMethodAbsoluteMomentum =
-      identical_to<TypeScalar<T>, ReturnTypeAbsoluteMomentum, const T>;
-  constexpr static bool hasMethodCharge =
-      identical_to<TypeScalar<T>, ReturnTypeCharge, const T>;
-
-  // provide meaningful error messages in case of non-compliance
-  static_assert(hasTypeScalar, "Scalar type is missing");
-  static_assert(hasTypeParametersVector, "Parameters vector type is missing");
-  static_assert(hasTypeCovarianceMatrix, "Covariance matrix type is missing");
-  static_assert(hasMethodParameters, "Missing or invalid 'parameters' method");
-  static_assert(hasMethodCovariance, "Missing or invalid 'covariance' method");
-  static_assert(hasMethodFourPosition,
-                "Missing or invalid 'fourPosition' method");
-  static_assert(hasMethodPosition, "Missing or invalid 'position' method");
-  static_assert(hasMethodTime, "Missing or invalid 'time' method");
-  static_assert(hasMethodDirection, "Missing or invalid 'direction' method");
-  static_assert(hasMethodAbsoluteMomentum,
-                "Missing or invalid 'absoluteMomentum' method");
-  static_assert(hasMethodCharge, "Missing or invalid 'charge' method");
-
-  constexpr static bool value =
-      require<hasTypeScalar, hasTypeParametersVector, hasTypeCovarianceMatrix,
-              hasMethodParameters, hasMethodCovariance, hasMethodFourPosition,
-              hasMethodPosition, hasMethodTime, hasMethodDirection,
-              hasMethodAbsoluteMomentum, hasMethodCharge>;
+/// @brief Concept that asserts that a given type meets the requirements to be
+/// considered free track parameters in Acts.
+template <typename Parameters>
+concept FreeTrackParameters = BasicTrackParameters<Parameters> && requires {
+  requires requires(const Parameters &p) {
+    { p.parameters() } -> std::convertible_to<FreeVector>;
+    { p.covariance() } -> std::convertible_to<std::optional<FreeSquareMatrix>>;
+    { p.fourPosition() } -> std::same_as<Vector4>;
+    { p.position() } -> std::same_as<Vector3>;
+  };
 };
 
-template <typename parameters_t>
-constexpr bool BoundTrackParametersConcept =
-    BoundTrackParametersConceptImpl<parameters_t>::value;
+/// @brief Concept that asserts that a given type meets the requirements to be
+/// considered bound track parameters in Acts.
+template <typename Parameters>
+concept BoundTrackParameters = BasicTrackParameters<Parameters> && requires {
+  requires requires(const Parameters &p) {
+    { p.parameters() } -> std::convertible_to<BoundVector>;
+    { p.covariance() } -> std::convertible_to<std::optional<BoundSquareMatrix>>;
+    { p.referenceSurface() } -> std::same_as<const Surface &>;
 
-template <typename parameters_t>
-constexpr bool FreeTrackParametersConcept =
-    FreeTrackParametersConceptImpl<parameters_t>::value;
-
+    requires requires(GeometryContext & c) {
+      { p.position(c) } -> std::same_as<Vector3>;
+      { p.fourPosition(c) } -> std::same_as<Vector4>;
+      { p.position(c) } -> std::same_as<Vector3>;
+    };
+  };
+};
 }  // namespace Concepts
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -106,16 +106,15 @@ class Propagator final
   /// Re-define bound track parameters dependent on the stepper
   using StepperBoundTrackParameters =
       detail::stepper_bound_parameters_type_t<stepper_t>;
-  static_assert(
-      Concepts::BoundTrackParametersConcept<StepperBoundTrackParameters>,
-      "Stepper bound track parameters do not fulfill bound "
-      "parameters concept.");
+  static_assert(Concepts::BoundTrackParameters<StepperBoundTrackParameters>,
+                "Stepper bound track parameters do not fulfill bound "
+                "parameters concept.");
 
   /// Re-define curvilinear track parameters dependent on the stepper
   using StepperCurvilinearTrackParameters =
       detail::stepper_curvilinear_parameters_type_t<stepper_t>;
   static_assert(
-      Concepts::BoundTrackParametersConcept<StepperCurvilinearTrackParameters>,
+      Concepts::BoundTrackParameters<StepperCurvilinearTrackParameters>,
       "Stepper bound track parameters do not fulfill bound "
       "parameters concept.");
 

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -125,7 +125,7 @@ auto Acts::Propagator<S, N>::propagate(
     -> Result<action_list_t_result_t<
         StepperBoundTrackParameters,
         typename propagator_options_t::action_list_type>> {
-  static_assert(Concepts::BoundTrackParametersConcept<parameters_t>,
+  static_assert(Concepts::BoundTrackParameters<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
   auto state = makeState<parameters_t, propagator_options_t, target_aborter_t,
@@ -142,7 +142,7 @@ template <typename parameters_t, typename propagator_options_t,
           typename path_aborter_t>
 auto Acts::Propagator<S, N>::makeState(
     const parameters_t& start, const propagator_options_t& options) const {
-  static_assert(Concepts::BoundTrackParametersConcept<parameters_t>,
+  static_assert(Concepts::BoundTrackParameters<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
   // Type of track parameters produced by the propagation
@@ -189,7 +189,7 @@ template <typename parameters_t, typename propagator_options_t,
 auto Acts::Propagator<S, N>::makeState(
     const parameters_t& start, const Surface& target,
     const propagator_options_t& options) const {
-  static_assert(Concepts::BoundTrackParametersConcept<parameters_t>,
+  static_assert(Concepts::BoundTrackParameters<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
   // Type of provided options

--- a/Core/src/EventData/TrackParameters.cpp
+++ b/Core/src/EventData/TrackParameters.cpp
@@ -15,21 +15,18 @@ namespace Acts {
 // ensure concrete classes satisfy the concepts
 
 static_assert(
-    Concepts::BoundTrackParametersConcept<SinglyChargedBoundTrackParameters>);
-static_assert(Concepts::BoundTrackParametersConcept<
-              SinglyChargedCurvilinearTrackParameters>);
+    Concepts::BoundTrackParameters<SinglyChargedBoundTrackParameters>);
 static_assert(
-    Concepts::FreeTrackParametersConcept<SinglyChargedFreeTrackParameters>);
+    Concepts::BoundTrackParameters<SinglyChargedCurvilinearTrackParameters>);
+static_assert(Concepts::FreeTrackParameters<SinglyChargedFreeTrackParameters>);
 
+static_assert(Concepts::BoundTrackParameters<NeutralBoundTrackParameters>);
 static_assert(
-    Concepts::BoundTrackParametersConcept<NeutralBoundTrackParameters>);
-static_assert(
-    Concepts::BoundTrackParametersConcept<NeutralCurvilinearTrackParameters>);
-static_assert(Concepts::FreeTrackParametersConcept<NeutralFreeTrackParameters>);
+    Concepts::BoundTrackParameters<NeutralCurvilinearTrackParameters>);
+static_assert(Concepts::FreeTrackParameters<NeutralFreeTrackParameters>);
 
-static_assert(Concepts::BoundTrackParametersConcept<BoundTrackParameters>);
-static_assert(
-    Concepts::BoundTrackParametersConcept<CurvilinearTrackParameters>);
-static_assert(Concepts::FreeTrackParametersConcept<FreeTrackParameters>);
+static_assert(Concepts::BoundTrackParameters<BoundTrackParameters>);
+static_assert(Concepts::BoundTrackParameters<CurvilinearTrackParameters>);
+static_assert(Concepts::FreeTrackParameters<FreeTrackParameters>);
 
 }  // namespace Acts


### PR DESCRIPTION
With the switch to C++20, the old Acts concepts setup using detection idioms can be replaced by a more readable variant based on language built-in concepts. This commit swaps the bound and free track parameter concepts over to C++20-style concepts.