### PR TITLE
ci: Fix `build_performance` GitHub CI job after #3135

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -87,7 +87,6 @@ jobs:
   build_performance:
     runs-on: ubuntu-latest
     container: ghcr.io/acts-project/ubuntu2404:53
-    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -98,6 +97,7 @@ jobs:
           --preset=github-ci
           -DCMAKE_BUILD_TYPE=RelWithDebInfo
           -DCMAKE_CXX_FLAGS="-Werror"
+          -DACTS_BUILD_ODD=OFF
       - name: Measure
         run: cmakeperf collect build/compile_commands.json -o perf.csv
       - name: Results


### PR DESCRIPTION
https://github.com/acts-project/acts/pull/3135 broke `build_performance` which was not observed in the PR because this job only runs on the main branch