### PR TITLE
ci: bump histcmp to 0.6.7 to try to fix yerr issue

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -179,7 +179,7 @@ jobs:
         run: >
           echo "::group::Dependencies"
           && git config --global safe.directory "$GITHUB_WORKSPACE"
-          && pip3 install histcmp==0.6.6 matplotlib
+          && pip3 install histcmp==0.6.7 matplotlib
           && pip3 install -r Examples/Scripts/requirements.txt
           && /usr/local/bin/geant4-config --install-datasets
           && source build/this_acts_withdeps.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,7 +232,7 @@ linux_physmon:
     - cd ..
 
     - git config --global safe.directory "$GITHUB_WORKSPACE"
-    - pip3 install histcmp==0.6.6 matplotlib
+    - pip3 install histcmp==0.6.7 matplotlib
     - pip3 install -r src/Examples/Scripts/requirements.txt
     - /usr/local/bin/geant4-config --install-datasets
     - source build/this_acts_withdeps.sh


### PR DESCRIPTION
The physmon job strangely fails with negative y errors for some ratio plot in the seeding, but only **sometimes**. This smells like a non-reproducibility. I'm bumping histcmp here which should have a guard against the negative values.