### PR TITLE
fix: Add missing newline for `Sequencer` `timing.csv` in Examples

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -78,7 +78,7 @@ class Sequencer {
     /// output directory for timing information, empty for working directory
     std::string outputDir;
     /// output name of the timing file
-    std::string outputTimingFile = "timing.tsv";
+    std::string outputTimingFile = "timing.csv";
     /// Callback that is invoked in the event loop.
     /// @warning This function can be called from multiple threads and should therefore be thread-safe
     IterationCallback iterationCallback = []() {};

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -400,9 +400,9 @@ void storeTiming(const std::vector<std::string>& identifiers,
     const auto time_total_s =
         std::chrono::duration_cast<Seconds>(durations[i]).count();
     file << identifiers[i] << "," << time_total_s << ","
-         << time_total_s / numEvents;
+         << time_total_s / numEvents << "\n";
   }
-  file << std::endl;
+  file << "\n";
 }
 }  // namespace
 


### PR DESCRIPTION
- Add missing new line back in
- Rename to `csv` from `tsv`