### PR TITLE
refactor(gx2f): remove outdated navigation abort conditions

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -622,19 +622,6 @@ class Gx2Fitter {
                                << " has no measurement/material/hole.");
         }
       }
-      ACTS_VERBOSE("result.processedMeasurements: "
-                   << result.processedMeasurements << "\n"
-                   << "inputMeasurements.size(): "
-                   << inputMeasurements->size());
-      if (result.processedMeasurements >= inputMeasurements->size()) {
-        ACTS_INFO("Actor: finish: all measurements found.");
-        result.finished = true;
-      }
-
-      if (result.surfaceCount > 900) {
-        ACTS_INFO("Actor: finish due to limit. Result might be garbage.");
-        result.finished = true;
-      }
     }
   };
 


### PR DESCRIPTION
Removes some unnecessary navigation limits from the GX2F.

## `if (result.processedMeasurements >= inputMeasurements->size()) {`
Not necessary anymore, since we have the same limit already in the beginning of the actor.

## `if (result.surfaceCount > 900) {`
This limit was set to abort the navigation, even if not all measurements have been found. The navigation in the GX2F is now stable enough, that we don't need this limit anymore