### PR TITLE
ci: Add pre-commit hooks for most of our linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,26 +8,26 @@ REQUEST.
 
     The prefix must be one of:
 
-    - `fix`: for a bugfix
-    - `feat`: for a new feature
-    - `refactor`: for an improvement of an existing feature
-    - `perf`, `test`: for performance- or test-related changes
-    - `docs`: for documentation-related changes
-    - `build`, `ci`, `chore`: as appropriated for infrastructure changes
+  - `fix`: for a bugfix
+  - `feat`: for a new feature
+  - `refactor`: for an improvement of an existing feature
+  - `perf`, `test`: for performance- or test-related changes
+  - `docs`: for documentation-related changes
+  - `build`, `ci`, `chore`: as appropriated for infrastructure changes
 
 - [ ] Does this modify the public API as defined in `docs/versioning.rst`?
 
-    - [ ] Does the PR title contain a `!` to indicate a breaking change?
-    - [ ] Is there section starting with `BREAKING CHANGE:` in the PR body
+  - [ ] Does the PR title contain a `!` to indicate a breaking change?
+  - [ ] Is there section starting with `BREAKING CHANGE:` in the PR body
           that explains the breaking change?
 
 - [ ] Is the PR ready to be merged?
 
-    - [ ] If not: is it marked as a draft PR?
+  - [ ] If not: is it marked as a draft PR?
 
 - [ ] Does this PR close an existing issue?
 
-    - [ ] Is the issue correctly linked so it will be automatically closed
+  - [ ] Is the issue correctly linked so it will be automatically closed
         upon successful merge (See closing keywords link in the sidebar)?
 
 - The CI will initially report a missing milestone. One of the maintainers will
@@ -36,6 +36,6 @@ REQUEST.
 - An automated workflow will assign labels based on changed files, and whether
   or not reference files were changed. These do not have to be set manually.
 
-- If you push updates, and you know they will be superceded later on, consider adding
+- If you push updates, and you know they will be superseded later on, consider adding
   `[skip ci]` in the commit message. This will instruct the CI system not to run any
   jobs on this commit.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,61 @@ repos:
     hooks:
     - id: gersemi
       args: ["-i", "--no-warn-about-unknown-commands"]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+    - id: codespell
+      args: [
+        "-S", "*.ipynb,*.onnx,_build,*.svg",
+        "-I", "./CI/codespell_ignore.txt"
+      ]
+      exclude: ^CI/.*$
+
+  - repo: local
+    hooks:
+    - id: license
+      name: license
+      language: system
+      entry: CI/check_license.py
+      files: \.(cpp|hpp|ipp|cu|cuh)$
+
+  - repo: local
+    hooks:
+    - id: include_guards
+      name: include_guards
+      language: system
+      entry: CI/check_include_guards.py --fail-global
+      files: \.hpp$
+
+  - repo: local
+    hooks:
+    - id: pragma_once
+      name: pragma_once
+      language: system
+      entry: CI/check_pragma_once.sh
+      files: \.hpp$
+
+  - repo: local
+    hooks:
+    - id: type_t
+      name: type_t
+      language: system
+      entry: CI/check_type_t.py
+      files: \.(cpp|hpp|ipp|cu|cuh)$
+
+  - repo: local
+    hooks:
+    - id: boost_test
+      name: boost_test
+      language: system
+      entry: CI/check_boost_test_macro.sh
+      files: ^Tests\/.*\.(cpp|hpp|ipp|cu|cuh)$
+
+  - repo: local
+    hooks:
+    - id: cmake_options
+      name: cmake_options
+      language: system
+      entry: docs/parse_cmake_options.py --write docs/getting_started.md
+      files: ^CMakeLists.txt$

--- a/CI/check_boost_test_macro.sh
+++ b/CI/check_boost_test_macro.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-test_string="BOOST_TEST("
-grep $test_string -n -r Tests --include "*.cpp" --include "*.hpp" --include "*.ipp"
+files="$@"
 
-status=$?
-
-if [[ $status -eq 0 ]]; then
-  echo "Found occurrences of '$test_string'"
-  exit 1
-else
-  echo "Did not find occurrences of '$test_string'"
-  exit 0
+if [ -z "$files" ]; then
+    files=$(find Tests -name "*.hpp" -or -name "*.cpp" -or -name "*.ipp")
 fi
+
+test_string="BOOST_TEST("
+
+ec=0
+for file in $files; do
+  grep -n "$test_string" "$file"
+  status=$?
+  if [ $status -ne 1 ]; then
+    echo "Found occurrences of '$test_string' in '$file'"
+    ec=1
+  fi
+done
+
+exit $ec

--- a/CI/check_include_guards.py
+++ b/CI/check_include_guards.py
@@ -75,7 +75,7 @@ def main():
     input_help = """
 Input files: either file path, dir path (will glob for headers) or custom glob pattern
     """
-    p.add_argument("input", help=input_help.strip())
+    p.add_argument("input", nargs="+", help=input_help.strip())
     p.add_argument(
         "--fail-local", "-l", action="store_true", help="Fail on local include guards"
     )
@@ -90,15 +90,20 @@ Input files: either file path, dir path (will glob for headers) or custom glob p
 
     headers = []
 
-    if os.path.isfile(args.input):
-        headers = [args.input]
-    elif os.path.isdir(args.input):
-        patterns = ["**/*.hpp", "**/*.h"]
-        headers = sum(
-            [glob(os.path.join(args.input, p), recursive=True) for p in patterns], []
-        )
-    else:
-        headers = glob(args.input, recursive=True)
+    if len(args.input) == 1:
+        if os.path.isdir(args.input[0]):
+            patterns = ["**/*.hpp", "**/*.h"]
+            headers = sum(
+                [
+                    glob(os.path.join(args.input[0], p), recursive=True)
+                    for p in patterns
+                ],
+                [],
+            )
+        else:
+            headers = glob(args.input[0], recursive=True)
+    elif all([os.path.isfile(i) for i in args.input]):
+        headers = args.input
 
     valid = True
     nlocal = 0

--- a/CI/check_license.py
+++ b/CI/check_license.py
@@ -80,7 +80,7 @@ def check_git_dates(src):
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("input")
+    p.add_argument("input", nargs="+")
     p.add_argument(
         "--fix", action="store_true", help="Attempt to fix any license issues found."
     )
@@ -99,13 +99,13 @@ def main():
     args = p.parse_args()
     print(args.exclude)
 
-    if os.path.isdir(args.input):
+    if len(args.input) == 1 and os.path.isdir(args.input[0]):
         srcs = (
             str(
                 check_output(
                     [
                         "find",
-                        args.input,
+                        args.input[0],
                         "-iname",
                         "*.cpp",
                         "-or",
@@ -123,7 +123,7 @@ def main():
         )
         srcs = filter(lambda p: not p.startswith("./build"), srcs)
     else:
-        srcs = [args.input]
+        srcs = args.input
 
     year = int(datetime.now().strftime("%Y"))
 

--- a/CI/check_pragma_once.sh
+++ b/CI/check_pragma_once.sh
@@ -2,7 +2,13 @@
 
 ec=0
 
-for file in $(find Core Examples Tests Plugins -name "*.hpp"); do
+files="$@"
+
+if [ -z "$files" ]; then
+    files=$(find Core Examples Tests Plugins -name "*.hpp")
+fi
+
+for file in $files; do
     res=$(grep -e "^[[:space:]]*#pragma once" $file)
     if [[ "$res" != "#pragma once" ]]; then
         ec=1

--- a/CI/check_type_t.py
+++ b/CI/check_type_t.py
@@ -56,7 +56,7 @@ def main():
 
     exit_code = 0
 
-    files = []
+    inputs = []
 
     if len(args.input) == 1 and os.path.isdir(args.input[0]):
         # walk over all files
@@ -80,12 +80,12 @@ def main():
                 if any([fnmatch(str(filepath), e) for e in args.exclude]):
                     continue
 
-                files.append(filepath)
+                inputs.append(filepath)
     else:
         for file in args.input:
-            files.append(Path(file))
+            inputs.append(Path(file))
 
-    for filepath in files:
+    for filepath in inputs:
         for c_type in type_list:
             changed_lines = handle_file(file=filepath, fix=args.fix, c_type=c_type)
             if len(changed_lines) > 0:

--- a/CI/check_type_t.py
+++ b/CI/check_type_t.py
@@ -48,7 +48,7 @@ def handle_file(file: Path, fix: bool, c_type: str) -> list[tuple[int, str]]:
 
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("input")
+    p.add_argument("input", nargs="+")
     p.add_argument("--fix", action="store_true", help="Attempt to fix C-style types.")
     p.add_argument("--exclude", "-e", action="append", default=[])
 
@@ -56,40 +56,49 @@ def main():
 
     exit_code = 0
 
-    # walk over all files
-    for root, _, files in os.walk("."):
-        root = Path(root)
-        for filename in files:
-            # get the full path of the file
-            filepath = root / filename
-            if filepath.suffix not in (
-                ".hpp",
-                ".cpp",
-                ".ipp",
-                ".h",
-                ".C",
-                ".c",
-                ".cu",
-                ".cuh",
-            ):
-                continue
+    files = []
 
-            if any([fnmatch(str(filepath), e) for e in args.exclude]):
-                continue
+    if len(args.input) == 1 and os.path.isdir(args.input[0]):
+        # walk over all files
+        for root, _, files in os.walk(args.input[0]):
+            root = Path(root)
+            for filename in files:
+                # get the full path of the file
+                filepath = root / filename
+                if filepath.suffix not in (
+                    ".hpp",
+                    ".cpp",
+                    ".ipp",
+                    ".h",
+                    ".C",
+                    ".c",
+                    ".cu",
+                    ".cuh",
+                ):
+                    continue
 
-            for c_type in type_list:
-                changed_lines = handle_file(file=filepath, fix=args.fix, c_type=c_type)
-                if len(changed_lines) > 0:
-                    exit_code = 1
-                    print()
-                    print(filepath)
-                    for i, oline in changed_lines:
-                        print(f"{i}: {oline}")
+                if any([fnmatch(str(filepath), e) for e in args.exclude]):
+                    continue
 
-                        if github:
-                            print(
-                                f"::error file={filepath},line={i+1},title=Do not use C-style {c_type}::Replace {c_type} with std::{c_type}"
-                            )
+                files.append(filepath)
+    else:
+        for file in args.input:
+            files.append(Path(file))
+
+    for filepath in files:
+        for c_type in type_list:
+            changed_lines = handle_file(file=filepath, fix=args.fix, c_type=c_type)
+            if len(changed_lines) > 0:
+                exit_code = 1
+                print()
+                print(filepath)
+                for i, oline in changed_lines:
+                    print(f"{i}: {oline}")
+
+                    if github:
+                        print(
+                            f"::error file={filepath},line={i+1},title=Do not use C-style {c_type}::Replace {c_type} with std::{c_type}"
+                        )
 
     return exit_code
 

--- a/CI/codespell_ignore.txt
+++ b/CI/codespell_ignore.txt
@@ -22,3 +22,5 @@ dthe
 dthe
 vart
 pixelx
+millepede
+dependees

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,6 @@ authors:
   affiliation: Universite Paris-Saclay / CNRS/IN2P3
 - given-names: Robert
   family-names: Langenberg
-  affiliation: University of Massachussets
 - given-names: Corentin
   family-names: Allaire
   affiliation: CERN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ option(ACTS_BUILD_DOCS "Build documentation" OFF)
 option(ACTS_SETUP_BOOST "Explicitly set up Boost for the project" ON)
 option(ACTS_SETUP_EIGEN3 "Explicitly set up Eigen3 for the project" ON)
 option(ACTS_BUILD_ODD "Build the OpenDataDetector" OFF)
-# profiling related optios
+# profiling related options
 option(ACTS_ENABLE_CPU_PROFILING "Enable CPU profiling using gperftools" OFF)
 option(ACTS_ENABLE_MEMORY_PROFILING "Enable memory profiling using gperftools" OFF)
 set(ACTS_GPERF_INSTALL_DIR "" CACHE STRING "Hint to help find gperf if profiling is enabled")
@@ -298,7 +298,7 @@ find_package(Filesystem REQUIRED)
 
 # the `<project_name>_VERSION` variables set by `setup(... VERSION ...)` have
 # only local scope, i.e. they are not accessible her for dependencies added
-# via `add_subdirectory`. this overrides the `project(...)` funcion for
+# via `add_subdirectory`. this overrides the `project(...)` function for
 # sub-projects such that the resulting `<project_name>_VERSION` has
 # global scope and is accessible within the main project later on.
 cmake_policy(SET CMP0048 NEW)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -220,7 +220,7 @@ bugfix should happen in a different branch. The recommended procedure
 for handling this situation is the following:
 
 #. Get into a clean state of your working directory on your feature
-   branch (either by commiting open changes or by stashing them).
+   branch (either by committing open changes or by stashing them).
 #. Checkout the branch the bugfix should be merged into (either *main*
    or *release/X.Y.Z*) and get the most recent version.
 #. Create a new branch for the bugfix.
@@ -238,7 +238,7 @@ Example: Backporting a feature or bugfix
 
 Suppose you have a bugfix or feature branch that is eventually going to
 be merged in ``main``. You might want to have the feature/bugfix
-avilable in a patch (say ``0.25.1``) tag. To to that, find the
+available in a patch (say ``0.25.1``) tag. To to that, find the
 corresponding release branch, for this example that would be
 ``release/v0.25.X``. You must create a dedicated branch that **only**
 contains the commits that relate to your feature/bugfix, otherwise the

--- a/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
+++ b/Fatras/include/ActsFatras/Digitization/PlanarSurfaceMask.hpp
@@ -30,7 +30,7 @@ struct PlanarSurfaceMask {
   using Segment2D = std::array<Acts::Vector2, 2>;
 
   /// Apply the mask on the segment
-  /// - If the semgent is full inside the surface, return unchanged
+  /// - If the segment is fully inside the surface, return unchanged
   /// - Otherwise mask/clip the segment to fit into the bounds
   ///
   /// @note Only PlaneSurface/DiscSurface are supported
@@ -64,7 +64,7 @@ struct PlanarSurfaceMask {
   ///
   /// @param rBounds The radial disc for the masking
   /// @param segment The track segment (on surface)
-  /// @param polarSegment The track segmetn (on surface, in polar)
+  /// @param polarSegment The track segment (on surface, in polar)
   /// @param firstInside The indicator if the first is inside
   ///
   /// @return a result wrapping a segment

--- a/Fatras/include/ActsFatras/Digitization/Segmentizer.hpp
+++ b/Fatras/include/ActsFatras/Digitization/Segmentizer.hpp
@@ -74,7 +74,7 @@ struct Segmentizer {
     /// Constructor with arguments
     ///
     /// @param bin_ The bin corresponding to this step
-    /// @param path2D_ The start/end 2D position of the segement
+    /// @param path2D_ The start/end 2D position of the segment
     /// @param activation_ The segment activation (clean: length) for this bin
     ChannelSegment(Bin2D bin_, Segment2D path2D_, double activation_)
         : bin(bin_), path2D(std::move(path2D_)), activation(activation_) {}

--- a/Fatras/include/ActsFatras/Kernel/ContinuousProcess.hpp
+++ b/Fatras/include/ActsFatras/Kernel/ContinuousProcess.hpp
@@ -37,7 +37,7 @@ namespace ActsFatras {
 /// filter the generated child particles.
 ///
 /// @note The output and child particle selectors are identical unless the
-///       child particle selector is explicitely specified.
+///       child particle selector is explicitly specified.
 template <typename physics_t, typename input_particle_selector_t,
           typename output_particle_selector_t,
           typename child_particle_selector_t = output_particle_selector_t>

--- a/Fatras/include/ActsFatras/Kernel/InteractionList.hpp
+++ b/Fatras/include/ActsFatras/Kernel/InteractionList.hpp
@@ -119,7 +119,7 @@ using PointLikeIndices = TupleFilter<IsPointLikeProcess, processes_t>;
 ///
 /// Continuous processes scale with the passed material. They tpyically
 /// describe effective results of a large number of small interactions such as
-/// multiple scattering or ionisation. Continous process types **must** provide
+/// multiple scattering or ionisation. Continuous process types **must** provide
 /// a call operator with the following signature:
 ///
 ///     template <typename generator_t>
@@ -167,7 +167,7 @@ using PointLikeIndices = TupleFilter<IsPointLikeProcess, processes_t>;
 ///   destruction is typically of more interest to the user and this simplifies
 ///   validation.
 ///
-/// The physics processes are extendable by the user to accomodate their
+/// The physics processes are extendable by the user to accommodate their
 /// specific requirements. While the set of available physics processes must be
 /// configured at compile-time, within that set, processes can again be
 /// selectively disabled at run-time. By default all processes are applied.
@@ -221,7 +221,7 @@ class InteractionList {
   /// @param[in]     slab      is the passed material
   /// @param[in,out] particle  is the particle being updated
   /// @param[out]    generated is the container of generated particles
-  /// @return Break condition, i.e. whether a process stoped the propagation
+  /// @return Break condition, i.e. whether a process stopped the propagation
   template <typename generator_t>
   bool runContinuous(generator_t& rng, const Acts::MaterialSlab& slab,
                      Particle& particle,

--- a/Fatras/include/ActsFatras/Kernel/Simulation.hpp
+++ b/Fatras/include/ActsFatras/Kernel/Simulation.hpp
@@ -259,7 +259,7 @@ struct Simulation {
       }
     }
 
-    // the overall function call succeeded, i.e. no fatal errors occured.
+    // the overall function call succeeded, i.e. no fatal errors occurred.
     // yet, there might have been some particle for which the propagation
     // failed. thus, the successful result contains a list of failed particles.
     // sounds a bit weird, but that is the way it is.

--- a/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
+++ b/Fatras/include/ActsFatras/Kernel/detail/SimulationActor.hpp
@@ -262,8 +262,8 @@ struct SimulationActor {
 
   /// Run the interaction simulation for the given material.
   ///
-  /// Simulate all continous processes and at most one point-like process within
-  /// the material.
+  /// Simulate all continuous processes and at most one point-like process
+  /// within the material.
   void interact(const Acts::MaterialSlab &slab, result_type &result) const {
     // run the continuous processes over a fraction of the material. returns
     // true on break condition (same as the underlying physics lists).
@@ -283,7 +283,7 @@ struct SimulationActor {
       // the SimulationActor is in charge of keeping track of the material.
       // since the accumulated material is stored in the particle it could (but
       // should not) be modified by a physics process. to avoid issues, the
-      // material is updated only after process simulation has occured. this
+      // material is updated only after process simulation has occurred. this
       // intentionally overwrites any material updates made by the process.
       result.particle.setMaterialPassed(x0, l0);
       return retval;
@@ -306,7 +306,7 @@ struct SimulationActor {
     //
     // fraction < 0:
     //   this is an error case where the point-like interaction should have
-    //   occured before reaching the material. not sure how this could happen,
+    //   occurred before reaching the material. not sure how this could happen,
     //   but in such a case the point-like interaction happens immediately.
     // 1 < fraction:
     //   the next point-like interaction does not occur within the current

--- a/Fatras/include/ActsFatras/Physics/ElectroMagnetic/PhotonConversion.hpp
+++ b/Fatras/include/ActsFatras/Physics/ElectroMagnetic/PhotonConversion.hpp
@@ -59,7 +59,7 @@ class PhotonConversion {
   /// @param [in, out] particle The interacting photon
   /// @param [out] generated List of generated particles
   ///
-  /// @return True if the conversion occured, else false
+  /// @return True if the conversion occurred, else false
   template <typename generator_t>
   bool run(generator_t& generator, Particle& particle,
            std::vector<Particle>& generated) const;

--- a/Fatras/include/ActsFatras/Selectors/SelectorHelpers.hpp
+++ b/Fatras/include/ActsFatras/Selectors/SelectorHelpers.hpp
@@ -53,12 +53,12 @@ struct Range {
   }
 };
 
-/// Select objects that fullfil all selectors.
+/// Select objects that fulfill all selectors.
 template <typename... selectors_t>
 using CombineAnd =
     detail::CombineSelectors<true, std::logical_and<bool>, selectors_t...>;
 
-/// Select objects that fullfil at least one selector.
+/// Select objects that fulfill at least one selector.
 template <typename... selectors_t>
 using CombineOr =
     detail::CombineSelectors<false, std::logical_or<bool>, selectors_t...>;

--- a/Fatras/src/Digitization/DigitizationError.cpp
+++ b/Fatras/src/Digitization/DigitizationError.cpp
@@ -26,7 +26,7 @@ class DigitizationErrorCategory : public std::error_category {
       case DigitizationError::SmearingOutOfRange:
         return "Smeared out of surface bounds.";
       case DigitizationError::SmearingError:
-        return "Smearing error occured.";
+        return "Smearing error occurred.";
       case DigitizationError::UndefinedSurface:
         return "Surface undefined for this operation.";
       case DigitizationError::MaskingError:

--- a/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceDrift.cpp
@@ -25,7 +25,7 @@ ActsFatras::PlanarSurfaceDrift::toReadout(const Acts::GeometryContext& gctx,
   Acts::Vector3 seg3Local = invTransform.linear() * dir;
   // Scale unit direction to the actual segment in the (depletion/drift) zone
   seg3Local *= thickness / std::cos(Acts::VectorHelpers::theta(seg3Local));
-  // Calulate local entry/exit before drift
+  // Calculate local entry/exit before drift
   Acts::Vector2 entry = pos2Local - 0.5 * seg3Local.segment<2>(0);
   Acts::Vector2 exit = pos2Local + 0.5 * seg3Local.segment<2>(0);
   // Actually apply a drift


### PR DESCRIPTION
Use pre-commit for more of our linting. I'm adding local-only hooks for most of the check scripts we run in the CI, and I'm adding a codespell hook.

The pre-commit CI job will now implicitly also run these checks, but I suggest we keep the dedicated jobs for now and remove them at a later time if we want.