### PR TITLE
revert: "refactor: Remove `calculateTrackQuantities` from Core CKF (#3536)"

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -1330,6 +1330,10 @@ class CombinatorialKalmanFilter {
       return error.error();
     }
 
+    for (const auto& track : combKalmanResult.collectedTracks) {
+      calculateTrackQuantities(track);
+    }
+
     return std::move(combKalmanResult.collectedTracks);
   }
 };


### PR DESCRIPTION
This is causing FPEs in Athena which seem to originate from the ambiguity solver. I suspect that the reason is not setting `ndf` in the CKF which is then directly passed to the ambi in Athena