### PR TITLE
refactor: Detector Element refactoring proposal

### DIFF
--- a/Core/include/Acts/Geometry/DetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/DetectorElementBase.hpp
@@ -31,7 +31,9 @@ class Surface;
 
 class DetectorElementBase {
  public:
-  DetectorElementBase() = default;
+  /// Construct a detector element. It will have ownership of the surface
+  DetectorElementBase(std::shared_ptr<Surface>&& surface)
+      : m_surface(surface) {}
   virtual ~DetectorElementBase() = default;
 
   /// Return the transform for the Element proxy mechanism

--- a/Core/include/Acts/Geometry/DetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/DetectorElementBase.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 
 #include <memory>
 #include <vector>
@@ -32,9 +33,16 @@ class Surface;
 class DetectorElementBase {
  public:
   /// Construct a detector element. It will have ownership of the surface
-  DetectorElementBase(std::shared_ptr<Surface>&& surface)
-      : m_surface(surface) {}
-  virtual ~DetectorElementBase() = default;
+  DetectorElementBase(std::shared_ptr<Surface>&& surface) : m_surface(surface) {
+    if (m_surface->m_associatedDetElement != nullptr) {
+      throw std::runtime_error("Detector Element already associated");
+    }
+
+    m_surface->m_associatedDetElement = this;
+  }
+  virtual ~DetectorElementBase() {
+    m_surface->m_associatedDetElement = nullptr;
+  }
 
   /// Return the transform for the Element proxy mechanism
   ///

--- a/Core/include/Acts/Geometry/DetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/DetectorElementBase.hpp
@@ -40,14 +40,17 @@ class DetectorElementBase {
   virtual const Transform3& transform(const GeometryContext& gctx) const = 0;
 
   /// Return surface representation - const return pattern
-  virtual const Surface& surface() const = 0;
+  virtual const Surface& surface() const { return *m_surface; };
 
   /// Non-const return pattern
-  virtual Surface& surface() = 0;
+  virtual Surface& surface() { return *m_surface; };
 
   /// Returns the thickness of the module
   /// @return double that indicates the thickness of the module
   virtual double thickness() const = 0;
+
+ private:
+  std::shared_ptr<Surface> m_surface;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Geometry/DetectorElementBase.hpp
+++ b/Core/include/Acts/Geometry/DetectorElementBase.hpp
@@ -33,7 +33,7 @@ class Surface;
 class DetectorElementBase {
  public:
   /// Construct a detector element. It will have ownership of the surface
-  DetectorElementBase(std::shared_ptr<Surface>&& surface) : m_surface(surface) {
+  explicit DetectorElementBase(std::shared_ptr<Surface>&& surface) : m_surface(surface) {
     if (m_surface->m_associatedDetElement != nullptr) {
       throw std::runtime_error("Detector Element already associated");
     }

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -68,13 +68,6 @@ class CylinderSurface : public RegularSurface {
   CylinderSurface(const Transform3& transform,
                   std::shared_ptr<const CylinderBounds> cbounds);
 
-  /// Constructor from DetectorElementBase: Element proxy
-  ///
-  /// @param cbounds are the provided cylinder bounds (shared)
-  /// @param detelement is the linked detector element to this surface
-  CylinderSurface(std::shared_ptr<const CylinderBounds> cbounds,
-                  const DetectorElementBase& detelement);
-
   /// Copy constructor
   ///
   /// @param other is the source cylinder for the copy

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -87,13 +87,6 @@ class DiscSurface : public RegularSurface {
   DiscSurface(const Transform3& transform,
               std::shared_ptr<const DiscBounds> dbounds = nullptr);
 
-  /// Constructor from DetectorElementBase : Element proxy
-  ///
-  /// @param dbounds The disc bounds describing the surface coverage
-  /// @param detelement The detector element represented by this surface
-  DiscSurface(std::shared_ptr<const DiscBounds> dbounds,
-              const DetectorElementBase& detelement);
-
   /// Copy Constructor
   ///
   /// @param other The source surface for the copy

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -67,13 +67,6 @@ class PlaneSurface : public RegularSurface {
   /// @param normal is thenormal vector of the plane surface
   PlaneSurface(const Vector3& center, const Vector3& normal);
 
-  /// Constructor from DetectorElementBase : Element proxy
-  ///
-  /// @param pbounds are the provided planar bounds
-  /// @param detelement is the linked detector element to this surface
-  PlaneSurface(std::shared_ptr<const PlanarBounds> pbounds,
-               const DetectorElementBase& detelement);
-
   /// Constructor for Planes with (optional) shared bounds object
   ///
   /// @param transform transform in 3D that positions this surface

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -64,6 +64,7 @@ class Surface : public virtual GeometryObject,
                 public std::enable_shared_from_this<Surface> {
  public:
   friend struct GeometryContextOstreamWrapper<Surface>;
+  friend class DetectorElementBase;
 
   /// @enum SurfaceType
   ///
@@ -224,11 +225,6 @@ class Surface : public virtual GeometryObject,
   /// @return SurfaceMaterial as shared_pointer, can be nullptr
   const std::shared_ptr<const ISurfaceMaterial>& surfaceMaterialSharedPtr()
       const;
-
-  /// Assign a detector element
-  ///
-  /// @param detelement Detector element which is represented by this surface
-  void assignDetectorElement(const DetectorElementBase& detelement);
 
   /// Assign the surface material description
   ///
@@ -491,9 +487,6 @@ class Surface : public virtual GeometryObject,
   /// (translation, rotation) the surface in global space
   std::unique_ptr<const Transform3> m_transform{};
 
-  /// Pointer to the a DetectorElementBase
-  const DetectorElementBase* m_associatedDetElement{nullptr};
-
   /// The associated layer Layer - layer in which the Surface is be embedded,
   /// nullptr if not associated
   const Layer* m_associatedLayer{nullptr};
@@ -523,6 +516,9 @@ class Surface : public virtual GeometryObject,
   AlignmentToBoundMatrix alignmentToBoundDerivativeWithoutCorrection(
       const GeometryContext& gctx, const Vector3& position,
       const Vector3& direction) const;
+
+  /// Pointer to the a DetectorElementBase
+  const DetectorElementBase* m_associatedDetElement{nullptr};
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -98,11 +98,6 @@ class Surface : public virtual GeometryObject,
   /// @param other Source surface for copy.
   Surface(const Surface& other);
 
-  /// Constructor from DetectorElementBase: Element proxy
-  ///
-  /// @param detelement Detector element which is represented by this surface
-  Surface(const DetectorElementBase& detelement);
-
   /// Copy constructor with optional shift
   ///
   /// @note copy construction invalidates the association


### PR DESCRIPTION
After several discussions with @asalzburger and @paulgessinger, I thought about a redesign of the `DetectorElementBase` with @andiwand. This should make clear the ownership model and order of construction, avoiding constructions like currently implemented.

Core ideas are:
- The `DetectorElementBase` has shared ownership to a surface
- Through `friend`ship with `Surface` it soley controls the association of a surface to a detector element.
- Surface constructors with `DetectorElementBase` are removed.  

**Note:** This is not meant to compile at the moment, it rather should be a point to discuss the interface on concrete code.