### PR TITLE
refactor!: Rename `EigenStepper` dense extension

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepperDenseExtension.hpp
+++ b/Core/include/Acts/Propagator/EigenStepperDenseExtension.hpp
@@ -25,7 +25,7 @@ namespace Acts {
 /// ioninisation, bremsstrahlung, pair production and photonuclear interaction
 /// in the propagation and the jacobian. These effects will only occur if the
 /// propagation is in a TrackingVolume with attached material.
-struct EigenStepperDenseEnvironmentExtension {
+struct EigenStepperDenseExtension {
   using Scalar = ActsScalar;
   /// @brief Vector3 replacement for the custom scalar type
   using ThisVector3 = Eigen::Matrix<Scalar, 3, 1>;

--- a/Tests/IntegrationTests/PropagationDenseConstant.cpp
+++ b/Tests/IntegrationTests/PropagationDenseConstant.cpp
@@ -16,7 +16,7 @@
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Material/HomogeneousVolumeMaterial.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
-#include "Acts/Propagator/EigenStepperDenseEnvironmentExtension.hpp"
+#include "Acts/Propagator/EigenStepperDenseExtension.hpp"
 #include "Acts/Propagator/Navigator.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/RiddersPropagator.hpp"
@@ -34,7 +34,7 @@ namespace ds = ActsTests::PropagationDatasets;
 using namespace Acts::UnitLiterals;
 
 using MagneticField = Acts::ConstantBField;
-using Stepper = Acts::EigenStepper<Acts::EigenStepperDenseEnvironmentExtension>;
+using Stepper = Acts::EigenStepper<Acts::EigenStepperDenseExtension>;
 using Propagator = Acts::Propagator<Stepper, Acts::Navigator>;
 using RiddersPropagator = Acts::RiddersPropagator<Propagator>;
 

--- a/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
@@ -35,7 +35,7 @@
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/EigenStepperDefaultExtension.hpp"
-#include "Acts/Propagator/EigenStepperDenseEnvironmentExtension.hpp"
+#include "Acts/Propagator/EigenStepperDenseExtension.hpp"
 #include "Acts/Propagator/EigenStepperError.hpp"
 #include "Acts/Propagator/MaterialInteractor.hpp"
 #include "Acts/Propagator/Navigator.hpp"
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
 }
 
 /// @brief This function tests the EigenStepper with the EigenStepperDefaultExtension and
-/// the EigenStepperDenseEnvironmentExtension. The focus of this tests lies in
+/// the EigenStepperDenseExtension. The focus of this tests lies in
 /// the choosing of the right extension for the individual use case. This is
 /// performed with three different detectors:
 /// a) Pure vacuum -> DefaultExtension needs to act
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
   const CurvilinearTrackParameters sbtp(Vector4::Zero(), startDir, 1_e / 1_GeV,
                                         cov, ParticleHypothesis::pion());
 
-  using Stepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using Stepper = EigenStepper<EigenStepperDenseExtension>;
   using Propagator = Propagator<Stepper, Navigator>;
   using PropagatorOptions =
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
@@ -609,7 +609,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacuum_test) {
     CHECK_CLOSE_ABS(mom, startMom, 1_keV);
   }
 
-  using DefStepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using DefStepper = EigenStepper<EigenStepperDenseExtension>;
   using DefPropagator = Acts::Propagator<DefStepper, Navigator>;
   using DefPropagatorOptions =
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
@@ -672,7 +672,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
   const CurvilinearTrackParameters sbtp(Vector4::Zero(), startDir, 1_e / 5_GeV,
                                         cov, ParticleHypothesis::pion());
 
-  using Stepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using Stepper = EigenStepper<EigenStepperDenseExtension>;
   using Propagator = Propagator<Stepper, Navigator>;
   using PropagatorOptions =
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
@@ -713,7 +713,7 @@ BOOST_AUTO_TEST_CASE(step_extension_material_test) {
     }
   }
 
-  using DenseStepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using DenseStepper = EigenStepper<EigenStepperDenseExtension>;
   using DensePropagator = Acts::Propagator<DenseStepper, Navigator>;
   using DensePropagatorOptions =
       DensePropagator::Options<ActionList<StepCollector>,
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
                                   1_e / 5_GeV, Covariance::Identity(),
                                   ParticleHypothesis::pion());
 
-  using Stepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using Stepper = EigenStepper<EigenStepperDenseExtension>;
   using Propagator = Acts::Propagator<Stepper, Navigator>;
   using PropagatorOptions =
       Propagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
@@ -872,7 +872,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   // Build launcher through vacuum
   // Set options for propagator
 
-  using DefStepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using DefStepper = EigenStepper<EigenStepperDenseExtension>;
   using DefPropagator = Acts::Propagator<DefStepper, Navigator>;
   using DefPropagatorOptions =
       DefPropagator::Options<ActionList<StepCollector>, AbortList<EndOfWorld>>;
@@ -922,7 +922,7 @@ BOOST_AUTO_TEST_CASE(step_extension_vacmatvac_test) {
   // Set initial parameters for the particle track by using the result of the
   // first volume
 
-  using DenseStepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using DenseStepper = EigenStepper<EigenStepperDenseExtension>;
   using DensePropagator = Acts::Propagator<DenseStepper, Navigator>;
   using DensePropagatorOptions =
       DensePropagator::Options<ActionList<StepCollector>,
@@ -1052,7 +1052,7 @@ BOOST_AUTO_TEST_CASE(step_extension_trackercalomdt_test) {
                                   1_e / 1_GeV, Covariance::Identity(),
                                   ParticleHypothesis::pion());
 
-  using Stepper = EigenStepper<EigenStepperDenseEnvironmentExtension>;
+  using Stepper = EigenStepper<EigenStepperDenseExtension>;
   using Propagator = Acts::Propagator<Stepper, Navigator>;
   using PropagatorOptions =
       Propagator::Options<ActionList<StepCollector, MaterialInteractor>,

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -24,7 +24,7 @@
 #include "Acts/Propagator/ActionList.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
-#include "Acts/Propagator/EigenStepperDenseEnvironmentExtension.hpp"
+#include "Acts/Propagator/EigenStepperDenseExtension.hpp"
 #include "Acts/Propagator/Navigator.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE(BasicPropagatorInterface) {
     BOOST_CHECK(resultCurv.ok());
   }
 
-  EigenStepper<EigenStepperDenseEnvironmentExtension> denseEigenStepper{field};
+  EigenStepper<EigenStepperDenseExtension> denseEigenStepper{field};
 
   {
     Propagator propagator{denseEigenStepper, navigator};

--- a/docs/core/propagation.md
+++ b/docs/core/propagation.md
@@ -110,15 +110,15 @@ The {class}`Acts::StraightLineStepper` is a very stripped down stepper that just
 
 The {class}`Acts::EigenStepper` implements the same functionality as the ATLAS stepper, however, the stepping code is rewritten by using `Eigen` primitives. Thus, it also uses a 4th-order Runge-Kutta algorithm for the integration of the EOM. Additionally, the {class}`Acts::EigenStepper` allows to customize the concrete integration step via **extension**.
 
-The extension encapsulate the relevant equations for different environments. There exists a {struct}`Acts::EigenStepperDefaultExtension` that is suited for propagation in a vacuum, and the {struct}`Acts::EigenStepperDenseEnvironmentExtension`, that contains additional code to handle the propagation inside materials. Which extension is used is decided by the user.
+The extension encapsulate the relevant equations for different environments. There exists a {struct}`Acts::EigenStepperDefaultExtension` that is suited for propagation in a vacuum, and the {struct}`Acts::EigenStepperDenseExtension`, that contains additional code to handle the propagation inside materials. Which extension is used is decided by the user.
 
 The extension can be configured via the {class}`Acts::EigenStepper`:
 
 ```c++
-using Stepper = Acts::EigenStepper<Acts::EigenStepperDenseEnvironmentExtension>;
+using Stepper = Acts::EigenStepper<Acts::EigenStepperDenseExtension>;
 ```
 
-By default, the {class}`Acts::EigenStepper` only uses the {struct}`Acts::EigenStepperDenseEnvironmentExtension`.
+By default, the {class}`Acts::EigenStepper` only uses the {struct}`Acts::EigenStepperDenseExtension`.
 
 ### MultiEigenStepperLoop
 


### PR DESCRIPTION
During Athena integration I realized that the naming is a bit inconsistent with `EigenStepperDefaultExtension` and `EigenStepperDenseEnvironmentExtension`. I think `EigenStepperDenseExtension` fits better.