### PR TITLE
refactor: TrackingGeometry interface cleanup

### DIFF
--- a/CI/physmon/workflows/physmon_simulation.py
+++ b/CI/physmon/workflows/physmon_simulation.py
@@ -87,7 +87,7 @@ with tempfile.TemporaryDirectory() as temp:
         rnd,
         preSelectParticles=None,
         postSelectParticles=ParticleSelectorConfig(removeSecondaries=True),
-        killVolume=setup.trackingGeometry.worldVolume,
+        killVolume=setup.trackingGeometry.highestTrackingVolume,
         killAfterTime=25 * u.ns,
         killSecondaries=True,
         inputParticles="particles_input",

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -64,11 +64,6 @@ class TrackingGeometry {
   /// @return plain pointer to the world volume
   const TrackingVolume* highestTrackingVolume() const;
 
-  /// Access to the world volume
-  /// @return shared pointer to the world volume
-  const std::shared_ptr<const TrackingVolume>& highestTrackingVolumeShared()
-      const;
-
   /// return the lowest tracking Volume
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -62,7 +62,7 @@ class TrackingGeometry {
 
   /// Access to the world volume
   /// @return shared pointer to the world volume
-  const std::shared_ptr<const TrackingVolume>& highestTrackingVolumePtr() const;
+  std::shared_ptr<const TrackingVolume> highestTrackingVolumePtr() const;
 
   /// return the lowest tracking Volume
   ///

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -60,6 +60,10 @@ class TrackingGeometry {
   /// @return plain pointer to the world volume
   const TrackingVolume* highestTrackingVolume() const;
 
+  /// Access to the world volume
+  /// @return shared pointer to the world volume
+  const std::shared_ptr<const TrackingVolume>& highestTrackingVolumePtr() const;
+
   /// return the lowest tracking Volume
   ///
   /// @param gctx The current geometry context object, e.g. alignment

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -87,19 +87,6 @@ class TrackingGeometry {
   const Layer* associatedLayer(const GeometryContext& gctx,
                                const Vector3& gp) const;
 
-  /// Register the beam tube
-  ///
-  /// @param beam is the beam line surface
-  void registerBeamTube(std::shared_ptr<const PerigeeSurface> beam);
-
-  /// @brief surface representing the beam pipe
-  ///
-  /// @note The ownership is not passed, e.g. do not delete the pointer
-  ///
-  /// @return raw pointer to surface representing the beam pipe
-  ///         (could be a null pointer)
-  const Surface* getBeamline() const;
-
   /// @brief Visit all reachable surfaces
   ///
   /// @tparam visitor_t Type of the callable visitor
@@ -166,8 +153,6 @@ class TrackingGeometry {
  private:
   // the known world
   TrackingVolumePtr m_world;
-  // beam line
-  std::shared_ptr<const PerigeeSurface> m_beam;
   // lookup containers
   std::unordered_map<GeometryIdentifier, const TrackingVolume*> m_volumesById;
   std::unordered_map<GeometryIdentifier, const Surface*> m_surfacesById;

--- a/Core/include/Acts/Geometry/TrackingGeometry.hpp
+++ b/Core/include/Acts/Geometry/TrackingGeometry.hpp
@@ -17,7 +17,6 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
-#include <string>
 #include <unordered_map>
 #include <utility>
 
@@ -28,9 +27,6 @@ class Surface;
 class PerigeeSurface;
 class IMaterialDecorator;
 class TrackingVolume;
-
-using TrackingVolumePtr = std::shared_ptr<const TrackingVolume>;
-using MutableTrackingVolumePtr = std::shared_ptr<TrackingVolume>;
 
 ///  @class TrackingGeometry
 ///
@@ -52,7 +48,7 @@ class TrackingGeometry {
   ///        surface or volume based material to the TrackingVolume
   /// @param hook Identifier hook to be applied to surfaces
   /// @param logger instance of a logger (defaulting to the "silent" one)
-  TrackingGeometry(const MutableTrackingVolumePtr& highestVolume,
+  TrackingGeometry(const std::shared_ptr<TrackingVolume>& highestVolume,
                    const IMaterialDecorator* materialDecorator = nullptr,
                    const GeometryIdentifierHook& hook = {},
                    const Logger& logger = getDummyLogger());
@@ -90,7 +86,7 @@ class TrackingGeometry {
   /// that is found, a selection of the surfaces can be done in the visitor
   /// @param restrictToSensitives If true, only sensitive surfaces are visited
   ///
-  /// @note If a context is needed for the visit, the vistitor has to provide
+  /// @note If a context is needed for the visit, the visitor has to provide
   /// this, e.g. as a private member
   template <SurfaceVisitor visitor_t>
   void visitSurfaces(visitor_t&& visitor, bool restrictToSensitives) const {
@@ -105,7 +101,7 @@ class TrackingGeometry {
   /// @param visitor The callable. Will be called for each sensitive surface
   /// that is found, a selection of the surfaces can be done in the visitor
   ///
-  /// @note If a context is needed for the visit, the vistitor has to provide
+  /// @note If a context is needed for the visit, the visitor has to provide
   /// this, e.g. as a private member
   template <SurfaceVisitor visitor_t>
   void visitSurfaces(visitor_t&& visitor) const {
@@ -119,7 +115,7 @@ class TrackingGeometry {
   /// @param visitor The callable. Will be called for each reachable volume
   /// that is found, a selection of the volumes can be done in the visitor
   ///
-  /// @note If a context is needed for the visit, the vistitor has to provide
+  /// @note If a context is needed for the visit, the visitor has to provide
   /// this, e.g. as a private member
   template <TrackingVolumeVisitor visitor_t>
   void visitVolumes(visitor_t&& visitor) const {
@@ -147,7 +143,7 @@ class TrackingGeometry {
 
  private:
   // the known world
-  TrackingVolumePtr m_world;
+  std::shared_ptr<TrackingVolume> m_world;
   // lookup containers
   std::unordered_map<GeometryIdentifier, const TrackingVolume*> m_volumesById;
   std::unordered_map<GeometryIdentifier, const Surface*> m_surfacesById;

--- a/Core/include/Acts/Geometry/TrackingVolume.hpp
+++ b/Core/include/Acts/Geometry/TrackingVolume.hpp
@@ -264,7 +264,7 @@ class TrackingVolume : public Volume {
   const IVolumeMaterial* volumeMaterial() const;
 
   /// Return the material of the volume as shared pointer
-  const std::shared_ptr<const IVolumeMaterial>& volumeMaterialSharedPtr() const;
+  const std::shared_ptr<const IVolumeMaterial>& volumeMaterialPtr() const;
 
   /// Set the volume material description
   ///

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -49,11 +49,6 @@ const Acts::TrackingVolume* Acts::TrackingGeometry::highestTrackingVolume()
   return m_world.get();
 }
 
-const std::shared_ptr<const Acts::TrackingVolume>&
-Acts::TrackingGeometry::highestTrackingVolumeShared() const {
-  return m_world;
-}
-
 const Acts::Layer* Acts::TrackingGeometry::associatedLayer(
     const GeometryContext& gctx, const Acts::Vector3& gp) const {
   const TrackingVolume* lowestVol = lowestTrackingVolume(gctx, gp);

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -49,6 +49,11 @@ const Acts::TrackingVolume* Acts::TrackingGeometry::highestTrackingVolume()
   return m_world.get();
 }
 
+const std::shared_ptr<const Acts::TrackingVolume>&
+Acts::TrackingGeometry::highestTrackingVolumePtr() const {
+  return m_world;
+}
+
 const Acts::Layer* Acts::TrackingGeometry::associatedLayer(
     const GeometryContext& gctx, const Acts::Vector3& gp) const {
   const TrackingVolume* lowestVol = lowestTrackingVolume(gctx, gp);

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -49,7 +49,7 @@ const Acts::TrackingVolume* Acts::TrackingGeometry::highestTrackingVolume()
   return m_world.get();
 }
 
-const std::shared_ptr<const Acts::TrackingVolume>&
+std::shared_ptr<const Acts::TrackingVolume>
 Acts::TrackingGeometry::highestTrackingVolumePtr() const {
   return m_world;
 }

--- a/Core/src/Geometry/TrackingGeometry.cpp
+++ b/Core/src/Geometry/TrackingGeometry.cpp
@@ -22,8 +22,7 @@ Acts::TrackingGeometry::TrackingGeometry(
     const MutableTrackingVolumePtr& highestVolume,
     const IMaterialDecorator* materialDecorator,
     const GeometryIdentifierHook& hook, const Logger& logger)
-    : m_world(highestVolume),
-      m_beam(Surface::makeShared<PerigeeSurface>(Vector3::Zero())) {
+    : m_world(highestVolume) {
   // Close the geometry: assign geometryID and successively the material
   std::size_t volumeID = 0;
   highestVolume->closeGeometry(materialDecorator, m_volumesById, volumeID, hook,
@@ -62,15 +61,6 @@ const Acts::Layer* Acts::TrackingGeometry::associatedLayer(
     return nullptr;
   }
   return lowestVol->associatedLayer(gctx, gp);
-}
-
-void Acts::TrackingGeometry::registerBeamTube(
-    std::shared_ptr<const PerigeeSurface> beam) {
-  m_beam = std::move(beam);
-}
-
-const Acts::Surface* Acts::TrackingGeometry::getBeamline() const {
-  return m_beam.get();
 }
 
 const Acts::TrackingVolume* Acts::TrackingGeometry::findVolume(

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -366,7 +366,7 @@ void TrackingVolume::closeGeometry(
         thisVolume->motherVolume()->volumeMaterial());
     if (protoMaterial == nullptr) {
       thisVolume->assignVolumeMaterial(
-          thisVolume->motherVolume()->volumeMaterialSharedPtr());
+          thisVolume->motherVolume()->volumeMaterialPtr());
     }
   }
 
@@ -577,7 +577,7 @@ const IVolumeMaterial* TrackingVolume::volumeMaterial() const {
 }
 
 const std::shared_ptr<const IVolumeMaterial>&
-TrackingVolume::volumeMaterialSharedPtr() const {
+TrackingVolume::volumeMaterialPtr() const {
   return m_volumeMaterial;
 }
 

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -173,8 +173,7 @@ void Acts::SurfaceMaterialMapper::collectMaterialVolumes(
                                    << "' for material surfaces.");
   ACTS_VERBOSE("- Insert Volume ...");
   if (tVolume.volumeMaterial() != nullptr) {
-    mState.volumeMaterial[tVolume.geometryId()] =
-        tVolume.volumeMaterialSharedPtr();
+    mState.volumeMaterial[tVolume.geometryId()] = tVolume.volumeMaterialPtr();
   }
 
   // Step down into the sub volume

--- a/Examples/Algorithms/MaterialMapping/include/ActsExamples/MaterialMapping/MappingMaterialDecorator.hpp
+++ b/Examples/Algorithms/MaterialMapping/include/ActsExamples/MaterialMapping/MappingMaterialDecorator.hpp
@@ -106,7 +106,7 @@ class MappingMaterialDecorator : public IMaterialDecorator {
     }
     if (tVolume->volumeMaterial() != nullptr) {
       m_volumeMaterialMap.insert(
-          {tVolume->geometryId(), tVolume->volumeMaterialSharedPtr()});
+          {tVolume->geometryId(), tVolume->volumeMaterialPtr()});
     }
     // there are confined volumes
     if (tVolume->confinedVolumes() != nullptr) {

--- a/Examples/Io/Root/src/RootMaterialWriter.cpp
+++ b/Examples/Io/Root/src/RootMaterialWriter.cpp
@@ -351,8 +351,8 @@ void ActsExamples::RootMaterialWriter::collectMaterial(
     const Acts::TrackingVolume& tVolume,
     Acts::DetectorMaterialMaps& detMatMap) {
   // If the volume has volume material, write that
-  if (tVolume.volumeMaterialSharedPtr() != nullptr && m_cfg.processVolumes) {
-    detMatMap.second[tVolume.geometryId()] = tVolume.volumeMaterialSharedPtr();
+  if (tVolume.volumeMaterialPtr() != nullptr && m_cfg.processVolumes) {
+    detMatMap.second[tVolume.geometryId()] = tVolume.volumeMaterialPtr();
   }
 
   // If confined layers exist, loop over them and collect the layer material

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -165,8 +165,9 @@ void addGeometry(Context& ctx) {
                self.visitSurfaces(selector, false);
                return selector.surfaces;
              })
-        .def_property_readonly("highestTrackingVolume",
-                               &Acts::TrackingGeometry::highestTrackingVolume);
+        .def_property_readonly(
+            "highestTrackingVolume",
+            &Acts::TrackingGeometry::highestTrackingVolumePtr);
   }
 
   {

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -165,7 +165,7 @@ void addGeometry(Context& ctx) {
                self.visitSurfaces(selector, false);
                return selector.surfaces;
              })
-        .def_property_readonly("highestTrackinhVolume",
+        .def_property_readonly("highestTrackingVolume",
                                &Acts::TrackingGeometry::highestTrackingVolume);
   }
 

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -165,9 +165,8 @@ void addGeometry(Context& ctx) {
                self.visitSurfaces(selector, false);
                return selector.surfaces;
              })
-        .def_property_readonly(
-            "worldVolume",
-            &Acts::TrackingGeometry::highestTrackingVolumeShared);
+        .def_property_readonly("highestTrackinhVolume",
+                               &Acts::TrackingGeometry::highestTrackingVolume);
   }
 
   {

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -273,7 +273,7 @@ else:
             outputDirRoot=outputDir if args.output_root else None,
             outputDirCsv=outputDir if args.output_csv else None,
             rnd=rnd,
-            killVolume=trackingGeometry.worldVolume,
+            killVolume=trackingGeometry.highestTrackingVolume,
             killAfterTime=25 * u.ns,
         )
     else:

--- a/Examples/Scripts/Python/full_chain_odd_LRT.py
+++ b/Examples/Scripts/Python/full_chain_odd_LRT.py
@@ -276,7 +276,7 @@ else:
             outputDirRoot=outputDir if args.output_root else None,
             outputDirCsv=outputDir if args.output_csv else None,
             rnd=rnd,
-            killVolume=trackingGeometry.worldVolume,
+            killVolume=trackingGeometry.highestTrackingVolume,
             killAfterTime=25 * u.ns,
         )
     else:

--- a/Plugins/Json/src/MaterialMapJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialMapJsonConverter.cpp
@@ -176,8 +176,8 @@ Acts::SurfaceAndMaterialWithContext defaultSurfaceMaterial(
 Acts::TrackingVolumeAndMaterial defaultVolumeMaterial(
     const Acts::TrackingVolume* volume) {
   Acts::BinUtility bUtility;
-  if (volume->volumeMaterialSharedPtr() != nullptr) {
-    return {volume, volume->volumeMaterialSharedPtr()};
+  if (volume->volumeMaterialPtr() != nullptr) {
+    return {volume, volume->volumeMaterialPtr()};
   }
   // Check which type of bound is associated to the volume
   auto cyBounds = dynamic_cast<const Acts::CylinderVolumeBounds*>(

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -26,6 +26,7 @@
 #include "Acts/Propagator/Navigator.hpp"
 #include "Acts/Propagator/StepperConcept.hpp"
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
+#include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
@@ -392,7 +393,9 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
                                            nullptr, nullptr, nullptr, nullptr,
                                            nullptr));
     ACTS_INFO("        iii) Because the target surface is reached");
-    const Surface* startSurf = tGeometry->getBeamline();
+
+    auto beamline = Surface::makeShared<PerigeeSurface>(Vector3::Zero());
+    const Surface* startSurf = beamline.get();
     state.stepping.pos4.segment<3>(Acts::ePos0) =
         startSurf->center(state.geoContext);
     const Surface* targetSurf = startSurf;


### PR DESCRIPTION
- Remove the beamline surface from `TrackingGeometry` (essentially unused)
- Remove unneeded shared ptr access to the highest volume
- `TrackingGeometry` holds the world volume as a mutable