### PR TITLE
refactor: Make `ViewConfig` usable with designated initializers

### DIFF
--- a/Core/include/Acts/Visualization/EventDataView3D.hpp
+++ b/Core/include/Acts/Visualization/EventDataView3D.hpp
@@ -32,11 +32,11 @@
 namespace Acts {
 class IVisualization3D;
 
-static ViewConfig s_viewParameter = ViewConfig({0, 0, 255});
-static ViewConfig s_viewMeasurement = ViewConfig({255, 102, 0});
-static ViewConfig s_viewPredicted = ViewConfig({51, 204, 51});
-static ViewConfig s_viewFiltered = ViewConfig({255, 255, 0});
-static ViewConfig s_viewSmoothed = ViewConfig({0, 102, 255});
+static ViewConfig s_viewParameter = {.color = {0, 0, 255}};
+static ViewConfig s_viewMeasurement = {.color = {255, 102, 0}};
+static ViewConfig s_viewPredicted = {.color = {51, 204, 51}};
+static ViewConfig s_viewFiltered = {.color = {255, 255, 0}};
+static ViewConfig s_viewSmoothed = {.color = {0, 102, 25}};
 
 struct EventDataView3D {
   /// Helper to find the eigen values and corr angle
@@ -277,7 +277,7 @@ struct EventDataView3D {
                                  state.predicted(), state.predictedCovariance(),
                                  particleHypothesis),
             gctx, momentumScale, locErrorScale, angularErrorScale,
-            predictedConfig, predictedConfig, ViewConfig(false));
+            predictedConfig, predictedConfig, {.visible = false});
       }
       // (b) filtered track parameters
       if (filteredConfig.visible && state.hasFiltered()) {
@@ -287,7 +287,7 @@ struct EventDataView3D {
                                  state.filtered(), state.filteredCovariance(),
                                  particleHypothesis),
             gctx, momentumScale, locErrorScale, angularErrorScale,
-            filteredConfig, filteredConfig, ViewConfig(false));
+            filteredConfig, filteredConfig, {.visible = false});
       }
       // (c) smoothed track parameters
       if (smoothedConfig.visible && state.hasSmoothed()) {
@@ -297,7 +297,7 @@ struct EventDataView3D {
                                  state.smoothed(), state.smoothedCovariance(),
                                  particleHypothesis),
             gctx, momentumScale, locErrorScale, angularErrorScale,
-            smoothedConfig, smoothedConfig, ViewConfig(false));
+            smoothedConfig, smoothedConfig, {.visible = false});
       }
       return true;
     });

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -102,8 +102,8 @@ struct GeometryView3D {
       IVisualization3D& helper, const Experimental::Portal& portal,
       const GeometryContext& gctx,
       const Transform3& transform = Transform3::Identity(),
-      const ViewConfig& connected = ViewConfig{.color = {0, 255, 0}},
-      const ViewConfig& disconnected = ViewConfig{.color = {255, 0, 0}});
+      const ViewConfig& connected = {.color = {0, 255, 0}},
+      const ViewConfig& disconnected = {.color = {255, 0, 0}});
 
   /// Helper method to draw DetectorVolume objects
   ///
@@ -119,8 +119,8 @@ struct GeometryView3D {
       const Acts::Experimental::DetectorVolume& volume,
       const GeometryContext& gctx,
       const Transform3& transform = Transform3::Identity(),
-      const ViewConfig& connected = ViewConfig{.color = {0, 255, 0}},
-      const ViewConfig& unconnected = ViewConfig{.color = {255, 0, 0}},
+      const ViewConfig& connected = {.color = {0, 255, 0}},
+      const ViewConfig& unconnected = {.color = {255, 0, 0}},
       const ViewConfig& viewConfig = s_viewSensitive);
 
   /// Helper method to draw Layer objects

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -98,12 +98,13 @@ struct GeometryView3D {
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param disconnected The config for disconnected portals
-  static void drawPortal(
-      IVisualization3D& helper, const Experimental::Portal& portal,
-      const GeometryContext& gctx,
-      const Transform3& transform = Transform3::Identity(),
-      const ViewConfig& connected = {.color = {0, 255, 0}},
-      const ViewConfig& disconnected = {.color = {255, 0, 0}});
+  static void drawPortal(IVisualization3D& helper,
+                         const Experimental::Portal& portal,
+                         const GeometryContext& gctx,
+                         const Transform3& transform = Transform3::Identity(),
+                         const ViewConfig& connected = {.color = {0, 255, 0}},
+                         const ViewConfig& disconnected = {
+                             .color = {255, 0, 0}});
 
   /// Helper method to draw DetectorVolume objects
   ///

--- a/Core/include/Acts/Visualization/GeometryView3D.hpp
+++ b/Core/include/Acts/Visualization/GeometryView3D.hpp
@@ -98,13 +98,12 @@ struct GeometryView3D {
   /// @param transform An option additional transform
   /// @param connected The config for connected portals
   /// @param disconnected The config for disconnected portals
-  static void drawPortal(IVisualization3D& helper,
-                         const Experimental::Portal& portal,
-                         const GeometryContext& gctx,
-                         const Transform3& transform = Transform3::Identity(),
-                         const ViewConfig& connected = ViewConfig({0, 255, 0}),
-                         const ViewConfig& disconnected = ViewConfig({255, 0,
-                                                                      0}));
+  static void drawPortal(
+      IVisualization3D& helper, const Experimental::Portal& portal,
+      const GeometryContext& gctx,
+      const Transform3& transform = Transform3::Identity(),
+      const ViewConfig& connected = ViewConfig{.color = {0, 255, 0}},
+      const ViewConfig& disconnected = ViewConfig{.color = {255, 0, 0}});
 
   /// Helper method to draw DetectorVolume objects
   ///
@@ -120,8 +119,8 @@ struct GeometryView3D {
       const Acts::Experimental::DetectorVolume& volume,
       const GeometryContext& gctx,
       const Transform3& transform = Transform3::Identity(),
-      const ViewConfig& connected = ViewConfig({0, 255, 0}),
-      const ViewConfig& unconnected = ViewConfig({255, 0, 0}),
+      const ViewConfig& connected = ViewConfig{.color = {0, 255, 0}},
+      const ViewConfig& unconnected = ViewConfig{.color = {255, 0, 0}},
       const ViewConfig& viewConfig = s_viewSensitive);
 
   /// Helper method to draw Layer objects

--- a/Core/include/Acts/Visualization/ViewConfig.hpp
+++ b/Core/include/Acts/Visualization/ViewConfig.hpp
@@ -22,12 +22,6 @@ using ColorRGB = std::array<int, 3>;
 /// @brief Struct to concentrate all visualization configurations
 /// in order to harmonize visualization interfaces
 struct ViewConfig {
-  /// Constructor to switch visibility off
-  ViewConfig(bool vis = true) : visible(vis) {}
-
-  /// Constructor for color settings only
-  ViewConfig(const ColorRGB& rgb) : color(rgb) {}
-
   /// Visible flag
   bool visible = true;
   /// The RGB color for this object

--- a/Core/src/Visualization/GeometryView3D.cpp
+++ b/Core/src/Visualization/GeometryView3D.cpp
@@ -41,11 +41,11 @@
 #include <vector>
 
 namespace Acts::Experimental {
-ViewConfig s_viewSensitive = ViewConfig({0, 180, 240});
-ViewConfig s_viewPassive = ViewConfig({240, 280, 0});
-ViewConfig s_viewVolume = ViewConfig({220, 220, 0});
-ViewConfig s_viewGrid = ViewConfig({220, 0, 0});
-ViewConfig s_viewLine = ViewConfig({0, 0, 220});
+ViewConfig s_viewSensitive = {.color = {0, 180, 240}};
+ViewConfig s_viewPassive = {.color = {240, 280, 0}};
+ViewConfig s_viewVolume = {.color = {220, 220, 0}};
+ViewConfig s_viewGrid = {.color = {220, 0, 0}};
+ViewConfig s_viewLine = {.color = {0, 0, 220}};
 }  // namespace Acts::Experimental
 
 void Acts::GeometryView3D::drawPolyhedron(IVisualization3D& helper,

--- a/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjTrackingGeometryWriter.hpp
+++ b/Examples/Io/Obj/include/ActsExamples/Plugins/Obj/ObjTrackingGeometryWriter.hpp
@@ -43,11 +43,11 @@ class ObjTrackingGeometryWriter {
     std::size_t outputPrecision = 6;  ///< floating point precision
     std::string outputDir = ".";
 
-    Acts::ViewConfig containerView = Acts::ViewConfig({220, 220, 220});
-    Acts::ViewConfig volumeView = Acts::ViewConfig({220, 220, 0});
-    Acts::ViewConfig sensitiveView = Acts::ViewConfig({0, 180, 240});
-    Acts::ViewConfig passiveView = Acts::ViewConfig({240, 280, 0});
-    Acts::ViewConfig gridView = Acts::ViewConfig({220, 0, 0});
+    Acts::ViewConfig containerView = {.color = {220, 220, 220}};
+    Acts::ViewConfig volumeView = {.color = {220, 220, 0}};
+    Acts::ViewConfig sensitiveView = {.color = {0, 180, 240}};
+    Acts::ViewConfig passiveView = {.color = {240, 280, 0}};
+    Acts::ViewConfig gridView = {.color = {220, 0, 0}};
   };
 
   /// Constructor

--- a/Examples/Python/src/Obj.cpp
+++ b/Examples/Python/src/Obj.cpp
@@ -43,7 +43,7 @@ void addObj(Context& ctx) {
                const GeometryContext& viewContext,
                const std::array<int, 3>& viewRgb, unsigned int viewSegements,
                const std::string& fileName) {
-              Acts::ViewConfig sConfig = Acts::ViewConfig{viewRgb};
+              Acts::ViewConfig sConfig = Acts::ViewConfig{.color = viewRgb};
               sConfig.nSegments = viewSegements;
               Acts::GeometryView3D view3D;
               Acts::ObjVisualization3D obj;
@@ -60,7 +60,7 @@ void addObj(Context& ctx) {
                const GeometryContext& viewContext,
                const std::array<int, 3>& viewRgb, unsigned int viewSegements,
                const std::string& fileName) {
-              Acts::ViewConfig sConfig = Acts::ViewConfig{viewRgb};
+              Acts::ViewConfig sConfig = Acts::ViewConfig{.color = viewRgb};
               sConfig.nSegments = viewSegements;
               Acts::GeometryView3D view3D;
               Acts::ObjVisualization3D obj;
@@ -79,7 +79,7 @@ void addObj(Context& ctx) {
                const GeometryContext& viewContext,
                const std::array<int, 3>& viewRgb, unsigned int viewSegements,
                const std::string& fileName) {
-              Acts::ViewConfig sConfig = Acts::ViewConfig{viewRgb};
+              Acts::ViewConfig sConfig = Acts::ViewConfig{.color = viewRgb};
               sConfig.nSegments = viewSegements;
               Acts::GeometryView3D view3D;
               Acts::ObjVisualization3D obj;

--- a/Tests/UnitTests/Core/Geometry/ProtoLayerHelperTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ProtoLayerHelperTests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
                             layerSurfaces.end());
   }
 
-  ViewConfig unsorted({252, 160, 0});
+  ViewConfig unsorted{.color = {252, 160, 0}};
   for (auto& sf : cylinderSurfaces) {
     GeometryView3D::drawSurface(objVis, *sf, tgContext, Transform3::Identity(),
                                 unsorted);
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   std::size_t il = 0;
   for (auto& layer : radialLayers) {
     for (auto& sf : layer.surfaces()) {
-      ViewConfig sorted(sortedColors[il]);
+      ViewConfig sorted{.color = sortedColors[il]};
       GeometryView3D::drawSurface(objVis, *sf, tgContext,
                                   Transform3::Identity(), sorted);
     }
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(ProtoLayerHelperTests) {
   il = 0;
   for (auto& layer : discLayersZ) {
     for (auto& sf : layer.surfaces()) {
-      ViewConfig ViewConfig(sortedColors[il]);
+      ViewConfig ViewConfig{.color = sortedColors[il]};
       GeometryView3D::drawSurface(objVis, *sf, tgContext,
                                   Transform3::Identity(), ViewConfig);
     }

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -1158,15 +1158,15 @@ BOOST_AUTO_TEST_CASE(Material) {
     ObjVisualization3D obj;
 
     bool triangulate = true;
-    ViewConfig viewSensitive = ViewConfig({0, 180, 240});
+    ViewConfig viewSensitive = {.color = {0, 180, 240}};
     viewSensitive.triangulate = triangulate;
-    ViewConfig viewPassive = ViewConfig({240, 280, 0});
+    ViewConfig viewPassive = {.color = {240, 280, 0}};
     viewPassive.triangulate = triangulate;
-    ViewConfig viewVolume = ViewConfig({220, 220, 0});
+    ViewConfig viewVolume = {.color = {220, 220, 0}};
     viewVolume.triangulate = triangulate;
-    ViewConfig viewContainer = ViewConfig({220, 220, 0});
+    ViewConfig viewContainer = {.color = {220, 220, 0}};
     viewContainer.triangulate = triangulate;
-    ViewConfig viewGrid = ViewConfig({220, 0, 0});
+    ViewConfig viewGrid = {.color = {220, 0, 0}};
     viewGrid.nSegments = 8;
     viewGrid.offset = 3.;
     viewGrid.triangulate = triangulate;
@@ -1186,7 +1186,7 @@ BOOST_AUTO_TEST_CASE(Material) {
     ObjVisualization3D obj;
 
     double localErrorScale = 10000000.;
-    ViewConfig mcolor({255, 145, 48});
+    ViewConfig mcolor{.color = {255, 145, 48}};
     mcolor.offset = 2;
     //  mcolor.visible = true;
 

--- a/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/EventDataView3DBase.hpp
@@ -165,8 +165,8 @@ void createDetector(GeometryContext& tgContext,
 static inline std::string testBoundTrackParameters(IVisualization3D& helper) {
   std::stringstream ss;
 
-  ViewConfig pcolor({20, 120, 20});
-  ViewConfig scolor({235, 198, 52});
+  ViewConfig pcolor{.color = {20, 120, 20}};
+  ViewConfig scolor{.color = {235, 198, 52}};
 
   auto gctx = GeometryContext();
   auto identity = Transform3::Identity();
@@ -245,7 +245,7 @@ static inline std::string testMeasurement(IVisualization3D& helper,
         eBoundLoc0, eBoundLoc1, loc, cov2D, surface->geometryId()});
   }
 
-  ViewConfig mcolor({255, 145, 48});
+  ViewConfig mcolor{.color = {255, 145, 48}};
   mcolor.offset = 0.01;
 
   // Draw the measurements
@@ -378,14 +378,14 @@ static inline std::string testMultiTrajectory(IVisualization3D& helper) {
   double localErrorScale = 100.;
   double directionErrorScale = 100000;
 
-  ViewConfig scolor({214, 214, 214});
-  ViewConfig mcolor({255, 145, 48});
+  ViewConfig scolor{.color = {214, 214, 214}};
+  ViewConfig mcolor{.color = {255, 145, 48}};
   mcolor.offset = -0.01;
-  ViewConfig ppcolor({51, 204, 51});
+  ViewConfig ppcolor{.color = {51, 204, 51}};
   ppcolor.offset = -0.02;
-  ViewConfig fpcolor({255, 255, 0});
+  ViewConfig fpcolor{.color = {255, 255, 0}};
   fpcolor.offset = -0.03;
-  ViewConfig spcolor({0, 125, 255});
+  ViewConfig spcolor{.color = {0, 125, 255}};
   spcolor.offset = -0.04;
 
   EventDataView3D::drawMultiTrajectory(

--- a/Tests/UnitTests/Core/Visualization/PrimitivesView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/PrimitivesView3DBase.hpp
@@ -40,7 +40,7 @@ GeometryContext gctx = GeometryContext();
 static inline std::string run(IVisualization3D& helper) {
   std::stringstream ss;
 
-  ViewConfig lineView({0, 0, 255});
+  ViewConfig lineView{.color = {0, 0, 255}};
   lineView.lineThickness = 0.1;
 
   // Line visualization ------------------------------------------------
@@ -71,7 +71,7 @@ static inline std::string run(IVisualization3D& helper) {
   // Error visualization: local ---------------------------------------------
   Acts::GeometryView3D::drawSurface(helper, *plane, gctx);
 
-  ViewConfig errorVis({250, 0, 0});
+  ViewConfig errorVis{.color = {250, 0, 0}};
   errorVis.lineThickness = 0.025;
 
   SquareMatrix2 cov = SquareMatrix2::Identity();

--- a/Tests/UnitTests/Core/Visualization/TrackingGeometryView3DBase.hpp
+++ b/Tests/UnitTests/Core/Visualization/TrackingGeometryView3DBase.hpp
@@ -37,15 +37,15 @@ static inline std::string run(IVisualization3D& helper, bool triangulate,
                               const std::string& tag) {
   std::stringstream cStream;
 
-  ViewConfig viewSensitive = ViewConfig({0, 180, 240});
+  ViewConfig viewSensitive = {.color = {0, 180, 240}};
   viewSensitive.triangulate = triangulate;
-  ViewConfig viewPassive = ViewConfig({240, 280, 0});
+  ViewConfig viewPassive = {.color = {240, 280, 0}};
   viewPassive.triangulate = triangulate;
-  ViewConfig viewVolume = ViewConfig({220, 220, 0});
+  ViewConfig viewVolume = {.color = {220, 220, 0}};
   viewVolume.triangulate = triangulate;
-  ViewConfig viewContainer = ViewConfig({220, 220, 0});
+  ViewConfig viewContainer = {.color = {220, 220, 0}};
   viewContainer.triangulate = triangulate;
-  ViewConfig viewGrid = ViewConfig({220, 0, 0});
+  ViewConfig viewGrid = {.color = {220, 0, 0}};
   viewGrid.nSegments = 8;
   viewGrid.offset = 3.;
   viewGrid.triangulate = triangulate;

--- a/Tests/UnitTests/Plugins/Geant4/Geant4DetectorSurfaceFactoryTests.cpp
+++ b/Tests/UnitTests/Plugins/Geant4/Geant4DetectorSurfaceFactoryTests.cpp
@@ -161,17 +161,14 @@ BOOST_AUTO_TEST_CASE(Geant4DetecturSurfaceFactory_Transforms) {
   Acts::ObjVisualization3D obj;
   Acts::Vector3 origin(0, 0, 0);
   Acts::GeometryView3D::drawArrowForward(obj, origin, Acts::Vector3(100, 0, 0),
-                                         1000, 10,
-                                         Acts::ViewConfig({255, 0, 0}));
+                                         1000, 10, {.color = {255, 0, 0}});
   Acts::GeometryView3D::drawArrowForward(obj, origin, Acts::Vector3(0, 100, 0),
-                                         1000, 10,
-                                         Acts::ViewConfig({0, 255, 0}));
+                                         1000, 10, {.color = {0, 255, 0}});
   Acts::GeometryView3D::drawArrowForward(obj, origin, Acts::Vector3(0, 0, 100),
-                                         1000, 10,
-                                         Acts::ViewConfig({0, 0, 255}));
-  Acts::GeometryView3D::drawArrowForward(
-      obj, surface->center(gctx), surface->center(gctx) + 100 * normal, 1000,
-      10, Acts::ViewConfig({0, 255, 0}));
+                                         1000, 10, {.color = {0, 0, 255}});
+  Acts::GeometryView3D::drawArrowForward(obj, surface->center(gctx),
+                                         surface->center(gctx) + 100 * normal,
+                                         1000, 10, {.color = {0, 255, 0}});
   auto surfaces = cache.sensitiveSurfaces;
   for (const auto& [k, val] : Acts::enumerate(cache.sensitiveSurfaces)) {
     const auto& [el, surf] = val;

--- a/Tests/UnitTests/Plugins/TGeo/TGeoArb8ConversionTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoArb8ConversionTests.cpp
@@ -36,9 +36,9 @@ namespace Acts::Test {
 
 GeometryContext tgContext = GeometryContext();
 
-ViewConfig red({200, 0, 0});
-ViewConfig green({0, 200, 0});
-ViewConfig blue({0, 0, 200});
+ViewConfig red{.color = {200, 0, 0}};
+ViewConfig green{.color = {0, 200, 0}};
+ViewConfig blue{.color = {0, 0, 200}};
 
 /// @brief Unit test to convert a TGeoTrd2 into a Plane
 ///

--- a/Tests/UnitTests/Plugins/TGeo/TGeoBBoxConversionTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoBBoxConversionTests.cpp
@@ -35,9 +35,9 @@ namespace Acts::Test {
 
 GeometryContext tgContext = GeometryContext();
 
-ViewConfig red({200, 0, 0});
-ViewConfig green({0, 200, 0});
-ViewConfig blue({0, 0, 200});
+ViewConfig red{.color = {200, 0, 0}};
+ViewConfig green{.color = {0, 200, 0}};
+ViewConfig blue{.color = {0, 0, 200}};
 
 /// @brief Unit test to convert a Bbox into a Plane
 ///

--- a/Tests/UnitTests/Plugins/TGeo/TGeoTrd1ConversionTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoTrd1ConversionTests.cpp
@@ -40,9 +40,9 @@ namespace Acts::Test {
 
 GeometryContext tgContext = GeometryContext();
 
-ViewConfig red({200, 0, 0});
-ViewConfig green({0, 200, 0});
-ViewConfig blue({0, 0, 200});
+ViewConfig red{.color = {200, 0, 0}};
+ViewConfig green{.color = {0, 200, 0}};
+ViewConfig blue{.color = {0, 0, 200}};
 
 /// @brief Unit test to convert a TGeoTrd1 into a Plane
 ///

--- a/Tests/UnitTests/Plugins/TGeo/TGeoTrd2ConversionTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoTrd2ConversionTests.cpp
@@ -40,9 +40,9 @@ namespace Acts::Test {
 
 GeometryContext tgContext = GeometryContext();
 
-ViewConfig red({200, 0, 0});
-ViewConfig green({0, 200, 0});
-ViewConfig blue({0, 0, 200});
+ViewConfig red{.color = {200, 0, 0}};
+ViewConfig green{.color = {0, 200, 0}};
+ViewConfig blue{.color = {0, 0, 200}};
 
 /// @brief Unit test to convert a TGeoTrd2 into a Plane
 ///

--- a/Tests/UnitTests/Plugins/TGeo/TGeoTubeConversionTests.cpp
+++ b/Tests/UnitTests/Plugins/TGeo/TGeoTubeConversionTests.cpp
@@ -40,9 +40,9 @@ namespace Acts::Test {
 
 GeometryContext tgContext = GeometryContext();
 
-ViewConfig red({200, 0, 0});
-ViewConfig green({0, 200, 0});
-ViewConfig blue({0, 0, 200});
+ViewConfig red{.color = {200, 0, 0}};
+ViewConfig green{.color = {0, 200, 0}};
+ViewConfig blue{.color = {0, 0, 200}};
 
 std::vector<std::string> allowedAxes = {"XY*", "Xy*", "xy*", "xY*",
                                         "YX*", "yx*", "yX*", "Yx*"};


### PR DESCRIPTION
Allows removing the custom constructors that were used for convenience.