### PR TITLE
feat: Improvements to multitrajectory iterators

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -87,6 +87,12 @@ class TrackStateRange {
       }
     }
 
+    Iterator operator++(int) {
+      Iterator tmp(*this);
+      operator++();
+      return tmp;
+    }
+
     bool operator==(const Iterator& other) const {
       if (!proxy && !other.proxy) {
         return true;
@@ -108,6 +114,9 @@ class TrackStateRange {
 
   Iterator begin() { return m_begin; }
   Iterator end() { return Iterator{std::nullopt}; }
+
+  Iterator cbegin() const { return m_begin; }
+  Iterator cend() const { return Iterator{std::nullopt}; }
 
  private:
   Iterator m_begin;


### PR DESCRIPTION
This small PR adds an post-increment operator to the multitrajectory iterator, as well as `cbegin` and `cend` methods.