### PR TITLE
feat: Allow digitization to save cells

### DIFF
--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationAlgorithm.hpp
@@ -96,6 +96,9 @@ class DigitizationAlgorithm final : public IAlgorithm {
   /// Geometric digtizer
   ActsFatras::Channelizer m_channelizer;
 
+  using CellsMap =
+      std::map<Acts::GeometryIdentifier, std::vector<Cluster::Cell>>;
+
   ReadDataHandle<SimHitContainer> m_simContainerReadHandle{this,
                                                            "SimHitContainer"};
 
@@ -103,6 +106,7 @@ class DigitizationAlgorithm final : public IAlgorithm {
       this, "SourceLinks"};
   WriteDataHandle<MeasurementContainer> m_measurementWriteHandle{
       this, "Measurements"};
+  WriteDataHandle<CellsMap> m_cellsWriteHandle{this, "Cells"};
   WriteDataHandle<ClusterContainer> m_clusterWriteHandle{this, "Clusters"};
   WriteDataHandle<IndexMultimap<ActsFatras::Barcode>>
       m_measurementParticlesMapWriteHandle{this, "MeasurementParticlesMap"};

--- a/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
+++ b/Examples/Algorithms/Digitization/include/ActsExamples/Digitization/DigitizationConfig.hpp
@@ -139,6 +139,8 @@ class DigitizationConfig {
   std::string outputSourceLinks = "sourcelinks";
   /// Output measurements collection.
   std::string outputMeasurements = "measurements";
+  /// Output cells map (geoID -> collection of cells).
+  std::string outputCells = "cells";
   /// Output cluster collection.
   std::string outputClusters = "clusters";
   /// Output collection to map measured hits to contributing particles.
@@ -150,6 +152,12 @@ class DigitizationConfig {
       surfaceByIdentifier;
   /// Random numbers tool.
   std::shared_ptr<const RandomNumbers> randomNumbers = nullptr;
+  /// Flag to determine whether cell data should be written to the
+  /// `outputCells` collection; if true, writes (rather voluminous) cell data.
+  bool doOutputCells = false;
+  /// Flag to determine whether or not to run the clusterization; if true,
+  /// clusters, measurements, and sim-hit-maps are output.
+  bool doClusterization = true;
   /// Do we merge hits or not
   bool doMerge;
   /// How close do parameters have to be to consider merged

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -44,39 +44,53 @@ ActsExamples::DigitizationAlgorithm::DigitizationAlgorithm(
   if (m_cfg.inputSimHits.empty()) {
     throw std::invalid_argument("Missing simulated hits input collection");
   }
-  if (m_cfg.outputMeasurements.empty()) {
-    throw std::invalid_argument("Missing measurements output collection");
-  }
-  if (m_cfg.outputSourceLinks.empty()) {
-    throw std::invalid_argument("Missing source links output collection");
-  }
-  if (m_cfg.outputMeasurementParticlesMap.empty()) {
-    throw std::invalid_argument(
-        "Missing hit-to-particles map output collection");
-  }
-  if (m_cfg.outputMeasurementSimHitsMap.empty()) {
-    throw std::invalid_argument(
-        "Missing hit-to-simulated-hits map output collection");
-  }
   if (m_cfg.surfaceByIdentifier.empty()) {
     throw std::invalid_argument("Missing Surface-GeometryID association map");
   }
   if (!m_cfg.randomNumbers) {
     throw std::invalid_argument("Missing random numbers tool");
   }
-
   if (m_cfg.digitizationConfigs.empty()) {
     throw std::invalid_argument("Missing digitization configuration");
   }
 
+  if (m_cfg.doClusterization) {
+    if (m_cfg.outputSourceLinks.empty()) {
+      throw std::invalid_argument("Missing source links output collection");
+    }
+    if (m_cfg.outputMeasurements.empty()) {
+      throw std::invalid_argument("Missing measurements output collection");
+    }
+    if (m_cfg.outputClusters.empty()) {
+      throw std::invalid_argument("Missing cluster output collection");
+    }
+    if (m_cfg.outputMeasurementParticlesMap.empty()) {
+      throw std::invalid_argument(
+          "Missing hit-to-particles map output collection");
+    }
+    if (m_cfg.outputMeasurementSimHitsMap.empty()) {
+      throw std::invalid_argument(
+          "Missing hit-to-simulated-hits map output collection");
+    }
+
+    m_sourceLinkWriteHandle.initialize(m_cfg.outputSourceLinks);
+    m_measurementWriteHandle.initialize(m_cfg.outputMeasurements);
+    m_clusterWriteHandle.initialize(m_cfg.outputClusters);
+    m_measurementParticlesMapWriteHandle.initialize(
+        m_cfg.outputMeasurementParticlesMap);
+    m_measurementSimHitsMapWriteHandle.initialize(
+        m_cfg.outputMeasurementSimHitsMap);
+  }
+
+  if (m_cfg.doOutputCells) {
+    if (m_cfg.outputCells.empty()) {
+      throw std::invalid_argument("Missing cell output collection");
+    }
+
+    m_cellsWriteHandle.initialize(m_cfg.outputCells);
+  }
+
   m_simContainerReadHandle.initialize(m_cfg.inputSimHits);
-  m_sourceLinkWriteHandle.initialize(m_cfg.outputSourceLinks);
-  m_measurementWriteHandle.initialize(m_cfg.outputMeasurements);
-  m_clusterWriteHandle.initialize(m_cfg.outputClusters);
-  m_measurementParticlesMapWriteHandle.initialize(
-      m_cfg.outputMeasurementParticlesMap);
-  m_measurementSimHitsMapWriteHandle.initialize(
-      m_cfg.outputMeasurementSimHitsMap);
 
   // Create the digitizers from the configuration
   std::vector<std::pair<Acts::GeometryIdentifier, Digitizer>> digitizerInput;
@@ -153,6 +167,10 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
 
   // Some statistics
   std::size_t skippedHits = 0;
+
+  // Some algorithms do the clusterization themselves such as the traccc chain.
+  // Thus we need to store the cell data from the simulation.
+  CellsMap cellsMap;
 
   ACTS_DEBUG("Starting loop over modules ...");
   for (const auto& simHitsGroup : groupByModule(simHits)) {
@@ -255,29 +273,44 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
             moduleClusters.add(std::move(dParameters), simHitIdx);
           }
 
-          for (auto& [dParameters, simhits] :
-               moduleClusters.digitizedParameters()) {
-            // The measurement container is unordered and the index under which
-            // the measurement will be stored is known before adding it.
-            Index measurementIdx = measurements.size();
-            IndexSourceLink sourceLink{moduleGeoId, measurementIdx};
+          auto digitizeParametersResult = moduleClusters.digitizedParameters();
 
-            // Add to output containers:
-            // index map and source link container are geometry-ordered.
-            // since the input is also geometry-ordered, new items can
-            // be added at the end.
-            sourceLinks.insert(sourceLinks.end(), sourceLink);
+          // Store the cell data into a map.
+          if (m_cfg.doOutputCells) {
+            std::vector<Cluster::Cell> cells;
+            for (const auto& [dParameters, simhits] :
+                 digitizeParametersResult) {
+              for (const auto& cell : dParameters.cluster.channels) {
+                cells.push_back(cell);
+              }
+            }
+            cellsMap.insert({moduleGeoId, std::move(cells)});
+          }
 
-            createMeasurement(measurements, dParameters, sourceLink);
-            clusters.emplace_back(std::move(dParameters.cluster));
-            // this digitization does hit merging so there can be more than one
-            // mapping entry for each digitized hit.
-            for (auto simHitIdx : simhits) {
-              measurementParticlesMap.emplace_hint(
-                  measurementParticlesMap.end(), measurementIdx,
-                  simHits.nth(simHitIdx)->particleId());
-              measurementSimHitsMap.emplace_hint(measurementSimHitsMap.end(),
-                                                 measurementIdx, simHitIdx);
+          if (m_cfg.doClusterization) {
+            for (auto& [dParameters, simhits] : digitizeParametersResult) {
+              // The measurement container is unordered and the index under
+              // which the measurement will be stored is known before adding it.
+              Index measurementIdx = measurements.size();
+              IndexSourceLink sourceLink{moduleGeoId, measurementIdx};
+
+              // Add to output containers:
+              // index map and source link container are geometry-ordered.
+              // since the input is also geometry-ordered, new items can
+              // be added at the end.
+              sourceLinks.insert(sourceLinks.end(), sourceLink);
+
+              createMeasurement(measurements, dParameters, sourceLink);
+              clusters.emplace_back(std::move(dParameters.cluster));
+              // this digitization does hit merging so there can be more than
+              // one mapping entry for each digitized hit.
+              for (auto simHitIdx : simhits) {
+                measurementParticlesMap.emplace_hint(
+                    measurementParticlesMap.end(), measurementIdx,
+                    simHits.nth(simHitIdx)->particleId());
+                measurementSimHitsMap.emplace_hint(measurementSimHitsMap.end(),
+                                                   measurementIdx, simHitIdx);
+              }
             }
           }
         },
@@ -290,11 +323,19 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
         << " skipped in Digitization. Enable DEBUG mode to see more details.");
   }
 
-  m_sourceLinkWriteHandle(ctx, std::move(sourceLinks));
-  m_measurementWriteHandle(ctx, std::move(measurements));
-  m_clusterWriteHandle(ctx, std::move(clusters));
-  m_measurementParticlesMapWriteHandle(ctx, std::move(measurementParticlesMap));
-  m_measurementSimHitsMapWriteHandle(ctx, std::move(measurementSimHitsMap));
+  if (m_cfg.doOutputCells) {
+    m_cellsWriteHandle(ctx, std::move(cellsMap));
+  }
+
+  if (m_cfg.doClusterization) {
+    m_sourceLinkWriteHandle(ctx, std::move(sourceLinks));
+    m_measurementWriteHandle(ctx, std::move(measurements));
+    m_clusterWriteHandle(ctx, std::move(clusters));
+    m_measurementParticlesMapWriteHandle(ctx,
+                                         std::move(measurementParticlesMap));
+    m_measurementSimHitsMapWriteHandle(ctx, std::move(measurementSimHitsMap));
+  }
+
   return ProcessCode::SUCCESS;
 }
 

--- a/Examples/Python/src/Digitization.cpp
+++ b/Examples/Python/src/Digitization.cpp
@@ -69,6 +69,8 @@ void addDigitization(Context& ctx) {
     ACTS_PYTHON_MEMBER(outputMeasurementSimHitsMap);
     ACTS_PYTHON_MEMBER(surfaceByIdentifier);
     ACTS_PYTHON_MEMBER(randomNumbers);
+    ACTS_PYTHON_MEMBER(doOutputCells);
+    ACTS_PYTHON_MEMBER(doClusterization);
     ACTS_PYTHON_MEMBER(doMerge);
     ACTS_PYTHON_MEMBER(minEnergyDeposit);
     ACTS_PYTHON_MEMBER(digitizationConfigs);


### PR DESCRIPTION
The current ditigization algorithm makes a round-trip from simulated hits to cells to clusters to measurements, but it doesn't allow us to keep the intermediate cell data to test custom clusterization implementations such as the one in traccc. This PR adds to additional flags to the digitization algorithm configuration, namely `doClusterization` and `doOutputCells`. The first flag enables or disables the clusterization, and the second one enables the saving of intermediate cell data. Also adds relevant data handles.