### PR TITLE
refactor: Reduce abuse of auto in mbf smoother

### DIFF
--- a/Core/include/Acts/TrackFitting/MbfSmoother.hpp
+++ b/Core/include/Acts/TrackFitting/MbfSmoother.hpp
@@ -51,21 +51,21 @@ class MbfSmoother {
 
     using TrackStateProxy = typename traj_t::TrackStateProxy;
 
-    TrackStateProxy start_ts = trajectory.getTrackState(entryIndex);
+    TrackStateProxy startTs = trajectory.getTrackState(entryIndex);
 
     // Notation consistent with the Wikipedia article
     // https://en.wikipedia.org/wiki/Kalman_filter
-    BoundMatrix big_lambda_hat = BoundMatrix::Zero();
-    BoundVector small_lambda_hat = BoundVector::Zero();
+    BoundMatrix bigLambdaHat = BoundMatrix::Zero();
+    BoundVector smallLambdaHat = BoundVector::Zero();
 
-    trajectory.applyBackwards(start_ts.index(), [&](TrackStateProxy ts) {
+    trajectory.applyBackwards(startTs.index(), [&](TrackStateProxy ts) {
       // ensure the track state has a smoothed component
       ts.addComponents(TrackStatePropMask::Smoothed);
 
       InternalTrackState internalTrackState(ts);
 
       // Smoothe the current state
-      calculateSmoothed(internalTrackState, big_lambda_hat, small_lambda_hat);
+      calculateSmoothed(internalTrackState, bigLambdaHat, smallLambdaHat);
 
       // We smoothed the last state - no need to update the lambdas
       if (!ts.hasPrevious()) {
@@ -74,10 +74,9 @@ class MbfSmoother {
 
       // Update the lambdas depending on the type of track state
       if (ts.typeFlags().test(TrackStateFlag::MeasurementFlag)) {
-        visitMeasurement(internalTrackState, big_lambda_hat, small_lambda_hat);
+        visitMeasurement(internalTrackState, bigLambdaHat, smallLambdaHat);
       } else {
-        visitNonMeasurement(internalTrackState, big_lambda_hat,
-                            small_lambda_hat);
+        visitNonMeasurement(internalTrackState, bigLambdaHat, smallLambdaHat);
       }
     });
 
@@ -143,18 +142,17 @@ class MbfSmoother {
 
   /// Calculate the smoothed parameters and covariance.
   void calculateSmoothed(InternalTrackState& ts,
-                         const BoundMatrix& big_lambda_hat,
-                         const BoundVector& small_lambda_hat) const;
+                         const BoundMatrix& bigLambdaHat,
+                         const BoundVector& smallLambdaHat) const;
 
   /// Visit a non-measurement track state and update the lambdas.
   void visitNonMeasurement(const InternalTrackState& ts,
-                           BoundMatrix& big_lambda_hat,
-                           BoundVector& small_lambda_hat) const;
+                           BoundMatrix& bigLambdaHat,
+                           BoundVector& smallLambdaHat) const;
 
   /// Visit a measurement track state and update the lambdas.
-  void visitMeasurement(const InternalTrackState& ts,
-                        BoundMatrix& big_lambda_hat,
-                        BoundVector& small_lambda_hat) const;
+  void visitMeasurement(const InternalTrackState& ts, BoundMatrix& bigLambdaHat,
+                        BoundVector& smallLambdaHat) const;
 };
 
 }  // namespace Acts

--- a/Core/src/TrackFitting/MbfSmoother.cpp
+++ b/Core/src/TrackFitting/MbfSmoother.cpp
@@ -22,7 +22,7 @@ void MbfSmoother::calculateSmoothed(InternalTrackState& ts,
 void MbfSmoother::visitNonMeasurement(const InternalTrackState& ts,
                                       BoundMatrix& bigLambdaHat,
                                       BoundVector& smallLambdaHat) const {
-  const Acts::BoundMatrix& F = ts.jacobian;
+  const Acts::BoundMatrix F = ts.jacobian;
 
   bigLambdaHat = F.transpose() * bigLambdaHat * F;
   smallLambdaHat = F.transpose() * smallLambdaHat;
@@ -34,7 +34,7 @@ void MbfSmoother::visitMeasurement(const InternalTrackState& ts,
   assert(ts.measurement.has_value());
 
   const InternalTrackState::Measurement& measurement = ts.measurement.value();
-  const Acts::BoundMatrix& F = ts.jacobian;
+  const Acts::BoundMatrix F = ts.jacobian;
 
   visit_measurement(measurement.calibratedSize, [&](auto N) -> void {
     constexpr std::size_t kMeasurementSize = decltype(N)::value;

--- a/Core/src/TrackFitting/MbfSmoother.cpp
+++ b/Core/src/TrackFitting/MbfSmoother.cpp
@@ -54,31 +54,26 @@ void MbfSmoother::visitMeasurement(const InternalTrackState& ts,
     // Measurement matrix
     const MeasurementMatrix H =
         measurement.projector
-            .template topLeftCorner<kMeasurementSize, eBoundSize>()
-            .eval();
+            .template topLeftCorner<kMeasurementSize, eBoundSize>();
 
     // Residual covariance
     const CovarianceMatrix S =
-        (H * ts.predictedCovariance * H.transpose() + calibratedCovariance)
-            .eval();
+        (H * ts.predictedCovariance * H.transpose() + calibratedCovariance);
     // TODO Sinv could be cached by the filter step
-    const CovarianceMatrix SInv = S.inverse().eval();
+    const CovarianceMatrix SInv = S.inverse();
 
     // Kalman gain
     // TODO K could be cached by the filter step
-    const KalmanGainMatrix K =
-        (ts.predictedCovariance * H.transpose() * SInv).eval();
+    const KalmanGainMatrix K = (ts.predictedCovariance * H.transpose() * SInv);
 
-    const Acts::BoundMatrix CHat =
-        (Acts::BoundMatrix::Identity() - K * H).eval();
+    const Acts::BoundMatrix CHat = (Acts::BoundMatrix::Identity() - K * H);
     const Eigen::Matrix<ActsScalar, kMeasurementSize, 1> y =
-        (calibrated - H * ts.predicted).eval();
+        (calibrated - H * ts.predicted);
 
     const Acts::BoundMatrix bigLambdaTilde =
-        (H.transpose() * SInv * H + CHat.transpose() * bigLambdaHat * CHat)
-            .eval();
+        (H.transpose() * SInv * H + CHat.transpose() * bigLambdaHat * CHat);
     const Eigen::Matrix<ActsScalar, eBoundSize, 1> smallLambdaTilde =
-        (-H.transpose() * SInv * y + CHat.transpose() * smallLambdaHat).eval();
+        (-H.transpose() * SInv * y + CHat.transpose() * smallLambdaHat);
 
     bigLambdaHat = F.transpose() * bigLambdaTilde * F;
     smallLambdaHat = F.transpose() * smallLambdaTilde;

--- a/Core/src/TrackFitting/MbfSmoother.cpp
+++ b/Core/src/TrackFitting/MbfSmoother.cpp
@@ -22,7 +22,7 @@ void MbfSmoother::calculateSmoothed(InternalTrackState& ts,
 void MbfSmoother::visitNonMeasurement(const InternalTrackState& ts,
                                       BoundMatrix& bigLambdaHat,
                                       BoundVector& smallLambdaHat) const {
-  const Acts::BoundMatrix F = ts.jacobian;
+  const InternalTrackState::Jacobian F = ts.jacobian;
 
   bigLambdaHat = F.transpose() * bigLambdaHat * F;
   smallLambdaHat = F.transpose() * smallLambdaHat;
@@ -34,7 +34,7 @@ void MbfSmoother::visitMeasurement(const InternalTrackState& ts,
   assert(ts.measurement.has_value());
 
   const InternalTrackState::Measurement& measurement = ts.measurement.value();
-  const Acts::BoundMatrix F = ts.jacobian;
+  const InternalTrackState::Jacobian F = ts.jacobian;
 
   visit_measurement(measurement.calibratedSize, [&](auto N) -> void {
     constexpr std::size_t kMeasurementSize = decltype(N)::value;

--- a/Core/src/TrackFitting/MbfSmoother.cpp
+++ b/Core/src/TrackFitting/MbfSmoother.cpp
@@ -34,6 +34,7 @@ void MbfSmoother::visitMeasurement(const InternalTrackState& ts,
   assert(ts.measurement.has_value());
 
   const InternalTrackState::Measurement& measurement = ts.measurement.value();
+  const InternalTrackState::Jacobian F = ts.jacobian;
 
   visit_measurement(measurement.calibratedSize, [&](auto N) -> void {
     constexpr std::size_t kMeasurementSize = decltype(N)::value;
@@ -72,8 +73,6 @@ void MbfSmoother::visitMeasurement(const InternalTrackState& ts,
     const Eigen::Matrix<ActsScalar, eBoundSize, 1> small_lambda_tilde =
         (-H.transpose() * S_inv * y + C_hat.transpose() * small_lambda_hat)
             .eval();
-
-    const InternalTrackState::Jacobian& F = ts.jacobian;
 
     big_lambda_hat = F.transpose() * big_lambda_tilde * F;
     small_lambda_hat = F.transpose() * small_lambda_tilde;

--- a/Core/src/TrackFitting/MbfSmoother.cpp
+++ b/Core/src/TrackFitting/MbfSmoother.cpp
@@ -22,7 +22,7 @@ void MbfSmoother::calculateSmoothed(InternalTrackState& ts,
 void MbfSmoother::visitNonMeasurement(const InternalTrackState& ts,
                                       BoundMatrix& big_lambda_hat,
                                       BoundVector& small_lambda_hat) const {
-  const InternalTrackState::Jacobian& F = ts.jacobian;
+  const InternalTrackState::Jacobian F = ts.jacobian;
 
   big_lambda_hat = F.transpose() * big_lambda_hat * F;
   small_lambda_hat = F.transpose() * small_lambda_hat;


### PR DESCRIPTION
Reduce abuse of `auto`