### PR TITLE
feat(util): Add GraphViz helper types

### DIFF
--- a/Core/include/Acts/Utilities/GraphViz.hpp
+++ b/Core/include/Acts/Utilities/GraphViz.hpp
@@ -1,0 +1,110 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <ostream>
+#include <vector>
+
+namespace Acts::GraphViz {
+
+enum class Shape {
+  Box,
+  Polygon,
+  Ellipse,
+  Oval,
+  Circle,
+  Point,
+  Egg,
+  Triangle,
+  Plaintext,
+  Plain,
+  Diamond,
+  Trapezium,
+  Parallelogram,
+  House,
+  Pentagon,
+  Hexagon,
+  Septagon,
+  Octagon,
+  DoubleCircle,
+  DoubleOctagon,
+  TripleOctagon,
+  InvTriangle,
+  InvTrapezium,
+  InvHouse,
+  Mdiamond,
+  Msquare,
+  Mcircle,
+  Rect,
+  Rectangle,
+  Square,
+  Star,
+  None,
+  Underline,
+  Cylinder,
+  Note,
+  Tab,
+  Folder,
+  Box3d,
+  Component,
+  Promoter,
+  Cds,
+  Terminator,
+  Utr,
+  PrimerSite,
+  RestrictionSite,
+  FivePOverhang,
+  ThreePOverhang,
+  NOverhang,
+  Assembly,
+  Signature,
+  Insulator,
+  Ribosite,
+  RNAStab,
+  ProteaseSite,
+  ProteinStab,
+  RPromoter,
+  RArrow,
+  LArrow,
+  LPromoter
+};
+
+std::ostream& operator<<(std::ostream& os, const Shape& shape);
+
+enum class Style {
+  Filled,
+  Invisible,
+  Diagonals,
+  Rounded,
+  Dashed,
+  Dotted,
+  Solid,
+  Bold
+};
+
+std::ostream& operator<<(std::ostream& os, const Style& style);
+
+struct Node {
+  std::string id;
+  std::string label;
+  Shape shape = Shape::Ellipse;
+  std::vector<Style> style = {Style::Solid};
+};
+
+std::ostream& operator<<(std::ostream& os, const Node& node);
+
+struct Edge {
+  Node from;
+  Node to;
+  Style style = Style::Solid;
+};
+
+std::ostream& operator<<(std::ostream& os, const Edge& node);
+
+}  // namespace Acts::GraphViz

--- a/Core/src/Utilities/CMakeLists.txt
+++ b/Core/src/Utilities/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(
         TrackHelpers.cpp
         BinningType.cpp
         Intersection.cpp
+        GraphViz.cpp
 )

--- a/Core/src/Utilities/GraphViz.cpp
+++ b/Core/src/Utilities/GraphViz.cpp
@@ -1,0 +1,286 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "Acts/Utilities/GraphViz.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+#include <boost/algorithm/string/join.hpp>
+
+namespace Acts::GraphViz {
+
+std::ostream& operator<<(std::ostream& os, const Shape& shape) {
+  switch (shape) {
+    using enum Shape;
+
+    case Box:
+      os << "box";
+      break;
+    case Polygon:
+      os << "polygon";
+      break;
+    case Ellipse:
+      os << "ellipse";
+      break;
+    case Oval:
+      os << "oval";
+      break;
+    case Circle:
+      os << "circle";
+      break;
+    case Point:
+      os << "point";
+      break;
+    case Egg:
+      os << "egg";
+      break;
+    case Triangle:
+      os << "triangle";
+      break;
+    case Plaintext:
+      os << "plaintext";
+      break;
+    case Plain:
+      os << "plain";
+      break;
+    case Diamond:
+      os << "diamond";
+      break;
+    case Trapezium:
+      os << "trapezium";
+      break;
+    case Parallelogram:
+      os << "parallelogram";
+      break;
+    case House:
+      os << "house";
+      break;
+    case Pentagon:
+      os << "pentagon";
+      break;
+    case Hexagon:
+      os << "hexagon";
+      break;
+    case Septagon:
+      os << "septagon";
+      break;
+    case Octagon:
+      os << "octagon";
+      break;
+    case DoubleCircle:
+      os << "doublecircle";
+      break;
+    case DoubleOctagon:
+      os << "doubleoctagon";
+      break;
+    case TripleOctagon:
+      os << "tripleoctagon";
+      break;
+    case InvTriangle:
+      os << "invtriangle";
+      break;
+    case InvTrapezium:
+      os << "invtrapezium";
+      break;
+    case InvHouse:
+      os << "invhouse";
+      break;
+    case Mdiamond:
+      os << "Mdiamond";
+      break;
+    case Msquare:
+      os << "Msquare";
+      break;
+    case Mcircle:
+      os << "Mcircle";
+      break;
+    case Rect:
+      os << "rect";
+      break;
+    case Rectangle:
+      os << "rectangle";
+      break;
+    case Square:
+      os << "square";
+      break;
+    case Star:
+      os << "star";
+      break;
+    case None:
+      os << "none";
+      break;
+    case Underline:
+      os << "underline";
+      break;
+    case Cylinder:
+      os << "cylinder";
+      break;
+    case Note:
+      os << "note";
+      break;
+    case Tab:
+      os << "tab";
+      break;
+    case Folder:
+      os << "folder";
+      break;
+    case Box3d:
+      os << "box3d";
+      break;
+    case Component:
+      os << "component";
+      break;
+    case Promoter:
+      os << "promoter";
+      break;
+    case Cds:
+      os << "cds";
+      break;
+    case Terminator:
+      os << "terminator";
+      break;
+    case Utr:
+      os << "utr";
+      break;
+    case PrimerSite:
+      os << "primersite";
+      break;
+    case RestrictionSite:
+      os << "restrictionsite";
+      break;
+    case FivePOverhang:
+      os << "fivepoverhang";
+      break;
+    case ThreePOverhang:
+      os << "threepoverhang";
+      break;
+    case NOverhang:
+      os << "noverhang";
+      break;
+    case Assembly:
+      os << "assembly";
+      break;
+    case Signature:
+      os << "signature";
+      break;
+    case Insulator:
+      os << "insulator";
+      break;
+    case Ribosite:
+      os << "ribosite";
+      break;
+    case RNAStab:
+      os << "rnastab";
+      break;
+    case ProteaseSite:
+      os << "proteasesite";
+      break;
+    case ProteinStab:
+      os << "proteinstab";
+      break;
+    case RPromoter:
+      os << "rpromoter";
+      break;
+    case RArrow:
+      os << "rarrow";
+      break;
+    case LArrow:
+      os << "larrow";
+      break;
+    case LPromoter:
+      os << "lpromoter";
+      break;
+    default:
+      std::terminate();
+  }
+
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Style& style) {
+  switch (style) {
+    using enum Style;
+    case Filled:
+      os << "filled";
+      break;
+    case Invisible:
+      os << "invisible";
+      break;
+    case Diagonals:
+      os << "diagonals";
+      break;
+    case Rounded:
+      os << "rounded";
+      break;
+    case Dashed:
+      os << "dashed";
+      break;
+    case Dotted:
+      os << "dotted";
+      break;
+    case Solid:
+      os << "solid";
+      break;
+    case Bold:
+      os << "bold";
+      break;
+    default:
+      os << "unknown";
+      break;
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Node& node) {
+  if (node.id.empty()) {
+    throw std::runtime_error("Node id must not be empty");
+  }
+
+  std::string id = node.id;
+  std::ranges::replace(id, ' ', '_');
+  os << id << " [";
+
+  std::vector<std::string> attributes;
+
+  std::vector<std::string> styles;
+  std::ranges::transform(node.style, std::back_inserter(styles),
+                         [](const Style& style) {
+                           std::stringstream ss;
+                           ss << style;
+                           return ss.str();
+                         });
+
+  if (!node.label.empty()) {
+    attributes.push_back("label=<" + node.label + ">");
+  }
+
+  std::stringstream ss;
+  ss << node.shape;
+  attributes.push_back("shape=" + ss.str());
+
+  attributes.push_back("style=" + boost::algorithm::join(styles, ","));
+
+  os << boost::algorithm::join(attributes, ", ");
+
+  os << "];\n";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Edge& node) {
+  os << node.from.id << " -> " << node.to.id << " [";
+
+  os << "style=" << node.style;
+
+  os << "];\n";
+
+  return os;
+}
+
+}  // namespace Acts::GraphViz

--- a/Tests/UnitTests/Core/Utilities/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Utilities/CMakeLists.txt
@@ -58,3 +58,4 @@ add_unittest(TransformRange TransformRangeTests.cpp)
 add_unittest(QuickMath QuickMathTests.cpp)
 
 add_unittest(TrackHelpers TrackHelpersTests.cpp)
+add_unittest(GraphViz GraphVizTests.cpp)

--- a/Tests/UnitTests/Core/Utilities/GraphVizTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/GraphVizTests.cpp
@@ -1,0 +1,54 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/tools/output_test_stream.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Utilities/GraphViz.hpp"
+
+namespace Acts::Test {
+
+BOOST_AUTO_TEST_SUITE(GraphViz)
+
+BOOST_AUTO_TEST_CASE(ApiTest) {
+  std::stringstream ss;
+
+  using namespace Acts::GraphViz;
+
+  Node node1{.id = "node1",
+             .label = "Node 1",
+             .shape = Shape::Ellipse,
+             .style = {Style::Filled}};
+
+  ss << node1;
+
+  std::string exp = R"(node1 [label=<Node 1>, shape=ellipse, style=filled];
+)";
+
+  BOOST_CHECK_EQUAL(ss.str(), exp);
+
+  Node node2{.id = "node2",
+             .label = "Node 2",
+             .shape = Shape::Rectangle,
+             .style = {Style::Dashed}};
+
+  Edge edge = {.from = node1, .to = node2, .style = Style::Dashed};
+
+  ss.str("");
+
+  ss << edge;
+
+  exp = R"(node1 -> node2 [style=dashed];
+)";
+
+  BOOST_CHECK_EQUAL(ss.str(), exp);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace Acts::Test


### PR DESCRIPTION
Adds some helper types to work with GraphViz output.

This allows writing code like 

```cpp
  Node node1{.id = "node1",
             .label = "Node 1",
             .shape = Shape::Ellipse,
             .style = {Style::Filled}};

  ss << node1;

  Node node2{.id = "node2",
             .label = "Node 2",
             .shape = Shape::Rectangle,
             .style = {Style::Dashed}};

  Edge edge = {.from = node1, .to = node2, .style = Style::Dashed};

ss << edge;
```

and get valid GraphViz output.