### PR TITLE
refactor(geo): Portal(Link)+Surface verbosity reduction

### DIFF
--- a/Core/src/Geometry/GridPortalLinkMerging.cpp
+++ b/Core/src/Geometry/GridPortalLinkMerging.cpp
@@ -213,11 +213,11 @@ std::unique_ptr<GridPortalLink> colinearMerge(
     auto mergedPortalLink = mergeVariableLocal();
     return mergedPortalLink;
   } else if (aType == AxisType::Equidistant && bType == AxisType::Variable) {
-    ACTS_WARNING("===> mixed merged");
+    ACTS_VERBOSE("===> mixed merged");
     auto mergedPortalLink = mergeVariableLocal();
     return mergedPortalLink;
   } else {
-    ACTS_WARNING("===> mixed merged");
+    ACTS_VERBOSE("===> mixed merged");
     auto mergedPortalLink = mergeVariableLocal();
     return mergedPortalLink;
   }

--- a/Core/src/Geometry/Portal.cpp
+++ b/Core/src/Geometry/Portal.cpp
@@ -175,7 +175,7 @@ const RegularSurface& Portal::surface() const {
 Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
                      Portal& bPortal, BinningValue direction,
                      const Logger& logger) {
-  ACTS_DEBUG("Merging to portals along " << direction);
+  ACTS_VERBOSE("Merging two portals along " << direction);
 
   if (&aPortal == &bPortal) {
     ACTS_ERROR("Cannot merge a portal with itself");
@@ -238,7 +238,7 @@ Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
 
 Portal Portal::fuse(const GeometryContext& gctx, Portal& aPortal,
                     Portal& bPortal, const Logger& logger) {
-  ACTS_DEBUG("Fusing two portals");
+  ACTS_VERBOSE("Fusing two portals");
   if (&aPortal == &bPortal) {
     ACTS_ERROR("Cannot merge a portal with itself");
     throw PortalMergingException{};

--- a/Core/src/Geometry/PortalLinkBase.cpp
+++ b/Core/src/Geometry/PortalLinkBase.cpp
@@ -64,7 +64,7 @@ void PortalLinkBase::checkMergePreconditions(const PortalLinkBase& a,
 std::unique_ptr<PortalLinkBase> PortalLinkBase::merge(
     std::unique_ptr<PortalLinkBase> a, std::unique_ptr<PortalLinkBase> b,
     BinningValue direction, const Logger& logger) {
-  ACTS_DEBUG("Merging two arbitrary portals");
+  ACTS_VERBOSE("Merging two arbitrary portals");
 
   ACTS_VERBOSE(" - a: " << *a);
   ACTS_VERBOSE(" - b: " << *b);

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -374,8 +374,8 @@ Acts::CylinderSurface::mergedWith(const CylinderSurface& other,
                                   const Logger& logger) const {
   using namespace Acts::UnitLiterals;
 
-  ACTS_DEBUG("Merging cylinder surfaces in " << binningValueName(direction)
-                                             << " direction");
+  ACTS_VERBOSE("Merging cylinder surfaces in " << binningValueName(direction)
+                                               << " direction");
 
   if (m_associatedDetElement != nullptr ||
       other.m_associatedDetElement != nullptr) {

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -385,7 +385,7 @@ Acts::DiscSurface::mergedWith(const DiscSurface& other, BinningValue direction,
                               const Logger& logger) const {
   using namespace Acts::UnitLiterals;
 
-  ACTS_DEBUG("Merging disc surfaces in " << direction << " direction");
+  ACTS_VERBOSE("Merging disc surfaces in " << direction << " direction");
 
   if (m_associatedDetElement != nullptr ||
       other.m_associatedDetElement != nullptr) {


### PR DESCRIPTION
Reduces the output level for some outputs. Some where erroneously WARNINGs, some were DEBUG where VERBOSE makes more sense.