### PR TITLE
docs: Add minimal Spack spec for ACTS core

### DIFF
--- a/docs/misc/spack.md
+++ b/docs/misc/spack.md
@@ -33,22 +33,30 @@ the environment every time you open a new shell.
 With the Spack environment activated, you are ready to install ACTS'
 dependencies. You can either do this manually, or you can rely on Spack's
 definition of how to do this. To use the Spack definition, execute the
-following command (tuned for ACTS version 36.1.0):
+following command (tuned for ACTS version 36.1.0; make sure you update the
+version number to match the version of ACTS you want to build):
+
+```console
+$ spack install --add --only dependencies "acts@36.1.0"
+```
+
+This specification will suffice to build the core ACTS library. If you want to
+build ACTS plugins, you will need to add additional _variants_; the following
+is a spec which can be used to build ACTS and all its plugins:
 
 ```console
 $ spack install --add --only dependencies "acts@36.1.0+tgeo+geomodel+podio+edm4hep+examples+odd+fatras+json+dd4hep+geant4+fatras_geant4+hepmc3+pythia8+python+svg+traccc"
 ```
 
-The string starting with `acts` in the command above is the so-called _spec_,
+The string starting with `acts` in the commands above is the so-called _spec_,
 and it consists of three parts. The first part is the name of the package,
 which is `acts`. The second part is the version of the package, in this case
 `36.1.0`; Spack will pull in a set of dependencies suitable for that given
 version, so it is recommended to tune the version number to match the version
 of ACTS you want to build. The final part is a series of variants, marked with
 the `+` symbol. The command above allows you to build virtually all components
-of ACTS, but it also pulls in a large number of dependencies. You can
-optionally remove variants you do not need in order to speed up the Spack
-build.
+of ACTS, but it also pulls in a large number of dependencies. You can remove
+variants you do not need in order to speed up the Spack build.
 
 Once Spack has concretized and installed the ACTS dependencies, you can build
 ACTS as normal using CMake.


### PR DESCRIPTION
The current Spack documentation recommends a Spack spec which can be used to build ACTS and all its plugins; this is useful but, as we encountered over the weekend, also takes a lot of build time. As such, I wanted to add additional instructions for a simplified Spack build which only allows you to build the core ACTS library.