### PR TITLE
ci: Run clang-tidy on the ActSVG plugin

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -96,7 +96,6 @@
             "displayName": "GitLab-CI",
             "inherits": "ci-common",
             "cacheVariables": {
-                "ACTS_BUILD_PLUGIN_ACTSVG": "OFF",
                 "ACTS_BUILD_ODD": "OFF",
                 "ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS": "OFF",
                 "ACTS_RUN_CLANG_TIDY": "ON"

--- a/Plugins/ActSVG/include/Acts/Plugins/ActSVG/EventDataSvgConverter.hpp
+++ b/Plugins/ActSVG/include/Acts/Plugins/ActSVG/EventDataSvgConverter.hpp
@@ -13,11 +13,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include <actsvg/core.hpp>
 
-namespace Acts {
-
-namespace Svg {
-
-namespace EventDataConverter {
+namespace Acts::Svg::EventDataConverter {
 
 /// Write/create a 3D point in XY view
 ///
@@ -62,8 +58,4 @@ actsvg::svg::object point(const Vector3& pos, ActsScalar size,
   return circle;
 }
 
-}  // namespace EventDataConverter
-
-}  // namespace Svg
-
-}  // namespace Acts
+}  // namespace Acts::Svg::EventDataConverter

--- a/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
+++ b/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
@@ -27,9 +27,7 @@
 #include <tuple>
 #include <vector>
 
-namespace Acts {
-
-namespace Svg {
+namespace Acts::Svg {
 
 using ProtoSurface = actsvg::proto::surface<std::vector<Vector3>>;
 using ProtoGrid = actsvg::proto::grid;
@@ -340,5 +338,4 @@ static inline actsvg::svg::object zphi(
 }
 
 }  // namespace View
-}  // namespace Svg
-}  // namespace Acts
+}  // namespace Acts::Svg

--- a/Plugins/ActSVG/include/Acts/Plugins/ActSVG/SvgUtils.hpp
+++ b/Plugins/ActSVG/include/Acts/Plugins/ActSVG/SvgUtils.hpp
@@ -17,8 +17,7 @@
 #include <tuple>
 #include <vector>
 
-namespace Acts {
-namespace Svg {
+namespace Acts::Svg {
 
 struct Style {
   // Fill parameters
@@ -178,5 +177,4 @@ inline static void toFile(const std::vector<actsvg::svg::object>& objects,
   fout.close();
 }
 
-}  // namespace Svg
-}  // namespace Acts
+}  // namespace Acts::Svg


### PR DESCRIPTION
In #3634, I am struggling with clang-tidy errors which popped up after I had to transiently enable the ActSVG plugin. In order to solve this problem is propose we unconditionally enable clang-tidy on ActSVG. This PR does that, and it also fixes any existing clang-tidy issues.