### PR TITLE
feat: Support seed from N space points

### DIFF
--- a/Core/include/Acts/EventData/Seed.hpp
+++ b/Core/include/Acts/EventData/Seed.hpp
@@ -14,9 +14,8 @@
 namespace Acts {
 
 template <typename external_spacepoint_t, std::size_t N = 3ul>
+  requires(N >= 3)
 class Seed {
-  static_assert(N >= 3ul, "A seed needs at least 3 space points");
-
  public:
   using value_type = external_spacepoint_t;
   static constexpr std::size_t DIM = N;
@@ -24,7 +23,7 @@ class Seed {
   template <typename... args_t>
     requires(sizeof...(args_t) == N) &&
             (std::same_as<external_spacepoint_t, args_t> && ...)
-  Seed(const args_t&... points);
+  explicit Seed(const args_t&... points);
 
   void setVertexZ(float vertex);
   void setQuality(float seedQuality);

--- a/Core/include/Acts/EventData/Seed.hpp
+++ b/Core/include/Acts/EventData/Seed.hpp
@@ -13,21 +13,28 @@
 
 namespace Acts {
 
-template <typename external_spacepoint_t>
+template <typename external_spacepoint_t, std::size_t N = 3ul>
 class Seed {
+  static_assert(N >= 3ul, "A seed needs at least 3 space points");
+
  public:
-  Seed(const external_spacepoint_t& b, const external_spacepoint_t& m,
-       const external_spacepoint_t& u);
+  using value_type = external_spacepoint_t;
+  static constexpr std::size_t DIM = N;
+
+  template <typename... args_t>
+    requires(sizeof...(args_t) == N) &&
+            (std::same_as<external_spacepoint_t, args_t> && ...)
+  Seed(const args_t&... points);
 
   void setVertexZ(float vertex);
   void setQuality(float seedQuality);
 
-  const std::array<const external_spacepoint_t*, 3>& sp() const;
+  const std::array<const external_spacepoint_t*, N>& sp() const;
   float z() const;
   float seedQuality() const;
 
  private:
-  std::array<const external_spacepoint_t*, 3> m_spacepoints;
+  std::array<const external_spacepoint_t*, N> m_spacepoints{};
   float m_vertexZ{0.f};
   float m_seedQuality{-std::numeric_limits<float>::infinity()};
 };

--- a/Core/include/Acts/EventData/Seed.ipp
+++ b/Core/include/Acts/EventData/Seed.ipp
@@ -8,35 +8,36 @@
 
 namespace Acts {
 
-template <typename external_spacepoint_t>
-Seed<external_spacepoint_t>::Seed(const external_spacepoint_t& b,
-                                  const external_spacepoint_t& m,
-                                  const external_spacepoint_t& u)
-    : m_spacepoints({&b, &m, &u}) {}
+template <typename external_spacepoint_t, std::size_t N>
+template <typename... args_t>
+  requires(sizeof...(args_t) == N) &&
+          (std::same_as<external_spacepoint_t, args_t> && ...)
+Seed<external_spacepoint_t, N>::Seed(const args_t&... points)
+    : m_spacepoints({&points...}) {}
 
-template <typename external_spacepoint_t>
-void Seed<external_spacepoint_t>::setVertexZ(float vertex) {
+template <typename external_spacepoint_t, std::size_t N>
+void Seed<external_spacepoint_t, N>::setVertexZ(float vertex) {
   m_vertexZ = vertex;
 }
 
-template <typename external_spacepoint_t>
-void Seed<external_spacepoint_t>::setQuality(float seedQuality) {
+template <typename external_spacepoint_t, std::size_t N>
+void Seed<external_spacepoint_t, N>::setQuality(float seedQuality) {
   m_seedQuality = seedQuality;
 }
 
-template <typename external_spacepoint_t>
-const std::array<const external_spacepoint_t*, 3>&
-Seed<external_spacepoint_t>::sp() const {
+template <typename external_spacepoint_t, std::size_t N>
+const std::array<const external_spacepoint_t*, N>&
+Seed<external_spacepoint_t, N>::sp() const {
   return m_spacepoints;
 }
 
-template <typename external_spacepoint_t>
-float Seed<external_spacepoint_t>::z() const {
+template <typename external_spacepoint_t, std::size_t N>
+float Seed<external_spacepoint_t, N>::z() const {
   return m_vertexZ;
 }
 
-template <typename external_spacepoint_t>
-float Seed<external_spacepoint_t>::seedQuality() const {
+template <typename external_spacepoint_t, std::size_t N>
+float Seed<external_spacepoint_t, N>::seedQuality() const {
   return m_seedQuality;
 }
 

--- a/Core/include/Acts/EventData/Seed.ipp
+++ b/Core/include/Acts/EventData/Seed.ipp
@@ -9,6 +9,7 @@
 namespace Acts {
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 template <typename... args_t>
   requires(sizeof...(args_t) == N) &&
           (std::same_as<external_spacepoint_t, args_t> && ...)
@@ -16,27 +17,32 @@ Seed<external_spacepoint_t, N>::Seed(const args_t&... points)
     : m_spacepoints({&points...}) {}
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 void Seed<external_spacepoint_t, N>::setVertexZ(float vertex) {
   m_vertexZ = vertex;
 }
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 void Seed<external_spacepoint_t, N>::setQuality(float seedQuality) {
   m_seedQuality = seedQuality;
 }
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 const std::array<const external_spacepoint_t*, N>&
 Seed<external_spacepoint_t, N>::sp() const {
   return m_spacepoints;
 }
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 float Seed<external_spacepoint_t, N>::z() const {
   return m_vertexZ;
 }
 
 template <typename external_spacepoint_t, std::size_t N>
+  requires(N >= 3)
 float Seed<external_spacepoint_t, N>::seedQuality() const {
   return m_seedQuality;
 }

--- a/Tests/UnitTests/Core/EventData/CMakeLists.txt
+++ b/Tests/UnitTests/Core/EventData/CMakeLists.txt
@@ -14,5 +14,6 @@ add_unittest(TrackStatePropMask TrackStatePropMaskTests.cpp)
 add_unittest(ParticleHypothesis ParticleHypothesisTests.cpp)
 add_unittest(MultiTrajectoryHelpers MultiTrajectoryHelpersTests.cpp)
 add_unittest(SubspaceHelpers SubspaceHelpersTests.cpp)
+add_unittest(SeedEdm SeedEdmTests.cpp)
 
 add_non_compile_test(MultiTrajectory TrackContainerComplianceTests.cpp)

--- a/Tests/UnitTests/Core/EventData/SeedEdmTests.cpp
+++ b/Tests/UnitTests/Core/EventData/SeedEdmTests.cpp
@@ -1,0 +1,105 @@
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/EventData/Seed.hpp"
+
+#include <vector>
+
+namespace Acts::Test {
+
+struct SpacePoint {};
+
+BOOST_AUTO_TEST_CASE(seed_edm_constructors) {
+  std::array<Acts::Test::SpacePoint, 5> storage{};
+  Acts::Seed<Acts::Test::SpacePoint, 5> seed(storage[0], storage[1], storage[2],
+                                             storage[3], storage[4]);
+  const std::array<const Acts::Test::SpacePoint*, 5>& sps = seed.sp();
+  for (std::size_t i(0ul); i < 5ul; ++i) {
+    BOOST_CHECK_NE(sps[i], nullptr);
+    BOOST_CHECK_EQUAL(sps[i], &storage[i]);
+  }
+
+  // Copy 1
+  Acts::Seed<Acts::Test::SpacePoint, 5> seedCopy1(seed);
+  const std::array<const Acts::Test::SpacePoint*, 5>& spsCopy1 = seedCopy1.sp();
+  for (std::size_t i(0ul); i < 5ul; ++i) {
+    BOOST_CHECK_NE(spsCopy1[i], nullptr);
+    BOOST_CHECK_EQUAL(spsCopy1[i], sps[i]);
+  }
+
+  // Copy 2
+  Acts::Seed<Acts::Test::SpacePoint, 5> seedCopy2{seed};
+  const std::array<const Acts::Test::SpacePoint*, 5>& spsCopy2 = seedCopy2.sp();
+  for (std::size_t i(0ul); i < 5ul; ++i) {
+    BOOST_CHECK_NE(spsCopy2[i], nullptr);
+    BOOST_CHECK_EQUAL(spsCopy2[i], sps[i]);
+  }
+
+  // Collection
+  std::vector<Acts::Seed<Acts::Test::SpacePoint, 5>> seeds{seed};
+  // Copy 1
+  std::vector<Acts::Seed<Acts::Test::SpacePoint, 5>> seedsCopy1(seeds);
+  BOOST_CHECK_EQUAL(seedsCopy1.size(), seeds.size());
+  // Copy 2
+  std::vector<Acts::Seed<Acts::Test::SpacePoint, 5>> seedsCopy2{seeds};
+  BOOST_CHECK_EQUAL(seedsCopy2.size(), seeds.size());
+}
+
+BOOST_AUTO_TEST_CASE(seed_edm_default) {
+  std::array<Acts::Test::SpacePoint, 3> storage{};
+  Acts::Seed<Acts::Test::SpacePoint> seed(storage[0], storage[1], storage[2]);
+  const std::array<const Acts::Test::SpacePoint*, 3>& sps = seed.sp();
+  for (std::size_t i(0ul); i < 3ul; ++i) {
+    BOOST_CHECK_NE(sps[i], nullptr);
+    BOOST_CHECK_EQUAL(sps[i], &storage[i]);
+  }
+
+  seed.setVertexZ(-1.2f);
+  BOOST_CHECK_EQUAL(seed.z(), -1.2f);
+
+  seed.setQuality(345.23f);
+  BOOST_CHECK_EQUAL(seed.seedQuality(), 345.23f);
+}
+
+BOOST_AUTO_TEST_CASE(seed_edm_3d) {
+  std::array<Acts::Test::SpacePoint, 3> storage{};
+  Acts::Seed<Acts::Test::SpacePoint, 3> seed(storage[0], storage[1],
+                                             storage[2]);
+  const std::array<const Acts::Test::SpacePoint*, 3>& sps = seed.sp();
+  for (std::size_t i(0ul); i < 3ul; ++i) {
+    BOOST_CHECK_NE(sps[i], nullptr);
+    BOOST_CHECK_EQUAL(sps[i], &storage[i]);
+  }
+
+  seed.setVertexZ(-1.2f);
+  BOOST_CHECK_EQUAL(seed.z(), -1.2f);
+
+  seed.setQuality(345.23f);
+  BOOST_CHECK_EQUAL(seed.seedQuality(), 345.23f);
+}
+
+BOOST_AUTO_TEST_CASE(seed_edm_4d) {
+  std::array<Acts::Test::SpacePoint, 4> storage{};
+  Acts::Seed<Acts::Test::SpacePoint, 4> seed(storage[0], storage[1], storage[2],
+                                             storage[3]);
+  const std::array<const Acts::Test::SpacePoint*, 4>& sps = seed.sp();
+  for (std::size_t i(0ul); i < 4ul; ++i) {
+    BOOST_CHECK_NE(sps[i], nullptr);
+    BOOST_CHECK_EQUAL(sps[i], &storage[i]);
+  }
+
+  seed.setVertexZ(-1.2f);
+  BOOST_CHECK_EQUAL(seed.z(), -1.2f);
+
+  seed.setQuality(345.23f);
+  BOOST_CHECK_EQUAL(seed.seedQuality(), 345.23f);
+}
+
+}  // namespace Acts::Test


### PR DESCRIPTION
Future support for seeds created from `N` space points, with `N >= 3`.
The seed EDM naturally support the possibility of requiring more than 3 space points, so the Seed class is now templated on both the external space point type and the required number of space points: `Seed<external_spacepoint_t, N>`.

By default `N == 3`, and there is a requirement that `N >= 3`.
The default values is to avoid a breaking change in the code.

This PR requires https://github.com/acts-project/acts/pull/3432 