### PR TITLE
feat!: Add a readius bin to the grid

### DIFF
--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.hpp
@@ -23,6 +23,7 @@ template <typename external_spacepoint_t>
 using CylindricalSpacePointGrid = Acts::Grid<
     std::vector<const external_spacepoint_t*>,
     Acts::Axis<Acts::AxisType::Equidistant, Acts::AxisBoundaryType::Closed>,
+    Acts::Axis<Acts::AxisType::Variable, Acts::AxisBoundaryType::Bound>,
     Acts::Axis<Acts::AxisType::Variable, Acts::AxisBoundaryType::Bound>>;
 
 /// Cylindrical Binned Group
@@ -40,6 +41,9 @@ struct CylindricalSpacePointGridConfig {
   // maximum extension of sensitive detector layer relevant for seeding as
   // distance from x=y=0 (i.e. in r)
   float rMax = 0;
+  // maximum extension of sensitive detector layer relevant for seeding as
+  // distance from x=y=0 (i.e. in r)
+  float rMin = 0;
   // maximum extension of sensitive detector layer relevant for seeding in
   // positive direction in z
   float zMax = 0;
@@ -66,7 +70,8 @@ struct CylindricalSpacePointGridConfig {
   // maximum number of phi bins
   int maxPhiBins = 10000;
   // enable non equidistant binning in z
-  std::vector<float> zBinEdges;
+  std::vector<float> zBinEdges{};
+  std::vector<float> rBinEdges{};
   bool isInInternalUnits = false;
   CylindricalSpacePointGridConfig toInternalUnits() const {
     if (isInInternalUnits) {
@@ -78,6 +83,7 @@ struct CylindricalSpacePointGridConfig {
     CylindricalSpacePointGridConfig config = *this;
     config.isInInternalUnits = true;
     config.minPt /= 1_MeV;
+    config.rMin /= 1_mm;
     config.rMax /= 1_mm;
     config.zMax /= 1_mm;
     config.zMin /= 1_mm;

--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.hpp
@@ -37,25 +37,25 @@ using CylindricalBinnedGroupIterator = Acts::BinnedGroupIterator<
 
 struct CylindricalSpacePointGridConfig {
   // minimum pT to be found by seedFinder
-  float minPt = 0;
+  float minPt = 0 * Acts::UnitConstants::MeV;
   // maximum extension of sensitive detector layer relevant for seeding as
   // distance from x=y=0 (i.e. in r)
-  float rMax = 0;
+  float rMax = 320 * Acts::UnitConstants::mm;
   // maximum extension of sensitive detector layer relevant for seeding as
   // distance from x=y=0 (i.e. in r)
-  float rMin = 0;
+  float rMin = 0 * Acts::UnitConstants::mm;
   // maximum extension of sensitive detector layer relevant for seeding in
   // positive direction in z
-  float zMax = 0;
+  float zMax = 0 * Acts::UnitConstants::mm;
   // maximum extension of sensitive detector layer relevant for seeding in
   // negative direction in z
-  float zMin = 0;
+  float zMin = 0 * Acts::UnitConstants::mm;
   // maximum distance in r from middle space point to bottom or top spacepoint
-  float deltaRMax = 0;
+  float deltaRMax = 0 * Acts::UnitConstants::mm;
   // maximum forward direction expressed as cot(theta)
   float cotThetaMax = 0;
   // maximum impact parameter in mm
-  float impactMax = 0;
+  float impactMax = 0 * Acts::UnitConstants::mm;
   // minimum phi value for phiAxis construction
   float phiMin = -M_PI;
   // maximum phi value for phiAxis construction

--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
@@ -218,6 +218,7 @@ void Acts::CylindricalSpacePointGridCreator::fillGrid(
     //     static_cast<std::size_t>(sp.radius() / config.binSizeR);
     // // if index out of bounds, the SP is outside the region of interest
     // if (rIndex >= numRBins) {
+    //   std::cout << "rejecting sp with radius: " << sp.radius() << std::endl;
     //   continue;
     // }
 

--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
@@ -1,3 +1,4 @@
+// -*- C++ -*-
 // This file is part of the Acts project.
 //
 // Copyright (C) 2024 CERN for the benefit of the Acts project
@@ -128,9 +129,19 @@ Acts::CylindricalSpacePointGridCreator::createGrid(
     }
   }
 
+  std::vector<AxisScalar> rValues;
+  rValues.reserve(std::max(2ul, config.rBinEdges.size()));
+  if (config.rBinEdges.empty()) {
+    rValues = {config.rMin, config.rMax};
+  } else {
+    rValues.insert(rValues.end(), config.rBinEdges.begin(),
+                   config.rBinEdges.end());
+  }
+
   Axis<AxisType::Variable, AxisBoundaryType::Bound> zAxis(std::move(zValues));
+  Axis<AxisType::Variable, AxisBoundaryType::Bound> rAxis(std::move(rValues));
   return Acts::CylindricalSpacePointGrid<external_spacepoint_t>(
-      std::make_tuple(std::move(phiAxis), std::move(zAxis)));
+      std::make_tuple(std::move(phiAxis), std::move(zAxis), std::move(rAxis)));
 }
 
 template <typename external_spacepoint_t,
@@ -203,16 +214,16 @@ void Acts::CylindricalSpacePointGridCreator::fillGrid(
 
     // calculate r-Bin index and protect against overflow (underflow not
     // possible)
-    std::size_t rIndex =
-        static_cast<std::size_t>(sp.radius() / config.binSizeR);
-    // if index out of bounds, the SP is outside the region of interest
-    if (rIndex >= numRBins) {
-      continue;
-    }
+    // std::size_t rIndex =
+    //     static_cast<std::size_t>(sp.radius() / config.binSizeR);
+    // // if index out of bounds, the SP is outside the region of interest
+    // if (rIndex >= numRBins) {
+    //   continue;
+    // }
 
     // fill rbins into grid
     std::size_t globIndex =
-        grid.globalBinFromPosition(Acts::Vector2{sp.phi(), sp.z()});
+        grid.globalBinFromPosition(Acts::Vector3{sp.phi(), sp.z(), sp.radius()});
     auto& rbin = grid.at(globIndex);
     rbin.push_back(&sp);
 

--- a/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
+++ b/Core/include/Acts/Seeding/detail/CylindricalSpacePointGrid.ipp
@@ -1,4 +1,3 @@
-// -*- C++ -*-
 // This file is part of the Acts project.
 //
 // Copyright (C) 2024 CERN for the benefit of the Acts project
@@ -102,7 +101,7 @@ Acts::CylindricalSpacePointGridCreator::createGrid(
       config.phiMin, config.phiMax, phiBins);
 
   // vector that will store the edges of the bins of z
-  std::vector<AxisScalar> zValues;
+  std::vector<AxisScalar> zValues{};
 
   // If zBinEdges is not defined, calculate the edges as zMin + bin * zBinSize
   if (config.zBinEdges.empty()) {
@@ -129,7 +128,7 @@ Acts::CylindricalSpacePointGridCreator::createGrid(
     }
   }
 
-  std::vector<AxisScalar> rValues;
+  std::vector<AxisScalar> rValues{};
   rValues.reserve(std::max(2ul, config.rBinEdges.size()));
   if (config.rBinEdges.empty()) {
     rValues = {config.rMin, config.rMax};
@@ -173,13 +172,13 @@ void Acts::CylindricalSpacePointGridCreator::fillGrid(
         "SeedFinderOptions not in ACTS internal units in BinnedSPGroup");
   }
 
-  // sort by radius
-  // add magnitude of beamPos to rMax to avoid excluding measurements
-  // create number of bins equal to number of millimeters rMax
-  // (worst case minR: configured minR + 1mm)
-  // binSizeR allows to increase or reduce numRBins if needed
-  std::size_t numRBins = static_cast<std::size_t>(
-      (config.rMax + options.beamPos.norm()) / config.binSizeR);
+  // Space points are assumed to be ALREADY CORRECTED for beamspot position
+  // phi, z and r space point selection comes naturally from the
+  // grid axis definition. No need to explicitly cut on those values.
+  // If a space point is outside the validity range of these quantities
+  // it goes in an over- or under-flow bin.
+  // Additional cuts can be applied by customizing the space point selector
+  // in the config object.
 
   // keep track of changed bins while sorting
   std::vector<bool> usedBinIndex(grid.size(), false);
@@ -194,37 +193,17 @@ void Acts::CylindricalSpacePointGridCreator::fillGrid(
     float spY = sp.y();
     float spZ = sp.z();
 
-    // store x,y,z values in extent
-    rRangeSPExtent.extend({spX, spY, spZ});
-
     // remove SPs according to experiment specific cuts
     if (!config.spacePointSelector(sp)) {
       continue;
     }
 
-    // remove SPs outside z and phi region
-    if (spZ > config.zMax || spZ < config.zMin) {
-      continue;
-    }
-
-    float spPhi = std::atan2(spY, spX);
-    if (spPhi > config.phiMax || spPhi < config.phiMin) {
-      continue;
-    }
-
-    // calculate r-Bin index and protect against overflow (underflow not
-    // possible)
-    // std::size_t rIndex =
-    //     static_cast<std::size_t>(sp.radius() / config.binSizeR);
-    // // if index out of bounds, the SP is outside the region of interest
-    // if (rIndex >= numRBins) {
-    //   std::cout << "rejecting sp with radius: " << sp.radius() << std::endl;
-    //   continue;
-    // }
+    // store x,y,z values in extent
+    rRangeSPExtent.extend({spX, spY, spZ});
 
     // fill rbins into grid
-    std::size_t globIndex =
-        grid.globalBinFromPosition(Acts::Vector3{sp.phi(), sp.z(), sp.radius()});
+    std::size_t globIndex = grid.globalBinFromPosition(
+        Acts::Vector3{sp.phi(), sp.z(), sp.radius()});
     auto& rbin = grid.at(globIndex);
     rbin.push_back(&sp);
 

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SeedingAlgorithm.hpp
@@ -100,8 +100,8 @@ class SeedingAlgorithm final : public IAlgorithm {
   Acts::SeedFinder<SpacePointProxy_t,
                    Acts::CylindricalSpacePointGrid<SpacePointProxy_t>>
       m_seedFinder;
-  std::unique_ptr<const Acts::GridBinFinder<2ul>> m_bottomBinFinder;
-  std::unique_ptr<const Acts::GridBinFinder<2ul>> m_topBinFinder;
+  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_bottomBinFinder{nullptr};
+  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_topBinFinder{nullptr};
 
   Config m_cfg;
 

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -191,10 +191,10 @@ ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
       ActsExamples::SpacePointContainer<std::vector<const SimSpacePoint*>>,
       Acts::detail::RefHolder>::SpacePointProxyType;
 
-  m_bottomBinFinder = std::make_unique<const Acts::GridBinFinder<2ul>>(
-      m_cfg.numPhiNeighbors, cfg.zBinNeighborsBottom);
-  m_topBinFinder = std::make_unique<const Acts::GridBinFinder<2ul>>(
-      m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsTop);
+  m_bottomBinFinder = std::make_unique<const Acts::GridBinFinder<3ul>>(
+								       m_cfg.numPhiNeighbors, cfg.zBinNeighborsBottom, 0);
+  m_topBinFinder = std::make_unique<const Acts::GridBinFinder<3ul>>(
+								    m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsTop, 0);
 
   m_cfg.seedFinderConfig.seedFilter =
       std::make_unique<Acts::SeedFilter<SpacePointProxy_type>>(
@@ -254,7 +254,7 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
       m_cfg.seedFinderConfig, m_cfg.seedFinderOptions, grid,
       spContainer.begin(), spContainer.end(), rRangeSPExtent);
 
-  std::array<std::vector<std::size_t>, 2ul> navigation;
+  std::array<std::vector<std::size_t>, 3ul> navigation;
   navigation[1ul] = m_cfg.seedFinderConfig.zBinsCustomLooping;
 
   auto spacePointsGrouping = Acts::CylindricalBinnedGroup<value_type>(

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -192,9 +192,9 @@ ActsExamples::SeedingAlgorithm::SeedingAlgorithm(
       Acts::detail::RefHolder>::SpacePointProxyType;
 
   m_bottomBinFinder = std::make_unique<const Acts::GridBinFinder<3ul>>(
-								       m_cfg.numPhiNeighbors, cfg.zBinNeighborsBottom, 0);
+      m_cfg.numPhiNeighbors, cfg.zBinNeighborsBottom, 0);
   m_topBinFinder = std::make_unique<const Acts::GridBinFinder<3ul>>(
-								    m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsTop, 0);
+      m_cfg.numPhiNeighbors, m_cfg.zBinNeighborsTop, 0);
 
   m_cfg.seedFinderConfig.seedFilter =
       std::make_unique<Acts::SeedFilter<SpacePointProxy_type>>(
@@ -254,17 +254,6 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
       m_cfg.seedFinderConfig, m_cfg.seedFinderOptions, grid,
       spContainer.begin(), spContainer.end(), rRangeSPExtent);
 
-  std::size_t nSpacePointsSaved = 0ul;
-  auto gridStart = grid.begin();
-  auto gridStop = grid.end();
-  for (; gridStart != gridStop; ++gridStart) {
-    const std::vector<const value_type*>& coll = *gridStart;
-    nSpacePointsSaved += coll.size();
-  }
-   
-  std::cout << "Saved space points: " << nSpacePointsSaved << std::endl;
-  
-  
   std::array<std::vector<std::size_t>, 3ul> navigation;
   navigation[1ul] = m_cfg.seedFinderConfig.zBinsCustomLooping;
 

--- a/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SeedingAlgorithm.cpp
@@ -254,6 +254,17 @@ ActsExamples::ProcessCode ActsExamples::SeedingAlgorithm::execute(
       m_cfg.seedFinderConfig, m_cfg.seedFinderOptions, grid,
       spContainer.begin(), spContainer.end(), rRangeSPExtent);
 
+  std::size_t nSpacePointsSaved = 0ul;
+  auto gridStart = grid.begin();
+  auto gridStop = grid.end();
+  for (; gridStart != gridStop; ++gridStart) {
+    const std::vector<const value_type*>& coll = *gridStart;
+    nSpacePointsSaved += coll.size();
+  }
+   
+  std::cout << "Saved space points: " << nSpacePointsSaved << std::endl;
+  
+  
   std::array<std::vector<std::size_t>, 3ul> navigation;
   navigation[1ul] = m_cfg.seedFinderConfig.zBinsCustomLooping;
 

--- a/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
   Acts::SeedFinderConfig<value_type> config;
   // silicon detector max
   config.rMax = 160._mm;
-  config.rMin = 1._mm;
+  config.rMin = 0._mm;
   config.deltaRMin = 5._mm;
   config.deltaRMax = 160._mm;
   config.deltaRMinTopSP = config.deltaRMin;
@@ -183,8 +183,10 @@ int main(int argc, char** argv) {
   std::vector<std::pair<int, int>> zBinNeighborsTop;
   std::vector<std::pair<int, int>> zBinNeighborsBottom;
 
-  auto bottomBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(numPhiNeighbors, zBinNeighborsBottom, 0);
-  auto topBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(numPhiNeighbors, zBinNeighborsTop, 0);
+  auto bottomBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(
+      numPhiNeighbors, zBinNeighborsBottom, 0);
+  auto topBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(
+      numPhiNeighbors, zBinNeighborsTop, 0);
   Acts::SeedFilterConfig sfconf;
 
   Acts::ATLASCuts<value_type> atlasCuts = Acts::ATLASCuts<value_type>();

--- a/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/SeedFinderTest.cpp
@@ -146,6 +146,7 @@ int main(int argc, char** argv) {
   Acts::SeedFinderConfig<value_type> config;
   // silicon detector max
   config.rMax = 160._mm;
+  config.rMin = 1._mm;
   config.deltaRMin = 5._mm;
   config.deltaRMax = 160._mm;
   config.deltaRMinTopSP = config.deltaRMin;
@@ -182,10 +183,8 @@ int main(int argc, char** argv) {
   std::vector<std::pair<int, int>> zBinNeighborsTop;
   std::vector<std::pair<int, int>> zBinNeighborsBottom;
 
-  auto bottomBinFinder = std::make_unique<Acts::GridBinFinder<2ul>>(
-      Acts::GridBinFinder<2ul>(numPhiNeighbors, zBinNeighborsBottom));
-  auto topBinFinder = std::make_unique<Acts::GridBinFinder<2ul>>(
-      Acts::GridBinFinder<2ul>(numPhiNeighbors, zBinNeighborsTop));
+  auto bottomBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(numPhiNeighbors, zBinNeighborsBottom, 0);
+  auto topBinFinder = std::make_unique<Acts::GridBinFinder<3ul>>(numPhiNeighbors, zBinNeighborsTop, 0);
   Acts::SeedFilterConfig sfconf;
 
   Acts::ATLASCuts<value_type> atlasCuts = Acts::ATLASCuts<value_type>();


### PR DESCRIPTION
This adds a radius bin to the grid. The binning can be provided by the user with a vector of values. If none is provided, the range `rMin -> rMax` will be used.  
That means that now the grids is 3D : `(phi, z, radius)`

By default `rMin = 0_mm`, while `rMax = 320_mm`