### PR TITLE
feat: adding possibility to read flat surface container

### DIFF
--- a/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
+++ b/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
@@ -36,4 +36,12 @@ struct Options {
 Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>> read(
     const Options& options);
 
+/// @brief Read the sflat surfaces urfaces from the input file
+///
+/// @param inputFile is the input file to read from
+///
+/// @return  a vector of surfaces
+std::vector<std::shared_ptr<Acts::Surface>> readSurfaces(
+    const Options& options);
+
 }  // namespace ActsExamples::JsonSurfacesReader

--- a/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
+++ b/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
@@ -36,7 +36,7 @@ struct Options {
 Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>> read(
     const Options& options);
 
-/// @brief Read the sflat surfaces urfaces from the input file
+/// @brief Read the flat surfaces from the input file
 ///
 /// @param inputFile is the input file to read from
 ///

--- a/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
+++ b/Examples/Io/Json/include/ActsExamples/Io/Json/JsonSurfacesReader.hpp
@@ -33,7 +33,7 @@ struct Options {
 /// @param options specifies which file and what to read
 ///
 /// @return  a vector of surfaces
-Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>> read(
+Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>> readHierarchyMap(
     const Options& options);
 
 /// @brief Read the flat surfaces from the input file
@@ -41,7 +41,6 @@ Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>> read(
 /// @param inputFile is the input file to read from
 ///
 /// @return  a vector of surfaces
-std::vector<std::shared_ptr<Acts::Surface>> readSurfaces(
-    const Options& options);
+std::vector<std::shared_ptr<Acts::Surface>> readVector(const Options& options);
 
 }  // namespace ActsExamples::JsonSurfacesReader

--- a/Examples/Io/Json/src/JsonSurfacesReader.cpp
+++ b/Examples/Io/Json/src/JsonSurfacesReader.cpp
@@ -50,4 +50,26 @@ JsonSurfacesReader::read(const JsonSurfacesReader::Options& options) {
   return SurfaceHierachyMap(std::move(surfaceElements));
 }
 
+std::vector<std::shared_ptr<Acts::Surface>> JsonSurfacesReader::readSurfaces(
+    const Options& options) {
+  // Read the json file into a json object
+  nlohmann::json j;
+  std::ifstream in(options.inputFile);
+  in >> j;
+  in.close();
+
+  // Walk down the path to the surface entries
+  nlohmann::json jSurfaces = j;
+  for (const auto& jep : options.jsonEntryPath) {
+    jSurfaces = jSurfaces[jep];
+  }
+
+  std::vector<std::shared_ptr<Acts::Surface>> surfaces;
+  for (const auto& jSurface : jSurfaces) {
+    auto surface = Acts::SurfaceJsonConverter::fromJson(jSurface);
+    surfaces.push_back(surface);
+  }
+  return surfaces;
+}
+
 }  // namespace ActsExamples

--- a/Examples/Io/Json/src/JsonSurfacesReader.cpp
+++ b/Examples/Io/Json/src/JsonSurfacesReader.cpp
@@ -20,7 +20,8 @@
 namespace ActsExamples {
 
 Acts::GeometryHierarchyMap<std::shared_ptr<Acts::Surface>>
-JsonSurfacesReader::read(const JsonSurfacesReader::Options& options) {
+JsonSurfacesReader::readHierarchyMap(
+    const JsonSurfacesReader::Options& options) {
   // Read the json file into a json object
   nlohmann::json j;
   std::ifstream in(options.inputFile);
@@ -50,7 +51,7 @@ JsonSurfacesReader::read(const JsonSurfacesReader::Options& options) {
   return SurfaceHierachyMap(std::move(surfaceElements));
 }
 
-std::vector<std::shared_ptr<Acts::Surface>> JsonSurfacesReader::readSurfaces(
+std::vector<std::shared_ptr<Acts::Surface>> JsonSurfacesReader::readVector(
     const Options& options) {
   // Read the json file into a json object
   nlohmann::json j;

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -163,7 +163,11 @@ void addJson(Context& ctx) {
     ACTS_PYTHON_MEMBER(jsonEntryPath);
     ACTS_PYTHON_STRUCT_END();
 
-    mex.def("readSurfaceFromJson", ActsExamples::JsonSurfacesReader::read);
+    mex.def("readSurfaceHierarchyMapFromJson",
+            ActsExamples::JsonSurfacesReader::read);
+
+    mex.def("readSurfacesFromJson",
+            ActsExamples::JsonSurfacesReader::readSurfaces);
   }
 
   {

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -164,10 +164,10 @@ void addJson(Context& ctx) {
     ACTS_PYTHON_STRUCT_END();
 
     mex.def("readSurfaceHierarchyMapFromJson",
-            ActsExamples::JsonSurfacesReader::read);
+            ActsExamples::JsonSurfacesReader::readHierarchyMap);
 
-    mex.def("readSurfacesFromJson",
-            ActsExamples::JsonSurfacesReader::readSurfaces);
+    mex.def("readSurfaceVectorFromJson",
+            ActsExamples::JsonSurfacesReader::readVector);
   }
 
   {


### PR DESCRIPTION
This PR adds a function to the `JsonSurfacesReader` that allows to read in a flat container rather than a Hierarchy map:

```python
>>> import acts
>>> from acts import examples
>>> sOptions = acts.examples.SurfaceJsonOptions()
>>> sOptions.inputFile = "some_sensitive_mod.json"
>>> sOptions.jsonEntryPath = ["surfaces"]
>>> surfaces = acts.examples.rreadSurfaceVectorFromJson(sOptions)
>>> print(len(surfaces))
16668
>>> geoContext = acts.GeometryContext()
>>> viewConfig = acts.ViewConfig()
>>> acts.examples.writeSurfacesObj(surfaces, geoContext, viewConfig, "some-surfaces.obj")
```

will work with this out of the box.



