### PR TITLE
refactor: use `contains` for maps and sets

### DIFF
--- a/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/VectorMultiTrajectory.hpp
@@ -220,7 +220,7 @@ class VectorMultiTrajectoryBase {
       case "typeFlags"_hash:
         return true;
       default:
-        return instance.m_dynamic.find(key) != instance.m_dynamic.end();
+        return instance.m_dynamic.contains(key);
     }
   }
 
@@ -287,7 +287,7 @@ class VectorMultiTrajectoryBase {
       case "typeFlags"_hash:
         return true;
       default:
-        return instance.m_dynamic.find(key) != instance.m_dynamic.end();
+        return instance.m_dynamic.contains(key);
     }
   }
 

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -144,7 +144,11 @@ class VectorTrackContainerBase {
 
  public:
   constexpr bool hasColumn_impl(HashedString key) const {
-    return m_dynamic.find(key) != m_dynamic.end();
+    using namespace Acts::HashedStringLiteral;
+    switch (key) {
+      default:
+        return m_dynamic.contains(key);
+    }
   }
 
   const Surface* referenceSurface_impl(IndexType itrack) const {

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -144,11 +144,7 @@ class VectorTrackContainerBase {
 
  public:
   constexpr bool hasColumn_impl(HashedString key) const {
-    using namespace Acts::HashedStringLiteral;
-    switch (key) {
-      default:
-        return m_dynamic.find(key) != m_dynamic.end();
-    }
+    return m_dynamic.contains(key);
   }
 
   const Surface* referenceSurface_impl(IndexType itrack) const {

--- a/Core/include/Acts/EventData/VectorTrackContainer.hpp
+++ b/Core/include/Acts/EventData/VectorTrackContainer.hpp
@@ -144,7 +144,7 @@ class VectorTrackContainerBase {
 
  public:
   constexpr bool hasColumn_impl(HashedString key) const {
-    return m_dynamic.contains(key);
+    return m_dynamic.find(key) != m_dynamic.end();
   }
 
   const Surface* referenceSurface_impl(IndexType itrack) const {

--- a/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
+++ b/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
@@ -117,6 +117,17 @@ class GeometryHierarchyMap {
   /// @retval `.end()` iterator if no matching element exists
   Iterator find(const GeometryIdentifier& id) const;
 
+  /// Check if the most specific value exists for a given geometry identifier.
+  ///
+  /// This function checks if there is an element matching exactly the given
+  /// geometry id, or from the element for the next available higher level
+  /// within the geometry hierarchy.
+  ///
+  /// @param id geometry identifier for which existence is being checked
+  /// @retval `true` if a matching element exists
+  /// @retval `false` if no matching element exists
+  bool contains(const GeometryIdentifier& id) const;
+
  private:
   // NOTE this class assumes that it knows the ordering of the levels within
   //      the geometry id. if the geometry id changes, this code has to be
@@ -301,6 +312,12 @@ inline auto GeometryHierarchyMap<value_t>::find(
 
   // all options are exhausted and no matching element was found.
   return end();
+}
+
+template <typename value_t>
+inline auto GeometryHierarchyMap<value_t>::contains(
+    const GeometryIdentifier& id) const -> bool {
+  return this->find(id) != this->end();
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/Visualization/detail/ObjVisualization3D.ipp
+++ b/Core/include/Acts/Visualization/detail/ObjVisualization3D.ipp
@@ -106,7 +106,7 @@ void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
     materialName += std::to_string(color[1]) + std::string("_");
     materialName += std::to_string(color[2]);
 
-    if (materials.find(materialName) == materials.end()) {
+    if (!materials.contains(materialName)) {
       mos << "newmtl " << materialName << "\n";
       std::vector<std::string> shadings = {"Ka", "Kd", "Ks"};
       for (const auto& shd : shadings) {
@@ -123,7 +123,7 @@ void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
   std::size_t iv = 0;
   Color lastVertexColor = {0, 0, 0};
   for (const VertexType& vtx : m_vertices) {
-    if (m_vertexColors.find(iv) != m_vertexColors.end()) {
+    if (m_vertexColors.contains(iv)) {
       auto color = m_vertexColors.find(iv)->second;
       if (color != lastVertexColor) {
         os << mixColor(color) << "\n";
@@ -139,7 +139,7 @@ void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
   std::size_t il = 0;
   Color lastLineColor = {0, 0, 0};
   for (const LineType& ln : m_lines) {
-    if (m_lineColors.find(il) != m_lineColors.end()) {
+    if (m_lineColors.contains(il)) {
       auto color = m_lineColors.find(il)->second;
       if (color != lastLineColor) {
         os << mixColor(color) << "\n";
@@ -152,7 +152,7 @@ void ObjVisualization3D<T>::write(std::ostream& os, std::ostream& mos) const {
   std::size_t is = 0;
   Color lastFaceColor = {0, 0, 0};
   for (const FaceType& fc : m_faces) {
-    if (m_faceColors.find(is) != m_faceColors.end()) {
+    if (m_faceColors.contains(is)) {
       auto color = m_faceColors.find(is)->second;
       if (color != lastFaceColor) {
         os << mixColor(color) << "\n";

--- a/Core/src/Detector/CylindricalContainerBuilder.cpp
+++ b/Core/src/Detector/CylindricalContainerBuilder.cpp
@@ -260,7 +260,7 @@ Acts::Experimental::CylindricalContainerBuilder::construct(
   // Assign the proto material
   // Material assignment from configuration
   for (const auto& [ip, bDescription] : m_cfg.portalMaterialBinning) {
-    if (portalContainer.find(ip) != portalContainer.end()) {
+    if (portalContainer.contains(ip)) {
       auto bd = detail::ProtoMaterialHelper::attachProtoMaterial(
           gctx, portalContainer[ip]->surface(), bDescription);
       ACTS_VERBOSE("-> Assigning proto material to portal " << ip << " with "

--- a/Core/src/Detector/Detector.cpp
+++ b/Core/src/Detector/Detector.cpp
@@ -64,7 +64,7 @@ Acts::Experimental::Detector::Detector(
     v->closePortals();
     // Store the name
     const std::string vName = v->name();
-    if (m_volumeNameIndex.find(vName) != m_volumeNameIndex.end()) {
+    if (m_volumeNameIndex.contains(vName)) {
       throw std::invalid_argument("Detector: duplicate volume name " + vName +
                                   " detected.");
     }
@@ -79,7 +79,7 @@ Acts::Experimental::Detector::Detector(
                                   "' with undefined geometry id detected" +
                                   ". Make sure a GeometryIdGenerator is used.");
     }
-    if (volumeGeoIdMap.find(vgeoID) != volumeGeoIdMap.end()) {
+    if (volumeGeoIdMap.contains(vgeoID)) {
       std::stringstream ss;
       ss << vgeoID;
       throw std::invalid_argument("Detector: duplicate volume geometry id '" +
@@ -104,7 +104,7 @@ Acts::Experimental::Detector::Detector(
       }
       // ---------------------------------------------------------------
 
-      if (surfaceGeoIdMap.find(sgeoID) != surfaceGeoIdMap.end()) {
+      if (surfaceGeoIdMap.contains(sgeoID)) {
         std::stringstream ss;
         ss << sgeoID;
         throw std::invalid_argument(

--- a/Core/src/Detector/DetectorVolumeBuilder.cpp
+++ b/Core/src/Detector/DetectorVolumeBuilder.cpp
@@ -93,7 +93,7 @@ Acts::Experimental::DetectorVolumeBuilder::construct(
 
   // Assign the proto material if configured to do so
   for (const auto& [ip, bDescription] : m_cfg.portalMaterialBinning) {
-    if (portalContainer.find(ip) != portalContainer.end()) {
+    if (portalContainer.contains(ip)) {
       auto bd = detail::ProtoMaterialHelper::attachProtoMaterial(
           gctx, portalContainer[ip]->surface(), bDescription);
       ACTS_VERBOSE("-> Assigning proto material to portal " << ip << " with "

--- a/Core/src/Detector/detail/CuboidalDetectorHelper.cpp
+++ b/Core/src/Detector/detail/CuboidalDetectorHelper.cpp
@@ -270,12 +270,12 @@ Acts::Experimental::detail::CuboidalDetectorHelper::connect(
     auto& formerContainer = containers[ic - 1];
     auto& currentContainer = containers[ic];
     // Check and throw exception
-    if (formerContainer.find(startIndex) == formerContainer.end()) {
+    if (!formerContainer.contains(startIndex)) {
       throw std::invalid_argument(
           "CuboidalDetectorHelper: proto container has no fuse portal at index "
           "of former container.");
     }
-    if (currentContainer.find(endIndex) == currentContainer.end()) {
+    if (!currentContainer.contains(endIndex)) {
       throw std::invalid_argument(
           "CuboidalDetectorHelper: proto container has no fuse portal at index "
           "of current container.");
@@ -343,11 +343,8 @@ Acts::Experimental::detail::CuboidalDetectorHelper::xyzBoundaries(
   auto fillMap = [&](std::map<ActsScalar, std::size_t>& map,
                      const std::array<ActsScalar, 2u>& values) {
     for (auto v : values) {
-      if (map.find(v) != map.end()) {
-        ++map[v];
-      } else {
-        map[v] = 1u;
-      }
+      // This will insert v with a value of 0 if it doesn't exist
+      ++map[v];
     }
   };
 

--- a/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
+++ b/Core/src/Detector/detail/CylindricalDetectorHelper.cpp
@@ -860,16 +860,14 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
     auto& formerContainer = containers[ic - 1];
     auto& currentContainer = containers[ic];
     // Check and throw exception
-    if (formerContainer.find(2u) == formerContainer.end()) {
+    if (!formerContainer.contains(2u)) {
       throw std::invalid_argument(
-          "CylindricalDetectorHelper: proto container has no outer cover, "
-          "can "
+          "CylindricalDetectorHelper: proto container has no outer cover, can "
           "not be connected in R");
     }
-    if (currentContainer.find(3u) == currentContainer.end()) {
+    if (!currentContainer.contains(3u)) {
       throw std::invalid_argument(
-          "CylindricalDetectorHelper: proto container has no inner cover, "
-          "can "
+          "CylindricalDetectorHelper: proto container has no inner cover, can "
           "not be connected in R");
     }
 
@@ -897,7 +895,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
   }
 
   // Proto container refurbishment
-  if (containers[0u].find(3u) != containers[0u].end()) {
+  if (containers[0u].contains(3u)) {
     dShell[3u] = containers[0u].find(3u)->second;
   }
   dShell[2u] = containers[containers.size() - 1u].find(2u)->second;
@@ -907,7 +905,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInR(
 
   for (auto [s, volumes] : sideVolumes) {
     auto pR = connectInR(gctx, volumes, {s});
-    if (pR.find(s) != pR.end()) {
+    if (pR.contains(s)) {
       dShell[s] = pR.find(s)->second;
     }
   }
@@ -934,12 +932,12 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInZ(
     auto& formerContainer = containers[ic - 1];
     auto& currentContainer = containers[ic];
     // Check and throw exception
-    if (formerContainer.find(1u) == formerContainer.end()) {
+    if (!formerContainer.contains(1u)) {
       throw std::invalid_argument(
           "CylindricalDetectorHelper: proto container has no negative disc, "
           "can not be connected in Z");
     }
-    if (currentContainer.find(0u) == currentContainer.end()) {
+    if (!currentContainer.contains(0u)) {
       throw std::invalid_argument(
           "CylindricalDetectorHelper: proto container has no positive disc, "
           "can not be connected in Z");
@@ -972,7 +970,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInZ(
 
   // Check if this is a tube or a cylinder container (check done on 1st)
   std::vector<unsigned int> nominalSides = {2u, 4u, 5u};
-  if (containers[0u].find(3u) != containers[0u].end()) {
+  if (containers[0u].contains(3u)) {
     nominalSides.push_back(3u);
   }
 
@@ -985,7 +983,7 @@ Acts::Experimental::detail::CylindricalDetectorHelper::connectInZ(
   for (auto [s, volumes] : sideVolumes) {
     ACTS_VERBOSE(" - connect " << volumes.size() << " at selected side " << s);
     auto pR = connectInZ(gctx, volumes, {s}, logLevel);
-    if (pR.find(s) != pR.end()) {
+    if (pR.contains(s)) {
       dShell[s] = pR.find(s)->second;
     }
   }

--- a/Core/src/EventData/VectorTrackContainer.cpp
+++ b/Core/src/EventData/VectorTrackContainer.cpp
@@ -115,7 +115,7 @@ void VectorTrackContainer::copyDynamicFrom_impl(IndexType dstIdx,
 void VectorTrackContainer::ensureDynamicColumns_impl(
     const detail_vtc::VectorTrackContainerBase& other) {
   for (auto& [key, value] : other.m_dynamic) {
-    if (m_dynamic.find(key) == m_dynamic.end()) {
+    if (!m_dynamic.contains(key)) {
       m_dynamic[key] = value->clone(true);
     }
   }

--- a/Core/src/Material/MaterialInteractionAssignment.cpp
+++ b/Core/src/Material/MaterialInteractionAssignment.cpp
@@ -110,8 +110,7 @@ Acts::MaterialInteractionAssignment::assign(
   // (empty bin correction can use this information)
   std::vector<IAssignmentFinder::SurfaceAssignment> surfacesWithoutAssignments;
   for (const auto& intersectedSurface : intersectedSurfaces) {
-    if (assignedSurfaces.find(intersectedSurface.surface) ==
-        assignedSurfaces.end()) {
+    if (!assignedSurfaces.contains(intersectedSurface.surface)) {
       surfacesWithoutAssignments.push_back(intersectedSurface);
     }
   }

--- a/Core/src/Material/MaterialInteractionAssignment.cpp
+++ b/Core/src/Material/MaterialInteractionAssignment.cpp
@@ -73,7 +73,7 @@ Acts::MaterialInteractionAssignment::assign(
 
     // A local veta veto kicked in
     GeometryIdentifier intersectionID = surface->geometryId();
-    if (options.localVetos.find(intersectionID) != options.localVetos.end()) {
+    if (options.localVetos.contains(intersectionID)) {
       const auto& localVeto = *options.localVetos.find(intersectionID);
       if (localVeto(materialInteraction, intersectedSurfaces[is])) {
         unassignedMaterialInteractions.push_back(materialInteraction);
@@ -91,8 +91,7 @@ Acts::MaterialInteractionAssignment::assign(
     assignedMaterialInteraction.intersectionID = intersectionID;
     // Check for possible reassignment
     if (is + 1u < intersectedSurfaces.size() &&
-        options.reAssignments.find(intersectionID) !=
-            options.reAssignments.end()) {
+        options.reAssignments.contains(intersectionID)) {
       auto reAssignment = (*options.reAssignments.find(intersectionID));
       reAssignment(assignedMaterialInteraction, intersectedSurfaces[is],
                    intersectedSurfaces[is + 1]);

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -392,8 +392,7 @@ void Acts::SurfaceMaterialMapper::mapInteraction(
     // Now assign the material for the accumulation process
     auto tBin = currentAccMaterial->second.accumulate(
         currentPos, rmIter->materialSlab, currentPathCorrection);
-    if (touchedMapBins.find(&(currentAccMaterial->second)) ==
-        touchedMapBins.end()) {
+    if (!touchedMapBins.contains(&(currentAccMaterial->second))) {
       touchedMapBins.insert(MapBin(&(currentAccMaterial->second), tBin));
     }
     if (m_cfg.computeVariance) {
@@ -483,8 +482,7 @@ void Acts::SurfaceMaterialMapper::mapSurfaceInteraction(
     // Now assign the material for the accumulation process
     auto tBin = currentAccMaterial->second.accumulate(
         currentPos, rmIter->materialSlab, rmIter->pathCorrection);
-    if (touchedMapBins.find(&(currentAccMaterial->second)) ==
-        touchedMapBins.end()) {
+    if (!touchedMapBins.contains(&(currentAccMaterial->second))) {
       touchedMapBins.insert(MapBin(&(currentAccMaterial->second), tBin));
     }
     if (m_cfg.computeVariance) {

--- a/Core/src/TrackFinding/GbtsConnector.cpp
+++ b/Core/src/TrackFinding/GbtsConnector.cpp
@@ -126,8 +126,7 @@ GbtsConnector::GbtsConnector(std::ifstream &inFile) {
     std::list<const GbtsConnection *>::iterator cIt = lConns.begin();
 
     while (cIt != lConns.end()) {
-      if (zeroLayers.find((*cIt)->m_dst) !=
-          zeroLayers.end()) {  // check if contains
+      if (zeroLayers.contains((*cIt)->m_dst)) {
         theStage.push_back(*cIt);
         cIt = lConns.erase(cIt);
         continue;

--- a/Core/src/Vertexing/AdaptiveGridTrackDensity.cpp
+++ b/Core/src/Vertexing/AdaptiveGridTrackDensity.cpp
@@ -286,7 +286,7 @@ Result<double> AdaptiveGridTrackDensity::estimateSeedWidth(
   bool binFilled = true;
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continuous z values
-    if (densityMap.count({rhmBin + 1, tMaxBin}) == 0) {
+    if (!densityMap.contains({rhmBin + 1, tMaxBin})) {
       binFilled = false;
       break;
     }
@@ -308,7 +308,7 @@ Result<double> AdaptiveGridTrackDensity::estimateSeedWidth(
   binFilled = true;
   while (gridValue > maxValue / 2) {
     // Check if we are still operating on continuous z values
-    if (densityMap.count({lhmBin - 1, tMaxBin}) == 0) {
+    if (!densityMap.contains({lhmBin - 1, tMaxBin})) {
       binFilled = false;
       break;
     }

--- a/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
+++ b/Core/src/Vertexing/AdaptiveMultiVertexFitter.cpp
@@ -224,7 +224,7 @@ Acts::Result<void> Acts::AdaptiveMultiVertexFitter::setAllVertexCompatibilities(
     auto& trkAtVtx = state.tracksAtVerticesMap.at(std::make_pair(trk, vtx));
     // Recover from cases where linearization point != 0 but
     // more tracks were added later on
-    if (vtxInfo.impactParams3D.find(trk) == vtxInfo.impactParams3D.end()) {
+    if (!vtxInfo.impactParams3D.contains(trk)) {
       auto res = m_cfg.ipEst.estimate3DImpactParameters(
           vertexingOptions.geoContext, vertexingOptions.magFieldContext,
           m_cfg.extractParameters(trk),

--- a/Examples/Algorithms/Digitization/src/DigitizationConfig.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationConfig.cpp
@@ -66,7 +66,7 @@ std::vector<Acts::ActsScalar> ActsExamples::GeometricConfig::variances(
   std::vector<Acts::ActsScalar> rVariances;
   for (const auto& bIndex : indices) {
     Acts::ActsScalar var = 0.;
-    if (varianceMap.find(bIndex) != varianceMap.end()) {
+    if (varianceMap.contains(bIndex)) {
       // Try to find the variance for this cluster size
       std::size_t lsize =
           std::min(csizes[bIndex], varianceMap.at(bIndex).size());

--- a/Examples/Algorithms/Geant4/src/Geant4Manager.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Manager.cpp
@@ -109,7 +109,7 @@ std::shared_ptr<Geant4Handle> Geant4Manager::createHandle(
 
 void Geant4Manager::registerPhysicsListFactory(
     std::string name, std::shared_ptr<PhysicsListFactory> physicsListFactory) {
-  if (m_physicsListFactories.find(name) != m_physicsListFactories.end()) {
+  if (m_physicsListFactories.contains(name)) {
     throw std::invalid_argument("name already mapped");
   }
   m_physicsListFactories.emplace(std::move(name),

--- a/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
@@ -97,7 +97,7 @@ void ActsExamples::MaterialSteppingAction::UserSteppingAction(
   G4Track* g4Track = step->GetTrack();
   std::size_t trackID = g4Track->GetTrackID();
   auto& materialTracks = eventStore().materialTracks;
-  if (materialTracks.find(trackID - 1) == materialTracks.end()) {
+  if (materialTracks.contains(trackID - 1)) {
     Acts::RecordedMaterialTrack rmTrack;
     const auto& g4Vertex = g4Track->GetVertexPosition();
     Acts::Vector3 vertex(g4Vertex[0], g4Vertex[1], g4Vertex[2]);

--- a/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/MaterialSteppingAction.cpp
@@ -97,7 +97,7 @@ void ActsExamples::MaterialSteppingAction::UserSteppingAction(
   G4Track* g4Track = step->GetTrack();
   std::size_t trackID = g4Track->GetTrackID();
   auto& materialTracks = eventStore().materialTracks;
-  if (materialTracks.contains(trackID - 1)) {
+  if (!materialTracks.contains(trackID - 1)) {
     Acts::RecordedMaterialTrack rmTrack;
     const auto& g4Vertex = g4Track->GetVertexPosition();
     Acts::Vector3 vertex(g4Vertex[0], g4Vertex[1], g4Vertex[2]);

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -148,7 +148,7 @@ ActsExamples::ParticleTrackingAction::makeParticleId(G4int trackId,
     return std::nullopt;
   }
 
-  if (!eventStore().trackIdMapping.find(parentId)) {
+  if (!eventStore().trackIdMapping.contains(parentId)) {
     ACTS_DEBUG("Parent particle " << parentId
                                   << " not registered, cannot build barcode");
     eventStore().parentIdNotFound++;

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -69,8 +69,7 @@ void ActsExamples::ParticleTrackingAction::PostUserTrackingAction(
     const G4Track* aTrack) {
   // The initial particle maybe was not registered because a particle ID
   // collision
-  if (eventStore().trackIdMapping.find(aTrack->GetTrackID()) ==
-      eventStore().trackIdMapping.end()) {
+  if (!eventStore().trackIdMapping.contains(aTrack->GetTrackID())) {
     ACTS_WARNING("Particle ID for track ID " << aTrack->GetTrackID()
                                              << " not registered. Skip");
     return;
@@ -78,8 +77,7 @@ void ActsExamples::ParticleTrackingAction::PostUserTrackingAction(
 
   const auto barcode = eventStore().trackIdMapping.at(aTrack->GetTrackID());
 
-  auto hasHits = eventStore().particleHitCount.find(barcode) !=
-                     eventStore().particleHitCount.end() &&
+  auto hasHits = eventStore().particleHitCount.contains(barcode) &&
                  eventStore().particleHitCount.at(barcode) > 0;
 
   if (!m_cfg.keepParticlesWithoutHits && !hasHits) {
@@ -146,13 +144,11 @@ ActsExamples::ParticleTrackingAction::makeParticleId(G4int trackId,
                                                      G4int parentId) const {
   // We already have this particle registered (it is one of the input particles
   // or we are making a final particle state)
-  if (eventStore().trackIdMapping.find(trackId) !=
-      eventStore().trackIdMapping.end()) {
+  if (eventStore().trackIdMapping.contains(trackId)) {
     return std::nullopt;
   }
 
-  if (eventStore().trackIdMapping.find(parentId) ==
-      eventStore().trackIdMapping.end()) {
+  if (!eventStore().trackIdMapping.find(parentId)) {
     ACTS_DEBUG("Parent particle " << parentId
                                   << " not registered, cannot build barcode");
     eventStore().parentIdNotFound++;

--- a/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSteppingAction.cpp
@@ -182,8 +182,7 @@ void ActsExamples::SensitiveSteppingAction::UserSteppingAction(
   }
 
   // This is not the case if we have a particle-ID collision
-  if (eventStore().trackIdMapping.find(track->GetTrackID()) ==
-      eventStore().trackIdMapping.end()) {
+  if (!eventStore().trackIdMapping.contains(track->GetTrackID())) {
     return;
   }
 
@@ -192,8 +191,7 @@ void ActsExamples::SensitiveSteppingAction::UserSteppingAction(
   ACTS_VERBOSE("Step of " << particleId << " in sensitive volume " << geoId);
 
   // Set particle hit count to zero, so we have this entry in the map later
-  if (eventStore().particleHitCount.find(particleId) ==
-      eventStore().particleHitCount.end()) {
+  if (!eventStore().particleHitCount.contains(particleId)) {
     eventStore().particleHitCount[particleId] = 0;
   }
 

--- a/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackFindingAlgorithm.cpp
@@ -222,12 +222,11 @@ class BranchStopper {
       // count both holes and outliers as holes for pixel/strip counts
       if (trackState.typeFlags().test(Acts::TrackStateFlag::HoleFlag) ||
           trackState.typeFlags().test(Acts::TrackStateFlag::OutlierFlag)) {
-        if (m_cfg.pixelVolumes.count(
-                trackState.referenceSurface().geometryId().volume()) >= 1) {
+        if (m_cfg.pixelVolumes.contains(
+                trackState.referenceSurface().geometryId().volume())) {
           ++branchState.nPixelHoles;
-        } else if (m_cfg.stripVolumes.count(
-                       trackState.referenceSurface().geometryId().volume()) >=
-                   1) {
+        } else if (m_cfg.stripVolumes.contains(
+                       trackState.referenceSurface().geometryId().volume())) {
           ++branchState.nStripHoles;
         }
       }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackTruthMatcher.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TrackTruthMatcher.cpp
@@ -84,7 +84,7 @@ ActsExamples::ProcessCode TrackTruthMatcher::execute(
         particleHitCounts.front().particleId;
     std::size_t nMajorityHits = particleHitCounts.front().hitCount;
 
-    if (particles.find(majorityParticleId) == particles.end()) {
+    if (!particles.contains(majorityParticleId)) {
       ACTS_DEBUG(
           "The majority particle is not in the input particle collection, "
           "majorityParticleId = "

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthVertexFinder.cpp
@@ -104,7 +104,7 @@ ProcessCode TruthVertexFinder::execute(const AlgorithmContext& ctx) const {
           particleHitCounts.front().particleId;
       std::size_t nMajorityHits = particleHitCounts.front().hitCount;
 
-      if (particles.find(majorityParticleId) == particles.end()) {
+      if (!particles.contains(majorityParticleId)) {
         ACTS_DEBUG(
             "The majority particle is not in the input particle collection, "
             "majorityParticleId = "

--- a/Examples/Detectors/TGeoDetector/src/TGeoITkModuleSplitter.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoITkModuleSplitter.cpp
@@ -33,11 +33,9 @@ void ActsExamples::TGeoITkModuleSplitter::initSplitCategories() {
        m_cfg.splitPatterns) {
     // mark pattern for disc or barrel module splits:
     bool is_disk = false;
-    if (m_cfg.discMap.find(pattern_split_category.second) !=
-        m_cfg.discMap.end()) {
+    if (m_cfg.discMap.contains(pattern_split_category.second)) {
       is_disk = true;
-    } else if (m_cfg.barrelMap.find(pattern_split_category.second) ==
-               m_cfg.barrelMap.end()) {
+    } else if (!m_cfg.barrelMap.contains(pattern_split_category.second)) {
       ACTS_ERROR(
           pattern_split_category.second +
           " is neither a category name for barrel or disk module splits.");

--- a/Examples/Framework/include/ActsExamples/EventData/Trajectories.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/Trajectories.hpp
@@ -79,7 +79,7 @@ struct Trajectories final {
   /// @return Whether having fitted track parameters or not
   bool hasTrackParameters(
       Acts::MultiTrajectoryTraits::IndexType entryIndex) const {
-    return (0 < m_trackParameters.count(entryIndex));
+    return m_trackParameters.contains(entryIndex);
   }
 
   /// Access the fitted track parameters for the given index.

--- a/Examples/Framework/include/ActsExamples/Framework/WhiteBoard.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/WhiteBoard.hpp
@@ -108,7 +108,7 @@ inline void ActsExamples::WhiteBoard::add(const std::string& name, T&& object) {
   if (name.empty()) {
     throw std::invalid_argument("Object can not have an empty name");
   }
-  if (0 < m_store.count(name)) {
+  if (m_store.contains(name)) {
     throw std::invalid_argument("Object '" + name + "' already exists");
   }
   auto holder = std::make_shared<HolderT<T>>(std::forward<T>(object));
@@ -154,5 +154,6 @@ inline const T& ActsExamples::WhiteBoard::get(const std::string& name) const {
 }
 
 inline bool ActsExamples::WhiteBoard::exists(const std::string& name) const {
-  return m_store.find(name) != m_store.end();
+  // TODO remove this function?
+  return m_store.contains(name);
 }

--- a/Examples/Io/Csv/src/CsvSeedWriter.cpp
+++ b/Examples/Io/Csv/src/CsvSeedWriter.cpp
@@ -130,7 +130,7 @@ ActsExamples::ProcessCode ActsExamples::CsvSeedWriter::writeT(
       truthDistance = sqrt(dPhi * dPhi + dEta * dEta);
       // If the seed is truth matched, check if it is the closest one for the
       // contributing particle
-      if (goodSeed.find(majorityParticleId) != goodSeed.end()) {
+      if (goodSeed.contains(majorityParticleId)) {
         if (goodSeed[majorityParticleId].second > truthDistance) {
           goodSeed[majorityParticleId] = std::make_pair(iparams, truthDistance);
         }

--- a/Examples/Io/Csv/src/CsvTrackWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackWriter.cpp
@@ -185,7 +185,7 @@ ProcessCode CsvTrackWriter::writeT(const AlgorithmContext& context,
 
   // good/duplicate/fake = 0/1/2
   for (auto& [id, trajState] : infoMap) {
-    if (listGoodTracks.find(id) != listGoodTracks.end()) {
+    if (listGoodTracks.contains(id)) {
       trajState.trackType = "good";
     } else if (trajState.trackType != "fake") {
       trajState.trackType = "duplicate";

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -177,7 +177,7 @@ void addLogging(Acts::Python::Context& ctx) {
   logging.def(
       "getLogger",
       [](const std::string& name) {
-        if (pythonLoggers.find(name) == pythonLoggers.end()) {
+        if (!pythonLoggers.contains(name)) {
           pythonLoggers[name] =
               std::make_shared<PythonLogger>(name, Acts::Logging::INFO);
         }

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -79,8 +79,7 @@ actsvg::svg::object drawDetectorVolume(const Svg::ProtoVolume& pVolume,
 
   // Helper lambda for material selection
   auto materialSel = [&](const Svg::ProtoSurface& s) -> bool {
-    return (materials &&
-            s._decorations.find("material") != s._decorations.end());
+    return (materials && s._decorations.contains("material"));
   };
 
   // Helper lambda for view range selection

--- a/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
+++ b/Examples/Scripts/MaterialMapping/MaterialComposition.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
     store(command_line_parser(argc, argv).options(description).run(), vm);
     notify(vm);
 
-    if (vm.count("help") != 0u) {
+    if (vm.contains("help")) {
       std::cout << description;
     }
 
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     // Subdetector configurations
     std::vector<Region> dRegion = {};
 
-    if (vm.count("config") > 0) {
+    if (vm.contains("config")) {
       std::filesystem::path config = vm["config"].as<std::string>();
       std::cout << "Reading region configuration from JSON: " << config
                 << std::endl;

--- a/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
+++ b/Examples/Scripts/MaterialMapping/materialPlotHelper.cpp
@@ -36,7 +36,7 @@ std::ostream& Acts::operator<<(std::ostream& os, Acts::GeometryIdentifier id) {
 /// Initialise the information on each surface.
 
 void Initialise_info(sinfo& surface_info,
-                     const std::map<std::string, std::string>& surface_name,
+                     const std::map<std::string, std::string>& surfaceName,
                      const std::uint64_t& id, const int& type, const float& pos,
                      const float& range_min, const float& range_max) {
   Acts::GeometryIdentifier ID(id);
@@ -67,10 +67,11 @@ void Initialise_info(sinfo& surface_info,
                         Ids[3] + "_s" + Ids[4];
   surface_info.type = type;
 
-  if (surface_name.find(surface_id) != surface_name.end()) {
-    surface_info.name = surface_name.at(surface_id);
-  } else
+  if (surfaceName.contains(surface_id)) {
+    surface_info.name = surfaceName.at(surface_id);
+  } else {
     surface_info.name = "";
+  }
 
   surface_info.id = surface_id;
   surface_info.pos = pos;

--- a/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
+++ b/Examples/Scripts/TrackingPerformance/ResidualsAndPulls.cpp
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     variables_map vm;
     store(command_line_parser(argc, argv).options(description).run(), vm);
 
-    if (vm.count("help") != 0u) {
+    if (vm.contains("help")) {
       std::cout << description;
       return 1;
     }

--- a/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
+++ b/Examples/Scripts/TrackingPerformance/TrackSummary.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv) {
     variables_map vm;
     store(command_line_parser(argc, argv).options(description).run(), vm);
 
-    if (vm.count("help") != 0u) {
+    if (vm.contains("help")) {
       std::cout << description;
       return 1;
     }

--- a/Examples/Scripts/TrackingPerformance/boundParamResolution.C
+++ b/Examples/Scripts/TrackingPerformance/boundParamResolution.C
@@ -141,7 +141,7 @@ int boundParamResolution(const std::string& inFile, const std::string& treeName,
   for (int volID = 1; volID <= volBins; ++volID) {
     for (int layID = 1; layID <= layBins; ++layID) {
       if (h2_volID_layID->GetBinContent(volID, layID) != 0.) {
-        if (volLayIds.find(volID) == volLayIds.end()) {
+        if (!volLayIds.contains(volID)) {
           // First occurrence of this layer, add -1 for volume plots
           volLayIds[volID] = {-1, layID};
         } else {

--- a/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
+++ b/Plugins/ActSVG/include/Acts/Plugins/ActSVG/IndexedSurfacesSvgConverter.hpp
@@ -302,7 +302,7 @@ static inline actsvg::svg::object xy(const ProtoIndexedSurfaceGrid& pIndexGrid,
     for (const auto [is, sis] : enumerate(pIndices[ig])) {
       const auto& ps = pSurfaces[sis];
       std::string oInfo = std::string("- object: ") + std::to_string(sis);
-      if (ps._aux_info.find("center") != ps._aux_info.end()) {
+      if (ps._aux_info.contains("center")) {
         for (const auto& ci : ps._aux_info.at("center")) {
           oInfo += ci;
         }

--- a/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
@@ -26,7 +26,7 @@ Acts::Experimental::DD4hepLayerStructure::builder(
     DD4hepDetectorElement::Store& dd4hepStore, const GeometryContext& gctx,
     const dd4hep::DetElement& dd4hepElement, const Options& options) const {
   // Check for misconfiguration with double naming
-  if (dd4hepStore.find(options.name) != dd4hepStore.end()) {
+  if (dd4hepStore.contains(options.name)) {
     std::string reMessage = "DD4hepLayerStructure: structure with name '";
     reMessage += options.name;
     reMessage += "' already registered in DetectorElementStore";

--- a/Plugins/ExaTrkX/src/CugraphTrackBuilding.cpp
+++ b/Plugins/ExaTrkX/src/CugraphTrackBuilding.cpp
@@ -65,7 +65,7 @@ std::vector<std::vector<int>> CugraphTrackBuilding::operator()(
     int spacepointID = spacepointIDs[idx];
 
     int trkId;
-    if (trackLableToIds.find(trackLabel) != trackLableToIds.end()) {
+    if (trackLableToIds.contains(trackLabel)) {
       trkId = trackLableToIds[trackLabel];
       trackCandidates[trkId].push_back(spacepointID);
     } else {

--- a/Plugins/Json/src/MaterialJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialJsonConverter.cpp
@@ -726,7 +726,7 @@ nlohmann::json Acts::MaterialJsonConverter::toJsonDetray(
     nlohmann::json jGridLink;
     jGridLink["type"] = gridIndexType;
     std::size_t gridIndex = 0;
-    if (gridLink.find(gridIndexType) != gridLink.end()) {
+    if (gridLink.contains(gridIndexType)) {
       std::size_t& fGridIndex = gridLink[gridIndex];
       gridIndex = fGridIndex;
       fGridIndex++;

--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackContainer.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackContainer.hpp
@@ -189,7 +189,7 @@ class MutablePodioTrackContainer : public PodioTrackContainerBase {
   }
 
   bool hasColumn_impl(HashedString key) const {
-    return m_dynamic.find(key) != m_dynamic.end();
+    return m_dynamic.contains(key);
   }
 
   std::size_t size_impl() const { return m_collection->size(); }
@@ -365,7 +365,7 @@ class ConstPodioTrackContainer : public PodioTrackContainerBase {
   }
 
   bool hasColumn_impl(HashedString key) const {
-    return m_dynamic.find(key) != m_dynamic.end();
+    return m_dynamic.contains(key);
   }
 
   std::size_t size_impl() const { return m_collection->size(); }

--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
@@ -88,7 +88,7 @@ class PodioTrackStateContainerBase {
       case "typeFlags"_hash:
         return true;
       default:
-        return instance.m_dynamic.find(key) != instance.m_dynamic.end();
+        return instance.m_dynamic.contains(key);
     }
 
     return false;
@@ -166,7 +166,7 @@ class PodioTrackStateContainerBase {
       case "typeFlags"_hash:
         return true;
       default:
-        return instance.m_dynamic.find(key) != instance.m_dynamic.end();
+        return instance.m_dynamic.contains(key);
     }
   }
 

--- a/Tests/Benchmarks/BinUtilityBenchmark.cpp
+++ b/Tests/Benchmarks/BinUtilityBenchmark.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
 
-    if (vm.count("help") != 0u) {
+    if (vm.contains("help")) {
       std::cout << desc << std::endl;
       return 0;
     }

--- a/Tests/Benchmarks/StepperBenchmarkCommons.hpp
+++ b/Tests/Benchmarks/StepperBenchmarkCommons.hpp
@@ -54,7 +54,7 @@ struct BenchmarkStepper {
       po::store(po::parse_command_line(argc, argv, desc), vm);
       po::notify(vm);
 
-      if (vm.count("help") != 0u) {
+      if (vm.contains("help")) {
         std::cout << desc << std::endl;
         return 0;
       }

--- a/Tests/UnitTests/Core/Seeding/UtilityFunctionsTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/UtilityFunctionsTests.cpp
@@ -62,9 +62,9 @@ BOOST_AUTO_TEST_CASE(pushBackOrInsertAtEnd_set) {
   Acts::detail::pushBackOrInsertAtEnd(coll, val);
   BOOST_CHECK(coll.size() == 3ul);
 
-  BOOST_CHECK(coll.find(2ul) != coll.end());
-  BOOST_CHECK(coll.find(5ul) != coll.end());
-  BOOST_CHECK(coll.find(1ul) != coll.end());
+  BOOST_CHECK(coll.contains(2ul));
+  BOOST_CHECK(coll.contains(5ul));
+  BOOST_CHECK(coll.contains(1ul));
 }
 
 BOOST_AUTO_TEST_CASE(pushBackOrInsertAtEnd_unordered_set) {
@@ -77,9 +77,9 @@ BOOST_AUTO_TEST_CASE(pushBackOrInsertAtEnd_unordered_set) {
   Acts::detail::pushBackOrInsertAtEnd(coll, val);
   BOOST_CHECK(coll.size() == 3ul);
 
-  BOOST_CHECK(coll.find(2ul) != coll.end());
-  BOOST_CHECK(coll.find(5ul) != coll.end());
-  BOOST_CHECK(coll.find(1ul) != coll.end());
+  BOOST_CHECK(coll.contains(2ul));
+  BOOST_CHECK(coll.contains(5ul));
+  BOOST_CHECK(coll.contains(1ul));
 }
 
 }  // namespace Acts::Test

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -149,7 +149,7 @@ std::shared_ptr<const TrackingGeometry> makeToyDetector(
         RectangleBounds(halfSizeSurface, halfSizeSurface));
 
     // Add material only for selected surfaces
-    if (surfaceIndexWithMaterial.count(surfPos) != 0) {
+    if (surfaceIndexWithMaterial.contains(surfPos)) {
       // Material of the surfaces
       MaterialSlab matProp(makeSilicon(), 5_mm);
       cfg.surMat = std::make_shared<HomogeneousSurfaceMaterial>(matProp);

--- a/Tests/UnitTests/Core/Utilities/GridIterationTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/GridIterationTests.cpp
@@ -538,9 +538,7 @@ BOOST_AUTO_TEST_CASE(grid_iteration_test_3d_local_norepetitions) {
       for (std::size_t z : navigation[2ul]) {
         std::array<std::size_t, 3ul> locPos({x, y, z});
         std::size_t globPos = grid.globalBinFromLocalBins(locPos);
-        BOOST_CHECK_EQUAL(
-            allowed_global_bins.find(globPos) != allowed_global_bins.end(),
-            false);
+        BOOST_CHECK(!allowed_global_bins.contains(globPos));
         allowed_global_bins.insert(globPos);
       }
     }
@@ -559,10 +557,8 @@ BOOST_AUTO_TEST_CASE(grid_iteration_test_3d_local_norepetitions) {
     ++numIterations;
     std::array<std::size_t, 3ul> locPos = gridStart.localBinsIndices();
     std::size_t globPos = grid.globalBinFromLocalBins(locPos);
-    BOOST_CHECK_EQUAL(
-        visited_global_bins.find(globPos) != visited_global_bins.end(), false);
-    BOOST_CHECK_EQUAL(
-        allowed_global_bins.find(globPos) != allowed_global_bins.end(), true);
+    BOOST_CHECK(!visited_global_bins.contains(globPos));
+    BOOST_CHECK(allowed_global_bins.contains(globPos));
     visited_global_bins.insert(globPos);
   }
 


### PR DESCRIPTION
I introduced also for `Core/include/Acts/Geometry/GeometryHierarchyMap.hpp` a contains method, as it would be expected from a map.