### PR TITLE
refactor!: Remove mean reduction from `MultiEigenStepperLoop`

### DIFF
--- a/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
@@ -138,31 +138,6 @@ auto makeDefaultBoundPars(bool cov = true, std::size_t n = 4,
 //////////////////////
 /// Test the reducers
 //////////////////////
-BOOST_AUTO_TEST_CASE(test_weighted_reducer) {
-  // Can use this multistepper since we only care about the state which is
-  // invariant
-  using MultiState = typename MultiStepperLoop::State;
-
-  constexpr std::size_t N = 4;
-  const auto multi_pars = makeDefaultBoundPars(false, N);
-
-  MultiState state(geoCtx, magCtx, defaultBField, multi_pars, defaultStepSize);
-  SingleStepper singleStepper(defaultBField);
-
-  WeightedComponentReducerLoop reducer{};
-
-  Acts::Vector3 pos = Acts::Vector3::Zero();
-  Acts::Vector3 dir = Acts::Vector3::Zero();
-  for (const auto &[sstate, weight, _] : state.components) {
-    pos += weight * singleStepper.position(sstate);
-    dir += weight * singleStepper.direction(sstate);
-  }
-  dir.normalize();
-
-  BOOST_CHECK_EQUAL(reducer.position(state), pos);
-  BOOST_CHECK_EQUAL(reducer.direction(state), dir);
-}
-
 BOOST_AUTO_TEST_CASE(test_max_weight_reducer) {
   // Can use this multistepper since we only care about the state which is
   // invariant

--- a/docs/core/reconstruction/track_fitting.md
+++ b/docs/core/reconstruction/track_fitting.md
@@ -65,7 +65,7 @@ Simplified overview of the GSF algorithm.
 :::
 
 ### The Multi-Stepper
-To implement the GSF, a special stepper is needed, that can handle a multi-component state internally: The {class}`Acts::MultiEigenStepperLoop`, which is based on the {class}`Acts::EigenStepper` and thus shares a lot of code with it. It interfaces to the navigation as one aggregate state to limit the navigation overhead, but internally processes a multi-component state. How this aggregation is performed can be configured via a template parameter, by default weighted average is used ({struct}`Acts::WeightedComponentReducerLoop`).
+To implement the GSF, a special stepper is needed, that can handle a multi-component state internally: The {class}`Acts::MultiEigenStepperLoop`, which is based on the {class}`Acts::EigenStepper` and thus shares a lot of code with it. It interfaces to the navigation as one aggregate state to limit the navigation overhead, but internally processes a multi-component state. How this aggregation is performed can be configured via a template parameter, by default maximum weight is used ({struct}`Acts::MaxWeightReducerLoop`).
 
 Even though the multi-stepper interface exposes only one aggregate state and thus is compatible with most standard tools, there is a special aborter is required to stop the navigation when the surface is reached, the {struct}`Acts::MultiStepperSurfaceReached`. It checks if all components have reached the target surface already and updates their state accordingly. Optionally, it also can stop the propagation when the aggregate state reaches the surface.
 

--- a/docs/core/reconstruction/track_fitting.md
+++ b/docs/core/reconstruction/track_fitting.md
@@ -65,7 +65,7 @@ Simplified overview of the GSF algorithm.
 :::
 
 ### The Multi-Stepper
-To implement the GSF, a special stepper is needed, that can handle a multi-component state internally: The {class}`Acts::MultiEigenStepperLoop`, which is based on the {class}`Acts::EigenStepper` and thus shares a lot of code with it. It interfaces to the navigation as one aggregate state to limit the navigation overhead, but internally processes a multi-component state. How this aggregation is performed can be configured via a template parameter, by default maximum weight is used ({struct}`Acts::MaxWeightReducerLoop`).
+To implement the GSF, a special stepper is needed, that can handle a multi-component state internally: The {class}`Acts::MultiEigenStepperLoop`, which is based on the {class}`Acts::EigenStepper` and thus shares a lot of code with it. It interfaces to the navigation as one aggregate state to limit the navigation overhead, but internally processes a multi-component state. How this aggregation is performed can be configured via a template parameter, by default maximum weight is used ({type}`Acts::MaxWeightReducerLoop`).
 
 Even though the multi-stepper interface exposes only one aggregate state and thus is compatible with most standard tools, there is a special aborter is required to stop the navigation when the surface is reached, the {struct}`Acts::MultiStepperSurfaceReached`. It checks if all components have reached the target surface already and updates their state accordingly. Optionally, it also can stop the propagation when the aggregate state reaches the surface.
 


### PR DESCRIPTION
After https://github.com/acts-project/acts/pull/3521 we also want to change the default and remove the weighted mean reduction as it is unstable.

This pull request primarily focuses on removing the `WeightedComponentReducerLoop` struct and its associated functionality from the `MultiEigenStepperLoop` class and its tests. The changes simplify the codebase by eliminating the weighted component reduction logic and replacing it with the `MaxWeightReducerLoop`.

### Removal of `WeightedComponentReducerLoop`:

* [`Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp`](diffhunk://#diff-2ec4ab79520c414c4eb526d00ede45a6a10f8eeba06398d81c315f9be5686e9eL48-L145): Removed the `WeightedComponentReducerLoop` struct and its methods, which were responsible for reducing the multicomponent state by summing weighted values.

### Replacement with `MaxWeightReducerLoop`:

* [`Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp`](diffhunk://#diff-2ec4ab79520c414c4eb526d00ede45a6a10f8eeba06398d81c315f9be5686e9eL243-R145): Updated the `MultiEigenStepperLoop` class to use `MaxWeightReducerLoop` instead of `WeightedComponentReducerLoop` as the default component reducer.

### Test updates:

* [`Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp`](diffhunk://#diff-35cd1eb9d226dec9f6017cd99b5605c2da3bbaa4c3f9ffbe5b0bed7efcfdc0ddL141-L165): Removed the test case for `WeightedComponentReducerLoop`, which validated the position and direction calculations using weighted sums.