### PR TITLE
feat(geo): Extent designated initialization

### DIFF
--- a/Core/include/Acts/Geometry/Extent.hpp
+++ b/Core/include/Acts/Geometry/Extent.hpp
@@ -52,12 +52,6 @@ struct ExtentEnvelope {
     }
   }
 
-  /// Constructor from an array of envelopes
-  /// @param values the array of envelopes
-  constexpr explicit ExtentEnvelope(
-      const std::array<Envelope, numBinningValues()>& values)
-      : m_values(values) {}
-
   /// Static factory for a zero envelope
   /// @return the zero envelope
   constexpr static ExtentEnvelope Zero() {

--- a/Core/include/Acts/Geometry/Extent.hpp
+++ b/Core/include/Acts/Geometry/Extent.hpp
@@ -74,6 +74,33 @@ struct ExtentEnvelope {
     }};
   }
 
+  /// Helper struct for designated initializer construction
+  struct Arguments {
+    Envelope x = zeroEnvelope;
+    Envelope y = zeroEnvelope;
+    Envelope z = zeroEnvelope;
+    Envelope r = zeroEnvelope;
+    Envelope phi = zeroEnvelope;
+    Envelope rPhi = zeroEnvelope;
+    Envelope h = zeroEnvelope;
+    Envelope eta = zeroEnvelope;
+    Envelope mag = zeroEnvelope;
+  };
+
+  /// Constructor using a helper struct for designated initializaion
+  /// @param args the arguments
+  constexpr explicit ExtentEnvelope(Arguments&& args) {
+    using enum BinningValue;
+    m_values[toUnderlying(binX)] = args.x;
+    m_values[toUnderlying(binY)] = args.y;
+    m_values[toUnderlying(binZ)] = args.z;
+    m_values[toUnderlying(binR)] = args.r;
+    m_values[toUnderlying(binPhi)] = args.phi;
+    m_values[toUnderlying(binH)] = args.h;
+    m_values[toUnderlying(binEta)] = args.eta;
+    m_values[toUnderlying(binMag)] = args.mag;
+  }
+
   /// Comparison operator between envelope sets
   /// @param lhs the left hand side
   /// @param rhs the right hand side

--- a/Tests/UnitTests/Core/Geometry/ExtentTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ExtentTests.cpp
@@ -176,6 +176,17 @@ BOOST_AUTO_TEST_CASE(ProtoSupportCaseTests) {
   BOOST_CHECK(volumeExtent.constrains(BinningValue::binR));
 }
 
+BOOST_AUTO_TEST_CASE(DesignatedInitializers) {
+  using enum BinningValue;
+  ExtentEnvelope exp;
+  exp[binX] = {1., 2.};
+  exp[binEta] = {-1., 1.};
+
+  ExtentEnvelope act{{.x = {1., 2.}, .eta = {-1., 1.}}};
+
+  BOOST_CHECK(exp == act);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace Acts::Test


### PR DESCRIPTION
This pull request introduces a new constructor for the `ExtentEnvelope` struct using a helper struct for designated initialization, and includes corresponding unit tests to ensure its functionality. The most important changes include the addition of the `Arguments` helper struct, the new constructor, and a new test case in the unit tests.

Enhancements to `ExtentEnvelope` struct:

* [`Core/include/Acts/Geometry/Extent.hpp`](diffhunk://#diff-82ced51a7d9c573938c161066e15e9d21194b2ca79b3033d8519b1317e6d18d6R77-R103): Added a new helper struct `Arguments` for designated initializer construction and a corresponding constructor in `ExtentEnvelope` to utilize this struct.

Unit tests:

* [`Tests/UnitTests/Core/Geometry/ExtentTests.cpp`](diffhunk://#diff-ec39444b2939b7caa485e011248f941d88a3d46a9e57f386c4c42c5550b23a4aR179-R189): Added a new test case `DesignatedInitializers` to verify the functionality of the new designated initializer constructor in `ExtentEnvelope`.