### PR TITLE
feat: Allow reflection of track parameters

### DIFF
--- a/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
@@ -250,6 +250,17 @@ class GenericBoundTrackParameters {
     return m_surface->referenceFrame(geoCtx, position(geoCtx), momentum());
   }
 
+  /// Reflect the parameters in place.
+  void reflectInplace() { m_params = reflectBoundParameters(m_params); }
+
+  /// Reflect the parameters.
+  /// @return Reflected parameters.
+  GenericBoundTrackParameters<ParticleHypothesis> reflect() const {
+    GenericBoundTrackParameters<ParticleHypothesis> reflected = *this;
+    reflected.reflectInplace();
+    return reflected;
+  }
+
  private:
   BoundVector m_params;
   std::optional<BoundSquareMatrix> m_cov;

--- a/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericBoundTrackParameters.hpp
@@ -251,13 +251,13 @@ class GenericBoundTrackParameters {
   }
 
   /// Reflect the parameters in place.
-  void reflectInplace() { m_params = reflectBoundParameters(m_params); }
+  void reflectInPlace() { m_params = reflectBoundParameters(m_params); }
 
   /// Reflect the parameters.
   /// @return Reflected parameters.
   GenericBoundTrackParameters<ParticleHypothesis> reflect() const {
     GenericBoundTrackParameters<ParticleHypothesis> reflected = *this;
-    reflected.reflectInplace();
+    reflected.reflectInPlace();
     return reflected;
   }
 

--- a/Core/include/Acts/EventData/GenericCurvilinearTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericCurvilinearTrackParameters.hpp
@@ -111,6 +111,14 @@ class GenericCurvilinearTrackParameters
   Vector3 position() const {
     return GenericBoundTrackParameters<ParticleHypothesis>::position({});
   }
+
+  /// Reflect the parameters.
+  /// @return Reflected parameters.
+  GenericCurvilinearTrackParameters<ParticleHypothesis> reflect() const {
+    GenericCurvilinearTrackParameters<ParticleHypothesis> reflected = *this;
+    reflected.reflectInPlace();
+    return reflected;
+  }
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
@@ -175,6 +175,17 @@ class GenericFreeTrackParameters {
     return m_particleHypothesis;
   }
 
+  /// Reflect the parameters in place.
+  void reflectInplace() { m_params = reflectFreeParameters(m_params); }
+
+  /// Reflect the parameters.
+  /// @return Reflected parameters.
+  GenericFreeTrackParameters<ParticleHypothesis> reflect() const {
+    GenericFreeTrackParameters<ParticleHypothesis> reflected = *this;
+    reflected.reflectInplace();
+    return reflected;
+  }
+
  private:
   FreeVector m_params;
   std::optional<FreeSquareMatrix> m_cov;

--- a/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
@@ -177,13 +177,13 @@ class GenericFreeTrackParameters {
   }
 
   /// Reflect the parameters in place.
-  void reflectInplace() { m_params = reflectFreeParameters(m_params); }
+  void reflectInPlace() { m_params = reflectFreeParameters(m_params); }
 
   /// Reflect the parameters.
   /// @return Reflected parameters.
   GenericFreeTrackParameters<ParticleHypothesis> reflect() const {
     GenericFreeTrackParameters<ParticleHypothesis> reflected = *this;
-    reflected.reflectInplace();
+    reflected.reflectInPlace();
     return reflected;
   }
 

--- a/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
+++ b/Core/include/Acts/EventData/GenericFreeTrackParameters.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Definitions/Common.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/TrackParametersConcept.hpp"
+#include "Acts/EventData/TransformationHelpers.hpp"
 #include "Acts/EventData/detail/PrintParameters.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"

--- a/Core/include/Acts/EventData/TransformationHelpers.hpp
+++ b/Core/include/Acts/EventData/TransformationHelpers.hpp
@@ -18,6 +18,18 @@ namespace Acts {
 
 class Surface;
 
+/// Reflect bound track parameters.
+///
+/// @param boundParams Bound track parameters vector
+/// @return Reflected bound track parameters vector
+BoundVector reflectBoundParameters(const BoundVector& boundParams);
+
+/// Reflect free track parameters.
+///
+/// @param freeParams Free track parameters vector
+/// @return Reflected free track parameters vector
+FreeVector reflectFreeParameters(const FreeVector& freeParams);
+
 /// Transform bound track parameters into equivalent free track parameters.
 ///
 /// @param surface Surface onto which the input parameters are bound

--- a/Core/include/Acts/EventData/TransformationHelpers.hpp
+++ b/Core/include/Acts/EventData/TransformationHelpers.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Utilities/Result.hpp"
+#include "Acts/Utilities/detail/periodic.hpp"
 
 namespace Acts {
 
@@ -22,13 +23,28 @@ class Surface;
 ///
 /// @param boundParams Bound track parameters vector
 /// @return Reflected bound track parameters vector
-BoundVector reflectBoundParameters(const BoundVector& boundParams);
+inline BoundVector reflectBoundParameters(const BoundVector& boundParams) {
+  BoundVector reflected = boundParams;
+  auto [phi, theta] = detail::normalizePhiTheta(
+      boundParams[eBoundPhi] - M_PI, M_PI - boundParams[eBoundTheta]);
+  reflected[eBoundPhi] = phi;
+  reflected[eBoundTheta] = theta;
+  reflected[eBoundQOverP] = -boundParams[eBoundQOverP];
+  return reflected;
+}
 
 /// Reflect free track parameters.
 ///
 /// @param freeParams Free track parameters vector
 /// @return Reflected free track parameters vector
-FreeVector reflectFreeParameters(const FreeVector& freeParams);
+inline FreeVector reflectFreeParameters(const FreeVector& freeParams) {
+  FreeVector reflected = freeParams;
+  reflected[eFreeDir0] = -freeParams[eFreeDir0];
+  reflected[eFreeDir1] = -freeParams[eFreeDir1];
+  reflected[eFreeDir2] = -freeParams[eFreeDir2];
+  reflected[eFreeQOverP] = -freeParams[eFreeQOverP];
+  return reflected;
+}
 
 /// Transform bound track parameters into equivalent free track parameters.
 ///

--- a/Core/src/EventData/TransformationHelpers.cpp
+++ b/Core/src/EventData/TransformationHelpers.cpp
@@ -17,27 +17,6 @@
 
 #include <algorithm>
 
-Acts::BoundVector Acts::reflectBoundParameters(
-    const Acts::BoundVector& boundParams) {
-  BoundVector reflected = boundParams;
-  auto [phi, theta] = Acts::detail::normalizePhiTheta(
-      boundParams[eBoundPhi] - M_PI, M_PI - boundParams[eBoundTheta]);
-  reflected[eBoundPhi] = phi;
-  reflected[eBoundTheta] = theta;
-  reflected[eBoundQOverP] = -boundParams[eBoundQOverP];
-  return reflected;
-}
-
-Acts::FreeVector Acts::reflectFreeParameters(
-    const Acts::FreeVector& freeParams) {
-  FreeVector reflected = freeParams;
-  reflected[eFreeDir0] = -freeParams[eFreeDir0];
-  reflected[eFreeDir1] = -freeParams[eFreeDir1];
-  reflected[eFreeDir2] = -freeParams[eFreeDir2];
-  reflected[eFreeQOverP] = -freeParams[eFreeQOverP];
-  return reflected;
-}
-
 Acts::FreeVector Acts::transformBoundToFreeParameters(
     const Acts::Surface& surface, const GeometryContext& geoCtx,
     const Acts::BoundVector& boundParams) {

--- a/Core/src/EventData/TransformationHelpers.cpp
+++ b/Core/src/EventData/TransformationHelpers.cpp
@@ -13,8 +13,30 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
+#include "Acts/Utilities/detail/periodic.hpp"
 
 #include <algorithm>
+
+Acts::BoundVector Acts::reflectBoundParameters(
+    const Acts::BoundVector& boundParams) {
+  BoundVector reflected = boundParams;
+  auto [phi, theta] = Acts::detail::normalizePhiTheta(
+      boundParams[eBoundPhi] - M_PI, M_PI - boundParams[eBoundTheta]);
+  reflected[eBoundPhi] = phi;
+  reflected[eBoundTheta] = theta;
+  reflected[eBoundQOverP] = -boundParams[eBoundQOverP];
+  return reflected;
+}
+
+Acts::FreeVector Acts::reflectFreeParameters(
+    const Acts::FreeVector& freeParams) {
+  FreeVector reflected = freeParams;
+  reflected[eFreeDir0] = -freeParams[eFreeDir0];
+  reflected[eFreeDir1] = -freeParams[eFreeDir1];
+  reflected[eFreeDir2] = -freeParams[eFreeDir2];
+  reflected[eFreeQOverP] = -freeParams[eFreeQOverP];
+  return reflected;
+}
 
 Acts::FreeVector Acts::transformBoundToFreeParameters(
     const Acts::Surface& surface, const GeometryContext& geoCtx,

--- a/Core/src/EventData/TransformationHelpers.cpp
+++ b/Core/src/EventData/TransformationHelpers.cpp
@@ -13,7 +13,6 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/UnitVectors.hpp"
-#include "Acts/Utilities/detail/periodic.hpp"
 
 #include <algorithm>
 

--- a/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/BoundTrackParametersTests.cpp
@@ -76,6 +76,14 @@ void checkParameters(const BoundTrackParameters& params, double l0, double l1,
                        eps);
   CHECK_CLOSE_OR_SMALL(params.momentum(), p * unitDir, eps, eps);
   BOOST_CHECK_EQUAL(params.charge(), q);
+
+  // reflection
+  BoundTrackParameters reflectedParams = params;
+  reflectedParams.reflectInPlace();
+  CHECK_CLOSE_OR_SMALL(params.reflect().parameters(),
+                       reflectedParams.parameters(), eps, eps);
+  CHECK_CLOSE_OR_SMALL(reflectedParams.reflect().parameters(),
+                       params.parameters(), eps, eps);
 }
 
 void runTest(const std::shared_ptr<const Surface>& surface, double l0,

--- a/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/CurvilinearTrackParametersTests.cpp
@@ -72,6 +72,15 @@ void checkParameters(const CurvilinearTrackParameters& params, double phi,
   // curvilinear reference surface
   CHECK_CLOSE_OR_SMALL(referenceSurface->center(geoCtx), pos, eps, eps);
   CHECK_CLOSE_OR_SMALL(referenceSurface->normal(geoCtx), unitDir, eps, eps);
+
+  // reflection
+  CurvilinearTrackParameters reflectedParams = params;
+  reflectedParams.reflectInPlace();
+  CHECK_CLOSE_OR_SMALL(params.reflect().parameters(),
+                       reflectedParams.parameters(), eps, eps);
+  CHECK_CLOSE_OR_SMALL(reflectedParams.reflect().parameters(),
+                       params.parameters(), eps, eps);
+
   // TODO verify reference frame
 }
 

--- a/Tests/UnitTests/Core/EventData/FreeTrackParametersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/FreeTrackParametersTests.cpp
@@ -67,6 +67,14 @@ void checkParameters(const FreeTrackParameters& params, const Vector4& pos4,
                        eps);
   CHECK_CLOSE_OR_SMALL(params.time(), params.template get<eFreeTime>(), eps,
                        eps);
+
+  // reflection
+  FreeTrackParameters reflectedParams = params;
+  reflectedParams.reflectInPlace();
+  CHECK_CLOSE_OR_SMALL(params.reflect().parameters(),
+                       reflectedParams.parameters(), eps, eps);
+  CHECK_CLOSE_OR_SMALL(reflectedParams.reflect().parameters(),
+                       params.parameters(), eps, eps);
 }
 
 }  // namespace


### PR DESCRIPTION
Add helper functions to reflect track parameters. This is useful when seed parameters are estimated for the spacepoints in reverse direction which is necessary for strip seeds.

---

This pull request introduces functionality to reflect track parameters for both bound and free track parameters in the Acts framework. The key changes include adding new methods to reflect parameters and the corresponding implementation to handle the reflection logic.

### New Methods for Reflecting Track Parameters:

* [`Core/include/Acts/EventData/GenericBoundTrackParameters.hpp`](diffhunk://#diff-b3a2aaa0a0f138a1b44e7e6494aae4f8b905ad83716a4253bbea6446623f0eb1R253-R263): Added `reflectInplace` and `reflect` methods to `GenericBoundTrackParameters` to enable in-place reflection and returning reflected parameters.
* [`Core/include/Acts/EventData/GenericFreeTrackParameters.hpp`](diffhunk://#diff-35a3d07a1eb05110c620e3cdbc38968456e66270c9f9460472f49e65d8b43acdR177-R187): Added `reflectInplace` and `reflect` methods to `GenericFreeTrackParameters` to enable in-place reflection and returning reflected parameters.

### Helper Functions for Reflection:

* [`Core/include/Acts/EventData/TransformationHelpers.hpp`](diffhunk://#diff-73d04b62535d54171256def2e580c39602c9a2ab36db1689ebd74d84b79c127dR21-R32): Introduced `reflectBoundParameters` and `reflectFreeParameters` functions to handle the reflection logic for bound and free track parameters.
* [`Core/src/EventData/TransformationHelpers.cpp`](diffhunk://#diff-59ee8d8625a58700aca8eae78a6655d0162483f2644cdd2c77c668493d7d8b87R16-R40): Implemented the `reflectBoundParameters` and `reflectFreeParameters` functions to perform the actual reflection calculations.