### PR TITLE
refactor: Only compute middle range once per bin

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -107,6 +107,14 @@ class SeedFinder {
                            const Acts::Range1D<float>& rMiddleSPRange) const;
 
  private:
+  /// Given a middle space point candidate get the proper radius validity range
+  /// In case the radius range changes according to the z-bin we need to
+  /// retrieve the proper range We can do it this computation only once, since
+  /// all the middle space point candidates belong to the same z-bin
+  std::pair<float, float> retrieveRadiusRangeForMiddle(
+      const external_spacepoint_t& spM,
+      const Acts::Range1D<float>& rMiddleSPRange) const;
+
   /// Iterates over dublets and tests the compatibility between them by applying
   /// a series of cuts that can be tested with only two SPs
   /// @param options frequently changing configuration (like beam position)

--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -111,6 +111,9 @@ class SeedFinder {
   /// In case the radius range changes according to the z-bin we need to
   /// retrieve the proper range We can do it this computation only once, since
   /// all the middle space point candidates belong to the same z-bin
+  /// @param SpM space point candidate to be used as middle SP in a seed
+  /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain z bin.
+  /// @output A pair of values representing the minimum and mazimum radius
   std::pair<float, float> retrieveRadiusRangeForMiddle(
       const external_spacepoint_t& spM,
       const Acts::Range1D<float>& rMiddleSPRange) const;

--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -113,7 +113,6 @@ class SeedFinder {
   /// all the middle space point candidates belong to the same z-bin
   /// @param spM space point candidate to be used as middle SP in a seed
   /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain z bin.
-  /// @output A pair of values representing the minimum and mazimum radius
   std::pair<float, float> retrieveRadiusRangeForMiddle(
       const external_spacepoint_t& spM,
       const Acts::Range1D<float>& rMiddleSPRange) const;

--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -111,7 +111,7 @@ class SeedFinder {
   /// In case the radius range changes according to the z-bin we need to
   /// retrieve the proper range We can do it this computation only once, since
   /// all the middle space point candidates belong to the same z-bin
-  /// @param SpM space point candidate to be used as middle SP in a seed
+  /// @param spM space point candidate to be used as middle SP in a seed
   /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain z bin.
   /// @output A pair of values representing the minimum and mazimum radius
   std::pair<float, float> retrieveRadiusRangeForMiddle(

--- a/Core/include/Acts/Seeding/SeedFinder.hpp
+++ b/Core/include/Acts/Seeding/SeedFinder.hpp
@@ -107,9 +107,9 @@ class SeedFinder {
                            const Acts::Range1D<float>& rMiddleSPRange) const;
 
  private:
-  /// Given a middle space point candidate get the proper radius validity range
+  /// Given a middle space point candidate, get the proper radius validity range
   /// In case the radius range changes according to the z-bin we need to
-  /// retrieve the proper range We can do it this computation only once, since
+  /// retrieve the proper range. We can do this computation only once, since
   /// all the middle space point candidates belong to the same z-bin
   /// @param spM space point candidate to be used as middle SP in a seed
   /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain z bin.

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -104,40 +104,20 @@ void SeedFinder<external_spacepoint_t, grid_t, platform_t>::createSeedsForGroup(
     return;
   }
 
+  // we compute this since all middle space point candidates belong to the same
+  // z-bin
+  auto [minRadiusRangeForMiddle, maxRadiusRangeForMiddle] =
+      retrieveRadiusRangeForMiddle(*middleSPs.front(), rMiddleSPRange);
   for (const external_spacepoint_t* spM : middleSPs) {
     const float rM = spM->radius();
 
     // check if spM is outside our radial region of interest
-    if (m_config.useVariableMiddleSPRange) {
-      if (rM < rMiddleSPRange.min()) {
-        continue;
-      }
-      if (rM > rMiddleSPRange.max()) {
-        // break because SPs are sorted in r
-        break;
-      }
-    } else if (!m_config.rRangeMiddleSP.empty()) {
-      /// get zBin position of the middle SP
-      auto pVal = std::lower_bound(m_config.zBinEdges.begin(),
-                                   m_config.zBinEdges.end(), spM->z());
-      int zBin = std::distance(m_config.zBinEdges.begin(), pVal);
-      /// protects against zM at the limit of zBinEdges
-      zBin == 0 ? zBin : --zBin;
-      if (rM < m_config.rRangeMiddleSP[zBin][0]) {
-        continue;
-      }
-      if (rM > m_config.rRangeMiddleSP[zBin][1]) {
-        // break because SPs are sorted in r
-        break;
-      }
-    } else {
-      if (rM < m_config.rMinMiddle) {
-        continue;
-      }
-      if (rM > m_config.rMaxMiddle) {
-        // break because SPs are sorted in r
-        break;
-      }
+    if (rM < minRadiusRangeForMiddle) {
+      continue;
+    }
+    if (rM > maxRadiusRangeForMiddle) {
+      // break because SPs are sorted in r
+      break;
     }
 
     const float zM = spM->z();
@@ -825,6 +805,27 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::filterCandidates(
         state.topSpVec, state.curvatures, state.impactParameters,
         seedFilterState, state.candidates_collector);
   }  // loop on bottoms
+}
+
+template <typename external_spacepoint_t, typename grid_t, typename platform_t>
+std::pair<float, float> SeedFinder<external_spacepoint_t, grid_t, platform_t>::
+    retrieveRadiusRangeForMiddle(
+        const external_spacepoint_t& spM,
+        const Acts::Range1D<float>& rMiddleSPRange) const {
+  if (m_config.useVariableMiddleSPRange) {
+    return std::make_pair(rMiddleSPRange.min(), rMiddleSPRange.max());
+  }
+  if (!m_config.rRangeMiddleSP.empty()) {
+    /// get zBin position of the middle SP
+    auto pVal = std::lower_bound(m_config.zBinEdges.begin(),
+                                 m_config.zBinEdges.end(), spM.z());
+    int zBin = std::distance(m_config.zBinEdges.begin(), pVal);
+    /// protects against zM at the limit of zBinEdges
+    zBin == 0 ? zBin : --zBin;
+    return std::make_pair(m_config.rRangeMiddleSP[zBin][0],
+                          m_config.rRangeMiddleSP[zBin][1]);
+  }
+  return std::make_pair(m_config.rMinMiddle, m_config.rMaxMiddle);
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -104,8 +104,8 @@ void SeedFinder<external_spacepoint_t, grid_t, platform_t>::createSeedsForGroup(
     return;
   }
 
-  // we compute this since all middle space point candidates belong to the same
-  // z-bin
+  // we compute this here since all middle space point candidates belong to the
+  // same z-bin
   auto [minRadiusRangeForMiddle, maxRadiusRangeForMiddle] =
       retrieveRadiusRangeForMiddle(*middleSPs.front(), rMiddleSPRange);
   for (const external_spacepoint_t* spM : middleSPs) {


### PR DESCRIPTION
Seeding is done one bin at a time. Where the bin corresponds to the area where the middle space point candidate may be.
That means that all middle space points processed by each call of `createSeedsForGroup` belong to the same bin and thus have the same z-bin.

In case a `rRangeMiddleSP` vector is provided by the user (that is the case where the radius validity range changes according to the z-bin), we have to retrieve from the middle space point the z-bin and then the right validity range. In the current code this is done for every middle space point in the bin! 

We can do it only once.
