### PR TITLE
fix: CylVolStack resizing issue

### DIFF
--- a/Core/include/Acts/Geometry/CylinderVolumeStack.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeStack.hpp
@@ -85,23 +85,12 @@ class CylinderVolumeStack : public Volume {
   /// construction.
   /// @param volbounds is the new bounds
   /// @param transform is the new transform
-  /// @pre The volume bounds need to be of type
-  ///      @c CylinderVolumeBounds.
-  void update(std::shared_ptr<VolumeBounds> volbounds,
-              std::optional<Transform3> transform = std::nullopt) override;
-
-  /// Update the volume bounds and transform. This
-  /// will update the bounds of all volumes in the stack
-  /// to accommodate the new bounds and optionally create
-  /// gap volumes according to the resize strategy set during
-  /// construction.
-  /// @param newBounds is the new bounds
-  /// @param transform is the new transform
   /// @param logger is the logger
   /// @pre The volume bounds need to be of type
   ///      @c CylinderVolumeBounds.
-  void update(std::shared_ptr<CylinderVolumeBounds> newBounds,
-              std::optional<Transform3> transform, const Logger& logger);
+  void update(std::shared_ptr<VolumeBounds> volbounds,
+              std::optional<Transform3> transform = std::nullopt,
+              const Logger& logger = getDummyLogger()) override;
 
   /// Access the gap volume that were created during attachment or resizing.
   /// @return the vector of gap volumes

--- a/Core/include/Acts/Geometry/CylinderVolumeStack.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeStack.hpp
@@ -122,11 +122,12 @@ class CylinderVolumeStack : public Volume {
                                   Acts::Logging::Level lvl);
 
   /// Helper function that prints output helping in debugging overlaps
+  /// @param direction is the overlap check direction
   /// @param a is the first volume
   /// @param b is the second volume
   /// @param logger is the logger
-  static void overlapPrint(const VolumeTuple& a, const VolumeTuple& b,
-                           const Logger& logger);
+  static void overlapPrint(BinningValue direction, const VolumeTuple& a,
+                           const VolumeTuple& b, const Logger& logger);
 
   /// Helper function that checks if volumes are properly aligned
   /// for attachment.

--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GeometryObject.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <iosfwd>
 #include <memory>
@@ -83,8 +84,10 @@ class Volume : public GeometryObject {
   /// Set the volume bounds and optionally also update the volume transform
   /// @param volbounds The volume bounds to be assigned
   /// @param transform The transform to be assigned, can be optional
+  /// @param logger A logger object to log messages
   virtual void update(std::shared_ptr<VolumeBounds> volbounds,
-                      std::optional<Transform3> transform = std::nullopt);
+                      std::optional<Transform3> transform = std::nullopt,
+                      const Logger& logger = Acts::getDummyLogger());
 
   /// Construct bounding box for this shape
   /// @param envelope Optional envelope to add / subtract from min/max

--- a/Core/src/Geometry/CylinderVolumeStack.cpp
+++ b/Core/src/Geometry/CylinderVolumeStack.cpp
@@ -286,25 +286,40 @@ void CylinderVolumeStack::initializeOuterVolume(BinningValue direction,
 }
 
 void CylinderVolumeStack::overlapPrint(
-    const CylinderVolumeStack::VolumeTuple& a,
+    BinningValue direction, const CylinderVolumeStack::VolumeTuple& a,
     const CylinderVolumeStack::VolumeTuple& b, const Logger& logger) {
   if (logger().doPrint(Acts::Logging::DEBUG)) {
     std::stringstream ss;
     ss << std::fixed;
     ss << std::setprecision(3);
     ss << std::setfill(' ');
-    ACTS_VERBOSE("Checking overlap between");
-    int w = 9;
-    ss << " - "
-       << " z: [ " << std::setw(w) << a.minZ() << " <- " << std::setw(w)
-       << a.midZ() << " -> " << std::setw(w) << a.maxZ() << " ]";
-    ACTS_VERBOSE(ss.str());
 
-    ss.str("");
-    ss << " - "
-       << " z: [ " << std::setw(w) << b.minZ() << " <- " << std::setw(w)
-       << b.midZ() << " -> " << std::setw(w) << b.maxZ() << " ]";
-    ACTS_VERBOSE(ss.str());
+    int w = 9;
+
+    ACTS_VERBOSE("Checking overlap between");
+    if (direction == BinningValue::binZ) {
+      ss << " - "
+         << " z: [ " << std::setw(w) << a.minZ() << " <- " << std::setw(w)
+         << a.midZ() << " -> " << std::setw(w) << a.maxZ() << " ]";
+      ACTS_VERBOSE(ss.str());
+
+      ss.str("");
+      ss << " - "
+         << " z: [ " << std::setw(w) << b.minZ() << " <- " << std::setw(w)
+         << b.midZ() << " -> " << std::setw(w) << b.maxZ() << " ]";
+      ACTS_VERBOSE(ss.str());
+    } else {
+      ss << " - "
+         << " r: [ " << std::setw(w) << a.minR() << " <-> " << std::setw(w)
+         << a.maxR() << " ]";
+      ACTS_VERBOSE(ss.str());
+
+      ss.str("");
+      ss << " - "
+         << " r: [ " << std::setw(w) << b.minR() << " <-> " << std::setw(w)
+         << b.maxR() << " ]";
+      ACTS_VERBOSE(ss.str());
+    }
   }
 }
 
@@ -319,7 +334,7 @@ CylinderVolumeStack::checkOverlapAndAttachInZ(
     auto& a = volumes.at(i);
     auto& b = volumes.at(j);
 
-    overlapPrint(a, b, logger);
+    overlapPrint(BinningValue::binZ, a, b, logger);
 
     if (a.maxZ() > b.minZ()) {
       ACTS_ERROR(" -> Overlap in z");
@@ -446,7 +461,7 @@ CylinderVolumeStack::checkOverlapAndAttachInR(
     auto& a = volumes.at(i);
     auto& b = volumes.at(j);
 
-    overlapPrint(a, b, logger);
+    overlapPrint(BinningValue::binR, a, b, logger);
 
     if (a.maxR() > b.minR()) {
       ACTS_ERROR(" -> Overlap in r");

--- a/Core/src/Geometry/GridPortalLink.cpp
+++ b/Core/src/Geometry/GridPortalLink.cpp
@@ -89,7 +89,10 @@ void GridPortalLink::checkConsistency(const CylinderSurface& cyl) const {
     ActsScalar hlZ = cyl.bounds().get(CylinderBounds::eHalfLengthZ);
     if (!same(axis.getMin(), -hlZ) || !same(axis.getMax(), hlZ)) {
       throw std::invalid_argument(
-          "GridPortalLink: CylinderBounds: invalid length setup.");
+          "GridPortalLink: CylinderBounds: invalid length setup: " +
+          std::to_string(axis.getMin()) + " != " + std::to_string(-hlZ) +
+          " or " + std::to_string(axis.getMax()) +
+          " != " + std::to_string(hlZ));
     }
   };
   auto checkRPhi = [&cyl, same](const IAxis& axis) {

--- a/Core/src/Geometry/TrivialPortalLink.cpp
+++ b/Core/src/Geometry/TrivialPortalLink.cpp
@@ -39,7 +39,7 @@ Result<const TrackingVolume*> TrivialPortalLink::resolveVolume(
 }
 
 void TrivialPortalLink::toStream(std::ostream& os) const {
-  os << "TrivialPortalLink<vol=" << m_volume << ">";
+  os << "TrivialPortalLink<vol=" << m_volume->volumeName() << ">";
 }
 
 }  // namespace Acts

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -79,7 +79,8 @@ void Volume::assignVolumeBounds(std::shared_ptr<VolumeBounds> volbounds) {
 }
 
 void Volume::update(std::shared_ptr<VolumeBounds> volbounds,
-                    std::optional<Transform3> transform) {
+                    std::optional<Transform3> transform,
+                    const Logger& /*logger*/) {
   if (volbounds) {
     m_volumeBounds = std::move(volbounds);
   }

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -153,10 +153,12 @@ std::vector<Acts::Vector3> Acts::CylinderBounds::circleVertices(
 
 void Acts::CylinderBounds::checkConsistency() noexcept(false) {
   if (get(eR) <= 0.) {
-    throw std::invalid_argument("CylinderBounds: invalid radial setup.");
+    throw std::invalid_argument(
+        "CylinderBounds: invalid radial setup: radius is negative");
   }
   if (get(eHalfLengthZ) <= 0.) {
-    throw std::invalid_argument("CylinderBounds: invalid length setup.");
+    throw std::invalid_argument(
+        "CylinderBounds: invalid length setup: half length is negative");
   }
   if (get(eHalfPhiSector) <= 0. || get(eHalfPhiSector) > M_PI) {
     throw std::invalid_argument("CylinderBounds: invalid phi sector setup.");

--- a/Tests/UnitTests/Core/Geometry/CylinderVolumeStackTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderVolumeStackTests.cpp
@@ -22,6 +22,7 @@
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/TrackHelpers.hpp"
 #include "Acts/Utilities/Zip.hpp"
 
 using namespace Acts::UnitLiterals;
@@ -811,6 +812,57 @@ BOOST_DATA_TEST_CASE(
                       50_mm);
     BOOST_CHECK_EQUAL(gap->center()[eZ], f * 950_mm);
   }
+}
+
+BOOST_AUTO_TEST_CASE(ResizeReproduction1) {
+  Transform3 trf1 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * -2000};
+  auto bounds1 = std::make_shared<CylinderVolumeBounds>(70, 100, 100.0);
+  Volume vol1{trf1, bounds1};
+
+  std::vector<Volume*> volumes = {&vol1};
+  CylinderVolumeStack stack(volumes, BinningValue::binZ,
+                            CylinderVolumeStack::AttachmentStrategy::Gap,
+                            CylinderVolumeStack::ResizeStrategy::Gap, *logger);
+
+  Transform3 trf2 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * -1500};
+  stack.update(std::make_shared<CylinderVolumeBounds>(30.0, 100, 600), trf2,
+               *logger);
+
+  std::cout << stack.volumeBounds() << std::endl;
+  std::cout << stack.transform().matrix() << std::endl;
+
+  Transform3 trf3 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * -1600};
+  stack.update(std::make_shared<CylinderVolumeBounds>(30.0, 100, 700), trf3,
+               *logger);
+}
+
+BOOST_AUTO_TEST_CASE(ResizeReproduction2) {
+  // The numbers are tuned a bit to reproduce the faulty behavior
+  Transform3 trf1 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * 263};
+  auto bounds1 = std::make_shared<CylinderVolumeBounds>(30, 100, 4.075);
+  Volume vol1{trf1, bounds1};
+
+  std::vector<Volume*> volumes = {&vol1};
+  CylinderVolumeStack stack(volumes, BinningValue::binZ,
+                            CylinderVolumeStack::AttachmentStrategy::Gap,
+                            CylinderVolumeStack::ResizeStrategy::Gap, *logger);
+
+  Transform3 trf2 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * 260.843};
+  stack.update(std::make_shared<CylinderVolumeBounds>(30.0, 100, 6.232), trf2,
+               *logger);
+
+  std::cout << stack.volumeBounds() << std::endl;
+  std::cout << stack.transform().matrix() << std::endl;
+
+  Transform3 trf3 =
+      Transform3::Identity() * Translation3{Vector3::UnitZ() * 1627.31};
+  stack.update(std::make_shared<CylinderVolumeBounds>(30.0, 100, 1372.699),
+               trf3, *logger);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes a bug where the local transform was not correctly synced
after resizing. Also improves a number of assertions to not rely on
floating point identity anymore

Related to #3502

---

This pull request includes several changes to the `CylinderVolumeStack` and `Volume` classes to improve logging, add new parameters, and enhance the overlap checking and volume updating mechanisms. The most important changes include adding a logger parameter to several methods, updating method signatures, and improving overlap checking logic.

### Enhancements to logging and method signatures:

* [`Core/include/Acts/Geometry/CylinderVolumeStack.hpp`](diffhunk://#diff-86daf525fefbaa344566ea4fc6493ca85afd3627922f04c3f16758fca8717a6eL88-R93): Added a `logger` parameter to the `update` method and modified its signature to include this parameter. [[1]](diffhunk://#diff-86daf525fefbaa344566ea4fc6493ca85afd3627922f04c3f16758fca8717a6eL88-R93) [[2]](diffhunk://#diff-86daf525fefbaa344566ea4fc6493ca85afd3627922f04c3f16758fca8717a6eR125-R130)
* [`Core/include/Acts/Geometry/Volume.hpp`](diffhunk://#diff-beb0194dfdd77fcfe13c0b73c9e7790cbe7bae313f1723f7979a4e9beb5d16d5R16): Added a `logger` parameter to the `update` method and included the necessary import for the `Logger` class. [[1]](diffhunk://#diff-beb0194dfdd77fcfe13c0b73c9e7790cbe7bae313f1723f7979a4e9beb5d16d5R16) [[2]](diffhunk://#diff-beb0194dfdd77fcfe13c0b73c9e7790cbe7bae313f1723f7979a4e9beb5d16d5R87-R90)
* [`Core/src/Geometry/CylinderVolumeStack.cpp`](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL70-R70): Updated the `commit` method to include a `logger` parameter and modified the `initializeOuterVolume` method to pass the `logger` parameter to the `update` method. [[1]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL70-R70) [[2]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL154-R156) [[3]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL188-R190) [[4]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL212-R215) [[5]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL244-R247) [[6]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL268-R272)

### Improvements to overlap checking:

* [`Core/src/Geometry/CylinderVolumeStack.cpp`](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL286-R301): Enhanced the `overlapPrint` method to include a `direction` parameter and updated the overlap checking logic to handle different directions more robustly. [[1]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL286-R301) [[2]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cR312-R323) [[3]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL319-R338) [[4]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL347-R368) [[5]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL357-R386) [[6]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL379-R405) [[7]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL397-R424) [[8]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cR436-R442) [[9]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL446-R472)

### Volume update improvements:

* [`Core/src/Geometry/CylinderVolumeStack.cpp`](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL625-R689): Updated the `update` method to provide detailed logging of the current and new bounds, and added checks to prevent shrinking the stack size. [[1]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL625-R689) [[2]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL676-R703) [[3]](diffhunk://#diff-39babeb41776345f10ffd90e329b67faf7a8a4f47f0abe7533f665442d52a44cL693-R754)