### PR TITLE
refactor: Python binding bits and pieces

### DIFF
--- a/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/CylinderVolumeBounds.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/Volume.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Utilities/BinningType.hpp"
@@ -78,6 +79,18 @@ class CylinderVolumeBounds : public VolumeBounds {
     eBevelMinZ = 5,
     eBevelMaxZ = 6,
     eSize
+  };
+
+  /// Enum describing the possible faces of a cylinder volume
+  /// @note These values are synchronized with the BoundarySurfaceFace enum.
+  ///       Once Gen1 is removed, this can be changed.
+  enum class Face : unsigned int {
+    PositiveDisc = BoundarySurfaceFace::positiveFaceXY,
+    NegativeDisc = BoundarySurfaceFace::negativeFaceXY,
+    OuterCylinder = BoundarySurfaceFace::tubeOuterCover,
+    InnerCylinder = BoundarySurfaceFace::tubeInnerCover,
+    NegativePhiPlane = BoundarySurfaceFace::tubeSectorNegativePhi,
+    PositivePhiPlane = BoundarySurfaceFace::tubeSectorPositivePhi
   };
 
   CylinderVolumeBounds() = delete;

--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -6,9 +6,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// This file is part of the Acts project.
+//
+// Copyright (C) 2024 CERN for the benefit of the Acts project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #pragma once
 
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
@@ -68,17 +77,7 @@ class PortalShellBase {
 /// volumes
 class CylinderPortalShell : public PortalShellBase {
  public:
-  /// Enum describing the possible faces of a cylinder portal shell
-  /// @note These values are synchronized with the BoundarySurfaceFace enum.
-  ///       Once Gen1 is removed, this can be changed.
-  enum class Face : unsigned int {
-    PositiveDisc = BoundarySurfaceFace::positiveFaceXY,
-    NegativeDisc = BoundarySurfaceFace::negativeFaceXY,
-    OuterCylinder = BoundarySurfaceFace::tubeOuterCover,
-    InnerCylinder = BoundarySurfaceFace::tubeInnerCover,
-    NegativePhiPlane = BoundarySurfaceFace::tubeSectorNegativePhi,
-    PositivePhiPlane = BoundarySurfaceFace::tubeSectorPositivePhi
-  };
+  using Face = CylinderVolumeBounds::Face;
 
   using enum Face;
 

--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "Acts/Geometry/BoundarySurfaceFace.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Logger.hpp"

--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -70,7 +70,7 @@ class CylinderPortalShell : public PortalShellBase {
  public:
   using Face = CylinderVolumeBounds::Face;
 
-  using enum Face;
+  using enum CylinderVolumeBounds::Face;
 
   /// Retrieve the portal associated to the given face. Can be nullptr if unset.
   /// @param face The face to retrieve the portal for

--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -6,14 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// This file is part of the Acts project.
-//
-// Copyright (C) 2024 CERN for the benefit of the Acts project
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 #pragma once
 
 #include "Acts/Geometry/BoundarySurfaceFace.hpp"

--- a/Core/src/Geometry/PortalShell.cpp
+++ b/Core/src/Geometry/PortalShell.cpp
@@ -367,7 +367,7 @@ std::string CylinderStackPortalShell::label() const {
 
 std::ostream& operator<<(std::ostream& os, CylinderPortalShell::Face face) {
   switch (face) {
-    using enum CylinderPortalShell::Face;
+    using enum CylinderVolumeBounds::Face;
     case PositiveDisc:
       return os << "PositiveDisc";
     case NegativeDisc:

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -364,12 +364,16 @@ void addBinning(Context& ctx) {
                           .value("binY", Acts::BinningValue::binY)
                           .value("binZ", Acts::BinningValue::binZ)
                           .value("binR", Acts::BinningValue::binR)
-                          .value("binPhi", Acts::BinningValue::binPhi);
+                          .value("binPhi", Acts::BinningValue::binPhi)
+                          .value("binRPhi", Acts::BinningValue::binRPhi)
+                          .value("binH", Acts::BinningValue::binH)
+                          .value("binEta", Acts::BinningValue::binEta)
+                          .value("binMag", Acts::BinningValue::binMag);
 
   auto boundaryType = py::enum_<Acts::AxisBoundaryType>(m, "AxisBoundaryType")
-                          .value("bound", Acts::AxisBoundaryType::Bound)
-                          .value("closed", Acts::AxisBoundaryType::Closed)
-                          .value("open", Acts::AxisBoundaryType::Open);
+                          .value("Bound", Acts::AxisBoundaryType::Bound)
+                          .value("Closed", Acts::AxisBoundaryType::Closed)
+                          .value("Open", Acts::AxisBoundaryType::Open);
 
   auto axisType = py::enum_<Acts::AxisType>(m, "AxisType")
                       .value("equidistant", Acts::AxisType::Equidistant)

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -188,7 +188,7 @@ void addGeometry(Context& ctx) {
     py::class_<Acts::VolumeBounds, std::shared_ptr<Acts::VolumeBounds>>(
         m, "VolumeBounds")
         .def("type", &Acts::VolumeBounds::type)
-        .def("__str__", [](Acts::VolumeBounds& self) {
+        .def("__str__", [](const Acts::VolumeBounds& self) {
           std::stringstream ss;
           ss << self;
           return ss.str();

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -180,13 +180,14 @@ void addGeometry(Context& ctx) {
     py::class_<Acts::VolumeBounds, std::shared_ptr<Acts::VolumeBounds>>(
         m, "VolumeBounds");
 
-    py::class_<Acts::CylinderVolumeBounds,
-               std::shared_ptr<Acts::CylinderVolumeBounds>, Acts::VolumeBounds>(
-        m, "CylinderVolumeBounds")
-        .def(py::init<ActsScalar, ActsScalar, ActsScalar, ActsScalar,
-                      ActsScalar, ActsScalar, ActsScalar>(),
-             "rmin"_a, "rmax"_a, "halfz"_a, "halfphi"_a = M_PI, "avgphi"_a = 0.,
-             "bevelMinZ"_a = 0., "bevelMaxZ"_a = 0.);
+    auto cvb =
+        py::class_<Acts::CylinderVolumeBounds,
+                   std::shared_ptr<Acts::CylinderVolumeBounds>,
+                   Acts::VolumeBounds>(m, "CylinderVolumeBounds")
+            .def(py::init<ActsScalar, ActsScalar, ActsScalar, ActsScalar,
+                          ActsScalar, ActsScalar, ActsScalar>(),
+                 "rmin"_a, "rmax"_a, "halfz"_a, "halfphi"_a = M_PI,
+                 "avgphi"_a = 0., "bevelMinZ"_a = 0., "bevelMaxZ"_a = 0.);
   }
 
   {
@@ -307,10 +308,15 @@ void addExperimentalGeometry(Context& ctx) {
     // Be able to construct a proto binning
     py::class_<ProtoBinning>(m, "ProtoBinning")
         .def(py::init<Acts::BinningValue, Acts::AxisBoundaryType,
-                      const std::vector<Acts::ActsScalar>&, std::size_t>())
+                      const std::vector<Acts::ActsScalar>&, std::size_t>(),
+             "bValue"_a, "bType"_a, "e"_a, "exp"_a = 0u)
         .def(py::init<Acts::BinningValue, Acts::AxisBoundaryType,
                       Acts::ActsScalar, Acts::ActsScalar, std::size_t,
-                      std::size_t>());
+                      std::size_t>(),
+             "bValue"_a, "bType"_a, "minE"_a, "maxE"_a, "nbins"_a, "exp"_a = 0u)
+        .def(py::init<Acts::BinningValue, Acts::AxisBoundaryType, std::size_t,
+                      std::size_t>(),
+             "bValue"_a, "bType"_a, "nbins"_a, "exp"_a = 0u);
   }
 
   {

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -106,7 +106,12 @@ void addGeometry(Context& ctx) {
         .def("approach", &Acts::GeometryIdentifier::approach)
         .def("sensitive", &Acts::GeometryIdentifier::sensitive)
         .def("extra", &Acts::GeometryIdentifier::extra)
-        .def("value", &Acts::GeometryIdentifier::value);
+        .def("value", &Acts::GeometryIdentifier::value)
+        .def("__str__", [](const Acts::GeometryIdentifier& self) {
+          std::stringstream ss;
+          ss << self;
+          return ss.str();
+        });
   }
 
   {

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -300,7 +300,6 @@ void addGeometry(Context& ctx) {
         .value("Gap", CylinderVolumeStack::ResizeStrategy::Gap)
         .value("Expand", CylinderVolumeStack::ResizeStrategy::Expand);
   }
-
 }
 
 void addExperimentalGeometry(Context& ctx) {

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -188,6 +188,15 @@ void addGeometry(Context& ctx) {
                           ActsScalar, ActsScalar, ActsScalar>(),
                  "rmin"_a, "rmax"_a, "halfz"_a, "halfphi"_a = M_PI,
                  "avgphi"_a = 0., "bevelMinZ"_a = 0., "bevelMaxZ"_a = 0.);
+
+    py::enum_<CylinderVolumeBounds::Face>(cvb, "Face")
+        .value("PositiveDisc", CylinderVolumeBounds::Face::PositiveDisc)
+        .value("NegativeDisc", CylinderVolumeBounds::Face::NegativeDisc)
+        .value("OuterCylinder", CylinderVolumeBounds::Face::OuterCylinder)
+        .value("InnerCylinder", CylinderVolumeBounds::Face::InnerCylinder)
+        .value("NegativePhiPlane", CylinderVolumeBounds::Face::NegativePhiPlane)
+        .value("PositivePhiPlane",
+               CylinderVolumeBounds::Face::PositivePhiPlane);
   }
 
   {

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -25,6 +25,7 @@
 #include "Acts/Detector/interface/IInternalStructureBuilder.hpp"
 #include "Acts/Detector/interface/IRootVolumeFinderBuilder.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
+#include "Acts/Geometry/CylinderVolumeStack.hpp"
 #include "Acts/Geometry/Extent.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryHierarchyMap.hpp"
@@ -183,7 +184,13 @@ void addGeometry(Context& ctx) {
 
   {
     py::class_<Acts::VolumeBounds, std::shared_ptr<Acts::VolumeBounds>>(
-        m, "VolumeBounds");
+        m, "VolumeBounds")
+        .def("type", &Acts::VolumeBounds::type)
+        .def("__str__", [](Acts::VolumeBounds& self) {
+          std::stringstream ss;
+          ss << self;
+          return ss.str();
+        });
 
     auto cvb =
         py::class_<Acts::CylinderVolumeBounds,
@@ -241,6 +248,22 @@ void addGeometry(Context& ctx) {
                                                   self.max(bval)};
         });
   }
+
+  {
+    auto cylStack = py::class_<CylinderVolumeStack>(m, "CylinderVolumeStack");
+
+    py::enum_<CylinderVolumeStack::AttachmentStrategy>(cylStack,
+                                                       "AttachmentStrategy")
+        .value("Gap", CylinderVolumeStack::AttachmentStrategy::Gap)
+        .value("First", CylinderVolumeStack::AttachmentStrategy::First)
+        .value("Second", CylinderVolumeStack::AttachmentStrategy::Second)
+        .value("Midpoint", CylinderVolumeStack::AttachmentStrategy::Midpoint);
+
+    py::enum_<CylinderVolumeStack::ResizeStrategy>(cylStack, "ResizeStrategy")
+        .value("Gap", CylinderVolumeStack::ResizeStrategy::Gap)
+        .value("Expand", CylinderVolumeStack::ResizeStrategy::Expand);
+  }
+
 }
 
 void addExperimentalGeometry(Context& ctx) {

--- a/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(ConstructionFromVolume) {
   SingleCylinderPortalShell shell1{cyl1};
   BOOST_CHECK_EQUAL(shell1.size(), 4);
 
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
 
   const auto* pDisc = shell1.portal(PositiveDisc);
   BOOST_REQUIRE_NE(pDisc, nullptr);

--- a/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
@@ -299,7 +299,7 @@ BOOST_AUTO_TEST_CASE(ConstructionFromVolume) {
 //              inner cylinder
 
 BOOST_AUTO_TEST_CASE(PortalAssignment) {
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
   TrackingVolume vol(
       Transform3::Identity(),
       std::make_shared<CylinderVolumeBounds>(30_mm, 100_mm, 100_mm));
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(PortalAssignment) {
 
 BOOST_AUTO_TEST_SUITE(CylinderStack)
 BOOST_AUTO_TEST_CASE(ZDirection) {
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
   BOOST_TEST_CONTEXT("rMin>0") {
     TrackingVolume vol1(
         Transform3{Translation3{Vector3::UnitZ() * -100_mm}},
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(ZDirection) {
 }
 
 BOOST_AUTO_TEST_CASE(RDirection) {
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
   BOOST_TEST_CONTEXT("rMin>0") {
     TrackingVolume vol1(
         Transform3::Identity(),
@@ -610,7 +610,7 @@ BOOST_AUTO_TEST_CASE(NestedStacks) {
       gctx, {&stack, &shell3}, BinningValue::binZ, *logger};
   BOOST_CHECK(stack2.isValid());
 
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
 
   auto lookup = [](auto& shell, CylinderPortalShell::Face face,
                    Vector3 position,
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE(ConnectOuter) {
 
   SingleCylinderPortalShell shell{cyl1};
 
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
   BOOST_CHECK_EQUAL(
       shell.portal(OuterCylinder)->getLink(Direction::AlongNormal), nullptr);
   BOOST_CHECK_EQUAL(
@@ -749,7 +749,7 @@ BOOST_AUTO_TEST_CASE(ConnectOuter) {
 }
 
 BOOST_AUTO_TEST_CASE(RegisterInto) {
-  using enum CylinderPortalShell::Face;
+  using enum CylinderVolumeBounds::Face;
   TrackingVolume vol1(
       Transform3::Identity(),
       std::make_shared<CylinderVolumeBounds>(0_mm, 100_mm, 100_mm));


### PR DESCRIPTION
This is a collection of python bindings bits that have accumulated.

Related #3502.

---

This pull request includes several updates to the `Acts` geometry and Python binding code. The most important changes involve the introduction of new enums and the addition of Python bindings for new geometry classes and methods.

### Geometry and Enum Updates:

* Added `Face` enum to `CylinderVolumeBounds` to describe possible faces of a cylinder volume. (`Core/include/Acts/Geometry/CylinderVolumeBounds.hpp`)
* Refactored `PortalShellBase` to use the `Face` enum from `CylinderVolumeBounds` instead of defining its own. (`Core/include/Acts/Geometry/PortalShell.hpp`)

### Python Bindings Enhancements:

* Added new binning values to the `addBinning` function in `Base.cpp`. (`Examples/Python/src/Base.cpp`)
* Extended `addGeometry` function to include new methods and enums for `CylinderVolumeBounds` and `ExtentEnvelope`. (`Examples/Python/src/Geometry.cpp`) [[1]](diffhunk://#diff-a103b5682fb7c6e7ea58777983e4381b62783b2facd3e367e03ff0a7aa49816dL181-R213) [[2]](diffhunk://#diff-a103b5682fb7c6e7ea58777983e4381b62783b2facd3e367e03ff0a7aa49816dL212-R303)
* Introduced Python bindings for `CylinderVolumeStack` and its enums `AttachmentStrategy` and `ResizeStrategy`. (`Examples/Python/src/Geometry.cpp`)

### Code Cleanup:

* Removed redundant includes and updated include paths to reflect new dependencies. (`Core/include/Acts/Geometry/PortalShell.hpp`, `Examples/Python/src/Geometry.cpp`) [[1]](diffhunk://#diff-80595cf723b4c4b0a2cf3de28ac0da38793f2955a2e0ce1dc4fd87381fac79aeL11-R11) [[2]](diffhunk://#diff-a103b5682fb7c6e7ea58777983e4381b62783b2facd3e367e03ff0a7aa49816dR40) [[3]](diffhunk://#diff-a103b5682fb7c6e7ea58777983e4381b62783b2facd3e367e03ff0a7aa49816dR51)

These changes improve the modularity and functionality of the geometry components and enhance the Python interface for better usability.