### PR TITLE
refactor: Combine material, measurement and hole handling in Core CKF `filter`

### DIFF
--- a/Core/include/Acts/TrackFinding/MeasurementSelector.ipp
+++ b/Core/include/Acts/TrackFinding/MeasurementSelector.ipp
@@ -23,8 +23,7 @@ MeasurementSelector::select(
 
   // Return if no measurement
   if (candidates.empty()) {
-    return Result::success(
-        std::make_pair(candidates.begin(), candidates.end()));
+    return Result::success(std::pair(candidates.begin(), candidates.end()));
   }
 
   // Get geoID of this surface
@@ -93,20 +92,19 @@ MeasurementSelector::select(
           "No measurement candidate. Return an outlier measurement chi2="
           << minChi2);
       isOutlier = true;
-      return Result::success(std::make_pair(candidates.begin() + minIndex,
-                                            candidates.begin() + minIndex + 1));
+      return Result::success(std::pair(candidates.begin() + minIndex,
+                                       candidates.begin() + minIndex + 1));
     } else {
       ACTS_VERBOSE("No measurement candidate. Return empty chi2=" << minChi2);
-      return Result::success(
-          std::make_pair(candidates.begin(), candidates.begin()));
+      return Result::success(std::pair(candidates.begin(), candidates.begin()));
     }
   }
 
   if (passedCandidates <= 1ul) {
     // return single item range, no sorting necessary
     ACTS_VERBOSE("Returning only 1 element chi2=" << minChi2);
-    return Result::success(std::make_pair(candidates.begin() + minIndex,
-                                          candidates.begin() + minIndex + 1));
+    return Result::success(std::pair(candidates.begin() + minIndex,
+                                     candidates.begin() + minIndex + 1));
   }
 
   std::sort(
@@ -116,7 +114,7 @@ MeasurementSelector::select(
   ACTS_VERBOSE("Number of selected measurements: "
                << passedCandidates << ", max: " << cuts.numMeasurements);
 
-  return Result::success(std::make_pair(
+  return Result::success(std::pair(
       candidates.begin(),
       candidates.begin() + std::min(cuts.numMeasurements, passedCandidates)));
 }

--- a/Core/include/Acts/TrackFinding/MeasurementSelector.ipp
+++ b/Core/include/Acts/TrackFinding/MeasurementSelector.ipp
@@ -21,9 +21,10 @@ MeasurementSelector::select(
 
   ACTS_VERBOSE("Invoked MeasurementSelector");
 
-  // Return error if no measurement
+  // Return if no measurement
   if (candidates.empty()) {
-    return CombinatorialKalmanFilterError::MeasurementSelectionFailed;
+    return Result::success(
+        std::make_pair(candidates.begin(), candidates.end()));
   }
 
   // Get geoID of this surface


### PR DESCRIPTION
Combines the handling of material, measurements and holes in the Core CKF.

---

This pull request includes several changes to the `CombinatorialKalmanFilter` class in the `Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp` file to improve error handling, state management, and logging. Additionally, there is a minor change in the `MeasurementSelector` class to handle empty measurement candidates more gracefully.

### Error Handling and State Management:

* Added checks and logging for empty active branches to ensure the filter stops correctly when no branches are active. (`Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp`) [[1]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09R583-R590) [[2]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09R660-R673)
* Modified the filter to reset and stop properly when all branches are stopped or when certain conditions are met, improving the robustness of the filtering process. (`Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp`) [[1]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L592-R600) [[2]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L623-L642)

### Logging Improvements:

* Enhanced logging to provide more detailed information about the state transitions and decisions made during the filtering process. (`Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp`) [[1]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L716-R761) [[2]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L749-L925) [[3]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L950-R907)

### Code Simplification and Cleanup:

* Simplified the handling of material and measurement surfaces by refactoring conditional checks and removing redundant code. (`Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp`) [[1]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L716-R761) [[2]](diffhunk://#diff-55dd901875f5a87b6a9fee495de245296efbfd45aa9f9483036bcd299a277e09L749-L925)

### Minor Change in MeasurementSelector:

* Updated the `MeasurementSelector::select` method to return a success result when no measurement candidates are found, instead of returning an error. (`Core/include/Acts/TrackFinding/MeasurementSelector.ipp`)