### PR TITLE
docs: Add comment on computation of impact parameter from the doublet

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -369,10 +369,13 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
       // We check the interaction point by evaluating the minimal distance
       // between the origin and the straight line connecting the two points in
       // the doublets. Using a geometric similarity, the Im is given by
-      // yNewFrame * rM / deltaR <= m_config.impactMax We use squared quantities
-      // to avoid square roots
-      if (yNewFrame * yNewFrame * rM * rM <=
-          m_config.impactMax * m_config.impactMax * deltaR2) {
+      // yNewFrame * rM / deltaR <= m_config.impactMax
+      // However, we make here an approximation of the impact parameter
+      // which is valid under the assumption xNewFrame / yNewFrame is small
+      // The correct computation would be:
+      // yNewFrame * yNewFrame * rM * rM <= m_config.impactMax *
+      // m_config.impactMax * deltaR2
+      if (std::abs(rM * yNewFrame) <= impactMax * xNewFrame) {
         // check if duplet cotTheta is within the region of interest
         // cotTheta is defined as (deltaZ / deltaR) but instead we multiply
         // cotThetaMax by deltaR to avoid division

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -373,7 +373,7 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
       // the doublets. Using a geometric similarity, the Im is given by
       // yNewFrame * rM / deltaR <= m_config.impactMax
       // However, we make here an approximation of the impact parameter
-      // which is valid under the assumption xNewFrame / yNewFrame is small
+      // which is valid under the assumption yNewFrame / xNewFrame is small
       // The correct computation would be:
       // yNewFrame * yNewFrame * rM * rM <= m_config.impactMax *
       // m_config.impactMax * deltaR2

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -362,13 +362,16 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
 
       const float deltaR2 = (deltaX * deltaX + deltaY * deltaY);
       const float iDeltaR2 = 1. / deltaR2;
-      
+
       const float uT = xNewFrame * iDeltaR2;
       const float vT = yNewFrame * iDeltaR2;
 
-      // interactionPointCut == true we apply this cut first cuts before
-      // coordinate transformation to avoid unnecessary calculations
-      if (yNewFrame*yNewFrame * rM*rM <= m_config.impactMax*m_config.impactMax * deltaR2) {
+      // We check the interaction point buy evaluating the minimal distance
+      // between the origin and the straight line connecting the two points in
+      // the doublets The Im is given by yNewFrame * rM / deltaR <=
+      // m_config.impactMax We use squared quantities to avoid square roots
+      if (yNewFrame * yNewFrame * rM * rM <=
+          m_config.impactMax * m_config.impactMax * deltaR2) {
         // check if duplet cotTheta is within the region of interest
         // cotTheta is defined as (deltaZ / deltaR) but instead we multiply
         // cotThetaMax by deltaR to avoid division
@@ -425,7 +428,7 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
           deltaZ < -m_config.cotThetaMax * deltaR) {
         continue;
       }
-      
+
       const float iDeltaR = std::sqrt(iDeltaR2);
       const float cotTheta = deltaZ * iDeltaR;
 

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -362,13 +362,13 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
 
       const float deltaR2 = (deltaX * deltaX + deltaY * deltaY);
       const float iDeltaR2 = 1. / deltaR2;
-
+      
       const float uT = xNewFrame * iDeltaR2;
       const float vT = yNewFrame * iDeltaR2;
 
       // interactionPointCut == true we apply this cut first cuts before
       // coordinate transformation to avoid unnecessary calculations
-      if (std::abs(rM * yNewFrame) <= impactMax * xNewFrame) {
+      if (yNewFrame*yNewFrame * rM*rM <= m_config.impactMax*m_config.impactMax * deltaR2) {
         // check if duplet cotTheta is within the region of interest
         // cotTheta is defined as (deltaZ / deltaR) but instead we multiply
         // cotThetaMax by deltaR to avoid division
@@ -425,7 +425,7 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
           deltaZ < -m_config.cotThetaMax * deltaR) {
         continue;
       }
-
+      
       const float iDeltaR = std::sqrt(iDeltaR2);
       const float cotTheta = deltaZ * iDeltaR;
 

--- a/Core/include/Acts/Seeding/SeedFinder.ipp
+++ b/Core/include/Acts/Seeding/SeedFinder.ipp
@@ -366,10 +366,11 @@ SeedFinder<external_spacepoint_t, grid_t, platform_t>::getCompatibleDoublets(
       const float uT = xNewFrame * iDeltaR2;
       const float vT = yNewFrame * iDeltaR2;
 
-      // We check the interaction point buy evaluating the minimal distance
+      // We check the interaction point by evaluating the minimal distance
       // between the origin and the straight line connecting the two points in
-      // the doublets The Im is given by yNewFrame * rM / deltaR <=
-      // m_config.impactMax We use squared quantities to avoid square roots
+      // the doublets. Using a geometric similarity, the Im is given by
+      // yNewFrame * rM / deltaR <= m_config.impactMax We use squared quantities
+      // to avoid square roots
       if (yNewFrame * yNewFrame * rM * rM <=
           m_config.impactMax * m_config.impactMax * deltaR2) {
         // check if duplet cotTheta is within the region of interest


### PR DESCRIPTION
One of the criterion used in doublet finding relies on computing the minimal distance between the origin and the straight line connecting the two points of the doublet. This distance is compared against a maximum impact parameter (`impactMax`) provided by the user. 

Let's consider for instance the middle-top doublet search. 
<img width="479" alt="Geometry" src="https://github.com/user-attachments/assets/bb1c3f87-d687-4f49-9582-02e91773f8ad">

In the attached image:
- `A` is the origin
- `B` is the middle space point, thus `AB = rM` (radius of middle space point) 
- `C` is the top space point

What the code does is to compute `BD` (`xNewFrame` in the code) and `CD` (`yNewFrame` in the code)  and then a simple geometric similarity to compute the impact parameter. 

The code currently does: `Im / CD = AB / BD`, where `Im` is the impact parameter we are trying to compute.  Thus `Im = (AB * CD) / BD <= impactMax`. Unfortunately `Im` is equal to `AF`, while we really want to compute `AE`. The proper computation would be `Im / CD = AB / BC`, which leads to `Im = (AB * CD) / BC <= impactMax`. In this case `Im = AE`.

However, `BC` has to be computed from `CD` and `BD`. In order to avoid square roots I'm using square quantities. 

It is also possible that the code assumes that the `alpha` angle is too small to make a difference and thus uses an approximation... But there are no comments in the code about this
