### PR TITLE
fix: FPE monitoring boost discovery, addr2line fallback

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,7 @@
             "inherits": "common",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_CXX_FLAGS": "-Werror",
+                "CMAKE_COMPILE_WARNING_AS_ERROR": "ON",
                 "ACTS_FORCE_ASSERTIONS": "ON",
                 "ACTS_ENABLE_LOG_FAILURE_THRESHOLD": "ON",
                 "ACTS_BUILD_BENCHMARKS": "ON",

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -206,8 +206,10 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
         ACTS_ERROR("Adding "
                    << elementType << " " << element->name() << ":"
                    << "\n-> white board will contain key '" << handle->key()
-                   << "'" << "\nat this point in the sequence (source: "
-                   << source.fullName() << ")," << "\nbut the type will be\n"
+                   << "'"
+                   << "\nat this point in the sequence (source: "
+                   << source.fullName() << "),"
+                   << "\nbut the type will be\n"
                    << "'" << demangleAndShorten(source.typeInfo().name()) << "'"
                    << "\nand not\n"
                    << "'" << demangleAndShorten(handle->typeInfo().name())
@@ -216,8 +218,8 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
       }
     } else {
       ACTS_ERROR("Adding " << elementType << " " << element->name() << ":"
-                           << "\n-> white board will not contain key" << " '"
-                           << handle->key()
+                           << "\n-> white board will not contain key"
+                           << " '" << handle->key()
                            << "' at this point in the sequence."
                            << "\n   Needed for read data handle '"
                            << handle->name() << "'");

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -126,6 +126,13 @@ Sequencer::Sequencer(const Sequencer::Config& cfg)
         "ACTS_SEQUENCER_DISABLE_FPEMON");
     m_cfg.trackFpes = false;
   }
+
+  if (m_cfg.trackFpes && !m_cfg.fpeMasks.empty() &&
+      !Acts::FpeMonitor::canSymbolize()) {
+    ACTS_ERROR("FPE monitoring is enabled but symbolization is not available");
+    throw std::runtime_error(
+        "FPE monitoring is enabled but symbolization is not available");
+  }
 }
 
 void Sequencer::addContextDecorator(
@@ -199,10 +206,8 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
         ACTS_ERROR("Adding "
                    << elementType << " " << element->name() << ":"
                    << "\n-> white board will contain key '" << handle->key()
-                   << "'"
-                   << "\nat this point in the sequence (source: "
-                   << source.fullName() << "),"
-                   << "\nbut the type will be\n"
+                   << "'" << "\nat this point in the sequence (source: "
+                   << source.fullName() << ")," << "\nbut the type will be\n"
                    << "'" << demangleAndShorten(source.typeInfo().name()) << "'"
                    << "\nand not\n"
                    << "'" << demangleAndShorten(handle->typeInfo().name())
@@ -211,8 +216,8 @@ void Sequencer::addElement(const std::shared_ptr<SequenceElement>& element) {
       }
     } else {
       ACTS_ERROR("Adding " << elementType << " " << element->name() << ":"
-                           << "\n-> white board will not contain key"
-                           << " '" << handle->key()
+                           << "\n-> white board will not contain key" << " '"
+                           << handle->key()
                            << "' at this point in the sequence."
                            << "\n   Needed for read data handle '"
                            << handle->name() << "'");

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -51,7 +51,9 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
-                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
+                CMAKE_FLAGS
+                    "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
+                    "-DCMAKE_CXX_FLAGS=\"\""
                 COMPILE_DEFINITIONS -DBOOST_STACKTRACE_USE_BACKTRACE
                 OUTPUT_VARIABLE __OUTPUT
             )
@@ -94,6 +96,7 @@ else()
                         LINK_LIBRARIES ${dl_LIBRARY}
                         CMAKE_FLAGS
                             "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
+                            "-DCMAKE_CXX_FLAGS=\"\""
                         COMPILE_DEFINITIONS
                             -DBOOST_STACKTRACE_USE_BACKTRACE
                             ${backtrace_include}
@@ -125,7 +128,9 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
-                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
+                CMAKE_FLAGS
+                    "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
+                    "-DCMAKE_CXX_FLAGS=\"\""
                 COMPILE_DEFINITIONS
                     -DBOOST_STACKTRACE_USE_BACKTRACE
                     ${backtrace_include}

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -29,6 +29,7 @@ else()
             NAMES "boost/stacktrace.hpp"
             REQUIRED
         )
+        message(STATUS "boost_stacktrace_include: ${boost_stacktrace_include}")
 
         if(Backtrace_FOUND)
             # check if we need to link against bracktrace or not
@@ -54,6 +55,8 @@ else()
                 COMPILE_DEFINITIONS -DBOOST_STACKTRACE_USE_BACKTRACE
                 OUTPUT_VARIABLE __OUTPUT
             )
+
+            message(STATUS "OUTPUT: ${__OUTPUT}")
 
             if(_backtrace_default_header)
                 message(CHECK_PASS "yes")
@@ -97,6 +100,8 @@ else()
                         OUTPUT_VARIABLE __OUTPUT
                     )
 
+                    message(STATUS "OUTPUT: ${__OUTPUT}")
+
                     if(_backtrace_explicit_header)
                         message(CHECK_PASS "yes")
                         list(APPEND _fpe_options "${backtrace_include}")
@@ -126,6 +131,8 @@ else()
                     ${backtrace_include}
                 OUTPUT_VARIABLE __OUTPUT
             )
+
+            message(STATUS "OUTPUT: ${__OUTPUT}")
 
             if(_backtrace_nolink)
                 message(CHECK_PASS "yes")

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -24,6 +24,12 @@ else()
 
         set(_backtrace_setup_complete FALSE)
 
+        find_path(
+            boost_stacktrace_include
+            NAMES "boost/stacktrace.hpp"
+            REQUIRED
+        )
+
         if(Backtrace_FOUND)
             # check if we need to link against bracktrace or not
             set(backtrace_include "")
@@ -44,6 +50,7 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
+                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                 COMPILE_DEFINITIONS -DBOOST_STACKTRACE_USE_BACKTRACE
                 OUTPUT_VARIABLE __OUTPUT
             )
@@ -54,9 +61,9 @@ else()
                 message(CHECK_FAIL "no")
 
                 file(GLOB hints "/usr/lib/gcc/*/*/include")
-                find_file(backtrace_header "backtrace.h" HINTS ${hints})
+                find_file(backtrace_header NAMES "backtrace.h" HINTS ${hints})
 
-                if(${backtrace_header} STREQUAL "backtrcae_header-NOTFOUND")
+                if(${backtrace_header} STREQUAL "backtrace_header-NOTFOUND")
                     message(STATUS "Could not find backtrace header file")
                 else()
                     set(backtrace_include
@@ -82,6 +89,8 @@ else()
                         "${CMAKE_BINARY_DIR}"
                         "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                         LINK_LIBRARIES ${dl_LIBRARY}
+                        CMAKE_FLAGS
+                            "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                         COMPILE_DEFINITIONS
                             -DBOOST_STACKTRACE_USE_BACKTRACE
                             ${backtrace_include}
@@ -111,6 +120,7 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
+                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                 COMPILE_DEFINITIONS
                     -DBOOST_STACKTRACE_USE_BACKTRACE
                     ${backtrace_include}

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -29,8 +29,6 @@ else()
             NAMES "boost/stacktrace.hpp"
             REQUIRED
         )
-        message(STATUS "boost_stacktrace_include: ${boost_stacktrace_include}")
-
         if(Backtrace_FOUND)
             # check if we need to link against bracktrace or not
             set(backtrace_include "")
@@ -92,7 +90,6 @@ else()
                         LINK_LIBRARIES ${dl_LIBRARY}
                         CMAKE_FLAGS
                             "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
-                            "-DCMAKE_CXX_FLAGS=\"\""
                         COMPILE_DEFINITIONS
                             -DBOOST_STACKTRACE_USE_BACKTRACE
                             ${backtrace_include}
@@ -122,9 +119,7 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
-                CMAKE_FLAGS
-                    "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
-                    "-DCMAKE_CXX_FLAGS=\"\""
+                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                 COMPILE_DEFINITIONS
                     -DBOOST_STACKTRACE_USE_BACKTRACE
                     ${backtrace_include}
@@ -151,6 +146,8 @@ else()
                     "${CMAKE_BINARY_DIR}"
                     "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                     LINK_LIBRARIES backtrace ${dl_LIBRARY}
+                    CMAKE_FLAGS
+                        "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                     COMPILE_DEFINITIONS
                         -DBOOST_STACKTRACE_USE_BACKTRACE
                         ${backtrace_include}
@@ -173,30 +170,13 @@ else()
         endif()
 
         if(NOT _backtrace_setup_complete)
-            message(CHECK_START "Is addr2line available")
-            if(addr2line_EXECUTABLE)
-                list(APPEND _fpe_options -DBOOST_STACKTRACE_USE_ADDR2LINE)
-                list(
-                    APPEND
-                    _fpe_options
-                    -DBOOST_STACKTRACE_ADDR2LINE_LOCATION=${addr2line_EXECUTABLE}
-                )
-                message(CHECK_PASS "yes")
-
-                set(_backtrace_setup_complete TRUE)
-            else()
-                message(CHECK_FAIL "no")
-            endif()
-        endif()
-
-        if(NOT _backtrace_setup_complete)
             message(STATUS "Unable to set up stacktrace setup: use noop")
             list(APPEND _fpe_options -BOOST_STACKTRACE_USE_NOOP)
         endif()
     endif()
 endif()
 
-target_compile_options(ActsPluginFpeMonitoring PUBLIC "${_fpe_options}")
+target_compile_options(ActsPluginFpeMonitoring PRIVATE "${_fpe_options}")
 
 install(
     TARGETS ActsPluginFpeMonitoring

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -51,14 +51,10 @@ else()
                 "${CMAKE_BINARY_DIR}"
                 "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/backtrace.cpp"
                 LINK_LIBRARIES ${dl_LIBRARY}
-                CMAKE_FLAGS
-                    "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
-                    "-DCMAKE_CXX_FLAGS=\"\""
+                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${boost_stacktrace_include}"
                 COMPILE_DEFINITIONS -DBOOST_STACKTRACE_USE_BACKTRACE
                 OUTPUT_VARIABLE __OUTPUT
             )
-
-            message(STATUS "OUTPUT: ${__OUTPUT}")
 
             if(_backtrace_default_header)
                 message(CHECK_PASS "yes")
@@ -103,8 +99,6 @@ else()
                         OUTPUT_VARIABLE __OUTPUT
                     )
 
-                    message(STATUS "OUTPUT: ${__OUTPUT}")
-
                     if(_backtrace_explicit_header)
                         message(CHECK_PASS "yes")
                         list(APPEND _fpe_options "${backtrace_include}")
@@ -136,8 +130,6 @@ else()
                     ${backtrace_include}
                 OUTPUT_VARIABLE __OUTPUT
             )
-
-            message(STATUS "OUTPUT: ${__OUTPUT}")
 
             if(_backtrace_nolink)
                 message(CHECK_PASS "yes")

--- a/Plugins/FpeMonitoring/CMakeLists.txt
+++ b/Plugins/FpeMonitoring/CMakeLists.txt
@@ -176,7 +176,7 @@ else()
     endif()
 endif()
 
-target_compile_options(ActsPluginFpeMonitoring PRIVATE "${_fpe_options}")
+target_compile_options(ActsPluginFpeMonitoring PUBLIC "${_fpe_options}")
 
 install(
     TARGETS ActsPluginFpeMonitoring

--- a/Plugins/FpeMonitoring/include/Acts/Plugins/FpeMonitoring/FpeMonitor.hpp
+++ b/Plugins/FpeMonitoring/include/Acts/Plugins/FpeMonitoring/FpeMonitor.hpp
@@ -131,6 +131,8 @@ class FpeMonitor {
                                         std::size_t depth);
   static std::string getSourceLocation(const boost::stacktrace::frame &frame);
 
+  static bool canSymbolize();
+
  private:
   void enable();
   void disable();

--- a/Plugins/FpeMonitoring/src/FpeMonitor.cpp
+++ b/Plugins/FpeMonitoring/src/FpeMonitor.cpp
@@ -332,4 +332,12 @@ std::string FpeMonitor::getSourceLocation(
   return frame.source_file() + ":" + std::to_string(frame.source_line());
 }
 
+bool FpeMonitor::canSymbolize() {
+#if defined(BOOST_STACKTRACE_USE_NOOP)
+  return false;
+#else
+  return true;
+#endif
+}
+
 }  // namespace Acts


### PR DESCRIPTION
This PR

- Changes the way FPE monitoring configures `boost::stacktrace`: the fallback to `addr2line` is dropped as that doesn't work anyway
- Change explicit `-Werror` in the CI to `CMAKE_COMPILE_WARNING_AS_ERROR=ON`
  - This is not applied in `try_compile`, which would otherwise cause false negatives because there are warnings we don't control.
- Add a static method in `FpeMonitor` that returns if `backtrace` / symbolization support is on or not.
- Make the sequencer fail early if it's configured to run the FPE monitor, has masks configured and symbolization is not supported.