### PR TITLE
fix: Make `DataHandle` type check more robust

### DIFF
--- a/Examples/Framework/CMakeLists.txt
+++ b/Examples/Framework/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(
     src/Framework/WhiteBoard.cpp
     src/Framework/RandomNumbers.cpp
     src/Framework/Sequencer.cpp
+    src/Framework/DataHandle.cpp
     src/Utilities/EventDataTransforms.cpp
     src/Utilities/Paths.cpp
     src/Utilities/Options.cpp

--- a/Examples/Framework/include/ActsExamples/Framework/DataHandle.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/DataHandle.hpp
@@ -8,11 +8,9 @@
 
 #pragma once
 
-#include "Acts/Utilities/ThrowAssert.hpp"
 #include "ActsExamples/Framework/SequenceElement.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
 
-#include <iostream>
 #include <stdexcept>
 #include <typeinfo>
 
@@ -54,14 +52,33 @@ class DataHandleBase {
   std::optional<std::string> m_key{};
 };
 
-template <typename T>
-class ReadDataHandle;
+class WriteDataHandleBase : public DataHandleBase {
+ protected:
+  WriteDataHandleBase(SequenceElement* parent, const std::string& name)
+      : DataHandleBase{parent, name} {}
+
+ public:
+  void initialize(const std::string& key);
+
+  bool isCompatible(const DataHandleBase& other) const final;
+};
+
+class ReadDataHandleBase : public DataHandleBase {
+ protected:
+  ReadDataHandleBase(SequenceElement* parent, const std::string& name)
+      : DataHandleBase{parent, name} {}
+
+ public:
+  void initialize(const std::string& key);
+
+  bool isCompatible(const DataHandleBase& other) const final;
+};
 
 template <typename T>
-class WriteDataHandle final : public DataHandleBase {
+class WriteDataHandle final : public WriteDataHandleBase {
  public:
   WriteDataHandle(SequenceElement* parent, const std::string& name)
-      : DataHandleBase{parent, name} {
+      : WriteDataHandleBase{parent, name} {
     m_parent->registerWriteHandle(*this);
   }
 
@@ -77,35 +94,15 @@ class WriteDataHandle final : public DataHandleBase {
     wb.add(m_key.value(), std::move(value));
   }
 
-  void initialize(const std::string& key) {
-    if (key.empty()) {
-      throw std::invalid_argument{"Write handle '" + fullName() +
-                                  "' cannot receive empty key"};
-    }
-    m_key = key;
-  }
-
-  bool isCompatible(const DataHandleBase& other) const override {
-    return dynamic_cast<const ReadDataHandle<T>*>(&other) != nullptr;
-  }
-
   const std::type_info& typeInfo() const override { return typeid(T); };
 };
 
 template <typename T>
-class ReadDataHandle final : public DataHandleBase {
+class ReadDataHandle final : public ReadDataHandleBase {
  public:
   ReadDataHandle(SequenceElement* parent, const std::string& name)
-      : DataHandleBase{parent, name} {
+      : ReadDataHandleBase{parent, name} {
     m_parent->registerReadHandle(*this);
-  }
-
-  void initialize(const std::string& key) {
-    if (key.empty()) {
-      throw std::invalid_argument{"Read handle '" + fullName() +
-                                  "' cannot receive empty key"};
-    }
-    m_key = key;
   }
 
   const T& operator()(const AlgorithmContext& ctx) const {
@@ -118,10 +115,6 @@ class ReadDataHandle final : public DataHandleBase {
                                "' not initialized"};
     }
     return wb.get<T>(m_key.value());
-  }
-
-  bool isCompatible(const DataHandleBase& other) const override {
-    return dynamic_cast<const WriteDataHandle<T>*>(&other) != nullptr;
   }
 
   const std::type_info& typeInfo() const override { return typeid(T); };

--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -22,7 +22,6 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <typeinfo>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/Examples/Python/CMakeLists.txt
+++ b/Examples/Python/CMakeLists.txt
@@ -66,6 +66,10 @@ target_link_libraries(
         ActsExamplesDetectorTelescope
         ActsExamplesUtilities
         ActsExamplesAmbiguityResolution
+        ActsExamplesTruthTracking
+        ActsExamplesDigitization
+        ActsExamplesPropagation
+        ActsExamplesMaterialMapping
 )
 
 set(py_files


### PR DESCRIPTION
It seems that the current implementation is prone to symbol hiding. I worked around this by inserting another non-templated layer in the class hierarchy which can do the type check more reliably.

The origin of the problem could be `-fvisibility=hidden` being toggled on all of my `ActsPythonBindings` compilation commands. It might be that this is another case where this flag leaks in via CMake from another library. I also did not want to change the visibility of the symbol manually as this would require some macros to be compiler agnostic.

Some resources
- https://www.qt.io/blog/quality-assurance/one-way-dynamic_cast-across-library-boundaries-can-fail-and-how-to-fix-it
- https://developers.redhat.com/articles/2021/10/27/compiler-option-hidden-visibility-and-weak-symbol-walk-bar#