### PR TITLE
ci: Reset `ccache` caches

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -20,7 +20,7 @@ env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXSIZE: 1.25G
-  CCACHE_KEY_SUFFIX: r1
+  CCACHE_KEY_SUFFIX: r2
   ACTS_LOG_FAILURE_THRESHOLD: WARNING
   DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/ubuntu-24.04/deps.v4.tar.zst
 
@@ -41,10 +41,10 @@ jobs:
       - name: Cache build
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache-linux_ubuntu_debug_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os  }}-ccache-linux_ubuntu_debug_${{ env.CCACHE_KEY_SUFFIX }}_
+            ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
       - name: Configure
         run: >

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,7 +19,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
   CCACHE_MAXSIZE: 500M
-  CCACHE_KEY_SUFFIX: r1
+  CCACHE_KEY_SUFFIX: r2
 
 jobs:
   linux_ubuntu:
@@ -43,10 +43,10 @@ jobs:
         uses: actions/cache/restore@v4
         id: ccache-restore
         with:
-          path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache-linux_ubuntu_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os  }}-ccache-linux_ubuntu_${{ env.CCACHE_KEY_SUFFIX }}_
+            ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
       - name: Configure
         # setting CMAKE_CXX_STANDARD=20 is a workaround for a bug in the
@@ -260,10 +260,10 @@ jobs:
         uses: actions/cache/restore@v4
         id: ccache-restore
         with:
-          path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache-linux_${{ matrix.image }}_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os  }}-ccache-linux_${{ matrix.image }}_${{ env.CCACHE_KEY_SUFFIX }}_
+            ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
 
       - name: Configure
@@ -339,10 +339,10 @@ jobs:
         uses: actions/cache/restore@v4
         id: ccache-restore
         with:
-          path: ${{ github.workspace }}/ccache
-          key: ${{ runner.os  }}-ccache_${{ env.CCACHE_KEY_SUFFIX }}_${{ github.sha }}
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os  }}-ccache_${{ env.CCACHE_KEY_SUFFIX }}_
+            ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
       - name: Configure
         run: >

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   CCACHE_DIR: ${CI_PROJECT_DIR}/ccache
   CCACHE_MAXSIZE: 2G
-  CCACHE_KEY_SUFFIX: r1
+  CCACHE_KEY_SUFFIX: r2
   CTEST_OUTPUT_ON_FAILURE: 1
 
   DEPENDENCY_TAG: v4
@@ -70,9 +70,12 @@ build_exatrkx_cpu:
     - large
 
   cache:
-    key: ccache-exatrkx-cpu-$CI_COMMIT_REF_SLUG
+    key: ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}
+    fallback_keys:
+      - ccache-${CI_JOB_NAME}-${CI_DEFAULT_BRANCH}-${CCACHE_KEY_SUFFIX}
+    when: always
     paths:
-      - ${CI_PROJECT_DIR}/ccache
+      - ${CCACHE_DIR}
 
   script:
     - export PATH=/usr/local/sbin:/usr/sbin:/sbin:$PATH
@@ -105,9 +108,12 @@ build_exatrkx:
     - large
 
   cache:
-    key: ccache-exatrkx-$CI_COMMIT_REF_SLUG
+    key: ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}
+    fallback_keys:
+      - ccache-${CI_JOB_NAME}-${CI_DEFAULT_BRANCH}-${CCACHE_KEY_SUFFIX}
+    when: always
     paths:
-      - ${CI_PROJECT_DIR}/ccache
+      - ${CCACHE_DIR}
 
   artifacts:
     paths:
@@ -173,10 +179,12 @@ build_linux_ubuntu:
     DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/ubuntu-24.04/deps.$DEPENDENCY_TAG.tar.zst
 
   cache:
-    key: ccache-${CI_JOB_NAME_SLUG}-${HEAD_REF}-${CCACHE_KEY_SUFFIX}
-    when: 'always'
+    key: ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}
+    fallback_keys:
+      - ccache-${CI_JOB_NAME}-${CI_DEFAULT_BRANCH}-${CCACHE_KEY_SUFFIX}
+    when: always
     paths:
-      - ${CI_PROJECT_DIR}/ccache
+      - ${CCACHE_DIR}
 
   artifacts:
     paths:
@@ -281,10 +289,12 @@ linux_physmon:
   stage: build
 
   cache:
-    key: ccache-${CI_JOB_NAME_SLUG}-${HEAD_REF}-${CCACHE_KEY_SUFFIX}
-    when: 'always'
+    key: ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}
+    fallback_keys:
+      - ccache-${CI_JOB_NAME}-${CI_DEFAULT_BRANCH}-${CCACHE_KEY_SUFFIX}
+    when: always
     paths:
-      - ${CI_PROJECT_DIR}/ccache
+      - ${CCACHE_DIR}
 
   script:
     - git clone $CLONE_URL src
@@ -360,10 +370,12 @@ linux_ubuntu_2204_clang:
     SETUP:
 
   cache:
-    key: ccache-${CI_JOB_NAME_SLUG}-${HEAD_REF}-${CCACHE_KEY_SUFFIX}
-    when: 'always'
+    key: ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}
+    fallback_keys:
+      - ccache-${CI_JOB_NAME}-${CI_DEFAULT_BRANCH}-${CCACHE_KEY_SUFFIX}
+    when: always
     paths:
-      - ${CI_PROJECT_DIR}/ccache
+      - ${CCACHE_DIR}
 
   before_script:
     - 'echo "LCG_VERSION: ${LCG_VERSION}"'


### PR DESCRIPTION
- reset all the `ccache` caches by bumping `CCACHE_KEY_SUFFIX` up to `r2`
- rework key naming scheme
  - GitHub `ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}`
  - GitLab `ccache-${CI_JOB_NAME}-${CI_COMMIT_REF_SLUG}-${CCACHE_KEY_SUFFIX}`
- GitLab: restore cache from main branch if there is none for the current branch