### PR TITLE
chore: Tweak DD4hep log level

### DIFF
--- a/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepGeometryService.hpp
+++ b/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepGeometryService.hpp
@@ -52,7 +52,7 @@ class DD4hepGeometryService {
     /// Log level for the geometry service.
     Acts::Logging::Level logLevel = Acts::Logging::Level::INFO;
     /// Log level for DD4hep itself
-    Acts::Logging::Level dd4hepLogLevel = Acts::Logging::Level::INFO;
+    Acts::Logging::Level dd4hepLogLevel = Acts::Logging::Level::WARNING;
     /// XML-file with the detector description
     std::vector<std::string> xmlFileNames;
     /// The name of the service

--- a/Examples/Python/python/acts/examples/odd.py
+++ b/Examples/Python/python/acts/examples/odd.py
@@ -90,7 +90,7 @@ def getOpenDataDetector(
     dd4hepConfig = acts.examples.dd4hep.DD4hepGeometryService.Config(
         xmlFileNames=[str(odd_xml)],
         logLevel=customLogLevel(),
-        dd4hepLogLevel=customLogLevel(),
+        dd4hepLogLevel=customLogLevel(minLevel=acts.logging.WARNING),
         geometryIdentifierHook=acts.GeometryIdentifierHook(geoid_hook),
     )
     detector = acts.examples.dd4hep.DD4hepDetector()


### PR DESCRIPTION
DD4hep is currently quite log-happy. I raised the threshold in both Examples and Python a bit to avoid getting spammed.