### PR TITLE
chore: change coverage badge from codecov to sonarcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ or *A Common Tracking Software* if you do not like recursive acronyms
 
 [![10.5281/zenodo.5141418](https://zenodo.org/badge/DOI/10.5281/zenodo.5141418.svg)](https://doi.org/10.5281/zenodo.5141418)
 [![Chat on Mattermost](https://badgen.net/badge/chat/on%20mattermost/cyan)](https://mattermost.web.cern.ch/acts/)
-[![codecov](https://codecov.io/gh/acts-project/acts/graph/badge.svg)](https://codecov.io/gh/acts-project/acts)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=acts-project_acts&metric=coverage)](https://sonarcloud.io/summary/new_code?id=acts-project_acts)
 [![Latest release](https://badgen.net/github/release/acts-project/acts)](https://github.com/acts-project/acts/releases)
 [![Status](https://badgen.net/github/checks/acts-project/acts/main)](https://github.com/acts-project/acts/actions)
 [![Metrics](https://badgen.net/badge/metric/tracker/purple)](https://acts-project.github.io/metrics/)


### PR DESCRIPTION
This is a relic from codecov. We fully switched to sonarcloud.