### PR TITLE
refactor: Expose IMaterialDecorator::decorate to python

### DIFF
--- a/Examples/Python/src/Material.cpp
+++ b/Examples/Python/src/Material.cpp
@@ -81,7 +81,9 @@ void addMaterial(Context& ctx) {
   {
     py::class_<Acts::IMaterialDecorator,
                std::shared_ptr<Acts::IMaterialDecorator>>(m,
-                                                          "IMaterialDecorator");
+                                                          "IMaterialDecorator")
+        .def("decorate", py::overload_cast<Surface&>(
+                             &Acts::IMaterialDecorator::decorate, py::const_));
   }
 
   {


### PR DESCRIPTION
Exposes the `decorate` function to python, so the decoration can itself be steered from python if needed.

Part of #3502
