### PR TITLE
refactor: rename PortalShell connect outer to fill

### DIFF
--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -34,12 +34,10 @@ class PortalShellBase {
   /// Virtusl destructor
   virtual ~PortalShellBase() = default;
 
-  /// Connect a volume to the outer side of all portal shells. Which "side" is
-  /// "outer" depends on the volume type.
-  /// This method essentially creates a @c TrivialPortalLink on the unconnected
-  /// side of each portal that is part of the chell
+  /// Fill the open slots of the shell with a @c TrivialPortalLink
+  /// to the given @p volume.
   /// @param volume The volume to connect
-  virtual void connectOuter(TrackingVolume& volume) = 0;
+  virtual void fill(TrackingVolume& volume) = 0;
 
   /// Get the number of portals in the shell. This number depends on the volume
   /// type
@@ -88,8 +86,8 @@ class CylinderPortalShell : public PortalShellBase {
   /// @param face The face to set the portal
   virtual void setPortal(std::shared_ptr<Portal> portal, Face face) = 0;
 
-  /// @copydoc PortalShellBase::connectOuter
-  void connectOuter(TrackingVolume& volume) override;
+  /// @copydoc PortalShellBase::fill
+  void fill(TrackingVolume& volume) override;
 };
 
 /// Output stream operator for the CylinderPortalShell::Face enum

--- a/Core/src/Geometry/PortalShell.cpp
+++ b/Core/src/Geometry/PortalShell.cpp
@@ -22,7 +22,7 @@
 
 namespace Acts {
 
-void CylinderPortalShell::connectOuter(TrackingVolume& volume) {
+void CylinderPortalShell::fill(TrackingVolume& volume) {
   for (Face face : {PositiveDisc, NegativeDisc, OuterCylinder, InnerCylinder,
                     NegativePhiPlane, PositivePhiPlane}) {
     const auto& portalAtFace = portalPtr(face);

--- a/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PortalShellTests.cpp
@@ -720,7 +720,7 @@ BOOST_AUTO_TEST_CASE(NestedStacks) {
                     nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(ConnectOuter) {
+BOOST_AUTO_TEST_CASE(Fill) {
   auto cyl1 = makeVolume(30_mm, 40_mm, 100_mm);
   auto cyl2 = makeVolume(0_mm, 50_mm, 110_mm);
 
@@ -736,7 +736,7 @@ BOOST_AUTO_TEST_CASE(ConnectOuter) {
   BOOST_CHECK_EQUAL(
       shell.portal(NegativeDisc)->getLink(Direction::OppositeNormal), nullptr);
 
-  shell.connectOuter(cyl2);
+  shell.fill(cyl2);
 
   BOOST_CHECK_NE(shell.portal(OuterCylinder)->getLink(Direction::AlongNormal),
                  nullptr);


### PR DESCRIPTION
This renames the `connectOuter` method in `PortalShell` to just `fill`, because that is more descriptive of what it actually does.

Part of #3502 