### PR TITLE
fix: oneAPI 2025 Fixes, main branch (2024.11.11.)

### DIFF
--- a/Core/include/Acts/EventData/detail/TestSourceLink.hpp
+++ b/Core/include/Acts/EventData/detail/TestSourceLink.hpp
@@ -139,14 +139,13 @@ void testSourceLinkCalibratorReturn(
     trackState.allocateCalibrated(2);
     trackState.template calibrated<2>() = sl.parameters;
     trackState.template calibratedCovariance<2>() = sl.covariance;
-    trackState.template setSubspaceIndices(
-        std::array{sl.indices[0], sl.indices[1]});
+    trackState.setSubspaceIndices(std::array{sl.indices[0], sl.indices[1]});
   } else if (sl.indices[0] != Acts::eBoundSize) {
     trackState.allocateCalibrated(1);
     trackState.template calibrated<1>() = sl.parameters.head<1>();
     trackState.template calibratedCovariance<1>() =
         sl.covariance.topLeftCorner<1, 1>();
-    trackState.template setSubspaceIndices(std::array{sl.indices[0]});
+    trackState.setSubspaceIndices(std::array{sl.indices[0]});
   } else {
     throw std::runtime_error(
         "Tried to extract measurement from invalid TestSourceLink");

--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -1306,12 +1306,12 @@ class Gx2Fitter {
       // existing states, but this needs some more thinking.
       trackContainerTemp.clear();
 
-      auto propagationResult = m_propagator.template propagate(propagatorState);
+      auto propagationResult = m_propagator.propagate(propagatorState);
 
       // Run the fitter
-      auto result = m_propagator.template makeResult(std::move(propagatorState),
-                                                     propagationResult,
-                                                     propagatorOptions, false);
+      auto result =
+          m_propagator.makeResult(std::move(propagatorState), propagationResult,
+                                  propagatorOptions, false);
 
       if (!result.ok()) {
         ACTS_ERROR("Propagation failed: " << result.error());
@@ -1502,12 +1502,12 @@ class Gx2Fitter {
       auto& r = propagatorState.template get<Gx2FitterResult<traj_t>>();
       r.fittedStates = &trackContainer.trackStateContainer();
 
-      auto propagationResult = m_propagator.template propagate(propagatorState);
+      auto propagationResult = m_propagator.propagate(propagatorState);
 
       // Run the fitter
-      auto result = m_propagator.template makeResult(std::move(propagatorState),
-                                                     propagationResult,
-                                                     propagatorOptions, false);
+      auto result =
+          m_propagator.makeResult(std::move(propagatorState), propagationResult,
+                                  propagatorOptions, false);
 
       if (!result.ok()) {
         ACTS_ERROR("Propagation failed: " << result.error());

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -1233,7 +1233,7 @@ class KalmanFitter {
                 track_container_t& trackContainer) const
       -> Result<typename track_container_t::TrackProxy> {
     auto propagatorState =
-        m_propagator.template makeState(sParameters, propagatorOptions);
+        m_propagator.makeState(sParameters, propagatorOptions);
 
     auto& kalmanResult =
         propagatorState.template get<KalmanFitterResult<traj_t>>();


### PR DESCRIPTION
After @CarloVarni's update in https://github.com/acts-project/traccc/pull/765, I became unable to build [traccc](https://github.com/acts-project/traccc) with [oneAPI 2025.0.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-toolkit-release-notes.html). 😦 

The issue being solved here is of the type:

```
[159/737] Building CXX object Core/CMakeFiles/ActsCore.dir/src/TrackFitting/GlobalChiSquareFitter.cpp.o
FAILED: Core/CMakeFiles/ActsCore.dir/src/TrackFitting/GlobalChiSquareFitter.cpp.o
/software/intel/oneapi-2025.0.0/compiler/2025.0/bin/compiler/clang++  --gcc-toolchain=/software/gcc/13.3.0/x86_64-el9 -DActsCore_EXPORTS -I/home/krasznaa/ATLAS/projects/acts/acts/Core/include -I/home/krasznaa/ATLAS/projects/acts/build-oneapi/Core -isystem /home/krasznaa/ATLAS/projects/acts/acts/cmake/assert_include -isystem /software/boost/1.83.0/x86_64-el9-gcc11-opt/include -isystem /home/krasznaa/ATLAS/projects/traccc/build-vanilla/_deps/eigen3-src -Wall -Wextra -Wpedantic -Wshadow -Wzero-as-null-pointer-constant -Wold-style-cast  -O2 -g -DNDEBUG -std=gnu++20 -fPIC -MD -MT Core/CMakeFiles/ActsCore.dir/src/TrackFitting/GlobalChiSquareFitter.cpp.o -MF Core/CMakeFiles/ActsCore.dir/src/TrackFitting/GlobalChiSquareFitter.cpp.o.d -o Core/CMakeFiles/ActsCore.dir/src/TrackFitting/GlobalChiSquareFitter.cpp.o -c /home/krasznaa/ATLAS/projects/acts/acts/Core/src/TrackFitting/GlobalChiSquareFitter.cpp
In file included from /home/krasznaa/ATLAS/projects/acts/acts/Core/src/TrackFitting/GlobalChiSquareFitter.cpp:9:
/home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp:1265:54: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1265 |       auto propagationResult = m_propagator.template propagate(propagatorState);
      |                                                      ^
/home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp:1268:43: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1268 |       auto result = m_propagator.template makeResult(std::move(propagatorState),
      |                                           ^
/home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp:1483:54: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1483 |       auto propagationResult = m_propagator.template propagate(propagatorState);
      |                                                      ^
/home/krasznaa/ATLAS/projects/acts/acts/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp:1486:43: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
 1486 |       auto result = m_propagator.template makeResult(std::move(propagatorState),
      |                                           ^
4 errors generated.
```

I imagine that those functions were templated once in the past, but they clearly are no longer. And Clang really doesn't like the erroneous call. 🤔

Unfortunately I was not able to reproduce these issues with [LLVM 18.1.8](https://discourse.llvm.org/t/18-1-8-released/79725). 😦 (That's the one I had already on hand. I imagine I'd need LLVM 19 to trigger this issue without oneAPI...) But I believe these will be useful fixes for vanilla Clang support as well.