### PR TITLE
fix: Particle selector works on measurements, not simhits

### DIFF
--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
@@ -26,6 +27,9 @@ class ParticleSelector final : public IAlgorithm {
   struct Config {
     /// The input particles collection.
     std::string inputParticles;
+    /// The input measurement particles map (optional, required if selection
+    /// based on number of measurements is requested).
+    std::string inputMeasurementParticlesMap;
     /// The output particles collection.
     std::string outputParticles;
 
@@ -75,6 +79,8 @@ class ParticleSelector final : public IAlgorithm {
   Config m_cfg;
 
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
+  ReadDataHandle<IndexMultimap<ActsFatras::Barcode>> m_inputMeasPartMap{
+      this, "InputMeasPartMap"};
 
   WriteDataHandle<SimParticleContainer> m_outputParticles{this,
                                                           "OutputParticles"};

--- a/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
@@ -161,8 +161,8 @@ class SimParticle final {
   /// Accumulated path within material measured in interaction lengths.
   double pathInL0() const { return final().pathInL0(); }
 
-  /// Number of hits.
-  std::uint32_t numberOfHits() const { return final().numberOfHits(); }
+  /// Number of simulated hits (not measurements).
+  std::uint32_t numberOfSimHits() const { return final().numberOfHits(); }
 
   /// Particle outcome.
   ActsFatras::ParticleOutcome outcome() const { return final().outcome(); }

--- a/Examples/Io/Json/src/TestSurfaceJsonRoundtrip.cpp
+++ b/Examples/Io/Json/src/TestSurfaceJsonRoundtrip.cpp
@@ -1,0 +1,37 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Json/JsonSurfacesReader.hpp"
+#include <Acts/Plugins/Json/SurfaceJsonConverter.hpp>
+
+#include <fstream>
+
+#include <nlohmann/json.hpp>
+
+void writeSurfaces(
+    std::ostream &os,
+    const std::vector<std::shared_ptr<Acts::Surface>> &jSurfaces) {
+  nlohmann::json j = nlohmann::json::array();
+
+  for (const auto &jSurface : jSurfaces) {
+    j.push_back(
+        Acts::SurfaceJsonConverter::toJson(Acts::GeometryContext{}, *jSurface));
+  }
+
+  os << j;
+}
+
+int main(int argc, char **argv) {
+  std::vector<std::string> args(argv, argv + argc);
+
+  auto surfaces =
+      ActsExamples::JsonSurfacesReader::readVector({args.at(1), {}});
+
+  std::ofstream outfile("output_surfaces.json");
+  writeSurfaces(outfile, surfaces);
+}

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -143,7 +143,7 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
         Acts::clampValue<float>(particle.pathInX0() / Acts::UnitConstants::mm));
     m_pathInL0.push_back(
         Acts::clampValue<float>(particle.pathInL0() / Acts::UnitConstants::mm));
-    m_numberOfHits.push_back(particle.numberOfHits());
+    m_numberOfHits.push_back(particle.numberOfSimHits());
     m_outcome.push_back(static_cast<std::uint32_t>(particle.outcome()));
   }
 

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -356,6 +356,7 @@ def addParticleSelection(
     config: ParticleSelectorConfig,
     inputParticles: str,
     outputParticles: str,
+    inputMeasurementParticlesMap: str = "",
     logLevel: Optional[acts.logging.Level] = None,
 ) -> None:
     """
@@ -401,6 +402,7 @@ def addParticleSelection(
             ),
             level=customLogLevel(),
             inputParticles=inputParticles,
+            inputMeasurementParticlesMap=inputMeasurementParticlesMap,
             outputParticles=outputParticles,
         )
     )

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -62,6 +62,7 @@ void addTruthTracking(Context& ctx) {
 
     ACTS_PYTHON_STRUCT_BEGIN(c, Config);
     ACTS_PYTHON_MEMBER(inputParticles);
+    ACTS_PYTHON_MEMBER(inputMeasurementParticlesMap);
     ACTS_PYTHON_MEMBER(outputParticles);
     ACTS_PYTHON_MEMBER(rhoMin);
     ACTS_PYTHON_MEMBER(rhoMax);


### PR DESCRIPTION
The particle selection did work on the simhit count, but usually we rather desire to select on the actual number of measurements in the detector, which can be different.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!
