### PR TITLE
feat: Random number channel for Examples

### DIFF
--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -162,7 +162,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
 
   // Count the number of hits per particle and module. Cleared before each
   // module.
-  std::map<SimBarcode, int> particleOnModuleHitCount;
+  std::map<SimBarcode, std::uint32_t> particleOnModuleHitCount;
 
   ACTS_DEBUG("Starting loop over modules ...");
   for (const auto& simHitsGroup : groupByModule(simHits)) {

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -18,6 +18,7 @@
 #include "ActsExamples/EventData/GeometryContainers.hpp"
 #include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
+#include "ActsExamples/Framework/RandomNumbers.hpp"
 #include "ActsExamples/Utilities/Range.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
 #include "ActsFatras/EventData/Hit.hpp"
@@ -149,7 +150,6 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
   measurementParticlesMap.reserve(simHits.size());
   measurementSimHitsMap.reserve(simHits.size());
 
-  // Setup random number generator
   auto eventSeed = m_cfg.randomNumbers->generateSeed(ctx);
 
   // Some statistics
@@ -188,19 +188,6 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
       ACTS_VERBOSE("Digitizer found for module " << moduleGeoId);
     }
 
-    auto moduleSeed = eventSeed + moduleGeoId.value();
-    RandomEngine rng(moduleSeed);
-
-    // Sort simhits by particle id to make sure we can iterate over them in
-    // a deterministic order.
-    std::vector<std::size_t> sortedSimHitOrdering(moduleSimHits.size());
-    std::iota(sortedSimHitOrdering.begin(), sortedSimHitOrdering.end(), 0);
-    std::sort(sortedSimHitOrdering.begin(), sortedSimHitOrdering.end(),
-              [&](std::size_t i, std::size_t j) {
-                return (moduleSimHits.begin() + i)->particleId() <
-                       (moduleSimHits.begin() + j)->particleId();
-              });
-
     // Run the digitizer. Iterate over the hits for this surface inside the
     // visitor so we do not need to lookup the variant object per-hit.
     std::visit(
@@ -209,8 +196,13 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
               digitizer.geometric.segmentation, digitizer.geometric.indices,
               m_cfg.doMerge, m_cfg.mergeNsigma, m_cfg.mergeCommonCorner);
 
-          for (std::size_t simHitIdx : sortedSimHitOrdering) {
-            const auto& simHit = *(moduleSimHits.begin() + simHitIdx);
+          for (auto h = moduleSimHits.begin(); h != moduleSimHits.end(); ++h) {
+            const auto& simHit = *h;
+            const auto simHitIdx = simHits.index_of(h);
+
+            auto particleSeed =
+                eventSeed + simHit.particleId().value() + simHit.index();
+            RandomEngine rng(particleSeed);
 
             DigitizedParameters dParameters;
 

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -151,7 +151,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
   measurementParticlesMap.reserve(simHits.size());
   measurementSimHitsMap.reserve(simHits.size());
 
-  auto eventSeed = m_cfg.randomNumbers->generateSeed(ctx);
+  RandomSeed eventSeed = m_cfg.randomNumbers->generateSeed(ctx);
 
   // Some statistics
   std::size_t skippedHits = 0;
@@ -216,8 +216,8 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
                          << " - still forwarding it to the digitizer");
             }
 
-            auto hitSeed = eventSeed + moduleGeoId.value() +
-                           simHit.particleId().value() + hitIndex;
+            RandomSeed hitSeed = eventSeed + moduleGeoId.value() +
+                                 simHit.particleId().value() + hitIndex;
             RandomEngine rng(hitSeed);
 
             DigitizedParameters dParameters;

--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -223,7 +223,7 @@ ActsExamples::ProcessCode ActsExamples::DigitizationAlgorithm::execute(
             DigitizedParameters dParameters;
 
             if (simHit.depositedEnergy() < m_cfg.minEnergyDeposit) {
-              ACTS_VERBOSE("Skip hit because energy deposit to small");
+              ACTS_VERBOSE("Skip hit because energy deposit too small");
               continue;
             }
 

--- a/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
@@ -15,10 +15,10 @@ namespace ActsExamples {
 struct AlgorithmContext;
 
 /// The random number generator used in the framework.
-using RandomEngine = std::mt19937;  ///< Mersenne Twister
+using RandomEngine = std::mt19937_64;  ///< Mersenne Twister
 
 /// The seed type used in the framework.
-using RandomSeed = std::uint32_t;
+using RandomSeed = std::uint64_t;
 
 /// Provide event and algorithm specific random number generator.s
 ///

--- a/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
@@ -6,17 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//
-//  RandomNumbers.hpp
-//  ActsExamples
-//
-//  Created by Andreas Salzburger on 17/05/16.
-//
-//
-
 #pragma once
-
-#include "ActsExamples/Framework/AlgorithmContext.hpp"
 
 #include <cstdint>
 #include <random>
@@ -26,6 +16,9 @@ struct AlgorithmContext;
 
 /// The random number generator used in the framework.
 using RandomEngine = std::mt19937;  ///< Mersenne Twister
+
+/// The seed type used in the framework.
+using RandomSeed = std::uint32_t;
 
 /// Provide event and algorithm specific random number generator.s
 ///
@@ -41,7 +34,7 @@ using RandomEngine = std::mt19937;  ///< Mersenne Twister
 class RandomNumbers {
  public:
   struct Config {
-    std::uint64_t seed = 1234567890u;  ///< random seed
+    RandomSeed seed = 1234567890u;  ///< random seed
   };
 
   explicit RandomNumbers(const Config& cfg);
@@ -59,7 +52,7 @@ class RandomNumbers {
   ///
   /// This should only be used in special cases e.g. where a custom
   /// random engine is used and `spawnGenerator` can not be used.
-  std::uint64_t generateSeed(const AlgorithmContext& context) const;
+  RandomSeed generateSeed(const AlgorithmContext& context) const;
 
  private:
   Config m_cfg;

--- a/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/RandomNumbers.hpp
@@ -20,7 +20,24 @@ using RandomEngine = std::mt19937_64;  ///< Mersenne Twister
 /// The seed type used in the framework.
 using RandomSeed = std::uint64_t;
 
-/// Provide event and algorithm specific random number generator.s
+class RandomNumbers;
+
+class RandomNumberChannel {
+ public:
+  RandomNumberChannel(const RandomNumbers& randomNumbers, RandomSeed seed);
+
+  RandomSeed seed() const;
+
+  RandomEngine createEngine() const;
+
+  RandomNumberChannel createSubChannel(RandomSeed seed) const;
+
+ private:
+  const RandomNumbers* m_randomNumbers = nullptr;
+  RandomSeed m_seed = 0;
+};
+
+/// Provide an event and algorithm specific random number generator.
 ///
 /// This provides local random number generators, allowing for
 /// thread-safe, lock-free, and reproducible random number generation across
@@ -39,6 +56,11 @@ class RandomNumbers {
 
   explicit RandomNumbers(const Config& cfg);
 
+  RandomNumberChannel createChannel() const;
+
+  RandomNumberChannel createAlgorithmEventChannel(
+      const AlgorithmContext& context) const;
+
   /// Spawn an algorithm-local random number generator. To avoid inefficiencies
   /// and multiple uses of a given RNG seed, this should only be done once per
   /// Algorithm invocation, after what the generator object should be reused.
@@ -48,7 +70,7 @@ class RandomNumbers {
   /// @param context is the AlgorithmContext of the host algorithm
   RandomEngine spawnGenerator(const AlgorithmContext& context) const;
 
-  /// Generate a event and algorithm specific seed value.
+  /// Generate an event and algorithm specific seed value.
   ///
   /// This should only be used in special cases e.g. where a custom
   /// random engine is used and `spawnGenerator` can not be used.

--- a/Examples/Framework/src/Framework/RandomNumbers.cpp
+++ b/Examples/Framework/src/Framework/RandomNumbers.cpp
@@ -6,26 +6,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//
-//  RandomNumbers.cpp
-//  ActsExamples
-//
-//  Created by Andreas Salzburger on 17/05/16.
-//
-//
-
 #include "ActsExamples/Framework/RandomNumbers.hpp"
 
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 
-ActsExamples::RandomNumbers::RandomNumbers(const Config& cfg) : m_cfg(cfg) {}
+#include <boost/functional/hash.hpp>
 
-ActsExamples::RandomEngine ActsExamples::RandomNumbers::spawnGenerator(
+namespace ActsExamples {
+
+RandomNumbers::RandomNumbers(const Config& cfg) : m_cfg(cfg) {}
+
+RandomEngine RandomNumbers::spawnGenerator(
     const AlgorithmContext& context) const {
   return RandomEngine(generateSeed(context));
 }
 
-std::uint64_t ActsExamples::RandomNumbers::generateSeed(
-    const AlgorithmContext& context) const {
+RandomSeed RandomNumbers::generateSeed(const AlgorithmContext& context) const {
   return m_cfg.seed + context.eventNumber;
 }
+
+}  // namespace ActsExamples

--- a/Examples/Framework/src/Framework/RandomNumbers.cpp
+++ b/Examples/Framework/src/Framework/RandomNumbers.cpp
@@ -14,7 +14,33 @@
 
 namespace ActsExamples {
 
+RandomNumberChannel::RandomNumberChannel(const RandomNumbers& randomNumbers,
+                                         RandomSeed seed)
+    : m_randomNumbers(&randomNumbers), m_seed(seed) {}
+
+RandomSeed RandomNumberChannel::seed() const {
+  return m_seed;
+}
+
+RandomEngine RandomNumberChannel::createEngine() const {
+  return RandomEngine(m_seed);
+}
+
+RandomNumberChannel RandomNumberChannel::createSubChannel(
+    RandomSeed seed) const {
+  return RandomNumberChannel(*m_randomNumbers, m_seed + seed);
+}
+
 RandomNumbers::RandomNumbers(const Config& cfg) : m_cfg(cfg) {}
+
+RandomNumberChannel RandomNumbers::createChannel() const {
+  return RandomNumberChannel(*this, m_cfg.seed);
+}
+
+RandomNumberChannel RandomNumbers::createAlgorithmEventChannel(
+    const AlgorithmContext& context) const {
+  return RandomNumberChannel(*this, generateSeed(context));
+}
 
 RandomEngine RandomNumbers::spawnGenerator(
     const AlgorithmContext& context) const {

--- a/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
+++ b/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(GaussianSmearing) {
     if (s.forcePositive[i]) {
       ref = std::abs(ref);
     }
-    CHECK_CLOSE_REL(par[i], ref, 0.15);
+    CHECK_CLOSE_ABS(par[i], ref, 0.15);
   }
 }
 


### PR DESCRIPTION
Utility to create independent random number channels which allows to have stable streams for different purposes. For example smearing bound parameters will create different results depending on which parameters are smeared and in which order. Having different channels avoids this.