### PR TITLE
fix: Estimate entry size before sorting in ROOT readers

### DIFF
--- a/Examples/Io/Root/src/RootMaterialTrackReader.cpp
+++ b/Examples/Io/Root/src/RootMaterialTrackReader.cpp
@@ -89,6 +89,10 @@ RootMaterialTrackReader::RootMaterialTrackReader(const Config& config,
 
   // Sort the entry numbers of the events
   {
+    // necessary to guarantee that m_inputChain->GetV1() is valid for the
+    // entire range
+    m_inputChain->SetEstimate(nentries + 1);
+
     m_entryNumbers.resize(nentries);
     m_inputChain->Draw("event_id", "", "goff");
     RootUtility::stableSort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -80,6 +80,10 @@ RootParticleReader::RootParticleReader(const RootParticleReader::Config& config,
 
   // Sort the entry numbers of the events
   {
+    // necessary to guarantee that m_inputChain->GetV1() is valid for the
+    // entire range
+    m_inputChain->SetEstimate(m_events + 1);
+
     m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_id", "", "goff");
     RootUtility::stableSort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootTrackSummaryReader.cpp
+++ b/Examples/Io/Root/src/RootTrackSummaryReader.cpp
@@ -99,6 +99,10 @@ RootTrackSummaryReader::RootTrackSummaryReader(
 
   // Sort the entry numbers of the events
   {
+    // necessary to guarantee that m_inputChain->GetV1() is valid for the
+    // entire range
+    m_inputChain->SetEstimate(m_events + 1);
+
     m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_nr", "", "goff");
     RootUtility::stableSort(m_inputChain->GetEntries(), m_inputChain->GetV1(),

--- a/Examples/Io/Root/src/RootVertexReader.cpp
+++ b/Examples/Io/Root/src/RootVertexReader.cpp
@@ -8,13 +8,12 @@
 
 #include "ActsExamples/Io/Root/RootVertexReader.hpp"
 
-#include "Acts/Definitions/PdgParticle.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
+#include "ActsExamples/Io/Root/RootUtility.hpp"
 #include "ActsFatras/EventData/ProcessType.hpp"
 
-#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <stdexcept>
@@ -64,11 +63,14 @@ RootVertexReader::RootVertexReader(const RootVertexReader::Config& config,
 
   // Sort the entry numbers of the events
   {
+    // necessary to guarantee that m_inputChain->GetV1() is valid for the
+    // entire range
+    m_inputChain->SetEstimate(m_events + 1);
+
     m_entryNumbers.resize(m_events);
     m_inputChain->Draw("event_id", "", "goff");
-    // Sort to get the entry numbers of the ordered events
-    TMath::Sort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
-                m_entryNumbers.data(), false);
+    RootUtility::stableSort(m_inputChain->GetEntries(), m_inputChain->GetV1(),
+                            m_entryNumbers.data(), false);
   }
 }
 

--- a/Examples/Scripts/TrackingPerformance/TreeReader.h
+++ b/Examples/Scripts/TrackingPerformance/TreeReader.h
@@ -145,6 +145,7 @@ struct TrackStatesReader : public TreeReader {
     // It's not necessary if you just need to read one file, but please do it to
     // synchronize events if multiple root files are read
     if (sortEvents) {
+      tree->SetEstimate(tree->GetEntries() + 1);
       entryNumbers.resize(tree->GetEntries());
       tree->Draw("event_nr", "", "goff");
       // Sort to get the entry numbers of the ordered events
@@ -338,6 +339,7 @@ struct TrackSummaryReader : public TreeReader {
     // It's not necessary if you just need to read one file, but please do it to
     // synchronize events if multiple root files are read
     if (sortEvents) {
+      tree->SetEstimate(tree->GetEntries() + 1);
       entryNumbers.resize(tree->GetEntries());
       tree->Draw("event_nr", "", "goff");
       // Sort to get the entry numbers of the ordered events
@@ -368,7 +370,8 @@ struct TrackSummaryReader : public TreeReader {
   std::vector<std::vector<double>>* outlierLayer =
       new std::vector<std::vector<double>>;
   std::vector<unsigned int>* nMajorityHits = new std::vector<unsigned int>;
-  std::vector<std::uint64_t>* majorityParticleId = new std::vector<std::uint64_t>;
+  std::vector<std::uint64_t>* majorityParticleId =
+      new std::vector<std::uint64_t>;
 
   std::vector<bool>* hasFittedParams = new std::vector<bool>;
 
@@ -427,6 +430,7 @@ struct ParticleReader : public TreeReader {
     // It's not necessary if you just need to read one file, but please do it to
     // synchronize events if multiple root files are read
     if (sortEvents) {
+      tree->SetEstimate(tree->GetEntries() + 1);
       entryNumbers.resize(tree->GetEntries());
       tree->Draw("event_id", "", "goff");
       // Sort to get the entry numbers of the ordered events
@@ -436,7 +440,8 @@ struct ParticleReader : public TreeReader {
   }
 
   // Get all the particles with requested event id
-  std::vector<ParticleInfo> getParticles(const std::uint32_t& eventNumber) const {
+  std::vector<ParticleInfo> getParticles(
+      const std::uint32_t& eventNumber) const {
     // Find the start entry and the batch size for this event
     std::string eventNumberStr = std::to_string(eventNumber);
     std::string findStartEntry = "event_id<" + eventNumberStr;


### PR DESCRIPTION
Extending the fix from here https://github.com/acts-project/acts/pull/3870 to other places.

See also discussion here https://mattermost.web.cern.ch/acts/pl/gp9mw1y1njr4bjxmbhurk1b4me

blocked by
- https://github.com/acts-project/acts/pull/3870