### PR TITLE
fix: User `localtime_r` instead of `localtime`

### DIFF
--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -482,7 +482,9 @@ class TimedOutputDecorator final : public OutputDecorator {
     char buffer[20];
     time_t t{};
     std::time(&t);
-    std::strftime(buffer, sizeof(buffer), m_format.c_str(), localtime(&t));
+    struct tm tbuf {};
+    std::strftime(buffer, sizeof(buffer), m_format.c_str(),
+                  localtime_r(&t, &tbuf));
     return buffer;
   }
 


### PR DESCRIPTION
This popped up as a warning in the ATLAS build:

```
/builds/acts/acts-athena-ci/acts-install/include/Acts/Utilities/Logger.hpp:485:61: warning: Non reentrant function 'localtime' called. For threadsafe applications it is recommended to use the reentrant replacement function 'localtime_r'. [localtimeCalled]
    std::strftime(buffer, sizeof(buffer), m_format.c_str(),
localtime(&t));
```