### PR TITLE
chore: add dependabot jobs for all python requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,33 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/Examples/Scripts"
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/Examples/Python/tests"
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/CI/clang_tidy"
+    schedule:
+      interval: "weekly"
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/CI"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This year, I we had again problems upgrading some dependencies. This way, we can hopefully catch those problems earlier.

blocked by:
- https://github.com/acts-project/acts/pull/3875