### PR TITLE
docs: Add troubleshooting section for Spack

### DIFF
--- a/CI/codespell_ignore.txt
+++ b/CI/codespell_ignore.txt
@@ -7,6 +7,7 @@ dependees
 dthe
 exprot
 gaus
+interprete
 iself
 lastr
 localy

--- a/docs/misc/spack.md
+++ b/docs/misc/spack.md
@@ -61,6 +61,16 @@ variants you do not need in order to speed up the Spack build.
 Once Spack has concretized and installed the ACTS dependencies, you can build
 ACTS as normal using CMake.
 
+### Running with dependencies
+
+In order to run code depending on ACTS dependencies such as DD4hep, you may
+need to run an additional shell script when you activate your Spack
+environment. This shell script is called `this_acts_withdeps.sh` and resides in
+your ACTS build directory:
+
+```console
+$ source <build directory>/this_acts_withdeps.sh
+```
 
 ## Build caches
 
@@ -74,3 +84,21 @@ at times be out of date. If you encounter any problems using Spack to build
 ACTS, unofficial support is available in the
 [#Spack](https://mattermost.web.cern.ch/acts/channels/spack) channel on the
 ACTS Mattermost.
+
+## Troubleshooting
+
+The following are some common problems you may encounter using Spack to build
+ACTS.
+
+### DD4hep not finding factories
+
+If you run into an error like the following, DD4hep is failing to find the
+object files required to parse some its required factories. Remember to
+initialize the ACTS dependencies as described in ["Running
+with dependencies"](#running-with-dependencies):
+
+```text
+dd4hep: Failed to locate plugin to interprete files of type "lccdd" - no factory:lccdd_XML_reader.
+        No factory with name Create(lccdd_XML_reader) for type lccdd_XML_reader found.
+        Please check library load path and/or plugin factory name.
+```


### PR DESCRIPTION
As @Cas1997 discovered, the DD4hep executables need some additional setup when using a Spack install. This commit adds documentation to the Spack page on how to do this, and on how to debug related issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Expanded documentation for building with Spack, adding a new section on "Running with dependencies."
	- Introduced a "Troubleshooting" section detailing common issues, including specific guidance for DD4hep errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->