### PR TITLE
fix: Add check on expected measurements on surface before marking as hole

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -739,7 +739,7 @@ class CombinatorialKalmanFilter {
         slRange = m_sourceLinkAccessor(*surface);
         hasMeasurements = slRange->first != slRange->second;
       }
-      bool isHole = isSensitive && !hasMeasurements;
+      bool isHole = isSensitive && expectMeasurements && !hasMeasurements;
 
       if (isHole) {
         ACTS_VERBOSE("Detected hole before measurement selection on surface "


### PR DESCRIPTION
Check expected measurement during track finding before marking state as hole

@andiwand 