### PR TITLE
docs: remove http-relics for license

### DIFF
--- a/Examples/Detectors/ITkModuleSplitting/include/ActsExamples/ITkModuleSplitting/ITkModuleSplitting.hpp
+++ b/Examples/Detectors/ITkModuleSplitting/include/ActsExamples/ITkModuleSplitting/ITkModuleSplitting.hpp
@@ -6,14 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// This file is part of the Acts project.
-//
-// Copyright (C) 2024 CERN for the benefit of the Acts project
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 #pragma once
 
 #include "Acts/Definitions/Algebra.hpp"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Contributors to the Acts project are listed in the [AUTHORS](AUTHORS) file.
 
 The Acts project is published under the terms of the Mozilla Public License, v. 2.0.
 A copy of the license can be found in the [LICENSE](LICENSE) file or at
-http://mozilla.org/MPL/2.0/ .
+https://mozilla.org/MPL/2.0/ .
 
 The Acts project contains copies of the following external packages:
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -2,7 +2,7 @@ License
 =======
 
 ACTS is licensed under the `Mozilla Public License Version 2.0
-<http://mozilla.org/MPL/2.0/>`_. The full text of the license can be found
+<https://mozilla.org/MPL/2.0/>`_. The full text of the license can be found
 below.
 
 .. literalinclude:: ../LICENSE


### PR DESCRIPTION
We had the docs test failing quite frequently during the last week, like in here: https://github.com/acts-project/acts/actions/runs/11990353442/job/33427764861?pr=3896 due to
```
(         license: line    4) broken    http://mozilla.org/MPL/2.0/ - 404 Client Error: Not Found for url: https://www.mozilla.org/en-US/mpl/2.0/
```

It seems, that mozilla forwards http sometimes to the wrong address with everything lovercase, which makes problems with `mpl` vs `MPL`.
