### PR TITLE
build: Update `FindFilesystem.cmake`

### DIFF
--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -103,6 +103,8 @@ if(TARGET std::filesystem)
     return()
 endif()
 
+cmake_minimum_required(VERSION 3.10)
+
 include(CMakePushCheckState)
 include(CheckIncludeFileCXX)
 
@@ -123,6 +125,9 @@ endif()
 cmake_push_check_state()
 
 set(CMAKE_REQUIRED_QUIET ${Filesystem_FIND_QUIETLY})
+
+# All of our tests required C++17 or later
+set(CMAKE_CXX_STANDARD 17)
 
 # Normalize and check the component list we were given
 set(want_components ${Filesystem_FIND_COMPONENTS})


### PR DESCRIPTION
Vector-of-bool's `FindFilesystem.cmake` was updated at some point to include and explicit `CMAKE_CXX_STANDARD=17`. We've observed occasionally that on macOS, the find module would fail because it would default to C++14, where `std::filesystem` is not available (and I guess the experimental implementation has since been removed).

This PR updates the `FindFilesystem.cmake` to include this.

Fixes #3900 