### PR TITLE
feat: Add `Propagator::propagateToSurface` with `FreeVector` as starting parameters

### DIFF
--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -13,13 +13,8 @@
 #include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
 // clang-format on
 
-#include "Acts/Definitions/Algebra.hpp"
-#include "Acts/Definitions/PdgParticle.hpp"
-#include "Acts/Definitions/Units.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TrackParametersConcept.hpp"
-#include "Acts/Geometry/GeometryContext.hpp"
-#include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/ActorList.hpp"
 #include "Acts/Propagator/PropagatorOptions.hpp"
 #include "Acts/Propagator/PropagatorResult.hpp"
@@ -31,8 +26,6 @@
 #include "Acts/Propagator/detail/ParameterTraits.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
-
-#include <optional>
 
 namespace Acts {
 
@@ -56,6 +49,17 @@ class BasePropagator {
       const BoundTrackParameters& start, const Surface& target,
       const Options& options) const = 0;
 
+  /// Method to propagate start free vector to a target surface.
+  /// @note this will not do covariance transport and the particle
+  ///       hypothesis in the result is meaningless
+  /// @param start The start free vector.
+  /// @param target The target surface.
+  /// @param options The propagation options.
+  /// @return The end bound track parameters.
+  virtual Result<BoundTrackParameters> propagateToSurface(
+      const FreeVector& start, const Surface& target,
+      const Options& options) const = 0;
+
   virtual ~BasePropagator() = default;
 };
 
@@ -67,6 +71,10 @@ class BasePropagatorHelper : public BasePropagator {
  public:
   Result<BoundTrackParameters> propagateToSurface(
       const BoundTrackParameters& start, const Surface& target,
+      const Options& options) const override;
+
+  Result<BoundTrackParameters> propagateToSurface(
+      const FreeVector& start, const Surface& target,
       const Options& options) const override;
 };
 }  // namespace detail

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -6,12 +6,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/TrackParametersConcept.hpp"
 #include "Acts/Propagator/ActorList.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/PropagatorError.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Propagator/detail/LoopProtection.hpp"
+#include "Acts/Surfaces/CurvilinearSurface.hpp"
 
 #include <concepts>
 
@@ -382,4 +384,19 @@ Acts::detail::BasePropagatorHelper<derived_t>::propagateToSurface(
   } else {
     return res.error();
   }
+}
+
+template <typename derived_t>
+Acts::Result<Acts::BoundTrackParameters>
+Acts::detail::BasePropagatorHelper<derived_t>::propagateToSurface(
+    const FreeVector& start, const Surface& target,
+    const Options& options) const {
+  // Convert free parameters to curvilinear parameters. Randomly picking pion
+  // hypothesis which should not make a difference as we extrapolate without
+  // interactions.
+  CurvilinearTrackParameters startBound(
+      start.segment<4>(Acts::eFreePos0), start.segment<3>(Acts::eFreeDir0),
+      start[Acts::eFreeQOverP], std::nullopt, ParticleHypothesis::pion());
+
+  return propagateToSurface(startBound, target, options);
 }


### PR DESCRIPTION
Similar to the existing `propagateToSurface` method for bound parameters, this adds another one for `FreeVector` inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for propagation from a `FreeVector` to a target surface, expanding the range of input types.
	- Enhanced the propagator interface to accommodate additional parameter types while maintaining existing functionality.

- **Documentation**
	- Updated comments to clarify the purpose and limitations of the new propagation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->