### PR TITLE
test: Use true start params for fitters in Examples Physmon

### DIFF
--- a/CI/physmon/workflows/physmon_trackfinding_1muon.py
+++ b/CI/physmon/workflows/physmon_trackfinding_1muon.py
@@ -91,19 +91,6 @@ def run_ckf_tracking(label, seeding):
             s,
             setup.trackingGeometry,
             setup.field,
-            ParticleSmearingSigmas(  # only used by SeedingAlgorithm.TruthSmeared
-                # zero eveything so the CKF has a chance to find the measurements
-                d0=0,
-                d0PtA=0,
-                d0PtB=0,
-                z0=0,
-                z0PtA=0,
-                z0PtB=0,
-                t0=0,
-                phi=0,
-                theta=0,
-                ptRel=0,
-            ),
             SeedFinderConfigArg(
                 r=(33 * u.mm, 200 * u.mm),
                 deltaR=(1 * u.mm, 60 * u.mm),
@@ -118,6 +105,9 @@ def run_ckf_tracking(label, seeding):
             SeedFinderOptionsArg(bFieldInZ=2 * u.T),
             TruthEstimatedSeedingAlgorithmConfigArg(deltaR=(10.0 * u.mm, None)),
             seedingAlgorithm=seeding,
+            # only used by SeedingAlgorithm.TruthSmeared
+            # zero eveything so the fitter has a chance to find the measurements
+            particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
             initialSigmas=[
                 1 * u.mm,
                 1 * u.mm,

--- a/CI/physmon/workflows/physmon_trackfitting_gsf.py
+++ b/CI/physmon/workflows/physmon_trackfitting_gsf.py
@@ -13,7 +13,7 @@ setup = makeSetup()
 
 with tempfile.TemporaryDirectory() as temp:
     s = acts.examples.Sequencer(
-        events=10000,
+        events=100000,
         numThreads=-1,
         logLevel=acts.logging.INFO,
     )

--- a/CI/physmon/workflows/physmon_trackfitting_gx2f.py
+++ b/CI/physmon/workflows/physmon_trackfitting_gx2f.py
@@ -13,7 +13,7 @@ setup = makeSetup()
 
 with tempfile.TemporaryDirectory() as temp:
     s = acts.examples.Sequencer(
-        events=10000,
+        events=100000,
         numThreads=-1,
         logLevel=acts.logging.INFO,
     )

--- a/CI/physmon/workflows/physmon_trackfitting_kf.py
+++ b/CI/physmon/workflows/physmon_trackfitting_kf.py
@@ -13,7 +13,7 @@ setup = makeSetup()
 
 with tempfile.TemporaryDirectory() as temp:
     s = acts.examples.Sequencer(
-        events=10000,
+        events=100000,
         numThreads=-1,
         logLevel=acts.logging.INFO,
     )

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -19,6 +19,8 @@ ParticleSmearingSigmas = namedtuple(
     defaults=[None] * 10,
 )
 
+ParticleSmearingSigmas.zeros = lambda: ParticleSmearingSigmas([0] * 10)
+
 SeedFinderConfigArg = namedtuple(
     "SeedFinderConfig",
     [

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -19,7 +19,18 @@ ParticleSmearingSigmas = namedtuple(
     defaults=[None] * 10,
 )
 
-ParticleSmearingSigmas.zeros = lambda: ParticleSmearingSigmas([0] * 10)
+ParticleSmearingSigmas.zeros = lambda: ParticleSmearingSigmas(
+    d0=0.0,
+    d0PtA=0.0,
+    d0PtB=0.0,
+    z0=0.0,
+    z0PtA=0.0,
+    z0PtB=0.0,
+    t0=0.0,
+    phi=0.0,
+    theta=0.0,
+    ptRel=0.0,
+)
 
 SeedFinderConfigArg = namedtuple(
     "SeedFinderConfig",

--- a/Examples/Scripts/Optimization/ckf.py
+++ b/Examples/Scripts/Optimization/ckf.py
@@ -188,19 +188,6 @@ def runCKFTracks(
         s,
         trackingGeometry,
         field,
-        ParticleSmearingSigmas(  # only used by SeedingAlgorithm.TruthSmeared
-            # zero eveything so the CKF has a chance to find the measurements
-            d0=0,
-            d0PtA=0,
-            d0PtB=0,
-            z0=0,
-            z0PtA=0,
-            z0PtB=0,
-            t0=0,
-            phi=0,
-            theta=0,
-            ptRel=0,
-        ),
         SeedFinderConfigArg(
             r=(None, 200 * u.mm),  # rMin=default, 33mm
             deltaR=(DeltaRMin * u.mm, DeltaRMax * u.mm),
@@ -225,6 +212,9 @@ def runCKFTracks(
                 else SeedingAlgorithm.Default
             )
         ),
+        # only used by SeedingAlgorithm.TruthSmeared
+        # zero eveything so the fitter has a chance to find the measurements
+        particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
         initialSigmas=[
             1 * u.mm,
             1 * u.mm,

--- a/Examples/Scripts/Python/ckf_tracks.py
+++ b/Examples/Scripts/Python/ckf_tracks.py
@@ -99,19 +99,6 @@ def runCKFTracks(
         s,
         trackingGeometry,
         field,
-        ParticleSmearingSigmas(  # only used by SeedingAlgorithm.TruthSmeared
-            # zero eveything so the CKF has a chance to find the measurements
-            d0=0,
-            d0PtA=0,
-            d0PtB=0,
-            z0=0,
-            z0PtA=0,
-            z0PtB=0,
-            t0=0,
-            phi=0,
-            theta=0,
-            ptRel=0,
-        ),
         SeedFinderConfigArg(
             r=(None, 200 * u.mm),  # rMin=default, 33mm
             deltaR=(1 * u.mm, 60 * u.mm),
@@ -134,6 +121,9 @@ def runCKFTracks(
                 else SeedingAlgorithm.Default
             )
         ),
+        # only used by SeedingAlgorithm.TruthSmeared
+        # zero eveything so the fitter has a chance to find the measurements
+        particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
         initialSigmas=[
             1 * u.mm,
             1 * u.mm,

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -101,19 +101,8 @@ def runTruthTrackingGsf(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
-        particleSmearingSigmas=ParticleSmearingSigmas(
-            # zero eveything so the fitter has a chance to find the measurements
-            d0=0,
-            d0PtA=0,
-            d0PtB=0,
-            z0=0,
-            z0PtA=0,
-            z0PtB=0,
-            t0=0,
-            phi=0,
-            theta=0,
-            ptRel=0,
-        ),
+        # zero eveything so the fitter has a chance to find the measurements
+        particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
         initialSigmas=[
             1 * u.mm,
             1 * u.mm,

--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -31,6 +31,7 @@ def runTruthTrackingGsf(
     from acts.examples.reconstruction import (
         addSeeding,
         SeedingAlgorithm,
+        ParticleSmearingSigmas,
         addTruthTrackingGsf,
     )
 
@@ -100,6 +101,29 @@ def runTruthTrackingGsf(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
+        particleSmearingSigmas=ParticleSmearingSigmas(
+            # zero eveything so the fitter has a chance to find the measurements
+            d0=0,
+            d0PtA=0,
+            d0PtB=0,
+            z0=0,
+            z0PtA=0,
+            z0PtB=0,
+            t0=0,
+            phi=0,
+            theta=0,
+            ptRel=0,
+        ),
+        initialSigmas=[
+            1 * u.mm,
+            1 * u.mm,
+            1 * u.degree,
+            1 * u.degree,
+            0.1 * u.e / u.GeV,
+            1 * u.ns,
+        ],
+        initialSigmaPtRel=0.01,
+        initialVarInflation=[1.0] * 6,
         particleHypothesis=acts.ParticleHypothesis.electron,
     )
 

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -98,19 +98,8 @@ def runTruthTrackingGx2f(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
-        particleSmearingSigmas=ParticleSmearingSigmas(
-            # zero eveything so the fitter has a chance to find the measurements
-            d0=0,
-            d0PtA=0,
-            d0PtB=0,
-            z0=0,
-            z0PtA=0,
-            z0PtB=0,
-            t0=0,
-            phi=0,
-            theta=0,
-            ptRel=0,
-        ),
+        # zero eveything so the fitter has a chance to find the measurements
+        particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
         initialSigmas=[
             1 * u.mm,
             1 * u.mm,

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -30,6 +30,7 @@ def runTruthTrackingGx2f(
     from acts.examples.reconstruction import (
         addSeeding,
         SeedingAlgorithm,
+        ParticleSmearingSigmas,
         addGx2fTracks,
     )
 
@@ -97,6 +98,29 @@ def runTruthTrackingGx2f(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
+        particleSmearingSigmas=ParticleSmearingSigmas(
+            # zero eveything so the fitter has a chance to find the measurements
+            d0=0,
+            d0PtA=0,
+            d0PtB=0,
+            z0=0,
+            z0PtA=0,
+            z0PtB=0,
+            t0=0,
+            phi=0,
+            theta=0,
+            ptRel=0,
+        ),
+        initialSigmas=[
+            1 * u.mm,
+            1 * u.mm,
+            1 * u.degree,
+            1 * u.degree,
+            0.1 * u.e / u.GeV,
+            1 * u.ns,
+        ],
+        initialSigmaPtRel=0.01,
+        initialVarInflation=[1.0] * 6,
         particleHypothesis=acts.ParticleHypothesis.muon,
     )
 

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -116,19 +116,8 @@ def runTruthTrackingKalman(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
-        particleSmearingSigmas=ParticleSmearingSigmas(
-            # zero eveything so the fitter has a chance to find the measurements
-            d0=0,
-            d0PtA=0,
-            d0PtB=0,
-            z0=0,
-            z0PtA=0,
-            z0PtB=0,
-            t0=0,
-            phi=0,
-            theta=0,
-            ptRel=0,
-        ),
+        # zero eveything so the fitter has a chance to find the measurements
+        particleSmearingSigmas=ParticleSmearingSigmas.zeros(),
         initialSigmas=[
             1 * u.mm,
             1 * u.mm,

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -34,6 +34,7 @@ def runTruthTrackingKalman(
     from acts.examples.reconstruction import (
         addSeeding,
         SeedingAlgorithm,
+        ParticleSmearingSigmas,
         addKalmanTracks,
     )
 
@@ -115,6 +116,29 @@ def runTruthTrackingKalman(
         rnd=rnd,
         inputParticles="particles_input",
         seedingAlgorithm=SeedingAlgorithm.TruthSmeared,
+        particleSmearingSigmas=ParticleSmearingSigmas(
+            # zero eveything so the fitter has a chance to find the measurements
+            d0=0,
+            d0PtA=0,
+            d0PtB=0,
+            z0=0,
+            z0PtA=0,
+            z0PtB=0,
+            t0=0,
+            phi=0,
+            theta=0,
+            ptRel=0,
+        ),
+        initialSigmas=[
+            1 * u.mm,
+            1 * u.mm,
+            1 * u.degree,
+            1 * u.degree,
+            0.1 * u.e / u.GeV,
+            1 * u.ns,
+        ],
+        initialSigmaPtRel=0.01,
+        initialVarInflation=[1.0] * 6,
         particleHypothesis=acts.ParticleHypothesis.muon,
     )
 


### PR DESCRIPTION
In order to factor out the effects of inaccurate starting parameters and potential navigation issues I propose to disable the start parameters smearing for the fitters in physmon. I also made the sigmas explicit.