### PR TITLE
chore(physmon): make configuration of all the fitters the same

### DIFF
--- a/CI/physmon/workflows/physmon_trackfitting_gsf.py
+++ b/CI/physmon/workflows/physmon_trackfitting_gsf.py
@@ -20,9 +20,9 @@ with tempfile.TemporaryDirectory() as temp:
 
     tp = Path(temp)
     runTruthTrackingGsf(
-        setup.trackingGeometry,
-        setup.field,
-        setup.digiConfig,
+        trackingGeometry=setup.trackingGeometry,
+        field=setup.field,
+        digiConfigFile=setup.digiConfig,
         outputDir=tp,
         s=s,
     )


### PR DESCRIPTION
Popped up in a discussion in https://github.com/acts-project/acts/pull/3889 that the configurations should be the same for all fitters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated parameter naming in function calls for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->