### PR TITLE
ci: Add LCG 106a job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -431,3 +431,17 @@ lcg_105:
         COMPILER:
           - gcc13
           - clang16
+
+lcg_106a:
+  extends: .lcg_base_job
+
+  variables:
+    LCG_VERSION: "106a"
+
+  parallel:
+    matrix:
+      - OS: [alma9]
+        COMPILER:
+          - gcc13
+          - gcc14
+          - clang16

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,11 +382,7 @@ linux_ubuntu_2204_clang:
     # Figure out LCG platform name based on version number and OS
     - >
       if [ "$OS" = "alma9"  ]; then
-        if [ "$LCG_VERSION" -ge "104" ]; then
-          export LCG_PLATFORM="el9"
-        else
-          export LCG_PLATFORM="centos9"
-        fi
+        export LCG_PLATFORM="el9"
       else
         export LCG_PLATFORM="$OS"
       fi


### PR DESCRIPTION
This adds jobs for LCG 106a to the GitLab CI.

I'm bumping ODD to the [`v4.0.3`](https://gitlab.cern.ch/acts/OpenDataDetector/-/tags/v4.0.3) where I cherry picked a tiny code fix that was breaking the build here.

Blocked by:
- #3921 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new CI/CD job `lcg_106a` for enhanced build configurations.
- **Improvements**
	- Simplified the `lcg_105` job by directly setting `LCG_PLATFORM` for the `alma9` OS.
- **Updates**
	- Updated the commit reference for the `OpenDataDetector` subproject to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->