### PR TITLE
feat: compatibility for EDM4hep < `0.99` & >= `0.99`

### DIFF
--- a/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepMeasurementWriter.hpp
+++ b/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepMeasurementWriter.hpp
@@ -16,9 +16,6 @@
 
 #include <string>
 
-#include <edm4hep/TrackerHitCollection.h>
-#include <edm4hep/TrackerHitPlaneCollection.h>
-
 namespace ActsExamples {
 
 /// Write out a measurement cluster collection to EDM4hep.

--- a/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepUtil.hpp
+++ b/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepUtil.hpp
@@ -16,15 +16,25 @@
 
 #include <functional>
 
-#include "edm4hep/MCParticle.h"
-#include "edm4hep/MutableMCParticle.h"
-#include "edm4hep/MutableSimTrackerHit.h"
-#include "edm4hep/MutableTrack.h"
-#include "edm4hep/MutableTrackerHitPlane.h"
-#include "edm4hep/SimTrackerHit.h"
-#include "edm4hep/TrackerHit.h"
-#include "edm4hep/TrackerHitCollection.h"
-#include "edm4hep/TrackerHitPlane.h"
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/MutableMCParticle.h>
+#include <edm4hep/MutableSimTrackerHit.h>
+#include <edm4hep/MutableTrack.h>
+#include <edm4hep/MutableTrackerHitPlane.h>
+#include <edm4hep/SimTrackerHit.h>
+#include <edm4hep/TrackerHitPlane.h>
+
+#if __has_include(<edm4hep/TrackerHit3D.h>)
+#include "edm4hep/TrackerHit3D.h"
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include <edm4hep/TrackerHit.h>
+#include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3D = edm4hep::TrackerHit;
+}  // namespace edm4hep
+#endif
 
 namespace ActsExamples::EDM4hepUtil {
 
@@ -91,7 +101,7 @@ void writeSimHit(const ActsFatras::Hit& from, edm4hep::MutableSimTrackerHit to,
 /// - local 2D coordinates and time are read from position
 VariableBoundMeasurementProxy readMeasurement(
     MeasurementContainer& container, const edm4hep::TrackerHitPlane& from,
-    const edm4hep::TrackerHitCollection* fromClusters, Cluster* toCluster,
+    const edm4hep::TrackerHit3DCollection* fromClusters, Cluster* toCluster,
     const MapGeometryIdFrom& geometryMapper);
 
 /// Writes a measurement cluster to EDM4hep.
@@ -107,7 +117,7 @@ VariableBoundMeasurementProxy readMeasurement(
 void writeMeasurement(const ConstVariableBoundMeasurementProxy& from,
                       edm4hep::MutableTrackerHitPlane to,
                       const Cluster* fromCluster,
-                      edm4hep::TrackerHitCollection& toClusters,
+                      edm4hep::TrackerHit3DCollection& toClusters,
                       const MapGeometryIdTo& geometryMapper);
 
 /// Writes a trajectory to EDM4hep.

--- a/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepUtil.hpp
+++ b/Examples/Io/EDM4hep/include/ActsExamples/Io/EDM4hep/EDM4hepUtil.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Plugins/EDM4hep/TrackerHitCompatibility.hpp"
 #include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
@@ -23,18 +24,6 @@
 #include <edm4hep/MutableTrackerHitPlane.h>
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/TrackerHitPlane.h>
-
-#if __has_include(<edm4hep/TrackerHit3D.h>)
-#include "edm4hep/TrackerHit3D.h"
-#include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include <edm4hep/TrackerHit.h>
-#include <edm4hep/TrackerHitCollection.h>
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-using TrackerHit3D = edm4hep::TrackerHit;
-}  // namespace edm4hep
-#endif
 
 namespace ActsExamples::EDM4hepUtil {
 

--- a/Examples/Io/EDM4hep/src/EDM4hepMeasurementReader.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepMeasurementReader.cpp
@@ -18,8 +18,18 @@
 #include <list>
 #include <stdexcept>
 
-#include <edm4hep/TrackerHit.h>
-#include <edm4hep/TrackerHitCollection.h>
+#if __has_include(<edm4hep/TrackerHit3D.h>)
+#include "edm4hep/TrackerHit3D.h"
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHit.h"
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3D = edm4hep::TrackerHit;
+}  // namespace edm4hep
+#endif
+
 #include <edm4hep/TrackerHitPlane.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
 
@@ -60,7 +70,7 @@ ProcessCode EDM4hepMeasurementReader::read(const AlgorithmContext& ctx) {
   const auto& trackerHitPlaneCollection =
       frame.get<edm4hep::TrackerHitPlaneCollection>("ActsTrackerHitsPlane");
   const auto& trackerHitRawCollection =
-      frame.get<edm4hep::TrackerHitCollection>("ActsTrackerHitsRaw");
+      frame.get<edm4hep::TrackerHit3DCollection>("ActsTrackerHitsRaw");
 
   for (const auto& trackerHitPlane : trackerHitPlaneCollection) {
     Cluster cluster;

--- a/Examples/Io/EDM4hep/src/EDM4hepMeasurementReader.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepMeasurementReader.cpp
@@ -9,6 +9,7 @@
 #include "ActsExamples/Io/EDM4hep/EDM4hepMeasurementReader.hpp"
 
 #include "Acts/Definitions/Units.hpp"
+#include "Acts/Plugins/EDM4hep/TrackerHitCompatibility.hpp"
 #include "Acts/Plugins/Podio/PodioUtil.hpp"
 #include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
@@ -17,18 +18,6 @@
 
 #include <list>
 #include <stdexcept>
-
-#if __has_include(<edm4hep/TrackerHit3D.h>)
-#include "edm4hep/TrackerHit3D.h"
-#include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHit.h"
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-using TrackerHit3D = edm4hep::TrackerHit;
-}  // namespace edm4hep
-#endif
 
 #include <edm4hep/TrackerHitPlane.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>

--- a/Examples/Io/EDM4hep/src/EDM4hepMeasurementWriter.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepMeasurementWriter.cpp
@@ -9,6 +9,7 @@
 #include "ActsExamples/Io/EDM4hep/EDM4hepMeasurementWriter.hpp"
 
 #include "Acts/Definitions/Units.hpp"
+#include "Acts/Plugins/EDM4hep/TrackerHitCompatibility.hpp"
 #include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
@@ -16,18 +17,9 @@
 
 #include <stdexcept>
 
-#include <podio/Frame.h>
-
-// Compatibility with EDM4hep < 0.99 and >= 0.99
-#if __has_include(<edm4hep/TrackerHit3DCollection.h>)
-#include <edm4hep/TrackerHit3DCollection.h>
-#else
-#include <edm4hep/TrackerHitCollection.h>
-namespace edm4hep {
-using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}
-#endif
+#include <edm4hep/TrackerHitPlane.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
+#include <podio/Frame.h>
 
 namespace ActsExamples {
 

--- a/Examples/Io/EDM4hep/src/EDM4hepMeasurementWriter.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepMeasurementWriter.cpp
@@ -18,6 +18,17 @@
 
 #include <podio/Frame.h>
 
+// Compatibility with EDM4hep < 0.99 and >= 0.99
+#if __has_include(<edm4hep/TrackerHit3DCollection.h>)
+#include <edm4hep/TrackerHit3DCollection.h>
+#else
+#include <edm4hep/TrackerHitCollection.h>
+namespace edm4hep {
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}
+#endif
+#include <edm4hep/TrackerHitPlaneCollection.h>
+
 namespace ActsExamples {
 
 EDM4hepMeasurementWriter::EDM4hepMeasurementWriter(
@@ -44,7 +55,7 @@ ActsExamples::ProcessCode EDM4hepMeasurementWriter::writeT(
   podio::Frame frame;
 
   edm4hep::TrackerHitPlaneCollection hitsPlane;
-  edm4hep::TrackerHitCollection hits;
+  edm4hep::TrackerHit3DCollection hits;
 
   if (!m_cfg.inputClusters.empty()) {
     ACTS_VERBOSE("Fetch clusters for writing: " << m_cfg.inputClusters);

--- a/Examples/Io/EDM4hep/src/EDM4hepReader.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepReader.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepDetectorElement.hpp"
+#include "Acts/Plugins/EDM4hep/EDM4hepUtil.hpp"
 #include "ActsExamples/DD4hepDetector/DD4hepDetector.hpp"
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
@@ -305,8 +306,9 @@ ProcessCode EDM4hepReader::read(const AlgorithmContext& ctx) {
       auto simHit = EDM4hepUtil::readSimHit(
           hit,
           [&](const auto& inParticle) {
-            ACTS_VERBOSE("SimHit has source particle: "
-                         << hit.getMCParticle().getObjectID().index);
+            ACTS_VERBOSE(
+                "SimHit has source particle: "
+                << Acts::EDM4hepUtil::getParticle(hit).getObjectID().index);
             auto it = edm4hepParticleMap.find(inParticle.getObjectID().index);
             if (it == edm4hepParticleMap.end()) {
               ACTS_ERROR(

--- a/Plugins/EDM4hep/include/Acts/Plugins/EDM4hep/EDM4hepUtil.hpp
+++ b/Plugins/EDM4hep/include/Acts/Plugins/EDM4hep/EDM4hepUtil.hpp
@@ -26,10 +26,12 @@
 
 #include <Eigen/src/Core/util/Memory.h>
 #include <boost/graph/graph_traits.hpp>
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/MutableSimTrackerHit.h>
+#include <edm4hep/MutableTrack.h>
+#include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/Track.h>
 #include <edm4hep/TrackState.h>
-
-#include "edm4hep/MutableTrack.h"
 
 namespace Acts::EDM4hepUtil {
 
@@ -60,6 +62,12 @@ BoundTrackParameters convertTrackParametersFromEdm4hep(
     double Bz, const Parameters& params);
 
 }  // namespace detail
+
+// Compatibility with EDM4hep < 0.99 and >= 0.99
+edm4hep::MCParticle getParticle(const edm4hep::SimTrackerHit& hit);
+
+void setParticle(edm4hep::MutableSimTrackerHit& hit,
+                 const edm4hep::MCParticle& particle);
 
 template <TrackProxyConcept track_proxy_t>
 void writeTrack(const Acts::GeometryContext& gctx, track_proxy_t track,

--- a/Plugins/EDM4hep/include/Acts/Plugins/EDM4hep/TrackerHitCompatibility.hpp
+++ b/Plugins/EDM4hep/include/Acts/Plugins/EDM4hep/TrackerHitCompatibility.hpp
@@ -1,0 +1,22 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+// Compatibility with EDM4hep < 0.99 and >= 0.99
+#if __has_include(<edm4hep/TrackerHit3D.h>)
+#include "edm4hep/TrackerHit3D.h"
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHit.h"
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+using TrackerHit3D = edm4hep::TrackerHit;
+}  // namespace edm4hep
+#endif

--- a/Plugins/EDM4hep/src/EDM4hepUtil.cpp
+++ b/Plugins/EDM4hep/src/EDM4hepUtil.cpp
@@ -18,7 +18,11 @@
 
 #include <numbers>
 
-#include "edm4hep/TrackState.h"
+#include <edm4hep/EDM4hepVersion.h>
+#include <edm4hep/MCParticle.h>
+#include <edm4hep/MutableSimTrackerHit.h>
+#include <edm4hep/SimTrackerHit.h>
+#include <edm4hep/TrackState.h>
 
 namespace Acts::EDM4hepUtil::detail {
 
@@ -184,5 +188,26 @@ BoundTrackParameters convertTrackParametersFromEdm4hep(
 
   return {params.surface, targetPars, cov, params.particleHypothesis};
 }
+
+#if EDM4HEP_VERSION_MAJOR >= 1 || \
+    (EDM4HEP_VERSION_MAJOR == 0 && EDM4HEP_VERSION_MINOR == 99)
+edm4hep::MCParticle getParticle(const edm4hep::SimTrackerHit& hit) {
+  return hit.getParticle();
+}
+
+void setParticle(edm4hep::MutableSimTrackerHit& hit,
+                 const edm4hep::MCParticle& particle) {
+  hit.setParticle(particle);
+}
+#else
+edm4hep::MCParticle getParticle(const edm4hep::SimTrackerHit& hit) {
+  return hit.getMCParticle();
+}
+
+void setParticle(edm4hep::MutableSimTrackerHit& hit,
+                 const edm4hep::MCParticle& particle) {
+  hit.setMCParticle(particle);
+}
+#endif
 
 }  // namespace Acts::EDM4hepUtil::detail

--- a/Plugins/EDM4hep/src/EDM4hepUtil.cpp
+++ b/Plugins/EDM4hep/src/EDM4hepUtil.cpp
@@ -24,7 +24,8 @@
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/TrackState.h>
 
-namespace Acts::EDM4hepUtil::detail {
+namespace Acts::EDM4hepUtil {
+namespace detail {
 
 ActsSquareMatrix<6> jacobianToEdm4hep(double theta, double qOverP, double Bz) {
   // Calculate jacobian from our internal parametrization (d0, z0, phi, theta,
@@ -189,6 +190,8 @@ BoundTrackParameters convertTrackParametersFromEdm4hep(
   return {params.surface, targetPars, cov, params.particleHypothesis};
 }
 
+}  // namespace detail
+
 #if EDM4HEP_VERSION_MAJOR >= 1 || \
     (EDM4HEP_VERSION_MAJOR == 0 && EDM4HEP_VERSION_MINOR == 99)
 edm4hep::MCParticle getParticle(const edm4hep::SimTrackerHit& hit) {
@@ -210,4 +213,4 @@ void setParticle(edm4hep::MutableSimTrackerHit& hit,
 }
 #endif
 
-}  // namespace Acts::EDM4hepUtil::detail
+}  // namespace Acts::EDM4hepUtil


### PR DESCRIPTION
This updates our code so it compiles with both EDM4hep versions below `0.99` and above/equal to `0.99`.

Breaking changes are:

- `TrackerHit` becomes `TrackerHit3D`.
- `SimTrackerHit::getMCParticle` becomes `SimTrackerHit::getParticle`, with the original name being deprecated.

I'm aliasing the new name `TrackerHit3D` and `TrackerHit3DCollection` to the old types, so that when we drop support for < `0.99` versions, they're already correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced compatibility with different versions of the EDM4hep library for particle handling.
  - Introduced utility functions for retrieving and setting particle information in `SimTrackerHit` objects.
  - Added type aliases to streamline the handling of tracker hit collections.

- **Bug Fixes**
  - Improved error handling in the `EDM4hepReader` for missing particles.

- **Refactor**
  - Updated function signatures and internal logic to utilize new utility functions for better maintainability.
  - Streamlined the `EDM4hepMeasurementWriter` and `EDM4hepMeasurementReader` to accommodate new data structures.
  - Adjusted header inclusions and conditional compilation for better flexibility.

- **Documentation**
  - Added comments to indicate changes in parameter handling for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->