### PR TITLE
fix: Explicitly disable paging in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
     - id: leftover_conflict_markers
       name: Leftover conflict markers
       language: system
-      entry: git diff --staged --check
+      entry: git --no-pager diff --staged --check
 
   - repo: local
     hooks:


### PR DESCRIPTION
The pre-commit hook that checks for leftover conflict markers introduced in #3708 calls git diff. While this works well in general, I am running into an edge case where git is failing to determine that it is not being run in a TTY, causing it to fire up a pager which, in turn, causes pre-commit to hang as it waits for the pager to close. This commit fixes this issue by adding the `--no-pager` flag to the git command.