### PR TITLE
fix: Add hit count in root dump reader

### DIFF
--- a/Examples/Io/Root/src/RootAthenaDumpReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaDumpReader.cpp
@@ -672,6 +672,7 @@ RootAthenaDumpReader::reprocessParticles(
     }
 
     auto newParticle = particle.withParticleId(fatrasBarcode);
+    newParticle.final().setNumberOfHits(std::distance(begin, end));
     newParticles.push_back(newParticle);
 
     for (auto it = begin; it != end; ++it) {


### PR DESCRIPTION
Adds hit count information to particles read from the `RootAthenaDumpReader`. Even though simhits != measurements strictely speaking, in that scenario it is ok to assume this I think.