### PR TITLE
refactor: avoid `addWhiteboardAlias` in truth tracking examples

### DIFF
--- a/Examples/Scripts/Python/truth_tracking_gsf.py
+++ b/Examples/Scripts/Python/truth_tracking_gsf.py
@@ -119,12 +119,11 @@ def runTruthTrackingGsf(
             ),
         )
     )
-    s.addWhiteboardAlias("tracks", "selected-tracks")
 
     s.addWriter(
         acts.examples.RootTrackStatesWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             inputSimHits="simhits",
@@ -136,7 +135,7 @@ def runTruthTrackingGsf(
     s.addWriter(
         acts.examples.RootTrackSummaryWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "tracksummary_gsf.root"),
@@ -147,7 +146,7 @@ def runTruthTrackingGsf(
     s.addWriter(
         acts.examples.TrackFitterPerformanceWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "performance_gsf.root"),

--- a/Examples/Scripts/Python/truth_tracking_gx2f.py
+++ b/Examples/Scripts/Python/truth_tracking_gx2f.py
@@ -119,12 +119,11 @@ def runTruthTrackingGx2f(
             ),
         )
     )
-    s.addWhiteboardAlias("tracks", "selected-tracks")
 
     s.addWriter(
         acts.examples.RootTrackStatesWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             inputSimHits="simhits",
@@ -136,7 +135,7 @@ def runTruthTrackingGx2f(
     s.addWriter(
         acts.examples.RootTrackSummaryWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "tracksummary_gx2f.root"),
@@ -147,7 +146,7 @@ def runTruthTrackingGx2f(
     s.addWriter(
         acts.examples.TrackFitterPerformanceWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "performance_gx2f.root"),

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -73,7 +73,6 @@ def runTruthTrackingKalman(
                 outputParticles="particles_input",
             )
         )
-        s.addWhiteboardAlias("particles", "particles_input")
 
     if inputHitsPath is None:
         addFatras(
@@ -136,12 +135,11 @@ def runTruthTrackingKalman(
             ),
         )
     )
-    s.addWhiteboardAlias("tracks", "selected-tracks")
 
     s.addWriter(
         acts.examples.RootTrackStatesWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             inputSimHits="simhits",
@@ -153,7 +151,7 @@ def runTruthTrackingKalman(
     s.addWriter(
         acts.examples.RootTrackSummaryWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "tracksummary_kf.root"),
@@ -163,7 +161,7 @@ def runTruthTrackingKalman(
     s.addWriter(
         acts.examples.TrackFitterPerformanceWriter(
             level=acts.logging.INFO,
-            inputTracks="tracks",
+            inputTracks="selected-tracks",
             inputParticles="particles_selected",
             inputTrackParticleMatching="track_particle_matching",
             filePath=str(outputDir / "performance_kf.root"),


### PR DESCRIPTION
The aliases might be confusing in these examples, since they are redefining previously used names. This might be a bit clearer, which objects are used and makes it hopefully easier to understand the examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated handling of track data to use "selected-tracks" across various output writers for improved clarity and consistency in data processing.
  
- **Bug Fixes**
	- Removed unnecessary whiteboard aliases to streamline the data flow in tracking functions.

- **Documentation**
	- Method signatures updated for clarity, though core functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->