### PR TITLE
fix: Test and fix broken `TrackHelpers` for chi2 and unbiased track state

### DIFF
--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -517,10 +517,11 @@ calculatePredictedResidual(track_state_proxy_t trackState) {
   }
 
   auto subspaceHelper =
-      trackState.template fixedBoundSubspaceHelper<nMeasurementDim>();
+      trackState.template projectorSubspaceHelper<nMeasurementDim>();
 
-  auto measurement = trackState.calibrated();
-  auto measurementCovariance = trackState.calibratedCovariance();
+  auto measurement = trackState.template calibrated<nMeasurementDim>();
+  auto measurementCovariance =
+      trackState.template calibratedCovariance<nMeasurementDim>();
   MeasurementVector predicted =
       subspaceHelper.projectVector(trackState.predicted());
   MeasurementMatrix predictedCovariance =
@@ -553,10 +554,11 @@ calculateFilteredResidual(track_state_proxy_t trackState) {
   }
 
   auto subspaceHelper =
-      trackState.template fixedBoundSubspaceHelper<nMeasurementDim>();
+      trackState.template projectorSubspaceHelper<nMeasurementDim>();
 
-  auto measurement = trackState.calibrated();
-  auto measurementCovariance = trackState.calibratedCovariance();
+  auto measurement = trackState.template calibrated<nMeasurementDim>();
+  auto measurementCovariance =
+      trackState.template calibratedCovariance<nMeasurementDim>();
   MeasurementVector filtered =
       subspaceHelper.projectVector(trackState.filtered());
   MeasurementMatrix filteredCovariance =
@@ -589,10 +591,11 @@ calculateSmoothedResidual(track_state_proxy_t trackState) {
   }
 
   auto subspaceHelper =
-      trackState.template fixedBoundSubspaceHelper<nMeasurementDim>();
+      trackState.template projectorSubspaceHelper<nMeasurementDim>();
 
-  auto measurement = trackState.calibrated();
-  auto measurementCovariance = trackState.calibratedCovariance();
+  auto measurement = trackState.template calibrated<nMeasurementDim>();
+  auto measurementCovariance =
+      trackState.template calibratedCovariance<nMeasurementDim>();
   MeasurementVector smoothed =
       subspaceHelper.projectVector(trackState.smoothed());
   MeasurementMatrix smoothedCovariance =
@@ -620,11 +623,13 @@ double calculatePredictedChi2(track_state_proxy_t trackState) {
 
   return visit_measurement(
       trackState.calibratedSize(),
-      [&]<std::size_t measdim>(std::integral_constant<std::size_t, measdim>) {
+      [&]<std::size_t measdim>(
+          std::integral_constant<std::size_t, measdim>) -> double {
         auto [residual, residualCovariance] =
             calculatePredictedResidual<measdim>(trackState);
 
-        return residual.transpose() * residualCovariance.inverse() * residual;
+        return (residual.transpose() * residualCovariance.inverse() * residual)
+            .eval()(0, 0);
       });
 }
 
@@ -643,11 +648,13 @@ double calculateFilteredChi2(track_state_proxy_t trackState) {
 
   return visit_measurement(
       trackState.calibratedSize(),
-      [&]<std::size_t measdim>(std::integral_constant<std::size_t, measdim>) {
+      [&]<std::size_t measdim>(
+          std::integral_constant<std::size_t, measdim>) -> double {
         auto [residual, residualCovariance] =
             calculateFilteredResidual<measdim>(trackState);
 
-        return residual.transpose() * residualCovariance.inverse() * residual;
+        return (residual.transpose() * residualCovariance.inverse() * residual)
+            .eval()(0, 0);
       });
 }
 
@@ -666,11 +673,13 @@ double calculateSmoothedChi2(track_state_proxy_t trackState) {
 
   return visit_measurement(
       trackState.calibratedSize(),
-      [&]<std::size_t measdim>(std::integral_constant<std::size_t, measdim>) {
+      [&]<std::size_t measdim>(
+          std::integral_constant<std::size_t, measdim>) -> double {
         auto [residual, residualCovariance] =
             calculateSmoothedResidual<measdim>(trackState);
 
-        return residual.transpose() * residualCovariance.inverse() * residual;
+        return (residual.transpose() * residualCovariance.inverse() * residual)
+            .eval()(0, 0);
       });
 }
 

--- a/Tests/UnitTests/Core/Utilities/TrackHelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TrackHelpersTests.cpp
@@ -8,14 +8,13 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/TrackContainer.hpp"
 #include "Acts/EventData/TrackStateType.hpp"
 #include "Acts/EventData/VectorMultiTrajectory.hpp"
 #include "Acts/EventData/VectorTrackContainer.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/TrackHelpers.hpp"
-
-#include <memory>
-#include <span>
 
 namespace Acts::Test {
 
@@ -33,6 +32,33 @@ auto createTestTrack(TrackContainer& tc, const FlagsPerState& flagsPerState) {
   }
 
   return t;
+}
+
+template <typename TrackContainer>
+auto createTestTrackState(TrackContainer& tc) {
+  auto t = tc.makeTrack();
+
+  auto ts = t.appendTrackState();
+
+  ts.allocateCalibrated(Vector2::Zero(), SquareMatrix2::Identity());
+  ts.setProjectorSubspaceIndices(std::array{eBoundLoc0, eBoundLoc1});
+
+  ts.predicted() = BoundVector::Zero();
+  ts.predicted()[eBoundLoc0] = 1.;
+  ts.predicted()[eBoundLoc1] = 1.;
+  ts.predictedCovariance() = BoundMatrix::Identity() * 1.;
+
+  ts.filtered() = BoundVector::Zero();
+  ts.filtered()[eBoundLoc0] = 0.5;
+  ts.filtered()[eBoundLoc1] = 0.5;
+  ts.filteredCovariance() = BoundMatrix::Identity() * 0.5;
+
+  ts.smoothed() = BoundVector::Zero();
+  ts.smoothed()[eBoundLoc0] = 0.1;
+  ts.smoothed()[eBoundLoc1] = 0.1;
+  ts.smoothedCovariance() = BoundMatrix::Identity() * 0.1;
+
+  return ts;
 }
 
 }  // namespace
@@ -104,6 +130,48 @@ BOOST_AUTO_TEST_CASE(TrimTrack) {
   BOOST_CHECK_EQUAL(t.nMeasurements(), 3);
   BOOST_CHECK_EQUAL(t.nOutliers(), 2);
   BOOST_CHECK_EQUAL(t.nSharedHits(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(CalculatePredictedChi2) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  auto ts = createTestTrackState(tc);
+
+  // reference found by running the code
+  BOOST_CHECK_CLOSE(calculatePredictedChi2(ts), 1., 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(CalculateFilteredChi2) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  auto ts = createTestTrackState(tc);
+
+  // reference found by running the code
+  BOOST_CHECK_CLOSE(calculateFilteredChi2(ts), 1. / 3., 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(CalculateSmoothedChi2) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  auto ts = createTestTrackState(tc);
+
+  // reference found by running the code
+  BOOST_CHECK_CLOSE(calculateSmoothedChi2(ts), 1. / 55., 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(CalculateUnbiasedParametersCovariance) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  auto ts = createTestTrackState(tc);
+
+  auto [params, cov] = calculateUnbiasedParametersCovariance(ts);
+
+  // reference found by running the code
+  BoundVector refParams = BoundVector::Zero();
+  refParams[eBoundLoc0] = 1. / 9.;
+  refParams[eBoundLoc1] = 1. / 9.;
+  BoundMatrix refCov = BoundMatrix::Identity() * 0.1;
+  refCov(eBoundLoc0, eBoundLoc0) = 1. / 9.;
+  refCov(eBoundLoc1, eBoundLoc1) = 1. / 9.;
+
+  CHECK_CLOSE_ABS(params, refParams, 1e-6);
+  CHECK_CLOSE_ABS(cov, refCov, 1e-6);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
New helper functions for chi2 and unbiased track states slipped in untested with https://github.com/acts-project/acts/pull/3877. Somehow I forgot to do this and the code ended up being broken in the latest release.

Here I add some quick unit tests and fix the code so it can actually be compiled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced track state calculations for improved precision in subspace projections and measurement handling.
  - Introduced a new template function for creating test track states, facilitating better testing of track-related functionalities.

- **Bug Fixes**
  - Improved type safety and clarity in chi-squared calculations.

- **Tests**
  - Added new test cases for calculating predicted, filtered, and smoothed chi-squared values, as well as unbiased parameters covariance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->