### PR TITLE
fix: oneAPI 2025 Fixes, main branch (2024.12.04.)

### DIFF
--- a/Core/include/Acts/EventData/MultiTrajectory.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectory.hpp
@@ -696,7 +696,7 @@ class MultiTrajectory {
 
     visit_measurement(measdim, [this, istate]<std::size_t DIM>(
                                    std::integral_constant<std::size_t, DIM>) {
-      self().template allocateCalibrated_impl(
+      self().allocateCalibrated_impl(
           istate, ActsVector<DIM>{ActsVector<DIM>::Zero()},
           ActsSquareMatrix<DIM>{ActsSquareMatrix<DIM>::Zero()});
     });
@@ -705,7 +705,7 @@ class MultiTrajectory {
   template <std::size_t measdim, typename val_t, typename cov_t>
   void allocateCalibrated(IndexType istate, const Eigen::DenseBase<val_t>& val,
                           const Eigen::DenseBase<cov_t>& cov) {
-    self().template allocateCalibrated_impl(istate, val, cov);
+    self().allocateCalibrated_impl(istate, val, cov);
   }
 
   void setUncalibratedSourceLink(IndexType istate, SourceLink&& sourceLink)

--- a/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
@@ -131,13 +131,13 @@ concept MutableMultiTrajectoryBackend =
       { v.template addColumn_impl<double>(col) };
 
       {
-        v.template allocateCalibrated_impl(istate, ActsVector<1>{},
-                                           ActsSquareMatrix<1>{})
+        v.allocateCalibrated_impl(istate, ActsVector<1>{},
+                                  ActsSquareMatrix<1>{})
       };
       // Assuming intermediate values also work
       {
-        v.template allocateCalibrated_impl(istate, ActsVector<eBoundSize>{},
-                                           ActsSquareMatrix<eBoundSize>{})
+        v.allocateCalibrated_impl(istate, ActsVector<eBoundSize>{},
+                                  ActsSquareMatrix<eBoundSize>{})
       };
 
       { v.setUncalibratedSourceLink_impl(istate, std::move(sl)) };

--- a/Core/include/Acts/EventData/detail/MultiTrajectoryTestsCommon.hpp
+++ b/Core/include/Acts/EventData/detail/MultiTrajectoryTestsCommon.hpp
@@ -1225,7 +1225,7 @@ class MultiTrajectoryTestsCommon {
 
     auto [par, cov] = generateBoundParametersCovariance(rng, {});
 
-    ts.template allocateCalibrated(par.head<3>(), cov.topLeftCorner<3, 3>());
+    ts.allocateCalibrated(par.head<3>(), cov.topLeftCorner<3, 3>());
 
     BOOST_CHECK_EQUAL(ts.calibratedSize(), 3);
     BOOST_CHECK_EQUAL(ts.template calibrated<3>(), par.head<3>());
@@ -1239,7 +1239,7 @@ class MultiTrajectoryTestsCommon {
     BOOST_CHECK_EQUAL(ts.template calibratedCovariance<3>(),
                       ActsSquareMatrix<3>::Zero());
 
-    ts.template allocateCalibrated(par2.head<3>(), cov2.topLeftCorner<3, 3>());
+    ts.allocateCalibrated(par2.head<3>(), cov2.topLeftCorner<3, 3>());
     BOOST_CHECK_EQUAL(ts.calibratedSize(), 3);
     // The values are re-assigned
     BOOST_CHECK_EQUAL(ts.template calibrated<3>(), par2.head<3>());
@@ -1247,9 +1247,9 @@ class MultiTrajectoryTestsCommon {
                       (cov2.topLeftCorner<3, 3>()));
 
     // Re-allocation with a different measurement dimension is an error
-    BOOST_CHECK_THROW(ts.template allocateCalibrated(
-                          par2.head<4>(), cov2.topLeftCorner<4, 4>()),
-                      std::invalid_argument);
+    BOOST_CHECK_THROW(
+        ts.allocateCalibrated(par2.head<4>(), cov2.topLeftCorner<4, 4>()),
+        std::invalid_argument);
   }
 };
 }  // namespace Acts::detail::Test


### PR DESCRIPTION
This is a twin of #3846. Unfortunately between that PR going in and [v38.0.0](https://github.com/acts-project/acts/releases/tag/v38.0.0) being made, some more errors of the same kind went in. This is meant to fix those.

--- END COMMIT MESSAGE ---

@paulgessinger, could we add a CI build with the latest clang version? That would pick up on these issues as well. We don't need oneAPI itself for catching these. :thinking:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified method invocation syntax by removing the `template` keyword from `allocateCalibrated` and `allocateCalibrated_impl` calls, enhancing readability without altering functionality.
- **Tests**
	- Updated test cases to reflect the syntax change in method calls while preserving existing validation logic and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->