### PR TITLE
feat: move spline to helper in Visualization

### DIFF
--- a/Core/include/Acts/Visualization/Interpolation3D.hpp
+++ b/Core/include/Acts/Visualization/Interpolation3D.hpp
@@ -27,6 +27,10 @@ std::vector<Acts::Vector3> spline(const std::vector<input_vector_type>& inputs,
                                   std::size_t nPoints) {
   std::vector<Acts::Vector3> output;
 
+  if (inputs.empty()) {
+    return output;
+  }
+
   if (nPoints < 2) {
     // No interpolation done return simply the output vector
     for (const auto& input : inputs) {

--- a/Core/include/Acts/Visualization/Interpolation3D.hpp
+++ b/Core/include/Acts/Visualization/Interpolation3D.hpp
@@ -6,7 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#pragma once
+
 #include "Acts/Definitions/Algebra.hpp"
+
 #include <unsupported/Eigen/Splines>
 
 namespace Acts::Interpolation3D {
@@ -20,8 +23,8 @@ namespace Acts::Interpolation3D {
 ///
 /// @return std::vector<Acts::Vector3> interpolated points
 template <typename input_vector_type>
-std::vector<Acts::Vector3> spline(
-    const std::vector<input_vector_type>& inputs, std::size_t nPoints) {
+std::vector<Acts::Vector3> spline(const std::vector<input_vector_type>& inputs,
+                                  std::size_t nPoints) {
   std::vector<Acts::Vector3> output;
 
   if (nPoints < 2) {

--- a/Core/include/Acts/Visualization/Interpolation3D.hpp
+++ b/Core/include/Acts/Visualization/Interpolation3D.hpp
@@ -1,0 +1,50 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Definitions/Algebra.hpp"
+#include <unsupported/Eigen/Splines>
+
+namespace Acts::Interpolation3D {
+
+/// @brief Helper function to interpolate points using a spline
+/// from Eigen
+///
+/// @tparam input_vector_type
+/// @param inputs input vector points
+/// @param nPoints number of interpolation points
+///
+/// @return std::vector<Acts::Vector3> interpolated points
+template <typename input_vector_type>
+std::vector<Acts::Vector3> spline(
+    const std::vector<input_vector_type>& inputs, std::size_t nPoints) {
+  std::vector<Acts::Vector3> output;
+
+  if (nPoints < 2) {
+    // No interpolation done return simply the output vector
+    for (const auto& input : inputs) {
+      output.push_back(input.template head<3>());
+    }
+
+  } else {
+    Eigen::MatrixXd points(3, inputs.size());
+    for (std::size_t i = 0; i < inputs.size(); ++i) {
+      points.col(i) = inputs[i].template head<3>().transpose();
+    }
+    Eigen::Spline<double, 3> spline3D =
+        Eigen::SplineFitting<Eigen::Spline<double, 3>>::Interpolate(points, 2);
+
+    double step = 1. / (nPoints - 1);
+    for (std::size_t i = 0; i < nPoints; ++i) {
+      double t = i * step;
+      output.push_back(spline3D(t));
+    }
+  }
+  return output;
+}
+
+}  // namespace Acts::Interpolation3D

--- a/Examples/Io/Obj/include/ActsExamples/Io/Obj/ObjSimHitWriter.hpp
+++ b/Examples/Io/Obj/include/ActsExamples/Io/Obj/ObjSimHitWriter.hpp
@@ -32,6 +32,9 @@ struct AlgorithmContext;
 ///     event000000002-<stem>.obj
 ///     event000000002-<stem>_trajectory.obj
 ///
+///
+/// The trajectory can be smoothed using a spline interpolation, where
+/// nInterpolatedPoints points are added between each hit.
 class ObjSimHitWriter : public WriterT<SimHitContainer> {
  public:
   struct Config {
@@ -49,8 +52,9 @@ class ObjSimHitWriter : public WriterT<SimHitContainer> {
     double momentumThreshold = 0.05 * Acts::UnitConstants::GeV;
     /// Momentum threshold for trajectories
     double momentumThresholdTraj = 0.05 * Acts::UnitConstants::GeV;
-    /// Number of points to interpolate between hits
-    std::size_t nInterpolatedPoints = 10;
+    /// Number of points to interpolated between hits to smooth the
+    /// trajectory view in the obj file.
+    std::size_t nInterpolatedPoints = 4;
   };
 
   /// Construct the particle writer.

--- a/Examples/Io/Obj/include/ActsExamples/Io/Obj/ObjSimHitWriter.hpp
+++ b/Examples/Io/Obj/include/ActsExamples/Io/Obj/ObjSimHitWriter.hpp
@@ -55,6 +55,8 @@ class ObjSimHitWriter : public WriterT<SimHitContainer> {
     /// Number of points to interpolated between hits to smooth the
     /// trajectory view in the obj file.
     std::size_t nInterpolatedPoints = 4;
+    /// Keep the original hits in the trajectory file
+    bool keepOriginalHits = false;
   };
 
   /// Construct the particle writer.

--- a/Examples/Io/Obj/src/ObjSimHitWriter.cpp
+++ b/Examples/Io/Obj/src/ObjSimHitWriter.cpp
@@ -112,15 +112,18 @@ ActsExamples::ProcessCode ActsExamples::ObjSimHitWriter::writeT(
       }
       osHits << '\n';
 
-      // Interpolate the points
+      // Interpolate the points, a minimum number of 3 hits is necessary for
+      // that
       std::vector<Acts::Vector3> trajectory;
-      if (pHits.size() < 3) {
+      if (pHits.size() < 3 || m_cfg.nInterpolatedPoints == 0) {
         for (const auto& hit : pHits) {
           trajectory.push_back(hit.template head<3>());
         }
       } else {
+        // The total number of points is the number of hits times the number of
+        // interpolated points plus the number of hits
         trajectory = Acts::Interpolation3D::spline(
-            pHits, pHits.size() * m_cfg.nInterpolatedPoints);
+            pHits, pHits.size() * (m_cfg.nInterpolatedPoints + 1) - 1);
       }
 
       osTrajectory << "o particle_trajectory_" << pId << std::endl;

--- a/Examples/Io/Obj/src/ObjSimHitWriter.cpp
+++ b/Examples/Io/Obj/src/ObjSimHitWriter.cpp
@@ -114,16 +114,15 @@ ActsExamples::ProcessCode ActsExamples::ObjSimHitWriter::writeT(
 
       // Interpolate the points, a minimum number of 3 hits is necessary for
       // that
-      std::vector<Acts::Vector3> trajectory;
+      std::vector<Acts::Vector4> trajectory;
       if (pHits.size() < 3 || m_cfg.nInterpolatedPoints == 0) {
-        for (const auto& hit : pHits) {
-          trajectory.push_back(hit.template head<3>());
-        }
+        trajectory = pHits;
       } else {
         // The total number of points is the number of hits times the number of
         // interpolated points plus the number of hits
         trajectory = Acts::Interpolation3D::spline(
-            pHits, pHits.size() * (m_cfg.nInterpolatedPoints + 1) - 1);
+            pHits, pHits.size() * (m_cfg.nInterpolatedPoints + 1) - 1,
+            m_cfg.keepOriginalHits);
       }
 
       osTrajectory << "o particle_trajectory_" << pId << std::endl;

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -114,7 +114,9 @@ void addOutput(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_WRITER(ActsExamples::ObjSimHitWriter, mex,
                              "ObjSimHitWriter", inputSimHits, outputDir,
-                             outputStem, outputPrecision, drawConnections);
+                             outputStem, outputPrecision, drawConnections,
+                             momentumThreshold, momentumThresholdTraj,
+                             nInterpolatedPoints, keepOriginalHits);
 
   {
     auto c = py::class_<ViewConfig>(m, "ViewConfig").def(py::init<>());

--- a/Tests/UnitTests/Core/Visualization/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Visualization/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unittest(Visualization3D Visualization3DTests.cpp)
 add_unittest(EventDataView3D EventDataView3DTests.cpp)
+add_unittest(Interpolation3D Interpolation3DTests.cpp)
 add_unittest(PrimitivesView3D PrimitivesView3DTests.cpp)
 add_unittest(SurfaceView3D SurfaceView3DTests.cpp)
 add_unittest(TrackingGeometryView3D TrackingGeometryView3DTests.cpp)

--- a/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
@@ -73,6 +73,20 @@ BOOST_AUTO_TEST_CASE(SplineInterpolationArray) {
   BOOST_CHECK_EQUAL(trajectory.size(), 108);
 }
 
+BOOST_AUTO_TEST_CASE(SplineInterpolationErrors) {
+  std::vector<std::array<double, 3u>> inputs;
+  
+  // Test with single point
+  inputs.push_back({0., 0., 0.});
+  auto result = Acts::Interpolation3D::spline(inputs, 10);
+  BOOST_CHECK_EQUAL(result.size(), 1);
+  
+  // Test with two points
+  inputs.push_back({1., 1., 1.});
+  result = Acts::Interpolation3D::spline(inputs, 10);
+  BOOST_CHECK_EQUAL(result.size(), 2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace Acts::Test

--- a/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
@@ -7,43 +7,50 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <boost/test/unit_test.hpp>
-#include <numbers>
 
-#include "Acts/Visualization/Interpolation3D.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+#include "Acts/Visualization/Interpolation3D.hpp"
+
+#include <numbers>
 
 namespace Acts::Test {
 
 BOOST_AUTO_TEST_SUITE(Visualization)
 
 BOOST_AUTO_TEST_CASE(SplineInterpolation) {
+  /// Define the input vector
+  double R = 10.;
+  std::vector<Acts::Vector3> inputs;
 
-    /// Define the input vector
-    double R = 10.;
-    std::vector<Acts::Vector3> inputs;
-    for (double phi = 0; phi < 2 * std::numbers::pi; phi += std::numbers::pi / 4) {
-        inputs.push_back(Acts::Vector3(R * cos(phi), R * sin(phi), 0.));
-    }
+  // Interpolate the points options
+  std::vector<Acts::Vector3> trajectory;
 
-    // Interpolate the points options
-    std::vector<Acts::Vector3> trajectory;
+  // Empty in empty out check
+  trajectory = Acts::Interpolation3D::spline(inputs, 10);
+  BOOST_CHECK(trajectory.empty());
 
-    // (0) - nothing happens
-    trajectory = Acts::Interpolation3D::spline(inputs, 1);
-    // Check input and output size are the same
-    BOOST_CHECK_EQUAL(trajectory.size(), inputs.size());
+  for (double phi = 0; phi < 2 * std::numbers::pi;
+       phi += std::numbers::pi / 4) {
+    inputs.push_back(Acts::Vector3(R * cos(phi), R * sin(phi), 0.));
+  }
 
-    // (1) - interpolate between the points with 12 points in total
-    trajectory = Acts::Interpolation3D::spline(inputs, 12);
-    // Check the output size is correct
-    BOOST_CHECK_EQUAL(trajectory.size(), 12);
+  // (0) - nothing happens
+  trajectory = Acts::Interpolation3D::spline(inputs, 1);
+  // Check input and output size are the same
+  BOOST_CHECK_EQUAL(trajectory.size(), inputs.size());
 
-    for (const auto& point : trajectory) {
-        // Check the interpolated points are on the circle
-        // with a tolerance of course
-        CHECK_CLOSE_ABS(point.norm(), R, 0.1);
-    }
+  // (1) - interpolate between the points with 12 points in total
+  trajectory = Acts::Interpolation3D::spline(inputs, 12);
+  // Check the output size is correct
+  BOOST_CHECK_EQUAL(trajectory.size(), 12);
 
+  for (const auto& point : trajectory) {
+    // Check the interpolated points are on the circle
+    // with a tolerance of course
+    CHECK_CLOSE_ABS(point.norm(), R, 0.1);
+    // Verify points remain in the XY plane
+    CHECK_CLOSE_ABS(point.z(), 0., 0.1);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
@@ -17,7 +17,7 @@ namespace Acts::Test {
 
 BOOST_AUTO_TEST_SUITE(Visualization)
 
-BOOST_AUTO_TEST_CASE(SplineInterpolation) {
+BOOST_AUTO_TEST_CASE(SplineInterpolationEigen) {
   /// Define the input vector
   double R = 10.;
   std::vector<Acts::Vector3> inputs;
@@ -51,6 +51,26 @@ BOOST_AUTO_TEST_CASE(SplineInterpolation) {
     // Verify points remain in the XY plane
     CHECK_CLOSE_ABS(point.z(), 0., 0.1);
   }
+}
+
+BOOST_AUTO_TEST_CASE(SplineInterpolationArray) {
+  /// Define the input vector
+  std::vector<std::array<double, 3u>> inputs;
+
+  for (double x = 0; x < 10; x += 1) {
+    inputs.push_back({x, x * x, 0.});
+  }
+
+  // This time we keep the original hits
+  auto trajectory = Acts::Interpolation3D::spline(inputs, 100, true);
+
+  // Check the outpu type is correct
+  constexpr bool isOutput =
+      std::is_same_v<decltype(trajectory), decltype(inputs)>;
+  BOOST_CHECK(isOutput);
+
+  // Check the output size is correct
+  BOOST_CHECK_EQUAL(trajectory.size(), 108);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
@@ -1,0 +1,51 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+#include <numbers>
+
+#include "Acts/Visualization/Interpolation3D.hpp"
+#include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
+
+namespace Acts::Test {
+
+BOOST_AUTO_TEST_SUITE(Visualization)
+
+BOOST_AUTO_TEST_CASE(SplineInterpolation) {
+
+    /// Define the input vector
+    double R = 10.;
+    std::vector<Acts::Vector3> inputs;
+    for (double phi = 0; phi < 2 * std::numbers::pi; phi += std::numbers::pi / 4) {
+        inputs.push_back(Acts::Vector3(R * cos(phi), R * sin(phi), 0.));
+    }
+
+    // Interpolate the points options
+    std::vector<Acts::Vector3> trajectory;
+
+    // (0) - nothing happens
+    trajectory = Acts::Interpolation3D::spline(inputs, 1);
+    // Check input and output size are the same
+    BOOST_CHECK_EQUAL(trajectory.size(), inputs.size());
+
+    // (1) - interpolate between the points with 12 points in total
+    trajectory = Acts::Interpolation3D::spline(inputs, 12);
+    // Check the output size is correct
+    BOOST_CHECK_EQUAL(trajectory.size(), 12);
+
+    for (const auto& point : trajectory) {
+        // Check the interpolated points are on the circle
+        // with a tolerance of course
+        CHECK_CLOSE_ABS(point.norm(), R, 0.1);
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace Acts::Test

--- a/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/Interpolation3DTests.cpp
@@ -75,12 +75,12 @@ BOOST_AUTO_TEST_CASE(SplineInterpolationArray) {
 
 BOOST_AUTO_TEST_CASE(SplineInterpolationErrors) {
   std::vector<std::array<double, 3u>> inputs;
-  
+
   // Test with single point
   inputs.push_back({0., 0., 0.});
   auto result = Acts::Interpolation3D::spline(inputs, 10);
   BOOST_CHECK_EQUAL(result.size(), 1);
-  
+
   // Test with two points
   inputs.push_back({1., 1., 1.});
   result = Acts::Interpolation3D::spline(inputs, 10);


### PR DESCRIPTION
This PR moves the spline-interpolation from `Examples/Plugins/Obj` to `Core/Visualization` because it can be used in other visualisation areas as well.

I've added also a UnitTest since this is from some `experimetnal/usupported` Eigen directory, but it works nicely!

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new interpolation method for 3D points using splines, enhancing the accuracy of data representation.
	- Expanded configurability of the `ObjSimHitWriter` with new parameters for trajectory smoothing and original hit retention.
	- Added unit tests for the new interpolation functionality to ensure reliability.

- **Bug Fixes**
	- Streamlined the interpolation process by replacing the previous method with a more efficient library function, improving maintainability.

- **Documentation**
	- Enhanced documentation for configuration parameters in the `ObjSimHitWriter` class, clarifying their purpose and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


![snapshot01](https://github.com/user-attachments/assets/9c2a2b64-dab0-43d3-ab8a-935471249a36)

