### PR TITLE
fix: Checkout branch in ExaTrk CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -155,7 +155,10 @@ test_exatrkx_unittests:
 
     - apt-get update -y
     - git clone $CLONE_URL src
-    - source src/CI/dependencies.sh
+    - cd src
+    - git checkout $HEAD_SHA
+    - source CI/dependencies.sh
+    - cd ..
     - ctest --test-dir build -R ExaTrkX
 
 test_exatrkx_python:


### PR DESCRIPTION
Currently, the ExaTrk CI is trying to run a dependency script before having properly checked out the right branch, possible causing a CI error. This commit ensures that the target branch is properly checked out before trying to use any files in the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved CI/CD pipeline configuration for better build and test job management.
	- Standardized caching mechanisms and dependency handling across jobs.
	- Enhanced clarity and maintainability of the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->