### PR TITLE
feat: Make TransformRange fulfill range concept

### DIFF
--- a/Core/include/Acts/Utilities/TransformRange.hpp
+++ b/Core/include/Acts/Utilities/TransformRange.hpp
@@ -169,6 +169,8 @@ struct TransformRangeIterator {
   /// Construct an iterator from an underlying iterator
   explicit TransformRangeIterator(iterator_t iterator) : m_iterator(iterator) {}
 
+  TransformRangeIterator() = default;
+
   /// Return a reference to the value that is transformed by the callable
   /// @return Reference to the transformed value
   reference operator*() { return Callable::apply(*m_iterator); }
@@ -182,6 +184,14 @@ struct TransformRangeIterator {
   TransformRangeIterator& operator++() {
     ++m_iterator;
     return *this;
+  }
+
+  /// Advance the iterator
+  /// @return Reference to the iterator
+  TransformRangeIterator operator++(int) {
+    auto tmp = *this;
+    ++m_iterator;
+    return tmp;
   }
 
   /// Compare two iterators for equality
@@ -219,3 +229,7 @@ struct DotGet {
 };
 
 }  // namespace Acts::detail
+
+template <typename Callable, typename container_t>
+constexpr bool std::ranges::enable_borrowed_range<
+    Acts::detail::TransformRange<Callable, container_t>> = true;

--- a/Core/include/Acts/Utilities/TransformRange.hpp
+++ b/Core/include/Acts/Utilities/TransformRange.hpp
@@ -230,6 +230,8 @@ struct DotGet {
 
 }  // namespace Acts::detail
 
+/// @cond
 template <typename Callable, typename container_t>
 constexpr bool std::ranges::enable_borrowed_range<
     Acts::detail::TransformRange<Callable, container_t>> = true;
+/// @endcond

--- a/Tests/UnitTests/Core/Utilities/TransformRangeTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TransformRangeTests.cpp
@@ -6,9 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Utilities/TransformRange.hpp"
+
+#include <algorithm>
 
 using namespace Acts;
 
@@ -99,6 +102,14 @@ BOOST_AUTO_TEST_CASE(TransformRangeDeref) {
       static_assert(std::is_same_v<decltype(*(++r.begin())), int&>);
       checkSameAddresses(v, r);
 
+      std::vector<int> unpacked;
+      std::ranges::transform(r, std::back_inserter(unpacked),
+                             [](auto val) { return val; });
+      std::vector<int> exp = {1, 2, 4};
+
+      BOOST_CHECK_EQUAL_COLLECTIONS(exp.begin(), exp.end(), unpacked.begin(),
+                                    unpacked.end());
+
       auto cr = detail::TransformRange{detail::ConstDereference{}, raw_v};
       static_assert(std::is_same_v<decltype(cr)::value_type, const int>);
       static_assert(std::is_same_v<decltype(cr)::reference, const int&>);
@@ -108,6 +119,13 @@ BOOST_AUTO_TEST_CASE(TransformRangeDeref) {
       static_assert(std::is_same_v<decltype(*cr.begin()), const int&>);
       static_assert(std::is_same_v<decltype(*(++cr.begin())), const int&>);
       checkSameAddresses(v, r);
+
+      unpacked.clear();
+      std::ranges::transform(cr, std::back_inserter(unpacked),
+                             [](auto val) { return val; });
+
+      BOOST_CHECK_EQUAL_COLLECTIONS(exp.begin(), exp.end(), unpacked.begin(),
+                                    unpacked.end());
     }
   }
 
@@ -127,6 +145,12 @@ BOOST_AUTO_TEST_CASE(TransformRangeDeref) {
       static_assert(std::is_same_v<decltype(*r.begin()), const int&>);
       static_assert(std::is_same_v<decltype(*(++r.begin())), const int&>);
       checkSameAddresses(v, r);
+
+      std::vector<int> unpacked;
+      std::ranges::transform(r, std::back_inserter(unpacked),
+                             [](auto val) { return val; });
+
+      BOOST_CHECK(unpacked == std::vector<int>({1, 2, 3}));
     }
 
     std::vector<const int*> raw_v;


### PR DESCRIPTION
This allows using it with range algorithms

--- END COMMIT MESSAGE ---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a default constructor for the iterator, allowing for its creation without an initial iterator.
	- Added a new overload for the post-increment operator in the iterator.
	- Enhanced interoperability with the C++ ranges library by defining a specialization for `TransformRange`.

- **Tests**
	- Added new tests for unpacking values from `TransformRange` instances into standard vectors, improving test robustness and ensuring correct transformation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->