### PR TITLE
refactor: Combine GSF actor and aborter

### DIFF
--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -77,20 +77,6 @@ struct GaussianSumFitter {
   /// The actor type
   using GsfActor = detail::GsfActor<bethe_heitler_approx_t, traj_t>;
 
-  /// This allows to break the propagation by setting the navigationBreak
-  /// TODO refactor once we can do this more elegantly
-  struct NavigationBreakAborter {
-    NavigationBreakAborter() = default;
-
-    template <typename propagator_state_t, typename stepper_t,
-              typename navigator_t>
-    bool checkAbort(propagator_state_t& state, const stepper_t& /*stepper*/,
-                    const navigator_t& navigator,
-                    const Logger& /*logger*/) const {
-      return navigator.navigationBreak(state.navigation);
-    }
-  };
-
   /// @brief The fit function for the Direct navigator
   template <typename source_link_it_t, typename start_parameters_t,
             TrackContainerFrontend track_container_t>
@@ -105,7 +91,7 @@ struct GaussianSumFitter {
 
     // Initialize the forward propagation with the DirectNavigator
     auto fwdPropInitializer = [&sSequence, this](const auto& opts) {
-      using Actors = ActorList<GsfActor, NavigationBreakAborter>;
+      using Actors = ActorList<GsfActor>;
       using PropagatorOptions = typename propagator_t::template Options<Actors>;
 
       PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);
@@ -151,8 +137,7 @@ struct GaussianSumFitter {
 
     // Initialize the forward propagation with the DirectNavigator
     auto fwdPropInitializer = [this](const auto& opts) {
-      using Actors =
-          ActorList<GsfActor, EndOfWorldReached, NavigationBreakAborter>;
+      using Actors = ActorList<GsfActor, EndOfWorldReached>;
       using PropagatorOptions = typename propagator_t::template Options<Actors>;
 
       PropagatorOptions propOptions(opts.geoContext, opts.magFieldContext);

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -317,13 +317,20 @@ struct GsfActor {
       applyMultipleScattering(state, stepper, navigator,
                               MaterialUpdateStage::PostUpdate);
     }
+  }
 
-    // Break the navigation if we found all measurements
+  template <typename propagator_state_t, typename stepper_t,
+            typename navigator_t>
+  bool checkAbort(propagator_state_t& /*state*/, const stepper_t& /*stepper*/,
+                  const navigator_t& /*navigator*/, const result_type& result,
+                  const Logger& /*logger*/) const {
     if (m_cfg.numberMeasurements &&
         result.measurementStates == m_cfg.numberMeasurements) {
       ACTS_VERBOSE("Stop navigation because all measurements are found");
-      navigator.navigationBreak(state.navigation, true);
+      return true;
     }
+
+    return false;
   }
 
   template <typename propagator_state_t, typename stepper_t,
@@ -365,12 +372,12 @@ struct GsfActor {
 
     // Evaluate material slab
     auto slab = surface.surfaceMaterial()->materialSlab(
-        old_bound.position(state.stepping.geoContext), state.options.direction,
+        old_bound.position(state.options.geoContext), state.options.direction,
         MaterialUpdateStage::FullUpdate);
 
     const auto pathCorrection = surface.pathCorrection(
-        state.stepping.geoContext,
-        old_bound.position(state.stepping.geoContext), old_bound.direction());
+        state.options.geoContext, old_bound.position(state.options.geoContext),
+        old_bound.direction());
     slab.scaleThickness(pathCorrection);
 
     const double pathXOverX0 = slab.thicknessInX0();
@@ -525,7 +532,7 @@ struct GsfActor {
       auto& cmp = *res;
       auto freeParams = cmp.pars();
       cmp.jacToGlobal() = surface.boundToFreeJacobian(
-          state.geoContext, freeParams.template segment<3>(eFreePos0),
+          state.options.geoContext, freeParams.template segment<3>(eFreePos0),
           freeParams.template segment<3>(eFreeDir0));
       cmp.pathAccumulated() = state.stepping.pathAccumulated;
       cmp.jacobian() = BoundMatrix::Identity();

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -372,12 +372,12 @@ struct GsfActor {
 
     // Evaluate material slab
     auto slab = surface.surfaceMaterial()->materialSlab(
-        old_bound.position(state.options.geoContext), state.options.direction,
+        old_bound.position(state.stepping.geoContext), state.options.direction,
         MaterialUpdateStage::FullUpdate);
 
     const auto pathCorrection = surface.pathCorrection(
-        state.options.geoContext, old_bound.position(state.options.geoContext),
-        old_bound.direction());
+        state.stepping.geoContext,
+        old_bound.position(state.stepping.geoContext), old_bound.direction());
     slab.scaleThickness(pathCorrection);
 
     const double pathXOverX0 = slab.thicknessInX0();
@@ -532,7 +532,7 @@ struct GsfActor {
       auto& cmp = *res;
       auto freeParams = cmp.pars();
       cmp.jacToGlobal() = surface.boundToFreeJacobian(
-          state.options.geoContext, freeParams.template segment<3>(eFreePos0),
+          state.stepping.geoContext, freeParams.template segment<3>(eFreePos0),
           freeParams.template segment<3>(eFreeDir0));
       cmp.pathAccumulated() = state.stepping.pathAccumulated;
       cmp.jacobian() = BoundMatrix::Identity();

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -532,7 +532,7 @@ struct GsfActor {
       auto& cmp = *res;
       auto freeParams = cmp.pars();
       cmp.jacToGlobal() = surface.boundToFreeJacobian(
-          state.stepping.geoContext, freeParams.template segment<3>(eFreePos0),
+          state.geoContext, freeParams.template segment<3>(eFreePos0),
           freeParams.template segment<3>(eFreeDir0));
       cmp.pathAccumulated() = state.stepping.pathAccumulated;
       cmp.jacobian() = BoundMatrix::Identity();


### PR DESCRIPTION
Currently the GSF actor communicates the abort flag via the navigation break which is not ideal. I want to remove setting this flag from outside in https://github.com/acts-project/acts/pull/3449. The GSF can carry this flag by itself and after the actor+aborter refactor we do not need a separate aborter anymore.

pulled out of https://github.com/acts-project/acts/pull/3449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to check if navigation should be aborted based on processed measurements.
- **Improvements**
	- Updated navigation handling in the fitting process by removing the `NavigationBreakAborter` struct.
	- Refined geo context management in multiple methods for better clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->