### PR TITLE
chore: Adjust target limit after reset in Core CKF

### DIFF
--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -689,8 +689,12 @@ class CombinatorialKalmanFilter {
       materialInteractor(navigator.currentSurface(state.navigation), state,
                          stepper, navigator, MaterialUpdateStage::PostUpdate);
 
+      // Set path limit based on loop protection
       detail::setupLoopProtection(state, stepper, result.pathLimitReached, true,
                                   logger());
+
+      // Set path limit based on target surface
+      targetReached.checkAbort(state, stepper, navigator, logger());
     }
 
     /// @brief CombinatorialKalmanFilter actor operation:


### PR DESCRIPTION
After a reset in the CKF we need to adjust the target limit again to make sure the next step picks it up. I don't think we hit this case yet but it is good to have it anyways.

pulled out of https://github.com/acts-project/acts/pull/3449