### PR TITLE
fix: user-defined literal operator syntax (to make clang20 happy)

### DIFF
--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -201,12 +201,12 @@ constexpr double mol = 1.0;
 
 namespace UnitLiterals {
 // define user literal functions for the given unit constant
-#define ACTS_DEFINE_UNIT_LITERAL(name)                        \
-  constexpr double operator""_##name(long double x) {         \
-    return ::Acts::UnitConstants::name * x;                   \
-  }                                                           \
-  constexpr double operator""_##name(unsigned long long x) {  \
-    return ::Acts::UnitConstants::name * x;                   \
+#define ACTS_DEFINE_UNIT_LITERAL(name)                       \
+  constexpr double operator""_##name(long double x) {        \
+    return ::Acts::UnitConstants::name * x;                  \
+  }                                                          \
+  constexpr double operator""_##name(unsigned long long x) { \
+    return ::Acts::UnitConstants::name * x;                  \
   }
 ACTS_DEFINE_UNIT_LITERAL(fm)
 ACTS_DEFINE_UNIT_LITERAL(pm)

--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -202,10 +202,10 @@ constexpr double mol = 1.0;
 namespace UnitLiterals {
 // define user literal functions for the given unit constant
 #define ACTS_DEFINE_UNIT_LITERAL(name)                        \
-  constexpr double operator"" _##name(long double x) {        \
+  constexpr double operator""_##name(long double x) {         \
     return ::Acts::UnitConstants::name * x;                   \
   }                                                           \
-  constexpr double operator"" _##name(unsigned long long x) { \
+  constexpr double operator""_##name(unsigned long long x) {  \
     return ::Acts::UnitConstants::name * x;                   \
   }
 ACTS_DEFINE_UNIT_LITERAL(fm)

--- a/Core/include/Acts/Utilities/HashedString.hpp
+++ b/Core/include/Acts/Utilities/HashedString.hpp
@@ -46,7 +46,7 @@ constexpr HashedString hashStringDynamic(std::string_view s) {
 }
 
 namespace HashedStringLiteral {
-constexpr HashedString operator"" _hash(char const* s, std::size_t count) {
+constexpr HashedString operator""_hash(char const* s, std::size_t count) {
   return detail::fnv1a_32(s, count);
 }
 


### PR DESCRIPTION
- fix: user-defined literal operator syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated user-defined literal operators for various unit constants to enhance naming consistency.
  - Standardized the operator signature for the hashing function to improve clarity.

- **Bug Fixes**
  - No specific bug fixes were addressed in this release.

- **Documentation**
  - Changes in function signatures documented for better understanding of updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->