### PR TITLE
feat: Add/activate reverse filter cov inflation for KF and GSF

### DIFF
--- a/CI/physmon/workflows/physmon_trackfitting_kf.py
+++ b/CI/physmon/workflows/physmon_trackfitting_kf.py
@@ -24,6 +24,8 @@ with tempfile.TemporaryDirectory() as temp:
         field=setup.field,
         digiConfigFile=setup.digiConfig,
         outputDir=tp,
+        reverseFilteringMomThreshold=float("inf"),
+        reverseFilteringCovarianceScaling=100.0,
         s=s,
     )
 

--- a/Core/include/Acts/TrackFitting/GsfOptions.hpp
+++ b/Core/include/Acts/TrackFitting/GsfOptions.hpp
@@ -112,6 +112,8 @@ struct GsfOptions {
 
   bool disableAllMaterialHandling = false;
 
+  double reverseFilteringCovarianceScaling = 1.0;
+
   std::string_view finalMultiComponentStateColumn = "";
 
   ComponentMergeMethod componentMergeMethod = ComponentMergeMethod::eMaxWeight;

--- a/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFitterFunction.hpp
+++ b/Examples/Algorithms/TrackFitting/include/ActsExamples/TrackFitting/TrackFitterFunction.hpp
@@ -66,6 +66,7 @@ std::shared_ptr<TrackFitterFunction> makeKalmanFitterFunction(
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
     bool multipleScattering = true, bool energyLoss = true,
     double reverseFilteringMomThreshold = 0.0,
+    double reverseFilteringCovarianceScaling = 1.0,
     Acts::FreeToBoundCorrection freeToBoundCorrection =
         Acts::FreeToBoundCorrection(),
     const Acts::Logger& logger = *Acts::getDefaultLogger("Kalman",
@@ -89,6 +90,8 @@ enum class MixtureReductionAlgorithm { weightCut, KLDistance };
 /// parameters and covariance
 /// @param mixtureReductionAlgorithm How to reduce the number of components
 /// in a mixture
+/// @param reverseFilteringCovarianceScaling How the covariance matrices are
+/// inflated before the reverse filtering pass
 /// @param logger a logger instance
 std::shared_ptr<TrackFitterFunction> makeGsfFitterFunction(
     std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry,
@@ -96,7 +99,7 @@ std::shared_ptr<TrackFitterFunction> makeGsfFitterFunction(
     BetheHeitlerApprox betheHeitlerApprox, std::size_t maxComponents,
     double weightCutoff, Acts::ComponentMergeMethod componentMergeMethod,
     MixtureReductionAlgorithm mixtureReductionAlgorithm,
-    const Acts::Logger& logger);
+    double reverseFilteringCovarianceScaling, const Acts::Logger& logger);
 
 /// Makes a fitter function object for the Global Chi Square Fitter (GX2F)
 ///

--- a/Examples/Algorithms/TrackFitting/src/GsfFitterFunction.cpp
+++ b/Examples/Algorithms/TrackFitting/src/GsfFitterFunction.cpp
@@ -87,6 +87,7 @@ struct GsfFitterFunctionImpl final : public ActsExamples::TrackFitterFunction {
       MixtureReductionAlgorithm::KLDistance;
   Acts::ComponentMergeMethod mergeMethod =
       Acts::ComponentMergeMethod::eMaxWeight;
+  double reverseFilteringCovarianceScaling = 0.0;
 
   IndexSourceLink::SurfaceAccessor m_slSurfaceAccessor;
 
@@ -115,6 +116,8 @@ struct GsfFitterFunctionImpl final : public ActsExamples::TrackFitterFunction {
     gsfOptions.abortOnError = abortOnError;
     gsfOptions.disableAllMaterialHandling = disableAllMaterialHandling;
     gsfOptions.componentMergeMethod = mergeMethod;
+    gsfOptions.reverseFilteringCovarianceScaling =
+        reverseFilteringCovarianceScaling;
 
     gsfOptions.extensions.calibrator.connect<&calibrator_t::calibrate>(
         &calibrator);
@@ -195,7 +198,7 @@ std::shared_ptr<TrackFitterFunction> ActsExamples::makeGsfFitterFunction(
     BetheHeitlerApprox betheHeitlerApprox, std::size_t maxComponents,
     double weightCutoff, Acts::ComponentMergeMethod componentMergeMethod,
     MixtureReductionAlgorithm mixtureReductionAlgorithm,
-    const Acts::Logger& logger) {
+    double reverseFilteringCovarianceScaling, const Acts::Logger& logger) {
   // Standard fitter
   MultiStepper stepper(magneticField, logger.cloneWithSuffix("Step"));
   const auto& geo = *trackingGeometry;
@@ -229,6 +232,8 @@ std::shared_ptr<TrackFitterFunction> ActsExamples::makeGsfFitterFunction(
   fitterFunction->weightCutoff = weightCutoff;
   fitterFunction->mergeMethod = componentMergeMethod;
   fitterFunction->reductionAlg = mixtureReductionAlgorithm;
+  fitterFunction->reverseFilteringCovarianceScaling =
+      reverseFilteringCovarianceScaling;
 
   return fitterFunction;
 }

--- a/Examples/Algorithms/TrackFitting/src/KalmanFitterFunction.cpp
+++ b/Examples/Algorithms/TrackFitting/src/KalmanFitterFunction.cpp
@@ -76,7 +76,7 @@ struct KalmanFitterFunctionImpl final : public TrackFitterFunction {
   Acts::GainMatrixUpdater kfUpdater;
   Acts::GainMatrixSmoother kfSmoother;
   SimpleReverseFilteringLogic reverseFilteringLogic;
-
+  double reverseFilteringCovarianceScaling;
   bool multipleScattering = false;
   bool energyLoss = false;
   Acts::FreeToBoundCorrection freeToBoundCorrection;
@@ -114,6 +114,8 @@ struct KalmanFitterFunctionImpl final : public TrackFitterFunction {
     kfOptions.freeToBoundCorrection = freeToBoundCorrection;
     kfOptions.extensions.calibrator.connect<&calibrator_t::calibrate>(
         &calibrator);
+    kfOptions.reversedFilteringCovarianceScaling =
+        reverseFilteringCovarianceScaling;
 
     if (options.doRefit) {
       kfOptions.extensions.surfaceAccessor
@@ -159,6 +161,7 @@ ActsExamples::makeKalmanFitterFunction(
     std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
     bool multipleScattering, bool energyLoss,
     double reverseFilteringMomThreshold,
+    double reverseFilteringCovarianceScaling,
     Acts::FreeToBoundCorrection freeToBoundCorrection,
     const Acts::Logger& logger) {
   // Stepper should be copied into the fitters
@@ -191,6 +194,8 @@ ActsExamples::makeKalmanFitterFunction(
   fitterFunction->reverseFilteringLogic.momentumThreshold =
       reverseFilteringMomThreshold;
   fitterFunction->freeToBoundCorrection = freeToBoundCorrection;
+  fitterFunction->reverseFilteringCovarianceScaling =
+      reverseFilteringCovarianceScaling;
 
   return fitterFunction;
 }

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -1289,6 +1289,7 @@ def addKalmanTracks(
     trackingGeometry: acts.TrackingGeometry,
     field: acts.MagneticFieldProvider,
     reverseFilteringMomThreshold: float = 0 * u.GeV,
+    reverseFilteringCovarianceScaling: float = 1.0,
     inputProtoTracks: str = "truth_particle_tracks",
     multipleScattering: bool = True,
     energyLoss: bool = True,
@@ -1302,6 +1303,7 @@ def addKalmanTracks(
         "multipleScattering": multipleScattering,
         "energyLoss": energyLoss,
         "reverseFilteringMomThreshold": reverseFilteringMomThreshold,
+        "reverseFilteringCovarianceScaling": reverseFilteringCovarianceScaling,
         "freeToBoundCorrection": acts.examples.FreeToBoundCorrection(False),
         "level": customLogLevel(),
     }
@@ -1362,6 +1364,7 @@ def addTruthTrackingGsf(
         "componentMergeMethod": acts.examples.ComponentMergeMethod.maxWeight,
         "mixtureReductionAlgorithm": acts.examples.MixtureReductionAlgorithm.KLDistance,
         "weightCutoff": 1.0e-4,
+        "reverseFilteringCovarianceScaling": 100.0,
         "level": customLogLevel(),
     }
 

--- a/Examples/Python/src/TrackFitting.cpp
+++ b/Examples/Python/src/TrackFitting.cpp
@@ -53,17 +53,18 @@ void addTrackFitting(Context& ctx) {
            std::shared_ptr<const Acts::MagneticFieldProvider> magneticField,
            bool multipleScattering, bool energyLoss,
            double reverseFilteringMomThreshold,
+           double reverseFilteringCovarianceScaling,
            Acts::FreeToBoundCorrection freeToBoundCorrection,
            Logging::Level level) {
           return ActsExamples::makeKalmanFitterFunction(
               trackingGeometry, magneticField, multipleScattering, energyLoss,
-              reverseFilteringMomThreshold, freeToBoundCorrection,
-              *Acts::getDefaultLogger("Kalman", level));
+              reverseFilteringMomThreshold, reverseFilteringCovarianceScaling,
+              freeToBoundCorrection, *Acts::getDefaultLogger("Kalman", level));
         },
-        py::arg("trackingGeometry"), py::arg("magneticField"),
-        py::arg("multipleScattering"), py::arg("energyLoss"),
-        py::arg("reverseFilteringMomThreshold"),
-        py::arg("freeToBoundCorrection"), py::arg("level"));
+        "trackingGeometry"_a, "magneticField"_a, "multipleScattering"_a,
+        "energyLoss"_a, "reverseFilteringMomThreshold"_a,
+        "reverseFilteringCovarianceScaling"_a, "freeToBoundCorrection"_a,
+        "level"_a);
 
     py::class_<MeasurementCalibrator, std::shared_ptr<MeasurementCalibrator>>(
         mex, "MeasurementCalibrator");
@@ -108,17 +109,17 @@ void addTrackFitting(Context& ctx) {
            BetheHeitlerApprox betheHeitlerApprox, std::size_t maxComponents,
            double weightCutoff, Acts::ComponentMergeMethod componentMergeMethod,
            ActsExamples::MixtureReductionAlgorithm mixtureReductionAlgorithm,
-           Logging::Level level) {
+           double reverseFilteringCovarianceScaling, Logging::Level level) {
           return ActsExamples::makeGsfFitterFunction(
               trackingGeometry, magneticField, betheHeitlerApprox,
               maxComponents, weightCutoff, componentMergeMethod,
-              mixtureReductionAlgorithm,
+              mixtureReductionAlgorithm, reverseFilteringCovarianceScaling,
               *Acts::getDefaultLogger("GSFFunc", level));
         },
-        py::arg("trackingGeometry"), py::arg("magneticField"),
-        py::arg("betheHeitlerApprox"), py::arg("maxComponents"),
-        py::arg("weightCutoff"), py::arg("componentMergeMethod"),
-        py::arg("mixtureReductionAlgorithm"), py::arg("level"));
+        "trackingGeometry"_a, "magneticField"_a, "betheHeitlerApprox"_a,
+        "maxComponents"_a, "weightCutoff"_a, "componentMergeMethod"_a,
+        "mixtureReductionAlgorithm"_a, "reverseFilteringCovarianceScaling"_a,
+        "level"_a);
 
     mex.def(
         "makeGlobalChiSquareFitterFunction",

--- a/Examples/Scripts/Python/truth_tracking_kalman.py
+++ b/Examples/Scripts/Python/truth_tracking_kalman.py
@@ -18,6 +18,7 @@ def runTruthTrackingKalman(
     inputHitsPath: Optional[Path] = None,
     decorators=[],
     reverseFilteringMomThreshold=0 * u.GeV,
+    reverseFilteringCovarianceScaling=1,
     s: acts.examples.Sequencer = None,
 ):
     from acts.examples.simulation import (
@@ -122,6 +123,7 @@ def runTruthTrackingKalman(
         trackingGeometry,
         field,
         reverseFilteringMomThreshold,
+        reverseFilteringCovarianceScaling,
     )
 
     s.addAlgorithm(


### PR DESCRIPTION
For KF, this wires the existing flags through the examples framework.
For the GSF, this adds this flag and activates it in the examples framework.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
