### PR TITLE
feat: Support negative tolerance for euclidean + chi2 tests

### DIFF
--- a/Core/include/Acts/Surfaces/BoundaryTolerance.hpp
+++ b/Core/include/Acts/Surfaces/BoundaryTolerance.hpp
@@ -98,6 +98,12 @@ class BoundaryTolerance {
         : maxChi2(maxChi2_), weight(weight_) {}
   };
 
+  enum class ToleranceMode {
+    Extend,  // Extend the boundary
+    None,    // No tolerance
+    Shrink   // Shrink the boundary
+  };
+
   /// Underlying variant type
   using Variant = std::variant<Infinite, None, AbsoluteBound, AbsoluteCartesian,
                                AbsoluteEuclidean, Chi2Bound>;
@@ -132,7 +138,7 @@ class BoundaryTolerance {
   bool hasChi2Bound() const;
 
   /// Check if any tolerance is set.
-  bool hasTolerance() const;
+  ToleranceMode toleranceMode() const;
 
   /// Get the tolerance as absolute bound.
   AbsoluteBound asAbsoluteBound(bool isCartesian = false) const;

--- a/Core/include/Acts/Surfaces/BoundaryTolerance.hpp
+++ b/Core/include/Acts/Surfaces/BoundaryTolerance.hpp
@@ -67,7 +67,12 @@ class BoundaryTolerance {
 
     AbsoluteBound() = default;
     AbsoluteBound(double tolerance0_, double tolerance1_)
-        : tolerance0(tolerance0_), tolerance1(tolerance1_) {}
+        : tolerance0(tolerance0_), tolerance1(tolerance1_) {
+      if (tolerance0 < 0 || tolerance1 < 0) {
+        throw std::invalid_argument(
+            "AbsoluteBound: Tolerance must be non-negative");
+      }
+    }
   };
 
   /// Absolute tolerance in Cartesian coordinates
@@ -77,7 +82,12 @@ class BoundaryTolerance {
 
     AbsoluteCartesian() = default;
     AbsoluteCartesian(double tolerance0_, double tolerance1_)
-        : tolerance0(tolerance0_), tolerance1(tolerance1_) {}
+        : tolerance0(tolerance0_), tolerance1(tolerance1_) {
+      if (tolerance0 < 0 || tolerance1 < 0) {
+        throw std::invalid_argument(
+            "AbsoluteCartesian: Tolerance must be non-negative");
+      }
+    }
   };
 
   /// Absolute tolerance in Euclidean distance

--- a/Core/include/Acts/Surfaces/detail/BoundaryCheckHelper.hpp
+++ b/Core/include/Acts/Surfaces/detail/BoundaryCheckHelper.hpp
@@ -11,7 +11,6 @@
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
 
-#include <iostream>
 #include <span>
 
 namespace Acts::detail {

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -207,6 +207,7 @@ bool AnnulusBounds::inside(const Vector2& lposition, double tolR,
 
 bool AnnulusBounds::inside(const Vector2& lposition,
                            const BoundaryTolerance& boundaryTolerance) const {
+  using enum BoundaryTolerance::ToleranceMode;
   if (boundaryTolerance.isInfinite()) {
     return true;
   }
@@ -221,154 +222,218 @@ bool AnnulusBounds::inside(const Vector2& lposition,
                   absoluteBound->tolerance1);
   }
 
-  // first check if inside. We don't need to look into the covariance if inside
-  if (inside(lposition, 0., 0.)) {
+  bool insideStrict = inside(lposition, 0., 0.);
+
+  BoundaryTolerance::ToleranceMode mode = boundaryTolerance.toleranceMode();
+  if (mode == None) {
+    // first check if inside if we're in None tolerance mode. We don't need to
+    // look into the covariance if inside
+    return insideStrict;
+  }
+
+  if (mode == Extend && insideStrict) {
     return true;
   }
-
-  if (!boundaryTolerance.hasChi2Bound()) {
-    throw std::logic_error("not implemented");
-  }
-
-  const auto& boundaryToleranceChi2 = boundaryTolerance.asChi2Bound();
 
   // locpo is PC in STRIP SYSTEM
   // we need to rotate the locpo
   Vector2 locpo_rotated = m_rotationStripPC * lposition;
 
-  // covariance is given in STRIP SYSTEM in PC we need to convert the covariance
-  // to the MODULE SYSTEM in PC via jacobian. The following transforms into
-  // STRIP XY, does the shift into MODULE XY, and then transforms into MODULE PC
+  // covariance is given in STRIP SYSTEM in PC we need to convert the
+  // covariance to the MODULE SYSTEM in PC via jacobian. The following
+  // transforms into STRIP XY, does the shift into MODULE XY, and then
+  // transforms into MODULE PC
   double dphi = get(eAveragePhi);
   double phi_strip = locpo_rotated[1];
   double r_strip = locpo_rotated[0];
   double O_x = m_shiftXY[0];
   double O_y = m_shiftXY[1];
 
-  // For a transformation from cartesian into polar coordinates
-  //
-  //              [         _________      ]
-  //              [        /  2    2       ]
-  //              [      \/  x  + y        ]
-  //     [ r' ]   [                        ]
-  // v = [    ] = [      /       y        \]
-  //     [phi']   [2*atan|----------------|]
-  //              [      |       _________|]
-  //              [      |      /  2    2 |]
-  //              [      \x + \/  x  + y  /]
-  //
-  // Where x, y are polar coordinates that can be rotated by dPhi
-  //
-  // [x]   [O_x + r*cos(dPhi - phi)]
-  // [ ] = [                       ]
-  // [y]   [O_y - r*sin(dPhi - phi)]
-  //
-  // The general jacobian is:
-  //
-  //        [d        d      ]
-  //        [--(f_x)  --(f_x)]
-  //        [dx       dy     ]
-  // Jgen = [                ]
-  //        [d        d      ]
-  //        [--(f_y)  --(f_y)]
-  //        [dx       dy     ]
-  //
-  // which means in this case:
-  //
-  //     [     d                   d           ]
-  //     [ ----------(rMod)    ---------(rMod) ]
-  //     [ dr_{strip}          dphiStrip       ]
-  // J = [                                     ]
-  //     [    d                   d            ]
-  //     [----------(phiMod)  ---------(phiMod)]
-  //     [dr_{strip}          dphiStrip        ]
-  //
-  // Performing the derivative one gets:
-  //
-  //     [B*O_x + C*O_y + rStrip  rStrip*(B*O_y + O_x*sin(dPhi - phiStrip))]
-  //     [----------------------  -----------------------------------------]
-  //     [          ___                               ___                  ]
-  //     [        \/ A                              \/ A                   ]
-  // J = [                                                                 ]
-  //     [  -(B*O_y - C*O_x)           rStrip*(B*O_x + C*O_y + rStrip)     ]
-  //     [  -----------------          -------------------------------     ]
-  //     [          A                                 A                    ]
-  //
-  // where
-  //        2                                          2
-  // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y
-  //                                                 2
-  //     - 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip
-  // B = cos(dPhi - phiStrip)
-  // C = -sin(dPhi - phiStrip)
+  auto closestPointDistanceBound = [&](const SquareMatrix2& weight) {
+    // For a transformation from cartesian into polar coordinates
+    //
+    //              [         _________      ]
+    //              [        /  2    2       ]
+    //              [      \/  x  + y        ]
+    //     [ r' ]   [                        ]
+    // v = [    ] = [      /       y        \]
+    //     [phi']   [2*atan|----------------|]
+    //              [      |       _________|]
+    //              [      |      /  2    2 |]
+    //              [      \x + \/  x  + y  /]
+    //
+    // Where x, y are polar coordinates that can be rotated by dPhi
+    //
+    // [x]   [O_x + r*cos(dPhi - phi)]
+    // [ ] = [                       ]
+    // [y]   [O_y - r*sin(dPhi - phi)]
+    //
+    // The general jacobian is:
+    //
+    //        [d        d      ]
+    //        [--(f_x)  --(f_x)]
+    //        [dx       dy     ]
+    // Jgen = [                ]
+    //        [d        d      ]
+    //        [--(f_y)  --(f_y)]
+    //        [dx       dy     ]
+    //
+    // which means in this case:
+    //
+    //     [     d                   d           ]
+    //     [ ----------(rMod)    ---------(rMod) ]
+    //     [ dr_{strip}          dphiStrip       ]
+    // J = [                                     ]
+    //     [    d                   d            ]
+    //     [----------(phiMod)  ---------(phiMod)]
+    //     [dr_{strip}          dphiStrip        ]
+    //
+    // Performing the derivative one gets:
+    //
+    //     [B*O_x + C*O_y + rStrip  rStrip*(B*O_y + O_x*sin(dPhi - phiStrip))]
+    //     [----------------------  -----------------------------------------]
+    //     [          ___                               ___                  ]
+    //     [        \/ A                              \/ A                   ]
+    // J = [                                                                 ]
+    //     [  -(B*O_y - C*O_x)           rStrip*(B*O_x + C*O_y + rStrip)     ]
+    //     [  -----------------          -------------------------------     ]
+    //     [          A                                 A                    ]
+    //
+    // where
+    //        2                                          2
+    // A = O_x  + 2*O_x*rStrip*cos(dPhi - phiStrip) + O_y
+    //                                                 2
+    //     - 2*O_y*rStrip*sin(dPhi - phiStrip) + rStrip
+    // B = cos(dPhi - phiStrip)
+    // C = -sin(dPhi - phiStrip)
 
-  double cosDPhiPhiStrip = std::cos(dphi - phi_strip);
-  double sinDPhiPhiStrip = std::sin(dphi - phi_strip);
+    double cosDPhiPhiStrip = std::cos(dphi - phi_strip);
+    double sinDPhiPhiStrip = std::sin(dphi - phi_strip);
 
-  double A = O_x * O_x + 2 * O_x * r_strip * cosDPhiPhiStrip + O_y * O_y -
-             2 * O_y * r_strip * sinDPhiPhiStrip + r_strip * r_strip;
-  double sqrtA = std::sqrt(A);
+    double A = O_x * O_x + 2 * O_x * r_strip * cosDPhiPhiStrip + O_y * O_y -
+               2 * O_y * r_strip * sinDPhiPhiStrip + r_strip * r_strip;
+    double sqrtA = std::sqrt(A);
 
-  double B = cosDPhiPhiStrip;
-  double C = -sinDPhiPhiStrip;
-  SquareMatrix2 jacobianStripPCToModulePC;
-  jacobianStripPCToModulePC(0, 0) = (B * O_x + C * O_y + r_strip) / sqrtA;
-  jacobianStripPCToModulePC(0, 1) =
-      r_strip * (B * O_y + O_x * sinDPhiPhiStrip) / sqrtA;
-  jacobianStripPCToModulePC(1, 0) = -(B * O_y - C * O_x) / A;
-  jacobianStripPCToModulePC(1, 1) = r_strip * (B * O_x + C * O_y + r_strip) / A;
+    double B = cosDPhiPhiStrip;
+    double C = -sinDPhiPhiStrip;
+    SquareMatrix2 jacobianStripPCToModulePC;
+    jacobianStripPCToModulePC(0, 0) = (B * O_x + C * O_y + r_strip) / sqrtA;
+    jacobianStripPCToModulePC(0, 1) =
+        r_strip * (B * O_y + O_x * sinDPhiPhiStrip) / sqrtA;
+    jacobianStripPCToModulePC(1, 0) = -(B * O_y - C * O_x) / A;
+    jacobianStripPCToModulePC(1, 1) =
+        r_strip * (B * O_x + C * O_y + r_strip) / A;
 
-  // Mahalanobis distance uses inverse covariance as weights
-  const auto& weightStripPC = boundaryToleranceChi2.weight;
-  auto weightModulePC = jacobianStripPCToModulePC.transpose() * weightStripPC *
-                        jacobianStripPCToModulePC;
+    // Mahalanobis distance uses inverse covariance as weights
+    const auto& weightStripPC = weight;
+    auto weightModulePC = jacobianStripPCToModulePC.transpose() *
+                          weightStripPC * jacobianStripPCToModulePC;
 
-  double minDist = std::numeric_limits<double>::max();
+    double minDist = std::numeric_limits<double>::max();
+    Vector2 delta;
 
-  Vector2 currentClosest;
-  double currentDist = 0;
+    Vector2 currentClosest;
+    double currentDist = 0;
 
-  // do projection in STRIP PC
+    // do projection in STRIP PC
 
-  // first: STRIP system. locpo is in STRIP PC already
-  currentClosest = closestOnSegment(m_inLeftStripPC, m_outLeftStripPC,
-                                    locpo_rotated, weightStripPC);
-  currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
-  minDist = currentDist;
-
-  currentClosest = closestOnSegment(m_inRightStripPC, m_outRightStripPC,
-                                    locpo_rotated, weightStripPC);
-  currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
-  if (currentDist < minDist) {
+    // first: STRIP system. locpo is in STRIP PC already
+    currentClosest = closestOnSegment(m_inLeftStripPC, m_outLeftStripPC,
+                                      locpo_rotated, weightStripPC);
+    currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
     minDist = currentDist;
+    delta = locpo_rotated - currentClosest;
+    currentClosest = closestOnSegment(m_inRightStripPC, m_outRightStripPC,
+                                      locpo_rotated, weightStripPC);
+    currentDist = squaredNorm(locpo_rotated - currentClosest, weightStripPC);
+    if (currentDist < minDist) {
+      minDist = currentDist;
+      delta = locpo_rotated - currentClosest;
+    }
+
+    // now: MODULE system. Need to transform locpo to MODULE PC
+    //  transform is STRIP PC -> STRIP XY -> MODULE XY -> MODULE PC
+    Vector2 locpoStripXY(
+        locpo_rotated[eBoundLoc0] * std::cos(locpo_rotated[eBoundLoc1]),
+        locpo_rotated[eBoundLoc0] * std::sin(locpo_rotated[eBoundLoc1]));
+    Vector2 locpoModulePC = stripXYToModulePC(locpoStripXY);
+
+    // now check edges in MODULE PC (inner and outer circle) assuming
+    // Mahalanobis distances are of same unit if covariance is correctly
+    // transformed
+    currentClosest = closestOnSegment(m_inLeftModulePC, m_inRightModulePC,
+                                      locpoModulePC, weightModulePC);
+    currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
+    if (currentDist < minDist) {
+      minDist = currentDist;
+      delta = jacobianStripPCToModulePC.inverse() *
+              (currentClosest - locpoModulePC);
+    }
+
+    currentClosest = closestOnSegment(m_outLeftModulePC, m_outRightModulePC,
+                                      locpoModulePC, weightModulePC);
+    currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
+    if (currentDist < minDist) {
+      minDist = currentDist;
+      delta = jacobianStripPCToModulePC.inverse() *
+              (currentClosest - locpoModulePC);
+    }
+
+    return std::tuple{delta, minDist};
+  };
+
+  if (boundaryTolerance.hasChi2Bound()) {
+    const auto& boundaryToleranceChi2 = boundaryTolerance.asChi2Bound();
+
+    // Calculate minDist based on weight from the boundary tolerance object.
+    // That weight matrix is in STRIP PC
+    auto [delta, minDist] =
+        closestPointDistanceBound(boundaryToleranceChi2.weight);
+
+    // compare resulting Mahalanobis distance to configured "number of sigmas"
+    // we square it b/c we never took the square root of the distance
+    if (mode == Extend) {
+      return minDist <
+             boundaryToleranceChi2.maxChi2 * boundaryToleranceChi2.maxChi2;
+    } else if (mode == Shrink) {
+      return minDist > boundaryToleranceChi2.maxChi2 *
+                           boundaryToleranceChi2.maxChi2 &&
+             insideStrict;
+    }
+  } else if (boundaryTolerance.hasAbsoluteEuclidean()) {
+    const auto& boundaryToleranceAbsoluteEuclidean =
+        boundaryTolerance.asAbsoluteEuclidean();
+
+    SquareMatrix2 jacobianPCToXY;
+    jacobianPCToXY(0, 0) = std::cos(phi_strip);
+    jacobianPCToXY(0, 1) = -r_strip * std::sin(phi_strip);
+    jacobianPCToXY(1, 0) = std::sin(phi_strip);
+    jacobianPCToXY(1, 1) = r_strip * std::cos(phi_strip);
+
+    // This is J.T * J but we can also calculate it directly
+    SquareMatrix2 weightStripPC;
+    weightStripPC(0, 0) = 1;
+    weightStripPC(0, 1) = 0;
+    weightStripPC(1, 0) = 0;
+    weightStripPC(1, 1) = r_strip * r_strip;
+
+    auto [delta, minDist] = closestPointDistanceBound(weightStripPC);
+
+    Vector2 cartesianDistance = jacobianPCToXY * delta;
+
+    if (mode == Extend) {
+      return cartesianDistance.squaredNorm() <
+             boundaryToleranceAbsoluteEuclidean.tolerance *
+                 boundaryToleranceAbsoluteEuclidean.tolerance;
+    } else if (mode == Shrink) {
+      return cartesianDistance.squaredNorm() >
+                 boundaryToleranceAbsoluteEuclidean.tolerance *
+                     boundaryToleranceAbsoluteEuclidean.tolerance &&
+             insideStrict;
+    }
   }
 
-  // now: MODULE system. Need to transform locpo to MODULE PC
-  //  transform is STRIP PC -> STRIP XY -> MODULE XY -> MODULE PC
-  Vector2 locpoStripXY(locpo_rotated[0] * std::cos(locpo_rotated[1]),
-                       locpo_rotated[0] * std::sin(locpo_rotated[1]));
-  Vector2 locpoModulePC = stripXYToModulePC(locpoStripXY);
-
-  // now check edges in MODULE PC (inner and outer circle) assuming Mahalanobis
-  // distances are of same unit if covariance is correctly transformed
-  currentClosest = closestOnSegment(m_inLeftModulePC, m_inRightModulePC,
-                                    locpoModulePC, weightModulePC);
-  currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
-  if (currentDist < minDist) {
-    minDist = currentDist;
-  }
-
-  currentClosest = closestOnSegment(m_outLeftModulePC, m_outRightModulePC,
-                                    locpoModulePC, weightModulePC);
-  currentDist = squaredNorm(locpoModulePC - currentClosest, weightModulePC);
-  if (currentDist < minDist) {
-    minDist = currentDist;
-  }
-
-  // compare resulting Mahalanobis distance to configured "number of sigmas" we
-  // square it b/c we never took the square root of the distance
-  return minDist <
-         boundaryToleranceChi2.maxChi2 * boundaryToleranceChi2.maxChi2;
+  throw std::logic_error("not implemented");
 }
 
 Vector2 AnnulusBounds::stripXYToModulePC(const Vector2& vStripXY) const {

--- a/Core/src/Surfaces/BoundaryTolerance.cpp
+++ b/Core/src/Surfaces/BoundaryTolerance.cpp
@@ -76,21 +76,7 @@ BoundaryTolerance::ToleranceMode BoundaryTolerance::toleranceMode() const {
       return None;
     }
 
-    // std::cout << absoluteBound->tolerance0 << " "
-    //           << std::copysign(1., absoluteBound->tolerance0) << std::endl;
-    // std::cout << absoluteBound->tolerance1 << " "
-    //           << std::copysign(1., absoluteBound->tolerance1) << std::endl;
-
-    if (std::copysign(1., absoluteBound->tolerance0) !=
-        std::copysign(1., absoluteBound->tolerance1)) {
-      throw std::logic_error("Inconsistent tolerance signs are not supported");
-    }
-
-    if (absoluteBound->tolerance0 > 0. || absoluteBound->tolerance1 > 0.) {
-      return Extend;
-    } else {
-      return Shrink;
-    }
+    return Extend;
   }
 
   if (const auto* absoluteCartesian = getVariantPtr<AbsoluteCartesian>();
@@ -100,17 +86,7 @@ BoundaryTolerance::ToleranceMode BoundaryTolerance::toleranceMode() const {
       return None;
     }
 
-    if (std::copysign(1., absoluteCartesian->tolerance0) !=
-        std::copysign(1., absoluteCartesian->tolerance1)) {
-      throw std::logic_error("Inconsistent tolerance signs are not supported");
-    }
-
-    if (absoluteCartesian->tolerance0 > 0. ||
-        absoluteCartesian->tolerance1 > 0.) {
-      return Extend;
-    } else {
-      return Shrink;
-    }
+    return Extend;
   }
 
   if (const auto* absoluteEuclidean = getVariantPtr<AbsoluteEuclidean>();

--- a/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
@@ -141,6 +141,161 @@ BOOST_AUTO_TEST_CASE(AnnulusBoundsVertices) {
   BOOST_CHECK_EQUAL(vertices.size(), 14u);
 }
 
+BOOST_AUTO_TEST_CASE(AnnulusBoundsNegativeTolerance) {
+  using namespace Acts::UnitLiterals;
+  AnnulusBounds aBounds(minRadius, maxRadius, minPhi, maxPhi, offset);
+  double phiAverage = (minPhi + maxPhi) / 2;
+
+  auto check = [&](const BoundaryTolerance& tolerance, const Vector2& point) {
+    Vector2 pointAverage(point[0], phiAverage + point[1]);
+
+    std::cout << "[" << pointAverage[0] << ", " << pointAverage[1] << "],"
+              << std::endl;
+    return aBounds.inside(pointAverage, tolerance);
+  };
+
+  double midRadius = (minRadius + maxRadius) / 2;
+  double hlPhi = (maxPhi - minPhi) / 2;
+
+  {
+    auto tolerance = BoundaryTolerance::AbsoluteEuclidean(1);
+
+    // Test points near radial boundaries
+    BOOST_CHECK(!check(tolerance, {minRadius - 1.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius - 0.1, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 0.4, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 0.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 1.5, 0}));
+
+    BOOST_CHECK(check(tolerance, {maxRadius - 1.5, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius - 0.1, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius + 0.3, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius + 0.55, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius + 1.2, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.7, 0}));
+
+    // Check points near axial boundaries
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.5}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 1.1}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.5}));
+
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.5}));
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.5}));
+  }
+
+  {
+    auto tolerance = BoundaryTolerance::AbsoluteEuclidean(-1);
+
+    // Test points near radial boundaries
+    BOOST_CHECK(!check(tolerance, {minRadius - 1.5, 0}));
+    BOOST_CHECK(!check(tolerance, {minRadius - 0.1, 0}));
+    BOOST_CHECK(!check(tolerance, {minRadius + 0.4, 0}));
+    BOOST_CHECK(!check(tolerance, {minRadius + 0.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 1.5, 0}));
+
+    BOOST_CHECK(check(tolerance, {maxRadius - 1.5, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius - 0.1, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 0.3, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 0.55, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.2, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.7, 0}));
+
+    // Check points near axial boundaries
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.5}));
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.5}));
+
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.5}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 0.8}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.5}));
+  }
+
+  {
+    auto tolerance =
+        BoundaryTolerance::Chi2Bound(SquareMatrix2::Identity(), 0.1);
+
+    // Test points near radial boundaries
+    BOOST_CHECK(!check(tolerance, {minRadius - 1.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius - 0.1, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 0.4, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 0.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 1.5, 0}));
+
+    BOOST_CHECK(check(tolerance, {maxRadius - 1.5, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius - 0.1, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius + 0.3, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius + 0.55, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.2, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.7, 0}));
+
+    // Check points near axial boundaries
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.5}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 1.1}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.5}));
+
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.5}));
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.5}));
+    // mc(tolerance);
+    // mc(BoundaryTolerance::Chi2Bound(SquareMatrix2::Identity(), 0.1));
+
+    // Test points near radial boundaries
+    // BOOST_CHECK(!check(tolerance, {minRadius - 0.2, 0}));
+    // BOOST_CHECK(!check(tolerance, {minRadius + 0.2, 0}));
+    // BOOST_CHECK(check(tolerance, {minRadius + 0.4, 0}));
+    // BOOST_CHECK(!check(tolerance, {maxRadius - 0.2, 0}));
+    // BOOST_CHECK(!check(tolerance, {maxRadius + 0.2, 0}));
+    // BOOST_CHECK(check(tolerance, {maxRadius - 0.4, 0}));
+
+    // // Test points near angular boundaries
+    // BOOST_CHECK(!check(tolerance, {(minRadius + maxRadius) / 2, minPhi -
+    // 0.2})); BOOST_CHECK(!check(tolerance, {(minRadius + maxRadius) / 2,
+    // minPhi + 0.2})); BOOST_CHECK(check(tolerance, {(minRadius + maxRadius) /
+    // 2, minPhi + 0.4})); BOOST_CHECK(!check(tolerance, {(minRadius +
+    // maxRadius) / 2, maxPhi - 0.2})); BOOST_CHECK(!check(tolerance,
+    // {(minRadius + maxRadius) / 2, maxPhi + 0.2}));
+    // BOOST_CHECK(check(tolerance, {(minRadius + maxRadius) / 2, maxPhi -
+    // 0.4}));
+  }
+
+  {
+    auto tolerance =
+        BoundaryTolerance::Chi2Bound(SquareMatrix2::Identity(), -0.1);
+
+    // Test points near radial boundaries
+    BOOST_CHECK(!check(tolerance, {minRadius - 1.5, 0}));
+    BOOST_CHECK(!check(tolerance, {minRadius - 0.1, 0}));
+    BOOST_CHECK(!check(tolerance, {minRadius + 0.4, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 0.5, 0}));
+    BOOST_CHECK(check(tolerance, {minRadius + 1.5, 0}));
+
+    BOOST_CHECK(check(tolerance, {maxRadius - 1.5, 0}));
+    BOOST_CHECK(check(tolerance, {maxRadius - 0.1, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 0.3, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 0.55, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.2, 0}));
+    BOOST_CHECK(!check(tolerance, {maxRadius + 1.7, 0}));
+
+    // Check points near axial boundaries
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.5}));
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, -hlPhi * 0.8}));
+    BOOST_CHECK(check(tolerance, {midRadius, -hlPhi * 0.5}));
+
+    BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.5}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 0.8}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.1}));
+    BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.5}));
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace Acts::Test

--- a/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
@@ -142,15 +142,11 @@ BOOST_AUTO_TEST_CASE(AnnulusBoundsVertices) {
 }
 
 BOOST_AUTO_TEST_CASE(AnnulusBoundsNegativeTolerance) {
-  using namespace Acts::UnitLiterals;
   AnnulusBounds aBounds(minRadius, maxRadius, minPhi, maxPhi, offset);
   double phiAverage = (minPhi + maxPhi) / 2;
 
   auto check = [&](const BoundaryTolerance& tolerance, const Vector2& point) {
     Vector2 pointAverage(point[0], phiAverage + point[1]);
-
-    std::cout << "[" << pointAverage[0] << ", " << pointAverage[1] << "],"
-              << std::endl;
     return aBounds.inside(pointAverage, tolerance);
   };
 
@@ -243,26 +239,6 @@ BOOST_AUTO_TEST_CASE(AnnulusBoundsNegativeTolerance) {
     BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 0.8}));
     BOOST_CHECK(check(tolerance, {midRadius, hlPhi * 1.1}));
     BOOST_CHECK(!check(tolerance, {midRadius, hlPhi * 1.5}));
-    // mc(tolerance);
-    // mc(BoundaryTolerance::Chi2Bound(SquareMatrix2::Identity(), 0.1));
-
-    // Test points near radial boundaries
-    // BOOST_CHECK(!check(tolerance, {minRadius - 0.2, 0}));
-    // BOOST_CHECK(!check(tolerance, {minRadius + 0.2, 0}));
-    // BOOST_CHECK(check(tolerance, {minRadius + 0.4, 0}));
-    // BOOST_CHECK(!check(tolerance, {maxRadius - 0.2, 0}));
-    // BOOST_CHECK(!check(tolerance, {maxRadius + 0.2, 0}));
-    // BOOST_CHECK(check(tolerance, {maxRadius - 0.4, 0}));
-
-    // // Test points near angular boundaries
-    // BOOST_CHECK(!check(tolerance, {(minRadius + maxRadius) / 2, minPhi -
-    // 0.2})); BOOST_CHECK(!check(tolerance, {(minRadius + maxRadius) / 2,
-    // minPhi + 0.2})); BOOST_CHECK(check(tolerance, {(minRadius + maxRadius) /
-    // 2, minPhi + 0.4})); BOOST_CHECK(!check(tolerance, {(minRadius +
-    // maxRadius) / 2, maxPhi - 0.2})); BOOST_CHECK(!check(tolerance,
-    // {(minRadius + maxRadius) / 2, maxPhi + 0.2}));
-    // BOOST_CHECK(check(tolerance, {(minRadius + maxRadius) / 2, maxPhi -
-    // 0.4}));
   }
 
   {

--- a/Tests/UnitTests/Core/Surfaces/BoundaryToleranceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/BoundaryToleranceTests.cpp
@@ -28,12 +28,22 @@ namespace Acts::Test {
 BOOST_AUTO_TEST_SUITE(Surfaces)
 
 BOOST_AUTO_TEST_CASE(BoundaryToleranceConstructors) {
+  using enum BoundaryTolerance::ToleranceMode;
+  {
+    // Test None constructor
+    BoundaryTolerance tolerance = BoundaryTolerance::None();
+    BOOST_CHECK(tolerance.toleranceMode() == None);
+  }
+
   // Test AbsoluteBound constructor
   {
     // Valid positive tolerances
     auto tolerance = BoundaryTolerance::AbsoluteBound(1.0, 2.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance0, 1.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance1, 2.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Extend);
+    BOOST_CHECK(BoundaryTolerance{BoundaryTolerance::AbsoluteBound(0.0, 0.0)}
+                    .toleranceMode() == None);
 
     // Negative tolerances should throw
     BOOST_CHECK_THROW(BoundaryTolerance::AbsoluteBound(-1.0, 2.0),
@@ -47,10 +57,14 @@ BOOST_AUTO_TEST_CASE(BoundaryToleranceConstructors) {
     // Valid positive tolerance
     auto tolerance = BoundaryTolerance::AbsoluteEuclidean(1.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance, 1.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Extend);
+    BOOST_CHECK(BoundaryTolerance{BoundaryTolerance::AbsoluteEuclidean(0.0)}
+                    .toleranceMode() == None);
 
     // Valid negative tolerance
     tolerance = BoundaryTolerance::AbsoluteEuclidean(-1.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance, -1.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Shrink);
   }
 
   // Test AbsoluteCartesian constructor
@@ -59,6 +73,10 @@ BOOST_AUTO_TEST_CASE(BoundaryToleranceConstructors) {
     auto tolerance = BoundaryTolerance::AbsoluteCartesian(1.0, 2.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance0, 1.0);
     BOOST_CHECK_EQUAL(tolerance.tolerance1, 2.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Extend);
+    BOOST_CHECK(
+        BoundaryTolerance{BoundaryTolerance::AbsoluteCartesian(0.0, 0.0)}
+            .toleranceMode() == None);
 
     // Negative tolerances should throw
     BOOST_CHECK_THROW(BoundaryTolerance::AbsoluteCartesian(-1.0, 2.0),
@@ -75,10 +93,14 @@ BOOST_AUTO_TEST_CASE(BoundaryToleranceConstructors) {
     // Valid positive chi2 bound
     auto tolerance = BoundaryTolerance::Chi2Bound(cov, 3.0);
     BOOST_CHECK_EQUAL(tolerance.maxChi2, 3.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Extend);
+    BOOST_CHECK(BoundaryTolerance{BoundaryTolerance::Chi2Bound(cov, 0.0)}
+                    .toleranceMode() == None);
 
     // Valid negative chi2 bound
     tolerance = BoundaryTolerance::Chi2Bound(cov, -3.0);
     BOOST_CHECK_EQUAL(tolerance.maxChi2, -3.0);
+    BOOST_CHECK(BoundaryTolerance{tolerance}.toleranceMode() == Shrink);
   }
 
   // Test None constructor

--- a/Tests/UnitTests/Core/Surfaces/BoundaryToleranceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/BoundaryToleranceTests.cpp
@@ -16,8 +16,10 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <fstream>
 #include <limits>
 #include <optional>
+#include <random>
 #include <vector>
 
 namespace Acts::Test {
@@ -201,6 +203,74 @@ BOOST_AUTO_TEST_CASE(BoundaryCheckDifferentTolerances) {
     BOOST_CHECK(
         !detail::insideAlignedBox(ll, ur, tolerance, {3, 3}, std::nullopt));
   }
+}
+
+BOOST_AUTO_TEST_CASE(BoundaryCheckNegativeTolerance) {
+  // Test points for boundary check with euclidean tolerance
+  Vector2 ll(1, 1);
+  Vector2 ur(3, 3);
+
+  auto check = [&ll, &ur](const BoundaryTolerance& tolerance,
+                          const Vector2& point) {
+    return detail::insideAlignedBox(ll, ur, tolerance, point, std::nullopt);
+  };
+
+  {
+    auto tolerance = BoundaryTolerance::AbsoluteEuclidean(-0.25);
+
+    BOOST_CHECK(!check(tolerance, {2.8, 2}));
+    BOOST_CHECK(!check(tolerance, {3.1, 2}));
+    BOOST_CHECK(check(tolerance, {2.7, 2}));
+    BOOST_CHECK(!check(tolerance, {2, 3.1}));
+    BOOST_CHECK(!check(tolerance, {2, 2.8}));
+    BOOST_CHECK(check(tolerance, {2, 2.7}));
+  }
+
+  {
+    auto tolerance = BoundaryTolerance::AbsoluteBound(-0.25, -0.0);
+
+    BOOST_CHECK(!check(tolerance, {2.8, 2}));
+    BOOST_CHECK(!check(tolerance, {3.1, 2}));
+    BOOST_CHECK(check(tolerance, {2.7, 2}));
+    BOOST_CHECK(!check(tolerance, {2, 3.1}));
+    BOOST_CHECK(check(tolerance, {2, 2.8}));
+    BOOST_CHECK(check(tolerance, {2, 2.7}));
+  }
+
+  // std::ofstream outFile("boundary_check_euclidean.csv");
+  // outFile << "x,y,inone,ipos,ineg\n";
+  //
+  // std::mt19937 gen(42);
+  // std::uniform_real_distribution<> dis(0.5, 3.5);
+  //
+  // for (int i = 0; i < 1000; i++) {
+  //   double x = dis(gen);
+  //   double y = dis(gen);
+  //   Vector2 point(x, y);
+  //
+  //   bool insideNone =
+  //       detail::insideAlignedBox(ll, ur, none, point, std::nullopt);
+  //   bool insidePos = detail::insideAlignedBox(ll, ur, pos, point,
+  //   std::nullopt); bool insideNeg = detail::insideAlignedBox(ll, ur, neg,
+  //   point, std::nullopt);
+  //
+  //   outFile << x << "," << y << "," << insideNone << "," << insidePos << ","
+  //           << insideNeg << "\n";
+  // }
+  //
+  // outFile.close();
+  //
+  // return;
+  // Verify some key points with known distances
+  // BOOST_CHECK(
+  //     detail::insideAlignedBox(ll, ur, tolerance, {0, 0}, std::nullopt));
+  // BOOST_CHECK(detail::insideAlignedBox(ll, ur, tolerance, {1.05, 0},
+  //                                      std::nullopt));  // Just within
+  //                                      tolerance
+  // BOOST_CHECK(!detail::insideAlignedBox(
+  //     ll, ur, tolerance, {1.2, 0}, std::nullopt));  // Just outside tolerance
+  // BOOST_CHECK(
+  //     !detail::insideAlignedBox(ll, ur, tolerance, {2, 2}, std::nullopt));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new enumeration for boundary tolerance modes: `Extend`, `None`, and `Shrink`.
  - Enhanced boundary checks to consider tolerance modes for point inclusion.

- **Bug Fixes**
  - Added validation checks to constructors to ensure non-negative tolerance values, throwing exceptions for invalid inputs.

- **Tests**
  - Added new test cases for `AnnulusBounds` and `BoundaryTolerance` to validate behavior with negative tolerances and constructor inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->