### PR TITLE
fix: Don't reset component state in `MultiStepperSurfaceReached`

### DIFF
--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
@@ -116,14 +116,17 @@ Result<double> MultiEigenStepperLoop<E, R>::step(
         }
       }
 
+      ACTS_VERBOSE("Stepper performed "
+                   << m_stepLimitAfterFirstComponentOnSurface
+                   << " steps after the first component hit a surface.");
+      ACTS_VERBOSE(
+          "-> remove all components not on a surface, perform no step");
+
       removeMissedComponents(stepping);
       reweightComponents(stepping);
 
-      ACTS_VERBOSE("Stepper performed "
-                   << m_stepLimitAfterFirstComponentOnSurface
-                   << " after the first component hit a surface.");
-      ACTS_VERBOSE(
-          "-> remove all components not on a surface, perform no step");
+      ACTS_VERBOSE(stepping.components.size()
+                   << " components left after removing missed components");
 
       stepping.stepCounterAfterFirstComponentOnSurface.reset();
 

--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.ipp
@@ -125,7 +125,7 @@ Result<double> MultiEigenStepperLoop<E, R>::step(
       removeMissedComponents(stepping);
       reweightComponents(stepping);
 
-      ACTS_VERBOSE(stepping.components.size()
+      ACTS_VERBOSE(components.size()
                    << " components left after removing missed components");
 
       stepping.stepCounterAfterFirstComponentOnSurface.reset();
@@ -187,7 +187,7 @@ Result<double> MultiEigenStepperLoop<E, R>::step(
   };
 
   // Loop over components and remove errorous components
-  stepping.components.erase(
+  components.erase(
       std::remove_if(components.begin(), components.end(), errorInStep),
       components.end());
 
@@ -221,8 +221,13 @@ Result<double> MultiEigenStepperLoop<E, R>::step(
   }
 
   // Return error if there is no ok result
-  if (stepping.components.empty()) {
+  if (components.empty()) {
     return MultiStepperError::AllComponentsSteppingError;
+  }
+
+  // Invalidate the component status after each step
+  for (auto& cmp : components) {
+    cmp.status = Status::unreachable;
   }
 
   // Return the weighted accumulated path length of all successful steps

--- a/Core/include/Acts/Propagator/MultiStepperAborters.hpp
+++ b/Core/include/Acts/Propagator/MultiStepperAborters.hpp
@@ -13,7 +13,7 @@
 
 namespace Acts {
 
-struct MultiStepperSurfaceReached : public SurfaceReached {
+struct MultiStepperSurfaceReached : public ForcedSurfaceReached {
   /// If this is set, we are also happy if the mean of the components is on the
   /// surface. How the averaging is performed depends on the stepper
   /// implementation
@@ -25,7 +25,6 @@ struct MultiStepperSurfaceReached : public SurfaceReached {
   double averageOnSurfaceTolerance = 0.2;
 
   MultiStepperSurfaceReached() = default;
-  explicit MultiStepperSurfaceReached(double oLimit) : SurfaceReached(oLimit) {}
 
   /// boolean operator for abort condition without using the result
   ///
@@ -82,8 +81,8 @@ struct MultiStepperSurfaceReached : public SurfaceReached {
       auto singleState = cmp.singleState(state);
       const auto& singleStepper = cmp.singleStepper(stepper);
 
-      if (!SurfaceReached::checkAbort(singleState, singleStepper, navigator,
-                                      logger)) {
+      if (!ForcedSurfaceReached::checkAbort(singleState, singleStepper,
+                                            navigator, logger)) {
         reached = false;
       } else {
         cmp.status() = Acts::IntersectionStatus::onSurface;

--- a/Core/include/Acts/Propagator/MultiStepperAborters.hpp
+++ b/Core/include/Acts/Propagator/MultiStepperAborters.hpp
@@ -84,7 +84,6 @@ struct MultiStepperSurfaceReached : public SurfaceReached {
 
       if (!SurfaceReached::checkAbort(singleState, singleStepper, navigator,
                                       logger)) {
-        cmp.status() = Acts::IntersectionStatus::reachable;
         reached = false;
       } else {
         cmp.status() = Acts::IntersectionStatus::onSurface;


### PR DESCRIPTION
After facing another problem with the GSF in https://github.com/acts-project/acts/pull/3449 this might resolve it. The problem seems to be that the navigator and the surface reached aborter are fighting over the surface reached status which can lead to removing all components if the target surface is not reached and the maximum step trials for the multi stepper are reached.

This might introduce other problems so waiting for physmon report.

blocked by
- https://github.com/acts-project/acts/pull/4025