### PR TITLE
fix: Off-by-one error in WhiteBoard levenshtein implementation

### DIFF
--- a/Examples/Framework/src/Framework/WhiteBoard.cpp
+++ b/Examples/Framework/src/Framework/WhiteBoard.cpp
@@ -37,9 +37,9 @@ inline int levenshteinDistance(const std::string_view &a,
   }
 
   // Fill matrix
-  for (std::size_t j = 1; j < b.size() + 1; ++j) {
-    for (std::size_t i = 1; i < a.size() + 1; ++i) {
-      const auto substitutionCost = a[i] == b[j] ? 0 : 1;
+  for (std::size_t j = 1; j < b.size(); ++j) {
+    for (std::size_t i = 1; i < a.size(); ++i) {
+      const auto substitutionCost = a.at(i) == b.at(j) ? 0 : 1;
 
       std::array<int, 3> possibilities = {{
           d(i - 1, j) + 1,                    // deletion


### PR DESCRIPTION
There was an off-by-one error where the algorithm would read the (usually present) terminating 0. With stdlib assertions or bounds checks this fails however.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved character access and loop boundaries in the Levenshtein distance calculation function for enhanced safety and precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->