### PR TITLE
feat: Allow multiple aliases for one whiteboard entry in Examples

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -177,7 +177,7 @@ class Sequencer {
   std::vector<SequenceElementWithFpeResult> m_sequenceElements;
   std::unique_ptr<const Acts::Logger> m_logger;
 
-  std::unordered_map<std::string, std::string> m_whiteboardObjectAliases;
+  std::unordered_multimap<std::string, std::string> m_whiteboardObjectAliases;
 
   std::unordered_map<std::string, const DataHandleBase *> m_whiteBoardState;
 


### PR DESCRIPTION
This allows us having multiple aliases pointing to the same object in the whiteboard which was not possible before because of the usage of `std::unordered_map` which is now replaced with `std:: unordered_multimap`

Pulled out of https://github.com/acts-project/acts/pull/3969