### PR TITLE
refactor: 

### DIFF
--- a/Core/include/Acts/Definitions/Algebra.hpp
+++ b/Core/include/Acts/Definitions/Algebra.hpp
@@ -87,7 +87,7 @@ using AngleAxis3 = Eigen::AngleAxis<double>;
 // - 2d affine compact stored as 2x3 matrix
 // - 3d affine stored as 4x4 matrix
 using Transform2 = Eigen::Transform<double, 2, Eigen::AffineCompact>;
-using Transform3 = Eigen::Transform<double, 3, Eigen::Affine>;
+using Transform3 = Eigen::Transform<double, 3, Eigen::Isometry>;
 
 constexpr double s_transformEquivalentTolerance = 1e-9;
 

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -97,18 +97,20 @@ std::vector<OrientedSurface> CylinderVolumeBounds::orientedSurfaces(
   double bevelMaxZ = get(eBevelMaxZ);
   Transform3 transMinZ, transMaxZ;
   if (bevelMinZ != 0.) {
-    double sy = 1 - 1 / std::cos(bevelMinZ);
-    transMinZ = transform * vMinZ *
-                Eigen::AngleAxisd(-bevelMinZ, Eigen::Vector3d(1., 0., 0.)) *
-                Eigen::Scaling(1., 1. + sy, 1.);
+    //double sy = 1 - 1 / std::cos(bevelMinZ);
+    //transMinZ = transform * vMinZ *
+    //            Eigen::AngleAxisd(-bevelMinZ, Eigen::Vector3d(1., 0., 0.)) *
+    //            Eigen::Scaling(1., 1. + sy, 1.);
+    throw std::invalid_argument("Bevel Min Z != 0 is not supported");
   } else {
     transMinZ = transform * vMinZ;
   }
   if (bevelMaxZ != 0.) {
-    double sy = 1 - 1 / std::cos(bevelMaxZ);
-    transMaxZ = transform * vMaxZ *
-                Eigen::AngleAxisd(bevelMaxZ, Eigen::Vector3d(1., 0., 0.)) *
-                Eigen::Scaling(1., 1. + sy, 1.);
+    //double sy = 1 - 1 / std::cos(bevelMaxZ);
+    //transMaxZ = transform * vMaxZ *
+    //            Eigen::AngleAxisd(bevelMaxZ, Eigen::Vector3d(1., 0., 0.)) *
+    //            Eigen::Scaling(1., 1. + sy, 1.);
+    throw std::invalid_argument("Bevel Max Z != 0 is not supported");
   } else {
     transMaxZ = transform * vMaxZ;
   }

--- a/Core/src/Geometry/PlaneLayer.cpp
+++ b/Core/src/Geometry/PlaneLayer.cpp
@@ -59,12 +59,13 @@ void Acts::PlaneLayer::buildApproachDescriptor() {
   const Vector3& lCenter = center(GeometryContext());
   const Vector3& lVector = normal(GeometryContext(), lCenter);
   // create new surfaces
-  const Transform3 apnTransform = Transform3(
-      Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector) *
-      lRotation);
-  const Transform3 appTransform = Transform3(
-      Translation3(lCenter + 0.5 * Layer::m_layerThickness * lVector) *
-      lRotation);
+
+  const auto lTrans = Translation3(lCenter - 0.5 * Layer::m_layerThickness * lVector);
+  const auto rTrans = Translation3(lCenter + 0.5 * Layer::m_layerThickness * lVector);
+    
+  const Transform3 apnTransform = Transform3(lTrans*Eigen::Isometry3d(lRotation));
+  const Transform3 appTransform = Transform3(rTrans*Eigen::Isometry3d(lRotation));
+    
   // create the new surfaces
   aSurfaces.push_back(Surface::makeShared<Acts::PlaneSurface>(
       apnTransform, PlaneSurface::m_bounds));

--- a/Core/src/Seeding/EstimateTrackParamsFromSeed.cpp
+++ b/Core/src/Seeding/EstimateTrackParamsFromSeed.cpp
@@ -30,11 +30,13 @@ Acts::FreeVector Acts::estimateTrackParamsFromSeed(const Vector3& sp0,
   rotation.col(0) = newXAxis;
   rotation.col(1) = newYAxis;
   rotation.col(2) = newZAxis;
+
   // The center of the new frame is at the bottom space point
   Translation3 trans(sp0);
-  // The transform which constructs the new frame
-  Transform3 transform(trans * rotation);
 
+  // The transform which constructs the new frame
+  Transform3 transform(trans * Eigen::Isometry3d(rotation));
+  
   // The coordinate of the middle and top space point in the new frame
   Vector3 local1 = transform.inverse() * sp1;
   Vector3 local2 = transform.inverse() * sp2;

--- a/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
@@ -170,7 +170,11 @@ void SensitiveSurfaceMapper::remapSensitiveNames(
       rotation << g4Rotation->xx(), g4Rotation->yx(), g4Rotation->zx(),
           g4Rotation->xy(), g4Rotation->yy(), g4Rotation->zy(),
           g4Rotation->xz(), g4Rotation->yz(), g4Rotation->zz();
-      localG4ToGlobal = motherTransform * (translation * rotation);
+
+      Acts::Transform3 tmp = Acts::Transform3::Identity();
+      tmp.translation() = translation.vector();
+      tmp.linear() = rotation;
+      localG4ToGlobal = motherTransform * tmp;
     }
   }
 

--- a/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/ProtoLayerCreatorT.hpp
+++ b/Examples/Detectors/GenericDetector/include/ActsExamples/GenericDetector/ProtoLayerCreatorT.hpp
@@ -262,8 +262,8 @@ ProtoLayerCreatorT<detector_element_t>::centralProtoLayers(
         moduleRotation.col(2) = moduleLocalZ;
         // get the moduleTransform
         std::shared_ptr<Acts::Transform3> mutableModuleTransform =
-            std::make_shared<Acts::Transform3>(
-                Acts::Translation3(moduleCenter) * moduleRotation);
+	  std::make_shared<Acts::Transform3>(
+					     Acts::Translation3(moduleCenter) * Eigen::Isometry3d(moduleRotation));
         // stereo angle if necessary
         if (!m_cfg.centralModuleFrontsideStereo.empty() &&
             m_cfg.centralModuleFrontsideStereo.at(icl) != 0.) {
@@ -299,7 +299,7 @@ ProtoLayerCreatorT<detector_element_t>::centralProtoLayers(
               moduleCenter +
               m_cfg.centralModuleBacksideGap.at(icl) * moduleLocalZ;
           mutableModuleTransform = std::make_shared<Acts::Transform3>(
-              Acts::Translation3(bsModuleCenter) * moduleRotation);
+								      Acts::Translation3(bsModuleCenter) * Eigen::Isometry3d(moduleRotation));
           // apply the stereo
           if (!m_cfg.centralModuleBacksideStereo.empty()) {
             // twist by the stereo angle
@@ -449,7 +449,7 @@ ProtoLayerCreatorT<detector_element_t>::createProtoLayers(
           // the transforms for the two modules
           std::shared_ptr<const Acts::Transform3> moduleTransform =
               std::make_shared<const Acts::Transform3>(
-                  Acts::Translation3(moduleCenter) * moduleRotation);
+						       Acts::Translation3(moduleCenter) * Eigen::Isometry3d(moduleRotation));
 
           // create the modules identifier
           GenericDetectorElement::Identifier moduleIdentifier =
@@ -472,7 +472,7 @@ ProtoLayerCreatorT<detector_element_t>::createProtoLayers(
                 m_cfg.posnegModuleBacksideGap.at(ipnl).at(ipnR) * moduleLocalZ;
             // the new transforms
             auto mutableModuleTransform = std::make_shared<Acts::Transform3>(
-                Acts::Translation3(moduleCenter) * moduleRotation);
+									     Acts::Translation3(moduleCenter) * Eigen::Isometry3d(moduleRotation));
             // apply the stereo
             if (!m_cfg.posnegModuleBacksideStereo.empty()) {
               // twist by the stereo angle

--- a/Examples/Detectors/TelescopeDetector/src/BuildTelescopeDetector.cpp
+++ b/Examples/Detectors/TelescopeDetector/src/BuildTelescopeDetector.cpp
@@ -83,7 +83,8 @@ ActsExamples::buildTelescopeDetector(
     Acts::Translation3 trans(offsets[0], offsets[1], positions[i]);
     // The entire transformation (the coordinate system, whose center is defined
     // by trans, will be rotated as well)
-    Acts::Transform3 trafo(rotation * trans);
+    Acts::Transform3 trafo(Eigen::Isometry3d(rotation) * trans);
+    
 
     // rotate around local z axis by stereo angle
     auto stereo = stereoAngles[i];
@@ -123,7 +124,7 @@ ActsExamples::buildTelescopeDetector(
   // The volume transform
   Acts::Translation3 transVol(offsets[0], offsets[1],
                               (positions.front() + positions.back()) * 0.5);
-  Acts::Transform3 trafoVol(rotation * transVol);
+  Acts::Transform3 trafoVol(Eigen::Isometry3d(rotation) * transVol);
 
   // The volume bounds is set to be a bit larger than either cubic with planes
   // or cylinder with discs

--- a/Plugins/Geant4/src/Geant4Converters.cpp
+++ b/Plugins/Geant4/src/Geant4Converters.cpp
@@ -252,9 +252,11 @@ Acts::Geant4ShapeConverter::planarBounds(const G4VSolid& g4Solid) {
 namespace {
 Acts::Transform3 axesOriented(const Acts::Transform3& toGlobalOriginal,
                               const std::array<int, 2u>& axes) {
-  auto originalRotation = toGlobalOriginal.rotation();
-  auto colX = originalRotation.col(std::abs(axes[0u]));
-  auto colY = originalRotation.col(std::abs(axes[1u]));
+  //auto originalRotation = toGlobalOriginal.rotation();
+  auto originalRotation = toGlobalOriginal.linear();
+  //make a copy
+  Acts::Vector3 colX = originalRotation.col(std::abs(axes[0u])).eval();
+  Acts::Vector3 colY = originalRotation.col(std::abs(axes[1u])).eval();
   colX *= std::copysign(1, axes[0u]);
   colY *= std::copysign(1, axes[1u]);
   Acts::Vector3 colZ = colX.cross(colY);

--- a/Plugins/Json/src/AlgebraJsonConverter.cpp
+++ b/Plugins/Json/src/AlgebraJsonConverter.cpp
@@ -61,7 +61,13 @@ nlohmann::json Acts::Transform3JsonConverter::toJson(const Transform3& t,
     jTransform["translation"] = nlohmann::json();
   }
   // Write out the rotation, could be transposed
-  auto rotation = options.transpose ? t.rotation().transpose() : t.rotation();
+  //auto rotation = options.transpose ? t.rotation().transpose() : t.rotation();
+
+  Acts::RotationMatrix3 rotation = t.rotation();
+  if (options.transpose) {
+    rotation.transposeInPlace();
+  }
+    
   if (rotation != Acts::RotationMatrix3::Identity() || options.writeIdentity) {
     std::array<double, 9> rdata = {
         rotation(0, 0), rotation(0, 1), rotation(0, 2),

--- a/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
+++ b/Tests/CommonHelpers/Acts/Tests/CommonHelpers/CylindricalTrackingGeometry.hpp
@@ -148,6 +148,7 @@ struct CylindricalTrackingGeometry {
                                 longitudinalOverlap, binningSchema);
 
     for (auto& mCenter : moduleCenters) {
+
       // The association transform
       double modulePhi = VectorHelpers::phi(mCenter);
       // Local z axis is the normal vector
@@ -165,7 +166,8 @@ struct CylindricalTrackingGeometry {
       moduleRotation.col(2) = moduleLocalZ;
       // Get the moduleTransform
       auto mModuleTransform =
-          Transform3(Translation3(mCenter) * moduleRotation);
+	Transform3(Translation3(mCenter) * Eigen::Isometry3d(moduleRotation));
+
       // Create the detector element
       auto detElement = std::make_unique<const DetectorElementStub>(
           mModuleTransform, mBounds, moduleThickness, moduleMaterialPtr);

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -322,7 +322,8 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceAlignment) {
   AngleAxis3 rotation(rotationAngle, Vector3::UnitY());
   RotationMatrix3 rotationMat = rotation.toRotationMatrix();
 
-  auto pTransform = Transform3{translation * rotationMat};
+  auto pTransform = Transform3{translation * Eigen::Isometry3d(rotationMat)};
+  
   auto planeSurfaceObject =
       Surface::makeShared<PlaneSurface>(pTransform, rBounds);
 


### PR DESCRIPTION
This PR proposes the explicit usage of Isometry instead of Affine in the Acts Algebra Definitions. 
This should imply an optimized inversion of the transforms (transpose of the linear part instead of general inversion). Additionally it should make it clear that current transformations in ACTS are isometries (no scaling, no sheers). 

- I just tested that ODD runs
- I disabled beveled disc bounds for the moment. That's the only place where the scaling is used
- I rewrote the initialization of transforms using Eigen::Isometry3d around rotations. This doesn't check that the rotation matrix is orthogonal and with det=1 (but we weren't doing it anyway). 

I haven't seen sensible improvement in processing time (just checked the full ODD processing time on 1k events) but I still propose the change as it makes clear we are using isometric transformations. 

