### PR TITLE
chore: Fix clang-tidy config file format

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,25 +1,26 @@
 ---
-Checks: '-*, \
-  clang-analyzer-optin.cplusplus.UninitializedObject, \
-  cppcoreguidelines-init-variables, \
-  cppcoreguidelines-pro-type-member-init, \
-  google-readability-casting, \
-  modernize-concat-nested-namespaces, \
-  modernize-use-equals-default, \
-  modernize-use-default-member-init, \
-  modernize-use-nullptr, \
-  modernize-use-override, \
-  modernize-use-using, \
-  performance-for-range-copy, \
-  performance-move-const-arg, \
-  performance-unnecessary-value-param, \
-  readability-braces-around-statements, \
-  readability-container-size-empty, \
-  readability-implicit-bool-cast, \
-  readability-implicit-bool-conversion, \
-  readability-inconsistent-declaration-parameter-name, \
-  readability-named-parameter, \
-  readability-operators-representation'
+Checks: >
+  -*,
+  clang-analyzer-optin.cplusplus.UninitializedObject,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-pro-type-member-init,
+  google-readability-casting,
+  modernize-concat-nested-namespaces,
+  modernize-use-equals-default,
+  modernize-use-default-member-init,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-for-range-copy,
+  performance-move-const-arg,
+  performance-unnecessary-value-param,
+  readability-braces-around-statements,
+  readability-container-size-empty,
+  readability-implicit-bool-cast,
+  readability-implicit-bool-conversion,
+  readability-inconsistent-declaration-parameter-name,
+  readability-named-parameter,
+  readability-operators-representation,
 HeaderFilterRegex: '.*(?<!nlohmann\/json)\.(hpp|cpp|ipp)$'
 CheckOptions:
   readability-operators-representation.BinaryOperators: '&&;&=;&;|;~;!;!=;||;|=;^;^='

--- a/cmake/ActsStaticAnalysis.cmake
+++ b/cmake/ActsStaticAnalysis.cmake
@@ -12,7 +12,7 @@ if(ACTS_RUN_CLANG_TIDY)
         set(CLANG_TIDY_HEADER_FILTER ".*")
 
         set(CMAKE_CXX_CLANG_TIDY
-            "${CLANG_TIDY_COMMAND};-header-filter=${CLANG_TIDY_HEADER_FILTER};"
+            "${CLANG_TIDY_COMMAND};-header-filter=${CLANG_TIDY_HEADER_FILTER};-config-file=${CMAKE_SOURCE_DIR}/.clang-tidy"
         )
     endif()
 endif()

--- a/cmake/ActsStaticAnalysis.cmake
+++ b/cmake/ActsStaticAnalysis.cmake
@@ -9,47 +9,10 @@ if(ACTS_RUN_CLANG_TIDY)
     else()
         message(STATUS "Setting up clang-tidy run")
 
-        set(_chks "")
-        list(APPEND _chks "-*")
-        list(APPEND _chks "clang-analyzer-optin.cplusplus.UninitializedObject")
-        list(APPEND _chks "cppcoreguidelines-init-variables")
-        list(APPEND _chks "cppcoreguidelines-pro-type-member-init")
-        list(APPEND _chks "google-readability-casting")
-        list(APPEND _chks "modernize-concat-nested-namespaces")
-        list(APPEND _chks "modernize-use-equals-default")
-        list(APPEND _chks "modernize-use-default-member-init")
-        list(APPEND _chks "modernize-use-nullptr")
-        list(APPEND _chks "modernize-use-override")
-        list(APPEND _chks "modernize-use-using")
-        list(APPEND _chks "performance-for-range-copy")
-        list(APPEND _chks "performance-move-const-arg")
-        list(APPEND _chks "performance-unnecessary-value-param")
-        list(APPEND _chks "readability-braces-around-statements")
-        list(APPEND _chks "readability-container-size-empty")
-        list(APPEND _chks "readability-implicit-bool-cast")
-        list(APPEND _chks "readability-implicit-bool-conversion")
-        list(APPEND _chks "readability-inconsistent-declaration-parameter-name")
-        list(APPEND _chks "readability-named-parameter")
-        list(APPEND _chks "readability-operators-representation")
-        list(JOIN _chks "," CLANG_TIDY_CHECKS)
-
-        message(STATUS "Configured checks")
-        foreach(_chk ${_chks})
-            message(STATUS "|-> ${_chk}")
-        endforeach()
-
-        set(_errs "")
-        list(JOIN _errs "," CLANG_TIDY_ERRORS)
-
-        message(STATUS "Enabled errors:")
-        foreach(_err ${_errs})
-            message(STATUS "|-> ${_err}")
-        endforeach()
-
         set(CLANG_TIDY_HEADER_FILTER ".*")
 
         set(CMAKE_CXX_CLANG_TIDY
-            "${CLANG_TIDY_COMMAND};-checks=${CLANG_TIDY_CHECKS};-header-filter=${CLANG_TIDY_HEADER_FILTER};-warnings-as-errors=${CLANG_TIDY_ERRORS}"
+            "${CLANG_TIDY_COMMAND};-header-filter=${CLANG_TIDY_HEADER_FILTER};"
         )
     endif()
 endif()


### PR DESCRIPTION
This PR fixes the format of the `.clang-tidy` and removes the separate configuration layer that we were using for the CI run of clang-tidy.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
	- Updated `.clang-tidy` configuration to use a more readable multiline format.
	- Added header file filtering for static analysis checks.
	- Simplified CMake static analysis configuration by removing explicit check and error lists.

- **Maintenance**
	- Streamlined clang-tidy setup process.
	- Reduced configuration complexity for static code analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->