### PR TITLE
feat: detray material collection

### DIFF
--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -290,6 +290,11 @@ void addGeometry(Context& ctx) {
               Acts::AxisDirection bval) -> std::array<double, 2> {
              return {self.min(bval), self.max(bval)};
            })
+      .def("setRange",
+           [](Extent& self, Acts::AxisDirection bval,
+              const std::array<double, 2>& range) {
+             self.set(bval, range[0], range[1]);
+           })
       .def("__str__", &Extent::toString);
 
   {

--- a/Plugins/Detray/src/DetrayMaterialConverter.cpp
+++ b/Plugins/Detray/src/DetrayMaterialConverter.cpp
@@ -108,7 +108,6 @@ Acts::DetrayMaterialConverter::convertHomogeneousSurfaceMaterial(
                                                       << " not found in cache");
     }
   }
-
   return materialPayload;
 }
 


### PR DESCRIPTION
This PR adds the possibility to record material from detray.

Currently, the material_tracer does not return enough information to fill the individual steps sense fully, this can come at a later stage.

![itk_gen2_v_eta_vs_t_X0](https://github.com/user-attachments/assets/c48b2c39-a145-4cbb-9b2b-6c8fc3ae1b72)

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
