### PR TITLE
feat: make layer envelope configurable in Gen1 geometry building

### DIFF
--- a/Core/include/Acts/Geometry/LayerCreator.hpp
+++ b/Core/include/Acts/Geometry/LayerCreator.hpp
@@ -51,8 +51,10 @@ class LayerCreator {
     double cylinderZtolerance{10.};
     /// cylinder module phi tolerance: it counts as same phi, if ...
     double cylinderPhiTolerance{0.1};
-    /// standard constructor
-    Config() = default;
+    /// Default z envelope. Can be overridden by proto layer
+    Envelope defaultEnvelopeZ = zeroEnvelope;
+    /// Default r envelope. Can be overridden by proto layer
+    Envelope defaultEnvelopeR = zeroEnvelope;
   };
 
   /// Constructor

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <iterator>
 #include <vector>
 
@@ -158,8 +159,10 @@ Acts::Layer::compatibleSurfaces(
       return;
     }
     BoundaryTolerance boundaryTolerance = options.boundaryTolerance;
+    bool extSurf = false;
     if (rangeContainsValue(options.externalSurfaces, sf.geometryId())) {
       boundaryTolerance = BoundaryTolerance::Infinite();
+      extSurf = true;
     }
     // the surface intersection
     SurfaceIntersection sfi =
@@ -167,7 +170,23 @@ Acts::Layer::compatibleSurfaces(
     if (sfi.isValid() &&
         detail::checkPathLength(sfi.pathLength(), nearLimit, farLimit) &&
         isUnique(sfi)) {
+      if (extSurf) {
+        std::cout << "VERBOSE   Accept external surface intersection for "
+                  << sf.geometryId() << std::endl;
+      }
       sIntersections.push_back(sfi);
+    } else {
+      if (extSurf) {
+        std::cout
+            << "VERBOSE   Do NOT accept external surface intersection for "
+            << sf.geometryId() << std::endl;
+        std::cout << "  - isValid: " << std::boolalpha << sfi.isValid() << "\n"
+                  << "  - path length: " << sfi.pathLength() << " / "
+                  << detail::checkPathLength(sfi.pathLength(), nearLimit,
+                                             farLimit)
+                  << "\n"
+                  << "  - is unique: " << isUnique(sfi) << std::endl;
+      }
     }
   };
 

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <iostream>
 #include <iterator>
 #include <vector>
 
@@ -159,10 +158,8 @@ Acts::Layer::compatibleSurfaces(
       return;
     }
     BoundaryTolerance boundaryTolerance = options.boundaryTolerance;
-    bool extSurf = false;
     if (rangeContainsValue(options.externalSurfaces, sf.geometryId())) {
       boundaryTolerance = BoundaryTolerance::Infinite();
-      extSurf = true;
     }
     // the surface intersection
     SurfaceIntersection sfi =
@@ -170,23 +167,7 @@ Acts::Layer::compatibleSurfaces(
     if (sfi.isValid() &&
         detail::checkPathLength(sfi.pathLength(), nearLimit, farLimit) &&
         isUnique(sfi)) {
-      if (extSurf) {
-        std::cout << "VERBOSE   Accept external surface intersection for "
-                  << sf.geometryId() << std::endl;
-      }
       sIntersections.push_back(sfi);
-    } else {
-      if (extSurf) {
-        std::cout
-            << "VERBOSE   Do NOT accept external surface intersection for "
-            << sf.geometryId() << std::endl;
-        std::cout << "  - isValid: " << std::boolalpha << sfi.isValid() << "\n"
-                  << "  - path length: " << sfi.pathLength() << " / "
-                  << detail::checkPathLength(sfi.pathLength(), nearLimit,
-                                             farLimit)
-                  << "\n"
-                  << "  - is unique: " << isUnique(sfi) << std::endl;
-      }
     }
   };
 

--- a/Core/src/Geometry/LayerCreator.cpp
+++ b/Core/src/Geometry/LayerCreator.cpp
@@ -57,6 +57,10 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
     const Transform3& transform, std::unique_ptr<ApproachDescriptor> ad) const {
   ProtoLayer protoLayer =
       _protoLayer ? *_protoLayer : ProtoLayer(gctx, surfaces);
+  if (!_protoLayer) {
+    protoLayer.envelope[AxisDirection::AxisR] = m_cfg.defaultEnvelopeR;
+    protoLayer.envelope[AxisDirection::AxisZ] = m_cfg.defaultEnvelopeZ;
+  }
 
   // Remaining layer parameters - they include the envelopes
   double layerR = protoLayer.medium(AxisDirection::AxisR);
@@ -130,6 +134,10 @@ Acts::MutableLayerPtr Acts::LayerCreator::cylinderLayer(
     const Transform3& transform, std::unique_ptr<ApproachDescriptor> ad) const {
   ProtoLayer protoLayer =
       _protoLayer ? *_protoLayer : ProtoLayer(gctx, surfaces);
+  if (!_protoLayer) {
+    protoLayer.envelope[AxisDirection::AxisR] = m_cfg.defaultEnvelopeR;
+    protoLayer.envelope[AxisDirection::AxisZ] = m_cfg.defaultEnvelopeZ;
+  }
 
   // remaining layer parameters
   double layerR = protoLayer.medium(AxisDirection::AxisR);
@@ -204,6 +212,10 @@ Acts::MutableLayerPtr Acts::LayerCreator::discLayer(
     const Transform3& transform, std::unique_ptr<ApproachDescriptor> ad) const {
   ProtoLayer protoLayer =
       _protoLayer ? *_protoLayer : ProtoLayer(gctx, surfaces);
+  if (!_protoLayer) {
+    protoLayer.envelope[AxisDirection::AxisR] = m_cfg.defaultEnvelopeR;
+    protoLayer.envelope[AxisDirection::AxisZ] = m_cfg.defaultEnvelopeZ;
+  }
 
   double layerZ = protoLayer.medium(AxisDirection::AxisZ);
   double layerThickness = protoLayer.range(AxisDirection::AxisZ);
@@ -270,6 +282,10 @@ Acts::MutableLayerPtr Acts::LayerCreator::discLayer(
     const Transform3& transform, std::unique_ptr<ApproachDescriptor> ad) const {
   ProtoLayer protoLayer =
       _protoLayer ? *_protoLayer : ProtoLayer(gctx, surfaces);
+  if (!_protoLayer) {
+    protoLayer.envelope[AxisDirection::AxisR] = m_cfg.defaultEnvelopeR;
+    protoLayer.envelope[AxisDirection::AxisZ] = m_cfg.defaultEnvelopeZ;
+  }
 
   double layerZ = protoLayer.medium(AxisDirection::AxisZ);
   double layerThickness = protoLayer.range(AxisDirection::AxisZ);
@@ -334,6 +350,10 @@ Acts::MutableLayerPtr Acts::LayerCreator::planeLayer(
     std::unique_ptr<ApproachDescriptor> ad) const {
   ProtoLayer protoLayer =
       _protoLayer ? *_protoLayer : ProtoLayer(gctx, surfaces);
+  if (!_protoLayer) {
+    protoLayer.envelope[AxisDirection::AxisR] = m_cfg.defaultEnvelopeR;
+    protoLayer.envelope[AxisDirection::AxisZ] = m_cfg.defaultEnvelopeZ;
+  }
 
   // remaining layer parameters
   double layerHalf1 = 0, layerHalf2 = 0, layerThickness = 0;

--- a/Examples/Python/src/GeometryBuildingGen1.cpp
+++ b/Examples/Python/src/GeometryBuildingGen1.cpp
@@ -58,6 +58,8 @@ void addGeometryBuildingGen1(Context &ctx) {
     ACTS_PYTHON_MEMBER(surfaceArrayCreator);
     ACTS_PYTHON_MEMBER(cylinderZtolerance);
     ACTS_PYTHON_MEMBER(cylinderPhiTolerance);
+    ACTS_PYTHON_MEMBER(defaultEnvelopeR);
+    ACTS_PYTHON_MEMBER(defaultEnvelopeZ);
     ACTS_PYTHON_STRUCT_END();
   }
 


### PR DESCRIPTION
Add a possibililty to configure layer envelopes in the `LayerCreator`. Since this is gonna be deprecated anyways rather soon, not big effort wrt consistent configuration was made.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded geometry configuration by introducing default settings for envelope dimensions, ensuring layers initialize with robust defaults.
  - Enhanced logging for geometry processing to provide clear traceability for external surface intersections.
  - Updated the Python interface to make the new default configuration options available, ensuring a consistent experience across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->