### PR TITLE
refactor: Disentangle stepper state creation and initialization

### DIFF
--- a/Core/include/Acts/Propagator/AtlasStepper.hpp
+++ b/Core/include/Acts/Propagator/AtlasStepper.hpp
@@ -12,6 +12,8 @@
 #include "Acts/Utilities/detail/ReferenceWrapperAnyCompat.hpp"
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Definitions/Common.hpp"
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TransformationHelpers.hpp"
@@ -137,33 +139,53 @@ class AtlasStepper {
 
   explicit AtlasStepper(const Config& config) : m_bField(config.bField) {}
 
-  State makeState(const Options& options,
-                  const BoundTrackParameters& par) const {
+  State makeState(const Options& options) const {
     State state{options, m_bField->makeCache(options.magFieldContext)};
+    return state;
+  }
 
-    state.particleHypothesis = par.particleHypothesis();
+  void initialize(State& state, const BoundTrackParameters& par) const {
+    initialize(state, par.parameters(), par.covariance(),
+               par.particleHypothesis(), par.referenceSurface());
+  }
+
+  void initialize(State& state, const BoundVector& boundParams,
+                  const std::optional<BoundMatrix>& cov,
+                  ParticleHypothesis particleHypothesis,
+                  const Surface& surface) const {
+    state.particleHypothesis = particleHypothesis;
+
+    state.pathAccumulated = 0;
+    state.nSteps = 0;
+    state.nStepTrials = 0;
+    state.stepSize = ConstrainedStep(state.options.maxStepSize);
+    state.previousStepSize = 0;
+    state.statistics = StepperStatistics();
 
     // The rest of this constructor is copy&paste of AtlasStepper::update() -
     // this is a nasty but working solution for the stepper state without
     // functions
 
-    const auto pos = par.position(options.geoContext);
-    const auto Vp = par.parameters();
+    const auto& Vp = boundParams;
 
     double Sf = std::sin(Vp[eBoundPhi]);
     double Cf = std::cos(Vp[eBoundPhi]);
     double Se = std::sin(Vp[eBoundTheta]);
     double Ce = std::cos(Vp[eBoundTheta]);
 
+    const Vector3 dir = {Cf * Se, Sf * Se, Ce};
+    const auto pos = surface.localToGlobal(
+        state.options.geoContext, boundParams.segment<2>(eBoundLoc0), dir);
+
     double* pVector = state.pVector.data();
 
     pVector[0] = pos[ePos0];
     pVector[1] = pos[ePos1];
     pVector[2] = pos[ePos2];
-    pVector[3] = par.time();
-    pVector[4] = Cf * Se;
-    pVector[5] = Sf * Se;
-    pVector[6] = Ce;
+    pVector[3] = boundParams[eBoundTime];
+    pVector[4] = dir[ePos0];
+    pVector[5] = dir[ePos1];
+    pVector[6] = dir[ePos2];
     pVector[7] = Vp[eBoundQOverP];
 
     // @todo: remove magic numbers - is that the charge ?
@@ -173,13 +195,13 @@ class AtlasStepper {
     }
 
     // prepare the jacobian if we have a covariance
-    if (par.covariance()) {
+    state.covTransport = cov.has_value();
+    if (state.covTransport) {
       // copy the covariance matrix
-      state.covariance = new BoundSquareMatrix(*par.covariance());
-      state.covTransport = true;
+      state.covariance = new BoundSquareMatrix(*cov);
       state.useJacobian = true;
-      const auto transform = par.referenceSurface().referenceFrame(
-          options.geoContext, pos, par.direction());
+      const auto transform =
+          surface.referenceFrame(state.options.geoContext, pos, dir);
 
       pVector[8] = transform(0, eBoundLoc0);
       pVector[16] = transform(0, eBoundLoc1);
@@ -243,7 +265,6 @@ class AtlasStepper {
       pVector[59] = 0.;
 
       // special treatment for surface types
-      const auto& surface = par.referenceSurface();
       // the disc needs polar coordinate adaptations
       if (surface.type() == Surface::Disc) {
         double lCf = std::cos(Vp[1]);
@@ -305,34 +326,8 @@ class AtlasStepper {
       }
     }
 
-    state.stepSize = ConstrainedStep(options.maxStepSize);
-
     // now declare the state as ready
     state.state_ready = true;
-
-    return state;
-  }
-
-  /// @brief Resets the state
-  ///
-  /// @param [in, out] state State of the stepper
-  /// @param [in] boundParams Parameters in bound parametrisation
-  /// @param [in] cov Covariance matrix
-  /// @param [in] surface Reset state will be on this surface
-  /// @param [in] stepSize Step size
-  void resetState(
-      State& state, const BoundVector& boundParams,
-      const BoundSquareMatrix& cov, const Surface& surface,
-      const double stepSize = std::numeric_limits<double>::max()) const {
-    // Update the stepping state
-    update(state,
-           transformBoundToFreeParameters(surface, state.options.geoContext,
-                                          boundParams),
-           boundParams, cov, surface);
-    state.stepSize = ConstrainedStep(stepSize);
-    state.pathAccumulated = 0.;
-
-    setIdentityJacobian(state);
   }
 
   /// Get the field for the stepping

--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -25,7 +25,6 @@
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 
-#include <limits>
 #include <type_traits>
 
 namespace Acts {
@@ -150,20 +149,14 @@ class EigenStepper {
   /// @param [in] config The configuration of the stepper
   explicit EigenStepper(const Config& config) : m_bField(config.bField) {}
 
-  State makeState(const Options& options,
-                  const BoundTrackParameters& par) const;
+  State makeState(const Options& options) const;
 
-  /// @brief Resets the state
-  ///
-  /// @param [in, out] state State of the stepper
-  /// @param [in] boundParams Parameters in bound parametrisation
-  /// @param [in] cov Covariance matrix
-  /// @param [in] surface The reference surface of the bound parameters
-  /// @param [in] stepSize Step size
-  void resetState(
-      State& state, const BoundVector& boundParams,
-      const BoundSquareMatrix& cov, const Surface& surface,
-      const double stepSize = std::numeric_limits<double>::max()) const;
+  void initialize(State& state, const BoundTrackParameters& par) const;
+
+  void initialize(State& state, const BoundVector& boundParams,
+                  const std::optional<BoundMatrix>& cov,
+                  ParticleHypothesis particleHypothesis,
+                  const Surface& surface) const;
 
   /// Get the field for the stepping, it checks first if the access is still
   /// within the Cell, and updates the cell if necessary.

--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
@@ -198,6 +198,9 @@ class MultiEigenStepperLoop : public EigenStepper<extension_t> {
       SingleState state;
       double weight;
       IntersectionStatus status;
+
+      Component(SingleState state_, double weight_, IntersectionStatus status_)
+          : state(std::move(state_)), weight(weight_), status(status_) {}
     };
 
     Options options;
@@ -259,9 +262,9 @@ class MultiEigenStepperLoop : public EigenStepper<extension_t> {
 
     for (auto i = 0ul; i < par.components().size(); ++i) {
       const auto& [weight, singlePars] = par[i];
-      auto singleState = SingleStepper::makeState(state.options);
-      auto& cmp = state.components.emplace_back(std::move(singleState), weight,
-                                                IntersectionStatus::onSurface);
+      auto& cmp =
+          state.components.emplace_back(SingleStepper::makeState(state.options),
+                                        weight, IntersectionStatus::onSurface);
       SingleStepper::initialize(cmp.state, singlePars);
     }
 

--- a/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
+++ b/Core/include/Acts/Propagator/MultiEigenStepperLoop.hpp
@@ -259,9 +259,9 @@ class MultiEigenStepperLoop : public EigenStepper<extension_t> {
 
     for (auto i = 0ul; i < par.components().size(); ++i) {
       const auto& [weight, singlePars] = par[i];
-      auto& cmp =
-          state.components.emplace_back(SingleStepper::makeState(state.options),
-                                        weight, IntersectionStatus::onSurface);
+      auto singleState = SingleStepper::makeState(state.options);
+      auto& cmp = state.components.emplace_back(std::move(singleState), weight,
+                                                IntersectionStatus::onSurface);
       SingleStepper::initialize(cmp.state, singlePars);
     }
 

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -386,8 +386,9 @@ class Propagator final
  private:
   const Logger& logger() const { return *m_logger; }
 
-  template <typename propagator_state_t, typename path_aborter_t>
-  void initialize(propagator_state_t& state) const;
+  template <typename propagator_state_t, typename parameters_t,
+            typename path_aborter_t>
+  void initialize(propagator_state_t& state, const parameters_t& start) const;
 
   template <typename propagator_state_t, typename result_t>
   void moveStateToResult(propagator_state_t& state, result_t& result) const;

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -255,7 +255,7 @@ auto Acts::Propagator<S, N>::makeState(
       actor_list_t_state_t<OptionsType,
                            typename propagator_options_t::actor_list_type>;
   // Initialize the internal propagator state
-  StateType state{eOptions, m_stepper.makeState(eOptions.stepping, start),
+  StateType state{eOptions, m_stepper.makeState(eOptions.stepping),
                   m_navigator.makeState(eOptions.navigation)};
 
   static_assert(
@@ -263,7 +263,7 @@ auto Acts::Propagator<S, N>::makeState(
       "Step method of the Stepper is not compatible with the propagator "
       "state");
 
-  initialize<StateType, path_aborter_t>(state);
+  initialize<StateType, parameters_t, path_aborter_t>(state, start);
 
   return state;
 }
@@ -294,7 +294,7 @@ auto Acts::Propagator<S, N>::makeState(
   using StateType =
       actor_list_t_state_t<OptionsType,
                            typename propagator_options_t::actor_list_type>;
-  StateType state{eOptions, m_stepper.makeState(eOptions.stepping, start),
+  StateType state{eOptions, m_stepper.makeState(eOptions.stepping),
                   m_navigator.makeState(eOptions.navigation)};
 
   static_assert(
@@ -302,7 +302,7 @@ auto Acts::Propagator<S, N>::makeState(
       "Step method of the Stepper is not compatible with the propagator "
       "state");
 
-  initialize<StateType, path_aborter_t>(state);
+  initialize<StateType, parameters_t, path_aborter_t>(state, start);
 
   return state;
 }
@@ -396,8 +396,12 @@ auto Acts::Propagator<S, N>::makeResult(
 }
 
 template <typename S, typename N>
-template <typename propagator_state_t, typename path_aborter_t>
-void Acts::Propagator<S, N>::initialize(propagator_state_t& state) const {
+template <typename propagator_state_t, typename parameters_t,
+          typename path_aborter_t>
+void Acts::Propagator<S, N>::initialize(propagator_state_t& state,
+                                        const parameters_t& start) const {
+  m_stepper.initialize(state.stepping, start);
+
   state.position = m_stepper.position(state.stepping);
   state.direction =
       state.options.direction * m_stepper.direction(state.stepping);

--- a/Core/include/Acts/Propagator/StepperConcept.hpp
+++ b/Core/include/Acts/Propagator/StepperConcept.hpp
@@ -32,11 +32,6 @@ concept CommonStepper = requires {
   requires requires(const Stepper& s, State& t) {
     { s.transportCovarianceToCurvilinear(t) } -> std::same_as<void>;
 
-    requires requires(const BoundVector& bv, const BoundSquareMatrix& bm,
-                      const Surface& sf, const double d) {
-      { s.resetState(t, bv, bm, sf, d) } -> std::same_as<void>;
-    };
-
     requires requires(const Surface& sf, bool b,
                       const FreeToBoundCorrection& corr) {
       {

--- a/Core/include/Acts/Propagator/StraightLineStepper.hpp
+++ b/Core/include/Acts/Propagator/StraightLineStepper.hpp
@@ -30,7 +30,6 @@
 #include "Acts/Utilities/Result.hpp"
 
 #include <cmath>
-#include <limits>
 #include <string>
 #include <tuple>
 
@@ -114,48 +113,14 @@ class StraightLineStepper {
     StepperStatistics statistics;
   };
 
-  StraightLineStepper() = default;
+  State makeState(const Options& options) const;
 
-  State makeState(const Options& options,
-                  const BoundTrackParameters& par) const {
-    State state{options};
+  void initialize(State& state, const BoundTrackParameters& par) const;
 
-    state.particleHypothesis = par.particleHypothesis();
-
-    Vector3 position = par.position(options.geoContext);
-    Vector3 direction = par.direction();
-    state.pars.template segment<3>(eFreePos0) = position;
-    state.pars.template segment<3>(eFreeDir0) = direction;
-    state.pars[eFreeTime] = par.time();
-    state.pars[eFreeQOverP] = par.parameters()[eBoundQOverP];
-
-    // Init the jacobian matrix if needed
-    if (par.covariance()) {
-      // Get the reference surface for navigation
-      const auto& surface = par.referenceSurface();
-      // set the covariance transport flag to true and copy
-      state.covTransport = true;
-      state.cov = BoundSquareMatrix(*par.covariance());
-      state.jacToGlobal =
-          surface.boundToFreeJacobian(options.geoContext, position, direction);
-    }
-
-    state.stepSize = ConstrainedStep(options.maxStepSize);
-
-    return state;
-  }
-
-  /// @brief Resets the state
-  ///
-  /// @param [in, out] state State of the stepper
-  /// @param [in] boundParams Parameters in bound parametrisation
-  /// @param [in] cov Covariance matrix
-  /// @param [in] surface The reset @c State will be on this surface
-  /// @param [in] stepSize Step size
-  void resetState(
-      State& state, const BoundVector& boundParams,
-      const BoundSquareMatrix& cov, const Surface& surface,
-      const double stepSize = std::numeric_limits<double>::max()) const;
+  void initialize(State& state, const BoundVector& boundParams,
+                  const std::optional<BoundMatrix>& cov,
+                  ParticleHypothesis particleHypothesis,
+                  const Surface& surface) const;
 
   /// Get the field for the stepping, this gives back a zero field
   Result<Vector3> getField(State& /*state*/, const Vector3& /*pos*/) const {

--- a/Core/include/Acts/Propagator/SympyStepper.hpp
+++ b/Core/include/Acts/Propagator/SympyStepper.hpp
@@ -117,20 +117,14 @@ class SympyStepper {
   /// @param config The configuration of the stepper
   explicit SympyStepper(const Config& config);
 
-  State makeState(const Options& options,
-                  const BoundTrackParameters& par) const;
+  State makeState(const Options& options) const;
 
-  /// @brief Resets the state
-  ///
-  /// @param [in, out] state State of the stepper
-  /// @param [in] boundParams Parameters in bound parametrisation
-  /// @param [in] cov Covariance matrix
-  /// @param [in] surface The reference surface of the bound parameters
-  /// @param [in] stepSize Step size
-  void resetState(
-      State& state, const BoundVector& boundParams,
-      const BoundSquareMatrix& cov, const Surface& surface,
-      const double stepSize = std::numeric_limits<double>::max()) const;
+  void initialize(State& state, const BoundTrackParameters& par) const;
+
+  void initialize(State& state, const BoundVector& boundParams,
+                  const std::optional<BoundMatrix>& cov,
+                  ParticleHypothesis particleHypothesis,
+                  const Surface& surface) const;
 
   /// Get the field for the stepping, it checks first if the access is still
   /// within the Cell, and updates the cell if necessary.

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -21,13 +21,12 @@
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/ActorList.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
+#include "Acts/Propagator/PropagatorState.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Propagator/detail/LoopProtection.hpp"
 #include "Acts/Propagator/detail/PointwiseMaterialInteraction.hpp"
 #include "Acts/TrackFinding/CombinatorialKalmanFilterError.hpp"
 #include "Acts/TrackFinding/CombinatorialKalmanFilterExtensions.hpp"
-#include "Acts/TrackFinding/TrackStateCreator.hpp"
-#include "Acts/TrackFitting/detail/VoidFitterComponents.hpp"
 #include "Acts/Utilities/CalibrationContext.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -35,7 +34,6 @@
 #include <functional>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <type_traits>
 
 namespace Acts {
@@ -372,10 +370,10 @@ class CombinatorialKalmanFilter {
                    << currentBranch.tipIndex());
 
       // Reset the stepping state
-      stepper.resetState(state.stepping, currentState.filtered(),
+      stepper.initialize(state.stepping, currentState.filtered(),
                          currentState.filteredCovariance(),
-                         currentState.referenceSurface(),
-                         state.options.stepping.maxStepSize);
+                         stepper.particleHypothesis(state.stepping),
+                         currentState.referenceSurface());
 
       // Reset the navigation state
       // Set targetSurface to nullptr for forward filtering

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -14,14 +14,13 @@
 #include "Acts/EventData/MultiTrajectory.hpp"
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/SourceLink.hpp"
-#include "Acts/EventData/TrackContainerFrontendConcept.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/VectorMultiTrajectory.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/ActorList.hpp"
 #include "Acts/Propagator/DirectNavigator.hpp"
-#include "Acts/Propagator/Propagator.hpp"
+#include "Acts/Propagator/PropagatorOptions.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Propagator/detail/PointwiseMaterialInteraction.hpp"
 #include "Acts/TrackFitting/KalmanFitterError.hpp"
@@ -545,10 +544,10 @@ class KalmanFitter {
       auto st = result.fittedStates->getTrackState(result.lastMeasurementIndex);
 
       // Update the stepping state
-      stepper.resetState(
+      stepper.initialize(
           state.stepping, st.filtered(),
           reversedFilteringCovarianceScaling * st.filteredCovariance(),
-          st.referenceSurface(), state.options.stepping.maxStepSize);
+          stepper.particleHypothesis(state.stepping), st.referenceSurface());
 
       // For the last measurement state, smoothed is filtered
       st.smoothed() = st.filtered();
@@ -1011,16 +1010,16 @@ class KalmanFitter {
       }
       bool reverseDirection = false;
       if (useFirstTrackState) {
-        stepper.resetState(state.stepping, firstCreatedState.smoothed(),
+        stepper.initialize(state.stepping, firstCreatedState.smoothed(),
                            firstCreatedState.smoothedCovariance(),
-                           firstCreatedState.referenceSurface(),
-                           state.options.stepping.maxStepSize);
+                           stepper.particleHypothesis(state.stepping),
+                           firstCreatedState.referenceSurface());
         reverseDirection = firstIntersection.pathLength() < 0;
       } else {
-        stepper.resetState(state.stepping, lastCreatedMeasurement.smoothed(),
+        stepper.initialize(state.stepping, lastCreatedMeasurement.smoothed(),
                            lastCreatedMeasurement.smoothedCovariance(),
-                           lastCreatedMeasurement.referenceSurface(),
-                           state.options.stepping.maxStepSize);
+                           stepper.particleHypothesis(state.stepping),
+                           lastCreatedMeasurement.referenceSurface());
         reverseDirection = lastIntersection.pathLength() < 0;
       }
       // Reverse the navigation direction if necessary

--- a/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/EigenStepperTests.cpp
@@ -14,7 +14,6 @@
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/EventData/GenericBoundTrackParameters.hpp"
-#include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/ParticleHypothesis.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TransformationHelpers.hpp"
@@ -194,7 +193,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_state_test) {
   CurvilinearTrackParameters cp(makeVector4(pos, time), dir, charge / absMom,
                                 std::nullopt, ParticleHypothesis::pion());
   EigenStepper<> es(bField);
-  EigenStepper<>::State esState = es.makeState(esOptions, cp);
+  EigenStepper<>::State esState = es.makeState(esOptions);
+  es.initialize(esState, cp);
 
   // Test the result & compare with the input/test for reasonable members
   BOOST_CHECK_EQUAL(esState.jacToGlobal, BoundToFreeMatrix::Zero());
@@ -209,14 +209,14 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_state_test) {
   CurvilinearTrackParameters ncp(makeVector4(pos, time), dir, 1 / absMom,
                                  std::nullopt, ParticleHypothesis::pion0());
   esOptions = EigenStepper<>::Options(tgContext, mfContext);
-  esState = es.makeState(esOptions, ncp);
+  es.initialize(esState, ncp);
   BOOST_CHECK_EQUAL(es.charge(esState), 0.);
 
   // Test with covariance matrix
   Covariance cov = 8. * Covariance::Identity();
   ncp = CurvilinearTrackParameters(makeVector4(pos, time), dir, 1 / absMom, cov,
                                    ParticleHypothesis::pion0());
-  esState = es.makeState(esOptions, ncp);
+  es.initialize(esState, ncp);
   BOOST_CHECK_NE(esState.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK(esState.covTransport);
   BOOST_CHECK_EQUAL(esState.cov, cov);
@@ -246,7 +246,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
 
   // Build the stepper and the state
   EigenStepper<> es(bField);
-  EigenStepper<>::State esState = es.makeState(esOptions, cp);
+  EigenStepper<>::State esState = es.makeState(esOptions);
+  es.initialize(esState, cp);
 
   // Test the getters
   CHECK_CLOSE_ABS(es.position(esState), pos, eps);
@@ -339,11 +340,11 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   FreeVector freeParams = transformBoundToFreeParameters(
       cp2.referenceSurface(), tgContext, cp2.parameters());
   navDir = Direction::Forward();
-  double stepSize2 = -2. * stepSize;
 
   auto copyState = [&](auto& field, const auto& state) {
     using field_t = std::decay_t<decltype(field)>;
-    std::decay_t<decltype(state)> copy = es.makeState(esOptions, cp);
+    std::decay_t<decltype(state)> copy = es.makeState(esOptions);
+    es.initialize(copy, cp);
     copy.pars = state.pars;
     copy.covTransport = state.covTransport;
     copy.cov = state.cov;
@@ -368,8 +369,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   // Reset all possible parameters
   EigenStepper<>::State esStateCopy = copyState(*bField, ps.stepping);
   BOOST_CHECK(cp2.covariance().has_value());
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface(), stepSize2);
+  es.initialize(esStateCopy, cp2.parameters(), *cp2.covariance(),
+                cp2.particleHypothesis(), cp2.referenceSurface());
   // Test all components
   BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
@@ -386,56 +387,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
   BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(), navDir * stepSize2);
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
-
-  // Reset all possible parameters except the step size
-  esStateCopy = copyState(*bField, ps.stepping);
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(esStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(esStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(esStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(esStateCopy.cov, cov2);
-  BOOST_CHECK_EQUAL(es.position(esStateCopy),
-                    freeParams.template segment<3>(eFreePos0));
-  BOOST_CHECK_EQUAL(es.direction(esStateCopy),
-                    freeParams.template segment<3>(eFreeDir0).normalized());
-  BOOST_CHECK_EQUAL(es.absoluteMomentum(esStateCopy),
-                    std::abs(1. / freeParams[eFreeQOverP]));
-  BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
-  BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
-  BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
-
-  // Reset the least amount of parameters
-  esStateCopy = copyState(*bField, ps.stepping);
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(esStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(esStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(esStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(esStateCopy.cov, cov2);
-  BOOST_CHECK_EQUAL(es.position(esStateCopy),
-                    freeParams.template segment<3>(eFreePos0));
-  BOOST_CHECK_EQUAL(es.direction(esStateCopy),
-                    freeParams.template segment<3>(eFreeDir0).normalized());
-  BOOST_CHECK_EQUAL(es.absoluteMomentum(esStateCopy),
-                    std::abs(1. / freeParams[eFreeQOverP]));
-  BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
-  BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
-  BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
+  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(), stepSize);
+  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, 0.);
 
   /// Repeat with surface related methods
   auto plane = CurvilinearSurface(pos, dir.normalized()).planeSurface();
@@ -443,7 +396,7 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
                 plane, tgContext, makeVector4(pos, time), dir, charge / absMom,
                 cov, ParticleHypothesis::pion())
                 .value();
-  esState = es.makeState(esOptions, bp);
+  es.initialize(esState, bp);
 
   // Test the intersection in the context of a surface
   auto targetSurface =
@@ -517,7 +470,8 @@ BOOST_AUTO_TEST_CASE(eigen_stepper_test) {
   auto nBfield = std::make_shared<NullBField>();
   EigenStepper<> nes(nBfield);
   EigenStepper<>::Options nesOptions(tgContext, mfContext);
-  EigenStepper<>::State nesState = nes.makeState(nesOptions, cp);
+  EigenStepper<>::State nesState = nes.makeState(nesOptions);
+  nes.initialize(nesState, cp);
   PropState nps(navDir, copyState(*nBfield, nesState));
   // Test that we can reach the minimum step size
   nps.options.stepping.stepTolerance = 1e-21;

--- a/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/JacobianTests.cpp
@@ -134,11 +134,13 @@ void testJacobianToGlobal(const Parameters& pars) {
   // a) ATLAS stepper
   AtlasStepperType astep(bField);
   AtlasStepperType::State astepState =
-      astep.makeState(AtlasStepperType::Options(tgContext, mfContext), pars);
+      astep.makeState(AtlasStepperType::Options(tgContext, mfContext));
+  astep.initialize(astepState, pars);
   // b) Eigen stepper
   EigenStepperType estep(bField);
   EigenStepperType::State estepState =
-      estep.makeState(EigenStepperType::Options(tgContext, mfContext), pars);
+      estep.makeState(EigenStepperType::Options(tgContext, mfContext));
+  estep.initialize(estepState, pars);
 
   // create the matrices
   auto asMatrix = convertToMatrix(astepState.pVector);

--- a/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/MultiStepperTests.cpp
@@ -173,7 +173,8 @@ BOOST_AUTO_TEST_CASE(test_max_weight_reducer) {
 
   constexpr std::size_t N = 4;
   const auto multi_pars = makeDefaultBoundPars(false, N);
-  MultiState state = multiStepper.makeState(options, multi_pars);
+  MultiState state = multiStepper.makeState(options);
+  multiStepper.initialize(state, multi_pars);
 
   double w = 0.1;
   double wSum = 0.0;
@@ -206,7 +207,8 @@ BOOST_AUTO_TEST_CASE(test_max_momentum_reducer) {
 
   constexpr std::size_t N = 4;
   const auto multi_pars = makeDefaultBoundPars(false, N);
-  MultiState state = multiStepper.makeState(options, multi_pars);
+  MultiState state = multiStepper.makeState(options);
+  multiStepper.initialize(state, multi_pars);
 
   double p = 1.0;
   double q = 1.0;
@@ -241,7 +243,8 @@ void test_multi_stepper_state() {
   constexpr std::size_t N = 4;
   const auto multi_pars = makeDefaultBoundPars(Cov, N, BoundVector::Ones());
 
-  MultiState state = multiStepper.makeState(options, multi_pars);
+  MultiState state = multiStepper.makeState(options);
+  multiStepper.initialize(state, multi_pars);
 
   BOOST_CHECK_EQUAL(N, multiStepper.numberComponents(state));
 
@@ -279,16 +282,18 @@ BOOST_AUTO_TEST_CASE(multi_stepper_state_no_cov) {
 template <typename multi_stepper_t>
 void test_multi_stepper_state_invalid() {
   using MultiOptions = typename multi_stepper_t::Options;
+  using MultiState = typename multi_stepper_t::State;
 
   MultiOptions options(geoCtx, magCtx);
   options.maxStepSize = defaultStepSize;
 
-  MultiStepperLoop multi_stepper(defaultBField);
+  MultiStepperLoop multiStepper(defaultBField);
 
   // Empty component vector
   const auto multi_pars = makeDefaultBoundPars(false, 0);
+  MultiState state = multiStepper.makeState(options);
 
-  BOOST_CHECK_THROW(multi_stepper.makeState(options, multi_pars),
+  BOOST_CHECK_THROW(multiStepper.initialize(state, multi_pars),
                     std::invalid_argument);
 }
 
@@ -325,9 +330,11 @@ void test_multi_stepper_vs_eigen_stepper() {
                                                 particleHypothesis);
   BoundTrackParameters single_pars(surface, pars, cov, particleHypothesis);
 
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
-  SingleStepper::State single_state =
-      single_stepper.makeState(options, single_pars);
+  MultiState multi_state = multi_stepper.makeState(options);
+  SingleStepper::State single_state = single_stepper.makeState(options);
+
+  multi_stepper.initialize(multi_state, multi_pars);
+  single_stepper.initialize(single_state, single_pars);
 
   for (auto cmp : multi_stepper.componentIterable(multi_state)) {
     cmp.status() = Acts::IntersectionStatus::reachable;
@@ -389,9 +396,12 @@ void test_components_modifying_accessors() {
 
   MultiStepper multi_stepper(defaultBField);
 
-  MultiState mutable_multi_state = multi_stepper.makeState(options, multi_pars);
-  const MultiState const_multi_state =
-      multi_stepper.makeState(options, multi_pars);
+  MultiState mutable_multi_state = multi_stepper.makeState(options);
+  MultiState const_multi_state_backend = multi_stepper.makeState(options);
+  const MultiState &const_multi_state = const_multi_state_backend;
+
+  multi_stepper.initialize(mutable_multi_state, multi_pars);
+  multi_stepper.initialize(const_multi_state_backend, multi_pars);
 
   auto modify = [&](const auto &projector) {
     // Here test the mutable overloads of the mutable iterable
@@ -500,9 +510,11 @@ void test_multi_stepper_surface_status_update() {
                     .direction()
                     .isApprox(Vector3{-1.0, 0.0, 0.0}, 1.e-10));
 
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
-  SingleStepper::State single_state =
-      single_stepper.makeState(options, std::get<1>(multi_pars[0]));
+  MultiState multi_state = multi_stepper.makeState(options);
+  SingleStepper::State single_state = single_stepper.makeState(options);
+
+  multi_stepper.initialize(multi_state, multi_pars);
+  single_stepper.initialize(single_state, std::get<1>(multi_pars[0]));
 
   // Update surface status and check
   {
@@ -617,9 +629,11 @@ void test_component_bound_state() {
                     .direction()
                     .isApprox(Vector3{-1.0, 0.0, 0.0}, 1.e-10));
 
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
-  SingleStepper::State single_state =
-      single_stepper.makeState(options, std::get<1>(multi_pars[0]));
+  MultiState multi_state = multi_stepper.makeState(options);
+  SingleStepper::State single_state = single_stepper.makeState(options);
+
+  multi_stepper.initialize(multi_state, multi_pars);
+  single_stepper.initialize(single_state, std::get<1>(multi_pars[0]));
 
   // Step forward now
   {
@@ -692,7 +706,8 @@ void test_combined_bound_state_function() {
 
   MultiComponentBoundTrackParameters multi_pars(surface, cmps,
                                                 particleHypothesis);
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
+  MultiState multi_state = multi_stepper.makeState(options);
+  multi_stepper.initialize(multi_state, multi_pars);
 
   auto res = multi_stepper.boundState(multi_state, *surface, true,
                                       FreeToBoundCorrection(false));
@@ -743,7 +758,8 @@ void test_combined_curvilinear_state_function() {
 
   MultiComponentBoundTrackParameters multi_pars(surface, cmps,
                                                 particleHypothesis);
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
+  MultiState multi_state = multi_stepper.makeState(options);
+  multi_stepper.initialize(multi_state, multi_pars);
 
   const auto [curv_pars, jac, pathLength] =
       multi_stepper.curvilinearState(multi_state);
@@ -777,7 +793,9 @@ void test_single_component_interface_function() {
 
   MultiComponentBoundTrackParameters multi_pars = makeDefaultBoundPars(true, 4);
 
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
+  MultiState multi_state = multi_stepper.makeState(options);
+
+  multi_stepper.initialize(multi_state, multi_pars);
 
   DummyPropState multi_prop_state(defaultNDir, multi_state);
 
@@ -824,7 +842,9 @@ void remove_add_components_function() {
 
   const auto multi_pars = makeDefaultBoundPars(4);
 
-  MultiState multi_state = multi_stepper.makeState(options, multi_pars);
+  MultiState multi_state = multi_stepper.makeState(options);
+
+  multi_stepper.initialize(multi_state, multi_pars);
 
   {
     BoundTrackParameters pars(multi_pars.referenceSurface().getSharedPtr(),

--- a/Tests/UnitTests/Core/Propagator/StraightLineStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/StraightLineStepperTests.cpp
@@ -13,7 +13,6 @@
 #include "Acts/Definitions/Tolerance.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/EventData/GenericBoundTrackParameters.hpp"
-#include "Acts/EventData/GenericCurvilinearTrackParameters.hpp"
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/EventData/TransformationHelpers.hpp"
 #include "Acts/EventData/detail/CorrectedTransformationFreeToBound.hpp"
@@ -81,7 +80,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_state_test) {
                                 std::nullopt, ParticleHypothesis::pion());
 
   StraightLineStepper sls;
-  StraightLineStepper::State slsState = sls.makeState(slsOptions, cp);
+  StraightLineStepper::State slsState = sls.makeState(slsOptions);
+  sls.initialize(slsState, cp);
 
   // Test the result & compare with the input/test for reasonable members
   BOOST_CHECK_EQUAL(slsState.jacToGlobal, BoundToFreeMatrix::Zero());
@@ -101,13 +101,13 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_state_test) {
   // Test without charge and covariance matrix
   CurvilinearTrackParameters ncp(makeVector4(pos, time), dir, 1 / absMom,
                                  std::nullopt, ParticleHypothesis::pion0());
-  slsState = sls.makeState(slsOptions, ncp);
+  sls.initialize(slsState, ncp);
 
   // Test with covariance matrix
   Covariance cov = 8. * Covariance::Identity();
   ncp = CurvilinearTrackParameters(makeVector4(pos, time), dir, 1 / absMom, cov,
                                    ParticleHypothesis::pion0());
-  slsState = sls.makeState(slsOptions, ncp);
+  sls.initialize(slsState, ncp);
   BOOST_CHECK_NE(slsState.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK(slsState.covTransport);
   BOOST_CHECK_EQUAL(slsState.cov, cov);
@@ -137,7 +137,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
 
   // Build the stepper and the state
   StraightLineStepper sls;
-  StraightLineStepper::State slsState = sls.makeState(options, cp);
+  StraightLineStepper::State slsState = sls.makeState(options);
+  sls.initialize(slsState, cp);
 
   // Test the getters
   CHECK_CLOSE_ABS(sls.position(slsState), pos, 1e-6);
@@ -235,12 +236,11 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
   FreeVector freeParams = transformBoundToFreeParameters(
       cp2.referenceSurface(), tgContext, cp2.parameters());
   navDir = Direction::Forward();
-  double stepSize2 = -2. * stepSize;
 
   // Reset all possible parameters
   StraightLineStepper::State slsStateCopy = ps.stepping;
-  sls.resetState(slsStateCopy, cp2.parameters(), *cp2.covariance(),
-                 cp2.referenceSurface(), stepSize2);
+  sls.initialize(slsStateCopy, cp2.parameters(), cp2.covariance(),
+                 cp2.particleHypothesis(), cp2.referenceSurface());
   // Test all components
   BOOST_CHECK_NE(slsStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK_NE(slsStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
@@ -257,59 +257,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
   CHECK_CLOSE_ABS(sls.charge(slsStateCopy), -sls.charge(ps.stepping), 1e-6);
   CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
   BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(), navDir * stepSize2);
-  BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
-                    ps.stepping.previousStepSize);
-
-  // Reset all possible parameters except the step size
-  slsStateCopy = ps.stepping;
-  sls.resetState(slsStateCopy, cp2.parameters(), *cp2.covariance(),
-                 cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(slsStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(slsStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(slsStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(slsStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(slsStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(slsStateCopy.cov, cov2);
-  CHECK_CLOSE_ABS(sls.position(slsStateCopy),
-                  freeParams.template segment<3>(eFreePos0), 1e-6);
-  CHECK_CLOSE_ABS(sls.direction(slsStateCopy),
-                  freeParams.template segment<3>(eFreeDir0), 1e-6);
-  CHECK_CLOSE_ABS(sls.absoluteMomentum(slsStateCopy),
-                  std::abs(1. / freeParams[eFreeQOverP]), 1e-6);
-  CHECK_CLOSE_ABS(sls.charge(slsStateCopy), -sls.charge(ps.stepping), 1e-6);
-  CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
-  BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
-                    ps.stepping.previousStepSize);
-
-  // Reset the least amount of parameters
-  slsStateCopy = ps.stepping;
-  sls.resetState(slsStateCopy, cp2.parameters(), *cp2.covariance(),
-                 cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(slsStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(slsStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(slsStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(slsStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(slsStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(slsStateCopy.cov, cov2);
-  CHECK_CLOSE_ABS(sls.position(slsStateCopy),
-                  freeParams.template segment<3>(eFreePos0), 1e-6);
-  CHECK_CLOSE_ABS(sls.direction(slsStateCopy),
-                  freeParams.template segment<3>(eFreeDir0).normalized(), 1e-6);
-  CHECK_CLOSE_ABS(sls.absoluteMomentum(slsStateCopy),
-                  std::abs(1. / freeParams[eFreeQOverP]), 1e-6);
-  CHECK_CLOSE_ABS(sls.charge(slsStateCopy), -sls.charge(ps.stepping), 1e-6);
-  CHECK_CLOSE_ABS(sls.time(slsStateCopy), freeParams[eFreeTime], 1e-6);
-  BOOST_CHECK_EQUAL(slsStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize,
-                    ps.stepping.previousStepSize);
+  BOOST_CHECK_EQUAL(slsStateCopy.stepSize.value(), stepSize);
+  BOOST_CHECK_EQUAL(slsStateCopy.previousStepSize, 0.);
 
   /// Repeat with surface related methods
   auto plane = CurvilinearSurface(pos, dir).planeSurface();
@@ -317,7 +266,8 @@ BOOST_AUTO_TEST_CASE(straight_line_stepper_test) {
                 plane, tgContext, makeVector4(pos, time), dir, charge / absMom,
                 cov, ParticleHypothesis::pion())
                 .value();
-  slsState = sls.makeState(options, bp);
+  slsState = sls.makeState(options);
+  sls.initialize(slsState, bp);
 
   // Test the intersection in the context of a surface
   auto targetSurface =

--- a/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/SympyStepperTests.cpp
@@ -169,7 +169,8 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_state_test) {
   // Test charged parameters without covariance matrix
   CurvilinearTrackParameters cp(makeVector4(pos, time), dir, charge / absMom,
                                 std::nullopt, ParticleHypothesis::pion());
-  SympyStepper::State esState = es.makeState(esOptions, cp);
+  SympyStepper::State esState = es.makeState(esOptions);
+  es.initialize(esState, cp);
 
   // Test the result & compare with the input/test for reasonable members
   BOOST_CHECK_EQUAL(esState.jacToGlobal, BoundToFreeMatrix::Zero());
@@ -183,14 +184,14 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_state_test) {
   // Test without charge and covariance matrix
   CurvilinearTrackParameters ncp(makeVector4(pos, time), dir, 1 / absMom,
                                  std::nullopt, ParticleHypothesis::pion0());
-  esState = es.makeState(esOptions, ncp);
+  es.initialize(esState, ncp);
   BOOST_CHECK_EQUAL(es.charge(esState), 0.);
 
   // Test with covariance matrix
   Covariance cov = 8. * Covariance::Identity();
   ncp = CurvilinearTrackParameters(makeVector4(pos, time), dir, 1 / absMom, cov,
                                    ParticleHypothesis::pion0());
-  esState = es.makeState(esOptions, ncp);
+  es.initialize(esState, ncp);
   BOOST_CHECK_NE(esState.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK(esState.covTransport);
   BOOST_CHECK_EQUAL(esState.cov, cov);
@@ -220,7 +221,8 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_test) {
 
   // Build the stepper and the state
   SympyStepper es(bField);
-  SympyStepper::State esState = es.makeState(esOptions, cp);
+  SympyStepper::State esState = es.makeState(esOptions);
+  es.initialize(esState, cp);
 
   // Test the getters
   CHECK_CLOSE_ABS(es.position(esState), pos, eps);
@@ -313,11 +315,11 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_test) {
   FreeVector freeParams = transformBoundToFreeParameters(
       cp2.referenceSurface(), tgContext, cp2.parameters());
   navDir = Direction::Forward();
-  double stepSize2 = -2. * stepSize;
 
   auto copyState = [&](auto& field, const auto& state) {
     using field_t = std::decay_t<decltype(field)>;
-    std::decay_t<decltype(state)> copy = es.makeState(esOptions, cp);
+    std::decay_t<decltype(state)> copy = es.makeState(esOptions);
+    es.initialize(esState, cp);
     copy.pars = state.pars;
     copy.covTransport = state.covTransport;
     copy.cov = state.cov;
@@ -339,8 +341,8 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_test) {
   // Reset all possible parameters
   SympyStepper::State esStateCopy = copyState(*bField, ps.stepping);
   BOOST_CHECK(cp2.covariance().has_value());
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface(), stepSize2);
+  es.initialize(esStateCopy, cp2.parameters(), *cp2.covariance(),
+                cp2.particleHypothesis(), cp2.referenceSurface());
   // Test all components
   BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
   BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
@@ -357,56 +359,8 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_test) {
   BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
   BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
   BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(), navDir * stepSize2);
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
-
-  // Reset all possible parameters except the step size
-  esStateCopy = copyState(*bField, ps.stepping);
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(esStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(esStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(esStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(esStateCopy.cov, cov2);
-  BOOST_CHECK_EQUAL(es.position(esStateCopy),
-                    freeParams.template segment<3>(eFreePos0));
-  BOOST_CHECK_EQUAL(es.direction(esStateCopy),
-                    freeParams.template segment<3>(eFreeDir0).normalized());
-  BOOST_CHECK_EQUAL(es.absoluteMomentum(esStateCopy),
-                    std::abs(1. / freeParams[eFreeQOverP]));
-  BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
-  BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
-  BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
-
-  // Reset the least amount of parameters
-  esStateCopy = copyState(*bField, ps.stepping);
-  es.resetState(esStateCopy, cp2.parameters(), *cp2.covariance(),
-                cp2.referenceSurface());
-  // Test all components
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, BoundToFreeMatrix::Zero());
-  BOOST_CHECK_NE(esStateCopy.jacToGlobal, ps.stepping.jacToGlobal);
-  BOOST_CHECK_EQUAL(esStateCopy.jacTransport, FreeMatrix::Identity());
-  BOOST_CHECK_EQUAL(esStateCopy.derivative, FreeVector::Zero());
-  BOOST_CHECK(esStateCopy.covTransport);
-  BOOST_CHECK_EQUAL(esStateCopy.cov, cov2);
-  BOOST_CHECK_EQUAL(es.position(esStateCopy),
-                    freeParams.template segment<3>(eFreePos0));
-  BOOST_CHECK_EQUAL(es.direction(esStateCopy),
-                    freeParams.template segment<3>(eFreeDir0).normalized());
-  BOOST_CHECK_EQUAL(es.absoluteMomentum(esStateCopy),
-                    std::abs(1. / freeParams[eFreeQOverP]));
-  BOOST_CHECK_EQUAL(es.charge(esStateCopy), -es.charge(ps.stepping));
-  BOOST_CHECK_EQUAL(es.time(esStateCopy), freeParams[eFreeTime]);
-  BOOST_CHECK_EQUAL(esStateCopy.pathAccumulated, 0.);
-  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(),
-                    std::numeric_limits<double>::max());
-  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, ps.stepping.previousStepSize);
+  BOOST_CHECK_EQUAL(esStateCopy.stepSize.value(), stepSize);
+  BOOST_CHECK_EQUAL(esStateCopy.previousStepSize, 0.);
 
   /// Repeat with surface related methods
   auto plane = CurvilinearSurface(pos, dir.normalized()).planeSurface();
@@ -415,7 +369,8 @@ BOOST_AUTO_TEST_CASE(sympy_stepper_test) {
                 cov, ParticleHypothesis::pion())
                 .value();
   esOptions = SympyStepper::Options(tgContext, mfContext);
-  esState = es.makeState(esOptions, bp);
+  esState = es.makeState(esOptions);
+  es.initialize(esState, bp);
 
   // Test the intersection in the context of a surface
   auto targetSurface =


### PR DESCRIPTION
Disentangles the state creation and initialization for the steppers. This is analog to what is done in the navigator. The idea is that a state can be used for multiple propagations so its creation should be decoupled from the initialization to allow the reuse of the existing state. At the same time `resetState` is removed as it has no use anymore. `initialize` will reset and reinitialize the state.

Pulled out of https://github.com/acts-project/acts/pull/4036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Redesigned the state management workflow across propagation and tracking features to separate object creation from parameter initialization, resulting in a clearer, more streamlined API.
  - Removed legacy reset mechanisms in favor of explicit initialization methods that accommodate configurable parameters.
  
- **Tests**
  - Updated unit tests to align with the new initialization process, ensuring improved consistency and robustness across propagation-related functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->