### PR TITLE
fix: Centre from confex face in Annulus

### DIFF
--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -176,8 +176,8 @@ Polyhedron DiscSurface::polyhedronRepresentation(
       if (addCentreFromConvexFace) {
         vertices.push_back(wCenter);
       }
-      auto [faces, triangularMesh] =
-          detail::FacesHelper::convexFaceMesh(vertices, true);
+      auto [faces, triangularMesh] = detail::FacesHelper::convexFaceMesh(
+          vertices, addCentreFromConvexFace);
       return Polyhedron(vertices, faces, triangularMesh, exactPolyhedron);
     } else {
       // Two concentric rings, we use the pure concentric method momentarily,


### PR DESCRIPTION
Fixes a small error where the last vertex was being ignore for Annulus shapes.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal logic for surface rendering by switching to a dynamic option for including a central geometric feature. This update allows the system to adapt to varying conditions, resulting in more accurate and reliable representations. Users should benefit from enhanced performance during complex graphical operations as internal computations are better optimized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->