### PR TITLE
refactor: Add back DD4hep field access

### DIFF
--- a/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepDetector.hpp
+++ b/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepDetector.hpp
@@ -28,6 +28,10 @@ class Detector;
 class DetElement;
 }  // namespace dd4hep
 
+namespace Acts {
+class DD4hepFieldAdapter;
+}
+
 namespace ActsExamples {
 
 void sortFCChhDetElements(std::vector<dd4hep::DetElement>& det);
@@ -83,6 +87,10 @@ class DD4hepDetector : public Detector {
 
   /// Interface method to access to the DD4hep geometry
   dd4hep::Detector& dd4hepDetector();
+
+  /// @brief Access to the DD4hep field
+  /// @return a shared pointer to the DD4hep field
+  std::shared_ptr<Acts::DD4hepFieldAdapter> field() const;
 
   /// Interface method to Access the TGeo geometry
   /// @return The world TGeoNode (physical volume)

--- a/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepDetector.hpp
+++ b/Examples/Detectors/DD4hepDetector/include/ActsExamples/DD4hepDetector/DD4hepDetector.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Material/IMaterialDecorator.hpp"
+#include "Acts/Plugins/DD4hep/DD4hepFieldAdapter.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/DetectorCommons/Detector.hpp"
@@ -27,10 +28,6 @@ namespace dd4hep {
 class Detector;
 class DetElement;
 }  // namespace dd4hep
-
-namespace Acts {
-class DD4hepFieldAdapter;
-}
 
 namespace ActsExamples {
 

--- a/Examples/Detectors/DD4hepDetector/src/DD4hepDetector.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/DD4hepDetector.cpp
@@ -47,6 +47,10 @@ dd4hep::Detector& DD4hepDetector::dd4hepDetector() {
   return *m_detector;
 }
 
+std::shared_ptr<Acts::DD4hepFieldAdapter> DD4hepDetector::field() const {
+  return std::make_shared<Acts::DD4hepFieldAdapter>(m_detector->field());
+}
+
 TGeoNode& DD4hepDetector::tgeoGeometry() {
   return *m_detector->world().placement().ptr();
 }

--- a/Examples/Detectors/DD4hepDetector/src/DD4hepDetector.cpp
+++ b/Examples/Detectors/DD4hepDetector/src/DD4hepDetector.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Plugins/DD4hep/ConvertDD4hepDetector.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <algorithm>
 #include <memory>
@@ -48,6 +49,7 @@ dd4hep::Detector& DD4hepDetector::dd4hepDetector() {
 }
 
 std::shared_ptr<Acts::DD4hepFieldAdapter> DD4hepDetector::field() const {
+  throw_assert(m_detector != nullptr, "Detector not initialized");
   return std::make_shared<Acts::DD4hepFieldAdapter>(m_detector->field());
 }
 

--- a/Examples/Python/src/DD4hepComponent.cpp
+++ b/Examples/Python/src/DD4hepComponent.cpp
@@ -37,7 +37,8 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
     auto f =
         py::class_<DD4hepDetector, Detector, std::shared_ptr<DD4hepDetector>>(
             m, "DD4hepDetector")
-            .def(py::init<const DD4hepDetector::Config&>());
+            .def(py::init<const DD4hepDetector::Config&>())
+            .def_property_readonly("field", &DD4hepDetector::field);
 
     auto c = py::class_<DD4hepDetector::Config>(f, "Config").def(py::init<>());
     ACTS_PYTHON_STRUCT_BEGIN(c, DD4hepDetector::Config);


### PR DESCRIPTION
This was removed in https://github.com/acts-project/acts/pull/3498, but we do need it.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced detector functionality by providing direct access to field-related information through a new method.
	- Extended Python integration with a new read-only field property for streamlined access.
	- Introduced a new class for configuration options, allowing improved setup and customization of the detector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->