### PR TITLE
chore: pre-commit check for type_t uses `--fix`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
     - id: type_t
       name: type_t
       language: system
-      entry: CI/check_type_t.py
+      entry: CI/check_type_t.py --fix
       files: \.(cpp|hpp|ipp|cu|cuh)$
 
   - repo: local


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
