### PR TITLE
fix: require CUDA_STANDARD 20 in Plugins/Cuda

### DIFF
--- a/Plugins/Cuda/CMakeLists.txt
+++ b/Plugins/Cuda/CMakeLists.txt
@@ -47,7 +47,11 @@ target_include_directories(
 target_link_libraries(ActsPluginCuda2 PUBLIC ActsCore)
 set_target_properties(
     ActsPluginCuda2
-    PROPERTIES CUDA_SEPARABLE_COMPILATION ON POSITION_INDEPENDENT_CODE ON
+    PROPERTIES
+        CUDA_STANDARD 17
+        CUDA_STANDARD_REQUIRED ON
+        CUDA_SEPARABLE_COMPILATION ON
+        POSITION_INDEPENDENT_CODE ON
 )
 
 # Install all CUDA plugins.

--- a/Plugins/Cuda/CMakeLists.txt
+++ b/Plugins/Cuda/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(ActsPluginCuda2 PUBLIC ActsCore)
 set_target_properties(
     ActsPluginCuda2
     PROPERTIES
-        CUDA_STANDARD 17
+        CUDA_STANDARD 20
         CUDA_STANDARD_REQUIRED ON
         CUDA_SEPARABLE_COMPILATION ON
         POSITION_INDEPENDENT_CODE ON


### PR DESCRIPTION
This PR requires CUDA_STANDARD 20 in the CUDA plugin, which is required since the use of the `numbers` header in https://github.com/acts-project/acts/pull/3781 (specifically through `Acts/Definitions/Units.hpp`.

--- END COMMIT MESSAGE ---

It does not see that Plugins/ExaTrkX needs CUDA_STANDARD 20 just yet, since it does not seem that 