### PR TITLE
feat: Testing propagator for same positioned surfaces -rpc case for muons

### DIFF
--- a/Core/include/Acts/Propagator/SurfaceCollector.hpp
+++ b/Core/include/Acts/Propagator/SurfaceCollector.hpp
@@ -8,12 +8,15 @@
 
 #pragma once
 
+#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
 #include <sstream>
 
 namespace Acts {
+
+using Covariance = BoundSquareMatrix;
 
 /// Simple struct to select surfaces
 struct SurfaceSelector {
@@ -54,6 +57,7 @@ struct SurfaceHit {
   const Surface* surface = nullptr;
   Vector3 position;
   Vector3 direction;
+  Covariance covariance;
 };
 
 /// A Surface Collector struct
@@ -108,6 +112,8 @@ struct SurfaceCollector {
       surface_hit.surface = currentSurface;
       surface_hit.position = stepper.position(state.stepping);
       surface_hit.direction = stepper.direction(state.stepping);
+      auto&& [pars,jac,pathLength] = stepper.boundState(state.stepping, *currentSurface).value();
+      surface_hit.covariance = *pars.covariance();
       // Save if in the result
       result.collected.push_back(surface_hit);
       // Screen output

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -17,20 +17,27 @@
 #include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/MagneticField/ConstantBField.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
 #include "Acts/Propagator/ActorList.hpp"
+#include "Acts/Propagator/AbortList.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/EigenStepper.hpp"
 #include "Acts/Propagator/EigenStepperDenseExtension.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/StraightLineStepper.hpp"
 #include "Acts/Propagator/VoidNavigator.hpp"
+#include "Acts/Propagator/SurfaceCollector.hpp"
+#include "Acts/Navigation/DetectorVolumeFinders.hpp"
+#include "Acts/Navigation/InternalNavigation.hpp"
+#include "Acts/Navigation/DetectorNavigator.hpp"
 #include "Acts/Surfaces/CurvilinearSurface.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Tests/CommonHelpers/FloatComparisons.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -49,6 +56,7 @@ namespace bdata = boost::unit_test::data;
 using namespace Acts::UnitLiterals;
 using Acts::VectorHelpers::makeVector4;
 using Acts::VectorHelpers::perp;
+using namespace Acts::Experimental;
 
 namespace Acts::Test {
 
@@ -124,6 +132,17 @@ struct SurfaceObserver {
     }
   }
 };
+
+struct PlaneSelector {
+  /// Call operator
+  /// @param sf The input surface to be checked
+  bool operator()(const Acts::Surface& sf) const {
+    return (sf.type() == Acts::Surface::Plane && sf.geometryId().value() != 0u);
+  
+  }
+};
+
+
 
 // Global definitions
 using BFieldType = ConstantBField;
@@ -475,4 +494,179 @@ BOOST_AUTO_TEST_CASE(BasicPropagatorInterface) {
                   "Propagator unexpectedly inherits from BasePropagator");
   }
 }
+
+
+  //function that checks the covariances if they are rotaed correctly
+
+  void testCovariances(Covariance cov1, Covariance cov2){
+  //check if the covariances' for phi,theta,q/p and t remain the same
+
+  BOOST_CHECK((cov1.block<4,4>(2,2)).isApprox(cov2.block<4,4>(2,2)));
+
+  //check if the covariances are rotated
+  BOOST_CHECK((cov1.block<2,4>(0,2).row(0)).isApprox(-cov2.block<2,4>(0,2).row(1)));
+  BOOST_CHECK((cov1.block<2,4>(0,2).row(1)).isApprox(cov2.block<2,4>(0,2).row(0)));
+
+
+  BOOST_CHECK((cov1.block<4,2>(2,0).col(0)).isApprox(-cov2.block<4,2>(2,0).col(1)));
+  BOOST_CHECK((cov1.block<4,2>(2,0).col(1)).isApprox(cov2.block<4,2>(2,0).col(0)));
+
+  auto subcov1 = cov1.block<2,2>(0,0);
+  auto subcov2 = cov2.block<2,2>(0,0);
+  BOOST_CHECK(subcov1(0,0) == subcov2(1,1));
+  BOOST_CHECK(subcov1(1,1) == subcov2(0,0));
+  BOOST_CHECK(subcov1(0,1) == -subcov2(1,0));
+  BOOST_CHECK(subcov1(1,0) == -subcov2(0,1));
+
+  }
+
+//check what the propagator does with two surfaces on the same position rotated by 90deg
+BOOST_AUTO_TEST_CASE(PlaneSurfacesOnSamePositionPropagationTest){
+
+
+
+    
+    using ActorList = ActorList<SurfaceCollector<PlaneSelector>, EndOfWorldReached>;
+
+    //Setup the two surfaces and rotate them by 90 degrees on the same plane
+    Acts::Transform3 transform2 = Acts::Transform3::Identity();
+    transform2.prerotate(Acts::AngleAxis3(0.5*M_PI, Acts::Vector3::UnitZ()));
+
+    auto surface1 = Surface::makeShared<PlaneSurface>(Transform3::Identity(), std::make_shared<RectangleBounds>(1000_mm, 1000_mm));
+    auto surface2 = Surface::makeShared<PlaneSurface>(transform2, std::make_shared<RectangleBounds>(1000_mm, 1000_mm));
+
+    surface1->assignGeometryId(Acts::GeometryIdentifier{}.setSensitive(1));
+    surface2->assignGeometryId(Acts::GeometryIdentifier{}.setSensitive(2));
+
+    // Define the start parameters for propagattion
+    double x = 0.1;
+    double y = 0.2;
+    double z = -20.;
+    double px = 0.1;
+    double py = 0.1;
+    double pz = 20.;
+    double q = 1;
+    double absMom = sqrt(px*px + py*py + pz*pz);
+    Vector3 pos(x, y, z);
+    Vector3 mom(px, py, pz);
+    Covariance cov;
+      // Take some correlations for the covariance matrix
+    cov << 10.5_mm, 0, 0.123, 0, 0.5, 0,
+           0, 6.7_mm, 0, 0.162, 0, 0,
+           0.123, 0, 0.1, 0, 0, 0,
+           0, 0.162, 0, 0.1, 0, 0,
+           0.5, 0, 0, 0, 1. / (10.2_GeV), 0,
+           0, 0, 0, 0, 0, 0;
+
+    CurvilinearTrackParameters startParams(makeVector4(pos, 0), mom.normalized(), q / absMom,
+                                cov, ParticleHypothesis::pion());
+   
+    // Set the stepper for the propagator with a magnetic field
+    auto field = std::make_shared<ConstantBField>(Vector3{0, 0, 0});
+   
+
+    {
+
+      //first check "force propagation" to each surface separately
+
+    auto stepper = Acts::EigenStepper(field);
+   
+    VoidNavigator navigator{};
+    EigenPropagatorType::Options<ActorList> options(tgContext, mfContext);
+    EigenPropagatorType propagator(std::move(stepper), navigator,
+                                getDefaultLogger("Propagator_Test1", Logging::VERBOSE));
+  
+
+
+
+    // Propagate to each surface seperately
+    auto result1 = propagator.propagateToSurface(startParams, *surface1, options);
+
+    auto result2 = propagator.propagateToSurface(startParams, *surface2, options);
+
+    BOOST_CHECK(result1.ok());
+
+    BOOST_CHECK(result2.ok());
+
+    //check the covariances
+    auto endParams1 = *result1;
+    BoundSquareMatrix cov1 = endParams1.covariance().value();
+
+    auto endParams2 = *result2;
+    BoundSquareMatrix cov2 = endParams2.covariance().value();
+
+
+    //check the covariances
+
+    testCovariances(cov1, cov2);
+
+
+    }
+
+    //check also full propagation case to surfaces put in a volume
+
+    {
+      using PropagatorType = Propagator<EigenStepperType, DetectorNavigator>;
+
+      //create a volume and put the surfaces inside -start propagate from the volume inside
+
+      auto bounds = std::make_unique<CuboidVolumeBounds>(2000_mm, 2000_mm, 2000_mm);
+
+      auto testVolume = DetectorVolumeFactory::construct(
+      defaultPortalAndSubPortalGenerator(), tgContext,
+      "Detector_Volume",
+      Acts::Transform3(Acts::Transform3::Identity()),
+      std::move(bounds), std::vector<std::shared_ptr<Acts::Surface>>{surface1, surface2}, 
+      std::vector<std::shared_ptr<DetectorVolume>>{},
+      tryNoVolumes(),
+      tryAllPortalsAndSurfaces());
+
+      testVolume->assignGeometryId(
+      Acts::GeometryIdentifier{}.setVolume(1));
+
+     
+      auto testDetector = Detector::makeShared(
+        "Detector", {testVolume}, tryRootVolumes());
+
+      DetectorNavigator::Config navCfg;
+      navCfg.detector = testDetector.get();
+
+      DetectorNavigator detNavigator(navCfg);
+
+      auto stepper = Acts::EigenStepper(field);
+
+      PropagatorType::Options<ActorList> options(tgContext, mfContext);
+      PropagatorType propagator(std::move(stepper), detNavigator,
+                                getDefaultLogger("Propagator_Test2", Logging::VERBOSE));
+   
+      auto result = propagator.propagate(startParams, options);
+
+      BOOST_CHECK(result.ok());
+
+      //check if the surfaces are collected during the propagation and if the covariances are rotated
+      auto cSurfaces = result.value().get<Acts::SurfaceCollector<PlaneSelector>::result_type>();
+      //two plane surfaces should be collected
+      BOOST_CHECK(cSurfaces.collected.size() == 2); 
+      testCovariances(cSurfaces.collected[0].covariance, cSurfaces.collected[1].covariance);   
+
+      BoundVector startPars;
+      startPars << 0.5_mm, 0.5_mm, 0.01, 0.01, 1 / 1_GeV, 0;
+      cov << 0.1_mm, 0, 0.123, 0, 0.5, 0,
+            0, 0.1_mm, 0, 0.162, 0, 0,
+            0.123, 0, 0.1, 0, 0, 0,
+            0, 0.162, 0, 0.1, 0, 0,
+            0.5, 0, 0, 0, 1. / (10.2_GeV), 0,
+            0, 0, 0, 0, 0, 0;
+
+      BoundTrackParameters startParameters{surface1, startPars, cov,
+                                         ParticleHypothesis::pion()};   
+      auto resultSurf = propagator.propagate(startParameters, options);
+      cSurfaces = resultSurf.value().get<Acts::SurfaceCollector<PlaneSelector>::result_type>();
+      BOOST_CHECK(resultSurf.ok());
+      BOOST_CHECK(cSurfaces.collected.size() == 2);
+      testCovariances(cSurfaces.collected[0].covariance, cSurfaces.collected[1].covariance);
+
+    }
+}
+
 }  // namespace Acts::Test


### PR DESCRIPTION
This tests with Gen2 Geometry the following:
Set up includes two plane surfaces placed on the same plane and rotated by 90deg, testing:
-How the propagator works when we force propagation to each surface seperately and if the covariances are also transported correctly.
-How the propagation works if we do a full propagation (by checking if we collect both surfaces and also the covariances)
-How the propagator works if I start from the one surface and want to reach the other (again looking if the surfaces are collected and if the covariances are correct).

This needed to be tested for the RPC plane surfaces case for muons.
I do not know if we want this in, just to let people also see it.
Also I needed to add the functionality of returning the covaranice from the hitted surface, in order to check them after the propagation is done. 

@junggjo9 @noemina 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced surface propagation by capturing additional covariance data for more detailed tracking.
  
- **Tests**
  - Introduced comprehensive tests to ensure accurate handling and rotation of covariance data during propagation, including scenarios with rotated plane surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->