### PR TITLE
test: Python test fixes: GSF + EDM4hep

### DIFF
--- a/Examples/Python/tests/test_misc.py
+++ b/Examples/Python/tests/test_misc.py
@@ -44,7 +44,7 @@ def test_gsf_debugger(tmp_path):
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{scriptdir}:{env['PYTHONPATH']}"
     gsf_result = subprocess.run(
-        [gsf_script], capture_output=True, cwd=tmp_path, env=env
+        [sys.executable, gsf_script], capture_output=True, cwd=tmp_path, env=env
     )
 
     logfile = tmp_path / "test.log"
@@ -54,6 +54,6 @@ def test_gsf_debugger(tmp_path):
     assert gsf_result.returncode == 0
 
     debugger_result = subprocess.run(
-        [debugger, f"--logfile={logfile}", "--nogui"], cwd=tmp_path
+        [sys.executable, debugger, f"--logfile={logfile}", "--nogui"], cwd=tmp_path
     )
     assert debugger_result.returncode == 0

--- a/Examples/Python/tests/test_reader.py
+++ b/Examples/Python/tests/test_reader.py
@@ -278,6 +278,7 @@ def generate_input_test_edm4hep_simhit_reader(input, output):
     ddsim.gun.distribution = "eta"
     ddsim.numberOfEvents = 10
     ddsim.outputFile = output
+    ddsim.outputConfig.forceEDM4HEP = True
     ddsim.run()
 
 

--- a/Examples/Scripts/GsfDebugger/make_gsf_verbose_log.py
+++ b/Examples/Scripts/GsfDebugger/make_gsf_verbose_log.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 from pathlib import Path
 

--- a/Examples/Scripts/GsfDebugger/src/main.py
+++ b/Examples/Scripts/GsfDebugger/src/main.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 import argparse
 import os
 import sys


### PR DESCRIPTION
This fixes a few small issues with the GSF debugger (shebangs) and using the python interpreter that runs pytest (otherwise modules might not be available).

It also forces DD4hep to write EDM4hep for the EDM4hep ddsim run, which gives a better error message if DD4hep was built without EDM4hep.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved execution of testing scripts by explicitly using the current Python interpreter.
  - Enforced simulation output settings for more consistent test outcomes.
  
- **Chores**
  - Updated script headers to reliably detect and use the user's Python environment for smoother execution across different setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->