### PR TITLE
build: Remove `ACTS_BUILD_NONCOMPILE_TESTS`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,7 +51,6 @@
                 "ACTS_FORCE_ASSERTIONS": "ON",
                 "ACTS_ENABLE_LOG_FAILURE_THRESHOLD": "ON",
                 "ACTS_BUILD_BENCHMARKS": "ON",
-                "ACTS_BUILD_NONCOMPILE_TESTS": "ON",
                 "ACTS_BUILD_ANALYSIS_APPS": "ON",
                 "ACTS_BUILD_ALIGNMENT": "ON",
                 "ACTS_BUILD_FATRAS_GEANT4": "ON",


### PR DESCRIPTION
Seems like I forgot this in
https://github.com/acts-project/acts/pull/4076


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined continuous integration settings by removing a non-essential testing phase to streamline the build process.
  - This update improves overall efficiency without impacting the product’s features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->