### PR TITLE
refactor: GeometryIdentifier checks value range

### DIFF
--- a/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
@@ -45,18 +45,18 @@ BOOST_AUTO_TEST_CASE(GeometryIdentifier_max_values) {
   constexpr GeometryIdentifier ref = 0xdeadaffe01234567;
   // values above the maximum are truncated
   // max+1 has all available bits zeroed
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setVolume(volumeMax + 1),
-                    GeometryIdentifier(ref).setVolume(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setBoundary(boundaryMax + 1),
-                    GeometryIdentifier(ref).setBoundary(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setLayer(layerMax + 1),
-                    GeometryIdentifier(ref).setLayer(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setApproach(approachMax + 1),
-                    GeometryIdentifier(ref).setApproach(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setSensitive(sensitiveMax + 1),
-                    GeometryIdentifier(ref).setSensitive(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setExtra(extraMax + 1),
-                    GeometryIdentifier(ref).setExtra(0u));
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setVolume(volumeMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setBoundary(boundaryMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setLayer(layerMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setApproach(approachMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setSensitive(sensitiveMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setExtra(extraMax + 1),
+                    std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(GeometryIdentifier_order) {


### PR DESCRIPTION
I've run into overflowing ID values one too many times now. This PR proposes making the value setters check the value to be assigned to be within the valid range.

I'm currently throwing an exception, which we can debate if that's the best way to handle failure.

--- END COMMIT MESSAGE ---

Thoughts @benjaminhuth @andiwand?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to calculate the maximum value for identifiers, enhancing validation capabilities.
- **Bug Fixes**
  - Improved error handling now throws exceptions for out-of-bound values, ensuring robust identifier configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->