### PR TITLE
refactor: GeometryIdentifier immutable modification

### DIFF
--- a/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
+++ b/Core/include/Acts/Geometry/GeometryHierarchyMap.hpp
@@ -132,18 +132,19 @@ class GeometryHierarchyMap {
   // NOTE this class assumes that it knows the ordering of the levels within
   //      the geometry id. if the geometry id changes, this code has to be
   //      adapted too. the asserts ensure that such a change is caught.
-  static_assert(GeometryIdentifier().setVolume(1).value() <
-                    GeometryIdentifier().setVolume(1).setBoundary(1).value(),
+  static_assert(GeometryIdentifier().withVolume(1).value() <
+                    GeometryIdentifier().withVolume(1).withBoundary(1).value(),
                 "Incompatible GeometryIdentifier hierarchy");
-  static_assert(GeometryIdentifier().setBoundary(1).value() <
-                    GeometryIdentifier().setBoundary(1).setLayer(1).value(),
+  static_assert(GeometryIdentifier().withBoundary(1).value() <
+                    GeometryIdentifier().withBoundary(1).withLayer(1).value(),
                 "Incompatible GeometryIdentifier hierarchy");
-  static_assert(GeometryIdentifier().setLayer(1).value() <
-                    GeometryIdentifier().setLayer(1).setApproach(1).value(),
+  static_assert(GeometryIdentifier().withLayer(1).value() <
+                    GeometryIdentifier().withLayer(1).withApproach(1).value(),
                 "Incompatible GeometryIdentifier hierarchy");
-  static_assert(GeometryIdentifier().setApproach(1).value() <
-                    GeometryIdentifier().setApproach(1).setSensitive(1).value(),
-                "Incompatible GeometryIdentifier hierarchy");
+  static_assert(
+      GeometryIdentifier().withApproach(1).value() <
+          GeometryIdentifier().withApproach(1).withSensitive(1).value(),
+      "Incompatible GeometryIdentifier hierarchy");
 
   using Identifier = GeometryIdentifier::Value;
 
@@ -156,31 +157,31 @@ class GeometryHierarchyMap {
   /// Construct a mask where all leading non-zero levels are set.
   static constexpr Identifier makeLeadingLevelsMask(GeometryIdentifier id) {
     // construct id from encoded value with all bits set
-    auto allSet = GeometryIdentifier(~GeometryIdentifier::Value{0u});
+    const auto allSet = GeometryIdentifier(~GeometryIdentifier::Value{0u});
     // manually iterate over identifier levels starting from the lowest
     if (id.sensitive() != 0u) {
       // all levels are valid; keep all bits set.
-      return allSet.setExtra(0u).value();
+      return allSet.withExtra(0u).value();
     }
     if (id.approach() != 0u) {
-      return allSet.setExtra(0u).setSensitive(0u).value();
+      return allSet.withExtra(0u).withSensitive(0u).value();
     }
     if (id.layer() != 0u) {
-      return allSet.setExtra(0u).setSensitive(0u).setApproach(0u).value();
+      return allSet.withExtra(0u).withSensitive(0u).withApproach(0u).value();
     }
     if (id.boundary() != 0u) {
-      return allSet.setExtra(0u)
-          .setSensitive(0u)
-          .setApproach(0u)
-          .setLayer(0u)
+      return allSet.withExtra(0u)
+          .withSensitive(0u)
+          .withApproach(0u)
+          .withLayer(0u)
           .value();
     }
     if (id.volume() != 0u) {
-      return allSet.setExtra(0u)
-          .setSensitive(0u)
-          .setApproach(0u)
-          .setLayer(0u)
-          .setBoundary(0u)
+      return allSet.withExtra(0u)
+          .withSensitive(0u)
+          .withApproach(0u)
+          .withLayer(0u)
+          .withBoundary(0u)
           .value();
     }
     // no valid levels; all bits are zero.
@@ -189,7 +190,7 @@ class GeometryHierarchyMap {
 
   /// Construct a mask where only the highest level is set.
   static constexpr Identifier makeHighestLevelMask() {
-    return makeLeadingLevelsMask(GeometryIdentifier(0u).setVolume(1u));
+    return makeLeadingLevelsMask(GeometryIdentifier(0u).withVolume(1u));
   }
 
   /// Compare the two identifiers only within the masked bits.

--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <functional>
 #include <iosfwd>
+#include <stdexcept>
 
 namespace Acts {
 

--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -91,6 +91,76 @@ class GeometryIdentifier {
     return setBits(kExtraMask, extra);
   }
 
+  /// Return a new identifier with the volume set to @p volume
+  /// @param volume the new volume identifier
+  /// @return a new identifier with the volume set to @p volume
+  [[nodiscard]]
+  constexpr GeometryIdentifier withVolume(Value volume) const {
+    GeometryIdentifier id = *this;
+    id.setVolume(volume);
+    return id;
+  }
+
+  /// Return a new identifier with the boundary set to @p boundary
+  /// @param boundary the new boundary identifier
+  /// @return a new identifier with the boundary set to @p boundary
+  [[nodiscard]]
+  constexpr GeometryIdentifier withBoundary(Value boundary) const {
+    GeometryIdentifier id = *this;
+    id.setBoundary(boundary);
+    return id;
+  }
+
+  /// Return a new identifier with the layer set to @p layer
+  /// @param layer the new layer identifier
+  /// @return a new identifier with the layer set to @p layer
+  [[nodiscard]]
+  constexpr GeometryIdentifier withLayer(Value layer) const {
+    GeometryIdentifier id = *this;
+    id.setLayer(layer);
+    return id;
+  }
+
+  /// Return a new identifier with the approach set to @p approach
+  /// @param approach the new approach identifier
+  /// @return a new identifier with the approach set to @p approach
+  [[nodiscard]]
+  constexpr GeometryIdentifier withApproach(Value approach) const {
+    GeometryIdentifier id = *this;
+    id.setApproach(approach);
+    return id;
+  }
+
+  /// Return a new identifier with the passive set to @p passive
+  /// @param passive the new passive identifier
+  /// @return a new identifier with the passive set to @p passive
+  [[nodiscard]]
+  constexpr GeometryIdentifier withPassive(Value passive) const {
+    GeometryIdentifier id = *this;
+    id.setPassive(passive);
+    return id;
+  }
+
+  /// Return a new identifier with the sensitive set to @p sensitive
+  /// @param sensitive the new sensitive identifier
+  /// @return a new identifier with the sensitive set to @p sensitive
+  [[nodiscard]]
+  constexpr GeometryIdentifier withSensitive(Value sensitive) const {
+    GeometryIdentifier id = *this;
+    id.setSensitive(sensitive);
+    return id;
+  }
+
+  /// Return a new identifier with the extra set to @p extra
+  /// @param extra the new extra identifier
+  /// @return a new identifier with the extra set to @p extra
+  [[nodiscard]]
+  constexpr GeometryIdentifier withExtra(Value extra) const {
+    GeometryIdentifier id = *this;
+    id.setExtra(extra);
+    return id;
+  }
+
  private:
   // clang-format off
   /// (2^8)-1 = 255 volumes
@@ -119,6 +189,7 @@ class GeometryIdentifier {
     // WARNING undefined behaviour for mask == 0 which we should not have.
     return __builtin_ctzll(mask);
   }
+
   /// Extract the masked bits from the encoded value.
   constexpr Value getBits(Value mask) const {
     return (m_value & mask) >> extractShift(mask);
@@ -126,7 +197,8 @@ class GeometryIdentifier {
   /// Set the masked bits to id in the encoded value.
   constexpr GeometryIdentifier& setBits(Value mask, Value id) {
     m_value = (m_value & ~mask) | ((id << extractShift(mask)) & mask);
-    // return *this here that we need to write fewer lines in the setXXX methods
+    // return *this here that we need to write fewer lines in the setXXX
+    // methods
     return *this;
   }
 

--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -76,7 +76,7 @@ void Acts::Layer::closeGeometry(const IMaterialDecorator* materialDecorator,
     // loop through the approachSurfaces and assign unique GeomeryID
     GeometryIdentifier::Value iasurface = 0;
     for (auto& aSurface : m_approachDescriptor->containedSurfaces()) {
-      auto asurfaceID = GeometryIdentifier(layerID).setApproach(++iasurface);
+      auto asurfaceID = GeometryIdentifier(layerID).withApproach(++iasurface);
       auto mutableASurface = const_cast<Surface*>(aSurface);
       mutableASurface->assignGeometryId(asurfaceID);
       if (materialDecorator != nullptr) {
@@ -95,7 +95,7 @@ void Acts::Layer::closeGeometry(const IMaterialDecorator* materialDecorator,
     // loop sensitive surfaces and assign unique GeometryIdentifier
     GeometryIdentifier::Value issurface = 0;
     for (auto& sSurface : m_surfaceArray->surfaces()) {
-      auto ssurfaceID = GeometryIdentifier(layerID).setSensitive(++issurface);
+      auto ssurfaceID = GeometryIdentifier(layerID).withSensitive(++issurface);
       ssurfaceID = hook.decorateIdentifier(ssurfaceID, *sSurface);
       auto mutableSSurface = const_cast<Surface*>(sSurface);
       mutableSSurface->assignGeometryId(ssurfaceID);

--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -381,7 +381,7 @@ void TrackingVolume::closeGeometry(
   }
 
   // we can construct the volume ID from this
-  auto volumeID = GeometryIdentifier().setVolume(++vol);
+  auto volumeID = GeometryIdentifier().withVolume(++vol);
   // assign the Volume ID to the volume itself
   auto thisVolume = const_cast<TrackingVolume*>(this);
   thisVolume->assignGeometryId(volumeID);
@@ -413,7 +413,7 @@ void TrackingVolume::closeGeometry(
     auto& bSurface = bSurfIter->surfaceRepresentation();
     // create the boundary surface id
     iboundary++;
-    auto boundaryID = GeometryIdentifier(volumeID).setBoundary(iboundary);
+    auto boundaryID = GeometryIdentifier(volumeID).withBoundary(iboundary);
     // now assign to the boundary surface
     auto& mutableBSurface = *(const_cast<RegularSurface*>(&bSurface));
     mutableBSurface.assignGeometryId(boundaryID);
@@ -432,7 +432,7 @@ void TrackingVolume::closeGeometry(
       for (auto& layerPtr : m_confinedLayers->arrayObjects()) {
         // create the layer identification
         ilayer++;
-        auto layerID = GeometryIdentifier(volumeID).setLayer(ilayer);
+        auto layerID = GeometryIdentifier(volumeID).withLayer(ilayer);
         // now close the geometry
         auto mutableLayerPtr = std::const_pointer_cast<Layer>(layerPtr);
         mutableLayerPtr->closeGeometry(materialDecorator, layerID, hook,
@@ -464,7 +464,7 @@ void TrackingVolume::closeGeometry(
   GeometryIdentifier::Value iportal = 0;
   for (auto& portal : portals()) {
     iportal++;
-    auto portalId = GeometryIdentifier(volumeID).setBoundary(iportal);
+    auto portalId = GeometryIdentifier(volumeID).withBoundary(iportal);
     assert(portal.isValid() && "Invalid portal encountered during closing");
 
     portal.surface().assignGeometryId(portalId);
@@ -477,7 +477,7 @@ void TrackingVolume::closeGeometry(
       continue;
     }
     isensitive++;
-    auto sensitiveId = GeometryIdentifier(volumeID).setSensitive(isensitive);
+    auto sensitiveId = GeometryIdentifier(volumeID).withSensitive(isensitive);
     surface.assignGeometryId(sensitiveId);
   }
 

--- a/Examples/Algorithms/Digitization/src/DigitizationConfigurator.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationConfigurator.cpp
@@ -249,7 +249,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
         // Check for a representing volume configuration, insert if not
         // present
         Acts::GeometryIdentifier volGeoId =
-            Acts::GeometryIdentifier().setVolume(geoId.volume());
+            Acts::GeometryIdentifier().withVolume(geoId.volume());
 
         auto volRep = volumeLayerComponents.find(volGeoId);
         if (volRep != volumeLayerComponents.end() &&
@@ -263,7 +263,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
 
         // Check for a representing layer configuration, insert if not present
         Acts::GeometryIdentifier volLayGeoId =
-            Acts::GeometryIdentifier(volGeoId).setLayer(geoId.layer());
+            Acts::GeometryIdentifier(volGeoId).withLayer(geoId.layer());
         auto volLayRep = volumeLayerComponents.find(volLayGeoId);
 
         if (volLayRep != volumeLayerComponents.end() &&

--- a/Examples/Framework/include/ActsExamples/EventData/GeometryContainers.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/GeometryContainers.hpp
@@ -103,11 +103,11 @@ template <typename T>
 inline Range<typename GeometryIdMultiset<T>::const_iterator> selectVolume(
     const GeometryIdMultiset<T>& container,
     Acts::GeometryIdentifier::Value volume) {
-  auto cmp = Acts::GeometryIdentifier().setVolume(volume);
+  auto cmp = Acts::GeometryIdentifier().withVolume(volume);
   auto beg = std::lower_bound(container.begin(), container.end(), cmp,
                               detail::CompareGeometryId{});
   // WARNING overflows to volume==0 if the input volume is the last one
-  cmp = Acts::GeometryIdentifier().setVolume(volume + 1u);
+  cmp = Acts::GeometryIdentifier().withVolume(volume + 1u);
   // optimize search by using the lower bound as start point. also handles
   // volume overflows since the geo id would be located before the start of
   // the upper edge search window.
@@ -129,11 +129,11 @@ inline Range<typename GeometryIdMultiset<T>::const_iterator> selectLayer(
     const GeometryIdMultiset<T>& container,
     Acts::GeometryIdentifier::Value volume,
     Acts::GeometryIdentifier::Value layer) {
-  auto cmp = Acts::GeometryIdentifier().setVolume(volume).setLayer(layer);
+  auto cmp = Acts::GeometryIdentifier().withVolume(volume).withLayer(layer);
   auto beg = std::lower_bound(container.begin(), container.end(), cmp,
                               detail::CompareGeometryId{});
   // WARNING resets to layer==0 if the input layer is the last one
-  cmp = Acts::GeometryIdentifier().setVolume(volume).setLayer(layer + 1u);
+  cmp = Acts::GeometryIdentifier().withVolume(volume).withLayer(layer + 1u);
   // optimize search by using the lower bound as start point. also handles
   // volume overflows since the geo id would be located before the start of
   // the upper edge search window.
@@ -163,10 +163,10 @@ inline auto selectModule(const GeometryIdMultiset<T>& container,
                          Acts::GeometryIdentifier::Value volume,
                          Acts::GeometryIdentifier::Value layer,
                          Acts::GeometryIdentifier::Value sensitive) {
-  return selectModule(
-      container,
-      Acts::GeometryIdentifier().setVolume(volume).setLayer(layer).setSensitive(
-          sensitive));
+  return selectModule(container, Acts::GeometryIdentifier()
+                                     .withVolume(volume)
+                                     .withLayer(layer)
+                                     .withSensitive(sensitive));
 }
 
 /// Select all elements for the lowest non-zero identifier component.

--- a/Plugins/Json/include/Acts/Plugins/Json/GeometryHierarchyMapJsonConverter.hpp
+++ b/Plugins/Json/include/Acts/Plugins/Json/GeometryHierarchyMapJsonConverter.hpp
@@ -96,12 +96,13 @@ class GeometryHierarchyMapJsonConverter {
   /// @return a valid geometry Identifier
   static GeometryIdentifier decodeIdentifier(const nlohmann::json& encoded) {
     return GeometryIdentifier()
-        .setVolume(encoded.value("volume", GeometryIdentifier::Value{0u}))
-        .setBoundary(encoded.value("boundary", GeometryIdentifier::Value{0u}))
-        .setLayer(encoded.value("layer", GeometryIdentifier::Value{0u}))
-        .setApproach(encoded.value("approach", GeometryIdentifier::Value{0u}))
-        .setSensitive(encoded.value("sensitive", GeometryIdentifier::Value{0u}))
-        .setExtra(encoded.value("extra", GeometryIdentifier::Value{0u}));
+        .withVolume(encoded.value("volume", GeometryIdentifier::Value{0u}))
+        .withBoundary(encoded.value("boundary", GeometryIdentifier::Value{0u}))
+        .withLayer(encoded.value("layer", GeometryIdentifier::Value{0u}))
+        .withApproach(encoded.value("approach", GeometryIdentifier::Value{0u}))
+        .withSensitive(
+            encoded.value("sensitive", GeometryIdentifier::Value{0u}))
+        .withExtra(encoded.value("extra", GeometryIdentifier::Value{0u}));
   }
 
  private:

--- a/Tests/UnitTests/Core/Detector/DetectorTests.cpp
+++ b/Tests/UnitTests/Core/Detector/DetectorTests.cpp
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(DetectorConstructionWithHierarchyMap) {
         Acts::Transform3::Identity(),
         std::make_shared<Acts::CylinderBounds>(r, 190.), 0.1);
     auto surface = detElement->surface().getSharedPtr();
-    surface->assignGeometryId(Acts::GeometryIdentifier{}.setSensitive(ir + 1));
+    surface->assignGeometryId(Acts::GeometryIdentifier{}.withSensitive(ir + 1));
     surfaces.push_back(std::move(surface));
     detStore.push_back(std::move(detElement));
   }
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(DetectorConstructionWithHierarchyMap) {
   const auto& sensitiveHierarchyMap = det->sensitiveHierarchyMap();
 
   const Acts::Surface* surface0 =
-      det->findSurface(Acts::GeometryIdentifier{}.setSensitive(1));
+      det->findSurface(Acts::GeometryIdentifier{}.withSensitive(1));
 
   BOOST_CHECK_EQUAL(sensitiveHierarchyMap.size(), 6u);
   BOOST_CHECK_NE(surface0, nullptr);

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryHelpersTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryHelpersTests.cpp
@@ -70,9 +70,10 @@ BOOST_AUTO_TEST_CASE(trajectoryStateVolume) {
   std::vector<GeometryIdentifier::Value> volumes = {searchVolume};
 
   auto searchSurface = Surface::makeShared<PerigeeSurface>(Vector3(0, 0, 0));
-  searchSurface->assignGeometryId(GeometryIdentifier().setVolume(searchVolume));
+  searchSurface->assignGeometryId(
+      GeometryIdentifier().withVolume(searchVolume));
   auto otherSurface = Surface::makeShared<PerigeeSurface>(Vector3(0, 0, 0));
-  otherSurface->assignGeometryId(GeometryIdentifier().setVolume(otherVolume));
+  otherSurface->assignGeometryId(GeometryIdentifier().withVolume(otherVolume));
 
   VectorMultiTrajectory traj;
 

--- a/Tests/UnitTests/Core/Geometry/GeometryHierarchyMapTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GeometryHierarchyMapTests.cpp
@@ -22,7 +22,7 @@ using Acts::GeometryIdentifier;
 
 // helper function to create geometry ids
 GeometryIdentifier makeId(int volume = 0, int layer = 0, int sensitive = 0) {
-  return GeometryIdentifier().setVolume(volume).setLayer(layer).setSensitive(
+  return GeometryIdentifier().withVolume(volume).withLayer(layer).withSensitive(
       sensitive);
 }
 

--- a/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
@@ -60,35 +60,35 @@ BOOST_AUTO_TEST_CASE(GeometryIdentifier_max_values) {
 }
 
 BOOST_AUTO_TEST_CASE(GeometryIdentifier_order) {
-  auto vol1 = GeometryIdentifier()
-                  .setVolume(1u)
-                  .setLayer(14u)
-                  .setSensitive(5u)
-                  .setExtra(42u);
-  auto vol2 = GeometryIdentifier()
-                  .setVolume(2u)
-                  .setLayer(13u)
-                  .setSensitive(3u)
-                  .setExtra(43u);
+  GeometryIdentifier vol1;
+  vol1.setVolume(1u);
+  vol1.setLayer(14u);
+  vol1.setSensitive(5u);
+  vol1.setExtra(42u);
+  GeometryIdentifier vol2;
+  vol2.setVolume(2u);
+  vol2.setLayer(13u);
+  vol2.setSensitive(3u);
+  vol2.setExtra(43u);
   // order uses volume first even if other components are larger
   BOOST_CHECK_LT(vol1, vol2);
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setBoundary(64u), vol2);
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setLayer(64u), vol2);
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setApproach(64u), vol2);
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setSensitive(64u), vol2);
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setSensitive(64u), vol2);
-  BOOST_CHECK_LT(vol2, GeometryIdentifier(vol1).setVolume(3u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withBoundary(64u), vol2);
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withLayer(64u), vol2);
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withApproach(64u), vol2);
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withSensitive(64u), vol2);
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withSensitive(64u), vol2);
+  BOOST_CHECK_LT(vol2, GeometryIdentifier(vol1).withVolume(3u));
   // other components are hierarchical
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setVolume(1u).setBoundary(2u),
-                 GeometryIdentifier(vol1).setVolume(2u).setBoundary(1u));
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setBoundary(1u).setLayer(2u),
-                 GeometryIdentifier(vol1).setBoundary(2u).setLayer(1u));
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setLayer(1u).setApproach(2u),
-                 GeometryIdentifier(vol1).setLayer(2u).setApproach(1u));
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setApproach(1u).setSensitive(2u),
-                 GeometryIdentifier(vol1).setApproach(2u).setSensitive(1u));
-  BOOST_CHECK_LT(GeometryIdentifier(vol1).setSensitive(1u).setExtra(2u),
-                 GeometryIdentifier(vol1).setSensitive(2u).setExtra(1u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withVolume(1u).withBoundary(2u),
+                 GeometryIdentifier(vol1).withVolume(2u).withBoundary(1u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withBoundary(1u).withLayer(2u),
+                 GeometryIdentifier(vol1).withBoundary(2u).withLayer(1u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withLayer(1u).withApproach(2u),
+                 GeometryIdentifier(vol1).withLayer(2u).withApproach(1u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withApproach(1u).withSensitive(2u),
+                 GeometryIdentifier(vol1).withApproach(2u).withSensitive(1u));
+  BOOST_CHECK_LT(GeometryIdentifier(vol1).withSensitive(1u).withExtra(2u),
+                 GeometryIdentifier(vol1).withSensitive(2u).withExtra(1u));
 }
 
 }  // namespace Acts::Test

--- a/Tests/UnitTests/Core/Material/BinnedSurfaceMaterialAccumulaterTests.cpp
+++ b/Tests/UnitTests/Core/Material/BinnedSurfaceMaterialAccumulaterTests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(InvalidSetupTest) {
   };
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   // First is homogeneous
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(AccumulationTest) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   // Accepted materials are:
@@ -169,15 +169,15 @@ BOOST_AUTO_TEST_CASE(AccumulationTest) {
 
   BOOST_CHECK_EQUAL(maps.size(), 3u);
 
-  auto m0Itr = maps.find(GeometryIdentifier().setSensitive(1));
+  auto m0Itr = maps.find(GeometryIdentifier().withSensitive(1));
   BOOST_CHECK(m0Itr != maps.end());
   BOOST_CHECK(m0Itr->second != nullptr);
 
-  auto m1Itr = maps.find(GeometryIdentifier().setSensitive(2));
+  auto m1Itr = maps.find(GeometryIdentifier().withSensitive(2));
   BOOST_CHECK(m1Itr != maps.end());
   BOOST_CHECK(m1Itr->second != nullptr);
 
-  auto m2Itr = maps.find(GeometryIdentifier().setSensitive(3));
+  auto m2Itr = maps.find(GeometryIdentifier().withSensitive(3));
   BOOST_CHECK(m2Itr != maps.end());
   BOOST_CHECK(m2Itr->second != nullptr);
 
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(AccumulationTest) {
   // Check failures
   auto invalidSurface =
       Surface::makeShared<CylinderSurface>(Transform3::Identity(), 40.0, 100.0);
-  invalidSurface->assignGeometryId(GeometryIdentifier().setSensitive(4));
+  invalidSurface->assignGeometryId(GeometryIdentifier().withSensitive(4));
 
   // Invalid surface amongst material
   MaterialInteraction mXX;

--- a/Tests/UnitTests/Core/Material/MaterialInteractionAssignmentTests.cpp
+++ b/Tests/UnitTests/Core/Material/MaterialInteractionAssignmentTests.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(AssignToClosest) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   std::vector<IAssignmentFinder::SurfaceAssignment> intersectedSurfaces = {
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withGlobalVeto) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   std::vector<IAssignmentFinder::SurfaceAssignment> intersectedSurfaces = {
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withLocalVeto) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   std::vector<IAssignmentFinder::SurfaceAssignment> intersectedSurfaces = {
@@ -183,7 +183,8 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withLocalVeto) {
   // We assign this to
   std::vector<
       std::pair<GeometryIdentifier, MaterialInteractionAssignment::LocalVeto>>
-      localVetoVector = {{GeometryIdentifier().setSensitive(2), VetoThisOne{}}};
+      localVetoVector = {
+          {GeometryIdentifier().withSensitive(2), VetoThisOne{}}};
   GeometryHierarchyMap<MaterialInteractionAssignment::LocalVeto> localVetos(
       localVetoVector);
   MaterialInteractionAssignment::Options options;
@@ -209,7 +210,7 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withReassignment) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   std::vector<IAssignmentFinder::SurfaceAssignment> intersectedSurfaces = {
@@ -250,7 +251,7 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withReassignment) {
   std::vector<std::pair<GeometryIdentifier,
                         MaterialInteractionAssignment::ReAssignment>>
       reassignmentVector = {
-          {GeometryIdentifier().setSensitive(2), ReAssignToNeighbor{}}};
+          {GeometryIdentifier().withSensitive(2), ReAssignToNeighbor{}}};
   GeometryHierarchyMap<MaterialInteractionAssignment::ReAssignment>
       reassignments(reassignmentVector);
   MaterialInteractionAssignment::Options options;
@@ -268,14 +269,14 @@ BOOST_AUTO_TEST_CASE(AssignToClosest_withReassignment) {
 
   // Check that the geoid with number 2 never shows up
   for (const auto& mi : assigned) {
-    BOOST_CHECK_NE(mi.intersectionID, GeometryIdentifier().setSensitive(2));
+    BOOST_CHECK_NE(mi.intersectionID, GeometryIdentifier().withSensitive(2));
   }
 }
 
 BOOST_AUTO_TEST_CASE(AssignWithPathLength) {
   auto surface =
       Surface::makeShared<CylinderSurface>(Transform3::Identity(), 20.0, 100.0);
-  surface->assignGeometryId(GeometryIdentifier().setSensitive(1));
+  surface->assignGeometryId(GeometryIdentifier().withSensitive(1));
 
   Vector3 position = {20., 10., 0.};
   Vector3 direction = position.normalized();

--- a/Tests/UnitTests/Core/Material/MaterialMapperTests.cpp
+++ b/Tests/UnitTests/Core/Material/MaterialMapperTests.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(MaterialMapperFlowTest) {
                                            100.0)};
 
   for (auto [is, surface] : enumerate(surfaces)) {
-    surface->assignGeometryId(GeometryIdentifier().setSensitive(is + 1));
+    surface->assignGeometryId(GeometryIdentifier().withSensitive(is + 1));
   }
 
   // The assigner

--- a/Tests/UnitTests/Core/Material/PropagatorMaterialAssignerTests.cpp
+++ b/Tests/UnitTests/Core/Material/PropagatorMaterialAssignerTests.cpp
@@ -119,11 +119,11 @@ BOOST_AUTO_TEST_CASE(FindSurfaceIntersectionsTrackingGeometry) {
 BOOST_AUTO_TEST_CASE(FindSurfaceIntersectionsTrackingVolume) {
   unsigned int volID = 1;
   auto assignGeoIds = [&volID](Experimental::DetectorVolume& dVol) -> void {
-    dVol.assignGeometryId(GeometryIdentifier().setVolume(volID));
+    dVol.assignGeometryId(GeometryIdentifier().withVolume(volID));
     unsigned int pID = 1;
     for (auto& p : dVol.portalPtrs()) {
       p->surface().assignGeometryId(
-          GeometryIdentifier().setVolume(volID).setBoundary(pID));
+          GeometryIdentifier().withVolume(volID).withBoundary(pID));
     }
     volID++;
   };
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(FindSurfaceIntersectionsTrackingVolume) {
   auto pCylinderSurface =
       Surface::makeShared<CylinderSurface>(Transform3::Identity(), pCylinder);
   pCylinderSurface->assignSurfaceMaterial(surfaceMaterial);
-  pCylinderSurface->assignGeometryId(GeometryIdentifier().setSensitive(1));
+  pCylinderSurface->assignGeometryId(GeometryIdentifier().withSensitive(1));
 
   auto layer0 = Experimental::DetectorVolumeFactory::construct(
       portalGenerator, tContext, "Layer0", nominal, std::move(vCylinderL0),

--- a/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/DirectNavigatorTests.cpp
@@ -280,8 +280,8 @@ BOOST_AUTO_TEST_CASE(test_direct_navigator_fwd_bwd) {
     transform.translate(Vector3{0.0_mm, 0.0_mm, i * 100.0_mm});
     auto surface = Surface::makeShared<PlaneSurface>(transform, nullptr);
     surface->assignGeometryId(
-        Acts::GeometryIdentifier().setVolume(1).setLayer(1).setSensitive(i +
-                                                                         1));
+        Acts::GeometryIdentifier().withVolume(1).withLayer(1).withSensitive(i +
+                                                                            1));
     surfaces.push_back(surface);
   }
 

--- a/Tests/UnitTests/Core/SpacePointFormation/SpacePointBuilderTests.cpp
+++ b/Tests/UnitTests/Core/SpacePointFormation/SpacePointBuilderTests.cpp
@@ -107,11 +107,11 @@ const MeasurementResolution resPixel = {MeasurementType::eLoc01,
 const MeasurementResolution resStrip = {MeasurementType::eLoc01,
                                         {100_um, 100_um}};
 const MeasurementResolutionMap resolutions = {
-    {GeometryIdentifier().setVolume(2), resPixel},
-    {GeometryIdentifier().setVolume(3).setLayer(2), resStrip},
-    {GeometryIdentifier().setVolume(3).setLayer(4), resStrip},
-    {GeometryIdentifier().setVolume(3).setLayer(6), resStrip},
-    {GeometryIdentifier().setVolume(3).setLayer(8), resStrip},
+    {GeometryIdentifier().withVolume(2), resPixel},
+    {GeometryIdentifier().withVolume(3).withLayer(2), resStrip},
+    {GeometryIdentifier().withVolume(3).withLayer(4), resStrip},
+    {GeometryIdentifier().withVolume(3).withLayer(6), resStrip},
+    {GeometryIdentifier().withVolume(3).withLayer(8), resStrip},
 };
 
 std::default_random_engine rng(42);

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -97,11 +97,11 @@ struct Detector {
   MeasurementResolution resStrip0 = {MeasurementType::eLoc0, {100_um}};
   MeasurementResolution resStrip1 = {MeasurementType::eLoc1, {150_um}};
   MeasurementResolutionMap resolutions = {
-      {Acts::GeometryIdentifier().setVolume(2), resPixel},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(2), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(4), resStrip1},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(6), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(8), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(2), resPixel},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(2), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(4), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(6), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(8), resStrip1},
   };
 
   Detector(const Acts::GeometryContext& geoCtx)

--- a/Tests/UnitTests/Core/TrackFinding/TrackSelectorTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/TrackSelectorTests.cpp
@@ -648,26 +648,27 @@ BOOST_AUTO_TEST_CASE(SubsetHitCountCut) {
   };
 
   auto vol7_lay3_sen2 = makeSurface(
-      GeometryIdentifier{}.setVolume(7).setLayer(3).setSensitive(2));
-  auto vol7_lay4 = makeSurface(GeometryIdentifier{}.setVolume(7).setLayer(4));
+      GeometryIdentifier{}.withVolume(7).withLayer(3).withSensitive(2));
+  auto vol7_lay4 = makeSurface(GeometryIdentifier{}.withVolume(7).withLayer(4));
   auto vol7_lay3_sen8 = makeSurface(
-      GeometryIdentifier{}.setVolume(7).setLayer(3).setSensitive(8));
+      GeometryIdentifier{}.withVolume(7).withLayer(3).withSensitive(8));
   auto vol7_lay5_sen11 = makeSurface(
-      GeometryIdentifier{}.setVolume(7).setLayer(5).setSensitive(11));
+      GeometryIdentifier{}.withVolume(7).withLayer(5).withSensitive(11));
   auto vol7_lay5_sen12 = makeSurface(
-      GeometryIdentifier{}.setVolume(7).setLayer(5).setSensitive(12));
+      GeometryIdentifier{}.withVolume(7).withLayer(5).withSensitive(12));
   auto vol7_lay6_sen3 = makeSurface(
-      GeometryIdentifier{}.setVolume(7).setLayer(6).setSensitive(3));
+      GeometryIdentifier{}.withVolume(7).withLayer(6).withSensitive(3));
 
   auto vol8_lay8_sen1 = makeSurface(
-      GeometryIdentifier{}.setVolume(8).setLayer(8).setSensitive(1));
+      GeometryIdentifier{}.withVolume(8).withLayer(8).withSensitive(1));
   auto vol8_lay8_sen2 = makeSurface(
-      GeometryIdentifier{}.setVolume(8).setLayer(8).setSensitive(2));
+      GeometryIdentifier{}.withVolume(8).withLayer(8).withSensitive(2));
   auto vol8_lay9_sen1 = makeSurface(
-      GeometryIdentifier{}.setVolume(8).setLayer(9).setSensitive(1));
+      GeometryIdentifier{}.withVolume(8).withLayer(9).withSensitive(1));
 
   TrackSelector::Config cfgVol7;
-  cfgVol7.measurementCounter.addCounter({GeometryIdentifier{}.setVolume(7)}, 3);
+  cfgVol7.measurementCounter.addCounter({GeometryIdentifier{}.withVolume(7)},
+                                        3);
   TrackSelector selectorVol7{cfgVol7};
 
   auto trackVol7 = makeTrack();
@@ -687,7 +688,8 @@ BOOST_AUTO_TEST_CASE(SubsetHitCountCut) {
   BOOST_CHECK(selectorVol7.isValidTrack(trackVol7));
 
   TrackSelector::Config cfgVol8;
-  cfgVol8.measurementCounter.addCounter({GeometryIdentifier{}.setVolume(8)}, 2);
+  cfgVol8.measurementCounter.addCounter({GeometryIdentifier{}.withVolume(8)},
+                                        2);
   TrackSelector selectorVol8{cfgVol8};
 
   // Previous trackVol7 has no measurements in volume 8
@@ -705,7 +707,7 @@ BOOST_AUTO_TEST_CASE(SubsetHitCountCut) {
 
   TrackSelector::Config cfgVol7Lay5;
   cfgVol7Lay5.measurementCounter.addCounter(
-      {GeometryIdentifier{}.setVolume(7).setLayer(5)}, 2);
+      {GeometryIdentifier{}.withVolume(7).withLayer(5)}, 2);
   TrackSelector selectorVol7Lay5{cfgVol7Lay5};
 
   // Only one hit on volume 7 layer 5
@@ -716,7 +718,7 @@ BOOST_AUTO_TEST_CASE(SubsetHitCountCut) {
   // Check requirement on volume 7 OR 8
   TrackSelector::Config cfgVol7Or8;
   cfgVol7Or8.measurementCounter.addCounter(
-      {GeometryIdentifier{}.setVolume(7), GeometryIdentifier{}.setVolume(8)},
+      {GeometryIdentifier{}.withVolume(7), GeometryIdentifier{}.withVolume(8)},
       4);
   TrackSelector selectorVol7Or8{cfgVol7Or8};
 
@@ -732,10 +734,10 @@ BOOST_AUTO_TEST_CASE(SubsetHitCountCut) {
   BOOST_CHECK(selectorVol7Or8.isValidTrack(trackVol8));
 
   TrackSelector::Config cfgVol7And8;
-  cfgVol7And8.measurementCounter.addCounter({GeometryIdentifier{}.setVolume(7)},
-                                            4);
-  cfgVol7And8.measurementCounter.addCounter({GeometryIdentifier{}.setVolume(8)},
-                                            2);
+  cfgVol7And8.measurementCounter.addCounter(
+      {GeometryIdentifier{}.withVolume(7)}, 4);
+  cfgVol7And8.measurementCounter.addCounter(
+      {GeometryIdentifier{}.withVolume(8)}, 2);
   TrackSelector selectorVol7And8{cfgVol7And8};
 
   // this track has enough hits in vol 7 but not enough in vol 8

--- a/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
+++ b/Tests/UnitTests/Core/TrackFitting/FitterTestsCommon.hpp
@@ -144,11 +144,11 @@ struct FitterTester {
   MeasurementResolution resStrip0 = {MeasurementType::eLoc0, {100_um}};
   MeasurementResolution resStrip1 = {MeasurementType::eLoc1, {150_um}};
   MeasurementResolutionMap resolutions = {
-      {Acts::GeometryIdentifier().setVolume(2), resPixel},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(2), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(4), resStrip1},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(6), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(3).setLayer(8), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(2), resPixel},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(2), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(4), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(6), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(3).withLayer(8), resStrip1},
   };
 
   // simulation propagator

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -228,7 +228,7 @@ const MeasurementResolution resPixel = {MeasurementType::eLoc01,
 const MeasurementResolution resStrip0 = {MeasurementType::eLoc0, {25_um}};
 const MeasurementResolution resStrip1 = {MeasurementType::eLoc1, {50_um}};
 const MeasurementResolutionMap resMapAllPixel = {
-    {Acts::GeometryIdentifier().setVolume(0), resPixel}};
+    {Acts::GeometryIdentifier().withVolume(0), resPixel}};
 
 // This test checks if the call to the fitter works and no errors occur in the
 // framework, without fitting and updating any parameters
@@ -429,13 +429,13 @@ BOOST_AUTO_TEST_CASE(MixedDetector) {
 
   ACTS_DEBUG("Create the measurements");
   const MeasurementResolutionMap resMap = {
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(2), resPixel},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(4), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(6), resStrip1},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(8), resPixel},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(10), resStrip0},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(12), resStrip1},
-      {Acts::GeometryIdentifier().setVolume(2).setLayer(14), resPixel},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(2), resPixel},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(4), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(6), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(8), resPixel},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(10), resStrip0},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(12), resStrip1},
+      {Acts::GeometryIdentifier().withVolume(2).withLayer(14), resPixel},
   };
 
   using SimPropagator =

--- a/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
+++ b/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
@@ -46,7 +46,7 @@ struct Fixture {
 
   Fixture(std::uint64_t rngSeed, std::shared_ptr<Acts::Surface> surf)
       : rng(rngSeed),
-        gid(Acts::GeometryIdentifier().setVolume(1).setLayer(2).setSensitive(
+        gid(Acts::GeometryIdentifier().withVolume(1).withLayer(2).withSensitive(
             3)),
         pid(ActsFatras::Barcode().setVertexPrimary(12).setParticle(23)),
         surface(std::move(surf)) {

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -85,7 +85,7 @@ struct Fixture {
 
   Fixture(std::uint64_t rngSeed, std::shared_ptr<Acts::Surface> surf)
       : rng(rngSeed),
-        gid(Acts::GeometryIdentifier().setVolume(1).setLayer(2).setSensitive(
+        gid(Acts::GeometryIdentifier().withVolume(1).withLayer(2).withSensitive(
             3)),
         pid(ActsFatras::Barcode().setVertexPrimary(12).setParticle(23)),
         surface(std::move(surf)) {

--- a/Tests/UnitTests/Fatras/EventData/HitTests.cpp
+++ b/Tests/UnitTests/Fatras/EventData/HitTests.cpp
@@ -21,7 +21,7 @@ namespace {
 constexpr auto eps = std::numeric_limits<double>::epsilon();
 const auto pid = Barcode().setVertexPrimary(12).setParticle(23);
 const auto gid =
-    Acts::GeometryIdentifier().setVolume(1).setLayer(2).setSensitive(3);
+    Acts::GeometryIdentifier().withVolume(1).withLayer(2).withSensitive(3);
 }  // namespace
 
 BOOST_AUTO_TEST_SUITE(FatrasHit)

--- a/Tests/UnitTests/Plugins/Detray/DetrayGeometryConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Detray/DetrayGeometryConverterTests.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(DetraySurfaceConversion) {
   auto cylinderSurface = Acts::Surface::makeShared<CylinderSurface>(
       Transform3::Identity(), std::make_shared<CylinderBounds>(20., 100.));
 
-  auto sgID = Acts::GeometryIdentifier().setSensitive(1);
+  auto sgID = Acts::GeometryIdentifier().withSensitive(1);
   cylinderSurface->assignGeometryId(sgID);
 
   detray::io::surface_payload payload = DetrayGeometryConverter::convertSurface(

--- a/Tests/UnitTests/Plugins/Json/GeometryHierarchyMapJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/GeometryHierarchyMapJsonConverterTests.cpp
@@ -29,7 +29,7 @@ using nlohmann::json;
 
 // helper function to create geometry ids.
 GeometryIdentifier makeId(int volume = 0, int layer = 0, int sensitive = 0) {
-  return GeometryIdentifier().setVolume(volume).setLayer(layer).setSensitive(
+  return GeometryIdentifier().withVolume(volume).withLayer(layer).withSensitive(
       sensitive);
 }
 


### PR DESCRIPTION
This adds `withXXX` methods that return a new GeometryIdentifier with
one of the components replaced with a different value. This is currently
in addition to the existing `setXXX` methods, which are not modified to
remain API compatible.

In future, I'm planning to make the `setXXX` methods not return a
reference to it's original value, to encourage using the `withXXX`
methods and decrease the likelihood of accidental misuse.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
