### PR TITLE
refactor: Expose max component values for geometry ids

### DIFF
--- a/Core/include/Acts/Geometry/GeometryIdentifier.hpp
+++ b/Core/include/Acts/Geometry/GeometryIdentifier.hpp
@@ -161,6 +161,32 @@ class GeometryIdentifier {
     return id;
   }
 
+  /// Get the maximum value for the volume identifier.
+  /// @return the maximum value for the volume identifier
+  static constexpr Value getMaxVolume() { return getMaxValue(kVolumeMask); }
+
+  /// Get the maximum value for the boundary identifier.
+  /// @return the maximum value for the boundary identifier
+  static constexpr Value getMaxBoundary() { return getMaxValue(kBoundaryMask); }
+
+  /// Get the maximum value for the layer identifier.
+  /// @return the maximum value for the layer identifier
+  static constexpr Value getMaxLayer() { return getMaxValue(kLayerMask); }
+
+  /// Get the maximum value for the approach identifier.
+  /// @return the maximum value for the approach identifier
+  static constexpr Value getMaxApproach() { return getMaxValue(kApproachMask); }
+
+  /// Get the maximum value for the sensitive identifier.
+  /// @return the maximum value for the sensitive identifier
+  static constexpr Value getMaxSensitive() {
+    return getMaxValue(kSensitiveMask);
+  }
+
+  /// Get the maximum value for the extra identifier.
+  /// @return the maximum value for the extra identifier
+  static constexpr Value getMaxExtra() { return getMaxValue(kExtraMask); }
+
  private:
   // clang-format off
   /// (2^8)-1 = 255 volumes
@@ -233,7 +259,6 @@ struct GeometryIdentifierHook {
 };
 
 }  // namespace Acts
-
 // specialize std::hash so GeometryIdentifier can be used e.g. in an
 // unordered_map
 namespace std {

--- a/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
@@ -57,6 +57,13 @@ BOOST_AUTO_TEST_CASE(GeometryIdentifier_max_values) {
                     std::invalid_argument);
   BOOST_CHECK_THROW(GeometryIdentifier(ref).setExtra(extraMax + 1),
                     std::invalid_argument);
+
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxVolume(), 255);
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxBoundary(), 255);
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxLayer(), 4095);
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxApproach(), 255);
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxSensitive(), 1048575);
+  BOOST_CHECK_EQUAL(GeometryIdentifier::getMaxExtra(), 255);
 }
 
 BOOST_AUTO_TEST_CASE(GeometryIdentifier_order) {

--- a/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/GeometryIdentifierTests.cpp
@@ -45,18 +45,18 @@ BOOST_AUTO_TEST_CASE(GeometryIdentifier_max_values) {
   constexpr GeometryIdentifier ref = 0xdeadaffe01234567;
   // values above the maximum are truncated
   // max+1 has all available bits zeroed
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setVolume(volumeMax + 1),
-                    GeometryIdentifier(ref).setVolume(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setBoundary(boundaryMax + 1),
-                    GeometryIdentifier(ref).setBoundary(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setLayer(layerMax + 1),
-                    GeometryIdentifier(ref).setLayer(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setApproach(approachMax + 1),
-                    GeometryIdentifier(ref).setApproach(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setSensitive(sensitiveMax + 1),
-                    GeometryIdentifier(ref).setSensitive(0u));
-  BOOST_CHECK_EQUAL(GeometryIdentifier(ref).setExtra(extraMax + 1),
-                    GeometryIdentifier(ref).setExtra(0u));
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setVolume(volumeMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setBoundary(boundaryMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setLayer(layerMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setApproach(approachMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setSensitive(sensitiveMax + 1),
+                    std::invalid_argument);
+  BOOST_CHECK_THROW(GeometryIdentifier(ref).setExtra(extraMax + 1),
+                    std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(GeometryIdentifier_order) {


### PR DESCRIPTION
Surface the maximum values for the `GeometryIdentifier` components.

Blocked by:
- https://github.com/acts-project/acts/pull/4094

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality that displays the maximum allowable values for various components.
  
- **Bug Fixes**
  - Enhanced error handling so that attempting to assign a value beyond the allowed limit now triggers a clear, informative error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->