### PR TITLE
build: Allow exporting Eigen3 alignment values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ set(ACTS_GPERF_INSTALL_DIR "" CACHE STRING "Hint to help find gperf if profiling
 option(ACTS_ENABLE_LOG_FAILURE_THRESHOLD "Enable failing on log messages with level above certain threshold" OFF)
 set(ACTS_LOG_FAILURE_THRESHOLD "" CACHE STRING "Log level above which an exception should be automatically thrown. If ACTS_ENABLE_LOG_FAILURE_THRESHOLD is set and this is unset, this will enable a runtime check of the log level.")
 option(ACTS_COMPILE_HEADERS "Generate targets to compile header files" ON)
+# eigen3 options
+option(ACTS_ENFORCE_EIGEN3_ALIGNMENT "Add public Eigen3 compiler definitions for alignment" OFF)
 # gersemi: on
 
 # handle option inter-dependencies and the everything flag

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -82,6 +82,22 @@ if(ACTS_ENABLE_MEMORY_PROFILING)
     endif()
 endif()
 
+add_custom_command(
+    TARGET ActsCore
+    POST_BUILD
+    COMMAND
+        strings "$<TARGET_FILE:ActsCore>" | grep -qE
+        \"ACTS::EigenAlignment=[[:digit:]]{4}\" ||
+        (
+            echo
+            "ERROR: $<TARGET_FILE:ActsCore> does not contain any Eigen3 alignment information"
+            &&
+            false
+        )
+    COMMENT
+        "Verifying that the ActsCore library contains Eigen3 alignment information"
+)
+
 install(
     TARGETS ActsCore
     EXPORT ActsCoreTargets

--- a/Core/src/Utilities/CMakeLists.txt
+++ b/Core/src/Utilities/CMakeLists.txt
@@ -10,4 +10,5 @@ target_sources(
         IAxis.cpp
         GraphViz.cpp
         ProtoAxis.cpp
+        Eigen3Alignment.cpp
 )

--- a/Core/src/Utilities/Eigen3Alignment.cpp
+++ b/Core/src/Utilities/Eigen3Alignment.cpp
@@ -1,0 +1,40 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <Eigen/Dense>
+
+const char* __acts_internal_get_eigen_alignment_str() {
+  static constexpr char _ACTS_EIGEN_ALIGN_STR[] = {
+      'A',
+      'C',
+      'T',
+      'S',
+      ':',
+      ':',
+      'E',
+      'i',
+      'g',
+      'e',
+      'n',
+      'A',
+      'l',
+      'i',
+      'g',
+      'n',
+      'm',
+      'e',
+      'n',
+      't',
+      '=',
+      ('0' + ((EIGEN_MAX_ALIGN_BYTES / 1000) % 10)),
+      ('0' + ((EIGEN_MAX_ALIGN_BYTES / 100) % 10)),
+      ('0' + ((EIGEN_MAX_ALIGN_BYTES / 10) % 10)),
+      ('0' + ((EIGEN_MAX_ALIGN_BYTES) % 10))};
+
+  return _ACTS_EIGEN_ALIGN_STR;
+}

--- a/cmake/ActsConfig.cmake.in
+++ b/cmake/ActsConfig.cmake.in
@@ -117,3 +117,30 @@ foreach(_component ${Acts_COMPONENTS})
   # include the targets file to create the imported targets for the user
   include(${CMAKE_CURRENT_LIST_DIR}/Acts${_component}Targets.cmake)
 endforeach()
+
+if (@ACTS_ENFORCE_EIGEN3_ALIGNMENT@)
+  if (NOT TARGET ActsCore)
+    message(FATAL_ERROR "Eigen3 alignment enforcement is enabled, but the ActsCore target does not exist.")
+  endif()
+
+  set(_ACTS_CORE_EIGEN3_ALIGNMENT_REGEX "ACTS::EigenAlignment=([0-9]+)")
+  get_target_property(_ACTS_CORE_LOCATION ActsCore LOCATION)
+
+  file(
+    STRINGS ${_ACTS_CORE_LOCATION} _ACTS_CORE_EIGEN3_ALIGNMENT_VALUE_STRING
+    LIMIT_COUNT 1
+    REGEX ${_ACTS_CORE_EIGEN3_ALIGNMENT_REGEX}
+  )
+
+  if (_ACTS_CORE_EIGEN3_ALIGNMENT_VALUE_STRING STREQUAL "")
+    message(WARNING "Eigen3 alignment enforcement is enabled, but string was not found in object file.")
+  else()
+    string(REGEX REPLACE ${_ACTS_CORE_EIGEN3_ALIGNMENT_REGEX} "\\1" _ACTS_CORE_EIGEN3_ALIGNMENT_VALUE_PADDED ${_ACTS_CORE_EIGEN3_ALIGNMENT_VALUE_STRING})
+
+    math(EXPR _ACTS_CORE_EIGEN3_ALIGNMENT_VALUE ${_ACTS_CORE_EIGEN3_ALIGNMENT_VALUE_PADDED})
+
+    message(STATUS "Setting ACTS Eigen3 alignment to ${_ACTS_CORE_EIGEN3_ALIGNMENT_VALUE}")
+
+    target_compile_definitions(ActsCore INTERFACE -DEIGEN_MAX_ALIGN_BYTES=${_ACTS_CORE_EIGEN3_ALIGNMENT_VALUE})
+  endif()
+endif()

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -316,6 +316,7 @@ components.
 | ACTS_ENABLE_LOG_FAILURE_THRESHOLD   | Enable failing on log messages with<br>level above certain threshold<br> type: `bool`, default: `OFF`                                                                                                                              |
 | ACTS_LOG_FAILURE_THRESHOLD          | Log level above which an exception<br>should be automatically thrown. If<br>ACTS_ENABLE_LOG_FAILURE_THRESHOLD is set<br>and this is unset, this will enable a<br>runtime check of the log level.<br> type: `string`, default: `""` |
 | ACTS_COMPILE_HEADERS                | Generate targets to compile header files<br> type: `bool`, default: `ON`                                                                                                                                                           |
+| ACTS_ENFORCE_EIGEN3_ALIGNMENT       | Add public Eigen3 compiler definitions<br>for alignment<br> type: `bool`, default: `OFF`                                                                                                                                           |
 <!-- CMAKE_OPTS_END -->
 
 All ACTS-specific options are disabled or empty by default and must be


### PR DESCRIPTION
As I discovered in #4049, having Eigen3 types on ABI boundaries invites a variety of compiler issues. In cases where ACTS and the depending project are compiled with different vectorization instruction sets, the ABIs become incompatible with each other, because the matrices are differently aligned.

This commit adds the `ACTS_ENFORCE_EIGEN3_ALIGNMENT` flag which, if enabled, will encode the Eigen3 alignment in the ACTS shared object, and the ACTS `find_package` code will then attempt to read this and set it appropriately on any dependent targets.

Closes #4049.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new build configuration option to enforce Eigen3 memory alignment during compilation.
  - Enhanced the build process with error handling and warnings related to Eigen3 alignment settings.
  - Added a new source file to support Eigen3 alignment functionality.

- **Documentation**
  - Updated the getting-started guide to include details on the new alignment enforcement option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->