### PR TITLE
refactor: Drop `SympyStepper::stepImpl`

### DIFF
--- a/Core/include/Acts/Propagator/SympyStepper.hpp
+++ b/Core/include/Acts/Propagator/SympyStepper.hpp
@@ -379,11 +379,6 @@ class SympyStepper {
  protected:
   /// Magnetic field inside of the detector
   std::shared_ptr<const MagneticFieldProvider> m_bField;
-
- private:
-  Result<double> stepImpl(State& state, Direction propDir, double stepTolerance,
-                          double stepSizeCutOff,
-                          std::size_t maxRungeKuttaStepTrials) const;
 };
 
 template <>


### PR DESCRIPTION
After getting rid of the templated `step` function there is no reason to have a separate `stepImpl` function anymore. This PR is merging `stepImpl` into `step` and drops former.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the stepping process by centralizing configuration parameters within the system's state.
	- Improved error handling and step size scaling to maintain consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->