### PR TITLE
feat: Add UniformVertexGenerator to the examples

### DIFF
--- a/Examples/Algorithms/Generators/ActsExamples/Generators/VertexGenerators.hpp
+++ b/Examples/Algorithms/Generators/ActsExamples/Generators/VertexGenerators.hpp
@@ -80,4 +80,24 @@ struct GaussianDisplacedVertexPositionGenerator
     return Acts::Vector4(x, y, z, t);
   }
 };
+
+struct UniformPrimaryVertexPositionGenerator
+    : public EventGenerator::PrimaryVertexPositionGenerator {
+  /// Vertex position and time minimum.
+  Acts::Vector4 min = {0.0, 0.0, 0.0, 0.0};
+  /// Vertex position and time maximum.
+  Acts::Vector4 max = {0.0, 0.0, 0.0, 0.0};
+
+  Acts::Vector4 operator()(RandomEngine& rng) const override {
+    auto uniform = std::uniform_real_distribution<double>(0.0, 1.0);
+    Acts::Vector4 rndUniform = {
+        uniform(rng),
+        uniform(rng),
+        uniform(rng),
+        uniform(rng),
+    };
+    return min + rndUniform.cwiseProduct(max - min);
+  }
+};
+
 }  // namespace ActsExamples

--- a/Examples/Python/src/Generators.cpp
+++ b/Examples/Python/src/Generators.cpp
@@ -138,6 +138,24 @@ void addGenerators(Context& ctx) {
           &ActsExamples::GaussianDisplacedVertexPositionGenerator::tStdDev);
 
   py::class_<
+      ActsExamples::UniformPrimaryVertexPositionGenerator,
+      ActsExamples::EventGenerator::PrimaryVertexPositionGenerator,
+      std::shared_ptr<ActsExamples::UniformPrimaryVertexPositionGenerator>>(
+      mex, "UniformVertexGenerator")
+      .def(py::init<>())
+      .def(py::init([](const Acts::Vector4& min, const Acts::Vector4& max) {
+             ActsExamples::UniformPrimaryVertexPositionGenerator g;
+             g.min = min;
+             g.max = max;
+             return g;
+           }),
+           py::arg("min"), py::arg("max"))
+      .def_readwrite("min",
+                     &ActsExamples::UniformPrimaryVertexPositionGenerator::min)
+      .def_readwrite("max",
+                     &ActsExamples::UniformPrimaryVertexPositionGenerator::max);
+
+  py::class_<
       ActsExamples::FixedPrimaryVertexPositionGenerator,
       ActsExamples::EventGenerator::PrimaryVertexPositionGenerator,
       std::shared_ptr<ActsExamples::FixedPrimaryVertexPositionGenerator>>(


### PR DESCRIPTION
A uniform vertex generator is added to generate a flat distribution between the min and max 4-vectors.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
