### PR TITLE
fix: Reserve Memory of cluster collection

### DIFF
--- a/Core/include/Acts/Clusterization/Clusterization.ipp
+++ b/Core/include/Acts/Clusterization/Clusterization.ipp
@@ -145,7 +145,7 @@ ClusterCollection mergeClustersImpl(CellCollection& cells) {
 
   // Accumulate clusters into the output collection
   ClusterCollection outv;
-  outv.reserve(cells.size());
+  outv.reserve(cells.size() + 1);
   Cluster cl;
   int lbl = getCellLabel(cells.front());
   for (auto& cell : cells) {

--- a/Core/include/Acts/Clusterization/Clusterization.ipp
+++ b/Core/include/Acts/Clusterization/Clusterization.ipp
@@ -145,6 +145,7 @@ ClusterCollection mergeClustersImpl(CellCollection& cells) {
 
   // Accumulate clusters into the output collection
   ClusterCollection outv;
+  outv.reserve(cells.size());
   Cluster cl;
   int lbl = getCellLabel(cells.front());
   for (auto& cell : cells) {


### PR DESCRIPTION
vtune highlighted the push_back calls. Reserving enough memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Optimized internal resource management for clustering operations to enhance performance and stability during data processing. This update ensures more efficient memory allocation, particularly under heavy data loads, leading to a smoother experience without any changes to visible functionality. These internal improvements underscore our ongoing efforts to maintain system efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->