### PR TITLE
fix: allow to compile without examples.

### DIFF
--- a/Tests/CommonHelpers/CMakeLists.txt
+++ b/Tests/CommonHelpers/CMakeLists.txt
@@ -17,10 +17,19 @@ target_include_directories(
     ActsTestsCommonHelpers
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
+if(ACTS_BUILD_EXAMPLES)
 target_link_libraries(
     ActsTestsCommonHelpers
     PUBLIC ActsCore ActsExamplesFramework
     PRIVATE std::filesystem
 )
+else()
+target_link_libraries(
+    ActsTestsCommonHelpers
+    PUBLIC ActsCore
+    PRIVATE std::filesystem
+    )
+
+endif()
 
 acts_compile_headers(ActsTestsCommonHelpers GLOB "include/Acts/**/*.hpp")


### PR DESCRIPTION
When compiling without examples the ActsExamplesFramework library does not exist, but it is also not needed.

--- END COMMIT MESSAGE ---
