### PR TITLE
ci: Set `errexit`, `nounset` in dependency script

### DIFF
--- a/CI/dependencies.sh
+++ b/CI/dependencies.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 function run() {
-    set -x
+    set -xeu
     "$@"
-    { set +x;  } 2> /dev/null
+    { set +xeu;  } 2> /dev/null
 }
 
 function set_env {


### PR DESCRIPTION
This commit adds the `-e` and `-u` flags to the CI dependency downloading shell script. I recently noticed that any error in some of these scripts is silently ignored, which causes the CI to fail later and with worse errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced internal script reliability with improved error handling for quicker and clearer feedback during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->