### PR TITLE
feat: Enable TransformRange to work with C++20 views

### DIFF
--- a/Core/include/Acts/Utilities/TransformRange.hpp
+++ b/Core/include/Acts/Utilities/TransformRange.hpp
@@ -10,6 +10,7 @@
 
 #include <concepts>
 #include <iterator>
+#include <ranges>
 #include <type_traits>
 #include <utility>
 

--- a/Core/include/Acts/Utilities/TransformRange.hpp
+++ b/Core/include/Acts/Utilities/TransformRange.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -31,7 +32,8 @@ struct TransformRangeIterator;
 /// @tparam Callable The callable to apply to each element.
 /// @tparam container_t The container to wrap.
 template <typename Callable, typename container_t>
-struct TransformRange {
+struct TransformRange : public std::ranges::view_interface<
+                            TransformRange<Callable, container_t>> {
  private:
   using internal_value_type = typename container_t::value_type;
 
@@ -194,11 +196,17 @@ struct TransformRangeIterator {
     return tmp;
   }
 
-  /// Compare two iterators for equality
-  /// @param other The other iterator to compare to
-  bool operator==(const TransformRangeIterator& other) const {
+  /// Equality operator between arbitrary iterators whose internal iterators are
+  /// comparable. Needed for C++20 range interface
+  template <typename I, bool F>
+  bool operator==(const TransformRangeIterator<Callable, I, F>& other) const
+    requires(std::equality_comparable_with<iterator_t, I>)
+  {
     return m_iterator == other.m_iterator;
   }
+
+  template <typename C, typename I, bool F>
+  friend struct TransformRangeIterator;
 
  private:
   iterator_t m_iterator;

--- a/Tests/UnitTests/Core/Utilities/TransformRangeTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TransformRangeTests.cpp
@@ -8,10 +8,12 @@
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
 
 #include "Acts/Utilities/TransformRange.hpp"
 
 #include <algorithm>
+#include <ranges>
 
 using namespace Acts;
 
@@ -248,6 +250,25 @@ BOOST_AUTO_TEST_CASE(TransformRangeReferenceWrappers) {
   std::copy(r.begin(), r.end(), std::back_inserter(act));
   std::vector<int> exp = {5, 6, 7};
   BOOST_CHECK_EQUAL_COLLECTIONS(exp.begin(), exp.end(), act.begin(), act.end());
+}
+
+BOOST_AUTO_TEST_CASE(Ranges) {
+  std::vector<std::unique_ptr<int>> v;
+  v.push_back(std::make_unique<int>(1));
+  v.push_back(std::make_unique<int>(2));
+  v.push_back(std::make_unique<int>(3));
+  v.push_back(std::make_unique<int>(4));
+  v.push_back(std::make_unique<int>(5));
+  auto r = detail::TransformRange{detail::Dereference{}, v};
+
+  std::vector<int> results;
+  std::ranges::copy(r | std::views::transform([](int val) { return val * 3; }) |
+                        std::views::filter([](int val) { return val < 10; }),
+                    std::back_inserter(results));
+  BOOST_CHECK_EQUAL(results.size(), 3);
+  std::vector exp{3, 6, 9};
+  BOOST_CHECK_EQUAL_COLLECTIONS(exp.begin(), exp.end(), results.begin(),
+                                results.end());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upgraded the transformation utility to support modern C++ range views, providing enhanced flexibility and robust iterator comparisons.

- **Tests**
  - Added a new test scenario that validates range-based transformation operations including mapping and filtering, ensuring the expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->