### PR TITLE
ci: Replace clang-14 job with clang-19

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -249,10 +249,10 @@ jobs:
           - image: ubuntu2204
             std: 20
             cxx: g++
-          - image: ubuntu2204
+          - image: ubuntu2404_clang19
             std: 20
-            cxx: clang++
-    container: ghcr.io/acts-project/${{ matrix.image }}:71
+            cxx: clang++-19
+    container: ghcr.io/acts-project/${{ matrix.image }}:75
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -403,13 +403,13 @@ linux_ubuntu_2204:
     DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/ubuntu-22.04/deps.$DEPENDENCY_TAG.tar.zst
   image: registry.cern.ch/ghcr.io/acts-project/ubuntu2204:71
 
-linux_ubuntu_2204_clang:
+linux_ubuntu_2404_clang19:
   extends: .linux_ubuntu_extra
   variables:
-    CXX: clang++
+    CXX: clang++-19
     CXXSTD: 20
-    DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/ubuntu-22.04/deps.$DEPENDENCY_TAG.tar.zst
-  image: registry.cern.ch/ghcr.io/acts-project/ubuntu2204:71
+    DEPENDENCY_URL: https://acts.web.cern.ch/ACTS/ci/ubuntu-24.04/deps.$DEPENDENCY_TAG.tar.zst
+  image: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_clang19:75
 
 
 ######################


### PR DESCRIPTION
This commit replaces the clang-14 CI job based on Ubuntu 22.04 with a job using clang-19 based on Ubuntu 24.04. This is because clang-14 has a compiler bug that causes it to break on #4125.