### PR TITLE
fix: Suppress warnings in odd construction in pytest

### DIFF
--- a/Examples/Python/python/acts/examples/odd.py
+++ b/Examples/Python/python/acts/examples/odd.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 import acts
 import acts.examples
+import warnings
 
 
 def getOpenDataDetectorDirectory():
@@ -100,5 +101,7 @@ def getOpenDataDetector(
         geometryIdentifierHook=acts.GeometryIdentifierHook(geoid_hook),
         materialDecorator=mdecorator,
     )
-    detector = acts.examples.dd4hep.DD4hepDetector(dd4hepConfig)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        detector = acts.examples.dd4hep.DD4hepDetector(dd4hepConfig)
     return detector


### PR DESCRIPTION
This suppresses a message about some material mixture in TGeo during the ODD construction, that we will not act on anyway.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of warning notifications during the detector initialization process, resulting in a cleaner and more stable runtime experience without altering the core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->