### PR TITLE
chore: add codegen artefacts to git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ x86_64-slc6-gcc49-opt
 /cmake_cmd
 /cleanup.sh
 
+#codegen related
+codegen/build/
+codegen/src/codegen.egg-info/
+
 # dont ignore hidden configs
 !.clang-format
 !.github


### PR DESCRIPTION
This PR simply adds the generated artefacts which we do not want to submit to git to the gitignore file.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
