### PR TITLE
feat: Allow turning off Layer center of gravity

### DIFF
--- a/Core/include/Acts/Geometry/LayerBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/LayerBlueprintNode.hpp
@@ -96,6 +96,14 @@ class LayerBlueprintNode : public StaticBlueprintNode {
   /// @return Reference to this node for chaining
   LayerBlueprintNode& setLayerType(LayerType layerType);
 
+  /// Set the layer volume to be centered on the center of gravity of the
+  /// surfaces.
+  /// @param x Whether to center the layer volume on the x-axis
+  /// @param y Whether to center the layer volume on the y-axis
+  /// @param z Whether to center the layer volume on the z-axis
+  /// @return Reference to this node for chaining
+  LayerBlueprintNode& setUseCenterOfGravity(bool x, bool y, bool z);
+
   /// Access the layer type of the layer node.
   /// @return The layer type
   const LayerType& layerType() const;
@@ -136,6 +144,7 @@ class LayerBlueprintNode : public StaticBlueprintNode {
   Transform3 m_transform = Transform3::Identity();
   ExtentEnvelope m_envelope = ExtentEnvelope::Zero();
   LayerType m_layerType = LayerType::Cylinder;
+  std::array<bool, 3> m_useCenterOfGravity = {true, true, true};
 };
 
 }  // namespace Acts::Experimental

--- a/Core/src/Geometry/LayerBlueprintNode.cpp
+++ b/Core/src/Geometry/LayerBlueprintNode.cpp
@@ -79,8 +79,18 @@ void LayerBlueprintNode::buildVolume(const Extent& extent,
   ACTS_VERBOSE(prefix() << " -> bounds: " << *bounds);
 
   Transform3 transform = m_transform;
-  transform.translation() =
-      Vector3{extent.medium(AxisX), extent.medium(AxisY), extent.medium(AxisZ)};
+  Vector3 translation = Vector3::Zero();
+  if (m_useCenterOfGravity.at(toUnderlying(AxisX))) {
+    translation.x() = extent.medium(AxisX);
+  }
+  if (m_useCenterOfGravity.at(toUnderlying(AxisY))) {
+    translation.y() = extent.medium(AxisY);
+  }
+  if (m_useCenterOfGravity.at(toUnderlying(AxisZ))) {
+    translation.z() = extent.medium(AxisZ);
+  }
+
+  transform.translation() = translation;
 
   ACTS_VERBOSE(prefix() << " -> adjusted transform:\n" << transform.matrix());
 
@@ -130,6 +140,12 @@ LayerBlueprintNode& LayerBlueprintNode::setLayerType(LayerType layerType) {
 
 const LayerBlueprintNode::LayerType& LayerBlueprintNode::layerType() const {
   return m_layerType;
+}
+
+LayerBlueprintNode& LayerBlueprintNode::setUseCenterOfGravity(bool x, bool y,
+                                                              bool z) {
+  m_useCenterOfGravity = {x, y, z};
+  return *this;
 }
 
 void LayerBlueprintNode::addToGraphviz(std::ostream& os) const {


### PR DESCRIPTION
Previously, the transform center of a Layer would always be at the center of gravity of the sensors. This changes this to be optional, so that it can be turned off.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
