### PR TITLE
feat: Regional measurement counts for `ParticleSelector` in Examples

### DIFF
--- a/Core/include/Acts/TrackFinding/TrackSelector.hpp
+++ b/Core/include/Acts/TrackFinding/TrackSelector.hpp
@@ -528,12 +528,9 @@ bool TrackSelector::MeasurementCounter::isValidTrack(
 
     for (std::size_t i = 0; i < counters.size(); i++) {
       const auto& [counterMap, threshold] = counters[i];
-      const auto it = counterMap.find(geoId);
-      if (it == counterMap.end()) {
-        continue;
+      if (const auto it = counterMap.find(geoId); it != counterMap.end()) {
+        counterValues[i]++;
       }
-
-      counterValues[i]++;
     }
   }
 

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
@@ -29,14 +29,14 @@ bool ParticleSelector::MeasurementCounter::isValidParticle(
     return true;
   }
 
-  const auto measurementRange =
+  const auto [measurementsBegin, measurementsEnd] =
       particleMeasurementsMap.equal_range(particle.particleId());
 
   boost::container::small_vector<unsigned int, 4> counterValues;
   counterValues.resize(counters.size(), 0);
 
-  for (auto measurementIt = measurementRange.first;
-       measurementIt != measurementRange.second; ++measurementIt) {
+  for (auto measurementIt = measurementsBegin; measurementIt != measurementsEnd;
+       ++measurementIt) {
     const auto measurementIndex = measurementIt->second;
     const auto measurement = measurements.at(measurementIndex);
 
@@ -44,8 +44,7 @@ bool ParticleSelector::MeasurementCounter::isValidParticle(
 
     for (std::size_t i = 0; i < counters.size(); i++) {
       const auto& [counterMap, threshold] = counters[i];
-      const auto it = counterMap.find(geoId);
-      if (it != counterMap.end()) {
+      if (const auto it = counterMap.find(geoId); it != counterMap.end()) {
         counterValues[i]++;
       }
     }

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Utilities/VectorHelpers.hpp"
 #include "ActsExamples/EventData/Index.hpp"
+#include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 
@@ -18,6 +19,50 @@
 #include <utility>
 
 namespace ActsExamples {
+
+bool ParticleSelector::MeasurementCounter::isValidParticle(
+    const SimParticle& particle,
+    const InverseMultimap<SimBarcode>& particleMeasurementsMap,
+    const MeasurementContainer& measurements) const {
+  // No hit cuts, accept everything
+  if (counters.empty()) {
+    return true;
+  }
+
+  const auto measurementRange =
+      particleMeasurementsMap.equal_range(particle.particleId());
+
+  boost::container::small_vector<unsigned int, 4> counterValues;
+  counterValues.resize(counters.size(), 0);
+
+  for (auto measurementIt = measurementRange.first;
+       measurementIt != measurementRange.second; ++measurementIt) {
+    const auto measurementIndex = measurementIt->second;
+    const auto measurement = measurements.at(measurementIndex);
+
+    const auto geoId = measurement.geometryId();
+
+    for (std::size_t i = 0; i < counters.size(); i++) {
+      const auto& [counterMap, threshold] = counters[i];
+      const auto it = counterMap.find(geoId);
+      if (it == counterMap.end()) {
+        continue;
+      }
+
+      counterValues[i]++;
+    }
+  }
+
+  for (std::size_t i = 0; i < counters.size(); i++) {
+    const auto& [counterMap, threshold] = counters[i];
+    const unsigned int value = counterValues[i];
+    if (value < threshold) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 ParticleSelector::ParticleSelector(const Config& config,
                                    Acts::Logging::Level level)
@@ -32,6 +77,7 @@ ParticleSelector::ParticleSelector(const Config& config,
   m_inputParticles.initialize(m_cfg.inputParticles);
   m_inputParticleMeasurementsMap.maybeInitialize(
       m_cfg.inputParticleMeasurementsMap);
+  m_inputMeasurements.maybeInitialize(m_cfg.inputMeasurements);
   m_outputParticles.initialize(m_cfg.outputParticles);
 
   if (!m_inputParticleMeasurementsMap.isInitialized() &&
@@ -39,6 +85,13 @@ ParticleSelector::ParticleSelector(const Config& config,
        m_cfg.measurementsMax < std::numeric_limits<std::size_t>::max())) {
     throw std::invalid_argument(
         "Measurement-based cuts require the inputMeasurementParticlesMap");
+  }
+  if (!m_cfg.measurementCounter.counters.empty() &&
+      (!m_inputParticleMeasurementsMap.isInitialized() ||
+       !m_inputMeasurements.isInitialized())) {
+    throw std::invalid_argument(
+        "Measurement count-based cuts require the inputMeasurementParticlesMap "
+        "and inputMeasurements");
   }
 
   ACTS_DEBUG("selection particle rho [" << m_cfg.rhoMin << "," << m_cfg.rhoMax
@@ -82,9 +135,15 @@ ProcessCode ParticleSelector::execute(const AlgorithmContext& ctx) const {
           ? m_inputParticleMeasurementsMap(ctx)
           : emptyMeasurementParticlesMap;
 
+  const static MeasurementContainer emptyMeasurements;
+  const MeasurementContainer& inputMeasurements =
+      m_inputMeasurements.isInitialized() ? m_inputMeasurements(ctx)
+                                          : emptyMeasurements;
+
   std::size_t nInvalidCharge = 0;
   std::size_t nInvalidHitCount = 0;
   std::size_t nInvalidMeasurementCount = 0;
+  std::size_t nInvalidMeasurementRegionCount = 0;
 
   // helper functions to select tracks
   auto within = [](auto x, auto min, auto max) {
@@ -117,6 +176,12 @@ ProcessCode ParticleSelector::execute(const AlgorithmContext& ctx) const {
     nInvalidMeasurementCount +=
         static_cast<std::size_t>(!validMeasurementCount);
 
+    const bool validMeasurementRegionCount =
+        m_cfg.measurementCounter.isValidParticle(
+            p, inputMeasurementParticlesMap, inputMeasurements);
+    nInvalidMeasurementRegionCount +=
+        static_cast<std::size_t>(!validMeasurementRegionCount);
+
     // Pdg selection
     bool validPdg = true;
     for (auto pdg : m_cfg.excludeAbsPdgs) {
@@ -128,6 +193,7 @@ ProcessCode ParticleSelector::execute(const AlgorithmContext& ctx) const {
 
     return validPdg && validCharge && validSecondary && validPrimaryVertexId &&
            validHitCount && validMeasurementCount &&
+           validMeasurementRegionCount &&
            within(p.transverseMomentum(), m_cfg.ptMin, m_cfg.ptMax) &&
            within(std::abs(eta), m_cfg.absEtaMin, m_cfg.absEtaMax) &&
            within(eta, m_cfg.etaMin, m_cfg.etaMax) &&

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.cpp
@@ -45,11 +45,9 @@ bool ParticleSelector::MeasurementCounter::isValidParticle(
     for (std::size_t i = 0; i < counters.size(); i++) {
       const auto& [counterMap, threshold] = counters[i];
       const auto it = counterMap.find(geoId);
-      if (it == counterMap.end()) {
-        continue;
+      if (it != counterMap.end()) {
+        counterValues[i]++;
       }
-
-      counterValues[i]++;
     }
   }
 

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/ParticleSelector.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/Index.hpp"
+#include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
@@ -24,12 +25,38 @@ struct AlgorithmContext;
 /// Select particles by applying some selection cuts.
 class ParticleSelector final : public IAlgorithm {
  public:
+  struct MeasurementCounter {
+    // Combination of a geometry hierarchy map and a minimum hit count
+    using CounterElement =
+        std::pair<Acts::GeometryHierarchyMap<unsigned int>, unsigned int>;
+
+    boost::container::small_vector<CounterElement, 4> counters;
+
+    bool isValidParticle(
+        const SimParticle& particle,
+        const InverseMultimap<SimBarcode>& particleMeasurementsMap,
+        const MeasurementContainer& measurements) const;
+
+    void addCounter(const std::vector<Acts::GeometryIdentifier>& identifiers,
+                    unsigned int threshold) {
+      std::vector<Acts::GeometryHierarchyMap<unsigned int>::InputElement>
+          elements;
+      for (const auto& id : identifiers) {
+        elements.emplace_back(id, 0);
+      }
+      counters.emplace_back(std::move(elements), threshold);
+    }
+  };
+
   struct Config {
     /// The input particles collection.
     std::string inputParticles;
     /// (Optionally) The input particle measurements map. Only required for
     /// measurement-based cuts.
     std::string inputParticleMeasurementsMap;
+    /// (Optionally) The input measurements collection. Only required for
+    /// measurement-based cuts.
+    std::string inputMeasurements;
     /// The output particles collection.
     std::string outputParticles;
 
@@ -75,6 +102,9 @@ class ParticleSelector final : public IAlgorithm {
     /// Max primary vertex ID cut
     std::uint64_t maxPrimaryVertexId =
         std::numeric_limits<std::uint64_t>::max();
+
+    /// The measurement counter to be used for the measurement cuts.
+    MeasurementCounter measurementCounter;
   };
 
   ParticleSelector(const Config& config, Acts::Logging::Level level);
@@ -90,6 +120,8 @@ class ParticleSelector final : public IAlgorithm {
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
   ReadDataHandle<InverseMultimap<SimBarcode>> m_inputParticleMeasurementsMap{
       this, "InputParticleMeasurementsMap"};
+  ReadDataHandle<MeasurementContainer> m_inputMeasurements{this,
+                                                           "InputMeasurements"};
 
   WriteDataHandle<SimParticleContainer> m_outputParticles{this,
                                                           "OutputParticles"};

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -46,8 +46,9 @@ ParticleSelectorConfig = namedtuple(
         "removeCharged",  # bool
         "removeNeutral",  # bool
         "removeSecondaries",  # bool
+        "nMeasurementsGroupMin",
     ],
-    defaults=[(None, None)] * 10 + [None] * 3,
+    defaults=[(None, None)] * 10 + [None] * 4,
 )
 
 
@@ -76,6 +77,7 @@ def _getParticleSelectionKWargs(config: ParticleSelectorConfig) -> dict:
         "removeCharged": config.removeCharged,
         "removeNeutral": config.removeNeutral,
         "removeSecondaries": config.removeSecondaries,
+        "measurementCounter": config.nMeasurementsGroupMin,
     }
 
 
@@ -797,6 +799,7 @@ def addDigiParticleSelection(
         level=customLogLevel(),
         inputParticles="particles_simulated_selected",
         inputParticleMeasurementsMap="particle_measurements_map",
+        inputMeasurements="measurements",
         outputParticles="tmp_particles_digitized_selected",
     )
     s.addAlgorithm(selector)

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -63,11 +63,18 @@ void addTruthTracking(Context& ctx) {
                         py::arg("config"), py::arg("level"))
                    .def_property_readonly("config", &Alg::config);
 
+    {
+      auto mc = py::class_<Alg::MeasurementCounter>(alg, "MeasurementCounter")
+                    .def(py::init<>())
+                    .def("addCounter", &Alg::MeasurementCounter::addCounter);
+    }
+
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT_BEGIN(c, Config);
     ACTS_PYTHON_MEMBER(inputParticles);
     ACTS_PYTHON_MEMBER(inputParticleMeasurementsMap);
+    ACTS_PYTHON_MEMBER(inputMeasurements);
     ACTS_PYTHON_MEMBER(outputParticles);
     ACTS_PYTHON_MEMBER(rhoMin);
     ACTS_PYTHON_MEMBER(rhoMax);
@@ -95,6 +102,7 @@ void addTruthTracking(Context& ctx) {
     ACTS_PYTHON_MEMBER(excludeAbsPdgs);
     ACTS_PYTHON_MEMBER(minPrimaryVertexId);
     ACTS_PYTHON_MEMBER(maxPrimaryVertexId);
+    ACTS_PYTHON_MEMBER(measurementCounter);
     ACTS_PYTHON_STRUCT_END();
 
     pythonRangeProperty(c, "rho", &Config::rhoMin, &Config::rhoMax);


### PR DESCRIPTION
While trying to get rid of inefficiencies with the truth seeder I realized that not all particles might have 3 pixes hits which is required for forming a seed. This PR adds a selection cut to `ParticleSelector` which allows to cut the truth for a number of measurements in different regions. This is similar to what exists in `Acts::TrackSelector` where the majority of the code was taken from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced particle selection with advanced measurement validation, allowing improved filtering based on user-configured measurement thresholds.
  - Updated configuration options now support additional measurement inputs across both simulation and digitization workflows.
  - Integrated enhancements into Python interfaces, enabling more robust and customizable tracking performance through measurement-driven selection.
  - Introduced a new field for minimum measurement groups in the particle selector configuration.
  - Added a new struct and methods for managing measurement counters within the particle selection process.
  - New method for validating particles based on associated measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->