### PR TITLE
fix: Move Pythia8 gen to full-on PIMPL

### DIFF
--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
@@ -89,7 +89,7 @@ Pythia8Generator::Pythia8Generator(const Config& cfg, Acts::Logging::Level lvl)
 #if PYTHIA_VERSION_INTEGER >= 8310
   m_pythia8->setRndmEnginePtr(m_impl->m_pythia8RndmEngine);
 #else
-  m_pythia8->setRndmEnginePtr(m_pythia8RndmEngine.get());
+  m_pythia8->setRndmEnginePtr(m_impl->m_pythia8RndmEngine.get());
 #endif
 
   RandomEngine rng{m_cfg.initializationSeed};

--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.cpp
@@ -58,6 +58,14 @@ struct Pythia8RandomEngineWrapper : public Pythia8::RndmEngine {
   void clearRandomEngine() { rng = nullptr; }
 };
 
+struct Pythia8GeneratorImpl {
+#if defined(_HAS_HEPMC3)
+  std::unique_ptr<HepMC3::Writer> m_hepMC3Writer;
+  std::unique_ptr<HepMC3::Pythia8ToHepMC3> m_hepMC3Converter;
+#endif
+  std::shared_ptr<Pythia8RandomEngineWrapper> m_pythia8RndmEngine;
+};
+
 Pythia8Generator::Pythia8Generator(const Config& cfg, Acts::Logging::Level lvl)
     : m_cfg(cfg),
       m_logger(Acts::getDefaultLogger("Pythia8Generator", lvl)),
@@ -74,24 +82,26 @@ Pythia8Generator::Pythia8Generator(const Config& cfg, Acts::Logging::Level lvl)
   m_pythia8->settings.parm("Beams:eCM",
                            m_cfg.cmsEnergy / Acts::UnitConstants::GeV);
 
-  m_pythia8RndmEngine = std::make_shared<Pythia8RandomEngineWrapper>();
+  m_impl = std::make_unique<Pythia8GeneratorImpl>();
+
+  m_impl->m_pythia8RndmEngine = std::make_shared<Pythia8RandomEngineWrapper>();
 
 #if PYTHIA_VERSION_INTEGER >= 8310
-  m_pythia8->setRndmEnginePtr(m_pythia8RndmEngine);
+  m_pythia8->setRndmEnginePtr(m_impl->m_pythia8RndmEngine);
 #else
   m_pythia8->setRndmEnginePtr(m_pythia8RndmEngine.get());
 #endif
 
   RandomEngine rng{m_cfg.initializationSeed};
-  m_pythia8RndmEngine->setRandomEngine(rng);
+  m_impl->m_pythia8RndmEngine->setRandomEngine(rng);
   m_pythia8->init();
-  m_pythia8RndmEngine->clearRandomEngine();
+  m_impl->m_pythia8RndmEngine->clearRandomEngine();
 
   if (m_cfg.writeHepMC3.has_value()) {
 #if defined(_HAS_HEPMC3)
     ACTS_DEBUG("Initializing HepMC3 output to: " << m_cfg.writeHepMC3.value());
-    m_hepMC3Converter = std::make_unique<HepMC3::Pythia8ToHepMC3>();
-    m_hepMC3Writer =
+    m_impl->m_hepMC3Converter = std::make_unique<HepMC3::Pythia8ToHepMC3>();
+    m_impl->m_hepMC3Writer =
         std::make_unique<HepMC3::WriterAscii>(m_cfg.writeHepMC3.value());
 #else
     throw std::runtime_error("HepMC3 output requested but not available");
@@ -102,18 +112,18 @@ Pythia8Generator::Pythia8Generator(const Config& cfg, Acts::Logging::Level lvl)
 // needed to allow unique_ptr of forward-declared Pythia class
 Pythia8Generator::~Pythia8Generator() {
 #if defined(_HAS_HEPMC3)
-  if (m_hepMC3Writer) {
-    m_hepMC3Writer->close();
+  if (m_impl->m_hepMC3Writer) {
+    m_impl->m_hepMC3Writer->close();
   }
 #endif
 
   ACTS_INFO("Pythia8Generator produced "
-            << m_pythia8RndmEngine->statistics.numUniformRandomNumbers
+            << m_impl->m_pythia8RndmEngine->statistics.numUniformRandomNumbers
             << " uniform random numbers");
-  ACTS_INFO(
-      "                 first = " << m_pythia8RndmEngine->statistics.first);
-  ACTS_INFO(
-      "                  last = " << m_pythia8RndmEngine->statistics.last);
+  ACTS_INFO("                 first = "
+            << m_impl->m_pythia8RndmEngine->statistics.first);
+  ACTS_INFO("                  last = "
+            << m_impl->m_pythia8RndmEngine->statistics.last);
 }
 
 std::pair<SimVertexContainer, SimParticleContainer>
@@ -127,7 +137,7 @@ Pythia8Generator::operator()(RandomEngine& rng) {
   std::lock_guard<std::mutex> lock(m_pythia8Mutex);
   // use per-thread random engine also in pythia
 
-  m_pythia8RndmEngine->setRandomEngine(rng);
+  m_impl->m_pythia8RndmEngine->setRandomEngine(rng);
 
   {
     Acts::FpeMonitor mon{0};  // disable all FPEs while we're in Pythia8
@@ -142,11 +152,11 @@ Pythia8Generator::operator()(RandomEngine& rng) {
   }
 
 #if defined(_HAS_HEPMC3)
-  if (m_hepMC3Converter && m_hepMC3Writer) {
+  if (m_impl->m_hepMC3Converter && m_impl->m_hepMC3Writer) {
     auto hepmc_event = std::make_shared<HepMC3::GenEvent>();
-    m_hepMC3Converter->fill_next_event(*m_pythia8, hepmc_event.get());
+    m_impl->m_hepMC3Converter->fill_next_event(*m_pythia8, hepmc_event.get());
     hepmc_event->set_units(HepMC3::Units::GEV, HepMC3::Units::MM);
-    m_hepMC3Writer->write_event(*hepmc_event);
+    m_impl->m_hepMC3Writer->write_event(*hepmc_event);
   }
 #endif
 
@@ -224,7 +234,7 @@ Pythia8Generator::operator()(RandomEngine& rng) {
   out.first.insert(vertices.begin(), vertices.end());
   out.second.insert(particles.begin(), particles.end());
 
-  m_pythia8RndmEngine->clearRandomEngine();
+  m_impl->m_pythia8RndmEngine->clearRandomEngine();
 
   return out;
 }

--- a/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.hpp
+++ b/Examples/Algorithms/GeneratorsPythia8/ActsExamples/Generators/Pythia8ProcessGenerator.hpp
@@ -25,14 +25,9 @@ namespace Pythia8 {
 class Pythia;
 }
 
-namespace HepMC3 {
-class Writer;
-class Pythia8ToHepMC3;
-}  // namespace HepMC3
-
 namespace ActsExamples {
 
-struct Pythia8RandomEngineWrapper;
+struct Pythia8GeneratorImpl;
 
 class Pythia8Generator : public EventGenerator::ParticlesGenerator {
  public:
@@ -81,11 +76,9 @@ class Pythia8Generator : public EventGenerator::ParticlesGenerator {
   Config m_cfg;
   std::unique_ptr<const Acts::Logger> m_logger;
   std::unique_ptr<::Pythia8::Pythia> m_pythia8;
-  std::shared_ptr<Pythia8RandomEngineWrapper> m_pythia8RndmEngine;
   std::mutex m_pythia8Mutex;
 
-  std::unique_ptr<HepMC3::Writer> m_hepMC3Writer;
-  std::unique_ptr<HepMC3::Pythia8ToHepMC3> m_hepMC3Converter;
+  std::unique_ptr<Pythia8GeneratorImpl> m_impl;
 };
 
 }  // namespace ActsExamples


### PR DESCRIPTION
Moves the hepmc3 aware code in the Pythia8 generation class to PIMPL to properly hide the symbols.

Fixes https://github.com/acts-project/acts/issues/4159

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Consolidated the generator’s internal components into a unified implementation for improved clarity and maintainability.
	- Streamlined the initialization and access flow of critical components, reducing internal complexity.
	- Removed dependencies on the `HepMC3` namespace to simplify the design and pave the way for easier future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->