### PR TITLE
refactor: Add variadic python POD helper macro

### DIFF
--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -82,6 +82,12 @@ void patchKwargsConstructor(T& c) {
 /// This macro is needed to use the BOOST_PP_SEQ_FOR_EACH loop macro
 #define ACTS_PYTHON_MEMBER_LOOP(r, data, elem) ACTS_PYTHON_MEMBER(elem);
 
+#define ACTS_PYTHON_STRUCT(object, cls, ...)                   \
+  ACTS_PYTHON_STRUCT_BEGIN(object, cls);                       \
+  BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,            \
+                        BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+  ACTS_PYTHON_STRUCT_END();
+
 /// A macro that uses Boost.Preprocessor to create the python binding for an
 /// algorithm and the additional config struct. The binding can be customized
 /// by a lambda function that takes the algorithm and config class as arguments.

--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -82,25 +82,43 @@ void patchKwargsConstructor(T& c) {
 /// This macro is needed to use the BOOST_PP_SEQ_FOR_EACH loop macro
 #define ACTS_PYTHON_MEMBER_LOOP(r, data, elem) ACTS_PYTHON_MEMBER(elem);
 
-/// A macro that uses Boost.Preprocessor to create the python binding for and
+/// A macro that uses Boost.Preprocessor to create the python binding for an
+/// algorithm and the additional config struct. The binding can be customized
+/// by a lambda function that takes the algorithm and config class as arguments.
+#define ACTS_PYTHON_DECLARE_ALGORITHM_CUSTOM(algorithm, mod, name, ...)      \
+  [&]() {                                                                    \
+    struct A {                                                               \
+      using Alg = algorithm;                                                 \
+      using Config = Alg::Config;                                            \
+      A& operator=(                                                          \
+          const std::function<void(py::class_<Alg, ActsExamples::IAlgorithm, \
+                                              std::shared_ptr<Alg>>&,        \
+                                   py::class_<Config>&)>& cb) {              \
+        auto alg =                                                           \
+            py::class_<Alg, ActsExamples::IAlgorithm, std::shared_ptr<Alg>>( \
+                m_mod, name)                                                 \
+                .def(py::init<const Config&, Acts::Logging::Level>(),        \
+                     py::arg("config"), py::arg("level"))                    \
+                .def_property_readonly("config", &Alg::config);              \
+                                                                             \
+        auto c = py::class_<Config>(alg, "Config").def(py::init<>());        \
+        ACTS_PYTHON_STRUCT_BEGIN(c, Config);                                 \
+        BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                    \
+                              BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))         \
+        ACTS_PYTHON_STRUCT_END();                                            \
+        cb(alg, c);                                                          \
+        return *this;                                                        \
+      }                                                                      \
+      using mod_t = std::remove_cvref_t<decltype(mod)>;                      \
+      mod_t& m_mod;                                                          \
+    };                                                                       \
+    return A{mod};                                                           \
+  }() = [&]([[maybe_unused]] auto& alg, [[maybe_unused]] auto& cfg)
+
+/// A macro that uses Boost.Preprocessor to create the python binding for an
 /// algorithm and the additional config struct.
-#define ACTS_PYTHON_DECLARE_ALGORITHM(algorithm, mod, name, ...)              \
-  do {                                                                        \
-    using Alg = algorithm;                                                    \
-    using Config = Alg::Config;                                               \
-    auto alg =                                                                \
-        py::class_<Alg, ActsExamples::IAlgorithm, std::shared_ptr<Alg>>(mod,  \
-                                                                        name) \
-            .def(py::init<const Config&, Acts::Logging::Level>(),             \
-                 py::arg("config"), py::arg("level"))                         \
-            .def_property_readonly("config", &Alg::config);                   \
-                                                                              \
-    auto c = py::class_<Config>(alg, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);                                      \
-    BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                         \
-                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))              \
-    ACTS_PYTHON_STRUCT_END();                                                 \
-  } while (0)
+#define ACTS_PYTHON_DECLARE_ALGORITHM(algorithm, mod, name, ...) \
+  ACTS_PYTHON_DECLARE_ALGORITHM_CUSTOM(algorithm, mod, name, __VA_ARGS__) {}
 
 /// Similar as above for writers
 #define ACTS_PYTHON_DECLARE_WRITER(writer, mod, name, ...)                  \

--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -67,11 +67,11 @@ void patchKwargsConstructor(T& c) {
 #define ACTS_PYTHON_MEMBER(name) \
   _binding_instance.def_readwrite(#name, &_struct_type::name)
 
-#define ACTS_PYTHON_STRUCT_BEGIN(obj, cls)          \
-  {                                                 \
-    [[maybe_unused]] auto& _binding_instance = obj; \
-    using _struct_type = cls;                       \
-    do {                                            \
+#define ACTS_PYTHON_STRUCT_BEGIN(object)               \
+  {                                                    \
+    [[maybe_unused]] auto& _binding_instance = object; \
+    using _struct_type = decltype(object)::type;       \
+    do {                                               \
     } while (0)
 
 #define ACTS_PYTHON_STRUCT_END() \
@@ -82,11 +82,15 @@ void patchKwargsConstructor(T& c) {
 /// This macro is needed to use the BOOST_PP_SEQ_FOR_EACH loop macro
 #define ACTS_PYTHON_MEMBER_LOOP(r, data, elem) ACTS_PYTHON_MEMBER(elem);
 
-#define ACTS_PYTHON_STRUCT(object, cls, ...)                   \
-  ACTS_PYTHON_STRUCT_BEGIN(object, cls);                       \
-  BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,            \
-                        BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
-  ACTS_PYTHON_STRUCT_END();
+/// Macro that accepts a variadic set of member names that are to be registered
+/// into an object as read-write fields
+#define ACTS_PYTHON_STRUCT(object, ...)                          \
+  do {                                                           \
+    ACTS_PYTHON_STRUCT_BEGIN(object);                            \
+    BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,            \
+                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__)) \
+    ACTS_PYTHON_STRUCT_END();                                    \
+  } while (0)
 
 /// A macro that uses Boost.Preprocessor to create the python binding for and
 /// algorithm and the additional config struct.
@@ -102,7 +106,7 @@ void patchKwargsConstructor(T& c) {
             .def_property_readonly("config", &Alg::config);                   \
                                                                               \
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);                                      \
+    ACTS_PYTHON_STRUCT_BEGIN(c);                                              \
     BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                         \
                           BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))              \
     ACTS_PYTHON_STRUCT_END();                                                 \
@@ -128,7 +132,7 @@ void patchKwargsConstructor(T& c) {
     }                                                                       \
                                                                             \
     auto c = py::class_<Config>(w, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);                                    \
+    ACTS_PYTHON_STRUCT_BEGIN(c);                                            \
     BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                       \
                           BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))            \
     ACTS_PYTHON_STRUCT_END();                                               \
@@ -147,7 +151,7 @@ void patchKwargsConstructor(T& c) {
             .def_property_readonly("config", &Reader::config);              \
                                                                             \
     auto c = py::class_<Config>(r, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);                                    \
+    ACTS_PYTHON_STRUCT_BEGIN(c);                                            \
     BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                       \
                           BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))            \
     ACTS_PYTHON_STRUCT_END();                                               \

--- a/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
+++ b/Examples/Python/include/Acts/Plugins/Python/Utilities.hpp
@@ -106,10 +106,7 @@ void patchKwargsConstructor(T& c) {
             .def_property_readonly("config", &Alg::config);                   \
                                                                               \
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c);                                              \
-    BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                         \
-                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))              \
-    ACTS_PYTHON_STRUCT_END();                                                 \
+    ACTS_PYTHON_STRUCT(c, __VA_ARGS__);                                       \
   } while (0)
 
 /// Similar as above for writers
@@ -130,12 +127,8 @@ void patchKwargsConstructor(T& c) {
     if constexpr (has_write_method) {                                       \
       w.def("write", &Writer::write);                                       \
     }                                                                       \
-                                                                            \
     auto c = py::class_<Config>(w, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c);                                            \
-    BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                       \
-                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))            \
-    ACTS_PYTHON_STRUCT_END();                                               \
+    ACTS_PYTHON_STRUCT(c, __VA_ARGS__);                                     \
   } while (0)
 
 /// Similar as above for readers
@@ -151,8 +144,5 @@ void patchKwargsConstructor(T& c) {
             .def_property_readonly("config", &Reader::config);              \
                                                                             \
     auto c = py::class_<Config>(r, "Config").def(py::init<>());             \
-    ACTS_PYTHON_STRUCT_BEGIN(c);                                            \
-    BOOST_PP_SEQ_FOR_EACH(ACTS_PYTHON_MEMBER_LOOP, _,                       \
-                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))            \
-    ACTS_PYTHON_STRUCT_END();                                               \
+    ACTS_PYTHON_STRUCT(c, __VA_ARGS__);                                     \
   } while (0)

--- a/Examples/Python/src/Blueprint.cpp
+++ b/Examples/Python/src/Blueprint.cpp
@@ -251,7 +251,7 @@ void addBlueprint(Context& ctx) {
 
   {
     auto c = py::class_<Blueprint::Config>(rootNode, "Config").def(py::init());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Blueprint::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(envelope);
     ACTS_PYTHON_STRUCT_END();
   }

--- a/Examples/Python/src/Blueprint.cpp
+++ b/Examples/Python/src/Blueprint.cpp
@@ -251,9 +251,7 @@ void addBlueprint(Context& ctx) {
 
   {
     auto c = py::class_<Blueprint::Config>(rootNode, "Config").def(py::init());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(envelope);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, envelope);
   }
 
   auto addContextManagerProtocol = []<typename class_>(class_& cls) {

--- a/Examples/Python/src/DD4hepComponent.cpp
+++ b/Examples/Python/src/DD4hepComponent.cpp
@@ -41,20 +41,7 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
             .def_property_readonly("field", &DD4hepDetector::field);
 
     auto c = py::class_<DD4hepDetector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_MEMBER(dd4hepLogLevel);
-    ACTS_PYTHON_MEMBER(xmlFileNames);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(bTypePhi);
-    ACTS_PYTHON_MEMBER(bTypeR);
-    ACTS_PYTHON_MEMBER(bTypeZ);
-    ACTS_PYTHON_MEMBER(envelopeR);
-    ACTS_PYTHON_MEMBER(envelopeZ);
-    ACTS_PYTHON_MEMBER(defaultLayerThickness);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_MEMBER(geometryIdentifierHook);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, logLevel, dd4hepLogLevel, xmlFileNames, name, bTypePhi, bTypeR, bTypeZ, envelopeR, envelopeZ, defaultLayerThickness, materialDecorator, geometryIdentifierHook);
 
     patchKwargsConstructor(c);
   }
@@ -101,12 +88,7 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
   {
     using Options = Acts::Experimental::DD4hepDetectorStructure::Options;
     auto o = py::class_<Options>(m, "DD4hepDetectorOptions").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(o);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_MEMBER(emulateToGraph);
-    ACTS_PYTHON_MEMBER(geoIdGenerator);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(o, logLevel, emulateToGraph, geoIdGenerator, materialDecorator);
 
     patchKwargsConstructor(o);
 

--- a/Examples/Python/src/DD4hepComponent.cpp
+++ b/Examples/Python/src/DD4hepComponent.cpp
@@ -41,7 +41,10 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
             .def_property_readonly("field", &DD4hepDetector::field);
 
     auto c = py::class_<DD4hepDetector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, logLevel, dd4hepLogLevel, xmlFileNames, name, bTypePhi, bTypeR, bTypeZ, envelopeR, envelopeZ, defaultLayerThickness, materialDecorator, geometryIdentifierHook);
+    ACTS_PYTHON_STRUCT(c, logLevel, dd4hepLogLevel, xmlFileNames, name,
+                       bTypePhi, bTypeR, bTypeZ, envelopeR, envelopeZ,
+                       defaultLayerThickness, materialDecorator,
+                       geometryIdentifierHook);
 
     patchKwargsConstructor(c);
   }
@@ -88,7 +91,8 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
   {
     using Options = Acts::Experimental::DD4hepDetectorStructure::Options;
     auto o = py::class_<Options>(m, "DD4hepDetectorOptions").def(py::init<>());
-    ACTS_PYTHON_STRUCT(o, logLevel, emulateToGraph, geoIdGenerator, materialDecorator);
+    ACTS_PYTHON_STRUCT(o, logLevel, emulateToGraph, geoIdGenerator,
+                       materialDecorator);
 
     patchKwargsConstructor(o);
 

--- a/Examples/Python/src/DD4hepComponent.cpp
+++ b/Examples/Python/src/DD4hepComponent.cpp
@@ -41,7 +41,7 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
             .def_property_readonly("field", &DD4hepDetector::field);
 
     auto c = py::class_<DD4hepDetector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, DD4hepDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(logLevel);
     ACTS_PYTHON_MEMBER(dd4hepLogLevel);
     ACTS_PYTHON_MEMBER(xmlFileNames);
@@ -101,7 +101,7 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
   {
     using Options = Acts::Experimental::DD4hepDetectorStructure::Options;
     auto o = py::class_<Options>(m, "DD4hepDetectorOptions").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(o, Options);
+    ACTS_PYTHON_STRUCT_BEGIN(o);
     ACTS_PYTHON_MEMBER(logLevel);
     ACTS_PYTHON_MEMBER(emulateToGraph);
     ACTS_PYTHON_MEMBER(geoIdGenerator);

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -67,15 +67,7 @@ void addDetector(Context& ctx) {
             .def(py::init<const GenericDetector::Config&>());
 
     auto c = py::class_<GenericDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(buildLevel);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_MEMBER(surfaceLogLevel);
-    ACTS_PYTHON_MEMBER(layerLogLevel);
-    ACTS_PYTHON_MEMBER(volumeLogLevel);
-    ACTS_PYTHON_MEMBER(buildProto);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, buildLevel, logLevel, surfaceLogLevel, layerLogLevel, volumeLogLevel, buildProto, materialDecorator);
   }
 
   {
@@ -86,17 +78,7 @@ void addDetector(Context& ctx) {
 
     auto c =
         py::class_<TelescopeDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(positions);
-    ACTS_PYTHON_MEMBER(stereos);
-    ACTS_PYTHON_MEMBER(offsets);
-    ACTS_PYTHON_MEMBER(bounds);
-    ACTS_PYTHON_MEMBER(thickness);
-    ACTS_PYTHON_MEMBER(surfaceType);
-    ACTS_PYTHON_MEMBER(binValue);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, positions, stereos, offsets, bounds, thickness, surfaceType, binValue, materialDecorator, logLevel);
   }
 
   {
@@ -108,19 +90,7 @@ void addDetector(Context& ctx) {
     auto c = py::class_<AlignedDetector::Config, GenericDetector::Config>(
                  d, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(seed);
-    ACTS_PYTHON_MEMBER(iovSize);
-    ACTS_PYTHON_MEMBER(flushSize);
-    ACTS_PYTHON_MEMBER(doGarbageCollection);
-    ACTS_PYTHON_MEMBER(sigmaInPlane);
-    ACTS_PYTHON_MEMBER(sigmaOutPlane);
-    ACTS_PYTHON_MEMBER(sigmaInRot);
-    ACTS_PYTHON_MEMBER(sigmaOutRot);
-    ACTS_PYTHON_MEMBER(firstIovNominal);
-    ACTS_PYTHON_MEMBER(decoratorLogLevel);
-    ACTS_PYTHON_MEMBER(mode);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, seed, iovSize, flushSize, doGarbageCollection, sigmaInPlane, sigmaOutPlane, sigmaInRot, sigmaOutRot, firstIovNominal, decoratorLogLevel, mode);
 
     py::enum_<AlignedDetector::Config::Mode>(c, "Mode")
         .value("Internal", AlignedDetector::Config::Mode::Internal)
@@ -156,32 +126,7 @@ void addDetector(Context& ctx) {
 
     auto volume =
         py::class_<TGeoDetector::Config::Volume>(c, "Volume").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(volume);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(binToleranceR);
-    ACTS_PYTHON_MEMBER(binTolerancePhi);
-    ACTS_PYTHON_MEMBER(binToleranceZ);
-    ACTS_PYTHON_MEMBER(cylinderDiscSplit);
-    ACTS_PYTHON_MEMBER(cylinderNZSegments);
-    ACTS_PYTHON_MEMBER(cylinderNPhiSegments);
-    ACTS_PYTHON_MEMBER(discNRSegments);
-    ACTS_PYTHON_MEMBER(discNPhiSegments);
-    ACTS_PYTHON_MEMBER(itkModuleSplit);
-    ACTS_PYTHON_MEMBER(barrelMap);
-    ACTS_PYTHON_MEMBER(discMap);
-    ACTS_PYTHON_MEMBER(splitPatterns);
-
-    ACTS_PYTHON_MEMBER(layers);
-    ACTS_PYTHON_MEMBER(subVolumeName);
-    ACTS_PYTHON_MEMBER(sensitiveNames);
-    ACTS_PYTHON_MEMBER(sensitiveAxes);
-    ACTS_PYTHON_MEMBER(rRange);
-    ACTS_PYTHON_MEMBER(zRange);
-    ACTS_PYTHON_MEMBER(splitTolR);
-    ACTS_PYTHON_MEMBER(splitTolZ);
-    ACTS_PYTHON_MEMBER(binning0);
-    ACTS_PYTHON_MEMBER(binning1);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(volume, name, binToleranceR, binTolerancePhi, binToleranceZ, cylinderDiscSplit, cylinderNZSegments, cylinderNPhiSegments, discNRSegments, discNPhiSegments, itkModuleSplit, barrelMap, discMap, splitPatterns, layers, subVolumeName, sensitiveNames, sensitiveAxes, rRange, zRange, splitTolR, splitTolZ, binning0, binning1);
 
     auto regTriplet = [&c](const std::string& name, auto v) {
       using type = decltype(v);
@@ -207,21 +152,7 @@ void addDetector(Context& ctx) {
     regTriplet("LayerTripletVectorBinning",
                std::vector<std::pair<int, Acts::BinningType>>{});
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(surfaceLogLevel);
-    ACTS_PYTHON_MEMBER(layerLogLevel);
-    ACTS_PYTHON_MEMBER(volumeLogLevel);
-    ACTS_PYTHON_MEMBER(fileName);
-    ACTS_PYTHON_MEMBER(buildBeamPipe);
-    ACTS_PYTHON_MEMBER(beamPipeRadius);
-    ACTS_PYTHON_MEMBER(beamPipeHalflengthZ);
-    ACTS_PYTHON_MEMBER(beamPipeLayerThickness);
-    ACTS_PYTHON_MEMBER(beamPipeEnvelopeR);
-    ACTS_PYTHON_MEMBER(layerEnvelopeR);
-    ACTS_PYTHON_MEMBER(unitScalor);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_MEMBER(volumes);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, surfaceLogLevel, layerLogLevel, volumeLogLevel, fileName, buildBeamPipe, beamPipeRadius, beamPipeHalflengthZ, beamPipeLayerThickness, beamPipeEnvelopeR, layerEnvelopeR, unitScalor, materialDecorator, volumes);
 
     patchKwargsConstructor(c);
   }

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -67,7 +67,8 @@ void addDetector(Context& ctx) {
             .def(py::init<const GenericDetector::Config&>());
 
     auto c = py::class_<GenericDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, buildLevel, logLevel, surfaceLogLevel, layerLogLevel, volumeLogLevel, buildProto, materialDecorator);
+    ACTS_PYTHON_STRUCT(c, buildLevel, logLevel, surfaceLogLevel, layerLogLevel,
+                       volumeLogLevel, buildProto, materialDecorator);
   }
 
   {
@@ -78,7 +79,8 @@ void addDetector(Context& ctx) {
 
     auto c =
         py::class_<TelescopeDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, positions, stereos, offsets, bounds, thickness, surfaceType, binValue, materialDecorator, logLevel);
+    ACTS_PYTHON_STRUCT(c, positions, stereos, offsets, bounds, thickness,
+                       surfaceType, binValue, materialDecorator, logLevel);
   }
 
   {
@@ -90,7 +92,9 @@ void addDetector(Context& ctx) {
     auto c = py::class_<AlignedDetector::Config, GenericDetector::Config>(
                  d, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, seed, iovSize, flushSize, doGarbageCollection, sigmaInPlane, sigmaOutPlane, sigmaInRot, sigmaOutRot, firstIovNominal, decoratorLogLevel, mode);
+    ACTS_PYTHON_STRUCT(c, seed, iovSize, flushSize, doGarbageCollection,
+                       sigmaInPlane, sigmaOutPlane, sigmaInRot, sigmaOutRot,
+                       firstIovNominal, decoratorLogLevel, mode);
 
     py::enum_<AlignedDetector::Config::Mode>(c, "Mode")
         .value("Internal", AlignedDetector::Config::Mode::Internal)
@@ -126,7 +130,12 @@ void addDetector(Context& ctx) {
 
     auto volume =
         py::class_<TGeoDetector::Config::Volume>(c, "Volume").def(py::init<>());
-    ACTS_PYTHON_STRUCT(volume, name, binToleranceR, binTolerancePhi, binToleranceZ, cylinderDiscSplit, cylinderNZSegments, cylinderNPhiSegments, discNRSegments, discNPhiSegments, itkModuleSplit, barrelMap, discMap, splitPatterns, layers, subVolumeName, sensitiveNames, sensitiveAxes, rRange, zRange, splitTolR, splitTolZ, binning0, binning1);
+    ACTS_PYTHON_STRUCT(
+        volume, name, binToleranceR, binTolerancePhi, binToleranceZ,
+        cylinderDiscSplit, cylinderNZSegments, cylinderNPhiSegments,
+        discNRSegments, discNPhiSegments, itkModuleSplit, barrelMap, discMap,
+        splitPatterns, layers, subVolumeName, sensitiveNames, sensitiveAxes,
+        rRange, zRange, splitTolR, splitTolZ, binning0, binning1);
 
     auto regTriplet = [&c](const std::string& name, auto v) {
       using type = decltype(v);
@@ -152,7 +161,11 @@ void addDetector(Context& ctx) {
     regTriplet("LayerTripletVectorBinning",
                std::vector<std::pair<int, Acts::BinningType>>{});
 
-    ACTS_PYTHON_STRUCT(c, surfaceLogLevel, layerLogLevel, volumeLogLevel, fileName, buildBeamPipe, beamPipeRadius, beamPipeHalflengthZ, beamPipeLayerThickness, beamPipeEnvelopeR, layerEnvelopeR, unitScalor, materialDecorator, volumes);
+    ACTS_PYTHON_STRUCT(c, surfaceLogLevel, layerLogLevel, volumeLogLevel,
+                       fileName, buildBeamPipe, beamPipeRadius,
+                       beamPipeHalflengthZ, beamPipeLayerThickness,
+                       beamPipeEnvelopeR, layerEnvelopeR, unitScalor,
+                       materialDecorator, volumes);
 
     patchKwargsConstructor(c);
   }

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -67,7 +67,7 @@ void addDetector(Context& ctx) {
             .def(py::init<const GenericDetector::Config&>());
 
     auto c = py::class_<GenericDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, GenericDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(buildLevel);
     ACTS_PYTHON_MEMBER(logLevel);
     ACTS_PYTHON_MEMBER(surfaceLogLevel);
@@ -86,7 +86,7 @@ void addDetector(Context& ctx) {
 
     auto c =
         py::class_<TelescopeDetector::Config>(d, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, TelescopeDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(positions);
     ACTS_PYTHON_MEMBER(stereos);
     ACTS_PYTHON_MEMBER(offsets);
@@ -108,7 +108,7 @@ void addDetector(Context& ctx) {
     auto c = py::class_<AlignedDetector::Config, GenericDetector::Config>(
                  d, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, AlignedDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(seed);
     ACTS_PYTHON_MEMBER(iovSize);
     ACTS_PYTHON_MEMBER(flushSize);
@@ -156,7 +156,7 @@ void addDetector(Context& ctx) {
 
     auto volume =
         py::class_<TGeoDetector::Config::Volume>(c, "Volume").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(volume, TGeoDetector::Config::Volume);
+    ACTS_PYTHON_STRUCT_BEGIN(volume);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(binToleranceR);
     ACTS_PYTHON_MEMBER(binTolerancePhi);
@@ -207,7 +207,7 @@ void addDetector(Context& ctx) {
     regTriplet("LayerTripletVectorBinning",
                std::vector<std::pair<int, Acts::BinningType>>{});
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, TGeoDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(surfaceLogLevel);
     ACTS_PYTHON_MEMBER(layerLogLevel);
     ACTS_PYTHON_MEMBER(volumeLogLevel);

--- a/Examples/Python/src/Detray.cpp
+++ b/Examples/Python/src/Detray.cpp
@@ -61,11 +61,7 @@ void addDetray(Context& ctx) {
     auto options = py::class_<DetrayConverter::Options>(converter, "Options")
                        .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(options);
-    ACTS_PYTHON_MEMBER(convertMaterial);
-    ACTS_PYTHON_MEMBER(convertSurfaceGrids);
-    ACTS_PYTHON_MEMBER(writeToJson);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(options, convertMaterial, convertSurfaceGrids, writeToJson);
   }
 }
 }  // namespace Acts::Python

--- a/Examples/Python/src/Detray.cpp
+++ b/Examples/Python/src/Detray.cpp
@@ -61,7 +61,8 @@ void addDetray(Context& ctx) {
     auto options = py::class_<DetrayConverter::Options>(converter, "Options")
                        .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(options, convertMaterial, convertSurfaceGrids, writeToJson);
+    ACTS_PYTHON_STRUCT(options, convertMaterial, convertSurfaceGrids,
+                       writeToJson);
   }
 }
 }  // namespace Acts::Python

--- a/Examples/Python/src/Detray.cpp
+++ b/Examples/Python/src/Detray.cpp
@@ -61,7 +61,7 @@ void addDetray(Context& ctx) {
     auto options = py::class_<DetrayConverter::Options>(converter, "Options")
                        .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(options, DetrayConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(options);
     ACTS_PYTHON_MEMBER(convertMaterial);
     ACTS_PYTHON_MEMBER(convertSurfaceGrids);
     ACTS_PYTHON_MEMBER(writeToJson);

--- a/Examples/Python/src/Digitization.cpp
+++ b/Examples/Python/src/Digitization.cpp
@@ -49,22 +49,7 @@ void addDigitization(Context& ctx) {
 
     auto c = py::class_<Config>(a, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputSimHits);
-    ACTS_PYTHON_MEMBER(outputMeasurements);
-    ACTS_PYTHON_MEMBER(outputClusters);
-    ACTS_PYTHON_MEMBER(outputMeasurementParticlesMap);
-    ACTS_PYTHON_MEMBER(outputMeasurementSimHitsMap);
-    ACTS_PYTHON_MEMBER(outputParticleMeasurementsMap);
-    ACTS_PYTHON_MEMBER(outputSimHitMeasurementsMap);
-    ACTS_PYTHON_MEMBER(surfaceByIdentifier);
-    ACTS_PYTHON_MEMBER(randomNumbers);
-    ACTS_PYTHON_MEMBER(doOutputCells);
-    ACTS_PYTHON_MEMBER(doClusterization);
-    ACTS_PYTHON_MEMBER(doMerge);
-    ACTS_PYTHON_MEMBER(minEnergyDeposit);
-    ACTS_PYTHON_MEMBER(digitizationConfigs);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputSimHits, outputMeasurements, outputClusters, outputMeasurementParticlesMap, outputMeasurementSimHitsMap, outputParticleMeasurementsMap, outputSimHitMeasurementsMap, surfaceByIdentifier, randomNumbers, doOutputCells, doClusterization, doMerge, minEnergyDeposit, digitizationConfigs);
 
     c.def_readonly("mergeNsigma", &Config::mergeNsigma);
     c.def_readonly("mergeCommonCorner", &Config::mergeCommonCorner);
@@ -74,10 +59,7 @@ void addDigitization(Context& ctx) {
     auto cc = py::class_<DigiComponentsConfig>(mex, "DigiComponentsConfig")
                   .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(cc);
-    ACTS_PYTHON_MEMBER(geometricDigiConfig);
-    ACTS_PYTHON_MEMBER(smearingDigiConfig);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(cc, geometricDigiConfig, smearingDigiConfig);
 
     py::class_<DigiConfigContainer>(mex, "DigiConfigContainer")
         .def(py::init<std::vector<
@@ -90,12 +72,7 @@ void addDigitization(Context& ctx) {
 
     dc.def("__call__", &DC::operator());
 
-    ACTS_PYTHON_STRUCT_BEGIN(dc);
-    ACTS_PYTHON_MEMBER(inputDigiComponents);
-    ACTS_PYTHON_MEMBER(compactify);
-    ACTS_PYTHON_MEMBER(volumeLayerComponents);
-    ACTS_PYTHON_MEMBER(outputDigiComponents);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(dc, inputDigiComponents, compactify, volumeLayerComponents, outputDigiComponents);
   }
 
   {

--- a/Examples/Python/src/Digitization.cpp
+++ b/Examples/Python/src/Digitization.cpp
@@ -49,7 +49,7 @@ void addDigitization(Context& ctx) {
 
     auto c = py::class_<Config>(a, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputSimHits);
     ACTS_PYTHON_MEMBER(outputMeasurements);
     ACTS_PYTHON_MEMBER(outputClusters);
@@ -74,7 +74,7 @@ void addDigitization(Context& ctx) {
     auto cc = py::class_<DigiComponentsConfig>(mex, "DigiComponentsConfig")
                   .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(cc, DigiComponentsConfig);
+    ACTS_PYTHON_STRUCT_BEGIN(cc);
     ACTS_PYTHON_MEMBER(geometricDigiConfig);
     ACTS_PYTHON_MEMBER(smearingDigiConfig);
     ACTS_PYTHON_STRUCT_END();
@@ -90,7 +90,7 @@ void addDigitization(Context& ctx) {
 
     dc.def("__call__", &DC::operator());
 
-    ACTS_PYTHON_STRUCT_BEGIN(dc, DC);
+    ACTS_PYTHON_STRUCT_BEGIN(dc);
     ACTS_PYTHON_MEMBER(inputDigiComponents);
     ACTS_PYTHON_MEMBER(compactify);
     ACTS_PYTHON_MEMBER(volumeLayerComponents);

--- a/Examples/Python/src/Digitization.cpp
+++ b/Examples/Python/src/Digitization.cpp
@@ -49,7 +49,12 @@ void addDigitization(Context& ctx) {
 
     auto c = py::class_<Config>(a, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, inputSimHits, outputMeasurements, outputClusters, outputMeasurementParticlesMap, outputMeasurementSimHitsMap, outputParticleMeasurementsMap, outputSimHitMeasurementsMap, surfaceByIdentifier, randomNumbers, doOutputCells, doClusterization, doMerge, minEnergyDeposit, digitizationConfigs);
+    ACTS_PYTHON_STRUCT(
+        c, inputSimHits, outputMeasurements, outputClusters,
+        outputMeasurementParticlesMap, outputMeasurementSimHitsMap,
+        outputParticleMeasurementsMap, outputSimHitMeasurementsMap,
+        surfaceByIdentifier, randomNumbers, doOutputCells, doClusterization,
+        doMerge, minEnergyDeposit, digitizationConfigs);
 
     c.def_readonly("mergeNsigma", &Config::mergeNsigma);
     c.def_readonly("mergeCommonCorner", &Config::mergeCommonCorner);
@@ -72,7 +77,8 @@ void addDigitization(Context& ctx) {
 
     dc.def("__call__", &DC::operator());
 
-    ACTS_PYTHON_STRUCT(dc, inputDigiComponents, compactify, volumeLayerComponents, outputDigiComponents);
+    ACTS_PYTHON_STRUCT(dc, inputDigiComponents, compactify,
+                       volumeLayerComponents, outputDigiComponents);
   }
 
   {

--- a/Examples/Python/src/ExaTrkXTrackFinding.cpp
+++ b/Examples/Python/src/ExaTrkXTrackFinding.cpp
@@ -67,14 +67,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(modelPath);
-    ACTS_PYTHON_MEMBER(selectedFeatures);
-    ACTS_PYTHON_MEMBER(embeddingDim);
-    ACTS_PYTHON_MEMBER(rVal);
-    ACTS_PYTHON_MEMBER(knnVal);
-    ACTS_PYTHON_MEMBER(deviceID);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, embeddingDim, rVal, knnVal, deviceID);
   }
   {
     using Alg = Acts::TorchEdgeClassifier;
@@ -91,15 +84,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(modelPath);
-    ACTS_PYTHON_MEMBER(selectedFeatures);
-    ACTS_PYTHON_MEMBER(cut);
-    ACTS_PYTHON_MEMBER(nChunks);
-    ACTS_PYTHON_MEMBER(undirected);
-    ACTS_PYTHON_MEMBER(deviceID);
-    ACTS_PYTHON_MEMBER(useEdgeFeatures);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, nChunks, undirected, deviceID, useEdgeFeatures);
   }
   {
     using Alg = Acts::BoostTrackBuilding;
@@ -130,12 +115,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(modelPath);
-    ACTS_PYTHON_MEMBER(selectedFeatures);
-    ACTS_PYTHON_MEMBER(cut);
-    ACTS_PYTHON_MEMBER(deviceID);
-    ACTS_PYTHON_MEMBER(doSigmoid);
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, deviceID, doSigmoid);
   }
 #endif
 
@@ -153,8 +133,6 @@ void addExaTrkXTrackFinding(Context &ctx) {
                         "config"_a, "level"_a);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_STRUCT_END();
   }
 #endif
 
@@ -174,13 +152,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(modelPath);
-    ACTS_PYTHON_MEMBER(spacepointFeatures);
-    ACTS_PYTHON_MEMBER(embeddingDim);
-    ACTS_PYTHON_MEMBER(rVal);
-    ACTS_PYTHON_MEMBER(knnVal);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, modelPath, spacepointFeatures, embeddingDim, rVal, knnVal);
   }
   {
     using Alg = Acts::OnnxEdgeClassifier;
@@ -197,10 +169,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(modelPath);
-    ACTS_PYTHON_MEMBER(cut);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, modelPath, cut);
   }
 #endif
 

--- a/Examples/Python/src/ExaTrkXTrackFinding.cpp
+++ b/Examples/Python/src/ExaTrkXTrackFinding.cpp
@@ -67,7 +67,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(modelPath);
     ACTS_PYTHON_MEMBER(selectedFeatures);
     ACTS_PYTHON_MEMBER(embeddingDim);
@@ -91,7 +91,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(modelPath);
     ACTS_PYTHON_MEMBER(selectedFeatures);
     ACTS_PYTHON_MEMBER(cut);
@@ -130,7 +130,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(modelPath);
     ACTS_PYTHON_MEMBER(selectedFeatures);
     ACTS_PYTHON_MEMBER(cut);
@@ -153,7 +153,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
                         "config"_a, "level"_a);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_STRUCT_END();
   }
 #endif
@@ -174,7 +174,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(modelPath);
     ACTS_PYTHON_MEMBER(spacepointFeatures);
     ACTS_PYTHON_MEMBER(embeddingDim);
@@ -197,7 +197,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(modelPath);
     ACTS_PYTHON_MEMBER(cut);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/ExaTrkXTrackFinding.cpp
+++ b/Examples/Python/src/ExaTrkXTrackFinding.cpp
@@ -67,7 +67,8 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, embeddingDim, rVal, knnVal, deviceID);
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, embeddingDim, rVal,
+                       knnVal, deviceID);
   }
   {
     using Alg = Acts::TorchEdgeClassifier;
@@ -84,7 +85,8 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, nChunks, undirected, deviceID, useEdgeFeatures);
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, nChunks, undirected,
+                       deviceID, useEdgeFeatures);
   }
   {
     using Alg = Acts::BoostTrackBuilding;
@@ -115,7 +117,8 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, deviceID, doSigmoid);
+    ACTS_PYTHON_STRUCT(c, modelPath, selectedFeatures, cut, deviceID,
+                       doSigmoid);
   }
 #endif
 
@@ -152,7 +155,8 @@ void addExaTrkXTrackFinding(Context &ctx) {
             .def_property_readonly("config", &Alg::config);
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, modelPath, spacepointFeatures, embeddingDim, rVal, knnVal);
+    ACTS_PYTHON_STRUCT(c, modelPath, spacepointFeatures, embeddingDim, rVal,
+                       knnVal);
   }
   {
     using Alg = Acts::OnnxEdgeClassifier;

--- a/Examples/Python/src/ExampleAlgorithms.cpp
+++ b/Examples/Python/src/ExampleAlgorithms.cpp
@@ -58,7 +58,7 @@ void addExampleAlgorithms(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputTracks);
     ACTS_PYTHON_MEMBER(outputTracks);
     ACTS_PYTHON_MEMBER(selectorConfig);
@@ -86,7 +86,7 @@ void addExampleAlgorithms(Context& ctx) {
 
       patchKwargsConstructor(c);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+      ACTS_PYTHON_STRUCT_BEGIN(c);
       ACTS_PYTHON_MEMBER(loc0Min);
       ACTS_PYTHON_MEMBER(loc0Max);
       ACTS_PYTHON_MEMBER(loc1Min);
@@ -129,7 +129,7 @@ void addExampleAlgorithms(Context& ctx) {
 
       c.def_property_readonly("nEtaBins", &EtaBinnedConfig::nEtaBins);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c, EtaBinnedConfig);
+      ACTS_PYTHON_STRUCT_BEGIN(c);
       ACTS_PYTHON_MEMBER(cutSets);
       ACTS_PYTHON_MEMBER(absEtaEdges);
       ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/ExampleAlgorithms.cpp
+++ b/Examples/Python/src/ExampleAlgorithms.cpp
@@ -58,11 +58,7 @@ void addExampleAlgorithms(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputTracks);
-    ACTS_PYTHON_MEMBER(outputTracks);
-    ACTS_PYTHON_MEMBER(selectorConfig);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputTracks, outputTracks, selectorConfig);
   }
 
   {
@@ -86,30 +82,11 @@ void addExampleAlgorithms(Context& ctx) {
 
       patchKwargsConstructor(c);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c);
-      ACTS_PYTHON_MEMBER(loc0Min);
-      ACTS_PYTHON_MEMBER(loc0Max);
-      ACTS_PYTHON_MEMBER(loc1Min);
-      ACTS_PYTHON_MEMBER(loc1Max);
-      ACTS_PYTHON_MEMBER(timeMin);
-      ACTS_PYTHON_MEMBER(timeMax);
-      ACTS_PYTHON_MEMBER(phiMin);
-      ACTS_PYTHON_MEMBER(phiMax);
-      ACTS_PYTHON_MEMBER(etaMin);
-      ACTS_PYTHON_MEMBER(etaMax);
-      ACTS_PYTHON_MEMBER(absEtaMin);
-      ACTS_PYTHON_MEMBER(absEtaMax);
-      ACTS_PYTHON_MEMBER(ptMin);
-      ACTS_PYTHON_MEMBER(ptMax);
-      ACTS_PYTHON_MEMBER(minMeasurements);
-      ACTS_PYTHON_MEMBER(maxHoles);
-      ACTS_PYTHON_MEMBER(maxOutliers);
-      ACTS_PYTHON_MEMBER(maxHolesAndOutliers);
-      ACTS_PYTHON_MEMBER(maxSharedHits);
-      ACTS_PYTHON_MEMBER(maxChi2);
-      ACTS_PYTHON_MEMBER(measurementCounter);
-      ACTS_PYTHON_MEMBER(requireReferenceSurface);
-      ACTS_PYTHON_STRUCT_END();
+      ACTS_PYTHON_STRUCT(c, loc0Min, loc0Max, loc1Min, loc1Max, timeMin, timeMax,
+                        phiMin, phiMax, etaMin, etaMax, absEtaMin, absEtaMax,
+                        ptMin, ptMax, minMeasurements, maxHoles, maxOutliers,
+                        maxHolesAndOutliers, maxSharedHits, maxChi2,
+                        measurementCounter, requireReferenceSurface);
 
       pythonRangeProperty(c, "loc0", &Config::loc0Min, &Config::loc0Max);
       pythonRangeProperty(c, "loc1", &Config::loc1Min, &Config::loc1Max);
@@ -129,10 +106,7 @@ void addExampleAlgorithms(Context& ctx) {
 
       c.def_property_readonly("nEtaBins", &EtaBinnedConfig::nEtaBins);
 
-      ACTS_PYTHON_STRUCT_BEGIN(c);
-      ACTS_PYTHON_MEMBER(cutSets);
-      ACTS_PYTHON_MEMBER(absEtaEdges);
-      ACTS_PYTHON_STRUCT_END();
+      ACTS_PYTHON_STRUCT(c, cutSets, absEtaEdges);
     }
   }
 }

--- a/Examples/Python/src/ExampleAlgorithms.cpp
+++ b/Examples/Python/src/ExampleAlgorithms.cpp
@@ -82,11 +82,11 @@ void addExampleAlgorithms(Context& ctx) {
 
       patchKwargsConstructor(c);
 
-      ACTS_PYTHON_STRUCT(c, loc0Min, loc0Max, loc1Min, loc1Max, timeMin, timeMax,
-                        phiMin, phiMax, etaMin, etaMax, absEtaMin, absEtaMax,
-                        ptMin, ptMax, minMeasurements, maxHoles, maxOutliers,
-                        maxHolesAndOutliers, maxSharedHits, maxChi2,
-                        measurementCounter, requireReferenceSurface);
+      ACTS_PYTHON_STRUCT(c, loc0Min, loc0Max, loc1Min, loc1Max, timeMin,
+                         timeMax, phiMin, phiMax, etaMin, etaMax, absEtaMin,
+                         absEtaMax, ptMin, ptMax, minMeasurements, maxHoles,
+                         maxOutliers, maxHolesAndOutliers, maxSharedHits,
+                         maxChi2, measurementCounter, requireReferenceSurface);
 
       pythonRangeProperty(c, "loc0", &Config::loc0Min, &Config::loc0Max);
       pythonRangeProperty(c, "loc1", &Config::loc1Min, &Config::loc1Max);

--- a/Examples/Python/src/Framework.cpp
+++ b/Examples/Python/src/Framework.cpp
@@ -181,7 +181,9 @@ void addFramework(Context& ctx) {
 
   auto c = py::class_<Config>(sequencer, "Config").def(py::init<>());
 
-  ACTS_PYTHON_STRUCT(c, skip, events, logLevel, numThreads, outputDir, outputTimingFile, trackFpes, fpeMasks, failOnFirstFpe, fpeStackTraceLength);
+  ACTS_PYTHON_STRUCT(c, skip, events, logLevel, numThreads, outputDir,
+                     outputTimingFile, trackFpes, fpeMasks, failOnFirstFpe,
+                     fpeStackTraceLength);
 
   auto fpem =
       py::class_<Sequencer::FpeMask>(sequencer, "_FpeMask")

--- a/Examples/Python/src/Framework.cpp
+++ b/Examples/Python/src/Framework.cpp
@@ -181,18 +181,7 @@ void addFramework(Context& ctx) {
 
   auto c = py::class_<Config>(sequencer, "Config").def(py::init<>());
 
-  ACTS_PYTHON_STRUCT_BEGIN(c);
-  ACTS_PYTHON_MEMBER(skip);
-  ACTS_PYTHON_MEMBER(events);
-  ACTS_PYTHON_MEMBER(logLevel);
-  ACTS_PYTHON_MEMBER(numThreads);
-  ACTS_PYTHON_MEMBER(outputDir);
-  ACTS_PYTHON_MEMBER(outputTimingFile);
-  ACTS_PYTHON_MEMBER(trackFpes);
-  ACTS_PYTHON_MEMBER(fpeMasks);
-  ACTS_PYTHON_MEMBER(failOnFirstFpe);
-  ACTS_PYTHON_MEMBER(fpeStackTraceLength);
-  ACTS_PYTHON_STRUCT_END();
+  ACTS_PYTHON_STRUCT(c, skip, events, logLevel, numThreads, outputDir, outputTimingFile, trackFpes, fpeMasks, failOnFirstFpe, fpeStackTraceLength);
 
   auto fpem =
       py::class_<Sequencer::FpeMask>(sequencer, "_FpeMask")
@@ -205,12 +194,7 @@ void addFramework(Context& ctx) {
             return ss.str();
           });
 
-  ACTS_PYTHON_STRUCT_BEGIN(fpem);
-  ACTS_PYTHON_MEMBER(file);
-  ACTS_PYTHON_MEMBER(lines);
-  ACTS_PYTHON_MEMBER(type);
-  ACTS_PYTHON_MEMBER(count);
-  ACTS_PYTHON_STRUCT_END();
+  ACTS_PYTHON_STRUCT(fpem, file, lines, type, count);
 
   struct FpeMonitorContext {
     std::optional<Acts::FpeMonitor> mon;

--- a/Examples/Python/src/Framework.cpp
+++ b/Examples/Python/src/Framework.cpp
@@ -181,7 +181,7 @@ void addFramework(Context& ctx) {
 
   auto c = py::class_<Config>(sequencer, "Config").def(py::init<>());
 
-  ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+  ACTS_PYTHON_STRUCT_BEGIN(c);
   ACTS_PYTHON_MEMBER(skip);
   ACTS_PYTHON_MEMBER(events);
   ACTS_PYTHON_MEMBER(logLevel);
@@ -205,7 +205,7 @@ void addFramework(Context& ctx) {
             return ss.str();
           });
 
-  ACTS_PYTHON_STRUCT_BEGIN(fpem, Sequencer::FpeMask);
+  ACTS_PYTHON_STRUCT_BEGIN(fpem);
   ACTS_PYTHON_MEMBER(file);
   ACTS_PYTHON_MEMBER(lines);
   ACTS_PYTHON_MEMBER(type);

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -112,12 +112,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
 
     auto c1 = py::class_<Config, std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c1);
-    ACTS_PYTHON_MEMBER(inputParticles);
-    ACTS_PYTHON_MEMBER(randomNumbers);
-    ACTS_PYTHON_MEMBER(detector);
-    ACTS_PYTHON_MEMBER(geant4Handle);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c1, inputParticles, randomNumbers, detector, geant4Handle);
   }
 
   {
@@ -135,11 +130,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     py::class_<State>(sm, "State").def(py::init<>());
 
     auto c = py::class_<Config>(sm, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(materialMappings);
-    ACTS_PYTHON_MEMBER(volumeMappings);
-    ACTS_PYTHON_MEMBER(candidateSurfaces);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, materialMappings, volumeMappings, candidateSurfaces);
 
     sm.def("create",
            [](const Config& cfg, Acts::Logging::Level level,
@@ -196,23 +187,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto c1 = py::class_<Config, Geant4SimulationBase::Config,
                          std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c1);
-    ACTS_PYTHON_MEMBER(outputSimHits);
-    ACTS_PYTHON_MEMBER(outputParticles);
-    ACTS_PYTHON_MEMBER(outputPropagationSummaries);
-    ACTS_PYTHON_MEMBER(sensitiveSurfaceMapper);
-    ACTS_PYTHON_MEMBER(magneticField);
-    ACTS_PYTHON_MEMBER(physicsList);
-    ACTS_PYTHON_MEMBER(killVolume);
-    ACTS_PYTHON_MEMBER(killAfterTime);
-    ACTS_PYTHON_MEMBER(killSecondaries);
-    ACTS_PYTHON_MEMBER(recordHitsOfCharged);
-    ACTS_PYTHON_MEMBER(recordHitsOfNeutrals);
-    ACTS_PYTHON_MEMBER(recordHitsOfPrimaries);
-    ACTS_PYTHON_MEMBER(recordHitsOfSecondaries);
-    ACTS_PYTHON_MEMBER(keepParticlesWithoutHits);
-    ACTS_PYTHON_MEMBER(recordPropagationSummaries);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c1, outputSimHits, outputParticles, outputPropagationSummaries, sensitiveSurfaceMapper, magneticField, physicsList, killVolume, killAfterTime, killSecondaries, recordHitsOfCharged, recordHitsOfNeutrals, recordHitsOfPrimaries, recordHitsOfSecondaries, keepParticlesWithoutHits, recordPropagationSummaries);
   }
 
   {
@@ -228,10 +203,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto c = py::class_<Config, Geant4SimulationBase::Config,
                         std::shared_ptr<Config>>(alg, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(outputMaterialTracks);
-    ACTS_PYTHON_MEMBER(excludeMaterials);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, outputMaterialTracks, excludeMaterials);
   }
 
   {
@@ -247,13 +219,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     using Factory = Acts::Geant4DetectorSurfaceFactory;
     auto o = py::class_<Factory::Options>(mod, "SurfaceFactoryOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(o);
-    ACTS_PYTHON_MEMBER(scaleConversion);
-    ACTS_PYTHON_MEMBER(convertMaterial);
-    ACTS_PYTHON_MEMBER(convertedMaterialThickness);
-    ACTS_PYTHON_MEMBER(sensitiveSurfaceSelector);
-    ACTS_PYTHON_MEMBER(passiveSurfaceSelector);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(o, scaleConversion, convertMaterial, convertedMaterialThickness, sensitiveSurfaceSelector, passiveSurfaceSelector);
   }
 
   {
@@ -263,14 +229,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
             .def(py::init<const Geant4Detector::Config&>());
 
     auto c = py::class_<Geant4Detector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(g4World);
-    ACTS_PYTHON_MEMBER(g4SurfaceOptions);
-    ACTS_PYTHON_MEMBER(protoDetector);
-    ACTS_PYTHON_MEMBER(geometryIdentifierHook);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, name, g4World, g4SurfaceOptions, protoDetector, geometryIdentifierHook, logLevel);
   }
 
   {
@@ -279,10 +238,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                  .def(py::init<const GdmlDetector::Config&>());
 
     auto c = py::class_<GdmlDetector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(path);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, path, logLevel);
   }
 
   {
@@ -361,18 +317,10 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
             .def("drawSector", &MockupSectorBuilder::drawSector);
 
     auto c = py::class_<Config>(ms, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(gdmlPath);
-    ACTS_PYTHON_MEMBER(NumberOfSectors);
-    ACTS_PYTHON_MEMBER(toleranceOverlap);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, gdmlPath, NumberOfSectors, toleranceOverlap);
 
     auto cch = py::class_<ChamberConfig>(ms, "ChamberConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(cch);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(SensitiveNames);
-    ACTS_PYTHON_MEMBER(PassiveNames);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(cch, name, SensitiveNames, PassiveNames);
   }
 
   {
@@ -383,13 +331,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                     .def_property_readonly("config", &Tool::config);
 
     auto c = py::class_<Config>(tool, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(gammaCut);
-    ACTS_PYTHON_MEMBER(electronCut);
-    ACTS_PYTHON_MEMBER(positronCut);
-    ACTS_PYTHON_MEMBER(protonCut);
-    ACTS_PYTHON_MEMBER(volumes);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, gammaCut, electronCut, positronCut, protonCut, volumes);
   }
 
   Acts::Python::Context ctx;

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -112,7 +112,8 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
 
     auto c1 = py::class_<Config, std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c1, inputParticles, randomNumbers, detector, geant4Handle);
+    ACTS_PYTHON_STRUCT(c1, inputParticles, randomNumbers, detector,
+                       geant4Handle);
   }
 
   {
@@ -187,7 +188,12 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto c1 = py::class_<Config, Geant4SimulationBase::Config,
                          std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c1, outputSimHits, outputParticles, outputPropagationSummaries, sensitiveSurfaceMapper, magneticField, physicsList, killVolume, killAfterTime, killSecondaries, recordHitsOfCharged, recordHitsOfNeutrals, recordHitsOfPrimaries, recordHitsOfSecondaries, keepParticlesWithoutHits, recordPropagationSummaries);
+    ACTS_PYTHON_STRUCT(
+        c1, outputSimHits, outputParticles, outputPropagationSummaries,
+        sensitiveSurfaceMapper, magneticField, physicsList, killVolume,
+        killAfterTime, killSecondaries, recordHitsOfCharged,
+        recordHitsOfNeutrals, recordHitsOfPrimaries, recordHitsOfSecondaries,
+        keepParticlesWithoutHits, recordPropagationSummaries);
   }
 
   {
@@ -219,7 +225,9 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     using Factory = Acts::Geant4DetectorSurfaceFactory;
     auto o = py::class_<Factory::Options>(mod, "SurfaceFactoryOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(o, scaleConversion, convertMaterial, convertedMaterialThickness, sensitiveSurfaceSelector, passiveSurfaceSelector);
+    ACTS_PYTHON_STRUCT(o, scaleConversion, convertMaterial,
+                       convertedMaterialThickness, sensitiveSurfaceSelector,
+                       passiveSurfaceSelector);
   }
 
   {
@@ -229,7 +237,8 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
             .def(py::init<const Geant4Detector::Config&>());
 
     auto c = py::class_<Geant4Detector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, name, g4World, g4SurfaceOptions, protoDetector, geometryIdentifierHook, logLevel);
+    ACTS_PYTHON_STRUCT(c, name, g4World, g4SurfaceOptions, protoDetector,
+                       geometryIdentifierHook, logLevel);
   }
 
   {
@@ -331,7 +340,8 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                     .def_property_readonly("config", &Tool::config);
 
     auto c = py::class_<Config>(tool, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, gammaCut, electronCut, positronCut, protonCut, volumes);
+    ACTS_PYTHON_STRUCT(c, gammaCut, electronCut, positronCut, protonCut,
+                       volumes);
   }
 
   Acts::Python::Context ctx;

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -112,7 +112,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
 
     auto c1 = py::class_<Config, std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c1, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c1);
     ACTS_PYTHON_MEMBER(inputParticles);
     ACTS_PYTHON_MEMBER(randomNumbers);
     ACTS_PYTHON_MEMBER(detector);
@@ -135,7 +135,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     py::class_<State>(sm, "State").def(py::init<>());
 
     auto c = py::class_<Config>(sm, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(materialMappings);
     ACTS_PYTHON_MEMBER(volumeMappings);
     ACTS_PYTHON_MEMBER(candidateSurfaces);
@@ -196,7 +196,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto c1 = py::class_<Config, Geant4SimulationBase::Config,
                          std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c1, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c1);
     ACTS_PYTHON_MEMBER(outputSimHits);
     ACTS_PYTHON_MEMBER(outputParticles);
     ACTS_PYTHON_MEMBER(outputPropagationSummaries);
@@ -228,7 +228,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto c = py::class_<Config, Geant4SimulationBase::Config,
                         std::shared_ptr<Config>>(alg, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(outputMaterialTracks);
     ACTS_PYTHON_MEMBER(excludeMaterials);
     ACTS_PYTHON_STRUCT_END();
@@ -247,7 +247,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     using Factory = Acts::Geant4DetectorSurfaceFactory;
     auto o = py::class_<Factory::Options>(mod, "SurfaceFactoryOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(o, Factory::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(o);
     ACTS_PYTHON_MEMBER(scaleConversion);
     ACTS_PYTHON_MEMBER(convertMaterial);
     ACTS_PYTHON_MEMBER(convertedMaterialThickness);
@@ -263,7 +263,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
             .def(py::init<const Geant4Detector::Config&>());
 
     auto c = py::class_<Geant4Detector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Geant4Detector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(g4World);
     ACTS_PYTHON_MEMBER(g4SurfaceOptions);
@@ -279,7 +279,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                  .def(py::init<const GdmlDetector::Config&>());
 
     auto c = py::class_<GdmlDetector::Config>(f, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, GdmlDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(path);
     ACTS_PYTHON_MEMBER(logLevel);
     ACTS_PYTHON_STRUCT_END();
@@ -361,14 +361,14 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
             .def("drawSector", &MockupSectorBuilder::drawSector);
 
     auto c = py::class_<Config>(ms, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(gdmlPath);
     ACTS_PYTHON_MEMBER(NumberOfSectors);
     ACTS_PYTHON_MEMBER(toleranceOverlap);
     ACTS_PYTHON_STRUCT_END();
 
     auto cch = py::class_<ChamberConfig>(ms, "ChamberConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(cch, ChamberConfig);
+    ACTS_PYTHON_STRUCT_BEGIN(cch);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(SensitiveNames);
     ACTS_PYTHON_MEMBER(PassiveNames);
@@ -383,7 +383,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                     .def_property_readonly("config", &Tool::config);
 
     auto c = py::class_<Config>(tool, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(gammaCut);
     ACTS_PYTHON_MEMBER(electronCut);
     ACTS_PYTHON_MEMBER(positronCut);

--- a/Examples/Python/src/GeoModel.cpp
+++ b/Examples/Python/src/GeoModel.cpp
@@ -70,7 +70,7 @@ void addGeoModel(Context& ctx) {
 
     auto c = py::class_<ActsExamples::GeoModelDetector::Config>(f, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, ActsExamples::GeoModelDetector::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(path);
     ACTS_PYTHON_MEMBER(logLevel);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/GeoModel.cpp
+++ b/Examples/Python/src/GeoModel.cpp
@@ -70,10 +70,7 @@ void addGeoModel(Context& ctx) {
 
     auto c = py::class_<ActsExamples::GeoModelDetector::Config>(f, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(path);
-    ACTS_PYTHON_MEMBER(logLevel);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, path, logLevel);
 
     // patch the constructor
     patchKwargsConstructor(c);

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -492,17 +492,9 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto lsConfig =
-        py::class_<LayerStructureBuilder::Config>(lsBuilder, "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(lsConfig);
-    ACTS_PYTHON_MEMBER(surfacesProvider);
-    ACTS_PYTHON_MEMBER(supports);
-    ACTS_PYTHON_MEMBER(binnings);
-    ACTS_PYTHON_MEMBER(quarterSegments);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    auto lsConfig = py::class_<LayerStructureBuilder::Config>(lsBuilder, "Config")
+                       .def(py::init<>());
+    ACTS_PYTHON_STRUCT(lsConfig, surfacesProvider, supports, binnings, quarterSegments, auxiliary);
 
     // The internal layer structure builder
     py::class_<Acts::Experimental::ISurfacesProvider,
@@ -607,16 +599,9 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto vsConfig =
-        py::class_<VolumeStructureBuilder::Config>(vsBuilder, "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(vsConfig);
-    ACTS_PYTHON_MEMBER(boundsType);
-    ACTS_PYTHON_MEMBER(boundValues);
-    ACTS_PYTHON_MEMBER(transform);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    auto vsConfig = py::class_<VolumeStructureBuilder::Config>(vsBuilder, "Config")
+                       .def(py::init<>());
+    ACTS_PYTHON_STRUCT(vsConfig, boundsType, boundValues, transform, auxiliary);
   }
 
   {
@@ -637,17 +622,11 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto geoIdGenConfig =
-        py::class_<Acts::Experimental::GeometryIdGenerator::Config>(geoIdGen,
-                                                                    "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(geoIdGenConfig);
-    ACTS_PYTHON_MEMBER(containerMode);
-    ACTS_PYTHON_MEMBER(containerId);
-    ACTS_PYTHON_MEMBER(resetSubCounters);
-    ACTS_PYTHON_MEMBER(overrideExistingIds);
-    ACTS_PYTHON_STRUCT_END();
+    auto geoIdGenConfig = py::class_<Acts::Experimental::GeometryIdGenerator::Config>(
+                             geoIdGen, "Config")
+                             .def(py::init<>());
+    ACTS_PYTHON_STRUCT(geoIdGenConfig, containerMode, containerId, resetSubCounters,
+                      overrideExistingIds);
   }
 
   {
@@ -669,17 +648,10 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &DetectorVolumeBuilder::construct);
 
-    auto dvConfig =
-        py::class_<DetectorVolumeBuilder::Config>(dvBuilder, "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(dvConfig);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(internalsBuilder);
-    ACTS_PYTHON_MEMBER(externalsBuilder);
-    ACTS_PYTHON_MEMBER(geoIdGenerator);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    auto dvConfig = py::class_<DetectorVolumeBuilder::Config>(dvBuilder, "Config")
+                       .def(py::init<>());
+    ACTS_PYTHON_STRUCT(dvConfig, name, internalsBuilder, externalsBuilder, geoIdGenerator,
+                      auxiliary);
   }
 
   {
@@ -712,18 +684,10 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &CylindricalContainerBuilder::construct);
 
-    auto ccConfig =
-        py::class_<CylindricalContainerBuilder::Config>(ccBuilder, "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(ccConfig);
-    ACTS_PYTHON_MEMBER(builders);
-    ACTS_PYTHON_MEMBER(binning);
-    ACTS_PYTHON_MEMBER(rootVolumeFinderBuilder);
-    ACTS_PYTHON_MEMBER(geoIdGenerator);
-    ACTS_PYTHON_MEMBER(geoIdReverseGen);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    auto ccConfig = py::class_<CylindricalContainerBuilder::Config>(ccBuilder, "Config")
+                       .def(py::init<>());
+    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder, geoIdGenerator,
+                      geoIdReverseGen, auxiliary);
   }
 
   {
@@ -741,18 +705,10 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &CuboidalContainerBuilder::construct);
 
-    auto ccConfig =
-        py::class_<CuboidalContainerBuilder::Config>(ccBuilder, "Config")
-            .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(ccConfig);
-    ACTS_PYTHON_MEMBER(builders);
-    ACTS_PYTHON_MEMBER(binning);
-    ACTS_PYTHON_MEMBER(rootVolumeFinderBuilder);
-    ACTS_PYTHON_MEMBER(geoIdGenerator);
-    ACTS_PYTHON_MEMBER(geoIdReverseGen);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    auto ccConfig = py::class_<CuboidalContainerBuilder::Config>(ccBuilder, "Config")
+                       .def(py::init<>());
+    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder, geoIdGenerator,
+                      geoIdReverseGen, auxiliary);
   }
 
   {
@@ -770,14 +726,7 @@ void addExperimentalGeometry(Context& ctx) {
 
     auto dConfig = py::class_<DetectorBuilder::Config>(dBuilder, "Config")
                        .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(dConfig);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(builder);
-    ACTS_PYTHON_MEMBER(geoIdGenerator);
-    ACTS_PYTHON_MEMBER(materialDecorator);
-    ACTS_PYTHON_MEMBER(auxiliary);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(dConfig, name, builder, geoIdGenerator, materialDecorator, auxiliary);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::VolumeAssociationTest, mex,

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -492,9 +492,11 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto lsConfig = py::class_<LayerStructureBuilder::Config>(lsBuilder, "Config")
-                       .def(py::init<>());
-    ACTS_PYTHON_STRUCT(lsConfig, surfacesProvider, supports, binnings, quarterSegments, auxiliary);
+    auto lsConfig =
+        py::class_<LayerStructureBuilder::Config>(lsBuilder, "Config")
+            .def(py::init<>());
+    ACTS_PYTHON_STRUCT(lsConfig, surfacesProvider, supports, binnings,
+                       quarterSegments, auxiliary);
 
     // The internal layer structure builder
     py::class_<Acts::Experimental::ISurfacesProvider,
@@ -599,8 +601,9 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto vsConfig = py::class_<VolumeStructureBuilder::Config>(vsBuilder, "Config")
-                       .def(py::init<>());
+    auto vsConfig =
+        py::class_<VolumeStructureBuilder::Config>(vsBuilder, "Config")
+            .def(py::init<>());
     ACTS_PYTHON_STRUCT(vsConfig, boundsType, boundValues, transform, auxiliary);
   }
 
@@ -622,11 +625,12 @@ void addExperimentalGeometry(Context& ctx) {
                   config, getDefaultLogger(name, level));
             }));
 
-    auto geoIdGenConfig = py::class_<Acts::Experimental::GeometryIdGenerator::Config>(
-                             geoIdGen, "Config")
-                             .def(py::init<>());
-    ACTS_PYTHON_STRUCT(geoIdGenConfig, containerMode, containerId, resetSubCounters,
-                      overrideExistingIds);
+    auto geoIdGenConfig =
+        py::class_<Acts::Experimental::GeometryIdGenerator::Config>(geoIdGen,
+                                                                    "Config")
+            .def(py::init<>());
+    ACTS_PYTHON_STRUCT(geoIdGenConfig, containerMode, containerId,
+                       resetSubCounters, overrideExistingIds);
   }
 
   {
@@ -648,10 +652,11 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &DetectorVolumeBuilder::construct);
 
-    auto dvConfig = py::class_<DetectorVolumeBuilder::Config>(dvBuilder, "Config")
-                       .def(py::init<>());
-    ACTS_PYTHON_STRUCT(dvConfig, name, internalsBuilder, externalsBuilder, geoIdGenerator,
-                      auxiliary);
+    auto dvConfig =
+        py::class_<DetectorVolumeBuilder::Config>(dvBuilder, "Config")
+            .def(py::init<>());
+    ACTS_PYTHON_STRUCT(dvConfig, name, internalsBuilder, externalsBuilder,
+                       geoIdGenerator, auxiliary);
   }
 
   {
@@ -684,10 +689,11 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &CylindricalContainerBuilder::construct);
 
-    auto ccConfig = py::class_<CylindricalContainerBuilder::Config>(ccBuilder, "Config")
-                       .def(py::init<>());
-    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder, geoIdGenerator,
-                      geoIdReverseGen, auxiliary);
+    auto ccConfig =
+        py::class_<CylindricalContainerBuilder::Config>(ccBuilder, "Config")
+            .def(py::init<>());
+    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder,
+                       geoIdGenerator, geoIdReverseGen, auxiliary);
   }
 
   {
@@ -705,10 +711,11 @@ void addExperimentalGeometry(Context& ctx) {
             }))
             .def("construct", &CuboidalContainerBuilder::construct);
 
-    auto ccConfig = py::class_<CuboidalContainerBuilder::Config>(ccBuilder, "Config")
-                       .def(py::init<>());
-    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder, geoIdGenerator,
-                      geoIdReverseGen, auxiliary);
+    auto ccConfig =
+        py::class_<CuboidalContainerBuilder::Config>(ccBuilder, "Config")
+            .def(py::init<>());
+    ACTS_PYTHON_STRUCT(ccConfig, builders, binning, rootVolumeFinderBuilder,
+                       geoIdGenerator, geoIdReverseGen, auxiliary);
   }
 
   {
@@ -726,7 +733,8 @@ void addExperimentalGeometry(Context& ctx) {
 
     auto dConfig = py::class_<DetectorBuilder::Config>(dBuilder, "Config")
                        .def(py::init<>());
-    ACTS_PYTHON_STRUCT(dConfig, name, builder, geoIdGenerator, materialDecorator, auxiliary);
+    ACTS_PYTHON_STRUCT(dConfig, name, builder, geoIdGenerator,
+                       materialDecorator, auxiliary);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::VolumeAssociationTest, mex,

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -496,7 +496,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<LayerStructureBuilder::Config>(lsBuilder, "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(lsConfig, LayerStructureBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(lsConfig);
     ACTS_PYTHON_MEMBER(surfacesProvider);
     ACTS_PYTHON_MEMBER(supports);
     ACTS_PYTHON_MEMBER(binnings);
@@ -611,7 +611,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<VolumeStructureBuilder::Config>(vsBuilder, "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(vsConfig, VolumeStructureBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(vsConfig);
     ACTS_PYTHON_MEMBER(boundsType);
     ACTS_PYTHON_MEMBER(boundValues);
     ACTS_PYTHON_MEMBER(transform);
@@ -642,8 +642,7 @@ void addExperimentalGeometry(Context& ctx) {
                                                                     "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(geoIdGenConfig,
-                             Acts::Experimental::GeometryIdGenerator::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(geoIdGenConfig);
     ACTS_PYTHON_MEMBER(containerMode);
     ACTS_PYTHON_MEMBER(containerId);
     ACTS_PYTHON_MEMBER(resetSubCounters);
@@ -674,7 +673,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<DetectorVolumeBuilder::Config>(dvBuilder, "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(dvConfig, DetectorVolumeBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(dvConfig);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(internalsBuilder);
     ACTS_PYTHON_MEMBER(externalsBuilder);
@@ -717,7 +716,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<CylindricalContainerBuilder::Config>(ccBuilder, "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(ccConfig, CylindricalContainerBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(ccConfig);
     ACTS_PYTHON_MEMBER(builders);
     ACTS_PYTHON_MEMBER(binning);
     ACTS_PYTHON_MEMBER(rootVolumeFinderBuilder);
@@ -746,7 +745,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<CuboidalContainerBuilder::Config>(ccBuilder, "Config")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(ccConfig, CuboidalContainerBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(ccConfig);
     ACTS_PYTHON_MEMBER(builders);
     ACTS_PYTHON_MEMBER(binning);
     ACTS_PYTHON_MEMBER(rootVolumeFinderBuilder);
@@ -772,7 +771,7 @@ void addExperimentalGeometry(Context& ctx) {
     auto dConfig = py::class_<DetectorBuilder::Config>(dBuilder, "Config")
                        .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(dConfig, DetectorBuilder::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(dConfig);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(builder);
     ACTS_PYTHON_MEMBER(geoIdGenerator);

--- a/Examples/Python/src/GeometryBuildingGen1.cpp
+++ b/Examples/Python/src/GeometryBuildingGen1.cpp
@@ -54,13 +54,8 @@ void addGeometryBuildingGen1(Context &ctx) {
     auto config =
         py::class_<LayerCreator::Config>(creator, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(config);
-    ACTS_PYTHON_MEMBER(surfaceArrayCreator);
-    ACTS_PYTHON_MEMBER(cylinderZtolerance);
-    ACTS_PYTHON_MEMBER(cylinderPhiTolerance);
-    ACTS_PYTHON_MEMBER(defaultEnvelopeR);
-    ACTS_PYTHON_MEMBER(defaultEnvelopeZ);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(config, surfaceArrayCreator, cylinderZtolerance,
+                      cylinderPhiTolerance, defaultEnvelopeR, defaultEnvelopeZ);
   }
 
   {
@@ -125,13 +120,9 @@ void addGeometryBuildingGen1(Context &ctx) {
     auto config = py::class_<CylinderVolumeHelper::Config>(helper, "Config")
                       .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(config);
-    ACTS_PYTHON_MEMBER(layerArrayCreator);
-    ACTS_PYTHON_MEMBER(trackingVolumeArrayCreator);
-    ACTS_PYTHON_MEMBER(passiveLayerThickness);
-    ACTS_PYTHON_MEMBER(passiveLayerPhiBins);
-    ACTS_PYTHON_MEMBER(passiveLayerRzBins);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(config, layerArrayCreator, trackingVolumeArrayCreator,
+                      passiveLayerThickness, passiveLayerPhiBins,
+                      passiveLayerRzBins);
   }
 }
 

--- a/Examples/Python/src/GeometryBuildingGen1.cpp
+++ b/Examples/Python/src/GeometryBuildingGen1.cpp
@@ -55,7 +55,8 @@ void addGeometryBuildingGen1(Context &ctx) {
         py::class_<LayerCreator::Config>(creator, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(config, surfaceArrayCreator, cylinderZtolerance,
-                      cylinderPhiTolerance, defaultEnvelopeR, defaultEnvelopeZ);
+                       cylinderPhiTolerance, defaultEnvelopeR,
+                       defaultEnvelopeZ);
   }
 
   {
@@ -121,8 +122,8 @@ void addGeometryBuildingGen1(Context &ctx) {
                       .def(py::init<>());
 
     ACTS_PYTHON_STRUCT(config, layerArrayCreator, trackingVolumeArrayCreator,
-                      passiveLayerThickness, passiveLayerPhiBins,
-                      passiveLayerRzBins);
+                       passiveLayerThickness, passiveLayerPhiBins,
+                       passiveLayerRzBins);
   }
 }
 

--- a/Examples/Python/src/GeometryBuildingGen1.cpp
+++ b/Examples/Python/src/GeometryBuildingGen1.cpp
@@ -54,7 +54,7 @@ void addGeometryBuildingGen1(Context &ctx) {
     auto config =
         py::class_<LayerCreator::Config>(creator, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(config, LayerCreator::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(config);
     ACTS_PYTHON_MEMBER(surfaceArrayCreator);
     ACTS_PYTHON_MEMBER(cylinderZtolerance);
     ACTS_PYTHON_MEMBER(cylinderPhiTolerance);
@@ -125,7 +125,7 @@ void addGeometryBuildingGen1(Context &ctx) {
     auto config = py::class_<CylinderVolumeHelper::Config>(helper, "Config")
                       .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(config, CylinderVolumeHelper::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(config);
     ACTS_PYTHON_MEMBER(layerArrayCreator);
     ACTS_PYTHON_MEMBER(trackingVolumeArrayCreator);
     ACTS_PYTHON_MEMBER(passiveLayerThickness);

--- a/Examples/Python/src/Hashing.cpp
+++ b/Examples/Python/src/Hashing.cpp
@@ -33,7 +33,7 @@ void addHashing(Context& ctx) {
     using Config = Acts::HashingAlgorithmConfig;
     auto c = py::class_<Config>(hashingModule, "HashingAlgorithmConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(bucketSize);
     ACTS_PYTHON_MEMBER(zBins);
     ACTS_PYTHON_MEMBER(phiBins);
@@ -45,7 +45,7 @@ void addHashing(Context& ctx) {
     using Config = Acts::HashingTrainingConfig;
     auto c = py::class_<Config>(hashingModule, "HashingTrainingConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(annoySeed);
     ACTS_PYTHON_MEMBER(f);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/Hashing.cpp
+++ b/Examples/Python/src/Hashing.cpp
@@ -33,11 +33,7 @@ void addHashing(Context& ctx) {
     using Config = Acts::HashingAlgorithmConfig;
     auto c = py::class_<Config>(hashingModule, "HashingAlgorithmConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(bucketSize);
-    ACTS_PYTHON_MEMBER(zBins);
-    ACTS_PYTHON_MEMBER(phiBins);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, bucketSize, zBins, phiBins);
     patchKwargsConstructor(c);
   }
 
@@ -45,10 +41,7 @@ void addHashing(Context& ctx) {
     using Config = Acts::HashingTrainingConfig;
     auto c = py::class_<Config>(hashingModule, "HashingTrainingConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(annoySeed);
-    ACTS_PYTHON_MEMBER(f);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, annoySeed, f);
     patchKwargsConstructor(c);
   }
 

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -76,8 +76,9 @@ void addJson(Context& ctx) {
 
     auto c = py::class_<MaterialMapJsonConverter::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, context, processSensitives, processApproaches, processRepresenting,
-                      processBoundaries, processVolumes, processDenseVolumes, processNonMaterial);
+    ACTS_PYTHON_STRUCT(c, context, processSensitives, processApproaches,
+                       processRepresenting, processBoundaries, processVolumes,
+                       processDenseVolumes, processNonMaterial);
   }
 
   {
@@ -156,7 +157,9 @@ void addJson(Context& ctx) {
     auto c =
         py::class_<JsonSurfacesWriter::Config>(cls, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, trackingGeometry, outputDir, outputPrecision, writeLayer, writeApproach, writeSensitive, writeBoundary, writePerEvent, writeOnlyNames);
+    ACTS_PYTHON_STRUCT(c, trackingGeometry, outputDir, outputPrecision,
+                       writeLayer, writeApproach, writeSensitive, writeBoundary,
+                       writePerEvent, writeOnlyNames);
   }
 
   {

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -76,16 +76,8 @@ void addJson(Context& ctx) {
 
     auto c = py::class_<MaterialMapJsonConverter::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(context);
-    ACTS_PYTHON_MEMBER(processSensitives);
-    ACTS_PYTHON_MEMBER(processApproaches);
-    ACTS_PYTHON_MEMBER(processRepresenting);
-    ACTS_PYTHON_MEMBER(processBoundaries);
-    ACTS_PYTHON_MEMBER(processVolumes);
-    ACTS_PYTHON_MEMBER(processDenseVolumes);
-    ACTS_PYTHON_MEMBER(processNonMaterial);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, context, processSensitives, processApproaches, processRepresenting,
+                      processBoundaries, processVolumes, processDenseVolumes, processNonMaterial);
   }
 
   {
@@ -110,12 +102,7 @@ void addJson(Context& ctx) {
 
     auto c =
         py::class_<JsonMaterialWriter::Config>(cls, "Config").def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(converterCfg);
-    ACTS_PYTHON_MEMBER(fileName);
-    ACTS_PYTHON_MEMBER(writeFormat);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, converterCfg, fileName, writeFormat);
   }
 
   {
@@ -132,10 +119,7 @@ void addJson(Context& ctx) {
     auto c = py::class_<Config>(cls, "Config")
                  .def(py::init<>())
                  .def(py::init<const std::string&>(), py::arg("path"));
-
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(path);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, path);
   }
 
   {
@@ -155,11 +139,7 @@ void addJson(Context& ctx) {
                                                   const Acts::Surface*>,
                                std::pair<double, double>>(),
                       py::arg("refLayers"), py::arg("bins"));
-
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(refLayers);
-    ACTS_PYTHON_MEMBER(bins);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, refLayers, bins);
   }
 
   {
@@ -176,17 +156,7 @@ void addJson(Context& ctx) {
     auto c =
         py::class_<JsonSurfacesWriter::Config>(cls, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_MEMBER(outputDir);
-    ACTS_PYTHON_MEMBER(outputPrecision);
-    ACTS_PYTHON_MEMBER(writeLayer);
-    ACTS_PYTHON_MEMBER(writeApproach);
-    ACTS_PYTHON_MEMBER(writeSensitive);
-    ACTS_PYTHON_MEMBER(writeBoundary);
-    ACTS_PYTHON_MEMBER(writePerEvent);
-    ACTS_PYTHON_MEMBER(writeOnlyNames);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, trackingGeometry, outputDir, outputPrecision, writeLayer, writeApproach, writeSensitive, writeBoundary, writePerEvent, writeOnlyNames);
   }
 
   {
@@ -207,11 +177,7 @@ void addJson(Context& ctx) {
     auto sjOptions =
         py::class_<Acts::JsonSurfacesReader::Options>(m, "SurfaceJsonOptions")
             .def(py::init<>());
-
-    ACTS_PYTHON_STRUCT_BEGIN(sjOptions);
-    ACTS_PYTHON_MEMBER(inputFile);
-    ACTS_PYTHON_MEMBER(jsonEntryPath);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(sjOptions, inputFile, jsonEntryPath);
 
     m.def("readSurfaceHierarchyMapFromJson",
           Acts::JsonSurfacesReader::readHierarchyMap);

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -76,7 +76,7 @@ void addJson(Context& ctx) {
 
     auto c = py::class_<MaterialMapJsonConverter::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, MaterialMapJsonConverter::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(context);
     ACTS_PYTHON_MEMBER(processSensitives);
     ACTS_PYTHON_MEMBER(processApproaches);
@@ -111,7 +111,7 @@ void addJson(Context& ctx) {
     auto c =
         py::class_<JsonMaterialWriter::Config>(cls, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, JsonMaterialWriter::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(converterCfg);
     ACTS_PYTHON_MEMBER(fileName);
     ACTS_PYTHON_MEMBER(writeFormat);
@@ -133,7 +133,7 @@ void addJson(Context& ctx) {
                  .def(py::init<>())
                  .def(py::init<const std::string&>(), py::arg("path"));
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(path);
     ACTS_PYTHON_STRUCT_END();
   }
@@ -156,7 +156,7 @@ void addJson(Context& ctx) {
                                std::pair<double, double>>(),
                       py::arg("refLayers"), py::arg("bins"));
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(refLayers);
     ACTS_PYTHON_MEMBER(bins);
     ACTS_PYTHON_STRUCT_END();
@@ -176,7 +176,7 @@ void addJson(Context& ctx) {
     auto c =
         py::class_<JsonSurfacesWriter::Config>(cls, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, JsonSurfacesWriter::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(trackingGeometry);
     ACTS_PYTHON_MEMBER(outputDir);
     ACTS_PYTHON_MEMBER(outputPrecision);
@@ -208,7 +208,7 @@ void addJson(Context& ctx) {
         py::class_<Acts::JsonSurfacesReader::Options>(m, "SurfaceJsonOptions")
             .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(sjOptions, Acts::JsonSurfacesReader::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(sjOptions);
     ACTS_PYTHON_MEMBER(inputFile);
     ACTS_PYTHON_MEMBER(jsonEntryPath);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/Material.cpp
+++ b/Examples/Python/src/Material.cpp
@@ -98,8 +98,9 @@ void addMaterial(Context& ctx) {
     using Config = RootMaterialDecorator::Config;
     auto c = py::class_<Config>(rmd, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, voltag, boutag, laytag, apptag, sentag, ntag, vtag, otag,
-                      mintag, maxtag, ttag, x0tag, l0tag, atag, ztag, rhotag, fileName);
+    ACTS_PYTHON_STRUCT(c, voltag, boutag, laytag, apptag, sentag, ntag, vtag,
+                       otag, mintag, maxtag, ttag, x0tag, l0tag, atag, ztag,
+                       rhotag, fileName);
   }
 
   {
@@ -129,9 +130,10 @@ void addMaterial(Context& ctx) {
                  .def(py::init<const Acts::GeometryContext&,
                                const Acts::MagneticFieldContext&>());
 
-    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappingMaterialCollection, materialSurfaceMapper,
-                      materialVolumeMapper, materialWriters, trackingGeometry, geoContext,
-                      magFieldContext);
+    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappingMaterialCollection,
+                       materialSurfaceMapper, materialVolumeMapper,
+                       materialWriters, trackingGeometry, geoContext,
+                       magFieldContext);
   }
 
   {
@@ -150,7 +152,8 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<SurfaceMaterialMapper::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, etaRange, emptyBinCorrection, mapperDebugOutput, computeVariance);
+    ACTS_PYTHON_STRUCT(c, etaRange, emptyBinCorrection, mapperDebugOutput,
+                       computeVariance);
   }
 
   {
@@ -256,8 +259,9 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<CoreMaterialMapping::Config>(mmca, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappedMaterialTracks, unmappedMaterialTracks,
-                      materialMapper, materiaMaplWriters);
+    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappedMaterialTracks,
+                       unmappedMaterialTracks, materialMapper,
+                       materiaMaplWriters);
   }
 
   {
@@ -289,8 +293,9 @@ void addMaterial(Context& ctx) {
 
     auto c =
         py::class_<MaterialValidation::Config>(mv, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, ntracks, startPosition, phiRange, etaRange, randomNumberSvc,
-                      materialValidater, outputMaterialTracks);
+    ACTS_PYTHON_STRUCT(c, ntracks, startPosition, phiRange, etaRange,
+                       randomNumberSvc, materialValidater,
+                       outputMaterialTracks);
   }
 }
 

--- a/Examples/Python/src/Material.cpp
+++ b/Examples/Python/src/Material.cpp
@@ -98,7 +98,7 @@ void addMaterial(Context& ctx) {
     using Config = RootMaterialDecorator::Config;
     auto c = py::class_<Config>(rmd, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(voltag);
     ACTS_PYTHON_MEMBER(boutag);
     ACTS_PYTHON_MEMBER(laytag);
@@ -146,7 +146,7 @@ void addMaterial(Context& ctx) {
                  .def(py::init<const Acts::GeometryContext&,
                                const Acts::MagneticFieldContext&>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Alg::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputMaterialTracks);
     ACTS_PYTHON_MEMBER(mappingMaterialCollection);
     ACTS_PYTHON_MEMBER(materialSurfaceMapper);
@@ -174,7 +174,7 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<SurfaceMaterialMapper::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, SurfaceMaterialMapper::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(etaRange);
     ACTS_PYTHON_MEMBER(emptyBinCorrection);
     ACTS_PYTHON_MEMBER(mapperDebugOutput);
@@ -197,7 +197,7 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<VolumeMaterialMapper::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, VolumeMaterialMapper::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(mappingStep);
     ACTS_PYTHON_STRUCT_END();
   }
@@ -227,7 +227,7 @@ void addMaterial(Context& ctx) {
     auto c =
         py::class_<Acts::IntersectionMaterialAssigner::Config>(isma, "Config")
             .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Acts::IntersectionMaterialAssigner::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(surfaces);
     ACTS_PYTHON_MEMBER(trackingVolumes);
     ACTS_PYTHON_MEMBER(detectorVolumes);
@@ -264,7 +264,7 @@ void addMaterial(Context& ctx) {
     auto c =
         py::class_<BinnedSurfaceMaterialAccumulater::Config>(bsma, "Config")
             .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, BinnedSurfaceMaterialAccumulater::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(emptyBinCorrection);
     ACTS_PYTHON_MEMBER(materialSurfaces);
     ACTS_PYTHON_STRUCT_END();
@@ -281,7 +281,7 @@ void addMaterial(Context& ctx) {
                        py::arg("config"), py::arg("level"));
 
     auto c = py::class_<MaterialMapper::Config>(mm, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, MaterialMapper::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(assignmentFinder);
     ACTS_PYTHON_MEMBER(surfaceMaterialAccumulater);
     ACTS_PYTHON_STRUCT_END();
@@ -297,7 +297,7 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<CoreMaterialMapping::Config>(mmca, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, CoreMaterialMapping::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputMaterialTracks);
     ACTS_PYTHON_MEMBER(mappedMaterialTracks);
     ACTS_PYTHON_MEMBER(unmappedMaterialTracks);
@@ -320,7 +320,7 @@ void addMaterial(Context& ctx) {
 
     auto c =
         py::class_<MaterialValidater::Config>(mvc, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, MaterialValidater::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(materialAssigner);
     ACTS_PYTHON_STRUCT_END();
   }
@@ -337,7 +337,7 @@ void addMaterial(Context& ctx) {
 
     auto c =
         py::class_<MaterialValidation::Config>(mv, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, MaterialValidation::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(ntracks);
     ACTS_PYTHON_MEMBER(startPosition);
     ACTS_PYTHON_MEMBER(phiRange);

--- a/Examples/Python/src/Material.cpp
+++ b/Examples/Python/src/Material.cpp
@@ -98,25 +98,8 @@ void addMaterial(Context& ctx) {
     using Config = RootMaterialDecorator::Config;
     auto c = py::class_<Config>(rmd, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(voltag);
-    ACTS_PYTHON_MEMBER(boutag);
-    ACTS_PYTHON_MEMBER(laytag);
-    ACTS_PYTHON_MEMBER(apptag);
-    ACTS_PYTHON_MEMBER(sentag);
-    ACTS_PYTHON_MEMBER(ntag);
-    ACTS_PYTHON_MEMBER(vtag);
-    ACTS_PYTHON_MEMBER(otag);
-    ACTS_PYTHON_MEMBER(mintag);
-    ACTS_PYTHON_MEMBER(maxtag);
-    ACTS_PYTHON_MEMBER(ttag);
-    ACTS_PYTHON_MEMBER(x0tag);
-    ACTS_PYTHON_MEMBER(l0tag);
-    ACTS_PYTHON_MEMBER(atag);
-    ACTS_PYTHON_MEMBER(ztag);
-    ACTS_PYTHON_MEMBER(rhotag);
-    ACTS_PYTHON_MEMBER(fileName);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, voltag, boutag, laytag, apptag, sentag, ntag, vtag, otag,
+                      mintag, maxtag, ttag, x0tag, l0tag, atag, ztag, rhotag, fileName);
   }
 
   {
@@ -146,16 +129,9 @@ void addMaterial(Context& ctx) {
                  .def(py::init<const Acts::GeometryContext&,
                                const Acts::MagneticFieldContext&>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputMaterialTracks);
-    ACTS_PYTHON_MEMBER(mappingMaterialCollection);
-    ACTS_PYTHON_MEMBER(materialSurfaceMapper);
-    ACTS_PYTHON_MEMBER(materialVolumeMapper);
-    ACTS_PYTHON_MEMBER(materialWriters);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_MEMBER(geoContext);
-    ACTS_PYTHON_MEMBER(magFieldContext);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappingMaterialCollection, materialSurfaceMapper,
+                      materialVolumeMapper, materialWriters, trackingGeometry, geoContext,
+                      magFieldContext);
   }
 
   {
@@ -174,12 +150,7 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<SurfaceMaterialMapper::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(etaRange);
-    ACTS_PYTHON_MEMBER(emptyBinCorrection);
-    ACTS_PYTHON_MEMBER(mapperDebugOutput);
-    ACTS_PYTHON_MEMBER(computeVariance);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, etaRange, emptyBinCorrection, mapperDebugOutput, computeVariance);
   }
 
   {
@@ -197,9 +168,7 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<VolumeMaterialMapper::Config>(cls, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(mappingStep);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, mappingStep);
   }
 
   {
@@ -227,11 +196,7 @@ void addMaterial(Context& ctx) {
     auto c =
         py::class_<Acts::IntersectionMaterialAssigner::Config>(isma, "Config")
             .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(surfaces);
-    ACTS_PYTHON_MEMBER(trackingVolumes);
-    ACTS_PYTHON_MEMBER(detectorVolumes);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, surfaces, trackingVolumes, detectorVolumes);
   }
 
   {
@@ -264,10 +229,7 @@ void addMaterial(Context& ctx) {
     auto c =
         py::class_<BinnedSurfaceMaterialAccumulater::Config>(bsma, "Config")
             .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(emptyBinCorrection);
-    ACTS_PYTHON_MEMBER(materialSurfaces);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, emptyBinCorrection, materialSurfaces);
   }
 
   {
@@ -281,10 +243,7 @@ void addMaterial(Context& ctx) {
                        py::arg("config"), py::arg("level"));
 
     auto c = py::class_<MaterialMapper::Config>(mm, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(assignmentFinder);
-    ACTS_PYTHON_MEMBER(surfaceMaterialAccumulater);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, assignmentFinder, surfaceMaterialAccumulater);
   }
 
   {
@@ -297,13 +256,8 @@ void addMaterial(Context& ctx) {
 
     auto c = py::class_<CoreMaterialMapping::Config>(mmca, "Config")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputMaterialTracks);
-    ACTS_PYTHON_MEMBER(mappedMaterialTracks);
-    ACTS_PYTHON_MEMBER(unmappedMaterialTracks);
-    ACTS_PYTHON_MEMBER(materialMapper);
-    ACTS_PYTHON_MEMBER(materiaMaplWriters);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputMaterialTracks, mappedMaterialTracks, unmappedMaterialTracks,
+                      materialMapper, materiaMaplWriters);
   }
 
   {
@@ -320,9 +274,7 @@ void addMaterial(Context& ctx) {
 
     auto c =
         py::class_<MaterialValidater::Config>(mvc, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(materialAssigner);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, materialAssigner);
   }
 
   {
@@ -337,15 +289,8 @@ void addMaterial(Context& ctx) {
 
     auto c =
         py::class_<MaterialValidation::Config>(mv, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(ntracks);
-    ACTS_PYTHON_MEMBER(startPosition);
-    ACTS_PYTHON_MEMBER(phiRange);
-    ACTS_PYTHON_MEMBER(etaRange);
-    ACTS_PYTHON_MEMBER(randomNumberSvc);
-    ACTS_PYTHON_MEMBER(materialValidater);
-    ACTS_PYTHON_MEMBER(outputMaterialTracks);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, ntracks, startPosition, phiRange, etaRange, randomNumberSvc,
+                      materialValidater, outputMaterialTracks);
   }
 }
 

--- a/Examples/Python/src/Navigation.cpp
+++ b/Examples/Python/src/Navigation.cpp
@@ -174,7 +174,7 @@ void addNavigation(Context& ctx) {
         py::class_<TryAllNavigationPolicy>(m, "TryAllNavigationPolicy");
     using Config = TryAllNavigationPolicy::Config;
     auto c = py::class_<Config>(tryAll, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(portals);
     ACTS_PYTHON_MEMBER(sensitives);
     ACTS_PYTHON_STRUCT_END();
@@ -219,7 +219,7 @@ void addNavigation(Context& ctx) {
 
     using Config = SurfaceArrayNavigationPolicy::Config;
     auto c = py::class_<Config>(saPolicy, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(layerType);
     ACTS_PYTHON_MEMBER(bins);
     ACTS_PYTHON_STRUCT_END();

--- a/Examples/Python/src/Navigation.cpp
+++ b/Examples/Python/src/Navigation.cpp
@@ -174,10 +174,7 @@ void addNavigation(Context& ctx) {
         py::class_<TryAllNavigationPolicy>(m, "TryAllNavigationPolicy");
     using Config = TryAllNavigationPolicy::Config;
     auto c = py::class_<Config>(tryAll, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(portals);
-    ACTS_PYTHON_MEMBER(sensitives);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, portals, sensitives);
   }
 
   py::class_<NavigationPolicyFactory, Acts::NavigationPolicyFactory,
@@ -219,10 +216,7 @@ void addNavigation(Context& ctx) {
 
     using Config = SurfaceArrayNavigationPolicy::Config;
     auto c = py::class_<Config>(saPolicy, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(layerType);
-    ACTS_PYTHON_MEMBER(bins);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, layerType, bins);
   }
 }
 

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -90,7 +90,7 @@ void register_csv_bfield_writer_binding(
                py::arg("config"), py::arg("level"));
   auto c = py::class_<Config>(w, (std::string("Config") + name).c_str())
                .def(py::init<>());
-  ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+  ACTS_PYTHON_STRUCT_BEGIN(c);
   ACTS_PYTHON_MEMBER(fileName);
   ACTS_PYTHON_MEMBER(bField);
   ACTS_PYTHON_MEMBER(range);
@@ -117,7 +117,7 @@ void addOutput(Context& ctx) {
   {
     auto c = py::class_<ViewConfig>(m, "ViewConfig").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, ViewConfig);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(visible);
     ACTS_PYTHON_MEMBER(color);
     ACTS_PYTHON_MEMBER(offset);
@@ -153,7 +153,7 @@ void addOutput(Context& ctx) {
                                    &Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(outputScalor);
     ACTS_PYTHON_MEMBER(outputPrecision);
     ACTS_PYTHON_MEMBER(outputDir);
@@ -242,7 +242,7 @@ void addOutput(Context& ctx) {
         .value("xyz", Writer::GridType::xyz);
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(treeName);
     ACTS_PYTHON_MEMBER(fileName);
     ACTS_PYTHON_MEMBER(fileMode);
@@ -265,7 +265,7 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputMeasurements);
     ACTS_PYTHON_MEMBER(inputClusters);
     ACTS_PYTHON_MEMBER(inputSimHits);
@@ -298,7 +298,7 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(processSensitives);
     ACTS_PYTHON_MEMBER(processApproaches);
     ACTS_PYTHON_MEMBER(processRepresenting);

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -112,8 +112,9 @@ void addOutput(Context& ctx) {
   {
     auto c = py::class_<ViewConfig>(m, "ViewConfig").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, visible, color, offset, lineThickness, surfaceThickness,
-                      quarterSegments, triangulate, outputName);
+    ACTS_PYTHON_STRUCT(c, visible, color, offset, lineThickness,
+                       surfaceThickness, quarterSegments, triangulate,
+                       outputName);
 
     patchKwargsConstructor(c);
 
@@ -141,8 +142,9 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, outputScalor, outputPrecision, outputDir, containerView,
-                      volumeView, sensitiveView, passiveView, gridView);
+    ACTS_PYTHON_STRUCT(c, outputScalor, outputPrecision, outputDir,
+                       containerView, volumeView, sensitiveView, passiveView,
+                       gridView);
   }
 
   // Bindings for the binning in e.g., TrackFinderPerformanceWriter
@@ -222,8 +224,8 @@ void addOutput(Context& ctx) {
         .value("xyz", Writer::GridType::xyz);
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, treeName, fileName, fileMode, bField, gridType, 
-                      rBounds, zBounds, rBins, zBins, phiBins);
+    ACTS_PYTHON_STRUCT(c, treeName, fileName, fileMode, bField, gridType,
+                       rBounds, zBounds, rBins, zBins, phiBins);
   }
 
   {
@@ -236,8 +238,8 @@ void addOutput(Context& ctx) {
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, inputMeasurements, inputClusters, inputSimHits,
-                      inputMeasurementSimHitsMap, filePath, fileMode,
-                      surfaceByIdentifier);
+                       inputMeasurementSimHitsMap, filePath, fileMode,
+                       surfaceByIdentifier);
   }
 
   py::class_<IMaterialWriter, std::shared_ptr<IMaterialWriter>>(
@@ -262,11 +264,12 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, processSensitives, processApproaches, processRepresenting,
-                      processBoundaries, processVolumes, folderSurfaceNameBase,
-                      folderVolumeNameBase, voltag, boutag, laytag, apptag, sentag,
-                      ntag, vtag, otag, mintag, maxtag, ttag, x0tag, l0tag, atag,
-                      ztag, rhotag, filePath, fileMode);
+    ACTS_PYTHON_STRUCT(c, processSensitives, processApproaches,
+                       processRepresenting, processBoundaries, processVolumes,
+                       folderSurfaceNameBase, folderVolumeNameBase, voltag,
+                       boutag, laytag, apptag, sentag, ntag, vtag, otag, mintag,
+                       maxtag, ttag, x0tag, l0tag, atag, ztag, rhotag, filePath,
+                       fileMode);
   }
 
   ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootSeedWriter, mex,

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -90,12 +90,7 @@ void register_csv_bfield_writer_binding(
                py::arg("config"), py::arg("level"));
   auto c = py::class_<Config>(w, (std::string("Config") + name).c_str())
                .def(py::init<>());
-  ACTS_PYTHON_STRUCT_BEGIN(c);
-  ACTS_PYTHON_MEMBER(fileName);
-  ACTS_PYTHON_MEMBER(bField);
-  ACTS_PYTHON_MEMBER(range);
-  ACTS_PYTHON_MEMBER(bins);
-  ACTS_PYTHON_STRUCT_END();
+  ACTS_PYTHON_STRUCT(c, fileName, bField, range, bins);
 }
 }  // namespace
 
@@ -117,16 +112,8 @@ void addOutput(Context& ctx) {
   {
     auto c = py::class_<ViewConfig>(m, "ViewConfig").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(visible);
-    ACTS_PYTHON_MEMBER(color);
-    ACTS_PYTHON_MEMBER(offset);
-    ACTS_PYTHON_MEMBER(lineThickness);
-    ACTS_PYTHON_MEMBER(surfaceThickness);
-    ACTS_PYTHON_MEMBER(quarterSegments);
-    ACTS_PYTHON_MEMBER(triangulate);
-    ACTS_PYTHON_MEMBER(outputName);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, visible, color, offset, lineThickness, surfaceThickness,
+                      quarterSegments, triangulate, outputName);
 
     patchKwargsConstructor(c);
 
@@ -153,16 +140,9 @@ void addOutput(Context& ctx) {
                                    &Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(outputScalor);
-    ACTS_PYTHON_MEMBER(outputPrecision);
-    ACTS_PYTHON_MEMBER(outputDir);
-    ACTS_PYTHON_MEMBER(containerView);
-    ACTS_PYTHON_MEMBER(volumeView);
-    ACTS_PYTHON_MEMBER(sensitiveView);
-    ACTS_PYTHON_MEMBER(passiveView);
-    ACTS_PYTHON_MEMBER(gridView);
-    ACTS_PYTHON_STRUCT_END();
+
+    ACTS_PYTHON_STRUCT(c, outputScalor, outputPrecision, outputDir, containerView,
+                      volumeView, sensitiveView, passiveView, gridView);
   }
 
   // Bindings for the binning in e.g., TrackFinderPerformanceWriter
@@ -242,18 +222,8 @@ void addOutput(Context& ctx) {
         .value("xyz", Writer::GridType::xyz);
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(treeName);
-    ACTS_PYTHON_MEMBER(fileName);
-    ACTS_PYTHON_MEMBER(fileMode);
-    ACTS_PYTHON_MEMBER(bField);
-    ACTS_PYTHON_MEMBER(gridType);
-    ACTS_PYTHON_MEMBER(rBounds);
-    ACTS_PYTHON_MEMBER(zBounds);
-    ACTS_PYTHON_MEMBER(rBins);
-    ACTS_PYTHON_MEMBER(zBins);
-    ACTS_PYTHON_MEMBER(phiBins);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, treeName, fileName, fileMode, bField, gridType, 
+                      rBounds, zBounds, rBins, zBins, phiBins);
   }
 
   {
@@ -265,15 +235,9 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputMeasurements);
-    ACTS_PYTHON_MEMBER(inputClusters);
-    ACTS_PYTHON_MEMBER(inputSimHits);
-    ACTS_PYTHON_MEMBER(inputMeasurementSimHitsMap);
-    ACTS_PYTHON_MEMBER(filePath);
-    ACTS_PYTHON_MEMBER(fileMode);
-    ACTS_PYTHON_MEMBER(surfaceByIdentifier);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputMeasurements, inputClusters, inputSimHits,
+                      inputMeasurementSimHitsMap, filePath, fileMode,
+                      surfaceByIdentifier);
   }
 
   py::class_<IMaterialWriter, std::shared_ptr<IMaterialWriter>>(
@@ -298,33 +262,11 @@ void addOutput(Context& ctx) {
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(processSensitives);
-    ACTS_PYTHON_MEMBER(processApproaches);
-    ACTS_PYTHON_MEMBER(processRepresenting);
-    ACTS_PYTHON_MEMBER(processBoundaries);
-    ACTS_PYTHON_MEMBER(processVolumes);
-    ACTS_PYTHON_MEMBER(folderSurfaceNameBase);
-    ACTS_PYTHON_MEMBER(folderVolumeNameBase);
-    ACTS_PYTHON_MEMBER(voltag);
-    ACTS_PYTHON_MEMBER(boutag);
-    ACTS_PYTHON_MEMBER(laytag);
-    ACTS_PYTHON_MEMBER(apptag);
-    ACTS_PYTHON_MEMBER(sentag);
-    ACTS_PYTHON_MEMBER(ntag);
-    ACTS_PYTHON_MEMBER(vtag);
-    ACTS_PYTHON_MEMBER(otag);
-    ACTS_PYTHON_MEMBER(mintag);
-    ACTS_PYTHON_MEMBER(maxtag);
-    ACTS_PYTHON_MEMBER(ttag);
-    ACTS_PYTHON_MEMBER(x0tag);
-    ACTS_PYTHON_MEMBER(l0tag);
-    ACTS_PYTHON_MEMBER(atag);
-    ACTS_PYTHON_MEMBER(ztag);
-    ACTS_PYTHON_MEMBER(rhotag);
-    ACTS_PYTHON_MEMBER(filePath);
-    ACTS_PYTHON_MEMBER(fileMode);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, processSensitives, processApproaches, processRepresenting,
+                      processBoundaries, processVolumes, folderSurfaceNameBase,
+                      folderVolumeNameBase, voltag, boutag, laytag, apptag, sentag,
+                      ntag, vtag, otag, mintag, maxtag, ttag, x0tag, l0tag, atag,
+                      ztag, rhotag, filePath, fileMode);
   }
 
   ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootSeedWriter, mex,

--- a/Examples/Python/src/Propagation.cpp
+++ b/Examples/Python/src/Propagation.cpp
@@ -81,7 +81,7 @@ void addPropagation(Context& ctx) {
 
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(resolveMaterial);
     ACTS_PYTHON_MEMBER(resolvePassive);
     ACTS_PYTHON_MEMBER(resolveSensitive);
@@ -104,7 +104,7 @@ void addPropagation(Context& ctx) {
 
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(resolveMaterial);
     ACTS_PYTHON_MEMBER(resolvePassive);
     ACTS_PYTHON_MEMBER(resolveSensitive);

--- a/Examples/Python/src/Propagation.cpp
+++ b/Examples/Python/src/Propagation.cpp
@@ -81,12 +81,8 @@ void addPropagation(Context& ctx) {
 
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(resolveMaterial);
-    ACTS_PYTHON_MEMBER(resolvePassive);
-    ACTS_PYTHON_MEMBER(resolveSensitive);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, resolveMaterial, resolvePassive, resolveSensitive,
+                      trackingGeometry);
   }
 
   {
@@ -104,12 +100,8 @@ void addPropagation(Context& ctx) {
 
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(resolveMaterial);
-    ACTS_PYTHON_MEMBER(resolvePassive);
-    ACTS_PYTHON_MEMBER(resolveSensitive);
-    ACTS_PYTHON_MEMBER(detector);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, resolveMaterial, resolvePassive, resolveSensitive,
+                      detector);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(

--- a/Examples/Python/src/Propagation.cpp
+++ b/Examples/Python/src/Propagation.cpp
@@ -82,7 +82,7 @@ void addPropagation(Context& ctx) {
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, resolveMaterial, resolvePassive, resolveSensitive,
-                      trackingGeometry);
+                       trackingGeometry);
   }
 
   {
@@ -101,7 +101,7 @@ void addPropagation(Context& ctx) {
     auto c = py::class_<Config>(nav, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, resolveMaterial, resolvePassive, resolveSensitive,
-                      detector);
+                       detector);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -218,7 +218,7 @@ void addSvg(Context& ctx) {
   // Core components, added as an acts.svg submodule
   {
     auto c = py::class_<Svg::Style>(svg, "Style").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::Style);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(fillColor);
     ACTS_PYTHON_MEMBER(fillOpacity);
     ACTS_PYTHON_MEMBER(highlightColor);
@@ -237,7 +237,7 @@ void addSvg(Context& ctx) {
   {
     auto c = py::class_<Svg::SurfaceConverter::Options>(svg, "SurfaceOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::SurfaceConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(style);
     ACTS_PYTHON_MEMBER(templateSurface);
     ACTS_PYTHON_STRUCT_END();
@@ -270,7 +270,7 @@ void addSvg(Context& ctx) {
     auto c = py::class_<Svg::PortalConverter::Options>(svg, "PortalOptions")
                  .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::PortalConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(surfaceOptions);
     ACTS_PYTHON_MEMBER(linkLength);
     ACTS_PYTHON_MEMBER(volumeIndices);
@@ -337,14 +337,14 @@ void addSvg(Context& ctx) {
   {
     auto gco = py::class_<Svg::GridConverter::Options>(svg, "GridOptions")
                    .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(gco, Svg::GridConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(gco);
     ACTS_PYTHON_MEMBER(style);
     ACTS_PYTHON_STRUCT_END();
 
     auto isco = py::class_<Svg::IndexedSurfacesConverter::Options>(
                     svg, "IndexedSurfacesOptions")
                     .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(isco, Svg::IndexedSurfacesConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(isco);
     ACTS_PYTHON_MEMBER(gridOptions);
     ACTS_PYTHON_STRUCT_END();
   }
@@ -355,7 +355,7 @@ void addSvg(Context& ctx) {
                  svg, "DetectorVolumeOptions")
                  .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::DetectorVolumeConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(portalIndices);
     ACTS_PYTHON_MEMBER(portalOptions);
     ACTS_PYTHON_MEMBER(surfaceOptions);
@@ -399,7 +399,7 @@ void addSvg(Context& ctx) {
 
     auto c = py::class_<Svg::LayerConverter::Options>(svg, "LayerOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::LayerConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(name);
     ACTS_PYTHON_MEMBER(surfaceStyles);
     ACTS_PYTHON_MEMBER(zRange);
@@ -425,7 +425,7 @@ void addSvg(Context& ctx) {
     auto c = py::class_<Svg::TrackingGeometryConverter::Options>(
                  svg, "TrackingGeometryOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Svg::TrackingGeometryConverter::Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(prefix);
     ACTS_PYTHON_MEMBER(layerOptions);
     ACTS_PYTHON_STRUCT_END();
@@ -444,7 +444,7 @@ void addSvg(Context& ctx) {
                                    &Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(outputDir);
     ACTS_PYTHON_MEMBER(converterOptions);
     ACTS_PYTHON_STRUCT_END();
@@ -460,7 +460,7 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(writerName);
     ACTS_PYTHON_MEMBER(trackingGeometry);
     ACTS_PYTHON_MEMBER(inputCollection);
@@ -481,7 +481,7 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Writer::Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(writerName);
     ACTS_PYTHON_MEMBER(trackingGeometry);
     ACTS_PYTHON_MEMBER(inputCollection);

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -218,7 +218,10 @@ void addSvg(Context& ctx) {
   // Core components, added as an acts.svg submodule
   {
     auto c = py::class_<Svg::Style>(svg, "Style").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, fillColor, fillOpacity, highlightColor, highlights, strokeWidth, strokeColor, highlightStrokeWidth, highlightStrokeColor, fontSize, fontColor, quarterSegments);
+    ACTS_PYTHON_STRUCT(c, fillColor, fillOpacity, highlightColor, highlights,
+                       strokeWidth, strokeColor, highlightStrokeWidth,
+                       highlightStrokeColor, fontSize, fontColor,
+                       quarterSegments);
   }
 
   // How surfaces should be drawn: Svg Surface options & drawning
@@ -332,7 +335,8 @@ void addSvg(Context& ctx) {
                  svg, "DetectorVolumeOptions")
                  .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT(c, portalIndices, portalOptions, surfaceOptions, indexedSurfacesOptions);
+    ACTS_PYTHON_STRUCT(c, portalIndices, portalOptions, surfaceOptions,
+                       indexedSurfacesOptions);
 
     // Define the proto volume & indexed surface grid
     py::class_<Svg::ProtoVolume>(svg, "ProtoVolume");
@@ -371,7 +375,8 @@ void addSvg(Context& ctx) {
 
     auto c = py::class_<Svg::LayerConverter::Options>(svg, "LayerOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, name, surfaceStyles, zRange, phiRange, gridInfo, moduleInfo, projectionInfo, labelProjection, labelGauge);
+    ACTS_PYTHON_STRUCT(c, name, surfaceStyles, zRange, phiRange, gridInfo,
+                       moduleInfo, projectionInfo, labelProjection, labelGauge);
   }
 
   {
@@ -416,9 +421,10 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection, infoBoxTitle, outputDir);
+    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection,
+                       infoBoxTitle, outputDir);
   }
-  
+
   {
     using Writer =
         ActsExamples::SvgPointWriter<ActsExamples::SimHit,
@@ -432,7 +438,8 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection, infoBoxTitle, outputDir);
+    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection,
+                       infoBoxTitle, outputDir);
   }
 }
 }  // namespace Acts::Python

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -218,29 +218,14 @@ void addSvg(Context& ctx) {
   // Core components, added as an acts.svg submodule
   {
     auto c = py::class_<Svg::Style>(svg, "Style").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(fillColor);
-    ACTS_PYTHON_MEMBER(fillOpacity);
-    ACTS_PYTHON_MEMBER(highlightColor);
-    ACTS_PYTHON_MEMBER(highlights);
-    ACTS_PYTHON_MEMBER(strokeWidth);
-    ACTS_PYTHON_MEMBER(strokeColor);
-    ACTS_PYTHON_MEMBER(highlightStrokeWidth);
-    ACTS_PYTHON_MEMBER(highlightStrokeColor);
-    ACTS_PYTHON_MEMBER(fontSize);
-    ACTS_PYTHON_MEMBER(fontColor);
-    ACTS_PYTHON_MEMBER(quarterSegments);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, fillColor, fillOpacity, highlightColor, highlights, strokeWidth, strokeColor, highlightStrokeWidth, highlightStrokeColor, fontSize, fontColor, quarterSegments);
   }
 
   // How surfaces should be drawn: Svg Surface options & drawning
   {
     auto c = py::class_<Svg::SurfaceConverter::Options>(svg, "SurfaceOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(style);
-    ACTS_PYTHON_MEMBER(templateSurface);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, style, templateSurface);
 
     // Define the proto surface
     py::class_<Svg::ProtoSurface>(svg, "ProtoSurface");
@@ -270,11 +255,7 @@ void addSvg(Context& ctx) {
     auto c = py::class_<Svg::PortalConverter::Options>(svg, "PortalOptions")
                  .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(surfaceOptions);
-    ACTS_PYTHON_MEMBER(linkLength);
-    ACTS_PYTHON_MEMBER(volumeIndices);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, surfaceOptions, linkLength, volumeIndices);
 
     // Define the proto portal
     py::class_<Svg::ProtoPortal>(svg, "ProtoPortal");
@@ -337,16 +318,12 @@ void addSvg(Context& ctx) {
   {
     auto gco = py::class_<Svg::GridConverter::Options>(svg, "GridOptions")
                    .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(gco);
-    ACTS_PYTHON_MEMBER(style);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(gco, style);
 
     auto isco = py::class_<Svg::IndexedSurfacesConverter::Options>(
                     svg, "IndexedSurfacesOptions")
                     .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(isco);
-    ACTS_PYTHON_MEMBER(gridOptions);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(isco, gridOptions);
   }
 
   // How detector volumes are drawn: Svg DetectorVolume options & drawning
@@ -355,12 +332,7 @@ void addSvg(Context& ctx) {
                  svg, "DetectorVolumeOptions")
                  .def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(portalIndices);
-    ACTS_PYTHON_MEMBER(portalOptions);
-    ACTS_PYTHON_MEMBER(surfaceOptions);
-    ACTS_PYTHON_MEMBER(indexedSurfacesOptions);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, portalIndices, portalOptions, surfaceOptions, indexedSurfacesOptions);
 
     // Define the proto volume & indexed surface grid
     py::class_<Svg::ProtoVolume>(svg, "ProtoVolume");
@@ -399,17 +371,7 @@ void addSvg(Context& ctx) {
 
     auto c = py::class_<Svg::LayerConverter::Options>(svg, "LayerOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(name);
-    ACTS_PYTHON_MEMBER(surfaceStyles);
-    ACTS_PYTHON_MEMBER(zRange);
-    ACTS_PYTHON_MEMBER(phiRange);
-    ACTS_PYTHON_MEMBER(gridInfo);
-    ACTS_PYTHON_MEMBER(moduleInfo);
-    ACTS_PYTHON_MEMBER(projectionInfo);
-    ACTS_PYTHON_MEMBER(labelProjection);
-    ACTS_PYTHON_MEMBER(labelGauge);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, name, surfaceStyles, zRange, phiRange, gridInfo, moduleInfo, projectionInfo, labelProjection, labelGauge);
   }
 
   {
@@ -425,10 +387,7 @@ void addSvg(Context& ctx) {
     auto c = py::class_<Svg::TrackingGeometryConverter::Options>(
                  svg, "TrackingGeometryOptions")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(prefix);
-    ACTS_PYTHON_MEMBER(layerOptions);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, prefix, layerOptions);
   }
 
   // Components from the ActsExamples - part of acts.examples
@@ -444,10 +403,7 @@ void addSvg(Context& ctx) {
                                    &Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(outputDir);
-    ACTS_PYTHON_MEMBER(converterOptions);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, outputDir, converterOptions);
   }
   {
     using Writer = ActsExamples::SvgPointWriter<ActsExamples::SimSpacePoint>;
@@ -460,14 +416,9 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(writerName);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_MEMBER(inputCollection);
-    ACTS_PYTHON_MEMBER(infoBoxTitle);
-    ACTS_PYTHON_MEMBER(outputDir);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection, infoBoxTitle, outputDir);
   }
+  
   {
     using Writer =
         ActsExamples::SvgPointWriter<ActsExamples::SimHit,
@@ -481,13 +432,7 @@ void addSvg(Context& ctx) {
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(writerName);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_MEMBER(inputCollection);
-    ACTS_PYTHON_MEMBER(infoBoxTitle);
-    ACTS_PYTHON_MEMBER(outputDir);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, writerName, trackingGeometry, inputCollection, infoBoxTitle, outputDir);
   }
 }
 }  // namespace Acts::Python

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -66,7 +66,7 @@ void addTrackFinding(Context& ctx) {
   {
     using Config = Acts::SeedFilterConfig;
     auto c = py::class_<Config>(m, "SeedFilterConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(deltaInvHelixDiameter);
     ACTS_PYTHON_MEMBER(impactWeightFactor);
     ACTS_PYTHON_MEMBER(zOriginWeightFactor);
@@ -91,7 +91,7 @@ void addTrackFinding(Context& ctx) {
         ActsExamples::SpacePointContainer<std::vector<const SimSpacePoint*>>,
         Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c = py::class_<Config>(m, "SeedFinderConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(minPt);
     ACTS_PYTHON_MEMBER(cotThetaMax);
     ACTS_PYTHON_MEMBER(deltaRMin);
@@ -141,7 +141,7 @@ void addTrackFinding(Context& ctx) {
   {
     using seedOptions = Acts::SeedFinderOptions;
     auto c = py::class_<seedOptions>(m, "SeedFinderOptions").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, seedOptions);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(beamPos);
     ACTS_PYTHON_MEMBER(bFieldInZ);
     ACTS_PYTHON_STRUCT_END();
@@ -155,7 +155,7 @@ void addTrackFinding(Context& ctx) {
             Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c =
         py::class_<Config>(m, "SeedFinderOrthogonalConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(minPt);
     ACTS_PYTHON_MEMBER(cotThetaMax);
     ACTS_PYTHON_MEMBER(deltaRMinBottomSP);
@@ -198,7 +198,7 @@ void addTrackFinding(Context& ctx) {
   {
     using Config = Acts::Experimental::SeedFinderGbtsConfig<SimSpacePoint>;
     auto c = py::class_<Config>(m, "SeedFinderGbtsConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(minPt);
     ACTS_PYTHON_MEMBER(sigmaScattering);
     ACTS_PYTHON_MEMBER(highland);
@@ -216,7 +216,7 @@ void addTrackFinding(Context& ctx) {
     using seedConf = Acts::SeedConfirmationRangeConfig;
     auto c = py::class_<seedConf>(m, "SeedConfirmationRangeConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, seedConf);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(zMinSeedConf);
     ACTS_PYTHON_MEMBER(zMaxSeedConf);
     ACTS_PYTHON_MEMBER(rMaxSeedConf);
@@ -233,7 +233,7 @@ void addTrackFinding(Context& ctx) {
     using Config = Acts::CylindricalSpacePointGridConfig;
     auto c = py::class_<Config>(m, "SpacePointGridConfig").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(minPt);
     ACTS_PYTHON_MEMBER(rMax);
     ACTS_PYTHON_MEMBER(zMax);
@@ -253,7 +253,7 @@ void addTrackFinding(Context& ctx) {
     using Options = Acts::CylindricalSpacePointGridOptions;
     auto c = py::class_<Options>(m, "SpacePointGridOptions").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Options);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(bFieldInZ);
     ACTS_PYTHON_STRUCT_END();
     patchKwargsConstructor(c);
@@ -325,7 +325,7 @@ void addTrackFinding(Context& ctx) {
         alg, "TrackFinderFunction");
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputMeasurements);
     ACTS_PYTHON_MEMBER(inputInitialTrackParameters);
     ACTS_PYTHON_MEMBER(inputSeeds);

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -66,23 +66,11 @@ void addTrackFinding(Context& ctx) {
   {
     using Config = Acts::SeedFilterConfig;
     auto c = py::class_<Config>(m, "SeedFilterConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(deltaInvHelixDiameter);
-    ACTS_PYTHON_MEMBER(impactWeightFactor);
-    ACTS_PYTHON_MEMBER(zOriginWeightFactor);
-    ACTS_PYTHON_MEMBER(compatSeedWeight);
-    ACTS_PYTHON_MEMBER(deltaRMin);
-    ACTS_PYTHON_MEMBER(maxSeedsPerSpM);
-    ACTS_PYTHON_MEMBER(compatSeedLimit);
-    ACTS_PYTHON_MEMBER(seedConfirmation);
-    ACTS_PYTHON_MEMBER(centralSeedConfirmationRange);
-    ACTS_PYTHON_MEMBER(forwardSeedConfirmationRange);
-    ACTS_PYTHON_MEMBER(useDeltaRorTopRadius);
-    ACTS_PYTHON_MEMBER(seedWeightIncrement);
-    ACTS_PYTHON_MEMBER(numSeedIncrement);
-    ACTS_PYTHON_MEMBER(maxSeedsPerSpMConf);
-    ACTS_PYTHON_MEMBER(maxQualitySeedsPerSpMConf);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, deltaInvHelixDiameter, impactWeightFactor, zOriginWeightFactor,
+                      compatSeedWeight, deltaRMin, maxSeedsPerSpM, compatSeedLimit,
+                      seedConfirmation, centralSeedConfirmationRange, forwardSeedConfirmationRange,
+                      useDeltaRorTopRadius, seedWeightIncrement, numSeedIncrement,
+                      maxSeedsPerSpMConf, maxQualitySeedsPerSpMConf);
     patchKwargsConstructor(c);
   }
 
@@ -91,60 +79,23 @@ void addTrackFinding(Context& ctx) {
         ActsExamples::SpacePointContainer<std::vector<const SimSpacePoint*>>,
         Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c = py::class_<Config>(m, "SeedFinderConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(minPt);
-    ACTS_PYTHON_MEMBER(cotThetaMax);
-    ACTS_PYTHON_MEMBER(deltaRMin);
-    ACTS_PYTHON_MEMBER(deltaRMax);
-    ACTS_PYTHON_MEMBER(deltaRMinBottomSP);
-    ACTS_PYTHON_MEMBER(deltaRMaxBottomSP);
-    ACTS_PYTHON_MEMBER(deltaRMinTopSP);
-    ACTS_PYTHON_MEMBER(deltaRMaxTopSP);
-    ACTS_PYTHON_MEMBER(impactMax);
-    ACTS_PYTHON_MEMBER(sigmaScattering);
-    ACTS_PYTHON_MEMBER(maxPtScattering);
-    ACTS_PYTHON_MEMBER(maxSeedsPerSpM);
-    ACTS_PYTHON_MEMBER(collisionRegionMin);
-    ACTS_PYTHON_MEMBER(collisionRegionMax);
-    ACTS_PYTHON_MEMBER(phiMin);
-    ACTS_PYTHON_MEMBER(phiMax);
-    ACTS_PYTHON_MEMBER(zMin);
-    ACTS_PYTHON_MEMBER(zMax);
-    ACTS_PYTHON_MEMBER(rMax);
-    ACTS_PYTHON_MEMBER(rMin);
-    ACTS_PYTHON_MEMBER(radLengthPerSeed);
-    ACTS_PYTHON_MEMBER(zAlign);
-    ACTS_PYTHON_MEMBER(rAlign);
-    ACTS_PYTHON_MEMBER(sigmaError);
-    ACTS_PYTHON_MEMBER(maxBlockSize);
-    ACTS_PYTHON_MEMBER(nTrplPerSpBLimit);
-    ACTS_PYTHON_MEMBER(nAvgTrplPerSpBLimit);
-    ACTS_PYTHON_MEMBER(impactMax);
-    ACTS_PYTHON_MEMBER(deltaZMax);
-    ACTS_PYTHON_MEMBER(zBinEdges);
-    ACTS_PYTHON_MEMBER(interactionPointCut);
-    ACTS_PYTHON_MEMBER(zBinsCustomLooping);
-    ACTS_PYTHON_MEMBER(useVariableMiddleSPRange);
-    ACTS_PYTHON_MEMBER(deltaRMiddleMinSPRange);
-    ACTS_PYTHON_MEMBER(deltaRMiddleMaxSPRange);
-    ACTS_PYTHON_MEMBER(rRangeMiddleSP);
-    ACTS_PYTHON_MEMBER(rMinMiddle);
-    ACTS_PYTHON_MEMBER(rMaxMiddle);
-    ACTS_PYTHON_MEMBER(binSizeR);
-    ACTS_PYTHON_MEMBER(seedConfirmation);
-    ACTS_PYTHON_MEMBER(centralSeedConfirmationRange);
-    ACTS_PYTHON_MEMBER(forwardSeedConfirmationRange);
-    ACTS_PYTHON_MEMBER(useDetailedDoubleMeasurementInfo);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, minPt, cotThetaMax, deltaRMin, deltaRMax, deltaRMinBottomSP,
+                      deltaRMaxBottomSP, deltaRMinTopSP, deltaRMaxTopSP, impactMax,
+                      sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
+                      collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
+                      radLengthPerSeed, zAlign, rAlign, sigmaError, maxBlockSize,
+                      nTrplPerSpBLimit, nAvgTrplPerSpBLimit, impactMax, deltaZMax,
+                      zBinEdges, interactionPointCut, zBinsCustomLooping,
+                      useVariableMiddleSPRange, deltaRMiddleMinSPRange,
+                      deltaRMiddleMaxSPRange, rRangeMiddleSP, rMinMiddle, rMaxMiddle,
+                      binSizeR, seedConfirmation, centralSeedConfirmationRange,
+                      forwardSeedConfirmationRange, useDetailedDoubleMeasurementInfo);
     patchKwargsConstructor(c);
   }
   {
     using seedOptions = Acts::SeedFinderOptions;
     auto c = py::class_<seedOptions>(m, "SeedFinderOptions").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(beamPos);
-    ACTS_PYTHON_MEMBER(bFieldInZ);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, beamPos, bFieldInZ);
     patchKwargsConstructor(c);
   }
   {
@@ -155,60 +106,24 @@ void addTrackFinding(Context& ctx) {
             Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c =
         py::class_<Config>(m, "SeedFinderOrthogonalConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(minPt);
-    ACTS_PYTHON_MEMBER(cotThetaMax);
-    ACTS_PYTHON_MEMBER(deltaRMinBottomSP);
-    ACTS_PYTHON_MEMBER(deltaRMaxBottomSP);
-    ACTS_PYTHON_MEMBER(deltaRMinTopSP);
-    ACTS_PYTHON_MEMBER(deltaRMaxTopSP);
-    ACTS_PYTHON_MEMBER(impactMax);
-    ACTS_PYTHON_MEMBER(deltaPhiMax);
-    ACTS_PYTHON_MEMBER(deltaZMax);
-    ACTS_PYTHON_MEMBER(sigmaScattering);
-    ACTS_PYTHON_MEMBER(maxPtScattering);
-    ACTS_PYTHON_MEMBER(maxSeedsPerSpM);
-    ACTS_PYTHON_MEMBER(collisionRegionMin);
-    ACTS_PYTHON_MEMBER(collisionRegionMax);
-    ACTS_PYTHON_MEMBER(phiMin);
-    ACTS_PYTHON_MEMBER(phiMax);
-    ACTS_PYTHON_MEMBER(zMin);
-    ACTS_PYTHON_MEMBER(zMax);
-    ACTS_PYTHON_MEMBER(rMax);
-    ACTS_PYTHON_MEMBER(rMin);
-    ACTS_PYTHON_MEMBER(radLengthPerSeed);
-    ACTS_PYTHON_MEMBER(deltaZMax);
-    ACTS_PYTHON_MEMBER(interactionPointCut);
-    ACTS_PYTHON_MEMBER(deltaPhiMax);
-    ACTS_PYTHON_MEMBER(highland);
-    ACTS_PYTHON_MEMBER(maxScatteringAngle2);
-    ACTS_PYTHON_MEMBER(useVariableMiddleSPRange);
-    ACTS_PYTHON_MEMBER(deltaRMiddleMinSPRange);
-    ACTS_PYTHON_MEMBER(deltaRMiddleMaxSPRange);
-    ACTS_PYTHON_MEMBER(rRangeMiddleSP);
-    ACTS_PYTHON_MEMBER(rMinMiddle);
-    ACTS_PYTHON_MEMBER(rMaxMiddle);
-    ACTS_PYTHON_MEMBER(seedConfirmation);
-    ACTS_PYTHON_MEMBER(centralSeedConfirmationRange);
-    ACTS_PYTHON_MEMBER(forwardSeedConfirmationRange);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, minPt, cotThetaMax, deltaRMinBottomSP, deltaRMaxBottomSP,
+                      deltaRMinTopSP, deltaRMaxTopSP, impactMax, deltaPhiMax, deltaZMax,
+                      sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
+                      collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
+                      radLengthPerSeed, deltaZMax, interactionPointCut, deltaPhiMax,
+                      highland, maxScatteringAngle2, useVariableMiddleSPRange,
+                      deltaRMiddleMinSPRange, deltaRMiddleMaxSPRange, rRangeMiddleSP,
+                      rMinMiddle, rMaxMiddle, seedConfirmation, centralSeedConfirmationRange,
+                      forwardSeedConfirmationRange);
     patchKwargsConstructor(c);
   }
 
   {
     using Config = Acts::Experimental::SeedFinderGbtsConfig<SimSpacePoint>;
     auto c = py::class_<Config>(m, "SeedFinderGbtsConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(minPt);
-    ACTS_PYTHON_MEMBER(sigmaScattering);
-    ACTS_PYTHON_MEMBER(highland);
-    ACTS_PYTHON_MEMBER(maxScatteringAngle2);
-    ACTS_PYTHON_MEMBER(ConnectorInputFile);
-    ACTS_PYTHON_MEMBER(m_phiSliceWidth);
-    ACTS_PYTHON_MEMBER(m_nMaxPhiSlice);
-    ACTS_PYTHON_MEMBER(m_useClusterWidth);
-    ACTS_PYTHON_MEMBER(m_layerGeometry);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, minPt, sigmaScattering, highland, maxScatteringAngle2,
+                      ConnectorInputFile, m_phiSliceWidth, m_nMaxPhiSlice,
+                      m_useClusterWidth, m_layerGeometry);
     patchKwargsConstructor(c);
   }
 
@@ -216,16 +131,9 @@ void addTrackFinding(Context& ctx) {
     using seedConf = Acts::SeedConfirmationRangeConfig;
     auto c = py::class_<seedConf>(m, "SeedConfirmationRangeConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(zMinSeedConf);
-    ACTS_PYTHON_MEMBER(zMaxSeedConf);
-    ACTS_PYTHON_MEMBER(rMaxSeedConf);
-    ACTS_PYTHON_MEMBER(nTopForLargeR);
-    ACTS_PYTHON_MEMBER(nTopForSmallR);
-    ACTS_PYTHON_MEMBER(seedConfMinBottomRadius);
-    ACTS_PYTHON_MEMBER(seedConfMaxZOrigin);
-    ACTS_PYTHON_MEMBER(minImpactSeedConf);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, zMinSeedConf, zMaxSeedConf, rMaxSeedConf, nTopForLargeR,
+                      nTopForSmallR, seedConfMinBottomRadius, seedConfMaxZOrigin,
+                      minImpactSeedConf);
     patchKwargsConstructor(c);
   }
 
@@ -233,29 +141,16 @@ void addTrackFinding(Context& ctx) {
     using Config = Acts::CylindricalSpacePointGridConfig;
     auto c = py::class_<Config>(m, "SpacePointGridConfig").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(minPt);
-    ACTS_PYTHON_MEMBER(rMax);
-    ACTS_PYTHON_MEMBER(zMax);
-    ACTS_PYTHON_MEMBER(zMin);
-    ACTS_PYTHON_MEMBER(phiMin);
-    ACTS_PYTHON_MEMBER(phiMax);
-    ACTS_PYTHON_MEMBER(deltaRMax);
-    ACTS_PYTHON_MEMBER(cotThetaMax);
-    ACTS_PYTHON_MEMBER(phiBinDeflectionCoverage);
-    ACTS_PYTHON_MEMBER(maxPhiBins);
-    ACTS_PYTHON_MEMBER(impactMax);
-    ACTS_PYTHON_MEMBER(zBinEdges);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, minPt, rMax, zMax, zMin, phiMin, phiMax, deltaRMax,
+                      cotThetaMax, phiBinDeflectionCoverage, maxPhiBins,
+                      impactMax, zBinEdges);
     patchKwargsConstructor(c);
   }
   {
     using Options = Acts::CylindricalSpacePointGridOptions;
     auto c = py::class_<Options>(m, "SpacePointGridOptions").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(bFieldInZ);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, bFieldInZ);
     patchKwargsConstructor(c);
   }
 
@@ -325,29 +220,13 @@ void addTrackFinding(Context& ctx) {
         alg, "TrackFinderFunction");
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputMeasurements);
-    ACTS_PYTHON_MEMBER(inputInitialTrackParameters);
-    ACTS_PYTHON_MEMBER(inputSeeds);
-    ACTS_PYTHON_MEMBER(outputTracks);
-    ACTS_PYTHON_MEMBER(trackingGeometry);
-    ACTS_PYTHON_MEMBER(magneticField);
-    ACTS_PYTHON_MEMBER(findTracks);
-    ACTS_PYTHON_MEMBER(measurementSelectorCfg);
-    ACTS_PYTHON_MEMBER(trackSelectorCfg);
-    ACTS_PYTHON_MEMBER(maxSteps);
-    ACTS_PYTHON_MEMBER(twoWay);
-    ACTS_PYTHON_MEMBER(reverseSearch);
-    ACTS_PYTHON_MEMBER(seedDeduplication);
-    ACTS_PYTHON_MEMBER(stayOnSeed);
-    ACTS_PYTHON_MEMBER(pixelVolumeIds);
-    ACTS_PYTHON_MEMBER(stripVolumeIds);
-    ACTS_PYTHON_MEMBER(maxPixelHoles);
-    ACTS_PYTHON_MEMBER(maxStripHoles);
-    ACTS_PYTHON_MEMBER(trimTracks);
-    ACTS_PYTHON_MEMBER(constrainToVolumeIds);
-    ACTS_PYTHON_MEMBER(endOfWorldVolumeIds);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputMeasurements, inputInitialTrackParameters,
+                      inputSeeds, outputTracks, trackingGeometry, magneticField,
+                      findTracks, measurementSelectorCfg, trackSelectorCfg,
+                      maxSteps, twoWay, reverseSearch, seedDeduplication,
+                      stayOnSeed, pixelVolumeIds, stripVolumeIds,
+                      maxPixelHoles, maxStripHoles, trimTracks, constrainToVolumeIds,
+                      endOfWorldVolumeIds);
   }
 
   {

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -86,7 +86,7 @@ void addTrackFinding(Context& ctx) {
         sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
         collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
         radLengthPerSeed, zAlign, rAlign, sigmaError, maxBlockSize,
-        nTrplPerSpBLimit, nAvgTrplPerSpBLimit, impactMax, deltaZMax, zBinEdges,
+        nTrplPerSpBLimit, nAvgTrplPerSpBLimit, deltaZMax, zBinEdges,
         interactionPointCut, zBinsCustomLooping, useVariableMiddleSPRange,
         deltaRMiddleMinSPRange, deltaRMiddleMaxSPRange, rRangeMiddleSP,
         rMinMiddle, rMaxMiddle, binSizeR, seedConfirmation,

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -66,11 +66,12 @@ void addTrackFinding(Context& ctx) {
   {
     using Config = Acts::SeedFilterConfig;
     auto c = py::class_<Config>(m, "SeedFilterConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, deltaInvHelixDiameter, impactWeightFactor, zOriginWeightFactor,
-                      compatSeedWeight, deltaRMin, maxSeedsPerSpM, compatSeedLimit,
-                      seedConfirmation, centralSeedConfirmationRange, forwardSeedConfirmationRange,
-                      useDeltaRorTopRadius, seedWeightIncrement, numSeedIncrement,
-                      maxSeedsPerSpMConf, maxQualitySeedsPerSpMConf);
+    ACTS_PYTHON_STRUCT(
+        c, deltaInvHelixDiameter, impactWeightFactor, zOriginWeightFactor,
+        compatSeedWeight, deltaRMin, maxSeedsPerSpM, compatSeedLimit,
+        seedConfirmation, centralSeedConfirmationRange,
+        forwardSeedConfirmationRange, useDeltaRorTopRadius, seedWeightIncrement,
+        numSeedIncrement, maxSeedsPerSpMConf, maxQualitySeedsPerSpMConf);
     patchKwargsConstructor(c);
   }
 
@@ -79,17 +80,18 @@ void addTrackFinding(Context& ctx) {
         ActsExamples::SpacePointContainer<std::vector<const SimSpacePoint*>>,
         Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c = py::class_<Config>(m, "SeedFinderConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, minPt, cotThetaMax, deltaRMin, deltaRMax, deltaRMinBottomSP,
-                      deltaRMaxBottomSP, deltaRMinTopSP, deltaRMaxTopSP, impactMax,
-                      sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
-                      collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
-                      radLengthPerSeed, zAlign, rAlign, sigmaError, maxBlockSize,
-                      nTrplPerSpBLimit, nAvgTrplPerSpBLimit, impactMax, deltaZMax,
-                      zBinEdges, interactionPointCut, zBinsCustomLooping,
-                      useVariableMiddleSPRange, deltaRMiddleMinSPRange,
-                      deltaRMiddleMaxSPRange, rRangeMiddleSP, rMinMiddle, rMaxMiddle,
-                      binSizeR, seedConfirmation, centralSeedConfirmationRange,
-                      forwardSeedConfirmationRange, useDetailedDoubleMeasurementInfo);
+    ACTS_PYTHON_STRUCT(
+        c, minPt, cotThetaMax, deltaRMin, deltaRMax, deltaRMinBottomSP,
+        deltaRMaxBottomSP, deltaRMinTopSP, deltaRMaxTopSP, impactMax,
+        sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
+        collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
+        radLengthPerSeed, zAlign, rAlign, sigmaError, maxBlockSize,
+        nTrplPerSpBLimit, nAvgTrplPerSpBLimit, impactMax, deltaZMax, zBinEdges,
+        interactionPointCut, zBinsCustomLooping, useVariableMiddleSPRange,
+        deltaRMiddleMinSPRange, deltaRMiddleMaxSPRange, rRangeMiddleSP,
+        rMinMiddle, rMaxMiddle, binSizeR, seedConfirmation,
+        centralSeedConfirmationRange, forwardSeedConfirmationRange,
+        useDetailedDoubleMeasurementInfo);
     patchKwargsConstructor(c);
   }
   {
@@ -106,15 +108,16 @@ void addTrackFinding(Context& ctx) {
             Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c =
         py::class_<Config>(m, "SeedFinderOrthogonalConfig").def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, minPt, cotThetaMax, deltaRMinBottomSP, deltaRMaxBottomSP,
-                      deltaRMinTopSP, deltaRMaxTopSP, impactMax, deltaPhiMax, deltaZMax,
-                      sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
-                      collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
-                      radLengthPerSeed, deltaZMax, interactionPointCut, deltaPhiMax,
-                      highland, maxScatteringAngle2, useVariableMiddleSPRange,
-                      deltaRMiddleMinSPRange, deltaRMiddleMaxSPRange, rRangeMiddleSP,
-                      rMinMiddle, rMaxMiddle, seedConfirmation, centralSeedConfirmationRange,
-                      forwardSeedConfirmationRange);
+    ACTS_PYTHON_STRUCT(
+        c, minPt, cotThetaMax, deltaRMinBottomSP, deltaRMaxBottomSP,
+        deltaRMinTopSP, deltaRMaxTopSP, impactMax, deltaPhiMax, deltaZMax,
+        sigmaScattering, maxPtScattering, maxSeedsPerSpM, collisionRegionMin,
+        collisionRegionMax, phiMin, phiMax, zMin, zMax, rMax, rMin,
+        radLengthPerSeed, deltaZMax, interactionPointCut, deltaPhiMax, highland,
+        maxScatteringAngle2, useVariableMiddleSPRange, deltaRMiddleMinSPRange,
+        deltaRMiddleMaxSPRange, rRangeMiddleSP, rMinMiddle, rMaxMiddle,
+        seedConfirmation, centralSeedConfirmationRange,
+        forwardSeedConfirmationRange);
     patchKwargsConstructor(c);
   }
 
@@ -122,8 +125,8 @@ void addTrackFinding(Context& ctx) {
     using Config = Acts::Experimental::SeedFinderGbtsConfig<SimSpacePoint>;
     auto c = py::class_<Config>(m, "SeedFinderGbtsConfig").def(py::init<>());
     ACTS_PYTHON_STRUCT(c, minPt, sigmaScattering, highland, maxScatteringAngle2,
-                      ConnectorInputFile, m_phiSliceWidth, m_nMaxPhiSlice,
-                      m_useClusterWidth, m_layerGeometry);
+                       ConnectorInputFile, m_phiSliceWidth, m_nMaxPhiSlice,
+                       m_useClusterWidth, m_layerGeometry);
     patchKwargsConstructor(c);
   }
 
@@ -131,9 +134,9 @@ void addTrackFinding(Context& ctx) {
     using seedConf = Acts::SeedConfirmationRangeConfig;
     auto c = py::class_<seedConf>(m, "SeedConfirmationRangeConfig")
                  .def(py::init<>());
-    ACTS_PYTHON_STRUCT(c, zMinSeedConf, zMaxSeedConf, rMaxSeedConf, nTopForLargeR,
-                      nTopForSmallR, seedConfMinBottomRadius, seedConfMaxZOrigin,
-                      minImpactSeedConf);
+    ACTS_PYTHON_STRUCT(c, zMinSeedConf, zMaxSeedConf, rMaxSeedConf,
+                       nTopForLargeR, nTopForSmallR, seedConfMinBottomRadius,
+                       seedConfMaxZOrigin, minImpactSeedConf);
     patchKwargsConstructor(c);
   }
 
@@ -142,8 +145,8 @@ void addTrackFinding(Context& ctx) {
     auto c = py::class_<Config>(m, "SpacePointGridConfig").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, minPt, rMax, zMax, zMin, phiMin, phiMax, deltaRMax,
-                      cotThetaMax, phiBinDeflectionCoverage, maxPhiBins,
-                      impactMax, zBinEdges);
+                       cotThetaMax, phiBinDeflectionCoverage, maxPhiBins,
+                       impactMax, zBinEdges);
     patchKwargsConstructor(c);
   }
   {
@@ -221,12 +224,12 @@ void addTrackFinding(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
     ACTS_PYTHON_STRUCT(c, inputMeasurements, inputInitialTrackParameters,
-                      inputSeeds, outputTracks, trackingGeometry, magneticField,
-                      findTracks, measurementSelectorCfg, trackSelectorCfg,
-                      maxSteps, twoWay, reverseSearch, seedDeduplication,
-                      stayOnSeed, pixelVolumeIds, stripVolumeIds,
-                      maxPixelHoles, maxStripHoles, trimTracks, constrainToVolumeIds,
-                      endOfWorldVolumeIds);
+                       inputSeeds, outputTracks, trackingGeometry,
+                       magneticField, findTracks, measurementSelectorCfg,
+                       trackSelectorCfg, maxSteps, twoWay, reverseSearch,
+                       seedDeduplication, stayOnSeed, pixelVolumeIds,
+                       stripVolumeIds, maxPixelHoles, maxStripHoles, trimTracks,
+                       constrainToVolumeIds, endOfWorldVolumeIds);
   }
 
   {

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -72,12 +72,12 @@ void addTruthTracking(Context& ctx) {
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(
-        c, inputParticles, inputParticleMeasurementsMap, outputParticles,
-        rhoMin, rhoMax, absZMin, absZMax, timeMin, timeMax, phiMin, phiMax,
-        etaMin, etaMax, absEtaMin, absEtaMax, mMin, mMax, ptMin, ptMax, hitsMin,
-        hitsMax, measurementsMin, measurementsMax, removeCharged, removeNeutral,
-        removeSecondaries, excludeAbsPdgs, minPrimaryVertexId,
-        maxPrimaryVertexId, measurementCounter);
+        c, inputParticles, inputParticleMeasurementsMap, inputMeasurements,
+        outputParticles, rhoMin, rhoMax, absZMin, absZMax, timeMin, timeMax,
+        phiMin, phiMax, etaMin, etaMax, absEtaMin, absEtaMax, mMin, mMax, ptMin,
+        ptMax, hitsMin, hitsMax, measurementsMin, measurementsMax,
+        removeCharged, removeNeutral, removeSecondaries, excludeAbsPdgs,
+        minPrimaryVertexId, maxPrimaryVertexId, measurementCounter);
 
     pythonRangeProperty(c, "rho", &Config::rhoMin, &Config::rhoMax);
     pythonRangeProperty(c, "absZ", &Config::absZMin, &Config::absZMax);

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -71,39 +71,13 @@ void addTruthTracking(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputParticles);
-    ACTS_PYTHON_MEMBER(inputParticleMeasurementsMap);
-    ACTS_PYTHON_MEMBER(inputMeasurements);
-    ACTS_PYTHON_MEMBER(outputParticles);
-    ACTS_PYTHON_MEMBER(rhoMin);
-    ACTS_PYTHON_MEMBER(rhoMax);
-    ACTS_PYTHON_MEMBER(absZMin);
-    ACTS_PYTHON_MEMBER(absZMax);
-    ACTS_PYTHON_MEMBER(timeMin);
-    ACTS_PYTHON_MEMBER(timeMax);
-    ACTS_PYTHON_MEMBER(phiMin);
-    ACTS_PYTHON_MEMBER(phiMax);
-    ACTS_PYTHON_MEMBER(etaMin);
-    ACTS_PYTHON_MEMBER(etaMax);
-    ACTS_PYTHON_MEMBER(absEtaMin);
-    ACTS_PYTHON_MEMBER(absEtaMax);
-    ACTS_PYTHON_MEMBER(mMin);
-    ACTS_PYTHON_MEMBER(mMax);
-    ACTS_PYTHON_MEMBER(ptMin);
-    ACTS_PYTHON_MEMBER(ptMax);
-    ACTS_PYTHON_MEMBER(hitsMin);
-    ACTS_PYTHON_MEMBER(hitsMax);
-    ACTS_PYTHON_MEMBER(measurementsMin);
-    ACTS_PYTHON_MEMBER(measurementsMax);
-    ACTS_PYTHON_MEMBER(removeCharged);
-    ACTS_PYTHON_MEMBER(removeNeutral);
-    ACTS_PYTHON_MEMBER(removeSecondaries);
-    ACTS_PYTHON_MEMBER(excludeAbsPdgs);
-    ACTS_PYTHON_MEMBER(minPrimaryVertexId);
-    ACTS_PYTHON_MEMBER(maxPrimaryVertexId);
-    ACTS_PYTHON_MEMBER(measurementCounter);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(
+        c, inputParticles, inputParticleMeasurementsMap, outputParticles,
+        rhoMin, rhoMax, absZMin, absZMax, timeMin, timeMax, phiMin, phiMax,
+        etaMin, etaMax, absEtaMin, absEtaMax, mMin, mMax, ptMin, ptMax, hitsMin,
+        hitsMax, measurementsMin, measurementsMax, removeCharged, removeNeutral,
+        removeSecondaries, excludeAbsPdgs, minPrimaryVertexId,
+        maxPrimaryVertexId, measurementCounter);
 
     pythonRangeProperty(c, "rho", &Config::rhoMin, &Config::rhoMax);
     pythonRangeProperty(c, "absZ", &Config::absZMin, &Config::absZMax);
@@ -132,24 +106,10 @@ void addTruthTracking(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c);
-    ACTS_PYTHON_MEMBER(inputTrackParameters);
-    ACTS_PYTHON_MEMBER(outputTrackParameters);
-    ACTS_PYTHON_MEMBER(loc0Min);
-    ACTS_PYTHON_MEMBER(loc0Max);
-    ACTS_PYTHON_MEMBER(loc1Min);
-    ACTS_PYTHON_MEMBER(loc1Max);
-    ACTS_PYTHON_MEMBER(timeMin);
-    ACTS_PYTHON_MEMBER(timeMax);
-    ACTS_PYTHON_MEMBER(phiMin);
-    ACTS_PYTHON_MEMBER(phiMax);
-    ACTS_PYTHON_MEMBER(etaMin);
-    ACTS_PYTHON_MEMBER(etaMax);
-    ACTS_PYTHON_MEMBER(absEtaMin);
-    ACTS_PYTHON_MEMBER(absEtaMax);
-    ACTS_PYTHON_MEMBER(ptMin);
-    ACTS_PYTHON_MEMBER(ptMax);
-    ACTS_PYTHON_STRUCT_END();
+    ACTS_PYTHON_STRUCT(c, inputTrackParameters, outputTrackParameters, loc0Min,
+                       loc0Max, loc1Min, loc1Max, timeMin, timeMax, phiMin,
+                       phiMax, etaMin, etaMax, absEtaMin, absEtaMax, ptMin,
+                       ptMax);
 
     pythonRangeProperty(c, "loc0", &Config::loc0Min, &Config::loc0Max);
     pythonRangeProperty(c, "loc1", &Config::loc1Min, &Config::loc1Max);

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -71,7 +71,7 @@ void addTruthTracking(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputParticles);
     ACTS_PYTHON_MEMBER(inputParticleMeasurementsMap);
     ACTS_PYTHON_MEMBER(inputMeasurements);
@@ -132,7 +132,7 @@ void addTruthTracking(Context& ctx) {
 
     auto c = py::class_<Config>(alg, "Config").def(py::init<>());
 
-    ACTS_PYTHON_STRUCT_BEGIN(c, Config);
+    ACTS_PYTHON_STRUCT_BEGIN(c);
     ACTS_PYTHON_MEMBER(inputTrackParameters);
     ACTS_PYTHON_MEMBER(outputTrackParameters);
     ACTS_PYTHON_MEMBER(loc0Min);


### PR DESCRIPTION
This PR refactors the variadic helper struct to avoid the need to pass in the type explicitly. We can determine it from the instance.


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a unified macro that simplifies the definition of Python structures.

- **Refactor**
	- Streamlined the Python binding registrations across various components by removing redundant type parameters.
	- Enhanced code clarity and consistency in the exposure of configuration objects without impacting overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->