### PR TITLE
fix: component wise digitisation (now for real)

### DIFF
--- a/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationAlgorithm.cpp
@@ -355,11 +355,11 @@ DigitizedParameters DigitizationAlgorithm::localParameters(
       for (std::size_t ib = 0; ib < 2; ++ib) {
         if (geoCfg.digital && geoCfg.componentDigital) {
           // only fill component of this row/column if not yet filled
-          if (componentChannels[ib].contains(bin[ib])) {
+          if (!componentChannels[ib].contains(bin[ib])) {
             totalWeight[ib] += weight;
             pos[ib] += weight * binningData[ib].center(bin[ib]);
+            componentChannels[ib].insert(bin[ib]);
           }
-          componentChannels[ib].insert(bin[ib]);
         } else {
           totalWeight[ib] += weight;
           pos[ib] += weight * binningData[ib].center(bin[ib]);


### PR DESCRIPTION
With my last `SonarCloud` inspired fix I introduced a stupid bug in the component wise clustering.

This fixes it.
 

--- END COMMIT MESSAGE ---

Before:
![hist_residual_loc0_vol23_csize2](https://github.com/user-attachments/assets/cc611596-78de-428a-a9b8-f8c07ae66fba)

After:
![hist_residual_loc0_vol23_csize2 2](https://github.com/user-attachments/assets/07da7deb-3c07-4fcc-b104-d4bb489742dd)


Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented redundant updates, ensuring that only new data is processed.
- **Refactor**
	- Streamlined the algorithm’s update logic for more reliable and precise data aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->