### PR TITLE
fix: typo in physmon modes for refit

### DIFF
--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -435,7 +435,7 @@ if [[ "$mode" == "all" || "$mode" == "gx2f" ]]; then
         --config CI/physmon/config/trackfitting_gx2f.yml
 fi
 
-if [[ "$mode" == "all" || "$mode" == "kf_refit" ]]; then
+if [[ "$mode" == "all" || "$mode" == "refit_kf" ]]; then
     run_histcmp \
         $outdir/data/trackrefitting_kf/performance_trackrefitting.root \
         $refdir/trackrefitting_kf/performance_trackrefitting.root \
@@ -445,7 +445,7 @@ if [[ "$mode" == "all" || "$mode" == "kf_refit" ]]; then
         --config CI/physmon/config/trackfitting_kf.yml
 fi
 
-if [[ "$mode" == "all" || "$mode" == "gsf_refit" ]]; then
+if [[ "$mode" == "all" || "$mode" == "refit_gsf" ]]; then
     run_histcmp \
         $outdir/data/trackrefitting_gsf/performance_trackrefitting.root \
         $refdir/trackrefitting_gsf/performance_trackrefitting.root \


### PR DESCRIPTION
We had a mix in modes with `refit_xx` and `xx_refit`. This didn't pop up since we run `all` in the CI.

I converged to `refit_xx` to not change the existing flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal naming conventions for performance mode checks, ensuring that identifiers for track refitting evaluations are consistent and aligned with updated standards. This update refines the process without altering the overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->