### PR TITLE
ci: Bump histcmp to v0.8.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -191,7 +191,7 @@ jobs:
         run: >
           echo "::group::Dependencies"
           && git config --global safe.directory "$GITHUB_WORKSPACE"
-          && python3 -m pip install histcmp==0.6.8 matplotlib
+          && python3 -m pip install histcmp==0.8.1 matplotlib
           && python3 -m pip install -r Examples/Scripts/requirements.txt
           && geant4-config --install-datasets
           && venv_python=$(which python3)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -327,7 +327,7 @@ linux_physmon:
     - cd ..
 
     - git config --global safe.directory "$GITHUB_WORKSPACE"
-    - python3 -m pip install histcmp==0.6.8 matplotlib
+    - python3 -m pip install histcmp==0.8.1 matplotlib
     - python3 -m pip install -r src/Examples/Scripts/requirements.txt
     - geant4-config --install-datasets
     - venv_python=$(which python3)


### PR DESCRIPTION
Physmon gave me:
```
histcmp 0.6.8 requires numpy<2.0.0,>=1.25.0, but you have numpy 2.1.3 which is incompatible.
histcmp 0.6.8 requires typer<0.10.0,>=0.9.0, but you have typer 0.13.1 which is incompatible.
```
This should work with the newer histcmp version