### PR TITLE
feat : Add generic pointer concept

### DIFF
--- a/Core/include/Acts/EventData/TrackStateProxy.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxy.hpp
@@ -41,6 +41,8 @@ using ConstIf = std::conditional_t<select, const T, T>;
 template <typename T>
 class TransitiveConstPointer {
  public:
+
+  using element_type = T;
   TransitiveConstPointer() = default;
   explicit TransitiveConstPointer(T* ptr) : m_ptr{ptr} {}
 
@@ -73,7 +75,7 @@ class TransitiveConstPointer {
  private:
   T* ptr() const { return m_ptr; }
 
-  T* m_ptr;
+  T* m_ptr{nullptr};
 };
 
 /// Type construction helper for fixed size coefficients and associated

--- a/Core/include/Acts/EventData/TrackStateProxy.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxy.hpp
@@ -72,6 +72,8 @@ class TransitiveConstPointer {
 
   T& operator*() { return *m_ptr; }
 
+  operator bool() const { return m_ptr != nullptr; }
+
  private:
   T* ptr() const { return m_ptr; }
 

--- a/Core/include/Acts/Utilities/PointerConcept.hpp
+++ b/Core/include/Acts/Utilities/PointerConcept.hpp
@@ -1,0 +1,44 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#pragma once
+#include <concepts>
+#include <type_traits>
+namespace Acts {
+/** @brief The Pointer concept is an extension of the usual std::is_pointer_v type trait to
+ *         also include the smart pointers like
+ *     std::shared_ptr<T>,
+ *     std::unique_ptr<T>
+ *  The smart pointer is required to have an element_type typedef indicating
+ * over which data type the pointer is constructed, the arrow operator
+ *
+ *      T* operator->() const;
+ *  and also the dereference operator
+ *
+ *      T& operator*() const  */
+template <typename Pointer_t>
+concept SmartPointerConcept = requires(Pointer_t ptr) {
+  
+  typename Pointer_t::element_type;
+  /** @brief arrow operator element_type* operator->() const; */
+  {
+    ptr.operator->()
+  } -> std::same_as<std::add_pointer_t<typename Pointer_t::element_type>>;
+  /** @brief dereference operator element_type& operator->() const; */
+  { ptr.operator*() } -> std::same_as<typename Pointer_t::element_type&>;
+};
+template <typename Pointer_t>
+concept PointerConcept =
+    (std::is_pointer_v<Pointer_t> || SmartPointerConcept<Pointer_t>);
+}  // namespace Acts
+
+namespace std {
+template <Acts::SmartPointerConcept T>
+struct remove_pointer<T> {
+  typedef typename T::element_type type;
+};
+}  // namespace std

--- a/Core/include/Acts/Utilities/PointerConcept.hpp
+++ b/Core/include/Acts/Utilities/PointerConcept.hpp
@@ -30,6 +30,8 @@ concept SmartPointerConcept = requires(Pointer_t ptr) {
   } -> std::same_as<std::add_pointer_t<typename Pointer_t::element_type>>;
   /** @brief dereference operator element_type& operator->() const; */
   { ptr.operator*() } -> std::same_as<typename Pointer_t::element_type&>;
+  /** @brief Simple cast to check for if(ptr) */
+  { ptr.operator bool() };
 };
 template <typename Pointer_t>
 concept PointerConcept =

--- a/Tests/UnitTests/Core/Utilities/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Utilities/CMakeLists.txt
@@ -6,6 +6,7 @@ add_unittest(BinAdjustment BinAdjustmentTests.cpp)
 add_unittest(BinAdjustmentVolume BinAdjustmentVolumeTests.cpp)
 add_unittest(BinningData BinningDataTests.cpp)
 add_unittest(BinUtility BinUtilityTests.cpp)
+add_unittest(PointerConcept PointerConceptTest.cpp)
 
 add_unittest(BoundingBox BoundingBoxTest.cpp)
 target_link_libraries(ActsUnitTestBoundingBox PRIVATE std::filesystem)

--- a/Tests/UnitTests/Core/Utilities/PointerConceptTest.cpp
+++ b/Tests/UnitTests/Core/Utilities/PointerConceptTest.cpp
@@ -44,8 +44,7 @@ BOOST_AUTO_TEST_CASE(testConceptPass) {
     BOOST_CHECK(testPointer(std::shared_ptr<const int>{nullptr}));
   
     BOOST_CHECK(testPointer(detail_lt::TransitiveConstPointer<int>{nullptr}));
-
-    // BOOST_CHECK(testPointer(std::unique_ptr<int []>{nullptr}));
+    BOOST_CHECK(testPointer(detail_lt::TransitiveConstPointer<const int>{nullptr}));
 
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Utilities/PointerConceptTest.cpp
+++ b/Tests/UnitTests/Core/Utilities/PointerConceptTest.cpp
@@ -1,0 +1,55 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Utilities/PointerConcept.hpp"
+#include "Acts/EventData/TrackStateProxy.hpp"
+#include <memory>
+#include <iostream>
+
+namespace Acts {
+namespace Test {
+
+template <typename T> 
+    bool testPointer(const T /*ptr*/) {
+        std::cout<<"Object of "<<typeid(T).name()<<" does not pass the pointer concept "<<std::endl;
+        return false;
+    }
+
+template <PointerConcept T>
+    bool testPointer(const T /*ptr*/) {
+        std::cout<<"Object of "<<typeid(T).name()<<" passes the pointer concept "<<std::endl;
+        return true;
+    }
+
+BOOST_AUTO_TEST_SUITE(PointerConceptTests)
+
+BOOST_AUTO_TEST_CASE(testConceptPass) {
+    int* raw_ptr{nullptr};
+    BOOST_CHECK(testPointer(raw_ptr));
+    int raw_val{0};
+    BOOST_CHECK(!testPointer(raw_val));
+
+    BOOST_CHECK(testPointer(std::unique_ptr<int>{nullptr}));
+    BOOST_CHECK(testPointer(std::unique_ptr<const int>{nullptr}));
+  
+    BOOST_CHECK(testPointer(std::shared_ptr<int>{nullptr}));
+    BOOST_CHECK(testPointer(std::shared_ptr<const int>{nullptr}));
+  
+    BOOST_CHECK(testPointer(detail_lt::TransitiveConstPointer<int>{nullptr}));
+
+    // BOOST_CHECK(testPointer(std::unique_ptr<int []>{nullptr}));
+
+}
+BOOST_AUTO_TEST_SUITE_END()
+
+
+}
+}  // namespace Acts


### PR DESCRIPTION
Introduce a new concept that's extending the ordinary std::is_pointer_v<T> concept by smart pointer like objects. These objects can be anything, but  need to have the 3 basic properties of a (smart) pointer: arrow operator,  derefrence, and check whether the pointer is valid

--- END COMMIT MESSAGE ---