### PR TITLE
refactor: remove useless asserts

### DIFF
--- a/Core/include/Acts/EventData/SpacePointData.ipp
+++ b/Core/include/Acts/EventData/SpacePointData.ipp
@@ -11,75 +11,61 @@
 namespace Acts {
 
 inline float SpacePointData::x(const std::size_t idx) const {
-  assert(idx < m_x.size());
   return m_x[idx];
 }
 
 inline float SpacePointData::y(const std::size_t idx) const {
-  assert(idx < m_y.size());
   return m_y[idx];
 }
 
 inline float SpacePointData::z(const std::size_t idx) const {
-  assert(idx < m_z.size());
   return m_z[idx];
 }
 
 inline float SpacePointData::radius(const std::size_t idx) const {
-  assert(idx < m_radius.size());
   return m_radius[idx];
 }
 
 inline float SpacePointData::phi(const std::size_t idx) const {
-  assert(idx < m_phi.size());
   return m_phi[idx];
 }
 
 inline float SpacePointData::varianceZ(const std::size_t idx) const {
-  assert(idx < m_varianceZ.size());
   return m_varianceZ[idx];
 }
 
 inline float SpacePointData::varianceR(const std::size_t idx) const {
-  assert(idx < m_varianceR.size());
   return m_varianceR[idx];
 }
 
 inline void SpacePointData::setX(const std::size_t idx, const float value) {
-  assert(idx < m_x.size());
   m_x[idx] = value;
 }
 
 inline void SpacePointData::setY(const std::size_t idx, const float value) {
-  assert(idx < m_y.size());
   m_y[idx] = value;
 }
 
 inline void SpacePointData::setZ(const std::size_t idx, const float value) {
-  assert(idx < m_z.size());
   m_z[idx] = value;
 }
 
 inline void SpacePointData::setRadius(const std::size_t idx,
                                       const float value) {
-  assert(idx < m_radius.size());
   m_radius[idx] = value;
 }
 
 inline void SpacePointData::setPhi(const std::size_t idx, const float value) {
-  assert(idx < m_phi.size());
   m_phi[idx] = value;
 }
 
 inline void SpacePointData::setVarianceZ(const std::size_t idx,
                                          const float value) {
-  assert(idx < m_varianceZ.size());
   m_varianceZ[idx] = value;
 }
 
 inline void SpacePointData::setVarianceR(const std::size_t idx,
                                          const float value) {
-  assert(idx < m_varianceR.size());
   m_varianceR[idx] = value;
 }
 
@@ -89,49 +75,41 @@ inline bool SpacePointData::hasDynamicVariable() const {
 
 inline const Acts::Vector3& SpacePointData::topStripVector(
     const std::size_t idx) const {
-  assert(idx < m_topStripVector.size());
   return m_topStripVector[idx];
 }
 
 inline const Acts::Vector3& SpacePointData::bottomStripVector(
     const std::size_t idx) const {
-  assert(idx < m_bottomStripVector.size());
   return m_bottomStripVector[idx];
 }
 
 inline const Acts::Vector3& SpacePointData::stripCenterDistance(
     const std::size_t idx) const {
-  assert(idx < m_stripCenterDistance.size());
   return m_stripCenterDistance[idx];
 }
 
 inline const Acts::Vector3& SpacePointData::topStripCenterPosition(
     const std::size_t idx) const {
-  assert(idx < m_topStripCenterPosition.size());
   return m_topStripCenterPosition[idx];
 }
 
 inline void SpacePointData::setTopStripVector(const std::size_t idx,
                                               const Acts::Vector3& value) {
-  assert(idx < m_topStripVector.size());
   m_topStripVector[idx] = value;
 }
 
 inline void SpacePointData::setBottomStripVector(const std::size_t idx,
                                                  const Acts::Vector3& value) {
-  assert(idx < m_bottomStripVector.size());
   m_bottomStripVector[idx] = value;
 }
 
 inline void SpacePointData::setStripCenterDistance(const std::size_t idx,
                                                    const Acts::Vector3& value) {
-  assert(idx < m_stripCenterDistance.size());
   m_stripCenterDistance[idx] = value;
 }
 
 inline void SpacePointData::setTopStripCenterPosition(
     const std::size_t idx, const Acts::Vector3& value) {
-  assert(idx < m_topStripCenterPosition.size());
   m_topStripCenterPosition[idx] = value;
 }
 


### PR DESCRIPTION
These asserts are not usefull. The SpacePointData object is constructed by the SpacePointContainer and the size of the vectors, as well as the number of space point proxies, are always consistent. Thus, there is no way these asserts can complain.

\cc @pbutti 