### PR TITLE
feat: Add an averaging timer

### DIFF
--- a/Core/include/Acts/Utilities/ScopedTimer.hpp
+++ b/Core/include/Acts/Utilities/ScopedTimer.hpp
@@ -83,7 +83,7 @@ class AveragingScopedTimer {
     Sample(const Sample&) = delete;
     Sample& operator=(const Sample&) = delete;
     /// @brief Move constructor that transfers ownership of timing to new sample
-    Sample(Sample&&);
+    Sample(Sample&& /*other*/);
     Sample& operator=(Sample&&) = delete;
 
    private:

--- a/Core/include/Acts/Utilities/ScopedTimer.hpp
+++ b/Core/include/Acts/Utilities/ScopedTimer.hpp
@@ -32,38 +32,103 @@ namespace Acts {
 ///
 class ScopedTimer {
  public:
+  using clock_type = std::chrono::high_resolution_clock;
+
   /// @brief Construct a new Scoped Timer
   ///
   /// @param name Identifier for the timed block
   /// @param logger Logger instance to use for output
   /// @param lvl Logging level for the timing output
   explicit ScopedTimer(const std::string& name, const Logger& logger,
-                       Logging::Level lvl = Logging::Level::INFO)
-      : m_name(name), m_lvl(lvl), m_logger(&logger) {
-    m_start = std::chrono::high_resolution_clock::now();
-  }
+                       Logging::Level lvl = Logging::Level::INFO);
 
   /// @brief Destructor that logs the execution time
   ///
   /// Automatically calculates and logs the duration between construction
   /// and destruction using the specified logger and level.
-  ~ScopedTimer() {
-    if (m_logger->doPrint(m_lvl)) {
-      auto end = std::chrono::high_resolution_clock::now();
-      auto duration =
-          std::chrono::duration_cast<std::chrono::milliseconds>(end - m_start);
-      std::ostringstream oss;
-      oss << m_name << " took " << duration.count() << " ms";
-      m_logger->log(m_lvl, oss.str());
-    }
-  }
+  ~ScopedTimer();
+
+  ScopedTimer(const ScopedTimer&) = delete;
+  ScopedTimer& operator=(const ScopedTimer&) = delete;
+  ScopedTimer(ScopedTimer&&) = delete;
+  ScopedTimer& operator=(ScopedTimer&&) = delete;
 
  private:
-  std::string m_name;      ///< Identifier for the timed block
-  Logging::Level m_lvl;    ///< Logging level for output
-  const Logger* m_logger;  ///< Logger instance for output
-  std::chrono::high_resolution_clock::time_point
-      m_start;  ///< Start time of the timer
+  std::string m_name;              ///< Identifier for the timed block
+  Logging::Level m_lvl;            ///< Logging level for output
+  const Logger* m_logger;          ///< Logger instance for output
+  clock_type::time_point m_start;  ///< Start time of the timer
 };
 
+/// @brief A timer class that measures and averages execution times of multiple samples
+///
+/// This class provides functionality to measure execution times of code blocks
+/// and calculate statistics (mean, standard deviation) across multiple samples.
+/// It uses RAII through the Sample class to automatically record timing
+/// information.
+class AveragingScopedTimer {
+ public:
+  using clock_type = std::chrono::high_resolution_clock;
+
+  /// @brief RAII wrapper class for measuring individual timing samples
+  ///
+  /// When constructed, starts a timer. When destroyed, automatically records
+  /// the duration to the parent AveragingScopedTimer.
+  class Sample {
+   public:
+    /// @brief Construct a new sample and start timing
+    explicit Sample(AveragingScopedTimer& parent);
+    /// @brief Record the duration when destroyed
+    ~Sample();
+    Sample(const Sample&) = delete;
+    Sample& operator=(const Sample&) = delete;
+    /// @brief Move constructor that transfers ownership of timing to new sample
+    Sample(Sample&&);
+    Sample& operator=(Sample&&) = delete;
+
+   private:
+    AveragingScopedTimer* m_parent;
+    clock_type::time_point m_start;
+  };
+
+  /// @brief Construct a new AveragingScopedTimer
+  ///
+  /// @param name Name of the timer for logging
+  /// @param logger Logger instance to use for output
+  /// @param lvl Logging level for timing output
+  explicit AveragingScopedTimer(const std::string& name, const Logger& logger,
+                                Logging::Level lvl = Logging::Level::INFO);
+
+  /// @brief Destroy the AveragingScopedTimer and log statistics
+  ///
+  /// Outputs total duration and per-sample statistics (mean ± stddev) if
+  /// logging is enabled at the configured level.
+  ~AveragingScopedTimer();
+  AveragingScopedTimer(const AveragingScopedTimer&) = delete;
+  AveragingScopedTimer& operator=(const AveragingScopedTimer&) = delete;
+  AveragingScopedTimer(AveragingScopedTimer&&) = delete;
+  AveragingScopedTimer& operator=(AveragingScopedTimer&&) = delete;
+
+  /// @brief Create a new timing sample
+  ///
+  /// @return Sample RAII wrapper for measuring a single timing sample
+  Sample sample();
+
+  friend class Sample;
+
+ private:
+  /// @brief Add a timing sample to the statistics
+  ///
+  /// @param duration Duration of the sample in milliseconds
+  void addSample(std::chrono::milliseconds duration);
+
+  double m_sumDuration = 0;  ///< Sum of all sample durations
+  double m_sumDurationSquared =
+      0;  ///< Sum of squared durations for stddev calculation
+  std::size_t m_nSamples = 0;  ///< Number of samples recorded
+
+  std::string m_name;      ///< Name of the timer for logging
+  Logging::Level m_lvl;    ///< Logging level for output
+  const Logger* m_logger;  ///< Logger instance for output
+};
 }  // namespace Acts

--- a/Core/src/Utilities/CMakeLists.txt
+++ b/Core/src/Utilities/CMakeLists.txt
@@ -10,4 +10,5 @@ target_sources(
         IAxis.cpp
         GraphViz.cpp
         ProtoAxis.cpp
+        ScopedTimer.cpp
 )

--- a/Core/src/Utilities/ScopedTimer.cpp
+++ b/Core/src/Utilities/ScopedTimer.cpp
@@ -1,0 +1,83 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Utilities/ScopedTimer.hpp"
+
+#include <chrono>
+#include <cmath>
+
+namespace Acts {
+
+ScopedTimer::ScopedTimer(const std::string& name, const Logger& logger,
+                         Logging::Level lvl)
+    : m_name(name), m_lvl(lvl), m_logger(&logger) {
+  m_start = clock_type::now();
+}
+
+ScopedTimer::~ScopedTimer() {
+  auto end = clock_type::now();
+  auto duration =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - m_start);
+  if (m_logger->doPrint(m_lvl)) {
+    std::ostringstream oss;
+    oss << m_name << " took " << duration.count() << " ms";
+    m_logger->log(m_lvl, oss.str());
+  }
+}
+
+AveragingScopedTimer::AveragingScopedTimer(const std::string& name,
+                                           const Logger& logger,
+                                           Logging::Level lvl)
+    : m_name(name), m_lvl(lvl), m_logger(&logger) {}
+
+void AveragingScopedTimer::addSample(std::chrono::milliseconds duration) {
+  m_sumDuration += duration.count();
+  m_sumDurationSquared += duration.count() * duration.count();
+  m_nSamples++;
+}
+
+AveragingScopedTimer::Sample::Sample(AveragingScopedTimer& parent)
+    : m_parent(&parent), m_start(clock_type::now()) {}
+
+AveragingScopedTimer::Sample::Sample(Sample&& other)
+    : m_parent(other.m_parent), m_start(other.m_start) {
+  // Disable the moved-from sample
+  other.m_parent = nullptr;
+}
+
+AveragingScopedTimer::Sample AveragingScopedTimer::sample() {
+  return Sample{*this};
+}
+
+AveragingScopedTimer::Sample::~Sample() {
+  // parent nullptr means the sample was moved
+  if (m_parent != nullptr) {
+    auto end = clock_type::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - m_start);
+    m_parent->addSample(duration);
+  }
+}
+
+AveragingScopedTimer::~AveragingScopedTimer() {
+  if (m_logger->doPrint(m_lvl)) {
+    std::ostringstream oss;
+    if (m_nSamples > 0) {
+      double mean = m_sumDuration / m_nSamples;
+      double stddev =
+          std::sqrt(m_sumDurationSquared / m_nSamples - mean * mean);
+      oss << m_name << " took " << m_sumDuration << " ms total, " << mean
+          << " ms +- " << stddev << " ms per sample (#" << m_nSamples << ")";
+    } else {
+      oss << m_name << " took " << m_sumDuration << " ms total (no samples)";
+    }
+    m_logger->log(m_lvl, oss.str());
+  }
+}
+
+}  // namespace Acts


### PR DESCRIPTION
This timer is a variation on the `ScopedTimer`: instead of recording it's own lifetime duration, it can collect samples (think: durations of loops) and will print the number of samples, their total time, mean and standard deviation when it's destroyed.

```cpp
{
  Acts::AveragingScopedTimer timer{"Measure", logger()};
  for(std::size_t i=0;i<1000;i++) {
    auto sample = timer.sample()
    // Do expensive stuff here
  }
  // `timer` prints output here now
}

```

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced performance monitoring tool that aggregates timing samples and displays statistical insights such as average and variability.

- **Chores**
  - Updated internal build configurations to support the new performance measurement components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->