### PR TITLE
chore: remove dir from proto axis

### DIFF
--- a/Core/include/Acts/Detector/Blueprint.hpp
+++ b/Core/include/Acts/Detector/Blueprint.hpp
@@ -100,8 +100,8 @@ struct Node final {
   std::vector<AxisDirection> binning = {};
 
   /// Portal proto material binning
-  std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
-      portalMaterialBinning = {};
+  std::map<unsigned int, std::vector<DirectedProtoAxis>> portalMaterialBinning =
+      {};
 
   /// Auxiliary information
   std::vector<std::string> auxiliary = {};

--- a/Core/include/Acts/Detector/Blueprint.hpp
+++ b/Core/include/Acts/Detector/Blueprint.hpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace Acts::Experimental {
@@ -99,7 +100,8 @@ struct Node final {
   std::vector<AxisDirection> binning = {};
 
   /// Portal proto material binning
-  std::map<unsigned int, std::vector<ProtoAxis>> portalMaterialBinning = {};
+  std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+      portalMaterialBinning = {};
 
   /// Auxiliary information
   std::vector<std::string> auxiliary = {};

--- a/Core/include/Acts/Detector/CylindricalContainerBuilder.hpp
+++ b/Core/include/Acts/Detector/CylindricalContainerBuilder.hpp
@@ -19,6 +19,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 namespace Acts::Experimental {
@@ -56,7 +57,8 @@ class CylindricalContainerBuilder : public IDetectorComponentBuilder {
     /// The geometry id generator
     std::shared_ptr<const IGeometryIdGenerator> geoIdGenerator = nullptr;
     /// Material binning to be assigned to portals
-    std::map<unsigned int, std::vector<ProtoAxis>> portalMaterialBinning = {};
+    std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+        portalMaterialBinning = {};
     /// An eventual reverse geometry id generation
     bool geoIdReverseGen = false;
     /// Auxiliary information, mainly for screen output

--- a/Core/include/Acts/Detector/CylindricalContainerBuilder.hpp
+++ b/Core/include/Acts/Detector/CylindricalContainerBuilder.hpp
@@ -57,7 +57,7 @@ class CylindricalContainerBuilder : public IDetectorComponentBuilder {
     /// The geometry id generator
     std::shared_ptr<const IGeometryIdGenerator> geoIdGenerator = nullptr;
     /// Material binning to be assigned to portals
-    std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+    std::map<unsigned int, std::vector<DirectedProtoAxis>>
         portalMaterialBinning = {};
     /// An eventual reverse geometry id generation
     bool geoIdReverseGen = false;

--- a/Core/include/Acts/Detector/DetectorVolumeBuilder.hpp
+++ b/Core/include/Acts/Detector/DetectorVolumeBuilder.hpp
@@ -45,7 +45,7 @@ class DetectorVolumeBuilder : public IDetectorComponentBuilder {
     /// The geometry id generator
     std::shared_ptr<const IGeometryIdGenerator> geoIdGenerator = nullptr;
     /// Material binning to be assigned to portals
-    std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+    std::map<unsigned int, std::vector<DirectedProtoAxis>>
         portalMaterialBinning = {};
     /// Add eventual internal volume to root
     bool addInternalsToRoot = false;

--- a/Core/include/Acts/Detector/DetectorVolumeBuilder.hpp
+++ b/Core/include/Acts/Detector/DetectorVolumeBuilder.hpp
@@ -11,11 +11,13 @@
 #include "Acts/Detector/DetectorComponents.hpp"
 #include "Acts/Detector/interface/IDetectorComponentBuilder.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 
 #include <memory>
 #include <string>
+#include <tuple>
 
 namespace Acts::Experimental {
 class IExternalStructureBuilder;
@@ -43,7 +45,8 @@ class DetectorVolumeBuilder : public IDetectorComponentBuilder {
     /// The geometry id generator
     std::shared_ptr<const IGeometryIdGenerator> geoIdGenerator = nullptr;
     /// Material binning to be assigned to portals
-    std::map<unsigned int, std::vector<ProtoAxis>> portalMaterialBinning = {};
+    std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+        portalMaterialBinning = {};
     /// Add eventual internal volume to root
     bool addInternalsToRoot = false;
     /// Auxiliary information

--- a/Core/include/Acts/Detector/LayerStructureBuilder.hpp
+++ b/Core/include/Acts/Detector/LayerStructureBuilder.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Detector/interface/ISurfacesProvider.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 
@@ -83,7 +84,8 @@ class LayerStructureBuilder : public IInternalStructureBuilder {
     /// Definition of Supports
     std::vector<ProtoSupport> supports = {};
     /// Definition of Binnings
-    std::vector<std::tuple<ProtoAxis, std::size_t>> binnings = {};
+    std::vector<std::tuple<ProtoAxis, AxisDirection, std::size_t>> binnings =
+        {};
     /// Optional extent (if already parsed), will trigger binning autorange
     /// check
     std::optional<Extent> extent = std::nullopt;

--- a/Core/include/Acts/Detector/MultiWireStructureBuilder.hpp
+++ b/Core/include/Acts/Detector/MultiWireStructureBuilder.hpp
@@ -14,6 +14,7 @@
 #include "Acts/Detector/interface/IInternalStructureBuilder.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 
@@ -42,7 +43,8 @@ class MultiWireStructureBuilder {
     std::vector<double> mlBounds = {};
 
     // The binning of the multi wire structure
-    std::vector<std::tuple<ProtoAxis, std::size_t>> mlBinning = {};
+    std::vector<std::tuple<ProtoAxis, AxisDirection, std::size_t>> mlBinning =
+        {};
 
     /// A tolerance config
     float toleranceOverlap = 10.;

--- a/Core/include/Acts/Detector/detail/IndexedSurfacesGenerator.hpp
+++ b/Core/include/Acts/Detector/detail/IndexedSurfacesGenerator.hpp
@@ -25,6 +25,7 @@ namespace Acts::detail::IndexedSurfacesGenerator {
 /// @param surfaces the surfaces to be indexed
 /// @param rGenerator the reference generator
 /// @param pAxis the proto axis
+/// @param pAxisDir the axis direction
 /// @param pFillExpansion the fill expansion
 /// @param assignToAll the indices assigned to all bins
 /// @param transform the transform into the local binning schema
@@ -34,14 +35,15 @@ template <template <typename> class indexed_updator, typename surface_container,
 Experimental::InternalNavigationDelegate createInternalNavigation(
     const GeometryContext& gctx, const surface_container& surfaces,
     const reference_generator& rGenerator, const ProtoAxis& pAxis,
-    std::size_t pFillExpansion, const std::vector<std::size_t> assignToAll = {},
+    AxisDirection pAxisDir, std::size_t pFillExpansion,
+    const std::vector<std::size_t> assignToAll = {},
     const Transform3 transform = Transform3::Identity()) {
   // Let the axis create the grid
   return pAxis.getAxis().visit([&]<typename AxisTypeA>(const AxisTypeA& axis) {
     Grid<std::vector<std::size_t>, AxisTypeA> grid(axis);
 
     // Prepare the indexed updator
-    std::array<AxisDirection, 1u> axisDirs = {pAxis.getAxisDirection()};
+    std::array<AxisDirection, 1u> axisDirs = {pAxisDir};
     indexed_updator<decltype(grid)> indexedSurfaces(std::move(grid), axisDirs,
                                                     transform);
 
@@ -76,8 +78,10 @@ Experimental::InternalNavigationDelegate createInternalNavigation(
 /// @param surfaces the surfaces to be indexed
 /// @param rGenerator the reference generator
 /// @param pAxisA the first proto axis
+/// @param pAxisDirA the axis direction
 /// @param fillExpansionA the fill expansion of the first axis
 /// @param pAxisB the second proto axis
+/// @param pAxisDirB the axis direction
 /// @param fillExpansionB the fill expansion of the second axis
 /// @param assignToAll the indices assigned to all bins
 /// @param transform the transform into the local binning schema
@@ -88,7 +92,8 @@ template <template <typename> class indexed_updator, typename surface_container,
 Experimental::InternalNavigationDelegate createInternalNavigation(
     const GeometryContext& gctx, const surface_container& surfaces,
     const reference_generator& rGenerator, const ProtoAxis& pAxisA,
-    std::size_t fillExpansionA, const ProtoAxis& pAxisB,
+    AxisDirection pAxisDirA, std::size_t fillExpansionA,
+    const ProtoAxis& pAxisB, AxisDirection pAxisDirB,
     std::size_t fillExpansionB, const std::vector<std::size_t> assignToAll = {},
     const Transform3 transform = Transform3::Identity()) {
   // Let the axes create the grid
@@ -100,8 +105,7 @@ Experimental::InternalNavigationDelegate createInternalNavigation(
       Experimental::InternalNavigationDelegate nStateUpdater;
 
       // Prepare the indexed updator
-      std::array<AxisDirection, 2u> axisDirs = {pAxisA.getAxisDirection(),
-                                                pAxisB.getAxisDirection()};
+      std::array<AxisDirection, 2u> axisDirs = {pAxisDirA, pAxisDirB};
       indexed_updator<decltype(grid)> indexedSurfaces(std::move(grid), axisDirs,
                                                       transform);
 

--- a/Core/include/Acts/Detector/detail/ProtoMaterialHelper.hpp
+++ b/Core/include/Acts/Detector/detail/ProtoMaterialHelper.hpp
@@ -30,9 +30,9 @@ namespace Experimental::detail::ProtoMaterialHelper {
 ///
 /// @return an (eventual) updated binning description for structured
 ///         screen logging output
-std::vector<std::tuple<ProtoAxis, AxisDirection>> attachProtoMaterial(
+std::vector<DirectedProtoAxis> attachProtoMaterial(
     const GeometryContext& gctx, Surface& surface,
-    const std::vector<std::tuple<ProtoAxis, AxisDirection>>& bDescription);
+    const std::vector<DirectedProtoAxis>& bDescription);
 
 }  // namespace Experimental::detail::ProtoMaterialHelper
 }  // namespace Acts

--- a/Core/include/Acts/Detector/detail/ProtoMaterialHelper.hpp
+++ b/Core/include/Acts/Detector/detail/ProtoMaterialHelper.hpp
@@ -9,7 +9,11 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
+
+#include <tuple>
+#include <vector>
 
 namespace Acts {
 
@@ -26,9 +30,9 @@ namespace Experimental::detail::ProtoMaterialHelper {
 ///
 /// @return an (eventual) updated binning description for structured
 ///         screen logging output
-std::vector<ProtoAxis> attachProtoMaterial(
+std::vector<std::tuple<ProtoAxis, AxisDirection>> attachProtoMaterial(
     const GeometryContext& gctx, Surface& surface,
-    const std::vector<ProtoAxis>& bDescription);
+    const std::vector<std::tuple<ProtoAxis, AxisDirection>>& bDescription);
 
 }  // namespace Experimental::detail::ProtoMaterialHelper
 }  // namespace Acts

--- a/Core/include/Acts/Geometry/MaterialDesignatorBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/MaterialDesignatorBlueprintNode.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Geometry/CuboidPortalShell.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
 #include "Acts/Geometry/CylinderPortalShell.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 
 #include <variant>
@@ -25,9 +26,13 @@ namespace Acts::Experimental {
 ///       tree building, but during geometry construction.
 class MaterialDesignatorBlueprintNode final : public BlueprintNode {
  public:
-  using BinningConfig = std::variant<
-      std::vector<std::tuple<CylinderVolumeBounds::Face, ProtoAxis, ProtoAxis>>,
-      std::vector<std::tuple<CuboidVolumeBounds::Face, ProtoAxis, ProtoAxis>>>;
+  using CylinderBinning = std::tuple<CylinderVolumeBounds::Face, ProtoAxis,
+                                     AxisDirection, ProtoAxis, AxisDirection>;
+  using CuboidBinning = std::tuple<CuboidVolumeBounds::Face, ProtoAxis,
+                                   AxisDirection, ProtoAxis, AxisDirection>;
+
+  using BinningConfig =
+      std::variant<std::vector<CylinderBinning>, std::vector<CuboidBinning>>;
 
   /// Main constructor for the material designator node.
   /// @param name The name of the node (for debug only)
@@ -78,48 +83,50 @@ class MaterialDesignatorBlueprintNode final : public BlueprintNode {
   /// @note This method can be called multiple times to configure different faces.
   /// @param face The face of the cylinder to configure
   /// @param loc0 The first binning configuration along local axis 0
+  /// @param aDir0 The direction of the first binning configuration
   /// @param loc1 The second binning configuration along local axis 1
+  /// @param aDir1 The direction of the second binning configuration
   /// @return The material designator node
   /// @note If this node has previously been configured with a different volume
   ///       shape, this will throw an exception.
   MaterialDesignatorBlueprintNode& configureFace(
       CylinderVolumeBounds::Face face, const ProtoAxis& loc0,
-      const ProtoAxis& loc1);
+      AxisDirection aDir0, const ProtoAxis& loc1, AxisDirection aDir1);
 
   /// Configure the designator with a cuboid face and corresponding binning
   /// information.
   /// @note This method can be called multiple times to configure different faces.
   /// @param face The face of the cuboid to configure
   /// @param loc0 The first binning configuration along local axis 0
+  /// @param aDir0 The direction of the first binning configuration
   /// @param loc1 The second binning configuration along local axis 1
+  /// @param aDir1 The direction of the second binning configuration
   /// @return The material designator node
   /// @note If this node has previously been configured with a different volume
   ///       shape, this will throw an exception.
   MaterialDesignatorBlueprintNode& configureFace(CuboidVolumeBounds::Face face,
                                                  const ProtoAxis& loc0,
-                                                 const ProtoAxis& loc1);
+                                                 AxisDirection aDir0,
+                                                 const ProtoAxis& loc1,
+                                                 AxisDirection aDir1);
 
  private:
   /// @copydoc BlueprintNode::addToGraphviz
   void addToGraphviz(std::ostream& os) const override;
 
-  void handleCylinderBinning(
-      CylinderPortalShell& cylShell,
-      const std::vector<
-          std::tuple<CylinderPortalShell::Face, ProtoAxis, ProtoAxis>>& binning,
-      const Logger& logger);
+  void handleCylinderBinning(CylinderPortalShell& cylShell,
+                             const std::vector<CylinderBinning>& binning,
+                             const Logger& logger);
 
-  void handleCuboidBinning(
-      CuboidPortalShell& cuboidShell,
-      const std::vector<
-          std::tuple<CuboidVolumeBounds::Face, ProtoAxis, ProtoAxis>>& binning,
-      const Logger& logger);
+  void handleCuboidBinning(CuboidPortalShell& cuboidShell,
+                           const std::vector<CuboidBinning>& binning,
+                           const Logger& logger);
 
   void validateCylinderFaceConfig(CylinderVolumeBounds::Face face,
-                                  const ProtoAxis& loc0, const ProtoAxis& loc1,
+                                  AxisDirection aDir0, AxisDirection aDir1,
                                   const Logger& logger = getDummyLogger());
 
-  void validateCuboidFaceConfig(const ProtoAxis& loc0, const ProtoAxis& loc1,
+  void validateCuboidFaceConfig(AxisDirection aDir0, AxisDirection aDir1,
                                 const Logger& logger = getDummyLogger());
 
   std::string m_name{};

--- a/Core/include/Acts/Material/GridSurfaceMaterialFactory.hpp
+++ b/Core/include/Acts/Material/GridSurfaceMaterialFactory.hpp
@@ -80,10 +80,6 @@ create2D(
     const std::vector<
         std::vector<typename material_accessor_t::grid_value_type>>& payload) {
   // Validate axis compatibility
-  if (pAxis0.getAxisDirection() == pAxis1.getAxisDirection()) {
-    throw std::invalid_argument(
-        "createGridSurfaceMaterial: ProtoAxes must have different directions");
-  }
   auto ism = pAxis0.getAxis().visit(
       [&]<typename AxisTypeA>(const AxisTypeA& axisA)
           -> std::unique_ptr<IGridSurfaceMaterial<

--- a/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
+++ b/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Material/ISurfaceMaterial.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 
@@ -111,6 +112,7 @@ class ProtoSurfaceMaterialT : public ISurfaceMaterial {
 
 using ProtoSurfaceMaterial = ProtoSurfaceMaterialT<Acts::BinUtility>;
 
-using ProtoGridSurfaceMaterial = ProtoSurfaceMaterialT<std::vector<ProtoAxis>>;
+using ProtoGridSurfaceMaterial =
+    ProtoSurfaceMaterialT<std::vector<std::tuple<ProtoAxis, AxisDirection>>>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
+++ b/Core/include/Acts/Material/ProtoSurfaceMaterial.hpp
@@ -113,6 +113,6 @@ class ProtoSurfaceMaterialT : public ISurfaceMaterial {
 using ProtoSurfaceMaterial = ProtoSurfaceMaterialT<Acts::BinUtility>;
 
 using ProtoGridSurfaceMaterial =
-    ProtoSurfaceMaterialT<std::vector<std::tuple<ProtoAxis, AxisDirection>>>;
+    ProtoSurfaceMaterialT<std::vector<DirectedProtoAxis>>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -105,24 +105,26 @@ class BinUtility {
   /// Create from ProtoAxis
   ///
   /// @param pAxis the ProtoAxis to be used
-  explicit BinUtility(const ProtoAxis& pAxis)
+  /// @param aDir the axis direction
+  explicit BinUtility(const ProtoAxis& pAxis, AxisDirection aDir)
       : m_binningData(),
         m_transform(Transform3::Identity()),
         m_itransform(Transform3::Identity()) {
     m_binningData.reserve(3);
-    m_binningData.emplace_back(pAxis);
+    m_binningData.emplace_back(BinningData(pAxis, aDir));
   }
 
   /// Create from ProtoAxis
   ///
-  /// @param pAxes the ProtoAxes to be used
-  explicit BinUtility(const std::vector<ProtoAxis>& pAxes)
+  /// @param pAxes the ProtoAxes to be used with axis directions
+  explicit BinUtility(
+      const std::vector<std::tuple<ProtoAxis, AxisDirection>>& pAxes)
       : m_binningData(),
         m_transform(Transform3::Identity()),
         m_itransform(Transform3::Identity()) {
     m_binningData.reserve(3);
-    for (const auto& pAxis : pAxes) {
-      m_binningData.emplace_back(pAxis);
+    for (const auto& [pAxis, aDir] : pAxes) {
+      m_binningData.emplace_back(BinningData(pAxis, aDir));
     }
   }
 

--- a/Core/include/Acts/Utilities/BinUtility.hpp
+++ b/Core/include/Acts/Utilities/BinUtility.hpp
@@ -117,8 +117,7 @@ class BinUtility {
   /// Create from ProtoAxis
   ///
   /// @param pAxes the ProtoAxes to be used with axis directions
-  explicit BinUtility(
-      const std::vector<std::tuple<ProtoAxis, AxisDirection>>& pAxes)
+  explicit BinUtility(const std::vector<DirectedProtoAxis>& pAxes)
       : m_binningData(),
         m_transform(Transform3::Identity()),
         m_itransform(Transform3::Identity()) {

--- a/Core/include/Acts/Utilities/BinningData.hpp
+++ b/Core/include/Acts/Utilities/BinningData.hpp
@@ -178,9 +178,10 @@ class BinningData {
   /// Constructor from ProtoAxis
   ///
   /// @param pAxis is the ProtoAxis object
+  /// @param aDir the axis direction
   ///
-  explicit BinningData(const ProtoAxis& pAxis)
-      : binvalue(pAxis.getAxisDirection()), subBinningData(nullptr) {
+  explicit BinningData(const ProtoAxis& pAxis, AxisDirection aDir)
+      : binvalue(aDir), subBinningData(nullptr) {
     const auto& axis = pAxis.getAxis();
     type = axis.getType() == AxisType::Equidistant ? equidistant : arbitrary;
     option = axis.getBoundaryType() == AxisBoundaryType::Closed ? closed : open;

--- a/Core/include/Acts/Utilities/ProtoAxis.hpp
+++ b/Core/include/Acts/Utilities/ProtoAxis.hpp
@@ -159,7 +159,7 @@ std::unique_ptr<IGrid> makeGrid(const ProtoAxis& a, const ProtoAxis& b) {
   });
 }
 
-using DirectedProtoAxis = DirectedProtoAxis;
+using DirectedProtoAxis = std::tuple<ProtoAxis, AxisDirection>;
 
 std::ostream& operator<<(std::ostream& os, const std::vector<ProtoAxis>& a);
 

--- a/Core/include/Acts/Utilities/ProtoAxis.hpp
+++ b/Core/include/Acts/Utilities/ProtoAxis.hpp
@@ -159,7 +159,7 @@ std::unique_ptr<IGrid> makeGrid(const ProtoAxis& a, const ProtoAxis& b) {
   });
 }
 
-using DirectedProtoAxis = std::tuple<ProtoAxis, AxisDirection>;
+using DirectedProtoAxis = DirectedProtoAxis;
 
 std::ostream& operator<<(std::ostream& os, const std::vector<ProtoAxis>& a);
 

--- a/Core/include/Acts/Utilities/ProtoAxis.hpp
+++ b/Core/include/Acts/Utilities/ProtoAxis.hpp
@@ -13,10 +13,12 @@
 #include "Acts/Utilities/Grid.hpp"
 #include "Acts/Utilities/IAxis.hpp"
 
+#include <memory>
+#include <tuple>
+#include <vector>
+
 namespace Acts {
-/// @brief Description of a ProtoAxis which holds an IAxis
-/// and lets the user to define a certain axis type, boundary type
-/// and associated binning.
+/// This class is a pure run-time placeholder for the axis definition
 ///
 /// The IAxis allows via the visitor pattern to access the actual axis type
 /// which helps to create grid creation code by the compiler as done
@@ -28,30 +30,26 @@ class ProtoAxis {
  public:
   /// Convenience constructors - for variable binning
   ///
-  /// @param aDir the value/cast in which this is binned
   /// @param abType the axis boundary type
   /// @param edges the bin edges (variable binning)
-  ProtoAxis(AxisDirection aDir, Acts::AxisBoundaryType abType,
-            const std::vector<double>& edges);
+  ProtoAxis(Acts::AxisBoundaryType abType, const std::vector<double>& edges);
 
   /// Convenience constructors - for equidistant binning
   ///
-  /// @param aDir the value/cast in which this is binned
   /// @param abType the axis boundary type
   /// @param minE the lowest edge of the binning
   /// @param maxE the highest edge of the binning
   /// @param nbins the number of bins
-  ProtoAxis(AxisDirection aDir, AxisBoundaryType abType, double minE,
-            double maxE, std::size_t nbins);
+  ProtoAxis(AxisBoundaryType abType, double minE, double maxE,
+            std::size_t nbins);
 
   /// Placeholder constructor for auto-range binning
   ///
-  /// @param aDir the value/cast in which this is binned
   /// @param abType the axis boundary type
   /// @param nbins the number of bins
   ///
   /// @note that auto-range is only supported for equidistant binning
-  ProtoAxis(AxisDirection aDir, AxisBoundaryType abType, std::size_t nbins);
+  ProtoAxis(AxisBoundaryType abType, std::size_t nbins);
 
   /// Custom copy constructor
   /// @param other is the right hand side ProtoAxis
@@ -63,11 +61,6 @@ class ProtoAxis {
 
   ProtoAxis(ProtoAxis&&) = default;
   ProtoAxis& operator=(ProtoAxis&&) = default;
-
-  /// @brief returns the axis direction
-  ///
-  /// @return @c AxisDirection of this axis
-  AxisDirection getAxisDirection() const;
 
   /// @brief Return the IAxis representation
   ///
@@ -111,9 +104,6 @@ class ProtoAxis {
   /// @param os output stream
   void toStream(std::ostream& os) const;
 
-  /// The axis direction
-  AxisDirection m_axisDir = AxisDirection::AxisX;
-
   /// The axis representation
   std::unique_ptr<IAxis> m_axis = nullptr;
 
@@ -153,12 +143,6 @@ std::unique_ptr<IGrid> makeGrid(const ProtoAxis& a) {
 /// @return an IGrid unique ptr and hence transfers ownership
 template <typename payload_t>
 std::unique_ptr<IGrid> makeGrid(const ProtoAxis& a, const ProtoAxis& b) {
-  // Validate axis compatibility
-  if (a.getAxisDirection() == b.getAxisDirection()) {
-    throw std::invalid_argument(
-        "ProtoAxis::makeGrid: Axes must have different directions");
-  }
-
   if (a.isAutorange() || b.isAutorange()) {
     throw std::invalid_argument(
         "ProtoAxis::makeGrid: Auto-range of the proto axis is not (yet) "
@@ -175,6 +159,13 @@ std::unique_ptr<IGrid> makeGrid(const ProtoAxis& a, const ProtoAxis& b) {
   });
 }
 
+using DirectedProtoAxis = std::tuple<ProtoAxis, AxisDirection>;
+
 std::ostream& operator<<(std::ostream& os, const std::vector<ProtoAxis>& a);
+
+std::ostream& operator<<(std::ostream& os, const DirectedProtoAxis& a);
+
+std::ostream& operator<<(std::ostream& os,
+                         const std::vector<DirectedProtoAxis>& a);
 
 }  // namespace Acts

--- a/Core/src/Detector/LayerStructureBuilder.cpp
+++ b/Core/src/Detector/LayerStructureBuilder.cpp
@@ -44,17 +44,18 @@ namespace {
 /// @param extent the extent from which the range is taken
 ///
 void adaptBinningRange(
-    std::vector<std::tuple<Acts::ProtoAxis, std::size_t>>& pBinning,
+    std::vector<std::tuple<Acts::ProtoAxis, Acts::AxisDirection, std::size_t>>&
+        pBinning,
     const Acts::Extent& extent) {
-  for (auto& [pb, pe] : pBinning) {
+  for (auto& [pb, ad, pe] : pBinning) {
     // Starting values
     const auto& axis = pb.getAxis();
     const auto& edges = axis.getBinEdges();
     double vmin = edges.front();
     double vmax = edges.back();
     // Check if extent overwrites that
-    if (extent.constrains(pb.getAxisDirection())) {
-      const auto& range = extent.range(pb.getAxisDirection());
+    if (extent.constrains(ad)) {
+      const auto& range = extent.range(ad);
       // Patch the edges values from the range
       vmin = range.min();
       vmax = range.max();
@@ -201,7 +202,7 @@ Acts::Experimental::LayerStructureBuilder::construct(
     } else {
       // Sort the binning for conventions
       std::ranges::sort(binnings, {}, [](const auto& b) {
-        return std::get<ProtoAxis>(b).getAxisDirection();
+        return std::get<AxisDirection>(b);
       });
       // Check if autorange for binning applies
       if (m_cfg.extent.has_value()) {
@@ -215,21 +216,22 @@ Acts::Experimental::LayerStructureBuilder::construct(
       // 1D surface binning
       if (binnings.size() == 1) {
         ACTS_DEBUG("- creating a 1D internal binning and portal navigation");
-        auto [protoAxis, fillExpansion] = binnings.at(0);
+        auto [protoAxis, axisDirection, fillExpansion] = binnings.at(0);
         internalCandidatesUpdater =
             Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
                 Experimental::IndexedSurfacesNavigation>(
-                gctx, internalSurfaces, rGenerator, protoAxis, fillExpansion,
-                assignToAll);
+                gctx, internalSurfaces, rGenerator, protoAxis, axisDirection,
+                fillExpansion, assignToAll);
       } else if (binnings.size() == 2u) {
         ACTS_DEBUG("- creating a 2D internal binning and portal navigation");
-        auto [protoAxisA, fillExpansionA] = binnings.at(0);
-        auto [protoAxisB, fillExpansionB] = binnings.at(1);
+        auto [protoAxisA, axisDirectionA, fillExpansionA] = binnings.at(0);
+        auto [protoAxisB, axisDirectionB, fillExpansionB] = binnings.at(1);
         internalCandidatesUpdater =
             Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
                 Experimental::IndexedSurfacesNavigation>(
-                gctx, internalSurfaces, rGenerator, protoAxisA, fillExpansionA,
-                protoAxisB, fillExpansionB, assignToAll);
+                gctx, internalSurfaces, rGenerator, protoAxisA, axisDirectionA,
+                fillExpansionA, protoAxisB, axisDirectionB, fillExpansionB,
+                assignToAll);
       } else {
         throw std::runtime_error(
             "LayerStructureBuilder: only 1D or 2D surface binning "

--- a/Core/src/Detector/MultiWireStructureBuilder.cpp
+++ b/Core/src/Detector/MultiWireStructureBuilder.cpp
@@ -37,7 +37,8 @@ class MultiWireInternalStructureBuilder
     std::vector<std::shared_ptr<Acts::Surface>> iSurfaces;
 
     /// Definition of Binning
-    std::vector<std::tuple<Acts::ProtoAxis, std::size_t>> binning;
+    std::vector<std::tuple<Acts::ProtoAxis, Acts::AxisDirection, std::size_t>>
+        binning;
 
     /// Extra information, mainly for screen output
     std::string auxiliary = "";
@@ -69,8 +70,8 @@ class MultiWireInternalStructureBuilder
           "MultiWireStructureBuilder: At least 2 binning axes required");
     }
 
-    auto [protoAxisA, expansionA] = m_cfg.binning.at(0);
-    auto [protoAxisB, expansionB] = m_cfg.binning.at(1);
+    auto [protoAxisA, axisDirectionA, expansionA] = m_cfg.binning.at(0);
+    auto [protoAxisB, axisDirectionB, expansionB] = m_cfg.binning.at(1);
 
     const auto& iaxisA = protoAxisA.getAxis();
     const auto& iaxisB = protoAxisB.getAxis();
@@ -93,8 +94,8 @@ class MultiWireInternalStructureBuilder
         axisA, axisB);
 
     // Prepare the indexed updator
-    std::array<Acts::AxisDirection, 2u> axisDirs = {
-        protoAxisA.getAxisDirection(), protoAxisB.getAxisDirection()};
+    std::array<Acts::AxisDirection, 2u> axisDirs = {axisDirectionA,
+                                                    axisDirectionB};
     Acts::Experimental::MultiLayerSurfacesNavigation<decltype(grid)>
         indexedSurfaces(std::move(grid), axisDirs, m_cfg.transform);
 

--- a/Core/src/Detector/detail/ProtoMaterialHelper.cpp
+++ b/Core/src/Detector/detail/ProtoMaterialHelper.cpp
@@ -12,22 +12,22 @@
 #include "Acts/Material/ProtoSurfaceMaterial.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
-std::vector<Acts::ProtoAxis>
+std::vector<std::tuple<Acts::ProtoAxis, Acts::AxisDirection>>
 Acts::Experimental::detail::ProtoMaterialHelper::attachProtoMaterial(
     const GeometryContext& gctx, Surface& surface,
-    const std::vector<ProtoAxis>& bDescription) {
+    const std::vector<std::tuple<ProtoAxis, AxisDirection>>& bDescription) {
   // The binning description, with eventually fixed range
-  std::vector<ProtoAxis> fbDescription;
+  std::vector<std::tuple<ProtoAxis, AxisDirection>> fbDescription;
   // Measure the surface
   Extent sExtent = surface.polyhedronRepresentation(gctx, 1).extent();
-  for (const auto& b : bDescription) {
-    ProtoAxis fBinning(b);
+  for (const auto& [b, aDir] : bDescription) {
+    ProtoAxis fAxis(b);
     // Check if the binning needs to be fixed
-    if (fBinning.isAutorange()) {
-      auto range = sExtent.range(b.getAxisDirection());
-      fBinning.setRange(range.min(), range.max());
+    if (fAxis.isAutorange()) {
+      auto range = sExtent.range(aDir);
+      fAxis.setRange(range.min(), range.max());
     }
-    fbDescription.emplace_back(std::move(fBinning));
+    fbDescription.emplace_back(fAxis, aDir);
   }
   // Create the new proto material description and assign it
   auto protoMaterial =

--- a/Core/src/Detector/detail/ProtoMaterialHelper.cpp
+++ b/Core/src/Detector/detail/ProtoMaterialHelper.cpp
@@ -12,12 +12,12 @@
 #include "Acts/Material/ProtoSurfaceMaterial.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
-std::vector<std::tuple<Acts::ProtoAxis, Acts::AxisDirection>>
+std::vector<Acts::DirectedProtoAxis>
 Acts::Experimental::detail::ProtoMaterialHelper::attachProtoMaterial(
     const GeometryContext& gctx, Surface& surface,
-    const std::vector<std::tuple<ProtoAxis, AxisDirection>>& bDescription) {
+    const std::vector<DirectedProtoAxis>& bDescription) {
   // The binning description, with eventually fixed range
-  std::vector<std::tuple<ProtoAxis, AxisDirection>> fbDescription;
+  std::vector<DirectedProtoAxis> fbDescription;
   // Measure the surface
   Extent sExtent = surface.polyhedronRepresentation(gctx, 1).extent();
   for (const auto& [b, aDir] : bDescription) {

--- a/Core/src/Utilities/ProtoAxis.cpp
+++ b/Core/src/Utilities/ProtoAxis.cpp
@@ -10,44 +10,20 @@
 
 #include <sstream>
 
-namespace {
-void checkConsistency(Acts::AxisDirection aDir, Acts::AxisBoundaryType abType) {
-  if (abType == Acts::AxisBoundaryType::Closed &&
-      aDir != Acts::AxisDirection::AxisPhi &&
-      aDir != Acts::AxisDirection::AxisRPhi) {
-    std::string msg =
-        "ProtoAxis: Invalid axis boundary type 'Closed' for direction '";
-    msg += axisDirectionName(aDir) +
-           "'. Closed boundary type is only valid for "
-           "AxisPhi and AxisRPhi directions.";
-    throw std::invalid_argument(msg);
-  }
-}
-}  // namespace
-
-Acts::ProtoAxis::ProtoAxis(AxisDirection aDir, Acts::AxisBoundaryType abType,
+Acts::ProtoAxis::ProtoAxis(Acts::AxisBoundaryType abType,
                            const std::vector<double>& edges)
-    : m_axisDir(aDir), m_axis(IAxis::createVariable(abType, edges)) {
-  checkConsistency(aDir, abType);
-}
+    : m_axis(IAxis::createVariable(abType, edges)) {}
 
-Acts::ProtoAxis::ProtoAxis(AxisDirection aDir, AxisBoundaryType abType,
-                           double minE, double maxE, std::size_t nbins)
-    : m_axisDir(aDir),
-      m_axis(IAxis::createEquidistant(abType, minE, maxE, nbins)) {
-  checkConsistency(aDir, abType);
-}
-
-Acts::ProtoAxis::ProtoAxis(AxisDirection aDir, AxisBoundaryType abType,
+Acts::ProtoAxis::ProtoAxis(AxisBoundaryType abType, double minE, double maxE,
                            std::size_t nbins)
-    : m_axisDir(aDir),
-      m_axis(IAxis::createEquidistant(abType, 0., 1., nbins)),
-      m_autorange(true) {
-  checkConsistency(aDir, abType);
-}
+    : m_axis(IAxis::createEquidistant(abType, minE, maxE, nbins)) {}
+
+Acts::ProtoAxis::ProtoAxis(AxisBoundaryType abType, std::size_t nbins)
+    : m_axis(IAxis::createEquidistant(abType, 0., 1., nbins)),
+      m_autorange(true) {}
 
 Acts::ProtoAxis::ProtoAxis(const ProtoAxis& other)
-    : m_axisDir(other.m_axisDir), m_autorange(other.m_autorange) {
+    : m_autorange(other.m_autorange) {
   const auto& axis = other.getAxis();
   if (!m_autorange) {
     const auto& edges = axis.getBinEdges();
@@ -65,7 +41,6 @@ Acts::ProtoAxis::ProtoAxis(const ProtoAxis& other)
 
 Acts::ProtoAxis& Acts::ProtoAxis::operator=(const ProtoAxis& other) {
   if (this != &other) {
-    m_axisDir = other.m_axisDir;
     m_autorange = other.m_autorange;
     const auto& axis = other.getAxis();
     if (!m_autorange) {
@@ -82,10 +57,6 @@ Acts::ProtoAxis& Acts::ProtoAxis::operator=(const ProtoAxis& other) {
     }
   }
   return *this;
-}
-
-Acts::AxisDirection Acts::ProtoAxis::getAxisDirection() const {
-  return m_axisDir;
 }
 
 const Acts::IAxis& Acts::ProtoAxis::getAxis() const {
@@ -128,8 +99,7 @@ void Acts::ProtoAxis::toStream(std::ostream& os) const {
 std::string Acts::ProtoAxis::toString() const {
   std::stringstream ss;
   const auto& axis = getAxis();
-  ss << "ProtoAxis: " << axis.getNBins() << " bins in "
-     << axisDirectionName(getAxisDirection());
+  ss << "ProtoAxis: " << axis.getNBins() << " bins";
   ss << (axis.getType() == AxisType::Variable ? ", variable "
                                               : ", equidistant ");
   if (!m_autorange) {
@@ -141,11 +111,27 @@ std::string Acts::ProtoAxis::toString() const {
   return ss.str();
 }
 
-// ostream operator implementation
+// Ostream operator implementation
 std::ostream& Acts::operator<<(std::ostream& os,
                                const std::vector<ProtoAxis>& as) {
   for (const auto& a : as) {
     os << a.toString() << '\n';
+  }
+  return os;
+}
+
+// Ostream operation implementation for directed proto axis
+std::ostream& Acts::operator<<(std::ostream& os, const DirectedProtoAxis& a) {
+  const auto& [axis, aDir] = a;
+  os << axis.toString() << ", direction: " << axisDirectionName(aDir) << '\n';
+  return os;
+}
+
+// Ostream operator implementation vector of directed proto axes
+std::ostream& Acts::operator<<(std::ostream& os,
+                               const std::vector<DirectedProtoAxis>& as) {
+  for (const auto& a : as) {
+    os << a << '\n';
   }
   return os;
 }

--- a/Examples/Python/src/Blueprint.cpp
+++ b/Examples/Python/src/Blueprint.cpp
@@ -406,20 +406,23 @@ void addBlueprint(Context& ctx) {
       },
       py::arg("name"), py::arg("direction"));
 
-  auto matNode = py::class_<MaterialDesignatorBlueprintNode, BlueprintNode,
-                            std::shared_ptr<MaterialDesignatorBlueprintNode>>(
-                     m, "MaterialDesignatorBlueprintNode")
-                     .def(py::init<const std::string&>(), "name"_a)
-                     .def("configureFace",
-                          py::overload_cast<CylinderVolumeBounds::Face,
-                                            const ProtoAxis&, const ProtoAxis&>(
-                              &MaterialDesignatorBlueprintNode::configureFace),
-                          "face"_a, "loc0"_a, "loc1"_a)
-                     .def("configureFace",
-                          py::overload_cast<CuboidVolumeBounds::Face,
-                                            const ProtoAxis&, const ProtoAxis&>(
-                              &MaterialDesignatorBlueprintNode::configureFace),
-                          "face"_a, "loc0"_a, "loc1"_a);
+  auto matNode =
+      py::class_<MaterialDesignatorBlueprintNode, BlueprintNode,
+                 std::shared_ptr<MaterialDesignatorBlueprintNode>>(
+          m, "MaterialDesignatorBlueprintNode")
+          .def(py::init<const std::string&>(), "name"_a)
+          .def(
+              "configureFace",
+              py::overload_cast<CylinderVolumeBounds::Face, const ProtoAxis&,
+                                AxisDirection, const ProtoAxis&, AxisDirection>(
+                  &MaterialDesignatorBlueprintNode::configureFace),
+              "face"_a, "loc0"_a, "aDir0"_a, "loc1"_a, "aDir1"_a)
+          .def(
+              "configureFace",
+              py::overload_cast<CuboidVolumeBounds::Face, const ProtoAxis&,
+                                AxisDirection, const ProtoAxis&, AxisDirection>(
+                  &MaterialDesignatorBlueprintNode::configureFace),
+              "face"_a, "loc0"_a, "aDir0"_a, "loc1"_a, "aDir1"_a);
 
   addContextManagerProtocol(matNode);
 

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -463,15 +463,12 @@ void addExperimentalGeometry(Context& ctx) {
   {
     // Be able to construct a proto binning
     py::class_<ProtoAxis>(m, "ProtoAxis")
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType,
-                      const std::vector<double>&>(),
-             "bValue"_a, "bType"_a, "e"_a)
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType, double,
-                      double, std::size_t>(),
-             "bValue"_a, "bType"_a, "minE"_a, "maxE"_a, "nbins"_a)
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType,
-                      std::size_t>(),
-             "bValue"_a, "bType"_a, "nbins"_a);
+        .def(py::init<Acts::AxisBoundaryType, const std::vector<double>&>(),
+             "bType"_a, "e"_a)
+        .def(py::init<Acts::AxisBoundaryType, double, double, std::size_t>(),
+             "bType"_a, "minE"_a, "maxE"_a, "nbins"_a)
+        .def(py::init<Acts::AxisBoundaryType, std::size_t>(), "bType"_a,
+             "nbins"_a);
   }
 
   {

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepBinningHelpers.hpp
@@ -84,7 +84,7 @@ namespace DD4hepBinningHelpers {
 /// @param bname the binning base name, e.g. surface_binning, material_binning
 ///
 /// @return a vector of proto binning descriptions
-std::vector<std::tuple<Acts::ProtoAxis, std::size_t>> convertBinning(
+std::vector<std::tuple<ProtoAxis, AxisDirection, std::size_t>> convertBinning(
     const dd4hep::DetElement &dd4hepElement, const std::string &bname);
 
 }  // namespace DD4hepBinningHelpers

--- a/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
+++ b/Plugins/DD4hep/include/Acts/Plugins/DD4hep/DD4hepDetectorSurfaceFactory.hpp
@@ -62,7 +62,8 @@ class DD4hepDetectorSurfaceFactory {
     /// matching and conversion statistics: materials
     std::size_t convertedMaterials = 0;
     /// The collected binnings
-    std::vector<std::tuple<ProtoAxis, std::size_t>> binnings = {};
+    std::vector<std::tuple<ProtoAxis, AxisDirection, std::size_t>> binnings =
+        {};
     /// The collected supports
     std::vector<Experimental::ProtoSupport> supports = {};
     /// Optionally provide an Extent object to measure the sensitives

--- a/Plugins/DD4hep/src/DD4hepBinningHelpers.cpp
+++ b/Plugins/DD4hep/src/DD4hepBinningHelpers.cpp
@@ -10,13 +10,13 @@
 
 #include <numbers>
 
-std::vector<std::tuple<Acts::ProtoAxis, std::size_t>>
+std::vector<std::tuple<Acts::ProtoAxis, Acts::AxisDirection, std::size_t>>
 Acts::DD4hepBinningHelpers::convertBinning(
     const dd4hep::DetElement &dd4hepElement, const std::string &bname) {
   // Return proto binning vector
-  std::vector<std::tuple<ProtoAxis, std::size_t>> protoBinnings;
+  std::vector<std::tuple<ProtoAxis, AxisDirection, std::size_t>> protoBinnings;
 
-  for (const auto &[ab, bVal] : allowedBinnings) {
+  for (const auto &[ab, axisDir] : allowedBinnings) {
     auto type =
         getParamOr<std::string>(bname + "_" + ab + "_type", dd4hepElement, "");
     if (!type.empty()) {
@@ -34,25 +34,27 @@ Acts::DD4hepBinningHelpers::convertBinning(
       // Equidistant binning
       if (aType == AxisType::Equidistant) {
         if (autoRange) {
-          protoBinnings.emplace_back(std::tuple<ProtoAxis, std::size_t>{
-              ProtoAxis(bVal, bType, nBins), nExpansion});
+          protoBinnings.emplace_back(
+              std::tuple<ProtoAxis, AxisDirection, std::size_t>{
+                  ProtoAxis(bType, nBins), axisDir, nExpansion});
         } else {
           // Equidistant binning
           double minDefault =
-              bVal == AxisDirection::AxisPhi ? -std::numbers::pi : 0.;
+              axisDir == AxisDirection::AxisPhi ? -std::numbers::pi : 0.;
           double maxDefault =
-              bVal == AxisDirection::AxisPhi ? std::numbers::pi : 0.;
+              axisDir == AxisDirection::AxisPhi ? std::numbers::pi : 0.;
           auto min = getParamOr<double>(bname + "_" + ab + "_min",
                                         dd4hepElement, minDefault);
           auto max = getParamOr<double>(bname + "_" + ab + "_max",
                                         dd4hepElement, maxDefault);
           // Check for closed phi binning
-          if (bVal == AxisDirection::AxisPhi &&
+          if (axisDir == AxisDirection::AxisPhi &&
               (max - min) > 1.9 * std::numbers::pi) {
             bType = Acts::AxisBoundaryType::Closed;
           }
-          protoBinnings.emplace_back(std::tuple<ProtoAxis, std::size_t>{
-              ProtoAxis(bVal, bType, min, max, nBins), nExpansion});
+          protoBinnings.emplace_back(
+              std::tuple<ProtoAxis, AxisDirection, std::size_t>{
+                  ProtoAxis(bType, min, max, nBins), axisDir, nExpansion});
         }
       } else {
         // Variable binning
@@ -62,12 +64,13 @@ Acts::DD4hepBinningHelpers::convertBinning(
               bname + "_" + ab + "_b" + std::to_string(ib), dd4hepElement, 0.));
         }
         // Check for closed phi binning
-        if (bVal == AxisDirection::AxisPhi &&
+        if (axisDir == AxisDirection::AxisPhi &&
             (edges.back() - edges.front()) > 1.9 * std::numbers::pi) {
           bType = Acts::AxisBoundaryType::Closed;
         }
-        protoBinnings.emplace_back(std::tuple<ProtoAxis, std::size_t>{
-            ProtoAxis(bVal, bType, edges), nExpansion});
+        protoBinnings.emplace_back(
+            std::tuple<ProtoAxis, AxisDirection, std::size_t>{
+                ProtoAxis(bType, edges), axisDir, nExpansion});
       }
     }
   }

--- a/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
@@ -122,9 +122,9 @@ void Acts::Experimental::DD4hepBlueprintFactory::recursiveParse(
           auto pmProtoAxis = DD4hepBinningHelpers::convertBinning(
               dd4hepElement, pmName + "_binning");
           // Strip out the axis without expansion
-          std::vector<ProtoAxis> pmAxisBare = {};
-          for (const auto& pma : pmProtoAxis) {
-            pmAxisBare.push_back(std::get<ProtoAxis>(pma));
+          std::vector<std::tuple<ProtoAxis, AxisDirection>> pmAxisBare = {};
+          for (const auto& [pAxis, aDir, nB] : pmProtoAxis) {
+            pmAxisBare.push_back({pAxis, aDir});
           }
           current->portalMaterialBinning[p] = pmAxisBare;
           ACTS_VERBOSE(ofs << " - binning description is "

--- a/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepBlueprintFactory.cpp
@@ -122,7 +122,7 @@ void Acts::Experimental::DD4hepBlueprintFactory::recursiveParse(
           auto pmProtoAxis = DD4hepBinningHelpers::convertBinning(
               dd4hepElement, pmName + "_binning");
           // Strip out the axis without expansion
-          std::vector<std::tuple<ProtoAxis, AxisDirection>> pmAxisBare = {};
+          std::vector<DirectedProtoAxis> pmAxisBare = {};
           for (const auto& [pAxis, aDir, nB] : pmProtoAxis) {
             pmAxisBare.push_back({pAxis, aDir});
           }

--- a/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
@@ -157,7 +157,7 @@ void Acts::DD4hepDetectorSurfaceFactory::attachSurfaceMaterial(
     ACTS_VERBOSE(" - proto material binning for passive surface found.");
     auto materialBinning = DD4hepBinningHelpers::convertBinning(
         dd4hepElement, prefix + "_proto_material_binning");
-    std::vector<std::tuple<ProtoAxis, AxisDirection>> pmBinning = {};
+    std::vector<DirectedProtoAxis> pmBinning = {};
     for (const auto& [axis, axisDir, bins] : materialBinning) {
       pmBinning.push_back({axis, axisDir});
     }

--- a/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
+++ b/Plugins/DD4hep/src/DD4hepDetectorSurfaceFactory.cpp
@@ -157,9 +157,9 @@ void Acts::DD4hepDetectorSurfaceFactory::attachSurfaceMaterial(
     ACTS_VERBOSE(" - proto material binning for passive surface found.");
     auto materialBinning = DD4hepBinningHelpers::convertBinning(
         dd4hepElement, prefix + "_proto_material_binning");
-    std::vector<ProtoAxis> pmBinning = {};
-    for (const auto& [axis, bins] : materialBinning) {
-      pmBinning.push_back(axis);
+    std::vector<std::tuple<ProtoAxis, AxisDirection>> pmBinning = {};
+    for (const auto& [axis, axisDir, bins] : materialBinning) {
+      pmBinning.push_back({axis, axisDir});
     }
     ACTS_VERBOSE(" - converted binning is " << pmBinning);
     Experimental::detail::ProtoMaterialHelper::attachProtoMaterial(

--- a/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerStructure.cpp
@@ -67,14 +67,13 @@ Acts::Experimental::DD4hepLayerStructure::builder(
     const auto& extent = fCache.sExtent.value();
     // Check if the binning
     ACTS_VERBOSE("Checking if surface binning ranges can be patched.");
-    for (auto& [b, bExp] : fCache.binnings) {
-      if (extent.constrains(b.getAxisDirection())) {
-        ACTS_VERBOSE("Binning '" << axisDirectionName(b.getAxisDirection())
+    for (auto& [b, axisDir, bExp] : fCache.binnings) {
+      if (extent.constrains(axisDir)) {
+        ACTS_VERBOSE("Binning '" << axisDirectionName(axisDir)
                                  << "' is patched.");
         ACTS_VERBOSE(" <- from : [" << b.getAxis().getBinEdges().front() << ", "
                                     << b.getAxis().getBinEdges().back() << "]");
-        b.setRange(extent.min(b.getAxisDirection()),
-                   extent.max(b.getAxisDirection()));
+        b.setRange(extent.min(axisDir), extent.max(axisDir));
         ACTS_VERBOSE(" -> to   : [" << b.getAxis().getBinEdges().front() << ", "
                                     << b.getAxis().getBinEdges().back() << "]");
       }

--- a/Plugins/GeoModel/include/Acts/Plugins/GeoModel/detail/GeoModelBinningHelper.hpp
+++ b/Plugins/GeoModel/include/Acts/Plugins/GeoModel/detail/GeoModelBinningHelper.hpp
@@ -45,8 +45,8 @@ inline AxisDirection toAxisDirection(const std::string& binning) {
 /// @param binning the binning string
 /// @param extent the extent of the binning
 ///
-/// @return a ProtoAxis object
-std::tuple<Acts::ProtoAxis, std::size_t> toProtoAxis(
+/// @return a ProtoAxis, the AxidDirection, the
+std::tuple<Acts::ProtoAxis, Acts::AxisDirection, std::size_t> toProtoAxis(
     const std::string& binning,
     const std::optional<Extent>& extent = std::nullopt);
 

--- a/Plugins/GeoModel/src/GeoModelBlueprintCreater.cpp
+++ b/Plugins/GeoModel/src/GeoModelBlueprintCreater.cpp
@@ -195,7 +195,8 @@ Acts::GeoModelBlueprintCreater::createNode(
   std::string entryType = entryTypeSplit[0u];
 
   // Check if material has to be attached
-  std::map<unsigned int, std::vector<ProtoAxis>> portalMaterialBinning;
+  std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
+      portalMaterialBinning;
   if (!entry.materials.empty()) {
     for (const auto& material : entry.materials) {
       std::vector<std::string> materialTokens;
@@ -211,14 +212,14 @@ Acts::GeoModelBlueprintCreater::createNode(
         std::vector<std::string> binningTokens;
         boost::split(binningTokens, materialTokens[1u], boost::is_any_of(";"));
 
-        std::vector<ProtoAxis> protoBinnings;
+        std::vector<std::tuple<ProtoAxis, AxisDirection>> protoBinnings;
         for (const auto& bToken : binningTokens) {
           ACTS_VERBOSE("   - Binning: " << bToken);
-          protoBinnings.push_back(std::get<ProtoAxis>(
-              detail::GeoModelBinningHelper::toProtoAxis(bToken)));
+          auto [pAxis, aDir, nB] =
+              detail::GeoModelBinningHelper::toProtoAxis(bToken, extent);
+          protoBinnings.push_back({pAxis, aDir});
         }
-        portalMaterialBinning[portalNumber] =
-            std::vector<ProtoAxis>{protoBinnings};
+        portalMaterialBinning[portalNumber] = protoBinnings;
       }
     }
     ACTS_VERBOSE("Node " << entry.name << " has "

--- a/Plugins/GeoModel/src/GeoModelBlueprintCreater.cpp
+++ b/Plugins/GeoModel/src/GeoModelBlueprintCreater.cpp
@@ -195,8 +195,7 @@ Acts::GeoModelBlueprintCreater::createNode(
   std::string entryType = entryTypeSplit[0u];
 
   // Check if material has to be attached
-  std::map<unsigned int, std::vector<std::tuple<ProtoAxis, AxisDirection>>>
-      portalMaterialBinning;
+  std::map<unsigned int, std::vector<DirectedProtoAxis>> portalMaterialBinning;
   if (!entry.materials.empty()) {
     for (const auto& material : entry.materials) {
       std::vector<std::string> materialTokens;
@@ -212,7 +211,7 @@ Acts::GeoModelBlueprintCreater::createNode(
         std::vector<std::string> binningTokens;
         boost::split(binningTokens, materialTokens[1u], boost::is_any_of(";"));
 
-        std::vector<std::tuple<ProtoAxis, AxisDirection>> protoBinnings;
+        std::vector<DirectedProtoAxis> protoBinnings;
         for (const auto& bToken : binningTokens) {
           ACTS_VERBOSE("   - Binning: " << bToken);
           auto [pAxis, aDir, nB] =

--- a/Plugins/GeoModel/src/detail/GeoModelBinningHelper.cpp
+++ b/Plugins/GeoModel/src/detail/GeoModelBinningHelper.cpp
@@ -12,12 +12,12 @@
 
 #include <boost/algorithm/string.hpp>
 
-std::tuple<Acts::ProtoAxis, std::size_t>
+std::tuple<Acts::ProtoAxis, Acts::AxisDirection, std::size_t>
 Acts::detail::GeoModelBinningHelper::toProtoAxis(
     const std::string& binning, const std::optional<Extent>& extent) {
   std::vector<std::string> binningTokens;
   boost::split(binningTokens, binning, boost::is_any_of(","));
-  AxisDirection bValue = toAxisDirection(binningTokens[0]);
+  AxisDirection axisDir = toAxisDirection(binningTokens[0]);
 
   std::vector<std::string> binningDetails = {binningTokens.begin() + 1,
                                              binningTokens.end()};
@@ -47,7 +47,7 @@ Acts::detail::GeoModelBinningHelper::toProtoAxis(
   // The Range
   double rangeMin = 0.;
   double rangeMax = 0.;
-  if (bValue == AxisDirection::AxisPhi &&
+  if (axisDir == AxisDirection::AxisPhi &&
       boundaryType == AxisBoundaryType::Closed) {
     rangeMin = -std::numbers::pi;
     rangeMax = std::numbers::pi;
@@ -55,9 +55,9 @@ Acts::detail::GeoModelBinningHelper::toProtoAxis(
     if (binningDetails.size() > 3u && binningDetails[3] != "*") {
       autoRange = false;
       rangeMin = std::stod(binningDetails[3]);
-    } else if (extent.has_value() && extent.value().constrains(bValue)) {
+    } else if (extent.has_value() && extent.value().constrains(axisDir)) {
       autoRange = false;
-      rangeMin = extent.value().min(bValue);
+      rangeMin = extent.value().min(axisDir);
     } else if (binningDetails[3] != "*") {
       throw std::invalid_argument(
           "GeoModelBinningHelper: Range minimum is not defined.");
@@ -66,16 +66,15 @@ Acts::detail::GeoModelBinningHelper::toProtoAxis(
     if (binningDetails.size() > 4u && binningDetails[4] != "*") {
       autoRange = false;
       rangeMax = std::stod(binningDetails[4]);
-    } else if (extent.has_value() && extent.value().constrains(bValue)) {
+    } else if (extent.has_value() && extent.value().constrains(axisDir)) {
       autoRange = false;
-      rangeMax = extent.value().max(bValue);
+      rangeMax = extent.value().max(axisDir);
     } else if (binningDetails[4] != "*") {
       throw std::invalid_argument(
           "GeoModelBinningHelper: Range maximum is not defined.");
     }
   }
-  auto pAxis = autoRange
-                   ? ProtoAxis(bValue, boundaryType, nBins)
-                   : ProtoAxis(bValue, boundaryType, rangeMin, rangeMax, nBins);
-  return {pAxis, nExpansion};
+  auto pAxis = autoRange ? ProtoAxis(boundaryType, nBins)
+                         : ProtoAxis(boundaryType, rangeMin, rangeMax, nBins);
+  return {pAxis, axisDir, nExpansion};
 }

--- a/Plugins/Json/src/ProtoAxisJsonConverter.cpp
+++ b/Plugins/Json/src/ProtoAxisJsonConverter.cpp
@@ -14,7 +14,6 @@
 
 nlohmann::json Acts::ProtoAxisJsonConverter::toJson(const Acts::ProtoAxis& pa) {
   nlohmann::json j;
-  j["axis_dir"] = pa.getAxisDirection();
   j["axis"] = AxisJsonConverter::toJson(pa.getAxis());
   j["autorange"] = pa.isAutorange();
   return j;
@@ -22,7 +21,6 @@ nlohmann::json Acts::ProtoAxisJsonConverter::toJson(const Acts::ProtoAxis& pa) {
 
 Acts::ProtoAxis Acts::ProtoAxisJsonConverter::fromJson(
     const nlohmann::json& j) {
-  auto axisDir = j.at("axis_dir").get<Acts::AxisDirection>();
   auto axisBoundaryType =
       j.at("axis").at("boundary_type").get<Acts::AxisBoundaryType>();
   if (auto axisType = j.at("axis").at("type").get<Acts::AxisType>();
@@ -33,14 +31,14 @@ Acts::ProtoAxis Acts::ProtoAxisJsonConverter::fromJson(
     }
 
     if (j.at("autorange").get<bool>()) {
-      return ProtoAxis(axisDir, axisBoundaryType, nbins);
+      return ProtoAxis(axisBoundaryType, nbins);
     }
     auto min = j.at("axis").at("range").at(0).get<double>();
     auto max = j.at("axis").at("range").at(1).get<double>();
     if (min >= max) {
       throw std::invalid_argument("Invalid range: min must be less than max");
     }
-    return ProtoAxis(axisDir, axisBoundaryType, min, max, nbins);
+    return ProtoAxis(axisBoundaryType, min, max, nbins);
   }
   auto binEdges = j.at("axis").at("boundaries").get<std::vector<double>>();
   if (binEdges.size() < 2) {
@@ -49,5 +47,5 @@ Acts::ProtoAxis Acts::ProtoAxisJsonConverter::fromJson(
   if (!std::ranges::is_sorted(binEdges)) {
     throw std::invalid_argument("Bin edges must be sorted in ascending order");
   }
-  return ProtoAxis(axisDir, axisBoundaryType, binEdges);
+  return ProtoAxis(axisBoundaryType, binEdges);
 }

--- a/Tests/UnitTests/Core/Detector/CylindricalContainerBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Detector/CylindricalContainerBuilderTests.cpp
@@ -129,10 +129,11 @@ BOOST_AUTO_TEST_CASE(CylindricaContainerBuildingZ) {
   tripleZCfg.binning = {AxisDirection::AxisZ};
   tripleZCfg.geoIdGenerator = std::make_shared<VolumeGeoIdGenerator>();
   // Create a materialBinning
-  tripleZCfg.portalMaterialBinning[2u] = std::vector<ProtoAxis>{
-      {ProtoAxis(AxisDirection::AxisZ, Acts::AxisBoundaryType::Bound, 50),
-       ProtoAxis(AxisDirection::AxisPhi, Acts::AxisBoundaryType::Closed,
-                 -std::numbers::pi, std::numbers::pi, 12)}};
+  tripleZCfg.portalMaterialBinning[2u] = std::vector<DirectedProtoAxis>{
+      {ProtoAxis(Acts::AxisBoundaryType::Bound, 50), AxisDirection::AxisZ},
+      {ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+                 std::numbers::pi, 12),
+       AxisDirection::AxisPhi}};
 
   // Let's test the reverse generation
   tripleZCfg.geoIdReverseGen = true;

--- a/Tests/UnitTests/Core/Detector/DetectorVolumeBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Detector/DetectorVolumeBuilderTests.cpp
@@ -158,10 +158,11 @@ BOOST_AUTO_TEST_CASE(DetectorVolumeBuilder_EmptyVolume) {
   dvCfg.internalsBuilder = nullptr;
 
   // Assign proto material to
-  dvCfg.portalMaterialBinning[2u] = std::vector<ProtoAxis>{
-      {ProtoAxis(AxisDirection::AxisZ, Acts::AxisBoundaryType::Bound, 50),
-       ProtoAxis(AxisDirection::AxisPhi, Acts::AxisBoundaryType::Closed,
-                 -std::numbers::pi, std::numbers::pi, 12)}};
+  dvCfg.portalMaterialBinning[2u] = std::vector<DirectedProtoAxis>{
+      {ProtoAxis(Acts::AxisBoundaryType::Bound, 50), AxisDirection::AxisZ},
+      {ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+                 std::numbers::pi, 12),
+       AxisDirection::AxisPhi}};
 
   auto dvBuilder = std::make_shared<DetectorVolumeBuilder>(
       dvCfg, getDefaultLogger("DetectorVolumeBuilder", Logging::VERBOSE));

--- a/Tests/UnitTests/Core/Detector/IndexedSurfacesGeneratorTests.cpp
+++ b/Tests/UnitTests/Core/Detector/IndexedSurfacesGeneratorTests.cpp
@@ -55,13 +55,13 @@ BOOST_AUTO_TEST_CASE(RingDisc1D) {
   // Polyhedron reference generator
   PolyhedronReferenceGenerator<1u, true> rGenerator;
   // A single proto axis clused in phi with 44 bins
-  ProtoAxis pAxis(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                  -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxis(AxisBoundaryType::Closed, -std::numbers::pi, std::numbers::pi,
+                  44u);
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           IndexedSurfacesNavigation, decltype(rSurfaces), decltype(rGenerator)>(
-          tContext, rSurfaces, rGenerator, pAxis, 0u);
+          tContext, rSurfaces, rGenerator, pAxis, AxisDirection::AxisPhi, 0u);
 
   using GridType =
       Grid<std::vector<std::size_t>,
@@ -105,12 +105,13 @@ BOOST_AUTO_TEST_CASE(RingDisc1DWithSupport) {
   // Polyhedron reference generator
   PolyhedronReferenceGenerator<1u, true> rGenerator;
   // A single proto axis clused in phi with 44 bins
-  ProtoAxis pAxis(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                  -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxis(AxisBoundaryType::Closed, -std::numbers::pi, std::numbers::pi,
+                  44u);
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxis, 0u, {rSurfaces.size() - 1u});
+          tContext, rSurfaces, rGenerator, pAxis, AxisDirection::AxisPhi, 0u,
+          {rSurfaces.size() - 1u});
 
   using GridType =
       Grid<std::vector<std::size_t>,
@@ -153,17 +154,17 @@ BOOST_AUTO_TEST_CASE(RingDisc2D) {
   decltype(rSurfacesR0) rSurfaces = rSurfacesR0;
   rSurfaces.insert(rSurfaces.end(), rSurfacesR1.begin(), rSurfacesR1.end());
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound,
-                   {24., 74., 110});
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, {24., 74., 110});
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 44u);
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 0u, pAxisPhi, 0u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 0u,
+          pAxisPhi, AxisDirection::AxisPhi, 0u);
 
   using GridType =
       Grid<std::vector<std::size_t>,
@@ -205,16 +206,17 @@ BOOST_AUTO_TEST_CASE(RingDisc2DFine) {
   rSurfaces.insert(rSurfaces.end(), rSurfacesR1.begin(), rSurfacesR1.end());
   rSurfaces.insert(rSurfaces.end(), rSurfacesR2.begin(), rSurfacesR2.end());
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound, 24., 152, 8u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 88u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, 24., 152, 8u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 88u);
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 0u, pAxisPhi, 0u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 0u,
+          pAxisPhi, AxisDirection::AxisPhi, 0u);
 
   using GridType =
       Grid<std::vector<std::size_t>,
@@ -258,14 +260,15 @@ BOOST_AUTO_TEST_CASE(RingDisc2DFineExpanded) {
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound, 24., 152, 8u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 88u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, 24., 152, 8u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 88u);
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 2u, pAxisPhi, 4u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 2u,
+          pAxisPhi, AxisDirection::AxisPhi, 4u);
 
   using GridType =
       Grid<std::vector<std::size_t>,
@@ -296,16 +299,16 @@ BOOST_AUTO_TEST_CASE(Cylinder2D) {
   auto surfaces = cGeometry.surfacesCylinder(dStore, 8.4, 36., 0.15, 0.145,
                                              116., 3., 2., {52, 14});
 
-  ProtoAxis pAxisZ(AxisDirection::AxisZ, AxisBoundaryType::Bound, -500., 500.,
-                   28u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 52u);
+  ProtoAxis pAxisZ(AxisBoundaryType::Bound, -500., 500., 28u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 52u);
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedCylinder =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, surfaces, rGenerator, pAxisZ, 1u, pAxisPhi, 1u);
+          tContext, surfaces, rGenerator, pAxisZ, AxisDirection::AxisZ, 1u,
+          pAxisPhi, AxisDirection::AxisPhi, 1u);
 
   using GridType =
       Grid<std::vector<std::size_t>,

--- a/Tests/UnitTests/Core/Detector/LayerStructureBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Detector/LayerStructureBuilderTests.cpp
@@ -67,10 +67,9 @@ BOOST_AUTO_TEST_CASE(LayerStructureBuilder_creationRing) {
   Acts::Experimental::LayerStructureBuilder::Config lsConfig;
   lsConfig.auxiliary = "*** Endcap with 22 surfaces ***";
   lsConfig.surfacesProvider = endcapSurfaces;
-  lsConfig.binnings = {
-      {ProtoAxis(Acts::AxisDirection::AxisPhi, Acts::AxisBoundaryType::Closed,
-                 -std::numbers::pi, std::numbers::pi, 22u),
-       1u}};
+  lsConfig.binnings = {{ProtoAxis(Acts::AxisBoundaryType::Closed,
+                                  -std::numbers::pi, std::numbers::pi, 22u),
+                        Acts::AxisDirection::AxisPhi, 1u}};
 
   auto endcapBuilder = Acts::Experimental::LayerStructureBuilder(
       lsConfig, Acts::getDefaultLogger("EndcapBuilder", Logging::VERBOSE));
@@ -188,13 +187,11 @@ BOOST_AUTO_TEST_CASE(LayerStructureBuilder_creationCylinder) {
   lsConfig.auxiliary = "*** Barrel with 448 surfaces ***";
   lsConfig.surfacesProvider = barrelSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis{Acts::AxisDirection::AxisZ,
-                       Acts::AxisBoundaryType::Bound, -480., 480., 14u},
-       1u},
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis{Acts::AxisBoundaryType::Bound, -480., 480., 14u},
+       Acts::AxisDirection::AxisZ, 1u},
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 32u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto barrelBuilder = Acts::Experimental::LayerStructureBuilder(
       lsConfig, Acts::getDefaultLogger("BarrelBuilder", Logging::VERBOSE));

--- a/Tests/UnitTests/Core/Detector/MultiWireStructureBuilderTests.cpp
+++ b/Tests/UnitTests/Core/Detector/MultiWireStructureBuilderTests.cpp
@@ -71,15 +71,12 @@ BOOST_AUTO_TEST_CASE(Multi_Wire_Structure_Builder_StrawSurfacesCreation) {
   mlCfg.name = "Multi_Layer_With_Wires";
   mlCfg.mlSurfaces = strawSurfaces;
   mlCfg.mlBounds = vBounds;
-  mlCfg.mlBinning = {
-      std::make_pair(
-          ProtoAxis(Acts::AxisDirection::AxisX, Acts::AxisBoundaryType::Bound,
-                    -vBounds[0], vBounds[0], nSurfacesX),
-          1u),
-      std::make_pair(
-          ProtoAxis(Acts::AxisDirection::AxisY, Acts::AxisBoundaryType::Bound,
-                    -vBounds[1], vBounds[1], nSurfacesY),
-          0u)};
+  mlCfg.mlBinning = {{ProtoAxis(Acts::AxisBoundaryType::Bound, -vBounds[0],
+                                vBounds[0], nSurfacesX),
+                      Acts::AxisDirection::AxisX, 1u},
+                     {ProtoAxis(Acts::AxisBoundaryType::Bound, -vBounds[1],
+                                vBounds[1], nSurfacesY),
+                      Acts::AxisDirection::AxisY, 0u}};
 
   MultiWireStructureBuilder mlBuilder(mlCfg);
   auto [volumes, portals, roots] = mlBuilder.construct(tContext);

--- a/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
@@ -272,9 +272,9 @@ BOOST_AUTO_TEST_CASE(NodeApiTestContainers) {
     using enum CylinderVolumeBounds::Face;
 
     // Configure cylinder faces with proper binning
-    mat.configureFace(OuterCylinder, {AxisRPhi, Bound, 20}, {AxisZ, Bound, 20});
-    mat.configureFace(NegativeDisc, {AxisR, Bound, 15}, {AxisPhi, Bound, 25});
-    mat.configureFace(PositiveDisc, {AxisR, Bound, 15}, {AxisPhi, Bound, 25});
+    mat.configureFace(OuterCylinder, {Bound, 20}, AxisRPhi, {Bound, 20}, AxisZ);
+    mat.configureFace(NegativeDisc, {Bound, 15}, AxisR, {Bound, 25}, AxisPhi);
+    mat.configureFace(PositiveDisc, {Bound, 15}, AxisR, {Bound, 25}, AxisPhi);
 
     mat.addCylinderContainer("Detector", AxisDirection::AxisR, [&](auto& det) {
       det.addCylinderContainer("Pixel", AxisDirection::AxisZ, [&](auto& cyl) {
@@ -422,12 +422,12 @@ BOOST_AUTO_TEST_CASE(NodeApiTestCuboid) {
     using enum CuboidVolumeBounds::Face;
 
     // Configure valid axis combinations for each face type
-    mat.configureFace(NegativeXFace, {AxisX, Bound, 20}, {AxisY, Bound, 20});
-    mat.configureFace(PositiveXFace, {AxisX, Bound, 20}, {AxisY, Bound, 20});
-    mat.configureFace(NegativeYFace, {AxisX, Bound, 15}, {AxisY, Bound, 25});
-    mat.configureFace(PositiveYFace, {AxisX, Bound, 15}, {AxisY, Bound, 25});
-    mat.configureFace(NegativeZFace, {AxisX, Bound, 15}, {AxisY, Bound, 25});
-    mat.configureFace(PositiveZFace, {AxisX, Bound, 15}, {AxisY, Bound, 25});
+    mat.configureFace(NegativeXFace, {Bound, 20}, AxisX, {Bound, 20}, AxisY);
+    mat.configureFace(PositiveXFace, {Bound, 20}, AxisX, {Bound, 20}, AxisY);
+    mat.configureFace(NegativeYFace, {Bound, 15}, AxisX, {Bound, 25}, AxisY);
+    mat.configureFace(PositiveYFace, {Bound, 15}, AxisX, {Bound, 25}, AxisY);
+    mat.configureFace(NegativeZFace, {Bound, 15}, AxisX, {Bound, 25}, AxisY);
+    mat.configureFace(PositiveZFace, {Bound, 15}, AxisX, {Bound, 25}, AxisY);
 
     mat.addStaticVolume(
         base, std::make_shared<CuboidVolumeBounds>(100_mm, 100_mm, 100_mm),

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -496,9 +496,9 @@ BOOST_AUTO_TEST_CASE(Material) {
   using enum AxisBoundaryType;
 
   root.addMaterial("Material", [&](auto& mat) {
-    mat.configureFace(NegativeDisc, {AxisR, Bound, 5}, {AxisPhi, Bound, 10});
-    mat.configureFace(PositiveDisc, {AxisR, Bound, 15}, {AxisPhi, Bound, 20});
-    mat.configureFace(OuterCylinder, {AxisRPhi, Bound, 25}, {AxisZ, Bound, 30});
+    mat.configureFace(NegativeDisc, {Bound, 5}, AxisR, {Bound, 10}, AxisPhi);
+    mat.configureFace(PositiveDisc, {Bound, 15}, AxisR, {Bound, 20}, AxisPhi);
+    mat.configureFace(OuterCylinder, {Bound, 25}, AxisRPhi, {Bound, 30}, AxisZ);
 
     mat.addStaticVolume(std::move(cyl));
   });
@@ -526,10 +526,14 @@ BOOST_AUTO_TEST_CASE(Material) {
   const auto& posDiscMat =
       dynamic_cast<const ProtoGridSurfaceMaterial&>(*posDisc);
 
-  BOOST_CHECK_EQUAL(negDiscMat.binning().at(0).getAxis().getNBins(), 5);
-  BOOST_CHECK_EQUAL(negDiscMat.binning().at(1).getAxis().getNBins(), 10);
-  BOOST_CHECK_EQUAL(posDiscMat.binning().at(0).getAxis().getNBins(), 15);
-  BOOST_CHECK_EQUAL(posDiscMat.binning().at(1).getAxis().getNBins(), 20);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(negDiscMat.binning().at(0)).getAxis().getNBins(), 5);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(negDiscMat.binning().at(1)).getAxis().getNBins(), 10);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(posDiscMat.binning().at(0)).getAxis().getNBins(), 15);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(posDiscMat.binning().at(1)).getAxis().getNBins(), 20);
 
   // Check outer cylinder material
   const auto* outerCyl = child.portals()
@@ -539,8 +543,12 @@ BOOST_AUTO_TEST_CASE(Material) {
   BOOST_CHECK_NE(outerCyl, nullptr);
   const auto& outerCylMat =
       dynamic_cast<const ProtoGridSurfaceMaterial&>(*outerCyl);
-  BOOST_CHECK_EQUAL(outerCylMat.binning().at(0).getAxis().getNBins(), 25);
-  BOOST_CHECK_EQUAL(outerCylMat.binning().at(1).getAxis().getNBins(), 30);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(outerCylMat.binning().at(0)).getAxis().getNBins(),
+      25);
+  BOOST_CHECK_EQUAL(
+      std::get<ProtoAxis>(outerCylMat.binning().at(1)).getAxis().getNBins(),
+      30);
 
   // Check that other faces have no material
   for (std::size_t i = 0; i < child.portals().size(); i++) {
@@ -568,7 +576,7 @@ BOOST_AUTO_TEST_CASE(MaterialInvalidAxisDirections) {
                        [&](auto& mat) {
                          mat.configureFace(
                              CylinderVolumeBounds::Face::NegativeDisc,
-                             {AxisZ, Bound, 5}, {AxisPhi, Bound, 10});
+                             {Bound, 5}, AxisZ, {Bound, 10}, AxisPhi);
                        }),
       std::invalid_argument);
 
@@ -577,7 +585,7 @@ BOOST_AUTO_TEST_CASE(MaterialInvalidAxisDirections) {
                        [&](auto& mat) {
                          mat.configureFace(
                              CylinderVolumeBounds::Face::OuterCylinder,
-                             {AxisR, Bound, 5}, {AxisR, Bound, 10});
+                             {Bound, 5}, AxisR, {Bound, 10}, AxisR);
                        }),
       std::invalid_argument);
 
@@ -587,7 +595,7 @@ BOOST_AUTO_TEST_CASE(MaterialInvalidAxisDirections) {
                        [&](auto& mat) {
                          mat.configureFace(
                              CuboidVolumeBounds::Face::NegativeXFace,
-                             {AxisX, Bound, 5}, {AxisZ, Bound, 10});
+                             {Bound, 5}, AxisX, {Bound, 10}, AxisZ);
                        }),
       std::invalid_argument);
 
@@ -596,7 +604,7 @@ BOOST_AUTO_TEST_CASE(MaterialInvalidAxisDirections) {
                        [&](auto& mat) {
                          mat.configureFace(
                              CuboidVolumeBounds::Face::PositiveYFace,
-                             {AxisY, Bound, 5}, {AxisX, Bound, 10});
+                             {Bound, 5}, AxisY, {Bound, 10}, AxisX);
                        }),
       std::invalid_argument);
 
@@ -605,7 +613,7 @@ BOOST_AUTO_TEST_CASE(MaterialInvalidAxisDirections) {
                        [&](auto& mat) {
                          mat.configureFace(
                              CuboidVolumeBounds::Face::NegativeZFace,
-                             {AxisZ, Bound, 5}, {AxisY, Bound, 10});
+                             {Bound, 5}, AxisZ, {Bound, 10}, AxisY);
                        }),
       std::invalid_argument);
 }
@@ -625,9 +633,9 @@ BOOST_AUTO_TEST_CASE(MaterialMixedVolumeTypes) {
           "Material",
           [&](auto& mat) {
             mat.configureFace(CylinderVolumeBounds::Face::NegativeDisc,
-                              {AxisR, Bound, 5}, {AxisPhi, Bound, 10});
+                              {Bound, 5}, AxisR, {Bound, 10}, AxisPhi);
             mat.configureFace(CuboidVolumeBounds::Face::NegativeXFace,
-                              {AxisX, Bound, 5}, {AxisY, Bound, 10});
+                              {Bound, 5}, AxisX, {Bound, 10}, AxisY);
           }),
       std::invalid_argument);
 
@@ -637,9 +645,9 @@ BOOST_AUTO_TEST_CASE(MaterialMixedVolumeTypes) {
           "Material",
           [&](auto& mat) {
             mat.configureFace(CuboidVolumeBounds::Face::NegativeXFace,
-                              {AxisX, Bound, 5}, {AxisY, Bound, 10});
+                              {Bound, 5}, AxisX, {Bound, 10}, AxisY);
             mat.configureFace(CylinderVolumeBounds::Face::NegativeDisc,
-                              {AxisR, Bound, 5}, {AxisPhi, Bound, 10});
+                              {Bound, 5}, AxisR, {Bound, 10}, AxisPhi);
           }),
       std::invalid_argument);
 }
@@ -664,12 +672,12 @@ BOOST_AUTO_TEST_CASE(MaterialCuboid) {
   auto mat = std::make_shared<MaterialDesignatorBlueprintNode>("Material");
 
   // Configure material for different faces with different binning
-  mat->configureFace(NegativeXFace, {AxisX, Bound, 5}, {AxisY, Bound, 10});
-  mat->configureFace(PositiveXFace, {AxisX, Bound, 15}, {AxisY, Bound, 20});
-  mat->configureFace(NegativeYFace, {AxisX, Bound, 25}, {AxisY, Bound, 30});
-  mat->configureFace(PositiveYFace, {AxisX, Bound, 35}, {AxisY, Bound, 40});
-  mat->configureFace(NegativeZFace, {AxisX, Bound, 45}, {AxisY, Bound, 50});
-  mat->configureFace(PositiveZFace, {AxisX, Bound, 55}, {AxisY, Bound, 60});
+  mat->configureFace(NegativeXFace, {Bound, 5}, AxisX, {Bound, 10}, AxisY);
+  mat->configureFace(PositiveXFace, {Bound, 15}, AxisX, {Bound, 20}, AxisY);
+  mat->configureFace(NegativeYFace, {Bound, 25}, AxisX, {Bound, 30}, AxisY);
+  mat->configureFace(PositiveYFace, {Bound, 35}, AxisX, {Bound, 40}, AxisY);
+  mat->configureFace(NegativeZFace, {Bound, 45}, AxisX, {Bound, 50}, AxisY);
+  mat->configureFace(PositiveZFace, {Bound, 55}, AxisX, {Bound, 60}, AxisY);
 
   mat->addChild(std::make_shared<StaticBlueprintNode>(std::move(cuboid)));
 
@@ -695,38 +703,63 @@ BOOST_AUTO_TEST_CASE(MaterialCuboid) {
     CuboidVolumeBounds::Face face = static_cast<CuboidVolumeBounds::Face>(i);
     switch (face) {
       case NegativeXFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(), 5);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
+                          5);
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           10);
         break;
       case PositiveXFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
                           15);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           20);
         break;
       case NegativeYFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
                           25);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           30);
         break;
       case PositiveYFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
                           35);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           40);
         break;
       case NegativeZFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
                           45);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           50);
         break;
       case PositiveZFace:
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(0).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(0))
+                              .getAxis()
+                              .getNBins(),
                           55);
-        BOOST_CHECK_EQUAL(gridMaterial.binning().at(1).getAxis().getNBins(),
+        BOOST_CHECK_EQUAL(std::get<ProtoAxis>(gridMaterial.binning().at(1))
+                              .getAxis()
+                              .getNBins(),
                           60);
         break;
     }

--- a/Tests/UnitTests/Core/Material/GridSurfaceMaterialTests.cpp
+++ b/Tests/UnitTests/Core/Material/GridSurfaceMaterialTests.cpp
@@ -147,8 +147,7 @@ BOOST_AUTO_TEST_CASE(GridMaterial1D) {
       Acts::Material::fromMolarDensity(31.0, 32.0, 33.0, 34.0, 35.0), 4.0);
 
   // Bound, equidistant axis
-  Acts::ProtoAxis pAxisX(Acts::AxisDirection::AxisX,
-                         Acts::AxisBoundaryType::Bound, 0.0, 5.0, 5);
+  Acts::ProtoAxis pAxisX(Acts::AxisBoundaryType::Bound, 0.0, 5.0, 5);
 
   auto localX = std::make_unique<const LocalAccessX>();
   Acts::GridAccess::BoundToGridLocal1DimDelegate bToX;
@@ -185,8 +184,7 @@ BOOST_AUTO_TEST_CASE(GridMaterial1D) {
 
   // Try the same with Closed access
   // Bound, equidistant axis
-  Acts::ProtoAxis pAxisPhi(Acts::AxisDirection::AxisPhi,
-                           Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+  Acts::ProtoAxis pAxisPhi(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                            std::numbers::pi, 8);
 
   auto localPhi = std::make_unique<const LocalAccessPhi>();
@@ -258,10 +256,8 @@ BOOST_AUTO_TEST_CASE(GridMaterial2D) {
   BOOST_CHECK(material2x3[1][1].material().X0() == 12.);
   BOOST_CHECK(material2x3[1][2].material().X0() == 22.);
 
-  Acts::ProtoAxis pAxisX(Acts::AxisDirection::AxisX,
-                         Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
-  Acts::ProtoAxis pAxisY(Acts::AxisDirection::AxisY,
-                         Acts::AxisBoundaryType::Bound, -1.5, 1.5, 3);
+  Acts::ProtoAxis pAxisX(Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
+  Acts::ProtoAxis pAxisY(Acts::AxisBoundaryType::Bound, -1.5, 1.5, 3);
 
   std::vector<std::vector<Acts::MaterialSlab>> materialXY = material2x3;
 
@@ -304,10 +300,8 @@ BOOST_AUTO_TEST_CASE(GridMaterial2D) {
   // Let's try a ZPhi model as well
   auto materialZPhi = material2x3;
 
-  Acts::ProtoAxis pAxisZ(Acts::AxisDirection::AxisZ,
-                         Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
-  Acts::ProtoAxis pAxisPhi(Acts::AxisDirection::AxisPhi,
-                           Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+  Acts::ProtoAxis pAxisZ(Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
+  Acts::ProtoAxis pAxisPhi(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                            std::numbers::pi, 3);
 
   auto localZPhi = std::make_unique<const LocalToZPhi>(1.);
@@ -458,8 +452,7 @@ BOOST_AUTO_TEST_CASE(GridIndexedMaterial1D) {
       Acts::IndexedMaterialAccessor{std::move(materialStorage)};
 
   // An X proto axis
-  Acts::ProtoAxis pAxisX(Acts::AxisDirection::AxisX,
-                         Acts::AxisBoundaryType::Bound, 0.0, 9.0, 9);
+  Acts::ProtoAxis pAxisX(Acts::AxisBoundaryType::Bound, 0.0, 9.0, 9);
 
   auto localXidx = std::make_unique<const LocalAccessX>();
   Acts::IndexedSurfaceMaterial<EqGrid>::BoundToGridLocalDelegate bToXidx;
@@ -555,10 +548,8 @@ BOOST_AUTO_TEST_CASE(GridIndexedMaterial2D) {
   Acts::GridAccess::GlobalToGridLocal2DimDelegate gToZphiT2;
   gToZphiT2.connect<&GlobalToZPhi::g2ZPhi>(std::move(globalToGridT2));
 
-  Acts::ProtoAxis pAxisZ(Acts::AxisDirection::AxisZ,
-                         Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
-  Acts::ProtoAxis pAxisPhi(Acts::AxisDirection::AxisPhi,
-                           Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+  Acts::ProtoAxis pAxisZ(Acts::AxisBoundaryType::Bound, -1.0, 1.0, 2);
+  Acts::ProtoAxis pAxisPhi(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                            std::numbers::pi, 4);
 
   std::vector<std::vector<std::size_t>> indexPayload = {

--- a/Tests/UnitTests/Core/Navigation/MultiWireNavigationTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/MultiWireNavigationTests.cpp
@@ -75,13 +75,12 @@ BOOST_AUTO_TEST_CASE(Navigation_in_Indexed_Surfaces) {
   mlCfg.name = "Multi_Layer_With_Wires";
   mlCfg.mlSurfaces = strawSurfaces;
 
-  mlCfg.mlBinning = {
-      {ProtoAxis(Acts::AxisDirection::AxisX, Acts::AxisBoundaryType::Bound,
-                 -vBounds[0], vBounds[0], nSurfacesX),
-       1u},
-      {ProtoAxis(Acts::AxisDirection::AxisY, Acts::AxisBoundaryType::Bound,
-                 -vBounds[1], vBounds[1], nSurfacesY),
-       0u}};
+  mlCfg.mlBinning = {{ProtoAxis(Acts::AxisBoundaryType::Bound, -vBounds[0],
+                                vBounds[0], nSurfacesX),
+                      Acts::AxisDirection::AxisX, 1u},
+                     {ProtoAxis(Acts::AxisBoundaryType::Bound, -vBounds[1],
+                                vBounds[1], nSurfacesY),
+                      Acts::AxisDirection::AxisY, 0u}};
   mlCfg.mlBounds = vBounds;
 
   MultiWireStructureBuilder mlBuilder(mlCfg);

--- a/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinUtilityTests.cpp
@@ -136,13 +136,13 @@ BOOST_AUTO_TEST_CASE(BinUtility_from_ProtoAxis) {
   using enum AxisDirection;
   using enum AxisBoundaryType;
 
-  ProtoAxis epabX(AxisX, Bound, 0.0, 1.0, 10);
-  BinUtility buX(epabX);
+  ProtoAxis epabX(Bound, 0.0, 1.0, 10);
+  BinUtility buX(epabX, AxisX);
   BOOST_CHECK_EQUAL(buX.bins(), std::size_t{10});
   BOOST_CHECK_EQUAL(buX.dimensions(), std::size_t{1});
 
-  ProtoAxis epabY(AxisY, Bound, 0.0, 1.0, 10);
-  BinUtility buXY({epabX, epabY});
+  ProtoAxis epabY(Bound, 0.0, 1.0, 10);
+  BinUtility buXY({{epabX, AxisX}, {epabY, AxisY}});
   BOOST_CHECK_EQUAL(buXY.bins(), std::size_t{100});
   BOOST_CHECK_EQUAL(buXY.dimensions(), std::size_t{2});
 }

--- a/Tests/UnitTests/Core/Utilities/BinningDataTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/BinningDataTests.cpp
@@ -430,8 +430,8 @@ BOOST_AUTO_TEST_CASE(BinningData_from_ProtoAxis) {
   using enum AxisBoundaryType;
 
   // Bound, equidistant axis
-  ProtoAxis epab(AxisX, Bound, 0.0, 1.0, 10);
-  BinningData bEpab(epab);
+  ProtoAxis epab(Bound, 0.0, 1.0, 10);
+  BinningData bEpab(epab, AxisX);
 
   BOOST_CHECK_EQUAL(bEpab.bins(), std::size_t{10});
   BOOST_CHECK_EQUAL(bEpab.min, 0.);
@@ -441,16 +441,16 @@ BOOST_AUTO_TEST_CASE(BinningData_from_ProtoAxis) {
   BOOST_CHECK(bEpab.type == equidistant);
 
   // Bound, equidistant axis, autorange
-  ProtoAxis epa(AxisY, Bound, 10);
-  BinningData bEpa(epa);
+  ProtoAxis epa(Bound, 10);
+  BinningData bEpa(epa, AxisY);
   BOOST_CHECK(bEpa.binvalue == AxisY);
   BOOST_CHECK_EQUAL(bEpa.bins(), std::size_t{10});
   BOOST_CHECK(bEpa.option == open);
   BOOST_CHECK(bEpa.type == equidistant);
 
   // Bound, equidistant axis
-  ProtoAxis vpab(AxisZ, Bound, {0.0, 1.0, 10});
-  BinningData bVpab(vpab);
+  ProtoAxis vpab(Bound, {0.0, 1.0, 10});
+  BinningData bVpab(vpab, AxisZ);
   BOOST_CHECK(bVpab.binvalue == AxisZ);
   BOOST_CHECK_EQUAL(bVpab.bins(), std::size_t{2});
   BOOST_CHECK(bVpab.option == open);

--- a/Tests/UnitTests/Core/Utilities/ProtoAxisTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/ProtoAxisTests.cpp
@@ -22,10 +22,9 @@ BOOST_AUTO_TEST_CASE(EquidistantProtoAxis) {
   using enum Acts::AxisType;
 
   // Bound, equidistant axis
-  Acts::ProtoAxis epab(AxisX, Bound, 0.0, 1.0, 10);
+  Acts::ProtoAxis epab(Bound, 0.0, 1.0, 10);
 
   // Direct access
-  BOOST_CHECK_EQUAL(epab.getAxisDirection(), AxisX);
   BOOST_CHECK(!epab.isAutorange());
 
   // Access via IAxis
@@ -46,21 +45,18 @@ BOOST_AUTO_TEST_CASE(EquidistantProtoAxis) {
 
   CHECK_CLOSE_ABS(epab.getAxis().getMax(), 1.0, 1e-15);
 
-  std::string rString =
-      "ProtoAxis: 10 bins in AxisX, equidistant within [0, 1]";
+  std::string rString = "ProtoAxis: 10 bins, equidistant within [0, 1]";
   std::string oString = epab.toString();
   BOOST_CHECK_EQUAL(rString, oString);
 
   // Test copy constructor
   Acts::ProtoAxis epabCopy(epab);
-  BOOST_CHECK_EQUAL(epabCopy.getAxisDirection(), epab.getAxisDirection());
   BOOST_CHECK_EQUAL(epabCopy.isAutorange(), epab.isAutorange());
   BOOST_CHECK(epabCopy.getAxis() == epab.getAxis());
 
   // Test Assignment operator
-  Acts::ProtoAxis epabAssign(AxisX, Bound, 0.0, 50.0, 20);
+  Acts::ProtoAxis epabAssign(Bound, 0.0, 50.0, 20);
   epabAssign = epab;
-  BOOST_CHECK_EQUAL(epabAssign.getAxisDirection(), epab.getAxisDirection());
   BOOST_CHECK_EQUAL(epabAssign.isAutorange(), epab.isAutorange());
   BOOST_CHECK(epabAssign.getAxis() == epab.getAxis());
 
@@ -74,7 +70,7 @@ BOOST_AUTO_TEST_CASE(EquidistantProtoAxis) {
   BOOST_CHECK(axis1D != nullptr);
 
   // Open, equidistant axis
-  Acts::ProtoAxis epao(AxisY, Open, 0., 2.0, 10.);
+  Acts::ProtoAxis epao(Open, 0., 2.0, 10.);
   BOOST_CHECK_EQUAL(epao.getAxis().getBoundaryType(), Open);
 
   // Create a 2D grid from a two proto axes
@@ -91,24 +87,12 @@ BOOST_AUTO_TEST_CASE(EquidistantProtoAxis) {
           grid2Daxes[1]);
   BOOST_CHECK(axis2D2 != nullptr);
 
-  // Invalid grid construction with two proto axis in the same direction
-  BOOST_CHECK_THROW(Acts::makeGrid<double>(epab, epab), std::invalid_argument);
-
   // Invalid constructor, min > max
-  BOOST_CHECK_THROW(Acts::ProtoAxis(AxisZ, Bound, 1.0, 0.0, 10),
+  BOOST_CHECK_THROW(Acts::ProtoAxis(Bound, 1.0, 0.0, 10),
                     std::invalid_argument);
 
   // Invalid constructor, nbins < 1
-  BOOST_CHECK_THROW(Acts::ProtoAxis(AxisZ, Bound, 0.0, 1.0, 0),
-                    std::invalid_argument);
-
-  // Invalid constructor, closed with something else than phi or rphi
-  std::vector<Acts::AxisDirection> invalidDirections = {
-      AxisX, AxisY, AxisZ, AxisR, AxisEta, AxisTheta, AxisMag};
-  for (const auto& adir : invalidDirections) {
-    BOOST_CHECK_THROW(Acts::ProtoAxis(adir, Closed, 0.0, 1.0, 10),
-                      std::invalid_argument);
-  }
+  BOOST_CHECK_THROW(Acts::ProtoAxis(Bound, 0.0, 1.0, 0), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(AutorangeProtoAxis) {
@@ -117,11 +101,9 @@ BOOST_AUTO_TEST_CASE(AutorangeProtoAxis) {
   using enum Acts::AxisType;
 
   // Bound, equidistant axis, autorange
-  Acts::ProtoAxis epa(AxisX, Bound, 10);
+  Acts::ProtoAxis epa(Bound, 10);
 
   // Direct access
-  BOOST_CHECK_EQUAL(epa.getAxisDirection(), AxisX);
-
   BOOST_CHECK(epa.isAutorange());
 
   // Access via IAxis
@@ -136,20 +118,18 @@ BOOST_AUTO_TEST_CASE(AutorangeProtoAxis) {
   BOOST_CHECK_EQUAL(epa.getAxis().getNBins(), 10);
 
   std::string rString =
-      "ProtoAxis: 10 bins in AxisX, equidistant within automatic range";
+      "ProtoAxis: 10 bins, equidistant within automatic range";
   std::string oString = epa.toString();
   BOOST_CHECK_EQUAL(rString, oString);
 
   // Test copy constructor
   Acts::ProtoAxis epaCopy(epa);
-  BOOST_CHECK_EQUAL(epaCopy.getAxisDirection(), epa.getAxisDirection());
   BOOST_CHECK_EQUAL(epaCopy.isAutorange(), epa.isAutorange());
   BOOST_CHECK(epaCopy.getAxis() == epa.getAxis());
 
   // Test Assignment operator
-  Acts::ProtoAxis epaAssign(AxisX, Bound, 0.0, 50.0, 20);
+  Acts::ProtoAxis epaAssign(Bound, 0.0, 50.0, 20);
   epaAssign = epa;
-  BOOST_CHECK_EQUAL(epaAssign.getAxisDirection(), epa.getAxisDirection());
   BOOST_CHECK_EQUAL(epaAssign.isAutorange(), epa.isAutorange());
   BOOST_CHECK(epaAssign.getAxis() == epa.getAxis());
 
@@ -157,7 +137,7 @@ BOOST_AUTO_TEST_CASE(AutorangeProtoAxis) {
   BOOST_CHECK_THROW(Acts::makeGrid<double>(epa), std::invalid_argument);
 
   // Invalid 2D grid construction with autorange axis
-  Acts::ProtoAxis epao(AxisY, Open, 0., 2.0, 10.);
+  Acts::ProtoAxis epao(Open, 0., 2.0, 10.);
   BOOST_CHECK_THROW(Acts::makeGrid<double>(epao, epa), std::invalid_argument);
   BOOST_CHECK_THROW(Acts::makeGrid<double>(epa, epao), std::invalid_argument);
 
@@ -171,9 +151,6 @@ BOOST_AUTO_TEST_CASE(AutorangeProtoAxis) {
   // 2D Grid consstruction works now
   BOOST_CHECK_NO_THROW(Acts::makeGrid<double>(epa, epao));
 
-  // Invalid constructor, closed with something else than phi or rphi
-  BOOST_CHECK_THROW(Acts::ProtoAxis(AxisZ, Closed, 10), std::invalid_argument);
-
   // Invalid setRange, min > max
   BOOST_CHECK_THROW(epa.setRange(20.0, 0.0), std::invalid_argument);
 }
@@ -184,11 +161,9 @@ BOOST_AUTO_TEST_CASE(VariableProtoAxis) {
   using enum Acts::AxisType;
 
   // Bound, equidistant axis
-  Acts::ProtoAxis vpab(AxisX, Bound, {0.0, 1.0, 10});
+  Acts::ProtoAxis vpab(Bound, {0.0, 1.0, 10});
 
   // Direct access
-  BOOST_CHECK_EQUAL(vpab.getAxisDirection(), AxisX);
-
   BOOST_CHECK(!vpab.isAutorange());
 
   // Access via IAxis
@@ -209,20 +184,18 @@ BOOST_AUTO_TEST_CASE(VariableProtoAxis) {
 
   CHECK_CLOSE_ABS(vpab.getAxis().getMax(), 10.0, 1e-15);
 
-  std::string rString = "ProtoAxis: 2 bins in AxisX, variable within [0, 10]";
+  std::string rString = "ProtoAxis: 2 bins, variable within [0, 10]";
   std::string oString = vpab.toString();
   BOOST_CHECK_EQUAL(rString, oString);
 
   // Test copy constructor
   Acts::ProtoAxis vpabCopy(vpab);
-  BOOST_CHECK_EQUAL(vpabCopy.getAxisDirection(), vpab.getAxisDirection());
   BOOST_CHECK_EQUAL(vpabCopy.isAutorange(), vpab.isAutorange());
   BOOST_CHECK(vpabCopy.getAxis() == vpab.getAxis());
 
   // Test Assignment operator
-  Acts::ProtoAxis vpabAssign(AxisX, Bound, 0.0, 50.0, 20);
+  Acts::ProtoAxis vpabAssign(Bound, 0.0, 50.0, 20);
   vpabAssign = vpab;
-  BOOST_CHECK_EQUAL(vpabAssign.getAxisDirection(), vpab.getAxisDirection());
   BOOST_CHECK_EQUAL(vpabAssign.isAutorange(), vpab.isAutorange());
   BOOST_CHECK(vpabAssign.getAxis() == vpab.getAxis());
 
@@ -234,20 +207,11 @@ BOOST_AUTO_TEST_CASE(VariableProtoAxis) {
   CHECK_CLOSE_ABS(vpab.getAxis().getMax(), 9.5, 1e-15);
 
   // Invalid constructor, min > max
-  BOOST_CHECK_THROW(Acts::ProtoAxis(AxisZ, Bound, std::vector<double>{2.}),
+  BOOST_CHECK_THROW(Acts::ProtoAxis(Bound, std::vector<double>{2.}),
                     std::invalid_argument);
 
   // Invalid constructor, nbins < 1
-  BOOST_CHECK_THROW(Acts::ProtoAxis(AxisZ, Bound, {3., 2., 1}),
-                    std::invalid_argument);
-
-  // Invalid constructor, closed with something else than phi or rphi
-  std::vector<Acts::AxisDirection> invalidDirections = {
-      AxisX, AxisY, AxisZ, AxisR, AxisEta, AxisTheta, AxisMag};
-  for (const auto& adir : invalidDirections) {
-    BOOST_CHECK_THROW(Acts::ProtoAxis(adir, Closed, {0., 1., 2., 3.}),
-                      std::invalid_argument);
-  }
+  BOOST_CHECK_THROW(Acts::ProtoAxis(Bound, {3., 2., 1}), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Plugins/ActSVG/DetectorVolumeSvgConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/ActSVG/DetectorVolumeSvgConverterTests.cpp
@@ -150,10 +150,9 @@ BOOST_AUTO_TEST_CASE(EndcapVolumeWithSurfaces) {
   lsConfig.auxiliary = "*** Endcap with 22 surfaces ***";
   lsConfig.surfacesProvider = endcapSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 22u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto layerBuilder =
       std::make_shared<Acts::Experimental::LayerStructureBuilder>(
@@ -222,13 +221,11 @@ BOOST_AUTO_TEST_CASE(BarrelVolumeWithSurfaces) {
   lsConfig.auxiliary = "*** Barrel with 448 surfaces ***";
   lsConfig.surfacesProvider = barrelSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis{Acts::AxisDirection::AxisZ,
-                       Acts::AxisBoundaryType::Bound, -480., 480., 14u},
-       1u},
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis{Acts::AxisBoundaryType::Bound, -480., 480., 14u},
+       Acts::AxisDirection::AxisZ, 1u},
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 32u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto barrelBuilder =
       std::make_shared<Acts::Experimental::LayerStructureBuilder>(

--- a/Tests/UnitTests/Plugins/ActSVG/IndexedSurfacesSvgConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/ActSVG/IndexedSurfacesSvgConverterTests.cpp
@@ -77,12 +77,12 @@ BOOST_AUTO_TEST_CASE(RingDisc1D) {
   // Polyhedron reference generator
   PolyhedronReferenceGenerator<1u, true> rGenerator;
   // A single proto axis clused in phi with 44 bins
-  ProtoAxis pAxis(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                  -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxis(AxisBoundaryType::Closed, -std::numbers::pi, std::numbers::pi,
+                  44u);
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
-          Experimental::IndexedSurfacesNavigation>(tContext, rSurfaces,
-                                                   rGenerator, pAxis, 0u);
+          Experimental::IndexedSurfacesNavigation>(
+          tContext, rSurfaces, rGenerator, pAxis, AxisDirection::AxisPhi, 0u);
   // The displaying
   auto pIndexedRing = IndexedSurfacesConverter::convert(
       tContext, rSurfaces, indexedRing, drawOptions);
@@ -104,12 +104,13 @@ BOOST_AUTO_TEST_CASE(RingDisc1DWithSupport) {
   // Polyhedron reference generator
   PolyhedronReferenceGenerator<1u, true> rGenerator;
   // A single proto axis clused in phi with 44 bins
-  ProtoAxis pAxis(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                  -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxis(AxisBoundaryType::Closed, -std::numbers::pi, std::numbers::pi,
+                  44u);
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxis, 0u, {rSurfaces.size() - 1u});
+          tContext, rSurfaces, rGenerator, pAxis, AxisDirection::AxisPhi, 0u,
+          {rSurfaces.size() - 1u});
   // The displaying
   auto pIndexedRing = IndexedSurfacesConverter::convert(
       tContext, rSurfaces, indexedRing, drawOptions);
@@ -129,17 +130,17 @@ BOOST_AUTO_TEST_CASE(RingDisc2D) {
   decltype(rSurfacesR0) rSurfaces = rSurfacesR0;
   rSurfaces.insert(rSurfaces.end(), rSurfacesR1.begin(), rSurfacesR1.end());
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound,
-                   {24., 74., 110});
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 44u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, {24., 74., 110});
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 44u);
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 0u, pAxisPhi, 0u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 0u,
+          pAxisPhi, AxisDirection::AxisPhi, 0u);
 
   // The displaying
   auto pIndexedRing = IndexedSurfacesConverter::convert(
@@ -165,16 +166,17 @@ BOOST_AUTO_TEST_CASE(RingDisc2DFine) {
   rSurfaces.insert(rSurfaces.end(), rSurfacesR1.begin(), rSurfacesR1.end());
   rSurfaces.insert(rSurfaces.end(), rSurfacesR2.begin(), rSurfacesR2.end());
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound, 24., 152, 8u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 88u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, 24., 152, 8u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 88u);
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 0u, pAxisPhi, 0u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 0u,
+          pAxisPhi, AxisDirection::AxisPhi, 0u);
 
   // The displaying
   auto pIndexedRing = IndexedSurfacesConverter::convert(
@@ -202,14 +204,15 @@ BOOST_AUTO_TEST_CASE(RingDisc2DFineExpanded) {
 
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
-  ProtoAxis pAxisR(AxisDirection::AxisR, AxisBoundaryType::Bound, 24., 152, 8u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 88u);
+  ProtoAxis pAxisR(AxisBoundaryType::Bound, 24., 152, 8u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 88u);
 
   auto indexedRing =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, rSurfaces, rGenerator, pAxisR, 2u, pAxisPhi, 4u);
+          tContext, rSurfaces, rGenerator, pAxisR, AxisDirection::AxisR, 2u,
+          pAxisPhi, AxisDirection::AxisPhi, 4u);
 
   // The displaying
   auto pIndexedRing = IndexedSurfacesConverter::convert(
@@ -224,16 +227,16 @@ BOOST_AUTO_TEST_CASE(Cylinder2D) {
   auto surfaces = cGeometry.surfacesCylinder(dStore, 8.4, 36., 0.15, 0.145,
                                              116., 3., 2., {52, 14});
 
-  ProtoAxis pAxisZ(AxisDirection::AxisZ, AxisBoundaryType::Bound, -500., 500.,
-                   28u);
-  ProtoAxis pAxisPhi(AxisDirection::AxisPhi, AxisBoundaryType::Closed,
-                     -std::numbers::pi, std::numbers::pi, 52u);
+  ProtoAxis pAxisZ(AxisBoundaryType::Bound, -500., 500., 28u);
+  ProtoAxis pAxisPhi(AxisBoundaryType::Closed, -std::numbers::pi,
+                     std::numbers::pi, 52u);
   PolyhedronReferenceGenerator<1u, true> rGenerator;
 
   auto indexedCylinder =
       Acts::detail::IndexedSurfacesGenerator::createInternalNavigation<
           Experimental::IndexedSurfacesNavigation>(
-          tContext, surfaces, rGenerator, pAxisZ, 1u, pAxisPhi, 1u);
+          tContext, surfaces, rGenerator, pAxisZ, AxisDirection::AxisZ, 1u,
+          pAxisPhi, AxisDirection::AxisPhi, 1u);
 
   // The displaying
   auto pIndexeCylinder = IndexedSurfacesConverter::convert(

--- a/Tests/UnitTests/Plugins/Json/DetectorJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/DetectorJsonConverterTests.cpp
@@ -169,10 +169,9 @@ BOOST_AUTO_TEST_CASE(BeamPipeEndcapBarrelDetector) {
     lsConfig.auxiliary = "*** Endcap with 22 surfaces ***";
     lsConfig.surfacesProvider = endcapSurfaces;
     lsConfig.binnings = {
-        {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                         Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+        {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                          std::numbers::pi, 22u),
-         1u}};
+         Acts::AxisDirection::AxisPhi, 1u}};
 
     auto layerBuilder =
         std::make_shared<Acts::Experimental::LayerStructureBuilder>(
@@ -233,13 +232,11 @@ BOOST_AUTO_TEST_CASE(BeamPipeEndcapBarrelDetector) {
   lsConfig.auxiliary = "*** Barrel with 448 surfaces ***";
   lsConfig.surfacesProvider = barrelSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisZ,
-                       Acts::AxisBoundaryType::Bound, -480., 480., 14u),
-       1u},
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Bound, -480., 480., 14u),
+       Acts::AxisDirection::AxisZ, 1u},
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 32u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto barrelBuilder =
       std::make_shared<Acts::Experimental::LayerStructureBuilder>(

--- a/Tests/UnitTests/Plugins/Json/DetectorVolumeJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/DetectorVolumeJsonConverterTests.cpp
@@ -149,10 +149,9 @@ BOOST_AUTO_TEST_CASE(EndcapVolumeWithSurfaces) {
   lsConfig.auxiliary = "*** Endcap with 22 surfaces ***";
   lsConfig.surfacesProvider = endcapSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 22u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto layerBuilder =
       std::make_shared<Acts::Experimental::LayerStructureBuilder>(
@@ -230,13 +229,11 @@ BOOST_AUTO_TEST_CASE(BarrelVolumeWithSurfaces) {
   lsConfig.auxiliary = "*** Barrel with 448 surfaces ***";
   lsConfig.surfacesProvider = barrelSurfaces;
   lsConfig.binnings = {
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisZ,
-                       Acts::AxisBoundaryType::Bound, -480., 480., 14u),
-       1u},
-      {Acts::ProtoAxis(Acts::AxisDirection::AxisPhi,
-                       Acts::AxisBoundaryType::Closed, -std::numbers::pi,
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Bound, -480., 480., 14u),
+       Acts::AxisDirection::AxisZ, 1u},
+      {Acts::ProtoAxis(Acts::AxisBoundaryType::Closed, -std::numbers::pi,
                        std::numbers::pi, 32u),
-       1u}};
+       Acts::AxisDirection::AxisPhi, 1u}};
 
   auto barrelBuilder =
       std::make_shared<Acts::Experimental::LayerStructureBuilder>(

--- a/Tests/UnitTests/Plugins/Json/ProtoAxisJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/ProtoAxisJsonConverterTests.cpp
@@ -20,21 +20,18 @@ BOOST_AUTO_TEST_SUITE(ProtoAxisJsonConversion)
 
 BOOST_AUTO_TEST_CASE(EquidistantProtoAxisJsonConversion) {
   using enum Acts::AxisBoundaryType;
-  using enum Acts::AxisDirection;
   using enum Acts::AxisType;
 
   // Bound, equidistant axis
-  Acts::ProtoAxis epab(AxisX, Bound, 0.0, 1.0, 10);
+  Acts::ProtoAxis epab(Bound, 0.0, 1.0, 10);
 
   nlohmann::json jProtoAxis = Acts::ProtoAxisJsonConverter::toJson(epab);
 
   BOOST_CHECK(jProtoAxis.contains("axis"));
-  BOOST_CHECK(jProtoAxis.contains("axis_dir"));
   BOOST_CHECK(jProtoAxis.contains("autorange"));
 
   Acts::ProtoAxis epabRead = Acts::ProtoAxisJsonConverter::fromJson(jProtoAxis);
 
-  BOOST_CHECK_EQUAL(epabRead.getAxisDirection(), epab.getAxisDirection());
   BOOST_CHECK_EQUAL(epabRead.getAxis(), epab.getAxis());
   BOOST_CHECK_EQUAL(epabRead.isAutorange(), epab.isAutorange());
   BOOST_CHECK_EQUAL(epabRead.toString(), epab.toString());
@@ -42,21 +39,18 @@ BOOST_AUTO_TEST_CASE(EquidistantProtoAxisJsonConversion) {
 
 BOOST_AUTO_TEST_CASE(AutorangeProtoAxisJsonConversion) {
   using enum Acts::AxisBoundaryType;
-  using enum Acts::AxisDirection;
   using enum Acts::AxisType;
 
   // Bound, equidistant axis, autorange
-  Acts::ProtoAxis epa(AxisX, Bound, 10);
+  Acts::ProtoAxis epa(Bound, 10);
 
   nlohmann::json jProtoAxis = Acts::ProtoAxisJsonConverter::toJson(epa);
 
   BOOST_CHECK(jProtoAxis.contains("axis"));
-  BOOST_CHECK(jProtoAxis.contains("axis_dir"));
   BOOST_CHECK(jProtoAxis.contains("autorange"));
 
   Acts::ProtoAxis epaRead = Acts::ProtoAxisJsonConverter::fromJson(jProtoAxis);
 
-  BOOST_CHECK_EQUAL(epaRead.getAxisDirection(), epa.getAxisDirection());
   BOOST_CHECK_EQUAL(epaRead.getAxis(), epa.getAxis());
   BOOST_CHECK_EQUAL(epaRead.isAutorange(), epa.isAutorange());
   BOOST_CHECK_EQUAL(epaRead.toString(), epa.toString());
@@ -64,20 +58,17 @@ BOOST_AUTO_TEST_CASE(AutorangeProtoAxisJsonConversion) {
 
 BOOST_AUTO_TEST_CASE(VariableProtoAxisJsonConversion) {
   using enum Acts::AxisBoundaryType;
-  using enum Acts::AxisDirection;
   using enum Acts::AxisType;
 
   // Bound, variable axis
-  Acts::ProtoAxis vpab(AxisX, Bound, {0.0, 1.0, 10});
+  Acts::ProtoAxis vpab(Bound, {0.0, 1.0, 10});
 
   nlohmann::json jProtoAxis = Acts::ProtoAxisJsonConverter::toJson(vpab);
   BOOST_CHECK(jProtoAxis.contains("axis"));
-  BOOST_CHECK(jProtoAxis.contains("axis_dir"));
   BOOST_CHECK(jProtoAxis.contains("autorange"));
 
   Acts::ProtoAxis vpabRead = Acts::ProtoAxisJsonConverter::fromJson(jProtoAxis);
 
-  BOOST_CHECK_EQUAL(vpabRead.getAxisDirection(), vpab.getAxisDirection());
   BOOST_CHECK_EQUAL(vpabRead.getAxis(), vpab.getAxis());
   BOOST_CHECK_EQUAL(vpabRead.isAutorange(), vpab.isAutorange());
   BOOST_CHECK_EQUAL(vpabRead.toString(), vpab.toString());
@@ -91,8 +82,7 @@ BOOST_AUTO_TEST_CASE(InvalidAndValidInputJson) {
                                  {"type", "Equidistant"}};
 
   // Valid input first
-  nlohmann::json jValidEq = {
-      {"axis", jValidEqAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  nlohmann::json jValidEq = {{"axis", jValidEqAxis}, {"autorange", false}};
 
   BOOST_CHECK_NO_THROW(Acts::ProtoAxisJsonConverter::fromJson(jValidEq));
 
@@ -100,15 +90,13 @@ BOOST_AUTO_TEST_CASE(InvalidAndValidInputJson) {
   nlohmann::json jInvalidEqAxis = jValidEqAxis;
   jInvalidEqAxis["bins"] = 0;
 
-  nlohmann::json jInvalidEq = {
-      {"axis", jInvalidEqAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  nlohmann::json jInvalidEq = {{"axis", jInvalidEqAxis}, {"autorange", false}};
 
   BOOST_CHECK_THROW(Acts::ProtoAxisJsonConverter::fromJson(jInvalidEq),
                     std::invalid_argument);
 
   // Invalid input - auto range without bins
-  jInvalidEq = {
-      {"axis", jInvalidEqAxis}, {"axis_dir", "AxisX"}, {"autorange", true}};
+  jInvalidEq = {{"axis", jInvalidEqAxis}, {"autorange", true}};
   BOOST_CHECK_THROW(Acts::ProtoAxisJsonConverter::fromJson(jInvalidEq),
                     std::invalid_argument);
 
@@ -116,8 +104,7 @@ BOOST_AUTO_TEST_CASE(InvalidAndValidInputJson) {
   jInvalidEqAxis = jValidEqAxis;
   jInvalidEqAxis["range"] = std::array<double, 2>{1.0, 0.0};
 
-  jInvalidEq = {
-      {"axis", jInvalidEqAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  jInvalidEq = {{"axis", jInvalidEqAxis}, {"autorange", false}};
 
   BOOST_CHECK_THROW(Acts::ProtoAxisJsonConverter::fromJson(jInvalidEq),
                     std::invalid_argument);
@@ -128,16 +115,15 @@ BOOST_AUTO_TEST_CASE(InvalidAndValidInputJson) {
       {"type", "Variable"}};
 
   // Valid input first
-  nlohmann::json jValidVar = {
-      {"axis", jValidVarAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  nlohmann::json jValidVar = {{"axis", jValidVarAxis}, {"autorange", false}};
   BOOST_CHECK_NO_THROW(Acts::ProtoAxisJsonConverter::fromJson(jValidVar));
 
   // Invalid input - less than two edges
   nlohmann::json jInvalidVarAxis = jValidVarAxis;
   jInvalidVarAxis["boundaries"] = std::vector<double>{0.0};
 
-  nlohmann::json jInvalidVar = {
-      {"axis", jInvalidVarAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  nlohmann::json jInvalidVar = {{"axis", jInvalidVarAxis},
+                                {"autorange", false}};
   BOOST_CHECK_THROW(Acts::ProtoAxisJsonConverter::fromJson(jInvalidVar),
                     std::invalid_argument);
 
@@ -145,8 +131,7 @@ BOOST_AUTO_TEST_CASE(InvalidAndValidInputJson) {
   jInvalidVarAxis = jValidVarAxis;
   jInvalidVarAxis["boundaries"] = std::vector<double>{0.0, 0.75, 0.25, 1.0};
 
-  jInvalidVar = {
-      {"axis", jInvalidVarAxis}, {"axis_dir", "AxisX"}, {"autorange", false}};
+  jInvalidVar = {{"axis", jInvalidVarAxis}, {"autorange", false}};
 
   BOOST_CHECK_THROW(Acts::ProtoAxisJsonConverter::fromJson(jInvalidVar),
                     std::invalid_argument);


### PR DESCRIPTION
This PR removes the `AxisDirection` from the `ProtoAxis` and turns the latter into a pure runtime representation of the actual axis that it creates.

The interpretation of the axis is moved one level higher, e.g. into a `DirectedProtoAxis = std::temple<ProtoAxis, AxisDirection>`, or e.g. for the `GritSurfaceMaterialT<>` classes done via `toGridLocal` delegates.

The reason for this change is that in some cases this information was not available or not applicable, e.g. for I/O of a grid. With this change the interpretation of the grid axis is forced to be explicitly done by the caller.

--- END COMMIT MESSAGE ---

@paulgessinger @dimitra97 @ldamenti  - have a look as this will touch your code (some more, some less)

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
