### PR TITLE
docs: Fix typo in the RKN method

### DIFF
--- a/docs/tracking.md
+++ b/docs/tracking.md
@@ -189,7 +189,7 @@ as the approximation of $y(t_{n+1})$ like
 
 $$
   \begin{aligned}
-    y_{n+1} &= y_n + \frac 1 6 h ( k_1 + 2 k_2 + 2 k_2 + k_4)\\
+    y_{n+1} &= y_n + \frac 1 6 h ( k_1 + 2 k_2 + 2 k_3 + k_4)\\
     t_{n+1} &= t_n + h
   \end{aligned}
 $$


### PR DESCRIPTION
Fix a typo in the y_{n+1} equation of RKN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the explanation of the numerical integration method in our documentation. The updated formula description now accurately reflects the intended calculation steps, ensuring improved approximation accuracy for users referencing the integration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->