### PR TITLE
fix: strip endcap measurement reading in RootAthenaDumpReader

### DIFF
--- a/Examples/Io/Root/src/RootAthenaDumpReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaDumpReader.cpp
@@ -433,10 +433,14 @@ RootAthenaDumpReader::readMeasurements(
       digiPars.variances = {locCov[0], locCov[3]};
       digiPars.values = localParams;
     } else {
-      digiPars.indices = {Acts::eBoundLoc0};
       assert(!locCov.empty());
-      digiPars.variances = {locCov[0]};
-      digiPars.values = {localParams[0]};
+      // index can be -2/2 for endcap or 0 for barrel
+      // choose index of local measurement depending on that
+      const static std::array boundLoc = {Acts::eBoundLoc0, Acts::eBoundLoc1};
+      auto i = CLbarrel_endcap[im] == 0 ? 0 : 1;
+      digiPars.variances = {locCov[i]};
+      digiPars.values = {localParams[i]};
+      digiPars.indices = {boundLoc[i]};
     }
 
     std::size_t measIndex = measurements.size();

--- a/Examples/Io/Root/src/RootAthenaDumpReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaDumpReader.cpp
@@ -434,8 +434,8 @@ RootAthenaDumpReader::readMeasurements(
       digiPars.values = localParams;
     } else {
       assert(!locCov.empty());
-      // index can be -2/2 for endcap or 0 for barrel
-      // choose index of local measurement depending on that
+      // Barrel-endcap index can be -2/2 for endcap or 0 for barrel
+      // We need to choose the coordinate of local measurement depending on that
       const static std::array boundLoc = {Acts::eBoundLoc0, Acts::eBoundLoc1};
       auto i = CLbarrel_endcap[im] == 0 ? 0 : 1;
       digiPars.variances = {locCov[i]};


### PR DESCRIPTION
The `RootAthenaDumpReader` did not correctly choose the measurement coordinates for strip-endcap measurements. This PR fixes this.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the internal measurement processing to dynamically select parameters based on spatial context, ensuring improved accuracy when handling different measurement regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->