### PR TITLE
feat: Expose ScopedLoggingThreshold to python + test

### DIFF
--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -208,6 +208,28 @@ void addLogging(Acts::Python::Context& ctx) {
   logging.def("setFailureThreshold", &Logging::setFailureThreshold);
   logging.def("getFailureThreshold", &Logging::getFailureThreshold);
 
+  struct ScopedFailureThresholdContextManager {
+    std::optional<Logging::ScopedFailureThreshold> m_scopedFailureThreshold =
+        std::nullopt;
+    Logging::Level m_level;
+
+    explicit ScopedFailureThresholdContextManager(Logging::Level level)
+        : m_level(level) {}
+
+    void enter() { m_scopedFailureThreshold.emplace(m_level); }
+
+    void exit(const py::object& /*exc_type*/, const py::object& /*exc_value*/,
+              const py::object& /*traceback*/) {
+      m_scopedFailureThreshold.reset();
+    }
+  };
+
+  py::class_<ScopedFailureThresholdContextManager>(logging,
+                                                   "ScopedFailureThreshold")
+      .def(py::init<Logging::Level>(), "level"_a)
+      .def("__enter__", &ScopedFailureThresholdContextManager::enter)
+      .def("__exit__", &ScopedFailureThresholdContextManager::exit);
+
   static py::exception<Logging::ThresholdFailure> exc(
       logging, "ThresholdFailure", PyExc_RuntimeError);
   // NOLINTNEXTLINE(performance-unnecessary-value-param)

--- a/Examples/Python/tests/test_logging.py
+++ b/Examples/Python/tests/test_logging.py
@@ -1,0 +1,20 @@
+import acts
+import pytest
+
+
+def test_logging_threshold():
+    assert acts.logging.getFailureThreshold() == acts.logging.Level.WARNING
+
+
+def test_logging_threshold_context_manager():
+    with acts.logging.ScopedFailureThreshold(acts.logging.ERROR):
+        assert acts.logging.getFailureThreshold() == acts.logging.Level.ERROR
+    assert acts.logging.getFailureThreshold() == acts.logging.Level.WARNING
+
+
+def test_logging_threshold_context_manager_exception():
+    with pytest.raises(RuntimeError):
+        with acts.logging.ScopedFailureThreshold(level=acts.logging.ERROR):
+            assert acts.logging.getFailureThreshold() == acts.logging.Level.ERROR
+            raise RuntimeError("test")
+    assert acts.logging.getFailureThreshold() == acts.logging.Level.WARNING


### PR DESCRIPTION
This PR exposes the `ScopeLoggingThreshold` as a context manager to python and adds a few small tests.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a context manager for logging thresholds, allowing Python users to temporarily adjust and automatically revert the failure threshold.
- **Tests**
	- Added tests verifying default, in-context, and exception-triggered threshold behavior to ensure robust logging management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->