### PR TITLE
refactor: Logger locks if writing to stdout

### DIFF
--- a/Core/include/Acts/Utilities/Logger.hpp
+++ b/Core/include/Acts/Utilities/Logger.hpp
@@ -13,6 +13,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -586,6 +587,15 @@ class DefaultPrintPolicy final : public OutputPrintPolicy {
   /// @param [in] lvl   debug level of debug message
   /// @param [in] input text of debug message
   void flush(const Level& lvl, const std::string& input) final {
+    /// Mutex to serialize access to std::cout
+    static std::mutex s_stdoutMutex;
+    std::unique_lock lock{s_stdoutMutex,
+                          std::defer_lock};  // prep empty, we might not need it
+
+    if (m_out == &std::cout) {
+      lock.lock();  // lock only if we are printing to std::cout
+    }
+
     (*m_out) << input << std::endl;
     if (lvl >= getFailureThreshold()) {
       throw ThresholdFailure(


### PR DESCRIPTION
In the Examples we mostly log to `std::cout`. This is not synchronized across threads automatically. This commit changes the `DefaultPrintPolicy` to lock a static mutex in case it's writing to `std::cout`. For other output streams, it will not lock, neither for multiple log calls to the same stream or lock calls to other streams.

The latter could be improved in the future by having the policy carry static locks keyed by the output stream address.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
