### PR TITLE
refactor(Examples): Sequencer informs readers that we're going to ski…

### DIFF
--- a/Examples/Framework/include/ActsExamples/Framework/IReader.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IReader.hpp
@@ -37,6 +37,13 @@ class IReader : public SequenceElement {
   /// event number provided to select the proper data to be read.
   virtual ProcessCode read(const AlgorithmContext& context) = 0;
 
+  /// Instructs this reader to skip over a fixed number of events
+  /// @param events
+  /// @return Process code indicating if the skip was successful
+  virtual ProcessCode skip(std::size_t /*events*/) {
+    return ProcessCode::SUCCESS;
+  }
+
   /// Internal execute method forwards to the read method as mutable
   /// @param context The algorithm context
   ProcessCode internalExecute(const AlgorithmContext& context) final {

--- a/Examples/Framework/include/ActsExamples/Framework/IWriter.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/IWriter.hpp
@@ -12,8 +12,6 @@
 #include "ActsExamples/Framework/ProcessCode.hpp"
 #include "ActsExamples/Framework/SequenceElement.hpp"
 
-#include <string>
-
 namespace ActsExamples {
 
 /// Event data writer interface.
@@ -31,6 +29,10 @@ class IWriter : public SequenceElement {
   ProcessCode internalExecute(const AlgorithmContext& context) final {
     return write(context);
   }
+
+  /// Informs the writer that the sequencer will start processing the next
+  /// event.
+  virtual ProcessCode beginEvent() { return ProcessCode::SUCCESS; }
 
   /// Fulfill the algorithm interface
   ProcessCode initialize() override { return ProcessCode::SUCCESS; }

--- a/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
+++ b/Examples/Framework/include/ActsExamples/Framework/Sequencer.hpp
@@ -174,6 +174,7 @@ class Sequencer {
   tbbWrap::task_arena m_taskArena;
   std::vector<std::shared_ptr<IContextDecorator>> m_decorators;
   std::vector<std::shared_ptr<IReader>> m_readers;
+  std::vector<std::shared_ptr<IWriter>> m_writers;
   std::vector<SequenceElementWithFpeResult> m_sequenceElements;
   std::unique_ptr<const Acts::Logger> m_logger;
 

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -122,6 +122,7 @@ void Sequencer::addWriter(std::shared_ptr<IWriter> writer) {
   if (!writer) {
     throw std::invalid_argument("Can not add empty/NULL writer");
   }
+  m_writers.push_back(writer);
   addElement(std::move(writer));
 }
 

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -390,6 +390,12 @@ int Sequencer::run() {
           std::size_t threadId = threadIds.local();
 
           for (std::size_t n = r.begin(); n != r.end(); ++n) {
+            ACTS_VERBOSE("Thread about to pick next event");
+
+            for (auto& writer : m_writers) {
+              writer->beginEvent();
+            }
+
             std::size_t event = nextEvent++;
 
             ACTS_DEBUG("start processing event " << event << " on thread "

--- a/Examples/Framework/src/Framework/Sequencer.cpp
+++ b/Examples/Framework/src/Framework/Sequencer.cpp
@@ -361,6 +361,15 @@ int Sequencer::run() {
     }
   }
 
+  // Inform readers that we're going to start from a specific event number
+  if (eventsRange.first > 0) {
+    for (const auto& reader : m_readers) {
+      if (reader->skip(eventsRange.first) != ProcessCode::SUCCESS) {
+        throw std::runtime_error("Failed to process event data");
+      }
+    }
+  }
+
   // execute the parallel event loop
   std::atomic<std::size_t> nProcessedEvents = 0;
   std::size_t nTotalEvents = eventsRange.second - eventsRange.first;


### PR DESCRIPTION
With this PR, the sequencer:

- Informs readers at the beginning of the job if it's going to skip a number of events. Readers don't have to take action on this, and indeed the default implementation for the corresponding method is just a noop
- Keeps a list of writers, the same way that it's already keeping a list of readers
- Calls a function on each writer (in order) at the beginning of an event **before** it assigns the currently executing thread the next event to be processed. This becomes relevant for https://github.com/acts-project/acts/pull/4213


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
…p events