### PR TITLE
feat: Adding efficiency vs production radius to output root files (Revision of PR #3539 and #3981)

### DIFF
--- a/CI/physmon/config/tracksummary_ckf.yml
+++ b/CI/physmon/config/tracksummary_ckf.yml
@@ -165,6 +165,11 @@ histograms:
     min: -200
     max: 200
 
+  t_prodR:
+    nbins: 100
+    min: 0
+    max: 200
+
   trackClassification:
     nbins: 4
     min: 0

--- a/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
@@ -36,55 +36,61 @@ class EffPlotTool {
         {"Pt", PlotHelpers::Binning("pT [GeV/c]", 40, 0, 100)},
         {"Z0", PlotHelpers::Binning("z_0 [mm]", 50, -200, 200)},
         {"DeltaR", PlotHelpers::Binning("#Delta R", 100, 0, 0.3)}};
+    { "prodR", PlotHelpers::Binning("prod_R [mm]", 100, 0, 900) }
   };
+};
 
-  /// @brief Nested Cache struct
-  struct EffPlotCache {
-    TEfficiency* trackEff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
-    TEfficiency* trackEff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
-    TEfficiency* trackEff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
-    TEfficiency* trackEff_vs_z0{nullptr};   ///< Tracking efficiency vs z0
-    TEfficiency* trackEff_vs_DeltaR{
-        nullptr};  ///< Tracking efficiency vs distance to the closest truth
-                   ///< particle
-  };
+/// @brief Nested Cache struct
+struct EffPlotCache {
+  TEfficiency* trackEff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
+  TEfficiency* trackEff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
+  TEfficiency* trackEff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
+  TEfficiency* trackEff_vs_z0{nullptr};   ///< Tracking efficiency vs z0
+  TEfficiency* trackEff_vs_DeltaR{
+      nullptr};  ///< Tracking efficiency vs distance to the closest truth
+                 ///< particle
+  TEfficiency* trackEff_vs_prodR{
+      nullptr};  ///< Tracking efficiency vs production radius
+};
 
-  /// Constructor
-  ///
-  /// @param cfg Configuration struct
-  /// @param lvl Message level declaration
-  EffPlotTool(const Config& cfg, Acts::Logging::Level lvl);
+/// Constructor
+///
+/// @param cfg Configuration struct
+/// @param lvl Message level declaration
+EffPlotTool(const Config& cfg, Acts::Logging::Level lvl);
 
-  /// @brief book the efficiency plots
-  ///
-  /// @param effPlotCache the cache for efficiency plots
-  void book(EffPlotCache& effPlotCache) const;
+/// @brief book the efficiency plots
+///
+/// @param effPlotCache the cache for efficiency plots
+void book(EffPlotCache& effPlotCache) const;
 
-  /// @brief fill efficiency plots
-  ///
-  /// @param effPlotCache cache object for efficiency plots
-  /// @param truthParticle the truth Particle
-  /// @param deltaR the distance to the closest truth particle
-  /// @param status the reconstruction status
-  void fill(EffPlotCache& effPlotCache, const SimParticleState& truthParticle,
-            double deltaR, bool status) const;
+/// @brief fill efficiency plots
+///
+/// @param effPlotCache cache object for efficiency plots
+/// @param truthParticle the truth Particle
+/// @param deltaR the distance to the closest truth particle
+/// @param status the reconstruction status
+void fill(EffPlotCache& effPlotCache, const SimParticleState& truthParticle,
+          double deltaR, bool status) const;
 
-  /// @brief write the efficiency plots to file
-  ///
-  /// @param effPlotCache cache object for efficiency plots
-  void write(const EffPlotCache& effPlotCache) const;
+/// @brief write the efficiency plots to file
+///
+/// @param effPlotCache cache object for efficiency plots
+void write(const EffPlotCache& effPlotCache) const;
 
-  /// @brief delete the efficiency plots
-  ///
-  /// @param effPlotCache cache object for efficiency plots
-  void clear(EffPlotCache& effPlotCache) const;
+/// @brief delete the efficiency plots
+///
+/// @param effPlotCache cache object for efficiency plots
+void clear(EffPlotCache& effPlotCache) const;
 
- private:
-  Config m_cfg;                                  ///< The Config class
-  std::unique_ptr<const Acts::Logger> m_logger;  ///< The logging instance
+private:
+Config m_cfg;                                  ///< The Config class
+std::unique_ptr<const Acts::Logger> m_logger;  ///< The logging instance
 
-  /// The logger
-  const Acts::Logger& logger() const { return *m_logger; }
+/// The logger
+const Acts::Logger& logger() const {
+  return *m_logger;
+}
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
@@ -36,7 +36,7 @@ class EffPlotTool {
         {"Pt", PlotHelpers::Binning("pT [GeV/c]", 40, 0, 100)},
         {"Z0", PlotHelpers::Binning("z_0 [mm]", 50, -200, 200)},
         {"DeltaR", PlotHelpers::Binning("#Delta R", 100, 0, 0.3)}};
-    { "prodR", PlotHelpers::Binning("prod_R [mm]", 100, 0, 900) }
+    { "prodR", PlotHelpers::Binning("prod_R [mm]", 100, 0, 200) }
   };
 };
 

--- a/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
@@ -35,62 +35,59 @@ class EffPlotTool {
         {"Phi", PlotHelpers::Binning("#phi", 100, -3.15, 3.15)},
         {"Pt", PlotHelpers::Binning("pT [GeV/c]", 40, 0, 100)},
         {"Z0", PlotHelpers::Binning("z_0 [mm]", 50, -200, 200)},
-        {"DeltaR", PlotHelpers::Binning("#Delta R", 100, 0, 0.3)}};
-    { "prodR", PlotHelpers::Binning("prod_R [mm]", 100, 0, 200) }
+        {"DeltaR", PlotHelpers::Binning("#Delta R", 100, 0, 0.3)},
+        {"prodR", PlotHelpers::Binning("prod_R [mm]", 100, 0, 200)}};
   };
-};
 
-/// @brief Nested Cache struct
-struct EffPlotCache {
-  TEfficiency* trackEff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
-  TEfficiency* trackEff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
-  TEfficiency* trackEff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
-  TEfficiency* trackEff_vs_z0{nullptr};   ///< Tracking efficiency vs z0
-  TEfficiency* trackEff_vs_DeltaR{
-      nullptr};  ///< Tracking efficiency vs distance to the closest truth
-                 ///< particle
-  TEfficiency* trackEff_vs_prodR{
-      nullptr};  ///< Tracking efficiency vs production radius
-};
+  /// @brief Nested Cache struct
+  struct EffPlotCache {
+    TEfficiency* trackEff_vs_pT{nullptr};   ///< Tracking efficiency vs pT
+    TEfficiency* trackEff_vs_eta{nullptr};  ///< Tracking efficiency vs eta
+    TEfficiency* trackEff_vs_phi{nullptr};  ///< Tracking efficiency vs phi
+    TEfficiency* trackEff_vs_z0{nullptr};   ///< Tracking efficiency vs z0
+    TEfficiency* trackEff_vs_DeltaR{
+        nullptr};  ///< Tracking efficiency vs distance to the closest truth
+                   ///< particle
+    TEfficiency* trackEff_vs_prodR{
+        nullptr};  ///< Tracking efficiency vs production radius
+  };
 
-/// Constructor
-///
-/// @param cfg Configuration struct
-/// @param lvl Message level declaration
-EffPlotTool(const Config& cfg, Acts::Logging::Level lvl);
+  /// Constructor
+  ///
+  /// @param cfg Configuration struct
+  /// @param lvl Message level declaration
+  EffPlotTool(const Config& cfg, Acts::Logging::Level lvl);
 
-/// @brief book the efficiency plots
-///
-/// @param effPlotCache the cache for efficiency plots
-void book(EffPlotCache& effPlotCache) const;
+  /// @brief book the efficiency plots
+  ///
+  /// @param effPlotCache the cache for efficiency plots
+  void book(EffPlotCache& effPlotCache) const;
 
-/// @brief fill efficiency plots
-///
-/// @param effPlotCache cache object for efficiency plots
-/// @param truthParticle the truth Particle
-/// @param deltaR the distance to the closest truth particle
-/// @param status the reconstruction status
-void fill(EffPlotCache& effPlotCache, const SimParticleState& truthParticle,
-          double deltaR, bool status) const;
+  /// @brief fill efficiency plots
+  ///
+  /// @param effPlotCache cache object for efficiency plots
+  /// @param truthParticle the truth Particle
+  /// @param deltaR the distance to the closest truth particle
+  /// @param status the reconstruction status
+  void fill(EffPlotCache& effPlotCache, const SimParticleState& truthParticle,
+            double deltaR, bool status) const;
 
-/// @brief write the efficiency plots to file
-///
-/// @param effPlotCache cache object for efficiency plots
-void write(const EffPlotCache& effPlotCache) const;
+  /// @brief write the efficiency plots to file
+  ///
+  /// @param effPlotCache cache object for efficiency plots
+  void write(const EffPlotCache& effPlotCache) const;
 
-/// @brief delete the efficiency plots
-///
-/// @param effPlotCache cache object for efficiency plots
-void clear(EffPlotCache& effPlotCache) const;
+  /// @brief delete the efficiency plots
+  ///
+  /// @param effPlotCache cache object for efficiency plots
+  void clear(EffPlotCache& effPlotCache) const;
 
-private:
-Config m_cfg;                                  ///< The Config class
-std::unique_ptr<const Acts::Logger> m_logger;  ///< The logging instance
+ private:
+  Config m_cfg;                                  ///< The Config class
+  std::unique_ptr<const Acts::Logger> m_logger;  ///< The logging instance
 
-/// The logger
-const Acts::Logger& logger() const {
-  return *m_logger;
-}
+  /// The logger
+  const Acts::Logger& logger() const { return *m_logger; }
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/src/Validation/EffPlotTool.cpp
+++ b/Examples/Framework/src/Validation/EffPlotTool.cpp
@@ -28,6 +28,7 @@ void ActsExamples::EffPlotTool::book(
   PlotHelpers::Binning bPt = m_cfg.varBinning.at("Pt");
   PlotHelpers::Binning bDeltaR = m_cfg.varBinning.at("DeltaR");
   PlotHelpers::Binning bZ0 = m_cfg.varBinning.at("Z0");
+  PlotHelpers::Binning bProdR = m_cfg.varBinning.at("prodR");
   ACTS_DEBUG("Initialize the histograms for efficiency plots");
   // efficiency vs pT
   effPlotCache.trackEff_vs_pT = PlotHelpers::bookEff(
@@ -45,6 +46,9 @@ void ActsExamples::EffPlotTool::book(
   effPlotCache.trackEff_vs_DeltaR = PlotHelpers::bookEff(
       "trackeff_vs_DeltaR",
       "Tracking efficiency;Closest track #Delta R;Efficiency", bDeltaR);
+  effPlotCache.trackEff_vs_prodR = PlotHelpers::bookEff(
+      "trackeff_vs_prodR",
+      "Tracking efficiency;Production radius [mm];Efficiency", bProdR);
 }
 
 void ActsExamples::EffPlotTool::clear(EffPlotCache& effPlotCache) const {
@@ -53,6 +57,7 @@ void ActsExamples::EffPlotTool::clear(EffPlotCache& effPlotCache) const {
   delete effPlotCache.trackEff_vs_phi;
   delete effPlotCache.trackEff_vs_z0;
   delete effPlotCache.trackEff_vs_DeltaR;
+  delete effPlotCache.trackEff_vs_prodR;
 }
 
 void ActsExamples::EffPlotTool::write(
@@ -63,6 +68,7 @@ void ActsExamples::EffPlotTool::write(
   effPlotCache.trackEff_vs_phi->Write();
   effPlotCache.trackEff_vs_z0->Write();
   effPlotCache.trackEff_vs_DeltaR->Write();
+  effPlotCache.trackEff_vs_prodR->Write();
 }
 
 void ActsExamples::EffPlotTool::fill(EffPlotTool::EffPlotCache& effPlotCache,
@@ -73,10 +79,12 @@ void ActsExamples::EffPlotTool::fill(EffPlotTool::EffPlotCache& effPlotCache,
   const auto t_pT = truthParticle.transverseMomentum();
   const auto t_z0 = truthParticle.position().z();
   const auto t_deltaR = deltaR;
+  const auto t_prodR = std::sqrt(vx * vx + vy * vy);
 
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_pT, t_pT, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_eta, t_eta, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_phi, t_phi, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_z0, t_z0, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_DeltaR, t_deltaR, status);
+  PlotHelpers::fillEff(effPlotCache.trackEff_vs_prodR, t_prodR, status);
 }

--- a/Examples/Framework/src/Validation/EffPlotTool.cpp
+++ b/Examples/Framework/src/Validation/EffPlotTool.cpp
@@ -79,7 +79,9 @@ void ActsExamples::EffPlotTool::fill(EffPlotTool::EffPlotCache& effPlotCache,
   const auto t_pT = truthParticle.transverseMomentum();
   const auto t_z0 = truthParticle.position().z();
   const auto t_deltaR = deltaR;
-  const auto t_prodR = std::sqrt(vx * vx + vy * vy);
+  const auto t_prodR =
+      std::sqrt(truthParticle.position().x() * truthParticle.position().x() +
+                truthParticle.position().y() * truthParticle.position().y());
 
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_pT, t_pT, status);
   PlotHelpers::fillEff(effPlotCache.trackEff_vs_eta, t_eta, status);

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackSummaryWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackSummaryWriter.hpp
@@ -170,6 +170,8 @@ class RootTrackSummaryWriter final : public WriterT<ConstTrackContainer> {
   std::vector<float> m_t_d0;
   /// The extrapolated truth longitudinal impact parameter
   std::vector<float> m_t_z0;
+  /// Production radius of majority particle
+  std::vector<float> m_t_prodR;
 
   /// If the track has fitted parameter
   std::vector<bool> m_hasFittedParams;

--- a/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
@@ -112,6 +112,7 @@ RootTrackSummaryWriter::RootTrackSummaryWriter(
   m_outputTree->Branch("t_pT", &m_t_pT);
   m_outputTree->Branch("t_d0", &m_t_d0);
   m_outputTree->Branch("t_z0", &m_t_z0);
+  m_outputTree->Branch("t_prodR", &m_t_prodR);
 
   m_outputTree->Branch("hasFittedParams", &m_hasFittedParams);
   m_outputTree->Branch("eLOC0_fit", &m_eLOC0_fit);
@@ -299,6 +300,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
     float t_d0 = NaNfloat;
     float t_z0 = NaNfloat;
     float t_qop = NaNfloat;
+    float t_prodR = NaNfloat;
 
     // Get the perigee surface
     const Acts::Surface* pSurface =
@@ -339,6 +341,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
         t_eta = eta(particle.direction());
         t_pT = t_p * perp(particle.direction());
         t_qop = particle.qOverP();
+        t_prodR = std::sqrt(t_vx * t_vx + t_vy * t_vy);
 
         if (pSurface != nullptr) {
           auto intersection =
@@ -390,6 +393,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
     m_t_pT.push_back(t_pT);
     m_t_d0.push_back(t_d0);
     m_t_z0.push_back(t_z0);
+    m_t_prodR.push_back(t_prodR);
 
     // Initialize the fitted track parameters info
     std::array<float, Acts::eBoundSize> param = {NaNfloat, NaNfloat, NaNfloat,
@@ -575,6 +579,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
   m_t_eta.clear();
   m_t_d0.clear();
   m_t_z0.clear();
+  m_t_prodR.clear();
 
   m_hasFittedParams.clear();
   m_eLOC0_fit.clear();

--- a/Examples/Scripts/Python/full_chain_odd_LRT.py
+++ b/Examples/Scripts/Python/full_chain_odd_LRT.py
@@ -234,8 +234,8 @@ else:
                 args.gun_particles, acts.PdgParticle.eMuon, randomizeCharge=True
             ),
             vtxGen=acts.examples.GaussianDisplacedVertexPositionGenerator(
-                rMean=2,
-                rStdDev=0.0125 * u.mm,
+                rMean=50.0,
+                rStdDev=50.0 * u.mm,
                 zMean=2,
                 zStdDev=55.5 * u.mm,
                 tMean=0,


### PR DESCRIPTION
This PR is the revised version of the work of @AichaMattouhi (https://github.com/acts-project/acts/pull/3539). Efficiency vs production radius plot is added to the performance and track summary root output files.