### PR TITLE
fix: Remove ROOT exposure from `MuonHoughSeeder` in Examples

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/MuonHoughSeeder.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/MuonHoughSeeder.hpp
@@ -10,9 +10,7 @@
 
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Seeding/HoughTransformUtils.hpp"
-#include "Acts/Utilities/Delegate.hpp"
 #include "Acts/Utilities/Logger.hpp"
-#include "Acts/Utilities/Result.hpp"
 #include "ActsExamples/EventData/MuonHoughMaximum.hpp"
 #include "ActsExamples/EventData/MuonSegment.hpp"
 #include "ActsExamples/EventData/MuonSpacePoint.hpp"
@@ -23,14 +21,9 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "TCanvas.h"
-
-namespace ActsExamples {
-struct AlgorithmContext;
-}
+class TCanvas;
 
 namespace ActsExamples {
 
@@ -56,6 +49,7 @@ class MuonHoughSeeder final : public IAlgorithm {
   };
 
   MuonHoughSeeder(Config cfg, Acts::Logging::Level lvl);
+  ~MuonHoughSeeder() override;
 
   /// Run the seeding algorithm.
   ///

--- a/Examples/Algorithms/TrackFinding/src/MuonHoughSeeder.cpp
+++ b/Examples/Algorithms/TrackFinding/src/MuonHoughSeeder.cpp
@@ -20,7 +20,6 @@
 #include "TBox.h"
 #include "TCanvas.h"
 #include "TH2D.h"
-#include "TLatex.h"
 #include "TLegend.h"
 #include "TMarker.h"
 #include "TStyle.h"
@@ -80,7 +79,7 @@ MuonHoughSeeder::MuonHoughSeeder(MuonHoughSeeder::Config cfg,
   m_outputMaxima.initialize(m_cfg.outHoughMax);
 }
 
-using PatternSeed = std::pair<double, double>;  // y0, tan theta
+MuonHoughSeeder::~MuonHoughSeeder() = default;
 
 ProcessCode MuonHoughSeeder::execute(const AlgorithmContext& ctx) const {
   // read the hits and circles


### PR DESCRIPTION
The exposure of ROOT resulted in downstream build errors. This PR hides ROOT in the source file and forward declares it for the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code maintainability by updating class declarations and removing unused code and includes. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->