### PR TITLE
chore: update actsvg, harmonize python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.50)
+set(_acts_actsvg_version 0.4.55)
 set(_acts_boost_version 1.71.0)
 set(_acts_dd4hep_version 1.21)
 set(_acts_geant4_version 11.1.3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ endif()
 # minimal dependency versions. they are defined here in a single place so
 # they can be easily upgraded, although they might not be used if the
 # dependency is included via `add_subdirectory(...)`.
-set(_acts_actsvg_version 0.4.55)
+set(_acts_actsvg_version 0.4.56)
 set(_acts_boost_version 1.71.0)
 set(_acts_dd4hep_version 1.21)
 set(_acts_geant4_version 11.1.3)

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -209,23 +209,6 @@ void addSvg(Context& ctx) {
 
   svg.def("toFile", &Svg::toFile);
 
-  // Some basics
-  py::class_<actsvg::svg::object>(svg, "object");
-
-  py::class_<actsvg::svg::file>(svg, "file")
-      .def(py::init<>())
-      .def("addObject", &actsvg::svg::file::add_object)
-      .def("addObjects", &actsvg::svg::file::add_objects)
-      .def("clip",
-           [](actsvg::svg::file& self, std::array<actsvg::scalar, 4> box) {
-             self.set_view_box(box);
-           })
-      .def("write", [](actsvg::svg::file& self, const std::string& filename) {
-        std::ofstream file(filename);
-        file << self;
-        file.close();
-      });
-
   // Core components, added as an acts.svg submodule
   {
     auto c = py::class_<Svg::Style>(svg, "Style").def(py::init<>());
@@ -349,13 +332,6 @@ void addSvg(Context& ctx) {
 
     ACTS_PYTHON_STRUCT(c, portalIndices, portalOptions, surfaceOptions,
                        indexedSurfacesOptions);
-
-    // Define the proto volume & indexed surface grid
-    py::class_<Svg::ProtoVolume>(svg, "ProtoVolume");
-    py::class_<Svg::ProtoIndexedSurfaceGrid>(svg, "ProtoIndexedSurfaceGrid");
-
-    // Define the proto grid
-    py::class_<Svg::ProtoGrid>(svg, "ProtoGrid");
 
     // Convert an Acts::Experimental::DetectorVolume object into an
     // acts::svg::proto::volume

--- a/cmake/ActsExternSources.cmake
+++ b/cmake/ActsExternSources.cmake
@@ -1,5 +1,5 @@
 set(ACTS_ACTSVG_SOURCE
-    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=cabac6dfe8466ad4b316e4e11211f06d566011ee01122a31daed92c6c44761a1"
+    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=75944cbc4444d3099764f19f6fa5fbf9f2b81e3ac776b5874746add74a7cd0f8"
     CACHE STRING
     "Source to take ACTSVG from"
 )

--- a/cmake/ActsExternSources.cmake
+++ b/cmake/ActsExternSources.cmake
@@ -1,5 +1,5 @@
 set(ACTS_ACTSVG_SOURCE
-    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=8073a371465ce2edef3bfdba5eae900e17ee61ae21766111ad1834e29250f304"
+    "URL;https://github.com/acts-project/actsvg/archive/refs/tags/v${_acts_actsvg_version}.tar.gz;URL_HASH;SHA256=cabac6dfe8466ad4b316e4e11211f06d566011ee01122a31daed92c6c44761a1"
     CACHE STRING
     "Source to take ACTSVG from"
 )

--- a/thirdparty/actsvg/CMakeLists.txt
+++ b/thirdparty/actsvg/CMakeLists.txt
@@ -22,11 +22,5 @@ set(ACTSVG_BUILD_PYTHON_BINDINGS
     "Build python bindings for actsvg if Acts python bindings are enabled"
 )
 
-set(ACTSVG_USE_SYSTEM_PYBIND11
-    ${ACTSVG_BUILD_PYTHON_BINDINGS}
-    CACHE BOOL
-    "Use system pybind11 if building python bindings for actsvg in order to keep consistency with ACTS"
-)
-
 # Now set up its build.
 FetchContent_MakeAvailable(actsvg)

--- a/thirdparty/actsvg/CMakeLists.txt
+++ b/thirdparty/actsvg/CMakeLists.txt
@@ -19,7 +19,7 @@ FetchContent_Declare(actsvg SYSTEM ${ACTS_ACTSVG_SOURCE})
 set(ACTSVG_BUILD_PYTHON_BINDINGS
     ${ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS}
     CACHE BOOL
-    "Build python bindings for actsvg if Acts python bindings are enabled"
+    "Build python bindings for actsvg if ACTS python bindings are enabled"
 )
 
 # Now set up its build.

--- a/thirdparty/actsvg/CMakeLists.txt
+++ b/thirdparty/actsvg/CMakeLists.txt
@@ -17,9 +17,15 @@ message(STATUS "Building actsvg as part of the ACTS project")
 FetchContent_Declare(actsvg SYSTEM ${ACTS_ACTSVG_SOURCE})
 
 set(ACTSVG_BUILD_PYTHON_BINDINGS
-    OFF
+    ${ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS}
     CACHE BOOL
-    "Do not build the Python bindings for actsvg"
+    "Build python bindings for actsvg if Acts python bindings are enabled"
+)
+
+set(ACTSVG_USE_SYSTEM_PYBIND11
+    ${ACTSVG_BUILD_PYTHON_BINDINGS}
+    CACHE BOOL
+    "Use system pybind11 if building python bindings for actsvg in order to keep consistency with ACTS"
 )
 
 # Now set up its build.


### PR DESCRIPTION
This PR updates the version of `actsvg` and harmonizes how the python bindings are used.

If python bindings are configured to be built and `actsvg` is configured to be built, it will also switch the python bindings of the plugin on. Native `actsvg` types are not anymore python-bound in ACTS but in the library itself (it anyway requires actsvg to be built).

These can now be nicely used together as such:

```sh
acts:  info - setting up run environment
acts: setting up virtual python environment
acts: setting up DD4hep environment
acts: setting up Geant4 environment
acts: setting up ACTS environment of acts-svg
INFO:    Acts Python 3.13 bindings setup complete.
(pyvenv) python
Python 3.13.2 (main, Mar 17 2025, 21:26:38) [Clang 20.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import acts, actsvg
>>>
```

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to use the system-installed pybind11 when building Python bindings for SVG functionality, improving consistency with the overall build process.

- **Removed Features**
  - Several SVG-related Python bindings, including basic SVG object and proto volume/grid classes, are no longer available in the Python API.

- **Chores**
  - Updated the minimum required version and checksum for an external SVG dependency to ensure compatibility and integrity.
  - Improved configuration options for enabling or disabling Python bindings during build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->