### PR TITLE
build: Require HepMC version 3.2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ set(_acts_eigen3_version 3.4.0)
 set(_acts_podio_version 1.0.1) # will try this first
 set(_acts_podio_fallback_version 0.16) # if not found, will try this one
 set(_acts_doxygen_version 1.9.4)
-set(_acts_hepmc3_version 3.2.1)
+set(_acts_hepmc3_version 3.2.5)
 set(_acts_nlohmanjson_version 3.10.5)
 set(_acts_onnxruntime_version 1.12.0)
 set(_acts_root_version 6.20)


### PR DESCRIPTION
The HepMC code in ACTS requires some functions (like `vertices_size`) that are available only in HepMC 3.2.5 onward, but the CMake configuration suggests that 3.2.1 is permissible. This commit updates the version requirement to the correct 3.2.5 minimum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the minimum required version of the HepMC3 dependency to 3.2.5 for example builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->