### PR TITLE
feat: Add trapezoid portal shells to StaticBlueprintNode

### DIFF
--- a/Core/src/Geometry/StaticBlueprintNode.cpp
+++ b/Core/src/Geometry/StaticBlueprintNode.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Geometry/CuboidPortalShell.hpp"
 #include "Acts/Geometry/CylinderPortalShell.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/TrapezoidPortalShell.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Navigation/INavigationPolicy.hpp"
 #include "Acts/Utilities/GraphViz.hpp"
@@ -64,6 +65,9 @@ PortalShellBase& StaticBlueprintNode::connect(const BlueprintOptions& options,
   } else if (type == VolumeBounds::eCuboid) {
     m_shell = std::make_unique<SingleCuboidPortalShell>(*m_volume);
 
+  } else if (type == VolumeBounds::eTrapezoid) {
+    m_shell = std::make_unique<SingleTrapezoidPortalShell>(*m_volume);
+    
   } else {
     throw std::logic_error("Volume type is not supported");
   }

--- a/Core/src/Geometry/StaticBlueprintNode.cpp
+++ b/Core/src/Geometry/StaticBlueprintNode.cpp
@@ -67,7 +67,7 @@ PortalShellBase& StaticBlueprintNode::connect(const BlueprintOptions& options,
 
   } else if (type == VolumeBounds::eTrapezoid) {
     m_shell = std::make_unique<SingleTrapezoidPortalShell>(*m_volume);
-    
+
   } else {
     throw std::logic_error("Volume type is not supported");
   }


### PR DESCRIPTION
This PR adds the `SingleTrapezoidPortalShell` to the `StaticBlueprintNode`
PLEASE DESCRIBE YOUR CHANGES.
THIS MESSAGE ENDS UP AS THE COMMIT MESSAGE.
DO NOT USE @-MENTIONS HERE!

--- END COMMIT MESSAGE ---

Tagging @dimitra97 @junggjo9 

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new trapezoid-shaped volume type when connecting nodes, expanding available geometry options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->