### PR TITLE
refactor: Replace `torch::Device` with `Acts::Device`

### DIFF
--- a/Examples/Algorithms/TrackFindingExaTrkX/src/TrackFindingAlgorithmExaTrkX.cpp
+++ b/Examples/Algorithms/TrackFindingExaTrkX/src/TrackFindingAlgorithmExaTrkX.cpp
@@ -183,8 +183,8 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
     std::lock_guard<std::mutex> lock(m_mutex);
 
     Acts::ExaTrkXTiming timing;
-    auto res =
-        m_pipeline.run(features, moduleIds, spacepointIDs, hook, &timing);
+    auto res = m_pipeline.run(features, moduleIds, spacepointIDs,
+                              Acts::Device::Cuda(0), hook, &timing);
 
     m_timing.graphBuildingTime(timing.graphBuildingTime.count());
 

--- a/Examples/Python/src/ExaTrkXTrackFinding.cpp
+++ b/Examples/Python/src/ExaTrkXTrackFinding.cpp
@@ -239,6 +239,13 @@ void addExaTrkXTrackFinding(Context &ctx) {
   }
 
   {
+    auto cls =
+        py::class_<Acts::Device>(mex, "Device")
+            .def_static("Cpu", &Acts::Device::Cpu)
+            .def_static("Cuda", &Acts::Device::Cuda, py::arg("index") = 0);
+  }
+
+  {
     using Class = Acts::ExaTrkXPipeline;
 
     auto cls =
@@ -255,6 +262,7 @@ void addExaTrkXTrackFinding(Context &ctx) {
                  py::arg("trackBuilder"), py::arg("level"))
             .def("run", &ExaTrkXPipeline::run, py::arg("features"),
                  py::arg("moduleIds"), py::arg("spacepoints"),
+                 py::arg("device") = Acts::Device::Cuda(0),
                  py::arg("hook") = Acts::ExaTrkXHook{},
                  py::arg("timing") = nullptr);
   }

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
@@ -20,7 +20,7 @@ namespace Acts {
 class BoostTrackBuilding final : public Acts::TrackBuildingBase {
  public:
   BoostTrackBuilding(std::unique_ptr<const Logger> logger)
-      : m_logger(std::move(logger)), m_device(torch::Device(torch::kCPU)) {}
+      : m_logger(std::move(logger)) {}
 
   std::vector<std::vector<int>> operator()(
       std::any nodes, std::any edges, std::any edge_weights,

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
@@ -27,8 +27,6 @@ class BoostTrackBuilding final : public Acts::TrackBuildingBase {
       std::vector<int> &spacepointIDs,
       const ExecutionContext &execContext = {}) override;
 
-  const Config &config() const { return m_cfg; }
-
  private:
   std::unique_ptr<const Acts::Logger> m_logger;
   const auto &logger() const { return *m_logger; }

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/BoostTrackBuilding.hpp
@@ -26,11 +26,11 @@ class BoostTrackBuilding final : public Acts::TrackBuildingBase {
       std::any nodes, std::any edges, std::any edge_weights,
       std::vector<int> &spacepointIDs,
       const ExecutionContext &execContext = {}) override;
-  torch::Device device() const override { return m_device; };
+
+  const Config &config() const { return m_cfg; }
 
  private:
   std::unique_ptr<const Acts::Logger> m_logger;
-  torch::Device m_device;
   const auto &logger() const { return *m_logger; }
 };
 

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/CudaTrackBuilding.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/CudaTrackBuilding.hpp
@@ -32,8 +32,6 @@ class CudaTrackBuilding final : public Acts::TrackBuildingBase {
       std::vector<int> &spacepointIDs,
       const ExecutionContext &execContext = {}) override;
 
-  const Config &config() const { return m_cfg; }
-
  private:
   Config m_cfg;
   std::unique_ptr<const Acts::Logger> m_logger;

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/CudaTrackBuilding.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/CudaTrackBuilding.hpp
@@ -25,20 +25,18 @@ class CudaTrackBuilding final : public Acts::TrackBuildingBase {
   };
 
   CudaTrackBuilding(const Config &cfg, std::unique_ptr<const Logger> logger)
-      : m_cfg(cfg),
-        m_logger(std::move(logger)),
-        m_device(torch::Device(torch::kCUDA)) {}
+      : m_cfg(cfg), m_logger(std::move(logger)) {}
 
   std::vector<std::vector<int>> operator()(
       std::any nodes, std::any edges, std::any edge_weights,
       std::vector<int> &spacepointIDs,
       const ExecutionContext &execContext = {}) override;
-  torch::Device device() const override { return m_device; };
+
+  const Config &config() const { return m_cfg; }
 
  private:
   Config m_cfg;
   std::unique_ptr<const Acts::Logger> m_logger;
-  torch::Device m_device;
   const auto &logger() const { return *m_logger; }
 };
 

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/ExaTrkXPipeline.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/ExaTrkXPipeline.hpp
@@ -48,6 +48,7 @@ class ExaTrkXPipeline {
   std::vector<std::vector<int>> run(std::vector<float> &features,
                                     const std::vector<std::uint64_t> &moduleIds,
                                     std::vector<int> &spacepointIDs,
+                                    Acts::Device device,
                                     const ExaTrkXHook &hook = {},
                                     ExaTrkXTiming *timing = nullptr) const;
 

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/OnnxEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/OnnxEdgeClassifier.hpp
@@ -38,14 +38,12 @@ class OnnxEdgeClassifier final : public Acts::EdgeClassificationBase {
       const ExecutionContext &execContext = {}) override;
 
   Config config() const { return m_cfg; }
-  torch::Device device() const override { return m_device; };
 
  private:
   std::unique_ptr<const Acts::Logger> m_logger;
   const auto &logger() const { return *m_logger; }
 
   Config m_cfg;
-  torch::Device m_device;
   std::unique_ptr<Ort::Env> m_env;
   std::unique_ptr<Ort::Session> m_model;
 

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/Stages.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/Stages.hpp
@@ -21,9 +21,28 @@ namespace Acts {
 /// Error that is thrown if no edges are found
 struct NoEdgesError : std::exception {};
 
+/// A simple device description struct
+struct Device {
+  enum class Type { eCPU, eCUDA };
+  Type type = Type::eCPU;
+  std::size_t index = 0;
+
+  static Device Cpu() { return {Type::eCPU, 0}; }
+  static Device Cuda(std::size_t index = 0) { return {Type::eCUDA, index}; }
+};
+
+inline std::ostream &operator<<(std::ostream &os, Device device) {
+  if (device.type == Device::Type::eCPU) {
+    os << "CPU";
+  } else {
+    os << "CUDA(" << device.index << ")";
+  }
+  return os;
+}
+
 /// Capture the context of the execution
 struct ExecutionContext {
-  torch::Device device{torch::kCPU};
+  Acts::Device device{Acts::Device::Type::eCPU};
   std::optional<c10::cuda::CUDAStream> stream;
 };
 
@@ -48,8 +67,6 @@ class GraphConstructionBase {
       const std::vector<std::uint64_t> &moduleIds,
       const ExecutionContext &execContext = {}) = 0;
 
-  virtual torch::Device device() const = 0;
-
   virtual ~GraphConstructionBase() = default;
 };
 
@@ -66,8 +83,6 @@ class EdgeClassificationBase {
   virtual std::tuple<std::any, std::any, std::any, std::any> operator()(
       std::any nodeFeatures, std::any edgeIndex, std::any edgeFeatures = {},
       const ExecutionContext &execContext = {}) = 0;
-
-  virtual torch::Device device() const = 0;
 
   virtual ~EdgeClassificationBase() = default;
 };
@@ -87,8 +102,6 @@ class TrackBuildingBase {
       std::any nodeFeatures, std::any edgeIndex, std::any edgeScores,
       std::vector<int> &spacepointIDs,
       const ExecutionContext &execContext = {}) = 0;
-
-  virtual torch::Device device() const = 0;
 
   virtual ~TrackBuildingBase() = default;
 };

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
@@ -44,7 +44,6 @@ class TensorRTEdgeClassifier final : public EdgeClassificationBase {
       const ExecutionContext &execContext = {}) override;
 
   Config config() const { return m_cfg; }
-  torch::Device device() const override { return torch::kCUDA; };
 
  private:
   std::unique_ptr<const Acts::Logger> m_logger;

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TorchEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TorchEdgeClassifier.hpp
@@ -45,15 +45,12 @@ class TorchEdgeClassifier final : public Acts::EdgeClassificationBase {
       const ExecutionContext &execContext = {}) override;
 
   Config config() const { return m_cfg; }
-  torch::Device device() const override { return m_device; };
 
  private:
   std::unique_ptr<const Acts::Logger> m_logger;
   const auto &logger() const { return *m_logger; }
 
   Config m_cfg;
-  c10::DeviceType m_deviceType;
-  torch::Device m_device;
   std::unique_ptr<torch::jit::Module> m_model;
 };
 

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TorchMetricLearning.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TorchMetricLearning.hpp
@@ -47,15 +47,12 @@ class TorchMetricLearning final : public Acts::GraphConstructionBase {
       const ExecutionContext &execContext = {}) override;
 
   Config config() const { return m_cfg; }
-  torch::Device device() const override { return m_device; };
 
  private:
   std::unique_ptr<const Acts::Logger> m_logger;
   const auto &logger() const { return *m_logger; }
 
   Config m_cfg;
-  c10::DeviceType m_deviceType;
-  torch::Device m_device;
   std::unique_ptr<torch::jit::Module> m_model;
 };
 

--- a/Plugins/ExaTrkX/src/ExaTrkXPipeline.cpp
+++ b/Plugins/ExaTrkX/src/ExaTrkXPipeline.cpp
@@ -37,13 +37,13 @@ ExaTrkXPipeline::ExaTrkXPipeline(
 
 std::vector<std::vector<int>> ExaTrkXPipeline::run(
     std::vector<float> &features, const std::vector<std::uint64_t> &moduleIds,
-    std::vector<int> &spacepointIDs, const ExaTrkXHook &hook,
-    ExaTrkXTiming *timing) const {
+    std::vector<int> &spacepointIDs, Acts::Device device,
+    const ExaTrkXHook &hook, ExaTrkXTiming *timing) const {
   ExecutionContext ctx;
-  ctx.device = m_graphConstructor->device();
+  ctx.device = device;
 #ifndef ACTS_EXATRKX_CPUONLY
-  if (ctx.device.type() == torch::kCUDA) {
-    ctx.stream = c10::cuda::getStreamFromPool(ctx.device.index());
+  if (ctx.device.type == Acts::Device::Type::eCUDA) {
+    ctx.stream = c10::cuda::getStreamFromPool(true, ctx.device.index);
   }
 #endif
 

--- a/Plugins/ExaTrkX/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/OnnxEdgeClassifier.cpp
@@ -46,10 +46,7 @@ namespace Acts {
 
 OnnxEdgeClassifier::OnnxEdgeClassifier(const Config &cfg,
                                        std::unique_ptr<const Logger> _logger)
-    : m_logger(std::move(_logger)),
-      m_cfg(cfg),
-      m_device(torch::cuda::is_available() ? torch::Device(torch::kCUDA)
-                                           : torch::Device(torch::kCPU)) {
+    : m_logger(std::move(_logger)), m_cfg(cfg) {
   ACTS_INFO("OnnxEdgeClassifier with ORT API version " << ORT_API_VERSION);
 
   OrtLoggingLevel onnxLevel = ORT_LOGGING_LEVEL_WARNING;
@@ -83,7 +80,7 @@ OnnxEdgeClassifier::OnnxEdgeClassifier(const Config &cfg,
   sessionOptions.SetGraphOptimizationLevel(
       GraphOptimizationLevel::ORT_ENABLE_EXTENDED);
 
-  if (m_device.is_cuda()) {
+  if (torch::cuda::is_available()) {
     ACTS_INFO("Try to add ONNX execution provider for CUDA");
     OrtCUDAProviderOptions cuda_options;
     cuda_options.device_id = 0;
@@ -119,24 +116,28 @@ std::tuple<std::any, std::any, std::any, std::any>
 OnnxEdgeClassifier::operator()(std::any inputNodes, std::any inputEdges,
                                std::any inEdgeFeatures,
                                const ExecutionContext &execContext) {
-  const char *deviceStr = execContext.device.is_cuda() ? "Cuda" : "Cpu";
+  const char *deviceStr = "Cpu";
+  torch::Device torchDevice(torch::kCPU);
+  if (execContext.device.type == Acts::Device::Type::eCUDA) {
+    deviceStr = "Cuda";
+    torchDevice = torch::Device(torch::kCUDA, execContext.device.index);
+  }
+
   ACTS_DEBUG("Create ORT memory info (" << deviceStr << ")");
   Ort::MemoryInfo memoryInfo(deviceStr, OrtArenaAllocator,
-                             execContext.device.index(), OrtMemTypeDefault);
+                             execContext.device.index, OrtMemTypeDefault);
 
   bc::static_vector<Ort::Value, 3> inputTensors;
   bc::static_vector<const char *, 3> inputNames;
 
   // Node tensor
-  auto nodeTensor =
-      std::any_cast<torch::Tensor>(inputNodes).to(execContext.device);
+  auto nodeTensor = std::any_cast<torch::Tensor>(inputNodes).to(torchDevice);
   ACTS_DEBUG("nodes: " << detail::TensorDetails{nodeTensor});
   inputTensors.push_back(torchToOnnx(memoryInfo, nodeTensor));
   inputNames.push_back(m_inputNames.at(0).c_str());
 
   // Edge tensor
-  auto edgeIndex =
-      std::any_cast<torch::Tensor>(inputEdges).to(execContext.device);
+  auto edgeIndex = std::any_cast<torch::Tensor>(inputEdges).to(torchDevice);
   ACTS_DEBUG("edgeIndex: " << detail::TensorDetails{edgeIndex});
   inputTensors.push_back(torchToOnnx(memoryInfo, edgeIndex));
   inputNames.push_back(m_inputNames.at(1).c_str());
@@ -144,8 +145,7 @@ OnnxEdgeClassifier::operator()(std::any inputNodes, std::any inputEdges,
   // Edge feature tensor
   std::optional<torch::Tensor> edgeFeatures;
   if (m_inputNames.size() == 3 && inEdgeFeatures.has_value()) {
-    edgeFeatures =
-        std::any_cast<torch::Tensor>(inEdgeFeatures).to(execContext.device);
+    edgeFeatures = std::any_cast<torch::Tensor>(inEdgeFeatures).to(torchDevice);
     ACTS_DEBUG("edgeFeatures: " << detail::TensorDetails{*edgeFeatures});
     inputTensors.push_back(torchToOnnx(memoryInfo, *edgeFeatures));
     inputNames.push_back(m_inputNames.at(2).c_str());
@@ -155,7 +155,7 @@ OnnxEdgeClassifier::operator()(std::any inputNodes, std::any inputEdges,
   ACTS_DEBUG("Create score tensor");
   auto scores = torch::empty(
       edgeIndex.size(1),
-      torch::TensorOptions().device(execContext.device).dtype(torch::kFloat32));
+      torch::TensorOptions().device(torchDevice).dtype(torch::kFloat32));
   if (m_model->GetOutputTypeInfo(0)
           .GetTensorTypeAndShapeInfo()
           .GetDimensionsCount() == 2) {

--- a/Plugins/ExaTrkX/src/TorchMetricLearning.cpp
+++ b/Plugins/ExaTrkX/src/TorchMetricLearning.cpp
@@ -28,19 +28,17 @@ namespace Acts {
 
 TorchMetricLearning::TorchMetricLearning(const Config &cfg,
                                          std::unique_ptr<const Logger> _logger)
-    : m_logger(std::move(_logger)),
-      m_cfg(cfg),
-      m_device(torch::Device(torch::kCPU)) {
+    : m_logger(std::move(_logger)), m_cfg(cfg) {
   c10::InferenceMode guard(true);
-  m_deviceType = torch::cuda::is_available() ? torch::kCUDA : torch::kCPU;
+  torch::Device device = torch::kCPU;
 
-  if (m_deviceType == torch::kCPU) {
+  if (!torch::cuda::is_available()) {
     ACTS_DEBUG("Running on CPU...");
   } else {
     if (cfg.deviceID >= 0 &&
         static_cast<std::size_t>(cfg.deviceID) < torch::cuda::device_count()) {
       ACTS_DEBUG("GPU device " << cfg.deviceID << " is being used.");
-      m_device = torch::Device(torch::kCUDA, cfg.deviceID);
+      device = torch::Device(torch::kCUDA, cfg.deviceID);
     } else {
       ACTS_WARNING("GPU device " << cfg.deviceID
                                  << " not available, falling back to CPU.");
@@ -51,14 +49,14 @@ TorchMetricLearning::TorchMetricLearning(const Config &cfg,
                                     << TORCH_VERSION_MINOR << "."
                                     << TORCH_VERSION_PATCH);
 #ifndef ACTS_EXATRKX_CPUONLY
-  if (not torch::cuda::is_available()) {
+  if (!torch::cuda::is_available()) {
     ACTS_INFO("CUDA not available, falling back to CPU");
   }
 #endif
 
   try {
     m_model = std::make_unique<torch::jit::Module>();
-    *m_model = torch::jit::load(m_cfg.modelPath, m_device);
+    *m_model = torch::jit::load(m_cfg.modelPath, device);
     m_model->eval();
   } catch (const c10::Error &e) {
     throw std::invalid_argument("Failed to load models: " + e.msg());
@@ -71,7 +69,10 @@ std::tuple<std::any, std::any, std::any> TorchMetricLearning::operator()(
     std::vector<float> &inputValues, std::size_t numNodes,
     const std::vector<std::uint64_t> & /*moduleIds*/,
     const ExecutionContext &execContext) {
-  const auto &device = execContext.device;
+  const auto device =
+      execContext.device.type == Acts::Device::Type::eCUDA
+          ? torch::Device(torch::kCUDA, execContext.device.index)
+          : torch::kCPU;
   ACTS_DEBUG("Start graph construction");
   c10::InferenceMode guard(true);
 


### PR DESCRIPTION
First step in getting rid of the public dependency on `libtorch`.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated device type for more explicit control over CPU and CUDA device selection.
- **Refactor**
  - Unified and simplified device handling across multiple components, replacing internal device state with explicit device parameters.
  - Updated interfaces to use the new device abstraction, removing legacy device accessors and member variables.
  - Adjusted pipeline and classifier methods to consistently accept and use the new device type for execution context.
- **Bug Fixes**
  - Improved robustness and clarity in device selection logic for model loading and inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->