### PR TITLE
feat: Set geometryIdentifier for portals in the shell construction and add check in the blueprint

### DIFF
--- a/Core/src/Geometry/Blueprint.cpp
+++ b/Core/src/Geometry/Blueprint.cpp
@@ -267,6 +267,9 @@ std::unique_ptr<TrackingGeometry> Blueprint::construct(
           ACTS_ERROR(prefix() << "No current volume found");
           throw std::logic_error("No current volume found");
         }
+        if (portal.surface().geometryId() != GeometryIdentifier{}) {
+          return;
+        }
 
         iportal += 1;
         auto id = currentVolume->geometryId().withBoundary(iportal);

--- a/Core/src/Geometry/TrapezoidPortalShell.cpp
+++ b/Core/src/Geometry/TrapezoidPortalShell.cpp
@@ -79,6 +79,8 @@ void SingleTrapezoidPortalShell::applyToVolume() {
         throw std::runtime_error{"Invalid portal found in shell at " +
                                  ss.str()};
       }
+      portal->surface().assignGeometryId(
+          m_volume->geometryId().withBoundary(i + 1));
       m_volume->addPortal(portal);
     }
   }


### PR DESCRIPTION
This PR adds the portal Ids for the portals when the shell is being constructed for the particular volume and during the blueprint construction it checks if the portals have geoIds set or not.
This allows us to set manually the portals ids from the particular volume's geoId before the construction of the blueprint is happening - which we do for the Atlas Muon Spectrometer
