### PR TITLE
fix: EDM4hep sim conv. allow separate vertices at same location

### DIFF
--- a/Examples/Python/tests/test_edm4hep.py
+++ b/Examples/Python/tests/test_edm4hep.py
@@ -321,7 +321,7 @@ def generate_input_test_edm4hep_simhit_reader(input, output):
 
     ddsim = DD4hepSimulation()
 
-    ddsim.random.seed = 42
+    ddsim.random.seed = 37
 
     if isinstance(ddsim.compactFile, list):
         ddsim.compactFile = [input]

--- a/Examples/Python/tests/test_edm4hep.py
+++ b/Examples/Python/tests/test_edm4hep.py
@@ -320,6 +320,9 @@ def generate_input_test_edm4hep_simhit_reader(input, output):
     from DDSim.DD4hepSimulation import DD4hepSimulation
 
     ddsim = DD4hepSimulation()
+
+    ddsim.random.seed = 42
+
     if isinstance(ddsim.compactFile, list):
         ddsim.compactFile = [input]
     else:
@@ -342,8 +345,7 @@ def ddsim_input_session():
             getOpenDataDetectorDirectory() / "xml" / "OpenDataDetector.xml"
         )
 
-        # output_file = str(Path(tmp_dir) / "output_edm4hep.root")
-        output_file = str(Path.cwd() / "output_edm4hep.root")
+        output_file = str(Path(tmp_dir) / "output_edm4hep.root")
 
         if not os.path.exists(output_file):
             # explicitly ask for "spawn" as CI failures were observed with "fork"
@@ -354,6 +356,8 @@ def ddsim_input_session():
             )
             p.start()
             p.join()
+            if p.exitcode != 0:
+                raise RuntimeError("ddsim process failed")
 
             assert os.path.exists(output_file)
 
@@ -382,7 +386,7 @@ def test_edm4hep_simhit_particle_reader(tmp_path, ddsim_input):
 
         s.addReader(
             PodioReader(
-                level=acts.logging.INFO,
+                level=acts.logging.VERBOSE,
                 inputPath=ddsim_input,
                 outputFrame="events",
                 category="events",


### PR DESCRIPTION
In simulation, we can (apparently) sometimes have vertices that are logically distinct but are at the same position. This causes issues because the conversion so far assumed this to be the case. The PR relaxes this and just makes separate vertices out of them.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved vertex identification and matching for simulation input conversion, reducing potential inconsistencies.
- **Enhancements**
	- Added detailed logging to better track particle and vertex processing during simulation input conversion.
- **Tests**
	- Improved test reliability by using a fixed random seed and isolating test output files.
	- Enhanced error handling and increased logging verbosity in simulation tests for easier debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->