### PR TITLE
feat: Add examples script for GNN4ITk workflow

### DIFF
--- a/Examples/Algorithms/TrackFindingExaTrkX/include/ActsExamples/TrackFindingExaTrkX/TrackFindingAlgorithmExaTrkX.hpp
+++ b/Examples/Algorithms/TrackFindingExaTrkX/include/ActsExamples/TrackFindingExaTrkX/TrackFindingAlgorithmExaTrkX.hpp
@@ -164,6 +164,7 @@ class TrackFindingAlgorithmExaTrkX final : public IAlgorithm {
     std::vector<Accumulator> classifierTimes;
     Accumulator trackBuildingTime;
     Accumulator postprocessingTime;
+    Accumulator fullTime;
   } m_timing;
 
   ReadDataHandle<SimSpacePointContainer> m_inputSpacePoints{this,

--- a/Examples/Algorithms/TrackFindingExaTrkX/src/TrackFindingAlgorithmExaTrkX.cpp
+++ b/Examples/Algorithms/TrackFindingExaTrkX/src/TrackFindingAlgorithmExaTrkX.cpp
@@ -58,24 +58,6 @@ ActsExamples::TrackFindingAlgorithmExaTrkX::TrackFindingAlgorithmExaTrkX(
     throw std::invalid_argument("Missing protoTrack output collection");
   }
 
-  // Sanitizer run with dummy input to detect configuration issues
-  // TODO This would be quite helpful I think, but currently it does not work
-  // in general because the stages do not expose the number of node features.
-  // However, this must be addressed anyway when we also want to allow to
-  // configure this more flexible with e.g. cluster information as input. So
-  // for now, we disable this.
-#if 0
-  if( m_cfg.sanitize ) {
-  Eigen::VectorXf dummyInput = Eigen::VectorXf::Random(3 * 15);
-  std::vector<float> dummyInputVec(dummyInput.data(),
-                                   dummyInput.data() + dummyInput.size());
-  std::vector<int> spacepointIDs;
-  std::iota(spacepointIDs.begin(), spacepointIDs.end(), 0);
-
-  runPipeline(dummyInputVec, spacepointIDs);
-  }
-#endif
-
   m_inputSpacePoints.initialize(m_cfg.inputSpacePoints);
   m_inputClusters.maybeInitialize(m_cfg.inputClusters);
   m_outputProtoTracks.initialize(m_cfg.outputProtoTracks);
@@ -133,11 +115,11 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
   }
 
   // Read input data
-  auto spacepoints = m_inputSpacePoints(ctx);
+  const auto& spacepoints = m_inputSpacePoints(ctx);
 
-  std::optional<ClusterContainer> clusters;
+  const ClusterContainer* clusters = nullptr;
   if (m_inputClusters.isInitialized()) {
-    clusters = m_inputClusters(ctx);
+    clusters = &m_inputClusters(ctx);
   }
 
   // Convert Input data to a list of size [num_measurements x
@@ -147,10 +129,9 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
   ACTS_DEBUG("Received " << numSpacepoints << " spacepoints");
   ACTS_DEBUG("Construct " << numFeatures << " node features");
 
-  std::vector<int> spacepointIDs;
-  std::vector<std::uint64_t> moduleIds;
+  auto t01 = Clock::now();
 
-  spacepointIDs.reserve(spacepoints.size());
+  std::vector<std::uint64_t> moduleIds;
   moduleIds.reserve(spacepoints.size());
 
   for (auto isp = 0ul; isp < numSpacepoints; ++isp) {
@@ -160,11 +141,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
     // per spacepoint
     // TODO does it work for the module map construction to use only the first
     // sp?
-    const auto& sl1 = sp.sourceLinks()[0].template get<IndexSourceLink>();
-
-    // TODO this makes it a bit useless, refactor so we do not need to pass this
-    // to the pipeline
-    spacepointIDs.push_back(isp);
+    const auto& sl1 = sp.sourceLinks().at(0).template get<IndexSourceLink>();
 
     if (m_cfg.geometryIdMap != nullptr) {
       moduleIds.push_back(m_cfg.geometryIdMap->right.at(sl1.geometryId()));
@@ -173,31 +150,44 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
     }
   }
 
-  auto features = createFeatures(spacepoints, clusters, m_cfg.nodeFeatures,
-                                 m_cfg.featureScales);
+  auto t02 = Clock::now();
+
+  // Sort the spacepoints by module ide. Required by module map
+  std::vector<int> idxs(numSpacepoints);
+  std::iota(idxs.begin(), idxs.end(), 0);
+  std::ranges::sort(idxs, {}, [&](auto i) { return moduleIds[i]; });
+
+  std::ranges::sort(moduleIds);
+
+  SimSpacePointContainer sortedSpacepoints;
+  sortedSpacepoints.reserve(spacepoints.size());
+  std::ranges::transform(idxs, std::back_inserter(sortedSpacepoints),
+                         [&](auto i) { return spacepoints[i]; });
+
+  auto t03 = Clock::now();
+
+  auto features = createFeatures(sortedSpacepoints, clusters,
+                                 m_cfg.nodeFeatures, m_cfg.featureScales);
 
   auto t1 = Clock::now();
 
+  auto ms = [](auto a, auto b) {
+    return std::chrono::duration<double, std::milli>(b - a).count();
+  };
+  ACTS_DEBUG("Setup time:              " << ms(t0, t01));
+  ACTS_DEBUG("ModuleId mapping & copy: " << ms(t01, t02));
+  ACTS_DEBUG("Spacepoint sort:         " << ms(t02, t03));
+  ACTS_DEBUG("Feature creation:        " << ms(t03, t1));
+
   // Run the pipeline
-  const auto trackCandidates = [&]() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-
-    Acts::ExaTrkXTiming timing;
-    auto res = m_pipeline.run(features, moduleIds, spacepointIDs,
-                              Acts::Device::Cuda(0), hook, &timing);
-
-    m_timing.graphBuildingTime(timing.graphBuildingTime.count());
-
-    assert(timing.classifierTimes.size() == m_timing.classifierTimes.size());
-    for (auto [aggr, a] :
-         Acts::zip(m_timing.classifierTimes, timing.classifierTimes)) {
-      aggr(a.count());
-    }
-
-    m_timing.trackBuildingTime(timing.trackBuildingTime.count());
-
-    return res;
-  }();
+  Acts::ExaTrkXTiming timing;
+#ifdef ACTS_EXATRKX_CPUONLY
+  Acts::Device device = {Acts::Device::Type::eCPU, 0};
+#else
+  Acts::Device device = {Acts::Device::Type::eCUDA, 0};
+#endif
+  auto trackCandidates =
+      m_pipeline.run(features, moduleIds, idxs, device, hook, &timing);
 
   auto t2 = Clock::now();
 
@@ -217,7 +207,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
     onetrack.reserve(candidate.size());
 
     for (auto i : candidate) {
-      for (const auto& sl : spacepoints[i].sourceLinks()) {
+      for (const auto& sl : spacepoints.at(i).sourceLinks()) {
         onetrack.push_back(sl.template get<IndexSourceLink>().index());
       }
     }
@@ -230,22 +220,37 @@ ActsExamples::ProcessCode ActsExamples::TrackFindingAlgorithmExaTrkX::execute(
     protoTracks.push_back(std::move(onetrack));
   }
 
-  ACTS_INFO("Removed " << nShortTracks << " with less then "
-                       << m_cfg.minMeasurementsPerTrack << " hits");
-  ACTS_INFO("Created " << protoTracks.size() << " proto tracks");
+  ACTS_DEBUG("Removed " << nShortTracks << " with less then "
+                        << m_cfg.minMeasurementsPerTrack << " hits");
+  ACTS_DEBUG("Created " << protoTracks.size() << " proto tracks");
+
   m_outputProtoTracks(ctx, std::move(protoTracks));
 
   if (m_outputGraph.isInitialized()) {
     auto graph = graphStoreHook->storedGraph();
-    std::transform(
-        graph.first.begin(), graph.first.end(), graph.first.begin(),
-        [&](const auto& a) -> std::int64_t { return spacepointIDs.at(a); });
+    std::transform(graph.first.begin(), graph.first.end(), graph.first.begin(),
+                   [&](const auto& a) -> std::int64_t { return idxs.at(a); });
     m_outputGraph(ctx, {graph.first, graph.second});
   }
 
   auto t3 = Clock::now();
-  m_timing.preprocessingTime(Duration(t1 - t0).count());
-  m_timing.postprocessingTime(Duration(t3 - t2).count());
+
+  {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    m_timing.preprocessingTime(Duration(t1 - t0).count());
+    m_timing.graphBuildingTime(timing.graphBuildingTime.count());
+
+    assert(timing.classifierTimes.size() == m_timing.classifierTimes.size());
+    for (auto [aggr, a] :
+         Acts::zip(m_timing.classifierTimes, timing.classifierTimes)) {
+      aggr(a.count());
+    }
+
+    m_timing.trackBuildingTime(timing.trackBuildingTime.count());
+    m_timing.postprocessingTime(Duration(t3 - t2).count());
+    m_timing.fullTime(Duration(t3 - t0).count());
+  }
 
   return ActsExamples::ProcessCode::SUCCESS;
 }
@@ -270,6 +275,7 @@ ActsExamples::ProcessCode TrackFindingAlgorithmExaTrkX::finalize() {
   // clang-format on
   ACTS_INFO("- track building: " << print(m_timing.trackBuildingTime));
   ACTS_INFO("- postprocessing: " << print(m_timing.postprocessingTime));
+  ACTS_INFO("- full timing:    " << print(m_timing.fullTime));
 
   return {};
 }

--- a/Examples/Algorithms/TrackFindingExaTrkX/src/createFeatures.cpp
+++ b/Examples/Algorithms/TrackFindingExaTrkX/src/createFeatures.cpp
@@ -14,8 +14,7 @@
 namespace ActsExamples {
 
 std::vector<float> createFeatures(
-    const SimSpacePointContainer& spacepoints,
-    const std::optional<ClusterContainer>& clusters,
+    const SimSpacePointContainer& spacepoints, const ClusterContainer* clusters,
     const std::vector<TrackFindingAlgorithmExaTrkX::NodeFeature>& nodeFeatures,
     const std::vector<float>& featureScales) {
   using namespace ActsExamples;
@@ -33,12 +32,13 @@ std::vector<float> createFeatures(
     const auto& sl1 = sp.sourceLinks()[0].template get<IndexSourceLink>();
 
     // This should be fine, because check in constructor
-    const Cluster* cl1 = clusters ? &clusters->at(sl1.index()) : nullptr;
+    const Cluster* cl1 =
+        clusters != nullptr ? &clusters->at(sl1.index()) : nullptr;
     const Cluster* cl2 = cl1;
 
     if (sp.sourceLinks().size() == 2) {
       const auto& sl2 = sp.sourceLinks()[1].template get<IndexSourceLink>();
-      cl2 = clusters ? &clusters->at(sl2.index()) : nullptr;
+      cl2 = clusters != nullptr ? &clusters->at(sl2.index()) : nullptr;
     }
 
     // I would prefer to use a std::span or boost::span here once available

--- a/Examples/Algorithms/TrackFindingExaTrkX/src/createFeatures.hpp
+++ b/Examples/Algorithms/TrackFindingExaTrkX/src/createFeatures.hpp
@@ -13,8 +13,7 @@
 namespace ActsExamples {
 
 std::vector<float> createFeatures(
-    const SimSpacePointContainer &spacepoints,
-    const std::optional<ClusterContainer> &clusters,
+    const SimSpacePointContainer &spacepoints, const ClusterContainer *clusters,
     const std::vector<TrackFindingAlgorithmExaTrkX::NodeFeature> &nodeFeatures,
     const std::vector<float> &featureScales);
 

--- a/Examples/Scripts/Python/gnn4itk_example.py
+++ b/Examples/Scripts/Python/gnn4itk_example.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+import argparse
+
+import acts
+import acts.examples
+from acts.examples.reconstruction import addTrackSelection, TrackSelectorConfig
+
+u = acts.UnitConstants
+
+
+def runGNN4ITk(
+    inputRootDump: Path,
+    moduleMapPath: str,
+    gnnModel: Path,
+    events: int = 1,
+    logLevel=acts.logging.INFO,
+):
+    assert inputRootDump.exists()
+    assert Path(moduleMapPath + ".doublets.root").exists()
+    assert Path(moduleMapPath + ".triplets.root").exists()
+    assert gnnModel.exists()
+
+    moduleMapConfig = {
+        "level": logLevel,
+        "moduleMapPath": moduleMapPath,
+        "rScale": 1000.0,
+        "phiScale": 3.141592654,
+        "zScale": 1000.0,
+        "gpuDevice": 0,
+        "gpuBlocks": 512,
+        "moreParallel": True,
+    }
+
+    gnnConfig = {
+        "level": logLevel,
+        "cut": 0.5,
+        "modelPath": str(gnnModel),
+        "useEdgeFeatures": True,
+    }
+
+    builderCfg = {
+        "level": logLevel,
+        "useOneBlockImplementation": False,
+        "doJunctionRemoval": True,
+    }
+
+    graphConstructor = acts.examples.ModuleMapCuda(**moduleMapConfig)
+    if gnnModel.suffix == ".pt":
+        edgeClassifier = acts.examples.TorchEdgeClassifier(**gnnConfig)
+    elif gnnModel.suffix == ".onnx":
+        del gnnConfig["useEdgeFeatures"]
+        edgeClassifier = acts.examples.OnnxEdgeClassifier(**gnnConfig)
+    elif gnnModel.suffix == ".engine":
+        edgeClassifier = acts.examples.TensorRTEdgeClassifier(**gnnConfig)
+    trackBuilder = acts.examples.CudaTrackBuilding(**builderCfg)
+
+    s = acts.examples.Sequencer(
+        events=events,
+        numThreads=1,
+    )
+
+    s.addReader(
+        acts.examples.RootAthenaDumpReader(
+            level=logLevel,
+            treename="GNN4ITk",
+            inputfiles=[str(inputRootDump)],
+            outputSpacePoints="spacepoints",
+            outputClusters="clusters",
+            outputMeasurements="measurements",
+            outputMeasurementParticlesMap="measurement_particles_map",
+            outputParticleMeasurementsMap="particle_measurements_map",
+            outputParticles="particles",
+            skipOverlapSPsPhi=True,
+            skipOverlapSPsEta=False,
+            absBoundaryTolerance=0.01 * u.mm,
+        )
+    )
+
+    e = acts.examples.NodeFeature
+    s.addAlgorithm(
+        acts.examples.TrackFindingAlgorithmExaTrkX(
+            level=logLevel,
+            graphConstructor=graphConstructor,
+            edgeClassifiers=[edgeClassifier],
+            trackBuilder=trackBuilder,
+            nodeFeatures=[
+                e.R,
+                e.Phi,
+                e.Z,
+                e.Eta,
+                e.Cluster1R,
+                e.Cluster1Phi,
+                e.Cluster1Z,
+                e.Cluster1Eta,
+                e.Cluster2R,
+                e.Cluster2Phi,
+                e.Cluster2Z,
+                e.Cluster2Eta,
+            ],
+            featureScales=[1000.0, 3.14159265359, 1000.0, 1.0] * 3,
+            inputSpacePoints="spacepoints",
+            inputClusters="clusters",
+            outputProtoTracks="prototracks",
+        )
+    )
+
+    s.addAlgorithm(
+        acts.examples.PrototracksToTracks(
+            level=logLevel,
+            inputProtoTracks="prototracks",
+            inputMeasurements="measurements",
+            outputTracks="gnn_only_tracks",
+        )
+    )
+
+    s.addAlgorithm(
+        acts.examples.ParticleSelector(
+            level=logLevel,
+            ptMin=1 * u.GeV,
+            rhoMax=26 * u.cm,
+            measurementsMin=7,
+            removeSecondaries=True,
+            removeNeutral=True,
+            excludeAbsPdgs=[
+                11,
+            ],
+            inputParticles="particles",
+            outputParticles="particles_selected",
+            inputParticleMeasurementsMap="particle_measurements_map",
+        )
+    )
+
+    addTrackSelection(
+        s,
+        TrackSelectorConfig(nMeasurementsMin=7, requireReferenceSurface=False),
+        inputTracks="gnn_only_tracks",
+        outputTracks="gnn_only_tracks_selected",
+        logLevel=logLevel,
+    )
+
+    # NOTE: This is not standard ATLAS matching
+    s.addAlgorithm(
+        acts.examples.TrackTruthMatcher(
+            level=logLevel,
+            inputTracks="gnn_only_tracks_selected",
+            inputParticles="particles_selected",
+            inputMeasurementParticlesMap="measurement_particles_map",
+            outputTrackParticleMatching="tpm",
+            outputParticleTrackMatching="ptm",
+            doubleMatching=True,
+        )
+    )
+
+    s.addWriter(
+        acts.examples.TrackFinderPerformanceWriter(
+            level=logLevel,
+            inputParticles="particles_selected",
+            inputParticleMeasurementsMap="particle_measurements_map",
+            inputTrackParticleMatching="tpm",
+            inputParticleTrackMatching="ptm",
+            inputTracks="gnn_only_tracks_selected",
+            filePath="performance_gnn4itk.root",
+        )
+    )
+
+    s.run()
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser(description="Run the GNN4ITk example")
+
+    argparser.add_argument(
+        "--inputRootDump",
+        type=Path,
+        required=True,
+        help="Path to the input ROOT dump file",
+    )
+    argparser.add_argument(
+        "--moduleMapPath",
+        type=str,
+        required=True,
+        help="Path to the module map file (without .doublets.root or .triplets.root suffixes)",
+    )
+    argparser.add_argument(
+        "--gnnModel",
+        type=Path,
+        required=True,
+        help="Path to the GNN model file (ONNX or Torch)",
+    )
+    argparser.add_argument(
+        "--events",
+        type=int,
+        default=1,
+        help="Number of events to process",
+    )
+
+    args = argparser.parse_args()
+
+    runGNN4ITk(
+        inputRootDump=args.inputRootDump,
+        moduleMapPath=args.moduleMapPath,
+        gnnModel=args.gnnModel,
+        events=args.events,
+    )


### PR DESCRIPTION
This adds a python script for the GNN4ITk workflow, since a demonstrator was requested several times recently. For now not tested in CI, since input files are no easy accessible.
Also adds a fix to the GNN algorithm, in order to sort the spacepoints by module id before the inference.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Python example script for running a GNN-based track reconstruction workflow with configurable model formats and performance metric output.

- **Refactor**
  - Improved timing instrumentation and reporting in the track finding algorithm.
  - Changed cluster container handling from optional to pointer-based for improved clarity and efficiency.
  - Enhanced data sorting and feature creation processes for more robust execution.

- **Style**
  - Adjusted logging levels for better debug information and output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->