### PR TITLE
chore: Cleanup some `Grid` related code

### DIFF
--- a/Core/include/Acts/Seeding/BinnedGroup.hpp
+++ b/Core/include/Acts/Seeding/BinnedGroup.hpp
@@ -10,10 +10,7 @@
 
 #include "Acts/Seeding/BinnedGroupIterator.hpp"
 #include "Acts/Utilities/GridBinFinder.hpp"
-#include "Acts/Utilities/GridIterator.hpp"
-#include "Acts/Utilities/Holders.hpp"
 
-#include <memory>
 #include <vector>
 
 namespace Acts {
@@ -35,19 +32,19 @@ class BinnedGroup {
   BinnedGroup() = delete;
 
   /// brief Constructor
-  BinnedGroup(grid_t&& grid, const Acts::GridBinFinder<DIM>& bottomFinder,
-              const Acts::GridBinFinder<DIM>& topFinder,
+  BinnedGroup(grid_t&& grid, const GridBinFinder<DIM>& bottomFinder,
+              const GridBinFinder<DIM>& topFinder,
               std::array<std::vector<std::size_t>, DIM> navigation =
                   std::array<std::vector<std::size_t>, DIM>());
 
   BinnedGroup(grid_t&& grid, std::vector<bool> mask,
-              const Acts::GridBinFinder<DIM>& bottomFinder,
-              const Acts::GridBinFinder<DIM>& topFinder,
+              const GridBinFinder<DIM>& bottomFinder,
+              const GridBinFinder<DIM>& topFinder,
               std::array<std::vector<std::size_t>, DIM> navigation =
                   std::array<std::vector<std::size_t>, DIM>());
 
-  BinnedGroup(grid_t& grid, const Acts::GridBinFinder<DIM>& bottomFinder,
-              const Acts::GridBinFinder<DIM>& topFinder,
+  BinnedGroup(grid_t& grid, const GridBinFinder<DIM>& bottomFinder,
+              const GridBinFinder<DIM>& topFinder,
               std::array<std::vector<std::size_t>, DIM> navigation =
                   std::array<std::vector<std::size_t>, DIM>()) = delete;
 
@@ -85,10 +82,10 @@ class BinnedGroup {
 
   /// @brief Get the begin iterator
   /// @return The iterator
-  Acts::BinnedGroupIterator<grid_t> begin() const;
+  BinnedGroupIterator<grid_t> begin() const;
   /// @brief Get the end iterator
   /// @return The iterator
-  Acts::BinnedGroupIterator<grid_t> end() const;
+  BinnedGroupIterator<grid_t> end() const;
 
  private:
   /// @brief The N-dimentional grid
@@ -97,9 +94,9 @@ class BinnedGroup {
   /// corresponds to the global bins in the grid
   std::vector<bool> m_mask{};
   /// @brief The Grid Bin Finder for bottom candidates
-  const Acts::GridBinFinder<DIM>* m_bottomBinFinder{nullptr};
+  const GridBinFinder<DIM>* m_bottomBinFinder{nullptr};
   /// @brief The Grid Bin Finder for top candidates
-  const Acts::GridBinFinder<DIM>* m_topBinFinder{nullptr};
+  const GridBinFinder<DIM>* m_topBinFinder{nullptr};
   /// @brief Order of bins to loop over when searching for SPs
   std::array<std::vector<std::size_t>, DIM> m_bins{};
 };

--- a/Core/include/Acts/Seeding/BinnedGroup.ipp
+++ b/Core/include/Acts/Seeding/BinnedGroup.ipp
@@ -6,15 +6,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include <numeric>
+
 namespace Acts {
 
 template <typename grid_t>
 BinnedGroup<grid_t>::BinnedGroup(
-    grid_t&& grid,
-    const Acts::GridBinFinder<Acts::BinnedGroup<grid_t>::DIM>& bottomFinder,
-    const Acts::GridBinFinder<Acts::BinnedGroup<grid_t>::DIM>& topFinder,
-    std::array<std::vector<std::size_t>, Acts::BinnedGroup<grid_t>::DIM>
-        navigation)
+    grid_t&& grid, const GridBinFinder<BinnedGroup<grid_t>::DIM>& bottomFinder,
+    const GridBinFinder<BinnedGroup<grid_t>::DIM>& topFinder,
+    std::array<std::vector<std::size_t>, BinnedGroup<grid_t>::DIM> navigation)
     : m_grid(std::move(grid)),
       m_mask(m_grid.size(true), true),
       m_bottomBinFinder(&bottomFinder),
@@ -35,10 +35,9 @@ BinnedGroup<grid_t>::BinnedGroup(
 template <typename grid_t>
 BinnedGroup<grid_t>::BinnedGroup(
     grid_t&& grid, std::vector<bool> mask,
-    const Acts::GridBinFinder<Acts::BinnedGroup<grid_t>::DIM>& bottomFinder,
-    const Acts::GridBinFinder<Acts::BinnedGroup<grid_t>::DIM>& topFinder,
-    std::array<std::vector<std::size_t>, Acts::BinnedGroup<grid_t>::DIM>
-        navigation)
+    const GridBinFinder<BinnedGroup<grid_t>::DIM>& bottomFinder,
+    const GridBinFinder<BinnedGroup<grid_t>::DIM>& topFinder,
+    std::array<std::vector<std::size_t>, BinnedGroup<grid_t>::DIM> navigation)
     : m_grid(std::move(grid)),
       m_mask(std::move(mask)),
       m_bottomBinFinder(&bottomFinder),
@@ -80,18 +79,18 @@ const std::vector<bool>& BinnedGroup<grid_t>::mask() const {
 }
 
 template <typename grid_t>
-Acts::BinnedGroupIterator<grid_t> BinnedGroup<grid_t>::begin() const {
-  return Acts::BinnedGroupIterator<grid_t>(
-      *this, std::array<std::size_t, Acts::BinnedGroup<grid_t>::DIM>(), m_bins);
+BinnedGroupIterator<grid_t> BinnedGroup<grid_t>::begin() const {
+  return BinnedGroupIterator<grid_t>(
+      *this, std::array<std::size_t, BinnedGroup<grid_t>::DIM>(), m_bins);
 }
 
 template <typename grid_t>
-Acts::BinnedGroupIterator<grid_t> BinnedGroup<grid_t>::end() const {
-  std::array<std::size_t, Acts::BinnedGroup<grid_t>::DIM> endline{};
-  for (std::size_t i(0ul); i < Acts::BinnedGroup<grid_t>::DIM; ++i) {
+BinnedGroupIterator<grid_t> BinnedGroup<grid_t>::end() const {
+  std::array<std::size_t, BinnedGroup<grid_t>::DIM> endline{};
+  for (std::size_t i(0ul); i < BinnedGroup<grid_t>::DIM; ++i) {
     endline[i] = m_bins[i].size();
   }
-  return Acts::BinnedGroupIterator<grid_t>(*this, endline, m_bins);
+  return BinnedGroupIterator<grid_t>(*this, endline, m_bins);
 }
 
 }  // namespace Acts

--- a/Core/include/Acts/Seeding/BinnedGroupIterator.hpp
+++ b/Core/include/Acts/Seeding/BinnedGroupIterator.hpp
@@ -8,17 +8,16 @@
 
 #pragma once
 
-#include "Acts/Utilities/GridIterator.hpp"
 #include "Acts/Utilities/Holders.hpp"
 #include "Acts/Utilities/detail/grid_helper.hpp"
 
 #include <array>
-#include <memory>
 #include <tuple>
 
 #include <boost/container/small_vector.hpp>
 
 namespace Acts {
+
 template <typename grid_t>
 class BinnedGroup;
 
@@ -34,7 +33,7 @@ class BinnedGroupIterator {
   /// @param [in] index Current local position in the grid
   /// @param [in] navigation The navigation pattern in the grid
   BinnedGroupIterator(
-      Acts::BinnedGroup<grid_t>&& group, std::array<std::size_t, DIM> index,
+      BinnedGroup<grid_t>&& group, std::array<std::size_t, DIM> index,
       std::array<std::vector<std::size_t>, DIM> navigation) = delete;
 
   /// @brief Constructor
@@ -43,16 +42,15 @@ class BinnedGroupIterator {
   /// @param [in] group The group we are iterating on
   /// @param [in] index Current local position in the grid
   /// @param [in] navigation The navigation pattern in the grid
-  BinnedGroupIterator(const Acts::BinnedGroup<grid_t>&& group,
-                      std::array<std::size_t, DIM> index,
-                      std::array<std::vector<std::size_t>, DIM> navigation) =
-      delete;
+  BinnedGroupIterator(
+      const BinnedGroup<grid_t>&& group, std::array<std::size_t, DIM> index,
+      std::array<std::vector<std::size_t>, DIM> navigation) = delete;
 
   /// @brief Constructor
   /// @param [in] group The group we are iterating on
   /// @param [in] index Current local position in the grid
   /// @param [in] navigation The navigation pattern in the grid
-  BinnedGroupIterator(const Acts::BinnedGroup<grid_t>& group,
+  BinnedGroupIterator(const BinnedGroup<grid_t>& group,
                       std::array<std::size_t, DIM> index,
                       std::array<std::vector<std::size_t>, DIM> navigation);
 
@@ -92,11 +90,10 @@ class BinnedGroupIterator {
   /// bins with the possible bottom and top candidates
   ///
   /// @return The collection of all the bins in the grid
-  std::tuple<boost::container::small_vector<std::size_t,
-                                            Acts::detail::ipow(3, grid_t::DIM)>,
-             std::size_t,
-             boost::container::small_vector<std::size_t,
-                                            Acts::detail::ipow(3, grid_t::DIM)>>
+  std::tuple<
+      boost::container::small_vector<std::size_t, detail::ipow(3, grid_t::DIM)>,
+      std::size_t,
+      boost::container::small_vector<std::size_t, detail::ipow(3, grid_t::DIM)>>
   operator*() const;
 
  private:
@@ -105,7 +102,7 @@ class BinnedGroupIterator {
 
  private:
   /// @brief The group that contains the grid and the bin finders
-  Acts::detail::RefHolder<const Acts::BinnedGroup<grid_t>> m_group{nullptr};
+  detail::RefHolder<const BinnedGroup<grid_t>> m_group{nullptr};
   /// @brief Current N-dimentional grid iterator
   typename grid_t::local_iterator_t m_gridItr;
   /// @brief End iterator;

--- a/Core/include/Acts/Seeding/BinnedGroupIterator.ipp
+++ b/Core/include/Acts/Seeding/BinnedGroupIterator.ipp
@@ -6,13 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Binned SP Group Iterator
+namespace Acts {
 
 template <typename grid_t>
-Acts::BinnedGroupIterator<grid_t>::BinnedGroupIterator(
-    const Acts::BinnedGroup<grid_t>& group,
-    std::array<std::size_t, Acts::BinnedGroupIterator<grid_t>::DIM> index,
-    std::array<std::vector<std::size_t>, Acts::BinnedGroupIterator<grid_t>::DIM>
+BinnedGroupIterator<grid_t>::BinnedGroupIterator(
+    const BinnedGroup<grid_t>& group,
+    std::array<std::size_t, BinnedGroupIterator<grid_t>::DIM> index,
+    std::array<std::vector<std::size_t>, BinnedGroupIterator<grid_t>::DIM>
         navigation)
     : m_group(group), m_gridItr(group.grid(), index, navigation) {
   std::array<std::size_t, DIM> endline{};
@@ -25,26 +25,24 @@ Acts::BinnedGroupIterator<grid_t>::BinnedGroupIterator(
 }
 
 template <typename grid_t>
-bool Acts::BinnedGroupIterator<grid_t>::operator==(
-    const Acts::BinnedGroupIterator<grid_t>& other) const {
+bool BinnedGroupIterator<grid_t>::operator==(
+    const BinnedGroupIterator<grid_t>& other) const {
   return m_group.ptr == other.m_group.ptr && m_gridItr == other.m_gridItr;
 }
 
 template <typename grid_t>
-Acts::BinnedGroupIterator<grid_t>&
-Acts::BinnedGroupIterator<grid_t>::operator++() {
+BinnedGroupIterator<grid_t>& BinnedGroupIterator<grid_t>::operator++() {
   ++m_gridItr;
   findNotEmptyBin();
   return *this;
 }
 
 template <typename grid_t>
-std::tuple<boost::container::small_vector<std::size_t,
-                                          Acts::detail::ipow(3, grid_t::DIM)>,
-           std::size_t,
-           boost::container::small_vector<std::size_t,
-                                          Acts::detail::ipow(3, grid_t::DIM)>>
-Acts::BinnedGroupIterator<grid_t>::operator*() const {
+std::tuple<
+    boost::container::small_vector<std::size_t, detail::ipow(3, grid_t::DIM)>,
+    std::size_t,
+    boost::container::small_vector<std::size_t, detail::ipow(3, grid_t::DIM)>>
+BinnedGroupIterator<grid_t>::operator*() const {
   /// Get the global and local position from current iterator. This is the bin
   /// with the middle candidate And we know this is not an empty bin
   std::array<std::size_t, DIM> localPosition = m_gridItr.localBinsIndices();
@@ -52,10 +50,9 @@ Acts::BinnedGroupIterator<grid_t>::operator*() const {
       m_group->grid().globalBinFromLocalBins(localPosition);
 
   /// Get the neighbouring bins
-  boost::container::small_vector<std::size_t, Acts::detail::ipow(3, DIM)>
-      bottoms =
-          m_group->m_bottomBinFinder->findBins(localPosition, m_group->grid());
-  boost::container::small_vector<std::size_t, Acts::detail::ipow(3, DIM)> tops =
+  boost::container::small_vector<std::size_t, detail::ipow(3, DIM)> bottoms =
+      m_group->m_bottomBinFinder->findBins(localPosition, m_group->grid());
+  boost::container::small_vector<std::size_t, detail::ipow(3, DIM)> tops =
       m_group->m_topBinFinder->findBins(localPosition, m_group->grid());
 
   // GCC12+ in Release throws an overread warning here due to the move.
@@ -71,7 +68,7 @@ Acts::BinnedGroupIterator<grid_t>::operator*() const {
 }
 
 template <typename grid_t>
-void Acts::BinnedGroupIterator<grid_t>::findNotEmptyBin() {
+void BinnedGroupIterator<grid_t>::findNotEmptyBin() {
   if (m_gridItr == m_gridItrEnd) {
     return;
   }
@@ -94,3 +91,5 @@ void Acts::BinnedGroupIterator<grid_t>::findNotEmptyBin() {
     passesMask = m_group->mask().at(m_gridItr.globalBinIndex());
   }
 }
+
+}  // namespace Acts

--- a/Core/include/Acts/Utilities/Grid.hpp
+++ b/Core/include/Acts/Utilities/Grid.hpp
@@ -8,12 +8,12 @@
 
 #pragma once
 
-#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Utilities/GridIterator.hpp"
 #include "Acts/Utilities/IAxis.hpp"
 #include "Acts/Utilities/Interpolation.hpp"
 #include "Acts/Utilities/TypeTag.hpp"
-#include "Acts/Utilities/TypeTraits.hpp"
 #include "Acts/Utilities/detail/grid_helper.hpp"
+#include "Acts/Utilities/detail/interpolation_impl.hpp"
 
 #include <any>
 #include <array>
@@ -23,13 +23,9 @@
 #include <utility>
 #include <vector>
 
+#include <boost/container/small_vector.hpp>
+
 namespace Acts {
-
-template <typename T, class... Axes>
-class GridGlobalIterator;
-
-template <typename T, class... Axes>
-class GridLocalIterator;
 
 namespace detail {
 
@@ -152,9 +148,9 @@ class Grid final : public IGrid {
   /// index type using local bin indices along each axis
   using index_t = std::array<std::size_t, DIM>;
   /// global iterator type
-  using global_iterator_t = Acts::GridGlobalIterator<T, Axes...>;
+  using global_iterator_t = GridGlobalIterator<T, Axes...>;
   /// local iterator type
-  using local_iterator_t = Acts::GridLocalIterator<T, Axes...>;
+  using local_iterator_t = GridLocalIterator<T, Axes...>;
 
   /// @brief Constructor from const axis tuple, this will allow
   /// creating a grid with a different value type from a template
@@ -263,7 +259,7 @@ class Grid final : public IGrid {
     return m_values.at(globalBinFromLocalBins(localBins));
   }
 
-  /// @copydoc Acts::IGrid::atLocalBinsAny
+  /// @copydoc IGrid::atLocalBinsAny
   std::any atLocalBinsAny(AnyIndexType indices) const override {
     const_reference cref = atLocalBins(toIndexType(indices));
     return &cref;
@@ -281,7 +277,7 @@ class Grid final : public IGrid {
     return m_values.at(globalBinFromLocalBins(localBins));
   }
 
-  /// @copydoc Acts::IGrid::atLocalBinsAny
+  /// @copydoc IGrid::atLocalBinsAny
   std::any atLocalBinsAny(AnyIndexType indices) override {
     reference ref = atLocalBins(toIndexType(indices));
     return &ref;
@@ -309,7 +305,7 @@ class Grid final : public IGrid {
   /// @return number of axes spanning the grid
   std::size_t dimensions() const override { return DIM; }
 
-  /// @copydoc Acts::IGrid::valueType
+  /// @copydoc IGrid::valueType
   const std::type_info& valueType() const override { return typeid(T); }
 
   /// @brief get center position of bin with given local bin numbers
@@ -434,7 +430,7 @@ class Grid final : public IGrid {
     return detail::grid_helper::getLowerLeftBinEdge(localBins, m_axes);
   }
 
-  /// @copydoc Acts::IGrid::lowerLeftBinEdgeAny
+  /// @copydoc IGrid::lowerLeftBinEdgeAny
   AnyPointType lowerLeftBinEdgeAny(AnyIndexType indices) const override {
     return toAnyPointType(lowerLeftBinEdge(toIndexType(indices)));
   }
@@ -450,7 +446,7 @@ class Grid final : public IGrid {
     return detail::grid_helper::getUpperRightBinEdge(localBins, m_axes);
   }
 
-  /// @copydoc Acts::IGrid::upperRightBinEdgeAny
+  /// @copydoc IGrid::upperRightBinEdgeAny
   AnyPointType upperRightBinEdgeAny(AnyIndexType indices) const override {
     return toAnyPointType(upperRightBinEdge(toIndexType(indices)));
   }
@@ -467,7 +463,7 @@ class Grid final : public IGrid {
   /// @note Not including under- and overflow bins
   index_t numLocalBins() const { return detail::grid_helper::getNBins(m_axes); }
 
-  /// @copydoc Acts::IGrid::numLocalBinsAny
+  /// @copydoc IGrid::numLocalBinsAny
   AnyIndexType numLocalBinsAny() const override {
     return toAnyIndexType(numLocalBins());
   }

--- a/Core/include/Acts/Utilities/GridAccessHelpers.hpp
+++ b/Core/include/Acts/Utilities/GridAccessHelpers.hpp
@@ -14,7 +14,6 @@
 #include "Acts/Utilities/VectorHelpers.hpp"
 
 #include <array>
-#include <vector>
 
 namespace Acts {
 

--- a/Core/include/Acts/Utilities/GridAxisGenerators.hpp
+++ b/Core/include/Acts/Utilities/GridAxisGenerators.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "Acts/Utilities/Axis.hpp"
 #include "Acts/Utilities/Grid.hpp"
 #include "Acts/Utilities/TypeList.hpp"
 
@@ -27,76 +26,71 @@ namespace Acts::GridAxisGenerators {
 /// @brief  Templated base generator for equidistant axis as a tuple - 1D
 ///
 /// @tparam aType the type of the axis (Bound, Closed, Open)
-template <Acts::AxisBoundaryType aType>
+template <AxisBoundaryType aType>
 struct Eq {
   /// Broadcast the return_type
-  using return_type =
-      std::tuple<Acts::Axis<Acts::AxisType::Equidistant, aType>>;
+  using return_type = std::tuple<Axis<AxisType::Equidistant, aType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type =
-      Acts::Grid<T, Acts::Axis<Acts::AxisType::Equidistant, aType>>;
+  using grid_type = Grid<T, Axis<AxisType::Equidistant, aType>>;
 
   std::array<double, 2u> range = {};
   std::size_t nBins = 0u;
 
   /// Call operator that generates the Axis
   return_type operator()() const {
-    Acts::Axis<Acts::AxisType::Equidistant, aType> eAxis(range[0u], range[1u],
-                                                         nBins);
+    Axis<AxisType::Equidistant, aType> eAxis(range[0u], range[1u], nBins);
     return {eAxis};
   }
 };
 
 // All 1D equidistant options
-using EqBound = Eq<Acts::AxisBoundaryType::Bound>;
-using EqOpen = Eq<Acts::AxisBoundaryType::Open>;
-using EqClosed = Eq<Acts::AxisBoundaryType::Closed>;
+using EqBound = Eq<AxisBoundaryType::Bound>;
+using EqOpen = Eq<AxisBoundaryType::Open>;
+using EqClosed = Eq<AxisBoundaryType::Closed>;
 
 /// @brief  Templated base generator for variable axis as a tuple - 1D
 ///
 /// @tparam aType the type of the axis (Bound, Closed, Open)
-template <Acts::AxisBoundaryType aType>
+template <AxisBoundaryType aType>
 struct Var {
   /// Broadcast the return_type
-  using return_type = std::tuple<Acts::Axis<Acts::AxisType::Variable, aType>>;
+  using return_type = std::tuple<Axis<AxisType::Variable, aType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type = Acts::Grid<T, Acts::Axis<Acts::AxisType::Variable, aType>>;
+  using grid_type = Grid<T, Axis<AxisType::Variable, aType>>;
 
   std::vector<double> edges = {};
 
   /// Call operator that generates the Axis
   return_type operator()() const {
-    Acts::Axis<Acts::AxisType::Variable, aType> vAxis(edges);
+    Axis<AxisType::Variable, aType> vAxis(edges);
     return {vAxis};
   }
 };
 
 // All 1D variable options
-using VarBound = Var<Acts::AxisBoundaryType::Bound>;
-using VarOpen = Var<Acts::AxisBoundaryType::Open>;
-using VarClosed = Var<Acts::AxisBoundaryType::Closed>;
+using VarBound = Var<AxisBoundaryType::Bound>;
+using VarOpen = Var<AxisBoundaryType::Open>;
+using VarClosed = Var<AxisBoundaryType::Closed>;
 
 /// @brief  Templated base generator for two equidistant axes as a tuple - 2D
 ///
 /// @tparam aType the type of the first axis (Bound, Closed, Open)
 /// @tparam bType the type of the second axis (Bound, Closed, Open)
 ///
-template <Acts::AxisBoundaryType aType, Acts::AxisBoundaryType bType>
+template <AxisBoundaryType aType, AxisBoundaryType bType>
 struct EqEq {
   /// Broadcast the return_type
-  using return_type =
-      std::tuple<Acts::Axis<Acts::AxisType::Equidistant, aType>,
-                 Acts::Axis<Acts::AxisType::Equidistant, bType>>;
+  using return_type = std::tuple<Axis<AxisType::Equidistant, aType>,
+                                 Axis<AxisType::Equidistant, bType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type =
-      Acts::Grid<T, Acts::Axis<Acts::AxisType::Equidistant, aType>,
-                 Acts::Axis<Acts::AxisType::Equidistant, bType>>;
+  using grid_type = Grid<T, Axis<AxisType::Equidistant, aType>,
+                         Axis<AxisType::Equidistant, bType>>;
 
   std::array<double, 2u> range0 = {};
   std::size_t nBins0 = 0u;
@@ -106,50 +100,39 @@ struct EqEq {
   /// Call operator that generates the Axis
   return_type operator()() const {
     // Create the two axis
-    Acts::Axis<Acts::AxisType::Equidistant, aType> aEq(range0[0u], range0[1u],
-                                                       nBins0);
-    Acts::Axis<Acts::AxisType::Equidistant, bType> bEq(range1[0u], range1[1u],
-                                                       nBins1);
+    Axis<AxisType::Equidistant, aType> aEq(range0[0u], range0[1u], nBins0);
+    Axis<AxisType::Equidistant, bType> bEq(range1[0u], range1[1u], nBins1);
     return {aEq, bEq};
   }
 };
 
 // All 2D EqEq options
-using EqBoundEqBound =
-    EqEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Bound>;
-using EqBoundEqOpen =
-    EqEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Open>;
-using EqBoundEqClosed =
-    EqEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Closed>;
-using EqOpenEqBound =
-    EqEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Bound>;
-using EqOpenEqOpen =
-    EqEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Open>;
-using EqOpenEqClosed =
-    EqEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Closed>;
-using EqClosedEqBound =
-    EqEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Bound>;
-using EqClosedEqOpen =
-    EqEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Open>;
+using EqBoundEqBound = EqEq<AxisBoundaryType::Bound, AxisBoundaryType::Bound>;
+using EqBoundEqOpen = EqEq<AxisBoundaryType::Bound, AxisBoundaryType::Open>;
+using EqBoundEqClosed = EqEq<AxisBoundaryType::Bound, AxisBoundaryType::Closed>;
+using EqOpenEqBound = EqEq<AxisBoundaryType::Open, AxisBoundaryType::Bound>;
+using EqOpenEqOpen = EqEq<AxisBoundaryType::Open, AxisBoundaryType::Open>;
+using EqOpenEqClosed = EqEq<AxisBoundaryType::Open, AxisBoundaryType::Closed>;
+using EqClosedEqBound = EqEq<AxisBoundaryType::Closed, AxisBoundaryType::Bound>;
+using EqClosedEqOpen = EqEq<AxisBoundaryType::Closed, AxisBoundaryType::Open>;
 using EqClosedEqClosed =
-    EqEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Closed>;
+    EqEq<AxisBoundaryType::Closed, AxisBoundaryType::Closed>;
 
 /// @brief  Templated base generator for equidistant / variable axes as a tuple - 2D
 ///
 /// @tparam aType the type of the first axis (Bound, Closed, Open)
 /// @tparam bType the type of the second axis (Bound, Closed, Open)
 ///
-template <Acts::AxisBoundaryType aType, Acts::AxisBoundaryType bType>
+template <AxisBoundaryType aType, AxisBoundaryType bType>
 struct EqVar {
   /// Broadcast the return_type
-  using return_type = std::tuple<Acts::Axis<Acts::AxisType::Equidistant, aType>,
-                                 Acts::Axis<Acts::AxisType::Variable, bType>>;
+  using return_type = std::tuple<Axis<AxisType::Equidistant, aType>,
+                                 Axis<AxisType::Variable, bType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type =
-      Acts::Grid<T, Acts::Axis<Acts::AxisType::Equidistant, aType>,
-                 Acts::Axis<Acts::AxisType::Variable, bType>>;
+  using grid_type = Grid<T, Axis<AxisType::Equidistant, aType>,
+                         Axis<AxisType::Variable, bType>>;
 
   std::array<double, 2u> range = {};
   std::size_t nBins = 0u;
@@ -157,49 +140,41 @@ struct EqVar {
 
   /// Call operator that generates the Axis
   return_type operator()() const {
-    Acts::Axis<Acts::AxisType::Equidistant, aType> eqA(range[0u], range[1u],
-                                                       nBins);
-    Acts::Axis<Acts::AxisType::Variable, bType> varB(edges);
+    Axis<AxisType::Equidistant, aType> eqA(range[0u], range[1u], nBins);
+    Axis<AxisType::Variable, bType> varB(edges);
     return {eqA, varB};
   }
 };
 
 // All 2D EqVar options
-using EqBoundVarBound =
-    EqVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Bound>;
-using EqBoundVarOpen =
-    EqVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Open>;
+using EqBoundVarBound = EqVar<AxisBoundaryType::Bound, AxisBoundaryType::Bound>;
+using EqBoundVarOpen = EqVar<AxisBoundaryType::Bound, AxisBoundaryType::Open>;
 using EqBoundVarClosed =
-    EqVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Closed>;
-using EqOpenVarBound =
-    EqVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Bound>;
-using EqOpenVarOpen =
-    EqVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Open>;
-using EqOpenVarClosed =
-    EqVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Closed>;
+    EqVar<AxisBoundaryType::Bound, AxisBoundaryType::Closed>;
+using EqOpenVarBound = EqVar<AxisBoundaryType::Open, AxisBoundaryType::Bound>;
+using EqOpenVarOpen = EqVar<AxisBoundaryType::Open, AxisBoundaryType::Open>;
+using EqOpenVarClosed = EqVar<AxisBoundaryType::Open, AxisBoundaryType::Closed>;
 using EqClosedVarBound =
-    EqVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Bound>;
-using EqClosedVarOpen =
-    EqVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Open>;
+    EqVar<AxisBoundaryType::Closed, AxisBoundaryType::Bound>;
+using EqClosedVarOpen = EqVar<AxisBoundaryType::Closed, AxisBoundaryType::Open>;
 using EqClosedVarClosed =
-    EqVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Closed>;
+    EqVar<AxisBoundaryType::Closed, AxisBoundaryType::Closed>;
 
 /// @brief  Templated base generator for a variable, equidistant axes tuple - 2D
 ///
 /// @tparam aType the type of the first axis (Bound, Closed, Open)
 /// @tparam bType the type of the second axis (Bound, Closed, Open)
 ///
-template <Acts::AxisBoundaryType aType, Acts::AxisBoundaryType bType>
+template <AxisBoundaryType aType, AxisBoundaryType bType>
 struct VarEq {
   /// Broadcast the return_type
-  using return_type =
-      std::tuple<Acts::Axis<Acts::AxisType::Variable, aType>,
-                 Acts::Axis<Acts::AxisType::Equidistant, bType>>;
+  using return_type = std::tuple<Axis<AxisType::Variable, aType>,
+                                 Axis<AxisType::Equidistant, bType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type = Acts::Grid<T, Acts::Axis<Acts::AxisType::Variable, aType>,
-                               Acts::Axis<Acts::AxisType::Equidistant, bType>>;
+  using grid_type = Grid<T, Axis<AxisType::Variable, aType>,
+                         Axis<AxisType::Equidistant, bType>>;
 
   std::vector<double> edges = {};
   std::array<double, 2u> range = {};
@@ -207,79 +182,69 @@ struct VarEq {
 
   /// Call operator that generates the Axis
   return_type operator()() const {
-    Acts::Axis<Acts::AxisType::Variable, aType> varA(edges);
-    Acts::Axis<Acts::AxisType::Equidistant, bType> eqB(range[0u], range[1u],
-                                                       nBins);
+    Axis<AxisType::Variable, aType> varA(edges);
+    Axis<AxisType::Equidistant, bType> eqB(range[0u], range[1u], nBins);
     return {varA, eqB};
   }
 };
 
 // All 2D VarEq options
-using VarBoundEqBound =
-    VarEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Bound>;
-using VarBoundEqOpen =
-    VarEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Open>;
+using VarBoundEqBound = VarEq<AxisBoundaryType::Bound, AxisBoundaryType::Bound>;
+using VarBoundEqOpen = VarEq<AxisBoundaryType::Bound, AxisBoundaryType::Open>;
 using VarBoundEqClosed =
-    VarEq<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Closed>;
-using VarOpenEqBound =
-    VarEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Bound>;
-using VarOpenEqOpen =
-    VarEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Open>;
-using VarOpenEqClosed =
-    VarEq<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Closed>;
+    VarEq<AxisBoundaryType::Bound, AxisBoundaryType::Closed>;
+using VarOpenEqBound = VarEq<AxisBoundaryType::Open, AxisBoundaryType::Bound>;
+using VarOpenEqOpen = VarEq<AxisBoundaryType::Open, AxisBoundaryType::Open>;
+using VarOpenEqClosed = VarEq<AxisBoundaryType::Open, AxisBoundaryType::Closed>;
 using VarClosedEqBound =
-    VarEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Bound>;
-using VarClosedEqOpen =
-    VarEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Open>;
+    VarEq<AxisBoundaryType::Closed, AxisBoundaryType::Bound>;
+using VarClosedEqOpen = VarEq<AxisBoundaryType::Closed, AxisBoundaryType::Open>;
 using VarClosedEqClosed =
-    VarEq<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Closed>;
+    VarEq<AxisBoundaryType::Closed, AxisBoundaryType::Closed>;
 
 /// @brief  Templated base generator for a two variable axes tuple - 2D
 ///
 /// @tparam aType the type of the first axis (Bound, Closed, Open)
 /// @tparam bType the type of the second axis (Bound, Closed, Open)
 ///
-template <Acts::AxisBoundaryType aType, Acts::AxisBoundaryType bType>
+template <AxisBoundaryType aType, AxisBoundaryType bType>
 struct VarVar {
   /// Broadcast the return_type
-  using return_type = std::tuple<Acts::Axis<Acts::AxisType::Variable, aType>,
-                                 Acts::Axis<Acts::AxisType::Variable, bType>>;
+  using return_type = std::tuple<Axis<AxisType::Variable, aType>,
+                                 Axis<AxisType::Variable, bType>>;
 
   /// Broadcast the grid type
   template <typename T>
-  using grid_type = Acts::Grid<T, Acts::Axis<Acts::AxisType::Variable, aType>,
-                               Acts::Axis<Acts::AxisType::Variable, bType>>;
+  using grid_type =
+      Grid<T, Axis<AxisType::Variable, aType>, Axis<AxisType::Variable, bType>>;
 
   std::vector<double> edges0 = {};
   std::vector<double> edges1 = {};
 
   /// Call operator that generates the Axis
   return_type operator()() const {
-    Acts::Axis<Acts::AxisType::Variable, aType> varA(edges0);
-    Acts::Axis<Acts::AxisType::Variable, bType> varB(edges1);
+    Axis<AxisType::Variable, aType> varA(edges0);
+    Axis<AxisType::Variable, bType> varB(edges1);
     return {varA, varB};
   }
 };
 
 // All 2D VarVar options
 using VarBoundVarBound =
-    VarVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Bound>;
-using VarBoundVarOpen =
-    VarVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Open>;
+    VarVar<AxisBoundaryType::Bound, AxisBoundaryType::Bound>;
+using VarBoundVarOpen = VarVar<AxisBoundaryType::Bound, AxisBoundaryType::Open>;
 using VarBoundVarClosed =
-    VarVar<Acts::AxisBoundaryType::Bound, Acts::AxisBoundaryType::Closed>;
-using VarOpenVarBound =
-    VarVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Bound>;
-using VarOpenVarOpen =
-    VarVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Open>;
+    VarVar<AxisBoundaryType::Bound, AxisBoundaryType::Closed>;
+using VarOpenVarBound = VarVar<AxisBoundaryType::Open, AxisBoundaryType::Bound>;
+using VarOpenVarOpen = VarVar<AxisBoundaryType::Open, AxisBoundaryType::Open>;
 using VarOpenVarClosed =
-    VarVar<Acts::AxisBoundaryType::Open, Acts::AxisBoundaryType::Closed>;
+    VarVar<AxisBoundaryType::Open, AxisBoundaryType::Closed>;
 using VarClosedVarBound =
-    VarVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Bound>;
+    VarVar<AxisBoundaryType::Closed, AxisBoundaryType::Bound>;
 using VarClosedVarOpen =
-    VarVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Open>;
+    VarVar<AxisBoundaryType::Closed, AxisBoundaryType::Open>;
 using VarClosedVarClosed =
-    VarVar<Acts::AxisBoundaryType::Closed, Acts::AxisBoundaryType::Closed>;
+    VarVar<AxisBoundaryType::Closed, AxisBoundaryType::Closed>;
 
 // Generate the possible axes in this case
 using PossibleAxes =

--- a/Core/include/Acts/Utilities/GridBinFinder.hpp
+++ b/Core/include/Acts/Utilities/GridBinFinder.hpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Utilities/Concepts.hpp"
 #include "Acts/Utilities/Grid.hpp"
-#include "Acts/Utilities/Holders.hpp"
 #include "Acts/Utilities/detail/grid_helper.hpp"
 
 #include <variant>
@@ -30,7 +29,7 @@ namespace Acts {
 template <std::size_t DIM>
 class GridBinFinder {
  public:
-  static constexpr std::size_t dimCubed = Acts::detail::ipow(3, DIM);
+  static constexpr std::size_t dimCubed = detail::ipow(3, DIM);
   /// @brief Constructor
   /// @tparam args ... Input parameters provided by the user
   ///
@@ -66,7 +65,7 @@ class GridBinFinder {
   template <typename stored_t, class... Axes>
   boost::container::small_vector<std::size_t, dimCubed> findBins(
       const std::array<std::size_t, DIM>& locPosition,
-      const Acts::Grid<stored_t, Axes...>& grid) const;
+      const Grid<stored_t, Axes...>& grid) const;
 
  private:
   /// @brief Store the values provided by the user for each axis in the grid
@@ -103,7 +102,7 @@ class GridBinFinder {
   /// @param [in] grid The Grid
   /// @return If the GridBinFinder is compatible with the grid
   template <typename stored_t, class... Axes>
-  bool isGridCompatible(const Acts::Grid<stored_t, Axes...>& grid) const;
+  bool isGridCompatible(const Grid<stored_t, Axes...>& grid) const;
 
  private:
   using stored_values_t =
@@ -122,4 +121,5 @@ class GridBinFinder {
 };
 
 }  // namespace Acts
+
 #include "Acts/Utilities/GridBinFinder.ipp"

--- a/Core/include/Acts/Utilities/GridBinFinder.ipp
+++ b/Core/include/Acts/Utilities/GridBinFinder.ipp
@@ -8,10 +8,11 @@
 
 #include <type_traits>
 
+namespace Acts {
+
 template <std::size_t DIM>
 template <typename first_value_t, typename... vals>
-void Acts::GridBinFinder<DIM>::storeValue(first_value_t&& fv,
-                                          vals&&... others) {
+void GridBinFinder<DIM>::storeValue(first_value_t&& fv, vals&&... others) {
   constexpr std::size_t N = sizeof...(vals);
   static_assert(N < DIM);
   /// Check the fist value is reasonable
@@ -36,7 +37,7 @@ void Acts::GridBinFinder<DIM>::storeValue(first_value_t&& fv,
 }
 
 template <std::size_t DIM>
-std::array<std::pair<int, int>, DIM> Acts::GridBinFinder<DIM>::getSizePerAxis(
+std::array<std::pair<int, int>, DIM> GridBinFinder<DIM>::getSizePerAxis(
     const std::array<std::size_t, DIM>& locPosition) const {
   std::array<std::pair<int, int>, DIM> output;
   for (std::size_t i(0ul); i < DIM; ++i) {
@@ -62,9 +63,9 @@ std::array<std::pair<int, int>, DIM> Acts::GridBinFinder<DIM>::getSizePerAxis(
 
 template <std::size_t DIM>
 template <typename stored_t, class... Axes>
-auto Acts::GridBinFinder<DIM>::findBins(
+auto GridBinFinder<DIM>::findBins(
     const std::array<std::size_t, DIM>& locPosition,
-    const Acts::Grid<stored_t, Axes...>& grid) const
+    const Grid<stored_t, Axes...>& grid) const
     -> boost::container::small_vector<std::size_t, dimCubed> {
   static_assert(sizeof...(Axes) == DIM);
   assert(isGridCompatible(grid));
@@ -75,8 +76,8 @@ auto Acts::GridBinFinder<DIM>::findBins(
 
 template <std::size_t DIM>
 template <typename stored_t, class... Axes>
-bool Acts::GridBinFinder<DIM>::isGridCompatible(
-    const Acts::Grid<stored_t, Axes...>& grid) const {
+bool GridBinFinder<DIM>::isGridCompatible(
+    const Grid<stored_t, Axes...>& grid) const {
   const std::array<std::size_t, DIM> nLocBins = grid.numLocalBins();
   for (std::size_t i(0ul); i < DIM; ++i) {
     std::size_t nBins = nLocBins[i];
@@ -97,3 +98,5 @@ bool Acts::GridBinFinder<DIM>::isGridCompatible(
   }
   return true;
 }
+
+}  // namespace Acts

--- a/Core/include/Acts/Utilities/GridIterator.hpp
+++ b/Core/include/Acts/Utilities/GridIterator.hpp
@@ -8,12 +8,16 @@
 
 #pragma once
 
-#include "Acts/Utilities/Grid.hpp"
 #include "Acts/Utilities/Holders.hpp"
 
 #include <array>
+#include <vector>
 
 namespace Acts {
+
+template <typename T, class... Axes>
+  requires(std::is_default_constructible_v<T> && !std::is_same_v<T, bool>)
+class Grid;
 
 /// @class GridGlobalIterator
 /// Grid iterator using the global position. This iterates on all
@@ -36,13 +40,13 @@ class GridGlobalIterator {
   /// @brief Constructor taking ownership of the grid is not allowed
   /// @param [in] grid The grid
   /// @param [in] idx The global bin
-  GridGlobalIterator(Acts::Grid<T, Axes...>&& grid, std::size_t idx) = delete;
+  GridGlobalIterator(Grid<T, Axes...>&& grid, std::size_t idx) = delete;
   /// @brief Constructor not taking ownership of the grid
   /// @param [in] grid The grid
   /// @param [in] idx The global bin
   ///
   /// @pre Global bin index must be a valid index for the grid
-  explicit GridGlobalIterator(const Acts::Grid<T, Axes...>& grid,
+  explicit GridGlobalIterator(const Grid<T, Axes...>& grid,
                               std::size_t idx = 0ul);
 
   /// @brief Copy constructor
@@ -133,7 +137,7 @@ class GridGlobalIterator {
   /// The iterator never takes ownership of the grid. If the grid gets
   /// invalidated (e.g. in a move operation) we can get undefined behaviours
   /// if the iterator gets used after being invalidated
-  Acts::detail::RefHolder<const Acts::Grid<T, Axes...>> m_grid{nullptr};
+  detail::RefHolder<const Grid<T, Axes...>> m_grid{nullptr};
   /// @brief The iteration index, corresponding to the global bin in the grid
   std::size_t m_idx{0ul};
 };
@@ -160,7 +164,7 @@ class GridLocalIterator {
   /// @brief Constructor taking ownership of the grid is not allowed
   /// @param [in] grid The grid
   /// @param [in] indices The local position
-  GridLocalIterator(Acts::Grid<T, Axes...>&& grid,
+  GridLocalIterator(Grid<T, Axes...>&& grid,
                     const std::array<std::size_t, DIM>& indices) = delete;
   /// @brief Constructor taking ownership of the grid is not allowed
   /// @param [in] grid The grid
@@ -168,16 +172,15 @@ class GridLocalIterator {
   /// @param [in] navigation The custom navigation pattern for each axis
   ///
   /// @pre None of the navigation vectors is allowed to be an empty vector
-  GridLocalIterator(Acts::Grid<T, Axes...>&& grid,
-                    const std::array<std::size_t, DIM>& indices,
-                    std::array<std::vector<std::size_t>, DIM> navigation) =
-      delete;
+  GridLocalIterator(
+      Grid<T, Axes...>&& grid, const std::array<std::size_t, DIM>& indices,
+      std::array<std::vector<std::size_t>, DIM> navigation) = delete;
   /// @brief Constructor
   /// @param [in] grid The grid
   /// @param [in] indices The local position
   ///
   /// @pre The local bins must be a valid local position in the grid
-  GridLocalIterator(const Acts::Grid<T, Axes...>& grid,
+  GridLocalIterator(const Grid<T, Axes...>& grid,
                     const std::array<std::size_t, DIM>& indices);
   /// @brief Constructor with custom navigation pattern
   /// @param [in] grid The grid
@@ -189,7 +192,7 @@ class GridLocalIterator {
   /// <= num bins in the axis) in the grid and have no repetitions.
   ///
   /// @pre None of the navigation vectors is allowed to be an empty vector
-  GridLocalIterator(const Acts::Grid<T, Axes...>& grid,
+  GridLocalIterator(const Grid<T, Axes...>& grid,
                     const std::array<std::size_t, DIM>& indices,
                     std::array<std::vector<std::size_t>, DIM> navigation);
 
@@ -221,7 +224,7 @@ class GridLocalIterator {
   /// @brief Equality operator
   /// @param [in] other The other GridLocalIterator to be compared against this one
   /// @return The result of the comparison
-  bool operator==(const Acts::GridLocalIterator<T, Axes...>& other) const;
+  bool operator==(const GridLocalIterator<T, Axes...>& other) const;
 
   /// @brief Return stored value at given local position
   /// @return The stored value in the grid from that given local position
@@ -257,7 +260,7 @@ class GridLocalIterator {
   /// The iterator never takes ownership of the grid. If the grid gets
   /// invalidated (e.g. in a move operation) we can get undefined behaviours
   /// if the iterator gets used after being invalidated
-  Acts::detail::RefHolder<const Acts::Grid<T, Axes...>> m_grid{nullptr};
+  detail::RefHolder<const Grid<T, Axes...>> m_grid{nullptr};
   /// @brief The maximum number of local bins in the grid. This does not include
   /// under- and over-flow bins
   std::array<std::size_t, DIM> m_numLocalBins{};
@@ -280,7 +283,7 @@ class GridLocalIterator {
 };
 
 template <typename T, class... Axes>
-GridGlobalIterator(const Acts::Grid<T, Axes...>& grid,
+GridGlobalIterator(const Grid<T, Axes...>& grid,
                    std::size_t idx) -> GridGlobalIterator<T, Axes...>;
 
 }  // namespace Acts

--- a/Core/include/Acts/Utilities/GridIterator.ipp
+++ b/Core/include/Acts/Utilities/GridIterator.ipp
@@ -12,8 +12,8 @@ namespace Acts {
 
 // Global Iterator
 template <typename T, class... Axes>
-GridGlobalIterator<T, Axes...>::GridGlobalIterator(
-    const Acts::Grid<T, Axes...>& grid, std::size_t idx)
+GridGlobalIterator<T, Axes...>::GridGlobalIterator(const Grid<T, Axes...>& grid,
+                                                   std::size_t idx)
     : m_grid(&grid), m_idx(idx) {}
 
 template <typename T, class... Axes>
@@ -114,9 +114,8 @@ GridGlobalIterator<T, Axes...>::localBinsIndices() const {
 
 // Local Iterator
 template <typename T, class... Axes>
-Acts::GridLocalIterator<T, Axes...>::GridLocalIterator(
-    const Acts::Grid<T, Axes...>& grid,
-    const std::array<std::size_t, DIM>& indices)
+GridLocalIterator<T, Axes...>::GridLocalIterator(
+    const Grid<T, Axes...>& grid, const std::array<std::size_t, DIM>& indices)
     : m_grid(&grid),
       m_numLocalBins(grid.numLocalBins()),
       m_currentIndex(indices) {
@@ -130,9 +129,8 @@ Acts::GridLocalIterator<T, Axes...>::GridLocalIterator(
 }
 
 template <typename T, class... Axes>
-Acts::GridLocalIterator<T, Axes...>::GridLocalIterator(
-    const Acts::Grid<T, Axes...>& grid,
-    const std::array<std::size_t, DIM>& indices,
+GridLocalIterator<T, Axes...>::GridLocalIterator(
+    const Grid<T, Axes...>& grid, const std::array<std::size_t, DIM>& indices,
     std::array<std::vector<std::size_t>, DIM> navigation)
     : m_grid(&grid),
       m_numLocalBins(grid.numLocalBins()),
@@ -160,17 +158,16 @@ Acts::GridLocalIterator<T, Axes...>::GridLocalIterator(
 }
 
 template <typename T, class... Axes>
-Acts::GridLocalIterator<T, Axes...>::GridLocalIterator(
-    Acts::GridLocalIterator<T, Axes...>&& other) noexcept
+GridLocalIterator<T, Axes...>::GridLocalIterator(
+    GridLocalIterator<T, Axes...>&& other) noexcept
     : m_grid(std::exchange(other.m_grid.ptr, nullptr)),
       m_numLocalBins(other.m_numLocalBins),
       m_currentIndex(other.m_currentIndex),
       m_navigationIndex(std::move(other.m_navigationIndex)) {}
 
 template <typename T, class... Axes>
-Acts::GridLocalIterator<T, Axes...>&
-Acts::GridLocalIterator<T, Axes...>::operator=(
-    Acts::GridLocalIterator<T, Axes...>&& other) noexcept {
+GridLocalIterator<T, Axes...>& GridLocalIterator<T, Axes...>::operator=(
+    GridLocalIterator<T, Axes...>&& other) noexcept {
   m_grid.ptr = std::exchange(other.m_grid.ptr, nullptr);
   m_numLocalBins = other.m_numLocalBins;
   m_currentIndex = other.m_currentIndex;
@@ -179,8 +176,8 @@ Acts::GridLocalIterator<T, Axes...>::operator=(
 }
 
 template <typename T, class... Axes>
-bool Acts::GridLocalIterator<T, Axes...>::operator==(
-    const Acts::GridLocalIterator<T, Axes...>& other) const {
+bool GridLocalIterator<T, Axes...>::operator==(
+    const GridLocalIterator<T, Axes...>& other) const {
   // This will always return false if we are comparing two iterators from
   // different grids.
   // As such a loop from itrStart (from grid A) to itrStop (from grid B) will
@@ -199,8 +196,8 @@ bool Acts::GridLocalIterator<T, Axes...>::operator==(
 }
 
 template <typename T, class... Axes>
-const typename Acts::GridLocalIterator<T, Axes...>::value_type&
-Acts::GridLocalIterator<T, Axes...>::operator*() const {
+const typename GridLocalIterator<T, Axes...>::value_type&
+GridLocalIterator<T, Axes...>::operator*() const {
   std::array<std::size_t, DIM> localPositionBin{};
   for (std::size_t i(0); i < DIM; ++i) {
     localPositionBin[i] = m_navigationIndex[i][m_currentIndex[i]];

--- a/Core/include/Acts/Utilities/detail/grid_helper.hpp
+++ b/Core/include/Acts/Utilities/detail/grid_helper.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Utilities/Axis.hpp"
 #include "Acts/Utilities/IAxis.hpp"
 


### PR DESCRIPTION
Proposal to clean up some of the `Grid` related code

- cleanup `#includes`
- remove duplicated `Acts::` namespaces
- add `namespace Acts {` to implementation
- improve `#include` chain for `Grid.hpp`
  - `Grid.hpp` now includes `GridIterator.hpp` not the other way around