### PR TITLE
fix: Zero remaining edges in TorchEdgeClassifier

### DIFF
--- a/Plugins/ExaTrkX/src/TorchEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/TorchEdgeClassifier.cpp
@@ -170,7 +170,7 @@ PipelineTensors TorchEdgeClassifier::operator()(
   torch::Tensor edgesAfterCut = edgeIndex.index({Slice(), mask});
   edgesAfterCut = edgesAfterCut.to(torch::kInt64);
 
-  if( edgesAfterCut.numel() == 0 ) {
+  if (edgesAfterCut.numel() == 0) {
     throw NoEdgesError{};
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling by detecting and reporting cases where no edges remain after filtering, preventing further processing in such scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->