### PR TITLE
docs: Align variable names with full_chain_odd.py

### DIFF
--- a/docs/examples/full_chain_odd.md
+++ b/docs/examples/full_chain_odd.md
@@ -8,12 +8,12 @@ The first step is to load the ODD detector description and to construct the dete
 
 ```python
 actsDir = pathlib.Path(__file__).parent.parent.parent.parent
-oddDir = getOpenDataDetectorDirectory()
+geoDir = getOpenDataDetectorDirectory()
 
-oddMaterialMap = oddDir / "data/odd-material-maps.root"
+oddMaterialMap = geoDir / "data/odd-material-maps.root"
 oddMaterialDeco = acts.IMaterialDecorator.fromFile(oddMaterialMap)
 
-detector = getOpenDataDetector(materialDecorator=oddMaterialDeco)
+detector = getOpenDataDetector(odd_dir=geoDir, materialDecorator=oddMaterialDeco)
 trackingGeometry = detector.trackingGeometry()
 decorators = detector.contextDecorators()
 ```


### PR DESCRIPTION
Updated example code snippet in documentation to match exact naming of linked script. This helps new users follow the code more easily when switching between the documentation and example script.

--- END COMMIT MESSAGE ---

Feel free to reject this. I'm just getting started with ACTS, and reading the docs. This is just a small nitpick I noticed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated example documentation to use clearer variable naming for directory paths and improved parameter specification in function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->