### PR TITLE
fix: Consistently use 2T field for seeding config

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderConfig.hpp
@@ -260,7 +260,7 @@ struct SeedFinderOptions {
   Acts::Vector2 beamPos{0 * Acts::UnitConstants::mm,
                         0 * Acts::UnitConstants::mm};
   // field induction
-  float bFieldInZ = 2.08 * Acts::UnitConstants::T;
+  float bFieldInZ = 2 * Acts::UnitConstants::T;
 
   // derived quantities
   float pTPerHelixRadius = std::numeric_limits<float>::quiet_NaN();


### PR DESCRIPTION
I don't see any good reason why we deviate from the usual 2 T field in the seeding config. This PR aligns the default which what we usually use in the code