### PR TITLE
fix: include guard protection for `HepMC3::WriterRootTree`

### DIFF
--- a/Examples/Io/HepMC3/src/HepMC3Writer.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Writer.cpp
@@ -87,7 +87,12 @@ std::unique_ptr<HepMC3::Writer> HepMC3Writer::createWriter(
       ACTS_ERROR("~~> Compression not supported for Root");
       throw std::invalid_argument("Compression not supported for Root");
     }
+#ifdef ACTS_HEPMC3_ROOT_SUPPORT
     return std::make_unique<HepMC3::WriterRootTree>(target);
+#else
+    ACTS_ERROR("~~> Root support not enabled in HepMC3");
+    throw std::runtime_error("Root support not enabled in HepMC3");
+#endif
   } else {
     std::filesystem::path path =
         target.string() +


### PR DESCRIPTION
There was a missing include guard protection.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
