### PR TITLE
fix: Make geo context ref in multiwire volume builder const

### DIFF
--- a/Core/include/Acts/Geometry/MultiWireVolumeBuilder.hpp
+++ b/Core/include/Acts/Geometry/MultiWireVolumeBuilder.hpp
@@ -48,7 +48,7 @@ class MultiWireVolumeBuilder {
   /// @brief Constructs the tracking volume with the wrapped surfaces
   /// @return a unique ptr of the tracking volume
   std::unique_ptr<Acts::TrackingVolume> buildVolume(
-      Acts::GeometryContext& gctx) const;
+      const Acts::GeometryContext& gctx) const;
 
  private:
   Config m_config;

--- a/Core/src/Geometry/MultiWireVolumeBuilder.cpp
+++ b/Core/src/Geometry/MultiWireVolumeBuilder.cpp
@@ -34,7 +34,7 @@ MultiWireVolumeBuilder::MultiWireVolumeBuilder(
 }
 
 std::unique_ptr<TrackingVolume> MultiWireVolumeBuilder::buildVolume(
-    GeometryContext& gctx) const {
+    const GeometryContext& gctx) const {
   // Create the tracking volume
 
   ACTS_VERBOSE("Building a tracking volume with name "


### PR DESCRIPTION
PLEASE DESCRIBE YOUR CHANGES.
THIS MESSAGE ENDS UP AS THE COMMIT MESSAGE.
DO NOT USE @-MENTIONS HERE!

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved method parameter handling to ensure certain inputs remain unmodified during processing. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->