### PR TITLE
refactor: TrivialPortalLink -> don't check on-surface in Release

### DIFF
--- a/Core/src/Geometry/TrivialPortalLink.cpp
+++ b/Core/src/Geometry/TrivialPortalLink.cpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Geometry/GridPortalLink.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
-#include "Acts/Utilities/ThrowAssert.hpp"
 
 #include <memory>
 
@@ -33,9 +32,9 @@ Result<const TrackingVolume*> TrivialPortalLink::resolveVolume(
   static_cast<void>(gctx);
   static_cast<void>(position);
   static_cast<void>(tolerance);
-  throw_assert(m_surface->isOnSurface(gctx, position, BoundaryTolerance::None(),
-                                      tolerance),
-               "Trivial portal lookup point should be on surface");
+  assert(m_surface->isOnSurface(gctx, position, BoundaryTolerance::None(),
+                                tolerance) &&
+         "Trivial portal lookup point should be on surface");
   return m_volume;
 }
 


### PR DESCRIPTION
Downgrade from a `throw_assert` to a plain `assert`. This showed up in the navigation profile for https://github.com/acts-project/acts/pull/4219/

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
