### PR TITLE
refactor: NavStream uses emplace correctly, can be reset

### DIFF
--- a/Core/include/Acts/Navigation/NavigationStream.hpp
+++ b/Core/include/Acts/Navigation/NavigationStream.hpp
@@ -171,6 +171,8 @@ class NavigationStream {
               const NavigationStream::QueryPoint& queryPoint,
               double onSurfaceTolerance = s_onSurfaceTolerance);
 
+  void reset();
+
  private:
   /// The candidates of this navigation stream
   std::vector<Candidate> m_candidates;

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -39,13 +39,6 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
     if (size == 1) {
       sIntersection = multiIntersection[0];
     } else if (size == 2) {
-      if (surface->type() == Surface::Plane) {
-        std::cout << "Multiple intersections (" << multiIntersection.size()
-                  << ") on planar surface (WEIRD): " << surface->toStream(gctx)
-                  << std::endl;
-        std::terminate();
-      }
-
       // Split them into valid intersections, keep track of potentially
       // additional candidates
       bool originalCandidateUpdated = false;

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -31,14 +31,17 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
     // Get the surface from the object intersection
     const Surface* surface = sIntersection.object();
     // Intersect the surface
+    std::cout << "SURFACE: " << surface->toStream(gctx) << std::endl;
     auto multiIntersection = surface->intersect(gctx, position, direction,
                                                 cTolerance, onSurfaceTolerance);
 
-    std::size_t size = (multiIntersection[0].isValid() ? 1 : 0) +
-                       (multiIntersection[1].isValid() ? 1 : 0);
-    if (size == 1) {
+    bool firstValid = multiIntersection[0].isValid();
+    bool secondValid = multiIntersection[1].isValid();
+    if (firstValid && !secondValid) {
       sIntersection = multiIntersection[0];
-    } else if (size == 2) {
+    } else if (!firstValid && secondValid) {
+      sIntersection = multiIntersection[1];
+    } else {
       // Split them into valid intersections, keep track of potentially
       // additional candidates
       bool originalCandidateUpdated = false;


### PR DESCRIPTION
This should improve the handling of surface intersection in the navigation stream a bit. See https://github.com/acts-project/acts/pull/4219

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
