### PR TITLE
chore: Update Geomodel version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ set(_acts_doxygen_version 1.9.4)
 set(_acts_hepmc3_version 3.2.4)
 set(_acts_nlohmanjson_version 3.10.5)
 set(_acts_onnxruntime_version 1.12.0)
-set(_acts_geomodel_version 6.13.0)
+set(_acts_geomodel_version 6.14.0)
 set(_acts_root_version 6.28.04) # first version with C++20 support
 set(_acts_tbb_version 2020.1)
 set(_acts_pythia8_version 8.310)


### PR DESCRIPTION
Update GeoModel to the lateset 6.14 release

--- END COMMIT MESSAGE ---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the minimum required version of the GeoModel dependency to 6.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->