### PR TITLE
docs: Fix documentation typos

### DIFF
--- a/Core/include/Acts/Geometry/CylinderPortalShell.hpp
+++ b/Core/include/Acts/Geometry/CylinderPortalShell.hpp
@@ -102,7 +102,7 @@ class SingleCylinderPortalShell : public CylinderPortalShell {
 /// the stacking. Depending on the direction, portals on the shells of children
 /// are merged or fused. Subsequently, portal access respects shared portals
 /// between shells. Below is an illustration of a stack in the r direction:
-///
+/// ```
 ///  Fused         +-----------------+
 /// portals ----+  |                 |
 ///   |         |  v           OuterCylinder
@@ -122,7 +122,7 @@ class SingleCylinderPortalShell : public CylinderPortalShell {
 ///   +----->      ^            (if rMin>0)
 ///          z     |                 |
 ///                +-----------------+
-///
+/// ```
 /// @note The shells must be ordered in the given direction
 /// Depending on the stack direction, the portal lookup will return different
 /// portals. In the illustration above, the `PositiveDisc` portal is shared

--- a/Core/include/Acts/Geometry/GridPortalLink.hpp
+++ b/Core/include/Acts/Geometry/GridPortalLink.hpp
@@ -115,7 +115,7 @@ class GridPortalLink : public PortalLinkBase {
       AxisDirection direction);
 
   /// Merge two grid portal links into a single one. The routine can merge
-  /// one-dimenaional, two-dimensional and mixed links. The merge will try to
+  /// one-dimensional, two-dimensional and mixed links. The merge will try to
   /// preserve equidistant binning in case bin widths match. Otherwise, the
   /// merge falls back to variable binning.
   ///

--- a/Core/include/Acts/Geometry/GridPortalLink.hpp
+++ b/Core/include/Acts/Geometry/GridPortalLink.hpp
@@ -115,7 +115,7 @@ class GridPortalLink : public PortalLinkBase {
       AxisDirection direction);
 
   /// Merge two grid portal links into a single one. The routine can merge
-  /// one-dimenaional, tow-dimensional and mixed links. The merge will try to
+  /// one-dimenaional, two-dimensional and mixed links. The merge will try to
   /// preserve equidistant binning in case bin widths match. Otherwise, the
   /// merge falls back to variable binning.
   ///

--- a/Core/include/Acts/Geometry/PortalShell.hpp
+++ b/Core/include/Acts/Geometry/PortalShell.hpp
@@ -27,7 +27,7 @@ class GeometryContext;
 /// This class is the base class for all portal shells
 class PortalShellBase {
  public:
-  /// Virtusl destructor
+  /// Virtual destructor
   virtual ~PortalShellBase() = default;
 
   /// Fill the open slots of the shell with a @c TrivialPortalLink


### PR DESCRIPTION
Small fixes to `GridPortalLink`, `PortalShell`, and `CylinderStackPortalShell` docs.

--- END COMMIT MESSAGE ---

I am just reading through docs, and getting myself familiar with ACTS.
Feel free to ignore/close this, I'm just fixing small nitpicks I notice as I go through the docs sporadically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of an ASCII art diagram in the documentation for better clarity.
  * Corrected typographical errors in comments to enhance readability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->