### PR TITLE
fix: inline Mutable to Const PodioTrackStateContainer c'tor

### DIFF
--- a/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
+++ b/Plugins/Podio/include/Acts/Plugins/Podio/PodioTrackStateContainer.hpp
@@ -731,7 +731,7 @@ static_assert(MutableMultiTrajectoryBackend<MutablePodioTrackStateContainer>,
               "MutablePodioTrackStateContainer does not fulfill "
               "TrackStateContainerBackend");
 
-ConstPodioTrackStateContainer::ConstPodioTrackStateContainer(
+inline ConstPodioTrackStateContainer::ConstPodioTrackStateContainer(
     const MutablePodioTrackStateContainer& other)
     : m_helper{other.m_helper},
       m_collection{other.m_collection.get()},


### PR DESCRIPTION
This PR resolves a multiple definition error in downstream code when including the `PodioTrackStateContainer.hpp` header in multiple source files.

--- END COMMIT MESSAGE ---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of the container's constructor for better maintainability. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->