### PR TITLE
chore: moved material decorator

### DIFF
--- a/Examples/Io/Root/CMakeLists.txt
+++ b/Examples/Io/Root/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(
     ActsExamplesIoRoot
     SHARED
     src/RootMeasurementWriter.cpp
-    src/RootMaterialDecorator.cpp
     src/RootMaterialWriter.cpp
     src/RootMaterialTrackReader.cpp
     src/RootMaterialTrackWriter.cpp

--- a/Examples/Python/src/RootInput.cpp
+++ b/Examples/Python/src/RootInput.cpp
@@ -7,9 +7,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/Plugins/Python/Utilities.hpp"
+#include "Acts/Plugins/Root/RootMaterialDecorator.hpp"
 #include "ActsExamples/Io/Root/RootAthenaDumpReader.hpp"
 #include "ActsExamples/Io/Root/RootAthenaNTupleReader.hpp"
-#include "ActsExamples/Io/Root/RootMaterialDecorator.hpp"
 #include "ActsExamples/Io/Root/RootMaterialTrackReader.hpp"
 #include "ActsExamples/Io/Root/RootParticleReader.hpp"
 #include "ActsExamples/Io/Root/RootSimHitReader.hpp"
@@ -71,15 +71,14 @@ void addRootInput(Context& ctx) {
                              outputSimHits);
 
   {
-    auto rmd =
-        py::class_<RootMaterialDecorator, Acts::IMaterialDecorator,
-                   std::shared_ptr<RootMaterialDecorator>>(
-            mex, "RootMaterialDecorator")
-            .def(
-                py::init<RootMaterialDecorator::Config, Acts::Logging::Level>(),
-                py::arg("config"), py::arg("level"));
+    auto rmd = py::class_<Acts::RootMaterialDecorator, Acts::IMaterialDecorator,
+                          std::shared_ptr<Acts::RootMaterialDecorator>>(
+                   mex, "RootMaterialDecorator")
+                   .def(py::init<Acts::RootMaterialDecorator::Config,
+                                 Acts::Logging::Level>(),
+                        py::arg("config"), py::arg("level"));
 
-    using Config = RootMaterialDecorator::Config;
+    using Config = Acts::RootMaterialDecorator::Config;
     auto c = py::class_<Config>(rmd, "Config").def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, voltag, boutag, laytag, apptag, sentag, ntag, vtag,

--- a/Plugins/Root/CMakeLists.txt
+++ b/Plugins/Root/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(library_sources
+    src/RootMaterialDecorator.cpp
     src/RootMaterialTrackAccessor.cpp
     src/TGeoCylinderDiscSplitter.cpp
     src/TGeoDetectorElement.cpp

--- a/Plugins/Root/include/Acts/Plugins/Root/RootMaterialDecorator.hpp
+++ b/Plugins/Root/include/Acts/Plugins/Root/RootMaterialDecorator.hpp
@@ -8,21 +8,18 @@
 
 #pragma once
 
-#include "ActsExamples/Framework/ProcessCode.hpp"
-#include <Acts/Definitions/Algebra.hpp>
-#include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <Acts/Geometry/TrackingVolume.hpp>
-#include <Acts/Material/IMaterialDecorator.hpp>
-#include <Acts/Material/ISurfaceMaterial.hpp>
-#include <Acts/Material/IVolumeMaterial.hpp>
-#include <Acts/Surfaces/Surface.hpp>
-#include <Acts/Utilities/Logger.hpp>
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Geometry/TrackingVolume.hpp"
+#include "Acts/Material/IMaterialDecorator.hpp"
+#include "Acts/Material/ISurfaceMaterial.hpp"
+#include "Acts/Material/IVolumeMaterial.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Logger.hpp"
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
-#include <utility>
 
 class TFile;
 
@@ -35,14 +32,11 @@ using SurfaceMaterialMap =
 using VolumeMaterialMap =
     std::map<GeometryIdentifier, std::shared_ptr<const IVolumeMaterial>>;
 using DetectorMaterialMaps = std::pair<SurfaceMaterialMap, VolumeMaterialMap>;
-}  // namespace Acts
-
-namespace ActsExamples {
 
 /// @class RootMaterialDecorator
 ///
 /// @brief Read the collection of SurfaceMaterial & VolumeMaterial
-class RootMaterialDecorator : public Acts::IMaterialDecorator {
+class RootMaterialDecorator : public IMaterialDecorator {
  public:
   /// @class Config
   /// Configuration of the Reader
@@ -91,7 +85,7 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   /// Constructor
   ///
   /// @param cfg configuration struct for the reader
-  RootMaterialDecorator(const Config& config, Acts::Logging::Level level);
+  RootMaterialDecorator(const Config& config, Logging::Level level);
 
   /// Destructor
   ~RootMaterialDecorator() override;
@@ -99,7 +93,7 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   /// Decorate a surface
   ///
   /// @param surface the non-cost surface that is decorated
-  void decorate(Acts::Surface& surface) const final {
+  void decorate(Surface& surface) const final {
     // Null out the material for this surface
     if (m_clearSurfaceMaterial) {
       surface.assignSurfaceMaterial(nullptr);
@@ -114,7 +108,7 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   /// Decorate a TrackingVolume
   ///
   /// @param volume the non-cost volume that is decorated
-  void decorate(Acts::TrackingVolume& volume) const final {
+  void decorate(TrackingVolume& volume) const final {
     // Null out the material for this volume
     if (m_clearSurfaceMaterial) {
       volume.assignVolumeMaterial(nullptr);
@@ -127,7 +121,7 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   }
 
   /// Return the maps
-  const Acts::DetectorMaterialMaps materialMaps() const {
+  const DetectorMaterialMaps materialMaps() const {
     return {m_surfaceMaterialMap, m_volumeMaterialMap};
   }
 
@@ -138,21 +132,21 @@ class RootMaterialDecorator : public Acts::IMaterialDecorator {
   /// The config class
   Config m_cfg;
 
-  std::unique_ptr<const Acts::Logger> m_logger{nullptr};
+  std::unique_ptr<const Logger> m_logger{nullptr};
 
   /// The input file
   TFile* m_inputFile{nullptr};
 
   /// Surface based material
-  Acts::SurfaceMaterialMap m_surfaceMaterialMap;
+  SurfaceMaterialMap m_surfaceMaterialMap;
 
   /// Volume based material
-  Acts::VolumeMaterialMap m_volumeMaterialMap;
+  VolumeMaterialMap m_volumeMaterialMap;
 
   bool m_clearSurfaceMaterial{true};
 
   /// Private access to the logging instance
-  const Acts::Logger& logger() const { return *m_logger; }
+  const Logger& logger() const { return *m_logger; }
 };
 
-}  // namespace ActsExamples
+}  // namespace Acts

--- a/Plugins/Root/src/RootMaterialDecorator.cpp
+++ b/Plugins/Root/src/RootMaterialDecorator.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "ActsExamples/Io/Root/RootMaterialDecorator.hpp"
+#include "Acts/Plugins/Root/RootMaterialDecorator.hpp"
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Material/InterpolatedMaterialMap.hpp"
@@ -15,18 +15,16 @@
 #include "Acts/Material/MaterialSlab.hpp"
 #include "Acts/Utilities/Grid.hpp"
 #include "Acts/Utilities/Logger.hpp"
-#include <Acts/Geometry/GeometryIdentifier.hpp>
-#include <Acts/Material/BinnedSurfaceMaterial.hpp>
-#include <Acts/Material/HomogeneousSurfaceMaterial.hpp>
-#include <Acts/Material/HomogeneousVolumeMaterial.hpp>
-#include <Acts/Utilities/AxisDefinitions.hpp>
-#include <Acts/Utilities/BinUtility.hpp>
-#include <Acts/Utilities/BinningType.hpp>
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Material/BinnedSurfaceMaterial.hpp"
+#include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
+#include "Acts/Material/HomogeneousVolumeMaterial.hpp"
+#include "Acts/Utilities/AxisDefinitions.hpp"
+#include "Acts/Utilities/BinUtility.hpp"
+#include "Acts/Utilities/BinningType.hpp"
 
 #include <algorithm>
-#include <cstdio>
 #include <functional>
-#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -43,16 +41,12 @@
 #include <boost/algorithm/string/finder.hpp>
 #include <boost/algorithm/string/iter_find.hpp>
 
-namespace Acts {
-class ISurfaceMaterial;
-class IVolumeMaterial;
-}  // namespace Acts
 
-ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
-    const ActsExamples::RootMaterialDecorator::Config& config,
-    Acts::Logging::Level level)
+Acts::RootMaterialDecorator::RootMaterialDecorator(
+    const Acts::RootMaterialDecorator::Config& config,
+    Logging::Level level)
     : m_cfg(config),
-      m_logger{Acts::getDefaultLogger("RootMaterialDecorator", level)} {
+      m_logger{getDefaultLogger("RootMaterialDecorator", level)} {
   // Validate the configuration
   if (m_cfg.folderSurfaceNameBase.empty()) {
     throw std::invalid_argument("Missing surface folder name base");
@@ -87,32 +81,32 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
     // Surface Material
     if (splitNames[0] == m_cfg.folderSurfaceNameBase) {
       // The surface material to be read in for this
-      std::shared_ptr<const Acts::ISurfaceMaterial> sMaterial = nullptr;
+      std::shared_ptr<const ISurfaceMaterial> sMaterial = nullptr;
 
       boost::split(splitNames, splitNames[1], boost::is_any_of("_"));
-      Acts::GeometryIdentifier::Value volID = std::stoi(splitNames[0]);
+      GeometryIdentifier::Value volID = std::stoi(splitNames[0]);
       // boundary
       iter_split(splitNames, tdName,
                  boost::algorithm::first_finder(m_cfg.boutag));
       boost::split(splitNames, splitNames[1], boost::is_any_of("_"));
-      Acts::GeometryIdentifier::Value bouID = std::stoi(splitNames[0]);
+      GeometryIdentifier::Value bouID = std::stoi(splitNames[0]);
       // layer
       iter_split(splitNames, tdName,
                  boost::algorithm::first_finder(m_cfg.laytag));
       boost::split(splitNames, splitNames[1], boost::is_any_of("_"));
-      Acts::GeometryIdentifier::Value layID = std::stoi(splitNames[0]);
+      GeometryIdentifier::Value layID = std::stoi(splitNames[0]);
       // approach
       iter_split(splitNames, tdName,
                  boost::algorithm::first_finder(m_cfg.apptag));
       boost::split(splitNames, splitNames[1], boost::is_any_of("_"));
-      Acts::GeometryIdentifier::Value appID = std::stoi(splitNames[0]);
+      GeometryIdentifier::Value appID = std::stoi(splitNames[0]);
       // sensitive
       iter_split(splitNames, tdName,
                  boost::algorithm::first_finder(m_cfg.sentag));
-      Acts::GeometryIdentifier::Value senID = std::stoi(splitNames[1]);
+      GeometryIdentifier::Value senID = std::stoi(splitNames[1]);
 
       // Reconstruct the geometry ID
-      auto geoID = Acts::GeometryIdentifier()
+      auto geoID = GeometryIdentifier()
                        .withVolume(volID)
                        .withBoundary(bouID)
                        .withLayer(layID)
@@ -156,9 +150,9 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
         int nbins1 = t->GetNbinsY();
 
         // The material matrix
-        Acts::MaterialSlabMatrix materialMatrix(
+        MaterialSlabMatrix materialMatrix(
             nbins1,
-            Acts::MaterialSlabVector(nbins0, Acts::MaterialSlab::Nothing()));
+            MaterialSlabVector(nbins0, MaterialSlab::Nothing()));
 
         // We need binned material properties
         if (nbins0 * nbins1 > 1) {
@@ -174,27 +168,27 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
                 double drho = rho->GetBinContent(ib0, ib1);
                 // Create material properties
                 const auto material =
-                    Acts::Material::fromMassDensity(dx0, dl0, da, dz, drho);
+                    Material::fromMassDensity(dx0, dl0, da, dz, drho);
                 materialMatrix[ib1 - 1][ib0 - 1] =
-                    Acts::MaterialSlab(material, dt);
+                    MaterialSlab(material, dt);
               }
             }
           }
 
           // Now reconstruct the bin untilities
-          Acts::BinUtility bUtility;
+          BinUtility bUtility;
           for (int ib = 1; ib < n->GetNbinsX() + 1; ++ib) {
             std::size_t nbins = static_cast<std::size_t>(n->GetBinContent(ib));
-            auto val = static_cast<Acts::AxisDirection>(v->GetBinContent(ib));
-            auto opt = static_cast<Acts::BinningOption>(o->GetBinContent(ib));
+            auto val = static_cast<AxisDirection>(v->GetBinContent(ib));
+            auto opt = static_cast<BinningOption>(o->GetBinContent(ib));
             float rmin = min->GetBinContent(ib);
             float rmax = max->GetBinContent(ib);
-            bUtility += Acts::BinUtility(nbins, rmin, rmax, opt, val);
+            bUtility += BinUtility(nbins, rmin, rmax, opt, val);
           }
           ACTS_VERBOSE("Created " << bUtility);
 
           // Construct the binned material with the right bin utility
-          sMaterial = std::make_shared<const Acts::BinnedSurfaceMaterial>(
+          sMaterial = std::make_shared<const BinnedSurfaceMaterial>(
               bUtility, std::move(materialMatrix));
 
         } else {
@@ -207,9 +201,9 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
           double drho = rho->GetBinContent(1, 1);
           // Create and set the homogeneous surface material
           const auto material =
-              Acts::Material::fromMassDensity(dx0, dl0, da, dz, drho);
-          sMaterial = std::make_shared<const Acts::HomogeneousSurfaceMaterial>(
-              Acts::MaterialSlab(material, dt));
+              Material::fromMassDensity(dx0, dl0, da, dz, drho);
+          sMaterial = std::make_shared<const HomogeneousSurfaceMaterial>(
+              MaterialSlab(material, dt));
         }
       }
       ACTS_VERBOSE("Successfully read Material for : " << geoID);
@@ -219,13 +213,13 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
 
     } else if (splitNames[0] == m_cfg.folderVolumeNameBase) {
       // The volume material to be read in for this
-      std::shared_ptr<const Acts::IVolumeMaterial> vMaterial = nullptr;
+      std::shared_ptr<const IVolumeMaterial> vMaterial = nullptr;
       // Volume key
       boost::split(splitNames, splitNames[1], boost::is_any_of("_"));
-      Acts::GeometryIdentifier::Value volID = std::stoi(splitNames[0]);
+      GeometryIdentifier::Value volID = std::stoi(splitNames[0]);
 
       // Reconstruct the geometry ID
-      auto geoID = Acts::GeometryIdentifier().withVolume(volID);
+      auto geoID = GeometryIdentifier().withVolume(volID);
       ACTS_VERBOSE("GeometryIdentifier re-constructed as " << geoID);
 
       // Construct the names
@@ -264,33 +258,33 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
           // Dimension of the grid
           int dim = n->GetNbinsX();
           // Now reconstruct the bin untilities
-          Acts::BinUtility bUtility;
+          BinUtility bUtility;
           for (int ib = 1; ib < dim + 1; ++ib) {
             std::size_t nbins = static_cast<std::size_t>(n->GetBinContent(ib));
-            Acts::AxisDirection val =
-                static_cast<Acts::AxisDirection>(v->GetBinContent(ib));
-            Acts::BinningOption opt =
-                static_cast<Acts::BinningOption>(o->GetBinContent(ib));
+            AxisDirection val =
+                static_cast<AxisDirection>(v->GetBinContent(ib));
+            BinningOption opt =
+                static_cast<BinningOption>(o->GetBinContent(ib));
             float rmin = min->GetBinContent(ib);
             float rmax = max->GetBinContent(ib);
-            bUtility += Acts::BinUtility(nbins, rmin, rmax, opt, val);
+            bUtility += BinUtility(nbins, rmin, rmax, opt, val);
           }
           ACTS_VERBOSE("Created " << bUtility);
 
           if (dim == 2) {
             // 2D Grid material
-            std::function<Acts::Vector2(Acts::Vector3)> transfoGlobalToLocal;
-            Acts::Grid2D grid = createGrid2D(bUtility, transfoGlobalToLocal);
+            std::function<Vector2(Vector3)> transfoGlobalToLocal;
+            Grid2D grid = createGrid2D(bUtility, transfoGlobalToLocal);
 
-            Acts::Grid2D::point_t gMin = grid.minPosition();
-            Acts::Grid2D::point_t gMax = grid.maxPosition();
-            Acts::Grid2D::index_t gNBins = grid.numLocalBins();
+            Grid2D::point_t gMin = grid.minPosition();
+            Grid2D::point_t gMax = grid.maxPosition();
+            Grid2D::index_t gNBins = grid.numLocalBins();
 
-            Acts::EAxis axis1(gMin[0], gMax[0], gNBins[0]);
-            Acts::EAxis axis2(gMin[1], gMax[1], gNBins[1]);
+            EAxis axis1(gMin[0], gMax[0], gNBins[0]);
+            EAxis axis2(gMin[1], gMax[1], gNBins[1]);
 
             // Build the grid and fill it with data
-            Acts::MaterialGrid2D mGrid(std::make_tuple(axis1, axis2));
+            MaterialGrid2D mGrid(std::make_tuple(axis1, axis2));
 
             for (int p = 1; p <= points; p++) {
               double dx0 = x0->GetBinContent(p);
@@ -300,29 +294,29 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
               double drho = rho->GetBinContent(p);
               // Create material properties
               const auto material =
-                  Acts::Material::fromMassDensity(dx0, dl0, da, dz, drho);
+                  Material::fromMassDensity(dx0, dl0, da, dz, drho);
               mGrid.at(p - 1) = material.parameters();
             }
-            Acts::MaterialMapper<Acts::MaterialGrid2D> matMap(
+            MaterialMapper<MaterialGrid2D> matMap(
                 transfoGlobalToLocal, mGrid);
-            vMaterial = std::make_shared<Acts::InterpolatedMaterialMap<
-                Acts::MaterialMapper<Acts::MaterialGrid2D>>>(std::move(matMap),
+            vMaterial = std::make_shared<InterpolatedMaterialMap<
+                MaterialMapper<MaterialGrid2D>>>(std::move(matMap),
                                                              bUtility);
           } else if (dim == 3) {
             // 3D Grid material
-            std::function<Acts::Vector3(Acts::Vector3)> transfoGlobalToLocal;
-            Acts::Grid3D grid = createGrid3D(bUtility, transfoGlobalToLocal);
+            std::function<Vector3(Vector3)> transfoGlobalToLocal;
+            Grid3D grid = createGrid3D(bUtility, transfoGlobalToLocal);
 
-            Acts::Grid3D::point_t gMin = grid.minPosition();
-            Acts::Grid3D::point_t gMax = grid.maxPosition();
-            Acts::Grid3D::index_t gNBins = grid.numLocalBins();
+            Grid3D::point_t gMin = grid.minPosition();
+            Grid3D::point_t gMax = grid.maxPosition();
+            Grid3D::index_t gNBins = grid.numLocalBins();
 
-            Acts::EAxis axis1(gMin[0], gMax[0], gNBins[0]);
-            Acts::EAxis axis2(gMin[1], gMax[1], gNBins[1]);
-            Acts::EAxis axis3(gMin[2], gMax[2], gNBins[2]);
+            EAxis axis1(gMin[0], gMax[0], gNBins[0]);
+            EAxis axis2(gMin[1], gMax[1], gNBins[1]);
+            EAxis axis3(gMin[2], gMax[2], gNBins[2]);
 
             // Build the grid and fill it with data
-            Acts::MaterialGrid3D mGrid(std::make_tuple(axis1, axis2, axis3));
+            MaterialGrid3D mGrid(std::make_tuple(axis1, axis2, axis3));
 
             for (int p = 1; p <= points; p++) {
               double dx0 = x0->GetBinContent(p);
@@ -332,13 +326,13 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
               double drho = rho->GetBinContent(p);
               // Create material properties
               const auto material =
-                  Acts::Material::fromMassDensity(dx0, dl0, da, dz, drho);
+                  Material::fromMassDensity(dx0, dl0, da, dz, drho);
               mGrid.at(p - 1) = material.parameters();
             }
-            Acts::MaterialMapper<Acts::MaterialGrid3D> matMap(
+            MaterialMapper<MaterialGrid3D> matMap(
                 transfoGlobalToLocal, mGrid);
-            vMaterial = std::make_shared<Acts::InterpolatedMaterialMap<
-                Acts::MaterialMapper<Acts::MaterialGrid3D>>>(std::move(matMap),
+            vMaterial = std::make_shared<InterpolatedMaterialMap<
+                MaterialMapper<MaterialGrid3D>>>(std::move(matMap),
                                                              bUtility);
           }
         } else {
@@ -350,9 +344,9 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
           double drho = rho->GetBinContent(1);
           // Create material properties
           const auto material =
-              Acts::Material::fromMassDensity(dx0, dl0, da, dz, drho);
+              Material::fromMassDensity(dx0, dl0, da, dz, drho);
           vMaterial =
-              std::make_shared<Acts::HomogeneousVolumeMaterial>(material);
+              std::make_shared<HomogeneousVolumeMaterial>(material);
         }
       }
       ACTS_VERBOSE("Successfully read Material for : " << geoID);
@@ -368,7 +362,7 @@ ActsExamples::RootMaterialDecorator::RootMaterialDecorator(
   }
 }
 
-ActsExamples::RootMaterialDecorator::~RootMaterialDecorator() {
+Acts::RootMaterialDecorator::~RootMaterialDecorator() {
   if (m_inputFile != nullptr) {
     m_inputFile->Close();
   }


### PR DESCRIPTION
This PR makes the ROOT based material decorator accessible through the `Root` plugin instead of the `Examples/Io/Root` directory and hence allows clients to use it w/o relying on the examples to be built.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
