### PR TITLE
refactor: PodioReader uses scoped timer

### DIFF
--- a/Examples/Io/Podio/src/PodioReader.cpp
+++ b/Examples/Io/Podio/src/PodioReader.cpp
@@ -9,6 +9,7 @@
 #include "ActsExamples/Io/Podio/PodioReader.hpp"
 
 #include "Acts/Plugins/Podio/PodioUtil.hpp"
+#include "Acts/Utilities/ScopedTimer.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 
 #include <filesystem>
@@ -65,7 +66,8 @@ PodioReader::PodioReader(const Config& config, Acts::Logging::Level level)
 PodioReader::~PodioReader() = default;
 
 ProcessCode PodioReader::read(const AlgorithmContext& context) {
-  ACTS_DEBUG("Reading EDM4hep inputs");
+  Acts::ScopedTimer timer("Reading PODIO inputs", logger(),
+                          Acts::Logging::DEBUG);
   podio::Frame frame = m_impl->reader().readEntry(
       m_impl->m_cfg.category, static_cast<unsigned int>(context.eventNumber));
   m_impl->m_frameWriteHandle(context, std::move(frame));


### PR DESCRIPTION
Add timing to the read method of PODIO reader.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
