### PR TITLE
refactor: Timer utility: use nanoseconds internally

### DIFF
--- a/Core/include/Acts/Utilities/ScopedTimer.hpp
+++ b/Core/include/Acts/Utilities/ScopedTimer.hpp
@@ -11,8 +11,6 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <chrono>
-#include <iostream>
-#include <ratio>
 
 namespace Acts {
 

--- a/Core/include/Acts/Utilities/ScopedTimer.hpp
+++ b/Core/include/Acts/Utilities/ScopedTimer.hpp
@@ -12,6 +12,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <ratio>
 
 namespace Acts {
 
@@ -119,8 +120,8 @@ class AveragingScopedTimer {
  private:
   /// @brief Add a timing sample to the statistics
   ///
-  /// @param duration Duration of the sample in milliseconds
-  void addSample(std::chrono::milliseconds duration);
+  /// @param duration Duration of the sample in nanoseconds
+  void addSample(std::chrono::nanoseconds duration);
 
   double m_sumDuration = 0;  ///< Sum of all sample durations
   double m_sumDurationSquared =


### PR DESCRIPTION
Use nanoseconds in timer utility to get useful outputs out of the averaging timers.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
