### PR TITLE
fix: store also empty Hough vertex collection

### DIFF
--- a/Examples/Algorithms/Vertexing/src/HoughVertexFinderAlgorithm.cpp
+++ b/Examples/Algorithms/Vertexing/src/HoughVertexFinderAlgorithm.cpp
@@ -65,6 +65,10 @@ ProcessCode HoughVertexFinderAlgorithm::execute(
   } else {
     ACTS_INFO("Not found a vertex in the event after "
               << (t2 - t1).count() / 1e6 << " ms");
+
+    // store empty container
+    std::vector<Acts::Vertex> vertexCollection;
+    m_outputVertices(ctx, std::move(vertexCollection));
   }
 
   return ProcessCode::SUCCESS;


### PR DESCRIPTION
store also empty collection

--- END COMMIT MESSAGE ---

In rare cases when `HoughVertexFinder` does not find any vertex (e.g. because of low multiplicity of the event), the `HoughVertexFinderAlgorithm` skipped saving anything.
If there's any other algorithm that uses this output, it can't find the collection and complains loudly.

This PR fixes it by saving empty collection.