### PR TITLE
ci: Reraise exception in lockfile selection

### DIFF
--- a/CI/dependencies/select_lockfile.py
+++ b/CI/dependencies/select_lockfile.py
@@ -151,10 +151,10 @@ def fetch_github(base_url: str, cache_dir: Optional[Path], cache_limit: int) -> 
                 return content
         except urllib.error.URLError as e:
             print(f"Failed to fetch from {base_url}: {e}")
-            exit(1)
+            raise e
         except json.JSONDecodeError as e:
             print(f"Failed to parse JSON response: {e}")
-            exit(1)
+            raise e
 
 
 def main():


### PR DESCRIPTION
I added a retry mechanism but that wasn't effective because the exceptions were not bubbled up.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
