### PR TITLE
fix: Efficiency printout for TrackFinderPerformanceWriter

### DIFF
--- a/Examples/Io/Root/src/TrackFinderPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/TrackFinderPerformanceWriter.cpp
@@ -304,7 +304,7 @@ ProcessCode TrackFinderPerformanceWriter::writeT(
 
       // Add number for total matched tracks here
       m_nTotalMatchedTracks += nMatchedTracks;
-      m_nTotalMatchedParticles += 1;
+      m_nTotalMatchedParticles += imatched->second.track.has_value() ? 1 : 0;
 
       // Check if the particle has more than one matched track for the duplicate
       // rate/ratio


### PR DESCRIPTION
The nominator for the integrated efficiency that is printed in the log is increased also if zero tracks are matched to a particle.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
