### PR TITLE
revert: build: Add compile check for std::format (originally #4415)

### DIFF
--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -67,24 +67,3 @@ set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # set relative library path for ACTS libraries
 set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
-
-# Check compiler features that we require.
-# This is an alternative to requiring compiler version checks and is more generic
-check_cxx_source_compiles(
-    "
-#include <format>
-#include <string>
-
-int main() {
-std::string s = std::format(\"Hello, {}!\", \"World\");
-}
-"
-    HAVE_STDFORMAT
-)
-
-if(NOT HAVE_STDFORMAT)
-    message(
-        SEND_ERROR
-        "C++20 std::format support is required, but not available in this compiler"
-    )
-endif()


### PR DESCRIPTION
This reverts commit 52f80a47fb3c7fb5091659a748f1e7edae58a45e.
This is causing issues in the Athena build. i'll come back to this next week.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
