### PR TITLE
build: Do not scan for C++ modules on new versions of CMake

### DIFF
--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -60,6 +60,9 @@ endif()
 set(CMAKE_CXX_FLAGS "${cxx_flags} ${CMAKE_CXX_FLAGS}")
 message(STATUS "Using compiler flags: ${CMAKE_CXX_FLAGS}")
 
+# do not scan for C++ modules
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
+
 # silence warning about missing RPATH on Mac OSX
 set(CMAKE_MACOSX_RPATH 1)
 


### PR DESCRIPTION
As far as I know (but correct me if I'm wrong), we do not use C++ modules in ACTS. By disabling the automated scanning this fixes VS Code integration and makes the build a bit faster.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
