### PR TITLE
fix: TrapezoidVolumeBounds - Fix printout legend

### DIFF
--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -160,7 +160,7 @@ bool TrapezoidVolumeBounds::inside(const Vector3& pos, double tol) const {
 std::ostream& TrapezoidVolumeBounds::toStream(std::ostream& os) const {
   os << std::setiosflags(std::ios::fixed);
   os << std::setprecision(5);
-  os << "TrapezoidVolumeBounds: (minhalfX, halfY, halfZ, alpha, beta) "
+  os << "TrapezoidVolumeBounds: (halfX @-Y, halfX @+Y, halfY, halfZ, alpha, beta) "
         "= ";
   os << "(" << get(eHalfLengthXnegY) << ", " << get(eHalfLengthXposY) << ", "
      << get(eHalfLengthY) << ", " << get(eHalfLengthZ);


### PR DESCRIPTION
- halfX was not split in  positive and negative Y
--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
