### PR TITLE
refactor: Improve flexibility of `CylindricalSpacePointGrid2`

### DIFF
--- a/Core/include/Acts/EventData/SpacePointContainer2.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer2.hpp
@@ -686,13 +686,20 @@ class SpacePointContainer2 {
   class Range {
    public:
     static constexpr bool ReadOnly = read_only;
-    using ContainerType = const_if_t<ReadOnly, SpacePointContainer2>;
+    using Container = const_if_t<ReadOnly, SpacePointContainer2>;
 
     using iterator = Iterator<read_only>;
     using const_iterator = Iterator<true>;
 
-    Range(ContainerType &container, const IndexRangeType &range) noexcept
+    Range(Container &container, const IndexRangeType &range) noexcept
         : m_container(&container), m_range(range) {}
+    explicit Range(const Range<false> &other) noexcept
+      requires(ReadOnly)
+        : m_container(&other.container()), m_range(other.range()) {}
+    Range(const Range &other) noexcept = default;
+
+    Container &container() const noexcept { return *m_container; }
+    const IndexRangeType &range() const noexcept { return m_range; }
 
     std::size_t size() const noexcept { return m_range.second - m_range.first; }
     bool empty() const noexcept { return size() == 0; }
@@ -712,7 +719,7 @@ class SpacePointContainer2 {
     }
 
    private:
-    ContainerType *m_container{};
+    Container *m_container{};
     IndexRangeType m_range{};
   };
   using MutableRange = Range<false>;

--- a/Core/include/Acts/EventData/SpacePointProxy2.hpp
+++ b/Core/include/Acts/EventData/SpacePointProxy2.hpp
@@ -13,7 +13,6 @@
 #include "Acts/Utilities/TypeTraits.hpp"
 
 #include <cassert>
-#include <optional>
 #include <span>
 
 #include <Eigen/Core>

--- a/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
+++ b/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
@@ -22,9 +22,9 @@ namespace Acts::Experimental {
 
 /// A cylindrical space point grid used for seeding in a cylindrical detector
 /// geometry.
-/// The grid is defined in cylindrical coordinates (phi, r, z) and allows for
-/// efficient access to space points based on their azimuthal angle, radial
-/// distance, and z-coordinate.
+/// The grid is defined in cylindrical coordinates (phi, z, r) and allows for
+/// efficient access to space points based on their azimuthal angle,
+/// z-coordinate, and radial distance.
 class CylindricalSpacePointGrid2 {
  public:
   /// Space point index type used in the grid.
@@ -102,7 +102,7 @@ class CylindricalSpacePointGrid2 {
 
   /// Get the bin index for a space point given its azimuthal angle, radial
   /// distance, and z-coordinate.
-  /// @param position The position of the space point in (phi, r, z) coordinates
+  /// @param position The position of the space point in (phi, z, r) coordinates
   /// @return The index of the bin in which the space point is located, or
   ///         `std::nullopt` if the space point is outside the grid bounds.
   std::optional<std::size_t> binIndex(const Vector3& position) const {
@@ -114,19 +114,19 @@ class CylindricalSpacePointGrid2 {
   /// Get the bin index for a space point given its azimuthal angle, radial
   /// distance, and z-coordinate.
   /// @param phi The azimuthal angle of the space point in radians
-  /// @param r The radial distance of the space point from the origin
   /// @param z The z-coordinate of the space point
+  /// @param r The radial distance of the space point from the origin
   /// @return The index of the bin in which the space point is located, or
   ///         `std::nullopt` if the space point is outside the grid bounds.
-  std::optional<std::size_t> binIndex(float phi, float r, float z) const {
-    return binIndex(Vector3(phi, r, z));
+  std::optional<std::size_t> binIndex(float phi, float z, float r) const {
+    return binIndex(Vector3(phi, z, r));
   }
 
   /// Insert a space point into the grid.
   /// @param index The index of the space point to insert
   /// @param phi The azimuthal angle of the space point in radians
-  /// @param r The radial distance of the space point from the origin
   /// @param z The z-coordinate of the space point
+  /// @param r The radial distance of the space point from the origin
   /// @return The index of the bin in which the space point was inserted, or
   ///         `std::nullopt` if the space point is outside the grid bounds.
   std::optional<std::size_t> insert(SpacePointIndex index, float phi, float r,
@@ -136,7 +136,7 @@ class CylindricalSpacePointGrid2 {
   /// @return The index of the bin in which the space point was inserted, or
   ///         `std::nullopt` if the space point is outside the grid bounds.
   std::optional<std::size_t> insert(const ConstSpacePointProxy2& sp) {
-    return insert(sp.index(), sp.phi(), sp.r(), sp.z());
+    return insert(sp.index(), sp.phi(), sp.z(), sp.r());
   }
 
   /// Fill the grid with space points from the container.

--- a/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
+++ b/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
@@ -20,15 +20,22 @@
 
 namespace Acts::Experimental {
 
+/// A cylindrical space point grid used for seeding in a cylindrical detector
+/// geometry.
+/// The grid is defined in cylindrical coordinates (phi, r, z) and allows for
+/// efficient access to space points based on their azimuthal angle, radial
+/// distance, and z-coordinate.
 class CylindricalSpacePointGrid2 {
  public:
-  /// Cylindrical Space Point bin is a 2D (phi,z) grid. It stores a vector of
+  /// Space point index type used in the grid.
+  using SpacePointIndex = std::uint32_t;
+  using BinType = std::vector<SpacePointIndex>;
+  /// Cylindrical space point bin is a 2D (phi,z) grid. It stores a vector of
   /// space point indices.
-  using GridType = Grid<std::vector<SpacePointIndex2>,
-                        Axis<AxisType::Equidistant, AxisBoundaryType::Closed>,
-                        Axis<AxisType::Variable, AxisBoundaryType::Open>,
-                        Axis<AxisType::Variable, AxisBoundaryType::Open>>;
-  /// Cylindrical Binned Group
+  using GridType =
+      Grid<BinType, Axis<AxisType::Equidistant, AxisBoundaryType::Closed>,
+           Axis<AxisType::Variable, AxisBoundaryType::Open>,
+           Axis<AxisType::Variable, AxisBoundaryType::Open>>;
   using BinnedGroupType = BinnedGroup<GridType>;
 
   struct Config {
@@ -80,31 +87,100 @@ class CylindricalSpacePointGrid2 {
     std::array<std::vector<std::size_t>, 3ul> navigation;
   };
 
+  /// Construct a cylindrical space point grid with the given configuration and
+  /// an optional logger.
   explicit CylindricalSpacePointGrid2(
       const Config& config,
       std::unique_ptr<const Logger> logger =
           getDefaultLogger("CylindricalSpacePointGrid2", Logging::Level::INFO));
 
+  /// Clear the grid and drop all state. The object will behave like a newly
+  /// constructed one.
   void clear();
 
-  void insert(const ConstSpacePointProxy2& sp);
+  /// Get the bin index for a space point given its azimuthal angle, radial
+  /// distance, and z-coordinate.
+  /// @param position The position of the space point in (phi, r, z) coordinates
+  /// @return The index of the bin in which the space point is located, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> binIndex(const Vector3& position) const {
+    if (!grid().isInside(position)) {
+      return std::nullopt;
+    }
+    return grid().globalBinFromPosition(position);
+  }
+  /// Get the bin index for a space point given its azimuthal angle, radial
+  /// distance, and z-coordinate.
+  /// @param phi The azimuthal angle of the space point in radians
+  /// @param r The radial distance of the space point from the origin
+  /// @param z The z-coordinate of the space point
+  /// @return The index of the bin in which the space point is located, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> binIndex(float phi, float r, float z) const {
+    return binIndex(Vector3(phi, r, z));
+  }
 
+  /// Insert a space point into the grid.
+  /// @param index The index of the space point to insert
+  /// @param phi The azimuthal angle of the space point in radians
+  /// @param r The radial distance of the space point from the origin
+  /// @param z The z-coordinate of the space point
+  /// @return The index of the bin in which the space point was inserted, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> insert(SpacePointIndex index, float phi, float r,
+                                    float z);
+  /// Insert a space point into the grid.
+  /// @param sp The space point to insert
+  /// @return The index of the bin in which the space point was inserted, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> insert(const ConstSpacePointProxy2& sp) {
+    return insert(sp.index(), sp.phi(), sp.r(), sp.z());
+  }
+
+  /// Fill the grid with space points from the container.
+  /// @param spacePoints The space point container to fill the grid with
   void extend(const SpacePointContainer2::ConstRange& spacePoints);
 
-  void fill(const SpacePointContainer2& spacePoints);
+  /// Sort the bins in the grid by the space point radius, which is required by
+  /// some algorithms that operate on the grid.
+  /// @param spacePoints The space point container to sort the bins by radius
+  void sortBinsByR(const SpacePointContainer2& spacePoints);
 
-  void sort(const SpacePointContainer2& spacePoints);
-
+  /// Compute the range of radii in the grid. This requires the grid to be
+  /// filled with space points and sorted by radius. The sorting can be done
+  /// with the `sortBinsByR` method.
+  /// @param spacePoints The space point container to compute the radius range
+  /// @return The range of radii in the grid
   Range1D<float> computeRadiusRange(
       const SpacePointContainer2& spacePoints) const;
 
-  auto& at(std::size_t index) { return grid().at(index); }
-  const auto& at(std::size_t index) const { return grid().at(index); }
+  /// Mutable bin access by index.
+  /// @param index The index of the bin to access
+  /// @return Mutable reference to the bin at the specified index
+  BinType& at(std::size_t index) { return grid().at(index); }
+  /// Const bin access by index.
+  /// @param index The index of the bin to access
+  /// @return Const reference to the bin at the specified index
+  const BinType& at(std::size_t index) const { return grid().at(index); }
 
+  /// Mutable grid access.
+  /// @return Mutable reference to the grid
   GridType& grid() { return *m_grid; }
+  /// Const grid access.
+  /// @return Const reference to the grid
   const GridType& grid() const { return *m_grid; }
 
+  /// Access to the binned group.
+  /// @return Reference to the binned group
   const BinnedGroupType& binnedGroup() const { return *m_binnedGroup; }
+
+  /// Get the number of space points in the grid.
+  /// @return The number of space points in the grid
+  std::size_t spacePointCount() const { return m_counter; }
+
+  /// Get the number of bins in the grid.
+  /// @return The number of bins in the grid
+  std::size_t numberOfBins() const { return grid().size(); }
 
  private:
   Config m_cfg;

--- a/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
+++ b/Core/include/Acts/Seeding2/CylindricalSpacePointGrid2.hpp
@@ -30,12 +30,14 @@ class CylindricalSpacePointGrid2 {
   /// Space point index type used in the grid.
   using SpacePointIndex = std::uint32_t;
   using BinType = std::vector<SpacePointIndex>;
-  /// Cylindrical space point bin is a 2D (phi,z) grid. It stores a vector of
-  /// space point indices.
-  using GridType =
-      Grid<BinType, Axis<AxisType::Equidistant, AxisBoundaryType::Closed>,
-           Axis<AxisType::Variable, AxisBoundaryType::Open>,
-           Axis<AxisType::Variable, AxisBoundaryType::Open>>;
+  using PhiAxisType = Axis<AxisType::Equidistant, AxisBoundaryType::Closed>;
+  using ZAxisType = Axis<AxisType::Variable, AxisBoundaryType::Open>;
+  using RAxisType = Axis<AxisType::Variable, AxisBoundaryType::Open>;
+  /// Cylindrical space point grid type, which is a grid over `BinType` with
+  /// axes defined by `PhiAxisType`, `ZAxisType`, and `RAxisType`.
+  /// The grid is a 3D grid with the axes representing azimuthal angle (phi),
+  /// z-coordinate, and radial distance (r).
+  using GridType = Grid<BinType, PhiAxisType, ZAxisType, RAxisType>;
   using BinnedGroupType = BinnedGroup<GridType>;
 
   struct Config {

--- a/Core/src/Seeding2/CylindricalSpacePointGrid2.cpp
+++ b/Core/src/Seeding2/CylindricalSpacePointGrid2.cpp
@@ -157,16 +157,23 @@ CylindricalSpacePointGrid2::CylindricalSpacePointGrid2(
   m_grid = &m_binnedGroup->grid();
 }
 
-void CylindricalSpacePointGrid2::insert(const ConstSpacePointProxy2& sp) {
-  Vector3 position(sp.phi(), sp.z(), sp.r());
-  if (!grid().isInside(position)) {
-    return;
+void CylindricalSpacePointGrid2::clear() {
+  for (std::size_t i = 0; i < grid().size(); ++i) {
+    BinType& bin = grid().at(i);
+    bin.clear();
   }
+  m_counter = 0;
+}
 
-  std::size_t globIndex = grid().globalBinFromPosition(position);
-  auto& bin = grid().at(globIndex);
-  bin.push_back(sp.index());
-  ++m_counter;
+std::optional<std::size_t> CylindricalSpacePointGrid2::insert(
+    SpacePointIndex index, float phi, float r, float z) {
+  const std::optional<std::size_t> gridIndex = binIndex(phi, r, z);
+  if (gridIndex.has_value()) {
+    BinType& bin = grid().at(*gridIndex);
+    bin.push_back(index);
+    ++m_counter;
+  }
+  return gridIndex;
 }
 
 void CylindricalSpacePointGrid2::extend(
@@ -174,21 +181,17 @@ void CylindricalSpacePointGrid2::extend(
   ACTS_VERBOSE("Inserting " << spacePoints.size()
                             << " space points to the grid");
 
-  for (const auto& sp : spacePoints) {
+  for (const ConstSpacePointProxy2& sp : spacePoints) {
     insert(sp);
   }
 }
 
-void CylindricalSpacePointGrid2::fill(const SpacePointContainer2& spacePoints) {
-  extend(spacePoints.range({0, spacePoints.size()}));
-  sort(spacePoints);
-}
-
-void CylindricalSpacePointGrid2::sort(const SpacePointContainer2& spacePoints) {
+void CylindricalSpacePointGrid2::sortBinsByR(
+    const SpacePointContainer2& spacePoints) {
   ACTS_VERBOSE("Sorting the grid");
 
   for (std::size_t i = 0; i < grid().size(); ++i) {
-    auto& bin = grid().at(i);
+    BinType& bin = grid().at(i);
     std::ranges::sort(bin, {}, [&](SpacePointIndex2 spIndex) {
       return spacePoints[spIndex].r();
     });
@@ -202,12 +205,12 @@ Range1D<float> CylindricalSpacePointGrid2::computeRadiusRange(
     const SpacePointContainer2& spacePoints) const {
   float minRange = std::numeric_limits<float>::max();
   float maxRange = std::numeric_limits<float>::lowest();
-  for (const auto& coll : grid()) {
-    if (coll.empty()) {
+  for (const BinType& bin : grid()) {
+    if (bin.empty()) {
       continue;
     }
-    auto first = spacePoints[coll.front()];
-    auto last = spacePoints[coll.back()];
+    auto first = spacePoints[bin.front()];
+    auto last = spacePoints[bin.back()];
     minRange = std::min(first.r(), minRange);
     maxRange = std::max(last.r(), maxRange);
   }

--- a/Core/src/Seeding2/CylindricalSpacePointGrid2.cpp
+++ b/Core/src/Seeding2/CylindricalSpacePointGrid2.cpp
@@ -105,7 +105,7 @@ CylindricalSpacePointGrid2::CylindricalSpacePointGrid2(
     phiBins = std::min(phiBins, m_cfg.maxPhiBins);
   }
 
-  Axis phiAxis(AxisClosed, m_cfg.phiMin, m_cfg.phiMax, phiBins);
+  PhiAxisType phiAxis(AxisClosed, m_cfg.phiMin, m_cfg.phiMax, phiBins);
 
   // vector that will store the edges of the bins of z
   std::vector<double> zValues{};
@@ -142,8 +142,8 @@ CylindricalSpacePointGrid2::CylindricalSpacePointGrid2(
                    m_cfg.rBinEdges.end());
   }
 
-  Axis zAxis(AxisOpen, std::move(zValues));
-  Axis rAxis(AxisOpen, std::move(rValues));
+  ZAxisType zAxis(AxisOpen, std::move(zValues));
+  RAxisType rAxis(AxisOpen, std::move(rValues));
 
   ACTS_VERBOSE("Defining Grid:");
   ACTS_VERBOSE("- Phi Axis: " << phiAxis);

--- a/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
@@ -125,7 +125,9 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
   Acts::Experimental::CylindricalSpacePointGrid2 grid(
       m_gridConfig, logger().cloneWithSuffix("Grid"));
 
-  grid.fill(coreSpacePoints);
+  grid.extend(Acts::Experimental::SpacePointContainer2::ConstRange(
+      coreSpacePoints.range({0, coreSpacePoints.size()})));
+  grid.sortBinsByR(coreSpacePoints);
 
   // Compute radius Range
   // we rely on the fact the grid is storing the proxies


### PR DESCRIPTION
- Allow to use `CylindricalSpacePointGrid2` without using the new space point EDM
  - I would like to assign space points to the grid with a different EDM and then copy to the new EDM resulting in sorted ranges
- Add documentation

--- END COMMIT MESSAGE ---
