### PR TITLE
refactor: Use uv build backend for codegen project

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,0 +1,4 @@
+# codegen library
+
+This folder contains python code that is shared between a number of components
+that generate C++ code at build-time.

--- a/codegen/pyproject.toml
+++ b/codegen/pyproject.toml
@@ -8,3 +8,7 @@ dependencies = [
   "numpy",
   "sympy"
 ]
+
+[build-system]
+requires = ["uv_build>=0.7.21,<0.8.0"]
+build-backend = "uv_build"


### PR DESCRIPTION
This could **possibly** help with the codegen install failures seen in the [devcontainer CI job](https://github.com/acts-project/acts/actions/runs/16290502445/job/45999138581?pr=4247). Let's see.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
