### PR TITLE
refactor: Use `zip` in `DoubletSeedFinder`

### DIFF
--- a/Core/include/Acts/EventData/SpacePointColumnProxy2.hpp
+++ b/Core/include/Acts/EventData/SpacePointColumnProxy2.hpp
@@ -27,7 +27,7 @@ class SpacePointColumnProxy {
   constexpr static bool ReadOnly = read_only;
   using Index = SpacePointIndex2;
   using IndexRange = SpacePointIndexRange2;
-  using IndexSubset = SpacePointSubset2;
+  using IndexSubset = SpacePointIndexSubset2;
   using Value = T;
   using Container = const_if_t<ReadOnly, SpacePointContainer2>;
   using Column = const_if_t<ReadOnly, std::vector<Value>>;

--- a/Core/include/Acts/EventData/SpacePointColumnProxy2.hpp
+++ b/Core/include/Acts/EventData/SpacePointColumnProxy2.hpp
@@ -26,6 +26,8 @@ class SpacePointColumnProxy {
  public:
   constexpr static bool ReadOnly = read_only;
   using Index = SpacePointIndex2;
+  using IndexRange = SpacePointIndexRange2;
+  using IndexSubset = SpacePointSubset2;
   using Value = T;
   using Container = const_if_t<ReadOnly, SpacePointContainer2>;
   using Column = const_if_t<ReadOnly, std::vector<Value>>;
@@ -129,6 +131,120 @@ class SpacePointColumnProxy {
   const Value &operator[](Index index) const noexcept {
     assert(index < column().size() && "Index out of bounds");
     return data()[index];
+  }
+
+  class Subset {
+   public:
+    class Iterator {
+     public:
+      using SubsetIterator = IndexSubset::iterator;
+
+      using value_type = T;
+      using difference_type = std::ptrdiff_t;
+
+      using iterator_category = std::random_access_iterator_tag;
+      using iterator_concept = std::random_access_iterator_tag;
+
+      constexpr Iterator() noexcept = default;
+      constexpr Iterator(Column &column, SubsetIterator iterator) noexcept
+          : m_column(&column), m_iterator(iterator) {}
+
+      constexpr value_type operator*() const noexcept {
+        return (*m_column)[*m_iterator];
+      }
+      constexpr value_type operator[](difference_type n) const noexcept {
+        return (*m_column)[m_iterator[n]];
+      }
+
+      constexpr Iterator &operator++() noexcept {
+        ++m_iterator;
+        return *this;
+      }
+      constexpr Iterator operator++(int) noexcept {
+        auto tmp = *this;
+        ++(*this);
+        return tmp;
+      }
+      constexpr Iterator &operator--() noexcept {
+        --m_iterator;
+        return *this;
+      }
+      constexpr Iterator operator--(int) noexcept {
+        auto tmp = *this;
+        --(*this);
+        return tmp;
+      }
+
+      constexpr Iterator &operator+=(difference_type n) noexcept {
+        m_iterator += n;
+        return *this;
+      }
+      constexpr Iterator &operator-=(difference_type n) noexcept {
+        m_iterator -= n;
+        return *this;
+      }
+
+     private:
+      Column *m_column{};
+      SubsetIterator m_iterator{};
+
+      friend constexpr Iterator operator+(Iterator it,
+                                          difference_type n) noexcept {
+        return it += n;
+      }
+
+      friend constexpr Iterator operator+(difference_type n,
+                                          Iterator it) noexcept {
+        return it += n;
+      }
+
+      friend constexpr Iterator operator-(Iterator it,
+                                          difference_type n) noexcept {
+        return it -= n;
+      }
+
+      friend constexpr difference_type operator-(const Iterator &lhs,
+                                                 const Iterator &rhs) noexcept {
+        return lhs.m_iterator - rhs.m_iterator;
+      }
+
+      friend constexpr auto operator<=>(const Iterator &a,
+                                        const Iterator &b) noexcept {
+        return a.m_iterator <=> b.m_iterator;
+      }
+      friend constexpr bool operator==(const Iterator &a,
+                                       const Iterator &b) noexcept {
+        return a.m_iterator == b.m_iterator;
+      }
+    };
+    using iterator = Iterator;
+
+    constexpr Subset(Column &column, const IndexSubset &subset) noexcept
+        : m_column(&column), m_subset(subset) {}
+
+    constexpr Container &column() const noexcept { return *m_column; }
+    constexpr const IndexSubset &subset() const noexcept { return m_subset; }
+
+    constexpr std::size_t size() const noexcept { return m_subset.size(); }
+    constexpr bool empty() const noexcept { return size() == 0; }
+
+    constexpr auto front() const noexcept { return column()[m_subset.front()]; }
+    constexpr auto back() const noexcept { return column()[m_subset.back()]; }
+
+    constexpr iterator begin() const noexcept {
+      return iterator(*m_column, m_subset.begin());
+    }
+    constexpr iterator end() const noexcept {
+      return iterator(*m_column, m_subset.end());
+    }
+
+   private:
+    Column *m_column{};
+    IndexSubset m_subset{};
+  };
+
+  Subset subset(const IndexSubset &subset) const noexcept {
+    return Subset(*m_column, subset);
   }
 
  private:

--- a/Core/include/Acts/EventData/SpacePointContainer2.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer2.hpp
@@ -73,7 +73,7 @@ class SpacePointContainer2 {
  public:
   using Index = SpacePointIndex2;
   using IndexRange = SpacePointIndexRange2;
-  using IndexSubset = SpacePointSubset2;
+  using IndexSubset = SpacePointIndexSubset2;
   using MutableProxy = MutableSpacePointProxy2;
   using ConstProxy = ConstSpacePointProxy2;
 

--- a/Core/include/Acts/EventData/SpacePointContainer2.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer2.hpp
@@ -819,6 +819,11 @@ class SpacePointContainer2 {
       return RangeIterator(container(), m_range.second);
     }
 
+    template <typename... Ts>
+    auto zip(const ConstSpacePointColumnProxy<Ts> &...columns) const noexcept {
+      return m_container->zip(m_range, columns...);
+    }
+
    private:
     Container *m_container{};
     IndexRange m_range{};
@@ -963,6 +968,11 @@ class SpacePointContainer2 {
       return iterator(*m_container, m_subset.end());
     }
 
+    template <typename... Ts>
+    auto zip(const ConstSpacePointColumnProxy<Ts> &...columns) const noexcept {
+      return m_container->zip(m_subset, columns...);
+    }
+
    private:
     Container *m_container{};
     IndexSubset m_subset{};
@@ -987,35 +997,80 @@ class SpacePointContainer2 {
    public:
     class Iterator {
      public:
-      using iterator_category = std::forward_iterator_tag;
-      using value_type = SpacePointIndex2;
+      using value_type = Index;
       using difference_type = std::ptrdiff_t;
 
-      Iterator() noexcept = default;
-      explicit Iterator(SpacePointIndex2 index) noexcept : m_index{index} {}
+      using iterator_category = std::random_access_iterator_tag;
+      using iterator_concept = std::random_access_iterator_tag;
 
-      Iterator &operator++() noexcept {
+      constexpr Iterator() noexcept = default;
+      explicit constexpr Iterator(SpacePointIndex2 index) noexcept
+          : m_index{index} {}
+
+      constexpr value_type operator*() const noexcept { return m_index; }
+      constexpr value_type operator[](difference_type n) const noexcept {
+        return m_index + n;
+      }
+
+      constexpr Iterator &operator++() noexcept {
         ++m_index;
         return *this;
       }
-      Iterator operator++(int) noexcept {
-        Iterator tmp(*this);
+      constexpr Iterator operator++(int) noexcept {
+        auto tmp = *this;
         ++(*this);
         return tmp;
       }
+      constexpr Iterator &operator--() noexcept {
+        --m_index;
+        return *this;
+      }
+      constexpr Iterator operator--(int) noexcept {
+        auto tmp = *this;
+        --(*this);
+        return tmp;
+      }
 
-      value_type operator*() const noexcept { return m_index; }
+      constexpr Iterator &operator+=(difference_type n) noexcept {
+        m_index += n;
+        return *this;
+      }
+      constexpr Iterator &operator-=(difference_type n) noexcept {
+        m_index -= n;
+        return *this;
+      }
 
      private:
       SpacePointIndex2 m_index{0};
 
-      friend bool operator==(const Iterator &a,
-                             const Iterator &b) noexcept = default;
+      friend constexpr Iterator operator+(Iterator it,
+                                          difference_type n) noexcept {
+        return it += n;
+      }
+
+      friend constexpr Iterator operator+(difference_type n,
+                                          Iterator it) noexcept {
+        return it += n;
+      }
+
+      friend constexpr Iterator operator-(Iterator it,
+                                          difference_type n) noexcept {
+        return it -= n;
+      }
+
+      friend constexpr difference_type operator-(const Iterator &lhs,
+                                                 const Iterator &rhs) noexcept {
+        return lhs.m_index - rhs.m_index;
+      }
+
+      friend constexpr auto operator<=>(const Iterator &a,
+                                        const Iterator &b) noexcept = default;
+      friend constexpr bool operator==(const Iterator &a,
+                                       const Iterator &b) noexcept = default;
     };
     using iterator = Iterator;
 
-    explicit IndexIteratorRange(SpacePointIndexRange2 range) noexcept
-        : m_range(range) {}
+    explicit IndexIteratorRange(IndexRange range) noexcept : m_range(range) {}
 
     std::size_t size() const noexcept { return m_range.second - m_range.first; }
     bool empty() const noexcept { return size() == 0; }
@@ -1024,7 +1079,7 @@ class SpacePointContainer2 {
     iterator end() const noexcept { return iterator(m_range.second); }
 
    private:
-    SpacePointIndexRange2 m_range{};
+    IndexRange m_range{};
   };
 
   /// Creates a zipped mutable range of space point data from the given columns.
@@ -1061,6 +1116,17 @@ class SpacePointContainer2 {
            const ConstSpacePointColumnProxy<Ts> &...columns) const noexcept {
     return Acts::zip(IndexIteratorRange(range),
                      columns.data().subspan(range.first, range.second)...);
+  }
+
+  template <typename... Ts>
+  auto zip(const IndexSubset &subset,
+           const MutableSpacePointColumnProxy<Ts> &...columns) noexcept {
+    return Acts::zip(subset, columns.subset(subset)...);
+  }
+  template <typename... Ts>
+  auto zip(const IndexSubset &subset,
+           const ConstSpacePointColumnProxy<Ts> &...columns) const noexcept {
+    return Acts::zip(subset, columns.subset(subset)...);
   }
 
  private:

--- a/Core/include/Acts/EventData/Types.hpp
+++ b/Core/include/Acts/EventData/Types.hpp
@@ -16,12 +16,6 @@
 
 namespace Acts {
 
-using SpacePointIndex2 = std::uint32_t;
-using SpacePointIndexRange2 = std::pair<SpacePointIndex2, SpacePointIndex2>;
-using SpacePointSubset2 = std::span<const SpacePointIndex2>;
-
-using SeedIndex2 = std::uint32_t;
-
 using TrackIndexType = std::uint32_t;
 static constexpr TrackIndexType kTrackIndexInvalid =
     std::numeric_limits<TrackIndexType>::max();
@@ -36,3 +30,13 @@ static constexpr BoundSubspaceIndices kBoundSubspaceIndicesInvalid = {
 using SerializedSubspaceIndices = std::uint64_t;
 
 }  // namespace Acts
+
+namespace Acts::Experimental {
+
+using SpacePointIndex2 = std::uint32_t;
+using SpacePointIndexRange2 = std::pair<SpacePointIndex2, SpacePointIndex2>;
+using SpacePointIndexSubset2 = std::span<const SpacePointIndex2>;
+
+using SeedIndex2 = std::uint32_t;
+
+}  // namespace Acts::Experimental

--- a/Core/src/Seeding2/DoubletSeedFinder.cpp
+++ b/Core/src/Seeding2/DoubletSeedFinder.cpp
@@ -97,7 +97,7 @@ void createDoubletsImpl(
     candidateSps = candidateSps.subrange(offset);
   }
 
-  const SpacePointContainer2 container = candidateSps.container();
+  const SpacePointContainer2& container = candidateSps.container();
   for (auto [indexO, xO, yO, zO, rO, varianceZO, varianceRO] : candidateSps.zip(
            container.xColumn(), container.yColumn(), container.zColumn(),
            container.rColumn(), container.varianceZColumn(),

--- a/Core/src/Seeding2/DoubletSeedFinder.cpp
+++ b/Core/src/Seeding2/DoubletSeedFinder.cpp
@@ -69,11 +69,8 @@ void createDoubletsImpl(
                              static_cast<int>(value > max));
   };
 
-  const auto calculateError = [&](const ConstSpacePointProxy2& otherSp,
+  const auto calculateError = [&](float varianceZO, float varianceRO,
                                   float iDeltaR2, float cotTheta) {
-    const float varianceZO = otherSp.varianceZ();
-    const float varianceRO = otherSp.varianceR();
-
     return iDeltaR2 * ((varianceZM + varianceZO) +
                        (cotTheta * cotTheta) * (varianceRM + varianceRO));
   };
@@ -100,12 +97,11 @@ void createDoubletsImpl(
     candidateSps = candidateSps.subrange(offset);
   }
 
-  for (ConstSpacePointProxy2 otherSp : candidateSps) {
-    const float xO = otherSp.x();
-    const float yO = otherSp.y();
-    const float zO = otherSp.z();
-    const float rO = otherSp.r();
-
+  const SpacePointContainer2 container = candidateSps.container();
+  for (auto [indexO, xO, yO, zO, rO, varianceZO, varianceRO] : candidateSps.zip(
+           container.xColumn(), container.yColumn(), container.zColumn(),
+           container.rColumn(), container.varianceZColumn(),
+           container.varianceRColumn())) {
     if constexpr (isBottomCandidate) {
       deltaR = rM - rO;
 
@@ -185,12 +181,12 @@ void createDoubletsImpl(
       const float iDeltaR = std::sqrt(iDeltaR2);
       const float cotTheta = deltaZ * iDeltaR;
 
-      const float er = calculateError(otherSp, iDeltaR2, cotTheta);
+      const float er =
+          calculateError(varianceZO, varianceRO, iDeltaR2, cotTheta);
 
       // fill output vectors
       compatibleDoublets.emplace_back(
-          otherSp.index(),
-          {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
+          indexO, {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
       continue;
     }
 
@@ -239,12 +235,12 @@ void createDoubletsImpl(
         }
       }
 
-      const float er = calculateError(otherSp, iDeltaR2, cotTheta);
+      const float er =
+          calculateError(varianceZO, varianceRO, iDeltaR2, cotTheta);
 
       // fill output vectors
       compatibleDoublets.emplace_back(
-          otherSp.index(),
-          {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
+          indexO, {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
       continue;
     }
 
@@ -284,11 +280,11 @@ void createDoubletsImpl(
       }
     }
 
-    const float er = calculateError(otherSp, iDeltaR2, cotTheta);
+    const float er = calculateError(varianceZO, varianceRO, iDeltaR2, cotTheta);
 
     // fill output vectors
     compatibleDoublets.emplace_back(
-        otherSp.index(), {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
+        indexO, {cotTheta, iDeltaR, er, uT, vT, xNewFrame, yNewFrame});
   }
 }
 

--- a/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
@@ -119,10 +119,11 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
   }
 
   for (std::size_t i = 0; i < grid.numberOfBins(); ++i) {
-    std::ranges::sort(grid.at(i), [&](const Acts::SpacePointIndex2& a,
-                                      const Acts::SpacePointIndex2& b) {
-      return spacePoints[a].r() < spacePoints[b].r();
-    });
+    std::ranges::sort(grid.at(i),
+                      [&](const Acts::Experimental::SpacePointIndex2& a,
+                          const Acts::Experimental::SpacePointIndex2& b) {
+                        return spacePoints[a].r() < spacePoints[b].r();
+                      });
   }
 
   Acts::Experimental::SpacePointContainer2 coreSpacePoints(
@@ -131,15 +132,14 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
       Acts::Experimental::SpacePointColumns::Y |
       Acts::Experimental::SpacePointColumns::Z |
       Acts::Experimental::SpacePointColumns::R |
-      Acts::Experimental::SpacePointColumns::Phi |
       Acts::Experimental::SpacePointColumns::VarianceR |
       Acts::Experimental::SpacePointColumns::VarianceZ);
   coreSpacePoints.reserve(grid.numberOfSpacePoints());
-  std::vector<Acts::SpacePointIndexRange2> gridSpacePointRanges;
+  std::vector<Acts::Experimental::SpacePointIndexRange2> gridSpacePointRanges;
   gridSpacePointRanges.reserve(grid.numberOfBins());
   for (std::size_t i = 0; i < grid.numberOfBins(); ++i) {
     std::uint32_t begin = coreSpacePoints.size();
-    for (Acts::SpacePointIndex2 spIndex : grid.at(i)) {
+    for (Acts::Experimental::SpacePointIndex2 spIndex : grid.at(i)) {
       const SimSpacePoint& sp = spacePoints[spIndex];
 
       auto newSp = coreSpacePoints.createSpacePoint();
@@ -149,7 +149,6 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
       newSp.y() = sp.y();
       newSp.z() = sp.z();
       newSp.r() = sp.r();
-      newSp.phi() = std::atan2(sp.y(), sp.x());
       newSp.varianceR() = sp.varianceR();
       newSp.varianceZ() = sp.varianceZ();
     }
@@ -162,7 +161,8 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
   const Acts::Range1D<float> rRange = [&]() -> Acts::Range1D<float> {
     float minRange = std::numeric_limits<float>::max();
     float maxRange = std::numeric_limits<float>::lowest();
-    for (const Acts::SpacePointIndexRange2& range : gridSpacePointRanges) {
+    for (const Acts::Experimental::SpacePointIndexRange2& range :
+         gridSpacePointRanges) {
       if (range.first == range.second) {
         continue;
       }

--- a/Plugins/Root/include/Acts/Plugins/Root/RootSpacePointIo.hpp
+++ b/Plugins/Root/include/Acts/Plugins/Root/RootSpacePointIo.hpp
@@ -52,7 +52,7 @@ class RootSpacePointIo {
   /// @param spacePoint the space point to read into
   /// @param index the original index of the space point in the ROOT file
   void read(Experimental::MutableSpacePointProxy2& spacePoint,
-            SpacePointIndex2 index);
+            Experimental::SpacePointIndex2 index);
 
   /// @brief Read the space points from the tree
   ///

--- a/Plugins/Root/src/RootSpacePointIo.cpp
+++ b/Plugins/Root/src/RootSpacePointIo.cpp
@@ -118,7 +118,7 @@ void RootSpacePointIo::write(
 }
 
 void RootSpacePointIo::read(Experimental::MutableSpacePointProxy2& spacePoint,
-                            SpacePointIndex2 index) {
+                            Experimental::SpacePointIndex2 index) {
   using enum Experimental::SpacePointColumns;
 
   if (spacePoint.container().hasColumns(SourceLinks)) {
@@ -160,7 +160,7 @@ void RootSpacePointIo::read(TChain& tchain,
     tchain.GetEntry(i);
 
     auto spacePoint = spacePoints.createSpacePoint();
-    read(spacePoint, static_cast<SpacePointIndex2>(i));
+    read(spacePoint, static_cast<Experimental::SpacePointIndex2>(i));
   }
 }
 


### PR DESCRIPTION
Makes use of the `zip` function of the `SpacePointContainer2` which allows iterating on unrolled individual column entries. The advantage of this is that we do not need to add the index all the time but rather move multiple iterators along. Potentially this is also easier for the compiler to reason about than operating on the proxy.

--- END COMMIT MESSAGE ---

The added code and API is still experimental - I would like to bring the iterator related code down