### PR TITLE
refactor(gen3): Material designator node takes arbitrary surface material

### DIFF
--- a/Core/include/Acts/Geometry/MaterialDesignatorBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/MaterialDesignatorBlueprintNode.hpp
@@ -95,7 +95,7 @@ class MaterialDesignatorBlueprintNode final : public BlueprintNode {
   ///       shape, this will throw an exception.
   MaterialDesignatorBlueprintNode& configureFace(
       CylinderVolumeBounds::Face face,
-      std::shared_ptr<const Acts::HomogeneousSurfaceMaterial> material);
+      std::shared_ptr<const Acts::ISurfaceMaterial> material);
 
   /// Configure the designator with a cuboid face and corresponding binning
   /// information.
@@ -119,7 +119,7 @@ class MaterialDesignatorBlueprintNode final : public BlueprintNode {
   ///       shape, this will throw an exception.
   MaterialDesignatorBlueprintNode& configureFace(
       CuboidVolumeBounds::Face face,
-      std::shared_ptr<const Acts::HomogeneousSurfaceMaterial> material);
+      std::shared_ptr<const Acts::ISurfaceMaterial> material);
 
  private:
   /// @copydoc BlueprintNode::addToGraphviz

--- a/Core/src/Geometry/MaterialDesignatorBlueprintNode.cpp
+++ b/Core/src/Geometry/MaterialDesignatorBlueprintNode.cpp
@@ -152,14 +152,14 @@ MaterialDesignatorBlueprintNode& MaterialDesignatorBlueprintNode::configureFace(
 
 MaterialDesignatorBlueprintNode& MaterialDesignatorBlueprintNode::configureFace(
     CylinderVolumeBounds::Face face,
-    std::shared_ptr<const Acts::HomogeneousSurfaceMaterial> material) {
+    std::shared_ptr<const Acts::ISurfaceMaterial> material) {
   if (material == nullptr) {
     throw std::invalid_argument(prefix() + "Material is nullptr");
   }
 
   impl().m_designator = impl().m_designator->merged(
-      detail::HomogeneousMaterialDesignator<CylinderVolumeBounds::Face,
-                                            CylinderPortalShell>(
+      detail::ISurfaceMaterialDesignator<CylinderVolumeBounds::Face,
+                                         CylinderPortalShell>(
           face, std::move(material)));
 
   return *this;
@@ -176,14 +176,14 @@ MaterialDesignatorBlueprintNode& MaterialDesignatorBlueprintNode::configureFace(
 
 MaterialDesignatorBlueprintNode& MaterialDesignatorBlueprintNode::configureFace(
     CuboidVolumeBounds::Face face,
-    std::shared_ptr<const Acts::HomogeneousSurfaceMaterial> material) {
+    std::shared_ptr<const Acts::ISurfaceMaterial> material) {
   if (material == nullptr) {
     throw std::invalid_argument(prefix() + "Material is nullptr");
   }
 
   impl().m_designator = impl().m_designator->merged(
-      detail::HomogeneousMaterialDesignator<CuboidVolumeBounds::Face,
-                                            CuboidPortalShell>(
+      detail::ISurfaceMaterialDesignator<CuboidVolumeBounds::Face,
+                                         CuboidPortalShell>(
           face, std::move(material)));
 
   return *this;

--- a/Core/src/Geometry/detail/MaterialDesignator.hpp
+++ b/Core/src/Geometry/detail/MaterialDesignator.hpp
@@ -23,14 +23,13 @@ class CylinderProtoDesignator;
 class CuboidProtoDesignator;
 class NullDesignator;
 template <typename face_enum_t, typename shell_type_t>
-class HomogeneousMaterialDesignator;
+class ISurfaceMaterialDesignator;
 
 using CylinderHomogeneousMaterialDesignator =
-    HomogeneousMaterialDesignator<CylinderVolumeBounds::Face,
-                                  CylinderPortalShell>;
+    ISurfaceMaterialDesignator<CylinderVolumeBounds::Face, CylinderPortalShell>;
 
 using CuboidHomogeneousMaterialDesignator =
-    HomogeneousMaterialDesignator<CuboidVolumeBounds::Face, CuboidPortalShell>;
+    ISurfaceMaterialDesignator<CuboidVolumeBounds::Face, CuboidPortalShell>;
 
 class DesignatorBase {
  public:
@@ -261,19 +260,18 @@ class CuboidProtoDesignator : public DesignatorBase {
 };
 
 template <typename face_enum_t, typename shell_type_t>
-class HomogeneousMaterialDesignator : public DesignatorBase {
+class ISurfaceMaterialDesignator : public DesignatorBase {
  public:
   using FaceType = face_enum_t;
   using ShellType = shell_type_t;
 
-  HomogeneousMaterialDesignator(
-      FaceType face,
-      std::shared_ptr<const HomogeneousSurfaceMaterial> material) {
+  ISurfaceMaterialDesignator(FaceType face,
+                             std::shared_ptr<const ISurfaceMaterial> material) {
     m_materials.emplace_back(face, std::move(material));
   }
 
   std::string label() const override {
-    return std::string{shellTypeName()} + " HomogeneousMaterialDesignator";
+    return std::string{shellTypeName()} + " ISurfaceMaterialDesignator";
   }
 
   void apply(PortalShellBase& shell, const Logger& logger,
@@ -322,8 +320,8 @@ class HomogeneousMaterialDesignator : public DesignatorBase {
   }
 
   std::unique_ptr<DesignatorBase> merged(
-      const HomogeneousMaterialDesignator& other) const override {
-    auto merged = std::make_unique<HomogeneousMaterialDesignator>(*this);
+      const ISurfaceMaterialDesignator& other) const override {
+    auto merged = std::make_unique<ISurfaceMaterialDesignator>(*this);
     std::ranges::copy(other.m_materials,
                       std::back_inserter(merged->m_materials));
     return merged;
@@ -331,12 +329,11 @@ class HomogeneousMaterialDesignator : public DesignatorBase {
 
   std::unique_ptr<DesignatorBase> merged(
       const NullDesignator& /*other*/) const override {
-    return std::make_unique<HomogeneousMaterialDesignator>(*this);
+    return std::make_unique<ISurfaceMaterialDesignator>(*this);
   }
 
  private:
-  std::vector<
-      std::pair<FaceType, std::shared_ptr<const HomogeneousSurfaceMaterial>>>
+  std::vector<std::pair<FaceType, std::shared_ptr<const ISurfaceMaterial>>>
       m_materials;
 };
 


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
