### PR TITLE
refactor: Tracking geometry visitor does not call surface on portals

### DIFF
--- a/Core/src/Geometry/TrackingVolume.cpp
+++ b/Core/src/Geometry/TrackingVolume.cpp
@@ -682,12 +682,10 @@ void TrackingVolume::apply(TrackingGeometryVisitor& visitor) const {
   // Visit the boundary surfaces
   for (const auto& bs : m_boundarySurfaces) {
     visitor.visitBoundarySurface(*bs);
-    visitor.visitSurface(bs->surfaceRepresentation());
   }
 
   for (const auto& portal : portals()) {
     visitor.visitPortal(portal);
-    visitor.visitSurface(portal.surface());
   }
 
   // Internal structure

--- a/Plugins/ActSVG/src/TrackingGeometrySvgConverter.cpp
+++ b/Plugins/ActSVG/src/TrackingGeometrySvgConverter.cpp
@@ -222,6 +222,9 @@ struct Visitor : TrackingGeometryVisitor {
   }
 
   void visitPortal(const Portal& portal) override {
+    // Include portal surface itself
+    visitSurface(portal.surface());
+
     auto pIt = std::ranges::find_if(
         portals, [&](const auto& p) { return p.first == &portal; });
 


### PR DESCRIPTION
Previously, the tracking geometry visitor would call the `visitSurface` method for child surface (sensitive + passive) as well as portals (and boundaries). With this PR, it does not do that anymore. Also includes a fix to the Gen3 SVG conversion which relied on this behavior.

--- END COMMIT MESSAGE ---

@dimitra97 do you see any issues with this?