### PR TITLE
refactor: Generalize sorting requirement for `BroadTripletSeedFinder`

### DIFF
--- a/Core/include/Acts/Seeding2/BroadTripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding2/BroadTripletSeedFinder.hpp
@@ -45,6 +45,9 @@ class BroadTripletSeedFinder {
     /// produced when combining measurement from strips on back-to-back modules.
     /// Enables setting of the following delegates.
     bool useStripMeasurementInfo = false;
+
+    /// Whether the input space points are sorted by radius
+    bool spacePointsSortedByRadius = false;
   };
 
   struct TripletCuts {
@@ -142,8 +145,7 @@ class BroadTripletSeedFinder {
                                       getDefaultLogger("BroadTripletSeedFinder",
                                                        Logging::Level::INFO));
 
-  /// Create all possible seeds from bottom, middle, and top space points. No
-  /// assumptions on the order of the space points are made.
+  /// Create all possible seeds from bottom, middle, and top space points.
   ///
   /// @param options Configuration options for the seed finder
   /// @param state State of the seed finder
@@ -168,8 +170,7 @@ class BroadTripletSeedFinder {
                             SpacePointContainer2::ConstSubset& topSps,
                             SeedContainer2& outputSeeds) const;
 
-  /// Create all possible seeds from bottom, middle, and top space points. This
-  /// requires all space points within their groups to be sorted by radius.
+  /// Create all possible seeds from bottom, middle, and top space points.
   ///
   /// @param options Configuration options for the seed finder
   /// @param state State of the seed finder
@@ -179,20 +180,20 @@ class BroadTripletSeedFinder {
   /// @param tripletCuts Derived cuts for the triplet space points
   /// @param filter Triplet seed filter that defines the filtering criteria
   /// @param spacePoints Space point container
-  /// @param bottomSpRanges Ranges of space points to be used as innermost SP in a seed
-  /// @param middleSpRange Range of space points to be used as middle SP in a seed
-  /// @param topSpRanges Ranges of space points to be used as outermost SP in a seed
+  /// @param bottomSpGroups Groups of space points to be used as innermost SP in a seed
+  /// @param middleSpGroup Group of space points to be used as middle SP in a seed
+  /// @param topSpGroups Groups of space points to be used as outermost SP in a seed
   /// @param radiusRangeForMiddle Range of radii for the middle space points
   /// @param outputSeeds Output container for the seeds
-  void createSeedsFromSortedGroups(
+  void createSeedsFromGroups(
       const Options& options, State& state, Cache& cache,
       const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
       const DerivedTripletCuts& tripletCuts,
       const BroadTripletSeedFilter& filter,
       const SpacePointContainer2& spacePoints,
-      const std::span<SpacePointContainer2::ConstRange>& bottomSpRanges,
-      const SpacePointContainer2::ConstRange& middleSpRange,
-      const std::span<SpacePointContainer2::ConstRange>& topSpRanges,
+      const std::span<SpacePointContainer2::ConstRange>& bottomSpGroups,
+      const SpacePointContainer2::ConstRange& middleSpGroup,
+      const std::span<SpacePointContainer2::ConstRange>& topSpGroups,
       const std::pair<float, float>& radiusRangeForMiddle,
       SeedContainer2& outputSeeds) const;
 

--- a/Core/include/Acts/Seeding2/BroadTripletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding2/BroadTripletSeedFinder.hpp
@@ -122,9 +122,6 @@ class BroadTripletSeedFinder {
   };
 
   struct Cache {
-    std::vector<std::size_t> bottomSpOffsets;
-    std::vector<std::size_t> topSpOffsets;
-
     DoubletSeedFinder::DoubletsForMiddleSp bottomDoublets;
     DoubletSeedFinder::DoubletsForMiddleSp topDoublets;
 
@@ -201,55 +198,6 @@ class BroadTripletSeedFinder {
   std::unique_ptr<const Logger> m_logger;
 
   const Logger& logger() const { return *m_logger; }
-
-  /// Create triplets from the bottom, middle, and top space points.
-  ///
-  /// @param cache Cache object to store intermediate results
-  /// @param cuts Triplet cuts that define the compatibility of space points
-  /// @param rMaxSeedConf Maximum radius of bottom space point to use seed confirmation
-  /// @param filter Triplet seed filter that defines the filtering criteria
-  /// @param filterState State object that holds the state of the filter
-  /// @param filterCache Cache object that holds memory used in SeedFilter
-  /// @param spacePoints Space point container
-  /// @param spM Space point candidate to be used as middle SP in a seed
-  /// @param bottomDoublets Bottom doublets to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation
-  /// @param tripletTopCandidates Cache for triplet top candidates
-  /// @param candidatesCollector Collector for candidates for middle space points
-  static void createTriplets(
-      TripletCache& cache, const DerivedTripletCuts& cuts, float rMaxSeedConf,
-      const BroadTripletSeedFilter& filter,
-      BroadTripletSeedFilter::State& filterState,
-      BroadTripletSeedFilter::Cache& filterCache,
-      const SpacePointContainer2& spacePoints, const ConstSpacePointProxy2& spM,
-      const DoubletSeedFinder::DoubletsForMiddleSp& bottomDoublets,
-      const DoubletSeedFinder::DoubletsForMiddleSp& topDoublets,
-      TripletTopCandidates& tripletTopCandidates,
-      CandidatesForMiddleSp2& candidatesCollector);
-
-  /// Create triplets from the bottom, middle, and top space points.
-  ///
-  /// @param cuts Triplet cuts that define the compatibility of space points
-  /// @param rMaxSeedConf Maximum radius of bottom space point to use seed confirmation
-  /// @param filter Triplet seed filter that defines the filtering criteria
-  /// @param filterState State object that holds the state of the filter
-  /// @param filterCache Cache object that holds memory used in SeedFilter
-  /// @param spacePoints Space point container
-  /// @param spM Space point candidate to be used as middle SP in a seed
-  /// @param bottomDoublets Bottom doublets to be used for triplet creation
-  /// @param topDoublets Top doublets to be used for triplet creation
-  /// @param tripletTopCandidates Cache for triplet top candidates
-  /// @param candidatesCollector Collector for candidates for middle space points
-  static void createStripTriplets(
-      const DerivedTripletCuts& cuts, float rMaxSeedConf,
-      const BroadTripletSeedFilter& filter,
-      BroadTripletSeedFilter::State& filterState,
-      BroadTripletSeedFilter::Cache& filterCache,
-      const SpacePointContainer2& spacePoints, const ConstSpacePointProxy2& spM,
-      const DoubletSeedFinder::DoubletsForMiddleSp& bottomDoublets,
-      const DoubletSeedFinder::DoubletsForMiddleSp& topDoublets,
-      TripletTopCandidates& tripletTopCandidates,
-      CandidatesForMiddleSp2& candidatesCollector);
 };
 
 }  // namespace Acts::Experimental

--- a/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
@@ -65,7 +65,7 @@ class DoubletSeedFinder {
     Delegate<bool(float /*bottomRadius*/, float /*cotTheta*/)> experimentCuts;
 
     /// Whether the input space points are sorted by radius
-    bool sortedInR = false;
+    bool spacePointsSortedByRadius = false;
   };
 
   struct DerivedConfig : public Config {

--- a/Core/src/Seeding2/BroadTripletSeedFinder.cpp
+++ b/Core/src/Seeding2/BroadTripletSeedFinder.cpp
@@ -68,300 +68,30 @@ bool stripCoordinateCheck(float tolerance, const ConstSpacePointProxy2& sp,
   return true;
 }
 
-}  // namespace
-
-BroadTripletSeedFinder::DerivedTripletCuts::DerivedTripletCuts(
-    const TripletCuts& cuts, float bFieldInZ_)
-    : TripletCuts(cuts), bFieldInZ(bFieldInZ_) {
-  // similar to `theta0Highland` in `Core/src/Material/Interactions.cpp`
-  {
-    const double xOverX0 = radLengthPerSeed;
-    const double q2OverBeta2 = 1;  // q^2=1, beta^2~1
-    // RPP2018 eq. 33.15 (treats beta and q² consistently)
-    const double t = std::sqrt(xOverX0 * q2OverBeta2);
-    // log((x/X0) * (q²/beta²)) = log((sqrt(x/X0) * (q/beta))²)
-    //                          = 2 * log(sqrt(x/X0) * (q/beta))
-    highland =
-        static_cast<float>(13.6_MeV * t * (1.0 + 0.038 * 2 * std::log(t)));
-  }
-
-  const float maxScatteringAngle = highland / minPt;
-  const float maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
-
-  // bFieldInZ is in (pT/radius) natively, no need for conversion
-  pTPerHelixRadius = bFieldInZ;
-  minHelixDiameter2 = square(minPt * 2 / pTPerHelixRadius) * helixCutTolerance;
-  const float pT2perRadius = square(highland / pTPerHelixRadius);
-  sigmapT2perRadius = pT2perRadius * square(2 * sigmaScattering);
-  multipleScattering2 = maxScatteringAngle2 * square(sigmaScattering);
-}
-
-BroadTripletSeedFinder::BroadTripletSeedFinder(
-    std::unique_ptr<const Logger> logger_)
-    : m_logger(std::move(logger_)) {}
-
-void BroadTripletSeedFinder::createSeedsFromGroup(
-    const Options& options, State& state, Cache& cache,
-    const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
-    const DerivedTripletCuts& tripletCuts, const BroadTripletSeedFilter& filter,
-    const SpacePointContainer2& spacePoints,
-    SpacePointContainer2::ConstSubset& bottomSps,
-    const ConstSpacePointProxy2& middleSp,
-    SpacePointContainer2::ConstSubset& topSps,
-    SeedContainer2& outputSeeds) const {
-  assert((options.spacePointsSortedByRadius ==
-              bottomFinder.config().spacePointsSortedByRadius &&
-          options.spacePointsSortedByRadius ==
-              topFinder.config().spacePointsSortedByRadius) &&
-         "Inconsistent space point sorting");
-
-  cache.candidatesCollector.setMaxElements(
-      filter.config().maxSeedsPerSpMConf,
-      filter.config().maxQualitySeedsPerSpMConf);
-
-  DoubletSeedFinder::MiddleSpInfo middleSpInfo =
-      DoubletSeedFinder::computeMiddleSpInfo(middleSp);
-
-  // create middle-top doublets
-  cache.topDoublets.clear();
-  topFinder.createDoublets(middleSp, middleSpInfo, topSps, cache.topDoublets);
-
-  // no top SP found -> cannot form any triplet
-  if (cache.topDoublets.empty()) {
-    ACTS_VERBOSE("No compatible Tops, returning");
-    return;
-  }
-
-  // apply cut on the number of top SP if seedConfirmation is true
-  float rMaxSeedConf = 0;
-  if (filter.config().seedConfirmation) {
-    // check if middle SP is in the central or forward region
-    const bool isForwardRegion =
-        middleSp.z() >
-            filter.config().centralSeedConfirmationRange.zMaxSeedConf ||
-        middleSp.z() <
-            filter.config().centralSeedConfirmationRange.zMinSeedConf;
-    SeedConfirmationRangeConfig seedConfRange =
-        isForwardRegion ? filter.config().forwardSeedConfirmationRange
-                        : filter.config().centralSeedConfirmationRange;
-    // set the minimum number of top SP depending on whether the middle SP is
-    // in the central or forward region
-    std::size_t nTopSeedConf = middleSp.r() > seedConfRange.rMaxSeedConf
-                                   ? seedConfRange.nTopForLargeR
-                                   : seedConfRange.nTopForSmallR;
-    // set max bottom radius for seed confirmation
-    rMaxSeedConf = seedConfRange.rMaxSeedConf;
-    // continue if number of top SPs is smaller than minimum
-    if (cache.topDoublets.size() < nTopSeedConf) {
-      ACTS_VERBOSE("Number of top SPs is "
-                   << cache.topDoublets.size()
-                   << " and is smaller than minimum, returning");
-      return;
-    }
-  }
-
-  // create middle-bottom doublets
-  cache.bottomDoublets.clear();
-  bottomFinder.createDoublets(middleSp, middleSpInfo, bottomSps,
-                              cache.bottomDoublets);
-
-  // no bottom SP found -> cannot form any triplet
-  if (cache.bottomDoublets.empty()) {
-    ACTS_VERBOSE("No compatible Bottoms, returning");
-    return;
-  }
-
-  ACTS_VERBOSE("Candidates: " << cache.bottomDoublets.size() << " bottoms and "
-                              << cache.topDoublets.size()
-                              << " tops for middle candidate indexed "
-                              << middleSp.index());
-
-  // combine doublets to triplets
-  cache.candidatesCollector.clear();
-  if (options.useStripMeasurementInfo) {
-    createStripTriplets(tripletCuts, rMaxSeedConf, filter, state.filter,
-                        cache.filter, spacePoints, middleSp,
-                        cache.bottomDoublets, cache.topDoublets,
-                        cache.tripletTopCandidates, cache.candidatesCollector);
-  } else {
-    createTriplets(cache.tripletCache, tripletCuts, rMaxSeedConf, filter,
-                   state.filter, cache.filter, spacePoints, middleSp,
-                   cache.bottomDoublets, cache.topDoublets,
-                   cache.tripletTopCandidates, cache.candidatesCollector);
-  }
-
-  // retrieve all candidates
-  // this collection is already sorted, higher weights first
-  const std::size_t numQualitySeeds =
-      cache.candidatesCollector.nHighQualityCandidates();
-  cache.candidatesCollector.toSortedCandidates(spacePoints,
-                                               cache.sortedCandidates);
-  filter.filter1SpFixed(state.filter, spacePoints, cache.sortedCandidates,
-                        numQualitySeeds, outputSeeds);
-}
-
-void BroadTripletSeedFinder::createSeedsFromGroups(
-    const Options& options, State& state, Cache& cache,
-    const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
-    const DerivedTripletCuts& tripletCuts, const BroadTripletSeedFilter& filter,
-    const SpacePointContainer2& spacePoints,
-    const std::span<SpacePointContainer2::ConstRange>& bottomSpGroups,
-    const SpacePointContainer2::ConstRange& middleSpGroup,
-    const std::span<SpacePointContainer2::ConstRange>& topSpGroups,
-    const std::pair<float, float>& radiusRangeForMiddle,
-    SeedContainer2& outputSeeds) const {
-  assert((options.spacePointsSortedByRadius ==
-              bottomFinder.config().spacePointsSortedByRadius &&
-          options.spacePointsSortedByRadius ==
-              topFinder.config().spacePointsSortedByRadius) &&
-         "Inconsistent space point sorting");
-
-  if (middleSpGroup.empty()) {
-    return;
-  }
-
-  // initialize cache
-  cache.candidatesCollector.setMaxElements(
-      filter.config().maxSeedsPerSpMConf,
-      filter.config().maxQualitySeedsPerSpMConf);
-
-  cache.bottomSpOffsets.clear();
-  cache.topSpOffsets.clear();
-
-  if (options.spacePointsSortedByRadius) {
-    // Initialize initial offsets for bottom and top space points with binary
-    // search. This requires at least one middle space point to be present which
-    // is already checked above.
-    const ConstSpacePointProxy2 firstMiddleSp = middleSpGroup.front();
-    const float firstMiddleSpR = firstMiddleSp.r();
-
-    std::ranges::transform(
-        bottomSpGroups, std::back_inserter(cache.bottomSpOffsets),
-        [&](const SpacePointContainer2::ConstRange& bottomSps) {
-          auto low = std::ranges::lower_bound(
-              bottomSps, firstMiddleSpR - bottomFinder.config().deltaRMax, {},
-              [&](const ConstSpacePointProxy2& sp) { return sp.r(); });
-          return low - bottomSps.begin();
-        });
-    std::ranges::transform(
-        topSpGroups, std::back_inserter(cache.topSpOffsets),
-        [&](const SpacePointContainer2::ConstRange& topSps) {
-          auto low = std::ranges::lower_bound(
-              topSps, firstMiddleSpR + topFinder.config().deltaRMin, {},
-              [&](const ConstSpacePointProxy2& sp) { return sp.r(); });
-          return low - topSps.begin();
-        });
-  }
-
-  for (ConstSpacePointProxy2 spM : middleSpGroup) {
-    const float rM = spM.r();
-
-    if (options.spacePointsSortedByRadius) {
-      // check if spM is outside our radial region of interest
-      if (rM < radiusRangeForMiddle.first) {
-        continue;
-      }
-      if (rM > radiusRangeForMiddle.second) {
-        // break because SPs are sorted in r
-        break;
-      }
-    }
-
-    DoubletSeedFinder::MiddleSpInfo middleSpInfo =
-        DoubletSeedFinder::computeMiddleSpInfo(spM);
-
-    // create middle-top doublets
-    cache.topDoublets.clear();
-    for (SpacePointContainer2::ConstRange& topSpGroup : topSpGroups) {
-      topFinder.createDoublets(spM, middleSpInfo, topSpGroup,
-                               cache.topDoublets);
-    }
-
-    // no top SP found -> try next spM
-    if (cache.topDoublets.empty()) {
-      ACTS_VERBOSE("No compatible Tops, moving to next middle candidate");
-      continue;
-    }
-
-    // apply cut on the number of top SP if seedConfirmation is true
-    float rMaxSeedConf = 0;
-    if (filter.config().seedConfirmation) {
-      // check if middle SP is in the central or forward region
-      const bool isForwardRegion =
-          spM.z() > filter.config().centralSeedConfirmationRange.zMaxSeedConf ||
-          spM.z() < filter.config().centralSeedConfirmationRange.zMinSeedConf;
-      SeedConfirmationRangeConfig seedConfRange =
-          isForwardRegion ? filter.config().forwardSeedConfirmationRange
-                          : filter.config().centralSeedConfirmationRange;
-      // set the minimum number of top SP depending on whether the middle SP is
-      // in the central or forward region
-      std::size_t nTopSeedConf = spM.r() > seedConfRange.rMaxSeedConf
-                                     ? seedConfRange.nTopForLargeR
-                                     : seedConfRange.nTopForSmallR;
-      // set max bottom radius for seed confirmation
-      rMaxSeedConf = seedConfRange.rMaxSeedConf;
-      // continue if number of top SPs is smaller than minimum
-      if (cache.topDoublets.size() < nTopSeedConf) {
-        ACTS_VERBOSE(
-            "Number of top SPs is "
-            << cache.topDoublets.size()
-            << " and is smaller than minimum, moving to next middle candidate");
-        continue;
-      }
-    }
-
-    // create middle-bottom doublets
-    cache.bottomDoublets.clear();
-    for (SpacePointContainer2::ConstRange& bottomSpGroup : bottomSpGroups) {
-      bottomFinder.createDoublets(spM, middleSpInfo, bottomSpGroup,
-                                  cache.bottomDoublets);
-    }
-
-    // no bottom SP found -> try next spM
-    if (cache.bottomDoublets.empty()) {
-      ACTS_VERBOSE("No compatible Bottoms, moving to next middle candidate");
-      continue;
-    }
-
-    ACTS_VERBOSE("Candidates: " << cache.bottomDoublets.size()
-                                << " bottoms and " << cache.topDoublets.size()
-                                << " tops for middle candidate indexed "
-                                << spM.index());
-
-    // combine doublets to triplets
-    cache.candidatesCollector.clear();
-    if (options.useStripMeasurementInfo) {
-      createStripTriplets(tripletCuts, rMaxSeedConf, filter, state.filter,
-                          cache.filter, spacePoints, spM, cache.bottomDoublets,
-                          cache.topDoublets, cache.tripletTopCandidates,
-                          cache.candidatesCollector);
-    } else {
-      createTriplets(cache.tripletCache, tripletCuts, rMaxSeedConf, filter,
-                     state.filter, cache.filter, spacePoints, spM,
-                     cache.bottomDoublets, cache.topDoublets,
-                     cache.tripletTopCandidates, cache.candidatesCollector);
-    }
-
-    // retrieve all candidates
-    // this collection is already sorted, higher weights first
-    const std::size_t numQualitySeeds =
-        cache.candidatesCollector.nHighQualityCandidates();
-    cache.candidatesCollector.toSortedCandidates(spacePoints,
-                                                 cache.sortedCandidates);
-    filter.filter1SpFixed(state.filter, spacePoints, cache.sortedCandidates,
-                          numQualitySeeds, outputSeeds);
-  }
-}
-
-void BroadTripletSeedFinder::createTriplets(
-    TripletCache& cache, const DerivedTripletCuts& cuts, float rMaxSeedConf,
+/// Create triplets from the bottom, middle, and top space points.
+///
+/// @param cache Cache object to store intermediate results
+/// @param cuts Triplet cuts that define the compatibility of space points
+/// @param rMaxSeedConf Maximum radius of bottom space point to use seed confirmation
+/// @param filter Triplet seed filter that defines the filtering criteria
+/// @param filterState State object that holds the state of the filter
+/// @param filterCache Cache object that holds memory used in SeedFilter
+/// @param spacePoints Space point container
+/// @param spM Space point candidate to be used as middle SP in a seed
+/// @param bottomDoublets Bottom doublets to be used for triplet creation
+/// @param topDoublets Top doublets to be used for triplet creation
+/// @param tripletTopCandidates Cache for triplet top candidates
+/// @param candidatesCollector Collector for candidates for middle space points
+static void createTriplets(
+    BroadTripletSeedFinder::TripletCache& cache,
+    const BroadTripletSeedFinder::DerivedTripletCuts& cuts, float rMaxSeedConf,
     const BroadTripletSeedFilter& filter,
     BroadTripletSeedFilter::State& filterState,
     BroadTripletSeedFilter::Cache& filterCache,
     const SpacePointContainer2& spacePoints, const ConstSpacePointProxy2& spM,
     const DoubletSeedFinder::DoubletsForMiddleSp& bottomDoublets,
     const DoubletSeedFinder::DoubletsForMiddleSp& topDoublets,
-    TripletTopCandidates& tripletTopCandidates,
+    BroadTripletSeedFinder::TripletTopCandidates& tripletTopCandidates,
     CandidatesForMiddleSp2& candidatesCollector) {
   const float rM = spM.r();
   const float varianceRM = spM.varianceR();
@@ -547,15 +277,28 @@ void BroadTripletSeedFinder::createTriplets(
   }  // loop on bottoms
 }
 
-void BroadTripletSeedFinder::createStripTriplets(
-    const DerivedTripletCuts& cuts, float rMaxSeedConf,
+/// Create triplets from the bottom, middle, and top space points.
+///
+/// @param cuts Triplet cuts that define the compatibility of space points
+/// @param rMaxSeedConf Maximum radius of bottom space point to use seed confirmation
+/// @param filter Triplet seed filter that defines the filtering criteria
+/// @param filterState State object that holds the state of the filter
+/// @param filterCache Cache object that holds memory used in SeedFilter
+/// @param spacePoints Space point container
+/// @param spM Space point candidate to be used as middle SP in a seed
+/// @param bottomDoublets Bottom doublets to be used for triplet creation
+/// @param topDoublets Top doublets to be used for triplet creation
+/// @param tripletTopCandidates Cache for triplet top candidates
+/// @param candidatesCollector Collector for candidates for middle space points
+static void createStripTriplets(
+    const BroadTripletSeedFinder::DerivedTripletCuts& cuts, float rMaxSeedConf,
     const BroadTripletSeedFilter& filter,
     BroadTripletSeedFilter::State& filterState,
     BroadTripletSeedFilter::Cache& filterCache,
     const SpacePointContainer2& spacePoints, const ConstSpacePointProxy2& spM,
     const DoubletSeedFinder::DoubletsForMiddleSp& bottomDoublets,
     const DoubletSeedFinder::DoubletsForMiddleSp& topDoublets,
-    TripletTopCandidates& tripletTopCandidates,
+    BroadTripletSeedFinder::TripletTopCandidates& tripletTopCandidates,
     CandidatesForMiddleSp2& candidatesCollector) {
   const float rM = spM.r();
   const float cosPhiM = spM.x() / rM;
@@ -789,6 +532,233 @@ void BroadTripletSeedFinder::createStripTriplets(
         tripletTopCandidates.topSpacePoints, tripletTopCandidates.curvatures,
         tripletTopCandidates.impactParameters, zOrigin, candidatesCollector);
   }  // loop on bottoms
+}
+
+template <typename SpacePointCollections>
+void createSeedsFromGroupsImpl(
+    const Logger& logger, const BroadTripletSeedFinder::Options& options,
+    BroadTripletSeedFinder::State& state, BroadTripletSeedFinder::Cache& cache,
+    const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
+    const BroadTripletSeedFinder::DerivedTripletCuts& tripletCuts,
+    const BroadTripletSeedFilter& filter,
+    const SpacePointContainer2& spacePoints,
+    SpacePointCollections& bottomSpGroups,
+    const ConstSpacePointProxy2& middleSp, SpacePointCollections& topSpGroups,
+    SeedContainer2& outputSeeds) {
+  DoubletSeedFinder::MiddleSpInfo middleSpInfo =
+      DoubletSeedFinder::computeMiddleSpInfo(middleSp);
+
+  // create middle-top doublets
+  cache.topDoublets.clear();
+  for (auto& topSpGroup : topSpGroups) {
+    topFinder.createDoublets(middleSp, middleSpInfo, topSpGroup,
+                             cache.topDoublets);
+  }
+
+  // no top SP found -> cannot form any triplet
+  if (cache.topDoublets.empty()) {
+    ACTS_VERBOSE("No compatible Tops, returning");
+    return;
+  }
+
+  // apply cut on the number of top SP if seedConfirmation is true
+  float rMaxSeedConf = 0;
+  if (filter.config().seedConfirmation) {
+    // check if middle SP is in the central or forward region
+    const bool isForwardRegion =
+        middleSp.z() >
+            filter.config().centralSeedConfirmationRange.zMaxSeedConf ||
+        middleSp.z() <
+            filter.config().centralSeedConfirmationRange.zMinSeedConf;
+    SeedConfirmationRangeConfig seedConfRange =
+        isForwardRegion ? filter.config().forwardSeedConfirmationRange
+                        : filter.config().centralSeedConfirmationRange;
+    // set the minimum number of top SP depending on whether the middle SP is
+    // in the central or forward region
+    std::size_t nTopSeedConf = middleSp.r() > seedConfRange.rMaxSeedConf
+                                   ? seedConfRange.nTopForLargeR
+                                   : seedConfRange.nTopForSmallR;
+    // set max bottom radius for seed confirmation
+    rMaxSeedConf = seedConfRange.rMaxSeedConf;
+    // continue if number of top SPs is smaller than minimum
+    if (cache.topDoublets.size() < nTopSeedConf) {
+      ACTS_VERBOSE("Number of top SPs is "
+                   << cache.topDoublets.size()
+                   << " and is smaller than minimum, returning");
+      return;
+    }
+  }
+
+  // create middle-bottom doublets
+  cache.bottomDoublets.clear();
+  for (auto& bottomSpGroup : bottomSpGroups) {
+    bottomFinder.createDoublets(middleSp, middleSpInfo, bottomSpGroup,
+                                cache.bottomDoublets);
+  }
+
+  // no bottom SP found -> cannot form any triplet
+  if (cache.bottomDoublets.empty()) {
+    ACTS_VERBOSE("No compatible Bottoms, returning");
+    return;
+  }
+
+  ACTS_VERBOSE("Candidates: " << cache.bottomDoublets.size() << " bottoms and "
+                              << cache.topDoublets.size()
+                              << " tops for middle candidate indexed "
+                              << middleSp.index());
+
+  // combine doublets to triplets
+  cache.candidatesCollector.clear();
+  if (options.useStripMeasurementInfo) {
+    createStripTriplets(tripletCuts, rMaxSeedConf, filter, state.filter,
+                        cache.filter, spacePoints, middleSp,
+                        cache.bottomDoublets, cache.topDoublets,
+                        cache.tripletTopCandidates, cache.candidatesCollector);
+  } else {
+    createTriplets(cache.tripletCache, tripletCuts, rMaxSeedConf, filter,
+                   state.filter, cache.filter, spacePoints, middleSp,
+                   cache.bottomDoublets, cache.topDoublets,
+                   cache.tripletTopCandidates, cache.candidatesCollector);
+  }
+
+  // retrieve all candidates
+  // this collection is already sorted, higher weights first
+  const std::size_t numQualitySeeds =
+      cache.candidatesCollector.nHighQualityCandidates();
+  cache.candidatesCollector.toSortedCandidates(spacePoints,
+                                               cache.sortedCandidates);
+  filter.filter1SpFixed(state.filter, spacePoints, cache.sortedCandidates,
+                        numQualitySeeds, outputSeeds);
+}
+
+}  // namespace
+
+BroadTripletSeedFinder::DerivedTripletCuts::DerivedTripletCuts(
+    const TripletCuts& cuts, float bFieldInZ_)
+    : TripletCuts(cuts), bFieldInZ(bFieldInZ_) {
+  // similar to `theta0Highland` in `Core/src/Material/Interactions.cpp`
+  {
+    const double xOverX0 = radLengthPerSeed;
+    const double q2OverBeta2 = 1;  // q^2=1, beta^2~1
+    // RPP2018 eq. 33.15 (treats beta and q² consistently)
+    const double t = std::sqrt(xOverX0 * q2OverBeta2);
+    // log((x/X0) * (q²/beta²)) = log((sqrt(x/X0) * (q/beta))²)
+    //                          = 2 * log(sqrt(x/X0) * (q/beta))
+    highland =
+        static_cast<float>(13.6_MeV * t * (1.0 + 0.038 * 2 * std::log(t)));
+  }
+
+  const float maxScatteringAngle = highland / minPt;
+  const float maxScatteringAngle2 = maxScatteringAngle * maxScatteringAngle;
+
+  // bFieldInZ is in (pT/radius) natively, no need for conversion
+  pTPerHelixRadius = bFieldInZ;
+  minHelixDiameter2 = square(minPt * 2 / pTPerHelixRadius) * helixCutTolerance;
+  const float pT2perRadius = square(highland / pTPerHelixRadius);
+  sigmapT2perRadius = pT2perRadius * square(2 * sigmaScattering);
+  multipleScattering2 = maxScatteringAngle2 * square(sigmaScattering);
+}
+
+BroadTripletSeedFinder::BroadTripletSeedFinder(
+    std::unique_ptr<const Logger> logger_)
+    : m_logger(std::move(logger_)) {}
+
+void BroadTripletSeedFinder::createSeedsFromGroup(
+    const Options& options, State& state, Cache& cache,
+    const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
+    const DerivedTripletCuts& tripletCuts, const BroadTripletSeedFilter& filter,
+    const SpacePointContainer2& spacePoints,
+    SpacePointContainer2::ConstSubset& bottomSps,
+    const ConstSpacePointProxy2& middleSp,
+    SpacePointContainer2::ConstSubset& topSps,
+    SeedContainer2& outputSeeds) const {
+  assert((options.spacePointsSortedByRadius ==
+              bottomFinder.config().spacePointsSortedByRadius &&
+          options.spacePointsSortedByRadius ==
+              topFinder.config().spacePointsSortedByRadius) &&
+         "Inconsistent space point sorting");
+
+  cache.candidatesCollector.setMaxElements(
+      filter.config().maxSeedsPerSpMConf,
+      filter.config().maxQualitySeedsPerSpMConf);
+
+  std::array<SpacePointContainer2::ConstSubset, 1> bottomSpGroups{bottomSps};
+  std::array<SpacePointContainer2::ConstSubset, 1> topSpGroups{topSps};
+
+  createSeedsFromGroupsImpl(*m_logger, options, state, cache, bottomFinder,
+                            topFinder, tripletCuts, filter, spacePoints,
+                            bottomSpGroups, middleSp, topSpGroups, outputSeeds);
+}
+
+void BroadTripletSeedFinder::createSeedsFromGroups(
+    const Options& options, State& state, Cache& cache,
+    const DoubletSeedFinder& bottomFinder, const DoubletSeedFinder& topFinder,
+    const DerivedTripletCuts& tripletCuts, const BroadTripletSeedFilter& filter,
+    const SpacePointContainer2& spacePoints,
+    const std::span<SpacePointContainer2::ConstRange>& bottomSpGroups,
+    const SpacePointContainer2::ConstRange& middleSpGroup,
+    const std::span<SpacePointContainer2::ConstRange>& topSpGroups,
+    const std::pair<float, float>& radiusRangeForMiddle,
+    SeedContainer2& outputSeeds) const {
+  assert((options.spacePointsSortedByRadius ==
+              bottomFinder.config().spacePointsSortedByRadius &&
+          options.spacePointsSortedByRadius ==
+              topFinder.config().spacePointsSortedByRadius) &&
+         "Inconsistent space point sorting");
+
+  if (middleSpGroup.empty()) {
+    return;
+  }
+
+  // initialize cache
+  cache.candidatesCollector.setMaxElements(
+      filter.config().maxSeedsPerSpMConf,
+      filter.config().maxQualitySeedsPerSpMConf);
+
+  if (options.spacePointsSortedByRadius) {
+    // Initialize initial offsets for bottom and top space points with binary
+    // search. This requires at least one middle space point to be present which
+    // is already checked above.
+    const ConstSpacePointProxy2 firstMiddleSp = middleSpGroup.front();
+    const float firstMiddleSpR = firstMiddleSp.r();
+
+    for (auto& bottomSpGroup : bottomSpGroups) {
+      // Find the first bottom space point that is within the deltaRMax of the
+      // first middle space point.
+      auto low = std::ranges::lower_bound(
+          bottomSpGroup, firstMiddleSpR - bottomFinder.config().deltaRMax, {},
+          [&](const ConstSpacePointProxy2& sp) { return sp.r(); });
+      bottomSpGroup = bottomSpGroup.subrange(low - bottomSpGroup.begin());
+    }
+
+    for (auto& topSpGroup : topSpGroups) {
+      // Find the first top space point that is within the deltaRMin of the
+      // first middle space point.
+      auto low = std::ranges::lower_bound(
+          topSpGroup, firstMiddleSpR + topFinder.config().deltaRMin, {},
+          [&](const ConstSpacePointProxy2& sp) { return sp.r(); });
+      topSpGroup = topSpGroup.subrange(low - topSpGroup.begin());
+    }
+  }
+
+  for (ConstSpacePointProxy2 spM : middleSpGroup) {
+    const float rM = spM.r();
+
+    if (options.spacePointsSortedByRadius) {
+      // check if spM is outside our radial region of interest
+      if (rM < radiusRangeForMiddle.first) {
+        continue;
+      }
+      if (rM > radiusRangeForMiddle.second) {
+        // break because SPs are sorted in r
+        break;
+      }
+    }
+
+    createSeedsFromGroupsImpl(*m_logger, options, state, cache, bottomFinder,
+                              topFinder, tripletCuts, filter, spacePoints,
+                              bottomSpGroups, spM, topSpGroups, outputSeeds);
+  }
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Seeding2/BroadTripletSeedFinder.cpp
+++ b/Core/src/Seeding2/BroadTripletSeedFinder.cpp
@@ -82,7 +82,7 @@ bool stripCoordinateCheck(float tolerance, const ConstSpacePointProxy2& sp,
 /// @param topDoublets Top doublets to be used for triplet creation
 /// @param tripletTopCandidates Cache for triplet top candidates
 /// @param candidatesCollector Collector for candidates for middle space points
-static void createTriplets(
+void createTriplets(
     BroadTripletSeedFinder::TripletCache& cache,
     const BroadTripletSeedFinder::DerivedTripletCuts& cuts, float rMaxSeedConf,
     const BroadTripletSeedFilter& filter,
@@ -290,7 +290,7 @@ static void createTriplets(
 /// @param topDoublets Top doublets to be used for triplet creation
 /// @param tripletTopCandidates Cache for triplet top candidates
 /// @param candidatesCollector Collector for candidates for middle space points
-static void createStripTriplets(
+void createStripTriplets(
     const BroadTripletSeedFinder::DerivedTripletCuts& cuts, float rMaxSeedConf,
     const BroadTripletSeedFilter& filter,
     BroadTripletSeedFilter::State& filterState,

--- a/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
@@ -176,6 +176,7 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
 
   Acts::Experimental::BroadTripletSeedFinder::Options finderOptions;
   finderOptions.bFieldInZ = m_cfg.bFieldInZ;
+  finderOptions.spacePointsSortedByRadius = true;
 
   Acts::Experimental::DoubletSeedFinder::Config bottomDoubletFinderConfig;
   bottomDoubletFinderConfig.candidateDirection = Acts::Direction::Backward();
@@ -197,7 +198,7 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
   if (m_cfg.useExtraCuts) {
     bottomDoubletFinderConfig.experimentCuts.connect<itkFastTrackingCuts>();
   }
-  bottomDoubletFinderConfig.sortedInR = true;
+  bottomDoubletFinderConfig.spacePointsSortedByRadius = true;
   Acts::Experimental::DoubletSeedFinder bottomDoubletFinder(
       Acts::Experimental::DoubletSeedFinder::DerivedConfig(
           bottomDoubletFinderConfig, m_cfg.bFieldInZ));
@@ -271,7 +272,7 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
                  << radiusRangeForMiddle.first << ", "
                  << radiusRangeForMiddle.second << "]");
 
-    m_seedFinder->createSeedsFromSortedGroups(
+    m_seedFinder->createSeedsFromGroups(
         finderOptions, state, cache, bottomDoubletFinder, topDoubletFinder,
         derivedTripletCuts, *m_seedFilter, coreSpacePoints, bottomSpRanges,
         *middleSpRange, topSpRanges, radiusRangeForMiddle, seeds);


### PR DESCRIPTION
With https://github.com/acts-project/acts/pull/4447 the sorting requirement of the `DoubletSeedFinder` becomes an option. The same can now be done for the `BroadTripletSeedFinder`. This generalizes the use of the `BroadTripletSeedFinder` and will be beneficial for the module map approach.

--- END COMMIT MESSAGE ---

blocked by
- https://github.com/acts-project/acts/pull/4447