### PR TITLE
build: VecMem Setup Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,6 +484,16 @@ if(ACTS_BUILD_PLUGIN_GEANT4)
 endif()
 
 if(ACTS_BUILD_PLUGIN_TRACCC)
+    if(ACTS_SETUP_VECMEM)
+        if(ACTS_USE_SYSTEM_VECMEM)
+            find_package(vecmem ${_acts_vecmem_version} REQUIRED)
+        else()
+            add_subdirectory(thirdparty/vecmem)
+            # Make the "VecMem language code" available for the whole project.
+            include("${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake")
+        endif()
+    endif()
+
     if(ACTS_SETUP_ALGEBRAPLUGINS)
         if(ACTS_USE_SYSTEM_ALGEBRAPLUGINS)
             find_package(
@@ -501,16 +511,6 @@ if(ACTS_BUILD_PLUGIN_TRACCC)
             find_package(detray ${_acts_detray_version} REQUIRED CONFIG)
         else()
             add_subdirectory(thirdparty/detray)
-        endif()
-    endif()
-
-    if(ACTS_SETUP_VECMEM)
-        if(ACTS_USE_SYSTEM_VECMEM)
-            find_package(vecmem ${_acts_vecmem_version} REQUIRED)
-        else()
-            add_subdirectory(thirdparty/vecmem)
-            # Make the "VecMem language code" available for the whole project.
-            include("${VECMEM_LANGUAGE_DIR}/vecmem-check-language.cmake")
         endif()
     endif()
 


### PR DESCRIPTION
Find vecmem before setting up the libraries that need it.

So that a pre-built vecmem installation could be used together with algebra-plugins
and detray being built by this project.

--- END COMMIT MESSAGE ---

[traccc](https://github.com/acts-project/traccc) was already working, as its setup came after that of vecmem already.

The way to trigger these issues is like the following:
  - First one needs to build/install [vecmem](https://github.com/acts-project/vecmem) on its own. Like:

```
[bash][atspot01]:acts > ls vecmem-1.18.0*
vecmem-1.18.0:
benchmarks  cmake  CMakeLists.txt  core  cuda  hip  LICENSE  README.md  sycl  tests

vecmem-1.18.0-build:
bin             cmake_install.cmake  CPackSourceConfig.cmake  DartConfiguration.tcl  lib       Testing
CMakeCache.txt  core                 CTestTestfile.cmake      _deps                  lib64     tests
CMakeFiles      CPackConfig.cmake    cuda                     install_manifest.txt   Makefile

vecmem-1.18.0-install:
include  lib64
[bash][atspot01]:acts >
```

  - Then attempt the build of this project with (the recipe here is pretty specific to the build environment that I tried this in):

```
[bash][atspot01]:acts > CMAKE_PREFIX_PATH=$PWD/vecmem-1.18.0-install:$CMAKE_PREFIX_PATH /software/cmake/3.31.1/x86_64-el9-gcc11-opt/bin/cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=Release -DACTS_USE_SYSTEM_EIGEN3=FALSE -DACTS_BUILD_PLUGIN_TRACCC=TRUE -DACTS_USE_SYSTEM_VECMEM=TRUE -S acts/ -B acts-build
-- The CXX compiler identification is GNU 13.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /software/gcc/13.3.0/x86_64-el9/bin/g++-13 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
...
-- Ignore subdirectory 'docs'
-- Configuring done (23.1s)
CMake Error at /home/krasznaa/ATLAS/projects/acts/acts-build/_deps/algebraplugins-src/storage/vecmem/CMakeLists.txt:10 (target_link_libraries):
  The link interface of target "algebra_vecmem_storage" contains:

    vecmem::core

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



CMake Error at /home/krasznaa/ATLAS/projects/acts/acts-build/_deps/detray-src/core/CMakeLists.txt:42 (target_link_libraries):
  The link interface of target "detray_core" contains:

    vecmem::core

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
...
```

@paulgessinger, I ran into this while trying to experiment with the build that we discussed before lunch...
