### PR TITLE
fix: take iterator distance within vector in AxisDefinitions

### DIFF
--- a/Core/src/Utilities/AxisDefinitions.cpp
+++ b/Core/src/Utilities/AxisDefinitions.cpp
@@ -45,9 +45,11 @@ AxisDirection axisDirectionFromName(const std::string& name) {
     // Legacy binning check - this should be removed once BinUtility is gone
     it = std::ranges::find(s_legacyBinningValueNames, name);
     if (it == s_legacyBinningValueNames.end()) {
+      // both legacy and current failed
       throw std::invalid_argument("Unknown AxisDirection value name: " + name);
     }
-    // both legacy and current failed
+    return static_cast<AxisDirection>(
+        std::distance(s_legacyBinningValueNames.begin(), it));
   }
   return static_cast<AxisDirection>(
       std::distance(s_axisDirectionNames.begin(), it));


### PR DESCRIPTION
In ePIC we noticed (upon upgrading to v39) that our material map json geometry did not get the correct `AxisPhi` and `AxisZ` binning directions (instead we got `AxisX`). This turned out to be due to the incorrect parsing of the `binPhi` and `binZ` fields. In particular, the iterator `it` in `s_legacyBinningValueNames` cannot be compared to `s_axisDirectionNames.begin()` (a different vector) to get the index.

This PR introduces an early return when the `name` is found in the `s_legacyBinningValueNames` vector. I confirmed that with this fix the json output indeed changes `CylinderBounds` from:
```json
    "binUtility": {
      "binningdata": [
        {
          "bins": 144,
          "max": 3.1415927410125732,
          "min": -3.1415927410125732,
          "option": "closed",
          "type": "equidistant",
          "value": "AxisX"
        },
        {
          "bins": 10,
          "max": 0.0,
          "min": 0.0,
          "option": "open",
          "type": "equidistant",
          "value": "AxisX"
        }
      ]
    },
```
to
```json
    "binUtility": {
      "binningdata": [
        {
          "bins": 144,
          "max": 3.1415927410125732,
          "min": -3.1415927410125732,
          "option": "closed",
          "type": "equidistant",
          "value": "AxisPhi"
        },
        {
          "bins": 10,
          "max": 0.0,
          "min": 0.0,
          "option": "open",
          "type": "equidistant",
          "value": "AxisZ"
        }
      ]
    },
```

Note: this is an error that one could argue could/should have been caught by static analysis. A quick search of `std::distance` calls on reused iterators within the same function did not turn up any other instances (in the v39.2.0 source tree that I was looking at).