### PR TITLE
ci: Reduce LCG coverage, keep representative set of version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -541,8 +541,6 @@ lcg_106a:
     matrix:
       - OS: [alma9]
         COMPILER:
-          - gcc13
-          - gcc14
           - clang16
 
 lcg_107:
@@ -556,8 +554,6 @@ lcg_107:
       - OS: [alma9]
         COMPILER:
           - gcc13
-          - gcc14
-          - clang19
 
 lcg_107a:
   extends: .lcg_base_job
@@ -569,7 +565,6 @@ lcg_107a:
     matrix:
       - OS: [alma9]
         COMPILER:
-          - gcc13
           - gcc14
 
 lcg_108:
@@ -582,6 +577,5 @@ lcg_108:
     matrix:
       - OS: [alma9]
         COMPILER:
-          - gcc14
           - gcc15
           - clang19


### PR DESCRIPTION
The goal is to cover as many compilers as possible, so now we test on clang16, gcc13, gcc14, gcc15 and clang19 across LCG 106a, 107 and 108

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
