### PR TITLE
chore: Lockfile selection script also retries on URLError

### DIFF
--- a/CI/dependencies/select_lockfile.py
+++ b/CI/dependencies/select_lockfile.py
@@ -40,6 +40,13 @@ def retry_on_http_error(max_retries: int = 3, base_delay: float = 1.0):
                         time.sleep(delay)
                         continue
                     raise
+                except urllib.error.URLError as e:
+                    if attempt < max_retries - 1:
+                        delay = base_delay * (2**attempt)
+                        print(f"Got URL error {e}, retrying in {delay} seconds...")
+                        time.sleep(delay)
+                        continue
+                    raise
             return func(*args, **kwargs)  # Final attempt
 
         return wrapper


### PR DESCRIPTION
The retry logic currently only works for HTTPError. I'm observing URLError in CI now, so I'm including this exception in the retry logic as well now.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
