### PR TITLE
ci: hotfix for eic-shell failures

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -463,6 +463,9 @@ jobs:
             echo "::endgroup::"
             popd
 
+            # workaround ccache build picking up Acts installed in the container and causing linker errors
+            unset CMAKE_CXX_COMPILER_LAUNCHER
+
             pushd EICrecon
             export LD_LIBRARY_PATH="$CMAKE_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
             echo "::group::EICrecon configure phase"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -463,14 +463,11 @@ jobs:
             echo "::endgroup::"
             popd
 
-            # workaround ccache build picking up Acts installed in the container and causing linker errors
-            unset CMAKE_CXX_COMPILER_LAUNCHER
-
             pushd EICrecon
             export LD_LIBRARY_PATH="$CMAKE_INSTALL_PREFIX/lib:$LD_LIBRARY_PATH"
             echo "::group::EICrecon configure phase"
             ccache -z && \
-            env CXXFLAGS="-I$CMAKE_INSTALL_PREFIX/include" \
+            env CXXFLAGS="-I$CMAKE_INSTALL_PREFIX/include -L$CMAKE_INSTALL_PREFIX/lib" \
                 LDFLAGS="-L$CMAKE_INSTALL_PREFIX/lib" \
             cmake -B build -S . \
               -GNinja \


### PR DESCRIPTION
Since recent container upgrade we are seeing build failures. This allows to bypass the erroneous process until we figure out a proper fix.

--- END COMMIT MESSAGE ---

cc @paulgessinger

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
