### PR TITLE
fix: allow more secondary vertices

### DIFF
--- a/Fatras/include/ActsFatras/EventData/Barcode.hpp
+++ b/Fatras/include/ActsFatras/EventData/Barcode.hpp
@@ -91,8 +91,8 @@ namespace ActsFatras {
 /// easily solved by renumbering the sub-particle identifier within each
 /// generation to contain unique values. However, this can only be done when all
 /// particles are known.
-class Barcode : public Acts::MultiIndex<std::uint64_t, 12, 12, 16, 8, 16> {
-  using Base = Acts::MultiIndex<std::uint64_t, 12, 12, 16, 8, 16>;
+class Barcode : public Acts::MultiIndex<std::uint64_t, 10, 14, 16, 8, 16> {
+  using Base = Acts::MultiIndex<std::uint64_t, 10, 14, 16, 8, 16>;
 
  public:
   using Base::Base;


### PR DESCRIPTION
allow more secondary vertices

--- END COMMIT MESSAGE ---

In Fatras, a [barcode](https://github.com/acts-project/acts/blob/main/Fatras/include/ActsFatras/EventData/Barcode.hpp) enumerates primary and secondary vertices. As of now, there are reserved 12 bits for each, i.e. maximum number of vertices is 4096.
In pp collisions, we may have 200 primary vertices. One vertex may have up to around 100 secondary vertices (tested in 1000 events). Thus, there's a large reserve for both.
In PbPb collisions, we have only 1 primary vertex but we may have up to 6000 secondary vertices (again, tested in 1000 events). That exceeds the limit of 12 bits, causing [an error](https://github.com/acts-project/acts/blob/main/Core/include/Acts/Utilities/MultiIndex.hpp#L89). This problem is present in about 10% of all PbPb events.

This PR allocates 10 bits for primary vertices (allowing pile-up of 1000) and 14 bits for secondary vertices (allowing more than 16000 of them).