### PR TITLE
refactor: Simplify SurfaceArray flexibility

### DIFF
--- a/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
+++ b/Core/include/Acts/Geometry/SurfaceArrayCreator.hpp
@@ -367,11 +367,11 @@ class SurfaceArrayCreator {
   /// @param localToGlobal transform callable
   /// @param pAxisA ProtoAxis object for axis A
   /// @param pAxisB ProtoAxis object for axis B
-  template <AxisBoundaryType bdtA, AxisBoundaryType bdtB, typename F1,
-            typename F2>
+  template <AxisBoundaryType bdtA, AxisBoundaryType bdtB>
   static std::unique_ptr<SurfaceArray::ISurfaceGridLookup>
-  makeSurfaceGridLookup2D(F1 globalToLocal, F2 localToGlobal, ProtoAxis pAxisA,
-                          ProtoAxis pAxisB) {
+  makeSurfaceGridLookup2D(Surface::SurfaceType type,
+                          const Transform3& transform, double R, double Z,
+                          ProtoAxis pAxisA, ProtoAxis pAxisB) {
     using ISGL = SurfaceArray::ISurfaceGridLookup;
     std::unique_ptr<ISGL> ptr;
 
@@ -384,7 +384,7 @@ class SurfaceArrayCreator {
 
       using SGL = SurfaceArray::SurfaceGridLookup<decltype(axisA), decltype(axisB)>;
       ptr = std::make_unique<SGL>(
-            globalToLocal, localToGlobal, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
+            type, transform, R, Z, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
 
     } else if (pAxisA.bType == equidistant && pAxisB.bType == arbitrary) {
 
@@ -393,7 +393,7 @@ class SurfaceArrayCreator {
 
       using SGL = SurfaceArray::SurfaceGridLookup<decltype(axisA), decltype(axisB)>;
       ptr = std::make_unique<SGL>(
-            globalToLocal, localToGlobal, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
+            type, transform, R, Z, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
 
     } else if (pAxisA.bType == arbitrary && pAxisB.bType == equidistant) {
 
@@ -402,7 +402,7 @@ class SurfaceArrayCreator {
 
       using SGL = SurfaceArray::SurfaceGridLookup<decltype(axisA), decltype(axisB)>;
       ptr = std::make_unique<SGL>(
-            globalToLocal, localToGlobal, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
+            type, transform, R, Z, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
 
     } else /*if (pAxisA.bType == arbitrary && pAxisB.bType == arbitrary)*/ {
 
@@ -411,7 +411,7 @@ class SurfaceArrayCreator {
 
       using SGL = SurfaceArray::SurfaceGridLookup<decltype(axisA), decltype(axisB)>;
       ptr = std::make_unique<SGL>(
-            globalToLocal, localToGlobal, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
+            type, transform, R, Z, std::pair{axisA, axisB}, std::vector{pAxisA.axisDir, pAxisB.axisDir});
     }
     // clang-format on
 

--- a/Core/include/Acts/Surfaces/SurfaceArray.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceArray.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/AnyGridView.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Grid.hpp"
 #include "Acts/Utilities/IAxis.hpp"
@@ -93,6 +94,13 @@ class SurfaceArray {
     /// @return The axes
     /// @note This returns copies. Use for introspection and querying.
     virtual std::vector<const IAxis*> getAxes() const = 0;
+
+    virtual std::optional<AnyGridConstView<SurfaceVector>> getGridView()
+        const = 0;
+
+    virtual const Transform3& getTransform() const = 0;
+
+    virtual Surface::SurfaceType surfaceType() const = 0;
 
     /// @brief Get the number of dimensions of the grid.
     /// @return number of dimensions
@@ -312,6 +320,15 @@ class SurfaceArray {
       return std::vector<const IAxis*>(arr.begin(), arr.end());
     }
 
+    std::optional<AnyGridConstView<SurfaceVector>> getGridView()
+        const override {
+      return AnyGridConstView<SurfaceVector>{m_grid};
+    }
+
+    const Transform3& getTransform() const override { return m_transform; }
+
+    Surface::SurfaceType surfaceType() const override { return m_type; }
+
     /// @brief Get the number of dimensions of the grid.
     /// @return number of dimensions
     std::size_t dimensions() const override { return DIM; }
@@ -446,6 +463,20 @@ class SurfaceArray {
     /// @return empty vector
     std::vector<const IAxis*> getAxes() const override { return {}; }
 
+    std::optional<AnyGridConstView<SurfaceVector>> getGridView()
+        const override {
+      return std::nullopt;
+    }
+
+    const Transform3& getTransform() const override {
+      static const Transform3 identityTransform = Transform3::Identity();
+      return identityTransform;
+    }
+
+    Surface::SurfaceType surfaceType() const override {
+      return Surface::SurfaceType::Other;
+    }
+
     /// @brief Get the number of dimensions
     /// @return always 0
     std::size_t dimensions() const override { return 0; }
@@ -569,6 +600,9 @@ class SurfaceArray {
   /// @param sl Output stream to write to
   /// @return the output stream given as @p sl
   std::ostream& toStream(const GeometryContext& gctx, std::ostream& sl) const;
+
+  /// Return the lookup object
+  const ISurfaceGridLookup& gridLookup() const { return *p_gridLookup; }
 
  private:
   std::unique_ptr<ISurfaceGridLookup> p_gridLookup;

--- a/Core/src/Geometry/SurfaceArrayCreator.cpp
+++ b/Core/src/Geometry/SurfaceArrayCreator.cpp
@@ -50,21 +50,10 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnCylinder(
 
   double R = protoLayer.medium(AxisDirection::AxisR, true);
 
-  Transform3 itransform = ftransform.inverse();
-  // Transform lambda captures the transform matrix
-  auto globalToLocal = [ftransform](const Vector3& pos) {
-    Vector3 loc = ftransform * pos;
-    return Vector2(phi(loc), loc.z());
-  };
-  auto localToGlobal = [itransform, R](const Vector2& loc) {
-    return itransform *
-           Vector3(R * std::cos(loc[0]), R * std::sin(loc[0]), loc[1]);
-  };
-
   std::unique_ptr<SurfaceArray::ISurfaceGridLookup> sl =
       makeSurfaceGridLookup2D<AxisBoundaryType::Closed,
                               AxisBoundaryType::Bound>(
-          globalToLocal, localToGlobal, pAxisPhi, pAxisZ);
+          Surface::SurfaceType::Cylinder, ftransform, R, 0, pAxisPhi, pAxisZ);
 
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
@@ -106,20 +95,10 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnCylinder(
                                 protoLayer, ftransform);
   }
 
-  Transform3 itransform = ftransform.inverse();
-  auto globalToLocal = [ftransform](const Vector3& pos) {
-    Vector3 loc = ftransform * pos;
-    return Vector2(phi(loc), loc.z());
-  };
-  auto localToGlobal = [itransform, R](const Vector2& loc) {
-    return itransform *
-           Vector3(R * std::cos(loc[0]), R * std::sin(loc[0]), loc[1]);
-  };
-
   std::unique_ptr<SurfaceArray::ISurfaceGridLookup> sl =
       makeSurfaceGridLookup2D<AxisBoundaryType::Closed,
                               AxisBoundaryType::Bound>(
-          globalToLocal, localToGlobal, pAxisPhi, pAxisZ);
+          Surface::SurfaceType::Cylinder, ftransform, R, 0, pAxisPhi, pAxisZ);
 
   sl->fill(gctx, surfacesRaw);
   completeBinning(gctx, *sl, surfacesRaw);
@@ -160,21 +139,10 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnDisc(
   double Z = protoLayer.medium(AxisDirection::AxisZ, true);
   ACTS_VERBOSE("- z-position of disc estimated as " << Z);
 
-  Transform3 itransform = ftransform.inverse();
-  // transform lambda captures the transform matrix
-  auto globalToLocal = [ftransform](const Vector3& pos) {
-    Vector3 loc = ftransform * pos;
-    return Vector2(perp(loc), phi(loc));
-  };
-  auto localToGlobal = [itransform, Z](const Vector2& loc) {
-    return itransform *
-           Vector3(loc[0] * std::cos(loc[1]), loc[0] * std::sin(loc[1]), Z);
-  };
-
   std::unique_ptr<SurfaceArray::ISurfaceGridLookup> sl =
       makeSurfaceGridLookup2D<AxisBoundaryType::Bound,
                               AxisBoundaryType::Closed>(
-          globalToLocal, localToGlobal, pAxisR, pAxisPhi);
+          Surface::SurfaceType::Disc, ftransform, 0, Z, pAxisR, pAxisPhi);
 
   // get the number of bins
   auto axes = sl->getAxes();
@@ -266,21 +234,10 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnDisc(
   double Z = protoLayer.medium(AxisDirection::AxisZ, true);
   ACTS_VERBOSE("- z-position of disc estimated as " << Z);
 
-  Transform3 itransform = ftransform.inverse();
-  // transform lambda captures the transform matrix
-  auto globalToLocal = [ftransform](const Vector3& pos) {
-    Vector3 loc = ftransform * pos;
-    return Vector2(perp(loc), phi(loc));
-  };
-  auto localToGlobal = [itransform, Z](const Vector2& loc) {
-    return itransform *
-           Vector3(loc[0] * std::cos(loc[1]), loc[0] * std::sin(loc[1]), Z);
-  };
-
   std::unique_ptr<SurfaceArray::ISurfaceGridLookup> sl =
       makeSurfaceGridLookup2D<AxisBoundaryType::Bound,
                               AxisBoundaryType::Closed>(
-          globalToLocal, localToGlobal, pAxisR, pAxisPhi);
+          Surface::SurfaceType::Disc, ftransform, 0, Z, pAxisR, pAxisPhi);
 
   // get the number of bins
   auto axes = sl->getAxes();
@@ -315,15 +272,6 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnPlane(
   ACTS_VERBOSE(" -- with " << bins1 << " x " << bins2 << " = " << bins1 * bins2
                            << " bins.");
   Transform3 ftransform = transform;
-  Transform3 itransform = ftransform.inverse();
-  // transform lambda captures the transform matrix
-  auto globalToLocal = [ftransform](const Vector3& pos) {
-    Vector3 loc = ftransform * pos;
-    return Vector2(loc.x(), loc.y());
-  };
-  auto localToGlobal = [itransform](const Vector2& loc) {
-    return itransform * Vector3(loc.x(), loc.y(), 0);
-  };
   // Build the grid
   std::unique_ptr<SurfaceArray::ISurfaceGridLookup> sl;
 
@@ -338,7 +286,7 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnPlane(
                                 protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<AxisBoundaryType::Bound,
                                    AxisBoundaryType::Bound>(
-          globalToLocal, localToGlobal, pAxis1, pAxis2);
+          Surface::SurfaceType::Plane, ftransform, 0, 0, pAxis1, pAxis2);
       break;
     }
     case AxisDirection::AxisY: {
@@ -350,7 +298,7 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnPlane(
                                 protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<AxisBoundaryType::Bound,
                                    AxisBoundaryType::Bound>(
-          globalToLocal, localToGlobal, pAxis1, pAxis2);
+          Surface::SurfaceType::Plane, ftransform, 0, 0, pAxis1, pAxis2);
       break;
     }
     case AxisDirection::AxisZ: {
@@ -362,7 +310,7 @@ std::unique_ptr<SurfaceArray> SurfaceArrayCreator::surfaceArrayOnPlane(
                                 protoLayer, ftransform, bins2);
       sl = makeSurfaceGridLookup2D<AxisBoundaryType::Bound,
                                    AxisBoundaryType::Bound>(
-          globalToLocal, localToGlobal, pAxis1, pAxis2);
+          Surface::SurfaceType::Plane, ftransform, 0, 0, pAxis1, pAxis2);
       break;
     }
     default: {

--- a/Core/src/Surfaces/SurfaceArray.cpp
+++ b/Core/src/Surfaces/SurfaceArray.cpp
@@ -28,8 +28,7 @@ SurfaceArray::SurfaceArray(std::unique_ptr<ISurfaceGridLookup> gridLookup,
       m_transform(transform) {}
 
 SurfaceArray::SurfaceArray(std::shared_ptr<const Surface> srf)
-    : p_gridLookup(
-          static_cast<ISurfaceGridLookup*>(new SingleElementLookup(srf.get()))),
+    : p_gridLookup(std::make_unique<SingleElementLookup>(srf.get())),
       m_surfaces({std::move(srf)}) {
   m_surfacesRawPointers.push_back(m_surfaces.at(0).get());
 }

--- a/Tests/UnitTests/Core/Geometry/TrackingVolumeCreation.hpp
+++ b/Tests/UnitTests/Core/Geometry/TrackingVolumeCreation.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Geometry/CylinderLayer.hpp"
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Geometry/SurfaceArrayCreator.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
@@ -47,25 +48,16 @@ TrackingVolumePtr constructCylinderVolume(
   ///  prepare the surfaces
 
   ///  make the binned array
-  double bUmin = sfnPosition.z() - surfaceHalfLengthZ;
   double bUmax = sfpPosition.z() + surfaceHalfLengthZ;
 
   std::vector<std::shared_ptr<const Surface>> surfaces_only = {{sfn, sfc, sfp}};
   std::vector<const Surface*> surfaces_only_raw = {
       {sfn.get(), sfc.get(), sfp.get()}};
 
-  Axis<AxisType::Equidistant, AxisBoundaryType::Bound> axis(
-      bUmin, bUmax, surfaces_only.size());
-  auto g2l = [](const Vector3& glob) {
-    return std::array<double, 1>({{glob.z()}});
-  };
-  auto l2g = [](const std::array<double, 1>& loc) {
-    return Vector3(0, 0, loc[0]);
-  };
-  auto sl = std::make_unique<SurfaceArray::SurfaceGridLookup<decltype(axis)>>(
-      g2l, l2g, std::make_tuple(axis));
-  sl->fill(gctx, surfaces_only_raw);
-  auto bArray = std::make_unique<SurfaceArray>(std::move(sl), surfaces_only);
+  SurfaceArrayCreator::Config sacConfig;
+  SurfaceArrayCreator sac{sacConfig};
+
+  auto bArray = sac.surfaceArrayOnCylinder(gctx, surfaces_only);
 
   ///  now create the Layer
   auto layer0bounds = std::make_shared<const CylinderBounds>(surfaceR, bUmax);


### PR DESCRIPTION
To ease inspection for detray conversion, I'm taking away some of the flexibility in SurfaceArray which we don't really need as far as I'm aware.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
