### PR TITLE
fix: change implementation of the spaceship operator when using span

### DIFF
--- a/Core/include/Acts/EventData/SpacePointContainer2.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer2.hpp
@@ -924,14 +924,14 @@ class SpacePointContainer2 {
         return lhs.m_iterator - rhs.m_iterator;
       }
 
-      friend constexpr std::strong_ordering operator<=>(const Iterator &a,
-							const Iterator &b) noexcept {
-	if (a.m_iterator < b.m_iterator) {
-	  return std::strong_ordering::less;
-	}
+      friend constexpr std::strong_ordering operator<=>(
+          const Iterator &a, const Iterator &b) noexcept {
+        if (a.m_iterator < b.m_iterator) {
+          return std::strong_ordering::less;
+        }
         if (a.m_iterator > b.m_iterator) {
-	  return std::strong_ordering::greater;
-	}
+          return std::strong_ordering::greater;
+        }
         return std::strong_ordering::equal;
       }
       friend constexpr bool operator==(const Iterator &a,

--- a/Core/include/Acts/EventData/SpacePointContainer2.hpp
+++ b/Core/include/Acts/EventData/SpacePointContainer2.hpp
@@ -924,9 +924,15 @@ class SpacePointContainer2 {
         return lhs.m_iterator - rhs.m_iterator;
       }
 
-      friend constexpr auto operator<=>(const Iterator &a,
-                                        const Iterator &b) noexcept {
-        return a.m_iterator <=> b.m_iterator;
+      friend constexpr std::strong_ordering operator<=>(const Iterator &a,
+							const Iterator &b) noexcept {
+	if (a.m_iterator < b.m_iterator) {
+	  return std::strong_ordering::less;
+	}
+        if (a.m_iterator > b.m_iterator) {
+	  return std::strong_ordering::greater;
+	}
+        return std::strong_ordering::equal;
       }
       friend constexpr bool operator==(const Iterator &a,
                                        const Iterator &b) noexcept {


### PR DESCRIPTION
I had problems compiling, due to the spaceship operator being called on a span