### PR TITLE
ci: Configure spack repo location as safe git repository

### DIFF
--- a/CI/dependencies/setup.sh
+++ b/CI/dependencies/setup.sh
@@ -131,10 +131,8 @@ _spack_repo_directory="$(realpath "$(spack location --repo builtin)/../../../")"
 
 echo "Ensure repo is synced with version ${_spack_repo_version}"
 
-set -x
 git config --global --add safe.directory "${_spack_repo_directory}"
 spack repo update builtin --tag "${_spack_repo_version}"
-set +x
 
 end_section
 


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
