### PR TITLE
feat: Add a TrackStateFlag for split hits

### DIFF
--- a/Core/include/Acts/EventData/TrackStateType.hpp
+++ b/Core/include/Acts/EventData/TrackStateType.hpp
@@ -28,8 +28,9 @@ enum TrackStateFlag {
   HoleFlag = 3,
   MaterialFlag = 4,
   SharedHitFlag = 5,
-  NoExpectedHitFlag = 6,
-  NumTrackStateFlags = 7
+  SplitHitFlag = 6,
+  NoExpectedHitFlag = 7,
+  NumTrackStateFlags = 8,
 };
 
 class ConstTrackStateType;


### PR DESCRIPTION
Add a new `TrackStateFlag` value, namely `SplitHitFlag`, that allows identifying cases where an underlying measurement is _rightfully_ shared between states from different tracks. This is like `SharedHitFlag` but for situations where it has been determined that the underlying measurement is "shareable", e.g. if it originates from multiple particles.

--- END COMMIT MESSAGE ---