### PR TITLE
fix: enlarge cylinder volume rmax for layers with displaced center

### DIFF
--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -574,8 +574,8 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
             CylinderBounds::eHalfLengthZ);
         lConfig.rMin =
             std::min(lConfig.rMin, rMinC - m_cfg.layerEnvelopeR.first);
-        lConfig.rMax =
-            std::max(lConfig.rMax, rCenter + rMaxC + m_cfg.layerEnvelopeR.second);
+        lConfig.rMax = std::max(lConfig.rMax,
+                                rCenter + rMaxC + m_cfg.layerEnvelopeR.second);
         lConfig.zMin =
             std::min(lConfig.zMin, center.z() - hZ - m_cfg.layerEnvelopeZ);
         lConfig.zMax =
@@ -592,8 +592,8 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
         double zMaxD = center.z() + 0.5 * thickness;
         lConfig.rMin =
             std::min(lConfig.rMin, rMinD - m_cfg.layerEnvelopeR.first);
-        lConfig.rMax =
-            std::max(lConfig.rMax, rCenter + rMaxD + m_cfg.layerEnvelopeR.second);
+        lConfig.rMax = std::max(lConfig.rMax,
+                                rCenter + rMaxD + m_cfg.layerEnvelopeR.second);
         lConfig.rMin = std::max(0.0, lConfig.rMin);
         lConfig.zMin = std::min(lConfig.zMin, zMinD - m_cfg.layerEnvelopeZ);
         lConfig.zMax = std::max(lConfig.zMax, zMaxD + m_cfg.layerEnvelopeZ);

--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -557,6 +557,7 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
       double thickness = layer->thickness();
       // get the center of the layer
       const Vector3& center = layer->surfaceRepresentation().center(gctx);
+      double rCenter = std::hypot(center.x(), center.y());
       // check if it is a cylinder layer
       const CylinderLayer* cLayer =
           dynamic_cast<const CylinderLayer*>(layer.get());
@@ -574,7 +575,7 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
         lConfig.rMin =
             std::min(lConfig.rMin, rMinC - m_cfg.layerEnvelopeR.first);
         lConfig.rMax =
-            std::max(lConfig.rMax, rMaxC + m_cfg.layerEnvelopeR.second);
+            std::max(lConfig.rMax, rCenter + rMaxC + m_cfg.layerEnvelopeR.second);
         lConfig.zMin =
             std::min(lConfig.zMin, center.z() - hZ - m_cfg.layerEnvelopeZ);
         lConfig.zMax =
@@ -592,7 +593,7 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
         lConfig.rMin =
             std::min(lConfig.rMin, rMinD - m_cfg.layerEnvelopeR.first);
         lConfig.rMax =
-            std::max(lConfig.rMax, rMaxD + m_cfg.layerEnvelopeR.second);
+            std::max(lConfig.rMax, rCenter + rMaxD + m_cfg.layerEnvelopeR.second);
         lConfig.rMin = std::max(0.0, lConfig.rMin);
         lConfig.zMin = std::min(lConfig.zMin, zMinD - m_cfg.layerEnvelopeZ);
         lConfig.zMax = std::max(lConfig.zMax, zMaxD + m_cfg.layerEnvelopeZ);


### PR DESCRIPTION
This PR ensures that cylinder volumes fully enclose cylinder and radial bound layers with displaced centers. Without this fix, the `rmax` for the volume is (without envelope) equal to the `rmax` of the layer, even if the volume is not placed on axis. This leads to the layer sticking out of the cylinder.

It would be possible to modify the `rmin` as well, but it adds branching (three options for 'donut' radial/cylinder bounds: z axis through donut hole, z axis through donut itself, z axis outside donut) and it does not resolve any current buggy behavior (it just uses an `rmin` that could be smaller than it currently is). Therefore that is not included here.

Before (cross hairs are xy, looking along z, off-axis detector with its layer shown in blue, cylinder volume in dark yellow):
<img width="1058" height="857" alt="image" src="https://github.com/user-attachments/assets/ac0dacdc-be14-416a-8d30-e2b64483d75b" />

After (cross hairs are xy, looking along z, off-axis detector with its layer shown in blue, cylinder volume in dark yellow):
<img width="1058" height="857" alt="image" src="https://github.com/user-attachments/assets/1ff24274-35d9-42a8-b426-314d01f0d7bc" />


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
