### PR TITLE
Fix: Fix naming to convert Rpc detectors

### DIFF
--- a/Examples/Detectors/MuonSpectrometerMockupDetector/src/GeoMuonMockupExperiment.cpp
+++ b/Examples/Detectors/MuonSpectrometerMockupDetector/src/GeoMuonMockupExperiment.cpp
@@ -495,7 +495,7 @@ FpvLink GeoMuonMockupExperiment::assembleRpcChamber(const double chamberWidth) {
         make_intrusive<GeoBox>(0.5 * s_rpcGasHeight, rpcBox->getYHalfLength(),
                                rpcBox->getZHalfLength());
     auto gasLogVol = cacheVolume(make_intrusive<GeoLogVol>(
-        "RpcGas", cacheShape(gasBox), matMan->getMaterial("std::ArCO2")));
+        "RpcGasGap", cacheShape(gasBox), matMan->getMaterial("std::ArCO2")));
 
     rpcEnvelope->add(geoId(gap));
     rpcEnvelope->add(makeTransform(GeoTrf::TranslateX3D(currentX)));

--- a/Examples/Scripts/Python/geomodel_G4.py
+++ b/Examples/Scripts/Python/geomodel_G4.py
@@ -136,7 +136,7 @@ def main():
         "MDTDriftGas",
     ]
     gmFactoryConfig.convertSubVolumes = True
-    gmFactoryConfig.convertBox = ["MDT"]
+    gmFactoryConfig.convertBox = ["MDT", "RPC"]
 
     gmFactory = gm.GeoModelDetectorObjectFactory(gmFactoryConfig, logLevel)
     # The options


### PR DESCRIPTION
- Rpc gasgaps from the GeoModelMuonMockup experiment were not converted into sensitive surfaces due to a naming typo
--- END COMMIT MESSAGE ---
@paulgessinger, @andiwand, @dimitra97   
