### PR TITLE
refactor: Avoid spin lock in TensorRT inference

### DIFF
--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
@@ -12,6 +12,8 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <memory>
+#include <mutex>
+#include <semaphore>
 #include <vector>
 
 namespace nvinfer1 {
@@ -52,6 +54,10 @@ class TensorRTEdgeClassifier final : public EdgeClassificationBase {
   std::unique_ptr<nvinfer1::ICudaEngine> m_engine;
   std::unique_ptr<nvinfer1::ILogger> m_trtLogger;
 
+  std::size_t m_maxEdges = 0;
+  std::size_t m_maxNodes = 0;
+
+  mutable std::optional<std::counting_semaphore<>> m_count;
   mutable std::mutex m_contextMutex;
   mutable std::vector<std::unique_ptr<nvinfer1::IExecutionContext>> m_contexts;
 };

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
@@ -54,9 +54,6 @@ class TensorRTEdgeClassifier final : public EdgeClassificationBase {
   std::unique_ptr<nvinfer1::ICudaEngine> m_engine;
   std::unique_ptr<nvinfer1::ILogger> m_trtLogger;
 
-  std::size_t m_maxEdges = 0;
-  std::size_t m_maxNodes = 0;
-
   mutable std::optional<std::counting_semaphore<>> m_count;
   mutable std::mutex m_contextMutex;
   mutable std::vector<std::unique_ptr<nvinfer1::IExecutionContext>> m_contexts;

--- a/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
@@ -102,6 +102,8 @@ TensorRTEdgeClassifier::TensorRTEdgeClassifier(
   ACTS_DEBUG("Used CUDA memory after TensorRT initialization: "
              << (totalMem - freeMem) * 1e-9 << " / " << totalMem * 1e-9
              << " GB");
+
+  m_count.emplace(m_contexts.size());
 }
 
 TensorRTEdgeClassifier::~TensorRTEdgeClassifier() {}

--- a/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
@@ -115,14 +115,18 @@ PipelineTensors TensorRTEdgeClassifier::operator()(
 
   // get a context from the list of contexts
   std::unique_ptr<nvinfer1::IExecutionContext> context;
-  while (context == nullptr) {
+
+  // Try to decrement the count before getting a context. By this it should be
+  // garantueed that a context is available
+  m_count->acquire();
+  assert(!m_contexts.empty());
+
+  // Protect access to the context by a mutex
+  {
     std::lock_guard<std::mutex> lock(m_contextMutex);
-    if (!m_contexts.empty()) {
-      context = std::move(m_contexts.back());
-      m_contexts.pop_back();
-    }
+    context = std::move(m_contexts.back());
+    m_contexts.pop_back();
   }
-  assert(context != nullptr);
 
   context->setInputShape(
       "x", nvinfer1::Dims2{static_cast<long>(tensors.nodeFeatures.shape()[0]),
@@ -162,6 +166,9 @@ PipelineTensors TensorRTEdgeClassifier::operator()(
     std::lock_guard<std::mutex> lock(m_contextMutex);
     m_contexts.push_back(std::move(context));
   }
+
+  // Increment the count after the context have been put back in the vector
+  m_count->release();
 
   sigmoid(scores, execContext.stream);
 


### PR DESCRIPTION
Use counting semaphore instead, should improve performance, since waiting time can be O(ms). But was never benchmarked.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
