### PR TITLE
fix: Cut edges in TensorRT inference if maximum size is exceeded

### DIFF
--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/Tensor.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/Tensor.hpp
@@ -136,4 +136,15 @@ std::pair<Tensor<float>, Tensor<std::int64_t>> applyScoreCut(
     const Tensor<float> &scores, const Tensor<std::int64_t> &edgeIndex,
     float cut, std::optional<cudaStream_t> stream = {});
 
+/// Apply a limit on the number of edges consistently on edgeIndex and
+/// edgeFeatures.
+/// @param edgeIndex The edge index tensor
+/// @param edgeFeatures The edge feature tensor
+/// @param maxEdges The edge limit to apply
+/// @param stream The stream to use for operation in case of CUDA
+std::pair<Tensor<std::int64_t>, std::optional<Tensor<float>>> applyEdgeLimit(
+    const Tensor<std::int64_t> &edgeIndex,
+    const std::optional<Tensor<float>> &edgeFeatures, std::size_t maxEdges,
+    std::optional<cudaStream_t> stream);
+
 }  // namespace Acts

--- a/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
+++ b/Plugins/ExaTrkX/include/Acts/Plugins/ExaTrkX/TensorRTEdgeClassifier.hpp
@@ -52,6 +52,9 @@ class TensorRTEdgeClassifier final : public EdgeClassificationBase {
   std::unique_ptr<nvinfer1::ICudaEngine> m_engine;
   std::unique_ptr<nvinfer1::ILogger> m_trtLogger;
 
+  std::size_t m_maxEdges = 0;
+  std::size_t m_maxNodes = 0;
+
   mutable std::mutex m_contextMutex;
   mutable std::vector<std::unique_ptr<nvinfer1::IExecutionContext>> m_contexts;
 };

--- a/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
@@ -89,6 +89,9 @@ TensorRTEdgeClassifier::TensorRTEdgeClassifier(
     throw std::runtime_error("Failed to deserialize CUDA engine");
   }
 
+  ACTS_INFO("Device memory required by TRT context: "
+            << m_engine->getDeviceMemorySizeV2() * 1e-9 << " GB");
+
   for (auto i = 0ul; i < m_cfg.numExecutionContexts; ++i) {
     ACTS_DEBUG("Create execution context " << i);
     m_contexts.emplace_back(m_engine->createExecutionContext());
@@ -102,6 +105,35 @@ TensorRTEdgeClassifier::TensorRTEdgeClassifier(
   ACTS_DEBUG("Used CUDA memory after TensorRT initialization: "
              << (totalMem - freeMem) * 1e-9 << " / " << totalMem * 1e-9
              << " GB");
+
+  m_count.emplace(m_contexts.size());
+
+  if (m_engine->getNbOptimizationProfiles() > 1) {
+    ACTS_WARNING("Cannot handle more then one optimization profile for now");
+  }
+
+  m_maxNodes =
+      m_engine->getProfileShape("x", 0, nvinfer1::OptProfileSelector::kMAX)
+          .d[0];
+  ACTS_INFO("Maximum number of nodes: " << m_maxNodes);
+
+  auto maxEdgesA =
+      m_engine
+          ->getProfileShape("edge_index", 0, nvinfer1::OptProfileSelector::kMAX)
+          .d[1];
+  auto maxEdgesB =
+      m_engine
+          ->getProfileShape("edge_attr", 0, nvinfer1::OptProfileSelector::kMAX)
+          .d[0];
+
+  if (maxEdgesA != maxEdgesB) {
+    throw std::invalid_argument(
+        "Inconsistent max edges definition in engine for 'edge_index' and "
+        "'edge_attr'");
+  }
+
+  m_maxEdges = maxEdgesA;
+  ACTS_INFO("Maximum number of edges: " << m_maxEdges);
 }
 
 TensorRTEdgeClassifier::~TensorRTEdgeClassifier() {}
@@ -112,6 +144,26 @@ PipelineTensors TensorRTEdgeClassifier::operator()(
 
   decltype(std::chrono::high_resolution_clock::now()) t0, t1, t2, t3, t4;
   t0 = std::chrono::high_resolution_clock::now();
+
+  // Curing this would require more complicated handling, and should happen
+  // almost never
+  if (auto nNodes = tensors.nodeFeatures.shape().at(0); nNodes > m_maxNodes) {
+    ACTS_WARNING("Number of nodes ("
+                 << nNodes << ") exceeds configured maximum, return 0 edges");
+    throw NoEdgesError{};
+  }
+
+  if (auto nEdges = tensors.edgeIndex.shape().at(1); nEdges > m_maxEdges) {
+    ACTS_WARNING("Number of edges ("
+                 << nEdges << ") exceeds maximum, shrink edge tensor to "
+                 << m_maxEdges);
+
+    auto [newEdgeIndex, newEdgeFeatures] =
+        applyEdgeLimit(tensors.edgeIndex, tensors.edgeFeatures, m_maxEdges,
+                       execContext.stream);
+    tensors.edgeIndex = std::move(newEdgeIndex);
+    tensors.edgeFeatures = std::move(newEdgeFeatures);
+  }
 
   // get a context from the list of contexts
   std::unique_ptr<nvinfer1::IExecutionContext> context;

--- a/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
+++ b/Plugins/ExaTrkX/src/TensorRTEdgeClassifier.cpp
@@ -106,8 +106,6 @@ TensorRTEdgeClassifier::TensorRTEdgeClassifier(
              << (totalMem - freeMem) * 1e-9 << " / " << totalMem * 1e-9
              << " GB");
 
-  m_count.emplace(m_contexts.size());
-
   if (m_engine->getNbOptimizationProfiles() > 1) {
     ACTS_WARNING("Cannot handle more then one optimization profile for now");
   }


### PR DESCRIPTION
A TensorRT model contains limits for the input tensor sizes, for which the model compilation is optimized. TensorRT raises an Error if the size is exceeded. To avoid Error messages, cut the edges and display a warning instead.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
