### PR TITLE
refactor: SimParticle rename final to finalState

### DIFF
--- a/Examples/Algorithms/Fatras/src/FatrasSimulation.cpp
+++ b/Examples/Algorithms/Fatras/src/FatrasSimulation.cpp
@@ -222,7 +222,7 @@ ActsExamples::ProcessCode ActsExamples::FatrasSimulation::execute(
   std::vector<ActsFatras::Particle> particlesInput;
   particlesInput.reserve(inputParticles.size());
   for (const auto &p : inputParticles) {
-    particlesInput.push_back(p.initial());
+    particlesInput.push_back(p.initialState());
   }
 
   // prepare output containers
@@ -302,7 +302,7 @@ ActsExamples::ProcessCode ActsExamples::FatrasSimulation::execute(
 
     if (auto it = particlesFinal.find(particleInitial.particleId());
         it != particlesFinal.end()) {
-      particleSimulated.final() = *it;
+      particleSimulated.finalState() = *it;
     } else {
       ACTS_ERROR("particle " << particleInitial.particleId()
                              << " has no final state");

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -95,7 +95,7 @@ void ParticleTrackingAction::PostUserTrackingAction(const G4Track* aTrack) {
     return;
   }
   SimParticle particle = *particleIt;
-  particle.final() = convert(*aTrack, barcode);
+  particle.finalState() = convert(*aTrack, barcode);
 
   auto [it, success] = eventStore().particlesSimulated.insert(particle);
 

--- a/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
@@ -56,11 +56,11 @@ class SimParticle final {
     }
   }
 
-  const SimParticleState& initial() const { return m_initial; }
-  const SimParticleState& final() const { return m_final; }
+  const SimParticleState& initialState() const { return m_initial; }
+  const SimParticleState& finalState() const { return m_final; }
 
-  SimParticleState& initial() { return m_initial; }
-  SimParticleState& final() { return m_final; }
+  SimParticleState& initialState() { return m_initial; }
+  SimParticleState& finalState() { return m_final; }
 
   /// Construct a new particle with a new identifier but same kinematics.
   ///
@@ -68,100 +68,108 @@ class SimParticle final {
   ///       is used to identify the whole particle. Setting it on an existing
   ///       particle is usually a mistake.
   SimParticle withParticleId(SimBarcode particleId) const {
-    return SimParticle(initial().withParticleId(particleId),
-                       final().withParticleId(particleId));
+    return SimParticle(initialState().withParticleId(particleId),
+                       finalState().withParticleId(particleId));
   }
 
   /// Set the process type that generated this particle.
   SimParticle& setProcess(ActsFatras::ProcessType proc) {
-    initial().setProcess(proc);
-    final().setProcess(proc);
+    initialState().setProcess(proc);
+    finalState().setProcess(proc);
     return *this;
   }
   /// Set the pdg.
   SimParticle& setPdg(Acts::PdgParticle pdg) {
-    initial().setPdg(pdg);
-    final().setPdg(pdg);
+    initialState().setPdg(pdg);
+    finalState().setPdg(pdg);
     return *this;
   }
   /// Set the charge.
   SimParticle& setCharge(double charge) {
-    initial().setCharge(charge);
-    final().setCharge(charge);
+    initialState().setCharge(charge);
+    finalState().setCharge(charge);
     return *this;
   }
   /// Set the mass.
   SimParticle& setMass(double mass) {
-    initial().setMass(mass);
-    final().setMass(mass);
+    initialState().setMass(mass);
+    finalState().setMass(mass);
     return *this;
   }
   /// Set the particle ID.
   SimParticle& setParticleId(SimBarcode barcode) {
-    initial().setParticleId(barcode);
-    final().setParticleId(barcode);
+    initialState().setParticleId(barcode);
+    finalState().setParticleId(barcode);
     return *this;
   }
 
   /// Particle identifier within an event.
-  SimBarcode particleId() const { return initial().particleId(); }
+  SimBarcode particleId() const { return initialState().particleId(); }
   /// Which type of process generated this particle.
-  ActsFatras::ProcessType process() const { return initial().process(); }
+  ActsFatras::ProcessType process() const { return initialState().process(); }
   /// PDG particle number that identifies the type.
-  Acts::PdgParticle pdg() const { return initial().pdg(); }
+  Acts::PdgParticle pdg() const { return initialState().pdg(); }
   /// Absolute PDG particle number that identifies the type.
-  Acts::PdgParticle absolutePdg() const { return initial().absolutePdg(); }
+  Acts::PdgParticle absolutePdg() const { return initialState().absolutePdg(); }
   /// Particle charge.
-  double charge() const { return initial().charge(); }
+  double charge() const { return initialState().charge(); }
   /// Particle absolute charge.
-  double absoluteCharge() const { return initial().absoluteCharge(); }
+  double absoluteCharge() const { return initialState().absoluteCharge(); }
   /// Particle mass.
-  double mass() const { return initial().mass(); }
+  double mass() const { return initialState().mass(); }
 
   /// Check if this is a secondary particle.
-  bool isSecondary() const { return initial().isSecondary(); }
+  bool isSecondary() const { return initialState().isSecondary(); }
 
   /// Particle hypothesis.
-  Acts::ParticleHypothesis hypothesis() const { return initial().hypothesis(); }
+  Acts::ParticleHypothesis hypothesis() const {
+    return initialState().hypothesis();
+  }
   /// Particl qOverP.
-  double qOverP() const { return initial().qOverP(); }
+  double qOverP() const { return initialState().qOverP(); }
 
   /// Space-time position four-vector.
-  const Acts::Vector4& fourPosition() const { return initial().fourPosition(); }
+  const Acts::Vector4& fourPosition() const {
+    return initialState().fourPosition();
+  }
   /// Three-position, i.e. spatial coordinates without the time.
-  auto position() const { return initial().position(); }
+  auto position() const { return initialState().position(); }
   /// Time coordinate.
-  double time() const { return initial().time(); }
+  double time() const { return initialState().time(); }
   /// Energy-momentum four-vector.
-  Acts::Vector4 fourMomentum() const { return initial().fourMomentum(); }
+  Acts::Vector4 fourMomentum() const { return initialState().fourMomentum(); }
   /// Unit three-direction, i.e. the normalized momentum three-vector.
-  const Acts::Vector3& direction() const { return initial().direction(); }
+  const Acts::Vector3& direction() const { return initialState().direction(); }
   /// Polar angle.
-  double theta() const { return initial().theta(); }
+  double theta() const { return initialState().theta(); }
   /// Azimuthal angle.
-  double phi() const { return initial().phi(); }
+  double phi() const { return initialState().phi(); }
   /// Absolute momentum in the x-y plane.
-  double transverseMomentum() const { return initial().transverseMomentum(); }
+  double transverseMomentum() const {
+    return initialState().transverseMomentum();
+  }
   /// Absolute momentum.
-  double absoluteMomentum() const { return initial().absoluteMomentum(); }
+  double absoluteMomentum() const { return initialState().absoluteMomentum(); }
   /// Absolute momentum.
-  Acts::Vector3 momentum() const { return initial().momentum(); }
+  Acts::Vector3 momentum() const { return initialState().momentum(); }
   /// Total energy, i.e. norm of the four-momentum.
-  double energy() const { return initial().energy(); }
+  double energy() const { return initialState().energy(); }
 
   /// Energy loss over the particles lifetime or simulation time.
-  double energyLoss() const { return initial().energy() - final().energy(); }
+  double energyLoss() const {
+    return initialState().energy() - finalState().energy();
+  }
 
   /// Accumulated path within material measured in radiation lengths.
-  double pathInX0() const { return final().pathInX0(); }
+  double pathInX0() const { return finalState().pathInX0(); }
   /// Accumulated path within material measured in interaction lengths.
-  double pathInL0() const { return final().pathInL0(); }
+  double pathInL0() const { return finalState().pathInL0(); }
 
   /// Number of hits.
-  std::uint32_t numberOfHits() const { return final().numberOfHits(); }
+  std::uint32_t numberOfHits() const { return finalState().numberOfHits(); }
 
   /// Particle outcome.
-  ActsFatras::ParticleOutcome outcome() const { return final().outcome(); }
+  ActsFatras::ParticleOutcome outcome() const { return finalState().outcome(); }
 
  private:
   SimParticleState m_initial;

--- a/Examples/Io/EDM4hep/src/EDM4hepSimInputConverter.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepSimInputConverter.cpp
@@ -434,7 +434,7 @@ ProcessCode EDM4hepSimInputConverter::convert(const AlgorithmContext& ctx,
         }
       }
 
-      particleSimulated.final().setPosition4(
+      particleSimulated.finalState().setPosition4(
           inParticle.getEndpoint()[0] * Acts::UnitConstants::mm,
           inParticle.getEndpoint()[1] * Acts::UnitConstants::mm,
           inParticle.getEndpoint()[2] * Acts::UnitConstants::mm, time);
@@ -442,17 +442,19 @@ ProcessCode EDM4hepSimInputConverter::convert(const AlgorithmContext& ctx,
       Acts::Vector3 momentumFinal = {inParticle.getMomentumAtEndpoint()[0],
                                      inParticle.getMomentumAtEndpoint()[1],
                                      inParticle.getMomentumAtEndpoint()[2]};
-      particleSimulated.final().setDirection(momentumFinal.normalized());
-      particleSimulated.final().setAbsoluteMomentum(momentumFinal.norm());
+      particleSimulated.finalState().setDirection(momentumFinal.normalized());
+      particleSimulated.finalState().setAbsoluteMomentum(momentumFinal.norm());
 
-      ACTS_VERBOSE("- Updated particle initial -> final, position: "
-                   << particleSimulated.initial().fourPosition().transpose()
-                   << " -> "
-                   << particleSimulated.final().fourPosition().transpose());
-      ACTS_VERBOSE("                                     momentum: "
-                   << particleSimulated.initial().fourMomentum().transpose()
-                   << " -> "
-                   << particleSimulated.final().fourMomentum().transpose());
+      ACTS_VERBOSE(
+          "- Updated particle initial -> final, position: "
+          << particleSimulated.initialState().fourPosition().transpose()
+          << " -> "
+          << particleSimulated.finalState().fourPosition().transpose());
+      ACTS_VERBOSE(
+          "                                     momentum: "
+          << particleSimulated.initialState().fourMomentum().transpose()
+          << " -> "
+          << particleSimulated.finalState().fourMomentum().transpose());
 
       particlesSimulatedUnordered->push_back(particleSimulated);
     }
@@ -564,11 +566,13 @@ ProcessCode EDM4hepSimInputConverter::convert(const AlgorithmContext& ctx,
         if (auto itSim = particlesSimulated.find(simHit.particleId());
             itSim != particlesSimulated.end()) {
           ACTS_VERBOSE("Found associated simulated particle");
-          itSim->final().setNumberOfHits(itSim->final().numberOfHits() + 1);
+          itSim->finalState().setNumberOfHits(
+              itSim->finalState().numberOfHits() + 1);
         } else if (auto itGen = particlesGenerator.find(simHit.particleId());
                    itGen != particlesGenerator.end()) {
           ACTS_VERBOSE("Found associated generator particle");
-          itGen->final().setNumberOfHits(itGen->final().numberOfHits() + 1);
+          itGen->finalState().setNumberOfHits(
+              itGen->finalState().numberOfHits() + 1);
         } else {
           const auto& ptcl = Acts::EDM4hepUtil::getParticle(hit);
           ACTS_ERROR("SimHit (r="
@@ -710,7 +714,7 @@ ProcessCode EDM4hepSimInputConverter::convert(const AlgorithmContext& ctx,
     for (const auto& particle : particlesSimulated) {
       // Add current particle to the outgoing particles of the vertex
 
-      if (particle.final().numberOfHits() == 0) {
+      if (particle.finalState().numberOfHits() == 0) {
         // Only produce vertices for particles that actually produced any hits
         continue;
       }

--- a/Examples/Io/EDM4hep/src/EDM4hepUtil.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepUtil.cpp
@@ -35,17 +35,17 @@ SimParticle EDM4hepUtil::readParticle(const edm4hep::MCParticle& from,
   // TODO do we have that in EDM4hep?
   // particle.setProcess(static_cast<ActsFatras::ProcessType>(data.process));
 
-  to.initial().setPosition4(from.getVertex()[0] * Acts::UnitConstants::mm,
-                            from.getVertex()[1] * Acts::UnitConstants::mm,
-                            from.getVertex()[2] * Acts::UnitConstants::mm,
-                            from.getTime() * Acts::UnitConstants::ns);
+  to.initialState().setPosition4(from.getVertex()[0] * Acts::UnitConstants::mm,
+                                 from.getVertex()[1] * Acts::UnitConstants::mm,
+                                 from.getVertex()[2] * Acts::UnitConstants::mm,
+                                 from.getTime() * Acts::UnitConstants::ns);
 
   // Only used for direction; normalization/units do not matter
   Acts::Vector3 momentum = {from.getMomentum()[0], from.getMomentum()[1],
                             from.getMomentum()[2]};
-  to.initial().setDirection(momentum.normalized());
+  to.initialState().setDirection(momentum.normalized());
 
-  to.initial().setAbsoluteMomentum(momentum.norm() * 1_GeV);
+  to.initialState().setAbsoluteMomentum(momentum.norm() * 1_GeV);
 
   return to;
 }
@@ -62,9 +62,9 @@ void EDM4hepUtil::writeParticle(const SimParticle& from,
                   static_cast<float>(from.fourMomentum().y()),
                   static_cast<float>(from.fourMomentum().z())});
   to.setMomentumAtEndpoint(
-      {static_cast<float>(from.final().fourMomentum().x()),
-       static_cast<float>(from.final().fourMomentum().y()),
-       static_cast<float>(from.final().fourMomentum().z())});
+      {static_cast<float>(from.finalState().fourMomentum().x()),
+       static_cast<float>(from.finalState().fourMomentum().y()),
+       static_cast<float>(from.finalState().fourMomentum().z())});
 }
 
 ActsFatras::Hit EDM4hepUtil::readSimHit(

--- a/Examples/Io/HepMC3/src/HepMC3InputConverter.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3InputConverter.cpp
@@ -192,15 +192,15 @@ void HepMC3InputConverter::handleVertex(const HepMC3::GenVertex& genVertex,
       }
 
       SimParticle simParticle{particleId, pdg, charge, mass};
-      simParticle.initial().setPosition4(vertex.position4);
+      simParticle.initialState().setPosition4(vertex.position4);
 
       const HepMC3::FourVector& genMomentum = particle->momentum();
       Acts::Vector3 momentum{genMomentum.px() * 1_GeV, genMomentum.py() * 1_GeV,
                              genMomentum.pz() * 1_GeV};
       double p = momentum.norm();
 
-      simParticle.initial().setDirection(momentum.normalized());
-      simParticle.initial().setAbsoluteMomentum(p);
+      simParticle.initialState().setDirection(momentum.normalized());
+      simParticle.initialState().setAbsoluteMomentum(p);
 
       particles.push_back(simParticle);
       vertex.outgoing.insert(particleId);

--- a/Examples/Io/Root/src/RootAthenaDumpReader.cpp
+++ b/Examples/Io/Root/src/RootAthenaDumpReader.cpp
@@ -680,7 +680,7 @@ RootAthenaDumpReader::reprocessParticles(
     }
 
     auto newParticle = particle.withParticleId(fatrasBarcode);
-    newParticle.final().setNumberOfHits(std::distance(begin, end));
+    newParticle.finalState().setNumberOfHits(std::distance(begin, end));
     newParticles.push_back(newParticle);
 
     for (auto it = begin; it != end; ++it) {

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -157,7 +157,7 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
     p.setMass((*m_m).at(i) * Acts::UnitConstants::GeV);
     p.setParticleId(SimBarcode((*m_particleId).at(i)));
 
-    SimParticleState& initialState = p.initial();
+    SimParticleState& initialState = p.initialState();
 
     initialState.setPosition4((*m_vx).at(i) * Acts::UnitConstants::mm,
                               (*m_vy).at(i) * Acts::UnitConstants::mm,
@@ -167,7 +167,7 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
     initialState.setDirection((*m_px).at(i), (*m_py).at(i), (*m_pz).at(i));
     initialState.setAbsoluteMomentum((*m_p).at(i) * Acts::UnitConstants::GeV);
 
-    SimParticleState& finalState = p.final();
+    SimParticleState& finalState = p.finalState();
 
     // TODO eloss cannot be read since we need the final momentum
     finalState.setMaterialPassed((*m_pathInX0).at(i) * Acts::UnitConstants::mm,

--- a/Examples/Io/Root/src/TrackFinderPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/TrackFinderPerformanceWriter.cpp
@@ -337,15 +337,15 @@ ProcessCode TrackFinderPerformanceWriter::writeT(
     }
 
     // Fill efficiency plots
-    m_effPlotTool.fill(m_effPlotCache, particle.initial(), minDeltaR,
+    m_effPlotTool.fill(m_effPlotCache, particle.initialState(), minDeltaR,
                        isReconstructed);
     // Fill number of duplicated tracks for this particle
-    m_duplicationPlotTool.fill(m_duplicationPlotCache, particle.initial(),
+    m_duplicationPlotTool.fill(m_duplicationPlotCache, particle.initialState(),
                                nMatchedTracks - 1);
 
     // Fill number of reconstructed/truth-matched/fake tracks for this particle
-    m_fakePlotTool.fill(m_fakePlotCache, particle.initial(), nMatchedTracks,
-                        nFakeTracks);
+    m_fakePlotTool.fill(m_fakePlotCache, particle.initialState(),
+                        nMatchedTracks, nFakeTracks);
 
     m_nTotalParticles += 1;
   }

--- a/Examples/Io/Root/src/TrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/TrackFitterPerformanceWriter.cpp
@@ -148,7 +148,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFitterPerformanceWriter::writeT(
     // Record this majority particle ID of this trajectory
     reconParticleIds.push_back(ip->particleId());
     // Fill the residual plots
-    m_resPlotTool.fill(m_resPlotCache, ctx.geoContext, ip->initial(),
+    m_resPlotTool.fill(m_resPlotCache, ctx.geoContext, ip->initialState(),
                        fittedParameters);
     // Fill the trajectory summary info
     m_trackSummaryPlotTool.fill(m_trackSummaryPlotCache, fittedParameters,
@@ -182,7 +182,7 @@ ActsExamples::ProcessCode ActsExamples::TrackFitterPerformanceWriter::writeT(
         minDeltaR = distance;
       }
     }
-    m_effPlotTool.fill(m_effPlotCache, particle.initial(), minDeltaR,
+    m_effPlotTool.fill(m_effPlotCache, particle.initialState(), minDeltaR,
                        isReconstructed);
   }
 


### PR DESCRIPTION
Rename SimParticle's final and initial to finalState and initialState to avoid use of the keyword `final`. Sonar flagged this as a potential issue

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
