### PR TITLE
perf!: Speed-up hit access in HoughTransFormUtils

### DIFF
--- a/Core/include/Acts/Seeding/HoughTransformUtils.hpp
+++ b/Core/include/Acts/Seeding/HoughTransformUtils.hpp
@@ -204,9 +204,9 @@ class HoughPlane {
   /// @param xBin: bin index in the first coordinate
   /// @param yBin: bin index in the second coordinate
   /// @return the list of identifiers of the hits for this cell
-  /// Can include duplicates if a hit was filled more than once 
-  std::span<const identifier_t,std::dynamic_extent> hitIds(std::size_t xBin,
-                                          std::size_t yBin) const {
+  /// Can include duplicates if a hit was filled more than once
+  std::span<const identifier_t, std::dynamic_extent> hitIds(
+      std::size_t xBin, std::size_t yBin) const {
     return m_houghHist.atLocalBins({xBin, yBin}).getHits();
   }
   /// @brief get the identifiers of all hits in one cell of the histogram
@@ -215,7 +215,7 @@ class HoughPlane {
   /// @return the list of identifiers of the hits for this cell
   /// Guaranteed to not duplicate identifiers
   std::unordered_set<const identifier_t> uniqueHitIds(std::size_t xBin,
-                                          std::size_t yBin) const {
+                                                      std::size_t yBin) const {
     const auto hits_span = m_houghHist.atLocalBins({xBin, yBin}).getHits();
     return std::unordered_set<identifier_t>(hits_span.begin(), hits_span.end());
   }

--- a/Core/include/Acts/Seeding/HoughTransformUtils.ipp
+++ b/Core/include/Acts/Seeding/HoughTransformUtils.ipp
@@ -166,9 +166,9 @@ Acts::HoughTransformUtils::PeakFinders::LayerGuidedCombinatoric<
     if (passThreshold(plane, xy[0], xy[1])) {
       // write out a maximum
       Maximum max;
-      auto hitIds = plane.hitIds(xy[0], xy[1]); 
+      auto hitIds = plane.hitIds(xy[0], xy[1]);
       max.hitIdentifiers.insert(std::make_move_iterator(hitIds.begin()),
-                                    std::make_move_iterator(hitIds.end()));
+                                std::make_move_iterator(hitIds.end()));
       maxima.push_back(max);
     }
   }
@@ -331,11 +331,11 @@ Acts::HoughTransformUtils::PeakFinders::IslandsAroundMax<
     // loop over cells in the island and get the weighted mean position.
     // Also collect all hit identifiers in the island and the maximum
     // extent (within the count threshold!) of the island
-    std::vector<identifier_t> allHits; 
+    std::vector<identifier_t> allHits;
     for (auto& [xBin, yBin] : solution) {
       auto hidIds = plane.hitIds(xBin, yBin);
-      allHits.insert(allHits.end(),std::make_move_iterator(hidIds.begin()),
-                                    std::make_move_iterator(hidIds.end()));
+      allHits.insert(allHits.end(), std::make_move_iterator(hidIds.begin()),
+                     std::make_move_iterator(hidIds.end()));
       CoordType xHit =
           binCenter(ranges.xMin, ranges.xMax, plane.nBinsX(), xBin);
       CoordType yHit =
@@ -358,7 +358,7 @@ Acts::HoughTransformUtils::PeakFinders::IslandsAroundMax<
       }
     }
     maximum.hitIdentifiers.insert(std::make_move_iterator(allHits.begin()),
-                                    std::make_move_iterator(allHits.end())); 
+                                  std::make_move_iterator(allHits.end()));
     // calculate mean position
     maximum.x = max_x / pos_den;
     maximum.y = max_y / pos_den;


### PR DESCRIPTION
Speed-up hit access in HoughTransFormUtils
--- END COMMIT MESSAGE ---

This MR removes a bottleneck in the `HoughTransformUtils` where access to the hits in a given cell would always perform a sorting operation. Speeds up use cases where hit duplication is guaranteed not to happen, such as ATLAS muon reco. 
Add a legacy `uniqueHitIds` method providing the old-style sorted hit access. 
CC @jojungge 
