### PR TITLE
[fix] Fix setup script for installed ACTS

### DIFF
--- a/cmake/setup_withdeps.sh.in
+++ b/cmake/setup_withdeps.sh.in
@@ -19,6 +19,11 @@ else
     exit 1
 fi
 
+# detect if we are installed as there is no lib subdirectory
+if [ ! -d "$script_dir/lib" ]; then
+    script_dir=$( cd -- "$script_dir" &> /dev/null && cd .. &> /dev/null && pwd )
+fi
+
 # source the python and ODD environment
 # first check if python bindings are enabled
 # then check if the setup.sh file exists


### PR DESCRIPTION
Fix setup script for installed ACTS as the current one assumes running from the build directory. Once installed, setup scripts are actually in the `bin` folder so we need to move one folder up.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
