### PR TITLE
build: Allow building static Core library

### DIFF
--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -4,7 +4,7 @@ configure_file(
 )
 
 # source files will be added later
-acts_add_library(Core SHARED "")
+acts_add_library(Core "")
 
 target_sources(ActsCore PRIVATE src/ActsVersion.cpp)
 

--- a/Core/src/Definitions/CMakeLists.txt
+++ b/Core/src/Definitions/CMakeLists.txt
@@ -8,4 +8,4 @@ acts_code_generation(
     OUTPUT ParticleDataTable.hpp
 )
 
-target_link_libraries(ActsCore PRIVATE Acts::ParticleDataTable)
+target_link_libraries(ActsCore PRIVATE $<COMPILE_ONLY:Acts::ParticleDataTable>)

--- a/Core/src/Propagator/CMakeLists.txt
+++ b/Core/src/Propagator/CMakeLists.txt
@@ -47,9 +47,9 @@ acts_code_generation(
 target_link_libraries(
     ActsCore
     PRIVATE
-        Acts::SympyCovarianceEngine
-        Acts::SympyStepperMath
-        Acts::SympyJacobianEngine
+        $<COMPILE_ONLY:Acts::SympyCovarianceEngine>
+        $<COMPILE_ONLY:Acts::SympyStepperMath>
+        $<COMPILE_ONLY:Acts::SympyJacobianEngine>
 )
 
 # message(FATAL_ERROR "stop")

--- a/Examples/Algorithms/Alignment/CMakeLists.txt
+++ b/Examples/Algorithms/Alignment/CMakeLists.txt
@@ -10,9 +10,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesAlignment
-    PUBLIC
-        Acts::Core
-        Acts::Alignment
-        Acts::ExamplesFramework
-        Acts::ExamplesMagneticField
+    PUBLIC Acts::Alignment Acts::ExamplesFramework Acts::ExamplesMagneticField
 )

--- a/Examples/Algorithms/AmbiguityResolution/CMakeLists.txt
+++ b/Examples/Algorithms/AmbiguityResolution/CMakeLists.txt
@@ -12,5 +12,5 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesAmbiguityResolution
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::PluginJson
+    PUBLIC Acts::ExamplesFramework Acts::PluginJson
 )

--- a/Examples/Algorithms/Digitization/CMakeLists.txt
+++ b/Examples/Algorithms/Digitization/CMakeLists.txt
@@ -12,9 +12,6 @@ target_include_directories(
     ActsExamplesDigitization
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_link_libraries(
-    ActsExamplesDigitization
-    PUBLIC Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExamplesDigitization PUBLIC Acts::ExamplesFramework)
 
 acts_compile_headers(ExamplesDigitization GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/Fatras/CMakeLists.txt
+++ b/Examples/Algorithms/Fatras/CMakeLists.txt
@@ -5,9 +5,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesFatras
-    PUBLIC
-        Acts::Core
-        Acts::Fatras
-        Acts::ExamplesFramework
-        Acts::ExamplesMagneticField
+    PUBLIC Acts::Fatras Acts::ExamplesFramework Acts::ExamplesMagneticField
 )

--- a/Examples/Algorithms/Geant4/CMakeLists.txt
+++ b/Examples/Algorithms/Geant4/CMakeLists.txt
@@ -28,10 +28,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesGeant4
-    PUBLIC
-        Acts::Core
-        Acts::ExamplesFramework
-        Acts::ExamplesDetectorsCommon
-        Boost::headers
-        ${Geant4_LIBRARIES}
+    PUBLIC Acts::ExamplesDetectorsCommon Boost::headers ${Geant4_LIBRARIES}
 )

--- a/Examples/Algorithms/Generators/CMakeLists.txt
+++ b/Examples/Algorithms/Generators/CMakeLists.txt
@@ -9,9 +9,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesGenerators
-    PUBLIC
-        Acts::Core
-        Acts::ExamplesFramework
-        Acts::ExamplesIoHepMC3
-        HepMC3::HepMC3
+    PUBLIC Acts::ExamplesIoHepMC3 HepMC3::HepMC3
 )

--- a/Examples/Algorithms/GeneratorsPythia8/CMakeLists.txt
+++ b/Examples/Algorithms/GeneratorsPythia8/CMakeLists.txt
@@ -9,6 +9,6 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesGeneratorsPythia8
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::ExamplesGenerators
+    PUBLIC Acts::ExamplesFramework Acts::ExamplesGenerators
     PRIVATE Pythia8::Pythia8
 )

--- a/Examples/Algorithms/Geometry/CMakeLists.txt
+++ b/Examples/Algorithms/Geometry/CMakeLists.txt
@@ -5,7 +5,4 @@ target_include_directories(
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(
-    ActsExamplesGeometry
-    PUBLIC Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExamplesGeometry PUBLIC Acts::ExamplesFramework)

--- a/Examples/Algorithms/Jets/CMakeLists.txt
+++ b/Examples/Algorithms/Jets/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesJets
-    PUBLIC Acts::Core Acts::PluginFastJet Acts::ExamplesFramework
+    PUBLIC Acts::PluginFastJet Acts::ExamplesFramework
 )
 
 acts_compile_headers(ExamplesJets GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/MaterialMapping/CMakeLists.txt
+++ b/Examples/Algorithms/MaterialMapping/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesMaterialMapping
-    PUBLIC Acts::Core Acts::ExamplesFramework
+    PUBLIC Acts::ExamplesFramework
 )
 
 acts_compile_headers(ExamplesMaterialMapping GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/Printers/CMakeLists.txt
+++ b/Examples/Algorithms/Printers/CMakeLists.txt
@@ -10,5 +10,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesPrinters
-    PUBLIC Acts::Core Acts::Fatras Acts::ExamplesFramework
+    PUBLIC Acts::Fatras Acts::ExamplesFramework
 )

--- a/Examples/Algorithms/Propagation/CMakeLists.txt
+++ b/Examples/Algorithms/Propagation/CMakeLists.txt
@@ -5,9 +5,6 @@ target_include_directories(
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_link_libraries(
-    ActsExamplesPropagation
-    PUBLIC Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExamplesPropagation PUBLIC Acts::ExamplesFramework)
 
 acts_compile_headers(ExamplesPropagation GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/Traccc/CMakeLists.txt
+++ b/Examples/Algorithms/Traccc/CMakeLists.txt
@@ -8,7 +8,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesTraccc
     INTERFACE
-        Acts::Core
         Acts::ExamplesFramework
         Acts::ExamplesPropagation
         Acts::PluginDetray

--- a/Examples/Algorithms/TrackFinding/CMakeLists.txt
+++ b/Examples/Algorithms/TrackFinding/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesTrackFinding
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::ExamplesMagneticField
+    PUBLIC Acts::ExamplesMagneticField
     PRIVATE ROOT::Core ROOT::Geom ROOT::Graf ROOT::Hist ROOT::Gpad
 )
 

--- a/Examples/Algorithms/TrackFindingML/CMakeLists.txt
+++ b/Examples/Algorithms/TrackFindingML/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesTrackFindingML
-    PUBLIC Acts::Core Acts::PluginOnnx Acts::ExamplesFramework
+    PUBLIC Acts::PluginOnnx Acts::ExamplesFramework
 )
 
 acts_compile_headers(ExamplesTrackFindingML GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/TrackFitting/CMakeLists.txt
+++ b/Examples/Algorithms/TrackFitting/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesTrackFitting
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::ExamplesMagneticField
+    PUBLIC Acts::ExamplesFramework Acts::ExamplesMagneticField
 )
 
 acts_compile_headers(ExamplesTrackFitting GLOB "include/**/*.hpp")

--- a/Examples/Algorithms/TruthTracking/CMakeLists.txt
+++ b/Examples/Algorithms/TruthTracking/CMakeLists.txt
@@ -16,7 +16,4 @@ target_include_directories(
     ActsExamplesTruthTracking
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
-target_link_libraries(
-    ActsExamplesTruthTracking
-    PUBLIC Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExamplesTruthTracking PUBLIC Acts::ExamplesFramework)

--- a/Examples/Algorithms/Utilities/CMakeLists.txt
+++ b/Examples/Algorithms/Utilities/CMakeLists.txt
@@ -13,7 +13,4 @@ target_include_directories(
     ActsExamplesUtilities
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
-target_link_libraries(
-    ActsExamplesUtilities
-    PUBLIC Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExamplesUtilities PUBLIC Acts::ExamplesFramework)

--- a/Examples/Algorithms/Vertexing/CMakeLists.txt
+++ b/Examples/Algorithms/Vertexing/CMakeLists.txt
@@ -13,6 +13,6 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesVertexing
-    PUBLIC Acts::Core Acts::ExamplesFramework
+    PUBLIC Acts::ExamplesFramework
     PRIVATE Acts::ExamplesTruthTracking
 )

--- a/Examples/Detectors/Common/CMakeLists.txt
+++ b/Examples/Detectors/Common/CMakeLists.txt
@@ -11,5 +11,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesDetectorsCommon
-    PUBLIC Acts::Core Acts::ExamplesFramework
+    PUBLIC Acts::ExamplesFramework
 )

--- a/Examples/Detectors/DD4hepDetector/CMakeLists.txt
+++ b/Examples/Detectors/DD4hepDetector/CMakeLists.txt
@@ -11,11 +11,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesDetectorDD4hep
-    PUBLIC
-        Acts::Core
-        Acts::PluginDD4hep
-        Acts::ExamplesFramework
-        Acts::ExamplesDetectorsCommon
+    PUBLIC Acts::PluginDD4hep Acts::ExamplesDetectorsCommon
 )
 
 if(ACTS_BUILD_EXAMPLES_GEANT4)
@@ -61,5 +57,3 @@ set_target_properties(
     ActsExamplesDetectorDD4hep
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
-dd4hep_set_version(ActsExamplesDetectorDD4hep MAJOR 1 MINOR 0 PATCH 0)
-dd4hep_generate_rootmap(ActsExamplesDetectorDD4hep)

--- a/Examples/Detectors/Geant4Detector/CMakeLists.txt
+++ b/Examples/Detectors/Geant4Detector/CMakeLists.txt
@@ -13,10 +13,5 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesDetectorGeant4
-    PUBLIC
-        Acts::Core
-        Acts::ExamplesFramework
-        Acts::ExamplesGeant4
-        Acts::PluginGeant4
-        Acts::ExamplesDetectorsCommon
+    PUBLIC Acts::ExamplesGeant4 Acts::PluginGeant4 Acts::ExamplesDetectorsCommon
 )

--- a/Examples/Detectors/GenericDetector/CMakeLists.txt
+++ b/Examples/Detectors/GenericDetector/CMakeLists.txt
@@ -18,5 +18,5 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesDetectorGeneric
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::ExamplesDetectorsCommon
+    PUBLIC Acts::ExamplesDetectorsCommon
 )

--- a/Examples/Detectors/GeoModelDetector/CMakeLists.txt
+++ b/Examples/Detectors/GeoModelDetector/CMakeLists.txt
@@ -14,7 +14,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesDetectorGeoModel
     PUBLIC
-        Acts::Core
         Acts::ExamplesFramework
         Acts::PluginGeoModel
         Acts::ExamplesDetectorsCommon

--- a/Examples/Detectors/MagneticField/CMakeLists.txt
+++ b/Examples/Detectors/MagneticField/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(
     ActsExamplesMagneticField
     # the ROOT libraries should be private, but if we do that then the linker
     # fails with some missing ROOT symbols.
-    PUBLIC Acts::Core Acts::ExamplesFramework ROOT::Core ROOT::Tree
+    PUBLIC Acts::ExamplesFramework ROOT::Core ROOT::Tree
     PRIVATE std::filesystem
 )
 

--- a/Examples/Detectors/MuonSpectrometerMockupDetector/CMakeLists.txt
+++ b/Examples/Detectors/MuonSpectrometerMockupDetector/CMakeLists.txt
@@ -3,7 +3,7 @@ if(ACTS_BUILD_PLUGIN_GEOMODEL OR ACTS_BUILD_EXAMPLES_GEANT4)
 
     target_link_libraries(
         ActsExamplesMuonSpectrometerMockupDetector
-        PUBLIC Acts::Core Acts::ExamplesFramework
+        PUBLIC Acts::ExamplesFramework
     )
     target_include_directories(
         ActsExamplesMuonSpectrometerMockupDetector

--- a/Examples/Detectors/TGeoDetector/CMakeLists.txt
+++ b/Examples/Detectors/TGeoDetector/CMakeLists.txt
@@ -15,7 +15,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesDetectorTGeo
     PUBLIC
-        Acts::Core
         Acts::PluginRoot
         Acts::PluginJson
         Acts::ExamplesFramework

--- a/Examples/Detectors/TelescopeDetector/CMakeLists.txt
+++ b/Examples/Detectors/TelescopeDetector/CMakeLists.txt
@@ -13,7 +13,7 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesDetectorTelescope
-    PUBLIC Acts::Core Acts::ExamplesFramework Acts::ExamplesDetectorsCommon
+    PUBLIC Acts::ExamplesFramework Acts::ExamplesDetectorsCommon
 )
 
 if(ACTS_BUILD_EXAMPLES_GEANT4)

--- a/Examples/Framework/CMakeLists.txt
+++ b/Examples/Framework/CMakeLists.txt
@@ -39,7 +39,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesFramework
     PUBLIC
-        Acts::Core
         Acts::Fatras
         Acts::PluginFpeMonitoring
         Boost::boost

--- a/Examples/HelloWorld/CMakeLists.txt
+++ b/Examples/HelloWorld/CMakeLists.txt
@@ -5,10 +5,7 @@ add_executable(
     HelloRandomAlgorithm.cpp
     HelloWhiteBoardAlgorithm.cpp
 )
-target_link_libraries(
-    ActsExampleHelloWorld
-    PRIVATE Acts::Core Acts::ExamplesFramework
-)
+target_link_libraries(ActsExampleHelloWorld PRIVATE Acts::ExamplesFramework)
 
 install(
     TARGETS ActsExampleHelloWorld

--- a/Examples/Io/Csv/CMakeLists.txt
+++ b/Examples/Io/Csv/CMakeLists.txt
@@ -30,9 +30,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesIoCsv
-    PRIVATE
-        Acts::Core
-        Acts::ExamplesFramework
-        Acts::ExamplesDigitization
-        Threads::Threads
+    PRIVATE Acts::ExamplesFramework Acts::ExamplesDigitization Threads::Threads
 )

--- a/Examples/Io/EDM4hep/CMakeLists.txt
+++ b/Examples/Io/EDM4hep/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(
         EDM4HEP::edm4hep
         Acts::PluginEDM4hep
         podio::podioRootIO
-        Acts::Core
         Acts::Fatras
         Acts::ExamplesFramework
         Acts::ExamplesDigitization

--- a/Examples/Io/HepMC3/CMakeLists.txt
+++ b/Examples/Io/HepMC3/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesIoHepMC3
-    PUBLIC Acts::Core Acts::ExamplesFramework ${HEPMC3_LIBRARIES}
+    PUBLIC Acts::ExamplesFramework ${HEPMC3_LIBRARIES}
     PRIVATE Acts::Fatras
 )
 

--- a/Examples/Io/Json/CMakeLists.txt
+++ b/Examples/Io/Json/CMakeLists.txt
@@ -13,7 +13,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesIoJson
     PUBLIC
-        Acts::Core
         Acts::PluginJson
         Acts::ExamplesDigitization
         Acts::ExamplesFramework

--- a/Examples/Io/Obj/CMakeLists.txt
+++ b/Examples/Io/Obj/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesIoObj
-    PUBLIC Acts::Core Acts::ExamplesFramework Threads::Threads
+    PUBLIC Acts::ExamplesFramework Threads::Threads
 )
 
 acts_compile_headers(ExamplesIoObj GLOB "include/**/*.hpp")

--- a/Examples/Io/Podio/CMakeLists.txt
+++ b/Examples/Io/Podio/CMakeLists.txt
@@ -12,5 +12,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesIoPodio
-    PUBLIC podio::podio Acts::ExamplesFramework Acts::PluginPodio Acts::Core
+    PUBLIC podio::podio Acts::ExamplesFramework Acts::PluginPodio
 )

--- a/Examples/Io/Root/CMakeLists.txt
+++ b/Examples/Io/Root/CMakeLists.txt
@@ -37,7 +37,6 @@ target_include_directories(
 target_link_libraries(
     ActsExamplesIoRoot
     PUBLIC
-        Acts::Core
         Acts::PluginRoot
         Acts::ExamplesDigitization
         Acts::ExamplesFramework

--- a/Examples/Io/Svg/CMakeLists.txt
+++ b/Examples/Io/Svg/CMakeLists.txt
@@ -5,9 +5,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsExamplesIoSvg
-    PUBLIC
-        Acts::Core
-        Acts::ExamplesFramework
-        Acts::PluginActSVG
-        Threads::Threads
+    PUBLIC Acts::ExamplesFramework Acts::PluginActSVG Threads::Threads
 )

--- a/Examples/Python/CMakeLists.txt
+++ b/Examples/Python/CMakeLists.txt
@@ -48,7 +48,6 @@ set_target_properties(
 target_link_libraries(
     ActsPythonBindings
     PUBLIC
-        Acts::Core
         Acts::PythonUtilities
         Acts::ExamplesFramework
         Acts::ExamplesGeometry

--- a/Fatras/Geant4/CMakeLists.txt
+++ b/Fatras/Geant4/CMakeLists.txt
@@ -18,7 +18,4 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(
-    ActsFatrasGeant4
-    PUBLIC Acts::Core Acts::Fatras ${Geant4_LIBRARIES}
-)
+target_link_libraries(ActsFatrasGeant4 PUBLIC Acts::Fatras ${Geant4_LIBRARIES})

--- a/Plugins/DD4hep/CMakeLists.txt
+++ b/Plugins/DD4hep/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(ActsPluginDD4hep PUBLIC Acts::Core Acts::PluginRoot)
+target_link_libraries(ActsPluginDD4hep PUBLIC Acts::PluginRoot)
 
 if(${DD4hep_VERSION} VERSION_LESS 1.11)
     target_include_directories(ActsPluginDD4hep PUBLIC ${DD4hep_INCLUDE_DIRS})

--- a/Plugins/Detray/CMakeLists.txt
+++ b/Plugins/Detray/CMakeLists.txt
@@ -21,7 +21,6 @@ target_include_directories(
 target_link_libraries(
     ActsPluginDetray
     PUBLIC
-        Acts::Core
         Acts::PluginJson
         detray::core
         detray::core_array

--- a/Plugins/EDM4hep/CMakeLists.txt
+++ b/Plugins/EDM4hep/CMakeLists.txt
@@ -13,5 +13,5 @@ target_include_directories(
 )
 target_link_libraries(
     ActsPluginEDM4hep
-    PUBLIC Acts::Core Acts::PluginPodio EDM4HEP::edm4hep
+    PUBLIC Acts::PluginPodio EDM4HEP::edm4hep
 )

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -20,7 +20,6 @@ macro(add_unittest _name _source)
     target_link_libraries(
         ${_target}
         PRIVATE
-            Acts::Core
             Acts::TestsCommonHelpers
             Boost::unit_test_framework
             ${unittest_extra_libraries}


### PR DESCRIPTION
This requires dropping the explicit link instructions against the `Acts::Core` library, as that causes warnings about duplicate libraries being given to the linker.

Closes #4526

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
