### PR TITLE
ci: Add synchronize trigger for milestone check

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -2,7 +2,7 @@ name: Check PR milestone
 
 on:
   pull_request_target:
-    types: [milestoned, demilestoned, opened, reopened]
+    types: [milestoned, demilestoned, opened, reopened, synchronize]
     branches:
       - main
 

--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -1,7 +1,6 @@
 rules:
   - required_checks:
       - Lint PR / Validate PR title
-      - milestone-set
     required_pattern:
       - "policy-bot: *"
 


### PR DESCRIPTION

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
