### PR TITLE
fix: Improve layer surface array lookup with representative intersection

### DIFF
--- a/Core/src/Geometry/Layer.cpp
+++ b/Core/src/Geometry/Layer.cpp
@@ -192,9 +192,23 @@ Layer::compatibleSurfaces(const GeometryContext& gctx, const Vector3& position,
   // check the sensitive surfaces if you have some
   if (m_surfaceArray && (options.resolveMaterial || options.resolvePassive ||
                          options.resolveSensitive)) {
+    Vector3 lookupPosition = position;
+
+    // if possible use a position on the representative surface for the surface
+    // array lookup
+    if (SurfaceIntersection intersection =
+            surfaceRepresentation()
+                .intersect(gctx, position, direction)
+                .closestForward();
+        intersection.isValid() &&
+        detail::checkPathLength(intersection.pathLength(), nearLimit,
+                                farLimit)) {
+      lookupPosition = intersection.position();
+    }
+
     // get the candidates
     const std::vector<const Surface*>& sensitiveSurfaces =
-        m_surfaceArray->neighbors(position);
+        m_surfaceArray->neighbors(lookupPosition);
     // loop through and veto
     // - if the approach surface is the parameter surface
     // - if the surface is not compatible with the type(s) that are collected


### PR DESCRIPTION
Try to intersect the representative surface of the layer to get a better estimate of the position to lookup the surface grid. If the intersection is not successful this falls back to the original behavior.

This will have a computational overhead but should lead to better physics results. After tuning the ITk surface grid we started seeing missing innermost hits in the innermost barrel layer due to high inclination of the track.

--- END COMMIT MESSAGE ---

