### PR TITLE
fix: Include missing PortalShell.hpp header

### DIFF
--- a/Core/include/Acts/Geometry/ContainerBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/ContainerBlueprintNode.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Geometry/BlueprintNode.hpp"
 #include "Acts/Geometry/BlueprintOptions.hpp"
+#include "Acts/Geometry/PortalShell.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"


### PR DESCRIPTION
Include missing `PortalShell.hpp` in `ContainerBlueprintNode.hpp`

--- END COMMIT MESSAGE ---

I encountered this issue when including `ContainerBlueprintNode.hpp` from outside the ACTS build. The header defines members of type `std::unique_ptr<PortalShellBase>` but does not include `PortalShell.hpp`, which leads to incomplete type errors.

This can easily be worked around downstream by adding the missing include in the external translation unit, but fixing it upstream ensures the header is self-contained and prevents future build issues.
