### PR TITLE
perf: Cleanup and optimize strip triplet formation in `Seeding2`

### DIFF
--- a/Core/src/Seeding2/BroadTripletSeedFilter.cpp
+++ b/Core/src/Seeding2/BroadTripletSeedFilter.cpp
@@ -178,24 +178,24 @@ void BroadTripletSeedFilter::filterTripletTopCandidates(
     for (std::size_t variableCompTopIndex = beginCompTopIndex;
          variableCompTopIndex < cache().topSpIndexVec.size();
          variableCompTopIndex++) {
-      std::size_t compatibletopSpIndex =
+      std::size_t compatibleTopSpIndex =
           cache().topSpIndexVec[variableCompTopIndex];
-      if (compatibletopSpIndex == topSpIndex) {
+      if (compatibleTopSpIndex == topSpIndex) {
         continue;
       }
       auto otherSpT = spacePoints[tripletTopCandidates
-                                      .topSpacePoints()[compatibletopSpIndex]];
+                                      .topSpacePoints()[compatibleTopSpIndex]];
 
       float otherTopR = getTopR(otherSpT);
 
       // curvature difference within limits?
-      if (tripletTopCandidates.curvatures()[compatibletopSpIndex] <
+      if (tripletTopCandidates.curvatures()[compatibleTopSpIndex] <
           lowerLimitCurv) {
         // the SPs are sorted in curvature so we skip unnecessary iterations
         beginCompTopIndex = variableCompTopIndex + 1;
         continue;
       }
-      if (tripletTopCandidates.curvatures()[compatibletopSpIndex] >
+      if (tripletTopCandidates.curvatures()[compatibleTopSpIndex] >
           upperLimitCurv) {
         // the SPs are sorted in curvature so we skip unnecessary iterations
         break;

--- a/Core/src/Seeding2/TripletSeedFinder.cpp
+++ b/Core/src/Seeding2/TripletSeedFinder.cpp
@@ -297,7 +297,7 @@ class Impl final : public TripletSeedFinder {
           rotationTermsUVtoXY[0] * A0 + rotationTermsUVtoXY[1],
           zPositionMiddle};
 
-      std::array<float, 3> rMTransf;
+      std::array<float, 3> rMTransf{};
       if (!stripCoordinateCheck(m_cfg.toleranceParam, spM, positionMiddle,
                                 rMTransf)) {
         continue;
@@ -314,7 +314,7 @@ class Impl final : public TripletSeedFinder {
 
       const ConstSpacePointProxy2 spB =
           spacePoints[bottomDoublet.spacePointIndex()];
-      std::array<float, 3> rBTransf;
+      std::array<float, 3> rBTransf{};
       if (!stripCoordinateCheck(m_cfg.toleranceParam, spB, positionBottom,
                                 rBTransf)) {
         continue;
@@ -330,7 +330,7 @@ class Impl final : public TripletSeedFinder {
 
       const ConstSpacePointProxy2 spT =
           spacePoints[topDoublet.spacePointIndex()];
-      std::array<float, 3> rTTransf;
+      std::array<float, 3> rTTransf{};
       if (!stripCoordinateCheck(m_cfg.toleranceParam, spT, positionTop,
                                 rTTransf)) {
         continue;


### PR DESCRIPTION
- cleanup
  - `SortedInCotTheta` vs `SortedByCotTheta`
  - `const` consistency
  - `2.` vs `2`
- perf
  - this version achieves similar (within measurement error of about ~1%) performance as the original ACTS code
  - it seems to me that the performance depends on auto vectorization which appears to be very fragile

--- END COMMIT MESSAGE ---

