### PR TITLE
feat: Score monitors for Score Based Ambiguity solver.

### DIFF
--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -178,8 +178,9 @@ class ScoreBasedAmbiguityResolution {
   explicit ScoreBasedAmbiguityResolution(
       const Config& cfg,
       std::unique_ptr<const Logger> logger =
-          getDefaultLogger("ScoreBasedAmbiguityResolution", Logging::INFO))
-      : m_cfg{cfg}, m_logger{std::move(logger)} {}
+          getDefaultLogger("ScoreBasedAmbiguityResolution", Logging::INFO),
+      const std::string& monitorFilePath = "scoreMonitor.root")
+      : m_cfg{cfg}, m_logger{std::move(logger)}, m_monitorFilePath{monitorFilePath} {}
 
   /// Compute the initial state of the tracks.
   ///
@@ -260,14 +261,16 @@ class ScoreBasedAmbiguityResolution {
       source_link_equality_t sourceLinkEquality,
       const Optionals<typename track_container_t::ConstTrackProxy>& optionals =
           {}) const;
-  void saveScoreMonitor(const std::vector<ScoreMonitor>& scoreMonitor,
-                        const std::string& monitorFile) const;
+  void saveScoreMonitor(const std::vector<ScoreMonitor>& scoreMonitor) const;
 
  private:
   Config m_cfg;
 
   /// Logging instance
   std::unique_ptr<const Logger> m_logger = nullptr;
+
+  /// Default path for the score monitor file
+  std::string m_monitorFilePath = "scoreMonitor.root";
 
   /// Private access to logging instance
   const Logger& logger() const;

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -260,6 +260,8 @@ class ScoreBasedAmbiguityResolution {
       source_link_equality_t sourceLinkEquality,
       const Optionals<typename track_container_t::ConstTrackProxy>& optionals =
           {}) const;
+  void saveScoreMonitor(const std::vector<ScoreMonitor>& scoreMonitor,
+                        const std::string& monitorFile) const;
 
  private:
   Config m_cfg;

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -151,6 +151,30 @@ class ScoreBasedAmbiguityResolution {
     std::vector<OptionalHitSelection> hitSelections = {};
   };
 
+  struct ScoreMonitor {
+    std::size_t ptScore = 0;
+    std::vector<std::size_t> detectorHitScore;
+    std::vector<std::size_t> detectorHoleScore;
+    std::vector<std::size_t> detectorOutlierScore;
+    std::vector<std::size_t> detectorOtherScore;
+    std::size_t chi2Score = 0;
+
+    std::vector<std::size_t> optionalScore;
+
+    std::size_t totalScore = 0;
+
+    void setZero() {
+      ptScore = 0;
+      detectorHitScore.clear();
+      detectorHoleScore.clear();
+      detectorOutlierScore.clear();
+      detectorOtherScore.clear();
+      chi2Score = 0;
+      optionalScore.clear();
+      totalScore = 0;
+    }
+  };
+
   explicit ScoreBasedAmbiguityResolution(
       const Config& cfg,
       std::unique_ptr<const Logger> logger =

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -152,16 +152,20 @@ class ScoreBasedAmbiguityResolution {
   };
 
   struct ScoreMonitor {
-    std::size_t ptScore = 0;
-    std::vector<std::size_t> detectorHitScore;
-    std::vector<std::size_t> detectorHoleScore;
-    std::vector<std::size_t> detectorOutlierScore;
-    std::vector<std::size_t> detectorOtherScore;
-    std::size_t chi2Score = 0;
+    double pT = 0.0;
+    double eta = 0.0;
+    double phi = 0.0;
 
-    std::vector<std::size_t> optionalScore;
+    double ptScore = 0;
+    std::vector<double> detectorHitScore;
+    std::vector<double> detectorHoleScore;
+    std::vector<double> detectorOutlierScore;
+    std::vector<double> detectorOtherScore;
+    double chi2Score = 0;
 
-    std::size_t totalScore = 0;
+    std::vector<double> optionalScore;
+
+    double totalScore = 0;
 
     void setZero() {
       ptScore = 0;
@@ -261,7 +265,7 @@ class ScoreBasedAmbiguityResolution {
       const Optionals<typename track_container_t::ConstTrackProxy>& optionals =
           {}) const;
 
-  std::vector<ScoreMonitor> getScoreMonitor() const ;
+  std::vector<ScoreMonitor> getScoreMonitor() const;
 
  private:
   Config m_cfg;

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -178,9 +178,8 @@ class ScoreBasedAmbiguityResolution {
   explicit ScoreBasedAmbiguityResolution(
       const Config& cfg,
       std::unique_ptr<const Logger> logger =
-          getDefaultLogger("ScoreBasedAmbiguityResolution", Logging::INFO),
-      const std::string& monitorFilePath = "scoreMonitor.root")
-      : m_cfg{cfg}, m_logger{std::move(logger)}, m_monitorFilePath{monitorFilePath} {}
+          getDefaultLogger("ScoreBasedAmbiguityResolution", Logging::INFO))
+      : m_cfg{cfg}, m_logger{std::move(logger)} {}
 
   /// Compute the initial state of the tracks.
   ///
@@ -261,7 +260,8 @@ class ScoreBasedAmbiguityResolution {
       source_link_equality_t sourceLinkEquality,
       const Optionals<typename track_container_t::ConstTrackProxy>& optionals =
           {}) const;
-  void saveScoreMonitor(const std::vector<ScoreMonitor>& scoreMonitor) const;
+
+  std::vector<ScoreMonitor> scoreMonitor() const ;
 
  private:
   Config m_cfg;
@@ -269,8 +269,7 @@ class ScoreBasedAmbiguityResolution {
   /// Logging instance
   std::unique_ptr<const Logger> m_logger = nullptr;
 
-  /// Default path for the score monitor file
-  std::string m_monitorFilePath = "scoreMonitor.root";
+  mutable std::vector<ScoreMonitor> m_scoreMonitor;
 
   /// Private access to logging instance
   const Logger& logger() const;

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp
@@ -261,7 +261,7 @@ class ScoreBasedAmbiguityResolution {
       const Optionals<typename track_container_t::ConstTrackProxy>& optionals =
           {}) const;
 
-  std::vector<ScoreMonitor> scoreMonitor() const ;
+  std::vector<ScoreMonitor> getScoreMonitor() const ;
 
  private:
   Config m_cfg;

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
@@ -270,7 +270,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
     ACTS_DEBUG("Modifier for pT = " << pT << " GeV is : " << score
                                     << "  New score now: " << score);
 
-    monitor.ptScore = score;                                
+    monitor.ptScore = score;
 
     for (std::size_t detectorId = 0; detectorId < m_cfg.detectorConfigs.size();
          detectorId++) {
@@ -290,7 +290,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
                                  << " hits: " << detector.factorHits[nHits]
                                  << "  New score now: " << score);
 
-      monitor.detectorHitScore.push_back(score);                           
+      monitor.detectorHitScore.push_back(score);
       // choosing a scaling factor based on the number of holes in a track per
       // detector.
       std::size_t iHoles = trackFeatures.nHoles;
@@ -336,7 +336,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
 
   }  // end of loop over tracks
 
-  saveScoreMonitor(scoreMonitor);
+  m_scoreMonitor = scoreMonitor;
 
   return trackScore;
 }

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
@@ -336,7 +336,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
 
   }  // end of loop over tracks
 
-  saveScoreMonitor(scoreMonitor, "scoreMonitor.root");
+  saveScoreMonitor(scoreMonitor);
 
   return trackScore;
 }

--- a/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
+++ b/Core/include/Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.ipp
@@ -336,7 +336,7 @@ std::vector<double> Acts::ScoreBasedAmbiguityResolution::ambiguityScore(
 
   }  // end of loop over tracks
 
-  saveScoreMonitor(scoreMonitor, "scoreMonitor.csv");
+  saveScoreMonitor(scoreMonitor, "scoreMonitor.root");
 
   return trackScore;
 }

--- a/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
+++ b/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
@@ -25,6 +25,6 @@ bool Acts::ScoreBasedAmbiguityResolution::etaBasedCuts(
           trackFeatures.nSharedHits > detector.maxSharedHitsPerEta[etaBin]);
 }
 
-std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor> Acts::ScoreBasedAmbiguityResolution::scoreMonitor() const {
+std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor> Acts::ScoreBasedAmbiguityResolution::getScoreMonitor() const {
   return m_scoreMonitor;
 }

--- a/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
+++ b/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
@@ -28,12 +28,11 @@ bool Acts::ScoreBasedAmbiguityResolution::etaBasedCuts(
 }
 
 void Acts::ScoreBasedAmbiguityResolution::saveScoreMonitor(
-    const std::vector<ScoreMonitor>& scoreMonitor,
-    const std::string& monitorFilePath) const {
+    const std::vector<ScoreMonitor>& scoreMonitor) const {
   // Open ROOT file for writing
-  TFile* file = TFile::Open(monitorFilePath.c_str(), "RECREATE");
+  TFile* file = TFile::Open(m_monitorFilePath.c_str(), "RECREATE");
   if (!file || file->IsZombie()) {
-    throw std::runtime_error("Could not create ROOT file: " + monitorFilePath);
+    throw std::runtime_error("Could not create ROOT file: " + m_monitorFilePath);
   }
 
   // Create a TTree
@@ -62,7 +61,7 @@ void Acts::ScoreBasedAmbiguityResolution::saveScoreMonitor(
   tree->Branch("optionalScore", &optionalScore);
 
   // Fill the tree
-  for (const auto& monitor : scoreMonitor) {
+  for (const ScoreMonitor& monitor : scoreMonitor) {
     ptScore = monitor.ptScore;
     chi2Score = monitor.chi2Score;
     totalScore = monitor.totalScore;

--- a/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
+++ b/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
@@ -23,3 +23,54 @@ bool Acts::ScoreBasedAmbiguityResolution::etaBasedCuts(
           trackFeatures.nOutliers > detector.maxOutliersPerEta[etaBin] ||
           trackFeatures.nSharedHits > detector.maxSharedHitsPerEta[etaBin]);
 }
+void Acts::ScoreBasedAmbiguityResolution::saveScoreMonitor(
+  const std::vector<ScoreMonitor>& scoreMonitor,
+  const std::string& monitorFilePath) const {
+std::string headers;
+headers = "ptScore,";
+for (std::size_t i = 0; i < scoreMonitor[0].detectorHitScore.size(); i++) {
+  headers += "detectorHitScore" + std::to_string(i) + ",";
+}
+for (std::size_t i = 0; i < scoreMonitor[0].detectorHoleScore.size(); i++) {
+  headers += "detectorHoleScore" + std::to_string(i) + ",";
+}
+for (std::size_t i = 0; i < scoreMonitor[0].detectorOutlierScore.size();
+     i++) {
+  headers += "detectorOutlierScore" + std::to_string(i) + ",";
+}
+for (std::size_t i = 0; i < scoreMonitor[0].detectorOtherScore.size(); i++) {
+  headers += "detectorOtherScore" + std::to_string(i) + ",";
+}
+headers += "chi2Score,";
+for (std::size_t i = 0; i < scoreMonitor[0].optionalScore.size(); i++) {
+  headers += "optionalScore" + std::to_string(i) + ",";
+}
+headers += "totalScore\n";
+
+std::ofstream monitorFile;
+monitorFile.open(monitorFilePath, std::ios::app);
+monitorFile << headers;
+
+for (const auto& monitor : scoreMonitor) {
+  monitorFile << monitor.ptScore << ",";
+  for (const auto& score : monitor.detectorHitScore) {
+    monitorFile << score << ",";
+  }
+  for (const auto& score : monitor.detectorHoleScore) {
+    monitorFile << score << ",";
+  }
+  for (const auto& score : monitor.detectorOutlierScore) {
+    monitorFile << score << ",";
+  }
+  for (const auto& score : monitor.detectorOtherScore) {
+    monitorFile << score << ",";
+  }
+  monitorFile << monitor.chi2Score << ",";
+  for (const auto& score : monitor.optionalScore) {
+    monitorFile << score << ",";
+  }
+  monitorFile << monitor.totalScore << "\n";
+}
+
+monitorFile.close();
+}

--- a/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
+++ b/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
@@ -27,56 +27,6 @@ bool Acts::ScoreBasedAmbiguityResolution::etaBasedCuts(
           trackFeatures.nSharedHits > detector.maxSharedHitsPerEta[etaBin]);
 }
 
-void Acts::ScoreBasedAmbiguityResolution::saveScoreMonitor(
-    const std::vector<ScoreMonitor>& scoreMonitor) const {
-  // Open ROOT file for writing
-  TFile* file = TFile::Open(m_monitorFilePath.c_str(), "RECREATE");
-  if (!file || file->IsZombie()) {
-    throw std::runtime_error("Could not create ROOT file: " + m_monitorFilePath);
-  }
-
-  // Create a TTree
-  TTree* tree = new TTree("ScoreMonitorTree", "Score Monitor Data");
-
-  // Variables for branches
-  std::size_t ptScore;
-  std::size_t chi2Score;
-  std::size_t totalScore;
-
-  std::vector<std::size_t> detectorHitScore;
-  std::vector<std::size_t> detectorHoleScore;
-  std::vector<std::size_t> detectorOutlierScore;
-  std::vector<std::size_t> detectorOtherScore;
-  std::vector<std::size_t> optionalScore;
-
-  // Create branches
-  tree->Branch("ptScore", &ptScore);
-  tree->Branch("chi2Score", &chi2Score);
-  tree->Branch("totalScore", &totalScore);
-
-  tree->Branch("detectorHitScore", &detectorHitScore);
-  tree->Branch("detectorHoleScore", &detectorHoleScore);
-  tree->Branch("detectorOutlierScore", &detectorOutlierScore);
-  tree->Branch("detectorOtherScore", &detectorOtherScore);
-  tree->Branch("optionalScore", &optionalScore);
-
-  // Fill the tree
-  for (const ScoreMonitor& monitor : scoreMonitor) {
-    ptScore = monitor.ptScore;
-    chi2Score = monitor.chi2Score;
-    totalScore = monitor.totalScore;
-
-    detectorHitScore = monitor.detectorHitScore;
-    detectorHoleScore = monitor.detectorHoleScore;
-    detectorOutlierScore = monitor.detectorOutlierScore;
-    detectorOtherScore = monitor.detectorOtherScore;
-    optionalScore = monitor.optionalScore;
-
-    tree->Fill();
-  }
-
-  // Write tree to file
-  file->Write();
-  file->Close();
-  delete file;
+std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor> Acts::ScoreBasedAmbiguityResolution::scoreMonitor() const {
+  return m_scoreMonitor;
 }

--- a/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
+++ b/Core/src/AmbiguityResolution/ScoreBasedAmbiguityResolution.cpp
@@ -8,8 +8,6 @@
 
 #include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
 
-#include "TFile.h"
-#include "TTree.h"
 
 bool Acts::ScoreBasedAmbiguityResolution::etaBasedCuts(
     const DetectorConfig& detector, const TrackFeatures& trackFeatures,

--- a/Examples/Algorithms/AmbiguityResolution/CMakeLists.txt
+++ b/Examples/Algorithms/AmbiguityResolution/CMakeLists.txt
@@ -12,5 +12,5 @@ target_include_directories(
 
 target_link_libraries(
     ActsExamplesAmbiguityResolution
-    PUBLIC Acts::ExamplesFramework Acts::PluginJson
+    PUBLIC Acts::ExamplesFramework Acts::PluginJson Acts::PluginRoot
 )

--- a/Examples/Algorithms/AmbiguityResolution/include/ActsExamples/AmbiguityResolution/ScoreBasedAmbiguityResolutionAlgorithm.hpp
+++ b/Examples/Algorithms/AmbiguityResolution/include/ActsExamples/AmbiguityResolution/ScoreBasedAmbiguityResolutionAlgorithm.hpp
@@ -49,6 +49,9 @@ class ScoreBasedAmbiguityResolutionAlgorithm final : public IAlgorithm {
     // configuration file for the detector map
     std::string configFile = "detectorConfigs.json";
 
+    // score monitor file path
+    std::string monitorFile = "scoreMonitor.root";
+
     // maximum number of shared tracks per measurement
     std::size_t maxSharedTracksPerMeasurement = 10;
     // maximum number of shared hit per track

--- a/Examples/Algorithms/AmbiguityResolution/src/ScoreBasedAmbiguityResolutionAlgorithm.cpp
+++ b/Examples/Algorithms/AmbiguityResolution/src/ScoreBasedAmbiguityResolutionAlgorithm.cpp
@@ -11,6 +11,7 @@
 #include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
 #include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/Plugins/Json/AmbiguityConfigJsonConverter.hpp"
+#include "Acts/Plugins/Root/AmbiScoreMonitor.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
@@ -124,6 +125,13 @@ ActsExamples::ScoreBasedAmbiguityResolutionAlgorithm::execute(
     auto srcProxy = tracks.getTrack(iTrack);
     destProxy.copyFrom(srcProxy, false);
     destProxy.tipIndex() = srcProxy.tipIndex();
+  }
+
+  std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor> scoreMonitor = m_ambi.getScoreMonitor();
+  if (!scoreMonitor.empty()) {
+    Acts::saveScoreMonitor(scoreMonitor, m_cfg.monitorFile);
+  } else {
+    ACTS_ERROR("No score monitor data available to save.");
   }
 
   ActsExamples::ConstTrackContainer outputTracks{

--- a/Examples/Python/python/acts/examples/reconstruction.py
+++ b/Examples/Python/python/acts/examples/reconstruction.py
@@ -2125,6 +2125,7 @@ def addScoreBasedAmbiguityResolution(
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     ambiVolumeFile: Optional[Union[Path, str]] = None,
+    ambiMonitorFile: Optional[Union[Path, str]] = None,
     writeTrackSummary: bool = True,
     writeTrackStates: bool = False,
     writePerformance: bool = True,
@@ -2139,6 +2140,7 @@ def addScoreBasedAmbiguityResolution(
         level=customLogLevel(),
         inputTracks=tracks,
         configFile=ambiVolumeFile,
+        monitorFile=ambiMonitorFile,
         outputTracks="ambiTracksScoreBased",
         **acts.examples.defaultKWArgs(
             minScore=config.minScore,

--- a/Examples/Python/src/AmbiguityResolution.cpp
+++ b/Examples/Python/src/AmbiguityResolution.cpp
@@ -32,7 +32,7 @@ void addAmbiguityResolution(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       ActsExamples::ScoreBasedAmbiguityResolutionAlgorithm, mex,
-      "ScoreBasedAmbiguityResolutionAlgorithm", inputTracks, configFile,
+      "ScoreBasedAmbiguityResolutionAlgorithm", inputTracks, configFile, monitorFile,
       outputTracks, minScore, minScoreSharedTracks, maxShared, minUnshared,
       maxSharedTracksPerMeasurement, useAmbiguityScoring);
 }

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -429,11 +429,12 @@ if args.reco:
                 maxShared=2,
                 minUnshared=3,
                 maxSharedTracksPerMeasurement=2,
-                useAmbiguityScoring=False,
+                useAmbiguityScoring=True,
             ),
             outputDirRoot=outputDir if args.output_root else None,
             outputDirCsv=outputDir if args.output_csv else None,
             ambiVolumeFile=ambi_config,
+            ambiMonitorFile=outputDir / "scoreMonitor.root",
             writeCovMat=True,
         )
     else:

--- a/Examples/Scripts/Python/full_chain_odd_LRT.py
+++ b/Examples/Scripts/Python/full_chain_odd_LRT.py
@@ -426,6 +426,7 @@ if args.reco:
             outputDirRoot=outputDir if args.output_root else None,
             outputDirCsv=outputDir if args.output_csv else None,
             ambiVolumeFile=ambi_config,
+            ambiMonitorFile=outputDir / "scoreMonitor.root",
             writeCovMat=True,
         )
     else:

--- a/Examples/Scripts/Python/full_chain_test.py
+++ b/Examples/Scripts/Python/full_chain_test.py
@@ -737,6 +737,7 @@ def full_chain(args):
                 useAmbiguityScoring=False,
             ),
             ambiVolumeFile=args.ambi_config,
+            ambiMonitorFile=outputDirLessRoot / "scoreMonitor.root",
             **writeCovMat,
             outputDirRoot=outputDirLessRoot,
             outputDirCsv=outputDirLessCsv,

--- a/Plugins/Root/CMakeLists.txt
+++ b/Plugins/Root/CMakeLists.txt
@@ -1,6 +1,7 @@
 acts_add_library(
     PluginRoot
     SHARED
+    src/AmbiScoreMonitor.cpp
     src/RootMaterialMapIo.cpp
     src/RootMaterialTrackIo.cpp
     src/RootSpacePointIo.cpp

--- a/Plugins/Root/include/Acts/Plugins/Root/AmbiScoreMonitor.hpp
+++ b/Plugins/Root/include/Acts/Plugins/Root/AmbiScoreMonitor.hpp
@@ -1,0 +1,17 @@
+
+
+#pragma once
+
+#include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
+
+#include <TFile.h>
+#include <TTree.h>
+
+namespace Acts {
+
+void saveScoreMonitor(
+    const std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor>&
+        scoreMonitor,
+    const std::string& monitorFile);
+
+}

--- a/Plugins/Root/src/AmbiScoreMonitor.cpp
+++ b/Plugins/Root/src/AmbiScoreMonitor.cpp
@@ -2,14 +2,16 @@
 #include "Acts/Plugins/Root/AmbiScoreMonitor.hpp"
 
 #include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
+
 #include <TFile.h>
 #include <TTree.h>
 
 void Acts::saveScoreMonitor(
-    const std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor>& scoreMonitor,
+    const std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor>&
+        scoreMonitor,
     const std::string& monitorFilePath) {
   // Open ROOT file for writing
-  TFile* file = TFile::Open(monitorFilePath.c_str(), "RECREATE");
+  TFile* file = TFile::Open(monitorFilePath.c_str(), "UPDATE");
   if (!file || file->IsZombie()) {
     throw std::runtime_error("Could not create ROOT file: " + monitorFilePath);
   }
@@ -18,17 +20,25 @@ void Acts::saveScoreMonitor(
   TTree* tree = new TTree("ScoreMonitorTree", "Score Monitor Data");
 
   // Variables for branches
-  std::size_t ptScore;
-  std::size_t chi2Score;
-  std::size_t totalScore;
+  double pT = 0.0;
+  double eta = 0.0;
+  double phi = 0.0;
 
-  std::vector<std::size_t> detectorHitScore;
-  std::vector<std::size_t> detectorHoleScore;
-  std::vector<std::size_t> detectorOutlierScore;
-  std::vector<std::size_t> detectorOtherScore;
-  std::vector<std::size_t> optionalScore;
+  double ptScore = 0;
+  std::vector<double> detectorHitScore;
+  std::vector<double> detectorHoleScore;
+  std::vector<double> detectorOutlierScore;
+  std::vector<double> detectorOtherScore;
+  double chi2Score = 0;
+
+  std::vector<double> optionalScore;
+
+  double totalScore = 0;
 
   // Create branches
+  tree->Branch("pT", &pT);
+  tree->Branch("eta", &eta);
+  tree->Branch("phi", &phi);
   tree->Branch("ptScore", &ptScore);
   tree->Branch("chi2Score", &chi2Score);
   tree->Branch("totalScore", &totalScore);
@@ -41,6 +51,11 @@ void Acts::saveScoreMonitor(
 
   // Fill the tree
   for (const auto& monitor : scoreMonitor) {
+
+    pT = monitor.pT;
+    eta = monitor.eta;
+    phi = monitor.phi;
+
     ptScore = monitor.ptScore;
     chi2Score = monitor.chi2Score;
     totalScore = monitor.totalScore;

--- a/Plugins/Root/src/AmbiScoreMonitor.cpp
+++ b/Plugins/Root/src/AmbiScoreMonitor.cpp
@@ -1,0 +1,61 @@
+
+#include "Acts/Plugins/Root/AmbiScoreMonitor.hpp"
+
+#include "Acts/AmbiguityResolution/ScoreBasedAmbiguityResolution.hpp"
+#include <TFile.h>
+#include <TTree.h>
+
+void Acts::saveScoreMonitor(
+    const std::vector<Acts::ScoreBasedAmbiguityResolution::ScoreMonitor>& scoreMonitor,
+    const std::string& monitorFilePath) {
+  // Open ROOT file for writing
+  TFile* file = TFile::Open(monitorFilePath.c_str(), "RECREATE");
+  if (!file || file->IsZombie()) {
+    throw std::runtime_error("Could not create ROOT file: " + monitorFilePath);
+  }
+
+  // Create a TTree
+  TTree* tree = new TTree("ScoreMonitorTree", "Score Monitor Data");
+
+  // Variables for branches
+  std::size_t ptScore;
+  std::size_t chi2Score;
+  std::size_t totalScore;
+
+  std::vector<std::size_t> detectorHitScore;
+  std::vector<std::size_t> detectorHoleScore;
+  std::vector<std::size_t> detectorOutlierScore;
+  std::vector<std::size_t> detectorOtherScore;
+  std::vector<std::size_t> optionalScore;
+
+  // Create branches
+  tree->Branch("ptScore", &ptScore);
+  tree->Branch("chi2Score", &chi2Score);
+  tree->Branch("totalScore", &totalScore);
+
+  tree->Branch("detectorHitScore", &detectorHitScore);
+  tree->Branch("detectorHoleScore", &detectorHoleScore);
+  tree->Branch("detectorOutlierScore", &detectorOutlierScore);
+  tree->Branch("detectorOtherScore", &detectorOtherScore);
+  tree->Branch("optionalScore", &optionalScore);
+
+  // Fill the tree
+  for (const auto& monitor : scoreMonitor) {
+    ptScore = monitor.ptScore;
+    chi2Score = monitor.chi2Score;
+    totalScore = monitor.totalScore;
+
+    detectorHitScore = monitor.detectorHitScore;
+    detectorHoleScore = monitor.detectorHoleScore;
+    detectorOutlierScore = monitor.detectorOutlierScore;
+    detectorOtherScore = monitor.detectorOtherScore;
+    optionalScore = monitor.optionalScore;
+
+    tree->Fill();
+  }
+
+  // Write tree to file
+  file->Write();
+  file->Close();
+  delete file;
+}


### PR DESCRIPTION
This PR adds a score monitoring functionality to the score based solver.  
--- END COMMIT MESSAGE ---

This helps debug and improve designing of different scoring config and optional cuts. The program has 2 parts one is the monitoring which stores all the sub score into a structure, the second part is in the root plugin which saves the score monitor results into a root. 
