### PR TITLE
fix: Do not allow set Navigaiton Policy in the static blueprint node if the volume has already one assigned

### DIFF
--- a/Core/src/Geometry/StaticBlueprintNode.cpp
+++ b/Core/src/Geometry/StaticBlueprintNode.cpp
@@ -111,7 +111,11 @@ void StaticBlueprintNode::finalize(const BlueprintOptions& options,
   if (m_navigationPolicyFactory) {
     policyFactory = m_navigationPolicyFactory.get();
   }
-  m_volume->setNavigationPolicy(policyFactory->build(gctx, *m_volume, logger));
+
+  if (!m_volume->navigationPolicy()) {
+    m_volume->setNavigationPolicy(
+        policyFactory->build(gctx, *m_volume, logger));
+  }
 
   parent.addVolume(std::move(m_volume));
 }

--- a/Core/src/Geometry/StaticBlueprintNode.cpp
+++ b/Core/src/Geometry/StaticBlueprintNode.cpp
@@ -112,7 +112,7 @@ void StaticBlueprintNode::finalize(const BlueprintOptions& options,
     policyFactory = m_navigationPolicyFactory.get();
   }
 
-  if (!m_volume->navigationPolicy()) {
+  if (m_volume->navigationPolicy() == nullptr) {
     m_volume->setNavigationPolicy(
         policyFactory->build(gctx, *m_volume, logger));
   }


### PR DESCRIPTION
I also add a check in the `StaticBlueprintNode` finalize method in case the volume has already a navigation policy assigned before being attached to the static node 