### PR TITLE
fix: GNN change CUDA optimization flag

### DIFF
--- a/Plugins/Gnn/CMakeLists.txt
+++ b/Plugins/Gnn/CMakeLists.txt
@@ -71,7 +71,8 @@ if(ACTS_GNN_ENABLE_CUDA)
     target_compile_options(
         ActsPluginGnn
         PRIVATE
-            $<$<COMPILE_LANGUAGE:CUDA>:-g
+            $<$<COMPILE_LANGUAGE:CUDA>:
+            --dopt=on
             --generate-line-info
             --expt-relaxed-constexpr
             --extended-lambda>


### PR DESCRIPTION
I figured out that at least in the compile flags of the CUDA compilation units there seems to be the `-G` option present, which enables full device debug info. By specifying `-dopt=on` I hope that we only generate limited debug information, according to NVCC documentation.
I did not see a significant change in latencies, but it feels saver to have this flag on.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
