### PR TITLE
fix: GlobalChi2Fitter - Spell-out detail namespace

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -96,10 +96,10 @@ struct Gx2FitterExtensions {
 
   /// Default constructor which connects the default void components
   Gx2FitterExtensions() {
-    calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
-    updater.template connect<&detail::voidFitterUpdater<traj_t>>();
-    outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
-    surfaceAccessor.connect<&detail::voidSurfaceAccessor>();
+    calibrator.template connect<&Acts::detail::voidFitterCalibrator<traj_t>>();
+    updater.template connect<&Acts::detail::voidFitterUpdater<traj_t>>();
+    outlierFinder.template connect<&Acts::detail::voidOutlierFinder<traj_t>>();
+    surfaceAccessor.connect<&Acts::detail::voidSurfaceAccessor>();
   }
 };
 
@@ -818,8 +818,8 @@ class Gx2Fitter {
         if (scatteringMapId == scatteringMap->end()) {
           ACTS_DEBUG("    ... create entry in scattering map.");
 
-          detail::PointwiseMaterialInteraction interaction(surface, state,
-                                                           stepper);
+          Acts::detail::PointwiseMaterialInteraction interaction(surface, state,
+                                                                 stepper);
           // We need to evaluate the material to create the correct slab
           const bool slabIsValid = interaction.evaluateMaterialSlab(
               state, navigator, MaterialUpdateStage::FullUpdate);


### PR DESCRIPTION
- replace detail::<> by Acts::detail::<>
--- END COMMIT MESSAGE ---
I suddenly start to see these errors during athena compilation
```
In file included from /media/slowSSD/jojungge/MuonDDR4/athena/Tracking/Acts/ActsCalibration/ActsCalibrators/ActsCalibrators/xAODUncalibMeasCalibrator.h:10,
                 from /media/slowSSD/jojungge/MuonDDR4/athena/MuonSpectrometer/MuonPhaseII/MuonCalibration/MuonSpacePointCalibrator/src/SpacePointCalibrator.cxx:24:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp: In constructor 'Acts::Experimental::Gx2FitterExtensions<traj_t>::Gx2FitterExtensions()':
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:42: error: 'voidFitterCalibrator' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidFitterCalibrator'?
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                                          ^~~~~~~~~~~~~~~~~~~~
In file included from /cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:30:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:22:6: note: 'Acts::detail::voidFitterCalibrator' declared here
   22 | void voidFitterCalibrator(const GeometryContext& /*gctx*/,
      |      ^~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:25: error: parse error in template argument list
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:72: error: expected primary-expression before ')' token
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                                                                        ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:39: error: 'voidFitterUpdater' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidFitterUpdater'?
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                                       ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:30:14: note: 'Acts::detail::voidFitterUpdater' declared here
   30 | Result<void> voidFitterUpdater(const GeometryContext& /*gctx*/,
      |              ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:22: error: parse error in template argument list
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:66: error: expected primary-expression before ')' token
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                                                                  ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:45: error: 'voidOutlierFinder' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidOutlierFinder'?
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                                             ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:51:6: note: 'Acts::detail::voidOutlierFinder' declared here
   51 | bool voidOutlierFinder(typename traj_t::ConstTrackStateProxy /*trackState*/) {
      |      ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:28: error: parse error in template argument list
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:72: error: expected primary-expression before ')' token
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                                                                        ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:102:38: error: 'voidSurfaceAccessor' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidSurfaceAccessor'?
  102 |     surfaceAccessor.connect<&detail::voidSurfaceAccessor>();
      |                                      ^~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:61:23: note: 'Acts::detail::voidSurfaceAccessor' declared here
   61 | inline const Surface* voidSurfaceAccessor(const SourceLink& /*sourceLink*/) {
      |                       ^~~~~~~~~~~~~~~~~~~
In file included from /media/slowSSD/jojungge/MuonDDR4/athena/Tracking/Acts/ActsCalibration/ActsCalibrators/ActsCalibrators/xAODUncalibMeasCalibrator.h:10,
                 from /media/slowSSD/jojungge/MuonDDR4/athena/MuonSpectrometer/MuonPhaseII/MuonPatternRecognition/MuonPatternRecognitionAlgs/src/SegmentActsRefitAlg.cxx:7:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp: In constructor 'Acts::Experimental::Gx2FitterExtensions<traj_t>::Gx2FitterExtensions()':
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:42: error: 'voidFitterCalibrator' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidFitterCalibrator'?
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                                          ^~~~~~~~~~~~~~~~~~~~
In file included from /cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:30:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:22:6: note: 'Acts::detail::voidFitterCalibrator' declared here
   22 | void voidFitterCalibrator(const GeometryContext& /*gctx*/,
      |      ^~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:25: error: parse error in template argument list
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:99:72: error: expected primary-expression before ')' token
   99 |     calibrator.template connect<&detail::voidFitterCalibrator<traj_t>>();
      |                                                                        ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:39: error: 'voidFitterUpdater' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidFitterUpdater'?
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                                       ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:30:14: note: 'Acts::detail::voidFitterUpdater' declared here
   30 | Result<void> voidFitterUpdater(const GeometryContext& /*gctx*/,
      |              ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:22: error: parse error in template argument list
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:100:66: error: expected primary-expression before ')' token
  100 |     updater.template connect<&detail::voidFitterUpdater<traj_t>>();
      |                                                                  ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:45: error: 'voidOutlierFinder' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidOutlierFinder'?
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                                             ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:51:6: note: 'Acts::detail::voidOutlierFinder' declared here
   51 | bool voidOutlierFinder(typename traj_t::ConstTrackStateProxy /*trackState*/) {
      |      ^~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:28: error: parse error in template argument list
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:101:72: error: expected primary-expression before ')' token
  101 |     outlierFinder.template connect<&detail::voidOutlierFinder<traj_t>>();
      |                                                                        ^
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:102:38: error: 'voidSurfaceAccessor' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::voidSurfaceAccessor'?
  102 |     surfaceAccessor.connect<&detail::voidSurfaceAccessor>();
      |                                      ^~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/detail/VoidFitterComponents.hpp:61:23: note: 'Acts::detail::voidSurfaceAccessor' declared here
   61 | inline const Surface* voidSurfaceAccessor(const SourceLink& /*sourceLink*/) {
      |                       ^~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp: In member function 'void Acts::Experimental::Gx2Fitter<propagator_t, traj_t>::Actor<parameters_t>::act(propagator_state_t&, const stepper_t&, const navigator_t&, result_type&, const Acts::Logger&) const':
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:821:19: error: 'PointwiseMaterialInteraction' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::PointwiseMaterialInteraction'?
  821 |           detail::PointwiseMaterialInteraction interaction(surface, state,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:28:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/Propagator/detail/PointwiseMaterialInteraction.hpp:28:8: note: 'Acts::detail::PointwiseMaterialInteraction' declared here
   28 | struct PointwiseMaterialInteraction {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:824:36: error: 'interaction' was not declared in this scope; did you mean 'Intersection'?
  824 |           const bool slabIsValid = interaction.evaluateMaterialSlab(
      |                                    ^~~~~~~~~~~
      |                                    Intersection
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp: In member function 'void Acts::Experimental::Gx2Fitter<propagator_t, traj_t>::Actor<parameters_t>::act(propagator_state_t&, const stepper_t&, const navigator_t&, result_type&, const Acts::Logger&) const':
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:821:19: error: 'PointwiseMaterialInteraction' is not a member of 'Acts::Experimental::detail'; did you mean 'Acts::detail::PointwiseMaterialInteraction'?
  821 |           detail::PointwiseMaterialInteraction interaction(surface, state,
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/Propagator/MaterialInteractor.hpp:17,
                 from /media/slowSSD/jojungge/MuonDDR4/athena/Tracking/Acts/ActsGeometryInterfaces/ActsGeometryInterfaces/IActsExtrapolationTool.h:17,
                 from /media/slowSSD/jojungge/MuonDDR4/athena/MuonSpectrometer/MuonPhaseII/MuonPatternRecognition/MuonPatternRecognitionAlgs/src/SegmentActsRefitAlg.h:14,
                 from /media/slowSSD/jojungge/MuonDDR4/athena/MuonSpectrometer/MuonPhaseII/MuonPatternRecognition/MuonPatternRecognitionAlgs/src/SegmentActsRefitAlg.cxx:4:
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/Propagator/detail/PointwiseMaterialInteraction.hpp:28:8: note: 'Acts::detail::PointwiseMaterialInteraction' declared here
   28 | struct PointwiseMaterialInteraction {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/cvmfs/atlas-nightlies.cern.ch/repo/sw/main_Athena_x86_64-el9-gcc14-opt/2025-08-23T2100/AthenaExternals/25.0.41/InstallArea/x86_64-el9-gcc14-opt/include/Acts/Acts/TrackFitting/GlobalChiSquareFitter.hpp:824:36: error: 'interaction' was not declared in this scope; did you mean 'Intersection'?
  824 |           const bool slabIsValid = interaction.evaluateMaterialSlab(
      |                                    ^~~~~~~~~~~
      |                                    Intersection
In file included from /cvmfs/sft.cern.ch/lcg/releases/gcc/14.3.0-c8dfb/x86_64-el9/include/c++/14.3.0/memory:78,
```
Hopefully, that fixes the issue