### PR TITLE
docs: Fix doc comment on copyFromWithoutStates

### DIFF
--- a/Core/include/Acts/EventData/TrackProxy.hpp
+++ b/Core/include/Acts/EventData/TrackProxy.hpp
@@ -695,13 +695,13 @@ class TrackProxy {
   /// - All dynamic track columns
   ///
   /// **What does NOT get copied:**
-  /// - Track states (existing track states remain unchanged)
-  /// - tipIndex() and stemIndex() (track state linking is preserved)
+  /// - Track states (existing track states remain unchanged in the container)
   ///
   /// **Result:**
-  /// - The destination track keeps its existing track state sequence
   /// - All track-level properties are updated to match the source
-  /// - Track state tip and stem indices will be set to kInvalid
+  /// - tipIndex() and stemIndex() are set to kInvalid (track states become inaccessible)
+  /// - Existing track states remain in the container but are no longer linked to this track
+  /// - nTrackStates() will return 0 due to invalid indices
   ///
   /// @note Only available if the track proxy is not read-only
   /// @note Both track containers must have compatible dynamic columns


### PR DESCRIPTION
This previously in correctly stated that the track state indices remain as they were, but I've changed this behavior without adjusting the comment accordingly.


--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
