### PR TITLE
fix: Wrong gap volume creation in r-stack and z shift

### DIFF
--- a/Core/src/Geometry/CylinderVolumeStack.cpp
+++ b/Core/src/Geometry/CylinderVolumeStack.cpp
@@ -980,8 +980,10 @@ void CylinderVolumeStack::update(std::shared_ptr<VolumeBounds> volbounds,
             ACTS_VERBOSE("~> Creating new gap volume at inner r");
             auto gapBounds = std::make_shared<CylinderVolumeBounds>(
                 newMinR, oldMinR, newHlZ);
-            auto gapTransform = m_groupTransform;
+            ACTS_VERBOSE(*gapBounds);
+            auto gapTransform = newVolume.globalTransform;
             auto gapVolume = addGapVolume(gapTransform, gapBounds);
+            ACTS_VERBOSE("WITH target transform\n" << gapTransform.matrix());
             volumeTuples.insert(volumeTuples.begin(),
                                 VolumeTuple{*gapVolume, m_groupTransform});
             auto gap = volumeTuples.front();
@@ -1015,9 +1017,9 @@ void CylinderVolumeStack::update(std::shared_ptr<VolumeBounds> volbounds,
             ACTS_VERBOSE("~> Creating new gap volume at outer r");
             auto gapBounds = std::make_shared<CylinderVolumeBounds>(
                 oldMaxR, newMaxR, newHlZ);
-            auto gapTransform = m_groupTransform;
+            auto gapTransform = newVolume.globalTransform;
             auto gapVolume = addGapVolume(gapTransform, gapBounds);
-            volumeTuples.emplace_back(*gapVolume, m_groupTransform);
+            volumeTuples.emplace_back(*gapVolume, newVolume.globalTransform);
             auto gap = volumeTuples.back();
             printGapDimensions(gap);
           }


### PR DESCRIPTION
The gap volumes produced when resizing a cylinder r-stack was incorrect when the volume update included a z-shifted transform: the gap volume would be produced with the original transform and therefore break the stack. This PR adds a unit test for this failure mode and a fix for it.

--- END COMMIT MESSAGE ---

@tsulaiav 
