### PR TITLE
ci: Fix PR number lookup in sonar job

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Save PR number to file
         if: github.event_name == 'pull_request'
-        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+        run: echo -n ${{ github.event.number }} > PR_NUMBER.txt
 
       - name: Persist PR number
         if: github.event_name == 'pull_request'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -124,7 +124,7 @@ jobs:
             --define sonar.coverageReportPaths=build/coverage/cov.xml
             --define sonar.projectVersion="${{ steps.next_version.outputs.content }}"
             --define sonar.scm.revision="${{ github.event.workflow_run.head_sha }}"
-            --define sonar.pullrequest.key="${{ steps.pr_number.outputs.content }}"
+            --define sonar.pullrequest.key=${{ steps.pr_number.outputs.content }}
             --define sonar.pullrequest.branch="${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}"
             --define sonar.pullrequest.base="${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}"
 


### PR DESCRIPTION
After bumping from 5.3.0 to 5.3.1, the sonar action was treating the PR number given as `"1234 "` literally, including the `"` and therefore did not find the PR. I'm now removing the quotes and try to avoid the space (which I think comes from a newline at the end of the PR number artifact).

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
