### PR TITLE
fix: ensure DD4hep ProtoLayer understands local coordinate extent

### DIFF
--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -159,11 +159,23 @@ const LayerVector DD4hepLayerBuilder::endcapLayers(
         } else {
           ACTS_VERBOSE(" Disc layer has " << layerSurfaces.size()
                                           << " sensitive surfaces.");
+
+          // Transform geometry bounds to local coordinate system for envelope calculation
+          // Since ProtoLayer extent is in local coordinates due to itransform,
+          // we need to transform the geometry bounds to the same coordinate system
+          Vector3 localZMin = itransform * Vector3(0, 0, zMin);
+          Vector3 localZMax = itransform * Vector3(0, 0, zMax);
+          double localGeomZMin = localZMin.z();
+          double localGeomZMax = localZMax.z();
+          if (localGeomZMin > localGeomZMax) {
+            std::swap(localGeomZMin, localGeomZMax);
+          }
+          
           // set the values of the proto layer in case dimensions are given by
           // geometry
           pl.envelope[AxisDirection::AxisZ] = {
-              std::abs(zMin - pl.min(AxisDirection::AxisZ)),
-              std::abs(zMax - pl.max(AxisDirection::AxisZ))};
+              std::abs(localGeomZMin - pl.min(Acts::AxisDirection::AxisZ)),
+              std::abs(localGeomZMax - pl.max(Acts::AxisDirection::AxisZ))};
           pl.envelope[AxisDirection::AxisR] = {
               std::abs(rMin - pl.min(AxisDirection::AxisR)),
               std::abs(rMax - pl.max(AxisDirection::AxisR))};

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -174,8 +174,8 @@ const LayerVector DD4hepLayerBuilder::endcapLayers(
           // set the values of the proto layer in case dimensions are given by
           // geometry
           pl.envelope[AxisDirection::AxisZ] = {
-              std::abs(localGeomZMin - pl.min(Acts::AxisDirection::AxisZ)),
-              std::abs(localGeomZMax - pl.max(Acts::AxisDirection::AxisZ))};
+              std::abs(localGeomZMin - pl.min(AxisDirection::AxisZ)),
+              std::abs(localGeomZMax - pl.max(AxisDirection::AxisZ))};
           pl.envelope[AxisDirection::AxisR] = {
               std::abs(rMin - pl.min(AxisDirection::AxisR)),
               std::abs(rMax - pl.max(AxisDirection::AxisR))};

--- a/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
+++ b/Plugins/DD4hep/src/DD4hepLayerBuilder.cpp
@@ -170,7 +170,7 @@ const LayerVector DD4hepLayerBuilder::endcapLayers(
           if (localGeomZMin > localGeomZMax) {
             std::swap(localGeomZMin, localGeomZMax);
           }
-          
+
           // set the values of the proto layer in case dimensions are given by
           // geometry
           pl.envelope[AxisDirection::AxisZ] = {


### PR DESCRIPTION
fix: ensure DD4hep ProtoLayer understands local coordinate extent

--- END COMMIT MESSAGE ---

In #4502, I modified the DD4hep layer builder to create a ProtoLayer with knowledge of the transform of the layer. This means that an endcap layer at z = 100 mm  with sensors between 99 mm and 101 mm now ends up having a ProtoLayer extent in z from -1 mm to +1 mm.

In #4502, I tested explicitly (and implicitly, through the CI workflows that use ODD) only on the code path where `envelope_r_min` etc are defined. When no `envelope_r_min` etc are defined, the fix was not sufficient since then we still go through a code path that relies on getting a ProtoLayer that is in global coordinates.

I looked into how to avoid this by having more coverage in the CI checks, but didn't immediately see a clear path that doesn't require modifying the ODD to have at least one detector without envelope definitions.