### PR TITLE
chore: Introduce `Python` directory, shift `Acts::PythonUtilities` library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,9 @@ if(ACTS_BUILD_ODD)
     endif()
 endif()
 
+# Python bindings infrastructure
+add_subdirectory_if(Python ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS)
+
 # examples
 add_subdirectory_if(Examples ACTS_BUILD_EXAMPLES)
 

--- a/Examples/Python/CMakeLists.txt
+++ b/Examples/Python/CMakeLists.txt
@@ -1,6 +1,3 @@
-acts_add_library(PythonUtilities INTERFACE)
-target_include_directories(ActsPythonUtilities INTERFACE include)
-
 set(_python_dir "${CMAKE_BINARY_DIR}/python")
 file(MAKE_DIRECTORY ${_python_dir})
 file(MAKE_DIRECTORY ${_python_dir}/acts)

--- a/Examples/Python/src/Alignment.cpp
+++ b/Examples/Python/src/Alignment.cpp
@@ -6,10 +6,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/DetectorCommons/AlignmentDecorator.hpp"
 #include "ActsExamples/DetectorCommons/AlignmentGenerator.hpp"
 #include "ActsExamples/Framework/IContextDecorator.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
@@ -17,21 +18,23 @@
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
+
+using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addAlignment(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   {
-    auto ad = py::class_<AlignmentDecorator, IContextDecorator,
-                         std::shared_ptr<AlignmentDecorator>>(
-                  mex, "AlignmentDecorator")
-                  .def(py::init<const AlignmentDecorator::Config&,
-                                Acts::Logging::Level>())
-                  .def("decorate", &AlignmentDecorator::decorate)
-                  .def("name", &AlignmentDecorator::name);
+    auto ad =
+        py::class_<AlignmentDecorator, IContextDecorator,
+                   std::shared_ptr<AlignmentDecorator>>(mex,
+                                                        "AlignmentDecorator")
+            .def(py::init<const AlignmentDecorator::Config&, Logging::Level>())
+            .def("decorate", &AlignmentDecorator::decorate)
+            .def("name", &AlignmentDecorator::name);
 
     auto c =
         py::class_<AlignmentDecorator::Config>(ad, "Config").def(py::init<>());
@@ -48,8 +51,8 @@ void addAlignment(Context& ctx) {
   {
     py::class_<GeoIdAlignmentStore, IAlignmentStore,
                std::shared_ptr<GeoIdAlignmentStore>>(mex, "GeoIdAlignmentStore")
-        .def(py::init<const std::unordered_map<Acts::GeometryIdentifier,
-                                               Acts::Transform3>&>());
+        .def(py::init<
+             const std::unordered_map<GeometryIdentifier, Transform3>&>());
   }
 
   {
@@ -101,4 +104,4 @@ void addAlignment(Context& ctx) {
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/AmbiguityResolution.cpp
+++ b/Examples/Python/src/AmbiguityResolution.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/AmbiguityResolution/GreedyAmbiguityResolutionAlgorithm.hpp"
 #include "ActsExamples/AmbiguityResolution/ScoreBasedAmbiguityResolutionAlgorithm.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 
@@ -20,7 +21,7 @@ namespace py = pybind11;
 using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addAmbiguityResolution(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -37,4 +38,4 @@ void addAmbiguityResolution(Context& ctx) {
       maxSharedTracksPerMeasurement, useAmbiguityScoring);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Base.cpp
+++ b/Examples/Python/src/Base.cpp
@@ -11,12 +11,12 @@
 #include "Acts/Definitions/Units.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/MagneticField/MagneticFieldContext.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Any.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinningData.hpp"
 #include "Acts/Utilities/CalibrationContext.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <array>
 #include <exception>
@@ -31,8 +31,9 @@
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addContext(Context& ctx) {
   auto& m = ctx.get("main");
@@ -117,7 +118,7 @@ class PythonLogger {
   std::unique_ptr<const Logger> m_logger;
 };
 
-void addLogging(Acts::Python::Context& ctx) {
+void addLogging(Context& ctx) {
   auto& m = ctx.get("main");
   auto logging = m.def_submodule("logging", "");
 
@@ -258,7 +259,7 @@ void addLogging(Acts::Python::Context& ctx) {
   logging.def("fatal", makeModuleLogFunction(Acts::Logging::FATAL));
 }
 
-void addPdgParticle(Acts::Python::Context& ctx) {
+void addPdgParticle(Context& ctx) {
   auto& m = ctx.get("main");
   py::enum_<Acts::PdgParticle>(m, "PdgParticle")
       .value("eInvalid", Acts::PdgParticle::eInvalid)
@@ -282,7 +283,7 @@ void addPdgParticle(Acts::Python::Context& ctx) {
       .value("eLead", Acts::PdgParticle::eLead);
 }
 
-void addAlgebra(Acts::Python::Context& ctx) {
+void addAlgebra(Context& ctx) {
   auto& m = ctx.get("main");
 
   py::class_<Acts::Vector2>(m, "Vector2")
@@ -404,4 +405,4 @@ void addBinning(Context& ctx) {
                       .value("variable", Acts::AxisType::Variable);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Blueprint.cpp
+++ b/Examples/Python/src/Blueprint.cpp
@@ -19,9 +19,10 @@
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
 #include "Acts/Navigation/NavigationStream.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <fstream>
 #include <random>
@@ -37,7 +38,9 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-namespace Acts::Python {
+using namespace Acts;
+
+namespace ActsPython {
 namespace {
 using std::uniform_real_distribution;
 
@@ -47,7 +50,8 @@ void pseudoNavigation(const TrackingGeometry& trackingGeometry,
                       std::size_t runs, std::size_t substepsPerCm,
                       std::pair<double, double> etaRange,
                       Logging::Level logLevel) {
-  using namespace Acts::UnitLiterals;
+  using namespace Acts;
+  using namespace UnitLiterals;
 
   ACTS_LOCAL_LOGGER(getDefaultLogger("pseudoNavigation", logLevel));
 
@@ -63,7 +67,7 @@ void pseudoNavigation(const TrackingGeometry& trackingGeometry,
   double thetaMax = 2 * std::atan(std::exp(-etaRange.second));
   std::uniform_real_distribution<> thetaDist{thetaMin, thetaMax};
 
-  using namespace Acts::UnitLiterals;
+  using namespace UnitLiterals;
 
   for (std::size_t run = 0; run < runs; run++) {
     Vector3 position = Vector3::Zero();
@@ -214,15 +218,15 @@ void pseudoNavigation(const TrackingGeometry& trackingGeometry,
 }  // namespace
 
 void addBlueprint(Context& ctx) {
-  using Acts::Experimental::Blueprint;
-  using Acts::Experimental::BlueprintNode;
-  using Acts::Experimental::BlueprintOptions;
-  using Acts::Experimental::CuboidContainerBlueprintNode;
-  using Acts::Experimental::CylinderContainerBlueprintNode;
-  using Acts::Experimental::GeometryIdentifierBlueprintNode;
-  using Acts::Experimental::LayerBlueprintNode;
-  using Acts::Experimental::MaterialDesignatorBlueprintNode;
-  using Acts::Experimental::StaticBlueprintNode;
+  using Experimental::Blueprint;
+  using Experimental::BlueprintNode;
+  using Experimental::BlueprintOptions;
+  using Experimental::CuboidContainerBlueprintNode;
+  using Experimental::CylinderContainerBlueprintNode;
+  using Experimental::GeometryIdentifierBlueprintNode;
+  using Experimental::LayerBlueprintNode;
+  using Experimental::MaterialDesignatorBlueprintNode;
+  using Experimental::StaticBlueprintNode;
 
   auto m = ctx.get("main");
 
@@ -324,8 +328,7 @@ void addBlueprint(Context& ctx) {
                            const std::shared_ptr<VolumeBounds>& bounds,
                            const std::string& name) {
                  return std::make_shared<StaticBlueprintNode>(
-                     std::make_unique<Acts::TrackingVolume>(transform, bounds,
-                                                            name));
+                     std::make_unique<TrackingVolume>(transform, bounds, name));
                }),
                py::arg("transform"), py::arg("bounds"),
                py::arg("name") = "undefined")
@@ -519,4 +522,4 @@ void addBlueprint(Context& ctx) {
         "etaRange"_a = std::pair{-4.5, 4.5}, "logLevel"_a = Logging::INFO);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Covfie.cpp
+++ b/Examples/Python/src/Covfie.cpp
@@ -7,7 +7,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/Plugins/Covfie/FieldConversion.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <string>
 
@@ -16,8 +16,9 @@
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 namespace {
 template <typename field_t, typename scalar_type>
@@ -42,22 +43,20 @@ void addCovfie(Context& ctx) {
       .def("at", [](const covfie::array::array<float, 3ul>& self,
                     std::size_t i) { return self[i]; });
 
-  declareCovfieField<Acts::CovfiePlugin::ConstantField, float>(
-      m, "CovfieConstantField");
-  declareCovfieField<Acts::CovfiePlugin::InterpolatedField, float>(
+  declareCovfieField<CovfiePlugin::ConstantField, float>(m,
+                                                         "CovfieConstantField");
+  declareCovfieField<CovfiePlugin::InterpolatedField, float>(
       m, "CovfieAffineLinearStridedField");
 
+  m.def("makeCovfieField", py::overload_cast<const InterpolatedMagneticField&>(
+                               &CovfiePlugin::covfieField));
   m.def("makeCovfieField",
-        py::overload_cast<const Acts::InterpolatedMagneticField&>(
-            &Acts::CovfiePlugin::covfieField));
-  m.def("makeCovfieField", py::overload_cast<const Acts::ConstantBField&>(
-                               &Acts::CovfiePlugin::covfieField));
+        py::overload_cast<const ConstantBField&>(&CovfiePlugin::covfieField));
   m.def("makeCovfieField",
-        py::overload_cast<const Acts::MagneticFieldProvider&,
-                          Acts::MagneticFieldProvider::Cache&,
-                          const std::array<std::size_t, 3>&,
-                          const Acts::Vector3&, const Acts::Vector3&>(
-            &Acts::CovfiePlugin::covfieField));
+        py::overload_cast<
+            const MagneticFieldProvider&, MagneticFieldProvider::Cache&,
+            const std::array<std::size_t, 3>&, const Vector3&, const Vector3&>(
+            &CovfiePlugin::covfieField));
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/CovfieStub.cpp
+++ b/Examples/Python/src/CovfieStub.cpp
@@ -6,8 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addCovfie(Context& /* ctx */) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/DD4hepComponent.cpp
+++ b/Examples/Python/src/DD4hepComponent.cpp
@@ -11,10 +11,11 @@
 #include "Acts/Plugins/DD4hep/DD4hepDetectorStructure.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepFieldAdapter.hpp"
 #include "Acts/Plugins/DD4hep/DD4hepIdentifierMapper.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/DD4hepDetector/AlignedDD4hepDetectorElement.hpp"
 #include "ActsExamples/DD4hepDetector/DD4hepDetector.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <utility>
@@ -26,18 +27,18 @@
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
+using namespace Acts;
 using namespace ActsExamples;
-using namespace Acts::Python;
+using namespace ActsPython;
 
 PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
   {
-    py::class_<Acts::DD4hepDetectorElement, Acts::DetectorElementBase,
-               std::shared_ptr<Acts::DD4hepDetectorElement>>(
-        m, "DD4hepDetectorElement");
+    py::class_<DD4hepDetectorElement, DetectorElementBase,
+               std::shared_ptr<DD4hepDetectorElement>>(m,
+                                                       "DD4hepDetectorElement");
 
-    py::class_<ActsExamples::AlignedDD4hepDetectorElement,
-               Acts::DD4hepDetectorElement,
-               std::shared_ptr<ActsExamples::AlignedDD4hepDetectorElement>>(
+    py::class_<AlignedDD4hepDetectorElement, DD4hepDetectorElement,
+               std::shared_ptr<AlignedDD4hepDetectorElement>>(
         m, "AlignedDD4hepDetectorElement");
   }
 
@@ -61,89 +62,83 @@ PYBIND11_MODULE(ActsPythonBindingsDD4hep, m) {
     patchKwargsConstructor(c);
 
     m.def("alignedDD4hepDetectorElementFactory",
-          &ActsExamples::alignedDD4hepDetectorElementFactory);
+          &alignedDD4hepDetectorElementFactory);
   }
 
   {
-    py::class_<Acts::DD4hepFieldAdapter, Acts::MagneticFieldProvider,
-               std::shared_ptr<Acts::DD4hepFieldAdapter>>(m,
-                                                          "DD4hepFieldAdapter");
+    py::class_<DD4hepFieldAdapter, MagneticFieldProvider,
+               std::shared_ptr<DD4hepFieldAdapter>>(m, "DD4hepFieldAdapter");
   }
 
   {
-    m.def("createDD4hepIdGeoIdMap",
-          [](const Acts::TrackingGeometry& tGeometry)
-              -> std::map<Acts::DD4hepDetectorElement::DD4hepVolumeID,
-                          Acts::GeometryIdentifier> {
-            // The surface visitor
-            struct DD4hepIdGrabber {
-              std::map<Acts::DD4hepDetectorElement::DD4hepVolumeID,
-                       Acts::GeometryIdentifier>
-                  dd4hepIdGeoIdMap;
+    m.def(
+        "createDD4hepIdGeoIdMap",
+        [](const TrackingGeometry& tGeometry)
+            -> std::map<DD4hepDetectorElement::DD4hepVolumeID,
+                        GeometryIdentifier> {
+          // The surface visitor
+          struct DD4hepIdGrabber {
+            std::map<DD4hepDetectorElement::DD4hepVolumeID, GeometryIdentifier>
+                dd4hepIdGeoIdMap;
 
-              void operator()(const Acts::Surface* surface) {
-                const auto* dde = surface->associatedDetectorElement();
-                const auto* dd4hepDetElement =
-                    dynamic_cast<const Acts::DD4hepDetectorElement*>(dde);
-                // Check if it is valid
-                if (dd4hepDetElement != nullptr) {
-                  dd4hep::DDSegmentation::VolumeID dd4hepID =
-                      dd4hepDetElement->sourceElement().volumeID();
-                  auto geoID = surface->geometryId();
-                  dd4hepIdGeoIdMap[dd4hepID] = geoID;
-                }
+            void operator()(const Surface* surface) {
+              const auto* dde = surface->associatedDetectorElement();
+              const auto* dd4hepDetElement =
+                  dynamic_cast<const DD4hepDetectorElement*>(dde);
+              // Check if it is valid
+              if (dd4hepDetElement != nullptr) {
+                dd4hep::DDSegmentation::VolumeID dd4hepID =
+                    dd4hepDetElement->sourceElement().volumeID();
+                auto geoID = surface->geometryId();
+                dd4hepIdGeoIdMap[dd4hepID] = geoID;
               }
-            };
+            }
+          };
 
-            // Create an instance
-            DD4hepIdGrabber dd4hepIdGrabber;
-            // Visit the surfaces & return what you have
-            tGeometry.visitSurfaces(dd4hepIdGrabber);
-            return dd4hepIdGrabber.dd4hepIdGeoIdMap;
-          });
+          // Create an instance
+          DD4hepIdGrabber dd4hepIdGrabber;
+          // Visit the surfaces & return what you have
+          tGeometry.visitSurfaces(dd4hepIdGrabber);
+          return dd4hepIdGrabber.dd4hepIdGeoIdMap;
+        });
   }
 
   {
-    using Options = Acts::Experimental::DD4hepDetectorStructure::Options;
+    using Options = Experimental::DD4hepDetectorStructure::Options;
     auto o = py::class_<Options>(m, "DD4hepDetectorOptions").def(py::init<>());
     ACTS_PYTHON_STRUCT(o, logLevel, emulateToGraph, geoIdGenerator,
                        materialDecorator);
 
     patchKwargsConstructor(o);
 
-    m.def(
-        "attachDD4hepGeoIdMapper",
-        [](Acts::Experimental::DD4hepDetectorStructure::Options& options,
-           const std::map<Acts::DD4hepDetectorElement::DD4hepVolumeID,
-                          Acts::GeometryIdentifier>& dd4hepIdGeoIdMap) {
-          // The Geo mapper
-          auto geoIdMapper =
-              std::make_shared<const Acts::DD4hepIdentifierMapper>(
-                  Acts::DD4hepIdentifierMapper::Config{dd4hepIdGeoIdMap},
-                  Acts::getDefaultLogger("GeometryIdMapper", options.logLevel));
+    m.def("attachDD4hepGeoIdMapper",
+          [](Experimental::DD4hepDetectorStructure::Options& options,
+             const std::map<DD4hepDetectorElement::DD4hepVolumeID,
+                            GeometryIdentifier>& dd4hepIdGeoIdMap) {
+            // The Geo mapper
+            auto geoIdMapper = std::make_shared<const DD4hepIdentifierMapper>(
+                DD4hepIdentifierMapper::Config{dd4hepIdGeoIdMap},
+                getDefaultLogger("GeometryIdMapper", options.logLevel));
 
-          // A remaining recursive logger
-          auto geoIdGenerator =
-              std::make_shared<const Acts::Experimental::GeometryIdGenerator>(
-                  Acts::Experimental::GeometryIdGenerator::Config{},
-                  Acts::getDefaultLogger("GeometryIdGenerator",
-                                         options.logLevel));
+            // A remaining recursive logger
+            auto geoIdGenerator =
+                std::make_shared<const Experimental::GeometryIdGenerator>(
+                    Experimental::GeometryIdGenerator::Config{},
+                    getDefaultLogger("GeometryIdGenerator", options.logLevel));
 
-          std::tuple<
-              std::shared_ptr<const Acts::Experimental::GeometryIdGenerator>,
-              std::shared_ptr<const Acts::DD4hepIdentifierMapper>>
-              chainedGenerators = {geoIdGenerator, geoIdMapper};
+            std::tuple<std::shared_ptr<const Experimental::GeometryIdGenerator>,
+                       std::shared_ptr<const DD4hepIdentifierMapper>>
+                chainedGenerators = {geoIdGenerator, geoIdMapper};
 
-          auto chainedGeoIdGenerator = std::make_shared<
-              const Acts::Experimental::ChainedGeometryIdGenerator<
-                  std::shared_ptr<
-                      const Acts::Experimental::GeometryIdGenerator>,
-                  std::shared_ptr<const Acts::DD4hepIdentifierMapper>>>(
-              std::move(chainedGenerators),
-              Acts::getDefaultLogger("ChainedGeometryIdGenerator",
+            auto chainedGeoIdGenerator =
+                std::make_shared<const Experimental::ChainedGeometryIdGenerator<
+                    std::shared_ptr<const Experimental::GeometryIdGenerator>,
+                    std::shared_ptr<const DD4hepIdentifierMapper>>>(
+                    std::move(chainedGenerators),
+                    getDefaultLogger("ChainedGeometryIdGenerator",
                                      options.logLevel));
 
-          options.geoIdGenerator = chainedGeoIdGenerator;
-        });
+            options.geoIdGenerator = chainedGeoIdGenerator;
+          });
   }
 }

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -11,7 +11,6 @@
 #include "Acts/Geometry/DetectorElementBase.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Material/IMaterialDecorator.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/BinningType.hpp"
 #include "ActsExamples/DetectorCommons/Detector.hpp"
 #include "ActsExamples/DetectorCommons/StructureSelector.hpp"
@@ -21,6 +20,8 @@
 #include "ActsExamples/TGeoDetector/TGeoDetector.hpp"
 #include "ActsExamples/TelescopeDetector/TelescopeDetector.hpp"
 #include "ActsExamples/Utilities/Options.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <optional>
@@ -33,9 +34,11 @@
 #include <pybind11/stl/filesystem.h>
 
 namespace py = pybind11;
+
+using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addDetector(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -58,7 +61,7 @@ void addDetector(Context& ctx) {
   {
     py::class_<StructureSelector, std::shared_ptr<StructureSelector>>(
         mex, "StructureSelector")
-        .def(py::init<std::shared_ptr<const Acts::TrackingGeometry>>())
+        .def(py::init<std::shared_ptr<const TrackingGeometry>>())
         .def("selectSurfaces", &StructureSelector::selectSurfaces)
         .def("selectedTransforms", &StructureSelector::selectedTransforms);
   }
@@ -117,9 +120,9 @@ void addDetector(Context& ctx) {
         .value("Central", TGeoDetector::Config::SubVolume::Central)
         .value("Positive", TGeoDetector::Config::SubVolume::Positive);
 
-    py::enum_<Acts::BinningType>(c, "BinningType")
-        .value("equidistant", Acts::BinningType::equidistant)
-        .value("arbitrary", Acts::BinningType::arbitrary);
+    py::enum_<BinningType>(c, "BinningType")
+        .value("equidistant", BinningType::equidistant)
+        .value("arbitrary", BinningType::arbitrary);
 
     auto volume =
         py::class_<TGeoDetector::Config::Volume>(c, "Volume").def(py::init<>());
@@ -152,7 +155,7 @@ void addDetector(Context& ctx) {
     regTriplet("LayerTripletInterval", Options::Interval{});
     regTriplet("LayerTripletDouble", double{5.5});
     regTriplet("LayerTripletVectorBinning",
-               std::vector<std::pair<int, Acts::BinningType>>{});
+               std::vector<std::pair<int, BinningType>>{});
 
     ACTS_PYTHON_STRUCT(c, surfaceLogLevel, layerLogLevel, volumeLogLevel,
                        fileName, buildBeamPipe, beamPipeRadius,
@@ -164,10 +167,9 @@ void addDetector(Context& ctx) {
   }
 
   {
-    py::class_<Acts::DetectorElementBase,
-               std::shared_ptr<Acts::DetectorElementBase>>(
+    py::class_<DetectorElementBase, std::shared_ptr<DetectorElementBase>>(
         mex, "DetectorElementBase");
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Detray.cpp
+++ b/Examples/Python/src/Detray.cpp
@@ -9,7 +9,8 @@
 #include "Acts/Detector/Detector.hpp"
 #include "Acts/Plugins/Detray/DetrayConversionUtils.hpp"
 #include "Acts/Plugins/Detray/DetrayConverter.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <string>
@@ -23,10 +24,11 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 using namespace Acts;
+using namespace Acts::Experimental;
 using namespace detray;
 using namespace detray::io::detail;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addDetray(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -42,17 +44,17 @@ void addDetray(Context& ctx) {
     // and write it to the corresponding json files.
     //
     // The memory resource and the detector are destroyed after the function
-    detray.def("writeToJson", [](const GeometryContext& gctx,
-                                 const Experimental::Detector& detector) {
-      auto memoryResource = vecmem::host_memory_resource();
+    detray.def("writeToJson",
+               [](const GeometryContext& gctx, const Detector& detector) {
+                 auto memoryResource = vecmem::host_memory_resource();
 
-      DetrayConverter::Options options;
-      options.writeToJson = true;
-      options.convertMaterial = false;
-      options.convertSurfaceGrids = true;
-      auto DetrayHostDetector =
-          DetrayConverter().convert<>(gctx, detector, memoryResource, options);
-    });
+                 DetrayConverter::Options options;
+                 options.writeToJson = true;
+                 options.convertMaterial = false;
+                 options.convertSurfaceGrids = true;
+                 auto DetrayHostDetector = DetrayConverter().convert<>(
+                     gctx, detector, memoryResource, options);
+               });
   }
 
   {
@@ -65,4 +67,4 @@ void addDetray(Context& ctx) {
                        writeToJson);
   }
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/DetrayStub.cpp
+++ b/Examples/Python/src/DetrayStub.cpp
@@ -6,8 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addDetray(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Digitization.cpp
+++ b/Examples/Python/src/Digitization.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Digitization/DigitizationAlgorithm.hpp"
 #include "ActsExamples/Digitization/DigitizationConfig.hpp"
@@ -14,6 +13,8 @@
 #include "ActsExamples/Digitization/DigitizationCoordinatesConverter.hpp"
 #include "ActsExamples/Digitization/MuonSpacePointDigitizer.hpp"
 #include "ActsExamples/Io/Json/JsonDigitizationConfig.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <array>
 #include <memory>
@@ -28,25 +29,24 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addDigitization(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  mex.def("readDigiConfigFromJson", ActsExamples::readDigiConfigFromJson);
-  mex.def("writeDigiConfigToJson", ActsExamples::writeDigiConfigToJson);
+  mex.def("readDigiConfigFromJson", readDigiConfigFromJson);
+  mex.def("writeDigiConfigToJson", writeDigiConfigToJson);
 
   {
-    using Config = ActsExamples::DigitizationAlgorithm::Config;
+    using Config = DigitizationAlgorithm::Config;
 
-    auto a = py::class_<ActsExamples::DigitizationAlgorithm,
-                        ActsExamples::IAlgorithm,
-                        std::shared_ptr<ActsExamples::DigitizationAlgorithm>>(
-                 mex, "DigitizationAlgorithm")
-                 .def(py::init<Config&, Acts::Logging::Level>(),
-                      py::arg("config"), py::arg("level"))
-                 .def_property_readonly(
-                     "config", &ActsExamples::DigitizationAlgorithm::config);
+    auto a =
+        py::class_<DigitizationAlgorithm, IAlgorithm,
+                   std::shared_ptr<DigitizationAlgorithm>>(
+            mex, "DigitizationAlgorithm")
+            .def(py::init<Config&, Logging::Level>(), py::arg("config"),
+                 py::arg("level"))
+            .def_property_readonly("config", &DigitizationAlgorithm::config);
 
     auto c = py::class_<Config>(a, "Config").def(py::init<>());
 
@@ -73,8 +73,8 @@ void addDigitization(Context& ctx) {
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::MuonSpacePointDigitizer, mex, "MuonSpacePointDigitizer",
-      inputSimHits, inputParticles, outputSpacePoints, randomNumbers,
+      MuonSpacePointDigitizer, mex, "MuonSpacePointDigitizer", inputSimHits,
+      inputParticles, outputSpacePoints, randomNumbers,
       /// @todo: Expose <calibrator> to python bindings
       trackingGeometry, digitizeTime, dumpVisualization, strawDeadTime
 
@@ -91,18 +91,15 @@ void addDigitization(Context& ctx) {
   }
 
   {
-    py::class_<ActsExamples::DigitizationCoordinatesConverter,
-               std::shared_ptr<ActsExamples::DigitizationCoordinatesConverter>>(
+    py::class_<DigitizationCoordinatesConverter,
+               std::shared_ptr<DigitizationCoordinatesConverter>>(
         mex, "DigitizationCoordinatesConverter")
-        .def(py::init<ActsExamples::DigitizationAlgorithm::Config&>(),
-             py::arg("config"))
-        .def_property_readonly(
-            "config", &ActsExamples::DigitizationCoordinatesConverter::config)
-        .def("globalToLocal",
-             &ActsExamples::DigitizationCoordinatesConverter::globalToLocal)
-        .def("localToGlobal",
-             &ActsExamples::DigitizationCoordinatesConverter::localToGlobal);
+        .def(py::init<DigitizationAlgorithm::Config&>(), py::arg("config"))
+        .def_property_readonly("config",
+                               &DigitizationCoordinatesConverter::config)
+        .def("globalToLocal", &DigitizationCoordinatesConverter::globalToLocal)
+        .def("localToGlobal", &DigitizationCoordinatesConverter::localToGlobal);
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/EDM4hepComponent.cpp
+++ b/Examples/Python/src/EDM4hepComponent.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/DD4hepDetector/DD4hepDetector.hpp"
 #include "ActsExamples/Io/EDM4hep/EDM4hepMeasurementInputConverter.hpp"
 #include "ActsExamples/Io/EDM4hep/EDM4hepMeasurementOutputConverter.hpp"
@@ -17,6 +16,8 @@
 #include "ActsExamples/Io/EDM4hep/EDM4hepSimInputConverter.hpp"
 #include "ActsExamples/Io/EDM4hep/EDM4hepTrackInputConverter.hpp"
 #include "ActsExamples/Io/EDM4hep/EDM4hepTrackOutputConverter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <podio/CollectionBase.h>
 #include <podio/Frame.h>
@@ -28,7 +29,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 using namespace Acts;
-using namespace Acts::Python;
+using namespace ActsPython;
 using namespace ActsExamples;
 
 template <typename A, typename B = IAlgorithm>
@@ -64,7 +65,7 @@ PYBIND11_MODULE(ActsPythonBindingsEDM4hep, m) {
                         &Config::particlePtMax);
   }
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::EDM4hepTrackInputConverter, m,
+  ACTS_PYTHON_DECLARE_ALGORITHM(EDM4hepTrackInputConverter, m,
                                 "EDM4hepTrackInputConverter", inputFrame,
                                 inputTracks, outputTracks, Bz);
 
@@ -82,10 +83,10 @@ PYBIND11_MODULE(ActsPythonBindingsEDM4hep, m) {
                        outputSimTrackerHits);
   }
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::EDM4hepMeasurementInputConverter,
-                                m, "EDM4hepMeasurementInputConverter",
-                                inputFrame, outputMeasurements,
-                                outputMeasurementSimHitsMap, outputClusters);
+  ACTS_PYTHON_DECLARE_ALGORITHM(EDM4hepMeasurementInputConverter, m,
+                                "EDM4hepMeasurementInputConverter", inputFrame,
+                                outputMeasurements, outputMeasurementSimHitsMap,
+                                outputClusters);
 
   {
     auto [alg, config] = declareAlgorithm<EDM4hepMeasurementOutputConverter,

--- a/Examples/Python/src/EventData.cpp
+++ b/Examples/Python/src/EventData.cpp
@@ -8,7 +8,7 @@
 
 #include "Acts/Definitions/PdgParticle.hpp"
 #include "Acts/EventData/ParticleHypothesis.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <type_traits>
 
@@ -19,65 +19,55 @@ namespace py = pybind11;
 
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addEventData(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  py::class_<Acts::ParticleHypothesis>(m, "ParticleHypothesis")
-      .def(py::init([](Acts::PdgParticle absPdg, float mass, float absCharge) {
-             return Acts::ParticleHypothesis(absPdg, mass,
-                                             AnyCharge{absCharge});
+  py::class_<ParticleHypothesis>(m, "ParticleHypothesis")
+      .def(py::init([](PdgParticle absPdg, float mass, float absCharge) {
+             return ParticleHypothesis(absPdg, mass, AnyCharge{absCharge});
            }),
            py::arg("pdg"), py::arg("mass"), py::arg("absCharge"))
-      .def(py::init([](std::underlying_type_t<Acts::PdgParticle> absPdg,
-                       float mass, float absCharge) {
-             return Acts::ParticleHypothesis(
-                 static_cast<Acts::PdgParticle>(absPdg), mass,
-                 AnyCharge{absCharge});
+      .def(py::init([](std::underlying_type_t<PdgParticle> absPdg, float mass,
+                       float absCharge) {
+             return ParticleHypothesis(static_cast<PdgParticle>(absPdg), mass,
+                                       AnyCharge{absCharge});
            }),
            py::arg("absPdg"), py::arg("mass"), py::arg("absCharge"))
       .def("__str__",
-           [](const Acts::ParticleHypothesis& particleHypothesis) {
+           [](const ParticleHypothesis& particleHypothesis) {
              std::stringstream os;
              particleHypothesis.toStream(os);
              return os.str();
            })
       .def("absolutePdg",
-           [](const Acts::ParticleHypothesis& p) { return p.absolutePdg(); })
-      .def("mass", [](const Acts::ParticleHypothesis& p) { return p.mass(); })
+           [](const ParticleHypothesis& p) { return p.absolutePdg(); })
+      .def("mass", [](const ParticleHypothesis& p) { return p.mass(); })
       .def("absoluteCharge",
-           [](const Acts::ParticleHypothesis& p) { return p.absoluteCharge(); })
-      .def_property_readonly_static("muon",
-                                    [](py::object /* self */) {
-                                      return Acts::ParticleHypothesis::muon();
-                                    })
-      .def_property_readonly_static("pion",
-                                    [](py::object /* self */) {
-                                      return Acts::ParticleHypothesis::pion();
-                                    })
+           [](const ParticleHypothesis& p) { return p.absoluteCharge(); })
+      .def_property_readonly_static(
+          "muon",
+          [](py::object /* self */) { return ParticleHypothesis::muon(); })
+      .def_property_readonly_static(
+          "pion",
+          [](py::object /* self */) { return ParticleHypothesis::pion(); })
       .def_property_readonly_static(
           "electron",
-          [](py::object /* self */) {
-            return Acts::ParticleHypothesis::electron();
-          })
-      .def_property_readonly_static("kaon",
-                                    [](py::object /* self */) {
-                                      return Acts::ParticleHypothesis::kaon();
-                                    })
-      .def_property_readonly_static("proton",
-                                    [](py::object /* self */) {
-                                      return Acts::ParticleHypothesis::proton();
-                                    })
+          [](py::object /* self */) { return ParticleHypothesis::electron(); })
+      .def_property_readonly_static(
+          "kaon",
+          [](py::object /* self */) { return ParticleHypothesis::kaon(); })
+      .def_property_readonly_static(
+          "proton",
+          [](py::object /* self */) { return ParticleHypothesis::proton(); })
       .def_property_readonly_static(
           "geantino",
-          [](py::object /* self */) {
-            return Acts::ParticleHypothesis::geantino();
-          })
+          [](py::object /* self */) { return ParticleHypothesis::geantino(); })
       .def_property_readonly_static(
           "chargedGeantino", [](py::object /* self */) {
-            return Acts::ParticleHypothesis::chargedGeantino();
+            return ParticleHypothesis::chargedGeantino();
           });
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/ExampleAlgorithms.cpp
+++ b/Examples/Python/src/ExampleAlgorithms.cpp
@@ -7,7 +7,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/Definitions/Algebra.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/TrackFinding/TrackSelector.hpp"
 #include "ActsExamples/Fatras/FatrasSimulation.hpp"
 #include "ActsExamples/Io/Json/JsonGeometryList.hpp"
@@ -15,6 +14,8 @@
 #include "ActsExamples/Printers/TrackParametersPrinter.hpp"
 #include "ActsExamples/Utilities/Range.hpp"
 #include "ActsExamples/Utilities/TrackSelectorAlgorithm.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <vector>
 
@@ -26,7 +27,7 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addExampleAlgorithms(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -52,7 +53,7 @@ void addExampleAlgorithms(Context& ctx) {
 
     auto alg = py::class_<Alg, IAlgorithm, std::shared_ptr<Alg>>(
                    mex, "TrackSelectorAlgorithm")
-                   .def(py::init<const Alg::Config&, Acts::Logging::Level>(),
+                   .def(py::init<const Alg::Config&, Logging::Level>(),
                         py::arg("config"), py::arg("level"))
                    .def_property_readonly("config", &Alg::config);
 
@@ -62,19 +63,19 @@ void addExampleAlgorithms(Context& ctx) {
   }
 
   {
-    using EtaBinnedConfig = Acts::TrackSelector::EtaBinnedConfig;
-    using Config = Acts::TrackSelector::Config;
+    using EtaBinnedConfig = TrackSelector::EtaBinnedConfig;
+    using Config = TrackSelector::Config;
 
-    auto tool = py::class_<Acts::TrackSelector>(m, "TrackSelector")
+    auto tool = py::class_<TrackSelector>(m, "TrackSelector")
                     .def(py::init<const Config&>(), py::arg("config"))
                     .def(py::init<const EtaBinnedConfig&>(), py::arg("config"));
 
     {
-      auto mc = py::class_<Acts::TrackSelector::MeasurementCounter>(
+      auto mc = py::class_<TrackSelector::MeasurementCounter>(
                     tool, "MeasurementCounter")
                     .def(py::init<>())
                     .def("addCounter",
-                         &Acts::TrackSelector::MeasurementCounter::addCounter);
+                         &TrackSelector::MeasurementCounter::addCounter);
     }
 
     {
@@ -110,4 +111,4 @@ void addExampleAlgorithms(Context& ctx) {
     }
   }
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Framework.cpp
+++ b/Examples/Python/src/Framework.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
 #include "ActsExamples/Framework/IReader.hpp"
@@ -16,14 +15,17 @@
 #include "ActsExamples/Framework/SequenceElement.hpp"
 #include "ActsExamples/Framework/Sequencer.hpp"
 #include "ActsExamples/Framework/WhiteBoard.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
 using namespace py::literals;
+using namespace Acts;
 using namespace ActsExamples;
-using namespace Acts::Python;
+using namespace ActsPython;
 
 namespace {
 #if defined(__clang__)
@@ -96,18 +98,15 @@ void trigger_invalid() {
 
 }  // namespace
 
-namespace Acts::Python {
+namespace ActsPython {
 void addFramework(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  py::class_<ActsExamples::IWriter, std::shared_ptr<ActsExamples::IWriter>>(
-      mex, "IWriter");
+  py::class_<IWriter, std::shared_ptr<IWriter>>(mex, "IWriter");
 
-  py::class_<ActsExamples::IReader, std::shared_ptr<ActsExamples::IReader>>(
-      mex, "IReader");
+  py::class_<IReader, std::shared_ptr<IReader>>(mex, "IReader");
 
-  py::class_<ActsExamples::IContextDecorator,
-             std::shared_ptr<ActsExamples::IContextDecorator>>(
+  py::class_<IContextDecorator, std::shared_ptr<IContextDecorator>>(
       mex, "IContextDecorator")
       .def("decorate", &IContextDecorator::decorate)
       .def("name", &IContextDecorator::name);
@@ -118,9 +117,8 @@ void addFramework(Context& ctx) {
       .value("END", ProcessCode::END);
 
   py::class_<WhiteBoard>(mex, "WhiteBoard")
-      .def(py::init([](Acts::Logging::Level level, const std::string& name) {
-             return std::make_unique<WhiteBoard>(
-                 Acts::getDefaultLogger(name, level));
+      .def(py::init([](Logging::Level level, const std::string& name) {
+             return std::make_unique<WhiteBoard>(getDefaultLogger(name, level));
            }),
            py::arg("level"), py::arg("name") = "WhiteBoard")
       .def("exists", &WhiteBoard::exists)
@@ -142,21 +140,18 @@ void addFramework(Context& ctx) {
       .def_readwrite("fpeMonitor", &AlgorithmContext::fpeMonitor);
 
   auto pySequenceElement =
-      py::class_<ActsExamples::SequenceElement, PySequenceElement,
-                 std::shared_ptr<ActsExamples::SequenceElement>>(
-          mex, "SequenceElement")
+      py::class_<SequenceElement, PySequenceElement,
+                 std::shared_ptr<SequenceElement>>(mex, "SequenceElement")
           .def("internalExecute", &SequenceElement::internalExecute)
           .def("name", &SequenceElement::name);
 
   auto bareAlgorithm =
-      py::class_<ActsExamples::IAlgorithm,
-                 std::shared_ptr<ActsExamples::IAlgorithm>, SequenceElement,
+      py::class_<IAlgorithm, std::shared_ptr<IAlgorithm>, SequenceElement,
                  PyIAlgorithm>(mex, "IAlgorithm")
-          .def(py::init_alias<const std::string&, Acts::Logging::Level>(),
+          .def(py::init_alias<const std::string&, Logging::Level>(),
                py::arg("name"), py::arg("level"))
           .def("execute", &IAlgorithm::execute);
 
-  using ActsExamples::Sequencer;
   using Config = Sequencer::Config;
   auto sequencer =
       py::class_<Sequencer>(mex, "_Sequencer")
@@ -198,7 +193,7 @@ void addFramework(Context& ctx) {
       py::class_<Sequencer::FpeMask>(sequencer, "_FpeMask")
           .def(py::init<>())
           .def(py::init<std::string, std::pair<unsigned int, unsigned int>,
-                        Acts::FpeType, std::size_t>())
+                        FpeType, std::size_t>())
           .def("__repr__", [](const Sequencer::FpeMask& self) {
             std::stringstream ss;
             ss << self;
@@ -208,25 +203,24 @@ void addFramework(Context& ctx) {
   ACTS_PYTHON_STRUCT(fpem, file, lines, type, count);
 
   struct FpeMonitorContext {
-    std::optional<Acts::FpeMonitor> mon;
+    std::optional<FpeMonitor> mon;
   };
 
-  auto fpe = py::class_<Acts::FpeMonitor>(m, "FpeMonitor")
+  auto fpe = py::class_<FpeMonitor>(m, "FpeMonitor")
                  .def_static("_trigger_divbyzero", &trigger_divbyzero)
                  .def_static("_trigger_overflow", &trigger_overflow)
                  .def_static("_trigger_invalid", &trigger_invalid)
                  .def_static("context", []() { return FpeMonitorContext(); });
 
-  fpe.def_property_readonly("result",
-                            py::overload_cast<>(&Acts::FpeMonitor::result),
+  fpe.def_property_readonly("result", py::overload_cast<>(&FpeMonitor::result),
                             py::return_value_policy::reference_internal)
-      .def("rearm", &Acts::FpeMonitor::rearm);
+      .def("rearm", &FpeMonitor::rearm);
 
-  py::class_<Acts::FpeMonitor::Result>(fpe, "Result")
-      .def("merged", &Acts::FpeMonitor::Result::merged)
-      .def("merge", &Acts::FpeMonitor::Result::merge)
-      .def("count", &Acts::FpeMonitor::Result::count)
-      .def("__str__", [](const Acts::FpeMonitor::Result& result) {
+  py::class_<FpeMonitor::Result>(fpe, "Result")
+      .def("merged", &FpeMonitor::Result::merged)
+      .def("merge", &FpeMonitor::Result::merge)
+      .def("count", &FpeMonitor::Result::count)
+      .def("__str__", [](const FpeMonitor::Result& result) {
         std::stringstream os;
         result.summary(os);
         return os.str();
@@ -236,7 +230,7 @@ void addFramework(Context& ctx) {
       .def(py::init([]() { return std::make_unique<FpeMonitorContext>(); }))
       .def(
           "__enter__",
-          [](FpeMonitorContext& fm) -> Acts::FpeMonitor& {
+          [](FpeMonitorContext& fm) -> FpeMonitor& {
             fm.mon.emplace();
             return fm.mon.value();
           },
@@ -245,42 +239,37 @@ void addFramework(Context& ctx) {
                           py::object /*exc_value*/,
                           py::object /*traceback*/) { fm.mon.reset(); });
 
-  py::enum_<Acts::FpeType>(m, "FpeType")
-      .value("INTDIV", Acts::FpeType::INTDIV)
-      .value("INTOVF", Acts::FpeType::INTOVF)
-      .value("FLTDIV", Acts::FpeType::FLTDIV)
-      .value("FLTOVF", Acts::FpeType::FLTOVF)
-      .value("FLTUND", Acts::FpeType::FLTUND)
-      .value("FLTRES", Acts::FpeType::FLTRES)
-      .value("FLTINV", Acts::FpeType::FLTINV)
-      .value("FLTSUB", Acts::FpeType::FLTSUB)
+  py::enum_<FpeType>(m, "FpeType")
+      .value("INTDIV", FpeType::INTDIV)
+      .value("INTOVF", FpeType::INTOVF)
+      .value("FLTDIV", FpeType::FLTDIV)
+      .value("FLTOVF", FpeType::FLTOVF)
+      .value("FLTUND", FpeType::FLTUND)
+      .value("FLTRES", FpeType::FLTRES)
+      .value("FLTINV", FpeType::FLTINV)
+      .value("FLTSUB", FpeType::FLTSUB)
 
       .def_property_readonly_static(
           "values", [](py::object /*self*/) -> const auto& {
-            static const std::vector<Acts::FpeType> values = {
-                Acts::FpeType::INTDIV, Acts::FpeType::INTOVF,
-                Acts::FpeType::FLTDIV, Acts::FpeType::FLTOVF,
-                Acts::FpeType::FLTUND, Acts::FpeType::FLTRES,
-                Acts::FpeType::FLTINV, Acts::FpeType::FLTSUB};
+            static const std::vector<FpeType> values = {
+                FpeType::INTDIV, FpeType::INTOVF, FpeType::FLTDIV,
+                FpeType::FLTOVF, FpeType::FLTUND, FpeType::FLTRES,
+                FpeType::FLTINV, FpeType::FLTSUB};
             return values;
           });
 
-  py::register_exception<ActsExamples::FpeFailure>(m, "FpeFailure",
-                                                   PyExc_RuntimeError);
+  py::register_exception<FpeFailure>(m, "FpeFailure", PyExc_RuntimeError);
 
-  using ActsExamples::RandomNumbers;
   auto randomNumbers =
       py::class_<RandomNumbers, std::shared_ptr<RandomNumbers>>(mex,
                                                                 "RandomNumbers")
           .def(py::init<const RandomNumbers::Config&>());
 
-  py::class_<ActsExamples::RandomEngine>(mex, "RandomEngine").def(py::init<>());
+  py::class_<RandomEngine>(mex, "RandomEngine").def(py::init<>());
 
   py::class_<RandomNumbers::Config>(randomNumbers, "Config")
       .def(py::init<>())
       .def_readwrite("seed", &RandomNumbers::Config::seed);
-
-  // mex.def()
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -13,7 +13,6 @@
 #include "Acts/Plugins/Geant4/Geant4DetectorElement.hpp"
 #include "Acts/Plugins/Geant4/Geant4DetectorSurfaceFactory.hpp"
 #include "Acts/Plugins/Geant4/Geant4PhysicalVolumeSelectors.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Surfaces/SurfaceVisitorConcept.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Geant4/Geant4ConstructionOptions.hpp"
@@ -25,6 +24,8 @@
 #include "ActsExamples/Geant4Detector/GdmlDetectorConstruction.hpp"
 #include "ActsExamples/Geant4Detector/Geant4Detector.hpp"
 #include "ActsExamples/MuonSpectrometerMockupDetector/MockupSectorBuilder.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <algorithm>
 #include <memory>
@@ -47,17 +48,16 @@ using namespace pybind11::literals;
 
 using namespace ActsExamples;
 using namespace Acts;
-using namespace Acts::Python;
+using namespace ActsPython;
 
 struct ExperimentalSensitiveCandidates
     : public Geant4::SensitiveCandidatesBase {
   std::shared_ptr<const Experimental::Detector> detector;
 
   /// Find the sensitive surfaces for a given position
-  std::vector<const Acts::Surface*> queryPosition(
-      const Acts::GeometryContext& gctx,
-      const Acts::Vector3& position) const override {
-    std::vector<const Acts::Surface*> surfaces;
+  std::vector<const Surface*> queryPosition(
+      const GeometryContext& gctx, const Vector3& position) const override {
+    std::vector<const Surface*> surfaces;
     // Here's the detector volume
     auto volume = detector->findDetectorVolume(gctx, position);
     if (volume != nullptr) {
@@ -70,9 +70,9 @@ struct ExperimentalSensitiveCandidates
     return surfaces;
   }
 
-  std::vector<const Acts::Surface*> queryAll() const override {
-    std::vector<const Acts::Surface*> surfaces;
-    detector->visitSurfaces([&](const Acts::Surface* surface) {
+  std::vector<const Surface*> queryAll() const override {
+    std::vector<const Surface*> surfaces;
+    detector->visitSurfaces([&](const Surface* surface) {
       if (surface->associatedDetectorElement() != nullptr) {
         surfaces.push_back(surface);
       }
@@ -117,14 +117,13 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
   {
     using Config = Geant4::SensitiveSurfaceMapper::Config;
     using State = Geant4::SensitiveSurfaceMapper::State;
-    auto sm =
-        py::class_<Geant4::SensitiveSurfaceMapper,
-                   std::shared_ptr<Geant4::SensitiveSurfaceMapper>>(
-            mod, "SensitiveSurfaceMapper")
-            .def(py::init([](const Config& cfg, Acts::Logging::Level level) {
-              return std::make_shared<Geant4::SensitiveSurfaceMapper>(
-                  cfg, getDefaultLogger("SensitiveSurfaceMapper", level));
-            }));
+    auto sm = py::class_<Geant4::SensitiveSurfaceMapper,
+                         std::shared_ptr<Geant4::SensitiveSurfaceMapper>>(
+                  mod, "SensitiveSurfaceMapper")
+                  .def(py::init([](const Config& cfg, Logging::Level level) {
+                    return std::make_shared<Geant4::SensitiveSurfaceMapper>(
+                        cfg, getDefaultLogger("SensitiveSurfaceMapper", level));
+                  }));
 
     py::class_<State>(sm, "State").def(py::init<>());
 
@@ -132,7 +131,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     ACTS_PYTHON_STRUCT(c, materialMappings, volumeMappings, candidateSurfaces);
 
     sm.def("create",
-           [](const Config& cfg, Acts::Logging::Level level,
+           [](const Config& cfg, Logging::Level level,
               const std::shared_ptr<const TrackingGeometry>& tGeometry) {
              // Set a new surface finder
              Config ccfg = cfg;
@@ -144,7 +143,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
            });
 
     sm.def("create",
-           [](const Config& cfg, Acts::Logging::Level level,
+           [](const Config& cfg, Logging::Level level,
               const std::shared_ptr<const Experimental::Detector>& detector) {
              // Helper struct to find the sensitive surface candidates
 
@@ -178,8 +177,8 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto alg =
         py::class_<Algorithm, Geant4SimulationBase, std::shared_ptr<Algorithm>>(
             mod, "Geant4Simulation")
-            .def(py::init<const Config&, Acts::Logging::Level>(),
-                 py::arg("config"), py::arg("level"))
+            .def(py::init<const Config&, Logging::Level>(), py::arg("config"),
+                 py::arg("level"))
             .def_property_readonly("config", &Algorithm::config);
 
     auto c1 = py::class_<Config, Geant4SimulationBase::Config,
@@ -199,8 +198,8 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     auto alg =
         py::class_<Algorithm, Geant4SimulationBase, std::shared_ptr<Algorithm>>(
             mod, "Geant4MaterialRecording")
-            .def(py::init<const Config&, Acts::Logging::Level>(),
-                 py::arg("config"), py::arg("level"))
+            .def(py::init<const Config&, Logging::Level>(), py::arg("config"),
+                 py::arg("level"))
             .def_property_readonly("config", &Algorithm::config);
 
     auto c = py::class_<Config, Geant4SimulationBase::Config,
@@ -210,16 +209,16 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
   }
 
   {
-    using ISelector = Acts::IGeant4PhysicalVolumeSelector;
+    using ISelector = IGeant4PhysicalVolumeSelector;
     auto is = py::class_<ISelector, std::shared_ptr<ISelector>>(
         mod, "IVolumeSelector");
 
-    using NameSelector = Acts::Geant4PhysicalVolumeSelectors::NameSelector;
+    using NameSelector = Geant4PhysicalVolumeSelectors::NameSelector;
     auto ns = py::class_<NameSelector, std::shared_ptr<NameSelector>>(
                   mod, "VolumeNameSelector", is)
                   .def(py::init<const std::vector<std::string>&, bool>());
 
-    using Factory = Acts::Geant4DetectorSurfaceFactory;
+    using Factory = Geant4DetectorSurfaceFactory;
     auto o = py::class_<Factory::Options>(mod, "SurfaceFactoryOptions")
                  .def(py::init<>());
     ACTS_PYTHON_STRUCT(o, scaleConversion, convertMaterial,
@@ -253,61 +252,60 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
     /// @param gdmlFileName is the name of the GDML file
     /// @param sensitiveMatches is a list of strings to match sensitive volumes
     /// @param passiveMatches is a list of strings to match passive volumes
-    mod.def("convertSurfaces", [](const std::string& gdmlFileName,
-                                  const std::vector<std::string>&
-                                      sensitiveMatches,
-                                  const std::vector<std::string>&
-                                      passiveMatches,
-                                  bool convertMaterial) {
-      // Initiate the detector construction & retrieve world
-      ActsExamples::GdmlDetectorConstruction gdmlContruction(gdmlFileName, {});
-      const auto* world = gdmlContruction.Construct();
+    mod.def(
+        "convertSurfaces", [](const std::string& gdmlFileName,
+                              const std::vector<std::string>& sensitiveMatches,
+                              const std::vector<std::string>& passiveMatches,
+                              bool convertMaterial) {
+          // Initiate the detector construction & retrieve world
+          ActsExamples::GdmlDetectorConstruction gdmlContruction(gdmlFileName,
+                                                                 {});
+          const auto* world = gdmlContruction.Construct();
 
-      // Create the selectors
-      auto sensitiveSelectors =
-          std::make_shared<Acts::Geant4PhysicalVolumeSelectors::NameSelector>(
-              sensitiveMatches, false);
-      auto passiveSelectors =
-          std::make_shared<Acts::Geant4PhysicalVolumeSelectors::NameSelector>(
-              passiveMatches, false);
+          // Create the selectors
+          auto sensitiveSelectors =
+              std::make_shared<Geant4PhysicalVolumeSelectors::NameSelector>(
+                  sensitiveMatches, false);
+          auto passiveSelectors =
+              std::make_shared<Geant4PhysicalVolumeSelectors::NameSelector>(
+                  passiveMatches, false);
 
-      Acts::Geant4DetectorSurfaceFactory::Config config;
-      Acts::Geant4DetectorSurfaceFactory::Cache cache;
-      Acts::Geant4DetectorSurfaceFactory::Options options;
-      options.sensitiveSurfaceSelector = sensitiveSelectors;
-      options.passiveSurfaceSelector = passiveSelectors;
-      options.convertMaterial = convertMaterial;
+          Geant4DetectorSurfaceFactory::Config config;
+          Geant4DetectorSurfaceFactory::Cache cache;
+          Geant4DetectorSurfaceFactory::Options options;
+          options.sensitiveSurfaceSelector = sensitiveSelectors;
+          options.passiveSurfaceSelector = passiveSelectors;
+          options.convertMaterial = convertMaterial;
 
-      G4Transform3D nominal;
-      Acts::Geant4DetectorSurfaceFactory factory(config);
-      factory.construct(cache, nominal, *world, options);
+          G4Transform3D nominal;
+          Geant4DetectorSurfaceFactory factory(config);
+          factory.construct(cache, nominal, *world, options);
 
-      // Capture the sensitive elements and the surfaces
-      using Elements =
-          std::vector<std::shared_ptr<Acts::Geant4DetectorElement>>;
-      Elements detectorElements;
-      detectorElements.reserve(cache.sensitiveSurfaces.size());
-      using Surfaces = std::vector<std::shared_ptr<Acts::Surface>>;
-      Surfaces surfaces;
-      surfaces.reserve(cache.sensitiveSurfaces.size());
-      std::ranges::for_each(
-          cache.sensitiveSurfaces, [&](const auto& sensitive) {
-            detectorElements.push_back(std::get<0>(sensitive));
-            surfaces.push_back(std::get<1>(sensitive));
-          });
+          // Capture the sensitive elements and the surfaces
+          using Elements = std::vector<std::shared_ptr<Geant4DetectorElement>>;
+          Elements detectorElements;
+          detectorElements.reserve(cache.sensitiveSurfaces.size());
+          using Surfaces = std::vector<std::shared_ptr<Surface>>;
+          Surfaces surfaces;
+          surfaces.reserve(cache.sensitiveSurfaces.size());
+          std::ranges::for_each(
+              cache.sensitiveSurfaces, [&](const auto& sensitive) {
+                detectorElements.push_back(std::get<0>(sensitive));
+                surfaces.push_back(std::get<1>(sensitive));
+              });
 
-      // Capture the passive surfaces
-      Surfaces passiveSurfaces;
-      passiveSurfaces.reserve(cache.passiveSurfaces.size());
-      for (const auto& passive : cache.passiveSurfaces) {
-        passiveSurfaces.push_back(passive);
-      }
+          // Capture the passive surfaces
+          Surfaces passiveSurfaces;
+          passiveSurfaces.reserve(cache.passiveSurfaces.size());
+          for (const auto& passive : cache.passiveSurfaces) {
+            passiveSurfaces.push_back(passive);
+          }
 
-      // Return a convenient tuple for drawing
-      return std::tuple<Elements, Surfaces, Surfaces>(
-          std::move(detectorElements), std::move(surfaces),
-          std::move(passiveSurfaces));
-    });
+          // Return a convenient tuple for drawing
+          return std::tuple<Elements, Surfaces, Surfaces>(
+              std::move(detectorElements), std::move(surfaces),
+              std::move(passiveSurfaces));
+        });
   }
 
   {
@@ -342,6 +340,6 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                        volumes);
   }
 
-  Acts::Python::Context ctx;
+  Context ctx;
   ctx.modules["geant4"] = mod;
 }

--- a/Examples/Python/src/Generators.cpp
+++ b/Examples/Python/src/Generators.cpp
@@ -7,13 +7,14 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/Definitions/Algebra.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/AngleHelpers.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Generators/EventGenerator.hpp"
 #include "ActsExamples/Utilities/ParametricParticleGenerator.hpp"
 #include "ActsExamples/Utilities/VertexGenerators.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -29,39 +30,38 @@ class IReader;
 
 namespace py = pybind11;
 
-namespace Acts::Python {
+using namespace Acts;
+using namespace ActsExamples;
+
+namespace ActsPython {
 
 void addGenerators(Context& ctx) {
   auto mex = ctx.get("examples");
 
   {
-    using Config = ActsExamples::EventGenerator::Config;
-    auto gen = py::class_<ActsExamples::EventGenerator, ActsExamples::IReader,
-                          std::shared_ptr<ActsExamples::EventGenerator>>(
-                   mex, "EventGenerator")
-                   .def(py::init<const Config&, Acts::Logging::Level>(),
-                        py::arg("config"), py::arg("level"))
-                   .def_property_readonly(
-                       "config", &ActsExamples::EventGenerator::config);
+    using Config = EventGenerator::Config;
+    auto gen =
+        py::class_<EventGenerator, IReader, std::shared_ptr<EventGenerator>>(
+            mex, "EventGenerator")
+            .def(py::init<const Config&, Logging::Level>(), py::arg("config"),
+                 py::arg("level"))
+            .def_property_readonly("config", &EventGenerator::config);
 
-    py::class_<ActsExamples::PrimaryVertexPositionGenerator,
-               std::shared_ptr<ActsExamples::PrimaryVertexPositionGenerator>>(
+    py::class_<PrimaryVertexPositionGenerator,
+               std::shared_ptr<PrimaryVertexPositionGenerator>>(
         gen, "VertexGenerator");
-    py::class_<ActsExamples::ParticlesGenerator,
-               std::shared_ptr<ActsExamples::ParticlesGenerator>>(
+    py::class_<ParticlesGenerator, std::shared_ptr<ParticlesGenerator>>(
         gen, "ParticlesGenerator");
-    py::class_<ActsExamples::MultiplicityGenerator,
-               std::shared_ptr<ActsExamples::MultiplicityGenerator>>(
+    py::class_<MultiplicityGenerator, std::shared_ptr<MultiplicityGenerator>>(
         gen, "MultiplicityGenerator");
 
-    using EventGenerator = ActsExamples::EventGenerator;
+    using EventGenerator = EventGenerator;
     using Generator = EventGenerator::Generator;
     py::class_<Generator>(gen, "Generator")
         .def(py::init<>())
-        .def(py::init<
-                 std::shared_ptr<ActsExamples::MultiplicityGenerator>,
-                 std::shared_ptr<ActsExamples::PrimaryVertexPositionGenerator>,
-                 std::shared_ptr<ActsExamples::ParticlesGenerator>>(),
+        .def(py::init<std::shared_ptr<MultiplicityGenerator>,
+                      std::shared_ptr<PrimaryVertexPositionGenerator>,
+                      std::shared_ptr<ParticlesGenerator>>(),
              py::arg("multiplicity"), py::arg("vertex"), py::arg("particles"))
         .def_readwrite("multiplicity", &Generator::multiplicity)
         .def_readwrite("vertex", &Generator::vertex)
@@ -73,33 +73,28 @@ void addGenerators(Context& ctx) {
                        printListing);
   }
 
-  py::class_<
-      ActsExamples::GaussianPrimaryVertexPositionGenerator,
-      ActsExamples::PrimaryVertexPositionGenerator,
-      std::shared_ptr<ActsExamples::GaussianPrimaryVertexPositionGenerator>>(
+  py::class_<GaussianPrimaryVertexPositionGenerator,
+             PrimaryVertexPositionGenerator,
+             std::shared_ptr<GaussianPrimaryVertexPositionGenerator>>(
       mex, "GaussianVertexGenerator")
       .def(py::init<>())
-      .def(py::init([](const Acts::Vector4& stddev, const Acts::Vector4& mean) {
-             ActsExamples::GaussianPrimaryVertexPositionGenerator g;
+      .def(py::init([](const Vector4& stddev, const Vector4& mean) {
+             GaussianPrimaryVertexPositionGenerator g;
              g.stddev = stddev;
              g.mean = mean;
              return g;
            }),
            py::arg("stddev"), py::arg("mean"))
-      .def_readwrite(
-          "stddev",
-          &ActsExamples::GaussianPrimaryVertexPositionGenerator::stddev)
-      .def_readwrite(
-          "mean", &ActsExamples::GaussianPrimaryVertexPositionGenerator::mean);
-  py::class_<
-      ActsExamples::GaussianDisplacedVertexPositionGenerator,
-      ActsExamples::PrimaryVertexPositionGenerator,
-      std::shared_ptr<ActsExamples::GaussianDisplacedVertexPositionGenerator>>(
+      .def_readwrite("stddev", &GaussianPrimaryVertexPositionGenerator::stddev)
+      .def_readwrite("mean", &GaussianPrimaryVertexPositionGenerator::mean);
+  py::class_<GaussianDisplacedVertexPositionGenerator,
+             PrimaryVertexPositionGenerator,
+             std::shared_ptr<GaussianDisplacedVertexPositionGenerator>>(
       mex, "GaussianDisplacedVertexPositionGenerator")
       .def(py::init<>())
       .def(py::init([](double rMean, double rStdDev, double zMean,
                        double zStdDev, double tMean, double tStdDev) {
-             ActsExamples::GaussianDisplacedVertexPositionGenerator g;
+             GaussianDisplacedVertexPositionGenerator g;
              g.rMean = rMean;
              g.rStdDev = rStdDev;
              g.zMean = zMean;
@@ -110,51 +105,38 @@ void addGenerators(Context& ctx) {
            }),
            py::arg("rMean"), py::arg("rStdDev"), py::arg("zMean"),
            py::arg("zStdDev"), py::arg("tMean"), py::arg("tStdDev"))
-      .def_readwrite(
-          "rMean",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::rMean)
-      .def_readwrite(
-          "rStdDev",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::rStdDev)
-      .def_readwrite(
-          "zMean",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::zMean)
-      .def_readwrite(
-          "zStdDev",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::zStdDev)
-      .def_readwrite(
-          "tMean",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::tMean)
-      .def_readwrite(
-          "tStdDev",
-          &ActsExamples::GaussianDisplacedVertexPositionGenerator::tStdDev);
+      .def_readwrite("rMean", &GaussianDisplacedVertexPositionGenerator::rMean)
+      .def_readwrite("rStdDev",
+                     &GaussianDisplacedVertexPositionGenerator::rStdDev)
+      .def_readwrite("zMean", &GaussianDisplacedVertexPositionGenerator::zMean)
+      .def_readwrite("zStdDev",
+                     &GaussianDisplacedVertexPositionGenerator::zStdDev)
+      .def_readwrite("tMean", &GaussianDisplacedVertexPositionGenerator::tMean)
+      .def_readwrite("tStdDev",
+                     &GaussianDisplacedVertexPositionGenerator::tStdDev);
 
-  py::class_<
-      ActsExamples::FixedPrimaryVertexPositionGenerator,
-      ActsExamples::PrimaryVertexPositionGenerator,
-      std::shared_ptr<ActsExamples::FixedPrimaryVertexPositionGenerator>>(
+  py::class_<FixedPrimaryVertexPositionGenerator,
+             PrimaryVertexPositionGenerator,
+             std::shared_ptr<FixedPrimaryVertexPositionGenerator>>(
       mex, "FixedVertexGenerator")
       .def(py::init<>())
-      .def(py::init([](const Acts::Vector4& v) {
-             ActsExamples::FixedPrimaryVertexPositionGenerator g;
+      .def(py::init([](const Vector4& v) {
+             FixedPrimaryVertexPositionGenerator g;
              g.fixed = v;
              return g;
            }),
            py::arg("fixed"))
-      .def_readwrite("fixed",
-                     &ActsExamples::FixedPrimaryVertexPositionGenerator::fixed);
+      .def_readwrite("fixed", &FixedPrimaryVertexPositionGenerator::fixed);
 
-  py::class_<ActsExamples::SimParticle>(mex, "SimParticle");
-  py::class_<ActsExamples::SimParticleContainer>(mex, "SimParticleContainer");
+  py::class_<SimParticle>(mex, "SimParticle");
+  py::class_<SimParticleContainer>(mex, "SimParticleContainer");
 
   {
-    using Config = ActsExamples::ParametricParticleGenerator::Config;
-    auto gen =
-        py::class_<ActsExamples::ParametricParticleGenerator,
-                   ActsExamples::ParticlesGenerator,
-                   std::shared_ptr<ActsExamples::ParametricParticleGenerator>>(
-            mex, "ParametricParticleGenerator")
-            .def(py::init<const Config&>());
+    using Config = ParametricParticleGenerator::Config;
+    auto gen = py::class_<ParametricParticleGenerator, ParticlesGenerator,
+                          std::shared_ptr<ParametricParticleGenerator>>(
+                   mex, "ParametricParticleGenerator")
+                   .def(py::init<const Config&>());
 
     py::class_<Config>(gen, "Config")
         .def(py::init<>())
@@ -195,40 +177,38 @@ void addGenerators(Context& ctx) {
         .def_property(
             "eta",
             [](Config& cfg) {
-              return std::pair{Acts::AngleHelpers::etaFromTheta(cfg.thetaMin),
-                               Acts::AngleHelpers::etaFromTheta(cfg.thetaMax)};
+              return std::pair{AngleHelpers::etaFromTheta(cfg.thetaMin),
+                               AngleHelpers::etaFromTheta(cfg.thetaMax)};
             },
             [](Config& cfg, std::pair<double, double> value) {
-              cfg.thetaMin = Acts::AngleHelpers::thetaFromEta(value.first);
-              cfg.thetaMax = Acts::AngleHelpers::thetaFromEta(value.second);
+              cfg.thetaMin = AngleHelpers::thetaFromEta(value.first);
+              cfg.thetaMax = AngleHelpers::thetaFromEta(value.second);
             });
   }
 
-  py::class_<ActsExamples::FixedMultiplicityGenerator,
-             ActsExamples::MultiplicityGenerator,
-             std::shared_ptr<ActsExamples::FixedMultiplicityGenerator>>(
+  py::class_<FixedMultiplicityGenerator, MultiplicityGenerator,
+             std::shared_ptr<FixedMultiplicityGenerator>>(
       mex, "FixedMultiplicityGenerator")
       .def(py::init<>())
       .def(py::init([](std::size_t n) {
-             ActsExamples::FixedMultiplicityGenerator g;
+             FixedMultiplicityGenerator g;
              g.n = n;
              return g;
            }),
            py::arg("n"))
-      .def_readwrite("n", &ActsExamples::FixedMultiplicityGenerator::n);
+      .def_readwrite("n", &FixedMultiplicityGenerator::n);
 
-  py::class_<ActsExamples::PoissonMultiplicityGenerator,
-             ActsExamples::MultiplicityGenerator,
-             std::shared_ptr<ActsExamples::PoissonMultiplicityGenerator>>(
+  py::class_<PoissonMultiplicityGenerator, MultiplicityGenerator,
+             std::shared_ptr<PoissonMultiplicityGenerator>>(
       mex, "PoissonMultiplicityGenerator")
       .def(py::init<>())
       .def(py::init([](double mean) {
-             ActsExamples::PoissonMultiplicityGenerator g;
+             PoissonMultiplicityGenerator g;
              g.mean = mean;
              return g;
            }),
            py::arg("mean"))
-      .def_readwrite("mean", &ActsExamples::PoissonMultiplicityGenerator::mean);
+      .def_readwrite("mean", &PoissonMultiplicityGenerator::mean);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/GeoModel.cpp
+++ b/Examples/Python/src/GeoModel.cpp
@@ -23,7 +23,6 @@
 #include "Acts/Plugins/GeoModel/GeoModelReader.hpp"
 #include "Acts/Plugins/GeoModel/GeoModelTree.hpp"
 #include "Acts/Plugins/GeoModel/IGeoShapeConverter.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Surfaces/AnnulusBounds.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/PlaneSurface.hpp"
@@ -32,6 +31,8 @@
 #include "ActsExamples/GeoModelDetector/GeoModelMuonMockupBuilder.hpp"
 #include "ActsExamples/ITkModuleSplitting/ITkModuleSplitting.hpp"
 #include "ActsExamples/MuonSpectrometerMockupDetector/GeoMuonMockupExperiment.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <string>
 
@@ -43,7 +44,10 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-namespace Acts::Python {
+using namespace Acts;
+using namespace ActsExamples;
+
+namespace ActsPython {
 
 void addGeoModel(Context& ctx) {
   auto m = ctx.get("main");
@@ -55,30 +59,28 @@ void addGeoModel(Context& ctx) {
       .def("get", &GeoModelTree::FpvConstLink::get,
            py::return_value_policy::reference);
 
-  py::class_<Acts::GeoModelTree>(gm, "GeoModelTree").def(py::init<>());
+  py::class_<GeoModelTree>(gm, "GeoModelTree").def(py::init<>());
 
-  gm.def("readFromDb", &Acts::GeoModelReader::readFromDb);
+  gm.def("readFromDb", &GeoModelReader::readFromDb);
 
-  py::class_<Acts::GeoModelDetectorElement,
-             std::shared_ptr<Acts::GeoModelDetectorElement>>(
+  py::class_<GeoModelDetectorElement, std::shared_ptr<GeoModelDetectorElement>>(
       gm, "GeoModelDetectorElement")
-      .def("logVolName", &Acts::GeoModelDetectorElement::logVolName)
-      .def("databaseEntryName",
-           &Acts::GeoModelDetectorElement::databaseEntryName)
-      .def("surface", [](Acts::GeoModelDetectorElement self) {
+      .def("logVolName", &GeoModelDetectorElement::logVolName)
+      .def("databaseEntryName", &GeoModelDetectorElement::databaseEntryName)
+      .def("surface", [](GeoModelDetectorElement self) {
         return self.surface().getSharedPtr();
       });
 
   {
-    auto f = py::class_<ActsExamples::GeoModelDetector, ActsExamples::Detector,
-                        std::shared_ptr<ActsExamples::GeoModelDetector>>(
-                 gm, "GeoModelDetector")
-                 .def(py::init<const ActsExamples::GeoModelDetector::Config&>())
-                 .def("buildTrackingGeometry",
-                      &ActsExamples::GeoModelDetector::buildTrackingGeometry);
+    auto f =
+        py::class_<GeoModelDetector, Detector,
+                   std::shared_ptr<GeoModelDetector>>(gm, "GeoModelDetector")
+            .def(py::init<const GeoModelDetector::Config&>())
+            .def("buildTrackingGeometry",
+                 &GeoModelDetector::buildTrackingGeometry);
 
-    auto c = py::class_<ActsExamples::GeoModelDetector::Config>(f, "Config")
-                 .def(py::init<>());
+    auto c =
+        py::class_<GeoModelDetector::Config>(f, "Config").def(py::init<>());
     ACTS_PYTHON_STRUCT(c, geoModelTree, logLevel, path);
 
     // patch the constructor
@@ -86,26 +88,22 @@ void addGeoModel(Context& ctx) {
   }
   {
     // GeomodelMuonMockupBuilder
-    py::class_<Acts::ITrackingGeometryBuilder,
-               std::shared_ptr<Acts::ITrackingGeometryBuilder>>(
+    py::class_<ITrackingGeometryBuilder,
+               std::shared_ptr<ITrackingGeometryBuilder>>(
         gm, "ITrackingGeometryBuilder");
     auto gmMuonBuilder =
-        py::class_<ActsExamples::GeoModelMuonMockupBuilder,
-                   Acts::ITrackingGeometryBuilder,
-                   std::shared_ptr<ActsExamples::GeoModelMuonMockupBuilder>>(
+        py::class_<GeoModelMuonMockupBuilder, ITrackingGeometryBuilder,
+                   std::shared_ptr<GeoModelMuonMockupBuilder>>(
             gm, "GeoModelMuonMockupBuilder")
-            .def(py::init([](const ActsExamples::GeoModelMuonMockupBuilder::
-                                 Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
-              return std::make_shared<ActsExamples::GeoModelMuonMockupBuilder>(
+            .def(py::init([](const GeoModelMuonMockupBuilder::Config& config,
+                             const std::string& name, Logging::Level level) {
+              return std::make_shared<GeoModelMuonMockupBuilder>(
                   config, getDefaultLogger(name, level));
             }))
             .def("trackingGeometry",
-                 &ActsExamples::GeoModelMuonMockupBuilder::trackingGeometry);
+                 &GeoModelMuonMockupBuilder::trackingGeometry);
     auto gmMuonConfig =
-        py::class_<ActsExamples::GeoModelMuonMockupBuilder::Config>(
-            gmMuonBuilder, "Config")
+        py::class_<GeoModelMuonMockupBuilder::Config>(gmMuonBuilder, "Config")
             .def(py::init<>());
     ACTS_PYTHON_STRUCT(gmMuonConfig, volumeBoxFPVs, stationNames,
                        volumeBoundFactory);
@@ -113,71 +111,64 @@ void addGeoModel(Context& ctx) {
 
   // Shape converters
   {
-    py::class_<Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::IGeoShapeConverter>>(gm,
-                                                          "IGeoShapeConverter");
+    py::class_<IGeoShapeConverter, std::shared_ptr<IGeoShapeConverter>>(
+        gm, "IGeoShapeConverter");
 
-    py::class_<Acts::GeoBoxConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoBoxConverter>>(gm, "GeoBoxConverter")
+    py::class_<GeoBoxConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoBoxConverter>>(gm, "GeoBoxConverter")
         .def(py::init<>())
-        .def("toSensitiveSurface", &Acts::GeoBoxConverter::toSensitiveSurface)
-        .def("toPassiveSurface", &Acts::GeoBoxConverter::toPassiveSurface);
+        .def("toSensitiveSurface", &GeoBoxConverter::toSensitiveSurface)
+        .def("toPassiveSurface", &GeoBoxConverter::toPassiveSurface);
 
-    py::class_<Acts::GeoTrdConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoTrdConverter>>(gm, "GeoTrdConverter")
+    py::class_<GeoTrdConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoTrdConverter>>(gm, "GeoTrdConverter")
         .def(py::init<>())
-        .def("toSensitiveSurface", &Acts::GeoTrdConverter::toSensitiveSurface)
-        .def("toPassiveSurface", &Acts::GeoTrdConverter::toPassiveSurface);
+        .def("toSensitiveSurface", &GeoTrdConverter::toSensitiveSurface)
+        .def("toPassiveSurface", &GeoTrdConverter::toPassiveSurface);
 
-    py::class_<Acts::GeoTubeConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoTubeConverter>>(gm, "GeoTubeConverter")
+    py::class_<GeoTubeConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoTubeConverter>>(gm, "GeoTubeConverter")
         .def(py::init<>())
-        .def("toSensitiveSurface", &Acts::GeoTubeConverter::toSensitiveSurface)
-        .def("toPassiveSurface", &Acts::GeoTubeConverter::toPassiveSurface);
+        .def("toSensitiveSurface", &GeoTubeConverter::toSensitiveSurface)
+        .def("toPassiveSurface", &GeoTubeConverter::toPassiveSurface);
 
-    py::class_<Acts::GeoUnionDoubleTrdConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoUnionDoubleTrdConverter>>(
+    py::class_<GeoUnionDoubleTrdConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoUnionDoubleTrdConverter>>(
         gm, "GeoUnionDoubleTrdConverter")
         .def(py::init<>())
         .def("toSensitiveSurface",
-             &Acts::GeoUnionDoubleTrdConverter::toSensitiveSurface)
-        .def("toPassiveSurface",
-             &Acts::GeoUnionDoubleTrdConverter::toPassiveSurface);
+             &GeoUnionDoubleTrdConverter::toSensitiveSurface)
+        .def("toPassiveSurface", &GeoUnionDoubleTrdConverter::toPassiveSurface);
 
-    py::class_<Acts::GeoIntersectionAnnulusConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoIntersectionAnnulusConverter>>(
+    py::class_<GeoIntersectionAnnulusConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoIntersectionAnnulusConverter>>(
         gm, "GeoIntersectionAnnulusConverter")
         .def(py::init<>())
         .def("toSensitiveSurface",
-             &Acts::GeoIntersectionAnnulusConverter::toSensitiveSurface)
+             &GeoIntersectionAnnulusConverter::toSensitiveSurface)
         .def("toPassiveSurface",
-             &Acts::GeoIntersectionAnnulusConverter::toPassiveSurface);
+             &GeoIntersectionAnnulusConverter::toPassiveSurface);
 
-    py::class_<Acts::GeoShiftConverter, Acts::IGeoShapeConverter,
-               std::shared_ptr<Acts::GeoShiftConverter>>(gm,
-                                                         "GeoShiftConverter")
+    py::class_<GeoShiftConverter, IGeoShapeConverter,
+               std::shared_ptr<GeoShiftConverter>>(gm, "GeoShiftConverter")
         .def(py::init<>())
-        .def("toSensitiveSurface", &Acts::GeoShiftConverter::toSensitiveSurface)
-        .def("toPassiveSurface", &Acts::GeoShiftConverter::toPassiveSurface);
+        .def("toSensitiveSurface", &GeoShiftConverter::toSensitiveSurface)
+        .def("toPassiveSurface", &GeoShiftConverter::toPassiveSurface);
   }
   {
     // GeoMuonMockupExperiment
     auto f =
-        py::class_<ActsExamples::GeoMuonMockupExperiment,
-                   std::shared_ptr<ActsExamples::GeoMuonMockupExperiment>>(
+        py::class_<GeoMuonMockupExperiment,
+                   std::shared_ptr<GeoMuonMockupExperiment>>(
             gm, "GeoMuonMockupExperiment")
-            .def(py::init(
-                [](const ActsExamples::GeoMuonMockupExperiment::Config& config,
-                   const std::string& name, Acts::Logging::Level level) {
-                  return std::make_shared<
-                      ActsExamples::GeoMuonMockupExperiment>(
-                      config, getDefaultLogger(name, level));
-                }))
-            .def("constructMS",
-                 &ActsExamples::GeoMuonMockupExperiment::constructMS);
-    auto c =
-        py::class_<ActsExamples::GeoMuonMockupExperiment::Config>(f, "Config")
-            .def(py::init<>());
+            .def(py::init([](const GeoMuonMockupExperiment::Config& config,
+                             const std::string& name, Logging::Level level) {
+              return std::make_shared<GeoMuonMockupExperiment>(
+                  config, getDefaultLogger(name, level));
+            }))
+            .def("constructMS", &GeoMuonMockupExperiment::constructMS);
+    auto c = py::class_<GeoMuonMockupExperiment::Config>(f, "Config")
+                 .def(py::init<>());
     ACTS_PYTHON_STRUCT(c,
                        /// General properties
                        dumpTree, dbName,
@@ -194,147 +185,134 @@ void addGeoModel(Context& ctx) {
   // Volume factory
   {
     auto a =
-        py::class_<Acts::GeoModelDetectorObjectFactory,
-                   std::shared_ptr<Acts::GeoModelDetectorObjectFactory>>(
+        py::class_<GeoModelDetectorObjectFactory,
+                   std::shared_ptr<GeoModelDetectorObjectFactory>>(
             gm, "GeoModelDetectorObjectFactory")
-            .def(py::init(
-                [](const Acts::GeoModelDetectorObjectFactory::Config& cfg,
-                   Acts::Logging::Level level) {
-                  return std::make_shared<Acts::GeoModelDetectorObjectFactory>(
-                      cfg, Acts::getDefaultLogger(
-                               "GeoModelDetectorObjectFactory", level));
-                }))
-            .def("construct", &Acts::GeoModelDetectorObjectFactory::construct);
+            .def(py::init([](const GeoModelDetectorObjectFactory::Config& cfg,
+                             Logging::Level level) {
+              return std::make_shared<GeoModelDetectorObjectFactory>(
+                  cfg,
+                  getDefaultLogger("GeoModelDetectorObjectFactory", level));
+            }))
+            .def("construct", &GeoModelDetectorObjectFactory::construct);
 
-    py::class_<Acts::GeoModelDetectorObjectFactory::Config>(a, "Config")
+    py::class_<GeoModelDetectorObjectFactory::Config>(a, "Config")
         .def(py::init<>())
         .def_readwrite(
             "convertSubVolumes",
-            &Acts::GeoModelDetectorObjectFactory::Config::convertSubVolumes)
+            &GeoModelDetectorObjectFactory::Config::convertSubVolumes)
         .def_readwrite("nameList",
-                       &Acts::GeoModelDetectorObjectFactory::Config::nameList)
+                       &GeoModelDetectorObjectFactory::Config::nameList)
         .def_readwrite("convertBox",
-                       &Acts::GeoModelDetectorObjectFactory::Config::convertBox)
-        .def_readwrite(
-            "materialList",
-            &Acts::GeoModelDetectorObjectFactory::Config::materialList);
+                       &GeoModelDetectorObjectFactory::Config::convertBox)
+        .def_readwrite("materialList",
+                       &GeoModelDetectorObjectFactory::Config::materialList);
 
-    auto convVol =
-        py::class_<Acts::GeoModelDetectorObjectFactory::ConvertedGeoVol>(
-            a, "ConvertedGeoVol");
+    auto convVol = py::class_<GeoModelDetectorObjectFactory::ConvertedGeoVol>(
+        a, "ConvertedGeoVol");
 
     ACTS_PYTHON_STRUCT(convVol, volume, gen2Volume, fullPhysVol, name,
                        surfaces);
-    py::class_<Acts::GeoModelDetectorObjectFactory::Cache>(a, "Cache")
+    py::class_<GeoModelDetectorObjectFactory::Cache>(a, "Cache")
         .def(py::init<>())
-        .def_readwrite(
-            "sensitiveSurfaces",
-            &Acts::GeoModelDetectorObjectFactory::Cache::sensitiveSurfaces)
-        .def_readwrite(
-            "boundingBoxes",
-            &Acts::GeoModelDetectorObjectFactory::Cache::volumeBoxFPVs);
+        .def_readwrite("sensitiveSurfaces",
+                       &GeoModelDetectorObjectFactory::Cache::sensitiveSurfaces)
+        .def_readwrite("boundingBoxes",
+                       &GeoModelDetectorObjectFactory::Cache::volumeBoxFPVs);
 
-    py::class_<Acts::GeoModelDetectorObjectFactory::Options>(a, "Options")
+    py::class_<GeoModelDetectorObjectFactory::Options>(a, "Options")
         .def(py::init<>())
         .def_readwrite("queries",
-                       &Acts::GeoModelDetectorObjectFactory::Options::queries);
+                       &GeoModelDetectorObjectFactory::Options::queries);
   }
 
   {
-    py::class_<Acts::GeoModelBlueprintCreater::Blueprint,
-               std::shared_ptr<Acts::GeoModelBlueprintCreater::Blueprint>>(
+    py::class_<GeoModelBlueprintCreater::Blueprint,
+               std::shared_ptr<GeoModelBlueprintCreater::Blueprint>>(
         gm, "Blueprint")
-        .def("convertToBuilder",
-             [](Acts::GeoModelBlueprintCreater::Blueprint& self,
-                Acts::Logging::Level level) {
-               // It's a container builder
-               return std::make_shared<
-                   Acts::Experimental::CylindricalContainerBuilder>(self.node(),
-                                                                    level);
-             });
+        .def("convertToBuilder", [](GeoModelBlueprintCreater::Blueprint& self,
+                                    Logging::Level level) {
+          // It's a container builder
+          return std::make_shared<Experimental::CylindricalContainerBuilder>(
+              self.node(), level);
+        });
 
     auto bpc =
-        py::class_<Acts::GeoModelBlueprintCreater,
-                   std::shared_ptr<Acts::GeoModelBlueprintCreater>>(
+        py::class_<GeoModelBlueprintCreater,
+                   std::shared_ptr<GeoModelBlueprintCreater>>(
             gm, "GeoModelBlueprintCreater")
-            .def(py::init([](const Acts::GeoModelBlueprintCreater::Config& cfg,
-                             Acts::Logging::Level level) {
-              return std::make_shared<Acts::GeoModelBlueprintCreater>(
-                  cfg,
-                  Acts::getDefaultLogger("GeoModelBlueprintCreater", level));
+            .def(py::init([](const GeoModelBlueprintCreater::Config& cfg,
+                             Logging::Level level) {
+              return std::make_shared<GeoModelBlueprintCreater>(
+                  cfg, getDefaultLogger("GeoModelBlueprintCreater", level));
             }))
-            .def("create", &Acts::GeoModelBlueprintCreater::create);
+            .def("create", &GeoModelBlueprintCreater::create);
 
-    py::class_<Acts::GeoModelBlueprintCreater::Config>(bpc, "Config")
+    py::class_<GeoModelBlueprintCreater::Config>(bpc, "Config")
         .def(py::init<>())
-        .def_readwrite(
-            "detectorSurfaces",
-            &Acts::GeoModelBlueprintCreater::Config::detectorSurfaces)
+        .def_readwrite("detectorSurfaces",
+                       &GeoModelBlueprintCreater::Config::detectorSurfaces)
         .def_readwrite("kdtBinning",
-                       &Acts::GeoModelBlueprintCreater::Config::kdtBinning);
+                       &GeoModelBlueprintCreater::Config::kdtBinning);
 
-    py::class_<Acts::GeoModelBlueprintCreater::Options>(bpc, "Options")
+    py::class_<GeoModelBlueprintCreater::Options>(bpc, "Options")
         .def(py::init<>())
-        .def_readwrite("topEntry",
-                       &Acts::GeoModelBlueprintCreater::Options::topEntry)
-        .def_readwrite(
-            "topBoundsOverride",
-            &Acts::GeoModelBlueprintCreater::Options::topBoundsOverride)
-        .def_readwrite("table", &Acts::GeoModelBlueprintCreater::Options::table)
+        .def_readwrite("topEntry", &GeoModelBlueprintCreater::Options::topEntry)
+        .def_readwrite("topBoundsOverride",
+                       &GeoModelBlueprintCreater::Options::topBoundsOverride)
+        .def_readwrite("table", &GeoModelBlueprintCreater::Options::table)
         .def_readwrite("dotGraph",
-                       &Acts::GeoModelBlueprintCreater::Options::dotGraph);
+                       &GeoModelBlueprintCreater::Options::dotGraph);
   }
 
   gm.def(
       "splitBarrelModule",
-      [](const Acts::GeometryContext& gctx,
+      [](const GeometryContext& gctx,
          std::shared_ptr<const GeoModelDetectorElement> detElement,
-         unsigned nSegments, Acts::Logging::Level logLevel) {
-        auto logger = Acts::getDefaultLogger("ITkSlitBarrel", logLevel);
+         unsigned nSegments, Logging::Level logLevel) {
+        auto logger = getDefaultLogger("ITkSlitBarrel", logLevel);
         auto name = detElement->databaseEntryName();
 
         auto factory = [&](const auto& trafo, const auto& bounds) {
-          return Acts::GeoModelDetectorElement::createDetectorElement<
-              Acts::PlaneSurface, Acts::RectangleBounds>(
-              detElement->physicalVolume(), bounds, trafo,
-              detElement->thickness());
+          return GeoModelDetectorElement::createDetectorElement<
+              PlaneSurface, RectangleBounds>(detElement->physicalVolume(),
+                                             bounds, trafo,
+                                             detElement->thickness());
         };
 
-        return ActsExamples::ITk::splitBarrelModule(gctx, detElement, nSegments,
-                                                    factory, name, *logger);
+        return ITk::splitBarrelModule(gctx, detElement, nSegments, factory,
+                                      name, *logger);
       },
-      "gxtx"_a, "detElement"_a, "nSegments"_a,
-      "logLevel"_a = Acts::Logging::INFO);
+      "gxtx"_a, "detElement"_a, "nSegments"_a, "logLevel"_a = Logging::INFO);
 
   gm.def(
       "splitDiscModule",
-      [](const Acts::GeometryContext& gctx,
+      [](const GeometryContext& gctx,
          std::shared_ptr<const GeoModelDetectorElement> detElement,
          const std::vector<std::pair<double, double>>& patterns,
-         Acts::Logging::Level logLevel) {
-        auto logger = Acts::getDefaultLogger("ITkSlitBarrel", logLevel);
+         Logging::Level logLevel) {
+        auto logger = getDefaultLogger("ITkSlitBarrel", logLevel);
         auto name = detElement->databaseEntryName();
 
         auto factory = [&](const auto& trafo, const auto& bounds) {
-          return Acts::GeoModelDetectorElement::createDetectorElement<
-              Acts::DiscSurface, Acts::AnnulusBounds>(
+          return GeoModelDetectorElement::createDetectorElement<DiscSurface,
+                                                                AnnulusBounds>(
               detElement->physicalVolume(), bounds, trafo,
               detElement->thickness());
         };
 
-        return ActsExamples::ITk::splitDiscModule(gctx, detElement, patterns,
-                                                  factory, name, *logger);
+        return ITk::splitDiscModule(gctx, detElement, patterns, factory, name,
+                                    *logger);
       },
-      "gxtx"_a, "detElement"_a, "splitRanges"_a,
-      "logLevel"_a = Acts::Logging::INFO);
+      "gxtx"_a, "detElement"_a, "splitRanges"_a, "logLevel"_a = Logging::INFO);
 
-  py::class_<Acts::GeoModelDetectorElementITk,
-             std::shared_ptr<Acts::GeoModelDetectorElementITk>>(
+  py::class_<GeoModelDetectorElementITk,
+             std::shared_ptr<GeoModelDetectorElementITk>>(
       gm, "GeoModelDetectorElementITk")
-      .def("surface", [](Acts::GeoModelDetectorElementITk& self) {
+      .def("surface", [](GeoModelDetectorElementITk& self) {
         return self.surface().getSharedPtr();
       });
   gm.def("convertToItk", &GeoModelDetectorElementITk::convertFromGeomodel);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/GeoModelStub.cpp
+++ b/Examples/Python/src/GeoModelStub.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
 void addGeoModel(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Geometry.cpp
+++ b/Examples/Python/src/Geometry.cpp
@@ -41,7 +41,6 @@
 #include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
 #include "Acts/Material/ISurfaceMaterial.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
@@ -49,6 +48,8 @@
 #include "Acts/Utilities/RangeXD.hpp"
 #include "Acts/Visualization/ViewConfig.hpp"
 #include "ActsExamples/Geometry/VolumeAssociationTest.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <array>
 #include <memory>
@@ -63,23 +64,25 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+using namespace Acts;
+using namespace ActsExamples;
+
 namespace {
-struct GeometryIdentifierHookBinding : public Acts::GeometryIdentifierHook {
+struct GeometryIdentifierHookBinding : public GeometryIdentifierHook {
   py::object callable;
 
-  Acts::GeometryIdentifier decorateIdentifier(
-      Acts::GeometryIdentifier identifier,
-      const Acts::Surface& surface) const override {
+  GeometryIdentifier decorateIdentifier(GeometryIdentifier identifier,
+                                        const Surface& surface) const override {
     return callable(identifier, surface.getSharedPtr())
-        .cast<Acts::GeometryIdentifier>();
+        .cast<GeometryIdentifier>();
   }
 };
 
 struct MaterialSurfaceSelector {
-  std::vector<const Acts::Surface*> surfaces = {};
+  std::vector<const Surface*> surfaces = {};
 
   /// @param surface is the test surface
-  void operator()(const Acts::Surface* surface) {
+  void operator()(const Surface* surface) {
     if (surface->surfaceMaterial() != nullptr &&
         !rangeContainsValue(surfaces, surface)) {
       surfaces.push_back(surface);
@@ -88,9 +91,9 @@ struct MaterialSurfaceSelector {
 };
 
 struct IdentifierSurfacesCollector {
-  std::unordered_map<Acts::GeometryIdentifier, const Acts::Surface*> surfaces;
+  std::unordered_map<GeometryIdentifier, const Surface*> surfaces;
   /// @param surface is the test surface
-  void operator()(const Acts::Surface* surface) {
+  void operator()(const Surface* surface) {
     surfaces[surface->geometryId()] = surface;
   }
 };
@@ -106,25 +109,22 @@ struct IdentifierSurfacesCollector {
 
 // We only implement the mutable visitor here, because pybind11 always casts
 // away const ness in any case
-class PyTrackingGeometryVisitor : public Acts::TrackingGeometryMutableVisitor {
+class PyTrackingGeometryVisitor : public TrackingGeometryMutableVisitor {
  public:
-  void visitVolume(Acts::TrackingVolume& volume) override {
-    _INVOKE(Acts::TrackingGeometryMutableVisitor::visitVolume, "visitVolume",
-            volume);
+  void visitVolume(TrackingVolume& volume) override {
+    _INVOKE(TrackingGeometryMutableVisitor::visitVolume, "visitVolume", volume);
   }
 
-  void visitPortal(Acts::Portal& portal) override {
-    _INVOKE(Acts::TrackingGeometryMutableVisitor::visitPortal, "visitPortal",
-            portal);
+  void visitPortal(Portal& portal) override {
+    _INVOKE(TrackingGeometryMutableVisitor::visitPortal, "visitPortal", portal);
   }
 
-  void visitLayer(Acts::Layer& layer) override {
-    _INVOKE(Acts::TrackingGeometryMutableVisitor::visitLayer, "visitLayer",
-            layer);
+  void visitLayer(Layer& layer) override {
+    _INVOKE(TrackingGeometryMutableVisitor::visitLayer, "visitLayer", layer);
   }
 
-  void visitSurface(Acts::Surface& surface) override {
-    _INVOKE(Acts::TrackingGeometryMutableVisitor::visitSurface, "visitSurface",
+  void visitSurface(Surface& surface) override {
+    _INVOKE(TrackingGeometryMutableVisitor::visitSurface, "visitSurface",
             surface);
   }
 };
@@ -133,19 +133,19 @@ class PyTrackingGeometryVisitor : public Acts::TrackingGeometryMutableVisitor {
 
 }  // namespace
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addBlueprint(Context& ctx);
 
 void addGeometry(Context& ctx) {
   auto m = ctx.get("main");
   {
-    py::class_<Acts::GeometryIdentifier>(m, "GeometryIdentifier")
+    py::class_<GeometryIdentifier>(m, "GeometryIdentifier")
         .def(py::init<>())
-        .def(py::init<Acts::GeometryIdentifier::Value>())
+        .def(py::init<GeometryIdentifier::Value>())
         .def(py::init([](int volume, int boundary, int layer, int approach,
                          int sensitive, int extra) {
-               return Acts::GeometryIdentifier()
+               return GeometryIdentifier()
                    .withVolume(volume)
                    .withBoundary(boundary)
                    .withLayer(layer)
@@ -157,37 +157,37 @@ void addGeometry(Context& ctx) {
              py::arg("layer") = 0, py::arg("approach") = 0,
              py::arg("sensitive") = 0, py::arg("extra") = 0)
         .def_property(
-            "layer", &Acts::GeometryIdentifier::layer,
+            "layer", &GeometryIdentifier::layer,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withLayer(value);
             })
         .def_property(
-            "volume", &Acts::GeometryIdentifier::volume,
+            "volume", &GeometryIdentifier::volume,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withVolume(value);
             })
         .def_property(
-            "boundary", &Acts::GeometryIdentifier::boundary,
+            "boundary", &GeometryIdentifier::boundary,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withBoundary(value);
             })
         .def_property(
-            "approach", &Acts::GeometryIdentifier::approach,
+            "approach", &GeometryIdentifier::approach,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withApproach(value);
             })
         .def_property(
-            "sensitive", &Acts::GeometryIdentifier::sensitive,
+            "sensitive", &GeometryIdentifier::sensitive,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withSensitive(value);
             })
         .def_property(
-            "extra", &Acts::GeometryIdentifier::extra,
+            "extra", &GeometryIdentifier::extra,
             [](GeometryIdentifier& self, GeometryIdentifier::Value value) {
               self = self.withExtra(value);
             })
-        .def_property_readonly("value", &Acts::GeometryIdentifier::value)
-        .def("__str__", [](const Acts::GeometryIdentifier& self) {
+        .def_property_readonly("value", &GeometryIdentifier::value)
+        .def("__str__", [](const GeometryIdentifier& self) {
           std::stringstream ss;
           ss << self;
           return ss.str();
@@ -195,7 +195,7 @@ void addGeometry(Context& ctx) {
   }
 
   {
-    py::class_<Acts::Surface, std::shared_ptr<Acts::Surface>>(m, "Surface")
+    py::class_<Surface, std::shared_ptr<Surface>>(m, "Surface")
         // Can't bind directly because GeometryObject is virtual base of Surface
         .def_property_readonly(
             "geometryId", [](const Surface& self) { return self.geometryId(); })
@@ -203,64 +203,60 @@ void addGeometry(Context& ctx) {
         .def_property_readonly("type", &Surface::type)
         .def("visualize", &Surface::visualize)
         .def_property_readonly("surfaceMaterial",
-                               &Acts::Surface::surfaceMaterialSharedPtr);
+                               &Surface::surfaceMaterialSharedPtr);
   }
 
   {
-    py::enum_<Acts::Surface::SurfaceType>(m, "SurfaceType")
-        .value("Cone", Acts::Surface::SurfaceType::Cone)
-        .value("Cylinder", Acts::Surface::SurfaceType::Cylinder)
-        .value("Disc", Acts::Surface::SurfaceType::Disc)
-        .value("Perigee", Acts::Surface::SurfaceType::Perigee)
-        .value("Plane", Acts::Surface::SurfaceType::Plane)
-        .value("Straw", Acts::Surface::SurfaceType::Straw)
-        .value("Curvilinear", Acts::Surface::SurfaceType::Curvilinear)
-        .value("Other", Acts::Surface::SurfaceType::Other);
+    py::enum_<Surface::SurfaceType>(m, "SurfaceType")
+        .value("Cone", Surface::SurfaceType::Cone)
+        .value("Cylinder", Surface::SurfaceType::Cylinder)
+        .value("Disc", Surface::SurfaceType::Disc)
+        .value("Perigee", Surface::SurfaceType::Perigee)
+        .value("Plane", Surface::SurfaceType::Plane)
+        .value("Straw", Surface::SurfaceType::Straw)
+        .value("Curvilinear", Surface::SurfaceType::Curvilinear)
+        .value("Other", Surface::SurfaceType::Other);
   }
 
   {
-    py::enum_<Acts::VolumeBounds::BoundsType>(m, "VolumeBoundsType")
-        .value("Cone", Acts::VolumeBounds::BoundsType::eCone)
-        .value("Cuboid", Acts::VolumeBounds::BoundsType::eCuboid)
-        .value("CutoutCylinder",
-               Acts::VolumeBounds::BoundsType::eCutoutCylinder)
-        .value("Cylinder", Acts::VolumeBounds::BoundsType::eCylinder)
-        .value("GenericCuboid", Acts::VolumeBounds::BoundsType::eGenericCuboid)
-        .value("Trapezoid", Acts::VolumeBounds::BoundsType::eTrapezoid)
-        .value("Other", Acts::VolumeBounds::BoundsType::eOther);
+    py::enum_<VolumeBounds::BoundsType>(m, "VolumeBoundsType")
+        .value("Cone", VolumeBounds::BoundsType::eCone)
+        .value("Cuboid", VolumeBounds::BoundsType::eCuboid)
+        .value("CutoutCylinder", VolumeBounds::BoundsType::eCutoutCylinder)
+        .value("Cylinder", VolumeBounds::BoundsType::eCylinder)
+        .value("GenericCuboid", VolumeBounds::BoundsType::eGenericCuboid)
+        .value("Trapezoid", VolumeBounds::BoundsType::eTrapezoid)
+        .value("Other", VolumeBounds::BoundsType::eOther);
   }
 
   {
     auto trkGeo =
-        py::class_<Acts::TrackingGeometry,
-                   std::shared_ptr<Acts::TrackingGeometry>>(m,
-                                                            "TrackingGeometry")
+        py::class_<TrackingGeometry, std::shared_ptr<TrackingGeometry>>(
+            m, "TrackingGeometry")
             .def(py::init([](const MutableTrackingVolumePtr& volPtr,
                              std::shared_ptr<const IMaterialDecorator> matDec,
                              const GeometryIdentifierHook& hook,
-                             Acts::Logging::Level level) {
-              auto logger = Acts::getDefaultLogger("TrackingGeometry", level);
-              auto obj = std::make_shared<Acts::TrackingGeometry>(
+                             Logging::Level level) {
+              auto logger = getDefaultLogger("TrackingGeometry", level);
+              auto obj = std::make_shared<TrackingGeometry>(
                   volPtr, matDec.get(), hook, *logger);
               return obj;
             }))
             .def("visitSurfaces",
-                 [](Acts::TrackingGeometry& self, py::function& func) {
+                 [](TrackingGeometry& self, py::function& func) {
                    self.visitSurfaces(func);
                  })
-            .def("geoIdSurfaceMap", &Acts::TrackingGeometry::geoIdSurfaceMap)
+            .def("geoIdSurfaceMap", &TrackingGeometry::geoIdSurfaceMap)
             .def("extractMaterialSurfaces",
-                 [](Acts::TrackingGeometry& self) {
+                 [](TrackingGeometry& self) {
                    MaterialSurfaceSelector selector;
                    self.visitSurfaces(selector, false);
                    return selector.surfaces;
                  })
-            .def_property_readonly(
-                "highestTrackingVolume",
-                &Acts::TrackingGeometry::highestTrackingVolumePtr)
-            .def("visualize", &Acts::TrackingGeometry::visualize,
-                 py::arg("helper"), py::arg("gctx"),
-                 py::arg("viewConfig") = s_viewVolume,
+            .def_property_readonly("highestTrackingVolume",
+                                   &TrackingGeometry::highestTrackingVolumePtr)
+            .def("visualize", &TrackingGeometry::visualize, py::arg("helper"),
+                 py::arg("gctx"), py::arg("viewConfig") = s_viewVolume,
                  py::arg("portalViewConfig") = s_viewPortal,
                  py::arg("sensitiveViewConfig") = s_viewSensitive);
 
@@ -271,19 +267,17 @@ void addGeometry(Context& ctx) {
   }
 
   {
-    py::class_<Acts::VolumeBounds, std::shared_ptr<Acts::VolumeBounds>>(
-        m, "VolumeBounds")
-        .def("type", &Acts::VolumeBounds::type)
-        .def("__str__", [](const Acts::VolumeBounds& self) {
+    py::class_<VolumeBounds, std::shared_ptr<VolumeBounds>>(m, "VolumeBounds")
+        .def("type", &VolumeBounds::type)
+        .def("__str__", [](const VolumeBounds& self) {
           std::stringstream ss;
           ss << self;
           return ss.str();
         });
 
     auto cvb =
-        py::class_<Acts::CylinderVolumeBounds,
-                   std::shared_ptr<Acts::CylinderVolumeBounds>,
-                   Acts::VolumeBounds>(m, "CylinderVolumeBounds")
+        py::class_<CylinderVolumeBounds, std::shared_ptr<CylinderVolumeBounds>,
+                   VolumeBounds>(m, "CylinderVolumeBounds")
             .def(py::init<double, double, double, double, double, double,
                           double>(),
                  "rmin"_a, "rmax"_a, "halfz"_a, "halfphi"_a = std::numbers::pi,
@@ -300,17 +294,16 @@ void addGeometry(Context& ctx) {
   }
 
   {
-    py::class_<Acts::Volume, std::shared_ptr<Acts::Volume>>(m, "Volume");
+    py::class_<Volume, std::shared_ptr<Volume>>(m, "Volume");
 
-    py::class_<Acts::TrackingVolume, Acts::Volume,
-               std::shared_ptr<Acts::TrackingVolume>>(m, "TrackingVolume")
-        .def(py::init<const Transform3&, std::shared_ptr<Acts::VolumeBounds>,
+    py::class_<TrackingVolume, Volume, std::shared_ptr<TrackingVolume>>(
+        m, "TrackingVolume")
+        .def(py::init<const Transform3&, std::shared_ptr<VolumeBounds>,
                       std::string>());
   }
 
   {
-    py::class_<Acts::GeometryIdentifierHook,
-               std::shared_ptr<Acts::GeometryIdentifierHook>>(
+    py::class_<GeometryIdentifierHook, std::shared_ptr<GeometryIdentifierHook>>(
         m, "GeometryIdentifierHook")
         .def(py::init([](py::object callable) {
           auto hook = std::make_shared<GeometryIdentifierHookBinding>();
@@ -373,12 +366,11 @@ void addGeometry(Context& ctx) {
       .def(py::init<const ExtentEnvelope&>(),
            py::arg("envelope") = ExtentEnvelope::Zero())
       .def("range",
-           [](const Acts::Extent& self,
-              Acts::AxisDirection bval) -> std::array<double, 2> {
+           [](const Extent& self, AxisDirection bval) -> std::array<double, 2> {
              return {self.min(bval), self.max(bval)};
            })
       .def("setRange",
-           [](Extent& self, Acts::AxisDirection bval,
+           [](Extent& self, AxisDirection bval,
               const std::array<double, 2>& range) {
              self.set(bval, range[0], range[1]);
            })
@@ -404,7 +396,7 @@ void addGeometry(Context& ctx) {
 void addExperimentalGeometry(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  using namespace Acts::Experimental;
+  using namespace Experimental;
 
   // Detector volume definition
   py::class_<DetectorVolume, std::shared_ptr<DetectorVolume>>(m,
@@ -431,18 +423,18 @@ void addExperimentalGeometry(Context& ctx) {
              return collector.surfaces;
            })
       .def("cylindricalVolumeRepresentation",
-           [](const Detector& self, const Acts::GeometryContext& gctx) {
+           [](const Detector& self, const GeometryContext& gctx) {
              // Loop over the volumes and gather the extent
              Extent extent;
              for (const auto& volume : self.volumes()) {
                extent.extend(volume->extent(gctx));
              }
-             auto bounds = std::make_shared<Acts::CylinderVolumeBounds>(
-                 0., extent.max(Acts::AxisDirection::AxisR),
-                 extent.max(Acts::AxisDirection::AxisZ));
+             auto bounds = std::make_shared<CylinderVolumeBounds>(
+                 0., extent.max(AxisDirection::AxisR),
+                 extent.max(AxisDirection::AxisZ));
 
-             return std::make_shared<Acts::Volume>(Transform3::Identity(),
-                                                   std::move(bounds));
+             return std::make_shared<Volume>(Transform3::Identity(),
+                                             std::move(bounds));
            });
 
   // Portal definition
@@ -451,8 +443,7 @@ void addExperimentalGeometry(Context& ctx) {
 
   {
     // The surface hierarchy map
-    using SurfaceHierarchyMap =
-        Acts::GeometryHierarchyMap<std::shared_ptr<Surface>>;
+    using SurfaceHierarchyMap = GeometryHierarchyMap<std::shared_ptr<Surface>>;
 
     py::class_<SurfaceHierarchyMap, std::shared_ptr<SurfaceHierarchyMap>>(
         m, "SurfaceHierarchyMap");
@@ -479,39 +470,36 @@ void addExperimentalGeometry(Context& ctx) {
   {
     // Be able to construct a proto binning
     py::class_<ProtoAxis>(m, "ProtoAxis")
-        .def(py::init<Acts::AxisBoundaryType, const std::vector<double>&>(),
+        .def(py::init<AxisBoundaryType, const std::vector<double>&>(),
              "bType"_a, "e"_a)
-        .def(py::init<Acts::AxisBoundaryType, double, double, std::size_t>(),
+        .def(py::init<AxisBoundaryType, double, double, std::size_t>(),
              "bType"_a, "minE"_a, "maxE"_a, "nbins"_a)
-        .def(py::init<Acts::AxisBoundaryType, std::size_t>(), "bType"_a,
-             "nbins"_a);
+        .def(py::init<AxisBoundaryType, std::size_t>(), "bType"_a, "nbins"_a);
 
     py::class_<DirectedProtoAxis>(m, "DirectedProtoAxis")
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType,
+        .def(py::init<AxisDirection, AxisBoundaryType,
                       const std::vector<double>&>(),
              "bValue"_a, "bType"_a, "e"_a)
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType, double,
-                      double, std::size_t>(),
-             "bValue"_a, "bType"_a, "minE"_a, "maxE"_a, "nbins"_a)
-        .def(py::init<Acts::AxisDirection, Acts::AxisBoundaryType,
+        .def(py::init<AxisDirection, AxisBoundaryType, double, double,
                       std::size_t>(),
+             "bValue"_a, "bType"_a, "minE"_a, "maxE"_a, "nbins"_a)
+        .def(py::init<AxisDirection, AxisBoundaryType, std::size_t>(),
              "bValue"_a, "bType"_a, "nbins"_a);
   }
 
   {
     // The internal layer structure builder
-    py::class_<Acts::Experimental::IInternalStructureBuilder,
-               std::shared_ptr<Acts::Experimental::IInternalStructureBuilder>>(
+    py::class_<Experimental::IInternalStructureBuilder,
+               std::shared_ptr<Experimental::IInternalStructureBuilder>>(
         m, "IInternalStructureBuilder");
 
     auto lsBuilder =
         py::class_<LayerStructureBuilder,
-                   Acts::Experimental::IInternalStructureBuilder,
+                   Experimental::IInternalStructureBuilder,
                    std::shared_ptr<LayerStructureBuilder>>(
             m, "LayerStructureBuilder")
             .def(py::init([](const LayerStructureBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<LayerStructureBuilder>(
                   config, getDefaultLogger(name, level));
             }));
@@ -523,22 +511,22 @@ void addExperimentalGeometry(Context& ctx) {
                        quarterSegments, auxiliary);
 
     // The internal layer structure builder
-    py::class_<Acts::Experimental::ISurfacesProvider,
-               std::shared_ptr<Acts::Experimental::ISurfacesProvider>>(
+    py::class_<Experimental::ISurfacesProvider,
+               std::shared_ptr<Experimental::ISurfacesProvider>>(
         m, "ISurfacesProvider");
 
     py::class_<LayerStructureBuilder::SurfacesHolder,
-               Acts::Experimental::ISurfacesProvider,
+               Experimental::ISurfacesProvider,
                std::shared_ptr<LayerStructureBuilder::SurfacesHolder>>(
         lsBuilder, "SurfacesHolder")
         .def(py::init<std::vector<std::shared_ptr<Surface>>>());
   }
 
   {
-    using RangeXDDim1 = Acts::RangeXD<1u, double>;
-    using KdtSurfacesDim1Bin100 = Acts::Experimental::KdtSurfaces<1u, 100u>;
+    using RangeXDDim1 = RangeXD<1u, double>;
+    using KdtSurfacesDim1Bin100 = Experimental::KdtSurfaces<1u, 100u>;
     using KdtSurfacesProviderDim1Bin100 =
-        Acts::Experimental::KdtSurfacesProvider<1u, 100u>;
+        Experimental::KdtSurfacesProvider<1u, 100u>;
 
     py::class_<RangeXDDim1>(m, "RangeXDDim1")
         .def(py::init([](const std::array<double, 2u>& irange) {
@@ -550,23 +538,22 @@ void addExperimentalGeometry(Context& ctx) {
     py::class_<KdtSurfacesDim1Bin100, std::shared_ptr<KdtSurfacesDim1Bin100>>(
         m, "KdtSurfacesDim1Bin100")
         .def(py::init<const GeometryContext&,
-                      const std::vector<std::shared_ptr<Acts::Surface>>&,
-                      const std::array<Acts::AxisDirection, 1u>&>())
+                      const std::vector<std::shared_ptr<Surface>>&,
+                      const std::array<AxisDirection, 1u>&>())
         .def("surfaces", py::overload_cast<const RangeXDDim1&>(
                              &KdtSurfacesDim1Bin100::surfaces, py::const_));
 
-    py::class_<KdtSurfacesProviderDim1Bin100,
-               Acts::Experimental::ISurfacesProvider,
+    py::class_<KdtSurfacesProviderDim1Bin100, Experimental::ISurfacesProvider,
                std::shared_ptr<KdtSurfacesProviderDim1Bin100>>(
         m, "KdtSurfacesProviderDim1Bin100")
         .def(py::init<std::shared_ptr<KdtSurfacesDim1Bin100>, const Extent&>());
   }
 
   {
-    using RangeXDDim2 = Acts::RangeXD<2u, double>;
-    using KdtSurfacesDim2Bin100 = Acts::Experimental::KdtSurfaces<2u, 100u>;
+    using RangeXDDim2 = RangeXD<2u, double>;
+    using KdtSurfacesDim2Bin100 = Experimental::KdtSurfaces<2u, 100u>;
     using KdtSurfacesProviderDim2Bin100 =
-        Acts::Experimental::KdtSurfacesProvider<2u, 100u>;
+        Experimental::KdtSurfacesProvider<2u, 100u>;
 
     py::class_<RangeXDDim2>(m, "RangeXDDim2")
         .def(py::init([](const std::array<double, 2u>& range0,
@@ -580,20 +567,19 @@ void addExperimentalGeometry(Context& ctx) {
     py::class_<KdtSurfacesDim2Bin100, std::shared_ptr<KdtSurfacesDim2Bin100>>(
         m, "KdtSurfacesDim2Bin100")
         .def(py::init<const GeometryContext&,
-                      const std::vector<std::shared_ptr<Acts::Surface>>&,
-                      const std::array<Acts::AxisDirection, 2u>&>())
+                      const std::vector<std::shared_ptr<Surface>>&,
+                      const std::array<AxisDirection, 2u>&>())
         .def("surfaces", py::overload_cast<const RangeXDDim2&>(
                              &KdtSurfacesDim2Bin100::surfaces, py::const_));
 
-    py::class_<KdtSurfacesProviderDim2Bin100,
-               Acts::Experimental::ISurfacesProvider,
+    py::class_<KdtSurfacesProviderDim2Bin100, Experimental::ISurfacesProvider,
                std::shared_ptr<KdtSurfacesProviderDim2Bin100>>(
         m, "KdtSurfacesProviderDim2Bin100")
         .def(py::init<std::shared_ptr<KdtSurfacesDim2Bin100>, const Extent&>());
   }
 
   {
-    using RangeXDDim3 = Acts::RangeXD<3u, double>;
+    using RangeXDDim3 = RangeXD<3u, double>;
 
     py::class_<RangeXDDim3>(m, "RangeXDDim3")
         .def(py::init([](const std::array<double, 2u>& range0,
@@ -609,18 +595,17 @@ void addExperimentalGeometry(Context& ctx) {
 
   {
     // The external volume structure builder
-    py::class_<Acts::Experimental::IExternalStructureBuilder,
-               std::shared_ptr<Acts::Experimental::IExternalStructureBuilder>>(
+    py::class_<Experimental::IExternalStructureBuilder,
+               std::shared_ptr<Experimental::IExternalStructureBuilder>>(
         m, "IExternalStructureBuilder");
 
     auto vsBuilder =
         py::class_<VolumeStructureBuilder,
-                   Acts::Experimental::IExternalStructureBuilder,
+                   Experimental::IExternalStructureBuilder,
                    std::shared_ptr<VolumeStructureBuilder>>(
             m, "VolumeStructureBuilder")
             .def(py::init([](const VolumeStructureBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<VolumeStructureBuilder>(
                   config, getDefaultLogger(name, level));
             }));
@@ -632,45 +617,41 @@ void addExperimentalGeometry(Context& ctx) {
   }
 
   {
-    py::class_<Acts::Experimental::IGeometryIdGenerator,
-               std::shared_ptr<Acts::Experimental::IGeometryIdGenerator>>(
+    py::class_<Experimental::IGeometryIdGenerator,
+               std::shared_ptr<Experimental::IGeometryIdGenerator>>(
         m, "IGeometryIdGenerator");
 
     auto geoIdGen =
-        py::class_<Acts::Experimental::GeometryIdGenerator,
-                   Acts::Experimental::IGeometryIdGenerator,
-                   std::shared_ptr<Acts::Experimental::GeometryIdGenerator>>(
+        py::class_<Experimental::GeometryIdGenerator,
+                   Experimental::IGeometryIdGenerator,
+                   std::shared_ptr<Experimental::GeometryIdGenerator>>(
             m, "GeometryIdGenerator")
-            .def(py::init([](Acts::Experimental::GeometryIdGenerator::Config&
-                                 config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
-              return std::make_shared<Acts::Experimental::GeometryIdGenerator>(
+            .def(py::init([](Experimental::GeometryIdGenerator::Config& config,
+                             const std::string& name, Logging::Level level) {
+              return std::make_shared<Experimental::GeometryIdGenerator>(
                   config, getDefaultLogger(name, level));
             }));
 
-    auto geoIdGenConfig =
-        py::class_<Acts::Experimental::GeometryIdGenerator::Config>(geoIdGen,
-                                                                    "Config")
-            .def(py::init<>());
+    auto geoIdGenConfig = py::class_<Experimental::GeometryIdGenerator::Config>(
+                              geoIdGen, "Config")
+                              .def(py::init<>());
     ACTS_PYTHON_STRUCT(geoIdGenConfig, containerMode, containerId,
                        resetSubCounters, overrideExistingIds);
   }
 
   {
     // Put them together to a detector volume
-    py::class_<Acts::Experimental::IDetectorComponentBuilder,
-               std::shared_ptr<Acts::Experimental::IDetectorComponentBuilder>>(
+    py::class_<Experimental::IDetectorComponentBuilder,
+               std::shared_ptr<Experimental::IDetectorComponentBuilder>>(
         m, "IDetectorComponentBuilder");
 
     auto dvBuilder =
         py::class_<DetectorVolumeBuilder,
-                   Acts::Experimental::IDetectorComponentBuilder,
+                   Experimental::IDetectorComponentBuilder,
                    std::shared_ptr<DetectorVolumeBuilder>>(
             m, "DetectorVolumeBuilder")
             .def(py::init([](const DetectorVolumeBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<DetectorVolumeBuilder>(
                   config, getDefaultLogger(name, level));
             }))
@@ -685,29 +666,28 @@ void addExperimentalGeometry(Context& ctx) {
 
   {
     // The external volume structure builder
-    py::class_<Acts::Experimental::IRootVolumeFinderBuilder,
-               std::shared_ptr<Acts::Experimental::IRootVolumeFinderBuilder>>(
+    py::class_<Experimental::IRootVolumeFinderBuilder,
+               std::shared_ptr<Experimental::IRootVolumeFinderBuilder>>(
         m, "IRootVolumeFinderBuilder");
 
     auto irvBuilder =
-        py::class_<Acts::Experimental::IndexedRootVolumeFinderBuilder,
-                   Acts::Experimental::IRootVolumeFinderBuilder,
-                   std::shared_ptr<
-                       Acts::Experimental::IndexedRootVolumeFinderBuilder>>(
+        py::class_<
+            Experimental::IndexedRootVolumeFinderBuilder,
+            Experimental::IRootVolumeFinderBuilder,
+            std::shared_ptr<Experimental::IndexedRootVolumeFinderBuilder>>(
             m, "IndexedRootVolumeFinderBuilder")
-            .def(py::init<std::vector<Acts::AxisDirection>>());
+            .def(py::init<std::vector<AxisDirection>>());
   }
 
   {
     // Cylindrical container builder
     auto ccBuilder =
         py::class_<CylindricalContainerBuilder,
-                   Acts::Experimental::IDetectorComponentBuilder,
+                   Experimental::IDetectorComponentBuilder,
                    std::shared_ptr<CylindricalContainerBuilder>>(
             m, "CylindricalContainerBuilder")
             .def(py::init([](const CylindricalContainerBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<CylindricalContainerBuilder>(
                   config, getDefaultLogger(name, level));
             }))
@@ -724,12 +704,11 @@ void addExperimentalGeometry(Context& ctx) {
     // Cuboidal container builder
     auto ccBuilder =
         py::class_<CuboidalContainerBuilder,
-                   Acts::Experimental::IDetectorComponentBuilder,
+                   Experimental::IDetectorComponentBuilder,
                    std::shared_ptr<CuboidalContainerBuilder>>(
             m, "CuboidalContainerBuilder")
             .def(py::init([](const CuboidalContainerBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<CuboidalContainerBuilder>(
                   config, getDefaultLogger(name, level));
             }))
@@ -748,8 +727,7 @@ void addExperimentalGeometry(Context& ctx) {
         py::class_<DetectorBuilder, std::shared_ptr<DetectorBuilder>>(
             m, "DetectorBuilder")
             .def(py::init([](const DetectorBuilder::Config& config,
-                             const std::string& name,
-                             Acts::Logging::Level level) {
+                             const std::string& name, Logging::Level level) {
               return std::make_shared<DetectorBuilder>(
                   config, getDefaultLogger(name, level));
             }))
@@ -775,4 +753,4 @@ void addExperimentalGeometry(Context& ctx) {
       .def_property_readonly("surfaces", &ProtoLayer::surfaces);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/GeometryBuildingGen1.cpp
+++ b/Examples/Python/src/GeometryBuildingGen1.cpp
@@ -14,7 +14,8 @@
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/TrackingVolumeArrayCreator.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <vector>
@@ -24,26 +25,26 @@
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addGeometryBuildingGen1(Context &ctx) {
   auto m = ctx.get("main");
 
   using SurfacePtrVector = std::vector<std::shared_ptr<const Surface>>;
 
-  py::class_<Acts::Layer, std::shared_ptr<Acts::Layer>>(m, "Layer");
+  py::class_<Layer, std::shared_ptr<Layer>>(m, "Layer");
 
   {
     auto creator =
-        py::class_<Acts::LayerCreator>(m, "LayerCreator")
-            .def(py::init([](const Acts::LayerCreator::Config &cfg,
-                             Acts::Logging::Level level) {
-              return Acts::LayerCreator(
-                  cfg, Acts::getDefaultLogger("LayerCreator", level));
+        py::class_<LayerCreator>(m, "LayerCreator")
+            .def(py::init([](const LayerCreator::Config &cfg,
+                             Logging::Level level) {
+              return LayerCreator(cfg, getDefaultLogger("LayerCreator", level));
             }))
             .def(
                 "cylinderLayer",
-                [](const Acts::LayerCreator &self, const GeometryContext &gctx,
+                [](const LayerCreator &self, const GeometryContext &gctx,
                    SurfacePtrVector surfaces, std::size_t binsPhi,
                    std::size_t binsZ) {
                   return self.cylinderLayer(gctx, std::move(surfaces), binsPhi,
@@ -52,7 +53,7 @@ void addGeometryBuildingGen1(Context &ctx) {
                 "gctx"_a, "surfaces"_a, "binsPhi"_a, "binsZ"_a)
             .def(
                 "discLayer",
-                [](const Acts::LayerCreator &self, const GeometryContext &gctx,
+                [](const LayerCreator &self, const GeometryContext &gctx,
                    SurfacePtrVector surfaces, std::size_t binsR,
                    std::size_t binsPhi) {
                   return self.discLayer(gctx, std::move(surfaces), binsR,
@@ -69,7 +70,7 @@ void addGeometryBuildingGen1(Context &ctx) {
   }
 
   {
-    using Creator = Acts::SurfaceArrayCreator;
+    using Creator = SurfaceArrayCreator;
     using Config = typename Creator::Config;
 
     auto creator =
@@ -80,8 +81,8 @@ void addGeometryBuildingGen1(Context &ctx) {
   }
 
   {
-    using Base = Acts::ILayerArrayCreator;
-    using Creator = Acts::LayerArrayCreator;
+    using Base = ILayerArrayCreator;
+    using Creator = LayerArrayCreator;
     using Config = typename Creator::Config;
 
     py::class_<Base, std::shared_ptr<Base>>(m, "ILayerArrayCreator");
@@ -94,8 +95,8 @@ void addGeometryBuildingGen1(Context &ctx) {
   }
 
   {
-    using Base = Acts::ITrackingVolumeArrayCreator;
-    using Creator = Acts::TrackingVolumeArrayCreator;
+    using Base = ITrackingVolumeArrayCreator;
+    using Creator = TrackingVolumeArrayCreator;
     using Config = typename Creator::Config;
 
     py::class_<Base, std::shared_ptr<Base>>(m, "ITrackingVolumeArrayCreator");
@@ -109,15 +110,15 @@ void addGeometryBuildingGen1(Context &ctx) {
 
   {
     auto helper =
-        py::class_<Acts::CylinderVolumeHelper>(m, "CylinderVolumeHelper")
-            .def(py::init([](const Acts::CylinderVolumeHelper::Config &cfg,
-                             Acts::Logging::Level level) {
-              return Acts::CylinderVolumeHelper(
-                  cfg, Acts::getDefaultLogger("CylinderVolumeHelper", level));
+        py::class_<CylinderVolumeHelper>(m, "CylinderVolumeHelper")
+            .def(py::init([](const CylinderVolumeHelper::Config &cfg,
+                             Logging::Level level) {
+              return CylinderVolumeHelper(
+                  cfg, getDefaultLogger("CylinderVolumeHelper", level));
             }))
             .def("createTrackingVolume",
-                 [](const Acts::CylinderVolumeHelper &self,
-                    GeometryContext gctx, const LayerVector &layers,
+                 [](const CylinderVolumeHelper &self, GeometryContext gctx,
+                    const LayerVector &layers,
                     std::shared_ptr<VolumeBounds> volumeBounds,
                     const Transform3 &trafo, const std::string &name) {
                    return self.createTrackingVolume(gctx, layers, {},
@@ -125,7 +126,7 @@ void addGeometryBuildingGen1(Context &ctx) {
                                                     trafo, name);
                  })
             .def("createContainerTrackingVolume",
-                 &Acts::CylinderVolumeHelper::createContainerTrackingVolume);
+                 &CylinderVolumeHelper::createContainerTrackingVolume);
 
     auto config = py::class_<CylinderVolumeHelper::Config>(helper, "Config")
                       .def(py::init<>());
@@ -136,4 +137,4 @@ void addGeometryBuildingGen1(Context &ctx) {
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/GnnTrackFinding.cpp
+++ b/Examples/Python/src/GnnTrackFinding.cpp
@@ -15,11 +15,12 @@
 #include "Acts/Plugins/Gnn/TorchEdgeClassifier.hpp"
 #include "Acts/Plugins/Gnn/TorchMetricLearning.hpp"
 #include "Acts/Plugins/Gnn/TruthGraphMetricsHook.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/TrackFindingGnn/PrototracksToParameters.hpp"
 #include "ActsExamples/TrackFindingGnn/TrackFindingAlgorithmGnn.hpp"
 #include "ActsExamples/TrackFindingGnn/TrackFindingFromPrototrackAlgorithm.hpp"
 #include "ActsExamples/TrackFindingGnn/TruthGraphBuilder.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 
@@ -54,21 +55,21 @@ using namespace ActsExamples;
 using namespace Acts;
 using namespace py::literals;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addGnnTrackFinding(Context &ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   {
-    using C = Acts::GraphConstructionBase;
+    using C = GraphConstructionBase;
     auto c = py::class_<C, std::shared_ptr<C>>(mex, "GraphConstructionBase");
   }
   {
-    using C = Acts::EdgeClassificationBase;
+    using C = EdgeClassificationBase;
     auto c = py::class_<C, std::shared_ptr<C>>(mex, "EdgeClassificationBase");
   }
   {
-    using C = Acts::TrackBuildingBase;
+    using C = TrackBuildingBase;
     auto c = py::class_<C, std::shared_ptr<C>>(mex, "TrackBuildingBase");
   }
 
@@ -106,11 +107,11 @@ void addGnnTrackFinding(Context &ctx) {
       phiScale, zScale, etaScale, moreParallel, gpuDevice, gpuBlocks, epsilon);
 #endif
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TruthGraphBuilder, mex, "TruthGraphBuilder",
-      inputSpacePoints, inputSimHits, inputParticles,
-      inputMeasurementSimHitsMap, inputMeasurementParticlesMap, outputGraph,
-      targetMinPT, targetMinSize, uniqueModules);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TruthGraphBuilder, mex, "TruthGraphBuilder",
+                                inputSpacePoints, inputSimHits, inputParticles,
+                                inputMeasurementSimHitsMap,
+                                inputMeasurementParticlesMap, outputGraph,
+                                targetMinPT, targetMinSize, uniqueModules);
 
   {
     auto nodeFeatureEnum =
@@ -162,20 +163,17 @@ void addGnnTrackFinding(Context &ctx) {
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackFindingAlgorithmGnn, mex, "TrackFindingAlgorithmGnn",
+      TrackFindingAlgorithmGnn, mex, "TrackFindingAlgorithmGnn",
       inputSpacePoints, inputClusters, inputTruthGraph, outputProtoTracks,
       outputGraph, graphConstructor, edgeClassifiers, trackBuilder,
       nodeFeatures, featureScales, minMeasurementsPerTrack, geometryIdMap);
 
-  {
-    auto cls = py::class_<Acts::GnnHook, std::shared_ptr<Acts::GnnHook>>(
-        mex, "GnnHook");
-  }
+  { auto cls = py::class_<GnnHook, std::shared_ptr<GnnHook>>(mex, "GnnHook"); }
 
   {
-    using Class = Acts::TruthGraphMetricsHook;
+    using Class = TruthGraphMetricsHook;
 
-    auto cls = py::class_<Class, Acts::GnnHook, std::shared_ptr<Class>>(
+    auto cls = py::class_<Class, GnnHook, std::shared_ptr<Class>>(
                    mex, "TruthGraphMetricsHook")
                    .def(py::init([](const std::vector<std::int64_t> &g,
                                     Logging::Level lvl) {
@@ -185,14 +183,13 @@ void addGnnTrackFinding(Context &ctx) {
   }
 
   {
-    auto cls =
-        py::class_<Acts::Device>(mex, "Device")
-            .def_static("Cpu", &Acts::Device::Cpu)
-            .def_static("Cuda", &Acts::Device::Cuda, py::arg("index") = 0);
+    auto cls = py::class_<Device>(mex, "Device")
+                   .def_static("Cpu", &Device::Cpu)
+                   .def_static("Cuda", &Device::Cuda, py::arg("index") = 0);
   }
 
   {
-    using Class = Acts::GnnPipeline;
+    using Class = GnnPipeline;
 
     auto cls =
         py::class_<Class, std::shared_ptr<Class>>(mex, "GnnPipeline")
@@ -208,21 +205,20 @@ void addGnnTrackFinding(Context &ctx) {
                  py::arg("trackBuilder"), py::arg("level"))
             .def("run", &GnnPipeline::run, py::arg("features"),
                  py::arg("moduleIds"), py::arg("spacepoints"),
-                 py::arg("device") = Acts::Device::Cuda(0),
-                 py::arg("hook") = Acts::GnnHook{},
-                 py::arg("timing") = nullptr);
+                 py::arg("device") = Device::Cuda(0),
+                 py::arg("hook") = GnnHook{}, py::arg("timing") = nullptr);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::PrototracksToParameters, mex, "PrototracksToParameters",
-      inputProtoTracks, inputSpacePoints, outputSeeds, outputParameters,
-      outputProtoTracks, geometry, magneticField, buildTightSeeds);
+      PrototracksToParameters, mex, "PrototracksToParameters", inputProtoTracks,
+      inputSpacePoints, outputSeeds, outputParameters, outputProtoTracks,
+      geometry, magneticField, buildTightSeeds);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackFindingFromPrototrackAlgorithm, mex,
+      TrackFindingFromPrototrackAlgorithm, mex,
       "TrackFindingFromPrototrackAlgorithm", inputProtoTracks,
       inputMeasurements, inputInitialTrackParameters, outputTracks,
       measurementSelectorCfg, trackingGeometry, magneticField, findTracks, tag);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/GnnTrackFindingStub.cpp
+++ b/Examples/Python/src/GnnTrackFindingStub.cpp
@@ -6,12 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
-namespace Acts::Python {
+namespace ActsPython {
 void addGnnTrackFinding(Context& /*ctx*/) {
   // dummy function
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Hashing.cpp
+++ b/Examples/Python/src/Hashing.cpp
@@ -47,11 +47,11 @@ void addHashing(Context& ctx) {
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      SeedingAlgorithmHashing, hashingExampleModule,
-      "SeedingAlgorithmHashing", inputSpacePoints, outputSeeds, outputBuckets,
-      seedFilterConfig, seedFinderConfig, seedFinderOptions, gridConfig,
-      gridOptions, allowSeparateRMax, zBinNeighborsTop, zBinNeighborsBottom,
-      numPhiNeighbors, hashingConfig, hashingTrainingConfig, useExtraCuts);
+      SeedingAlgorithmHashing, hashingExampleModule, "SeedingAlgorithmHashing",
+      inputSpacePoints, outputSeeds, outputBuckets, seedFilterConfig,
+      seedFinderConfig, seedFinderOptions, gridConfig, gridOptions,
+      allowSeparateRMax, zBinNeighborsTop, zBinNeighborsBottom, numPhiNeighbors,
+      hashingConfig, hashingTrainingConfig, useExtraCuts);
 }
 
 }  // namespace ActsPython

--- a/Examples/Python/src/Hashing.cpp
+++ b/Examples/Python/src/Hashing.cpp
@@ -8,8 +8,8 @@
 
 #include "Acts/Plugins/Hashing/HashingAlgorithmConfig.hpp"
 #include "Acts/Plugins/Hashing/HashingTrainingConfig.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/TrackFinding/SeedingAlgorithmHashing.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <memory>
 
@@ -21,7 +21,7 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addHashing(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -53,4 +53,4 @@ void addHashing(Context& ctx) {
       numPhiNeighbors, hashingConfig, hashingTrainingConfig, useExtraCuts);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Hashing.cpp
+++ b/Examples/Python/src/Hashing.cpp
@@ -10,6 +10,7 @@
 #include "Acts/Plugins/Hashing/HashingTrainingConfig.hpp"
 #include "ActsExamples/TrackFinding/SeedingAlgorithmHashing.hpp"
 #include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 
@@ -46,7 +47,7 @@ void addHashing(Context& ctx) {
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::SeedingAlgorithmHashing, hashingExampleModule,
+      SeedingAlgorithmHashing, hashingExampleModule,
       "SeedingAlgorithmHashing", inputSpacePoints, outputSeeds, outputBuckets,
       seedFilterConfig, seedFinderConfig, seedFinderOptions, gridConfig,
       gridOptions, allowSeparateRMax, zBinNeighborsTop, zBinNeighborsBottom,

--- a/Examples/Python/src/HashingStub.cpp
+++ b/Examples/Python/src/HashingStub.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
-namespace Acts::Python {
+namespace ActsPython {
 void addHashing(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/HepMC3.cpp
+++ b/Examples/Python/src/HepMC3.cpp
@@ -6,12 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3InputConverter.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3OutputConverter.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Reader.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Util.hpp"
 #include "ActsExamples/Io/HepMC3/HepMC3Writer.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -21,35 +22,36 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 using namespace Acts;
+using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addHepMC3(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   auto hepmc3 = mex.def_submodule("_hepmc3");
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::HepMC3Writer, hepmc3, "HepMC3Writer",
-                             outputPath, perEvent, inputEvent, compression,
+  ACTS_PYTHON_DECLARE_WRITER(HepMC3Writer, hepmc3, "HepMC3Writer", outputPath,
+                             perEvent, inputEvent, compression,
                              maxEventsPending, writeEventsInOrder);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::HepMC3Reader, hepmc3, "HepMC3Reader",
-                             inputPath, inputPaths, outputEvent, printListing,
-                             numEvents, checkEventNumber, maxEventBufferSize,
+  ACTS_PYTHON_DECLARE_READER(HepMC3Reader, hepmc3, "HepMC3Reader", inputPath,
+                             inputPaths, outputEvent, printListing, numEvents,
+                             checkEventNumber, maxEventBufferSize,
                              vertexGenerator, randomNumbers);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::HepMC3OutputConverter, hepmc3,
+  ACTS_PYTHON_DECLARE_ALGORITHM(HepMC3OutputConverter, hepmc3,
                                 "HepMC3OutputConverter", inputParticles,
                                 inputVertices, outputEvent);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::HepMC3InputConverter, hepmc3, "HepMC3InputConverter",
-      inputEvent, outputParticles, outputVertices, printListing,
-      checkConsistency, mergePrimaries, primaryVertexSpatialThreshold,
-      vertexSpatialThreshold, mergeSecondaries);
+      HepMC3InputConverter, hepmc3, "HepMC3InputConverter", inputEvent,
+      outputParticles, outputVertices, printListing, checkConsistency,
+      mergePrimaries, primaryVertexSpatialThreshold, vertexSpatialThreshold,
+      mergeSecondaries);
 
   {
-    using enum ActsExamples::HepMC3Util::Compression;
-    py::enum_<ActsExamples::HepMC3Util::Compression>(hepmc3, "Compression")
+    using enum HepMC3Util::Compression;
+    py::enum_<HepMC3Util::Compression>(hepmc3, "Compression")
         .value("none", none)
         .value("zlib", zlib)
         .value("lzma", lzma)
@@ -58,11 +60,10 @@ void addHepMC3(Context& ctx) {
   }
 
   hepmc3.def("availableCompressionModes", []() {
-    auto modes = ActsExamples::HepMC3Util::availableCompressionModes();
+    auto modes = HepMC3Util::availableCompressionModes();
     return std::vector(modes.begin(), modes.end());
   });
 
-  hepmc3.def("compressionExtension",
-             &ActsExamples::HepMC3Util::compressionExtension);
+  hepmc3.def("compressionExtension", &HepMC3Util::compressionExtension);
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Input.cpp
+++ b/Examples/Python/src/Input.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/EventData/Cluster.hpp"
 #include "ActsExamples/Framework/BufferedReader.hpp"
 #include "ActsExamples/Io/Csv/CsvGnnGraphReader.hpp"
@@ -18,6 +17,8 @@
 #include "ActsExamples/Io/Csv/CsvSpacePointReader.hpp"
 #include "ActsExamples/Io/Csv/CsvTrackParameterReader.hpp"
 #include "ActsExamples/TrackFinding/ITrackParamsLookupReader.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -27,50 +28,45 @@ using namespace pybind11::literals;
 
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addInput(Context& ctx) {
   auto mex = ctx.get("examples");
 
   // Buffered reader
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::BufferedReader, mex,
-                             "BufferedReader", upstreamReader, selectionSeed,
-                             bufferSize);
+  ACTS_PYTHON_DECLARE_READER(BufferedReader, mex, "BufferedReader",
+                             upstreamReader, selectionSeed, bufferSize);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvParticleReader, mex,
-                             "CsvParticleReader", inputDir, inputStem,
-                             outputParticles);
+  ACTS_PYTHON_DECLARE_READER(CsvParticleReader, mex, "CsvParticleReader",
+                             inputDir, inputStem, outputParticles);
 
-  ACTS_PYTHON_DECLARE_READER(
-      ActsExamples::CsvMeasurementReader, mex, "CsvMeasurementReader", inputDir,
-      outputMeasurements, outputMeasurementSimHitsMap, outputClusters,
-      outputMeasurementParticlesMap, inputSimHits);
+  ACTS_PYTHON_DECLARE_READER(CsvMeasurementReader, mex, "CsvMeasurementReader",
+                             inputDir, outputMeasurements,
+                             outputMeasurementSimHitsMap, outputClusters,
+                             outputMeasurementParticlesMap, inputSimHits);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvSimHitReader, mex,
-                             "CsvSimHitReader", inputDir, inputStem,
-                             outputSimHits);
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvMuonSegmentReader, mex,
-                             "CsvMuonSegmentReader", inputDir, inputStem,
-                             outputSegments);
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvMuonSpacePointReader, mex,
+  ACTS_PYTHON_DECLARE_READER(CsvSimHitReader, mex, "CsvSimHitReader", inputDir,
+                             inputStem, outputSimHits);
+  ACTS_PYTHON_DECLARE_READER(CsvMuonSegmentReader, mex, "CsvMuonSegmentReader",
+                             inputDir, inputStem, outputSegments);
+  ACTS_PYTHON_DECLARE_READER(CsvMuonSpacePointReader, mex,
                              "CsvMuonSpacePointReader", inputDir, inputStem,
                              outputSpacePoints);
 
-  ACTS_PYTHON_DECLARE_READER(
-      ActsExamples::CsvSpacePointReader, mex, "CsvSpacePointReader", inputDir,
-      inputStem, inputCollection, outputSpacePoints, extendCollection);
+  ACTS_PYTHON_DECLARE_READER(CsvSpacePointReader, mex, "CsvSpacePointReader",
+                             inputDir, inputStem, inputCollection,
+                             outputSpacePoints, extendCollection);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvTrackParameterReader, mex,
+  ACTS_PYTHON_DECLARE_READER(CsvTrackParameterReader, mex,
                              "CsvTrackParameterReader", inputDir, inputStem,
                              outputTrackParameters, beamspot);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::CsvGnnGraphReader, mex,
-                             "CsvGnnGraphReader", inputDir, inputStem,
-                             outputGraph);
+  ACTS_PYTHON_DECLARE_READER(CsvGnnGraphReader, mex, "CsvGnnGraphReader",
+                             inputDir, inputStem, outputGraph);
 
-  py::class_<ActsExamples::ITrackParamsLookupReader,
-             std::shared_ptr<ActsExamples::ITrackParamsLookupReader>>(
+  py::class_<ITrackParamsLookupReader,
+             std::shared_ptr<ITrackParamsLookupReader>>(
       mex, "ITrackParamsLookupReader");
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Json.cpp
+++ b/Examples/Python/src/Json.cpp
@@ -14,13 +14,14 @@
 #include "Acts/Plugins/Json/JsonSurfacesReader.hpp"
 #include "Acts/Plugins/Json/MaterialMapJsonConverter.hpp"
 #include "Acts/Plugins/Json/ProtoDetectorJsonConverter.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
 #include "ActsExamples/Io/Json/JsonMaterialWriter.hpp"
 #include "ActsExamples/Io/Json/JsonSurfacesWriter.hpp"
 #include "ActsExamples/Io/Json/JsonTrackParamsLookupReader.hpp"
 #include "ActsExamples/Io/Json/JsonTrackParamsLookupWriter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <fstream>
 #include <initializer_list>
@@ -50,18 +51,19 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 using namespace Acts;
+using namespace Acts::Experimental;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addJson(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   {
-    py::class_<JsonMaterialDecorator, Acts::IMaterialDecorator,
+    py::class_<JsonMaterialDecorator, IMaterialDecorator,
                std::shared_ptr<JsonMaterialDecorator>>(m,
                                                        "JsonMaterialDecorator")
         .def(py::init<const MaterialMapJsonConverter::Config&,
-                      const std::string&, Acts::Logging::Level, bool, bool>(),
+                      const std::string&, Logging::Level, bool, bool>(),
              py::arg("rConfig"), py::arg("jFileName"), py::arg("level"),
              py::arg("clearSurfaceMaterial") = true,
              py::arg("clearVolumeMaterial") = true);
@@ -71,7 +73,7 @@ void addJson(Context& ctx) {
     auto cls =
         py::class_<MaterialMapJsonConverter>(m, "MaterialMapJsonConverter")
             .def(py::init<const MaterialMapJsonConverter::Config&,
-                          Acts::Logging::Level>(),
+                          Logging::Level>(),
                  py::arg("config"), py::arg("level"));
 
     auto c = py::class_<MaterialMapJsonConverter::Config>(cls, "Config")
@@ -94,8 +96,7 @@ void addJson(Context& ctx) {
         py::class_<JsonMaterialWriter, IMaterialWriter,
                    std::shared_ptr<JsonMaterialWriter>>(mex,
                                                         "JsonMaterialWriter")
-            .def(py::init<const JsonMaterialWriter::Config&,
-                          Acts::Logging::Level>(),
+            .def(py::init<const JsonMaterialWriter::Config&, Logging::Level>(),
                  py::arg("config"), py::arg("level"))
             .def("writeMaterial", &JsonMaterialWriter::writeMaterial)
             .def("write", &JsonMaterialWriter::write)
@@ -107,8 +108,8 @@ void addJson(Context& ctx) {
   }
 
   {
-    using IWriter = ActsExamples::ITrackParamsLookupWriter;
-    using Writer = ActsExamples::JsonTrackParamsLookupWriter;
+    using IWriter = ITrackParamsLookupWriter;
+    using Writer = JsonTrackParamsLookupWriter;
     using Config = Writer::Config;
 
     auto cls = py::class_<Writer, IWriter, std::shared_ptr<Writer>>(
@@ -124,8 +125,8 @@ void addJson(Context& ctx) {
   }
 
   {
-    using IReader = ActsExamples::ITrackParamsLookupReader;
-    using Reader = ActsExamples::JsonTrackParamsLookupReader;
+    using IReader = ITrackParamsLookupReader;
+    using Reader = JsonTrackParamsLookupReader;
     using Config = Reader::Config;
 
     auto cls = py::class_<Reader, IReader, std::shared_ptr<Reader>>(
@@ -134,12 +135,13 @@ void addJson(Context& ctx) {
                    .def("readLookup", &Reader::readLookup)
                    .def_property_readonly("config", &Reader::config);
 
-    auto c = py::class_<Config>(cls, "Config")
-                 .def(py::init<>())
-                 .def(py::init<std::unordered_map<Acts::GeometryIdentifier,
-                                                  const Acts::Surface*>,
-                               std::pair<double, double>>(),
-                      py::arg("refLayers"), py::arg("bins"));
+    auto c =
+        py::class_<Config>(cls, "Config")
+            .def(py::init<>())
+            .def(
+                py::init<std::unordered_map<GeometryIdentifier, const Surface*>,
+                         std::pair<double, double>>(),
+                py::arg("refLayers"), py::arg("bins"));
     ACTS_PYTHON_STRUCT(c, refLayers, bins);
   }
 
@@ -148,8 +150,7 @@ void addJson(Context& ctx) {
         py::class_<JsonSurfacesWriter, IWriter,
                    std::shared_ptr<JsonSurfacesWriter>>(mex,
                                                         "JsonSurfacesWriter")
-            .def(py::init<const JsonSurfacesWriter::Config&,
-                          Acts::Logging::Level>(),
+            .def(py::init<const JsonSurfacesWriter::Config&, Logging::Level>(),
                  py::arg("config"), py::arg("level"))
             .def("write", &JsonSurfacesWriter::write)
             .def_property_readonly("config", &JsonSurfacesWriter::config);
@@ -163,7 +164,7 @@ void addJson(Context& ctx) {
   }
 
   {
-    py::class_<Acts::ProtoDetector>(mex, "ProtoDetector")
+    py::class_<ProtoDetector>(mex, "ProtoDetector")
         .def(py::init<>([](std::string pathName) {
           nlohmann::json jDetector;
           auto in = std::ifstream(pathName, std::ifstream::in);
@@ -171,40 +172,37 @@ void addJson(Context& ctx) {
             in >> jDetector;
             in.close();
           }
-          Acts::ProtoDetector pDetector = jDetector["detector"];
+          ProtoDetector pDetector = jDetector["detector"];
           return pDetector;
         }));
   }
 
   {
     auto sjOptions =
-        py::class_<Acts::JsonSurfacesReader::Options>(m, "SurfaceJsonOptions")
+        py::class_<JsonSurfacesReader::Options>(m, "SurfaceJsonOptions")
             .def(py::init<>());
     ACTS_PYTHON_STRUCT(sjOptions, inputFile, jsonEntryPath);
 
     m.def("readSurfaceHierarchyMapFromJson",
-          Acts::JsonSurfacesReader::readHierarchyMap);
+          JsonSurfacesReader::readHierarchyMap);
 
-    m.def("readSurfaceVectorFromJson", Acts::JsonSurfacesReader::readVector);
+    m.def("readSurfaceVectorFromJson", JsonSurfacesReader::readVector);
 
-    py::class_<Acts::JsonDetectorElement, Acts::DetectorElementBase,
-               std::shared_ptr<Acts::JsonDetectorElement>>(
-        m, "JsonDetectorElement")
-        .def("surface", [](Acts::JsonDetectorElement& self) {
+    py::class_<JsonDetectorElement, DetectorElementBase,
+               std::shared_ptr<JsonDetectorElement>>(m, "JsonDetectorElement")
+        .def("surface", [](JsonDetectorElement& self) {
           return self.surface().getSharedPtr();
         });
 
     m.def("readDetectorElementsFromJson",
-          Acts::JsonSurfacesReader::readDetectorElements);
+          JsonSurfacesReader::readDetectorElements);
   }
 
   {
     mex.def("writeDetectorToJson",
-            [](const Acts::GeometryContext& gctx,
-               const Acts::Experimental::Detector& detector,
+            [](const GeometryContext& gctx, const Detector& detector,
                const std::string& name) -> void {
-              auto jDetector =
-                  Acts::DetectorJsonConverter::toJson(gctx, detector);
+              auto jDetector = DetectorJsonConverter::toJson(gctx, detector);
               std::ofstream out;
               out.open(name + ".json");
               out << jDetector.dump(4);
@@ -214,11 +212,10 @@ void addJson(Context& ctx) {
 
   {
     mex.def("writeDetectorToJsonDetray",
-            [](const Acts::GeometryContext& gctx,
-               const Acts::Experimental::Detector& detector,
+            [](const GeometryContext& gctx, const Detector& detector,
                const std::string& name) -> void {
               // Detray format test - manipulate for detray
-              Acts::DetectorVolumeJsonConverter::Options detrayOptions;
+              DetectorVolumeJsonConverter::Options detrayOptions;
               detrayOptions.transformOptions.writeIdentity = true;
               detrayOptions.transformOptions.transpose = true;
               detrayOptions.surfaceOptions.transformOptions =
@@ -226,9 +223,9 @@ void addJson(Context& ctx) {
               detrayOptions.portalOptions.surfaceOptions =
                   detrayOptions.surfaceOptions;
 
-              auto jDetector = Acts::DetectorJsonConverter::toJsonDetray(
+              auto jDetector = DetectorJsonConverter::toJsonDetray(
                   gctx, detector,
-                  Acts::DetectorJsonConverter::Options{detrayOptions});
+                  DetectorJsonConverter::Options{detrayOptions});
 
               // Write out the geometry, surface_grid, material
               auto jGeometry = jDetector["geometry"];
@@ -251,17 +248,17 @@ void addJson(Context& ctx) {
   }
 
   {
-    mex.def("readDetectorFromJson",
-            [](const Acts::GeometryContext& gctx,
-               const std::string& fileName) -> auto {
-              auto in = std::ifstream(
-                  fileName, std::ifstream::in | std::ifstream::binary);
-              nlohmann::json jDetectorIn;
-              in >> jDetectorIn;
-              in.close();
+    mex.def(
+        "readDetectorFromJson",
+        [](const GeometryContext& gctx, const std::string& fileName) -> auto {
+          auto in = std::ifstream(fileName,
+                                  std::ifstream::in | std::ifstream::binary);
+          nlohmann::json jDetectorIn;
+          in >> jDetectorIn;
+          in.close();
 
-              return Acts::DetectorJsonConverter::fromJson(gctx, jDetectorIn);
-            });
+          return DetectorJsonConverter::fromJson(gctx, jDetectorIn);
+        });
   }
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/JsonStub.cpp
+++ b/Examples/Python/src/JsonStub.cpp
@@ -6,8 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addJson(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/MagneticField.cpp
+++ b/Examples/Python/src/MagneticField.cpp
@@ -15,9 +15,9 @@
 #include "Acts/MagneticField/MultiRangeBField.hpp"
 #include "Acts/MagneticField/NullBField.hpp"
 #include "Acts/MagneticField/SolenoidBField.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/MagneticField/FieldMapRootIo.hpp"
 #include "ActsExamples/MagneticField/FieldMapTextIo.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <array>
 #include <cstddef>
@@ -34,13 +34,16 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-namespace Acts::Python {
+using namespace Acts;
+using namespace ActsExamples;
+using namespace ActsExamples::detail;
+
+namespace ActsPython {
 
 /// @brief Get the value of a field, throwing an exception if the result is
 /// invalid.
-Acts::Vector3 getField(Acts::MagneticFieldProvider& self,
-                       const Acts::Vector3& position,
-                       Acts::MagneticFieldProvider::Cache& cache) {
+Vector3 getField(MagneticFieldProvider& self, const Vector3& position,
+                 MagneticFieldProvider::Cache& cache) {
   if (Result<Vector3> res = self.getField(position, cache); !res.ok()) {
     std::stringstream ss;
 
@@ -55,56 +58,53 @@ Acts::Vector3 getField(Acts::MagneticFieldProvider& self,
 void addMagneticField(Context& ctx) {
   auto [m, mex, prop] = ctx.get("main", "examples", "propagation");
 
-  py::class_<Acts::MagneticFieldProvider,
-             std::shared_ptr<Acts::MagneticFieldProvider>>(
+  py::class_<MagneticFieldProvider, std::shared_ptr<MagneticFieldProvider>>(
       m, "MagneticFieldProvider")
       .def("getField", &getField)
-      .def("makeCache", &Acts::MagneticFieldProvider::makeCache);
+      .def("makeCache", &MagneticFieldProvider::makeCache);
 
-  py::class_<Acts::InterpolatedMagneticField,
-             std::shared_ptr<Acts::InterpolatedMagneticField>>(
+  py::class_<InterpolatedMagneticField,
+             std::shared_ptr<InterpolatedMagneticField>>(
       m, "InterpolatedMagneticField");
 
-  m.def("solenoidFieldMap", &Acts::solenoidFieldMap, py::arg("rlim"),
-        py::arg("zlim"), py::arg("nbins"), py::arg("field"));
+  m.def("solenoidFieldMap", &solenoidFieldMap, py::arg("rlim"), py::arg("zlim"),
+        py::arg("nbins"), py::arg("field"));
 
-  py::class_<Acts::ConstantBField, Acts::MagneticFieldProvider,
-             std::shared_ptr<Acts::ConstantBField>>(m, "ConstantBField")
-      .def(py::init<Acts::Vector3>());
+  py::class_<ConstantBField, MagneticFieldProvider,
+             std::shared_ptr<ConstantBField>>(m, "ConstantBField")
+      .def(py::init<Vector3>());
 
-  py::class_<ActsExamples::detail::InterpolatedMagneticField2,
-             Acts::InterpolatedMagneticField, Acts::MagneticFieldProvider,
-             std::shared_ptr<ActsExamples::detail::InterpolatedMagneticField2>>(
+  py::class_<::InterpolatedMagneticField2, InterpolatedMagneticField,
+             MagneticFieldProvider,
+             std::shared_ptr<::InterpolatedMagneticField2>>(
       mex, "InterpolatedMagneticField2");
 
-  py::class_<ActsExamples::detail::InterpolatedMagneticField3,
-             Acts::InterpolatedMagneticField, Acts::MagneticFieldProvider,
-             std::shared_ptr<ActsExamples::detail::InterpolatedMagneticField3>>(
+  py::class_<::InterpolatedMagneticField3, InterpolatedMagneticField,
+             MagneticFieldProvider,
+             std::shared_ptr<::InterpolatedMagneticField3>>(
       mex, "InterpolatedMagneticField3");
 
-  py::class_<Acts::NullBField, Acts::MagneticFieldProvider,
-             std::shared_ptr<Acts::NullBField>>(m, "NullBField")
+  py::class_<NullBField, MagneticFieldProvider, std::shared_ptr<NullBField>>(
+      m, "NullBField")
       .def(py::init<>());
 
-  py::class_<Acts::MultiRangeBField, Acts::MagneticFieldProvider,
-             std::shared_ptr<Acts::MultiRangeBField>>(m, "MultiRangeBField")
-      .def(py::init<
-           std::vector<std::pair<Acts::RangeXD<3, double>, Acts::Vector3>>>());
+  py::class_<MultiRangeBField, MagneticFieldProvider,
+             std::shared_ptr<MultiRangeBField>>(m, "MultiRangeBField")
+      .def(py::init<std::vector<std::pair<RangeXD<3, double>, Vector3>>>());
 
   {
-    using Config = Acts::SolenoidBField::Config;
+    using Config = SolenoidBField::Config;
 
-    auto sol =
-        py::class_<Acts::SolenoidBField, Acts::MagneticFieldProvider,
-                   std::shared_ptr<Acts::SolenoidBField>>(m, "SolenoidBField")
-            .def(py::init<Config>())
-            .def(py::init([](double radius, double length, std::size_t nCoils,
-                             double bMagCenter) {
-                   return Acts::SolenoidBField{
-                       Config{radius, length, nCoils, bMagCenter}};
-                 }),
-                 py::arg("radius"), py::arg("length"), py::arg("nCoils"),
-                 py::arg("bMagCenter"));
+    auto sol = py::class_<SolenoidBField, MagneticFieldProvider,
+                          std::shared_ptr<SolenoidBField>>(m, "SolenoidBField")
+                   .def(py::init<Config>())
+                   .def(py::init([](double radius, double length,
+                                    std::size_t nCoils, double bMagCenter) {
+                          return SolenoidBField{
+                              Config{radius, length, nCoils, bMagCenter}};
+                        }),
+                        py::arg("radius"), py::arg("length"), py::arg("nCoils"),
+                        py::arg("bMagCenter"));
 
     py::class_<Config>(sol, "Config")
         .def(py::init<>())
@@ -127,25 +127,22 @@ void addMagneticField(Context& ctx) {
         };
 
         if (file.extension() == ".root") {
-          auto map = ActsExamples::makeMagneticFieldMapXyzFromRoot(
+          auto map = makeMagneticFieldMapXyzFromRoot(
               std::move(mapBins), file.native(), tree, lengthUnit, BFieldUnit,
               firstOctant);
-          return std::make_shared<
-              ActsExamples::detail::InterpolatedMagneticField3>(std::move(map));
+          return std::make_shared<::InterpolatedMagneticField3>(std::move(map));
         } else if (file.extension() == ".txt") {
-          auto map = ActsExamples::makeMagneticFieldMapXyzFromText(
-              std::move(mapBins), file.native(), lengthUnit, BFieldUnit,
-              firstOctant);
-          return std::make_shared<
-              ActsExamples::detail::InterpolatedMagneticField3>(std::move(map));
+          auto map = makeMagneticFieldMapXyzFromText(std::move(mapBins),
+                                                     file.native(), lengthUnit,
+                                                     BFieldUnit, firstOctant);
+          return std::make_shared<::InterpolatedMagneticField3>(std::move(map));
         } else {
           throw std::runtime_error("Unsupported magnetic field map file type");
         }
       },
       py::arg("file"), py::arg("tree") = "bField",
-      py::arg("lengthUnit") = Acts::UnitConstants::mm,
-      py::arg("BFieldUnit") = Acts::UnitConstants::T,
-      py::arg("firstOctant") = false);
+      py::arg("lengthUnit") = UnitConstants::mm,
+      py::arg("BFieldUnit") = UnitConstants::T, py::arg("firstOctant") = false);
 
   mex.def(
       "MagneticFieldMapRz",
@@ -159,25 +156,23 @@ void addMagneticField(Context& ctx) {
         };
 
         if (file.extension() == ".root") {
-          auto map = ActsExamples::makeMagneticFieldMapRzFromRoot(
+          auto map = makeMagneticFieldMapRzFromRoot(
               std::move(mapBins), file.native(), tree, lengthUnit, BFieldUnit,
               firstQuadrant);
-          return std::make_shared<
-              ActsExamples::detail::InterpolatedMagneticField2>(std::move(map));
+          return std::make_shared<::InterpolatedMagneticField2>(std::move(map));
         } else if (file.extension() == ".txt") {
-          auto map = ActsExamples::makeMagneticFieldMapRzFromText(
-              std::move(mapBins), file.native(), lengthUnit, BFieldUnit,
-              firstQuadrant);
-          return std::make_shared<
-              ActsExamples::detail::InterpolatedMagneticField2>(std::move(map));
+          auto map = makeMagneticFieldMapRzFromText(std::move(mapBins),
+                                                    file.native(), lengthUnit,
+                                                    BFieldUnit, firstQuadrant);
+          return std::make_shared<::InterpolatedMagneticField2>(std::move(map));
         } else {
           throw std::runtime_error("Unsupported magnetic field map file type");
         }
       },
       py::arg("file"), py::arg("tree") = "bField",
-      py::arg("lengthUnit") = Acts::UnitConstants::mm,
-      py::arg("BFieldUnit") = Acts::UnitConstants::T,
+      py::arg("lengthUnit") = UnitConstants::mm,
+      py::arg("BFieldUnit") = UnitConstants::T,
       py::arg("firstQuadrant") = false);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/ModuleEntry.cpp
+++ b/Examples/Python/src/ModuleEntry.cpp
@@ -7,7 +7,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/ActsVersion.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <tuple>
 #include <unordered_map>
@@ -21,9 +21,9 @@
 #include <pyerrors.h>
 
 namespace py = pybind11;
-using namespace Acts::Python;
+using namespace ActsPython;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addContext(Context& ctx);
 void addAny(Context& ctx);
 void addUnits(Context& ctx);
@@ -78,10 +78,10 @@ void addCovfie(Context& ctx);
 void addTraccc(Context& ctx);
 void addHashing(Context& ctx);
 
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
 PYBIND11_MODULE(ActsPythonBindings, m) {
-  Acts::Python::Context ctx;
+  Context ctx;
   ctx.modules["main"] = m;
   auto mex = m.def_submodule("_examples");
   ctx.modules["examples"] = mex;

--- a/Examples/Python/src/Navigation.cpp
+++ b/Examples/Python/src/Navigation.cpp
@@ -11,11 +11,12 @@
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Navigation/SurfaceArrayNavigationPolicy.hpp"
 #include "Acts/Navigation/TryAllNavigationPolicy.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Utilities/Logger.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <stdexcept>
@@ -28,7 +29,9 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-namespace Acts::Python {
+using namespace Acts;
+
+namespace ActsPython {
 
 namespace Test {
 class DetectorElementStub : public DetectorElementBase {
@@ -68,13 +71,12 @@ void addNavigation(Context& ctx) {
     ACTS_PYTHON_STRUCT(c, portals, sensitives);
   }
 
-  py::class_<Acts::NavigationPolicyFactory,
-             std::shared_ptr<Acts::NavigationPolicyFactory>>(
+  py::class_<NavigationPolicyFactory, std::shared_ptr<NavigationPolicyFactory>>(
       m, "NavigationPolicyFactory")
       // only to mirror the C++ API
-      .def_static("make", []() { return Acts::NavigationPolicyFactory{}; })
+      .def_static("make", []() { return NavigationPolicyFactory{}; })
       .def("add",
-           [](Acts::NavigationPolicyFactory* self, const py::object& cls) {
+           [](NavigationPolicyFactory* self, const py::object& cls) {
              auto mod = py::module_::import("acts");
              if (py::object o = mod.attr("TryAllNavigationPolicy"); cls.is(o)) {
                return std::move(*self).template add<TryAllNavigationPolicy>();
@@ -86,7 +88,7 @@ void addNavigation(Context& ctx) {
            })
 
       .def("add",
-           [](Acts::NavigationPolicyFactory* self, const py::object& cls,
+           [](NavigationPolicyFactory* self, const py::object& cls,
               const SurfaceArrayNavigationPolicy::Config& config) {
              auto mod = py::module_::import("acts");
              if (py::object o = mod.attr("SurfaceArrayNavigationPolicy");
@@ -101,7 +103,7 @@ void addNavigation(Context& ctx) {
            })
 
       .def("add",
-           [](Acts::NavigationPolicyFactory* self, const py::object& cls,
+           [](NavigationPolicyFactory* self, const py::object& cls,
               const TryAllNavigationPolicy::Config& config) {
              auto mod = py::module_::import("acts");
              if (py::object o = mod.attr("TryAllNavigationPolicy");
@@ -115,7 +117,7 @@ void addNavigation(Context& ctx) {
                  config);
            })
 
-      .def("_buildTest", [](Acts::NavigationPolicyFactory* self) {
+      .def("_buildTest", [](NavigationPolicyFactory* self) {
         auto vol1 = std::make_shared<TrackingVolume>(
             Transform3::Identity(),
             std::make_shared<CylinderVolumeBounds>(30, 40, 100));
@@ -150,4 +152,4 @@ void addNavigation(Context& ctx) {
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Obj.cpp
+++ b/Examples/Python/src/Obj.cpp
@@ -7,10 +7,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "Acts/Visualization/IVisualization3D.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 #include <Acts/Definitions/Algebra.hpp>
 #include <Acts/Detector/DetectorVolume.hpp>
 #include <Acts/Geometry/GeometryContext.hpp>
-#include <Acts/Plugins/Python/Utilities.hpp>
 #include <Acts/Surfaces/Surface.hpp>
 #include <Acts/Visualization/GeometryView3D.hpp>
 #include <Acts/Visualization/ObjVisualization3D.hpp>
@@ -27,7 +27,7 @@ using namespace pybind11::literals;
 
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addObj(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
@@ -44,12 +44,12 @@ void addObj(Context& ctx) {
             [](const std::vector<std::shared_ptr<Surface>>& surfaces,
                const GeometryContext& viewContext, const ViewConfig& viewConfig,
                const std::string& fileName) {
-              Acts::GeometryView3D view3D;
-              Acts::ObjVisualization3D obj;
+              GeometryView3D view3D;
+              ObjVisualization3D obj;
 
               for (const auto& surface : surfaces) {
                 view3D.drawSurface(obj, *surface, viewContext,
-                                   Acts::Transform3::Identity(), viewConfig);
+                                   Transform3::Identity(), viewConfig);
               }
               obj.write(fileName);
             });
@@ -58,13 +58,12 @@ void addObj(Context& ctx) {
                    Volumes,
                const GeometryContext& viewContext, const ViewConfig& viewConfig,
                const std::string& fileName) {
-              Acts::GeometryView3D view3D;
-              Acts::ObjVisualization3D obj;
+              GeometryView3D view3D;
+              ObjVisualization3D obj;
 
               for (const auto& volume : Volumes) {
                 view3D.drawDetectorVolume(obj, *volume, viewContext,
-                                          Acts::Transform3::Identity(),
-                                          viewConfig);
+                                          Transform3::Identity(), viewConfig);
               }
               obj.write(fileName);
             });
@@ -74,17 +73,16 @@ void addObj(Context& ctx) {
                    Volumes,
                const GeometryContext& viewContext, const ViewConfig& viewConfig,
                const std::string& fileName) {
-              Acts::GeometryView3D view3D;
-              Acts::ObjVisualization3D obj;
+              GeometryView3D view3D;
+              ObjVisualization3D obj;
 
               for (const auto& volume : Volumes) {
                 view3D.drawDetectorVolume(obj, *volume, viewContext,
-                                          Acts::Transform3::Identity(),
-                                          viewConfig);
+                                          Transform3::Identity(), viewConfig);
               }
               for (const auto& surface : surfaces) {
                 view3D.drawSurface(obj, *surface, viewContext,
-                                   Acts::Transform3::Identity(), viewConfig);
+                                   Transform3::Identity(), viewConfig);
               }
               obj.write(fileName);
             });
@@ -93,4 +91,4 @@ void addObj(Context& ctx) {
   py::class_<ObjVisualization3D, IVisualization3D>(m, "ObjVisualization3D")
       .def(py::init<>());
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Onnx.cpp
+++ b/Examples/Python/src/Onnx.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/TrackFindingML/AmbiguityResolutionMLAlgorithm.hpp"
 #include "ActsExamples/TrackFindingML/SeedFilterMLAlgorithm.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -18,22 +19,21 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addOnnx(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
   auto onnx = mex.def_submodule("_onnx");
   ctx.modules["onnx"] = onnx;
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::AmbiguityResolutionMLAlgorithm,
-                                onnx, "AmbiguityResolutionMLAlgorithm",
-                                inputTracks, inputDuplicateNN, outputTracks,
-                                nMeasurementsMin);
+  ACTS_PYTHON_DECLARE_ALGORITHM(
+      AmbiguityResolutionMLAlgorithm, onnx, "AmbiguityResolutionMLAlgorithm",
+      inputTracks, inputDuplicateNN, outputTracks, nMeasurementsMin);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SeedFilterMLAlgorithm, onnx,
+  ACTS_PYTHON_DECLARE_ALGORITHM(SeedFilterMLAlgorithm, onnx,
                                 "SeedFilterMLAlgorithm", inputTrackParameters,
                                 inputSimSeeds, inputSeedFilterNN,
                                 outputTrackParameters, outputSimSeeds,
                                 epsilonDBScan, minPointsDBScan, minSeedScore);
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/OnnxNeuralCalibrator.cpp
+++ b/Examples/Python/src/OnnxNeuralCalibrator.cpp
@@ -6,7 +6,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 #include <ActsExamples/EventData/NeuralCalibrator.hpp>
 
 #include <pybind11/pybind11.h>
@@ -17,7 +17,7 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addOnnxNeuralCalibrator(Context &ctx) {
   auto [m, mex, onnx] = ctx.get("main", "examples", "onnx");
@@ -32,4 +32,4 @@ void addOnnxNeuralCalibrator(Context &ctx) {
       py::arg("modelPath"), py::arg("nComp") = 1,
       py::arg("volumeIds") = std::vector<std::size_t>({7, 8, 9}));
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/OnnxNeuralCalibratorStub.cpp
+++ b/Examples/Python/src/OnnxNeuralCalibratorStub.cpp
@@ -6,14 +6,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addOnnxNeuralCalibrator(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/OnnxStub.cpp
+++ b/Examples/Python/src/OnnxStub.cpp
@@ -6,12 +6,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
-namespace Acts::Python {
+namespace ActsPython {
 void addOnnx(Context& /*ctx*/) {
   // dummy function
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Output.cpp
+++ b/Examples/Python/src/Output.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Visualization/IVisualization3D.hpp"
 #include "Acts/Visualization/ViewConfig.hpp"
@@ -27,6 +26,8 @@
 #include "ActsExamples/Io/Obj/ObjTrackingGeometryWriter.hpp"
 #include "ActsExamples/MaterialMapping/IMaterialWriter.hpp"
 #include "ActsExamples/TrackFinding/ITrackParamsLookupWriter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <string>
@@ -49,22 +50,21 @@ struct AlgorithmContext;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+using namespace Acts;
 using namespace ActsExamples;
 
 namespace {
-template <ActsExamples::CsvBFieldWriter::CoordinateType CType, bool Grid>
-void register_csv_bfield_writer_binding(
-    pybind11::class_<ActsExamples::CsvBFieldWriter>& w) {
+template <CsvBFieldWriter::CoordinateType CType, bool Grid>
+void register_csv_bfield_writer_binding(pybind11::class_<CsvBFieldWriter>& w) {
   std::string name =
-      std::string(CType == ActsExamples::CsvBFieldWriter::CoordinateType::XYZ
-                      ? "Xyz"
-                      : "Rz") +
+      std::string(CType == CsvBFieldWriter::CoordinateType::XYZ ? "Xyz"
+                                                                : "Rz") +
       std::string(Grid ? "Grid" : "Gridless");
 
-  using Config = ActsExamples::CsvBFieldWriter::Config<CType, Grid>;
+  using Config = CsvBFieldWriter::Config<CType, Grid>;
   w.def_static((std::string("run") + name).c_str(),
-               [](const Config& config, Acts::Logging::Level level) {
-                 ActsExamples::CsvBFieldWriter::run(config, level);
+               [](const Config& config, Logging::Level level) {
+                 CsvBFieldWriter::run(config, level);
                },
                py::arg("config"), py::arg("level"));
   auto c = py::class_<Config>(w, (std::string("Config") + name).c_str())
@@ -73,20 +73,19 @@ void register_csv_bfield_writer_binding(
 }
 }  // namespace
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addOutput(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::ObjPropagationStepsWriter, mex,
+  ACTS_PYTHON_DECLARE_WRITER(ObjPropagationStepsWriter, mex,
                              "ObjPropagationStepsWriter", collection, outputDir,
                              outputScalor, outputPrecision);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::ObjSimHitWriter, mex,
-                             "ObjSimHitWriter", inputSimHits, outputDir,
-                             outputStem, outputPrecision, drawConnections,
-                             momentumThreshold, momentumThresholdTraj,
-                             nInterpolatedPoints, keepOriginalHits);
+  ACTS_PYTHON_DECLARE_WRITER(
+      ObjSimHitWriter, mex, "ObjSimHitWriter", inputSimHits, outputDir,
+      outputStem, outputPrecision, drawConnections, momentumThreshold,
+      momentumThresholdTraj, nInterpolatedPoints, keepOriginalHits);
 
   {
     auto c = py::class_<ViewConfig>(m, "ViewConfig").def(py::init<>());
@@ -110,14 +109,15 @@ void addOutput(Context& ctx) {
                         &IVisualization3D::write, py::const_));
 
   {
-    using Writer = ActsExamples::ObjTrackingGeometryWriter;
-    auto w = py::class_<Writer, std::shared_ptr<Writer>>(
-                 mex, "ObjTrackingGeometryWriter")
-                 .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
-                      py::arg("config"), py::arg("level"))
-                 .def("write", py::overload_cast<const AlgorithmContext&,
-                                                 const Acts::TrackingGeometry&>(
-                                   &Writer::write));
+    using Writer = ObjTrackingGeometryWriter;
+    auto w =
+        py::class_<Writer, std::shared_ptr<Writer>>(mex,
+                                                    "ObjTrackingGeometryWriter")
+            .def(py::init<const Writer::Config&, Logging::Level>(),
+                 py::arg("config"), py::arg("level"))
+            .def("write",
+                 py::overload_cast<const AlgorithmContext&,
+                                   const TrackingGeometry&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
 
@@ -126,52 +126,49 @@ void addOutput(Context& ctx) {
                        gridView);
   }
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvParticleWriter, mex,
-                             "CsvParticleWriter", inputParticles, outputDir,
-                             outputStem, outputPrecision);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvMeasurementWriter, mex,
-                             "CsvMeasurementWriter", inputMeasurements,
-                             inputClusters, inputMeasurementSimHitsMap,
-                             outputDir, outputPrecision);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvSimHitWriter, mex,
-                             "CsvSimHitWriter", inputSimHits, outputDir,
-                             outputStem, outputPrecision);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvSpacePointWriter, mex,
-                             "CsvSpacePointWriter", inputSpacepoints, outputDir,
+  ACTS_PYTHON_DECLARE_WRITER(CsvParticleWriter, mex, "CsvParticleWriter",
+                             inputParticles, outputDir, outputStem,
                              outputPrecision);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvSpacePointsBucketWriter, mex,
+  ACTS_PYTHON_DECLARE_WRITER(
+      CsvMeasurementWriter, mex, "CsvMeasurementWriter", inputMeasurements,
+      inputClusters, inputMeasurementSimHitsMap, outputDir, outputPrecision);
+
+  ACTS_PYTHON_DECLARE_WRITER(CsvSimHitWriter, mex, "CsvSimHitWriter",
+                             inputSimHits, outputDir, outputStem,
+                             outputPrecision);
+
+  ACTS_PYTHON_DECLARE_WRITER(CsvSpacePointWriter, mex, "CsvSpacePointWriter",
+                             inputSpacepoints, outputDir, outputPrecision);
+
+  ACTS_PYTHON_DECLARE_WRITER(CsvSpacePointsBucketWriter, mex,
                              "CsvSpacePointsBucketWriter", inputBuckets,
                              outputDir, outputPrecision);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvTrackWriter, mex,
-                             "CsvTrackWriter", inputTracks, outputDir, fileName,
-                             inputMeasurementParticlesMap, outputPrecision,
-                             nMeasurementsMin, truthMatchProbMin, ptMin);
+  ACTS_PYTHON_DECLARE_WRITER(CsvTrackWriter, mex, "CsvTrackWriter", inputTracks,
+                             outputDir, fileName, inputMeasurementParticlesMap,
+                             outputPrecision, nMeasurementsMin,
+                             truthMatchProbMin, ptMin);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvSeedWriter, mex, "CsvSeedWriter",
+  ACTS_PYTHON_DECLARE_WRITER(CsvSeedWriter, mex, "CsvSeedWriter",
                              inputTrackParameters, inputSimSeeds, inputSimHits,
                              inputMeasurementParticlesMap,
                              inputMeasurementSimHitsMap, fileName, outputDir);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::CsvTrackingGeometryWriter, mex, "CsvTrackingGeometryWriter",
+      CsvTrackingGeometryWriter, mex, "CsvTrackingGeometryWriter",
       trackingGeometry, outputDir, outputPrecision, writeSensitive,
       writeBoundary, writeSurfaceGrid, writeLayerVolume, writePerEvent);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvTrackParameterWriter, mex,
+  ACTS_PYTHON_DECLARE_WRITER(CsvTrackParameterWriter, mex,
                              "CsvTrackParameterWriter", inputTracks, outputDir,
                              outputStem, outputPrecision);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvProtoTrackWriter, mex,
-                             "CsvProtoTrackWriter", inputSpacepoints,
-                             inputPrototracks, outputDir);
+  ACTS_PYTHON_DECLARE_WRITER(CsvProtoTrackWriter, mex, "CsvProtoTrackWriter",
+                             inputSpacepoints, inputPrototracks, outputDir);
 
   {
-    using Writer = ActsExamples::CsvBFieldWriter;
+    using Writer = CsvBFieldWriter;
 
     auto w = py::class_<Writer>(mex, "CsvBFieldWriter");
 
@@ -185,16 +182,15 @@ void addOutput(Context& ctx) {
     register_csv_bfield_writer_binding<Writer::CoordinateType::RZ, false>(w);
   }
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::CsvGnnGraphWriter, mex,
-                             "CsvGnnGraphWriter", inputGraph, outputDir,
-                             outputStem);
+  ACTS_PYTHON_DECLARE_WRITER(CsvGnnGraphWriter, mex, "CsvGnnGraphWriter",
+                             inputGraph, outputDir, outputStem);
 
   py::class_<IMaterialWriter, std::shared_ptr<IMaterialWriter>>(
       mex, "IMaterialWriter");
 
-  py::class_<ActsExamples::ITrackParamsLookupWriter,
-             std::shared_ptr<ActsExamples::ITrackParamsLookupWriter>>(
+  py::class_<ITrackParamsLookupWriter,
+             std::shared_ptr<ITrackParamsLookupWriter>>(
       mex, "ITrackParamsLookupWriter");
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/PodioComponent.cpp
+++ b/Examples/Python/src/PodioComponent.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/Io/Podio/PodioReader.hpp"
 #include "ActsExamples/Io/Podio/PodioWriter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -17,13 +18,13 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-using namespace Acts;
-using namespace Acts::Python;
+using namespace ActsExamples;
+using namespace ActsPython;
 
 PYBIND11_MODULE(ActsPythonBindingsPodio, m) {
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::PodioReader, m, "PodioReader",
-                             inputPath, outputFrame, category);
+  ACTS_PYTHON_DECLARE_READER(PodioReader, m, "PodioReader", inputPath,
+                             outputFrame, category);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::PodioWriter, m, "PodioWriter",
-                             inputFrame, outputPath, category, collections);
+  ACTS_PYTHON_DECLARE_WRITER(PodioWriter, m, "PodioWriter", inputFrame,
+                             outputPath, category, collections);
 }

--- a/Examples/Python/src/Pythia8.cpp
+++ b/Examples/Python/src/Pythia8.cpp
@@ -6,9 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Generators/Pythia8ProcessGenerator.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 #include <string>
@@ -21,19 +22,18 @@
 namespace py = pybind11;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 void addPythia8(Context& ctx) {
   auto mex = ctx.get("examples");
 
   auto p8 = mex.def_submodule("pythia8");
   ctx.modules["pythia8"] = p8;
 
-  using Gen = ActsExamples::Pythia8Generator;
-  auto gen =
-      py::class_<Gen, ActsExamples::ParticlesGenerator, std::shared_ptr<Gen>>(
-          p8, "Pythia8Generator")
-          .def(py::init<const Gen::Config&, Acts::Logging::Level>(),
-               py::arg("config"), py::arg("level"));
+  using Gen = Pythia8Generator;
+  auto gen = py::class_<Gen, ParticlesGenerator, std::shared_ptr<Gen>>(
+                 p8, "Pythia8Generator")
+                 .def(py::init<const Gen::Config&, Acts::Logging::Level>(),
+                      py::arg("config"), py::arg("level"));
 
   py::class_<Gen::Config>(gen, "Config")
       .def(py::init<>())
@@ -53,4 +53,4 @@ void addPythia8(Context& ctx) {
 
   patchClassesWithConfig(p8);
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Pythia8Stub.cpp
+++ b/Examples/Python/src/Pythia8Stub.cpp
@@ -6,8 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addPythia8(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/RootInput.cpp
+++ b/Examples/Python/src/RootInput.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/Io/Root/RootAthenaDumpReader.hpp"
 #include "ActsExamples/Io/Root/RootAthenaNTupleReader.hpp"
 #include "ActsExamples/Io/Root/RootMaterialDecorator.hpp"
@@ -15,6 +14,8 @@
 #include "ActsExamples/Io/Root/RootSimHitReader.hpp"
 #include "ActsExamples/Io/Root/RootTrackSummaryReader.hpp"
 #include "ActsExamples/Io/Root/RootVertexReader.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -22,62 +23,58 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addRootInput(Context& ctx) {
   auto mex = ctx.get("examples");
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootParticleReader, mex,
-                             "RootParticleReader", outputParticles, treeName,
-                             filePath);
+  ACTS_PYTHON_DECLARE_READER(RootParticleReader, mex, "RootParticleReader",
+                             outputParticles, treeName, filePath);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootVertexReader, mex,
-                             "RootVertexReader", outputVertices, treeName,
-                             filePath);
+  ACTS_PYTHON_DECLARE_READER(RootVertexReader, mex, "RootVertexReader",
+                             outputVertices, treeName, filePath);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootMaterialTrackReader, mex,
+  ACTS_PYTHON_DECLARE_READER(RootMaterialTrackReader, mex,
                              "RootMaterialTrackReader", outputMaterialTracks,
                              treeName, fileList, readCachedSurfaceInformation);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootTrackSummaryReader, mex,
+  ACTS_PYTHON_DECLARE_READER(RootTrackSummaryReader, mex,
                              "RootTrackSummaryReader", outputTracks,
                              outputParticles, treeName, filePath);
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootAthenaNTupleReader, mex,
-                             "RootAthenaNTupleReader", inputTreeName,
-                             inputFilePath, outputTrackParameters,
-                             outputTruthVtxParameters, outputRecoVtxParameters,
-                             outputBeamspotConstraint);
+  ACTS_PYTHON_DECLARE_READER(
+      RootAthenaNTupleReader, mex, "RootAthenaNTupleReader", inputTreeName,
+      inputFilePath, outputTrackParameters, outputTruthVtxParameters,
+      outputRecoVtxParameters, outputBeamspotConstraint);
 
   ACTS_PYTHON_DECLARE_READER(
-      ActsExamples::RootAthenaDumpReader, mex, "RootAthenaDumpReader", treename,
-      inputfiles, outputMeasurements, outputPixelSpacePoints,
-      outputStripSpacePoints, outputSpacePoints, outputClusters,
-      outputMeasurementParticlesMap, outputParticleMeasurementsMap,
-      outputParticles, onlySpacepoints, onlyPassedParticles, skipOverlapSPsPhi,
-      skipOverlapSPsEta, geometryIdMap, trackingGeometry, absBoundaryTolerance,
-      onlySpacepoints, noTruth, readCellData);
+      RootAthenaDumpReader, mex, "RootAthenaDumpReader", treename, inputfiles,
+      outputMeasurements, outputPixelSpacePoints, outputStripSpacePoints,
+      outputSpacePoints, outputClusters, outputMeasurementParticlesMap,
+      outputParticleMeasurementsMap, outputParticles, onlySpacepoints,
+      onlyPassedParticles, skipOverlapSPsPhi, skipOverlapSPsEta, geometryIdMap,
+      trackingGeometry, absBoundaryTolerance, onlySpacepoints, noTruth,
+      readCellData);
 
 #ifdef WITH_GEOMODEL_PLUGIN
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootAthenaDumpGeoIdCollector, mex,
+  ACTS_PYTHON_DECLARE_READER(RootAthenaDumpGeoIdCollector, mex,
                              "RootAthenaDumpGeoIdCollector", treename,
                              inputfile, trackingGeometry, geometryIdMap);
 #endif
 
-  ACTS_PYTHON_DECLARE_READER(ActsExamples::RootSimHitReader, mex,
-                             "RootSimHitReader", treeName, filePath,
-                             outputSimHits);
+  ACTS_PYTHON_DECLARE_READER(RootSimHitReader, mex, "RootSimHitReader",
+                             treeName, filePath, outputSimHits);
 
   {
     auto rmd =
-        py::class_<RootMaterialDecorator, Acts::IMaterialDecorator,
+        py::class_<RootMaterialDecorator, IMaterialDecorator,
                    std::shared_ptr<RootMaterialDecorator>>(
             mex, "RootMaterialDecorator")
-            .def(
-                py::init<RootMaterialDecorator::Config, Acts::Logging::Level>(),
-                py::arg("config"), py::arg("level"));
+            .def(py::init<RootMaterialDecorator::Config, Logging::Level>(),
+                 py::arg("config"), py::arg("level"));
 
     using Config = RootMaterialDecorator::Config;
     auto c = py::class_<Config>(rmd, "Config").def(py::init<>());
@@ -86,4 +83,4 @@ void addRootInput(Context& ctx) {
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/RootOutput.cpp
+++ b/Examples/Python/src/RootOutput.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Plugins/Root/RootMaterialMapIo.hpp"
 #include "ActsExamples/Io/Root/RootBFieldWriter.hpp"
 #include "ActsExamples/Io/Root/RootMaterialTrackWriter.hpp"
@@ -27,6 +26,8 @@
 #include "ActsExamples/Io/Root/TrackFinderPerformanceWriter.hpp"
 #include "ActsExamples/Io/Root/TrackFitterPerformanceWriter.hpp"
 #include "ActsExamples/Io/Root/VertexNTupleWriter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -46,9 +47,10 @@ struct AlgorithmContext;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addRootOutput(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -74,56 +76,51 @@ void addRootOutput(Context& ctx) {
   }
 
   // ROOT WRITERS
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootPropagationStepsWriter, mex,
+  ACTS_PYTHON_DECLARE_WRITER(RootPropagationStepsWriter, mex,
                              "RootPropagationStepsWriter", collection, filePath,
                              fileMode);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootPropagationSummaryWriter, mex,
+  ACTS_PYTHON_DECLARE_WRITER(RootPropagationSummaryWriter, mex,
                              "RootPropagationSummaryWriter",
                              inputSummaryCollection, filePath, fileMode);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootParticleWriter, mex,
-                             "RootParticleWriter", inputParticles, filePath,
-                             fileMode, treeName);
+  ACTS_PYTHON_DECLARE_WRITER(RootParticleWriter, mex, "RootParticleWriter",
+                             inputParticles, filePath, fileMode, treeName);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootVertexWriter, mex,
-                             "RootVertexWriter", inputVertices, filePath,
-                             fileMode, treeName);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::TrackFinderNTupleWriter, mex,
-                             "TrackFinderNTupleWriter", inputTracks,
-                             inputParticles, inputParticleMeasurementsMap,
-                             inputTrackParticleMatching, filePath, fileMode,
-                             treeNameTracks, treeNameParticles);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::TrackFitterPerformanceWriter, mex,
-                             "TrackFitterPerformanceWriter", inputTracks,
-                             inputParticles, inputTrackParticleMatching,
-                             filePath, resPlotToolConfig, effPlotToolConfig,
-                             trackSummaryPlotToolConfig);
+  ACTS_PYTHON_DECLARE_WRITER(RootVertexWriter, mex, "RootVertexWriter",
+                             inputVertices, filePath, fileMode, treeName);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::RootTrackParameterWriter, mex, "RootTrackParameterWriter",
+      TrackFinderNTupleWriter, mex, "TrackFinderNTupleWriter", inputTracks,
+      inputParticles, inputParticleMeasurementsMap, inputTrackParticleMatching,
+      filePath, fileMode, treeNameTracks, treeNameParticles);
+
+  ACTS_PYTHON_DECLARE_WRITER(
+      TrackFitterPerformanceWriter, mex, "TrackFitterPerformanceWriter",
+      inputTracks, inputParticles, inputTrackParticleMatching, filePath,
+      resPlotToolConfig, effPlotToolConfig, trackSummaryPlotToolConfig);
+
+  ACTS_PYTHON_DECLARE_WRITER(
+      RootTrackParameterWriter, mex, "RootTrackParameterWriter",
       inputTrackParameters, inputProtoTracks, inputParticles, inputSimHits,
       inputMeasurementParticlesMap, inputMeasurementSimHitsMap, filePath,
       treeName, fileMode);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::RootMaterialTrackWriter, mex, "RootMaterialTrackWriter",
+      RootMaterialTrackWriter, mex, "RootMaterialTrackWriter",
       inputMaterialTracks, filePath, fileMode, treeName, recalculateTotals,
       prePostStep, storeSurface, storeVolume, collapseInteractions);
 
   {
-    using Writer = ActsExamples::RootBFieldWriter;
-    auto w =
-        py::class_<Writer>(mex, "RootBFieldWriter")
-            .def_static(
-                "run",
-                [](const Writer::Config& config, Acts::Logging::Level level) {
-                  Writer::run(config, Acts::getDefaultLogger("RootBFieldWriter",
-                                                             level));
-                },
-                py::arg("config"), py::arg("level"));
+    using Writer = RootBFieldWriter;
+    auto w = py::class_<Writer>(mex, "RootBFieldWriter")
+                 .def_static(
+                     "run",
+                     [](const Writer::Config& config, Logging::Level level) {
+                       Writer::run(config,
+                                   getDefaultLogger("RootBFieldWriter", level));
+                     },
+                     py::arg("config"), py::arg("level"));
 
     py::enum_<Writer::GridType>(w, "GridType")
         .value("rz", Writer::GridType::rz)
@@ -135,10 +132,10 @@ void addRootOutput(Context& ctx) {
   }
 
   {
-    using Writer = ActsExamples::RootMeasurementWriter;
+    using Writer = RootMeasurementWriter;
     auto w = py::class_<Writer, IWriter, std::shared_ptr<Writer>>(
                  mex, "RootMeasurementWriter")
-                 .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
+                 .def(py::init<const Writer::Config&, Logging::Level>(),
                       py::arg("config"), py::arg("level"));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
@@ -149,13 +146,14 @@ void addRootOutput(Context& ctx) {
   }
 
   {
-    using Writer = ActsExamples::RootMaterialWriter;
-    auto w = py::class_<Writer, IMaterialWriter, std::shared_ptr<Writer>>(
-                 mex, "RootMaterialWriter")
-                 .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
-                      py::arg("config"), py::arg("level"))
-                 .def("write", py::overload_cast<const Acts::TrackingGeometry&>(
-                                   &Writer::write));
+    using Writer = RootMaterialWriter;
+    auto w =
+        py::class_<Writer, IMaterialWriter, std::shared_ptr<Writer>>(
+            mex, "RootMaterialWriter")
+            .def(py::init<const Writer::Config&, Logging::Level>(),
+                 py::arg("config"), py::arg("level"))
+            .def("write",
+                 py::overload_cast<const TrackingGeometry&>(&Writer::write));
 
     auto ac = py::class_<RootMaterialMapIo::Config>(w, "AccessorConfig")
                   .def(py::init<>());
@@ -181,50 +179,46 @@ void addRootOutput(Context& ctx) {
                        accessorOptions, filePath, fileMode);
   }
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootSeedWriter, mex,
-                             "RootSeedWriter", inputSeeds, writingMode,
+  ACTS_PYTHON_DECLARE_WRITER(RootSeedWriter, mex, "RootSeedWriter", inputSeeds,
+                             writingMode, filePath, fileMode, treeName);
+
+  ACTS_PYTHON_DECLARE_WRITER(RootSimHitWriter, mex, "RootSimHitWriter",
+                             inputSimHits, filePath, fileMode, treeName);
+
+  ACTS_PYTHON_DECLARE_WRITER(RootSpacepointWriter, mex, "RootSpacepointWriter",
+                             inputSpacepoints, inputMeasurementParticlesMap,
                              filePath, fileMode, treeName);
 
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootSimHitWriter, mex,
-                             "RootSimHitWriter", inputSimHits, filePath,
-                             fileMode, treeName);
-
-  ACTS_PYTHON_DECLARE_WRITER(ActsExamples::RootSpacepointWriter, mex,
-                             "RootSpacepointWriter", inputSpacepoints,
-                             inputMeasurementParticlesMap, filePath, fileMode,
-                             treeName);
-
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::RootTrackStatesWriter, mex, "RootTrackStatesWriter",
-      inputTracks, inputParticles, inputTrackParticleMatching, inputSimHits,
+      RootTrackStatesWriter, mex, "RootTrackStatesWriter", inputTracks,
+      inputParticles, inputTrackParticleMatching, inputSimHits,
       inputMeasurementSimHitsMap, filePath, treeName, fileMode);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::RootTrackSummaryWriter, mex, "RootTrackSummaryWriter",
-      inputTracks, inputParticles, inputTrackParticleMatching, filePath,
-      treeName, fileMode, writeCovMat, writeGsfSpecific, writeGx2fSpecific);
+      RootTrackSummaryWriter, mex, "RootTrackSummaryWriter", inputTracks,
+      inputParticles, inputTrackParticleMatching, filePath, treeName, fileMode,
+      writeCovMat, writeGsfSpecific, writeGx2fSpecific);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::VertexNTupleWriter, mex, "VertexNTupleWriter",
-      inputVertices, inputTracks, inputTruthVertices, inputParticles,
-      inputSelectedParticles, inputTrackParticleMatching, bField, filePath,
-      treeName, fileMode, vertexMatchThreshold, trackMatchThreshold,
-      writeTrackInfo);
+      VertexNTupleWriter, mex, "VertexNTupleWriter", inputVertices, inputTracks,
+      inputTruthVertices, inputParticles, inputSelectedParticles,
+      inputTrackParticleMatching, bField, filePath, treeName, fileMode,
+      vertexMatchThreshold, trackMatchThreshold, writeTrackInfo);
 
   ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::TrackFinderPerformanceWriter, mex,
-      "TrackFinderPerformanceWriter", inputTracks, inputParticles,
-      inputTrackParticleMatching, inputParticleTrackMatching,
-      inputParticleMeasurementsMap, filePath, fileMode, effPlotToolConfig,
-      fakePlotToolConfig, duplicationPlotToolConfig, trackSummaryPlotToolConfig,
+      TrackFinderPerformanceWriter, mex, "TrackFinderPerformanceWriter",
+      inputTracks, inputParticles, inputTrackParticleMatching,
+      inputParticleTrackMatching, inputParticleMeasurementsMap, filePath,
+      fileMode, effPlotToolConfig, fakePlotToolConfig,
+      duplicationPlotToolConfig, trackSummaryPlotToolConfig,
       subDetectorTrackSummaryVolumes, writeMatchingDetails);
 
-  ACTS_PYTHON_DECLARE_WRITER(
-      ActsExamples::RootNuclearInteractionParametersWriter, mex,
-      "RootNuclearInteractionParametersWriter", inputSimulationProcesses,
-      filePath, fileMode, interactionProbabilityBins, momentumBins,
-      invariantMassBins, multiplicityMax, writeOptionalHistograms,
-      nSimulatedEvents);
+  ACTS_PYTHON_DECLARE_WRITER(RootNuclearInteractionParametersWriter, mex,
+                             "RootNuclearInteractionParametersWriter",
+                             inputSimulationProcesses, filePath, fileMode,
+                             interactionProbabilityBins, momentumBins,
+                             invariantMassBins, multiplicityMax,
+                             writeOptionalHistograms, nSimulatedEvents);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/RootStub.cpp
+++ b/Examples/Python/src/RootStub.cpp
@@ -6,9 +6,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addRootInput(Context& /*ctx*/) {}
 void addRootOutput(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Svg.cpp
+++ b/Examples/Python/src/Svg.cpp
@@ -26,7 +26,6 @@
 #include "Acts/Plugins/ActSVG/SurfaceSvgConverter.hpp"
 #include "Acts/Plugins/ActSVG/SvgUtils.hpp"
 #include "Acts/Plugins/ActSVG/TrackingGeometrySvgConverter.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/DiscBounds.hpp"
 #include "Acts/Utilities/Enumerate.hpp"
@@ -36,6 +35,8 @@
 #include "ActsExamples/EventData/SimSpacePoint.hpp"
 #include "ActsExamples/Io/Svg/SvgPointWriter.hpp"
 #include "ActsExamples/Io/Svg/SvgTrackingGeometryWriter.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 #include <actsvg/core/draw.hpp>
 
 #include <algorithm>
@@ -53,6 +54,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 using namespace Acts;
+using namespace Acts::Experimental;
 using namespace ActsExamples;
 
 namespace {
@@ -75,8 +77,7 @@ bool viewRangeSel(const Svg::ProtoSurface& s, const Extent& vRange) {
 ///
 /// @param view is the view type, e.g. 'xy', 'zr', ...
 /// @param selection is the selection of the volume, e.g. 'all', 'sensitives', 'portals', 'materials'
-using ViewAndRange =
-    std::tuple<std::string, std::vector<std::string>, Acts::Extent>;
+using ViewAndRange = std::tuple<std::string, std::vector<std::string>, Extent>;
 
 /// Helper function to be picked in different access patterns
 ///
@@ -166,8 +167,7 @@ actsvg::svg::object drawDetectorVolume(const Svg::ProtoVolume& pVolume,
 
 // Helper function to be picked in different access patterns
 std::vector<actsvg::svg::object> drawDetector(
-    const Acts::GeometryContext& gctx,
-    const Acts::Experimental::Detector& detector,
+    const GeometryContext& gctx, const Detector& detector,
     const std::string& identification,
     const std::vector<std::tuple<int, Svg::DetectorVolumeConverter::Options>>&
         volumeIdxOpts,
@@ -190,7 +190,7 @@ std::vector<actsvg::svg::object> drawDetector(
     auto [pVolume, pGrid] =
         Svg::DetectorVolumeConverter::convert(gctx, *v, vopts);
 
-    for (auto [iv, var] : Acts::enumerate(viewAndRanges)) {
+    for (auto [iv, var] : enumerate(viewAndRanges)) {
       auto [view, selection, range] = var;
       // Get the view and the range
       auto svgVolView = drawDetectorVolume(
@@ -204,16 +204,13 @@ std::vector<actsvg::svg::object> drawDetector(
 
 }  // namespace
 
-namespace Acts::Python {
+namespace ActsPython {
 void addSvg(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   auto svg = m.def_submodule("svg");
 
-  {
-    svg.def("toFile", &Acts::Svg::toFile, py::arg("objects"),
-            py::arg("filename"));
-  }
+  { svg.def("toFile", &Svg::toFile, py::arg("objects"), py::arg("filename")); }
 
   py::class_<actsvg::svg::object>(svg, "object")
       .def_readwrite("id", &actsvg::svg::object::_id);
@@ -233,10 +230,7 @@ void addSvg(Context& ctx) {
              file.close();
            });
 
-  {
-    svg.def("toFile", &Acts::Svg::toFile, py::arg("objects"),
-            py::arg("filename"));
-  }
+  { svg.def("toFile", &Svg::toFile, py::arg("objects"), py::arg("filename")); }
 
   // Core components, added as an acts.svg submodule
   {
@@ -255,7 +249,7 @@ void addSvg(Context& ctx) {
 
     // Define the proto surface
     py::class_<Svg::ProtoSurface>(svg, "ProtoSurface");
-    // Convert an Acts::Surface object into an acts::svg::proto::surface
+    // Convert an Surface object into an svg::proto::surface
 
     svg.def("convertSurface", &Svg::SurfaceConverter::convert);
 
@@ -286,8 +280,8 @@ void addSvg(Context& ctx) {
 
     // Define the proto portal
     py::class_<Svg::ProtoPortal>(svg, "ProtoPortal");
-    // Convert an Acts::Experimental::Portal object into an
-    // acts::svg::proto::portal
+    // Convert an Portal object into an
+    // svg::proto::portal
     svg.def("convertPortal", &Svg::PortalConverter::convert);
 
     // Define the view functions
@@ -362,8 +356,8 @@ void addSvg(Context& ctx) {
     ACTS_PYTHON_STRUCT(c, portalIndices, portalOptions, surfaceOptions,
                        indexedSurfacesOptions);
 
-    // Convert an Acts::Experimental::DetectorVolume object into an
-    // acts::svg::proto::volume
+    // Convert an DetectorVolume object into an
+    // svg::proto::volume
     svg.def("convertDetectorVolume", &Svg::DetectorVolumeConverter::convert);
 
     // Define the view functions
@@ -417,24 +411,25 @@ void addSvg(Context& ctx) {
   // Components from the ActsExamples - part of acts.examples
 
   {
-    using Writer = ActsExamples::SvgTrackingGeometryWriter;
-    auto w = py::class_<Writer, std::shared_ptr<Writer>>(
-                 mex, "SvgTrackingGeometryWriter")
-                 .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
-                      py::arg("config"), py::arg("level"))
-                 .def("write", py::overload_cast<const AlgorithmContext&,
-                                                 const Acts::TrackingGeometry&>(
-                                   &Writer::write));
+    using Writer = SvgTrackingGeometryWriter;
+    auto w =
+        py::class_<Writer, std::shared_ptr<Writer>>(mex,
+                                                    "SvgTrackingGeometryWriter")
+            .def(py::init<const Writer::Config&, Logging::Level>(),
+                 py::arg("config"), py::arg("level"))
+            .def("write",
+                 py::overload_cast<const AlgorithmContext&,
+                                   const TrackingGeometry&>(&Writer::write));
 
     auto c = py::class_<Writer::Config>(w, "Config").def(py::init<>());
     ACTS_PYTHON_STRUCT(c, outputDir, converterOptions);
   }
   {
-    using Writer = ActsExamples::SvgPointWriter<ActsExamples::SimSpacePoint>;
+    using Writer = SvgPointWriter<SimSpacePoint>;
     auto w =
-        py::class_<Writer, ActsExamples::IWriter, std::shared_ptr<Writer>>(
+        py::class_<Writer, IWriter, std::shared_ptr<Writer>>(
             mex, "SvgSimSpacePointWriter")
-            .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
+            .def(py::init<const Writer::Config&, Logging::Level>(),
                  py::arg("config"), py::arg("level"))
             .def("write",
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
@@ -445,13 +440,11 @@ void addSvg(Context& ctx) {
   }
 
   {
-    using Writer =
-        ActsExamples::SvgPointWriter<ActsExamples::SimHit,
-                                     ActsExamples::AccessorPositionXYZ>;
+    using Writer = SvgPointWriter<SimHit, AccessorPositionXYZ>;
     auto w =
-        py::class_<Writer, ActsExamples::IWriter, std::shared_ptr<Writer>>(
-            mex, "SvgSimHitWriter")
-            .def(py::init<const Writer::Config&, Acts::Logging::Level>(),
+        py::class_<Writer, IWriter, std::shared_ptr<Writer>>(mex,
+                                                             "SvgSimHitWriter")
+            .def(py::init<const Writer::Config&, Logging::Level>(),
                  py::arg("config"), py::arg("level"))
             .def("write",
                  py::overload_cast<const AlgorithmContext&>(&Writer::write));
@@ -480,4 +473,4 @@ void addSvg(Context& ctx) {
       py::arg("gctx"), py::arg("tGeometry"), py::arg("view"),
       py::arg("drawSurfaces") = true, py::arg("highlightMaterial") = false);
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/SvgStub.cpp
+++ b/Examples/Python/src/SvgStub.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
-namespace Acts::Python {
+namespace ActsPython {
 void addSvg(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TGeo.cpp
+++ b/Examples/Python/src/TGeo.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Plugins/Root/TGeoDetectorElement.hpp"
 #include "Acts/Plugins/Root/TGeoLayerBuilder.hpp"
 #include "Acts/Plugins/Root/TGeoParser.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <vector>
 
@@ -22,17 +22,18 @@
 namespace py = pybind11;
 using namespace pybind11::literals;
 
-namespace Acts::Python {
+using namespace Acts;
+
+namespace ActsPython {
 void addTGeo(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
   auto tgeo = mex.def_submodule("tgeo");
 
   {
-    py::class_<Acts::TGeoDetectorElement,
-               std::shared_ptr<Acts::TGeoDetectorElement>>(
+    py::class_<TGeoDetectorElement, std::shared_ptr<TGeoDetectorElement>>(
         tgeo, "TGeoDetectorElement")
-        .def("surface", [](const Acts::TGeoDetectorElement& self) {
+        .def("surface", [](const TGeoDetectorElement& self) {
           return self.surface().getSharedPtr();
         });
   }
@@ -44,44 +45,44 @@ void addTGeo(Context& ctx) {
     /// @param sensitiveMatches is a list of strings to match sensitive volumes
     /// @param localAxes is the TGeo->ACTS axis conversion convention
     /// @param scaleConversion is a unit scalor conversion factor
-    tgeo.def("_convertToElements",
-             [](const std::string& rootFileName,
-                const std::vector<std::string>& sensitiveMatches,
-                const std::string& localAxes, double scaleConversion) {
-               // Return vector
-               std::vector<std::shared_ptr<const Acts::TGeoDetectorElement>>
-                   tgElements;
-               // TGeo import
-               TGeoManager::Import(rootFileName.c_str());
-               if (gGeoManager != nullptr) {
-                 auto tVolume = gGeoManager->GetTopVolume();
-                 if (tVolume != nullptr) {
-                   TGeoHMatrix gmatrix = TGeoIdentity(tVolume->GetName());
+    tgeo.def(
+        "_convertToElements",
+        [](const std::string& rootFileName,
+           const std::vector<std::string>& sensitiveMatches,
+           const std::string& localAxes, double scaleConversion) {
+          // Return vector
+          std::vector<std::shared_ptr<const TGeoDetectorElement>> tgElements;
+          // TGeo import
+          TGeoManager::Import(rootFileName.c_str());
+          if (gGeoManager != nullptr) {
+            auto tVolume = gGeoManager->GetTopVolume();
+            if (tVolume != nullptr) {
+              TGeoHMatrix gmatrix = TGeoIdentity(tVolume->GetName());
 
-                   TGeoParser::Options tgpOptions;
-                   tgpOptions.volumeNames = {tVolume->GetName()};
-                   tgpOptions.targetNames = sensitiveMatches;
-                   tgpOptions.unit = scaleConversion;
-                   TGeoParser::State tgpState;
-                   tgpState.volume = tVolume;
-                   tgpState.onBranch = true;
+              TGeoParser::Options tgpOptions;
+              tgpOptions.volumeNames = {tVolume->GetName()};
+              tgpOptions.targetNames = sensitiveMatches;
+              tgpOptions.unit = scaleConversion;
+              TGeoParser::State tgpState;
+              tgpState.volume = tVolume;
+              tgpState.onBranch = true;
 
-                   TGeoParser::select(tgpState, tgpOptions, gmatrix);
-                   tgElements.reserve(tgpState.selectedNodes.size());
+              TGeoParser::select(tgpState, tgpOptions, gmatrix);
+              tgElements.reserve(tgpState.selectedNodes.size());
 
-                   for (const auto& snode : tgpState.selectedNodes) {
-                     auto identifier = Acts::TGeoDetectorElement::Identifier();
-                     auto tgElement = TGeoLayerBuilder::defaultElementFactory(
-                         identifier, *snode.node, *snode.transform, localAxes,
-                         scaleConversion, nullptr);
-                     tgElements.emplace_back(tgElement);
-                   }
-                 }
-               }
-               // Return the elements
-               return tgElements;
-             });
+              for (const auto& snode : tgpState.selectedNodes) {
+                auto identifier = TGeoDetectorElement::Identifier();
+                auto tgElement = TGeoLayerBuilder::defaultElementFactory(
+                    identifier, *snode.node, *snode.transform, localAxes,
+                    scaleConversion, nullptr);
+                tgElements.emplace_back(tgElement);
+              }
+            }
+          }
+          // Return the elements
+          return tgElements;
+        });
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TGeoStub.cpp
+++ b/Examples/Python/src/TGeoStub.cpp
@@ -6,10 +6,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-namespace Acts::Python {
+namespace ActsPython {
 struct Context;
-}  // namespace Acts::Python
+}  // namespace ActsPython
 
-namespace Acts::Python {
+namespace ActsPython {
 void addTGeo(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Traccc.cpp
+++ b/Examples/Python/src/Traccc.cpp
@@ -8,10 +8,10 @@
 
 #include "Acts/Plugins/Detray/DetrayConversionUtils.hpp"
 #include "Acts/Plugins/Detray/DetrayConverter.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/Propagation/PropagatorInterface.hpp"
 #include "ActsExamples/Traccc/DetrayPropagator.hpp"
 #include "ActsExamples/Traccc/DetrayStore.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <detray/propagator/line_stepper.hpp>
 #include <pybind11/pybind11.h>
@@ -24,7 +24,7 @@ using namespace pybind11::literals;
 using namespace Acts;
 using namespace ActsExamples;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addTraccc(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
@@ -68,4 +68,4 @@ void addTraccc(Context& ctx) {
         });
   }
 }
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TracccStub.cpp
+++ b/Examples/Python/src/TracccStub.cpp
@@ -6,8 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addTraccc(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TrackFinding.cpp
+++ b/Examples/Python/src/TrackFinding.cpp
@@ -8,7 +8,6 @@
 
 #include "Acts/EventData/SpacePointContainer.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Seeding/SeedConfirmationRangeConfig.hpp"
 #include "Acts/Seeding/SeedFilterConfig.hpp"
 #include "Acts/Seeding/SeedFinderConfig.hpp"
@@ -28,6 +27,8 @@
 #include "ActsExamples/TrackFinding/TrackFindingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/TrackParamsLookupEstimation.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -41,17 +42,16 @@
 namespace py = pybind11;
 
 using namespace ActsExamples;
-using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addTrackFinding(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SpacePointMaker, mex,
-                                "SpacePointMaker", inputMeasurements,
-                                outputSpacePoints, trackingGeometry,
-                                geometrySelection, stripGeometrySelection);
+  ACTS_PYTHON_DECLARE_ALGORITHM(SpacePointMaker, mex, "SpacePointMaker",
+                                inputMeasurements, outputSpacePoints,
+                                trackingGeometry, geometrySelection,
+                                stripGeometrySelection);
 
   {
     using Config = Acts::SeedFilterConfig;
@@ -67,7 +67,7 @@ void addTrackFinding(Context& ctx) {
 
   {
     using Config = Acts::SeedFinderConfig<typename Acts::SpacePointContainer<
-        ActsExamples::SpacePointContainer<std::vector<const SimSpacePoint*>>,
+        SpacePointContainer<std::vector<const SimSpacePoint*>>,
         Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c = py::class_<Config>(m, "SeedFinderConfig").def(py::init<>());
     ACTS_PYTHON_STRUCT(
@@ -85,16 +85,15 @@ void addTrackFinding(Context& ctx) {
     patchKwargsConstructor(c);
   }
   {
-    using seedOptions = Acts::SeedFinderOptions;
-    auto c = py::class_<seedOptions>(m, "SeedFinderOptions").def(py::init<>());
+    auto c = py::class_<Acts::SeedFinderOptions>(m, "SeedFinderOptions")
+                 .def(py::init<>());
     ACTS_PYTHON_STRUCT(c, beamPos, bFieldInZ);
     patchKwargsConstructor(c);
   }
   {
     using Config =
         Acts::SeedFinderOrthogonalConfig<typename Acts::SpacePointContainer<
-            ActsExamples::SpacePointContainer<
-                std::vector<const SimSpacePoint*>>,
+            SpacePointContainer<std::vector<const SimSpacePoint*>>,
             Acts::detail::RefHolder>::SpacePointProxyType>;
     auto c =
         py::class_<Config>(m, "SeedFinderOrthogonalConfig").def(py::init<>());
@@ -121,8 +120,8 @@ void addTrackFinding(Context& ctx) {
   }
 
   {
-    using seedConf = Acts::SeedConfirmationRangeConfig;
-    auto c = py::class_<seedConf>(m, "SeedConfirmationRangeConfig")
+    auto c = py::class_<Acts::SeedConfirmationRangeConfig>(
+                 m, "SeedConfirmationRangeConfig")
                  .def(py::init<>());
     ACTS_PYTHON_STRUCT(c, zMinSeedConf, zMaxSeedConf, rMaxSeedConf,
                        nTopForLargeR, nTopForSmallR, seedConfMinBottomRadius,
@@ -131,8 +130,9 @@ void addTrackFinding(Context& ctx) {
   }
 
   {
-    using Config = Acts::CylindricalSpacePointGridConfig;
-    auto c = py::class_<Config>(m, "SpacePointGridConfig").def(py::init<>());
+    auto c = py::class_<Acts::CylindricalSpacePointGridConfig>(
+                 m, "SpacePointGridConfig")
+                 .def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, minPt, rMax, zMax, zMin, phiMin, phiMax, deltaRMax,
                        cotThetaMax, phiBinDeflectionCoverage, maxPhiBins,
@@ -140,25 +140,26 @@ void addTrackFinding(Context& ctx) {
     patchKwargsConstructor(c);
   }
   {
-    using Options = Acts::CylindricalSpacePointGridOptions;
-    auto c = py::class_<Options>(m, "SpacePointGridOptions").def(py::init<>());
+    auto c = py::class_<Acts::CylindricalSpacePointGridOptions>(
+                 m, "SpacePointGridOptions")
+                 .def(py::init<>());
 
     ACTS_PYTHON_STRUCT(c, bFieldInZ);
     patchKwargsConstructor(c);
   }
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::SeedingAlgorithm, mex, "SeedingAlgorithm", inputSpacePoints,
-      outputSeeds, seedFilterConfig, seedFinderConfig, seedFinderOptions,
-      gridConfig, gridOptions, allowSeparateRMax, zBinNeighborsTop,
-      zBinNeighborsBottom, numPhiNeighbors, useExtraCuts);
+      SeedingAlgorithm, mex, "SeedingAlgorithm", inputSpacePoints, outputSeeds,
+      seedFilterConfig, seedFinderConfig, seedFinderOptions, gridConfig,
+      gridOptions, allowSeparateRMax, zBinNeighborsTop, zBinNeighborsBottom,
+      numPhiNeighbors, useExtraCuts);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::GridTripletSeedingAlgorithm, mex,
-      "GridTripletSeedingAlgorithm", inputSpacePoints, outputSeeds, bFieldInZ,
-      minPt, cotThetaMax, impactMax, deltaRMin, deltaRMax, deltaRMinTop,
-      deltaRMaxTop, deltaRMinBottom, deltaRMaxBottom, rMin, rMax, zMin, zMax,
-      phiMin, phiMax, phiBinDeflectionCoverage, maxPhiBins, zBinNeighborsTop,
+      GridTripletSeedingAlgorithm, mex, "GridTripletSeedingAlgorithm",
+      inputSpacePoints, outputSeeds, bFieldInZ, minPt, cotThetaMax, impactMax,
+      deltaRMin, deltaRMax, deltaRMinTop, deltaRMaxTop, deltaRMinBottom,
+      deltaRMaxBottom, rMin, rMax, zMin, zMax, phiMin, phiMax,
+      phiBinDeflectionCoverage, maxPhiBins, zBinNeighborsTop,
       zBinNeighborsBottom, numPhiNeighbors, zBinEdges, zBinsCustomLooping,
       rMinMiddle, rMaxMiddle, useVariableMiddleSPRange, rRangeMiddleSP,
       deltaRMiddleMinSPRange, deltaRMiddleMaxSPRange, deltaZMin, deltaZMax,
@@ -170,54 +171,51 @@ void addTrackFinding(Context& ctx) {
       forwardSeedConfirmationRange, maxSeedsPerSpMConf,
       maxQualitySeedsPerSpMConf, useDeltaRinsteadOfTopRadius, useExtraCuts);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SeedingOrthogonalAlgorithm, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(SeedingOrthogonalAlgorithm, mex,
                                 "SeedingOrthogonalAlgorithm", inputSpacePoints,
                                 outputSeeds, seedFilterConfig, seedFinderConfig,
                                 seedFinderOptions);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::GbtsSeedingAlgorithm, mex, "GbtsSeedingAlgorithm",
-      inputSpacePoints, outputSeeds, seedFinderConfig, seedFinderOptions,
-      layerMappingFile, geometrySelection, trackingGeometry, ActsGbtsMap,
-      fill_module_csv, inputClusters);
+      GbtsSeedingAlgorithm, mex, "GbtsSeedingAlgorithm", inputSpacePoints,
+      outputSeeds, seedFinderConfig, seedFinderOptions, layerMappingFile,
+      geometrySelection, trackingGeometry, ActsGbtsMap, fill_module_csv,
+      inputClusters);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::HoughTransformSeeder, mex, "HoughTransformSeeder",
-      inputSpacePoints, outputProtoTracks, trackingGeometry, geometrySelection,
-      inputMeasurements, subRegions, nLayers, xMin, xMax, yMin, yMax,
-      houghHistSize_x, houghHistSize_y, hitExtend_x, threshold,
-      localMaxWindowSize, kA);
+      HoughTransformSeeder, mex, "HoughTransformSeeder", inputSpacePoints,
+      outputProtoTracks, trackingGeometry, geometrySelection, inputMeasurements,
+      subRegions, nLayers, xMin, xMax, yMin, yMax, houghHistSize_x,
+      houghHistSize_y, hitExtend_x, threshold, localMaxWindowSize, kA);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::AdaptiveHoughTransformSeeder, mex,
-      "AdaptiveHoughTransformSeeder", inputSpacePoints, outputSeeds,
-      outputProtoTracks, trackingGeometry, qOverPtMin, qOverPtMinBinSize,
-      phiMinBinSize, threshold, noiseThreshold, deduplicate, inverseA,
-      doSecondPhase, zRange, cotThetaRange, cotThetaMinBinSize, zMinBinSize);
+      AdaptiveHoughTransformSeeder, mex, "AdaptiveHoughTransformSeeder",
+      inputSpacePoints, outputSeeds, outputProtoTracks, trackingGeometry,
+      qOverPtMin, qOverPtMinBinSize, phiMinBinSize, threshold, noiseThreshold,
+      deduplicate, inverseA, doSecondPhase, zRange, cotThetaRange,
+      cotThetaMinBinSize, zMinBinSize);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(MuonHoughSeeder, mex, "MuonHoughSeeder",
+                                inTruthSegments, inSpacePoints, outHoughMax,
+                                nBinsTanTheta, nBinsY0, nBinsTanPhi, nBinsX0);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::MuonHoughSeeder, mex, "MuonHoughSeeder", inTruthSegments,
-      inSpacePoints, outHoughMax, nBinsTanTheta, nBinsY0, nBinsTanPhi, nBinsX0);
+      TrackParamsEstimationAlgorithm, mex, "TrackParamsEstimationAlgorithm",
+      inputSeeds, inputProtoTracks, outputTrackParameters, outputSeeds,
+      outputProtoTracks, trackingGeometry, magneticField, bFieldMin,
+      initialSigmas, initialSigmaQoverPt, initialSigmaPtRel,
+      initialVarInflation, noTimeVarInflation, particleHypothesis);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackParamsEstimationAlgorithm, mex,
-      "TrackParamsEstimationAlgorithm", inputSeeds, inputProtoTracks,
-      outputTrackParameters, outputSeeds, outputProtoTracks, trackingGeometry,
-      magneticField, bFieldMin, initialSigmas, initialSigmaQoverPt,
-      initialSigmaPtRel, initialVarInflation, noTimeVarInflation,
-      particleHypothesis);
-
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrackParamsLookupEstimation, mex,
-                                "TrackParamsLookupEstimation", refLayers, bins,
-                                inputHits, inputParticles,
-                                trackLookupGridWriters);
+      TrackParamsLookupEstimation, mex, "TrackParamsLookupEstimation",
+      refLayers, bins, inputHits, inputParticles, trackLookupGridWriters);
 
   {
-    using Alg = ActsExamples::TrackFindingAlgorithm;
+    using Alg = TrackFindingAlgorithm;
     using Config = Alg::Config;
 
     auto alg =
-        py::class_<Alg, ActsExamples::IAlgorithm, std::shared_ptr<Alg>>(
+        py::class_<Alg, IAlgorithm, std::shared_ptr<Alg>>(
             mex, "TrackFindingAlgorithm")
             .def(py::init<const Config&, Acts::Logging::Level>(),
                  py::arg("config"), py::arg("level"))
@@ -227,7 +225,7 @@ void addTrackFinding(Context& ctx) {
                                trackingGeometry,
                            std::shared_ptr<const Acts::MagneticFieldProvider>
                                magneticField,
-                           Logging::Level level) {
+                           Acts::Logging::Level level) {
                           return Alg::makeTrackFinderFunction(
                               std::move(trackingGeometry),
                               std::move(magneticField),
@@ -251,41 +249,42 @@ void addTrackFinding(Context& ctx) {
   {
     auto constructor =
         [](const std::vector<std::pair<
-               GeometryIdentifier,
+               Acts::GeometryIdentifier,
                std::tuple<std::vector<double>, std::vector<double>,
                           std::vector<double>, std::vector<std::size_t>>>>&
                input) {
-          std::vector<std::pair<GeometryIdentifier, MeasurementSelectorCuts>>
+          std::vector<std::pair<Acts::GeometryIdentifier,
+                                Acts::MeasurementSelectorCuts>>
               converted;
           converted.reserve(input.size());
           for (const auto& [id, cuts] : input) {
             const auto& [bins, chi2Measurement, chi2Outlier, num] = cuts;
             converted.emplace_back(
-                id, MeasurementSelectorCuts{bins, chi2Measurement, num,
-                                            chi2Outlier});
+                id, Acts::MeasurementSelectorCuts{bins, chi2Measurement, num,
+                                                  chi2Outlier});
           }
-          return std::make_unique<MeasurementSelector::Config>(converted);
+          return std::make_unique<Acts::MeasurementSelector::Config>(converted);
         };
 
-    py::class_<MeasurementSelectorCuts>(m, "MeasurementSelectorCuts")
+    py::class_<Acts::MeasurementSelectorCuts>(m, "MeasurementSelectorCuts")
         .def(py::init<>())
         .def(py::init<std::vector<double>, std::vector<double>,
                       std::vector<std::size_t>, std::vector<double>>())
-        .def_readwrite("etaBins", &MeasurementSelectorCuts::etaBins)
+        .def_readwrite("etaBins", &Acts::MeasurementSelectorCuts::etaBins)
         .def_readwrite("chi2CutOffMeasurement",
-                       &MeasurementSelectorCuts::chi2CutOff)
+                       &Acts::MeasurementSelectorCuts::chi2CutOff)
         .def_readwrite("chi2CutOffOutlier",
-                       &MeasurementSelectorCuts::chi2CutOffOutlier)
+                       &Acts::MeasurementSelectorCuts::chi2CutOffOutlier)
         .def_readwrite("numMeasurementsCutOff",
-                       &MeasurementSelectorCuts::numMeasurementsCutOff);
+                       &Acts::MeasurementSelectorCuts::numMeasurementsCutOff);
 
-    auto ms = py::class_<MeasurementSelector>(m, "MeasurementSelector");
-    auto c =
-        py::class_<MeasurementSelector::Config>(ms, "Config")
-            .def(py::init<std::vector<
-                     std::pair<GeometryIdentifier, MeasurementSelectorCuts>>>())
-            .def(py::init(constructor));
+    auto ms = py::class_<Acts::MeasurementSelector>(m, "MeasurementSelector");
+    auto c = py::class_<Acts::MeasurementSelector::Config>(ms, "Config")
+                 .def(py::init<
+                      std::vector<std::pair<Acts::GeometryIdentifier,
+                                            Acts::MeasurementSelectorCuts>>>())
+                 .def(py::init(constructor));
   }
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TruthJet.cpp
+++ b/Examples/Python/src/TruthJet.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Jets/TruthJetAlgorithm.hpp"
 #include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -19,15 +20,13 @@
 namespace py = pybind11;
 
 using namespace ActsExamples;
-using namespace Acts;
 
 namespace ActsPython {
 
 void addTruthJet(Context& ctx) {
   auto mex = ctx.get("examples");
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TruthJetAlgorithm, mex,
-                                "TruthJetAlgorithm", inputTruthParticles,
-                                outputJets, jetPtMin);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TruthJetAlgorithm, mex, "TruthJetAlgorithm",
+                                inputTruthParticles, outputJets, jetPtMin);
 }  // addTruthJet
 }  // namespace ActsPython

--- a/Examples/Python/src/TruthJet.cpp
+++ b/Examples/Python/src/TruthJet.cpp
@@ -6,9 +6,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Jets/TruthJetAlgorithm.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
 #include <cstddef>
 #include <memory>
@@ -21,7 +21,7 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addTruthJet(Context& ctx) {
   auto mex = ctx.get("examples");
@@ -30,4 +30,4 @@ void addTruthJet(Context& ctx) {
                                 "TruthJetAlgorithm", inputTruthParticles,
                                 outputJets, jetPtMin);
 }  // addTruthJet
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TruthJetStub.cpp
+++ b/Examples/Python/src/TruthJetStub.cpp
@@ -7,8 +7,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // This is a stub version when the FastJet plugin is not available
-#include "Acts/Plugins/Python/Utilities.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
 
-namespace Acts::Python {
+namespace ActsPython {
 void addTruthJet(Context& /*ctx*/) {}
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/TruthTracking.cpp
+++ b/Examples/Python/src/TruthTracking.cpp
@@ -6,7 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/TruthTracking/HitSelector.hpp"
 #include "ActsExamples/TruthTracking/ParticleSelector.hpp"
@@ -18,6 +17,8 @@
 #include "ActsExamples/TruthTracking/TruthSeedingAlgorithm.hpp"
 #include "ActsExamples/TruthTracking/TruthTrackFinder.hpp"
 #include "ActsExamples/TruthTracking/TruthVertexFinder.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 
@@ -33,22 +34,22 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addTruthTracking(Context& ctx) {
   auto mex = ctx.get("examples");
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TruthTrackFinder, mex, "TruthTrackFinder", inputParticles,
-      inputParticleMeasurementsMap, inputMeasurements, inputSimHits,
-      inputMeasurementSimHitsMap, outputProtoTracks);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TruthTrackFinder, mex, "TruthTrackFinder",
+                                inputParticles, inputParticleMeasurementsMap,
+                                inputMeasurements, inputSimHits,
+                                inputMeasurementSimHitsMap, outputProtoTracks);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::ParticleTrackParamExtractor, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(ParticleTrackParamExtractor, mex,
                                 "ParticleTrackParamExtractor", inputParticles,
                                 outputTrackParameters);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackParameterSmearing, mex, "TrackParameterSmearing",
+      TrackParameterSmearing, mex, "TrackParameterSmearing",
       inputTrackParameters, outputTrackParameters, sigmaLoc0, sigmaLoc0PtA,
       sigmaLoc0PtB, sigmaLoc1, sigmaLoc1PtA, sigmaLoc1PtB, sigmaTime, sigmaPhi,
       sigmaTheta, sigmaPtRel, initialSigmas, initialSigmaQoverPt,
@@ -56,12 +57,12 @@ void addTruthTracking(Context& ctx) {
       randomNumbers);
 
   {
-    using Alg = ActsExamples::ParticleSelector;
+    using Alg = ParticleSelector;
     using Config = Alg::Config;
 
     auto alg = py::class_<Alg, IAlgorithm, std::shared_ptr<Alg>>(
                    mex, "ParticleSelector")
-                   .def(py::init<const Alg::Config&, Acts::Logging::Level>(),
+                   .def(py::init<const Alg::Config&, Logging::Level>(),
                         py::arg("config"), py::arg("level"))
                    .def_property_readonly("config", &Alg::config);
 
@@ -97,12 +98,12 @@ void addTruthTracking(Context& ctx) {
   }
 
   {
-    using Alg = ActsExamples::TrackParameterSelector;
+    using Alg = TrackParameterSelector;
     using Config = Alg::Config;
 
     auto alg = py::class_<Alg, IAlgorithm, std::shared_ptr<Alg>>(
                    mex, "TrackParameterSelector")
-                   .def(py::init<const Alg::Config&, Acts::Logging::Level>(),
+                   .def(py::init<const Alg::Config&, Logging::Level>(),
                         py::arg("config"), py::arg("level"))
                    .def_property_readonly("config", &Alg::config);
 
@@ -122,31 +123,31 @@ void addTruthTracking(Context& ctx) {
     pythonRangeProperty(c, "pt", &Config::ptMin, &Config::ptMax);
   }
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TruthVertexFinder, mex,
-                                "TruthVertexFinder", inputTracks,
-                                inputTrackParticleMatching, outputProtoVertices,
-                                excludeSecondaries, separateSecondaries);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TruthVertexFinder, mex, "TruthVertexFinder",
+                                inputTracks, inputTrackParticleMatching,
+                                outputProtoVertices, excludeSecondaries,
+                                separateSecondaries);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrackModifier, mex,
-                                "TrackModifier", inputTracks, outputTracks,
-                                dropCovariance, covScale, killTime);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TrackModifier, mex, "TrackModifier",
+                                inputTracks, outputTracks, dropCovariance,
+                                covScale, killTime);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TruthSeedingAlgorithm, mex, "TruthSeedingAlgorithm",
-      inputParticles, inputParticleMeasurementsMap, inputSimHits,
-      inputMeasurementSimHitsMap, inputSpacePoints, outputParticles,
-      outputSeeds, outputProtoTracks, deltaRMin, deltaRMax);
+      TruthSeedingAlgorithm, mex, "TruthSeedingAlgorithm", inputParticles,
+      inputParticleMeasurementsMap, inputSimHits, inputMeasurementSimHitsMap,
+      inputSpacePoints, outputParticles, outputSeeds, outputProtoTracks,
+      deltaRMin, deltaRMax);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::HitSelector, mex, "HitSelector",
-                                inputHits, inputParticlesSelected, outputHits,
-                                minX, maxX, minY, maxY, minZ, maxZ, minR, maxR,
-                                minTime, maxTime, minEnergyLoss, maxEnergyLoss,
+  ACTS_PYTHON_DECLARE_ALGORITHM(HitSelector, mex, "HitSelector", inputHits,
+                                inputParticlesSelected, outputHits, minX, maxX,
+                                minY, maxY, minZ, maxZ, minR, maxR, minTime,
+                                maxTime, minEnergyLoss, maxEnergyLoss,
                                 minPrimaryVertexId, maxPrimaryVertexId);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::TrackTruthMatcher, mex, "TrackTruthMatcher", inputTracks,
-      inputParticles, inputMeasurementParticlesMap, outputTrackParticleMatching,
+      TrackTruthMatcher, mex, "TrackTruthMatcher", inputTracks, inputParticles,
+      inputMeasurementParticlesMap, outputTrackParticleMatching,
       outputParticleTrackMatching, matchingRatio, doubleMatching);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Utilities.cpp
+++ b/Examples/Python/src/Utilities.cpp
@@ -6,8 +6,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
-
 #include "ActsExamples/Utilities/MeasurementMapSelector.hpp"
 #include "ActsExamples/Utilities/PrototracksToSeeds.hpp"
 #include "ActsExamples/Utilities/PrototracksToTracks.hpp"
@@ -15,6 +13,8 @@
 #include "ActsExamples/Utilities/TracksToParameters.hpp"
 #include "ActsExamples/Utilities/TracksToTrajectories.hpp"
 #include "ActsExamples/Utilities/TrajectoriesToPrototracks.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -22,41 +22,38 @@
 namespace py = pybind11;
 
 using namespace ActsExamples;
-using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addUtilities(Context& ctx) {
   auto [m, mex] = ctx.get("main", "examples");
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TrajectoriesToPrototracks, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(TrajectoriesToPrototracks, mex,
                                 "TrajectoriesToPrototracks", inputTrajectories,
                                 outputProtoTracks);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TracksToTrajectories, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(TracksToTrajectories, mex,
                                 "TracksToTrajectories", inputTracks,
                                 outputTrajectories);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::TracksToParameters, mex,
-                                "TracksToParameters", inputTracks,
-                                outputTrackParameters);
+  ACTS_PYTHON_DECLARE_ALGORITHM(TracksToParameters, mex, "TracksToParameters",
+                                inputTracks, outputTrackParameters);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::SeedsToPrototracks, mex,
-                                "SeedsToPrototracks", inputSeeds,
+  ACTS_PYTHON_DECLARE_ALGORITHM(SeedsToPrototracks, mex, "SeedsToPrototracks",
+                                inputSeeds, outputProtoTracks);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(PrototracksToSeeds, mex, "PrototracksToSeeds",
+                                inputProtoTracks, inputSpacePoints, outputSeeds,
                                 outputProtoTracks);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::PrototracksToSeeds, mex, "PrototracksToSeeds",
-      inputProtoTracks, inputSpacePoints, outputSeeds, outputProtoTracks);
+      MeasurementMapSelector, mex, "MeasurementMapSelector", inputMeasurements,
+      inputMeasurementParticleMap, outputMeasurementParticleMap,
+      geometrySelection);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::MeasurementMapSelector, mex, "MeasurementMapSelector",
-      inputMeasurements, inputMeasurementParticleMap,
-      outputMeasurementParticleMap, geometrySelection);
-
-  ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::PrototracksToTracks, mex, "PrototracksToTracks",
-      inputMeasurements, inputProtoTracks, inputTrackParameters, outputTracks);
+  ACTS_PYTHON_DECLARE_ALGORITHM(PrototracksToTracks, mex, "PrototracksToTracks",
+                                inputMeasurements, inputProtoTracks,
+                                inputTrackParameters, outputTracks);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Examples/Python/src/Vertexing.cpp
+++ b/Examples/Python/src/Vertexing.cpp
@@ -6,12 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#include "Acts/Plugins/Python/Utilities.hpp"
 #include "ActsExamples/EventData/Index.hpp"
 #include "ActsExamples/Vertexing/AdaptiveMultiVertexFinderAlgorithm.hpp"
 #include "ActsExamples/Vertexing/HoughVertexFinderAlgorithm.hpp"
 #include "ActsExamples/Vertexing/IterativeVertexFinderAlgorithm.hpp"
 #include "ActsExamples/Vertexing/VertexFitterAlgorithm.hpp"
+#include "ActsPython/Utilities/Helpers.hpp"
+#include "ActsPython/Utilities/Macros.hpp"
 
 #include <memory>
 
@@ -23,10 +24,10 @@ namespace py = pybind11;
 using namespace ActsExamples;
 using namespace Acts;
 
-namespace Acts::Python {
+namespace ActsPython {
 
 void addVertexing(Context& ctx) {
-  using Seeder = ActsExamples::AdaptiveMultiVertexFinderAlgorithm::SeedFinder;
+  using Seeder = AdaptiveMultiVertexFinderAlgorithm::SeedFinder;
   auto mex = ctx.get("examples");
   auto& m = ctx.get("main");
 
@@ -36,7 +37,7 @@ void addVertexing(Context& ctx) {
       .value("AdaptiveGridSeeder", Seeder::AdaptiveGridSeeder);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
-      ActsExamples::AdaptiveMultiVertexFinderAlgorithm, mex,
+      AdaptiveMultiVertexFinderAlgorithm, mex,
       "AdaptiveMultiVertexFinderAlgorithm", inputTrackParameters,
       inputTruthParticles, inputTruthVertices, outputProtoVertices,
       outputVertices, seedFinder, bField, minWeight, doSmoothing, maxIterations,
@@ -44,20 +45,20 @@ void addVertexing(Context& ctx) {
       tracksMaxSignificance, maxMergeVertexSignificance, spatialBinExtent,
       temporalBinExtent);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::IterativeVertexFinderAlgorithm,
-                                mex, "IterativeVertexFinderAlgorithm",
+  ACTS_PYTHON_DECLARE_ALGORITHM(IterativeVertexFinderAlgorithm, mex,
+                                "IterativeVertexFinderAlgorithm",
                                 inputTrackParameters, outputProtoVertices,
                                 outputVertices, bField, maxIterations);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::VertexFitterAlgorithm, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(VertexFitterAlgorithm, mex,
                                 "VertexFitterAlgorithm", inputTrackParameters,
                                 inputProtoVertices, outputVertices, bField,
                                 doConstrainedFit, constraintPos, constraintCov);
 
-  ACTS_PYTHON_DECLARE_ALGORITHM(ActsExamples::HoughVertexFinderAlgorithm, mex,
+  ACTS_PYTHON_DECLARE_ALGORITHM(HoughVertexFinderAlgorithm, mex,
                                 "HoughVertexFinderAlgorithm", inputSpacepoints,
                                 outputVertices, targetSPs, minAbsEta, maxAbsEta,
                                 minHits, defVtxPosition);
 }
 
-}  // namespace Acts::Python
+}  // namespace ActsPython

--- a/Plugins/GeoModel/include/Acts/Plugins/GeoModel/GeoModelDetectorObjectFactory.hpp
+++ b/Plugins/GeoModel/include/Acts/Plugins/GeoModel/GeoModelDetectorObjectFactory.hpp
@@ -21,7 +21,6 @@
 #include "GeoModelKernel/GeoDefinitions.h"
 
 class GeoShape;
-struct GeoModelTree;
 class Surface;
 
 namespace Acts {

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Utilities)

--- a/Python/Utilities/CMakeLists.txt
+++ b/Python/Utilities/CMakeLists.txt
@@ -1,0 +1,17 @@
+acts_add_library(PythonUtilities INTERFACE)
+
+target_include_directories(
+    ActsPythonUtilities
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(ActsPythonUtilities INTERFACE ActsCore)
+
+install(
+    TARGETS ActsPythonUtilities
+    EXPORT ActsPythonUtilitiesTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+install(DIRECTORY include/ActsPython DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/Python/Utilities/include/ActsPython/Utilities/Helpers.hpp
+++ b/Python/Utilities/include/ActsPython/Utilities/Helpers.hpp
@@ -1,0 +1,55 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace ActsPython {
+
+struct Context {
+  std::unordered_map<std::string, pybind11::module_> modules;
+
+  pybind11::module_& get(const std::string& name) { return modules.at(name); }
+
+  template <typename... Args>
+  auto get(Args&&... args)
+    requires(sizeof...(Args) >= 2)
+  {
+    return std::make_tuple((modules.at(args))...);
+  }
+};
+
+/// This method calls the acts adapter to patch the classes with a config object
+///
+/// @param m the module to patch
+inline void patchClassesWithConfig(pybind11::module_& m) {
+  pybind11::module::import("acts._adapter").attr("_patch_config")(m);
+}
+
+/// @brief This method patches a class with kwargs arguments
+/// @tparam T the config or class object type
+/// @param c the config or class object to patch
+template <typename T>
+void patchKwargsConstructor(T& c) {
+  pybind11::module::import("acts._adapter").attr("_patchKwargsConstructor")(c);
+}
+
+/// @brief  This sets a range property on a class
+template <typename T, typename Ur, typename Ut>
+void pythonRangeProperty(T& obj, const std::string& name, Ur Ut::*begin,
+                         Ur Ut::*end) {
+  obj.def_property(
+      name.c_str(), [=](Ut& self) { return std::pair{self.*begin, self.*end}; },
+      [=](Ut& self, std::pair<Ur, Ur> p) {
+        self.*begin = p.first;
+        self.*end = p.second;
+      });
+}
+
+}  // namespace ActsPython

--- a/Python/Utilities/include/ActsPython/Utilities/Macros.hpp
+++ b/Python/Utilities/include/ActsPython/Utilities/Macros.hpp
@@ -109,8 +109,8 @@ concept has_write_method =
     ACTS_PYTHON_STRUCT(c, __VA_ARGS__);                                     \
   } while (0)
 
-#define ACTS_PYTHON_ADD_STUB_MODULE(mod)                                   \
-  namespace py = pybind11;                                                 \
-  namespace ActsPython {                                                   \
-  void add##mod(py::module_& /*m*/) {}                                     \
+#define ACTS_PYTHON_ADD_STUB_MODULE(mod) \
+  namespace py = pybind11;               \
+  namespace ActsPython {                 \
+  void add##mod(py::module_& /*m*/) {}   \
   }

--- a/Python/Utilities/include/ActsPython/Utilities/Macros.hpp
+++ b/Python/Utilities/include/ActsPython/Utilities/Macros.hpp
@@ -8,61 +8,23 @@
 
 #pragma once
 
-#include "ActsExamples/Framework/AlgorithmContext.hpp"
-#include "ActsExamples/Framework/ProcessCode.hpp"
-
-#include <string>
-#include <unordered_map>
+#include <concepts>
 
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
-#include <pybind11/pybind11.h>
 
-namespace Acts {
-namespace Concepts {
+namespace ActsExamples {
+struct AlgorithmContext;
+enum class ProcessCode;
+}  // namespace ActsExamples
+
+namespace ActsPython::Concepts {
 template <typename T>
 concept has_write_method =
     requires(T& t, const ActsExamples::AlgorithmContext& ctx) {
       { t.write(ctx) } -> std::same_as<ActsExamples::ProcessCode>;
     };
-}  // namespace Concepts
-
-namespace Python {
-
-struct Context {
-  std::unordered_map<std::string, pybind11::module_> modules;
-
-  pybind11::module_& get(const std::string& name) { return modules.at(name); }
-
-  template <typename... Args>
-  auto get(Args&&... args)
-    requires(sizeof...(Args) >= 2)
-  {
-    return std::make_tuple((modules.at(args))...);
-  }
-};
-
-template <typename T, typename Ur, typename Ut>
-void pythonRangeProperty(T& obj, const std::string& name, Ur Ut::*begin,
-                         Ur Ut::*end) {
-  obj.def_property(
-      name.c_str(), [=](Ut& self) { return std::pair{self.*begin, self.*end}; },
-      [=](Ut& self, std::pair<Ur, Ur> p) {
-        self.*begin = p.first;
-        self.*end = p.second;
-      });
-}
-
-inline void patchClassesWithConfig(pybind11::module_& m) {
-  pybind11::module::import("acts._adapter").attr("_patch_config")(m);
-}
-
-template <typename T>
-void patchKwargsConstructor(T& c) {
-  pybind11::module::import("acts._adapter").attr("_patchKwargsConstructor")(c);
-}
-}  // namespace Python
-}  // namespace Acts
+}  // namespace ActsPython::Concepts
 
 #define ACTS_PYTHON_MEMBER(name) \
   _binding_instance.def_readwrite(#name, &_struct_type::name)
@@ -122,7 +84,7 @@ void patchKwargsConstructor(T& c) {
             .def_property_readonly("config", &Writer::config);              \
                                                                             \
     constexpr bool has_write_method =                                       \
-        Acts::Concepts::has_write_method<Writer>;                           \
+        ActsPython::Concepts::has_write_method<Writer>;                     \
                                                                             \
     if constexpr (has_write_method) {                                       \
       w.def("write", &Writer::write);                                       \
@@ -146,3 +108,9 @@ void patchKwargsConstructor(T& c) {
     auto c = py::class_<Config>(r, "Config").def(py::init<>());             \
     ACTS_PYTHON_STRUCT(c, __VA_ARGS__);                                     \
   } while (0)
+
+#define ACTS_PYTHON_ADD_STUB_MODULE(mod)                                   \
+  namespace py = pybind11;                                                 \
+  namespace ActsPython {                                                   \
+  void add##mod(py::module_& /*m*/) {}                                     \
+  }


### PR DESCRIPTION
This PR does not change any functionality of ACTS and its python bindings nor tests.

* It introduces the new `Python` directory and `ActsPython` namespace
* cleans the namespace usage in the python binding code (wherever possible, one file can not be done yet)
* fixes a bug in GeoModel plugin (include and shadowing declaration in one file) that prevented local macOS build to succeed

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
