### PR TITLE
fix: setup script for installed ACTS with `lib64`

### DIFF
--- a/cmake/setup_withdeps.sh.in
+++ b/cmake/setup_withdeps.sh.in
@@ -20,7 +20,7 @@ else
 fi
 
 # detect if we are installed as there is no lib subdirectory
-if [ ! -d "$script_dir/lib" ]; then
+if [ ! -d "$script_dir/lib" ] && [ ! -d "$script_dir/lib64" ]; then
     script_dir=$( cd -- "$script_dir" &> /dev/null && cd .. &> /dev/null && pwd )
 fi
 


### PR DESCRIPTION
Fixes a case where the previous PR breaks the behaviour:
- https://github.com/acts-project/acts/pull/4517/files

--- END COMMIT MESSAGE ---
@ntadej I hope this doesn't break your setup.