### PR TITLE
fix: Incorrect usage of `CMAKE_SOURCE_DIR`

### DIFF
--- a/Core/src/Definitions/CMakeLists.txt
+++ b/Core/src/Definitions/CMakeLists.txt
@@ -4,6 +4,6 @@ include(ActsCodegen)
 
 acts_code_generation(
     ADD_TO_TARGET ActsCore
-    PYTHON ${CMAKE_SOURCE_DIR}/Fatras/scripts/generate_particle_data_table.py
+    PYTHON ${PROJECT_SOURCE_DIR}/Fatras/scripts/generate_particle_data_table.py
     OUTPUT ParticleDataTable.hpp
 )

--- a/Core/src/Propagator/CMakeLists.txt
+++ b/Core/src/Propagator/CMakeLists.txt
@@ -20,8 +20,8 @@ include(ActsCodegen)
 acts_code_generation(
     ADD_TO_TARGET ActsCore
     PYTHON detail/generate_sympy_cov.py
-    WITH_REQUIREMENTS ${CMAKE_SOURCE_DIR}/codegen/requirements.txt
-    WITH ${CMAKE_SOURCE_DIR}/codegen
+    WITH_REQUIREMENTS ${PROJECT_SOURCE_DIR}/codegen/requirements.txt
+    WITH ${PROJECT_SOURCE_DIR}/codegen
     ISOLATED
     OUTPUT codegen/sympy_cov_math.hpp
 )
@@ -29,8 +29,8 @@ acts_code_generation(
 acts_code_generation(
     ADD_TO_TARGET ActsCore
     PYTHON generate_sympy_stepper.py
-    WITH_REQUIREMENTS ${CMAKE_SOURCE_DIR}/codegen/requirements.txt
-    WITH ${CMAKE_SOURCE_DIR}/codegen
+    WITH_REQUIREMENTS ${PROJECT_SOURCE_DIR}/codegen/requirements.txt
+    WITH ${PROJECT_SOURCE_DIR}/codegen
     ISOLATED
     OUTPUT codegen/sympy_stepper_math.hpp
 )
@@ -38,8 +38,8 @@ acts_code_generation(
 acts_code_generation(
     ADD_TO_TARGET ActsCore
     PYTHON detail/generate_sympy_jac.py
-    WITH_REQUIREMENTS ${CMAKE_SOURCE_DIR}/codegen/requirements.txt
-    WITH ${CMAKE_SOURCE_DIR}/codegen
+    WITH_REQUIREMENTS ${PROJECT_SOURCE_DIR}/codegen/requirements.txt
+    WITH ${PROJECT_SOURCE_DIR}/codegen
     ISOLATED
     OUTPUT codegen/sympy_jac_math.hpp
 )

--- a/cmake/ActsCompilerOptions.cmake
+++ b/cmake/ActsCompilerOptions.cmake
@@ -75,7 +75,7 @@ set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
 message(CHECK_START "Checking C++20 std::format support")
 try_compile(
     HAVE_STDFORMAT
-    SOURCES ${CMAKE_SOURCE_DIR}/cmake/src/format.cpp
+    SOURCES ${PROJECT_SOURCE_DIR}/cmake/src/format.cpp
     CXX_STANDARD 20
 )
 


### PR DESCRIPTION
This commit fixes several instances where the `CMAKE_SOURCE_DIR` variable is incorrectly used, breaking `FetchContents` builds using ACTS.