### PR TITLE
fix: added missing include statement in TrackSelector

### DIFF
--- a/Core/include/Acts/TrackFinding/TrackSelector.hpp
+++ b/Core/include/Acts/TrackFinding/TrackSelector.hpp
@@ -13,6 +13,7 @@
 #include <limits>
 #include <ostream>
 #include <vector>
+#include <algorithm>
 
 namespace Acts {
 

--- a/Core/include/Acts/TrackFinding/TrackSelector.hpp
+++ b/Core/include/Acts/TrackFinding/TrackSelector.hpp
@@ -8,12 +8,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <limits>
 #include <ostream>
 #include <vector>
-#include <algorithm>
 
 namespace Acts {
 


### PR DESCRIPTION
While trying to compile main with particular set of cmake flags got an error as below.
It turned out that there is missing include ini TrackSlector.hpp
This PR adds it.

Error:
```
In file included from /srv/acts/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrackSelectorAlgorithm.hpp:11,
                 from /srv/acts/Examples/Algorithms/Utilities/src/TrackSelectorAlgorithm.cpp:9:
/srv/acts/Core/include/Acts/TrackFinding/TrackSelector.hpp: In member function 'std::size_t Acts::TrackSelector::EtaBinnedConfig::binIndex(double) const':
/srv/acts/Core/include/Acts/TrackFinding/TrackSelector.hpp:307:12: error: 'upper_bound' is not a member of 'std'; did you mean 'lower_bound'?
  307 |       std::upper_bound(absEtaEdges.begin(), absEtaEdges.end(), std::abs(eta));
      |            ^~~~~~~~~~~
      |            lower_bound
```





--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
