### PR TITLE
feat: RootParticleWriter propagates particles to perigee

### DIFF
--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/ProcessCode.hpp"
@@ -47,6 +48,10 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
     /// Usually the beamspot position.
     /// Default is (0, 0, 0).
     std::array<double, 3> referencePoint{0., 0., 0.};
+    /// Magnetic field
+    std::shared_ptr<Acts::MagneticFieldProvider> bField;
+    /// Flag to enable writing of helix parameters.
+    bool writeHelixParameters = false;
   };
 
   /// Construct the particle writer.

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
@@ -43,6 +43,10 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
     std::string fileMode = "RECREATE";
     /// Name of the tree within the output file.
     std::string treeName = "particles";
+    /// Reference point for the perigee surface.
+    /// Usually the beamspot position.
+    /// Default is (0, 0, 0).
+    std::array<double, 3> referencePoint{0., 0., 0.};
   };
 
   /// Construct the particle writer.
@@ -106,6 +110,14 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
   std::vector<float> m_phi;
   /// Transverse momentum in GeV.
   std::vector<float> m_pt;
+  /// Polar angle.
+  std::vector<float> m_theta;
+  /// Charge over momentum in e.GeV^-1.
+  std::vector<float> m_qop;
+  /// Transverse impact parameter in mm.
+  std::vector<float> m_d0;
+  /// Longitudinal impact parameter in mm.
+  std::vector<float> m_z0;
   // Decoded particle identifier; see Barcode definition for details.
   std::vector<std::uint32_t> m_vertexPrimary;
   std::vector<std::uint32_t> m_vertexSecondary;

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -166,6 +166,13 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
     float d0 = NaNfloat;
     float z0 = NaNfloat;
 
+    if (particle.charge() == 0) {
+      ACTS_WARNING("Particle has zero charge, can't write d0/z0");
+      m_d0.push_back(NaNfloat);
+      m_z0.push_back(NaNfloat);
+      continue;
+    }
+
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(
         Acts::Vector3(m_cfg.referencePoint[0], m_cfg.referencePoint[1],
                       m_cfg.referencePoint[2]));

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -132,6 +132,22 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
         Acts::clampValue<float>(particle.mass() / Acts::UnitConstants::GeV));
     m_q.push_back(
         Acts::clampValue<float>(particle.charge() / Acts::UnitConstants::e));
+    // decoded barcode components
+    m_vertexPrimary.push_back(particle.particleId().vertexPrimary());
+    m_vertexSecondary.push_back(particle.particleId().vertexSecondary());
+    m_particle.push_back(particle.particleId().particle());
+    m_generation.push_back(particle.particleId().generation());
+    m_subParticle.push_back(particle.particleId().subParticle());
+
+    m_eLoss.push_back(Acts::clampValue<float>(particle.energyLoss() /
+                                              Acts::UnitConstants::GeV));
+    m_pathInX0.push_back(
+        Acts::clampValue<float>(particle.pathInX0() / Acts::UnitConstants::mm));
+    m_pathInL0.push_back(
+        Acts::clampValue<float>(particle.pathInL0() / Acts::UnitConstants::mm));
+    m_numberOfHits.push_back(particle.numberOfHits());
+    m_outcome.push_back(static_cast<std::uint32_t>(particle.outcome()));
+
     if (!m_cfg.writeHelixParameters) {
       // momentum
       const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
@@ -151,22 +167,11 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
       m_qop.push_back(
           Acts::clampValue<float>(particle.qOverP() * Acts::UnitConstants::GeV /
                                   Acts::UnitConstants::e));
+      // d0, z0 are 0 (reference point is at production vertex)
+      m_d0.push_back(0);
+      m_z0.push_back(0);
+      continue;
     }
-    // decoded barcode components
-    m_vertexPrimary.push_back(particle.particleId().vertexPrimary());
-    m_vertexSecondary.push_back(particle.particleId().vertexSecondary());
-    m_particle.push_back(particle.particleId().particle());
-    m_generation.push_back(particle.particleId().generation());
-    m_subParticle.push_back(particle.particleId().subParticle());
-
-    m_eLoss.push_back(Acts::clampValue<float>(particle.energyLoss() /
-                                              Acts::UnitConstants::GeV));
-    m_pathInX0.push_back(
-        Acts::clampValue<float>(particle.pathInX0() / Acts::UnitConstants::mm));
-    m_pathInL0.push_back(
-        Acts::clampValue<float>(particle.pathInL0() / Acts::UnitConstants::mm));
-    m_numberOfHits.push_back(particle.numberOfHits());
-    m_outcome.push_back(static_cast<std::uint32_t>(particle.outcome()));
 
     // Perigee surface at configured reference point
     auto pSurface = Acts::Surface::makeShared<Acts::PerigeeSurface>(

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -177,6 +177,17 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
       ACTS_WARNING("Particle has zero charge, can't write d0/z0");
       m_d0.push_back(NaNfloat);
       m_z0.push_back(NaNfloat);
+      if (m_cfg.writeHelixParameters) {
+        m_phi.push_back(NaNfloat);
+        m_theta.push_back(NaNfloat);
+        m_qop.push_back(NaNfloat);
+        m_p.push_back(NaNfloat);
+        m_px.push_back(NaNfloat);
+        m_py.push_back(NaNfloat);
+        m_pz.push_back(NaNfloat);
+        m_eta.push_back(NaNfloat);
+        m_pt.push_back(NaNfloat);
+      }
       continue;
     }
 

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -8,7 +8,10 @@
 
 #include "ActsExamples/Io/Root/RootParticleWriter.hpp"
 
+#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
+#include "Acts/Surfaces/PerigeeSurface.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -122,12 +122,6 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
                                            Acts::UnitConstants::mm));
     m_vt.push_back(Acts::clampValue<float>(particle.fourPosition().w() /
                                            Acts::UnitConstants::mm));
-    // momentum
-    const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
-    m_p.push_back(Acts::clampValue<float>(p));
-    m_px.push_back(Acts::clampValue<float>(p * particle.direction().x()));
-    m_py.push_back(Acts::clampValue<float>(p * particle.direction().y()));
-    m_pz.push_back(Acts::clampValue<float>(p * particle.direction().z()));
 
     // particle constants
     if (!std::isfinite(particle.mass()) || !std::isfinite(particle.charge())) {
@@ -138,12 +132,18 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
         Acts::clampValue<float>(particle.mass() / Acts::UnitConstants::GeV));
     m_q.push_back(
         Acts::clampValue<float>(particle.charge() / Acts::UnitConstants::e));
-    // derived kinematic quantities
-    m_eta.push_back(Acts::clampValue<float>(
-        Acts::VectorHelpers::eta(particle.direction())));
-    m_pt.push_back(Acts::clampValue<float>(
-        p * Acts::VectorHelpers::perp(particle.direction())));
-    if (!m_cfg.writeHelixParameters) {  // need to update p, px, py, pz as well
+    if (!m_cfg.writeHelixParameters) {
+      // momentum
+      const auto p = particle.absoluteMomentum() / Acts::UnitConstants::GeV;
+      m_p.push_back(Acts::clampValue<float>(p));
+      m_px.push_back(Acts::clampValue<float>(p * particle.direction().x()));
+      m_py.push_back(Acts::clampValue<float>(p * particle.direction().y()));
+      m_pz.push_back(Acts::clampValue<float>(p * particle.direction().z()));
+      // derived kinematic quantities
+      m_eta.push_back(Acts::clampValue<float>(
+          Acts::VectorHelpers::eta(particle.direction())));
+      m_pt.push_back(Acts::clampValue<float>(
+          p * Acts::VectorHelpers::perp(particle.direction())));
       m_phi.push_back(Acts::clampValue<float>(
           Acts::VectorHelpers::phi(particle.direction())));
       m_theta.push_back(Acts::clampValue<float>(
@@ -238,6 +238,12 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
         m_qop.push_back(NaNfloat);
         m_d0.push_back(NaNfloat);
         m_z0.push_back(NaNfloat);
+        m_p.push_back(NaNfloat);
+        m_px.push_back(NaNfloat);
+        m_py.push_back(NaNfloat);
+        m_pz.push_back(NaNfloat);
+        m_eta.push_back(NaNfloat);
+        m_pt.push_back(NaNfloat);
         continue;
       }
       const Acts::BoundTrackParameters& atPerigee = *propRes->endParameters;
@@ -258,6 +264,17 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
       m_theta.push_back(Acts::clampValue<float>(theta));
       m_qop.push_back(Acts::clampValue<float>(qop * Acts::UnitConstants::GeV /
                                               Acts::UnitConstants::e));
+      // update p, px, py, pz, eta, pt
+      const auto p = atPerigee.absoluteMomentum() / Acts::UnitConstants::GeV;
+      m_p.push_back(Acts::clampValue<float>(p));
+      const auto dir = atPerigee.direction();
+      m_px.push_back(Acts::clampValue<float>(p * dir.x()));
+      m_py.push_back(Acts::clampValue<float>(p * dir.y()));
+      m_pz.push_back(Acts::clampValue<float>(p * dir.z()));
+      m_eta.push_back(Acts::clampValue<float>(
+          Acts::VectorHelpers::eta(atPerigee.direction())));
+      m_pt.push_back(Acts::clampValue<float>(
+          p * Acts::VectorHelpers::perp(atPerigee.direction())));
     }
 
     // Push the truth particle info.

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -519,6 +519,7 @@ def addFatras(
         s,
         alg.config.outputSimHits,
         outputParticles,
+        field,
         outputDirCsv,
         outputDirRoot,
         outputDirObj,
@@ -532,6 +533,7 @@ def addSimWriters(
     s: acts.examples.Sequencer,
     simHits: str = "simhits",
     particlesSimulated: str = "particles_simulated",
+    field: acts.MagneticFieldProvider = None,
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     outputDirObj: Optional[Union[Path, str]] = None,
@@ -568,6 +570,7 @@ def addSimWriters(
             acts.examples.RootParticleWriter(
                 level=customLogLevel(),
                 inputParticles=particlesSimulated,
+                bField=field,
                 filePath=str(outputDirRoot / "particles_simulation.root"),
             )
         )
@@ -689,6 +692,7 @@ def addGeant4(
         s,
         alg.config.outputSimHits,
         outputParticles,
+        field,
         outputDirCsv,
         outputDirRoot,
         outputDirObj,

--- a/Examples/Python/src/RootOutput.cpp
+++ b/Examples/Python/src/RootOutput.cpp
@@ -86,7 +86,7 @@ void addRootOutput(Context& ctx) {
 
   ACTS_PYTHON_DECLARE_WRITER(RootParticleWriter, mex, "RootParticleWriter",
                              inputParticles, filePath, fileMode, treeName,
-                             referencePoint);
+                             referencePoint, bField, writeHelixParameters);
 
   ACTS_PYTHON_DECLARE_WRITER(RootVertexWriter, mex, "RootVertexWriter",
                              inputVertices, filePath, fileMode, treeName);

--- a/Examples/Python/src/RootOutput.cpp
+++ b/Examples/Python/src/RootOutput.cpp
@@ -85,7 +85,8 @@ void addRootOutput(Context& ctx) {
                              inputSummaryCollection, filePath, fileMode);
 
   ACTS_PYTHON_DECLARE_WRITER(RootParticleWriter, mex, "RootParticleWriter",
-                             inputParticles, filePath, fileMode, treeName);
+                             inputParticles, filePath, fileMode, treeName,
+                             referencePoint);
 
   ACTS_PYTHON_DECLARE_WRITER(RootVertexWriter, mex, "RootVertexWriter",
                              inputVertices, filePath, fileMode, treeName);


### PR DESCRIPTION
Add particle propagation to perigee. The`writeHelixParameters` config flag toggle writing track parameters at the perigee instead of the ones at production vertex. Neutral particles are propagated with a linear track hypothesis.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
