### PR TITLE
feat: Add test for same position surfaces in gen3

### DIFF
--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -60,8 +60,16 @@ Acts::Result<void> Acts::Propagator<S, N>::propagate(
         // navigator, so we skip this target.
         // This can also happen in a well-behaved geometry with external
         // surfaces.
+        if (state.options.onSurfaceAccept) {
+          ACTS_VERBOSE(
+              "Pre-step surface status is onSurface and flag is enabled, keep "
+              "the target "
+              << nextTarget.surface().geometryId());
+          return nextTarget;
+        }
         ACTS_VERBOSE("Pre-step surface status is onSurface, skipping target "
                      << nextTarget.surface().geometryId());
+
         continue;
       }
       if (preStepSurfaceStatus == IntersectionStatus::reachable) {

--- a/Core/include/Acts/Propagator/PropagatorOptions.hpp
+++ b/Core/include/Acts/Propagator/PropagatorOptions.hpp
@@ -47,6 +47,9 @@ struct PurePropagatorPlainOptions {
   /// Allowed loop fraction, 1 is a full loop
   double loopFraction = 0.5;
 
+  /// keeps next target if the prestep is on surface
+  bool onSurfaceAccept = false;
+
   /// Required tolerance to reach surface
   double surfaceTolerance = s_onSurfaceTolerance;
 

--- a/Core/src/Navigation/TryAllNavigationPolicy.cpp
+++ b/Core/src/Navigation/TryAllNavigationPolicy.cpp
@@ -42,10 +42,6 @@ void TryAllNavigationPolicy::initializeCandidates(
 
   if (m_cfg.sensitives && args.wantsSurfaces) {
     for (const auto& surface : m_volume->surfaces()) {
-      // skip no sensitive surfaces
-      if (surface.associatedDetectorElement() == nullptr) {
-        continue;
-      }
       stream.addSurfaceCandidate(surface, args.tolerance);
     }
   }

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(PropagationToSamePositionSurfacesGen3) {
     }
     auto sensId = step.surface->geometryId().sensitive();
     // exclude portals
-    if (sensId) {
+    if (sensId != 0u) {
       geoIds.insert(sensId);
     }
   }


### PR DESCRIPTION
This checks how the propagation work for surfaces placed in the same position for gen3 geometry (case for trigger muon chambers in atlas).
From navigator side it works. 
From propagator side the change for the `prestepSurface` is required in order not to reject one of the two surfaces.

Also I am reverting the change in the TryAll Policy. I think after the Navigator refactoring for gen3 https://github.com/acts-project/acts/pull/4638 it is not needed.
Unless you have objections or you think makes more sense- it can be kept
Branching out of: https://github.com/acts-project/acts/pull/4638

@andiwand @junggjo9 
--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
