### PR TITLE
fix: Use . instead of -> with EDM4hep collections

### DIFF
--- a/Examples/Io/EDM4hep/src/EDM4hepParticleOutputConverter.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepParticleOutputConverter.cpp
@@ -41,7 +41,7 @@ ProcessCode EDM4hepParticleOutputConverter::execute(
   edm4hep::MCParticleCollection mcParticleCollection;
 
   for (const auto& particle : particles) {
-    auto p = mcParticleCollection->create();
+    auto p = mcParticleCollection.create();
     EDM4hepUtil::writeParticle(particle, p);
   }
 

--- a/Examples/Io/EDM4hep/src/EDM4hepSimHitOutputConverter.cpp
+++ b/Examples/Io/EDM4hep/src/EDM4hepSimHitOutputConverter.cpp
@@ -58,7 +58,7 @@ ProcessCode EDM4hepSimHitOutputConverter::execute(
     auto particles = m_inputParticles(ctx);
 
     for (const auto& particle : particles) {
-      auto p = mcParticles->create();
+      auto p = mcParticles.create();
       particleMap[particle.particleId()] = p;
       EDM4hepUtil::writeParticle(particle, p);
     }
@@ -76,7 +76,7 @@ ProcessCode EDM4hepSimHitOutputConverter::execute(
   const auto& simHits = m_inputSimHits(ctx);
 
   for (const auto& simHit : simHits) {
-    auto simTrackerHit = simTrackerHitCollection->create();
+    auto simTrackerHit = simTrackerHitCollection.create();
     EDM4hepUtil::writeSimHit(
         simHit, simTrackerHit, particleMapper,
         [](Acts::GeometryIdentifier id) { return id.value(); });


### PR DESCRIPTION
-> was deprecated in https://github.com/AIDASoft/podio/pull/811 (v1.4 of Podio)
and removed in https://github.com/AIDASoft/podio/pull/812 (v1.5 of Podio). Note
that . always works for any version.

--- END COMMIT MESSAGE ---

Fix https://github.com/acts-project/acts/issues/4764