### PR TITLE
fix: Use string for JSON keys in HepMC3 metadata

### DIFF
--- a/Examples/Io/HepMC3/src/HepMC3Metadata.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3Metadata.cpp
@@ -16,7 +16,7 @@
 
 namespace ActsExamples::HepMC3Metadata {
 
-constexpr std::string_view kEventCountKey = "num_events";
+static const std::string kEventCountKey = "num_events";
 
 std::filesystem::path getSidecarPath(const std::filesystem::path& hepmc3File) {
   return hepmc3File.string() + ".json";


### PR DESCRIPTION
This pull request makes a minor change to the definition of the `kEventCountKey` constant in `HepMC3Metadata.cpp`, switching from a `constexpr std::string_view` to a `static const std::string`. 

Closes https://github.com/acts-project/acts/issues/4798