### PR TITLE
fix: include cmath in ActsExamples/../Helpers.hpp for log10, pow

### DIFF
--- a/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp
+++ b/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
Include `cmath` in `ActsExamples/../Helpers.hpp` for `log10` and `pow`.

--- END COMMIT MESSAGE ---

This PR avoids the following compilation error on gcc15:
```
     1296    In file included from /home/wdconinc/git/acts/Examples/Framework/src/Utilities/Helpers.cpp:9:
     1297    /home/wdconinc/git/acts/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp: In static member function 'static ActsExamples::PlotHelpers::Binning ActsExamples::PlotHelpers::Binning::Logarithmic(std::string, std::
             size_t, double, double)':
  >> 1298    /home/wdconinc/git/acts/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp:45:32: error: 'log10' is not a member of 'std'
     1299       45 |     const double logMin = std::log10(bMin);
     1300          |                                ^~~~~
  >> 1301    /home/wdconinc/git/acts/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp:46:32: error: 'log10' is not a member of 'std'
     1302       46 |     const double logMax = std::log10(bMax);
     1303          |                                ^~~~~
  >> 1304    /home/wdconinc/git/acts/Examples/Framework/include/ActsExamples/Utilities/Helpers.hpp:49:26: error: 'pow' is not a member of 'std'
     1305       49 |       binEdges[i] = std::pow(10, logMin + i * step);
     1306          |                          ^~~
  >> 1307    make[2]: *** [Examples/Framework/CMakeFiles/ActsExamplesFramework.dir/build.make:306: Examples/Framework/CMakeFiles/ActsExamplesFramework.dir/src/Utilities/Helpers.cpp.o] Error 1
     1308    make[2]: *** Waiting for unfinished jobs....
```
