### PR TITLE
fix: figure path after #4875

### DIFF
--- a/Core/include/Acts/Geometry/ConvexPolygonVolumeBounds.hpp
+++ b/Core/include/Acts/Geometry/ConvexPolygonVolumeBounds.hpp
@@ -29,7 +29,7 @@ class DiamondBounds;
 /// Bounds for a polygonal prism shaped Volume, the orientedSurface(...) method
 /// creates a vector of 8 surfaces:
 /// 2 Diamond Shape Surfaces (see
-/// https://github.com/acts-project/acts/blob/main/docs/figures/doxygen/DiamondBounds.svg)
+/// https://github.com/acts-project/acts/blob/main/docs/old/figures/doxygen/DiamondBounds.svg)
 /// and 6 Rectangular Shape Surfaces.
 ///
 ///  BoundarySurfaceFace [index]:


### PR DESCRIPTION
Breaks the CI but was not detected, because only the docs-build was tried in #4875.

This fixes the CI, but long term another solution should be found. 