### PR TITLE
refactor: StrawLineSeeder - Use forwarding in constructor & minor clean

### DIFF
--- a/Core/include/Acts/Seeding/CompositeSpacePointLineSeeder.hpp
+++ b/Core/include/Acts/Seeding/CompositeSpacePointLineSeeder.hpp
@@ -43,7 +43,7 @@ concept CompositeSpacePointSeedFiller =
       /// @param t0: Offse in the time of arrival of the particle
       /// @param testSp: Reference to the straw space point to test
       {
-        filler.candidatePull(cctx, pos, dir, t0, testSp)
+        filler.candidateChi2(cctx, pos, dir, t0, testSp)
       } -> std::same_as<double>;
       /// @brief Returns the radius of the straw tube in which the space point
       ///        is recorded

--- a/Core/include/Acts/Seeding/CompositeSpacePointLineSeeder.ipp
+++ b/Core/include/Acts/Seeding/CompositeSpacePointLineSeeder.ipp
@@ -511,7 +511,7 @@ CompositeSpacePointLineSeeder::buildSeed(
             m_cfg.useSimpleStrawPull
                 ? Acts::square(distance - Acts::abs(testMe->driftRadius())) /
                       testMe->covariance()[covIdx]
-                : state.candidatePull(cctx, seedPos, seedDir, t0, *testMe);
+                : state.candidateChi2(cctx, seedPos, seedDir, t0, *testMe);
 
         if (pullSq < maxPullSq) {
           ACTS_VERBOSE(__func__
@@ -571,7 +571,7 @@ CompositeSpacePointLineSeeder::consructSegmentSeed(
     /// Find the hit with the lowest pull
     for (const auto& [hitIdx, testMe] : Acts::enumerate(stripLayerHits)) {
       const double chi2 =
-          state.candidatePull(cctx, seedPos, seedDir, t0, *testMe);
+          state.candidateChi2(cctx, seedPos, seedDir, t0, *testMe);
       if (testMe->measuresLoc0() && chi2 < bestChi2Loc0) {
         bestChi2Loc0 = chi2;
         bestIdxLoc0 = hitIdx;

--- a/Tests/UnitTests/Core/Seeding/StrawHitGeneratorHelper.hpp
+++ b/Tests/UnitTests/Core/Seeding/StrawHitGeneratorHelper.hpp
@@ -425,7 +425,7 @@ class SpSorter {
   /// @param dir: Direction of the candidate seed line
   /// @param t0: Offse in the time of arrival of the particle
   /// @param testSp: Reference to the straw space point to test
-  double candidatePull(const CalibrationContext& /* cctx*/, const Vector3& pos,
+  double candidateChi2(const CalibrationContext& /* cctx*/, const Vector3& pos,
                        const Vector3& dir, const double /*t0*/,
                        const FitTestSpacePoint& testSp) const {
     return CompSpacePointAuxiliaries::chi2Term(pos, dir, testSp);

--- a/Tests/UnitTests/Core/Seeding/StrawLineSeederTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/StrawLineSeederTest.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(SeedTangents) {
             Seeder::constructTangentLine(topTube, bottomTube, trueAmbi);
         /// Construct line parameters
         ACTS_DEBUG(__func__
-                   << "() " << __LINE__ << " - Line tan theta: " << lineTanBeta
+                   << "() " << __LINE__ << " - Line tan beta: " << lineTanBeta
                    << ", reconstructed tan theta: " << std::tan(seedPars.theta)
                    << ", line y0: " << lineY0
                    << ", reconstructed y0: " << seedPars.y0);


### PR DESCRIPTION
- Use perfect forwarding to define the constructor
- Rework the interface -> tube radius is fetched from a helper function / rename candidatePull to candidateChi2

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
