### PR TITLE
fix: limit external-eic-shell error reports to downstream use only

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -453,7 +453,7 @@ jobs:
             pushd acts
             ccache -p | grep cache_dir
             ccache -z && \
-            export CMAKE_INSTALL_PREFIX=$HOME/prefix
+            export CMAKE_INSTALL_PREFIX=/work/prefix
             export CMAKE_CXX_COMPILER_LAUNCHER=ccache
             echo "::group::Acts configure phase"
             cmake -B build -S . \
@@ -486,7 +486,7 @@ jobs:
             done
             cd /work
             set -ue
-            export CMAKE_INSTALL_PREFIX=$HOME/prefix
+            export CMAKE_INSTALL_PREFIX=/work/prefix
             export CMAKE_CXX_COMPILER_LAUNCHER=ccache
             pushd EICrecon
             echo "::group::EICrecon configure phase"


### PR DESCRIPTION
Limit the types of errors that external-eic-shell reports in the summary to build errors after ACTS has been successfully built, and treat failure to build ACTS itself as a pipeline error.

--- END COMMIT MESSAGE ---

With the notifications of failures in the external-eic-shell stack, we now also receive notifications of code in PR that is not yet ready where ACTS fails to compile (rather than this being a change in interface that EIC needs to be aware of). This is not actionable for EIC, so the notifications are noise. Example is https://github.com/acts-project/acts/actions/runs/20168575581/job/57898016435

This PR modifies the strategy to treat build failures of ACTS within the EIC environment as a primary error that will fail a pipeline (instead of only reporting a failure in the comment). This is unlikely to suppress true EIC-specific issues, which would be cases where ACTS builds fine, but somehow the EIC environment can't build it.