### PR TITLE
docs: minor cmake option name correction

### DIFF
--- a/docs/old/plugins/MLAlgorithms.md
+++ b/docs/old/plugins/MLAlgorithms.md
@@ -5,7 +5,7 @@ A replacement for the ambiguity solver and a filtering algorithm for seeds are a
 
 ## Onnx plugin
 
-To be able to perform neural network (NN) models' inferences in C++, ACTS uses [ONNX Runtime](https://onnxruntime.ai/). An interface to use ONNX Runtime has been implemented as an ACTS plugin; to use it, you will need to compile ACTS with the `ACTS_PLUGIN_ONNX` option. For more details on how to export your model to ONNX, please see the documentation on their [website](https://onnxruntime.ai/docs/).
+To be able to perform neural network (NN) models' inferences in C++, ACTS uses [ONNX Runtime](https://onnxruntime.ai/). An interface to use ONNX Runtime has been implemented as an ACTS plugin; to use it, you will need to compile ACTS with the `-DACTS_BUILD_PLUGIN_ONNX=ON` option. For more details on how to export your model to ONNX, please see the documentation on their [website](https://onnxruntime.ai/docs/).
 
 ### OnnxRuntimeBase
 


### PR DESCRIPTION
--- END COMMIT MESSAGE ---
Accidentally stumbled on this while grepping the code.

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
