### PR TITLE
Proposal: Propagation with range-based for loop

### DIFF
--- a/Core/include/Acts/Propagator/EigenStepper.hpp
+++ b/Core/include/Acts/Propagator/EigenStepper.hpp
@@ -431,7 +431,7 @@ class EigenStepper {
   /// @param [in,out] state State of the stepper
   void setIdentityJacobian(State& state) const;
 
- protected:
+ private:
   /// Magnetic field inside of the detector
   std::shared_ptr<const MagneticFieldProvider> m_bField;
 };

--- a/Core/include/Acts/Propagator/Propagation.hpp
+++ b/Core/include/Acts/Propagator/Propagation.hpp
@@ -1,0 +1,78 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Utilities/Result.hpp"
+
+#include <cassert>
+
+namespace Acts {
+
+class Surface;
+
+// TODO what about ridders propagator?
+// TODO should there also be Stepping and Navigation?
+// TODO should the Propagation be composed of Stepping and Navigation objects?
+// TODO make this a detail for now?
+template <typename propagator_t, typename propagator_state_t>
+class Propagation {
+ public:
+  using Propagator = propagator_t;
+  using Stepper = typename propagator_t::Stepper;
+  using Navigator = typename propagator_t::Navigator;
+  using State = propagator_state_t;
+
+  Propagation(const Propagator &propagator, State &state)
+      : m_propagator(&propagator), m_state(&state) {
+    assert(m_propagator != nullptr && "Propagator pointer is null");
+    assert(m_state != nullptr && "State pointer is null");
+  }
+
+  const Propagator &propagator() const { return *m_propagator; }
+  const Stepper &stepper() const { return propagator().stepper(); }
+  const Navigator &navigator() const { return propagator().navigator(); }
+  State &state() const { return *m_state; }
+
+  template <typename parameters_t>
+  Result<void> initialize(const parameters_t &parameters) {
+    return propagator().initialize(*m_state, parameters);
+  }
+  Result<void> performStep() { return propagator().performStep(*m_state); }
+  Result<void> reachNextSurface() {
+    return propagator().reachNextSurface(*m_state);
+  }
+
+  Vector3 position() const { return stepper().position(m_state->stepping); }
+  Vector3 direction() const { return stepper().direction(m_state->stepping); }
+  const Surface *currentSurface() const {
+    return navigator().currentSurface(m_state->navigation);
+  }
+
+  void transportCovarianceToBound() {
+    stepper().transportCovarianceToBound(m_state->stepping, *currentSurface());
+  }
+  void transportCovarianceToCurvilinear() {
+    stepper().transportCovarianceToCurvilinear(m_state->stepping);
+  }
+
+  auto boundState(bool transportCov) {
+    return stepper().boundState(m_state->stepping, *currentSurface(),
+                                transportCov);
+  }
+  auto curvilinearState(bool transportCov) {
+    return stepper().curvilinearState(m_state->stepping, transportCov);
+  }
+
+ private:
+  const Propagator *m_propagator{nullptr};
+  State *m_state{nullptr};
+};
+
+}  // namespace Acts

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -453,12 +453,17 @@ class Propagator final
     auto state = makeState<propagator_options_t, path_aborter_t>(options);
     using StateType = decltype(state);
 
-    auto initRes =
+    // TODO check result
+    const Result<void> initRes =
         initialize<StateType, parameters_t, path_aborter_t>(state, start);
-    // TODO check result
+    if (!initRes.ok()) {
+      throw std::runtime_error(
+          "Error during initialization of step-by-step propagation: " +
+          initRes.error().message());
+    }
 
-    auto preRes = prePropagation(state);
     // TODO check result
+    prePropagation(state);
 
     return StepByStepPropagation<StateType>(*this, std::move(state));
   }
@@ -532,12 +537,17 @@ class Propagator final
     auto state = makeState<propagator_options_t, path_aborter_t>(options);
     using StateType = decltype(state);
 
-    auto initRes =
+    // TODO check result
+    const Result<void> initRes =
         initialize<StateType, parameters_t, path_aborter_t>(state, start);
-    // TODO check result
+    if (!initRes.ok()) {
+      throw std::runtime_error(
+          "Error during initialization of surface-by-surface propagation: " +
+          initRes.error().message());
+    }
 
-    auto preRes = prePropagation(state);
     // TODO check result
+    prePropagation(state);
 
     return SurfaceBySurfacePropagation<StateType>(*this, std::move(state));
   }

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -105,66 +105,27 @@ class Propagator final
   static_assert(StepperConcept<stepper_t>,
                 "Stepper does not fulfill stepper concept.");
 
- public:
-  /// Type of the stepper in use for public scope
-  using Stepper = stepper_t;
-
-  /// Type of the navigator in use for public scope
-  using Navigator = navigator_t;
-
-  /// Type of state object used by the propagation implementation
-  using StepperState = typename Stepper::State;
-
-  /// Typedef the navigator state
-  using NavigatorState = typename navigator_t::State;
-
-  /// Type alias for propagator state combining stepper and navigator states
-  template <typename propagator_options_t, typename... extension_state_t>
-  using State = PropagatorState<propagator_options_t, StepperState,
-                                NavigatorState, extension_state_t...>;
-
-  /// Type alias for stepper configuration options
-  using StepperOptions = typename stepper_t::Options;
-
-  /// Type alias for navigator configuration options
-  using NavigatorOptions = typename navigator_t::Options;
-
-  /// Type alias for propagator configuration options with actor list
-  template <typename actor_list_t = ActorList<>>
-  using Options =
-      PropagatorOptions<StepperOptions, NavigatorOptions, actor_list_t>;
-
-  /// Constructor from implementation object
-  ///
-  /// @param stepper The stepper implementation is moved to a private member
-  /// @param navigator The navigator implementation, moved to a private member
-  /// @param _logger a logger instance
-  explicit Propagator(stepper_t stepper, navigator_t navigator = navigator_t(),
-                      std::shared_ptr<const Logger> _logger =
-                          getDefaultLogger("Propagator", Acts::Logging::INFO))
-      : m_stepper(std::move(stepper)),
-        m_navigator(std::move(navigator)),
-        m_logger{std::move(_logger)} {}
-
- private:
   /// @brief Helper struct determining the state's type
   ///
   /// @tparam propagator_options_t Propagator options type
-  /// @tparam actor_list_t List of propagation action types
   ///
   /// This helper struct provides type definitions to extract the correct
   /// propagation state type from a given TrackParameter type and an
   /// ActorList.
   ///
-  template <typename propagator_options_t, typename actor_list_t>
+  template <typename propagator_options_t>
   struct state_type_helper {
+    using actor_list_t = typename propagator_options_t::actor_list_type;
+
     /// @brief Propagation state type for an arbitrary list of additional
     ///        propagation states
     ///
     /// @tparam args Parameter pack specifying additional propagation states
     ///
     template <typename... args>
-    using this_state_type = State<propagator_options_t, args...>;
+    using this_state_type =
+        PropagatorState<propagator_options_t, typename stepper_t::State,
+                        typename navigator_t::State, args...>;
 
     /// @brief Propagation result type derived from a given action list
     using type = typename actor_list_t::template result_type<this_state_type>;
@@ -172,15 +133,17 @@ class Propagator final
 
   /// @brief Helper struct determining the result's type
   ///
-  /// @tparam parameters_t Type of final track parameters
-  /// @tparam actor_list_t List of propagation action types
+  /// @tparam propagator_options_t Propagator options type
   ///
   /// This helper struct provides type definitions to extract the correct
   /// propagation result type from a given TrackParameter type and an
   /// ActorList.
   ///
-  template <typename parameters_t, typename actor_list_t>
+  template <typename propagator_options_t>
   struct result_type_helper {
+    using parameters_t = StepperBoundTrackParameters;
+    using actor_list_t = typename propagator_options_t::actor_list_type;
+
     /// @brief Propagation result type for an arbitrary list of additional
     ///        propagation results
     ///
@@ -194,24 +157,58 @@ class Propagator final
   };
 
  public:
-  /// @brief Short-hand type definition for propagation state derived from
-  ///        an action list
-  ///
-  /// @tparam actor_list_t List of propagation action types
-  ///
-  template <typename propagator_options_t, typename actor_list_t>
-  using actor_list_t_state_t =
-      typename state_type_helper<propagator_options_t, actor_list_t>::type;
+  /// Type of the stepper in use
+  using Stepper = stepper_t;
 
-  /// @brief Short-hand type definition for propagation result derived from
-  ///        an action list
+  /// Type of the navigator in use
+  using Navigator = navigator_t;
+
+  /// Type of the stepper options
+  using StepperOptions = typename Stepper::Options;
+
+  /// Type of the navigator options
+  using NavigatorOptions = typename Navigator::Options;
+
+  /// Type of the propagator options with actor list
+  template <typename actor_list_t = ActorList<>>
+  using Options =
+      PropagatorOptions<StepperOptions, NavigatorOptions, actor_list_t>;
+
+  /// Type of the stepper state
+  using StepperState = typename Stepper::State;
+
+  /// Type of the navigator state
+  using NavigatorState = typename Navigator::State;
+
+  /// Type of the propagation state derived from the propagator options
+  /// @tparam propagator_options_t Type of the propagator options
+  template <typename propagator_options_t>
+  using State = typename state_type_helper<propagator_options_t>::type;
+
+  /// Type of the propagation result derived from the propagator options
+  /// @tparam propagator_options_t Type of the propagator options
+  template <typename propagator_options_t>
+  using ResultType = typename result_type_helper<propagator_options_t>::type;
+
+  /// Constructor from implementation object
   ///
-  /// @tparam parameters_t Type of the final track parameters
-  /// @tparam actor_list_t List of propagation action types
-  ///
-  template <typename parameters_t, typename actor_list_t>
-  using actor_list_t_result_t =
-      typename result_type_helper<parameters_t, actor_list_t>::type;
+  /// @param stepper The stepper implementation is moved to a private member
+  /// @param navigator The navigator implementation, moved to a private member
+  /// @param _logger a logger instance
+  explicit Propagator(Stepper stepper, Navigator navigator = Navigator(),
+                      std::shared_ptr<const Logger> _logger =
+                          getDefaultLogger("Propagator", Acts::Logging::INFO))
+      : m_stepper(std::move(stepper)),
+        m_navigator(std::move(navigator)),
+        m_logger{std::move(_logger)} {}
+
+  /// Access to the stepper instance
+  /// @return Const reference to the stepper
+  const Stepper& stepper() const { return m_stepper; }
+
+  /// Access to the navigator instance
+  /// @return Const reference to the navigator
+  const Navigator& navigator() const { return m_navigator; }
 
   /// @brief Propagate track parameters
   ///
@@ -233,10 +230,9 @@ class Propagator final
   ///
   template <typename parameters_t, typename propagator_options_t,
             typename path_aborter_t = PathLimitReached>
-  Result<actor_list_t_result_t<StepperBoundTrackParameters,
-                               typename propagator_options_t::actor_list_type>>
-  propagate(const parameters_t& start, const propagator_options_t& options,
-            bool createFinalParameters = true) const;
+  Result<ResultType<propagator_options_t>> propagate(
+      const parameters_t& start, const propagator_options_t& options,
+      bool createFinalParameters = true) const;
 
   /// @brief Propagate track parameters - User method
   ///
@@ -259,10 +255,9 @@ class Propagator final
   template <typename parameters_t, typename propagator_options_t,
             typename target_aborter_t = SurfaceReached,
             typename path_aborter_t = PathLimitReached>
-  Result<actor_list_t_result_t<StepperBoundTrackParameters,
-                               typename propagator_options_t::actor_list_type>>
-  propagate(const parameters_t& start, const Surface& target,
-            const propagator_options_t& options) const;
+  Result<ResultType<propagator_options_t>> propagate(
+      const parameters_t& start, const Surface& target,
+      const propagator_options_t& options) const;
 
   /// @brief Builds the propagator state object
   ///
@@ -349,11 +344,9 @@ class Propagator final
   ///
   /// @return Propagation result
   template <typename propagator_state_t, typename propagator_options_t>
-  Result<actor_list_t_result_t<StepperBoundTrackParameters,
-                               typename propagator_options_t::actor_list_type>>
-  makeResult(propagator_state_t state, Result<void> result,
-             const propagator_options_t& options,
-             bool createFinalParameters) const;
+  Result<ResultType<propagator_options_t>> makeResult(
+      propagator_state_t state, Result<void> result,
+      const propagator_options_t& options, bool createFinalParameters) const;
 
   /// @brief Builds the propagator result object
   ///
@@ -372,32 +365,23 @@ class Propagator final
   ///
   /// @return Propagation result
   template <typename propagator_state_t, typename propagator_options_t>
-  Result<actor_list_t_result_t<StepperBoundTrackParameters,
-                               typename propagator_options_t::actor_list_type>>
-  makeResult(propagator_state_t state, Result<void> result,
-             const Surface& target, const propagator_options_t& options) const;
-
-  /// Access to the stepper instance
-  /// @return Const reference to the stepper
-  const stepper_t& stepper() const { return m_stepper; }
-
-  /// Access to the navigator instance
-  /// @return Const reference to the navigator
-  const navigator_t& navigator() const { return m_navigator; }
+  Result<ResultType<propagator_options_t>> makeResult(
+      propagator_state_t state, Result<void> result, const Surface& target,
+      const propagator_options_t& options) const;
 
  private:
+  /// Implementation of propagation algorithm
+  Stepper m_stepper;
+
+  /// Implementation of navigator
+  Navigator m_navigator;
+
+  std::shared_ptr<const Logger> m_logger;
+
   const Logger& logger() const { return *m_logger; }
 
   template <typename propagator_state_t, typename result_t>
   void moveStateToResult(propagator_state_t& state, result_t& result) const;
-
-  /// Implementation of propagation algorithm
-  stepper_t m_stepper;
-
-  /// Implementation of navigator
-  navigator_t m_navigator;
-
-  std::shared_ptr<const Logger> m_logger;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/Propagator.hpp
+++ b/Core/include/Acts/Propagator/Propagator.hpp
@@ -380,8 +380,9 @@ class Propagator final
 
   const Logger& logger() const { return *m_logger; }
 
-  template <typename propagator_state_t, typename result_t>
-  void moveStateToResult(propagator_state_t& state, result_t& result) const;
+  template <typename propagator_state_t, typename propagator_result_t>
+  void moveStateToResult(propagator_state_t& state,
+                         propagator_result_t& result) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -417,9 +417,9 @@ auto Propagator<S, N>::makeResult(propagator_state_t state,
 }
 
 template <typename S, typename N>
-template <typename propagator_state_t, typename result_t>
+template <typename propagator_state_t, typename propagator_result_t>
 void Propagator<S, N>::moveStateToResult(propagator_state_t& state,
-                                         result_t& result) const {
+                                         propagator_result_t& result) const {
   result.tuple() = std::move(state.tuple());
 
   result.steps = state.steps;

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -11,7 +11,6 @@
 #include "Acts/Propagator/Propagator.hpp"
 
 #include "Acts/EventData/TrackParametersConcept.hpp"
-#include "Acts/Propagator/ActorList.hpp"
 #include "Acts/Propagator/ConstrainedStep.hpp"
 #include "Acts/Propagator/NavigationTarget.hpp"
 #include "Acts/Propagator/PropagatorError.hpp"
@@ -21,10 +20,11 @@
 
 #include <concepts>
 
+namespace Acts {
+
 template <typename S, typename N>
 template <typename propagator_state_t>
-Acts::Result<void> Acts::Propagator<S, N>::propagate(
-    propagator_state_t& state) const {
+Result<void> Propagator<S, N>::propagate(propagator_state_t& state) const {
   ACTS_VERBOSE("Entering propagation.");
 
   state.stage = PropagatorStage::prePropagation;
@@ -192,12 +192,10 @@ Acts::Result<void> Acts::Propagator<S, N>::propagate(
 template <typename S, typename N>
 template <typename parameters_t, typename propagator_options_t,
           typename path_aborter_t>
-auto Acts::Propagator<S, N>::propagate(const parameters_t& start,
-                                       const propagator_options_t& options,
-                                       bool createFinalParameters) const
-    -> Result<
-        actor_list_t_result_t<StepperBoundTrackParameters,
-                              typename propagator_options_t::actor_list_type>> {
+auto Propagator<S, N>::propagate(const parameters_t& start,
+                                 const propagator_options_t& options,
+                                 bool createFinalParameters) const
+    -> Result<ResultType<propagator_options_t>> {
   static_assert(std::copy_constructible<StepperBoundTrackParameters>,
                 "return track parameter type must be copy-constructible");
 
@@ -219,12 +217,10 @@ auto Acts::Propagator<S, N>::propagate(const parameters_t& start,
 template <typename S, typename N>
 template <typename parameters_t, typename propagator_options_t,
           typename target_aborter_t, typename path_aborter_t>
-auto Acts::Propagator<S, N>::propagate(
-    const parameters_t& start, const Surface& target,
-    const propagator_options_t& options) const
-    -> Result<
-        actor_list_t_result_t<StepperBoundTrackParameters,
-                              typename propagator_options_t::actor_list_type>> {
+auto Propagator<S, N>::propagate(const parameters_t& start,
+                                 const Surface& target,
+                                 const propagator_options_t& options) const
+    -> Result<ResultType<propagator_options_t>> {
   static_assert(BoundTrackParametersConcept<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
@@ -246,8 +242,7 @@ auto Acts::Propagator<S, N>::propagate(
 
 template <typename S, typename N>
 template <typename propagator_options_t, typename path_aborter_t>
-auto Acts::Propagator<S, N>::makeState(
-    const propagator_options_t& options) const {
+auto Propagator<S, N>::makeState(const propagator_options_t& options) const {
   // Type of track parameters produced by the propagation
   using ReturnParameterType = StepperBoundTrackParameters;
 
@@ -264,9 +259,7 @@ auto Acts::Propagator<S, N>::makeState(
   auto eOptions = options.extend(actorList);
 
   using OptionsType = decltype(eOptions);
-  using StateType =
-      actor_list_t_state_t<OptionsType,
-                           typename propagator_options_t::actor_list_type>;
+  using StateType = State<OptionsType>;
 
   StateType state{eOptions, m_stepper.makeState(eOptions.stepping),
                   m_navigator.makeState(eOptions.navigation)};
@@ -277,8 +270,8 @@ auto Acts::Propagator<S, N>::makeState(
 template <typename S, typename N>
 template <typename propagator_options_t, typename target_aborter_t,
           typename path_aborter_t>
-auto Acts::Propagator<S, N>::makeState(
-    const Surface& target, const propagator_options_t& options) const {
+auto Propagator<S, N>::makeState(const Surface& target,
+                                 const propagator_options_t& options) const {
   // Expand the actor list with a target and path aborter
   target_aborter_t targetAborter;
   targetAborter.surface = &target;
@@ -292,9 +285,7 @@ auto Acts::Propagator<S, N>::makeState(
   eOptions.navigation.targetSurface = &target;
 
   using OptionsType = decltype(eOptions);
-  using StateType =
-      actor_list_t_state_t<OptionsType,
-                           typename propagator_options_t::actor_list_type>;
+  using StateType = State<OptionsType>;
 
   StateType state{eOptions, m_stepper.makeState(eOptions.stepping),
                   m_navigator.makeState(eOptions.navigation)};
@@ -305,8 +296,8 @@ auto Acts::Propagator<S, N>::makeState(
 template <typename S, typename N>
 template <typename propagator_state_t, typename parameters_t,
           typename path_aborter_t>
-Acts::Result<void> Acts::Propagator<S, N>::initialize(
-    propagator_state_t& state, const parameters_t& start) const {
+Result<void> Propagator<S, N>::initialize(propagator_state_t& state,
+                                          const parameters_t& start) const {
   static_assert(BoundTrackParametersConcept<parameters_t>,
                 "Parameters do not fulfill bound parameters concept.");
 
@@ -336,13 +327,11 @@ Acts::Result<void> Acts::Propagator<S, N>::initialize(
 
 template <typename S, typename N>
 template <typename propagator_state_t, typename propagator_options_t>
-auto Acts::Propagator<S, N>::makeResult(propagator_state_t state,
-                                        Result<void> propagationResult,
-                                        const propagator_options_t& /*options*/,
-                                        bool createFinalParameters) const
-    -> Result<
-        actor_list_t_result_t<StepperBoundTrackParameters,
-                              typename propagator_options_t::actor_list_type>> {
+auto Propagator<S, N>::makeResult(propagator_state_t state,
+                                  Result<void> propagationResult,
+                                  const propagator_options_t& /*options*/,
+                                  bool createFinalParameters) const
+    -> Result<ResultType<propagator_options_t>> {
   // Type of track parameters produced by the propagation
   using ReturnParameterType = StepperBoundTrackParameters;
 
@@ -350,15 +339,13 @@ auto Acts::Propagator<S, N>::makeResult(propagator_state_t state,
                 "return track parameter type must be copy-constructible");
 
   // Type of the full propagation result, including output from actors
-  using ResultType =
-      actor_list_t_result_t<ReturnParameterType,
-                            typename propagator_options_t::actor_list_type>;
+  using ThisResultType = ResultType<propagator_options_t>;
 
   if (!propagationResult.ok()) {
     return propagationResult.error();
   }
 
-  ResultType result{};
+  ThisResultType result{};
   moveStateToResult(state, result);
 
   const Surface* currentSurface = m_navigator.currentSurface(state.navigation);
@@ -387,17 +374,16 @@ auto Acts::Propagator<S, N>::makeResult(propagator_state_t state,
     }
   }
 
-  return Result<ResultType>::success(std::move(result));
+  return Result<ThisResultType>::success(std::move(result));
 }
 
 template <typename S, typename N>
 template <typename propagator_state_t, typename propagator_options_t>
-auto Acts::Propagator<S, N>::makeResult(
-    propagator_state_t state, Result<void> propagationResult,
-    const Surface& target, const propagator_options_t& /*options*/) const
-    -> Result<
-        actor_list_t_result_t<StepperBoundTrackParameters,
-                              typename propagator_options_t::actor_list_type>> {
+auto Propagator<S, N>::makeResult(propagator_state_t state,
+                                  Result<void> propagationResult,
+                                  const Surface& target,
+                                  const propagator_options_t& /*options*/) const
+    -> Result<ResultType<propagator_options_t>> {
   // Type of track parameters produced at the end of the propagation
   using ReturnParameterType = StepperBoundTrackParameters;
 
@@ -405,15 +391,13 @@ auto Acts::Propagator<S, N>::makeResult(
                 "return track parameter type must be copy-constructible");
 
   // Type of the full propagation result, including output from actors
-  using ResultType =
-      actor_list_t_result_t<ReturnParameterType,
-                            typename propagator_options_t::actor_list_type>;
+  using ThisResultType = ResultType<propagator_options_t>;
 
   if (!propagationResult.ok()) {
     return propagationResult.error();
   }
 
-  ResultType result{};
+  ThisResultType result{};
   moveStateToResult(state, result);
 
   // Compute the final results and mark the propagation as successful
@@ -429,15 +413,13 @@ auto Acts::Propagator<S, N>::makeResult(
   if (state.stepping.covTransport) {
     result.transportJacobian = std::get<Jacobian>(bs);
   }
-  return Result<ResultType>::success(std::move(result));
+  return Result<ThisResultType>::success(std::move(result));
 }
 
 template <typename S, typename N>
 template <typename propagator_state_t, typename result_t>
-void Acts::Propagator<S, N>::moveStateToResult(propagator_state_t& state,
-                                               result_t& result) const {
-  result.tuple() = std::move(state.tuple());
-
+void Propagator<S, N>::moveStateToResult(propagator_state_t& state,
+                                         result_t& result) const {
   result.steps = state.steps;
   result.pathLength = state.pathLength;
 
@@ -446,18 +428,18 @@ void Acts::Propagator<S, N>::moveStateToResult(propagator_state_t& state,
 }
 
 template <typename derived_t>
-Acts::Result<Acts::BoundTrackParameters>
-Acts::detail::BasePropagatorHelper<derived_t>::propagateToSurface(
+Result<BoundTrackParameters>
+detail::BasePropagatorHelper<derived_t>::propagateToSurface(
     const BoundTrackParameters& start, const Surface& target,
     const Options& options) const {
-  using ResultType = Result<typename derived_t::template actor_list_t_result_t<
-      BoundTrackParameters, ActorList<>>>;
   using DerivedOptions = typename derived_t::template Options<>;
+  using DerivedResult = typename derived_t::template ResultType<DerivedOptions>;
 
   DerivedOptions derivedOptions(options);
 
   // dummy initialization
-  ResultType res = ResultType::failure(PropagatorError::Failure);
+  Result<DerivedResult> res =
+      Result<DerivedResult>::failure(PropagatorError::Failure);
 
   // Due to the geometry of the perigee surface the overstepping tolerance
   // is sometimes not met.
@@ -482,3 +464,5 @@ Acts::detail::BasePropagatorHelper<derived_t>::propagateToSurface(
   assert((*res).endParameters);
   return std::move((*res).endParameters.value());
 }
+
+}  // namespace Acts

--- a/Core/include/Acts/Propagator/Propagator.ipp
+++ b/Core/include/Acts/Propagator/Propagator.ipp
@@ -420,6 +420,8 @@ template <typename S, typename N>
 template <typename propagator_state_t, typename result_t>
 void Propagator<S, N>::moveStateToResult(propagator_state_t& state,
                                          result_t& result) const {
+  result.tuple() = std::move(state.tuple());
+
   result.steps = state.steps;
   result.pathLength = state.pathLength;
 

--- a/Core/include/Acts/Propagator/PropagatorError.hpp
+++ b/Core/include/Acts/Propagator/PropagatorError.hpp
@@ -23,6 +23,8 @@ enum class PropagatorError {
   StepCountLimitReached,
   /// Propagation reached the configured maximum number of next target calls
   NextTargetLimitReached,
+  /// Propagation did not reach a next surface
+  NextSurfaceNotReached,
 };
 
 /// Create error code from PropagatorError

--- a/Core/include/Acts/Propagator/PropagatorState.hpp
+++ b/Core/include/Acts/Propagator/PropagatorState.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Propagator/NavigationTarget.hpp"
 #include "Acts/Propagator/PropagatorStatistics.hpp"
 #include "Acts/Utilities/detail/Extendable.hpp"
 
@@ -68,6 +69,8 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
   /// Propagation stage
   PropagatorStage stage = PropagatorStage::invalid;
 
+  NavigationTarget nextTarget = NavigationTarget::None();
+
   /// The position of the propagation
   Vector3 position = Vector3::Zero();
 
@@ -85,6 +88,8 @@ struct PropagatorState : private detail::Extendable<extension_state_t...> {
 
   /// Signed distance over which the parameters were propagated
   double pathLength = 0.;
+
+  bool terminatedNormally = false;
 
   /// Statistics of the propagation
   PropagatorStatistics statistics;

--- a/Core/include/Acts/Propagator/RiddersPropagator.ipp
+++ b/Core/include/Acts/Propagator/RiddersPropagator.ipp
@@ -11,6 +11,7 @@
 #include "Acts/Propagator/RiddersPropagator.hpp"
 
 #include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
 
 #include <numbers>
 
@@ -88,10 +89,8 @@ template <typename propagator_t>
 template <typename parameters_t, typename propagator_options_t>
 auto RiddersPropagator<propagator_t>::propagate(
     const parameters_t& start, const propagator_options_t& options) const
-    -> Result<actor_list_t_result_t<
-        BoundTrackParameters, typename propagator_options_t::actor_list_type>> {
-  using ThisResult = Result<actor_list_t_result_t<
-      BoundTrackParameters, typename propagator_options_t::actor_list_type>>;
+    -> Result<ResultType<propagator_options_t>> {
+  using ThisResult = Result<ResultType<propagator_options_t>>;
 
   // Remove the covariance from our start parameters in order to skip jacobian
   // transport for the nominal propagation
@@ -130,10 +129,8 @@ template <typename parameters_t, typename propagator_options_t>
 auto RiddersPropagator<propagator_t>::propagate(
     const parameters_t& start, const Surface& target,
     const propagator_options_t& options) const
-    -> Result<actor_list_t_result_t<
-        BoundTrackParameters, typename propagator_options_t::actor_list_type>> {
-  using ThisResult = Result<actor_list_t_result_t<
-      BoundTrackParameters, typename propagator_options_t::actor_list_type>>;
+    -> Result<ResultType<propagator_options_t>> {
+  using ThisResult = Result<ResultType<propagator_options_t>>;
 
   // Remove the covariance from our start parameters in order to skip jacobian
   // transport for the nominal propagation
@@ -171,9 +168,7 @@ template <typename propagator_t>
 template <typename parameters_t, typename propagator_options_t>
 BoundMatrix RiddersPropagator<propagator_t>::wiggleAndCalculateJacobian(
     const parameters_t& start, const propagator_options_t& options,
-    const actor_list_t_result_t<BoundTrackParameters,
-                                typename propagator_options_t::actor_list_type>&
-        nominalResult) const {
+    const ResultType<propagator_options_t>& nominalResult) const {
   const auto& nominalFinalParameters = nominalResult.endParameters.value();
   // Use the curvilinear surface of the propagated parameters as target
   const Surface& target = nominalFinalParameters.referenceSurface();

--- a/Core/src/Material/SurfaceMaterialMapper.cpp
+++ b/Core/src/Material/SurfaceMaterialMapper.cpp
@@ -215,6 +215,7 @@ void SurfaceMaterialMapper::mapMaterialTrack(
     return;
   }
 }
+
 void SurfaceMaterialMapper::mapInteraction(
     State& mState, RecordedMaterialTrack& mTrack) const {
   // Retrieve the recorded material from the recorded material track

--- a/Core/src/Propagator/PropagatorError.cpp
+++ b/Core/src/Propagator/PropagatorError.cpp
@@ -29,6 +29,8 @@ class PropagatorErrorCategory : public std::error_category {
       case PropagatorError::NextTargetLimitReached:
         return "Propagation reached the configured maximum number of next "
                "target calls";
+      case PropagatorError::NextSurfaceNotReached:
+        return "Propagation did not reach a next surface";
       default:
         return "unknown";
     }

--- a/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/PropagatorTests.cpp
@@ -484,6 +484,49 @@ BOOST_AUTO_TEST_CASE(BasicPropagatorInterface) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(BLA) {
+  auto field = std::make_shared<ConstantBField>(Vector3{0, 0, 2_T});
+  EigenStepper<> eigenStepper{field};
+  VoidNavigator navigator{};
+
+  std::shared_ptr<PlaneSurface> startSurface =
+      CurvilinearSurface(Vector3::Zero(), Vector3::UnitX()).planeSurface();
+  std::shared_ptr<PlaneSurface> targetSurface =
+      CurvilinearSurface(Vector3::UnitX() * 20_mm, Vector3::UnitX())
+          .planeSurface();
+
+  BoundVector startPars;
+  startPars << 0, 0, 0, std::numbers::pi / 2., 1 / 1_GeV, 0;
+
+  BoundTrackParameters startParameters{startSurface, startPars, std::nullopt,
+                                       ParticleHypothesis::pion()};
+
+  BoundTrackParameters startCurv = BoundTrackParameters::createCurvilinear(
+      Vector4::Zero(), Vector3::UnitX(), 1. / 1_GeV, std::nullopt,
+      ParticleHypothesis::pion());
+
+  GeometryContext gctx;
+  MagneticFieldContext mctx;
+
+  EigenPropagatorType::Options<> options{gctx, mctx};
+
+  Propagator propagator{eigenStepper, navigator};
+
+  for (auto [result, propagation] :
+       propagator.propagateStepByStep(startParameters, options)) {
+    BOOST_CHECK(result.ok());
+
+    std::cout << "position: " << propagation.position().transpose() << "\n";
+  }
+
+  for (auto [result, surface, propagation] :
+       propagator.propagateSurfaceBySurface(startParameters, options)) {
+    BOOST_CHECK(result.ok());
+
+    std::cout << "position: " << propagation.position().transpose() << "\n";
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace ActsTests


### PR DESCRIPTION
This is a proposal for an alternative propagation mechanism using range-based for loop.

The idea is to invert the control flow we force on users of the current propagation, where an `Actor` has to be implemented and is essentially decoupled from the calling site of the propagation:
```c++
struct Actor {
  void act() {
    // do stuff
  }
  // remember stuff
};

void fit() {
  Propagator p;
  Options<Actor> o;

  Result r = p.propagate(o);
  // extract stuff remembered by `Actor`
}
```
IMO that has the big downside that variables have to be moved into the `Actor`, the `act` function is called for each step and cannot hold on to information which pushes it to mutable member variables, the important information at the end needs to be extracted from the propagation state to be useful to the user.
Apart from that error handling gets complicated as it has to be passed through multiple layers to end back at the calling site.

The proposed alternative is to use a range-based for loop to do the propagation steps and then have the client code simply inside the `for` loop:
```c++
void fit() {
  Propagator p;
  Options o;

  // remember stuff
  for (auto s : p.propagate(o)) {
    // do stuff
  }
  // no extraction needed
}
```
The propagation loop could be either step by step or surface by surface. Errors can be dealt with directly on the caller site by inspecting the step result `s`.

At first, both mechanisms can coexist as they do not exclude each other. If we converge on this newly proposed mechanism we could get rid of `Actor`s entirely which would make quite some templating obsolete. Thinking further ahead we could push path limit abortion, target surface, and maybe even material interaction directly into the `Propagator` as this is very common functionality.

--- END COMMIT MESSAGE ---

