### PR TITLE
refactor: Remove `virtual` from `Surface::isSensitive`

### DIFF
--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -445,7 +445,7 @@ class Surface : public virtual GeometryObject,
   virtual std::string name() const = 0;
 
   /// @brief Returns whether the Surface is sensitive
-  virtual bool isSensitive() const;
+  bool isSensitive() const;
 
   /// Return a Polyhedron for surface objects
   ///


### PR DESCRIPTION
We do not expect or want surfaces to overwrite this standard behavior so `virtual` should be dropped. After https://github.com/acts-project/acts/pull/4970

--- END COMMIT MESSAGE ---

@junggjo9 