### PR TITLE
refactor!: Rename thickness to layerThickness

### DIFF
--- a/Core/include/Acts/Geometry/Layer.hpp
+++ b/Core/include/Acts/Geometry/Layer.hpp
@@ -114,7 +114,7 @@ class Layer : public virtual GeometryObject {
   /// Return the Thickness of the Layer
   /// this is by definition along the normal vector of the surfaceRepresentation
   /// @return The layer thickness value
-  double thickness() const;
+  double layerThickness() const;
 
   /// geometrical isOnLayer() method
   ///

--- a/Core/include/Acts/Geometry/Layer.ipp
+++ b/Core/include/Acts/Geometry/Layer.ipp
@@ -20,7 +20,7 @@ inline SurfaceArray* Layer::surfaceArray() {
   return const_cast<SurfaceArray*>(m_surfaceArray.get());
 }
 
-inline double Layer::thickness() const {
+inline double Layer::layerThickness() const {
   return m_layerThickness;
 }
 

--- a/Core/src/Geometry/CylinderVolumeBuilder.cpp
+++ b/Core/src/Geometry/CylinderVolumeBuilder.cpp
@@ -554,7 +554,7 @@ VolumeConfig CylinderVolumeBuilder::analyzeContent(
     // loop over the layer
     for (auto& layer : lVector) {
       // the thickness of the layer needs to be taken into account
-      double thickness = layer->thickness();
+      double thickness = layer->layerThickness();
       // get the center of the layer
       const Vector3& center = layer->surfaceRepresentation().center(gctx);
       double rCenter = std::hypot(center.x(), center.y());

--- a/Core/src/Geometry/CylinderVolumeHelper.cpp
+++ b/Core/src/Geometry/CylinderVolumeHelper.cpp
@@ -454,8 +454,8 @@ bool CylinderVolumeHelper::estimateAndCheckDimension(
       double currentR = cylBounds->get(CylinderBounds::eR);
       double centerZ = (layerIter->surfaceRepresentation()).center(gctx).z();
       // check for min/max in the cylinder bounds case
-      currentRmin = currentR - (0.5 * (layerIter)->thickness());
-      currentRmax = currentR + (0.5 * (layerIter)->thickness());
+      currentRmin = currentR - (0.5 * (layerIter)->layerThickness());
+      currentRmax = currentR + (0.5 * (layerIter)->layerThickness());
       currentZmin = centerZ - cylBounds->get(CylinderBounds::eHalfLengthZ);
       currentZmax = centerZ + cylBounds->get(CylinderBounds::eHalfLengthZ);
     }
@@ -467,8 +467,8 @@ bool CylinderVolumeHelper::estimateAndCheckDimension(
       double centerZ = (layerIter->surfaceRepresentation()).center(gctx).z();
       currentRmin = discBounds->rMin();
       currentRmax = discBounds->rMax();
-      currentZmin = centerZ - (0.5 * (layerIter)->thickness());
-      currentZmax = centerZ + (0.5 * (layerIter)->thickness());
+      currentZmin = centerZ - (0.5 * (layerIter)->layerThickness());
+      currentZmax = centerZ + (0.5 * (layerIter)->layerThickness());
     }
     // the raw data
     rMinClean = std::min(rMinClean, currentRmin);

--- a/Core/src/Geometry/LayerArrayCreator.cpp
+++ b/Core/src/Geometry/LayerArrayCreator.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<const LayerArray> LayerArrayCreator::layerArray(
       // loop over layers
       for (auto& layIter : layers) {
         // estimate the offset
-        layerThickness = layIter->thickness();
+        layerThickness = layIter->layerThickness();
         layerValue = layIter->referencePositionValue(gctx, aDir);
         // register the new boundaries in the step vector
         boundaries.push_back(layerValue - 0.5 * layerThickness);

--- a/Tests/UnitTests/Core/Geometry/ConeLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/ConeLayerTests.cpp
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(ConeLayerConstruction) {
   // construct with thickness:
   auto pConeLayerWithThickness =
       ConeLayer::create(pTransform, pCone, nullptr, thickness);
-  BOOST_CHECK_EQUAL(pConeLayerWithThickness->thickness(), thickness);
+  BOOST_CHECK_EQUAL(pConeLayerWithThickness->layerThickness(), thickness);
   // with an approach descriptor...
   std::unique_ptr<ApproachDescriptor> ad(
       new GenericApproachDescriptor(aSurfaces));

--- a/Tests/UnitTests/Core/Geometry/CylinderLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderLayerTests.cpp
@@ -59,10 +59,10 @@ BOOST_AUTO_TEST_CASE(CylinderLayerConstruction) {
   // construct with thickness:
   auto pCylinderLayerWithThickness =
       CylinderLayer::create(pTransform, pCylinder, nullptr, thickness);
-  CHECK_CLOSE_REL(pCylinderLayerWithThickness->thickness(), thickness, 1e-6);
+  CHECK_CLOSE_REL(pCylinderLayerWithThickness->layerThickness(), thickness,
+                  1e-6);
   // with an approach descriptor...
-  std::unique_ptr<ApproachDescriptor> ad(
-      new GenericApproachDescriptor(aSurfaces));
+  auto ad(std::make_unique<GenericApproachDescriptor>(aSurfaces));
   auto adPtr = ad.get();
   auto pCylinderLayerWithApproachDescriptor = CylinderLayer::create(
       pTransform, pCylinder, nullptr, thickness, std::move(ad));

--- a/Tests/UnitTests/Core/Geometry/DiscLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/DiscLayerTests.cpp
@@ -56,10 +56,9 @@ BOOST_AUTO_TEST_CASE(DiscLayerConstruction) {
   // construct with thickness:
   auto pDiscLayerWithThickness =
       DiscLayer::create(pTransform, pDisc, nullptr, thickness);
-  BOOST_CHECK_EQUAL(pDiscLayerWithThickness->thickness(), thickness);
+  BOOST_CHECK_EQUAL(pDiscLayerWithThickness->layerThickness(), thickness);
   // with an approach descriptor...
-  std::unique_ptr<ApproachDescriptor> ad(
-      new GenericApproachDescriptor(aSurfaces));
+  auto ad(std::make_unique<GenericApproachDescriptor>(aSurfaces));
   auto adPtr = ad.get();
   auto pDiscLayerWithApproachDescriptor =
       DiscLayer::create(pTransform, pDisc, nullptr, thickness, std::move(ad));

--- a/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerCreatorTests.cpp
@@ -252,7 +252,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
 
   //
   double rMax = 10.6071, rMin = 9.59111;  // empirical - w/o envelopes
-  CHECK_CLOSE_REL(layer->thickness(), (rMax - rMin) + 2. * envR, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), (rMax - rMin) + 2. * envR, 1e-3);
 
   const CylinderBounds* bounds = &layer->bounds();
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eR), (rMax + rMin) / 2., 1e-3);
@@ -273,7 +273,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
   pl2.envelope[AxisDirection::AxisZ] = {envZ, envZ};
   layer = std::dynamic_pointer_cast<CylinderLayer>(
       p_LC->cylinderLayer(tgContext, srf, 30, 7, pl2));
-  CHECK_CLOSE_REL(layer->thickness(), (rMax - rMin) + 2 * envR, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), (rMax - rMin) + 2 * envR, 1e-3);
   bounds = &layer->bounds();
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eR), (rMax + rMin) / 2., 1e-3);
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eHalfLengthZ), 14 + envZ, 1e-3);
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
 
   layer = std::dynamic_pointer_cast<CylinderLayer>(
       p_LC->cylinderLayer(tgContext, srf, 13, 3, pl2));
-  CHECK_CLOSE_REL(layer->thickness(), (rMax - rMin) + 2 * envR, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), (rMax - rMin) + 2 * envR, 1e-3);
   bounds = &layer->bounds();
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eR), (rMax + rMin) / 2., 1e-3);
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eHalfLengthZ), 14 + envZ, 1e-3);
@@ -309,7 +309,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createCylinderLayer, LayerCreatorFixture) {
   pl3.extent.range(AxisDirection::AxisZ).set(-25, 25);
   layer = std::dynamic_pointer_cast<CylinderLayer>(
       p_LC->cylinderLayer(tgContext, srf, equidistant, equidistant, pl3));
-  CHECK_CLOSE_REL(layer->thickness(), 19, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), 19, 1e-3);
   bounds = &layer->bounds();
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eR), 10.5, 1e-3);
   CHECK_CLOSE_REL(bounds->get(CylinderBounds::eHalfLengthZ), 25, 1e-3);
@@ -343,7 +343,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createDiscLayer, LayerCreatorFixture) {
   pl.extent.range(AxisDirection::AxisR).set(5., 25.);
   std::shared_ptr<DiscLayer> layer = std::dynamic_pointer_cast<DiscLayer>(
       p_LC->discLayer(tgContext, surfaces, equidistant, equidistant, pl));
-  CHECK_CLOSE_REL(layer->thickness(), 20, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), 20, 1e-3);
   const RadialBounds* bounds =
       dynamic_cast<const RadialBounds*>(&layer->bounds());
   CHECK_CLOSE_REL(bounds->rMin(), 5, 1e-3);
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createDiscLayer, LayerCreatorFixture) {
       p_LC->discLayer(tgContext, surfaces, nBinsR, nBinsPhi, pl2));
 
   double rMin = 8, rMax = 22.0227;
-  CHECK_CLOSE_REL(layer->thickness(), 0.4 + 2 * envZ, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), 0.4 + 2 * envZ, 1e-3);
   bounds = dynamic_cast<const RadialBounds*>(&layer->bounds());
   CHECK_CLOSE_REL(bounds->rMin(), rMin - envMinR, 1e-3);
   CHECK_CLOSE_REL(bounds->rMax(), rMax + envMaxR, 1e-3);
@@ -395,7 +395,7 @@ BOOST_FIXTURE_TEST_CASE(LayerCreator_createDiscLayer, LayerCreatorFixture) {
 
   layer = std::dynamic_pointer_cast<DiscLayer>(
       p_LC->discLayer(tgContext, surfaces, equidistant, equidistant, pl2));
-  CHECK_CLOSE_REL(layer->thickness(), 0.4 + 2 * envZ, 1e-3);
+  CHECK_CLOSE_REL(layer->layerThickness(), 0.4 + 2 * envZ, 1e-3);
   bounds = dynamic_cast<const RadialBounds*>(&layer->bounds());
   CHECK_CLOSE_REL(bounds->rMin(), rMin - envMinR, 1e-3);
   CHECK_CLOSE_REL(bounds->rMax(), rMax + envMaxR, 1e-3);

--- a/Tests/UnitTests/Core/Geometry/LayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/LayerTests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(LayerProperties) {
   /// surfaceArray()
   BOOST_CHECK_EQUAL(layerStub.surfaceArray(), nullptr);
   /// thickness()
-  BOOST_CHECK_EQUAL(layerStub.thickness(), thickness);
+  BOOST_CHECK_EQUAL(layerStub.layerThickness(), thickness);
   // onLayer() is templated; can't find implementation!
   /// isOnLayer() (delegates to the Surface 'isOnSurface()')
   const Vector3 pos{0.0, 0.0, 0.0};

--- a/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PlaneLayerTests.cpp
@@ -62,10 +62,9 @@ BOOST_AUTO_TEST_CASE(PlaneLayerConstruction) {
   // construct with thickness:
   auto pPlaneLayerWithThickness = PlaneLayer::create(
       pTransform, pRectangle, std::move(pSurfaceArray), thickness);
-  BOOST_CHECK_EQUAL(pPlaneLayerWithThickness->thickness(), thickness);
+  BOOST_CHECK_EQUAL(pPlaneLayerWithThickness->layerThickness(), thickness);
   // with an approach descriptor...
-  std::unique_ptr<ApproachDescriptor> ad(
-      new GenericApproachDescriptor(aSurfaces));
+  auto ad(std::make_unique<GenericApproachDescriptor>(aSurfaces));
   auto adPtr = ad.get();
   auto pPlaneLayerWithApproachDescriptor =
       PlaneLayer::create(pTransform, pRectangle, std::move(pSurfaceArray),


### PR DESCRIPTION
- Rename the thickness -> layerThicknes of the layer

--- END COMMIT MESSAGE ---
Needed in order to move the thickness method of the `DetectorElementBase` to  the `Surface` (cf. https://github.com/acts-project/acts/pull/5005)

Tagging: @paulgessinger, @andiwand  