### PR TITLE
fix: Attach full namespace to PWMI in GX2F

### DIFF
--- a/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GlobalChiSquareFitter.hpp
@@ -852,8 +852,8 @@ class Gx2Fitter {
         if (scatteringMapId == scatteringMap->end()) {
           ACTS_DEBUG("    ... create entry in scattering map.");
 
-          detail::PointwiseMaterialInteraction interaction(state, stepper,
-                                                           navigator);
+          Acts::detail::PointwiseMaterialInteraction interaction(state, stepper,
+                                                                 navigator);
           // We need to evaluate the material to create the correct slab
           const bool slabIsValid =
               interaction.evaluateMaterialSlab(MaterialUpdateMode::FullUpdate);


### PR DESCRIPTION
Athena seems to be strongly attached to the full namespace

--- END COMMIT MESSAGE ---
