### PR TITLE
refactor: Make SurfaceBounds::BoundsType an enum class

### DIFF
--- a/Core/include/Acts/Surfaces/AnnulusBounds.hpp
+++ b/Core/include/Acts/Surfaces/AnnulusBounds.hpp
@@ -66,7 +66,7 @@ class AnnulusBounds : public DiscBounds {
   explicit AnnulusBounds(const std::array<double, eSize>& values) noexcept(
       false);
 
-  BoundsType type() const final { return eAnnulus; }
+  BoundsType type() const final { return Annulus; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/AnnulusBounds.hpp
+++ b/Core/include/Acts/Surfaces/AnnulusBounds.hpp
@@ -66,7 +66,7 @@ class AnnulusBounds : public DiscBounds {
   explicit AnnulusBounds(const std::array<double, eSize>& values) noexcept(
       false);
 
-  BoundsType type() const final { return Annulus; }
+  Type type() const final { return Annulus; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/ConeBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConeBounds.hpp
@@ -73,7 +73,7 @@ class ConeBounds : public SurfaceBounds {
   explicit ConeBounds(const std::array<double, eSize>& values) noexcept(false);
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eCone; }
+  BoundsType type() const final { return Cone; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/ConeBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConeBounds.hpp
@@ -73,7 +73,7 @@ class ConeBounds : public SurfaceBounds {
   explicit ConeBounds(const std::array<double, eSize>& values) noexcept(false);
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Cone; }
+  Type type() const final { return Cone; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
@@ -37,7 +37,7 @@ class ConvexPolygonBoundsBase : public PlanarBounds {
 
   /// Return the bounds type of this bounds object.
   /// @return The bounds type
-  BoundsType type() const final { return ConvexPolygon; }
+  Type type() const final { return ConvexPolygon; }
 
   /// Return the bound values as dynamically sized vector
   /// @return this returns a copy of the internal values

--- a/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
+++ b/Core/include/Acts/Surfaces/ConvexPolygonBounds.hpp
@@ -37,7 +37,7 @@ class ConvexPolygonBoundsBase : public PlanarBounds {
 
   /// Return the bounds type of this bounds object.
   /// @return The bounds type
-  BoundsType type() const final { return eConvexPolygon; }
+  BoundsType type() const final { return ConvexPolygon; }
 
   /// Return the bound values as dynamically sized vector
   /// @return this returns a copy of the internal values

--- a/Core/include/Acts/Surfaces/CylinderBounds.hpp
+++ b/Core/include/Acts/Surfaces/CylinderBounds.hpp
@@ -86,7 +86,7 @@ class CylinderBounds : public SurfaceBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Cylinder; }
+  Type type() const final { return Cylinder; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/CylinderBounds.hpp
+++ b/Core/include/Acts/Surfaces/CylinderBounds.hpp
@@ -86,7 +86,7 @@ class CylinderBounds : public SurfaceBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eCylinder; }
+  BoundsType type() const final { return Cylinder; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/DiamondBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiamondBounds.hpp
@@ -69,7 +69,7 @@ class DiamondBounds : public PlanarBounds {
                     values[eHalfLengthYpos]}) {}
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eDiamond; }
+  BoundsType type() const final { return Diamond; }
 
   /// Return the bound values as dynamically sized vector
   ///

--- a/Core/include/Acts/Surfaces/DiamondBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiamondBounds.hpp
@@ -69,7 +69,7 @@ class DiamondBounds : public PlanarBounds {
                     values[eHalfLengthYpos]}) {}
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Diamond; }
+  Type type() const final { return Diamond; }
 
   /// Return the bound values as dynamically sized vector
   ///

--- a/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
@@ -64,7 +64,7 @@ class DiscTrapezoidBounds : public DiscBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eDiscTrapezoid; }
+  BoundsType type() const final { return DiscTrapezoid; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/DiscTrapezoidBounds.hpp
@@ -64,7 +64,7 @@ class DiscTrapezoidBounds : public DiscBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return DiscTrapezoid; }
+  Type type() const final { return DiscTrapezoid; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/EllipseBounds.hpp
+++ b/Core/include/Acts/Surfaces/EllipseBounds.hpp
@@ -69,7 +69,7 @@ class EllipseBounds : public PlanarBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eEllipse; }
+  BoundsType type() const final { return Ellipse; }
 
   /// Return the bound values as dynamically sized vector
   ///

--- a/Core/include/Acts/Surfaces/EllipseBounds.hpp
+++ b/Core/include/Acts/Surfaces/EllipseBounds.hpp
@@ -69,7 +69,7 @@ class EllipseBounds : public PlanarBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Ellipse; }
+  Type type() const final { return Ellipse; }
 
   /// Return the bound values as dynamically sized vector
   ///

--- a/Core/include/Acts/Surfaces/InfiniteBounds.hpp
+++ b/Core/include/Acts/Surfaces/InfiniteBounds.hpp
@@ -22,7 +22,7 @@ namespace Acts {
 class InfiniteBounds : public SurfaceBounds {
  public:
   /// @copydoc SurfaceBounds::type
-  SurfaceBounds::BoundsType type() const final { return eBoundless; }
+  SurfaceBounds::BoundsType type() const final { return Boundless; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/InfiniteBounds.hpp
+++ b/Core/include/Acts/Surfaces/InfiniteBounds.hpp
@@ -22,7 +22,7 @@ namespace Acts {
 class InfiniteBounds : public SurfaceBounds {
  public:
   /// @copydoc SurfaceBounds::type
-  SurfaceBounds::BoundsType type() const final { return Boundless; }
+  Type type() const final { return Boundless; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/LineBounds.hpp
+++ b/Core/include/Acts/Surfaces/LineBounds.hpp
@@ -44,7 +44,7 @@ class LineBounds : public SurfaceBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Line; }
+  Type type() const final { return Line; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/LineBounds.hpp
+++ b/Core/include/Acts/Surfaces/LineBounds.hpp
@@ -44,7 +44,7 @@ class LineBounds : public SurfaceBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eLine; }
+  BoundsType type() const final { return Line; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return true; }

--- a/Core/include/Acts/Surfaces/RadialBounds.hpp
+++ b/Core/include/Acts/Surfaces/RadialBounds.hpp
@@ -59,7 +59,7 @@ class RadialBounds : public DiscBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eDisc; }
+  BoundsType type() const final { return Disc; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/RadialBounds.hpp
+++ b/Core/include/Acts/Surfaces/RadialBounds.hpp
@@ -59,7 +59,7 @@ class RadialBounds : public DiscBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Disc; }
+  Type type() const final { return Disc; }
 
   /// @copydoc SurfaceBounds::isCartesian
   bool isCartesian() const final { return false; }

--- a/Core/include/Acts/Surfaces/RectangleBounds.hpp
+++ b/Core/include/Acts/Surfaces/RectangleBounds.hpp
@@ -66,7 +66,7 @@ class RectangleBounds : public PlanarBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eRectangle; }
+  BoundsType type() const final { return Rectangle; }
 
   /// @copydoc SurfaceBounds::values
   std::vector<double> values() const final;

--- a/Core/include/Acts/Surfaces/RectangleBounds.hpp
+++ b/Core/include/Acts/Surfaces/RectangleBounds.hpp
@@ -66,7 +66,7 @@ class RectangleBounds : public PlanarBounds {
   }
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Rectangle; }
+  Type type() const final { return Rectangle; }
 
   /// @copydoc SurfaceBounds::values
   std::vector<double> values() const final;

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -31,7 +31,7 @@ class SurfaceBounds {
   /// @enum BoundsType
   /// This is nested to the SurfaceBounds, as also VolumeBounds will have
   /// Bounds Type.
-  enum class BoundsType : int {
+  enum class Type : int {
     eCone [[deprecated("Use the enum ::Cone instead")]] = 0,
     eCylinder [[deprecated("Use the enum ::Cylinder instead")]] = 1,
     eDiamond [[deprecated("Use the enum ::Diamond instead")]] = 2,
@@ -63,13 +63,15 @@ class SurfaceBounds {
     Other = 13
   };
 
-  using enum BoundsType;
+  using BoundsType [[deprecated("Use the enum class Type instead")]] = Type;
+
+  using enum Type;
 
   virtual ~SurfaceBounds() = default;
 
   /// Return the bounds type - for persistency optimization
   /// @return the bounds type
-  virtual BoundsType type() const = 0;
+  virtual Type type() const = 0;
 
   /// Check if the bound coordinates are cartesian
   /// @return true if the bound coordinates are cartesian
@@ -166,12 +168,11 @@ class SurfaceBounds {
 };
 
 /// Stream operator for SurfaceBounds::BoundsType
-std::ostream& operator<<(std::ostream& os, const SurfaceBounds::BoundsType& bt);
+std::ostream& operator<<(std::ostream& os, const SurfaceBounds::Type& bt);
 
 }  // namespace Acts
 
 namespace std {
 template <>
-struct formatter<Acts::SurfaceBounds::BoundsType>
-    : Acts::detail::OstreamFormatter {};
+struct formatter<Acts::SurfaceBounds::Type> : Acts::detail::OstreamFormatter {};
 }  // namespace std

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
+#include "Acts/Utilities/OstreamFormatter.hpp"
 
 #include <cmath>
 #include <ostream>
@@ -30,7 +31,7 @@ class SurfaceBounds {
   /// @enum BoundsType
   /// This is nested to the SurfaceBounds, as also VolumeBounds will have
   /// Bounds Type.
-  enum BoundsType : int {
+  enum class BoundsType : int {
     eCone = 0,
     eCylinder = 1,
     eDiamond = 2,
@@ -46,6 +47,8 @@ class SurfaceBounds {
     eBoundless = 12,
     eOther = 13
   };
+
+  using enum BoundsType;
 
   virtual ~SurfaceBounds() = default;
 
@@ -147,4 +150,13 @@ class SurfaceBounds {
   }
 };
 
+/// Stream operator for SurfaceBounds::BoundsType
+std::ostream& operator<<(std::ostream& os, const SurfaceBounds::BoundsType& bt);
+
 }  // namespace Acts
+
+namespace std {
+template <>
+struct formatter<Acts::SurfaceBounds::BoundsType>
+    : Acts::detail::OstreamFormatter {};
+}  // namespace std

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -32,20 +32,35 @@ class SurfaceBounds {
   /// This is nested to the SurfaceBounds, as also VolumeBounds will have
   /// Bounds Type.
   enum class BoundsType : int {
-    eCone = 0,
-    eCylinder = 1,
-    eDiamond = 2,
-    eDisc = 3,
-    eEllipse = 4,
-    eLine = 5,
-    eRectangle = 6,
-    eTrapezoid = 7,
-    eTriangle = 8,
+    eCone [[deprecated("Use the enum ::Cone instead")]] = 0,
+    eCylinder [[deprecated("Use the enum ::Cylinder instead")]] = 1,
+    eDiamond [[deprecated("Use the enum ::Diamond instead")]] = 2,
+    eDisc [[deprecated("Use the enum ::Disc instead")]] = 3,
+    eEllipse [[deprecated("Use the enum ::Ellipse instead")]] = 4,
+    eLine [[deprecated("Use the enum ::Line instead")]] = 5,
+    eRectangle [[deprecated("Use the enum ::Rectangle instead")]] = 6,
+    eTrapezoid [[deprecated("Use the enum ::Trapezoid instead")]] = 7,
+    eTriangle [[deprecated("Use the enum ::Triangle instead")]] = 8,
     eDiscTrapezoid = 9,
-    eConvexPolygon = 10,
-    eAnnulus = 11,
-    eBoundless = 12,
-    eOther = 13
+    eConvexPolygon [[deprecated("Use the enum ::ConvexPolygon instead")]] = 10,
+    eAnnulus [[deprecated("Use the enum ::Annulus instead")]] = 11,
+    eBoundless [[deprecated("Use the enum ::Boundless instead")]] = 12,
+    eOther [[deprecated("Use the enum ::Other instead")]] = 13,
+
+    Cone = 0,
+    Cylinder = 1,
+    Diamond = 2,
+    Disc = 3,
+    Ellipse = 4,
+    Line = 5,
+    Rectangle = 6,
+    Trapezoid = 7,
+    Triangle = 8,
+    DiscTrapezoid = 9,
+    ConvexPolygon = 10,
+    Annulus = 11,
+    Boundless = 12,
+    Other = 13
   };
 
   using enum BoundsType;

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -28,7 +28,6 @@ namespace Acts {
 ///
 class SurfaceBounds {
  public:
-  /// @enum BoundsType
   /// This is nested to the SurfaceBounds, as also VolumeBounds will have
   /// Bounds Type.
   enum class Type : int {

--- a/Core/include/Acts/Surfaces/SurfaceBounds.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceBounds.hpp
@@ -167,7 +167,7 @@ class SurfaceBounds {
   }
 };
 
-/// Stream operator for SurfaceBounds::BoundsType
+/// Stream operator for SurfaceBounds::Type
 std::ostream& operator<<(std::ostream& os, const SurfaceBounds::Type& bt);
 
 }  // namespace Acts

--- a/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
@@ -54,7 +54,7 @@ class TrapezoidBounds : public PlanarBounds {
       false);
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return eTrapezoid; }
+  BoundsType type() const final { return Trapezoid; }
 
   /// @copydoc SurfaceBounds::values
   std::vector<double> values() const final;

--- a/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
+++ b/Core/include/Acts/Surfaces/TrapezoidBounds.hpp
@@ -54,7 +54,7 @@ class TrapezoidBounds : public PlanarBounds {
       false);
 
   /// @copydoc SurfaceBounds::type
-  BoundsType type() const final { return Trapezoid; }
+  Type type() const final { return Trapezoid; }
 
   /// @copydoc SurfaceBounds::values
   std::vector<double> values() const final;

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -151,8 +151,8 @@ Polyhedron DiscSurface::polyhedronRepresentation(
   bool fullDisc = m_bounds->coversFullAzimuth();
   bool toCenter = m_bounds->rMin() < s_onSurfaceTolerance;
   // If you have bounds you can create a polyhedron representation
-  bool exactPolyhedron = (m_bounds->type() == SurfaceBounds::eDiscTrapezoid);
-  bool addCentreFromConvexFace = (m_bounds->type() != SurfaceBounds::eAnnulus);
+  bool exactPolyhedron = (m_bounds->type() == SurfaceBounds::DiscTrapezoid);
+  bool addCentreFromConvexFace = (m_bounds->type() != SurfaceBounds::Annulus);
   if (m_bounds) {
     auto vertices2D = m_bounds->vertices(quarterSegments);
     vertices.reserve(vertices2D.size() + 1);

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -104,7 +104,7 @@ Polyhedron PlaneSurface::polyhedronRepresentation(
       vertices.push_back(localToGlobalTransform(gctx) *
                          Vector3(v2D.x(), v2D.y(), 0.));
     }
-    bool isEllipse = bounds().type() == SurfaceBounds::eEllipse;
+    bool isEllipse = bounds().type() == SurfaceBounds::Ellipse;
     bool innerExists = false, coversFull = false;
     if (isEllipse) {
       exactPolyhedron = false;

--- a/Core/src/Surfaces/SurfaceBounds.cpp
+++ b/Core/src/Surfaces/SurfaceBounds.cpp
@@ -56,10 +56,9 @@ bool SurfaceBounds::inside(const Vector2& lposition,
   return boundaryTolerance.isTolerated(distance, boundToCartesian);
 }
 
-std::ostream& operator<<(std::ostream& os,
-                         const SurfaceBounds::BoundsType& bt) {
+std::ostream& operator<<(std::ostream& os, const SurfaceBounds::Type& bt) {
   switch (bt) {
-    using enum SurfaceBounds::BoundsType;
+    using enum SurfaceBounds::Type;
     case Cone:
       os << "Cone";
       break;

--- a/Core/src/Surfaces/SurfaceBounds.cpp
+++ b/Core/src/Surfaces/SurfaceBounds.cpp
@@ -56,4 +56,54 @@ bool SurfaceBounds::inside(const Vector2& lposition,
   return boundaryTolerance.isTolerated(distance, boundToCartesian);
 }
 
+std::ostream& Acts::operator<<(std::ostream& os,
+                               const SurfaceBounds::BoundsType& bt) {
+  switch (bt) {
+    using enum SurfaceBounds::BoundsType;
+    case eCone:
+      os << "Cone";
+      break;
+    case eCylinder:
+      os << "Cylinder";
+      break;
+    case eDiamond:
+      os << "Diamond";
+      break;
+    case eDisc:
+      os << "Disc";
+      break;
+    case eEllipse:
+      os << "Ellipse";
+      break;
+    case eLine:
+      os << "Line";
+      break;
+    case eRectangle:
+      os << "Rectangle";
+      break;
+    case eTrapezoid:
+      os << "Trapezoid";
+      break;
+    case eTriangle:
+      os << "Triangle";
+      break;
+    case eDiscTrapezoid:
+      os << "DiscTrapezoid";
+      break;
+    case eConvexPolygon:
+      os << "ConvexPolygon";
+      break;
+    case eAnnulus:
+      os << "Annulus";
+      break;
+    case eBoundless:
+      os << "Boundless";
+      break;
+    case eOther:
+      os << "Other";
+      break;
+  }
+  return os;
+}
+
 }  // namespace Acts

--- a/Core/src/Surfaces/SurfaceBounds.cpp
+++ b/Core/src/Surfaces/SurfaceBounds.cpp
@@ -60,46 +60,46 @@ std::ostream& operator<<(std::ostream& os,
                          const SurfaceBounds::BoundsType& bt) {
   switch (bt) {
     using enum SurfaceBounds::BoundsType;
-    case eCone:
+    case Cone:
       os << "Cone";
       break;
-    case eCylinder:
+    case Cylinder:
       os << "Cylinder";
       break;
-    case eDiamond:
+    case Diamond:
       os << "Diamond";
       break;
-    case eDisc:
+    case Disc:
       os << "Disc";
       break;
-    case eEllipse:
+    case Ellipse:
       os << "Ellipse";
       break;
-    case eLine:
+    case Line:
       os << "Line";
       break;
-    case eRectangle:
+    case Rectangle:
       os << "Rectangle";
       break;
-    case eTrapezoid:
+    case Trapezoid:
       os << "Trapezoid";
       break;
-    case eTriangle:
+    case Triangle:
       os << "Triangle";
       break;
-    case eDiscTrapezoid:
+    case DiscTrapezoid:
       os << "DiscTrapezoid";
       break;
-    case eConvexPolygon:
+    case ConvexPolygon:
       os << "ConvexPolygon";
       break;
-    case eAnnulus:
+    case Annulus:
       os << "Annulus";
       break;
-    case eBoundless:
+    case Boundless:
       os << "Boundless";
       break;
-    case eOther:
+    case Other:
       os << "Other";
       break;
   }

--- a/Core/src/Surfaces/SurfaceBounds.cpp
+++ b/Core/src/Surfaces/SurfaceBounds.cpp
@@ -56,8 +56,8 @@ bool SurfaceBounds::inside(const Vector2& lposition,
   return boundaryTolerance.isTolerated(distance, boundToCartesian);
 }
 
-std::ostream& Acts::operator<<(std::ostream& os,
-                               const SurfaceBounds::BoundsType& bt) {
+std::ostream& operator<<(std::ostream& os,
+                         const SurfaceBounds::BoundsType& bt) {
   switch (bt) {
     using enum SurfaceBounds::BoundsType;
     case eCone:

--- a/Examples/Algorithms/Digitization/src/DigitizationConfigurator.cpp
+++ b/Examples/Algorithms/Digitization/src/DigitizationConfigurator.cpp
@@ -81,7 +81,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
 
         switch (sBounds.type()) {
           // The module is a rectangle module
-          case Acts::SurfaceBounds::eRectangle: {
+          case Acts::SurfaceBounds::Rectangle: {
             if (inputSegmentation.binningData()[0].binvalue ==
                 Acts::AxisDirection::AxisX) {
               double minX = boundValues[Acts::RectangleBounds::eMinX];
@@ -109,7 +109,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
           } break;
 
           // The module is a trapezoid module
-          case Acts::SurfaceBounds::eTrapezoid: {
+          case Acts::SurfaceBounds::Trapezoid: {
             if (inputSegmentation.binningData()[0].binvalue ==
                 Acts::AxisDirection::AxisX) {
               double maxX = std::max(
@@ -137,7 +137,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
           } break;
 
           // The module is an annulus module
-          case Acts::SurfaceBounds::eAnnulus: {
+          case Acts::SurfaceBounds::Annulus: {
             if (inputSegmentation.binningData()[0].binvalue ==
                 Acts::AxisDirection::AxisR) {
               double minR = boundValues[Acts::AnnulusBounds::eMinR];
@@ -169,7 +169,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
           } break;
 
           // The module is a Disc Trapezoid
-          case Acts::SurfaceBounds::eDiscTrapezoid: {
+          case Acts::SurfaceBounds::DiscTrapezoid: {
             double minR = boundValues[Acts::DiscTrapezoidBounds::eMinR];
             double maxR = boundValues[Acts::DiscTrapezoidBounds::eMaxR];
 
@@ -206,7 +206,7 @@ void ActsExamples::DigitizationConfigurator::operator()(
 
           } break;
 
-          case Acts::SurfaceBounds::eDisc: {
+          case Acts::SurfaceBounds::Disc: {
             if (inputSegmentation.binningData()[0].binvalue ==
                 Acts::AxisDirection::AxisR) {
               double minR = boundValues[Acts::RadialBounds::eMinR];

--- a/Examples/Algorithms/Digitization/src/MuonSpacePointDigitizer.cpp
+++ b/Examples/Algorithms/Digitization/src/MuonSpacePointDigitizer.cpp
@@ -56,12 +56,12 @@ constexpr double quantize(const double x, const double pitch) {
 /// @brief Returns the half-height of a trapezoid / rectangular bounds
 /// @param bounds: Rectangle / Trapezoid bounds to fetch the half height from
 double halfHeight(const SurfaceBounds& bounds) {
-  if (bounds.type() == SurfaceBounds::BoundsType::eRectangle) {
+  if (bounds.type() == SurfaceBounds::BoundsType::Rectangle) {
     return static_cast<const RectangleBounds&>(bounds).get(
         RectangleBounds::eMaxY);
   }
   // Trapezoid -> endcap
-  else if (bounds.type() == SurfaceBounds::BoundsType::eTrapezoid) {
+  else if (bounds.type() == SurfaceBounds::BoundsType::Trapezoid) {
     return static_cast<const TrapezoidBounds&>(bounds).get(
         TrapezoidBounds::eHalfLengthY);
   }
@@ -253,7 +253,7 @@ ProcessCode MuonSpacePointDigitizer::execute(
           const auto hitPos = planeCross.position();
           Vector3 smearedHit{Vector3::Zero()};
           switch (bounds.type()) {
-            case SurfaceBounds::BoundsType::eRectangle: {
+            case SurfaceBounds::BoundsType::Rectangle: {
               smearedHit[ePos0] =
                   quantize(hitPos[ePos0], calibCfg.rpcPhiStripPitch);
               smearedHit[ePos1] =
@@ -325,7 +325,7 @@ ProcessCode MuonSpacePointDigitizer::execute(
               break;
             }
             /// Endcap strips not yet available
-            case SurfaceBounds::BoundsType::eTrapezoid:
+            case SurfaceBounds::BoundsType::Trapezoid:
               break;
             default:
               convertSp = false;

--- a/Examples/Algorithms/Digitization/src/MuonSpacePointDigitizer.cpp
+++ b/Examples/Algorithms/Digitization/src/MuonSpacePointDigitizer.cpp
@@ -56,12 +56,13 @@ constexpr double quantize(const double x, const double pitch) {
 /// @brief Returns the half-height of a trapezoid / rectangular bounds
 /// @param bounds: Rectangle / Trapezoid bounds to fetch the half height from
 double halfHeight(const SurfaceBounds& bounds) {
-  if (bounds.type() == SurfaceBounds::BoundsType::Rectangle) {
+  using enum SurfaceBounds::Type;
+  if (bounds.type() == Rectangle) {
     return static_cast<const RectangleBounds&>(bounds).get(
         RectangleBounds::eMaxY);
   }
   // Trapezoid -> endcap
-  else if (bounds.type() == SurfaceBounds::BoundsType::Trapezoid) {
+  else if (bounds.type() == Trapezoid) {
     return static_cast<const TrapezoidBounds&>(bounds).get(
         TrapezoidBounds::eHalfLengthY);
   }
@@ -247,13 +248,14 @@ ProcessCode MuonSpacePointDigitizer::execute(
         /// Strip measurements
         using enum Surface::SurfaceType;
         case Plane: {
+          using enum SurfaceBounds::Type;
           ACTS_VERBOSE("Hit is recorded in a strip detector ");
           auto planeCross =
               intersectPlane(locPos, locDir, Vector3::UnitZ(), 0.);
           const auto hitPos = planeCross.position();
           Vector3 smearedHit{Vector3::Zero()};
           switch (bounds.type()) {
-            case SurfaceBounds::BoundsType::Rectangle: {
+            case Rectangle: {
               smearedHit[ePos0] =
                   quantize(hitPos[ePos0], calibCfg.rpcPhiStripPitch);
               smearedHit[ePos1] =
@@ -325,7 +327,7 @@ ProcessCode MuonSpacePointDigitizer::execute(
               break;
             }
             /// Endcap strips not yet available
-            case SurfaceBounds::BoundsType::Trapezoid:
+            case Trapezoid:
               break;
             default:
               convertSp = false;

--- a/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
+++ b/Examples/Algorithms/Geant4/src/SensitiveSurfaceMapper.cpp
@@ -249,7 +249,7 @@ void SensitiveSurfaceMapper::remapSensitiveNames(
       mappedSurface = candidateSurface;
       break;
     } else if (candidateSurface->bounds().type() ==
-               Acts::SurfaceBounds::eAnnulus) {
+               Acts::SurfaceBounds::Annulus) {
       const auto& bounds =
           *static_cast<const Acts::AnnulusBounds*>(&candidateSurface->bounds());
 

--- a/Examples/Detectors/ITkModuleSplitting/include/ActsExamples/ITkModuleSplitting/ITkModuleSplitting.hpp
+++ b/Examples/Detectors/ITkModuleSplitting/include/ActsExamples/ITkModuleSplitting/ITkModuleSplitting.hpp
@@ -30,7 +30,7 @@ inline std::vector<std::shared_ptr<const detector_element_t>> splitBarrelModule(
   // Retrieve the surface
   const Acts::Surface& surface = detElement->surface();
   const Acts::SurfaceBounds& bounds = surface.bounds();
-  if (bounds.type() != Acts::SurfaceBounds::eRectangle || nSegments <= 1u) {
+  if (bounds.type() != Acts::SurfaceBounds::Rectangle || nSegments <= 1u) {
     ACTS_WARNING("Invalid splitting config for barrel node: "
                  << name << "! Node will not be slpit.");
     return {detElement};
@@ -94,7 +94,7 @@ inline std::vector<std::shared_ptr<detector_element_t>> splitDiscModule(
   };
   ACTS_DEBUG(printOrigin(surface));
 
-  if (bounds.type() != Acts::SurfaceBounds::eAnnulus || splitRanges.empty()) {
+  if (bounds.type() != Acts::SurfaceBounds::Annulus || splitRanges.empty()) {
     ACTS_WARNING("Invalid splitting config for disk node: "
                  << name << "! Node will not be slpit.");
     return {detElement};

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -139,7 +139,7 @@ void writeCylinderLayerVolume(LayerVolumeWriter& lvWriter,
   lvDims.volume_id = lv.geometryId().volume();
   lvDims.layer_id = lv.geometryId().layer();
   bool isCylinderLayer = (lv.surfaceRepresentation().bounds().type() ==
-                          Acts::SurfaceBounds::eCylinder);
+                          Acts::SurfaceBounds::Cylinder);
 
   auto lTranslation = transform.translation();
   // Change volume Bound values to r min, r max, z min, z max, phi min,

--- a/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
+++ b/Examples/Io/Csv/src/CsvTrackingGeometryWriter.cpp
@@ -21,6 +21,7 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/SurfaceArray.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/IAxis.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
@@ -95,7 +96,7 @@ void fillSurfaceData(SurfaceData& data, const Acts::Surface& surface,
       &data.bound_param6};
 
   const auto& bounds = surface.bounds();
-  data.bounds_type = static_cast<int>(bounds.type());
+  data.bounds_type = toUnderlying(bounds.type());
   auto boundValues = bounds.values();
 
   if (boundValues.size() > dataBoundParameters.size()) {

--- a/Examples/Io/Root/src/RootMuonSpacePointWriter.cpp
+++ b/Examples/Io/Root/src/RootMuonSpacePointWriter.cpp
@@ -172,7 +172,7 @@ ProcessCode RootMuonSpacePointWriter::writeT(
       Acts::Vector3 lowEdge{Vector3::Zero()};
       Acts::Vector3 highEdge{Vector3::Zero()};
       switch (bounds.type()) {
-        using enum Acts::SurfaceBounds::BoundsType;
+        using enum Acts::SurfaceBounds::Type;
         case Line: {
           const auto& lBounds = static_cast<const LineBounds&>(bounds);
           const double l = lBounds.get(LineBounds::eHalfLengthZ);

--- a/Examples/Io/Root/src/RootMuonSpacePointWriter.cpp
+++ b/Examples/Io/Root/src/RootMuonSpacePointWriter.cpp
@@ -173,14 +173,14 @@ ProcessCode RootMuonSpacePointWriter::writeT(
       Acts::Vector3 highEdge{Vector3::Zero()};
       switch (bounds.type()) {
         using enum Acts::SurfaceBounds::BoundsType;
-        case eLine: {
+        case Line: {
           const auto& lBounds = static_cast<const LineBounds&>(bounds);
           const double l = lBounds.get(LineBounds::eHalfLengthZ);
           lowEdge = trf * (-l * Vector3::UnitZ());
           highEdge = trf * (l * Vector3::UnitZ());
           break;
         }
-        case eRectangle: {
+        case Rectangle: {
           const auto& rBounds = static_cast<const RectangleBounds&>(bounds);
           const double l =
               rBounds.get(writeMe.measuresLoc1() ? RectangleBounds::eMaxX
@@ -191,7 +191,7 @@ ProcessCode RootMuonSpacePointWriter::writeT(
           highEdge = trf * (l * Vector3::Unit(dimIdx));
           break;
         }
-        case eTrapezoid: {
+        case Trapezoid: {
           ACTS_WARNING(__FILE__ << ":" << __LINE__ << " Implement me");
           break;
         }

--- a/Fatras/src/Digitization/PlanarSurfaceMask.cpp
+++ b/Fatras/src/Digitization/PlanarSurfaceMask.cpp
@@ -83,7 +83,7 @@ ActsFatras::PlanarSurfaceMask::apply(const Acts::Surface& surface,
 
   // Plane surface section -------------------
   if (surfaceType == Acts::Surface::Plane ||
-      surface.bounds().type() == Acts::SurfaceBounds::eDiscTrapezoid) {
+      surface.bounds().type() == Acts::SurfaceBounds::DiscTrapezoid) {
     Acts::Vector2 localStart =
         (surfaceType == Acts::Surface::Plane)
             ? segment[0]
@@ -112,7 +112,7 @@ ActsFatras::PlanarSurfaceMask::apply(const Acts::Surface& surface,
     if (surfaceType == Acts::Surface::Plane) {
       planarBounds =
           static_cast<const Acts::PlanarBounds*>(&(surface.bounds()));
-      if (planarBounds->type() == Acts::SurfaceBounds::eEllipse) {
+      if (planarBounds->type() == Acts::SurfaceBounds::Ellipse) {
         return DigitizationError::UndefinedSurface;
       }
     } else {
@@ -142,12 +142,12 @@ ActsFatras::PlanarSurfaceMask::apply(const Acts::Surface& surface,
     }
 
     auto boundsType = surface.bounds().type();
-    if (boundsType == Acts::SurfaceBounds::eDisc) {
+    if (boundsType == Acts::SurfaceBounds::Disc) {
       auto rBounds =
           static_cast<const Acts::RadialBounds*>(&(surface.bounds()));
       return radialMask(*rBounds, segment, {sPolar, ePolar}, startInside);
 
-    } else if (boundsType == Acts::SurfaceBounds::eAnnulus) {
+    } else if (boundsType == Acts::SurfaceBounds::Annulus) {
       auto aBounds =
           static_cast<const Acts::AnnulusBounds*>(&(surface.bounds()));
       return annulusMask(*aBounds, segment, startInside);

--- a/Plugins/ActSVG/src/SurfaceSvgConverter.cpp
+++ b/Plugins/ActSVG/src/SurfaceSvgConverter.cpp
@@ -50,7 +50,7 @@ ActsPlugins::Svg::ProtoSurface ActsPlugins::Svg::SurfaceConverter::convert(
       } else if (surface.type() == Surface::SurfaceType::Disc) {
         // Or disc bounds
         const auto& boundValues = surface.bounds().values();
-        if (surface.bounds().type() == SurfaceBounds::BoundsType::eDisc) {
+        if (surface.bounds().type() == SurfaceBounds::BoundsType::Disc) {
           // The radii
           actsvg::scalar ri = static_cast<actsvg::scalar>(boundValues[0]);
           actsvg::scalar ro = static_cast<actsvg::scalar>(boundValues[1]);
@@ -80,30 +80,30 @@ ActsPlugins::Svg::ProtoSurface ActsPlugins::Svg::SurfaceConverter::convert(
   const auto& boundValues = surface.bounds().values();
   auto bType = surface.bounds().type();
   auto bValues = surface.bounds().values();
-  if (bType == SurfaceBounds::BoundsType::eRectangle) {
+  if (bType == SurfaceBounds::BoundsType::Rectangle) {
     pSurface._type = ProtoSurface::type::e_rectangle;
     // Set the measure
     pSurface._measures = {
         static_cast<actsvg::scalar>(0.5 * (boundValues[2] - boundValues[0])),
         static_cast<actsvg::scalar>(0.5 * (boundValues[3] - boundValues[1]))};
-  } else if (bType == SurfaceBounds::BoundsType::eTrapezoid) {
+  } else if (bType == SurfaceBounds::BoundsType::Trapezoid) {
     pSurface._type = ProtoSurface::type::e_trapez;
     // Set the measure
     pSurface._measures = {static_cast<actsvg::scalar>(boundValues[0]),
                           static_cast<actsvg::scalar>(boundValues[1]),
                           static_cast<actsvg::scalar>(boundValues[2])};
-  } else if (bType == SurfaceBounds::BoundsType::eDiamond) {
+  } else if (bType == SurfaceBounds::BoundsType::Diamond) {
     // Set the measure
     for (const auto& bv : boundValues) {
       pSurface._measures.push_back(static_cast<actsvg::scalar>(bv));
     }
-  } else if (bType == SurfaceBounds::BoundsType::eAnnulus) {
+  } else if (bType == SurfaceBounds::BoundsType::Annulus) {
     pSurface._type = ProtoSurface::type::e_trapez;
     // Set the measure
     for (const auto& bv : boundValues) {
       pSurface._measures.push_back(static_cast<actsvg::scalar>(bv));
     }
-  } else if (bType == SurfaceBounds::BoundsType::eDisc) {
+  } else if (bType == SurfaceBounds::BoundsType::Disc) {
     pSurface._type = ProtoSurface::type::e_disc;
     // Set the openings
     actsvg::scalar ri = static_cast<actsvg::scalar>(boundValues[0]);

--- a/Plugins/ActSVG/src/SurfaceSvgConverter.cpp
+++ b/Plugins/ActSVG/src/SurfaceSvgConverter.cpp
@@ -17,6 +17,7 @@ using namespace Acts;
 ActsPlugins::Svg::ProtoSurface ActsPlugins::Svg::SurfaceConverter::convert(
     const GeometryContext& gctx, const Surface& surface,
     const SurfaceConverter::Options& cOptions) {
+  using enum SurfaceBounds::Type;
   ProtoSurface pSurface;
 
   // In case of non-template surfaces, the polyhedron does the trick
@@ -50,7 +51,7 @@ ActsPlugins::Svg::ProtoSurface ActsPlugins::Svg::SurfaceConverter::convert(
       } else if (surface.type() == Surface::SurfaceType::Disc) {
         // Or disc bounds
         const auto& boundValues = surface.bounds().values();
-        if (surface.bounds().type() == SurfaceBounds::BoundsType::Disc) {
+        if (surface.bounds().type() == Disc) {
           // The radii
           actsvg::scalar ri = static_cast<actsvg::scalar>(boundValues[0]);
           actsvg::scalar ro = static_cast<actsvg::scalar>(boundValues[1]);
@@ -80,30 +81,30 @@ ActsPlugins::Svg::ProtoSurface ActsPlugins::Svg::SurfaceConverter::convert(
   const auto& boundValues = surface.bounds().values();
   auto bType = surface.bounds().type();
   auto bValues = surface.bounds().values();
-  if (bType == SurfaceBounds::BoundsType::Rectangle) {
+  if (bType == Rectangle) {
     pSurface._type = ProtoSurface::type::e_rectangle;
     // Set the measure
     pSurface._measures = {
         static_cast<actsvg::scalar>(0.5 * (boundValues[2] - boundValues[0])),
         static_cast<actsvg::scalar>(0.5 * (boundValues[3] - boundValues[1]))};
-  } else if (bType == SurfaceBounds::BoundsType::Trapezoid) {
+  } else if (bType == Trapezoid) {
     pSurface._type = ProtoSurface::type::e_trapez;
     // Set the measure
     pSurface._measures = {static_cast<actsvg::scalar>(boundValues[0]),
                           static_cast<actsvg::scalar>(boundValues[1]),
                           static_cast<actsvg::scalar>(boundValues[2])};
-  } else if (bType == SurfaceBounds::BoundsType::Diamond) {
+  } else if (bType == Diamond) {
     // Set the measure
     for (const auto& bv : boundValues) {
       pSurface._measures.push_back(static_cast<actsvg::scalar>(bv));
     }
-  } else if (bType == SurfaceBounds::BoundsType::Annulus) {
+  } else if (bType == Annulus) {
     pSurface._type = ProtoSurface::type::e_trapez;
     // Set the measure
     for (const auto& bv : boundValues) {
       pSurface._measures.push_back(static_cast<actsvg::scalar>(bv));
     }
-  } else if (bType == SurfaceBounds::BoundsType::Disc) {
+  } else if (bType == Disc) {
     pSurface._type = ProtoSurface::type::e_disc;
     // Set the openings
     actsvg::scalar ri = static_cast<actsvg::scalar>(boundValues[0]);

--- a/Plugins/Detray/src/DetrayPayloadConverter.cpp
+++ b/Plugins/Detray/src/DetrayPayloadConverter.cpp
@@ -166,20 +166,20 @@ detray::io::mask_payload DetrayPayloadConverter::convertMask(
   switch (bounds.type()) {
     using enum SurfaceBounds::BoundsType;
     using enum detray::io::shape_id;
-    case eAnnulus:
+    case Annulus:
       payload = convertBounds(dynamic_cast<const AnnulusBounds&>(bounds));
       break;
-    case eRectangle:
+    case Rectangle:
       payload = convertBounds(dynamic_cast<const RectangleBounds&>(bounds));
       break;
-    case eCylinder:
+    case Cylinder:
       payload = convertBounds(dynamic_cast<const CylinderBounds&>(bounds),
                               forPortal ? portal_cylinder2 : cylinder2);
       break;
-    case eTrapezoid:
+    case Trapezoid:
       payload = convertBounds(dynamic_cast<const TrapezoidBounds&>(bounds));
       break;
-    case eDisc:
+    case Disc:
       if (auto* radial = dynamic_cast<const RadialBounds*>(&bounds);
           radial != nullptr) {
         payload = convertBounds(*radial);

--- a/Plugins/Detray/src/DetrayPayloadConverter.cpp
+++ b/Plugins/Detray/src/DetrayPayloadConverter.cpp
@@ -164,7 +164,7 @@ detray::io::mask_payload DetrayPayloadConverter::convertMask(
   detray::io::mask_payload payload;
 
   switch (bounds.type()) {
-    using enum SurfaceBounds::BoundsType;
+    using enum SurfaceBounds::Type;
     using enum detray::io::shape_id;
     case Annulus:
       payload = convertBounds(dynamic_cast<const AnnulusBounds&>(bounds));

--- a/Plugins/EDM4hep/src/PodioUtil.cpp
+++ b/Plugins/EDM4hep/src/PodioUtil.cpp
@@ -26,6 +26,7 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/StrawSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 #include "Acts/Utilities/TypeList.hpp"
 #include "ActsPodioEdm/Surface.h"
@@ -68,7 +69,7 @@ ActsPodioEdm::Surface convertSurfaceToPodio(const ConversionHelper& helper,
     // @TODO: Surface type is not well-defined for curvilinear surface: looks like any plane surface
     result.surfaceType = surface.type();
     // @TODO: Test line bounds, does not have bounds, so nullptr
-    result.boundsType = surface.bounds().type();
+    result.boundsType = toUnderlying(surface.bounds().type());
     result.geometryId = surface.geometryId().value();
     auto values = surface.bounds().values();
 
@@ -120,21 +121,23 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
       throw std::runtime_error{"Invalid surface type encountered"};
 
     case T::Cone:
-      throw_assert(surface.boundsType == B::eCone, "Unexpected bounds type");
+      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::eCone,
+                   "Unexpected bounds type");
       result = Surface::makeShared<ConeSurface>(
           transform, createBounds<ConeBounds>(surface));
       break;
 
     case T::Cylinder:
-      throw_assert(surface.boundsType == B::eCylinder,
-                   "Unexpected bounds type");
+      throw_assert(
+          static_cast<B::BoundsType>(surface.boundsType) == B::eCylinder,
+          "Unexpected bounds type");
       result = Surface::makeShared<CylinderSurface>(
           transform, createBounds<CylinderBounds>(surface));
       break;
 
     case T::Disc: {
       std::shared_ptr<const DiscBounds> dBounds;
-      switch (surface.boundsType) {
+      switch (static_cast<B::BoundsType>(surface.boundsType)) {
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
@@ -155,14 +158,15 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
     }
 
     case T::Perigee:
-      throw_assert(surface.boundsType == B::eBoundless,
-                   "Unexpected bounds type");
+      throw_assert(
+          static_cast<B::BoundsType>(surface.boundsType) == B::eBoundless,
+          "Unexpected bounds type");
       result = Surface::makeShared<PerigeeSurface>(transform);
       break;
 
     case T::Plane: {
       std::shared_ptr<const PlanarBounds> pBounds;
-      switch (surface.boundsType) {
+      switch (static_cast<B::BoundsType>(surface.boundsType)) {
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
@@ -191,14 +195,16 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
     }
 
     case T::Straw:
-      throw_assert(surface.boundsType == B::eLine, "Unexpected bounds type");
+      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::eLine,
+                   "Unexpected bounds type");
       result = Surface::makeShared<StrawSurface>(
           transform, createBounds<LineBounds>(surface));
       break;
 
     case T::Curvilinear:
-      throw_assert(surface.boundsType == B::eBoundless,
-                   "Unexpected bounds type");
+      throw_assert(
+          static_cast<B::BoundsType>(surface.boundsType) == B::eBoundless,
+          "Unexpected bounds type");
       result = Surface::makeShared<PlaneSurface>(transform);
       break;
   }

--- a/Plugins/EDM4hep/src/PodioUtil.cpp
+++ b/Plugins/EDM4hep/src/PodioUtil.cpp
@@ -104,6 +104,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
 
   using T = Surface::SurfaceType;
   using B = SurfaceBounds;
+  using enum B::Type;
 
   std::shared_ptr<const Surface> result;
 
@@ -121,35 +122,34 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
       throw std::runtime_error{"Invalid surface type encountered"};
 
     case T::Cone:
-      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::Cone,
+      throw_assert(static_cast<B::Type>(surface.boundsType) == Cone,
                    "Unexpected bounds type");
       result = Surface::makeShared<ConeSurface>(
           transform, createBounds<ConeBounds>(surface));
       break;
 
     case T::Cylinder:
-      throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::Cylinder,
-          "Unexpected bounds type");
+      throw_assert(static_cast<B::Type>(surface.boundsType) == Cylinder,
+                   "Unexpected bounds type");
       result = Surface::makeShared<CylinderSurface>(
           transform, createBounds<CylinderBounds>(surface));
       break;
 
     case T::Disc: {
       std::shared_ptr<const DiscBounds> dBounds;
-      switch (static_cast<B::BoundsType>(surface.boundsType)) {
+      switch (static_cast<B::Type>(surface.boundsType)) {
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
-        case B::Disc:
+        case Disc:
           dBounds = createBounds<RadialBounds>(surface);
           break;
 
-        case B::Annulus:
+        case Annulus:
           dBounds = createBounds<AnnulusBounds>(surface);
           break;
 
-        case B::DiscTrapezoid:
+        case DiscTrapezoid:
           dBounds = createBounds<DiscTrapezoidBounds>(surface);
           break;
       }
@@ -158,28 +158,27 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
     }
 
     case T::Perigee:
-      throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::Boundless,
-          "Unexpected bounds type");
+      throw_assert(static_cast<B::Type>(surface.boundsType) == Boundless,
+                   "Unexpected bounds type");
       result = Surface::makeShared<PerigeeSurface>(transform);
       break;
 
     case T::Plane: {
       std::shared_ptr<const PlanarBounds> pBounds;
-      switch (static_cast<B::BoundsType>(surface.boundsType)) {
+      switch (static_cast<B::Type>(surface.boundsType)) {
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
-        case B::Diamond:
+        case Diamond:
           pBounds = createBounds<DiamondBounds>(surface);
           break;
-        case B::Ellipse:
+        case Ellipse:
           pBounds = createBounds<EllipseBounds>(surface);
           break;
-        case B::Rectangle:
+        case Rectangle:
           pBounds = createBounds<RectangleBounds>(surface);
           break;
-        case B::ConvexPolygon:
+        case ConvexPolygon:
           template_switch_lambda<6, 32>(surface.boundValuesSize, [&](auto N) {
             constexpr std::size_t nValues = decltype(N)::value;
             constexpr std::size_t nVertices = nValues / 2;
@@ -195,16 +194,15 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
     }
 
     case T::Straw:
-      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::Line,
+      throw_assert(static_cast<B::Type>(surface.boundsType) == Line,
                    "Unexpected bounds type");
       result = Surface::makeShared<StrawSurface>(
           transform, createBounds<LineBounds>(surface));
       break;
 
     case T::Curvilinear:
-      throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::Boundless,
-          "Unexpected bounds type");
+      throw_assert(static_cast<B::Type>(surface.boundsType) == Boundless,
+                   "Unexpected bounds type");
       result = Surface::makeShared<PlaneSurface>(transform);
       break;
   }

--- a/Plugins/EDM4hep/src/PodioUtil.cpp
+++ b/Plugins/EDM4hep/src/PodioUtil.cpp
@@ -121,7 +121,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
       throw std::runtime_error{"Invalid surface type encountered"};
 
     case T::Cone:
-      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::eCone,
+      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::Cone,
                    "Unexpected bounds type");
       result = Surface::makeShared<ConeSurface>(
           transform, createBounds<ConeBounds>(surface));
@@ -129,7 +129,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
 
     case T::Cylinder:
       throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::eCylinder,
+          static_cast<B::BoundsType>(surface.boundsType) == B::Cylinder,
           "Unexpected bounds type");
       result = Surface::makeShared<CylinderSurface>(
           transform, createBounds<CylinderBounds>(surface));
@@ -141,15 +141,15 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
-        case B::eDisc:
+        case B::Disc:
           dBounds = createBounds<RadialBounds>(surface);
           break;
 
-        case B::eAnnulus:
+        case B::Annulus:
           dBounds = createBounds<AnnulusBounds>(surface);
           break;
 
-        case B::eDiscTrapezoid:
+        case B::DiscTrapezoid:
           dBounds = createBounds<DiscTrapezoidBounds>(surface);
           break;
       }
@@ -159,7 +159,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
 
     case T::Perigee:
       throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::eBoundless,
+          static_cast<B::BoundsType>(surface.boundsType) == B::Boundless,
           "Unexpected bounds type");
       result = Surface::makeShared<PerigeeSurface>(transform);
       break;
@@ -170,16 +170,16 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
         default:
           throw std::runtime_error{"Invalid bounds type encountered"};
 
-        case B::eDiamond:
+        case B::Diamond:
           pBounds = createBounds<DiamondBounds>(surface);
           break;
-        case B::eEllipse:
+        case B::Ellipse:
           pBounds = createBounds<EllipseBounds>(surface);
           break;
-        case B::eRectangle:
+        case B::Rectangle:
           pBounds = createBounds<RectangleBounds>(surface);
           break;
-        case B::eConvexPolygon:
+        case B::ConvexPolygon:
           template_switch_lambda<6, 32>(surface.boundValuesSize, [&](auto N) {
             constexpr std::size_t nValues = decltype(N)::value;
             constexpr std::size_t nVertices = nValues / 2;
@@ -195,7 +195,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
     }
 
     case T::Straw:
-      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::eLine,
+      throw_assert(static_cast<B::BoundsType>(surface.boundsType) == B::Line,
                    "Unexpected bounds type");
       result = Surface::makeShared<StrawSurface>(
           transform, createBounds<LineBounds>(surface));
@@ -203,7 +203,7 @@ std::shared_ptr<const Surface> convertSurfaceFromPodio(
 
     case T::Curvilinear:
       throw_assert(
-          static_cast<B::BoundsType>(surface.boundsType) == B::eBoundless,
+          static_cast<B::BoundsType>(surface.boundsType) == B::Boundless,
           "Unexpected bounds type");
       result = Surface::makeShared<PlaneSurface>(transform);
       break;

--- a/Plugins/GeoModel/src/GeoModelDetectorElementITk.cpp
+++ b/Plugins/GeoModel/src/GeoModelDetectorElementITk.cpp
@@ -109,11 +109,11 @@ GeoModelDetectorElementITk::convertFromGeomodel(
   };
 
   if (srf->type() == Surface::Plane &&
-      srf->bounds().type() == SurfaceBounds::eRectangle) {
+      srf->bounds().type() == SurfaceBounds::Rectangle) {
     return helper.operator()<PlaneSurface, RectangleBounds>();
   }
   if (srf->type() == Surface::Disc &&
-      srf->bounds().type() == SurfaceBounds::eAnnulus) {
+      srf->bounds().type() == SurfaceBounds::Annulus) {
     return helper.operator()<DiscSurface, AnnulusBounds>();
   }
 

--- a/Plugins/GeoModel/src/detail/GeoUnionDoubleTrdConverter.cpp
+++ b/Plugins/GeoModel/src/detail/GeoUnionDoubleTrdConverter.cpp
@@ -93,8 +93,8 @@ Result<GeoModelSensitiveSurface> GeoUnionDoubleTrdConverter::operator()(
     return GeoModelConversionError::WrongShapeForConverter;
   }
 
-  if (surfaceA->bounds().type() != Acts::SurfaceBounds::eTrapezoid ||
-      surfaceB->bounds().type() != Acts::SurfaceBounds::eTrapezoid) {
+  if (surfaceA->bounds().type() != Acts::SurfaceBounds::Trapezoid ||
+      surfaceB->bounds().type() != Acts::SurfaceBounds::Trapezoid) {
     return GeoModelConversionError::WrongShapeForConverter;
   }
 

--- a/Plugins/Json/include/ActsPlugins/Json/SurfaceBoundsJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/SurfaceBoundsJsonConverter.hpp
@@ -68,21 +68,21 @@ std::shared_ptr<const bounds_t> fromJson(const nlohmann::json& j) {
 
 // This macro create a conversion for the surface bounds type
 NLOHMANN_JSON_SERIALIZE_ENUM(
-    SurfaceBounds::BoundsType,
-    {{SurfaceBounds::BoundsType::Cone, "ConeBounds"},
-     {SurfaceBounds::BoundsType::Cylinder, "CylinderBounds"},
-     {SurfaceBounds::BoundsType::Diamond, "DiamondBounds"},
-     {SurfaceBounds::BoundsType::Disc, "RadialBounds"},
-     {SurfaceBounds::BoundsType::Ellipse, "EllipseBounds"},
-     {SurfaceBounds::BoundsType::Line, "LineBounds"},
-     {SurfaceBounds::BoundsType::Rectangle, "RectangleBounds"},
-     {SurfaceBounds::BoundsType::Trapezoid, "TrapezoidBounds"},
-     {SurfaceBounds::BoundsType::Triangle, "TriangleBounds"},
-     {SurfaceBounds::BoundsType::DiscTrapezoid, "DiscTrapezoidBounds"},
-     {SurfaceBounds::BoundsType::ConvexPolygon, "ConvexPolygonBounds"},
-     {SurfaceBounds::BoundsType::Annulus, "AnnulusBounds"},
-     {SurfaceBounds::BoundsType::Boundless, "Boundless"},
-     {SurfaceBounds::BoundsType::Other, "OtherBounds"}})
+    SurfaceBounds::Type,
+    {{SurfaceBounds::Type::Cone, "ConeBounds"},
+     {SurfaceBounds::Type::Cylinder, "CylinderBounds"},
+     {SurfaceBounds::Type::Diamond, "DiamondBounds"},
+     {SurfaceBounds::Type::Disc, "RadialBounds"},
+     {SurfaceBounds::Type::Ellipse, "EllipseBounds"},
+     {SurfaceBounds::Type::Line, "LineBounds"},
+     {SurfaceBounds::Type::Rectangle, "RectangleBounds"},
+     {SurfaceBounds::Type::Trapezoid, "TrapezoidBounds"},
+     {SurfaceBounds::Type::Triangle, "TriangleBounds"},
+     {SurfaceBounds::Type::DiscTrapezoid, "DiscTrapezoidBounds"},
+     {SurfaceBounds::Type::ConvexPolygon, "ConvexPolygonBounds"},
+     {SurfaceBounds::Type::Annulus, "AnnulusBounds"},
+     {SurfaceBounds::Type::Boundless, "Boundless"},
+     {SurfaceBounds::Type::Other, "OtherBounds"}})
 
 /// @}
 }  // namespace Acts

--- a/Plugins/Json/include/ActsPlugins/Json/SurfaceBoundsJsonConverter.hpp
+++ b/Plugins/Json/include/ActsPlugins/Json/SurfaceBoundsJsonConverter.hpp
@@ -69,20 +69,20 @@ std::shared_ptr<const bounds_t> fromJson(const nlohmann::json& j) {
 // This macro create a conversion for the surface bounds type
 NLOHMANN_JSON_SERIALIZE_ENUM(
     SurfaceBounds::BoundsType,
-    {{SurfaceBounds::BoundsType::eCone, "ConeBounds"},
-     {SurfaceBounds::BoundsType::eCylinder, "CylinderBounds"},
-     {SurfaceBounds::BoundsType::eDiamond, "DiamondBounds"},
-     {SurfaceBounds::BoundsType::eDisc, "RadialBounds"},
-     {SurfaceBounds::BoundsType::eEllipse, "EllipseBounds"},
-     {SurfaceBounds::BoundsType::eLine, "LineBounds"},
-     {SurfaceBounds::BoundsType::eRectangle, "RectangleBounds"},
-     {SurfaceBounds::BoundsType::eTrapezoid, "TrapezoidBounds"},
-     {SurfaceBounds::BoundsType::eTriangle, "TriangleBounds"},
-     {SurfaceBounds::BoundsType::eDiscTrapezoid, "DiscTrapezoidBounds"},
-     {SurfaceBounds::BoundsType::eConvexPolygon, "ConvexPolygonBounds"},
-     {SurfaceBounds::BoundsType::eAnnulus, "AnnulusBounds"},
-     {SurfaceBounds::BoundsType::eBoundless, "Boundless"},
-     {SurfaceBounds::BoundsType::eOther, "OtherBounds"}})
+    {{SurfaceBounds::BoundsType::Cone, "ConeBounds"},
+     {SurfaceBounds::BoundsType::Cylinder, "CylinderBounds"},
+     {SurfaceBounds::BoundsType::Diamond, "DiamondBounds"},
+     {SurfaceBounds::BoundsType::Disc, "RadialBounds"},
+     {SurfaceBounds::BoundsType::Ellipse, "EllipseBounds"},
+     {SurfaceBounds::BoundsType::Line, "LineBounds"},
+     {SurfaceBounds::BoundsType::Rectangle, "RectangleBounds"},
+     {SurfaceBounds::BoundsType::Trapezoid, "TrapezoidBounds"},
+     {SurfaceBounds::BoundsType::Triangle, "TriangleBounds"},
+     {SurfaceBounds::BoundsType::DiscTrapezoid, "DiscTrapezoidBounds"},
+     {SurfaceBounds::BoundsType::ConvexPolygon, "ConvexPolygonBounds"},
+     {SurfaceBounds::BoundsType::Annulus, "AnnulusBounds"},
+     {SurfaceBounds::BoundsType::Boundless, "Boundless"},
+     {SurfaceBounds::BoundsType::Other, "OtherBounds"}})
 
 /// @}
 }  // namespace Acts

--- a/Plugins/Json/src/DetrayJsonHelper.cpp
+++ b/Plugins/Json/src/DetrayJsonHelper.cpp
@@ -19,38 +19,39 @@ namespace Acts::DetrayJsonHelper {
 
 std::tuple<unsigned int, std::vector<double>> maskFromBounds(
     const Acts::SurfaceBounds& sBounds, bool portal) {
-  SurfaceBounds::BoundsType bType = sBounds.type();
+  using enum SurfaceBounds::Type;
+  SurfaceBounds::Type bType = sBounds.type();
   std::vector<double> bValues = sBounds.values();
   // Return value
   unsigned int type = 13u;
   std::vector<double> boundaries = bValues;
   // Special treatment for some portals
-  if (portal && bType == SurfaceBounds::BoundsType::Cylinder) {
+  if (portal && bType == Cylinder) {
     boundaries = {bValues.at(0u), -bValues.at(1u), bValues.at(1u)};
     type = 4u;
   } else {
     switch (bType) {
-      case SurfaceBounds::BoundsType::Annulus: {
+      case Annulus: {
         type = 0u;
       } break;
-      case SurfaceBounds::BoundsType::Rectangle: {
+      case Rectangle: {
         type = 5u;
         // ACTS: eMinX = 0, eMinY = 1, eMaxX = 2, eMaxY = 3,
         // detray: e_half_x, e_half_y
         boundaries = std::vector{0.5 * (bValues.at(2) - bValues.at(0)),
                                  0.5 * (bValues.at(3) - bValues.at(1))};
       } break;
-      case SurfaceBounds::BoundsType::Cylinder: {
+      case Cylinder: {
         boundaries =
             std::vector{bValues.at(0u), -bValues.at(1u), bValues.at(1u)};
         type = 2u;
       } break;
-      case SurfaceBounds::BoundsType::Trapezoid: {
+      case Trapezoid: {
         type = 7u;
         boundaries = std::vector{bValues.at(0u), bValues.at(1u), bValues.at(2u),
                                  1 / (2 * bValues.at(2u))};
       } break;
-      case SurfaceBounds::BoundsType::Disc: {
+      case Disc: {
         boundaries = std::vector{bValues[0u], bValues[1u]};
         type = 6u;
       } break;

--- a/Plugins/Json/src/DetrayJsonHelper.cpp
+++ b/Plugins/Json/src/DetrayJsonHelper.cpp
@@ -25,32 +25,32 @@ std::tuple<unsigned int, std::vector<double>> maskFromBounds(
   unsigned int type = 13u;
   std::vector<double> boundaries = bValues;
   // Special treatment for some portals
-  if (portal && bType == SurfaceBounds::BoundsType::eCylinder) {
+  if (portal && bType == SurfaceBounds::BoundsType::Cylinder) {
     boundaries = {bValues.at(0u), -bValues.at(1u), bValues.at(1u)};
     type = 4u;
   } else {
     switch (bType) {
-      case SurfaceBounds::BoundsType::eAnnulus: {
+      case SurfaceBounds::BoundsType::Annulus: {
         type = 0u;
       } break;
-      case SurfaceBounds::BoundsType::eRectangle: {
+      case SurfaceBounds::BoundsType::Rectangle: {
         type = 5u;
         // ACTS: eMinX = 0, eMinY = 1, eMaxX = 2, eMaxY = 3,
         // detray: e_half_x, e_half_y
         boundaries = std::vector{0.5 * (bValues.at(2) - bValues.at(0)),
                                  0.5 * (bValues.at(3) - bValues.at(1))};
       } break;
-      case SurfaceBounds::BoundsType::eCylinder: {
+      case SurfaceBounds::BoundsType::Cylinder: {
         boundaries =
             std::vector{bValues.at(0u), -bValues.at(1u), bValues.at(1u)};
         type = 2u;
       } break;
-      case SurfaceBounds::BoundsType::eTrapezoid: {
+      case SurfaceBounds::BoundsType::Trapezoid: {
         type = 7u;
         boundaries = std::vector{bValues.at(0u), bValues.at(1u), bValues.at(2u),
                                  1 / (2 * bValues.at(2u))};
       } break;
-      case SurfaceBounds::BoundsType::eDisc: {
+      case SurfaceBounds::BoundsType::Disc: {
         boundaries = std::vector{bValues[0u], bValues[1u]};
         type = 6u;
       } break;

--- a/Plugins/Json/src/SurfaceJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceJsonConverter.cpp
@@ -61,70 +61,73 @@ std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
     const nlohmann::json& j) {
   // The types to understand the types
   auto sType = j["type"].get<Surface::SurfaceType>();
-  auto bType = j["bounds"]["type"].get<SurfaceBounds::BoundsType>();
+  auto bType = j["bounds"]["type"].get<SurfaceBounds::Type>();
 
   std::shared_ptr<Surface> mutableSf = nullptr;
 
-  /// Unroll the types
-  switch (sType) {
-    // Surface is a plane surface
-    case Surface::SurfaceType::Plane:
-      switch (bType) {
-        case SurfaceBounds::BoundsType::Ellipse:
-          mutableSf = surfaceFromJsonT<PlaneSurface, EllipseBounds>(j);
-          break;
-        case SurfaceBounds::BoundsType::Rectangle:
-          mutableSf = surfaceFromJsonT<PlaneSurface, RectangleBounds>(j);
-          break;
-        case SurfaceBounds::BoundsType::Trapezoid:
-          mutableSf = surfaceFromJsonT<PlaneSurface, TrapezoidBounds>(j);
-          break;
+  {
+    using enum SurfaceBounds::Type;
+    /// Unroll the types
+    switch (sType) {
+      // Surface is a plane surface
+      case Surface::SurfaceType::Plane:
+        switch (bType) {
+          case Ellipse:
+            mutableSf = surfaceFromJsonT<PlaneSurface, EllipseBounds>(j);
+            break;
+          case Rectangle:
+            mutableSf = surfaceFromJsonT<PlaneSurface, RectangleBounds>(j);
+            break;
+          case Trapezoid:
+            mutableSf = surfaceFromJsonT<PlaneSurface, TrapezoidBounds>(j);
+            break;
 
-        case SurfaceBounds::BoundsType::Boundless:
-          mutableSf = surfaceFromJsonT<PlaneSurface, void>(j);
-          break;
-        default:
-          throw std::invalid_argument(
-              std::format("Invalid bounds type {} for plane surface", bType));
-      }
-      break;
-    // Surface is a disc surface
-    case Surface::SurfaceType::Disc:
-      switch (bType) {
-        case SurfaceBounds::BoundsType::Annulus:
-          mutableSf = surfaceFromJsonT<DiscSurface, AnnulusBounds>(j);
-          break;
-        case SurfaceBounds::BoundsType::Disc:
-          mutableSf = surfaceFromJsonT<DiscSurface, RadialBounds>(j);
-          break;
-        case SurfaceBounds::BoundsType::DiscTrapezoid:
-          mutableSf = surfaceFromJsonT<DiscSurface, DiscTrapezoidBounds>(j);
-          break;
-        default:
-          throw std::invalid_argument(
-              std::format("Invalid bounds type {} for disc surface", bType));
-      }
-      break;
-    // Surface is a cylinder surface
-    case Surface::SurfaceType::Cylinder:
-      mutableSf = surfaceFromJsonT<CylinderSurface, CylinderBounds>(j);
-      break;
-    // Surface is a cone surface
-    case Surface::SurfaceType::Cone:
-      mutableSf = surfaceFromJsonT<ConeSurface, ConeBounds>(j);
-      break;
-    // Surface is a straw surface
-    case Surface::SurfaceType::Straw:
-      mutableSf = surfaceFromJsonT<StrawSurface, LineBounds>(j);
-      break;
-    // Surface is a perigee surface
-    case Surface::SurfaceType::Perigee:
-      mutableSf = Surface::makeShared<PerigeeSurface>(
-          Transform3JsonConverter::fromJson(j["transform"]));
-      break;
-    default:
-      throw std::invalid_argument("Invalid surface type " +
-                                  std::to_string(sType));
+          case Boundless:
+            mutableSf = surfaceFromJsonT<PlaneSurface, void>(j);
+            break;
+          default:
+            throw std::invalid_argument(
+                std::format("Invalid bounds type {} for plane surface", bType));
+        }
+        break;
+      // Surface is a disc surface
+      case Surface::SurfaceType::Disc:
+        switch (bType) {
+          case Annulus:
+            mutableSf = surfaceFromJsonT<DiscSurface, AnnulusBounds>(j);
+            break;
+          case Disc:
+            mutableSf = surfaceFromJsonT<DiscSurface, RadialBounds>(j);
+            break;
+          case DiscTrapezoid:
+            mutableSf = surfaceFromJsonT<DiscSurface, DiscTrapezoidBounds>(j);
+            break;
+          default:
+            throw std::invalid_argument(
+                std::format("Invalid bounds type {} for disc surface", bType));
+        }
+        break;
+      // Surface is a cylinder surface
+      case Surface::SurfaceType::Cylinder:
+        mutableSf = surfaceFromJsonT<CylinderSurface, CylinderBounds>(j);
+        break;
+      // Surface is a cone surface
+      case Surface::SurfaceType::Cone:
+        mutableSf = surfaceFromJsonT<ConeSurface, ConeBounds>(j);
+        break;
+      // Surface is a straw surface
+      case Surface::SurfaceType::Straw:
+        mutableSf = surfaceFromJsonT<StrawSurface, LineBounds>(j);
+        break;
+      // Surface is a perigee surface
+      case Surface::SurfaceType::Perigee:
+        mutableSf = Surface::makeShared<PerigeeSurface>(
+            Transform3JsonConverter::fromJson(j["transform"]));
+        break;
+      default:
+        throw std::invalid_argument("Invalid surface type " +
+                                    std::to_string(sType));
+    }
   }
 
   throw_assert(mutableSf, "Could not create surface from json");

--- a/Plugins/Json/src/SurfaceJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceJsonConverter.cpp
@@ -70,17 +70,17 @@ std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
     // Surface is a plane surface
     case Surface::SurfaceType::Plane:
       switch (bType) {
-        case SurfaceBounds::BoundsType::eEllipse:
+        case SurfaceBounds::BoundsType::Ellipse:
           mutableSf = surfaceFromJsonT<PlaneSurface, EllipseBounds>(j);
           break;
-        case SurfaceBounds::BoundsType::eRectangle:
+        case SurfaceBounds::BoundsType::Rectangle:
           mutableSf = surfaceFromJsonT<PlaneSurface, RectangleBounds>(j);
           break;
-        case SurfaceBounds::BoundsType::eTrapezoid:
+        case SurfaceBounds::BoundsType::Trapezoid:
           mutableSf = surfaceFromJsonT<PlaneSurface, TrapezoidBounds>(j);
           break;
 
-        case SurfaceBounds::BoundsType::eBoundless:
+        case SurfaceBounds::BoundsType::Boundless:
           mutableSf = surfaceFromJsonT<PlaneSurface, void>(j);
           break;
         default:
@@ -91,13 +91,13 @@ std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
     // Surface is a disc surface
     case Surface::SurfaceType::Disc:
       switch (bType) {
-        case SurfaceBounds::BoundsType::eAnnulus:
+        case SurfaceBounds::BoundsType::Annulus:
           mutableSf = surfaceFromJsonT<DiscSurface, AnnulusBounds>(j);
           break;
-        case SurfaceBounds::BoundsType::eDisc:
+        case SurfaceBounds::BoundsType::Disc:
           mutableSf = surfaceFromJsonT<DiscSurface, RadialBounds>(j);
           break;
-        case SurfaceBounds::BoundsType::eDiscTrapezoid:
+        case SurfaceBounds::BoundsType::DiscTrapezoid:
           mutableSf = surfaceFromJsonT<DiscSurface, DiscTrapezoidBounds>(j);
           break;
         default:

--- a/Plugins/Json/src/SurfaceJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceJsonConverter.cpp
@@ -30,6 +30,8 @@
 #include "ActsPlugins/Json/DetrayJsonHelper.hpp"
 #include "ActsPlugins/Json/MaterialJsonConverter.hpp"
 
+#include <format>
+
 void Acts::to_json(nlohmann::json& j,
                    const Acts::SurfaceAndMaterialWithContext& surface) {
   toJson(j, std::get<0>(surface), std::get<2>(surface));
@@ -82,9 +84,8 @@ std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
           mutableSf = surfaceFromJsonT<PlaneSurface, void>(j);
           break;
         default:
-          throw std::invalid_argument("Invalid bounds type " +
-                                      std::to_string(bType) +
-                                      " for plane surface");
+          throw std::invalid_argument(
+              std::format("Invalid bounds type {} for plane surface", bType));
       }
       break;
     // Surface is a disc surface
@@ -100,9 +101,8 @@ std::shared_ptr<Acts::Surface> Acts::SurfaceJsonConverter::fromJson(
           mutableSf = surfaceFromJsonT<DiscSurface, DiscTrapezoidBounds>(j);
           break;
         default:
-          throw std::invalid_argument("Invalid bounds type " +
-                                      std::to_string(bType) +
-                                      " for disc surface");
+          throw std::invalid_argument(
+              std::format("Invalid bounds type {} for disc surface", bType));
       }
       break;
     // Surface is a cylinder surface

--- a/Plugins/Root/src/TGeoCylinderDiscSplitter.cpp
+++ b/Plugins/Root/src/TGeoCylinderDiscSplitter.cpp
@@ -43,7 +43,7 @@ ActsPlugins::TGeoCylinderDiscSplitter::split(
   if (m_cfg.discPhiSegments > 0 || m_cfg.discRadialSegments > 0) {
     // Splitting for discs detected
     if (sf.type() == Surface::Disc &&
-        sf.bounds().type() == SurfaceBounds::eDisc) {
+        sf.bounds().type() == SurfaceBounds::Disc) {
       ACTS_DEBUG("- splitting detected for a Disc shaped sensor.");
 
       std::vector<std::shared_ptr<const ActsPlugins::TGeoDetectorElement>>
@@ -111,7 +111,7 @@ ActsPlugins::TGeoCylinderDiscSplitter::split(
   // Cylinder segments are detected, attempt a split
   if (m_cfg.cylinderPhiSegments > 0 || m_cfg.cylinderLongitudinalSegments > 0) {
     if (sf.type() == Surface::Cylinder &&
-        sf.bounds().type() == SurfaceBounds::eCylinder) {
+        sf.bounds().type() == SurfaceBounds::Cylinder) {
       ACTS_DEBUG("- splitting detected for a Cylinder shaped sensor.");
 
       std::vector<std::shared_ptr<const ActsPlugins::TGeoDetectorElement>>

--- a/Tests/UnitTests/Core/Propagator/NavigationPolicyStateTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigationPolicyStateTests.cpp
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(ConeValidityPolicy_MagneticField) {
       for (const auto* srf : info.surfaces) {
         std::cout << srf->toString(gctx) << std::endl;
         if (srf->type() != Surface::Plane ||
-            srf->bounds().type() != SurfaceBounds::eRectangle) {
+            srf->bounds().type() != SurfaceBounds::Rectangle) {
           continue;
         }
         srf->visualize(srfVis, gctx);

--- a/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/AnnulusBoundsTests.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(AnnulusBoundsProperties) {
   AnnulusBounds aBounds(minRadius, maxRadius, minPhi, maxPhi, offset);
 
   /// Test type() (redundant; already used in constructor confirmation)
-  BOOST_CHECK_EQUAL(aBounds.type(), SurfaceBounds::eAnnulus);
+  BOOST_CHECK_EQUAL(aBounds.type(), SurfaceBounds::Annulus);
 
   /// Test positions inside/outside
   // - start from cartesian (from test drawing)

--- a/Tests/UnitTests/Core/Surfaces/ConeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeBoundsTests.cpp
@@ -51,21 +51,20 @@ BOOST_AUTO_TEST_CASE(ConeBoundsConstruction) {
 
   BOOST_TEST_CHECKPOINT("Four parameter constructor (last two at default)");
   ConeBounds defaultConeBounds(alpha, symmetric);
-  BOOST_CHECK_EQUAL(defaultConeBounds.type(), SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(defaultConeBounds.type(), SurfaceBounds::Cone);
 
   BOOST_TEST_CHECKPOINT("Four parameter constructor");
   ConeBounds fourParameterConstructed(alpha, symmetric, halfPhi, averagePhi);
-  BOOST_CHECK_EQUAL(fourParameterConstructed.type(), SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(fourParameterConstructed.type(), SurfaceBounds::Cone);
 
   BOOST_TEST_CHECKPOINT("Five parameter constructor (last two at default)");
   ConeBounds defaulted5ParamConeBounds(alpha, zMin, zMax);
-  BOOST_CHECK_EQUAL(defaulted5ParamConeBounds.type(), SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(defaulted5ParamConeBounds.type(), SurfaceBounds::Cone);
 
   BOOST_TEST_CHECKPOINT("Five parameter constructor)");
   ConeBounds fiveParamConstructedConeBounds(alpha, zMin, zMax, halfPhi,
                                             averagePhi);
-  BOOST_CHECK_EQUAL(fiveParamConstructedConeBounds.type(),
-                    SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(fiveParamConstructedConeBounds.type(), SurfaceBounds::Cone);
 
   BOOST_TEST_CHECKPOINT("Copy constructor");
   ConeBounds copyConstructedConeBounds(fiveParamConstructedConeBounds);
@@ -115,7 +114,7 @@ BOOST_AUTO_TEST_CASE(ConeBoundsProperties) {
   ConeBounds coneBoundsObject(alpha, zMin, zMax, halfPhi, averagePhi);
 
   /// Test for type (redundant)
-  BOOST_CHECK_EQUAL(coneBoundsObject.type(), SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(coneBoundsObject.type(), SurfaceBounds::Cone);
 
   /// Test for inside
   BOOST_CHECK(!coneBoundsObject.inside(origin));

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceProperties) {
                   1e-6);
 
   /// Test bounds
-  BOOST_CHECK_EQUAL(coneSurfaceObject->bounds().type(), SurfaceBounds::eCone);
+  BOOST_CHECK_EQUAL(coneSurfaceObject->bounds().type(), SurfaceBounds::Cone);
 
   /// Test localToGlobal
   Vector2 localPosition{1., std::numbers::pi / 2.};

--- a/Tests/UnitTests/Core/Surfaces/CylinderBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderBoundsTests.cpp
@@ -40,18 +40,18 @@ BOOST_AUTO_TEST_CASE(CylinderBoundsConstruction) {
   const double bevelMaxZ = std::numbers::pi / 6.;
 
   BOOST_CHECK_EQUAL(CylinderBounds(radius, halfZ).type(),
-                    SurfaceBounds::eCylinder);
+                    SurfaceBounds::Cylinder);
   BOOST_CHECK_EQUAL(CylinderBounds(radius, halfZ, halfPhi).type(),
-                    SurfaceBounds::eCylinder);
+                    SurfaceBounds::Cylinder);
   BOOST_CHECK_EQUAL(CylinderBounds(radius, halfZ, halfPhi, averagePhi).type(),
-                    SurfaceBounds::eCylinder);
+                    SurfaceBounds::Cylinder);
   BOOST_CHECK_EQUAL(
       CylinderBounds(radius, halfZ, std::numbers::pi, 0., bevelMinZ).type(),
-      SurfaceBounds::eCylinder);
+      SurfaceBounds::Cylinder);
   BOOST_CHECK_EQUAL(
       CylinderBounds(radius, halfZ, std::numbers::pi, 0., bevelMinZ, bevelMaxZ)
           .type(),
-      SurfaceBounds::eCylinder);
+      SurfaceBounds::Cylinder);
 
   /// Test copy construction;
   CylinderBounds cylinderBounds(radius, halfZ);
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(CylinderBoundsProperties) {
                                              0., bevelMinZ, bevelMaxZ);
 
   /// Test for type()
-  BOOST_CHECK_EQUAL(cylinderBoundsObject.type(), SurfaceBounds::eCylinder);
+  BOOST_CHECK_EQUAL(cylinderBoundsObject.type(), SurfaceBounds::Cylinder);
 
   /// Test for inside(), 2D coords are r or phi ,z? : needs clarification
   const Vector2 origin{0., 0.};

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceProperties) {
 
   /// Test bounds
   BOOST_CHECK_EQUAL(cylinderSurfaceObject->bounds().type(),
-                    SurfaceBounds::eCylinder);
+                    SurfaceBounds::Cylinder);
 
   /// Test localToGlobal
   Vector2 localPosition{0., 0.};

--- a/Tests/UnitTests/Core/Surfaces/DiamondBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiamondBoundsTests.cpp
@@ -39,12 +39,12 @@ BOOST_AUTO_TEST_CASE(DiamondBoundsConstruction) {
   /// Test construction with dimensions
   BOOST_CHECK_EQUAL(
       DiamondBounds(minHalfX, midHalfX, maxHalfX, halfY1, halfY2).type(),
-      SurfaceBounds::eDiamond);
+      SurfaceBounds::Diamond);
 
   /// Copy constructor
   DiamondBounds original(minHalfX, midHalfX, maxHalfX, halfY1, halfY2);
   DiamondBounds copied(original);
-  BOOST_CHECK_EQUAL(copied.type(), SurfaceBounds::eDiamond);
+  BOOST_CHECK_EQUAL(copied.type(), SurfaceBounds::Diamond);
 
   /// Test invalid inputs
   BOOST_CHECK_THROW(
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(DiamondBoundsProperties) {
                                     halfY2);
 
   /// Test type() (redundant; already used in constructor confirmation)
-  BOOST_CHECK_EQUAL(diamondBoundsObject.type(), SurfaceBounds::eDiamond);
+  BOOST_CHECK_EQUAL(diamondBoundsObject.type(), SurfaceBounds::Diamond);
 
   /// Test the half length at negative y
   BOOST_CHECK_EQUAL(diamondBoundsObject.get(DiamondBounds::eHalfLengthXnegY),

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceProperties) {
       origin3D);
 
   /// Test bounds
-  BOOST_CHECK_EQUAL(discSurfaceObject->bounds().type(), SurfaceBounds::eDisc);
+  BOOST_CHECK_EQUAL(discSurfaceObject->bounds().type(), SurfaceBounds::Disc);
 
   Vector3 ignoredMomentum{0., 0., 0.};
   /// Test isOnSurface()

--- a/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscTrapezoidBoundsTests.cpp
@@ -38,18 +38,18 @@ BOOST_AUTO_TEST_CASE(DiscTrapezoidBoundsConstruction) {
   /// Test construction with dimensions and default stereo
   BOOST_CHECK_EQUAL(
       DiscTrapezoidBounds(minHalfX, maxHalfX, rMin, rMax, averagePhi).type(),
-      SurfaceBounds::eDiscTrapezoid);
+      SurfaceBounds::DiscTrapezoid);
 
   /// Test construction with all dimensions
   BOOST_CHECK_EQUAL(
       DiscTrapezoidBounds(minHalfX, maxHalfX, rMin, rMax, averagePhi, stereo)
           .type(),
-      SurfaceBounds::eDiscTrapezoid);
+      SurfaceBounds::DiscTrapezoid);
 
   /// Copy constructor
   DiscTrapezoidBounds original(minHalfX, maxHalfX, rMin, rMax, averagePhi);
   DiscTrapezoidBounds copied(original);
-  BOOST_CHECK_EQUAL(copied.type(), SurfaceBounds::eDiscTrapezoid);
+  BOOST_CHECK_EQUAL(copied.type(), SurfaceBounds::DiscTrapezoid);
 }
 
 // Streaning and recreation test
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(DiscTrapezoidBoundsProperties) {
 
   /// Test type() (redundant; already used in constructor confirmation)
   BOOST_CHECK_EQUAL(DiscTrapezoidBoundsObject.type(),
-                    SurfaceBounds::eDiscTrapezoid);
+                    SurfaceBounds::DiscTrapezoid);
 
   /// Test distanceToBoundary
   Vector2 origin(0., 0.);

--- a/Tests/UnitTests/Core/Surfaces/EllipseBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/EllipseBoundsTests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(EllipseBoundsConstruction) {
   BOOST_CHECK_EQUAL(
       EllipseBounds(innerRx, innerRy, outerRx, outerRy, phiSector, averagePhi)
           .type(),
-      SurfaceBounds::eEllipse);
+      SurfaceBounds::Ellipse);
 
   /// Copy constructor
   EllipseBounds original(innerRx, innerRy, outerRx, outerRy, phiSector,
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(EllipseBoundsProperties) {
                                     phiSector, averagePhi);
 
   /// Test type() (redundant; already used in constructor confirmation)
-  BOOST_CHECK_EQUAL(ellipseBoundsObject.type(), SurfaceBounds::eEllipse);
+  BOOST_CHECK_EQUAL(ellipseBoundsObject.type(), SurfaceBounds::Ellipse);
 
   /// Test distanceToBoundary
   Vector2 origin{0., 0.};

--- a/Tests/UnitTests/Core/Surfaces/InfiniteBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/InfiniteBoundsTests.cpp
@@ -22,17 +22,17 @@ BOOST_AUTO_TEST_SUITE(SurfacesSuite)
 /// Unit test for creating compliant/non-compliant InfiniteBounds object
 BOOST_AUTO_TEST_CASE(InfiniteBoundsConstruction) {
   InfiniteBounds u;
-  BOOST_CHECK_EQUAL(u.type(), SurfaceBounds::eBoundless);
+  BOOST_CHECK_EQUAL(u.type(), SurfaceBounds::Boundless);
   // InfiniteBounds s(1);  // would act as std::size_t cast to InfiniteBounds
   // InfiniteBounds t(s);
   InfiniteBounds v(u);  // implicit
-  BOOST_CHECK_EQUAL(v.type(), SurfaceBounds::eBoundless);
+  BOOST_CHECK_EQUAL(v.type(), SurfaceBounds::Boundless);
 }
 /// Unit tests for InfiniteBounds properties
 BOOST_AUTO_TEST_CASE(InfiniteBoundsProperties) {
   InfiniteBounds infiniteBoundsObject;
   /// Test for type()
-  BOOST_CHECK_EQUAL(infiniteBoundsObject.type(), SurfaceBounds::eBoundless);
+  BOOST_CHECK_EQUAL(infiniteBoundsObject.type(), SurfaceBounds::Boundless);
 
   /// Test for inside()
   const Vector2 anyVector{0., 1.};

--- a/Tests/UnitTests/Core/Surfaces/LineBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/LineBoundsTests.cpp
@@ -31,11 +31,11 @@ BOOST_AUTO_TEST_CASE(LineBoundsConstruction) {
 
   /// Test LineBounds(double, double)
   LineBounds lineBounds(radius, halfZ);
-  BOOST_CHECK_EQUAL(lineBounds.type(), SurfaceBounds::eLine);
+  BOOST_CHECK_EQUAL(lineBounds.type(), SurfaceBounds::Line);
 
   /// Test copy construction;
   LineBounds copyConstructedLineBounds(lineBounds);  // implicit
-  BOOST_CHECK_EQUAL(copyConstructedLineBounds.type(), SurfaceBounds::eLine);
+  BOOST_CHECK_EQUAL(copyConstructedLineBounds.type(), SurfaceBounds::Line);
 }
 
 /// Unit test for testing LineBounds recreation from streaming
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(LineBoundsProperties) {
   LineBounds lineBoundsObject(radius, halfZ);
 
   /// Test for type()
-  BOOST_CHECK_EQUAL(lineBoundsObject.type(), SurfaceBounds::eLine);
+  BOOST_CHECK_EQUAL(lineBoundsObject.type(), SurfaceBounds::Line);
 
   /// Test for inside()
   const Vector2 origin{0., 0.};

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceProperties) {
 
   /// Test bounds
   BOOST_CHECK_EQUAL(planeSurfaceObject->bounds().type(),
-                    SurfaceBounds::eRectangle);
+                    SurfaceBounds::Rectangle);
 
   /// Test localToGlobal
   Vector2 localPosition{1.5, 1.7};

--- a/Tests/UnitTests/Core/Surfaces/RadialBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/RadialBoundsTests.cpp
@@ -37,11 +37,11 @@ BOOST_AUTO_TEST_CASE(RadialBoundsConstruction) {
   // default construction is deleted
 
   /// Test construction with radii and default sector
-  BOOST_CHECK_EQUAL(RadialBounds(rMin, rMax).type(), SurfaceBounds::eDisc);
+  BOOST_CHECK_EQUAL(RadialBounds(rMin, rMax).type(), SurfaceBounds::Disc);
 
   /// Test construction with radii and sector half angle
   BOOST_CHECK_EQUAL(RadialBounds(rMin, rMax, halfPhiSector).type(),
-                    SurfaceBounds::eDisc);
+                    SurfaceBounds::Disc);
 
   /// Copy constructor
   RadialBounds original(rMin, rMax);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(RadialBoundsException) {
 BOOST_AUTO_TEST_CASE(RadialBoundsProperties) {
   /// Test type() (redundant; already used in constructor confirmation)
   RadialBounds radialBoundsObject(rMin, rMax, halfPhiSector);
-  BOOST_CHECK_EQUAL(radialBoundsObject.type(), SurfaceBounds::eDisc);
+  BOOST_CHECK_EQUAL(radialBoundsObject.type(), SurfaceBounds::Disc);
 
   /// Test distanceToBoundary
   Vector2 outside(30., 0.);

--- a/Tests/UnitTests/Core/Surfaces/RectangleBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/RectangleBoundsTests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(RectangleBoundsConstruction) {
   const double halfY = 5.;
   RectangleBounds twentyByTenRectangle(halfX, halfY);
   BOOST_CHECK_EQUAL(twentyByTenRectangle.type(),
-                    Acts::SurfaceBounds::eRectangle);
+                    Acts::SurfaceBounds::Rectangle);
 
   // nonsensical bounds are also permitted, but maybe should not be
   const double zeroHalfX = 0.;
@@ -45,11 +45,11 @@ BOOST_AUTO_TEST_CASE(RectangleBoundsConstruction) {
   // Initialise with zero dimensions
   RectangleBounds zeroDimensionsRectangle(zeroHalfX, zeroHalfY);
   BOOST_CHECK_EQUAL(zeroDimensionsRectangle.type(),
-                    Acts::SurfaceBounds::eRectangle);
+                    Acts::SurfaceBounds::Rectangle);
 
   // Initialise with infinite dimensions
   RectangleBounds infinite(infHalfX, infHalfY);
-  BOOST_CHECK_EQUAL(infinite.type(), Acts::SurfaceBounds::eRectangle);
+  BOOST_CHECK_EQUAL(infinite.type(), Acts::SurfaceBounds::Rectangle);
 }
 
 /// Recreation

--- a/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
@@ -40,7 +40,7 @@ class SurfaceBoundsStub : public SurfaceBounds {
 #pragma GCC diagnostic pop
 #endif
 
-  BoundsType type() const final { return Other; }
+  Type type() const final { return Other; }
 
   bool isCartesian() const final { return true; }
 

--- a/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
@@ -40,7 +40,7 @@ class SurfaceBoundsStub : public SurfaceBounds {
 #pragma GCC diagnostic pop
 #endif
 
-  BoundsType type() const final { return eOther; }
+  BoundsType type() const final { return Other; }
 
   bool isCartesian() const final { return true; }
 

--- a/Tests/UnitTests/Core/Surfaces/TrapezoidBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/TrapezoidBoundsTests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(TrapezoidBoundsConstruction) {
 
   /// Test construction with defining half lengths
   BOOST_CHECK_EQUAL(TrapezoidBounds(minHalfX, maxHalfX, halfY).type(),
-                    SurfaceBounds::eTrapezoid);
+                    SurfaceBounds::Trapezoid);
   /// Copy constructor
   TrapezoidBounds original(minHalfX, maxHalfX, halfY);
   TrapezoidBounds copied(original);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(TrapezoidBoundsProperties) {
   TrapezoidBounds trapezoidBoundsObject(minHalfX, maxHalfX, halfY);
 
   /// Test type() (redundant; already used in constructor confirmation)
-  BOOST_CHECK_EQUAL(trapezoidBoundsObject.type(), SurfaceBounds::eTrapezoid);
+  BOOST_CHECK_EQUAL(trapezoidBoundsObject.type(), SurfaceBounds::Trapezoid);
 
   /// Test minHalflengthX
   BOOST_CHECK_EQUAL(

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepDetectorElementTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepDetectorElementTests.cpp
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginDetectorElementRectangle) {
   BOOST_CHECK(sTransform.translation().isApprox(Vector3(10., 20., 30.)));
 
   const auto& sBounds = surface.bounds();
-  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::eRectangle);
+  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::Rectangle);
 
   auto boundValues = sBounds.values();
 
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginDetectorElementTrapezoid) {
   BOOST_CHECK(sTransform.translation().isApprox(Vector3(20., 30., 40.)));
 
   const auto& sBounds = surface.bounds();
-  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::eTrapezoid);
+  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::Trapezoid);
 
   auto boundValues = sBounds.values();
   CHECK_CLOSE_ABS(boundValues[0u], 100., 1e-10);

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepDetectorElementTests.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepDetectorElementTests.cpp
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginDetectorElementRectangle) {
   BOOST_CHECK(sTransform.translation().isApprox(Vector3(10., 20., 30.)));
 
   const auto& sBounds = surface.bounds();
-  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::Rectangle);
+  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::Type::Rectangle);
 
   auto boundValues = sBounds.values();
 
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(DD4hepPluginDetectorElementTrapezoid) {
   BOOST_CHECK(sTransform.translation().isApprox(Vector3(20., 30., 40.)));
 
   const auto& sBounds = surface.bounds();
-  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::BoundsType::Trapezoid);
+  BOOST_CHECK_EQUAL(sBounds.type(), SurfaceBounds::Type::Trapezoid);
 
   auto boundValues = sBounds.values();
   CHECK_CLOSE_ABS(boundValues[0u], 100., 1e-10);

--- a/Tests/UnitTests/Plugins/DD4hep/DD4hepTestsHelper.cpp
+++ b/Tests/UnitTests/Plugins/DD4hep/DD4hepTestsHelper.cpp
@@ -135,7 +135,7 @@ std::string DD4hepTestsHelper::surfaceToXML(const GeometryContext& gctx,
   std::array<int, 2u> axes = {0, 1};
   // Change/adapt the behavior
   switch (surface.bounds().type()) {
-    case SurfaceBounds::eRectangle: {
+    case SurfaceBounds::Rectangle: {
       sxml << "<box ";
       double dx = (boundValues[2u] - boundValues[0u]);
       double dy = (boundValues[3u] - boundValues[1u]);
@@ -144,7 +144,7 @@ std::string DD4hepTestsHelper::surfaceToXML(const GeometryContext& gctx,
       sxml << "dy=\"" << dy << "*mm\" ";
       sxml << "dz=\"" << dz << "*mm\" ";
     }; break;
-    case SurfaceBounds::eTrapezoid: {
+    case SurfaceBounds::Trapezoid: {
       axes = {2, 0};
 
       sxml << "<trap ";

--- a/Tests/UnitTests/Plugins/Detray/DetrayPayloadConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Detray/DetrayPayloadConverterTests.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(DetrayMaskConversionErrors) {
   {
     class MockDiscBounds final : public Acts::SurfaceBounds {
      public:
-      BoundsType type() const final { return BoundsType::Disc; }
+      Type type() const final { return Disc; }
       bool isCartesian() const final { return true; }
       SquareMatrix2 boundToCartesianJacobian(
           const Vector2& /*lposition*/) const final {
@@ -243,8 +243,8 @@ BOOST_AUTO_TEST_CASE(DetrayMaskConversionErrors) {
   {
     class MockUnknownBounds final : public Acts::SurfaceBounds {
      public:
-      BoundsType type() const final {
-        return static_cast<BoundsType>(999);
+      Type type() const final {
+        return static_cast<Type>(999);
       }  // Invalid type
       bool isCartesian() const final { return true; }
       SquareMatrix2 boundToCartesianJacobian(

--- a/Tests/UnitTests/Plugins/Detray/DetrayPayloadConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Detray/DetrayPayloadConverterTests.cpp
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(DetrayMaskConversionErrors) {
   {
     class MockDiscBounds final : public Acts::SurfaceBounds {
      public:
-      BoundsType type() const final { return BoundsType::eDisc; }
+      BoundsType type() const final { return BoundsType::Disc; }
       bool isCartesian() const final { return true; }
       SquareMatrix2 boundToCartesianJacobian(
           const Vector2& /*lposition*/) const final {

--- a/Tests/UnitTests/Plugins/GeoModel/GeoDetectorObjectTest.cpp
+++ b/Tests/UnitTests/Plugins/GeoModel/GeoDetectorObjectTest.cpp
@@ -62,7 +62,7 @@ void test(const GeoModelDetectorObjectFactory::Cache& cache, GeoDims geoDims) {
                     lineBounds->get(LineBounds::eHalfLengthZ));
       }
       // rectangle Surface check corner position without trf
-      if (sbounds.type() == SurfaceBounds::eRectangle) {
+      if (sbounds.type() == SurfaceBounds::Rectangle) {
         double csxmin = sbounds.values()[0];
         double csymin = sbounds.values()[1];
         double csxmax = sbounds.values()[2];
@@ -73,7 +73,7 @@ void test(const GeoModelDetectorObjectFactory::Cache& cache, GeoDims geoDims) {
         BOOST_CHECK(geoDims.boxI[1] == csymax);
       }
       // trap Surface without trf
-      if (sbounds.type() == SurfaceBounds::eTrapezoid) {
+      if (sbounds.type() == SurfaceBounds::Trapezoid) {
         const auto* trapBounds = dynamic_cast<const TrapezoidBounds*>(&sbounds);
         std::vector<Vector2> trapVerts = trapBounds->vertices();
 


### PR DESCRIPTION
PLEASE DESCRIBE YOUR CHANGES.
THIS MESSAGE ENDS UP AS THE COMMIT MESSAGE.
DO NOT USE @-MENTIONS HERE!

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
