### PR TITLE
feat: Introduce new particle container to be used with Fatras and Examples

### DIFF
--- a/Fatras/CMakeLists.txt
+++ b/Fatras/CMakeLists.txt
@@ -7,6 +7,8 @@ acts_add_library(
     src/EventData/Particle.cpp
     src/EventData/ParticleOutcome.cpp
     src/EventData/ProcessType.cpp
+    src/EventData/HitContainer2.cpp
+    src/EventData/ParticleContainer2.cpp
     src/Kernel/SimulationError.cpp
     src/Physics/BetheHeitler.cpp
     src/Physics/StandardInteractions.cpp

--- a/Fatras/include/ActsFatras/EventData/Hit.hpp
+++ b/Fatras/include/ActsFatras/EventData/Hit.hpp
@@ -12,6 +12,7 @@
 #include "Acts/Definitions/Common.hpp"
 #include "Acts/Geometry/GeometryIdentifier.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
+#include "ActsFatras/EventData/ParticleContainer2.hpp"
 
 #include <cstdint>
 
@@ -28,55 +29,82 @@ class Hit {
  public:
   /// Construct default hit with (mostly) invalid information.
   Hit() = default;
+
   /// Construct from four-position and four-momenta.
   ///
-  /// @param geometryId      Geometry identifier of the surface
-  /// @param particleId Particle identifier of the particle that created the hit
-  /// @param pos4       Particle space-time four-vector on the surface
-  /// @param before4    Particle four-momentum before the interaction
-  /// @param after4     Particle four-momentum after the interaction
-  /// @param index_     Hit index along the particle trajectory
+  /// @param geometryId Geometry identifier of the surface
+  /// @param particleBarcode Barcode of the particle that created the hit
+  /// @param particleId Particle index of the particle that created the hit
+  /// @param pos4 Particle space-time four-vector on the surface
+  /// @param before4 Particle four-momentum before the interaction
+  /// @param after4 Particle four-momentum after the interaction
+  /// @param particleHitIndex Hit index along the particle trajectory
   ///
   /// All quantities are given in the global coordinate system. It is the
   /// users responsibility to ensure that the position correspond to a
   /// position on the given surface.
-  Hit(Acts::GeometryIdentifier geometryId, Barcode particleId,
+  Hit(Acts::GeometryIdentifier geometryId, Barcode particleBarcode,
       const Acts::Vector4& pos4, const Acts::Vector4& before4,
-      const Acts::Vector4& after4, std::int32_t index_ = -1)
+      const Acts::Vector4& after4, std::int32_t particleHitIndex = -1)
       : m_geometryId(geometryId),
-        m_particleId(particleId),
-        m_index(index_),
+        m_particleBarcode(particleBarcode),
+        m_particleHitIndex(particleHitIndex),
         m_pos4(pos4),
         m_before4(before4),
         m_after4(after4) {}
-  /// Copy constructor
-  Hit(const Hit&) = default;
-  /// Move constructor
-  Hit(Hit&&) = default;
-  /// Copy assignment operator
-  /// @return Reference to this hit after copying
-  Hit& operator=(const Hit&) = default;
-  /// Move assignment operator
-  /// @return Reference to this hit after moving
-  Hit& operator=(Hit&&) = default;
+
+  /// Construct from four-position and four-momenta.
+  ///
+  /// @param geometryId Geometry identifier of the surface
+  /// @param particleBarcode Barcode of the particle that created the hit
+  /// @param particleId Particle index of the particle that created the hit
+  /// @param pos4 Particle space-time four-vector on the surface
+  /// @param before4 Particle four-momentum before the interaction
+  /// @param after4 Particle four-momentum after the interaction
+  /// @param particleHitIndex Hit index along the particle trajectory
+  ///
+  /// All quantities are given in the global coordinate system. It is the
+  /// users responsibility to ensure that the position correspond to a
+  /// position on the given surface.
+  Hit(Acts::GeometryIdentifier geometryId, Barcode particleBarcode,
+      ParticleIndex2 particleId2, const Acts::Vector4& pos4,
+      const Acts::Vector4& before4, const Acts::Vector4& after4,
+      std::int32_t particleHitIndex = -1)
+      : m_geometryId(geometryId),
+        m_particleBarcode(particleBarcode),
+        m_particleId2(particleId2),
+        m_particleHitIndex(particleHitIndex),
+        m_pos4(pos4),
+        m_before4(before4),
+        m_after4(after4) {}
 
   /// Geometry identifier of the hit surface.
   /// @return GeometryIdentifier of the surface where the hit occurred
   constexpr Acts::GeometryIdentifier geometryId() const { return m_geometryId; }
-  /// Particle identifier of the particle that generated the hit.
-  /// @return Barcode identifier of the particle that created this hit
-  constexpr Barcode particleId() const { return m_particleId; }
+
+  constexpr Barcode particleId() const { return m_particleBarcode; }
+
+  constexpr Barcode particleBarcode() const { return m_particleBarcode; }
+
+  /// Particle index of the particle that generated the hit.
+  /// @return Particle index of the particle that created this hit
+  constexpr ParticleIndex2 particleId2() const { return m_particleId2; }
+
+  constexpr std::int32_t index() const { return m_particleHitIndex; }
+
   /// Hit index along the particle trajectory.
   ///
   /// @retval negative if the hit index is undefined.
-  constexpr std::int32_t index() const { return m_index; }
+  constexpr std::int32_t particleHitIndex() const { return m_particleHitIndex; }
 
   /// Space-time position four-vector.
   /// @return Reference to four-vector containing position and time coordinates
   const Acts::Vector4& fourPosition() const { return m_pos4; }
+
   /// Three-position, i.e. spatial coordinates without the time.
   /// @return Three-dimensional position vector (x,y,z)
   auto position() const { return m_pos4.segment<3>(Acts::ePos0); }
+
   /// Time coordinate.
   /// @return Time of the hit occurrence
   double time() const { return m_pos4[Acts::eTime]; }
@@ -84,19 +112,23 @@ class Hit {
   /// Particle four-momentum before the hit.
   /// @return Reference to four-momentum vector before interaction
   const Acts::Vector4& momentum4Before() const { return m_before4; }
+
   /// Particle four-momentum after the hit.
   /// @return Reference to four-momentum vector after interaction
   const Acts::Vector4& momentum4After() const { return m_after4; }
+
   /// Normalized particle direction vector before the hit.
   /// @return Normalized three-dimensional direction vector before interaction
   Acts::Vector3 directionBefore() const {
     return m_before4.segment<3>(Acts::eMom0).normalized();
   }
+
   /// Normalized particle direction vector the hit.
   /// @return Normalized three-dimensional direction vector after interaction
   Acts::Vector3 directionAfter() const {
     return m_after4.segment<3>(Acts::eMom0).normalized();
   }
+
   /// Average normalized particle direction vector through the surface.
   /// @return Average normalized direction vector of particle momentum before and after
   Acts::Vector3 direction() const {
@@ -104,6 +136,7 @@ class Hit {
     auto dir1 = m_after4.segment<3>(Acts::eMom0).normalized();
     return ((dir0 + dir1) / 2.).segment<3>(Acts::eMom0).normalized();
   }
+
   /// Energy deposited by the hit.
   ///
   /// @retval positive if the particle lost energy when it passed the surface
@@ -115,10 +148,12 @@ class Hit {
  private:
   /// Identifier of the surface.
   Acts::GeometryIdentifier m_geometryId;
-  /// Identifier of the generating particle.
-  Barcode m_particleId;
+  /// Barcode of the generating particle.
+  Barcode m_particleBarcode;
+  /// Index of the generating particle.
+  ParticleIndex2 m_particleId2{};
   /// Index of the hit along the particle trajectory.
-  std::int32_t m_index = -1;
+  std::int32_t m_particleHitIndex = -1;
   /// Global space-time position four-vector.
   Acts::Vector4 m_pos4 = Acts::Vector4::Zero();
   /// Global particle energy-momentum four-vector before the hit.

--- a/Fatras/include/ActsFatras/EventData/HitContainer2.hpp
+++ b/Fatras/include/ActsFatras/EventData/HitContainer2.hpp
@@ -1,0 +1,126 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "ActsFatras/EventData/Hit.hpp"
+#include "ActsFatras/EventData/ParticleContainer2.hpp"
+
+#include <unordered_map>
+
+namespace ActsFatras {
+
+using HitIndex = std::uint32_t;
+using HitIndexSubset = std::span<const HitIndex>;
+
+class HitContainer2 {
+ public:
+  /// Type alias for particle index in container
+  using Index = HitIndex;
+  /// Type alias for subset of particle indices
+  using IndexSubset = HitIndexSubset;
+
+  /// Returns the number of hits in the container.
+  /// @return The number of hits in the container.
+  [[nodiscard]] std::uint32_t size() const noexcept { return m_hits.size(); }
+  /// Checks if the container is empty.
+  /// @return True if the container is empty, false otherwise.
+  [[nodiscard]] bool empty() const noexcept { return m_hits.empty(); }
+
+  /// Reserves space for the given number of hits.
+  /// @param size The number of hits to reserve space for.
+  void reserve(std::uint32_t size) noexcept;
+
+  /// Clears the container, removing all hits and columns.
+  void clear() noexcept;
+
+  const std::vector<Hit>& hits() const noexcept { return m_hits; }
+
+  const std::unordered_map<ParticleIndex, std::vector<HitIndex>>&
+  hitsByParticles() const noexcept {
+    return m_hitsByParticles;
+  }
+
+  const std::unordered_map<Acts::GeometryIdentifier, std::vector<HitIndex>>&
+  hitsBySurfaces() const noexcept {
+    return m_hitsBySurfaces;
+  }
+
+  Hit& push_back(const Hit& hit);
+
+  Hit& emplace_back(Acts::GeometryIdentifier geometryId,
+                    ParticleIndex particleId, const Acts::Vector4& pos4,
+                    const Acts::Vector4& before4, const Acts::Vector4& after4,
+                    std::int32_t index = -1);
+
+  Hit& operator[](std::size_t index) { return m_hits[index]; }
+  const Hit& operator[](std::size_t index) const { return m_hits[index]; }
+
+  Hit& at(std::size_t index) { return m_hits.at(index); }
+  const Hit& at(std::size_t index) const { return m_hits.at(index); }
+
+  auto begin() noexcept { return m_hits.begin(); }
+  auto end() noexcept { return m_hits.end(); }
+  auto begin() const noexcept { return m_hits.begin(); }
+  auto end() const noexcept { return m_hits.end(); }
+
+  std::span<const HitIndex> hitIndicesByParticle(
+      ParticleIndex particleId) const;
+  std::span<const HitIndex> hitIndicesBySurface(
+      Acts::GeometryIdentifier geometryId) const;
+
+  /// Subset facade over arbitrary index sets.
+  template <bool read_only>
+  class Subset : public Acts::detail::ContainerSubset<
+                     Subset<read_only>, Subset<true>, HitContainer2,
+                     std::conditional_t<read_only, const Hit&, Hit&>,
+                     std::span<const Index>, read_only> {
+   public:
+    /// Base class type
+    using Base = Acts::detail::ContainerSubset<
+        Subset<read_only>, Subset<true>, HitContainer2,
+        std::conditional_t<read_only, const Hit&, Hit&>, std::span<const Index>,
+        read_only>;
+
+    using Base::Base;
+  };
+
+  /// Type alias for mutable subset of hits
+  using MutableSubset = Subset<false>;
+  /// Type alias for const subset of hits
+  using ConstSubset = Subset<true>;
+
+  /// Creates a mutable subset of hits from the given index subset.
+  /// @param subset The index subset to create the subset from.
+  /// @return A mutable subset of hits.
+  MutableSubset subset(const IndexSubset& subset) noexcept {
+    return MutableSubset(*this, subset);
+  }
+  /// Creates a const subset of hits from the given index subset.
+  /// @param subset The index subset to create the subset from.
+  /// @return A const subset of hits.
+  ConstSubset subset(const IndexSubset& subset) const noexcept {
+    return ConstSubset(*this, subset);
+  }
+
+  ConstSubset hitsByParticle(ParticleIndex particleId) const {
+    return subset(hitIndicesByParticle(particleId));
+  }
+  ConstSubset hitsBySurface(Acts::GeometryIdentifier geometryId) const {
+    return subset(hitIndicesBySurface(geometryId));
+  }
+
+ private:
+  std::vector<Hit> m_hits;
+  std::unordered_map<ParticleIndex, std::vector<HitIndex>> m_hitsByParticles;
+  std::unordered_map<Acts::GeometryIdentifier, std::vector<HitIndex>>
+      m_hitsBySurfaces;
+};
+
+}  // namespace ActsFatras

--- a/Fatras/include/ActsFatras/EventData/HitContainer2.hpp
+++ b/Fatras/include/ActsFatras/EventData/HitContainer2.hpp
@@ -42,7 +42,7 @@ class HitContainer2 {
 
   const std::vector<Hit>& hits() const noexcept { return m_hits; }
 
-  const std::unordered_map<ParticleIndex, std::vector<HitIndex>>&
+  const std::unordered_map<ParticleIndex2, std::vector<HitIndex>>&
   hitsByParticles() const noexcept {
     return m_hitsByParticles;
   }
@@ -55,9 +55,9 @@ class HitContainer2 {
   Hit& push_back(const Hit& hit);
 
   Hit& emplace_back(Acts::GeometryIdentifier geometryId,
-                    ParticleIndex particleId, const Acts::Vector4& pos4,
-                    const Acts::Vector4& before4, const Acts::Vector4& after4,
-                    std::int32_t index = -1);
+                    Barcode particleBarcode, ParticleIndex2 particleId,
+                    const Acts::Vector4& pos4, const Acts::Vector4& before4,
+                    const Acts::Vector4& after4, std::int32_t index = -1);
 
   Hit& operator[](std::size_t index) { return m_hits[index]; }
   const Hit& operator[](std::size_t index) const { return m_hits[index]; }
@@ -71,7 +71,7 @@ class HitContainer2 {
   auto end() const noexcept { return m_hits.end(); }
 
   std::span<const HitIndex> hitIndicesByParticle(
-      ParticleIndex particleId) const;
+      ParticleIndex2 particleId) const;
   std::span<const HitIndex> hitIndicesBySurface(
       Acts::GeometryIdentifier geometryId) const;
 
@@ -109,7 +109,7 @@ class HitContainer2 {
     return ConstSubset(*this, subset);
   }
 
-  ConstSubset hitsByParticle(ParticleIndex particleId) const {
+  ConstSubset hitsByParticle(ParticleIndex2 particleId) const {
     return subset(hitIndicesByParticle(particleId));
   }
   ConstSubset hitsBySurface(Acts::GeometryIdentifier geometryId) const {
@@ -118,7 +118,7 @@ class HitContainer2 {
 
  private:
   std::vector<Hit> m_hits;
-  std::unordered_map<ParticleIndex, std::vector<HitIndex>> m_hitsByParticles;
+  std::unordered_map<ParticleIndex2, std::vector<HitIndex>> m_hitsByParticles;
   std::unordered_map<Acts::GeometryIdentifier, std::vector<HitIndex>>
       m_hitsBySurfaces;
 };

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -35,6 +35,7 @@ class Particle {
  public:
   /// Construct a default particle with invalid identity.
   Particle() = default;
+
   /// Construct a particle at rest with explicit mass and charge.
   ///
   /// @param particleId Particle identifier within an event
@@ -47,6 +48,7 @@ class Particle {
   Particle(Barcode particleId, Acts::PdgParticle pdg, double charge,
            double mass)
       : m_particleId(particleId), m_pdg(pdg), m_charge(charge), m_mass(mass) {}
+
   /// Construct a particle at rest from a PDG particle number.
   ///
   /// @param particleId Particle identifier within an event
@@ -54,13 +56,17 @@ class Particle {
   ///
   /// Charge and mass are retrieved from the particle data table.
   Particle(Barcode particleId, Acts::PdgParticle pdg);
+
   /// Copy constructor
   Particle(const Particle &) = default;
+
   /// Move constructor
   Particle(Particle &&) = default;
+
   /// Copy assignment operator
   /// @return Reference to this particle after copying
   Particle &operator=(const Particle &) = default;
+
   /// Move assignment operator
   /// @return Reference to this particle after moving
   Particle &operator=(Particle &&) = default;
@@ -85,6 +91,7 @@ class Particle {
     m_process = proc;
     return *this;
   }
+
   /// Set the pdg.
   /// @param pdg PDG particle identifier
   /// @return Particle instance with updated PDG identifier
@@ -92,6 +99,7 @@ class Particle {
     m_pdg = pdg;
     return *this;
   }
+
   /// Set the charge.
   /// @param charge Particle charge in native units
   /// @return Particle instance with updated charge
@@ -99,6 +107,7 @@ class Particle {
     m_charge = charge;
     return *this;
   }
+
   /// Set the mass.
   /// @param mass Particle mass in native units
   /// @return Particle instance with updated mass
@@ -106,6 +115,7 @@ class Particle {
     m_mass = mass;
     return *this;
   }
+
   /// Set the particle ID.
   /// @param barcode New particle identifier barcode
   /// @return Reference to this particle for method chaining
@@ -113,6 +123,7 @@ class Particle {
     m_particleId = barcode;
     return *this;
   }
+
   /// Set the space-time position four-vector.
   /// @param pos4 Four-vector containing spatial position and time
   /// @return Reference to this particle for method chaining
@@ -120,6 +131,7 @@ class Particle {
     m_position4 = pos4;
     return *this;
   }
+
   /// Set the space-time position four-vector from three-position and time.
   /// @param position Three-dimensional spatial position vector
   /// @param time Time coordinate
@@ -129,6 +141,7 @@ class Particle {
     m_position4[Acts::eTime] = time;
     return *this;
   }
+
   /// Set the space-time position four-vector from scalar components.
   /// @param x X coordinate
   /// @param y Y coordinate
@@ -142,6 +155,7 @@ class Particle {
     m_position4[Acts::eTime] = time;
     return *this;
   }
+
   /// Set the direction three-vector
   /// @param direction Three-dimensional direction vector (will be normalized)
   /// @return Reference to this particle for method chaining
@@ -150,6 +164,7 @@ class Particle {
     m_direction.normalize();
     return *this;
   }
+
   /// Set the direction three-vector from scalar components.
   /// @param dx X component of direction
   /// @param dy Y component of direction
@@ -162,6 +177,7 @@ class Particle {
     m_direction.normalize();
     return *this;
   }
+
   /// Set the absolute momentum.
   /// @param absMomentum Absolute momentum magnitude
   /// @return Reference to this particle for method chaining
@@ -190,23 +206,29 @@ class Particle {
   /// Particle identifier within an event.
   /// @return The unique particle identifier barcode
   Barcode particleId() const { return m_particleId; }
+
   /// Which type of process generated this particle.
   /// @return The process type that generated this particle
   ProcessType process() const { return m_process; }
+
   /// PDG particle number that identifies the type.
   /// @return The PDG particle identifier
   Acts::PdgParticle pdg() const { return m_pdg; }
+
   /// Absolute PDG particle number that identifies the type.
   /// @return The absolute PDG particle identifier (positive value)
   Acts::PdgParticle absolutePdg() const {
     return Acts::makeAbsolutePdgParticle(pdg());
   }
+
   /// Particle charge.
   /// @return The particle charge in native units
   double charge() const { return m_charge; }
+
   /// Particle absolute charge.
   /// @return The absolute particle charge (positive value)
   double absoluteCharge() const { return std::abs(m_charge); }
+
   /// Particle mass.
   /// @return The particle mass in native units
   double mass() const { return m_mass; }
@@ -218,6 +240,7 @@ class Particle {
         absolutePdg(), static_cast<float>(mass()),
         Acts::AnyCharge{static_cast<float>(absoluteCharge())});
   }
+
   /// Particl qOverP.
   /// @return The charge over momentum ratio
   double qOverP() const {
@@ -227,12 +250,15 @@ class Particle {
   /// Space-time position four-vector.
   /// @return Reference to the four-dimensional position vector (x, y, z, t)
   const Acts::Vector4 &fourPosition() const { return m_position4; }
+
   /// Three-position, i.e. spatial coordinates without the time.
   /// @return Three-dimensional position vector (x, y, z)
   auto position() const { return m_position4.segment<3>(Acts::ePos0); }
+
   /// Time coordinate.
   /// @return The time coordinate value
   double time() const { return m_position4[Acts::eTime]; }
+
   /// Energy-momentum four-vector.
   /// @return Four-dimensional momentum vector (px, py, pz, E)
   Acts::Vector4 fourMomentum() const {
@@ -244,26 +270,33 @@ class Particle {
     mom4[Acts::eEnergy] = energy();
     return mom4;
   }
+
   /// Unit three-direction, i.e. the normalized momentum three-vector.
   /// @return Reference to the normalized direction vector
   const Acts::Vector3 &direction() const { return m_direction; }
+
   /// Polar angle.
   /// @return The polar angle (theta) in radians
   double theta() const { return Acts::VectorHelpers::theta(direction()); }
+
   /// Azimuthal angle.
   /// @return The azimuthal angle (phi) in radians
   double phi() const { return Acts::VectorHelpers::phi(direction()); }
+
   /// Absolute momentum in the x-y plane.
   /// @return The transverse momentum magnitude
   double transverseMomentum() const {
     return m_absMomentum * m_direction.segment<2>(Acts::eMom0).norm();
   }
+
   /// Absolute momentum.
   /// @return The absolute momentum magnitude
   double absoluteMomentum() const { return m_absMomentum; }
+
   /// Absolute momentum.
   /// @return Three-dimensional momentum vector
   Acts::Vector3 momentum() const { return absoluteMomentum() * direction(); }
+
   /// Total energy, i.e. norm of the four-momentum.
   /// @return The total energy calculated from mass and momentum
   double energy() const { return std::hypot(m_mass, m_absMomentum); }
@@ -289,6 +322,7 @@ class Particle {
     m_properTime = properTime;
     return *this;
   }
+
   /// Proper time in the particle rest frame.
   /// @return The proper time in the rest frame
   double properTime() const { return m_properTime; }
@@ -303,9 +337,11 @@ class Particle {
     m_pathInL0 = pathInL0;
     return *this;
   }
+
   /// Accumulated path within material measured in radiation lengths.
   /// @return The accumulated path in radiation lengths
   double pathInX0() const { return m_pathInX0; }
+
   /// Accumulated path within material measured in interaction lengths.
   /// @return The accumulated path in interaction lengths
   double pathInL0() const { return m_pathInL0; }

--- a/Fatras/include/ActsFatras/EventData/ParticleContainer2.hpp
+++ b/Fatras/include/ActsFatras/EventData/ParticleContainer2.hpp
@@ -1,0 +1,1389 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Definitions/Common.hpp"
+#include "Acts/Definitions/PdgParticle.hpp"
+#include "Acts/EventData/ParticleHypothesis.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
+#include "Acts/Utilities/EnumBitwiseOperators.hpp"
+#include "Acts/Utilities/MathHelpers.hpp"
+#include "Acts/Utilities/TypeTraits.hpp"
+#include "Acts/Utilities/detail/ContainerIterator.hpp"
+#include "Acts/Utilities/detail/ContainerSubset.hpp"
+#include "ActsFatras/EventData/Barcode.hpp"
+#include "ActsFatras/EventData/ParticleOutcome.hpp"
+#include "ActsFatras/EventData/ProcessType.hpp"
+
+#include <cstdint>
+#include <span>
+
+namespace Acts {
+class Surface;
+}
+
+namespace ActsFatras {
+
+using ParticleIndex2 = std::uint32_t;
+using ParticleIndexSubset2 = std::span<const ParticleIndex2>;
+
+static constexpr ParticleIndex2 InvalidParticleIndex2 =
+    std::numeric_limits<ParticleIndex2>::max();
+
+using HitIndex2 = std::uint32_t;
+
+class ParticleContainer2;
+
+template <bool>
+class ParticleProxy2;
+using MutableParticleProxy2 = ParticleProxy2<false>;
+using ConstParticleProxy2 = ParticleProxy2<true>;
+
+namespace detail {
+struct GenerationStateAccessor;
+struct SimulationStateAccessor;
+}  // namespace detail
+
+template <typename, bool>
+class ParticleStateProxy2;
+using MutableGeneratorParticleProxy2 =
+    ParticleStateProxy2<detail::GenerationStateAccessor, false>;
+using ConstGeneratorParticleProxy2 =
+    ParticleStateProxy2<detail::GenerationStateAccessor, true>;
+using MutableSimulationParticleProxy2 =
+    ParticleStateProxy2<detail::SimulationStateAccessor, false>;
+using ConstSimulationParticleProxy2 =
+    ParticleStateProxy2<detail::SimulationStateAccessor, true>;
+
+template <typename T, bool>
+class ParticleColumnProxy2;
+template <typename T>
+using MutableParticleColumnProxy2 = ParticleColumnProxy2<T, false>;
+template <typename T>
+using ConstParticleColumnProxy2 = ParticleColumnProxy2<T, true>;
+
+enum class ParticleColumns2 : std::uint32_t {
+  None = 0,
+
+  // General particle properties
+  Parents = 1 << 0,
+  Barcode = 1 << 1,
+  Pdg = 1 << 2,
+  Charge = 1 << 3,
+  Mass = 1 << 4,
+  GenerationProcess = 1 << 5,
+
+  // Initial kinematic properties at production vertex
+  InitialReferenceSurface = 1 << 6,
+  InitialFourPosition = 1 << 7,
+  InitialAbsoluteMomentum = 1 << 8,
+  InitialDirection = 1 << 9,
+
+  // Simulation-specific properties
+  CurrentReferenceSurface = 1 << 10,
+  CurrentFourPosition = 1 << 11,
+  CurrentAbsoluteMomentum = 1 << 12,
+  CurrentDirection = 1 << 13,
+  ProperTime = 1 << 14,
+  PathInX0 = 1 << 15,
+  PathInL0 = 1 << 16,
+  NumberOfHits = 1 << 17,
+  SimulationOutcome = 1 << 18,
+
+  Generated = Parents | Barcode | Pdg | Charge | Mass | GenerationProcess |
+              InitialReferenceSurface | InitialFourPosition |
+              InitialAbsoluteMomentum | InitialDirection,
+  Simulated = Generated | CurrentReferenceSurface | CurrentFourPosition |
+              CurrentAbsoluteMomentum | CurrentDirection | ProperTime |
+              PathInX0 | PathInL0 | NumberOfHits | SimulationOutcome,
+  All = Parents | Barcode | Pdg | Charge | Mass | GenerationProcess |
+        InitialReferenceSurface | InitialFourPosition |
+        InitialAbsoluteMomentum | InitialDirection | CurrentReferenceSurface |
+        CurrentFourPosition | CurrentAbsoluteMomentum | CurrentDirection |
+        ProperTime | PathInX0 | PathInL0 | NumberOfHits | SimulationOutcome,
+};
+
+/// Enable bitwise operators for ParticleColumns enum
+ACTS_DEFINE_ENUM_BITWISE_OPERATORS(ParticleColumns2);
+
+namespace detail {
+
+class ColumnHolderBase {
+ public:
+  virtual ~ColumnHolderBase() = default;
+
+  virtual std::unique_ptr<ColumnHolderBase> copy() const = 0;
+
+  virtual std::size_t size() const = 0;
+  virtual void reserve(std::size_t size) = 0;
+  virtual void resize(std::size_t size) = 0;
+  virtual void clear() = 0;
+  virtual void emplace_back() = 0;
+};
+
+template <typename T>
+class ColumnHolder final : public ColumnHolderBase {
+ public:
+  using Value = T;
+  using Container = std::vector<Value>;
+  using MutableProxy = MutableParticleColumnProxy2<Value>;
+  using ConstProxy = ConstParticleColumnProxy2<Value>;
+
+  ColumnHolder() = default;
+  explicit ColumnHolder(Value defaultValue)
+      : m_default(std::move(defaultValue)) {}
+
+  MutableProxy proxy(ParticleContainer2 &container) {
+    return MutableProxy(container, m_data);
+  }
+  ConstProxy proxy(const ParticleContainer2 &container) const {
+    return ConstProxy(container, m_data);
+  }
+
+  std::unique_ptr<ColumnHolderBase> copy() const override {
+    return std::make_unique<ColumnHolder<T>>(*this);
+  }
+
+  std::size_t size() const override { return m_data.size(); }
+  void reserve(std::size_t size) override { m_data.reserve(size); }
+  void clear() override { m_data.clear(); }
+  void resize(std::size_t size) override { m_data.resize(size, m_default); }
+  void emplace_back() override { m_data.emplace_back(m_default); }
+
+ private:
+  Value m_default{};
+  Container m_data;
+};
+
+}  // namespace detail
+
+class ParticleContainer2 final {
+ public:
+  /// Type alias for particle index in container
+  using Index = ParticleIndex2;
+  /// Type alias for subset of particle indices
+  using IndexSubset = ParticleIndexSubset2;
+  /// Type alias for mutable particle proxy
+  using MutableProxy = MutableParticleProxy2;
+  /// Type alias for const particle proxy
+  using ConstProxy = ConstParticleProxy2;
+
+  explicit ParticleContainer2(
+      ParticleColumns2 columns = ParticleColumns2::None) noexcept;
+
+  /// Constructs a copy of the given space point container.
+  /// @param other The space point container to copy.
+  ParticleContainer2(const ParticleContainer2 &other) noexcept;
+
+  /// Move constructs a space point container.
+  /// @param other The space point container to move.
+  ParticleContainer2(ParticleContainer2 &&other) noexcept;
+
+  /// Detructs the space point container.
+  ~ParticleContainer2() noexcept = default;
+
+  /// Assignment operator for copying a space point container.
+  /// @param other The space point container to copy.
+  /// @return A reference to this space point container.
+  ParticleContainer2 &operator=(const ParticleContainer2 &other) noexcept;
+
+  /// Move assignment operator for a space point container.
+  /// @param other The space point container to move.
+  /// @return A reference to this space point container.
+  ParticleContainer2 &operator=(ParticleContainer2 &&other) noexcept;
+
+  /// Returns the number of particles in the container.
+  /// @return The number of particles in the container.
+  [[nodiscard]] std::uint32_t size() const noexcept { return m_size; }
+  /// Checks if the container is empty.
+  /// @return True if the container is empty, false otherwise.
+  [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+
+  /// Reserves space for the given number of particles.
+  /// @param size The number of particles to reserve space for.
+  /// @param averageParentIndices The average number of parent indices per particle.
+  void reserve(std::uint32_t size, float averageParentIndices = 1) noexcept;
+
+  /// Clears the container, removing all particles and columns.
+  void clear() noexcept;
+
+  /// Creates a new particle at the end of the container.
+  /// @return A mutable proxy to the newly created particle.
+  MutableProxy createParticle() noexcept;
+
+  /// Creates additional columns. This will create the columns if they do not
+  /// already exist.
+  /// @param columns The columns to create.
+  void createColumns(ParticleColumns2 columns) noexcept;
+
+  /// Drops the specified columns from the container.
+  /// This will only drop columns if they exist.
+  /// @param columns The columns to drop.
+  void dropColumns(ParticleColumns2 columns) noexcept;
+
+  /// Checks if the container has the given Columns.
+  /// @param columns The Columns to check for.
+  /// @return True if the container has all the specified Columns, false
+  ///         otherwise.
+  bool hasColumns(ParticleColumns2 columns) const noexcept {
+    return (m_knownColumns & columns) == columns;
+  }
+
+  /// Creates a new column with the given name.
+  /// If a column with the same name already exists, an exception is thrown.
+  /// @param name The name of the column.
+  /// @return A reference to the newly created column.
+  /// @throws std::runtime_error if a column with the same name already exists.
+  /// @throws std::runtime_error if the column name is reserved.
+  template <typename T>
+  MutableParticleColumnProxy2<T> createColumn(const std::string &name) {
+    return createColumnImpl<ColumnHolder<T>>(name);
+  }
+
+  /// Drops the column with the given name.
+  /// If the column does not exist, an exception is thrown.
+  /// @param name The name of the column.
+  /// @throws std::runtime_error if the column does not exist.
+  /// @throws std::runtime_error if the column name is reserved.
+  void dropColumn(const std::string &name);
+
+  /// Checks if an Column with the given name exists.
+  /// @param name The name of the column.
+  /// @return True if the column exists, false otherwise.
+  bool hasColumn(const std::string &name) const noexcept {
+    return m_allColumns.contains(name);
+  }
+
+  /// Returns a mutable reference to the column with the given name.
+  /// If the column does not exist, an exception is thrown.
+  /// @param name The name of the column.
+  /// @return A mutable reference to the column.
+  /// @throws std::runtime_error if the column does not exist.
+  template <typename T>
+  MutableParticleColumnProxy2<T> column(const std::string &name) {
+    return columnImpl<ColumnHolder<T>>(name);
+  }
+
+  /// Returns a const reference to the column with the given name.
+  /// If the column does not exist, an exception is thrown.
+  /// @param name The name of the column.
+  /// @return A const reference to the column.
+  /// @throws std::runtime_error if the column does not exist.
+  template <typename T>
+  ConstParticleColumnProxy2<T> column(const std::string &name) const {
+    return columnImpl<ColumnHolder<T>>(name);
+  }
+
+  /// Returns a mutable proxy to the space point at the given index.
+  /// If the index is out of range, an exception is thrown.
+  /// @param index The index of the space point to access.
+  /// @return A mutable proxy to the space point at the given index.
+  /// @throws std::out_of_range if the index is out of range.
+  MutableProxy at(Index index);
+  /// Returns a const proxy to the space point at the given index.
+  /// If the index is out of range, an exception is thrown.
+  /// @param index The index of the space point to access.
+  /// @return A const proxy to the space point at the given index.
+  /// @throws std::out_of_range if the index is out of range.
+  ConstProxy at(Index index) const;
+
+  /// Returns a mutable proxy to the space point at the given index.
+  /// @param index The index of the space point to access.
+  /// @return A mutable proxy to the space point at the given index.
+  MutableProxy operator[](Index index) noexcept;
+  /// Returns a const proxy to the space point at the given index.
+  /// @param index The index of the space point to access.
+  /// @return A const proxy to the space point at the given index.
+  ConstProxy operator[](Index index) const noexcept;
+
+  /// Type alias for template iterator over space points in container
+  template <bool read_only>
+  using Iterator = Acts::detail::ContainerIterator<
+      ParticleContainer2,
+      std::conditional_t<read_only, ConstProxy, MutableProxy>, Index,
+      read_only>;
+
+  /// Type alias for mutable iterator over space points
+  using iterator = Iterator<false>;
+  /// Type alias for const iterator over space points
+  using const_iterator = Iterator<true>;
+
+  /// @brief Returns mutable iterator to the beginning of the container
+  /// @return Mutable iterator pointing to the first space point
+  iterator begin() noexcept { return iterator(*this, 0); }
+  /// @brief Returns mutable iterator to the end of the container
+  /// @return Mutable iterator pointing past the last space point
+  iterator end() noexcept { return iterator(*this, size()); }
+
+  /// @brief Returns const iterator to the beginning of the container
+  /// @return Const iterator pointing to the first space point
+  const_iterator begin() const noexcept { return const_iterator(*this, 0); }
+  /// @brief Returns const iterator to the end of the container
+  /// @return Const iterator pointing past the last space point
+  const_iterator end() const noexcept { return const_iterator(*this, size()); }
+
+  /// Subset facade over arbitrary index sets.
+  template <bool read_only>
+  class Subset final
+      : public Acts::detail::ContainerSubset<
+            Subset<read_only>, Subset<true>, ParticleContainer2,
+            std::conditional_t<read_only, ConstProxy, MutableProxy>,
+            std::span<const Index>, read_only> {
+   public:
+    /// Base class type
+    using Base = Acts::detail::ContainerSubset<
+        Subset<read_only>, Subset<true>, ParticleContainer2,
+        std::conditional_t<read_only, ConstProxy, MutableProxy>,
+        std::span<const Index>, read_only>;
+
+    using Base::Base;
+  };
+
+  /// Type alias for mutable subset of space points
+  using MutableSubset = Subset<false>;
+  /// Type alias for const subset of space points
+  using ConstSubset = Subset<true>;
+
+  /// Creates a mutable subset of space points from the given index subset.
+  /// @param subset The index subset to create the subset from.
+  /// @return A mutable subset of space points.
+  MutableSubset subset(const IndexSubset &subset) noexcept {
+    return MutableSubset(*this, subset);
+  }
+  /// Creates a const subset of space points from the given index subset.
+  /// @param subset The index subset to create the subset from.
+  /// @return A const subset of space points.
+  ConstSubset subset(const IndexSubset &subset) const noexcept {
+    return ConstSubset(*this, subset);
+  }
+
+ public:
+  using ColumnHolderBase = detail::ColumnHolderBase;
+  template <typename T>
+  using ColumnHolder = detail::ColumnHolder<T>;
+
+  template <bool>
+  friend class ParticleProxy2;
+  template <typename, bool>
+  friend class ParticleStateProxy2;
+
+  std::size_t m_size{0};
+
+  std::unordered_map<std::string, ColumnHolderBase *> m_allColumns;
+  ParticleColumns2 m_knownColumns{ParticleColumns2::None};
+  std::unordered_map<std::string, std::unique_ptr<ColumnHolderBase>>
+      m_dynamicColumns;
+
+  std::vector<ParticleIndex2> m_parentIndices;
+
+  std::optional<ColumnHolder<std::uint32_t>> m_parentIndicesOffsetColumn;
+  std::optional<ColumnHolder<std::uint8_t>> m_parentIndicesCountColumn;
+  std::optional<ColumnHolder<Barcode>> m_barcodeColumn;
+  std::optional<ColumnHolder<Acts::PdgParticle>> m_pdgColumn;
+  std::optional<ColumnHolder<double>> m_chargeColumn;
+  std::optional<ColumnHolder<double>> m_massColumn;
+  std::optional<ColumnHolder<ProcessType>> m_generationProcessColumn;
+
+  std::optional<ColumnHolder<const Acts::Surface *>>
+      m_initialReferenceSurfaceColumn;
+  std::optional<ColumnHolder<Acts::Vector4>> m_initialFourPositionColumn;
+  std::optional<ColumnHolder<double>> m_initialAbsoluteMomentumColumn;
+  std::optional<ColumnHolder<Acts::Vector3>> m_initialDirectionColumn;
+
+  std::optional<ColumnHolder<const Acts::Surface *>>
+      m_currentReferenceSurfaceColumn;
+  std::optional<ColumnHolder<Acts::Vector4>> m_currentFourPositionColumn;
+  std::optional<ColumnHolder<double>> m_currentAbsoluteMomentumColumn;
+  std::optional<ColumnHolder<Acts::Vector3>> m_currentDirectionColumn;
+  std::optional<ColumnHolder<double>> m_properTimeColumn;
+  std::optional<ColumnHolder<double>> m_pathInX0Column;
+  std::optional<ColumnHolder<double>> m_pathInL0Column;
+  std::optional<ColumnHolder<std::uint32_t>> m_numberOfHitsColumn;
+  std::optional<ColumnHolder<ParticleOutcome>> m_simulationOutcomeColumn;
+
+  static auto knownColumnMasks() noexcept {
+    using enum ParticleColumns2;
+    return std::tuple(
+        Parents, Parents, Barcode, Pdg, Charge, Mass, GenerationProcess,
+        InitialReferenceSurface, InitialFourPosition, InitialAbsoluteMomentum,
+        InitialDirection, CurrentReferenceSurface, CurrentFourPosition,
+        CurrentAbsoluteMomentum, CurrentDirection, ProperTime, PathInX0,
+        PathInL0, NumberOfHits, SimulationOutcome);
+  }
+
+  static auto knownColumnNames() noexcept {
+    return std::tuple(
+        "parentsOffset", "parentsCount", "barcode", "pdg", "charge", "mass",
+        "generationProcess", "initialReferenceSurface", "initialFourPosition",
+        "initialAbsoluteMomentum", "initialDirection",
+        "currentReferenceSurface", "currentFourPosition",
+        "currentAbsoluteMomentum", "currentDirection", "properTime", "pathInX0",
+        "pathInL0", "numberOfHits", "simulationOutcome");
+  }
+
+  static auto knownColumnDefaults() noexcept {
+    return std::tuple(
+        std::uint32_t{0}, std::uint8_t{0}, Barcode{},
+        Acts::PdgParticle::eInvalid, double{0}, double{0},
+        ProcessType::eUndefined, static_cast<const Acts::Surface *>(nullptr),
+        Acts::Vector4(Acts::Vector4::Zero()), double{0},
+        Acts::Vector3(Acts::Vector3::Zero()),
+        static_cast<const Acts::Surface *>(nullptr),
+        Acts::Vector4(Acts::Vector4::Zero()), double{0},
+        Acts::Vector3(Acts::Vector3::Zero()), double{0}, double{0}, double{0},
+        std::uint32_t{0}, ParticleOutcome::Alive);
+  }
+
+  template <typename Self>
+  static auto knownColumns(Self &&self) noexcept {
+    return std::tie(
+        self.m_parentIndicesOffsetColumn, self.m_parentIndicesCountColumn,
+        self.m_barcodeColumn, self.m_pdgColumn, self.m_chargeColumn,
+        self.m_massColumn, self.m_generationProcessColumn,
+        self.m_initialReferenceSurfaceColumn, self.m_initialFourPositionColumn,
+        self.m_initialAbsoluteMomentumColumn, self.m_initialDirectionColumn,
+        self.m_currentReferenceSurfaceColumn, self.m_currentFourPositionColumn,
+        self.m_currentAbsoluteMomentumColumn, self.m_currentDirectionColumn,
+        self.m_properTimeColumn, self.m_pathInX0Column, self.m_pathInL0Column,
+        self.m_numberOfHitsColumn, self.m_simulationOutcomeColumn);
+  }
+  auto knownColumns() & noexcept { return knownColumns(*this); }
+  auto knownColumns() const & noexcept { return knownColumns(*this); }
+  auto knownColumns() && noexcept { return knownColumns(*this); }
+
+  void copyColumns(const ParticleContainer2 &other);
+  void moveColumns(ParticleContainer2 &other) noexcept;
+
+  static bool reservedColumn(const std::string &name) noexcept;
+
+  template <typename Holder>
+  MutableParticleColumnProxy2<typename Holder::Value> createColumnImpl(
+      const std::string &name) {
+    if (reservedColumn(name)) {
+      throw std::runtime_error("Column name is reserved: " + name);
+    }
+    if (hasColumn(name)) {
+      throw std::runtime_error("Column already exists: " + name);
+    }
+    auto holder = std::make_unique<Holder>();
+    holder->resize(size());
+    auto proxy = holder->proxy(*this);
+    m_allColumns.try_emplace(name, holder.get());
+    m_dynamicColumns.try_emplace(name, std::move(holder));
+    return proxy;
+  }
+
+  template <typename Holder, typename Self>
+  static auto columnImpl(Self &&self, const std::string &name) {
+    const auto it = self.m_allColumns.find(name);
+    if (it == self.m_allColumns.end()) {
+      throw std::runtime_error("Column not found: " + name);
+    }
+    auto &holder = dynamic_cast<Holder &>(*it->second);
+    return holder.proxy(self);
+  }
+
+  template <typename Holder>
+  MutableParticleColumnProxy2<typename Holder::Value> columnImpl(
+      const std::string &name) {
+    return columnImpl<Holder>(*this, name);
+  }
+
+  template <typename Holder>
+  ConstParticleColumnProxy2<typename Holder::Value> columnImpl(
+      const std::string &name) const {
+    return columnImpl<Holder>(*this, name);
+  }
+};
+
+using ConstParticleSubset = ParticleContainer2::ConstSubset;
+using MutableParticleSubset = ParticleContainer2::MutableSubset;
+
+/// A proxy class for accessing individual particles.
+template <bool read_only>
+class ParticleProxy2 final {
+ public:
+  /// Indicates whether this particle proxy is read-only or data can be
+  /// modified
+  static constexpr bool ReadOnly = read_only;
+
+  /// Type alias for particle index type
+  using Index = ParticleIndex2;
+
+  /// Type alias for container type (const if read-only)
+  using Container = Acts::const_if_t<ReadOnly, ParticleContainer2>;
+
+  /// Constructs a particle proxy for the given container and index.
+  /// @param container The container holding the particle.
+  /// @param index The index of the particle in the container.
+  ParticleProxy2(Container &container, Index index) noexcept
+      : m_container(&container), m_index(index) {}
+
+  /// Copy construct a particle proxy.
+  /// @param other The particle proxy to copy.
+  ParticleProxy2(const ParticleProxy2 &other) noexcept = default;
+
+  /// Copy construct a mutable particle proxy.
+  /// @param other The mutable particle proxy to copy.
+  explicit ParticleProxy2(const ParticleProxy2<false> &other) noexcept
+    requires ReadOnly
+      : m_container(&other.container()), m_index(other.index()) {}
+
+  /// Copy assign a particle proxy.
+  /// @param other The particle proxy to copy.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleProxy2 &operator=(const ParticleProxy2 &other) noexcept = default;
+
+  /// Copy assign a mutable particle proxy.
+  /// @param other The mutable particle proxy to copy.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleProxy2 &operator=(const ParticleProxy2<false> &other) noexcept
+    requires ReadOnly
+  {
+    m_container = &other.container();
+    m_index = other.index();
+    return *this;
+  }
+
+  /// Move assign a particle proxy.
+  /// @param other The particle proxy to move.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleProxy2 &operator=(ParticleProxy2 &&other) noexcept = default;
+
+  /// Move assign a mutable particle proxy.
+  /// @param other The mutable particle proxy to move.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleProxy2 &operator=(ParticleProxy2<false> &&other) noexcept
+    requires ReadOnly
+  {
+    m_container = &other.container();
+    m_index = other.index();
+    return *this;
+  }
+
+  /// Returns a const proxy of the particle.
+  /// @return A const proxy of the particle.
+  ParticleProxy2<true> asConst() const noexcept
+    requires(!ReadOnly)
+  {
+    return {*m_container, m_index};
+  }
+
+  /// Gets the container holding the particle.
+  /// @return A reference to the container holding the particle.
+  ParticleContainer2 &container() const noexcept
+    requires(!ReadOnly)
+  {
+    return *m_container;
+  }
+  /// Gets the container holding the particle.
+  /// @return A const reference to the container holding the particle.
+  const ParticleContainer2 &container() const noexcept { return *m_container; }
+  /// Gets the index of the particle in the container.
+  /// @return The index of the particle in the container.
+  Index index() const noexcept { return m_index; }
+
+  MutableGeneratorParticleProxy2 generationState() noexcept
+    requires(!ReadOnly);
+  MutableSimulationParticleProxy2 simulationState() noexcept
+    requires(!ReadOnly);
+
+  ConstGeneratorParticleProxy2 generationState() const noexcept;
+  ConstSimulationParticleProxy2 simulationState() const noexcept;
+
+  void assignParentIndices(std::span<const ParticleIndex2> parentIndices)
+    requires(!ReadOnly)
+  {
+    if (!m_container->m_parentIndicesOffsetColumn.has_value() ||
+        !m_container->m_parentIndicesCountColumn.has_value()) {
+      throw std::logic_error("No parent indices column available");
+    }
+    if (accessImpl(m_container->m_parentIndicesCountColumn) != 0) {
+      throw std::logic_error("Parent indices already assigned to the particle");
+    }
+
+    accessImpl(m_container->m_parentIndicesOffsetColumn) =
+        static_cast<std::uint32_t>(m_container->m_parentIndices.size());
+    accessImpl(m_container->m_parentIndicesCountColumn) =
+        static_cast<std::uint8_t>(parentIndices.size());
+    m_container->m_parentIndices.insert(m_container->m_parentIndices.end(),
+                                        parentIndices.begin(),
+                                        parentIndices.end());
+  }
+
+  std::span<ParticleIndex2> parentIndices() noexcept
+    requires(!ReadOnly)
+  {
+    return {m_container->m_parentIndices.data() +
+                accessImpl(m_container->m_parentIndicesOffsetColumn),
+            accessImpl(m_container->m_parentIndicesCountColumn)};
+  }
+
+  Barcode &barcode() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_barcodeColumn);
+  }
+
+  Acts::PdgParticle &pdg() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_pdgColumn);
+  }
+
+  double &charge() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_chargeColumn);
+  }
+
+  double &mass() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_massColumn);
+  }
+
+  ProcessType &generationProcess() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_generationProcessColumn);
+  }
+
+  Acts::Vector4 &initialFourPosition() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_initialFourPositionColumn);
+  }
+
+  double &initialAbsoluteMomentum() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_initialAbsoluteMomentumColumn);
+  }
+
+  Acts::Vector3 &initialDirection() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_initialDirectionColumn);
+  }
+
+  const Acts::Surface *&currentReferenceSurface() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_currentReferenceSurfaceColumn);
+  }
+
+  Acts::Vector4 &currentFourPosition() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_currentFourPositionColumn);
+  }
+
+  double &currentAbsoluteMomentum() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_currentAbsoluteMomentumColumn);
+  }
+
+  Acts::Vector3 &currentDirection() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_currentDirectionColumn);
+  }
+
+  double &properTime() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_properTimeColumn);
+  }
+
+  double &pathInX0() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_pathInX0Column);
+  }
+
+  double &pathInL0() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_pathInL0Column);
+  }
+
+  std::uint32_t &numberOfHits() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_numberOfHitsColumn);
+  }
+
+  ParticleOutcome &simulationOutcome() noexcept
+    requires(!ReadOnly)
+  {
+    return accessImpl(m_container->m_simulationOutcomeColumn);
+  }
+
+  std::span<const ParticleIndex2> parentIndices() const noexcept {
+    return {m_container->m_parentIndices.data() +
+                accessImpl(m_container->m_parentIndicesOffsetColumn),
+            accessImpl(m_container->m_parentIndicesCountColumn)};
+  }
+
+  const Barcode &barcode() const noexcept {
+    return accessImpl(m_container->m_barcodeColumn);
+  }
+
+  Acts::PdgParticle pdg() const noexcept {
+    return accessImpl(m_container->m_pdgColumn);
+  }
+
+  double charge() const noexcept {
+    return accessImpl(m_container->m_chargeColumn);
+  }
+
+  double mass() const noexcept { return accessImpl(m_container->m_massColumn); }
+
+  ProcessType generationProcess() const noexcept {
+    return accessImpl(m_container->m_generationProcessColumn);
+  }
+
+  const Acts::Vector4 &initialFourPosition() const noexcept {
+    return accessImpl(m_container->m_initialFourPositionColumn);
+  }
+
+  double initialAbsoluteMomentum() const noexcept {
+    return accessImpl(m_container->m_initialAbsoluteMomentumColumn);
+  }
+
+  const Acts::Vector3 &initialDirection() const noexcept {
+    return accessImpl(m_container->m_initialDirectionColumn);
+  }
+
+  const Acts::Surface *currentReferenceSurface() const noexcept {
+    return accessImpl(m_container->m_currentReferenceSurfaceColumn);
+  }
+
+  const Acts::Vector4 &currentFourPosition() const noexcept {
+    return accessImpl(m_container->m_currentFourPositionColumn);
+  }
+
+  double currentAbsoluteMomentum() const noexcept {
+    return accessImpl(m_container->m_currentAbsoluteMomentumColumn);
+  }
+
+  const Acts::Vector3 &currentDirection() const noexcept {
+    return accessImpl(m_container->m_currentDirectionColumn);
+  }
+
+  double properTime() const noexcept {
+    return accessImpl(m_container->m_properTimeColumn);
+  }
+
+  double pathInX0() const noexcept {
+    return accessImpl(m_container->m_pathInX0Column);
+  }
+
+  double pathInL0() const noexcept {
+    return accessImpl(m_container->m_pathInL0Column);
+  }
+
+  std::uint32_t numberOfHits() const noexcept {
+    return accessImpl(m_container->m_numberOfHitsColumn);
+  }
+
+  const ParticleOutcome &simulationOutcome() const noexcept {
+    return accessImpl(m_container->m_simulationOutcomeColumn);
+  }
+
+  /// Const access to an extra column of data for the space point.
+  /// @param column The extra column proxy to access.
+  /// @return A const reference to the value in the extra column for the space point.
+  template <typename T>
+  const T &extra(const ConstParticleColumnProxy2<T> &column) const noexcept {
+    return column[m_index];
+  }
+
+  /// Check if this is a secondary particle.
+  /// @return True if particle is a secondary (has non-zero vertex secondary, generation, or sub-particle), false otherwise
+  bool isSecondary() const {
+    return barcode().vertexSecondary() != 0 || barcode().generation() != 0 ||
+           barcode().subParticle() != 0;
+  }
+
+  Acts::PdgParticle absolutePdg() const {
+    return Acts::makeAbsolutePdgParticle(pdg());
+  }
+
+  /// Particle absolute charge.
+  /// @return The absolute particle charge (positive value)
+  double absoluteCharge() const { return std::abs(charge()); }
+
+  /// Particle hypothesis.
+  /// @return Particle hypothesis containing PDG, mass, and charge information
+  Acts::ParticleHypothesis hypothesis() const {
+    return Acts::ParticleHypothesis(
+        absolutePdg(), static_cast<float>(mass()),
+        Acts::AnyCharge{static_cast<float>(absoluteCharge())});
+  }
+
+ private:
+  Container *m_container{nullptr};
+  Index m_index{0};
+
+  template <typename OptColumn>
+  auto &accessImpl(OptColumn &&column) const {
+    assert(column.has_value() && "Column does not exist");
+    assert(m_index < column->size() && "Index out of bounds");
+    return column->proxy(*m_container)[m_index];
+  }
+};
+
+template <typename state_accessor, bool read_only>
+class ParticleStateProxy2 final {
+ public:
+  ///
+  using Index = ParticleIndex2;
+
+  ///
+  using StateAccessor = state_accessor;
+
+  /// Indicates whether this particle proxy is read-only or data can be
+  /// modified
+  static constexpr bool ReadOnly = read_only;
+
+  using Particle = ParticleProxy2<ReadOnly>;
+
+  /// Type alias for container type (const if read-only)
+  using Container = Acts::const_if_t<ReadOnly, ParticleContainer2>;
+
+  ///
+  explicit ParticleStateProxy2(Particle particle) noexcept
+      : m_particle(std::move(particle)) {}
+
+  ///
+  explicit ParticleStateProxy2(ParticleProxy2<false> particle) noexcept
+    requires(ReadOnly)
+      : m_particle(std::move(particle)) {}
+
+  /// Copy construct a particle proxy.
+  /// @param other The particle proxy to copy.
+  ParticleStateProxy2(const ParticleStateProxy2 &other) noexcept = default;
+
+  /// Copy construct a mutable particle proxy.
+  /// @param other The mutable particle proxy to copy.
+  explicit ParticleStateProxy2(
+      const ParticleStateProxy2<StateAccessor, false> &other) noexcept
+    requires ReadOnly
+      : m_particle(other.m_particle) {}
+
+  /// Copy assign a particle proxy.
+  /// @param other The particle proxy to copy.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleStateProxy2 &operator=(const ParticleStateProxy2 &other) noexcept =
+      default;
+
+  /// Copy assign a mutable particle proxy.
+  /// @param other The mutable particle proxy to copy.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleStateProxy2 &operator=(
+      const ParticleStateProxy2<StateAccessor, false> &other) noexcept
+    requires ReadOnly
+  {
+    m_particle = other.m_particle;
+    return *this;
+  }
+
+  /// Move assign a particle proxy.
+  /// @param other The particle proxy to move.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleStateProxy2 &operator=(ParticleStateProxy2 &&other) noexcept =
+      default;
+
+  /// Move assign a mutable particle proxy.
+  /// @param other The mutable particle proxy to move.
+  /// @return Reference to this particle proxy after assignment.
+  ParticleStateProxy2 &operator=(
+      ParticleStateProxy2<StateAccessor, false> &&other) noexcept
+    requires ReadOnly
+  {
+    m_particle = other.m_particle;
+    return *this;
+  }
+
+  /// Returns a const proxy of the particle.
+  /// @return A const proxy of the particle.
+  ParticleStateProxy2<StateAccessor, true> asConst() const noexcept
+    requires(!ReadOnly)
+  {
+    return ParticleStateProxy2<StateAccessor, true>(m_particle.asConst());
+  }
+
+  ///
+  Particle particle() const noexcept { return m_particle; }
+
+  std::span<const ParticleIndex2> parentIndices() const noexcept {
+    return particle().parentIndices();
+  }
+
+  const Barcode &barcode() const noexcept { return particle().barcode(); }
+
+  Acts::PdgParticle pdg() const noexcept { return particle().pdg(); }
+
+  double charge() const noexcept { return particle().charge(); }
+
+  double mass() const noexcept { return particle().mass(); }
+
+  ProcessType generationProcess() const noexcept {
+    return particle().generationProcess();
+  }
+
+  const Acts::Surface *&referenceSurface() noexcept
+    requires(!ReadOnly)
+  {
+    return StateAccessor::referenceSurface(particle());
+  }
+
+  Acts::Vector4 &fourPosition() noexcept
+    requires(!ReadOnly)
+  {
+    return StateAccessor::fourPosition(particle());
+  }
+
+  double &absoluteMomentum() noexcept
+    requires(!ReadOnly)
+  {
+    return StateAccessor::absoluteMomentum(particle());
+  }
+
+  Acts::Vector3 &direction() noexcept
+    requires(!ReadOnly)
+  {
+    return StateAccessor::direction(particle());
+  }
+
+  const Acts::Surface *referenceSurface() const noexcept {
+    return StateAccessor::referenceSurface(particle());
+  }
+
+  const Acts::Vector4 &fourPosition() const noexcept {
+    return StateAccessor::fourPosition(particle());
+  }
+
+  double absoluteMomentum() const noexcept {
+    return StateAccessor::absoluteMomentum(particle());
+  }
+
+  const Acts::Vector3 &direction() const noexcept {
+    return StateAccessor::direction(particle());
+  }
+
+  /// Total energy, i.e. norm of the four-momentum.
+  /// @return The total energy calculated from mass and momentum
+  double energy() const {
+    return Acts::fastHypot(particle().mass(), absoluteMomentum());
+  }
+
+  /// Change the energy by the given amount.
+  ///
+  /// Energy loss corresponds to a negative change. If the updated energy
+  /// would result in an unphysical value, the particle is put to rest, i.e.
+  /// its absolute momentum is set to zero.
+  /// @param delta Energy change (negative for energy loss)
+  /// @return Reference to this particle for method chaining
+  void applyEnergyDelta(double delta)
+    requires(!ReadOnly)
+  {
+    const auto newEnergy = energy() + delta;
+    if (particle().mass() >= newEnergy) {
+      absoluteMomentum() = 0;
+    } else {
+      absoluteMomentum() = Acts::fastCathetus(newEnergy, particle().mass());
+    }
+  }
+  /// Particle qOverP.
+  /// @return The charge over momentum ratio
+  double qOverP() const {
+    return particle().hypothesis().qOverP(absoluteMomentum(),
+                                          particle().charge());
+  }
+
+  /// Three-position, i.e. spatial coordinates without the time.
+  /// @return Three-dimensional position vector (x, y, z)
+  auto position() const {
+    return fourPosition().template segment<3>(Acts::ePos0);
+  }
+  /// Time coordinate.
+  /// @return The time coordinate value
+  double time() const { return fourPosition()[Acts::eTime]; }
+  /// Energy-momentum four-vector.
+  /// @return Four-dimensional momentum vector (px, py, pz, E)
+  Acts::Vector4 fourMomentum() const {
+    Acts::Vector4 mom4;
+    // stored direction is always normalized
+    mom4[Acts::eMom0] = absoluteMomentum() * direction()[Acts::ePos0];
+    mom4[Acts::eMom1] = absoluteMomentum() * direction()[Acts::ePos1];
+    mom4[Acts::eMom2] = absoluteMomentum() * direction()[Acts::ePos2];
+    mom4[Acts::eEnergy] = energy();
+    return mom4;
+  }
+  /// Polar angle.
+  /// @return The polar angle (theta) in radians
+  double theta() const { return Acts::VectorHelpers::theta(direction()); }
+  /// Azimuthal angle.
+  /// @return The azimuthal angle (phi) in radians
+  double phi() const { return Acts::VectorHelpers::phi(direction()); }
+  /// Absolute momentum in the x-y plane.
+  /// @return The transverse momentum magnitude
+  double transverseMomentum() const {
+    return absoluteMomentum() *
+           direction().template segment<2>(Acts::eMom0).norm();
+  }
+  /// Absolute momentum.
+  /// @return Three-dimensional momentum vector
+  Acts::Vector3 momentum() const { return absoluteMomentum() * direction(); }
+
+  /// Check if the particle has a reference surface.
+  /// @return True if reference surface is set, false otherwise
+  bool hasReferenceSurface() const { return referenceSurface() != nullptr; }
+
+  /// Bound track parameters.
+  /// @param gctx Geometry context for coordinate transformations
+  /// @return Result containing bound track parameters or error if no reference surface
+  Acts::Result<Acts::BoundTrackParameters> boundParameters(
+      const Acts::GeometryContext &gctx) const {
+    if (!hasReferenceSurface()) {
+      return Acts::Result<Acts::BoundTrackParameters>::failure(
+          std::error_code());
+    }
+    Acts::Result<Acts::Vector2> localResult =
+        referenceSurface()->globalToLocal(gctx, position(), direction());
+    if (!localResult.ok()) {
+      return localResult.error();
+    }
+    Acts::BoundVector params;
+    params << localResult.value(), phi(), theta(), qOverP(), time();
+    return Acts::BoundTrackParameters(referenceSurface()->getSharedPtr(),
+                                      params, std::nullopt,
+                                      particle().hypothesis());
+  }
+
+  /// @return Curvilinear track parameters representation
+  Acts::BoundTrackParameters curvilinearParameters() const {
+    return Acts::BoundTrackParameters::createCurvilinear(
+        fourPosition(), direction(), qOverP(), std::nullopt,
+        particle().hypothesis());
+  }
+
+  /// Check if the particle is alive, i.e. is not at rest.
+  /// @return True if particle has non-zero momentum, false otherwise
+  bool isAlive() const { return absoluteMomentum() > 0; }
+
+ private:
+  Particle m_particle;
+};
+
+namespace detail {
+
+struct GenerationStateAccessor final {
+  static const Acts::Surface *&referenceSurface(
+      MutableParticleProxy2 particle) {
+    static_cast<void>(particle);
+    throw std::logic_error(
+        "Generation state does not have a reference surface");
+  }
+  static Acts::Vector4 &fourPosition(MutableParticleProxy2 particle) {
+    return particle.initialFourPosition();
+  }
+  static double &absoluteMomentum(MutableParticleProxy2 particle) {
+    return particle.initialAbsoluteMomentum();
+  }
+  static Acts::Vector3 &direction(MutableParticleProxy2 particle) {
+    return particle.initialDirection();
+  }
+  static const Acts::Surface *referenceSurface(ConstParticleProxy2 particle) {
+    static_cast<void>(particle);
+    return nullptr;
+  }
+  static const Acts::Vector4 &fourPosition(ConstParticleProxy2 particle) {
+    return particle.initialFourPosition();
+  }
+  static double absoluteMomentum(ConstParticleProxy2 particle) {
+    return particle.initialAbsoluteMomentum();
+  }
+  static const Acts::Vector3 &direction(ConstParticleProxy2 particle) {
+    return particle.initialDirection();
+  }
+};
+
+struct SimulationStateAccessor final {
+  static const Acts::Surface *&referenceSurface(
+      MutableParticleProxy2 particle) {
+    return particle.currentReferenceSurface();
+  }
+  static Acts::Vector4 &fourPosition(MutableParticleProxy2 particle) {
+    return particle.currentFourPosition();
+  }
+  static double &absoluteMomentum(MutableParticleProxy2 particle) {
+    return particle.currentAbsoluteMomentum();
+  }
+  static Acts::Vector3 &direction(MutableParticleProxy2 particle) {
+    return particle.currentDirection();
+  }
+  static const Acts::Surface *referenceSurface(ConstParticleProxy2 particle) {
+    return particle.currentReferenceSurface();
+  }
+  static const Acts::Vector4 &fourPosition(ConstParticleProxy2 particle) {
+    return particle.currentFourPosition();
+  }
+  static double absoluteMomentum(ConstParticleProxy2 particle) {
+    return particle.currentAbsoluteMomentum();
+  }
+  static const Acts::Vector3 &direction(ConstParticleProxy2 particle) {
+    return particle.currentDirection();
+  }
+};
+
+}  // namespace detail
+
+/// Additional column of data that can be added to the space point container.
+/// The column is indexed by the space point index.
+template <typename T, bool read_only>
+class ParticleColumnProxy2 final {
+ public:
+  /// Flag indicating whether this particle column proxy is read-only
+  constexpr static bool ReadOnly = read_only;
+  /// Type alias for particle index type
+  using Index = ParticleIndex2;
+  /// Type alias for particle index subset type
+  using IndexSubset = ParticleIndexSubset2;
+  /// Type alias for column value type
+  using Value = T;
+  /// Type alias for container type (const if read-only)
+  using Container = Acts::const_if_t<ReadOnly, ParticleContainer2>;
+  /// Type alias for column container type (const if read-only)
+  using Column = Acts::const_if_t<ReadOnly, std::vector<Value>>;
+
+  /// Constructs a particle column proxy for the given container and column.
+  /// @param container The container holding the particle.
+  /// @param column The column of data to access.
+  ParticleColumnProxy2(Container &container, Column &column)
+      : m_container{&container}, m_column(&column) {}
+
+  /// Copy construct a particle column proxy.
+  /// @param other The particle column proxy to copy.
+  ParticleColumnProxy2(const ParticleColumnProxy2 &other) noexcept = default;
+
+  /// Copy construct a mutable particle column proxy.
+  /// @param other The mutable particle column proxy to copy.
+  explicit ParticleColumnProxy2(
+      const ParticleColumnProxy2<T, false> &other) noexcept
+    requires ReadOnly
+      : m_container(&other.container()), m_column(&other.column()) {}
+
+  /// Returns the number of entries in the particle column.
+  /// @return The size of the particle column.
+  std::uint32_t size() const noexcept { return column().size(); }
+
+  /// Returns a const proxy of the particle column.
+  /// @return A const proxy of the particle column.
+  ParticleColumnProxy2<T, true> asConst() const noexcept
+    requires(!ReadOnly)
+  {
+    return {*m_container, *m_column};
+  }
+
+  /// Gets the container holding the particle.
+  /// @return A reference to the container holding the particle.
+  ParticleContainer2 &container() noexcept
+    requires(!ReadOnly)
+  {
+    return *m_container;
+  }
+  /// Gets the container holding the particle.
+  /// @return A const reference to the container holding the particle.
+  const ParticleContainer2 &container() const noexcept { return *m_container; }
+
+  /// Returns a const reference to the column container.
+  /// @return A const reference to the column container.
+  const std::vector<Value> &column() const noexcept { return *m_column; }
+
+  /// Returns a mutable span to the column data.
+  /// @return A mutable span to the column data.
+  std::span<Value> data() noexcept
+    requires(!ReadOnly)
+  {
+    return std::span<Value>(column().data(), column().size());
+  }
+  /// Returns a const span to the column data.
+  /// @return A const span to the column data.
+  std::span<const Value> data() const noexcept {
+    return std::span<const Value>(column().data(), column().size());
+  }
+
+  /// Returns a mutable reference to the column entry at the given index.
+  /// If the index is out of range, an exception is thrown.
+  /// @param index The index of the space point to access.
+  /// @return A mutable reference to the column entry at the given index.
+  /// @throws std::out_of_range if the index is out of range.
+  Value &at(Index index)
+    requires(!ReadOnly)
+  {
+    if (index >= column().size()) {
+      throw std::out_of_range(
+          "Index out of range in ParticleContainer: " + std::to_string(index) +
+          " >= " + std::to_string(size()));
+    }
+    return data()[index];
+  }
+  /// Returns a const reference to the column entry at the given index.
+  /// If the index is out of range, an exception is thrown.
+  /// @param index The index of the particle to access.
+  /// @return A const reference to the column entry at the given index.
+  /// @throws std::out_of_range if the index is out of range.
+  const Value &at(Index index) const {
+    if (index >= column().size()) {
+      throw std::out_of_range(
+          "Index out of range in ParticleContainer: " + std::to_string(index) +
+          " >= " + std::to_string(size()));
+    }
+    return data()[index];
+  }
+
+  /// Returns a mutable reference to the column entry at the given index.
+  /// @param index The index of the particle to access.
+  /// @return A mutable reference to the column entry at the given index.
+  Value &operator[](Index index) noexcept
+    requires(!ReadOnly)
+  {
+    assert(index < column().size() && "Index out of bounds");
+    return data()[index];
+  }
+  /// Returns a const reference to the column entry at the given index.
+  /// @param index The index of the particle to access.
+  /// @return A const reference to the column entry at the given index.
+  const Value &operator[](Index index) const noexcept {
+    assert(index < column().size() && "Index out of bounds");
+    return data()[index];
+  }
+
+  /// Subset view over selected column entries.
+  class Subset final
+      : public Acts::detail::ContainerSubset<Subset, Subset, Column, Value,
+                                             Index, ReadOnly> {
+   public:
+    /// Base class type
+    using Base = Acts::detail::ContainerSubset<Subset, Subset, Column, Value,
+                                               Index, ReadOnly>;
+
+    using Base::Base;
+  };
+
+  /// Creates a subset view of this particle column based on provided
+  /// indices.
+  ///
+  /// This method creates a subset proxy that provides access to only the
+  /// particles at the indices specified in the IndexSubset. The subset
+  /// maintains a reference to the original column data without copying,
+  /// enabling efficient access to selected particles for filtering, clustering,
+  /// or other operations.
+  ///
+  /// @param subset The index subset specifying which particles to include
+  /// @return A subset proxy providing access to the selected particles
+  ///
+  /// @note The returned subset shares data with the original column
+  /// @note The subset remains valid only as long as the original column exists
+  /// @note This operation does not copy data, providing efficient subset access
+  Subset subset(const IndexSubset &subset) const noexcept {
+    return Subset(*m_column, subset);
+  }
+
+ private:
+  Container *m_container{};
+  Column *m_column{};
+
+  std::vector<Value> &column() noexcept
+    requires(!ReadOnly)
+  {
+    return *m_column;
+  }
+};
+
+template <bool read_only>
+MutableGeneratorParticleProxy2
+ParticleProxy2<read_only>::generationState() noexcept
+  requires(!ReadOnly)
+{
+  return MutableGeneratorParticleProxy2(*this);
+}
+
+template <bool read_only>
+MutableSimulationParticleProxy2
+ParticleProxy2<read_only>::simulationState() noexcept
+  requires(!ReadOnly)
+{
+  return MutableSimulationParticleProxy2(*this);
+}
+
+template <bool read_only>
+ConstGeneratorParticleProxy2 ParticleProxy2<read_only>::generationState()
+    const noexcept {
+  return ConstGeneratorParticleProxy2(*this);
+}
+
+template <bool read_only>
+ConstSimulationParticleProxy2 ParticleProxy2<read_only>::simulationState()
+    const noexcept {
+  return ConstSimulationParticleProxy2(*this);
+}
+
+inline MutableParticleProxy2 ParticleContainer2::at(Index index) {
+  if (index >= size()) {
+    throw std::out_of_range(
+        "Index out of range in ParticleContainer: " + std::to_string(index) +
+        " >= " + std::to_string(size()));
+  }
+  return MutableProxy(*this, index);
+}
+
+inline ConstParticleProxy2 ParticleContainer2::at(Index index) const {
+  if (index >= size()) {
+    throw std::out_of_range(
+        "Index out of range in ParticleContainer: " + std::to_string(index) +
+        " >= " + std::to_string(size()));
+  }
+  return ConstProxy(*this, index);
+}
+
+inline MutableParticleProxy2 ParticleContainer2::operator[](
+    Index index) noexcept {
+  return MutableProxy(*this, index);
+}
+
+inline ConstParticleProxy2 ParticleContainer2::operator[](
+    Index index) const noexcept {
+  return ConstProxy(*this, index);
+}
+
+}  // namespace ActsFatras
+
+inline std::ostream &operator<<(std::ostream &os,
+                                ActsFatras::ConstParticleProxy2 particle) {
+  // compact format w/ only identity information but no kinematics
+  os << "id=" << particle.index();
+  os << "|barcode=" << "(" << particle.barcode() << ")";
+  os << "|pdg=" << particle.pdg();
+  os << "|q=" << particle.charge();
+  os << "|m=" << particle.mass();
+  os << "|p=" << particle.initialAbsoluteMomentum();
+  return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os,
+                                ActsFatras::MutableParticleProxy2 particle) {
+  return os << particle.asConst();
+}

--- a/Fatras/src/EventData/HitContainer2.cpp
+++ b/Fatras/src/EventData/HitContainer2.cpp
@@ -1,0 +1,64 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/EventData/HitContainer2.hpp"
+
+namespace ActsFatras {
+
+void HitContainer2::reserve(std::uint32_t size) noexcept {
+  m_hits.reserve(size);
+}
+
+void HitContainer2::clear() noexcept {
+  m_hits.clear();
+  m_hitsByParticles.clear();
+  m_hitsBySurfaces.clear();
+}
+
+Hit& HitContainer2::push_back(const Hit& hit) {
+  m_hits.push_back(hit);
+  const auto hitIndex = static_cast<HitIndex>(m_hits.size() - 1);
+  m_hitsByParticles[hit.particleId2()].push_back(hitIndex);
+  m_hitsBySurfaces[hit.geometryId()].push_back(hitIndex);
+  return m_hits.back();
+}
+
+Hit& HitContainer2::emplace_back(const Acts::GeometryIdentifier geometryId,
+                                 Barcode particleBarcode,
+                                 const ParticleIndex2 particleId,
+                                 const Acts::Vector4& pos4,
+                                 const Acts::Vector4& before4,
+                                 const Acts::Vector4& after4,
+                                 const std::int32_t index) {
+  m_hits.emplace_back(geometryId, particleBarcode, particleId, pos4, before4,
+                      after4, index);
+  const auto hitIndex = static_cast<HitIndex>(m_hits.size() - 1);
+  m_hitsByParticles[particleId].push_back(hitIndex);
+  m_hitsBySurfaces[geometryId].push_back(hitIndex);
+  return m_hits.back();
+}
+
+std::span<const HitIndex> HitContainer2::hitIndicesByParticle(
+    ParticleIndex2 particleId) const {
+  auto it = m_hitsByParticles.find(particleId);
+  if (it != m_hitsByParticles.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+std::span<const HitIndex> HitContainer2::hitIndicesBySurface(
+    Acts::GeometryIdentifier geometryId) const {
+  auto it = m_hitsBySurfaces.find(geometryId);
+  if (it != m_hitsBySurfaces.end()) {
+    return it->second;
+  }
+  return {};
+}
+
+}  // namespace ActsFatras

--- a/Fatras/src/EventData/ParticleContainer2.cpp
+++ b/Fatras/src/EventData/ParticleContainer2.cpp
@@ -1,0 +1,240 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsFatras/EventData/ParticleContainer2.hpp"
+
+#include "Acts/Utilities/Helpers.hpp"
+
+#include <unordered_set>
+
+namespace {
+
+template <typename Tuple>
+using tuple_indices =
+    std::make_index_sequence<std::tuple_size_v<std::remove_reference_t<Tuple>>>;
+
+}
+
+namespace ActsFatras {
+
+static_assert(std::random_access_iterator<ParticleContainer2::iterator>);
+static_assert(std::random_access_iterator<ParticleContainer2::const_iterator>);
+static_assert(
+    std::random_access_iterator<ParticleContainer2::MutableSubset::iterator>);
+static_assert(
+    std::random_access_iterator<ParticleContainer2::ConstSubset::iterator>);
+
+ParticleContainer2::ParticleContainer2(ParticleColumns2 columns) noexcept {
+  createColumns(columns);
+}
+
+ParticleContainer2::ParticleContainer2(const ParticleContainer2 &other) noexcept
+    : m_size(other.m_size), m_parentIndices(other.m_parentIndices) {
+  copyColumns(other);
+}
+
+ParticleContainer2::ParticleContainer2(ParticleContainer2 &&other) noexcept
+    : m_size(other.m_size), m_parentIndices(std::move(other.m_parentIndices)) {
+  moveColumns(other);
+
+  other.m_size = 0;
+}
+
+ParticleContainer2 &ParticleContainer2::operator=(
+    const ParticleContainer2 &other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  copyColumns(other);
+  m_parentIndices = other.m_parentIndices;
+  m_size = other.m_size;
+
+  return *this;
+}
+
+ParticleContainer2 &ParticleContainer2::operator=(
+    ParticleContainer2 &&other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  moveColumns(other);
+  m_parentIndices = std::move(other.m_parentIndices);
+  m_size = other.m_size;
+
+  other.m_size = 0;
+
+  return *this;
+}
+
+void ParticleContainer2::copyColumns(const ParticleContainer2 &other) {
+  m_allColumns.reserve(other.m_allColumns.size());
+  m_dynamicColumns.reserve(other.m_dynamicColumns.size());
+
+  const auto copyKnownColumns =
+      [&]<typename T>(std::string_view name,
+                      std::optional<ColumnHolder<T>> &column,
+                      const std::optional<ColumnHolder<T>> &otherColumn) {
+        column = otherColumn;
+        if (column.has_value()) {
+          m_allColumns.try_emplace(std::string(name), &column.value());
+        }
+      };
+
+  [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    ((copyKnownColumns(std::get<Is>(knownColumnNames()),
+                       std::get<Is>(knownColumns()),
+                       std::get<Is>(other.knownColumns()))),
+     ...);
+  }(tuple_indices<decltype(knownColumns())>{});
+  m_knownColumns = other.m_knownColumns;
+
+  for (auto &[name, column] : other.m_dynamicColumns) {
+    std::unique_ptr<ColumnHolderBase> columnCopy = column->copy();
+    m_allColumns.try_emplace(name, columnCopy.get());
+    m_dynamicColumns.try_emplace(name, std::move(columnCopy));
+  }
+}
+
+void ParticleContainer2::moveColumns(ParticleContainer2 &other) noexcept {
+  m_allColumns.reserve(other.m_allColumns.size());
+  m_dynamicColumns.reserve(other.m_dynamicColumns.size());
+
+  const auto moveKnownColumns =
+      [&]<typename T>(std::string_view name,
+                      std::optional<ColumnHolder<T>> &column,
+                      std::optional<ColumnHolder<T>> &otherColumn) {
+        column = std::move(otherColumn);
+        if (column.has_value()) {
+          m_allColumns.try_emplace(std::string(name), &column.value());
+        }
+      };
+
+  [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    ((moveKnownColumns(std::get<Is>(knownColumnNames()),
+                       std::get<Is>(knownColumns()),
+                       std::get<Is>(other.knownColumns()))),
+     ...);
+  }(tuple_indices<decltype(knownColumns())>{});
+  m_knownColumns = other.m_knownColumns;
+
+  for (auto &[name, column] : other.m_dynamicColumns) {
+    m_allColumns.try_emplace(name, column.get());
+    m_dynamicColumns.try_emplace(name, std::move(column));
+  }
+
+  other.m_allColumns.clear();
+  other.m_knownColumns = ParticleColumns2::None;
+  other.m_dynamicColumns.clear();
+}
+
+void ParticleContainer2::reserve(std::uint32_t size,
+                                 float averageParentIndices) noexcept {
+  if (hasColumns(ParticleColumns2::Parents)) {
+    m_parentIndices.reserve(
+        static_cast<std::uint32_t>(size * averageParentIndices));
+  }
+
+  for (const auto &[name, column] : m_allColumns) {
+    column->reserve(size);
+  }
+}
+
+void ParticleContainer2::clear() noexcept {
+  m_size = 0;
+  m_parentIndices.clear();
+
+  for (const auto &[name, column] : m_allColumns) {
+    column->clear();
+  }
+}
+
+MutableParticleProxy2 ParticleContainer2::createParticle() noexcept {
+  ++m_size;
+
+  for (const auto &[name, column] : m_allColumns) {
+    column->emplace_back();
+  }
+
+  return MutableProxy(*this, size() - 1);
+}
+
+void ParticleContainer2::createColumns(ParticleColumns2 columns) noexcept {
+  using enum ParticleColumns2;
+
+  const auto createColumn =
+      [&]<typename T>(ParticleColumns2 mask, std::string_view name,
+                      T defaultValue, std::optional<ColumnHolder<T>> &column) {
+        if (ACTS_CHECK_BIT(columns, mask) && !column.has_value()) {
+          column = ColumnHolder<T>(std::move(defaultValue));
+          column->resize(size());
+          m_allColumns.try_emplace(std::string(name), &column.value());
+          m_knownColumns = m_knownColumns | mask;
+        }
+      };
+
+  [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    ((createColumn(
+         std::get<Is>(knownColumnMasks()), std::get<Is>(knownColumnNames()),
+         std::get<Is>(knownColumnDefaults()), std::get<Is>(knownColumns()))),
+     ...);
+  }(tuple_indices<decltype(knownColumns())>{});
+}
+
+void ParticleContainer2::dropColumns(ParticleColumns2 columns) noexcept {
+  using enum ParticleColumns2;
+
+  const auto dropColumn = [&]<typename T>(
+                              ParticleColumns2 mask, std::string_view name,
+                              std::optional<ColumnHolder<T>> &column) {
+    if (ACTS_CHECK_BIT(columns, mask) && column.has_value()) {
+      m_allColumns.erase(std::string(name));
+      column.reset();
+      m_knownColumns = m_knownColumns & ~mask;
+    }
+  };
+
+  [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+    ((dropColumn(std::get<Is>(knownColumnMasks()),
+                 std::get<Is>(knownColumnNames()),
+                 std::get<Is>(knownColumns()))),
+     ...);
+  }(tuple_indices<decltype(knownColumns())>{});
+
+  if (ACTS_CHECK_BIT(columns, ParticleColumns2::Parents)) {
+    m_parentIndices.clear();
+  }
+}
+
+void ParticleContainer2::dropColumn(const std::string &name) {
+  if (reservedColumn(name)) {
+    throw std::runtime_error("Cannot drop reserved column: " + name);
+  }
+
+  auto it = m_allColumns.find(name);
+  if (it == m_allColumns.end()) {
+    throw std::runtime_error("Column does not exist: " + name);
+  }
+
+  m_allColumns.erase(it);
+  m_dynamicColumns.erase(name);
+}
+
+bool ParticleContainer2::reservedColumn(const std::string &name) noexcept {
+  static const auto reservedColumns = std::apply(
+      [](auto... reservedNames) {
+        return std::unordered_set<std::string, std::hash<std::string_view>,
+                                  std::equal_to<>>({reservedNames...});
+      },
+      knownColumnNames());
+
+  return reservedColumns.contains(name);
+}
+
+}  // namespace ActsFatras

--- a/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
+++ b/Tests/UnitTests/Examples/Io/Json/JsonDigitizationConfigTests.cpp
@@ -58,7 +58,8 @@ struct Fixture {
     surface->assignGeometryId(gid);
 
     // generate random track parameters
-    auto [par, cov] = detail::Test::generateBoundParametersCovariance(rng, {});
+    auto [par, cov] =
+        Acts::detail::Test::generateBoundParametersCovariance(rng, {});
     boundParams = par;
 
     freeParams = transformBoundToFreeParameters(*surface, geoCtx, boundParams);

--- a/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
+++ b/Tests/UnitTests/Fatras/Digitization/UncorrelatedHitSmearerTests.cpp
@@ -96,7 +96,8 @@ struct Fixture {
     surface->assignGeometryId(gid);
 
     // generate random track parameters
-    auto [par, cov] = detail::Test::generateBoundParametersCovariance(rng, {});
+    auto [par, cov] =
+        Acts::detail::Test::generateBoundParametersCovariance(rng, {});
     boundParams = par;
 
     freeParams = transformBoundToFreeParameters(*surface, geoCtx, boundParams);


### PR DESCRIPTION
Introduces a new concrete particle and hit container that is planned to be used for Fatras and Examples. It is similar to our existing track container and space point container with an extensible SoA-style layout.

This new container works with indices to identify particles and removes the dependency on a unique barcode. The barcode is now just a simple property of the particle. This makes handling of the container much easier and will also allow us to map it to Python very easily. Apart from that we can now also easily model the particle creation tree with a list of parent particles.

The plan is to migrate gradually to this new container as a single change would be too big. Bringing the container in and adding some tests without actually using it is the first step.

--- END COMMIT MESSAGE ---

A few more ideas we could consider:
- not only link to parents but also descendants
- a list of primary particles on the container level to easily access the "root" nodes
- a generic algorithm to generate barcodes after filling the container using the root and parent indices
- a way to represent stable and intermediate particles for generation processes
- vertex index

blocked by
- https://github.com/acts-project/acts/pull/5175
- https://github.com/acts-project/acts/pull/5211
- https://github.com/acts-project/acts/pull/5212
