### PR TITLE
fix(cmake): add Alignment component before Plugins subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -673,8 +673,8 @@ acts_enable_static_analysis() # enable static analysis for the main code, after 
 # core library, core plugins, and other components
 add_component(Core Core)
 add_component_if(Fatras Fatras ACTS_BUILD_FATRAS)
-add_subdirectory(Plugins)
 add_component_if(Alignment Alignment ACTS_BUILD_ALIGNMENT)
+add_subdirectory(Plugins)
 
 add_subdirectory_if(thirdparty/OpenDataDetector ACTS_BUILD_ODD)
 


### PR DESCRIPTION
fix(cmake): add Alignment component before Plugins subdirectory

--- END COMMIT MESSAGE ---

With the addition of the Mille plugin, which depends on the Alignment component, there is a new ordering requirement on how the targets are defined. This is in particular relevant in third party project (possibly why it was not noticed here) where without this fix we get:
```
-- loading components:
--   Core
--   Fatras
--   PluginActSVG
--   PluginFpeMonitoring
--   PluginGeant4
--   PluginJson
--   PluginMille
--   PluginOnnx
--   PluginRoot
--   PluginDD4hep
--   PluginEDM4hep
--   Alignment
CMake Error at CMakeLists.txt:237 (find_package):
  Found package configuration file:

    /opt/software/linux-skylake/acts-45.4.0-lcgvdhegpoy3yh6vgbkaoqohtwijhsz7/lib/cmake/Acts/ActsConfig.cmake

  but it set Acts_FOUND to FALSE so package "Acts" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  Acts::Alignment
```
which is caused because at the time PluginMille tries to check its dependencies, the Alignment component is not loaded yet.

With the change here, there are no errors loading Acts with the Mille plugin.

There are no Plugin dependencies in the Alignment component, so we are not introducing the reverse issue here.