### PR TITLE
refactor: Revise `GbtsLayerConnection` reading from file

### DIFF
--- a/Core/include/Acts/Seeding2/GbtsLayerConnection.hpp
+++ b/Core/include/Acts/Seeding2/GbtsLayerConnection.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <vector>
@@ -17,7 +18,6 @@ namespace Acts::Experimental {
 
 /// Connection between two GBTS layers with binning information.
 struct GbtsLayerConnection {
-  /// Constructor
   /// @param src_ Source layer index
   /// @param dst_ Destination layer index
   GbtsLayerConnection(std::uint32_t src_, std::uint32_t dst_)
@@ -35,9 +35,20 @@ struct GbtsLayerConnection {
 /// Loader and container for GBTS layer connection data.
 struct GbtsLayerConnectionMap {
  public:
+  /// Create a GbtsLayerConnectionMap from an input stream
+  /// @param inStream Input stream containing the connection data
+  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @return A GbtsLayerConnectionMap instance populated with the data from the stream
+  static GbtsLayerConnectionMap fromStream(std::istream& inStream,
+                                           bool lrtMode);
+  /// Create a GbtsLayerConnectionMap from a file
+  /// @param inFile Input configuration file path
+  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @return A GbtsLayerConnectionMap instance populated with the data from the file
+  static GbtsLayerConnectionMap fromFile(std::string& inFile, bool lrtMode);
+
   /// Group of connections targeting a destination layer.
   struct LayerGroup {
-    /// Constructor
     /// @param dst_ Destination layer key
     /// @param sources_ Vector of source connections
     LayerGroup(std::uint32_t dst_,
@@ -50,11 +61,6 @@ struct GbtsLayerConnectionMap {
     /// The source layers of the group
     std::vector<const GbtsLayerConnection*> sources;
   };
-
-  /// Constructor
-  /// @param inFile Input configuration file path
-  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
-  GbtsLayerConnectionMap(std::string& inFile, bool lrtMode);
 
   /// Eta bin width
   float etaBinWidth{};

--- a/Core/src/Seeding2/GbtsLayerConnection.cpp
+++ b/Core/src/Seeding2/GbtsLayerConnection.cpp
@@ -19,17 +19,13 @@
 
 namespace Acts::Experimental {
 
-GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
-                                               bool lrtMode) {
+GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
+    std::istream& inputStream, bool lrtMode) {
+  GbtsLayerConnectionMap connectionMap;
+
   std::uint32_t nLinks{};
 
-  std::ifstream input_ifstream(inFile.c_str(), std::ifstream::in);
-
-  if (!input_ifstream.is_open()) {
-    throw std::runtime_error("connection file not found");
-  }
-
-  input_ifstream >> nLinks >> etaBinWidth;
+  inputStream >> nLinks >> connectionMap.etaBinWidth;
 
   for (std::uint32_t l = 0; l < nLinks; l++) {
     std::uint32_t stage{};
@@ -40,8 +36,7 @@ GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
     std::uint32_t height{};
     std::uint32_t width{};
 
-    input_ifstream >> lIdx >> stage >> src >> dst >> height >> width >>
-        nEntries;
+    inputStream >> lIdx >> stage >> src >> dst >> height >> width >> nEntries;
 
     auto pC = std::make_unique<GbtsLayerConnection>(src, dst);
 
@@ -49,7 +44,7 @@ GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
 
     for (std::uint32_t i = 0; i < height; ++i) {
       for (std::uint32_t j = 0; j < width; ++j) {
-        input_ifstream >> dummy;
+        inputStream >> dummy;
       }
     }
 
@@ -68,11 +63,13 @@ GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
       }
     }
 
-    if (auto it = connectionMap.find(stage); it == connectionMap.end()) {
+    if (const auto it = connectionMap.connectionMap.find(stage);
+        it == connectionMap.connectionMap.end()) {
       std::vector<std::unique_ptr<GbtsLayerConnection>> v;
       v.push_back(std::move(pC));  // move the unique_ptr in
-      connectionMap.emplace(stage,
-                            std::move(v));  // move the vector into the map
+      connectionMap.connectionMap.emplace(
+          stage,
+          std::move(v));  // move the vector into the map
     } else {
       it->second.push_back(std::move(pC));  // move into existing vector
     }
@@ -84,7 +81,7 @@ GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
 
   std::map<std::int32_t, std::vector<const GbtsLayerConnection*>> newConnMap;
 
-  for (const auto& conn : connectionMap) {
+  for (const auto& conn : connectionMap.connectionMap) {
     for (const auto& up : conn.second) {
       lConns.push_back(up.get());
     }
@@ -183,12 +180,18 @@ GbtsLayerConnectionMap::GbtsLayerConnectionMap(std::string& inFile,
       lgv.push_back(LayerGroup(l1Group.first, l1Group.second));
     }
 
-    layerGroups.insert(std::make_pair(currentStage, lgv));
+    connectionMap.layerGroups.insert(std::make_pair(currentStage, lgv));
 
     currentStage++;
   }
 
-  newConnMap.clear();
+  return connectionMap;
+}
+
+GbtsLayerConnectionMap GbtsLayerConnectionMap::fromFile(std::string& inFile,
+                                                        bool lrtMode) {
+  std::ifstream inputStream(inFile.c_str());
+  return fromStream(inputStream, lrtMode);
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Seeding2/GbtsLayerConnection.cpp
+++ b/Core/src/Seeding2/GbtsLayerConnection.cpp
@@ -20,12 +20,12 @@
 namespace Acts::Experimental {
 
 GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
-    std::istream& inputStream, bool lrtMode) {
+    std::istream& inStream, bool lrtMode) {
   GbtsLayerConnectionMap connectionMap;
 
   std::uint32_t nLinks{};
 
-  inputStream >> nLinks >> connectionMap.etaBinWidth;
+  inStream >> nLinks >> connectionMap.etaBinWidth;
 
   for (std::uint32_t l = 0; l < nLinks; l++) {
     std::uint32_t stage{};
@@ -36,7 +36,7 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
     std::uint32_t height{};
     std::uint32_t width{};
 
-    inputStream >> lIdx >> stage >> src >> dst >> height >> width >> nEntries;
+    inStream >> lIdx >> stage >> src >> dst >> height >> width >> nEntries;
 
     auto pC = std::make_unique<GbtsLayerConnection>(src, dst);
 
@@ -44,7 +44,7 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
 
     for (std::uint32_t i = 0; i < height; ++i) {
       for (std::uint32_t j = 0; j < width; ++j) {
-        inputStream >> dummy;
+        inStream >> dummy;
       }
     }
 

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -41,9 +41,10 @@ GraphBasedSeedingAlgorithm::GraphBasedSeedingAlgorithm(
       layerNumbering(Acts::GeometryContext::dangerouslyDefaultConstruct());
 
   // create the connection objects
-  Acts::Experimental::GbtsLayerConnectionMap layerConnectionMap(
-      m_cfg.seedFinderConfig.connectorInputFile,
-      m_cfg.seedFinderConfig.lrtMode);
+  Acts::Experimental::GbtsLayerConnectionMap layerConnectionMap =
+      Acts::Experimental::GbtsLayerConnectionMap::fromFile(
+          m_cfg.seedFinderConfig.connectorInputFile,
+          m_cfg.seedFinderConfig.lrtMode);
 
   // option that allows for adding custom eta binning (default is at 0.2)
   if (m_cfg.seedFinderConfig.etaBinWidthOverride != 0.0f) {


### PR DESCRIPTION
Generalize `GbtsLayerConnection` creation with factory methods to read it from stream or file. This allows users to construct their own `GbtsLayerConnection` without depending on the proprietary file format or that it has to come directly from the filesystem.

--- END COMMIT MESSAGE ---

