### PR TITLE
refactor: Revise `GraphBasedTrackSeeder::createSeeds` interface

### DIFF
--- a/Core/include/Acts/Seeding2/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding2/GraphBasedTrackSeeder.hpp
@@ -172,7 +172,6 @@ class GraphBasedTrackSeeder {
     const GbtsEtaBin* bin{};
   };
 
-  /// Constructor.
   /// @param config Configuration for the seed finder
   /// @param geometry GBTS geometry
   /// @param logger Logging instance
@@ -188,12 +187,11 @@ class GraphBasedTrackSeeder {
   /// @param maxLayers Maximum number of layers
   /// @param filter Tracking filter to be applied
   /// @param options Event based options such as magnetic field strength
-  /// @return Container with generated seeds
-  SeedContainer2 createSeeds(const SpacePointContainer2& spacePoints,
-                             const GbtsRoiDescriptor& roi,
-                             std::uint32_t maxLayers,
-                             const GbtsTrackingFilter& filter,
-                             const Options& options) const;
+  /// @param outputSeeds Container with generated seeds
+  void createSeeds(const SpacePointContainer2& spacePoints,
+                   const GbtsRoiDescriptor& roi, std::uint32_t maxLayers,
+                   const GbtsTrackingFilter& filter, const Options& options,
+                   SeedContainer2& outputSeeds) const;
 
  private:
   DerivedConfig m_cfg;

--- a/Core/src/Seeding2/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding2/GraphBasedTrackSeeder.cpp
@@ -41,13 +41,14 @@ GraphBasedTrackSeeder::GraphBasedTrackSeeder(
   m_mlLut = parseGbtsMlLookupTable(m_cfg.lutInputFile);
 }
 
-SeedContainer2 GraphBasedTrackSeeder::createSeeds(
-    const SpacePointContainer2& spacePoints, const GbtsRoiDescriptor& roi,
-    const std::uint32_t maxLayers, const GbtsTrackingFilter& filter,
-    const Options& options) const {
+void GraphBasedTrackSeeder::createSeeds(const SpacePointContainer2& spacePoints,
+                                        const GbtsRoiDescriptor& roi,
+                                        const std::uint32_t maxLayers,
+                                        const GbtsTrackingFilter& filter,
+                                        const Options& options,
+                                        SeedContainer2& outputSeeds) const {
   GbtsNodeStorage nodeStorage(m_geometry, m_mlLut);
 
-  SeedContainer2 SeedContainer;
   std::vector<std::vector<GbtsNode>> nodesPerLayer =
       createNodes(spacePoints, maxLayers);
   std::uint32_t nPixelLoaded = 0;
@@ -98,19 +99,17 @@ SeedContainer2 GraphBasedTrackSeeder::createSeeds(
   extractSeedsFromTheGraph(maxLevel, graphStats.first, spacePoints.size(),
                            edgeStorage, vOutputSeeds, filter);
 
+  ACTS_DEBUG("GBTS created " << vOutputSeeds.size() << " seeds");
   if (vOutputSeeds.empty()) {
     ACTS_WARNING("No Seed Candidates");
   }
-  // add to seed container:
+
+  // add to output seed container
   for (const auto& seed : vOutputSeeds) {
-    auto newSeed = SeedContainer.createSeed();
+    auto newSeed = outputSeeds.createSeed();
     newSeed.assignSpacePointIndices(seed.spacePoints);
     newSeed.quality() = seed.seedQuality;
   }
-
-  ACTS_DEBUG("GBTS created " << SeedContainer.size() << " seeds");
-
-  return SeedContainer;
 }
 
 GbtsMlLookupTable GraphBasedTrackSeeder::parseGbtsMlLookupTable(

--- a/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GraphBasedSeedingAlgorithm.cpp
@@ -92,9 +92,12 @@ ProcessCode GraphBasedSeedingAlgorithm::execute(
   const Acts::Experimental::GraphBasedTrackSeeder::Options options(
       m_cfg.bFieldInZ);
 
+  Acts::SeedContainer2 seeds;
+  seeds.assignSpacePointContainer(spacePoints);
+
   // create the seeds
-  Acts::SeedContainer2 seeds = m_finder->createSeeds(
-      coreSpacePoints, internalRoi, maxLayers, *m_filter, options);
+  m_finder->createSeeds(coreSpacePoints, internalRoi, maxLayers, *m_filter,
+                        options, seeds);
 
   // update seed space point indices to original space point container
   for (auto seed : seeds) {


### PR DESCRIPTION
Changes the GBTS `createSeeds` interface to match the triplet seeding interface

--- END COMMIT MESSAGE ---

