### PR TITLE
refactor: Use `Acts::Result` in `GainMatrixUpdater`

### DIFF
--- a/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
+++ b/Core/include/Acts/TrackFitting/GainMatrixUpdater.hpp
@@ -14,8 +14,6 @@
 #include "Acts/Utilities/Result.hpp"
 
 #include <cassert>
-#include <system_error>
-#include <tuple>
 
 namespace Acts {
 
@@ -28,7 +26,7 @@ class GainMatrixUpdater {
   /// @tparam kMeasurementSizeMax
   /// @param[in,out] trackState The track state
   /// @param[in] logger Where to write logging information to
-  /// @return Success or failure of the update procedure with chi2 information
+  /// @return Success or failure of the update procedure
   template <typename traj_t>
   Result<void> operator()(const GeometryContext& /*gctx*/,
                           typename traj_t::TrackStateProxy trackState,
@@ -55,21 +53,16 @@ class GainMatrixUpdater {
     // auto filtered = trackState.filtered();
     // auto filteredCovariance = trackState.filteredCovariance();
 
-    const auto [chi2, error] =
-        visitMeasurement(AnyMutableTrackStateProxy{trackState}, logger);
-
-    trackState.chi2() = chi2;
-
-    return error ? Result<void>::failure(error) : Result<void>::success();
+    return visitMeasurement(AnyMutableTrackStateProxy{trackState}, logger);
   }
 
  private:
-  std::tuple<double, std::error_code> visitMeasurement(
-      AnyMutableTrackStateProxy trackState, const Logger& logger) const;
+  Result<void> visitMeasurement(AnyMutableTrackStateProxy trackState,
+                                const Logger& logger) const;
 
   template <std::size_t N>
-  std::tuple<double, std::error_code> visitMeasurementImpl(
-      AnyMutableTrackStateProxy trackState, const Logger& logger) const;
+  Result<void> visitMeasurementImpl(AnyMutableTrackStateProxy trackState,
+                                    const Logger& logger) const;
 };
 
 }  // namespace Acts

--- a/Core/include/Acts/TrackFitting/detail/GainMatrixUpdaterImpl.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GainMatrixUpdaterImpl.hpp
@@ -15,12 +15,11 @@
 #include "Acts/Utilities/Logger.hpp"
 
 #include <cstddef>
-#include <tuple>
 
 namespace Acts {
 
 template <std::size_t N>
-std::tuple<double, std::error_code> GainMatrixUpdater::visitMeasurementImpl(
+Result<void> GainMatrixUpdater::visitMeasurementImpl(
     AnyMutableTrackStateProxy trackState, const Logger& logger) const {
   constexpr std::size_t kMeasurementSize = N;
   using ProjectedVector = Vector<kMeasurementSize>;
@@ -60,7 +59,7 @@ std::tuple<double, std::error_code> GainMatrixUpdater::visitMeasurementImpl(
 
   if (K.hasNaN()) {
     // set to error abort execution
-    return {0, KalmanFitterError::UpdateFailed};
+    return Result<void>::failure(KalmanFitterError::UpdateFailed);
   }
 
   filtered = predicted + K * (calibrated - H * predicted);
@@ -78,14 +77,15 @@ std::tuple<double, std::error_code> GainMatrixUpdater::visitMeasurementImpl(
   const double chi2 = (residual.transpose() * m.inverse() * residual).value();
   ACTS_VERBOSE("Chi2: " << chi2);
 
-  return {chi2, {}};
+  trackState.chi2() = chi2;
+
+  return Result<void>::success();
 }
 
 // Ensure that the compiler does not implicitly instantiate the template
 
-#define _EXTERN(N)                                    \
-  extern template std::tuple<double, std::error_code> \
-  GainMatrixUpdater::visitMeasurementImpl<N>(         \
+#define _EXTERN(N)                                                         \
+  extern template Result<void> GainMatrixUpdater::visitMeasurementImpl<N>( \
       AnyMutableTrackStateProxy trackState, const Logger& logger) const
 
 _EXTERN(1);

--- a/Core/src/TrackFitting/GainMatrixUpdater.cpp
+++ b/Core/src/TrackFitting/GainMatrixUpdater.cpp
@@ -16,14 +16,14 @@
 
 namespace Acts {
 
-std::tuple<double, std::error_code> GainMatrixUpdater::visitMeasurement(
+Result<void> GainMatrixUpdater::visitMeasurement(
     AnyMutableTrackStateProxy trackState, const Logger& logger) const {
   // default-constructed error represents success, i.e. an invalid error code
 
   return visit_measurement(
       trackState.calibratedSize(),
-      [&, this]<std::size_t N>(std::integral_constant<std::size_t, N>)
-          -> std::tuple<double, std::error_code> {
+      [&, this]<std::size_t N>(
+          std::integral_constant<std::size_t, N>) -> Result<void> {
         return visitMeasurementImpl<N>(trackState, logger);
       });
 }

--- a/Core/src/TrackFitting/GainMatrixUpdaterImpl.cpp.in
+++ b/Core/src/TrackFitting/GainMatrixUpdaterImpl.cpp.in
@@ -13,7 +13,7 @@
 // clang-format off
 namespace Acts {
 
-template std::tuple<double, std::error_code>
+template Result<void>
 GainMatrixUpdater::visitMeasurementImpl<@DIM@>(AnyMutableTrackStateProxy trackState,
                                                const Logger& logger) const;
 


### PR DESCRIPTION
- consistently use `Acts::Result` in `GainMatrixUpdater`
- remove chi2 return and set chi2 to track state in implementation

--- END COMMIT MESSAGE ---

