### PR TITLE
docs: Update cppreference links

### DIFF
--- a/Core/include/Acts/Definitions/Units.hpp
+++ b/Core/include/Acts/Definitions/Units.hpp
@@ -54,7 +54,7 @@ namespace Acts {
 ///
 /// To further simplify the usage, physical quantities can also be expressed
 /// via [C++ user
-/// literals](https://en.cppreference.com/w/cpp/language/user_literal)
+/// literals](https://en.cppreference.com/cpp/language/user_literal)
 /// defined
 /// in @ref Acts::UnitLiterals. This allows us to express quantities in a
 /// concise way:

--- a/Core/include/Acts/EventData/detail/GenerateParameters.hpp
+++ b/Core/include/Acts/EventData/detail/GenerateParameters.hpp
@@ -113,7 +113,7 @@ inline std::pair<double, double> generateBoundDirection(
   // monothonical decreasing between [0, pi]
   double cosThetaMin = std::cos(options.thetaMax);
   // ensure upper bound is included. see e.g.
-  // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
+  // https://en.cppreference.com/cpp/numeric/random/uniform_real_distribution
   double cosThetaMax = std::nextafter(std::cos(options.thetaMin),
                                       std::numeric_limits<double>::max());
 

--- a/Examples/Framework/src/Utilities/ParametricParticleGenerator.cpp
+++ b/Examples/Framework/src/Utilities/ParametricParticleGenerator.cpp
@@ -58,7 +58,7 @@ ParametricParticleGenerator::ParametricParticleGenerator(const Config& cfg)
     // https://mathworld.wolfram.com/SpherePointPicking.html
     double cosThetaMin = std::cos(m_cfg.thetaMin);
     // ensure upper bound is included. see e.g.
-    // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
+    // https://en.cppreference.com/cpp/numeric/random/uniform_real_distribution
     double cosThetaMax = std::nextafter(std::cos(m_cfg.thetaMax),
                                         std::numeric_limits<double>::max());
 


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

```
URL        `https://en.cppreference.com/w/cpp/language/user_literal'
Name       `C++ user literals'
Parent URL file:///home/runner/work/acts/acts/build/docs/html/namespace_acts_1_1_unit_constants.html, line 272, col 104
Real URL   https://en.cppreference.com/cpp/language/user_literal
Check time 0.344 seconds
Warning    [http-redirected] Redirected to
           `https://en.cppreference.com/cpp/language/user_literal'
           status: 301 Moved Permanently.
Result     Valid: 200 OK
 4 threads active,  1159 links queued, 3401 links in 4566 URLs checked, runtime 1 minute, 16 seconds
```