### PR TITLE
ci(deps): gersemi pre-commit hook repo reference

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     - id: black-jupyter
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
-    rev: 0.27.2
+    rev: 0.26.1
     hooks:
     - id: gersemi
       args: ["-i", "--no-warn-about-unknown-commands"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
     - id: black-jupyter
 
-  - repo: https://github.com/BlankSpruce/gersemi
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.27.2
     hooks:
     - id: gersemi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     - id: black-jupyter
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
-    rev: 0.26.1
+    rev: 0.27.2
     hooks:
     - id: gersemi
       args: ["-i", "--no-warn-about-unknown-commands"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     - id: black-jupyter
 
   - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.26.1
+    rev: 0.27.2
     hooks:
     - id: gersemi
       args: ["-i", "--no-warn-about-unknown-commands"]


### PR DESCRIPTION
The pre-commit config referenced the package repo instead of the dedicated hook repo, causing `InvalidManifestError` due to missing `.pre-commit-hooks.yaml`.

Detected in https://github.com/acts-project/acts/pull/5366.

```
Run pre-commit run --all-files --show-diff-on-failure
  pre-commit run --all-files --show-diff-on-failure
  shell: /usr/bin/bash -e {0}
  env:
    PRE_COMMIT_HOME: /tmp/pre-commit
    pythonLocation: /opt/hostedtoolcache/Python/3.14.4/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.14.4/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.14.4/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.14.4/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.14.4/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.14.4/x64/lib
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-clang-format.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/psf/black-pre-commit-mirror.
[INFO] Initializing environment for https://github.com/psf/black-pre-commit-mirror:.[jupyter].
[INFO] Initializing environment for https://github.com/BlankSpruce/gersemi.
An error has occurred: InvalidManifestError: 
=====> /tmp/pre-commit/repo3wt466sb/.pre-commit-hooks.yaml is not a file
Check the log at /tmp/pre-commit/pre-commit.log
Error: Process completed with exit code 1.
```