### PR TITLE
chore: Add `referenceFrame` overload without position/direction for plane surfaces

### DIFF
--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -167,6 +167,18 @@ class DiscSurface : public RegularSurface {
   double referencePositionValue(const GeometryContext& gctx,
                                 AxisDirection aDir) const final;
 
+  using Surface::referenceFrame;
+
+  /// Return method for the reference frame
+  /// This is the frame in which the covariance matrix is defined (specialized
+  /// by all surfaces)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  ///
+  /// @return RotationMatrix3 which defines the three axes of the measurement
+  /// frame
+  RotationMatrix3 referenceFrame(const GeometryContext& gctx) const;
+
   /// This method returns the bounds by reference
   /// @return Reference to the surface bounds
   const SurfaceBounds& bounds() const final;

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -116,6 +116,18 @@ class PlaneSurface : public RegularSurface {
   Vector3 referencePosition(const GeometryContext& gctx,
                             AxisDirection aDir) const final;
 
+  using Surface::referenceFrame;
+
+  /// Return method for the reference frame
+  /// This is the frame in which the covariance matrix is defined (specialized
+  /// by all surfaces)
+  ///
+  /// @param gctx The current geometry context object, e.g. alignment
+  ///
+  /// @return RotationMatrix3 which defines the three axes of the measurement
+  /// frame
+  RotationMatrix3 referenceFrame(const GeometryContext& gctx) const;
+
   /// Return the surface type
   /// @return Surface type identifier
   SurfaceType type() const override;

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -337,9 +337,9 @@ class Surface : public virtual GeometryObject,
   ///
   /// @return RotationMatrix3 which defines the three axes of the measurement
   /// frame
-  virtual Acts::RotationMatrix3 referenceFrame(const GeometryContext& gctx,
-                                               const Vector3& position,
-                                               const Vector3& direction) const;
+  virtual RotationMatrix3 referenceFrame(const GeometryContext& gctx,
+                                         const Vector3& position,
+                                         const Vector3& direction) const;
 
   /// Calculate the jacobian from local to global which the surface knows best,
   /// hence the calculation is done here.

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -360,6 +360,10 @@ double DiscSurface::referencePositionValue(const GeometryContext& gctx,
   return GeometryObject::referencePositionValue(gctx, aDir);
 }
 
+RotationMatrix3 DiscSurface::referenceFrame(const GeometryContext& gctx) const {
+  return localToGlobalTransform(gctx).matrix().block<3, 3>(0, 0);
+}
+
 double DiscSurface::pathCorrection(const GeometryContext& gctx,
                                    const Vector3& /*position*/,
                                    const Vector3& direction) const {

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -60,6 +60,11 @@ PlaneSurface& PlaneSurface::operator=(const PlaneSurface& other) {
   return *this;
 }
 
+RotationMatrix3 PlaneSurface::referenceFrame(
+    const GeometryContext& gctx) const {
+  return localToGlobalTransform(gctx).matrix().block<3, 3>(0, 0);
+}
+
 Surface::SurfaceType PlaneSurface::type() const {
   return Surface::Plane;
 }


### PR DESCRIPTION


--- END COMMIT MESSAGE ---

