### PR TITLE
feat: Add appending of track states to tracks in PyACTS bindings

### DIFF
--- a/Examples/Configs/generic-pixel-sstrips-lstrips-spacepoints.json
+++ b/Examples/Configs/generic-pixel-sstrips-lstrips-spacepoints.json
@@ -1,0 +1,29 @@
+[
+    {
+        "volume": 7
+    },
+    {
+        "volume": 8
+    },
+    {
+        "volume": 9
+    },
+    {
+        "volume": 12
+    },
+    {
+        "volume": 13
+    },
+    {
+        "volume": 14
+    },
+    {
+        "volume": 16
+    },
+    {
+        "volume": 17
+    },
+    {
+        "volume": 18
+    }
+]

--- a/Examples/Scripts/Python/track_finding_python_only.py
+++ b/Examples/Scripts/Python/track_finding_python_only.py
@@ -79,6 +79,7 @@ def runTrackFindingPythonOnly(
         )
     )
 
+    # Option 1: Implement a track finding algorithm...
     class PythonTrackFinder(acts.examples.IAlgorithm):
         def __init__(self, name, level):
             acts.examples.IAlgorithm.__init__(self, name, level)
@@ -108,7 +109,26 @@ def runTrackFindingPythonOnly(
             self.prototracks(context, prototracks)
             return acts.examples.ProcessCode.SUCCESS
 
-    s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
+    # s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
+
+    # ... or option 2: use truth values
+    trkParamExtractor = acts.examples.ParticleTrackParamExtractor(
+        level=acts.logging.INFO,
+        inputParticles="particles_generated_selected",
+        outputTrackParameters="true_parameters",
+    )
+    s.addAlgorithm(trkParamExtractor)
+
+    truthTrkFndAlg = acts.examples.TruthTrackFinder(
+        level=acts.logging.INFO,
+        inputParticles="particles_generated_selected",
+        inputMeasurements="measurements",
+        inputParticleMeasurementsMap="particle_measurements_map",
+        inputSimHits="simhits",
+        inputMeasurementSimHitsMap="measurement_simhits_map",
+        outputProtoTracks="truth_particle_tracks",
+    )
+    s.addAlgorithm(truthTrkFndAlg)
 
     class PythonTrackFitter(acts.examples.IAlgorithm):
         def __init__(self, name, level):
@@ -117,21 +137,48 @@ def runTrackFindingPythonOnly(
             self.prototracks = acts.examples.ReadDataHandle(
                 self, acts.examples.ProtoTrackContainer, "Prototracks"
             )
-            self.prototracks.initialize("prototracks")
+            self.prototracks.initialize("truth_particle_tracks")
 
             self.tracks = acts.examples.WriteDataHandle(
                 self, acts.examples.ConstTrackContainer, "Tracks"
             )
             self.tracks.initialize("fitted_tracks")
 
+            self.spacepoints = acts.examples.ReadDataHandle(
+                self, acts.SpacePointContainer2, "Spacepoints"
+            )
+            self.spacepoints.initialize("spacepoints")
+
         def execute(self, context):
             prototracks = self.prototracks(context.eventStore)
+            spacepoints = self.spacepoints(context.eventStore)
+
+            measurement_to_spacepoint = {}
+            measurement_to_sourcelink = {}
+            for sp in spacepoints:
+                for sl in sp.sourceLinks:
+                    isl = acts.examples.IndexSourceLink.FromSourceLink(sl)
+                    meas_id = isl.index()
+                    measurement_to_spacepoint[meas_id] = sp
+                    measurement_to_sourcelink[meas_id] = sl
+            surface_map = trackingGeometry.geoIdSurfaceMap()
 
             container = acts.examples.TrackContainer()
             for prototrack in prototracks:
                 track = container.makeTrack()
                 track.parameters = acts.BoundVector(1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
                 track.nMeasurements = len(prototrack)
+
+                for meas_id in prototrack:
+                    sp = measurement_to_spacepoint[meas_id]
+                    sl = measurement_to_sourcelink[meas_id]
+                    isl = acts.examples.IndexSourceLink.FromSourceLink(sl)
+                    sf = surface_map[isl.geometryId()]
+
+                    trackState = track.appendTrackState()
+                    trackState.setIsMeasurement()
+                    trackState.setUncalibratedSourceLink(sl)
+                    trackState.setReferenceSurface(sf)
 
             self.tracks(context, container.makeConst())
             return acts.examples.ProcessCode.SUCCESS
@@ -174,7 +221,7 @@ if __name__ == "__main__":
     field = acts.ConstantBField(acts.Vector3(0.0, 0.0, 2.0 * u.T))
 
     digiConfigFile = srcdir / "Examples/Configs/generic-digi-smearing-config.json"
-    geoSelectionConfigFile = srcdir / "Examples/Configs/generic-seeding-config.json"
+    geoSelectionConfigFile = srcdir / "Examples/Configs/generic-pixel-sstrips-lstrips-spacepoints.json"
 
     outputDir = Path.cwd() / "output_track_finding_python_only"
     outputDir.mkdir(exist_ok=True)

--- a/Examples/Scripts/Python/track_finding_python_only.py
+++ b/Examples/Scripts/Python/track_finding_python_only.py
@@ -109,7 +109,7 @@ def runTrackFindingPythonOnly(
             self.prototracks(context, prototracks)
             return acts.examples.ProcessCode.SUCCESS
 
-    # s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
+    s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
 
     # ... or option 2: use truth values
     trkParamExtractor = acts.examples.ParticleTrackParamExtractor(
@@ -117,7 +117,7 @@ def runTrackFindingPythonOnly(
         inputParticles="particles_generated_selected",
         outputTrackParameters="true_parameters",
     )
-    s.addAlgorithm(trkParamExtractor)
+    # s.addAlgorithm(trkParamExtractor)
 
     truthTrkFndAlg = acts.examples.TruthTrackFinder(
         level=acts.logging.INFO,
@@ -126,9 +126,9 @@ def runTrackFindingPythonOnly(
         inputParticleMeasurementsMap="particle_measurements_map",
         inputSimHits="simhits",
         inputMeasurementSimHitsMap="measurement_simhits_map",
-        outputProtoTracks="truth_particle_tracks",
+        outputProtoTracks="prototracks",
     )
-    s.addAlgorithm(truthTrkFndAlg)
+    # s.addAlgorithm(truthTrkFndAlg)
 
     class PythonTrackFitter(acts.examples.IAlgorithm):
         def __init__(self, name, level):
@@ -137,7 +137,7 @@ def runTrackFindingPythonOnly(
             self.prototracks = acts.examples.ReadDataHandle(
                 self, acts.examples.ProtoTrackContainer, "Prototracks"
             )
-            self.prototracks.initialize("truth_particle_tracks")
+            self.prototracks.initialize("prototracks")
 
             self.tracks = acts.examples.WriteDataHandle(
                 self, acts.examples.ConstTrackContainer, "Tracks"
@@ -176,9 +176,9 @@ def runTrackFindingPythonOnly(
                     sf = surface_map[isl.geometryId()]
 
                     trackState = track.appendTrackState()
-                    trackState.setIsMeasurement()
-                    trackState.setUncalibratedSourceLink(sl)
-                    trackState.setReferenceSurface(sf)
+                    trackState.typeFlags.isMeasurement = True
+                    trackState.uncalibratedSourceLink = sl
+                    trackState.referenceSurface = sf
 
             self.tracks(context, container.makeConst())
             return acts.examples.ProcessCode.SUCCESS
@@ -221,7 +221,9 @@ if __name__ == "__main__":
     field = acts.ConstantBField(acts.Vector3(0.0, 0.0, 2.0 * u.T))
 
     digiConfigFile = srcdir / "Examples/Configs/generic-digi-smearing-config.json"
-    geoSelectionConfigFile = srcdir / "Examples/Configs/generic-pixel-sstrips-lstrips-spacepoints.json"
+    geoSelectionConfigFile = (
+        srcdir / "Examples/Configs/generic-pixel-sstrips-lstrips-spacepoints.json"
+    )
 
     outputDir = Path.cwd() / "output_track_finding_python_only"
     outputDir.mkdir(exist_ok=True)

--- a/Examples/Scripts/Python/track_finding_python_only.py
+++ b/Examples/Scripts/Python/track_finding_python_only.py
@@ -109,7 +109,7 @@ def runTrackFindingPythonOnly(
             self.prototracks(context, prototracks)
             return acts.examples.ProcessCode.SUCCESS
 
-    # s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
+    s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
 
     # ... or option 2: use truth values
     truthTrkFndAlg = acts.examples.TruthTrackFinder(
@@ -121,7 +121,7 @@ def runTrackFindingPythonOnly(
         inputMeasurementSimHitsMap="measurement_simhits_map",
         outputProtoTracks="prototracks",
     )
-    s.addAlgorithm(truthTrkFndAlg)
+    # s.addAlgorithm(truthTrkFndAlg)
 
     class PythonTrackFitter(acts.examples.IAlgorithm):
         def __init__(self, name, level):

--- a/Examples/Scripts/Python/track_finding_python_only.py
+++ b/Examples/Scripts/Python/track_finding_python_only.py
@@ -109,16 +109,9 @@ def runTrackFindingPythonOnly(
             self.prototracks(context, prototracks)
             return acts.examples.ProcessCode.SUCCESS
 
-    s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
+    # s.addAlgorithm(PythonTrackFinder("PythonTrackFinder", acts.logging.INFO))
 
     # ... or option 2: use truth values
-    trkParamExtractor = acts.examples.ParticleTrackParamExtractor(
-        level=acts.logging.INFO,
-        inputParticles="particles_generated_selected",
-        outputTrackParameters="true_parameters",
-    )
-    # s.addAlgorithm(trkParamExtractor)
-
     truthTrkFndAlg = acts.examples.TruthTrackFinder(
         level=acts.logging.INFO,
         inputParticles="particles_generated_selected",
@@ -128,7 +121,7 @@ def runTrackFindingPythonOnly(
         inputMeasurementSimHitsMap="measurement_simhits_map",
         outputProtoTracks="prototracks",
     )
-    # s.addAlgorithm(truthTrkFndAlg)
+    s.addAlgorithm(truthTrkFndAlg)
 
     class PythonTrackFitter(acts.examples.IAlgorithm):
         def __init__(self, name, level):

--- a/Python/Core/src/Geometry.cpp
+++ b/Python/Core/src/Geometry.cpp
@@ -175,6 +175,13 @@ void addGeometry(py::module_& m) {
               self = self.withExtra(value);
             })
         .def_property_readonly("value", &GeometryIdentifier::value)
+        .def("__eq__", [](const GeometryIdentifier& self,
+                           const GeometryIdentifier& other) {
+          return self == other;
+        })
+        .def("__hash__", [](const GeometryIdentifier& self) {
+          return std::hash<GeometryIdentifier>{}(self);
+        })
         .def("__str__", [](const GeometryIdentifier& self) {
           std::stringstream ss;
           ss << self;

--- a/Python/Core/src/Geometry.cpp
+++ b/Python/Core/src/Geometry.cpp
@@ -175,13 +175,13 @@ void addGeometry(py::module_& m) {
               self = self.withExtra(value);
             })
         .def_property_readonly("value", &GeometryIdentifier::value)
-        .def("__eq__", [](const GeometryIdentifier& self,
-                           const GeometryIdentifier& other) {
-          return self == other;
-        })
-        .def("__hash__", [](const GeometryIdentifier& self) {
-          return std::hash<GeometryIdentifier>{}(self);
-        })
+        .def("__eq__",
+             [](const GeometryIdentifier& self,
+                const GeometryIdentifier& other) { return self == other; })
+        .def("__hash__",
+             [](const GeometryIdentifier& self) {
+               return std::hash<GeometryIdentifier>{}(self);
+             })
         .def("__str__", [](const GeometryIdentifier& self) {
           std::stringstream ss;
           ss << self;

--- a/Python/Examples/src/EventData.cpp
+++ b/Python/Examples/src/EventData.cpp
@@ -104,12 +104,59 @@ void addEventData(py::module& mex) {
       .def_property_readonly("hasParameters",
                              &Acts::TrackStateType::hasParameters);
 
+  py::class_<Acts::ConstTrackStateTypeMap>(mex, "ConstTrackStateTypeFlags")
+      .def_property_readonly("hasMeasurement",
+                             &Acts::ConstTrackStateTypeMap::hasMeasurement)
+      .def_property_readonly("isMeasurement",
+                             &Acts::ConstTrackStateTypeMap::isMeasurement)
+      .def_property_readonly("isOutlier",
+                             &Acts::ConstTrackStateTypeMap::isOutlier)
+      .def_property_readonly("isHole", &Acts::ConstTrackStateTypeMap::isHole)
+      .def_property_readonly("hasMaterial",
+                             &Acts::ConstTrackStateTypeMap::hasMaterial)
+      .def_property_readonly("isSharedHit",
+                             &Acts::ConstTrackStateTypeMap::isSharedHit)
+      .def_property_readonly("hasParameters",
+                             &Acts::ConstTrackStateTypeMap::hasParameters);
+
+  py::class_<Acts::MutableTrackStateTypeMap>(mex, "MutableTrackStateTypeFlags")
+      .def_property("hasMeasurement",
+                    &Acts::MutableTrackStateTypeMap::hasMeasurement,
+                    [](Acts::MutableTrackStateTypeMap& self, bool value) {
+                      self.setHasMeasurement(value);
+                    })
+      .def_property("isMeasurement",
+                    &Acts::MutableTrackStateTypeMap::isMeasurement,
+                    [](Acts::MutableTrackStateTypeMap& self, bool value) {
+                      if (value) {
+                        self.setIsMeasurement();
+                      } else if (self.isMeasurement()) {
+                        self.setHasMeasurement(false);
+                      }
+                    })
+      .def_property("isOutlier", &Acts::MutableTrackStateTypeMap::isOutlier,
+                    [](Acts::MutableTrackStateTypeMap& self, bool value) {
+                      self.setIsOutlier(value);
+                    })
+      .def_property("isHole", &Acts::MutableTrackStateTypeMap::isHole,
+                    [](Acts::MutableTrackStateTypeMap& self, bool value) {
+                      self.setIsHole(value);
+                    })
+      .def_property_readonly("hasMaterial",
+                             &Acts::MutableTrackStateTypeMap::hasMaterial)
+      .def_property("isSharedHit", &Acts::MutableTrackStateTypeMap::isSharedHit,
+                    [](Acts::MutableTrackStateTypeMap& self, bool value) {
+                      self.setIsSharedHit(value);
+                    })
+      .def_property_readonly("hasParameters",
+                             &Acts::MutableTrackStateTypeMap::hasParameters);
+
   py::class_<ConstTrackStateProxy>(mex, "ConstTrackStateProxy")
       .def_property_readonly(
           "typeFlags",
-          [](const ConstTrackStateProxy& self) {
-            return Acts::TrackStateType{self.typeFlags().raw()};
-          })
+          py::cpp_function(
+              [](const ConstTrackStateProxy& self) { return self.typeFlags(); },
+              py::keep_alive<0, 1>()))
       .def_property_readonly("hasPredicted",
                              &ConstTrackStateProxy::hasPredicted)
       .def_property_readonly("hasFiltered", &ConstTrackStateProxy::hasFiltered)
@@ -144,18 +191,24 @@ void addEventData(py::module& mex) {
       .def_property_readonly("pathLength", &ConstTrackStateProxy::pathLength);
 
   py::class_<TrackStateProxy>(mex, "TrackStateProxy")
-      .def_property_readonly(
-          "typeFlags",
-          [](const TrackStateProxy& self) {
-            return Acts::TrackStateType{self.typeFlags().raw()};
-          })
+      .def_property_readonly("typeFlags", py::cpp_function(
+                                              [](TrackStateProxy& self) {
+                                                return self.typeFlags();
+                                              },
+                                              py::keep_alive<0, 1>()))
       .def_property_readonly("hasPredicted", &TrackStateProxy::hasPredicted)
       .def_property_readonly("hasFiltered", &TrackStateProxy::hasFiltered)
       .def_property_readonly("hasSmoothed", &TrackStateProxy::hasSmoothed)
       .def_property_readonly("hasReferenceSurface",
                              &TrackStateProxy::hasReferenceSurface)
-      .def_property_readonly("referenceSurface",
-                             &TrackStateProxy::referenceSurface)
+      .def_property(
+          "referenceSurface",
+          [](const TrackStateProxy& self) -> const Acts::Surface& {
+            return self.referenceSurface();
+          },
+          [](TrackStateProxy& self, std::shared_ptr<const Acts::Surface> srf) {
+            self.setReferenceSurface(std::move(srf));
+          })
       .def_property_readonly("predicted",
                              [](const TrackStateProxy& self) {
                                return Acts::BoundVector{self.predicted()};
@@ -183,44 +236,18 @@ void addEventData(py::module& mex) {
           [](const TrackStateProxy& self) {
             return Acts::BoundMatrix{self.smoothedCovariance()};
           })
-      .def("setReferenceSurface",
-           [](TrackStateProxy& self,
-              std::shared_ptr<const Acts::Surface> srf) {
-             self.setReferenceSurface(std::move(srf));
-           })
-      .def("getUncalibratedSourceLink",
-           &TrackStateProxy::getUncalibratedSourceLink)
-      .def("setUncalibratedSourceLink",
-           [](TrackStateProxy& self, const Acts::SourceLink& sourceLink) {
-             self.setUncalibratedSourceLink(Acts::SourceLink{sourceLink});
-           })
-      .def("setHasMeasurement",
-           [](TrackStateProxy& self, bool value = true) {
-             self.typeFlags().setHasMeasurement(value);
-           },
-           py::arg("value") = true)
-      .def("setIsMeasurement",
-           [](TrackStateProxy& self) { self.typeFlags().setIsMeasurement(); })
-      .def("setIsOutlier",
-           [](TrackStateProxy& self, bool value = true) {
-             self.typeFlags().setIsOutlier(value);
-           },
-           py::arg("value") = true)
-      .def("setIsHole",
-           [](TrackStateProxy& self, bool value = true) {
-             self.typeFlags().setIsHole(value);
-           },
-           py::arg("value") = true)
-      .def("setIsSharedHit",
-           [](TrackStateProxy& self, bool value = true) {
-             self.typeFlags().setIsSharedHit(value);
-           },
-           py::arg("value") = true)
+      .def_property(
+          "uncalibratedSourceLink", &TrackStateProxy::getUncalibratedSourceLink,
+          [](TrackStateProxy& self, const Acts::SourceLink& sourceLink) {
+            self.setUncalibratedSourceLink(Acts::SourceLink{sourceLink});
+          })
       .def("allocateCalibrated",
            [](TrackStateProxy& self, std::size_t measdim) {
              self.allocateCalibrated(measdim);
            })
-      .def_property_readonly("pathLength", &TrackStateProxy::pathLength);
+      .def_property_readonly("pathLength", [](const TrackStateProxy& self) {
+        return self.pathLength();
+      });
 
   auto constTrackProxy =
       py::class_<ConstTrackProxy>(mex, "ConstTrackProxy")
@@ -439,9 +466,10 @@ void addEventData(py::module& mex) {
       .def_property(
           "chi2", [](const TrackProxy& self) -> float { return self.chi2(); },
           [](TrackProxy& self, float v) { self.chi2() = v; })
-      .def("appendTrackState",
-           [](TrackProxy& self) { return self.appendTrackState(); },
-           py::keep_alive<0, 1>());
+      .def(
+          "appendTrackState",
+          [](TrackProxy& self) { return self.appendTrackState(); },
+          py::keep_alive<0, 1>());
 
   py::class_<TrackContainer>(mex, "TrackContainer")
       .def(py::init([]() {

--- a/Python/Examples/src/EventData.cpp
+++ b/Python/Examples/src/EventData.cpp
@@ -93,6 +93,8 @@ namespace ActsPython {
 
 void addEventData(py::module& mex) {
   py::class_<Acts::TrackStateType>(mex, "TrackStateTypeFlags")
+      .def_property_readonly("hasMeasurement",
+                             &Acts::TrackStateType::hasMeasurement)
       .def_property_readonly("isMeasurement",
                              &Acts::TrackStateType::isMeasurement)
       .def_property_readonly("isOutlier", &Acts::TrackStateType::isOutlier)
@@ -140,6 +142,85 @@ void addEventData(py::module& mex) {
             return Acts::BoundMatrix{self.smoothedCovariance()};
           })
       .def_property_readonly("pathLength", &ConstTrackStateProxy::pathLength);
+
+  py::class_<TrackStateProxy>(mex, "TrackStateProxy")
+      .def_property_readonly(
+          "typeFlags",
+          [](const TrackStateProxy& self) {
+            return Acts::TrackStateType{self.typeFlags().raw()};
+          })
+      .def_property_readonly("hasPredicted", &TrackStateProxy::hasPredicted)
+      .def_property_readonly("hasFiltered", &TrackStateProxy::hasFiltered)
+      .def_property_readonly("hasSmoothed", &TrackStateProxy::hasSmoothed)
+      .def_property_readonly("hasReferenceSurface",
+                             &TrackStateProxy::hasReferenceSurface)
+      .def_property_readonly("referenceSurface",
+                             &TrackStateProxy::referenceSurface)
+      .def_property_readonly("predicted",
+                             [](const TrackStateProxy& self) {
+                               return Acts::BoundVector{self.predicted()};
+                             })
+      .def_property_readonly("filtered",
+                             [](const TrackStateProxy& self) {
+                               return Acts::BoundVector{self.filtered()};
+                             })
+      .def_property_readonly("smoothed",
+                             [](const TrackStateProxy& self) {
+                               return Acts::BoundVector{self.smoothed()};
+                             })
+      .def_property_readonly(
+          "predictedCovariance",
+          [](const TrackStateProxy& self) {
+            return Acts::BoundMatrix{self.predictedCovariance()};
+          })
+      .def_property_readonly(
+          "filteredCovariance",
+          [](const TrackStateProxy& self) {
+            return Acts::BoundMatrix{self.filteredCovariance()};
+          })
+      .def_property_readonly(
+          "smoothedCovariance",
+          [](const TrackStateProxy& self) {
+            return Acts::BoundMatrix{self.smoothedCovariance()};
+          })
+      .def("setReferenceSurface",
+           [](TrackStateProxy& self,
+              std::shared_ptr<const Acts::Surface> srf) {
+             self.setReferenceSurface(std::move(srf));
+           })
+      .def("getUncalibratedSourceLink",
+           &TrackStateProxy::getUncalibratedSourceLink)
+      .def("setUncalibratedSourceLink",
+           [](TrackStateProxy& self, const Acts::SourceLink& sourceLink) {
+             self.setUncalibratedSourceLink(Acts::SourceLink{sourceLink});
+           })
+      .def("setHasMeasurement",
+           [](TrackStateProxy& self, bool value = true) {
+             self.typeFlags().setHasMeasurement(value);
+           },
+           py::arg("value") = true)
+      .def("setIsMeasurement",
+           [](TrackStateProxy& self) { self.typeFlags().setIsMeasurement(); })
+      .def("setIsOutlier",
+           [](TrackStateProxy& self, bool value = true) {
+             self.typeFlags().setIsOutlier(value);
+           },
+           py::arg("value") = true)
+      .def("setIsHole",
+           [](TrackStateProxy& self, bool value = true) {
+             self.typeFlags().setIsHole(value);
+           },
+           py::arg("value") = true)
+      .def("setIsSharedHit",
+           [](TrackStateProxy& self, bool value = true) {
+             self.typeFlags().setIsSharedHit(value);
+           },
+           py::arg("value") = true)
+      .def("allocateCalibrated",
+           [](TrackStateProxy& self, std::size_t measdim) {
+             self.allocateCalibrated(measdim);
+           })
+      .def_property_readonly("pathLength", &TrackStateProxy::pathLength);
 
   auto constTrackProxy =
       py::class_<ConstTrackProxy>(mex, "ConstTrackProxy")
@@ -357,7 +438,10 @@ void addEventData(py::module& mex) {
           [](TrackProxy& self, std::uint32_t n) { self.nHoles() = n; })
       .def_property(
           "chi2", [](const TrackProxy& self) -> float { return self.chi2(); },
-          [](TrackProxy& self, float v) { self.chi2() = v; });
+          [](TrackProxy& self, float v) { self.chi2() = v; })
+      .def("appendTrackState",
+           [](TrackProxy& self) { return self.appendTrackState(); },
+           py::keep_alive<0, 1>());
 
   py::class_<TrackContainer>(mex, "TrackContainer")
       .def(py::init([]() {


### PR DESCRIPTION
feat: Python bindings for appending track states to tracks + setting track state flags

This pull request adds Python bindings that allow for appending track states to tracks and setting track state flags. A brief example of usage has also been added in `track_finding_python_only.py`.