### PR TITLE
fix: Expand the detray component label to the detray plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,6 +13,7 @@
   - changed-files:
     - any-glob-to-any-file:
       - Detray/**
+      - Plugins/Detray/**
       - .github/detray.yml
 'Component - Examples':
   - changed-files:


### PR DESCRIPTION
Makes sure, PRs that make changes to the detray plugin are labeled correctly

--- END COMMIT MESSAGE ---
