### PR TITLE
fix: explicitly include <DD4hep/Fields.h> from DD4hepFieldAdapter

### DIFF
--- a/Plugins/DD4hep/include/ActsPlugins/DD4hep/DD4hepFieldAdapter.hpp
+++ b/Plugins/DD4hep/include/ActsPlugins/DD4hep/DD4hepFieldAdapter.hpp
@@ -13,9 +13,7 @@
 
 #include <memory>
 
-namespace dd4hep {
-class OverlayedField;
-}
+#include <DD4hep/Fields.h>
 
 namespace ActsPlugins {
 /// @addtogroup dd4hep_plugin


### PR DESCRIPTION
This fixes a compilation error with gcc 15
```
/include/c++/15.2.0/bits/unique_ptr.h:91:23: error: invalid application of 'sizeof' to incomplete type 'dd4hep::OverlayedField'
         static_assert(sizeof(_Tp)>0,
                       ^~~~~~~~~~~
```