### PR TITLE
fix: Make `JsonSurfacesWriter` work with `ConvexPolygonBounds`

### DIFF
--- a/Plugins/Json/src/SurfaceJsonConverter.cpp
+++ b/Plugins/Json/src/SurfaceJsonConverter.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Surfaces/AnnulusBounds.hpp"
 #include "Acts/Surfaces/ConeBounds.hpp"
 #include "Acts/Surfaces/ConeSurface.hpp"
+#include "Acts/Surfaces/ConvexPolygonBounds.hpp"
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiamondBounds.hpp"
@@ -60,6 +61,11 @@ std::string getSurfaceBoundsKind() {
     return "Cone";
   } else if (std::is_same_v<bounds_t, Acts::LineBounds>) {
     return "Line";
+  } else if (std::is_same_v<bounds_t, Acts::ConvexPolygonBoundsBase>) {
+    // Single kind for every Acts::ConvexPolygonBounds<N> specialization
+    // (including PolygonDynamic), routed via the abstract base class so the
+    // TypeDispatcher only needs one registration.
+    return "ConvexPolygon";
   } else if (std::is_same_v<bounds_t, Acts::SurfaceBounds>) {
     return "DefaultBounds";
   } else if (std::is_same_v<bounds_t, Acts::InfiniteBounds>) {
@@ -225,6 +231,16 @@ Acts::SurfaceJsonConverter::Config::defaultConfig() {
   cfg.surfaceBoundsEncoder.registerFunction(surfaceBoundsToJsonT<LineBounds>);
   cfg.surfaceBoundsEncoder.registerFunction(
       surfaceBoundsToJsonT<InfiniteBounds>);
+  // ConvexPolygonBounds is templated on the vertex count N. Registering the
+  // abstract ConvexPolygonBoundsBase lets a single encoder handle every
+  // specialization (ConvexPolygonBounds<3>, <4>, <6>, ..., <PolygonDynamic>);
+  // the runtime dynamic_cast inside TypeDispatcher resolves them all to the
+  // same handler. This fixes the regression introduced by PR #5195 where TGeo
+  // shapes that produce ConvexPolygonBounds<4> (e.g. TGeoTrap / TGeoArb8) made
+  // the JsonSurfacesWriter throw "No function registered for type:
+  // Acts::ConvexPolygonBounds<4>".
+  cfg.surfaceBoundsEncoder.registerFunction(
+      surfaceBoundsToJsonT<ConvexPolygonBoundsBase>);
 
   // Decoders
   cfg.surfaceDecoder.registerKind(
@@ -242,6 +258,34 @@ Acts::SurfaceJsonConverter::Config::defaultConfig() {
   cfg.surfaceDecoder.registerKind(
       getSurfaceKind<PlaneSurface>() + getSurfaceBoundsKind<InfiniteBounds>(),
       surfaceFromJsonT<PlaneSurface>);
+  // Custom decoder for ConvexPolygonBounds: the number of vertices is encoded
+  // only via the size of the "values" array (2 doubles per vertex), so we
+  // build a dynamically-sized polygon. The kind string ("PlaneConvexPolygon")
+  // is the same one the encoder writes, since getSurfaceBoundsKind returns
+  // "ConvexPolygon" for any ConvexPolygonBounds<N>.
+  cfg.surfaceDecoder.registerKind(
+      getSurfaceKind<PlaneSurface>() +
+          getSurfaceBoundsKind<ConvexPolygonBoundsBase>(),
+      [](const nlohmann::json& j) -> std::shared_ptr<Surface> {
+        Transform3 sTransform =
+            Transform3JsonConverter::fromJson(j["transform"]);
+        std::vector<double> bVector = j["bounds"]["values"];
+        if (bVector.size() < 6 || bVector.size() % 2 != 0) {
+          throw std::invalid_argument(
+              "Invalid ConvexPolygonBounds 'values' array: need an even "
+              "number of entries (>= 6) encoding at least 3 (x, y) vertices");
+        }
+        std::vector<Vector2> vertices;
+        vertices.reserve(bVector.size() / 2);
+        for (std::size_t i = 0; i < bVector.size(); i += 2) {
+          vertices.emplace_back(bVector[i], bVector[i + 1]);
+        }
+        auto sBounds =
+            std::make_shared<const ConvexPolygonBounds<PolygonDynamic>>(
+                vertices);
+        return Surface::makeShared<PlaneSurface>(sTransform,
+                                                 std::move(sBounds));
+      });
 
   cfg.surfaceDecoder.registerKind(
       getSurfaceKind<DiscSurface>() + getSurfaceBoundsKind<AnnulusBounds>(),


### PR DESCRIPTION
Before PR [#5195](https://github.com/acts-project/acts/pull/5195), `SurfaceJsonConverter::toJson` worked for any SurfaceBounds subclass. PR #5195 introduced the type-based TypeDispatcher, populated by `Config::defaultConfig()` in `Plugins/Json/src/SurfaceJsonConverter.cpp`. The default registration covers all bounds but not `ConvexPolygonBounds<N>`. The dispatcher then throws the error (`TypeDispatcher.hpp`:132–135) "RuntimeError: No function registered for type: Acts::ConvexPolygonBounds<4>").
The Fix:
1) Added `#include "Acts/Surfaces/ConvexPolygonBounds.hpp"`
2) Added a `getSurfaceBoundsKind<>` branch for `ConvexPolygonBoundsBase` returning "ConvexPolygon"
3) Registered `surfaceBoundsToJsonT<ConvexPolygonBoundsBase>` in `Config::defaultConfig()`
4) Registered "PlaneConvexPolygon" decoder.

Example from resulting .json:
<img width="425" height="571" alt="image" src="https://github.com/user-attachments/assets/93494ea2-7680-4d40-8ca8-9c149f248b8e" />
