### PR TITLE
ci: Run detray GitLab CI only for detray changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -511,6 +511,10 @@ detray_build_cuda:
   artifacts:
     paths:
       - build
+  only:
+    changes:
+      - Detray/*
+      - .gitlab-ci.yml
   script:
       - git clone $CLONE_URL src
       - git -C src checkout $HEAD_SHA
@@ -530,6 +534,10 @@ detray_test_cuda:
   image: ghcr.io/acts-project/ubuntu2404_cuda:82
   needs:
     - detray_build_cuda
+  only:
+    changes:
+      - Detray/*
+      - .gitlab-ci.yml
   script:
     - git clone $CLONE_URL src
     - git -C src checkout $HEAD_SHA
@@ -548,6 +556,10 @@ detray_build_sycl:
   artifacts:
     paths:
       - build
+  only:
+    changes:
+      - Detray/*
+      - .gitlab-ci.yml
   script:
       - git clone $CLONE_URL src
       - git -C src checkout $HEAD_SHA
@@ -567,6 +579,10 @@ detray_test_sycl:
     - detray_build_sycl
   variables:
     ONEAPI_DEVICE_SELECTOR: "*:cpu"
+  only:
+    changes:
+      - Detray/*
+      - .gitlab-ci.yml
   script:
     - git clone $CLONE_URL src
     - git -C src checkout $HEAD_SHA


### PR DESCRIPTION
Currently, the detray GitLab CI runs for any PR. This consumes a lot of resources, so this commit changes the CI configuration to run only when the `Detray/` directory is changed.

--- END COMMIT MESSAGE ---

Tagging @niermann999, @andiwand.