### PR TITLE
build: find VDT quietly since it is not used anymore with ROOT 6.40

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,7 +502,7 @@ endif()
 if(ACTS_BUILD_PLUGIN_ROOT)
     # In the ATLAS build, the ROOT find_package call does not find VDT unless these variables are set.
     # This should not affect other environments.
-    find_package(VDT)
+    find_package(VDT QUIET)
     if(VDT_FOUND)
         set(VDT_INCLUDE_DIR "${VDT_INCLUDE_DIR}" CACHE PATH "")
         set(VDT_LIBRARY "${VDT_vdt_LIBRARY}" CACHE FILEPATH "")


### PR DESCRIPTION
to suppress a CMake warning that will always appear with ROOT >= 6.40.