### PR TITLE
fix: Avoid use-after-free in Any copy assignment with type change

### DIFF
--- a/Core/include/Acts/Utilities/Any.hpp
+++ b/Core/include/Acts/Utilities/Any.hpp
@@ -207,8 +207,14 @@ class AnyBase : public AnyBaseAll {
   T& emplace(Args&&... args) {
     using U = std::decay_t<T>;
     destroy();
+    // Construct the new value before installing the handler. constructValue
+    // does not depend on m_handler, so if the constructor throws this object is
+    // left empty (m_handler == nullptr) rather than claiming to hold a value
+    // whose storage was never set up, which would make the next destroy()
+    // operate on stale/freed memory.
+    U* ptr = constructValue<U>(std::forward<Args>(args)...);
     m_handler = makeHandler<U>();
-    return *constructValue<U>(std::forward<Args>(args)...);
+    return *ptr;
   }
 
   /// Get reference to stored value of specified type
@@ -325,6 +331,11 @@ class AnyBase : public AnyBaseAll {
     _ACTS_ANY_VERBOSE("Copy assign (this="
                       << this << ") at: " << static_cast<void*>(m_data.data()));
 
+    if (this == &other) {
+      // self-assignment, noop
+      return *this;
+    }
+
     if (m_handler == nullptr && other.m_handler == nullptr) {
       // both are empty, noop
       return *this;
@@ -370,6 +381,11 @@ class AnyBase : public AnyBaseAll {
   AnyBase& operator=(AnyBase&& other) noexcept(detail::kAnyNoexcept) {
     _ACTS_ANY_VERBOSE("Move assign (this="
                       << this << ") at: " << static_cast<void*>(m_data.data()));
+    if (this == &other) {
+      // self-assignment, noop (avoids destroying our own value)
+      return *this;
+    }
+
     if (m_handler == nullptr && other.m_handler == nullptr) {
       // both are empty, noop
       return *this;

--- a/Core/include/Acts/Utilities/Any.hpp
+++ b/Core/include/Acts/Utilities/Any.hpp
@@ -570,20 +570,25 @@ class AnyBase : public AnyBaseAll {
       return;
     }
 
-    void* to = dataPtr();
     const void* from = fromAny.dataPtr();
 
     if (m_handler->copyConstruct == nullptr) {
       _ACTS_ANY_VERBOSE("Trivially copy construct");
       // trivially copy constructible
       m_data = fromAny.m_data;
+    } else if (m_handler->heapAllocated) {
+      // heap-allocated: always allocate fresh storage. We must not read the
+      // current contents of m_data here: when copyConstruct runs as part of a
+      // copy assignment with a type change, the previous value has already been
+      // destroyed but m_data still holds its stale bytes (a freed pointer, or
+      // the previous local value's bytes). Passing those as the destination
+      // would placement-new into garbage. Allocate and store the new pointer.
+      void* copyAt = m_handler->copyConstruct(from, nullptr);
+      assert(copyAt != nullptr);
+      setDataPtr(copyAt);
     } else {
-      void* copyAt = m_handler->copyConstruct(from, to);
-      if (to == nullptr) {
-        assert(copyAt != nullptr);
-        // copy allocated, store pointer
-        setDataPtr(copyAt);
-      }
+      // local storage: construct into the internal buffer
+      m_handler->copyConstruct(from, dataPtr());
     }
   }
 

--- a/Tests/UnitTests/Core/Utilities/AnyTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AnyTests.cpp
@@ -354,6 +354,39 @@ BOOST_AUTO_TEST_CASE(AnyCopyTypeChange) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(AnyCopyTypeChangeToHeap) {
+  // Copy-assigning a heap-allocated value over an Any that already holds a
+  // value of a different type. Before the fix this read the stale contents of
+  // the internal buffer as the copy destination (a freed pointer for the
+  // heap->heap case, or the previous local value's bytes for local->heap),
+  // resulting in a wild write / use-after-free.
+  using Large = std::array<unsigned long, 5>;
+
+  BOOST_TEST_CONTEXT("local -> heap") {
+    Any a{42};
+    Large v{1, 2, 3, 4, 5};
+    Any b{v};
+    a = b;
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.as<Large>().begin(), a.as<Large>().end(),
+                                  v.begin(), v.end());
+    // source is left intact
+    BOOST_CHECK_EQUAL_COLLECTIONS(b.as<Large>().begin(), b.as<Large>().end(),
+                                  v.begin(), v.end());
+  }
+  CHECK_ANY_ALLOCATIONS();
+
+  BOOST_TEST_CONTEXT("heap -> heap (different type)") {
+    std::array<int, 4> v1{1, 2, 3, 4};
+    Large v2{6, 7, 8, 9, 10};
+    Any a{v1};
+    Any b{v2};
+    a = b;
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.as<Large>().begin(), a.as<Large>().end(),
+                                  v2.begin(), v2.end());
+  }
+  CHECK_ANY_ALLOCATIONS();
+}
+
 BOOST_AUTO_TEST_CASE(AnyDestroy) {
   {  // small type
     bool destroyed = false;

--- a/Tests/UnitTests/Core/Utilities/AnyTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AnyTests.cpp
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -759,6 +760,82 @@ BOOST_AUTO_TEST_CASE(AnyTake) {
     Any a;
     BOOST_CHECK_THROW(a.take<int>(), std::bad_any_cast);
   }
+}
+
+struct ThrowOnDemand {
+  // larger than the small-buffer size, so this type is heap-allocated
+  std::array<char, 64> blob{};
+  explicit ThrowOnDemand(bool doThrow) {
+    if (doThrow) {
+      throw std::runtime_error{"boom"};
+    }
+  }
+};
+
+BOOST_AUTO_TEST_CASE(AnyEmplaceThrowingConstructor) {
+  // If the constructor of the emplaced type throws, the previously held value
+  // has already been destroyed, so the Any must be left empty rather than
+  // claiming to hold a value whose storage was never initialised (which would
+  // make the subsequent destruction operate on stale/freed memory).
+  BOOST_TEST_CONTEXT("local") {
+    struct SmallThrow {
+      int x{0};
+      explicit SmallThrow(bool doThrow) {
+        if (doThrow) {
+          throw std::runtime_error{"boom"};
+        }
+      }
+    };
+    Any a{std::in_place_type<SmallThrow>, false};
+    BOOST_CHECK(!!a);
+    BOOST_CHECK_THROW(a.emplace<SmallThrow>(true), std::runtime_error);
+    BOOST_CHECK(!a);
+  }
+  CHECK_ANY_ALLOCATIONS();
+
+  BOOST_TEST_CONTEXT("heap") {
+    Any a{std::in_place_type<ThrowOnDemand>, false};
+    BOOST_CHECK(!!a);
+    BOOST_CHECK_THROW(a.emplace<ThrowOnDemand>(true), std::runtime_error);
+    BOOST_CHECK(!a);
+  }
+  CHECK_ANY_ALLOCATIONS();
+}
+
+BOOST_AUTO_TEST_CASE(AnySelfAssign) {
+  using Large = std::array<unsigned long, 5>;
+
+  BOOST_TEST_CONTEXT("self copy-assign local") {
+    Any a{7};
+    Any& r = a;
+    a = r;
+    BOOST_CHECK_EQUAL(a.as<int>(), 7);
+  }
+  BOOST_TEST_CONTEXT("self copy-assign heap") {
+    Large v{1, 2, 3, 4, 5};
+    Any a{v};
+    Any& r = a;
+    a = r;
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.as<Large>().begin(), a.as<Large>().end(),
+                                  v.begin(), v.end());
+  }
+  BOOST_TEST_CONTEXT("self move-assign local") {
+    Any a{7};
+    Any& r = a;
+    a = std::move(r);
+    BOOST_CHECK(!!a);
+    BOOST_CHECK_EQUAL(a.as<int>(), 7);
+  }
+  BOOST_TEST_CONTEXT("self move-assign heap") {
+    Large v{1, 2, 3, 4, 5};
+    Any a{v};
+    Any& r = a;
+    a = std::move(r);
+    BOOST_CHECK(!!a);
+    BOOST_CHECK_EQUAL_COLLECTIONS(a.as<Large>().begin(), a.as<Large>().end(),
+                                  v.begin(), v.end());
+  }
+  CHECK_ANY_ALLOCATIONS();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes three bugs in a `Acts::Any`:

- it would copy into a freed memory address when copy constructing into an any with a type change
- `emplace` was not exception safe (any would claim to hold value that was never initialized)
- self assignment had unexpected behavior (invalidated itself). Fixed with a self assignment guard.