### PR TITLE
build(detray): Add CMake external include guards

### DIFF
--- a/Detray/extern/actsvg/CMakeLists.txt
+++ b/Detray/extern/actsvg/CMakeLists.txt
@@ -15,6 +15,13 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(TARGET actsvg::core)
+    message(
+        FATAL_ERROR
+        "Setup of actsvg requested, but target `actsvg::core` exists!"
+    )
+endif()
+
 # Tell the user what's happening.
 message(STATUS "Building actsvg as part of the Detray project")
 

--- a/Detray/extern/covfie/CMakeLists.txt
+++ b/Detray/extern/covfie/CMakeLists.txt
@@ -15,8 +15,15 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(TARGET covfie::core)
+    message(
+        FATAL_ERROR
+        "Setup of covfie requested, but target `covfie::core` exists!"
+    )
+endif()
+
 # Tell the user what's happening.
-message(STATUS "Fetching covfie as part of the Detray project")
+message(STATUS "Building covfie as part of the Detray project")
 
 # Declare where to get covfie from.
 set(DETRAY_COVFIE_SOURCE

--- a/Detray/extern/eigen3/CMakeLists.txt
+++ b/Detray/extern/eigen3/CMakeLists.txt
@@ -10,6 +10,13 @@
 cmake_minimum_required(VERSION 3.14)
 include(FetchContent)
 
+if(TARGET Eigen3::Eigen)
+    message(
+        FATAL_ERROR
+        "Setup of Eigen3 requested, but target `Eigen3::Eigen` exists!"
+    )
+endif()
+
 # Tell the user what's happening.
 message(STATUS "Building Eigen3 as part of the Detray project")
 

--- a/Detray/extern/nlohmann_json/CMakeLists.txt
+++ b/Detray/extern/nlohmann_json/CMakeLists.txt
@@ -14,6 +14,13 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(TARGET nlohmann_json::nlohmann_json)
+    message(
+        FATAL_ERROR
+        "Setup of nlohmann JSON requested, but target `nlohmann_json::nlohmann_json` exists!"
+    )
+endif()
+
 # Tell the user what's happening.
 message(STATUS "Building nlohmann_json as part of the detray project")
 

--- a/Detray/extern/vecmem/CMakeLists.txt
+++ b/Detray/extern/vecmem/CMakeLists.txt
@@ -15,6 +15,13 @@ if(POLICY CMP0135)
     cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(TARGET vecmem::core)
+    message(
+        FATAL_ERROR
+        "Setup of vecmem requested, but target `vecmem::core` exists!"
+    )
+endif()
+
 # Tell the user what's happening.
 message(STATUS "Building VecMem as part of the Detray project")
 


### PR DESCRIPTION
The detray setup currently makes it fairly easy to include dependencies twice through the FetchContent channel, and this can lead to extremely difficult to debug issues where multiple versions of a dependency fight for precedence. This commit therefore introduces some include guards, throwing an error if a configuration leads to the re-fetching of dependencies that are already in place.