### PR TITLE
feat: add options to use spacepoint time information in TripletSeeder, with a new ROOT seeding analysis tool

### DIFF
--- a/Core/include/Acts/Seeding2/BroadTripletSeedFilter.hpp
+++ b/Core/include/Acts/Seeding2/BroadTripletSeedFilter.hpp
@@ -141,6 +141,10 @@ class BroadTripletSeedFilter final : public ITripletSeedFilter {
     /// compatible SPs
     bool useDeltaRinsteadOfTopRadius = false;
 
+    /// time-ralated configurations
+    bool applyTripletTimeFilter = false;
+    float tripletTimeFilterChi2 = 15.f;
+
     /// Custom cuts interface for experiments
     std::shared_ptr<ITripletSeedCuts> experimentCuts;
   };

--- a/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
@@ -330,6 +330,10 @@ class DoubletSeedFinder {
     /// helix. This is useful for e.g. misaligned seeding.
     float helixCutTolerance = 1;
 
+    /// time-related configurations
+    bool applyTimeCut = false;
+    float timeCutCoff = 5.f;
+
     /// Type alias for delegate to apply experiment specific cuts during doublet
     /// finding
     using ExperimentCuts =

--- a/Core/src/Seeding2/BroadTripletSeedFilter.cpp
+++ b/Core/src/Seeding2/BroadTripletSeedFilter.cpp
@@ -348,6 +348,49 @@ void BroadTripletSeedFilter::filterTripletsMiddleFixed(
   std::size_t numTotalSeeds = 0;
   for (const auto& [bottom, middle, top, bestSeedQuality, zOrigin,
                     qualitySeed] : sortedCandidates) {
+    // calculate chi2 of the triplet time compatibility
+    if (config().applyTripletTimeFilter) {
+      const auto& spM = spacePoints[middle];
+      const auto& spB = spacePoints[bottom];
+      const auto& spT = spacePoints[top];
+
+      const float tM = spM.time();
+      const float tB = spB.time();
+      const float tT = spT.time();
+
+      if (!std::isnan(tB) && !std::isnan(tM) && !std::isnan(tT)) {
+        const float varianceTM = spM.varianceT();
+        const float t0M = tM - std::sqrt(spM.zr()[0] * spM.zr()[0] +
+                                         spM.zr()[1] * spM.zr()[1]) /
+                                   Acts::PhysicalConstants::c;
+        const float varianceTB = spB.varianceT();
+        const float t0B = tB - std::sqrt(spB.zr()[0] * spB.zr()[0] +
+                                         spB.zr()[1] * spB.zr()[1]) /
+                                   Acts::PhysicalConstants::c;
+        const float varianceTT = spT.varianceT();
+        const float t0T = tT - std::sqrt(spT.zr()[0] * spT.zr()[0] +
+                                         spT.zr()[1] * spT.zr()[1]) /
+                                   Acts::PhysicalConstants::c;
+
+        const float t0Mean = (t0B + t0M + t0T) / 3.f;
+        const float chi2_t0 = ((t0B - t0Mean) * (t0B - t0Mean)) / varianceTB +
+                              ((t0M - t0Mean) * (t0M - t0Mean)) / varianceTM +
+                              ((t0T - t0Mean) * (t0T - t0Mean)) / varianceTT;
+        if (chi2_t0 > config().tripletTimeFilterChi2) {
+          ACTS_VERBOSE("Triplet time compatibility chi2 is "
+                       << chi2_t0 << ", which is larger than the cut value "
+                       << config().tripletTimeFilterChi2
+                       << ", discarding the seed");
+          continue;
+        } else {
+          ACTS_VERBOSE("Triplet time compatibility chi2 is "
+                       << chi2_t0 << ", which is smaller than the cut value "
+                       << config().tripletTimeFilterChi2
+                       << ", keeping the seed");
+        }
+      }
+    }
+
     // stop if we reach the maximum number of seeds
     if (numTotalSeeds >= maxSeeds) {
       break;

--- a/Core/src/Seeding2/DoubletSeedFinder.cpp
+++ b/Core/src/Seeding2/DoubletSeedFinder.cpp
@@ -52,6 +52,10 @@ class Impl final : public DoubletSeedFinder {
     const float rM = middleSp.zr()[1];
     const float varianceZM = middleSp.varianceZ();
     const float varianceRM = middleSp.varianceR();
+    const float tM = middleSp.time();
+    const float varianceTM = middleSp.varianceT();
+    const float t0M =
+        tM - std::sqrt(rM * rM + zM * zM) / Acts::PhysicalConstants::c;
 
     // equivalent to impactMax / (rM * rM);
     const float vIPAbs = impactMax * middleSpInfo.uIP2;
@@ -93,13 +97,25 @@ class Impl final : public DoubletSeedFinder {
     }
 
     const SpacePointContainer2& container = candidateSps.container();
-    for (auto [indexO, xyO, zrO, varianceZO, varianceRO] : candidateSps.zip(
-             container.xyColumn(), container.zrColumn(),
-             container.varianceZColumn(), container.varianceRColumn())) {
+    for (auto [indexO, xyO, zrO, varianceZO, varianceRO, timeO, varianceTO] :
+         candidateSps.zip(container.xyColumn(), container.zrColumn(),
+                          container.varianceZColumn(),
+                          container.varianceRColumn(), container.timeColumn(),
+                          container.varianceTColumn())) {
       const float xO = xyO[0];
       const float yO = xyO[1];
       const float zO = zrO[0];
       const float rO = zrO[1];
+      const float t0O =
+          timeO - std::sqrt(rO * rO + zO * zO) / Acts::PhysicalConstants::c;
+
+      if (m_cfg.applyTimeCut && (!std::isnan(timeO) && !std::isnan(tM))) {
+        const float deltaT0 = std::abs(t0O - t0M);
+        const float sigmaT0 = std::sqrt(varianceTM + varianceTO);
+        if (deltaT0 > m_cfg.timeCutCoff * sigmaT0) {
+          continue;
+        }
+      }
 
       float deltaR = 0;
       if constexpr (isBottomCandidate) {

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GridTripletSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/GridTripletSeedingAlgorithm.hpp
@@ -223,6 +223,22 @@ class GridTripletSeedingAlgorithm final : public IAlgorithm {
     /// compatible SPs
     bool useDeltaRinsteadOfTopRadius = false;
 
+    /// time-ralated configurations
+    /// Whether to apply a time cut in the middle-bottom doublet finder
+    bool useTimeCutMiddleBottomDoubletFinder = false;
+    float timeCoffMiddleBottomDoubletFinder =
+        5.f;  // times the sigma of the time difference distribution for
+              // compatible doublets
+    /// Whether to apply a time cut in the middle-top doublet finder
+    bool useTimeCutMiddleTopDoubletFinder = false;
+    float timeCoffMiddleTopDoubletFinder =
+        5.f;  // times the sigma of the time difference distribution for
+              // compatible doublets
+    /// Whether to apply a time cut in the triplet filter
+    bool useTimeCutTripletFilter = false;
+    float timeCoffTripletFilter =
+        15.f;  // chi2 cut for the time compatibility of the triplet
+
     // other
 
     /// Connect custom selections on the space points or to the doublet

--- a/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/GridTripletSeedingAlgorithm.cpp
@@ -123,6 +123,8 @@ GridTripletSeedingAlgorithm::GridTripletSeedingAlgorithm(
   m_filterConfig.maxQualitySeedsPerSpMConf = m_cfg.maxQualitySeedsPerSpMConf;
   m_filterConfig.useDeltaRinsteadOfTopRadius =
       m_cfg.useDeltaRinsteadOfTopRadius;
+  m_filterConfig.applyTripletTimeFilter = m_cfg.useTimeCutTripletFilter;
+  m_filterConfig.tripletTimeFilterChi2 = m_cfg.timeCoffTripletFilter;
 
   m_filterLogger = this->logger().cloneWithSuffix("Filter");
 
@@ -157,7 +159,8 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
 
   Acts::SpacePointContainer2 coreSpacePoints(
       Acts::SpacePointColumns::PackedXY | Acts::SpacePointColumns::PackedZR |
-      Acts::SpacePointColumns::VarianceZ | Acts::SpacePointColumns::VarianceR |
+      Acts::SpacePointColumns::Time | Acts::SpacePointColumns::VarianceZ |
+      Acts::SpacePointColumns::VarianceR | Acts::SpacePointColumns::VarianceT |
       Acts::SpacePointColumns::CopyFromIndex);
   coreSpacePoints.reserve(grid.numberOfSpacePoints());
   std::vector<Acts::SpacePointIndexRange2> gridSpacePointRanges;
@@ -174,6 +177,8 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
                                         static_cast<float>(sp.r())};
       newSp.varianceZ() = static_cast<float>(sp.varianceZ());
       newSp.varianceR() = static_cast<float>(sp.varianceR());
+      newSp.time() = static_cast<float>(sp.time());
+      newSp.varianceT() = static_cast<float>(sp.varianceT());
       newSp.copyFromIndex() = sp.index();
     }
     std::uint32_t end = coreSpacePoints.size();
@@ -215,6 +220,10 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
   bottomDoubletFinderConfig.cotThetaMax = m_cfg.cotThetaMax;
   bottomDoubletFinderConfig.minPt = m_cfg.minPt;
   bottomDoubletFinderConfig.helixCutTolerance = m_cfg.helixCutTolerance;
+  bottomDoubletFinderConfig.applyTimeCut =
+      m_cfg.useTimeCutMiddleBottomDoubletFinder;
+  bottomDoubletFinderConfig.timeCutCoff =
+      m_cfg.timeCoffMiddleBottomDoubletFinder;
   if (m_cfg.useExtraCuts) {
     bottomDoubletFinderConfig.experimentCuts.connect<itkFastTrackingCuts>();
   }
@@ -229,6 +238,8 @@ ProcessCode GridTripletSeedingAlgorithm::execute(
       std::isnan(m_cfg.deltaRMaxTop) ? m_cfg.deltaRMin : m_cfg.deltaRMinTop;
   topDoubletFinderConfig.deltaRMax =
       std::isnan(m_cfg.deltaRMaxTop) ? m_cfg.deltaRMax : m_cfg.deltaRMaxTop;
+  topDoubletFinderConfig.applyTimeCut = m_cfg.useTimeCutMiddleTopDoubletFinder;
+  topDoubletFinderConfig.timeCutCoff = m_cfg.timeCoffMiddleTopDoubletFinder;
   auto topDoubletFinder =
       Acts::DoubletSeedFinder::create(Acts::DoubletSeedFinder::DerivedConfig(
           topDoubletFinderConfig, m_cfg.bFieldInZ));

--- a/Examples/Algorithms/TrackFinding/src/SpacePointMaker.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SpacePointMaker.cpp
@@ -71,6 +71,7 @@ void createPixelSpacePoint(
   sp.time() = t.value_or(nanf);
   sp.varianceZ() = varZR[0];
   sp.varianceR() = varZR[1];
+  sp.varianceT() = varT.value_or(nanf);
 }
 
 Acts::StripSpacePointBuilder::StripEnds getStripEnds(
@@ -346,7 +347,8 @@ ProcessCode SpacePointMaker::execute(const AlgorithmContext& ctx) const {
       SpacePointColumns::SourceLinks | SpacePointColumns::X |
       SpacePointColumns::Y | SpacePointColumns::Z | SpacePointColumns::R |
       SpacePointColumns::Time | SpacePointColumns::VarianceZ |
-      SpacePointColumns::VarianceR | SpacePointColumns::Strip);
+      SpacePointColumns::VarianceR | SpacePointColumns::VarianceT |
+      SpacePointColumns::Strip);
 
   for (Acts::GeometryIdentifier geoId : m_cfg.geometrySelection) {
     // select volume/layer depending on what is set in the geometry id

--- a/Examples/Io/Root/CMakeLists.txt
+++ b/Examples/Io/Root/CMakeLists.txt
@@ -9,6 +9,7 @@ acts_add_library(
     src/RootPropagationStepsWriter.cpp
     src/RootPropagationSummaryWriter.cpp
     src/RootSeedWriter.cpp
+    src/RootSeedEventAnaWriter.cpp
     src/RootSimHitWriter.cpp
     src/RootSimHitReader.cpp
     src/RootSpacePointWriter.cpp

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootSeedEventAnaWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootSeedEventAnaWriter.hpp
@@ -1,0 +1,211 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/ProtoTrack.hpp"
+#include "ActsExamples/EventData/Seed.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/EventData/SimParticle.hpp"
+#include "ActsExamples/EventData/Track.hpp"
+#include "ActsExamples/EventData/TruthMatching.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
+#include "ActsExamples/Framework/WriterT.hpp"
+
+#include <boost/container/small_vector.hpp>
+
+class TFile;
+class TTree;
+
+namespace ActsExamples {
+
+/// @class RootSeedEventAnaWriter
+///
+/// Write out the seed reconstructed by the seeding algorithm in
+/// comma-separated-value format.
+///
+/// This writes one file per event into the configured output directory. By
+/// default it writes to the current working directory.
+/// Files are named using the following schema
+///
+///     event000000001-seed.csv
+///     event000000002-seed.csv
+///
+/// and each line in the file corresponds to one seed.
+class RootSeedEventAnaWriter : public WriterT<TrackParametersContainer> {
+ public:
+  struct Config {
+    /// Input estimated track parameters collection.
+    std::string inputTrackParameters;
+    /// Input seed collection.
+    std::string inputSimSeeds;
+    /// Input collection of simulated hits.
+    std::string inputSimHits;
+    /// Input hit-particles map collection.
+    std::string inputMeasurementParticlesMap;
+    /// Input collection to map measured hits to simulated hits.
+    std::string inputMeasurementSimHitsMap;
+    /// output directory
+    std::string outputDir;
+
+    std::string fileMode = "RECREATE";
+    /// Name of the tree within the output file.
+    std::string treeName = "seedsEvent";
+    /// The writing mode
+    /// Path to the output ROOT file.
+    std::string ROOTFileName = "seedsEvent.root";
+  };
+
+  /// Constructor
+  ///
+  /// @param config Configuration struct
+  /// @param level Message level declaration
+  explicit RootSeedEventAnaWriter(
+      const Config& config, Acts::Logging::Level level = Acts::Logging::INFO);
+
+  /// Ensure underlying file is closed.
+  ~RootSeedEventAnaWriter() final;
+
+  /// End-of-run hook
+  ProcessCode finalize() final;
+
+  /// Get readonly access to the config parameters
+  const Config& config() const { return m_cfg; }
+
+ protected:
+  /// @brief Write method called by the base class
+  /// @param [in] ctx is the algorithm context for event information
+  /// @param [in] trackParams are parameters to write
+  ProcessCode writeT(const AlgorithmContext& ctx,
+                     const TrackParametersContainer& trackParams) override;
+
+ private:
+  Config m_cfg;  ///< The config class
+
+  ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
+  ReadDataHandle<SeedContainer> m_inputSimSeeds{this, "InputSimSeeds"};
+  ReadDataHandle<SimHitContainer> m_inputSimHits{this, "InputSimHits"};
+  ReadDataHandle<MeasurementParticlesMap> m_inputMeasurementParticlesMap{
+      this, "InputMeasurementParticlesMap"};
+  ReadDataHandle<MeasurementSimHitsMap> m_inputMeasurementSimHitsMap{
+      this, "InputMeasurementSimHitsMap"};
+
+  /// @brief Struct for brief seed summary info
+  ///
+  struct SeedInfo {
+    std::size_t seedID = 0;
+    SimBarcode particleId;
+    float seedPt = -1;
+    float seedPhi = 0;
+    float seedEta = 0;
+    float vertexZ = 0;
+    float quality = -1;
+    boost::container::small_vector<Acts::Vector3, 3> globalPosition;
+    std::vector<bool> haveTime;
+    std::vector<float> spTime;
+    std::vector<float> spVarR;
+    std::vector<float> spVarZ;
+    std::vector<float> spVarT;
+    float truthDistance = -1;
+    std::string seedType = "unknown";
+    int seedTypeInt = 0;  // 0: unknown, 1: good, 2: duplicate, 3: fake
+    ProtoTrack measurementsID;
+  };
+
+  /// ROOT file and tree
+  std::mutex m_writeMutex;
+  TFile* m_outputFile = nullptr;
+  TTree* m_outputTree = nullptr;
+  /// Event identifier.
+  std::uint32_t m_eventId = 0;
+  /// Hit surface identifier.
+  std::vector<std::uint64_t> m_measurementId_1;
+  std::vector<std::uint64_t> m_measurementId_2;
+  std::vector<std::uint64_t> m_measurementId_3;
+  /// Space point surface identifier.
+  std::vector<std::uint64_t> m_geometryId_1;
+  std::vector<std::uint64_t> m_geometryId_2;
+  std::vector<std::uint64_t> m_geometryId_3;
+  std::vector<int> m_have_time_1;
+  std::vector<int> m_have_time_2;
+  std::vector<int> m_have_time_3;
+  /// Global space point 4D position components in mm. init to NaN
+  std::vector<float> m_x_1;
+  std::vector<float> m_x_2;
+  std::vector<float> m_x_3;
+  std::vector<float> m_y_1;
+  std::vector<float> m_y_2;
+  std::vector<float> m_y_3;
+  std::vector<float> m_z_1;
+  std::vector<float> m_z_2;
+  std::vector<float> m_z_3;
+  std::vector<float> m_t_1;
+  std::vector<float> m_t_2;
+  std::vector<float> m_t_3;
+  // Global space point 4D position uncertainties
+  std::vector<float> m_var_r_1;
+  std::vector<float> m_var_r_2;
+  std::vector<float> m_var_r_3;
+  std::vector<float> m_var_z_1;
+  std::vector<float> m_var_z_2;
+  std::vector<float> m_var_z_3;
+  std::vector<float> m_var_t_1;
+  std::vector<float> m_var_t_2;
+  std::vector<float> m_var_t_3;
+  // Seed vertex position
+  std::vector<double> m_z_vertex;
+  // Seed quality
+  std::vector<float> m_seed_quality;
+  // Seed type int
+  std::vector<int> m_seedTypeInt;
+  // particle ID
+  std::vector<std::uint64_t> m_particleId;
+
+  // for seed estimated parameters
+  std::vector<float> m_est_loc0;
+  std::vector<float> m_est_loc1;
+  std::vector<float> m_est_phi;
+  std::vector<float> m_est_theta;
+  std::vector<float> m_est_qop;
+  std::vector<float> m_est_time;
+  std::vector<float> m_est_eta;
+
+  // for seed truth parameters
+  // std::vector<float> m_truth_loc0;
+  // std::vector<float> m_truth_loc1;
+  // std::vector<float> m_truth_phi;
+  // std::vector<float> m_truth_theta;
+  // std::vector<float> m_truth_qop;
+  // std::vector<float> m_truth_time;
+  // std::vector<float> m_truth_eta;
+
+  // for seed residuals
+  // std::vector<float> m_res_loc0;
+  // std::vector<float> m_res_loc1;
+  // std::vector<float> m_res_phi;
+  // std::vector<float> m_res_theta;
+  // std::vector<float> m_res_qop;
+  // std::vector<float> m_res_time;
+  // std::vector<float> m_res_eta;
+
+  //
+  // for volume, layer, surface ids
+  std::vector<int> m_volumeId_1;
+  std::vector<int> m_volumeId_2;
+  std::vector<int> m_volumeId_3;
+  std::vector<int> m_layerId_1;
+  std::vector<int> m_layerId_2;
+  std::vector<int> m_layerId_3;
+  std::vector<int> m_surfaceId_1;
+  std::vector<int> m_surfaceId_2;
+  std::vector<int> m_surfaceId_3;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Root/src/RootSeedEventAnaWriter.cpp
+++ b/Examples/Io/Root/src/RootSeedEventAnaWriter.cpp
@@ -1,0 +1,392 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Root/RootSeedEventAnaWriter.hpp"
+
+#include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/Utilities/VectorHelpers.hpp"
+#include "ActsExamples/Framework/AlgorithmContext.hpp"
+#include "ActsExamples/Utilities/EventDataTransforms.hpp"
+#include "ActsExamples/Utilities/Range.hpp"
+#include "ActsExamples/Validation/TrackClassification.hpp"
+#include "ActsFatras/EventData/Barcode.hpp"
+
+#include <cmath>
+#include <numbers>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+#include <TFile.h>
+#include <TTree.h>
+
+using Acts::VectorHelpers::eta;
+using Acts::VectorHelpers::phi;
+using Acts::VectorHelpers::theta;
+
+ActsExamples::RootSeedEventAnaWriter::RootSeedEventAnaWriter(
+    const ActsExamples::RootSeedEventAnaWriter::Config& config,
+    Acts::Logging::Level level)
+    : WriterT<TrackParametersContainer>(config.inputTrackParameters,
+                                        "RootSeedEventAnaWriter", level),
+      m_cfg(config) {
+  if (m_cfg.inputSimSeeds.empty()) {
+    throw std::invalid_argument("Missing space points input collection");
+  }
+  if (m_cfg.inputSimHits.empty()) {
+    throw std::invalid_argument("Missing simulated hits input collection");
+  }
+  if (m_cfg.inputMeasurementParticlesMap.empty()) {
+    throw std::invalid_argument("Missing hit-particles map input collection");
+  }
+  if (m_cfg.inputMeasurementSimHitsMap.empty()) {
+    throw std::invalid_argument(
+        "Missing hit-simulated-hits map input collection");
+  }
+  if (m_cfg.outputDir.empty()) {
+    throw std::invalid_argument("Missing output directory");
+  }
+  if (m_cfg.ROOTFileName.empty()) {
+    throw std::invalid_argument("Missing output ROOT file name");
+  }
+
+  m_inputSimSeeds.initialize(m_cfg.inputSimSeeds);
+  m_inputSimHits.initialize(m_cfg.inputSimHits);
+  m_inputMeasurementParticlesMap.initialize(m_cfg.inputMeasurementParticlesMap);
+  m_inputMeasurementSimHitsMap.initialize(m_cfg.inputMeasurementSimHitsMap);
+
+  // open root file and create the tree
+  std::string ROOTFilePath = m_cfg.outputDir + "/" + m_cfg.ROOTFileName;
+
+  m_outputFile = TFile::Open(ROOTFilePath.c_str(), m_cfg.fileMode.c_str());
+  if (m_outputFile == nullptr) {
+    throw std::ios_base::failure("Could not open '" + ROOTFilePath + "'");
+  }
+  m_outputFile->cd();
+  m_outputTree = new TTree(m_cfg.treeName.c_str(), m_cfg.treeName.c_str());
+  if (m_outputTree == nullptr) {
+    throw std::bad_alloc();
+  }
+
+  // setup the branches
+  m_outputTree->Branch("event_id", &m_eventId);
+  m_outputTree->Branch("measurement_id_1", &m_measurementId_1);
+  m_outputTree->Branch("measurement_id_2", &m_measurementId_2);
+  m_outputTree->Branch("measurement_id_3", &m_measurementId_3);
+  m_outputTree->Branch("geometry_id_1", &m_geometryId_1);
+  m_outputTree->Branch("geometry_id_2", &m_geometryId_2);
+  m_outputTree->Branch("geometry_id_3", &m_geometryId_3);
+  m_outputTree->Branch("have_time_1", &m_have_time_1);
+  m_outputTree->Branch("have_time_2", &m_have_time_2);
+  m_outputTree->Branch("have_time_3", &m_have_time_3);
+  m_outputTree->Branch("x_1", &m_x_1);
+  m_outputTree->Branch("x_2", &m_x_2);
+  m_outputTree->Branch("x_3", &m_x_3);
+  m_outputTree->Branch("y_1", &m_y_1);
+  m_outputTree->Branch("y_2", &m_y_2);
+  m_outputTree->Branch("y_3", &m_y_3);
+  m_outputTree->Branch("z_1", &m_z_1);
+  m_outputTree->Branch("z_2", &m_z_2);
+  m_outputTree->Branch("z_3", &m_z_3);
+  m_outputTree->Branch("t_1", &m_t_1);
+  m_outputTree->Branch("t_2", &m_t_2);
+  m_outputTree->Branch("t_3", &m_t_3);
+  m_outputTree->Branch("var_r_1", &m_var_r_1);
+  m_outputTree->Branch("var_r_2", &m_var_r_2);
+  m_outputTree->Branch("var_r_3", &m_var_r_3);
+  m_outputTree->Branch("var_z_1", &m_var_z_1);
+  m_outputTree->Branch("var_z_2", &m_var_z_2);
+  m_outputTree->Branch("var_z_3", &m_var_z_3);
+  m_outputTree->Branch("var_t_1", &m_var_t_1);
+  m_outputTree->Branch("var_t_2", &m_var_t_2);
+  m_outputTree->Branch("var_t_3", &m_var_t_3);
+  m_outputTree->Branch("z_vertex", &m_z_vertex);
+  m_outputTree->Branch("seed_quality", &m_seed_quality);
+  m_outputTree->Branch("seed_type", &m_seedTypeInt);
+  m_outputTree->Branch("particle_id", &m_particleId);
+  //
+  m_outputTree->Branch("est_loc0", &m_est_loc0);
+  m_outputTree->Branch("est_loc1", &m_est_loc1);
+  m_outputTree->Branch("est_phi", &m_est_phi);
+  m_outputTree->Branch("est_theta", &m_est_theta);
+  m_outputTree->Branch("est_qop", &m_est_qop);
+  m_outputTree->Branch("est_time", &m_est_time);
+  m_outputTree->Branch("est_eta", &m_est_eta);
+
+  // for seed truth parameters
+  // m_outputTree->Branch("truth_loc0", &m_truth_loc0);
+  // m_outputTree->Branch("truth_loc1", &m_truth_loc1);
+  // m_outputTree->Branch("truth_phi", &m_truth_phi);
+  // m_outputTree->Branch("truth_theta", &m_truth_theta);
+  // m_outputTree->Branch("truth_qop", &m_truth_qop);
+  // m_outputTree->Branch("truth_time", &m_truth_time);
+  // m_outputTree->Branch("truth_eta", &m_truth_eta);
+  // for residuals
+  // m_outputTree->Branch("res_loc0", &m_res_loc0);
+  // m_outputTree->Branch("res_loc1", &m_res_loc1);
+  // m_outputTree->Branch("res_phi", &m_res_phi);
+  // m_outputTree->Branch("res_theta", &m_res_theta);
+  // m_outputTree->Branch("res_qop", &m_res_qop);
+  // m_outputTree->Branch("res_time", &m_res_time);
+  // m_outputTree->Branch("res_eta", &m_res_eta);
+}
+
+ActsExamples::RootSeedEventAnaWriter::~RootSeedEventAnaWriter() {
+  if (m_outputFile != nullptr) {
+    m_outputFile->Close();
+  }
+}
+
+ActsExamples::ProcessCode ActsExamples::RootSeedEventAnaWriter::finalize() {
+  m_outputFile->cd();
+  m_outputTree->Write();
+  m_outputFile->Close();
+
+  ACTS_VERBOSE("Wrote seeds to tree '"
+               << m_cfg.treeName << "' in '"
+               << m_cfg.outputDir + "/" + m_cfg.ROOTFileName << "'");
+  return ProcessCode::SUCCESS;
+}
+
+ActsExamples::ProcessCode ActsExamples::RootSeedEventAnaWriter::writeT(
+    const ActsExamples::AlgorithmContext& ctx,
+    const TrackParametersContainer& trackParams) {
+  // ensure exclusive access to tree/file while writing
+  std::lock_guard<std::mutex> lock(m_writeMutex);
+
+  // reset all variables
+  m_eventId = 0;
+  m_measurementId_1.clear();
+  m_measurementId_2.clear();
+  m_measurementId_3.clear();
+  m_geometryId_1.clear();
+  m_geometryId_2.clear();
+  m_geometryId_3.clear();
+  m_have_time_1.clear();
+  m_have_time_2.clear();
+  m_have_time_3.clear();
+  m_x_1.clear();
+  m_x_2.clear();
+  m_x_3.clear();
+  m_y_1.clear();
+  m_y_2.clear();
+  m_y_3.clear();
+  m_z_1.clear();
+  m_z_2.clear();
+  m_z_3.clear();
+  m_t_1.clear();
+  m_t_2.clear();
+  m_t_3.clear();
+  m_var_r_1.clear();
+  m_var_r_2.clear();
+  m_var_r_3.clear();
+  m_var_z_1.clear();
+  m_var_z_2.clear();
+  m_var_z_3.clear();
+  m_var_t_1.clear();
+  m_var_t_2.clear();
+  m_var_t_3.clear();
+  m_z_vertex.clear();
+  m_seed_quality.clear();
+  m_seedTypeInt.clear();
+  m_particleId.clear();
+
+  m_est_loc0.clear();
+  m_est_loc1.clear();
+  m_est_phi.clear();
+  m_est_theta.clear();
+  m_est_qop.clear();
+  m_est_time.clear();
+  m_est_eta.clear();
+  // m_truth_loc0.clear();
+  // m_truth_loc1.clear();
+  // m_truth_phi.clear();
+  // m_truth_theta.clear();
+  // m_truth_qop.clear();
+  // m_truth_time.clear();
+  // m_truth_eta.clear();
+  // m_res_loc0.clear();
+  // m_res_loc1.clear();
+  // m_res_phi.clear();
+  // m_res_theta.clear();
+  // m_res_qop.clear();
+  // m_res_time.clear();
+  // m_res_eta.clear();
+
+  // Read additional input collections
+  const auto& seeds = m_inputSimSeeds(ctx);
+  const auto& simHits = m_inputSimHits(ctx);
+  const auto& hitParticlesMap = m_inputMeasurementParticlesMap(ctx);
+  const auto& hitSimHitsMap = m_inputMeasurementSimHitsMap(ctx);
+
+  // Get the event number
+  m_eventId = ctx.eventNumber;
+
+  std::unordered_map<std::size_t, SeedInfo> infoMap;
+  std::unordered_map<SimBarcode, std::pair<std::size_t, float>> goodSeed;
+
+  // Loop over the estimated track parameters
+  for (std::size_t iparams = 0; iparams < trackParams.size(); ++iparams) {
+    // The estimated bound parameters vector
+    const auto& seedEstParams = trackParams[iparams];
+    const auto params = trackParams[iparams].parameters();
+
+    // The reference surface of the parameters, i.e. also the reference surface
+    // of the first space point
+    // const auto& surface = params.referenceSurface();
+    // m_volumeId = surface.geometryId().volume();
+    // m_layerId = surface.geometryId().layer();
+    // m_surfaceId = surface.geometryId().sensitive();
+
+    // Get and fill the track estimated parameters
+    float seedPhi = params[Acts::eBoundPhi];
+    float seedEta = std::atanh(std::cos(params[Acts::eBoundTheta]));
+    m_est_loc0.push_back(params[Acts::eBoundLoc0]);
+    m_est_loc1.push_back(params[Acts::eBoundLoc1]);
+    m_est_phi.push_back(params[Acts::eBoundPhi]);
+    m_est_theta.push_back(params[Acts::eBoundTheta]);
+    m_est_qop.push_back(params[Acts::eBoundQOverP]);
+    m_est_time.push_back(params[Acts::eBoundTime]);
+
+    ACTS_VERBOSE("eta: " << eta(seedEstParams.momentum())
+                         << ", seedEta: " << seedEta);
+
+    // Get the proto track from which the track parameters are estimated
+    const auto& seed = seeds[iparams];
+    const auto& ptrack = seedToProtoTrack(seed);
+
+    std::vector<ParticleHitCount> particleHitCounts;
+    identifyContributingParticles(hitParticlesMap, ptrack, particleHitCounts);
+    bool truthMatched = false;
+    float truthDistance = -1;
+    auto majorityParticleId = particleHitCounts.front().particleId;
+    // Seed are considered truth matched if they have only one contributing
+    // particle
+    if (particleHitCounts.size() == 1) {
+      truthMatched = true;
+      // Get the index of the first space point
+      const auto& hitIdx = ptrack.front();
+      // Get the sim hits via the measurement to sim hits map
+      auto indices = makeRange(hitSimHitsMap.equal_range(hitIdx));
+      // Get the truth particle direction from the sim hits
+      Acts::Vector3 truthUnitDir = {0, 0, 0};
+      for (auto [_, simHitIdx] : indices) {
+        const auto& simHit = *simHits.nth(simHitIdx);
+        if (simHit.particleId() == majorityParticleId) {
+          truthUnitDir = simHit.direction();
+        }
+      }
+      // Compute the distance between the truth and estimated directions
+      float truthPhi = phi(truthUnitDir);
+      float truthEta = std::atanh(std::cos(theta(truthUnitDir)));
+      float dEta = std::abs(truthEta - seedEta);
+      float dPhi =
+          std::abs(truthPhi - seedPhi) < std::numbers::pi_v<float>
+              ? std::abs(truthPhi - seedPhi)
+              : std::abs(truthPhi - seedPhi) - std::numbers::pi_v<float>;
+      truthDistance = std::sqrt(dPhi * dPhi + dEta * dEta);
+      // If the seed is truth matched, check if it is the closest one for the
+      // contributing particle
+      if (goodSeed.contains(majorityParticleId)) {
+        if (goodSeed[majorityParticleId].second > truthDistance) {
+          goodSeed[majorityParticleId] = std::make_pair(iparams, truthDistance);
+        }
+      } else {
+        goodSeed[majorityParticleId] = std::make_pair(iparams, truthDistance);
+      }
+    }
+    // Store the global position of the space points
+    boost::container::small_vector<Acts::Vector3, 3> globalPosition;
+    std::vector<bool> haveTime;
+    std::vector<float> spTime;
+    std::vector<float> spVarR;
+    std::vector<float> spVarZ;
+    std::vector<float> spVarT;
+    for (auto spacePointPtr : seed.spacePoints()) {
+      Acts::Vector3 pos(spacePointPtr.x(), spacePointPtr.y(),
+                        spacePointPtr.z());
+      globalPosition.push_back(pos);
+      if (std::isnan(spacePointPtr.time())) {
+        haveTime.push_back(false);
+      } else {
+        haveTime.push_back(true);
+      }
+      spTime.push_back(spacePointPtr.time());
+      spVarR.push_back(spacePointPtr.varianceR());
+      spVarZ.push_back(spacePointPtr.varianceZ());
+      spVarT.push_back(spacePointPtr.varianceT());
+    }
+
+    // track info
+    SeedInfo toAdd;
+    toAdd.seedID = iparams;
+    toAdd.particleId = majorityParticleId;
+    toAdd.seedPt = std::abs(1.0 / params[Acts::eBoundQOverP]) *
+                   std::sin(params[Acts::eBoundTheta]);
+    toAdd.seedPhi = seedPhi;
+    toAdd.seedEta = seedEta;
+    toAdd.vertexZ = seed.vertexZ();
+    toAdd.quality = seed.quality();
+    toAdd.globalPosition = globalPosition;
+    toAdd.haveTime = haveTime;
+    toAdd.spTime = spTime;
+    toAdd.spVarR = spVarR;
+    toAdd.spVarZ = spVarZ;
+    toAdd.spVarT = spVarT;
+    toAdd.truthDistance = truthDistance;
+    toAdd.seedType = truthMatched ? "duplicate" : "fake";
+    toAdd.seedTypeInt = truthMatched ? 2 : 3;
+    toAdd.measurementsID = ptrack;
+
+    infoMap[toAdd.seedID] = toAdd;
+  }
+
+  for (auto& [id, info] : infoMap) {
+    if (goodSeed[info.particleId].first == id) {
+      info.seedType = "good";
+      info.seedTypeInt = 1;
+    }
+
+    // Fill the tree
+    m_measurementId_1.push_back(info.measurementsID[0]);
+    m_measurementId_2.push_back(info.measurementsID[1]);
+    m_measurementId_3.push_back(info.measurementsID[2]);
+
+    m_x_1.push_back(info.globalPosition[0].x());
+    m_x_2.push_back(info.globalPosition[1].x());
+    m_x_3.push_back(info.globalPosition[2].x());
+    m_y_1.push_back(info.globalPosition[0].y());
+    m_y_2.push_back(info.globalPosition[1].y());
+    m_y_3.push_back(info.globalPosition[2].y());
+    m_z_1.push_back(info.globalPosition[0].z());
+    m_z_2.push_back(info.globalPosition[1].z());
+    m_z_3.push_back(info.globalPosition[2].z());
+    m_have_time_1.push_back(info.haveTime[0]);
+    m_have_time_2.push_back(info.haveTime[1]);
+    m_have_time_3.push_back(info.haveTime[2]);
+    m_t_1.push_back(info.spTime[0]);
+    m_t_2.push_back(info.spTime[1]);
+    m_t_3.push_back(info.spTime[2]);
+    m_var_r_1.push_back(info.spVarR[0]);
+    m_var_r_2.push_back(info.spVarR[1]);
+    m_var_r_3.push_back(info.spVarR[2]);
+    m_var_z_1.push_back(info.spVarZ[0]);
+    m_var_z_2.push_back(info.spVarZ[1]);
+    m_var_z_3.push_back(info.spVarZ[2]);
+    m_var_t_1.push_back(info.spVarT[0]);
+    m_var_t_2.push_back(info.spVarT[1]);
+    m_var_t_3.push_back(info.spVarT[2]);
+    m_z_vertex.push_back(info.vertexZ);
+    m_seed_quality.push_back(info.quality);
+    m_seedTypeInt.push_back(info.seedTypeInt);
+    m_particleId.push_back(info.particleId.hash());
+  }
+  m_outputTree->Fill();
+  return ProcessCode::SUCCESS;
+}

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -9,6 +9,7 @@ import acts.examples
 # ROOT might not be available
 try:
     from acts.examples.root import (
+        RootSeedEventAnaWriter,
         RootTrackFinderNTupleWriter,
         RootTrackFinderPerformanceWriter,
         RootTrackFitterPerformanceWriter,
@@ -69,6 +70,10 @@ SeedFinderConfigArg = namedtuple(
         "forwardSeedConfirmationRange",
         "rMinMiddle",
         "rMaxMiddle",
+        "useTimeCutMiddleBottomDoubletFinder",
+        "timeCoffMiddleBottomDoubletFinder",
+        "useTimeCutMiddleTopDoubletFinder",
+        "timeCoffMiddleTopDoubletFinder",
         "deltaR",  # (min,max)
         "deltaRBottomSP",  # (min,max)
         "deltaRTopSP",  # (min,max)
@@ -77,7 +82,7 @@ SeedFinderConfigArg = namedtuple(
         "r",  # (min,max)
         "z",  # (min,max)
     ],
-    defaults=[None] * 20 + [(None, None)] * 7,
+    defaults=[None] * 24 + [(None, None)] * 7,
 )
 SeedFinderOptionsArg = namedtuple(
     "SeedFinderOptions", ["beamPos", "bFieldInZ"], defaults=[(None, None), None]
@@ -97,8 +102,10 @@ SeedFilterConfigArg = namedtuple(
         "maxQualitySeedsPerSpMConf",
         "useDeltaRorTopRadius",
         "deltaRMin",
+        "useTimeCutTripletFilter",
+        "timeCoffTripletFilter",
     ],
-    defaults=[None] * 11,
+    defaults=[None] * 13,
 )
 
 SpacePointGridConfigArg = namedtuple(
@@ -568,6 +575,18 @@ def addSeeding(
                 logLevel,
                 prefix=prefix,
             )
+            s.addWriter(
+                RootSeedEventAnaWriter(
+                    level=logLevel,
+                    inputTrackParameters=parEstimateAlg.config.outputTrackParameters,
+                    inputSimSeeds=seeds,
+                    inputSimHits="simhits",
+                    inputMeasurementParticlesMap="measurement_particles_map",
+                    inputMeasurementSimHitsMap="measurement_simhits_map",
+                    outputDir=str(outputDirRoot),
+                    ROOTFileName=str(f"seeds_ana.root"),
+                )
+            )
 
         if outputDirCsv is not None:
             outputDirCsv = Path(outputDirCsv)
@@ -960,6 +979,12 @@ def addGridTripletSeeding(
             maxSeedsPerSpMConf=seedFilterConfigArg.maxSeedsPerSpMConf,
             maxQualitySeedsPerSpMConf=seedFilterConfigArg.maxQualitySeedsPerSpMConf,
             useDeltaRinsteadOfTopRadius=seedFilterConfigArg.useDeltaRorTopRadius,
+            useTimeCutMiddleBottomDoubletFinder=seedFinderConfigArg.useTimeCutMiddleBottomDoubletFinder,
+            timeCoffMiddleBottomDoubletFinder=seedFinderConfigArg.timeCoffMiddleBottomDoubletFinder,
+            useTimeCutMiddleTopDoubletFinder=seedFinderConfigArg.useTimeCutMiddleTopDoubletFinder,
+            timeCoffMiddleTopDoubletFinder=seedFinderConfigArg.timeCoffMiddleTopDoubletFinder,
+            useTimeCutTripletFilter=seedFilterConfigArg.useTimeCutTripletFilter,
+            timeCoffTripletFilter=seedFilterConfigArg.timeCoffTripletFilter,
             useExtraCuts=seedingAlgorithmConfigArg.useExtraCuts,
         ),
     )

--- a/Python/Examples/src/TrackFinding.cpp
+++ b/Python/Examples/src/TrackFinding.cpp
@@ -60,7 +60,10 @@ void addTrackFinding(py::module& mex) {
       zOriginWeightFactor, maxSeedsPerSpM, compatSeedLimit, seedWeightIncrement,
       numSeedIncrement, seedConfirmation, centralSeedConfirmationRange,
       forwardSeedConfirmationRange, maxSeedsPerSpMConf,
-      maxQualitySeedsPerSpMConf, useDeltaRinsteadOfTopRadius, useExtraCuts);
+      maxQualitySeedsPerSpMConf, useDeltaRinsteadOfTopRadius,
+      useTimeCutMiddleBottomDoubletFinder, timeCoffMiddleBottomDoubletFinder,
+      useTimeCutMiddleTopDoubletFinder, timeCoffMiddleTopDoubletFinder,
+      useTimeCutTripletFilter, timeCoffTripletFilter, useExtraCuts);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       OrthogonalTripletSeedingAlgorithm, mex,

--- a/Python/Examples/src/plugins/Root.cpp
+++ b/Python/Examples/src/plugins/Root.cpp
@@ -22,6 +22,7 @@
 #include "ActsExamples/Io/Root/RootParticleWriter.hpp"
 #include "ActsExamples/Io/Root/RootPropagationStepsWriter.hpp"
 #include "ActsExamples/Io/Root/RootPropagationSummaryWriter.hpp"
+#include "ActsExamples/Io/Root/RootSeedEventAnaWriter.hpp"
 #include "ActsExamples/Io/Root/RootSeedWriter.hpp"
 #include "ActsExamples/Io/Root/RootSimHitReader.hpp"
 #include "ActsExamples/Io/Root/RootSimHitWriter.hpp"
@@ -244,6 +245,11 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsRoot, root) {
     ACTS_PYTHON_DECLARE_WRITER(RootSeedWriter, root, "RootSeedWriter",
                                inputSeeds, writingMode, filePath, fileMode,
                                treeName);
+    ACTS_PYTHON_DECLARE_WRITER(
+        RootSeedEventAnaWriter, root, "RootSeedEventAnaWriter",
+        inputTrackParameters, inputSimSeeds, inputSimHits,
+        inputMeasurementParticlesMap, inputMeasurementSimHitsMap, outputDir,
+        ROOTFileName, fileMode, treeName);
 
     ACTS_PYTHON_DECLARE_WRITER(RootSimHitWriter, root, "RootSimHitWriter",
                                inputSimHits, filePath, fileMode, treeName);


### PR DESCRIPTION
feat: add options to use spacepoint time information in TripletSeeder, with a new ROOT seeding analysis tool

--- END COMMIT MESSAGE ---


1. Core code change: add options to use time information in TripletSeeder, actually apply the cut of time in BroadTripletSeedFilter and DoubletSeedFinder
2. use time cut in Examples GridTripletSeedingAlgorithm 
3. add a ROOT seeding analysis tool


Still a draft for the moment. Some potential concerns:

- Extra CPU time consumption in DoubletSeedFinder in no-time situation, since reading too much useless `nan ` for time and time variance. even causing problems when no time info in spacepoint?


To @XiaocongAi  @pbutti  