### PR TITLE
feat: expose PlotTool configs in .py, add per-layer particleId to tree

### DIFF
--- a/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
+++ b/Examples/Framework/include/ActsExamples/Validation/EffPlotTool.hpp
@@ -90,6 +90,9 @@ class EffPlotTool {
   const std::vector<Efficiency1>& trackEffVsPtInAbsEtaRanges() const {
     return m_trackEffVsPtInAbsEtaRanges;
   }
+  const std::vector<Efficiency1>& trackEffVsLogPtInAbsEtaRanges() const {
+    return m_trackEffVsLogPtInAbsEtaRanges;
+  }
 
  private:
   const Acts::Logger& logger() const { return *m_logger; }
@@ -101,6 +104,7 @@ class EffPlotTool {
   std::map<std::string, Efficiency2> m_efficiencies2D;
   std::vector<Efficiency1> m_trackEffVsEtaInPtRanges;
   std::vector<Efficiency1> m_trackEffVsPtInAbsEtaRanges;
+  std::vector<Efficiency1> m_trackEffVsLogPtInAbsEtaRanges;
 };
 
 }  // namespace ActsExamples

--- a/Examples/Framework/src/Validation/EffPlotTool.cpp
+++ b/Examples/Framework/src/Validation/EffPlotTool.cpp
@@ -91,6 +91,7 @@ EffPlotTool::EffPlotTool(const EffPlotTool::Config& cfg,
 
   const auto& etaAxis = m_cfg.varBinning.at("Eta");
   const auto& ptAxis = m_cfg.varBinning.at("Pt");
+  const auto& logPtAxis = m_cfg.varBinning.at("LogPt");
 
   // efficiency vs eta in different pT ranges
   for (const auto& [i, ptRange] : Acts::enumerate(m_cfg.truthPtRangesForEta)) {
@@ -110,6 +111,13 @@ EffPlotTool::EffPlotTool(const EffPlotTool::Config& cfg,
         std::format("Tracking efficiency with |#eta| in [{}, {}]",
                     absEtaRange.first, absEtaRange.second);
     m_trackEffVsPtInAbsEtaRanges.emplace_back(name, title, std::array{ptAxis});
+
+    // log pT version of the efficiency vs pT in different abs(eta) ranges
+    const std::string nameLogPt = std::format("trackeff_vs_log_pT_absEtaRange_{}", i);
+    const std::string titleLogPt =
+        std::format("Tracking efficiency with |#eta| in [{}, {}]",
+                    absEtaRange.first, absEtaRange.second);
+    m_trackEffVsLogPtInAbsEtaRanges.emplace_back(nameLogPt, titleLogPt, std::array{logPtAxis});
   }
 }
 
@@ -169,6 +177,14 @@ void EffPlotTool::fill(const Acts::GeometryContext& gctx,
   // fill the efficiency vs pT in different eta ranges
   for (auto&& [absEtaRange, eff] :
        Acts::zip(m_cfg.truthAbsEtaRangesForPt, m_trackEffVsPtInAbsEtaRanges)) {
+    if (t_absEta >= absEtaRange.first && t_absEta < absEtaRange.second) {
+      eff.fill({t_pT}, status);
+    }
+  }
+
+  // fill the log pT version of the efficiency vs pT in different eta ranges
+  for (auto&& [absEtaRange, eff] :
+       Acts::zip(m_cfg.truthAbsEtaRangesForPt, m_trackEffVsLogPtInAbsEtaRanges)) {
     if (t_absEta >= absEtaRange.first && t_absEta < absEtaRange.second) {
       eff.fill({t_pT}, status);
     }

--- a/Examples/Framework/src/Validation/EffPlotTool.cpp
+++ b/Examples/Framework/src/Validation/EffPlotTool.cpp
@@ -113,11 +113,13 @@ EffPlotTool::EffPlotTool(const EffPlotTool::Config& cfg,
     m_trackEffVsPtInAbsEtaRanges.emplace_back(name, title, std::array{ptAxis});
 
     // log pT version of the efficiency vs pT in different abs(eta) ranges
-    const std::string nameLogPt = std::format("trackeff_vs_log_pT_absEtaRange_{}", i);
+    const std::string nameLogPt =
+        std::format("trackeff_vs_log_pT_absEtaRange_{}", i);
     const std::string titleLogPt =
         std::format("Tracking efficiency with |#eta| in [{}, {}]",
                     absEtaRange.first, absEtaRange.second);
-    m_trackEffVsLogPtInAbsEtaRanges.emplace_back(nameLogPt, titleLogPt, std::array{logPtAxis});
+    m_trackEffVsLogPtInAbsEtaRanges.emplace_back(nameLogPt, titleLogPt,
+                                                 std::array{logPtAxis});
   }
 }
 
@@ -183,8 +185,8 @@ void EffPlotTool::fill(const Acts::GeometryContext& gctx,
   }
 
   // fill the log pT version of the efficiency vs pT in different eta ranges
-  for (auto&& [absEtaRange, eff] :
-       Acts::zip(m_cfg.truthAbsEtaRangesForPt, m_trackEffVsLogPtInAbsEtaRanges)) {
+  for (auto&& [absEtaRange, eff] : Acts::zip(m_cfg.truthAbsEtaRangesForPt,
+                                             m_trackEffVsLogPtInAbsEtaRanges)) {
     if (t_absEta >= absEtaRange.first && t_absEta < absEtaRange.second) {
       eff.fill({t_pT}, status);
     }

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackSummaryWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootTrackSummaryWriter.hpp
@@ -56,6 +56,12 @@ class RootTrackSummaryWriter final : public WriterT<ConstTrackContainer> {
     std::string inputTrackParticleMatching;
     /// Input jet collection (optional).
     std::string inputJets;
+    /// Input collection of simulated hits (optional, only for truth-linked
+    /// per-measurement particle id branch).
+    std::string inputSimHits;
+    /// Input map from measurement index to sim-hit indices (optional, only
+    /// for truth-linked per-measurement particle id branch).
+    std::string inputMeasurementSimHitsMap;
     /// Output filename.
     std::string filePath = "tracksummary.root";
     /// Name of the output tree.
@@ -102,6 +108,9 @@ class RootTrackSummaryWriter final : public WriterT<ConstTrackContainer> {
   ReadDataHandle<TrackParticleMatching> m_inputTrackParticleMatching{
       this, "InputTrackParticleMatching"};
   ReadDataHandle<TruthJetContainer> m_inputJets{this, "InputJets"};
+  ReadDataHandle<SimHitContainer> m_inputSimHits{this, "InputSimHits"};
+  ReadDataHandle<MeasurementSimHitsMap> m_inputMeasurementSimHitsMap{
+      this, "InputMeasurementSimHitsMap"};
 
   /// Mutex used to protect multi-threaded writes
   std::mutex m_writeMutex;
@@ -136,6 +145,12 @@ class RootTrackSummaryWriter final : public WriterT<ConstTrackContainer> {
   std::vector<std::vector<std::uint32_t>> m_measurementVolume;
   /// The layer id of the measurements
   std::vector<std::vector<std::uint32_t>> m_measurementLayer;
+  /// The particle id of the truth particle that left each measurement.
+  /// Outer: one entry per track. Inner: one entry per measurement on
+  /// that track, ordered identically to m_measurementVolume /
+  /// m_measurementLayer (reverse state order). Sentinel value 0 means
+  /// no truth link or no truth inputs configured.
+  std::vector<std::vector<std::uint64_t>> m_measurementParticleId;
   /// The volume id of the outliers
   std::vector<std::vector<std::uint32_t>> m_outlierVolume;
   /// The layer id of the outliers

--- a/Examples/Io/Root/src/RootTrackFinderPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackFinderPerformanceWriter.cpp
@@ -126,6 +126,10 @@ ProcessCode RootTrackFinderPerformanceWriter::finalize() {
          m_collector.effPlotTool().trackEffVsPtInAbsEtaRanges()) {
       toRoot(eff)->Write();
     }
+    for (const auto& eff :
+         m_collector.effPlotTool().trackEffVsLogPtInAbsEtaRanges()) {
+      toRoot(eff)->Write();
+    }
 
     // Write fake ratio histograms
     for (const auto& [name, hist] : m_collector.fakePlotTool().histograms()) {

--- a/Examples/Io/Root/src/RootTrackFitterPerformanceWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackFitterPerformanceWriter.cpp
@@ -150,6 +150,9 @@ ProcessCode RootTrackFitterPerformanceWriter::finalize() {
   for (const auto& eff : m_effPlotTool.trackEffVsPtInAbsEtaRanges()) {
     toRoot(eff)->Write();
   }
+  for (const auto& eff : m_effPlotTool.trackEffVsLogPtInAbsEtaRanges()) {
+    toRoot(eff)->Write();
+  }
 
   // Write track summary histograms
   for (const auto& [name, prof] : m_trackSummaryPlotTool.profiles()) {

--- a/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
@@ -16,9 +16,11 @@
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
+#include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsExamples/EventData/TruthMatching.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 #include "ActsExamples/Framework/WriterT.hpp"
+#include "ActsExamples/Utilities/Range.hpp"
 #include "ActsExamples/Validation/TrackClassification.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
 
@@ -41,6 +43,43 @@ using Acts::VectorHelpers::perp;
 using Acts::VectorHelpers::phi;
 using Acts::VectorHelpers::theta;
 
+namespace {
+/// Tiebreaker for assigning a single particleId to a measurement.
+/// 1) Prefer the track's majority particle if any contributing sim hit
+///    matches it.
+/// 2) Otherwise fall back to the sim hit with the largest deposited
+///    energy. Ties broken by first occurrence.
+/// Returns 0 if the range is empty.
+template <typename Range>
+std::uint64_t pickParticleId(
+    const Range& simHitIndices,
+    const ActsExamples::SimHitContainer& simHits,
+    const ActsExamples::SimBarcode& majorityParticleId,
+    bool haveMajorityParticleId) {
+  // Rule 1: prefer the majority particle if any contributor matches.
+  if (haveMajorityParticleId) {
+    for (const auto& [measIdx, simHitIdx] : simHitIndices) {
+      const auto& simHit = *simHits.nth(simHitIdx);
+      if (simHit.particleId() == majorityParticleId) {
+        return static_cast<std::uint64_t>(majorityParticleId.hash());
+      }
+    }
+  }
+  // Rule 2: fall back to the highest-deposit hit.
+  std::uint64_t bestId = 0;
+  double bestDeposit = -std::numeric_limits<double>::infinity();
+  for (const auto& [measIdx, simHitIdx] : simHitIndices) {
+    const auto& simHit = *simHits.nth(simHitIdx);
+    const double dep = simHit.depositedEnergy();
+    if (dep > bestDeposit) {
+      bestDeposit = dep;
+      bestId = static_cast<std::uint64_t>(simHit.particleId().hash());
+    }
+  }
+  return bestId;
+}
+}  // namespace
+
 namespace ActsExamples {
 
 RootTrackSummaryWriter::RootTrackSummaryWriter(
@@ -58,6 +97,8 @@ RootTrackSummaryWriter::RootTrackSummaryWriter(
   m_inputParticles.maybeInitialize(m_cfg.inputParticles);
   m_inputTrackParticleMatching.maybeInitialize(
       m_cfg.inputTrackParticleMatching);
+  m_inputSimHits.maybeInitialize(m_cfg.inputSimHits);
+  m_inputMeasurementSimHitsMap.maybeInitialize(m_cfg.inputMeasurementSimHitsMap);
   if (m_cfg.writeJets) {
     m_inputJets.maybeInitialize(m_cfg.inputJets);
   }
@@ -89,6 +130,7 @@ RootTrackSummaryWriter::RootTrackSummaryWriter(
   m_outputTree->Branch("outlierChi2", &m_outlierChi2);
   m_outputTree->Branch("measurementVolume", &m_measurementVolume);
   m_outputTree->Branch("measurementLayer", &m_measurementLayer);
+  m_outputTree->Branch("measurementParticleId", &m_measurementParticleId);
   m_outputTree->Branch("outlierVolume", &m_outlierVolume);
   m_outputTree->Branch("outlierLayer", &m_outlierLayer);
 
@@ -235,6 +277,8 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
   // In case we do not have truth info, we bind to a empty collection
   const static SimParticleContainer emptyParticles;
   const static TrackParticleMatching emptyTrackParticleMatching;
+  const static SimHitContainer emptySimHits;
+  const static MeasurementSimHitsMap emptyMeasurementSimHitsMap;
 
   const auto& particles =
       m_inputParticles.isInitialized() ? m_inputParticles(ctx) : emptyParticles;
@@ -242,6 +286,13 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
       m_inputTrackParticleMatching.isInitialized()
           ? m_inputTrackParticleMatching(ctx)
           : emptyTrackParticleMatching;
+
+  const auto& simHits =
+      m_inputSimHits.isInitialized() ? m_inputSimHits(ctx) : emptySimHits;
+  const auto& measurementSimHitsMap =
+      m_inputMeasurementSimHitsMap.isInitialized()
+          ? m_inputMeasurementSimHitsMap(ctx)
+          : emptyMeasurementSimHitsMap;
 
   // For each particle within a track, how many hits did it contribute
   std::vector<ParticleHitCount> particleHitCounts;
@@ -289,10 +340,22 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
     m_chi2Sum.push_back(track.chi2());
     m_NDF.push_back(track.nDoF());
 
+    // Resolve the majority truth particle early so the per-measurement
+    // loop below can prefer it when assigning particle ids.
+    SimBarcode majorityParticleId{};
+    bool haveMajorityParticleId = false;
+    auto match = trackParticleMatching.find(track.index());
+    if (match != trackParticleMatching.end() &&
+        match->second.particle.has_value()) {
+      majorityParticleId = match->second.particle.value();
+      haveMajorityParticleId = true;
+    }
+
     {
       std::vector<double> measurementChi2;
       std::vector<std::uint32_t> measurementVolume;
       std::vector<std::uint32_t> measurementLayer;
+      std::vector<std::uint64_t> measurementParticleId;
       std::vector<double> outlierChi2;
       std::vector<std::uint32_t> outlierVolume;
       std::vector<std::uint32_t> outlierLayer;
@@ -308,18 +371,31 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
           measurementChi2.push_back(state.chi2());
           measurementVolume.push_back(volume);
           measurementLayer.push_back(layer);
+          // Resolve truth particle id for this measurement.
+          std::uint64_t particleId = 0;
+          if (state.hasUncalibratedSourceLink() &&
+              m_inputSimHits.isInitialized() &&
+              m_inputMeasurementSimHitsMap.isInitialized()) {
+            const auto sl = state.getUncalibratedSourceLink()
+                                .template get<IndexSourceLink>();
+            const auto indices =
+                makeRange(measurementSimHitsMap.equal_range(sl.index()));
+            particleId = pickParticleId(indices, simHits, majorityParticleId,
+                                        haveMajorityParticleId);
+          }
+          measurementParticleId.push_back(particleId);
         }
       }
       m_measurementChi2.push_back(std::move(measurementChi2));
       m_measurementVolume.push_back(std::move(measurementVolume));
       m_measurementLayer.push_back(std::move(measurementLayer));
+      m_measurementParticleId.push_back(std::move(measurementParticleId));
       m_outlierChi2.push_back(std::move(outlierChi2));
       m_outlierVolume.push_back(std::move(outlierVolume));
       m_outlierLayer.push_back(std::move(outlierLayer));
     }
 
     // Initialize the truth particle info
-    SimBarcode majorityParticleId{};
     TrackMatchClassification trackClassification =
         TrackMatchClassification::Unknown;
     unsigned int nMajorityHits = std::numeric_limits<unsigned int>::max();
@@ -346,13 +422,13 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
         track.hasReferenceSurface() ? &track.referenceSurface() : nullptr;
 
     // Get the majority truth particle to this track
-    auto match = trackParticleMatching.find(track.index());
     bool foundMajorityParticle = false;
     // Get the truth particle info
     if (match != trackParticleMatching.end() &&
         match->second.particle.has_value()) {
       // Get the barcode of the majority truth particle
-      majorityParticleId = match->second.particle.value();
+      // (majorityParticleId was already resolved above for the
+      // per-measurement particle-id assignment)
       trackClassification = match->second.classification;
       nMajorityHits = match->second.contributingParticles.front().hitCount;
 
@@ -604,6 +680,7 @@ ProcessCode RootTrackSummaryWriter::writeT(const AlgorithmContext& ctx,
   m_measurementLayer.clear();
   m_outlierVolume.clear();
   m_outlierLayer.clear();
+  m_measurementParticleId.clear();
 
   m_nMajorityHits.clear();
   m_majorityParticleVertexPrimary.clear();

--- a/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
+++ b/Examples/Io/Root/src/RootTrackSummaryWriter.cpp
@@ -51,11 +51,10 @@ namespace {
 ///    energy. Ties broken by first occurrence.
 /// Returns 0 if the range is empty.
 template <typename Range>
-std::uint64_t pickParticleId(
-    const Range& simHitIndices,
-    const ActsExamples::SimHitContainer& simHits,
-    const ActsExamples::SimBarcode& majorityParticleId,
-    bool haveMajorityParticleId) {
+std::uint64_t pickParticleId(const Range& simHitIndices,
+                             const ActsExamples::SimHitContainer& simHits,
+                             const ActsExamples::SimBarcode& majorityParticleId,
+                             bool haveMajorityParticleId) {
   // Rule 1: prefer the majority particle if any contributor matches.
   if (haveMajorityParticleId) {
     for (const auto& [measIdx, simHitIdx] : simHitIndices) {
@@ -98,7 +97,8 @@ RootTrackSummaryWriter::RootTrackSummaryWriter(
   m_inputTrackParticleMatching.maybeInitialize(
       m_cfg.inputTrackParticleMatching);
   m_inputSimHits.maybeInitialize(m_cfg.inputSimHits);
-  m_inputMeasurementSimHitsMap.maybeInitialize(m_cfg.inputMeasurementSimHitsMap);
+  m_inputMeasurementSimHitsMap.maybeInitialize(
+      m_cfg.inputMeasurementSimHitsMap);
   if (m_cfg.writeJets) {
     m_inputJets.maybeInitialize(m_cfg.inputJets);
   }

--- a/Examples/Scripts/Python/full_chain_odd.py
+++ b/Examples/Scripts/Python/full_chain_odd.py
@@ -36,6 +36,7 @@ from acts.examples.reconstruction import (
     VertexFinder,
     addSeedFilterML,
     SeedFilterMLDBScanConfig,
+    EffPlotToolConfig,
 )
 from acts.examples.odd import getOpenDataDetector, getOpenDataDetectorDirectory
 
@@ -174,6 +175,20 @@ trackingGeometry = detector.trackingGeometry()
 decorators = detector.contextDecorators()
 field = acts.ConstantBField(acts.Vector3(0.0, 0.0, 2.0 * u.T))
 rnd = acts.examples.RandomNumbers(seed=42)
+
+# Configuration of efficiency plots
+# (example of how to modify the binning; the values here are the default ones as in EffPlotTool.hpp)
+binning = EffPlotToolConfig.varBinning
+binning["Eta"] = acts.Axis.regular(40, -3.0, 3.0, "#eta")
+binning["Pt"] = acts.Axis.regular(40, 0, 100, "pT [GeV/c]")
+EffPlotToolConfig.varBinning = binning
+
+EffPlotToolConfig.truthAbsEtaRangesForPt = [
+    (0.0, 0.2),
+    (0.0, 0.8),
+    (1.0, 2.0),
+    (2.0, 3.0),
+]
 
 s = acts.examples.Sequencer(
     events=args.events,

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -24,6 +24,19 @@ except ImportError:
 
 u = acts.UnitConstants
 
+# Resolution Plots
+ResPlotToolConfig = acts.examples.root.ResPlotToolConfig()
+# Duplication Plots
+DuplicationPlotToolConfig = acts.examples.root.DuplicationPlotToolConfig()
+# Efficiency Plots
+EffPlotToolConfig = acts.examples.root.EffPlotToolConfig()
+# Fake rate Plots
+FakePlotToolConfig = acts.examples.root.FakePlotToolConfig()
+# TrackQuality Plots
+TrackQualityPlotToolConfig = acts.examples.root.TrackQualityPlotToolConfig()
+# Track Summary Plots
+TrackSummaryPlotToolConfig = acts.examples.root.TrackSummaryPlotToolConfig()
+
 SeedingAlgorithm = Enum(
     "SeedingAlgorithm",
     "TruthSmeared TruthEstimated HoughTransform AdaptiveHoughTransform Gbts Hashing GridTriplet OrthogonalTriplet HashingPrototype",
@@ -1354,6 +1367,11 @@ def addSeedPerformanceWriters(
             inputTrackParticleMatching=f"{prefix}seed_particle_matching",
             inputParticleTrackMatching=f"{prefix}particle_seed_matching",
             inputParticleMeasurementsMap="particle_measurements_map",
+            effPlotToolConfig=EffPlotToolConfig,
+            fakePlotToolConfig=FakePlotToolConfig,
+            duplicationPlotToolConfig=DuplicationPlotToolConfig,
+            trackQualityPlotToolConfig=TrackQualityPlotToolConfig,
+            trackSummaryPlotToolConfig=TrackSummaryPlotToolConfig,
             filePath=str(outputDirRoot / f"performance_{prefix}seeding.root"),
         )
     )
@@ -1868,6 +1886,8 @@ def addTrackWriters(
                 inputTracks=tracks,
                 inputParticles="particles_selected",
                 inputTrackParticleMatching="track_particle_matching",
+                inputSimHits="simhits",
+                inputMeasurementSimHitsMap="measurement_simhits_map",
                 filePath=str(outputDirRoot / f"tracksummary_{name}.root"),
                 treeName="tracksummary",
                 writeCovMat=writeCovMat,
@@ -1893,6 +1913,8 @@ def addTrackWriters(
                 inputTracks=tracks,
                 inputParticles="particles_selected",
                 inputTrackParticleMatching="track_particle_matching",
+                resPlotToolConfig=ResPlotToolConfig,
+                effPlotToolConfig=EffPlotToolConfig,
                 filePath=str(outputDirRoot / f"performance_fitting_{name}.root"),
             )
             s.addWriter(trackFitterPerformanceWriter)
@@ -1905,6 +1927,11 @@ def addTrackWriters(
                 inputTrackParticleMatching="track_particle_matching",
                 inputParticleTrackMatching="particle_track_matching",
                 inputParticleMeasurementsMap="particle_measurements_map",
+                effPlotToolConfig=EffPlotToolConfig,
+                fakePlotToolConfig=FakePlotToolConfig,
+                duplicationPlotToolConfig=DuplicationPlotToolConfig,
+                trackQualityPlotToolConfig=TrackQualityPlotToolConfig,
+                trackSummaryPlotToolConfig=TrackSummaryPlotToolConfig,
                 filePath=str(outputDirRoot / f"performance_finding_{name}.root"),
             )
             s.addWriter(trackFinderPerfWriter)

--- a/Python/Examples/src/PythonSpecific.cpp
+++ b/Python/Examples/src/PythonSpecific.cpp
@@ -114,6 +114,9 @@ class PythonTrackFinderPerformanceWriter final
     for (const auto& eff : coll.effPlotTool().trackEffVsPtInAbsEtaRanges()) {
       d[py::str(eff.name())] = py::cast(eff, py::return_value_policy::copy);
     }
+    for (const auto& eff : coll.effPlotTool().trackEffVsLogPtInAbsEtaRanges()) {
+      d[py::str(eff.name())] = py::cast(eff, py::return_value_policy::copy);
+    }
 
     for (const auto& [name, hist] : coll.fakePlotTool().histograms()) {
       d[py::str(name)] = py::cast(hist, py::return_value_policy::copy);

--- a/Python/Examples/src/plugins/Root.cpp
+++ b/Python/Examples/src/plugins/Root.cpp
@@ -104,7 +104,11 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsRoot, root) {
       py::class_<EffPlotTool::Config>(root, "EffPlotToolConfig")
           .def(py::init<>())
           .def_readwrite("varBinning", &EffPlotTool::Config::varBinning)
-          .def_readwrite("minTruthPt", &EffPlotTool::Config::minTruthPt);
+          .def_readwrite("minTruthPt", &EffPlotTool::Config::minTruthPt)
+          .def_readwrite("truthPtRangesForEta",
+                         &EffPlotTool::Config::truthPtRangesForEta)
+          .def_readwrite("truthAbsEtaRangesForPt",
+                         &EffPlotTool::Config::truthAbsEtaRangesForPt);
 
       py::class_<FakePlotTool::Config>(root, "FakePlotToolConfig")
           .def(py::init<>())
@@ -266,9 +270,9 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsRoot, root) {
 
     ACTS_PYTHON_DECLARE_WRITER(
         RootTrackSummaryWriter, root, "RootTrackSummaryWriter", inputTracks,
-        inputParticles, inputTrackParticleMatching, inputJets, filePath,
-        treeName, fileMode, writeCovMat, writeGsfSpecific, writeGx2fSpecific,
-        writeJets);
+        inputParticles, inputTrackParticleMatching, inputSimHits,
+        inputMeasurementSimHitsMap, inputJets, filePath, treeName, fileMode,
+        writeCovMat, writeGsfSpecific, writeGx2fSpecific, writeJets);
 
     ACTS_PYTHON_DECLARE_WRITER(
         RootVertexNTupleWriter, root, "RootVertexNTupleWriter", inputVertices,


### PR DESCRIPTION
This PR makes two (largely independent) improvements to the ActsExamples I/O and performance QA code:

1. Expose configurations of the plotting tools (`EffPlotToolConfig`, `ResPlotToolConfig` etc.) in the `reconstruction.py`, so binning, pT/eta ranges and other plotting parameters can be configured from .py steering scripts ("full_chain.py") instead of being hard-coded in C++. A small example is added to `full_chain_odd.py`.

Also, `truthPtRangesForEta` and `truthAbsEtaRangesForPt` from `EffPlotToolConfig` are now exposed to the python level and can be changed in .py scripts; a log-pT variant of the efficiency-vs-pT plots is added.

2. Add a per-measurement truth particleId branch to the track summary tree, allowing each measurement on a track to be linked back to the truth particle that produced it (e.g. for per-layer particle-identity studies).

