### PR TITLE
feat: augment portal merge failures with context

### DIFF
--- a/Core/include/Acts/Geometry/BlueprintOptions.hpp
+++ b/Core/include/Acts/Geometry/BlueprintOptions.hpp
@@ -20,6 +20,14 @@ struct BlueprintOptions {
   std::shared_ptr<NavigationPolicyFactory> defaultNavigationPolicyFactory{
       makeDefaultNavigationPolicyFactory()};
 
+  /// If set, material designated on a portal face that must be merged during
+  /// container stacking does not abort construction. Instead the offending
+  /// material is discarded, the merged surface is tagged with a
+  /// @ref MergedMaterialMarker, and a warning is emitted. This is lossy and
+  /// intended as a debugging aid: the material designation should be moved to a
+  /// face that is not merged (e.g. the enclosing container's face).
+  bool keepGoingOnMaterialMergeFailure = false;
+
   /// Validates the blueprint options
   void validate() const;
 

--- a/Core/include/Acts/Geometry/CuboidPortalShell.hpp
+++ b/Core/include/Acts/Geometry/CuboidPortalShell.hpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Geometry/CuboidVolumeBounds.hpp"
+#include "Acts/Geometry/Portal.hpp"
 #include "Acts/Geometry/PortalShell.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
@@ -105,10 +106,16 @@ class CuboidStackPortalShell final : public CuboidPortalShell {
   /// @note The shells must be ordered in the given direction
   /// @param direction The stacking direction (along x/y/z axis) in local stack coordinates
   /// @param logger A logging instance for debugging
+  /// @param materialPolicy How to treat material designated on faces that are
+  ///        merged during stacking. By default this is a fatal error; in
+  ///        @ref PortalMaterialMergePolicy::eDiscardAndMark mode the material is
+  ///        discarded and the merged surface is tagged with a marker.
   CuboidStackPortalShell(const GeometryContext& gctx,
                          std::vector<CuboidPortalShell*> shells,
                          AxisDirection direction,
-                         const Logger& logger = getDummyLogger());
+                         const Logger& logger = getDummyLogger(),
+                         PortalMaterialMergePolicy materialPolicy =
+                             PortalMaterialMergePolicy::eThrow);
 
   /// Return the faces that are *merged* (as opposed to fused) when stacking in
   /// the given direction. Material designated on these faces of a child shell

--- a/Core/include/Acts/Geometry/CuboidPortalShell.hpp
+++ b/Core/include/Acts/Geometry/CuboidPortalShell.hpp
@@ -110,6 +110,13 @@ class CuboidStackPortalShell final : public CuboidPortalShell {
                          AxisDirection direction,
                          const Logger& logger = getDummyLogger());
 
+  /// Return the faces that are *merged* (as opposed to fused) when stacking in
+  /// the given direction. Material designated on these faces of a child shell
+  /// cannot survive the stacking and will cause a merge failure.
+  /// @param direction The stacking direction
+  /// @return The faces that get merged for the given direction
+  static std::vector<Face> mergedFaces(AxisDirection direction);
+
   /// @copydoc PortalShellBase::size
   std::size_t size() const override;
 

--- a/Core/include/Acts/Geometry/CylinderPortalShell.hpp
+++ b/Core/include/Acts/Geometry/CylinderPortalShell.hpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <memory>
+#include <vector>
 
 namespace Acts {
 
@@ -139,6 +140,13 @@ class CylinderStackPortalShell : public CylinderPortalShell {
                            std::vector<CylinderPortalShell*> shells,
                            AxisDirection direction,
                            const Logger& logger = getDummyLogger());
+
+  /// Return the faces that are *merged* (as opposed to fused) when stacking in
+  /// the given direction. Material designated on these faces of a child shell
+  /// cannot survive the stacking and will cause a merge failure.
+  /// @param direction The stacking direction
+  /// @return The faces that get merged for the given direction
+  static std::vector<Face> mergedFaces(AxisDirection direction);
 
   /// @copydoc PortalShellBase::size
   std::size_t size() const final;

--- a/Core/include/Acts/Geometry/CylinderPortalShell.hpp
+++ b/Core/include/Acts/Geometry/CylinderPortalShell.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Acts/Geometry/CylinderVolumeBounds.hpp"
+#include "Acts/Geometry/Portal.hpp"
 #include "Acts/Geometry/PortalShell.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
@@ -136,10 +137,16 @@ class CylinderStackPortalShell : public CylinderPortalShell {
   /// @note The shells must be ordered in the given direction
   /// @param direction The stacking direction
   /// @param logger A logging instance for debugging
+  /// @param materialPolicy How to treat material designated on faces that are
+  ///        merged during stacking. By default this is a fatal error; in
+  ///        @ref PortalMaterialMergePolicy::eDiscardAndMark mode the material is
+  ///        discarded and the merged surface is tagged with a marker.
   CylinderStackPortalShell(const GeometryContext& gctx,
                            std::vector<CylinderPortalShell*> shells,
                            AxisDirection direction,
-                           const Logger& logger = getDummyLogger());
+                           const Logger& logger = getDummyLogger(),
+                           PortalMaterialMergePolicy materialPolicy =
+                               PortalMaterialMergePolicy::eThrow);
 
   /// Return the faces that are *merged* (as opposed to fused) when stacking in
   /// the given direction. Material designated on these faces of a child shell

--- a/Core/include/Acts/Geometry/Portal.hpp
+++ b/Core/include/Acts/Geometry/Portal.hpp
@@ -49,6 +49,17 @@ class PortalFusingException : public std::exception {
   const char* what() const noexcept override;
 };
 
+/// Policy controlling how @ref Portal::merge treats surfaces that carry
+/// material. Merged surfaces cannot retain the material of their inputs, so by
+/// default this is treated as a fatal error.
+enum class PortalMaterialMergePolicy {
+  /// Abort the merge by throwing a @ref PortalMergingException (default).
+  eThrow,
+  /// Continue the merge: discard the input material, tag the merged surface
+  /// with a @ref MergedMaterialMarker and emit a warning. This is lossy.
+  eDiscardAndMark,
+};
+
 /// A portal connects two or more neighboring volumes. Each volume has a set of
 /// portals that describes which volumes lie behind the portal in that
 /// direction. Portals use associated portal links to perform lookups of target
@@ -176,10 +187,17 @@ class Portal {
   /// @param bPortal The second portal
   /// @param direction The direction of the merge (e.g. along z)
   /// @param logger The logger to push output to
+  /// @param materialPolicy How to treat surfaces that carry material. By
+  ///        default the merge aborts with an exception; in
+  ///        @ref PortalMaterialMergePolicy::eDiscardAndMark mode the material is
+  ///        discarded, the merged surface is tagged with a
+  ///        @ref MergedMaterialMarker and a warning is emitted.
   /// @return A new merged portal that encompasses both input portals
   static Portal merge(const GeometryContext& gctx, Portal& aPortal,
                       Portal& bPortal, AxisDirection direction,
-                      const Logger& logger = getDummyLogger());
+                      const Logger& logger = getDummyLogger(),
+                      PortalMaterialMergePolicy materialPolicy =
+                          PortalMaterialMergePolicy::eThrow);
 
   /// Resolve the volume for a 3D position and a direction
   /// The @p direction is used to select the right portal link, if it is set.

--- a/Core/include/Acts/Geometry/Portal.hpp
+++ b/Core/include/Acts/Geometry/Portal.hpp
@@ -14,7 +14,9 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 
+#include <exception>
 #include <memory>
+#include <string>
 
 namespace Acts {
 
@@ -30,7 +32,16 @@ class PortalLinkBase;
 
 /// Exception thrown when portals cannot be merged
 class PortalMergingException : public std::exception {
+ public:
+  /// Default constructor producing a generic message.
+  PortalMergingException() = default;
+  /// Construct with a contextual message describing why the merge failed.
+  /// @param message The contextual error message
+  explicit PortalMergingException(std::string message);
   const char* what() const noexcept override;
+
+ private:
+  std::string m_message{"Failure to merge portals"};
 };
 
 /// Exception thrown when portals cannot be fused

--- a/Core/include/Acts/Geometry/Portal.hpp
+++ b/Core/include/Acts/Geometry/Portal.hpp
@@ -38,6 +38,8 @@ class PortalMergingException : public std::exception {
   /// Construct with a contextual message describing why the merge failed.
   /// @param message The contextual error message
   explicit PortalMergingException(std::string message);
+  /// Get exception description.
+  /// @return C-style string describing the exception
   const char* what() const noexcept override;
 
  private:
@@ -49,7 +51,7 @@ class PortalFusingException : public std::exception {
   const char* what() const noexcept override;
 };
 
-/// Policy controlling how @ref Portal::merge treats surfaces that carry
+/// Policy controlling how @ref Acts::Portal::merge treats surfaces that carry
 /// material. Merged surfaces cannot retain the material of their inputs, so by
 /// default this is treated as a fatal error.
 enum class PortalMaterialMergePolicy {

--- a/Core/include/Acts/Material/MergedMaterialMarker.hpp
+++ b/Core/include/Acts/Material/MergedMaterialMarker.hpp
@@ -40,17 +40,17 @@ class MergedMaterialMarker final : public ISurfaceMaterial {
   /// Scale operator -- no-op, the marker carries no material
   /// @param factor is the scale factor (ignored)
   /// @return Reference to this marker
-  MergedMaterialMarker& scale(double factor) final;
+  MergedMaterialMarker& scale(double factor) override;
 
   /// @copydoc ISurfaceMaterial::materialSlab(const Vector2&) const
   ///
   /// @note the input parameter is ignored, always returns
   ///       @ref MaterialSlab::Nothing()
-  const MaterialSlab& materialSlab(const Vector2& lp = Vector2{0.,
-                                                               0.}) const final;
+  const MaterialSlab& materialSlab(const Vector2& lp = Vector2{
+                                       0., 0.}) const override;
 
   /// @copydoc ISurfaceMaterial::localAxisDirections() const
-  std::vector<AxisDirection> localAxisDirections() const final;
+  std::vector<AxisDirection> localAxisDirections() const override;
 
   /// @copydoc ISurfaceMaterial::materialSlab(const Vector3&) const
   ///
@@ -59,7 +59,7 @@ class MergedMaterialMarker final : public ISurfaceMaterial {
   [[deprecated(
       "Use materialSlab(const Vector2& lp) with a prior "
       "Surface::globalToLocal() call instead")]] const MaterialSlab&
-  materialSlab(const Vector3& gp) const final;
+  materialSlab(const Vector3& gp) const override;
 
   // Inherit additional materialSlab overloads from base class
   using ISurfaceMaterial::materialSlab;
@@ -70,7 +70,7 @@ class MergedMaterialMarker final : public ISurfaceMaterial {
   /// Output Method for std::ostream
   /// @param sl The output stream
   /// @return Reference to the output stream for chaining
-  std::ostream& toStream(std::ostream& sl) const final;
+  std::ostream& toStream(std::ostream& sl) const override;
 
  private:
   /// The marker carries no material

--- a/Core/include/Acts/Material/MergedMaterialMarker.hpp
+++ b/Core/include/Acts/Material/MergedMaterialMarker.hpp
@@ -1,0 +1,80 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Material/ISurfaceMaterial.hpp"
+#include "Acts/Material/MaterialSlab.hpp"
+
+#include <iosfwd>
+#include <vector>
+
+namespace Acts {
+
+/// @ingroup material
+///
+/// Sentinel surface material used by `Portal::merge` in its "keep going" mode.
+///
+/// When two portal surfaces that both carry material (or one of them does) are
+/// merged, the original material cannot be transferred onto the (larger) merged
+/// surface. Instead of aborting the construction, the merge can be configured
+/// to discard the input material and tag the merged surface with this marker.
+///
+/// The marker carries no physical material -- it always returns
+/// @ref MaterialSlab::Nothing() -- but its presence makes the lossy merge
+/// discoverable downstream (e.g. when inspecting or writing out the geometry).
+class MergedMaterialMarker final : public ISurfaceMaterial {
+ public:
+  /// Default constructor
+  MergedMaterialMarker() = default;
+
+  /// Destructor
+  ~MergedMaterialMarker() override = default;
+
+  /// Scale operator -- no-op, the marker carries no material
+  /// @param factor is the scale factor (ignored)
+  /// @return Reference to this marker
+  MergedMaterialMarker& scale(double factor) final;
+
+  /// @copydoc ISurfaceMaterial::materialSlab(const Vector2&) const
+  ///
+  /// @note the input parameter is ignored, always returns
+  ///       @ref MaterialSlab::Nothing()
+  const MaterialSlab& materialSlab(const Vector2& lp = Vector2{0.,
+                                                               0.}) const final;
+
+  /// @copydoc ISurfaceMaterial::localAxisDirections() const
+  std::vector<AxisDirection> localAxisDirections() const final;
+
+  /// @copydoc ISurfaceMaterial::materialSlab(const Vector3&) const
+  ///
+  /// @note the input parameter is ignored, always returns
+  ///       @ref MaterialSlab::Nothing()
+  [[deprecated(
+      "Use materialSlab(const Vector2& lp) with a prior "
+      "Surface::globalToLocal() call instead")]] const MaterialSlab&
+  materialSlab(const Vector3& gp) const final;
+
+  // Inherit additional materialSlab overloads from base class
+  using ISurfaceMaterial::materialSlab;
+
+  // Inherit the scale-access helper from the base class
+  using ISurfaceMaterial::factor;
+
+  /// Output Method for std::ostream
+  /// @param sl The output stream
+  /// @return Reference to the output stream for chaining
+  std::ostream& toStream(std::ostream& sl) const final;
+
+ private:
+  /// The marker carries no material
+  MaterialSlab m_slab = MaterialSlab::Nothing();
+};
+
+}  // namespace Acts

--- a/Core/src/Geometry/ContainerBlueprintNode.cpp
+++ b/Core/src/Geometry/ContainerBlueprintNode.cpp
@@ -12,6 +12,12 @@
 #include "Acts/Geometry/CuboidVolumeStack.hpp"
 #include "Acts/Geometry/CylinderPortalShell.hpp"
 #include "Acts/Geometry/CylinderVolumeStack.hpp"
+#include "Acts/Geometry/Portal.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
+
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace Acts::Experimental {
 
@@ -239,6 +245,36 @@ PortalShellBase& ContainerBlueprintNode::connectImpl(
   throw_assert(std::ranges::all_of(
                    shells, [](const auto* shell) { return shell->isValid(); }),
                "Invalid shell");
+
+  // Fail fast (and with a node-scoped message) if material has been designated
+  // on a portal face that will be *merged* during stacking. Such material
+  // cannot survive the merge and would otherwise trigger a deep, hard-to-trace
+  // failure inside the stack shell construction. Faces that are *fused* (e.g.
+  // the boundary between two stacked volumes) legitimately carry material and
+  // are not flagged here.
+  std::vector<std::string> materialClashes;
+  for (auto face : ShellStack::mergedFaces(direction())) {
+    for (auto* shell : shells) {
+      auto portal = shell->portal(face);
+      if (portal != nullptr && portal->surface().hasMaterial()) {
+        std::stringstream ss;
+        ss << shell->label() << " carries material on face " << face;
+        materialClashes.push_back(ss.str());
+      }
+    }
+  }
+  if (!materialClashes.empty()) {
+    std::stringstream ss;
+    ss << prefix << "Cannot stack child volumes in " << direction()
+       << " direction: material is designated on portal faces that are merged "
+          "during stacking. Move the material designation to a face that is "
+          "not merged (e.g. the enclosing container's face).";
+    for (const auto& clash : materialClashes) {
+      ss << "\n  - " << clash;
+    }
+    ACTS_ERROR(ss.str());
+    throw PortalMergingException{ss.str()};
+  }
 
   ACTS_DEBUG(prefix << "Producing merged stack shell in " << direction()
                     << " direction from " << shells.size() << " shells");

--- a/Core/src/Geometry/ContainerBlueprintNode.cpp
+++ b/Core/src/Geometry/ContainerBlueprintNode.cpp
@@ -246,12 +246,17 @@ PortalShellBase& ContainerBlueprintNode::connectImpl(
                    shells, [](const auto* shell) { return shell->isValid(); }),
                "Invalid shell");
 
-  // Fail fast (and with a node-scoped message) if material has been designated
-  // on a portal face that will be *merged* during stacking. Such material
-  // cannot survive the merge and would otherwise trigger a deep, hard-to-trace
-  // failure inside the stack shell construction. Faces that are *fused* (e.g.
-  // the boundary between two stacked volumes) legitimately carry material and
-  // are not flagged here.
+  // Detect (with a node-scoped message) if material has been designated on a
+  // portal face that will be *merged* during stacking. Such material cannot
+  // survive the merge and would otherwise trigger a deep, hard-to-trace failure
+  // inside the stack shell construction. Faces that are *fused* (e.g. the
+  // boundary between two stacked volumes) legitimately carry material and are
+  // not flagged here.
+  const PortalMaterialMergePolicy materialPolicy =
+      options.keepGoingOnMaterialMergeFailure
+          ? PortalMaterialMergePolicy::eDiscardAndMark
+          : PortalMaterialMergePolicy::eThrow;
+
   std::vector<std::string> materialClashes;
   for (auto face : ShellStack::mergedFaces(direction())) {
     for (auto* shell : shells) {
@@ -265,21 +270,27 @@ PortalShellBase& ContainerBlueprintNode::connectImpl(
   }
   if (!materialClashes.empty()) {
     std::stringstream ss;
-    ss << prefix << "Cannot stack child volumes in " << direction()
-       << " direction: material is designated on portal faces that are merged "
-          "during stacking. Move the material designation to a face that is "
-          "not merged (e.g. the enclosing container's face).";
+    ss << prefix << "Material is designated on portal faces that are merged "
+       << "when stacking child volumes in " << direction() << " direction.";
     for (const auto& clash : materialClashes) {
       ss << "\n  - " << clash;
     }
-    ACTS_ERROR(ss.str());
-    throw PortalMergingException{ss.str()};
+    if (materialPolicy == PortalMaterialMergePolicy::eThrow) {
+      ss << "\nMove the material designation to a face that is not merged "
+            "(e.g. "
+            "the enclosing container's face).";
+      ACTS_ERROR(ss.str());
+      throw PortalMergingException{ss.str()};
+    }
+    ss << "\nContinuing anyway: this material will be discarded and the merged "
+          "surface tagged with a MergedMaterialMarker.";
+    ACTS_WARNING(ss.str());
   }
 
   ACTS_DEBUG(prefix << "Producing merged stack shell in " << direction()
                     << " direction from " << shells.size() << " shells");
   m_shell = std::make_unique<ShellStack>(gctx, std::move(shells), direction(),
-                                         logger);
+                                         logger, materialPolicy);
 
   assert(m_shell != nullptr && "No shell was built at the end of connect");
   assert(m_shell->isValid() && "Shell is not valid at the end of connect");

--- a/Core/src/Geometry/CuboidPortalShell.cpp
+++ b/Core/src/Geometry/CuboidPortalShell.cpp
@@ -20,6 +20,7 @@
 #include <array>
 #include <cstddef>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -184,18 +185,31 @@ CuboidStackPortalShell::CuboidStackPortalShell(
     std::ranges::transform(m_shells, std::back_inserter(portals),
                            [face](auto* shell) { return shell->portal(face); });
 
-    auto merged = std::accumulate(
-        std::next(portals.begin()), portals.end(), portals.front(),
-        [&](const auto& aPortal,
-            const auto& bPortal) -> std::shared_ptr<Portal> {
-          assert(aPortal != nullptr);
-          assert(bPortal != nullptr);
+    std::shared_ptr<Portal> merged;
+    try {
+      merged = std::accumulate(
+          std::next(portals.begin()), portals.end(), portals.front(),
+          [&](const auto& aPortal,
+              const auto& bPortal) -> std::shared_ptr<Portal> {
+            assert(aPortal != nullptr);
+            assert(bPortal != nullptr);
 
-          AxisDirection onSurfaceAxis = onSurfaceDirs.at(face);
+            AxisDirection onSurfaceAxis = onSurfaceDirs.at(face);
 
-          return std::make_shared<Portal>(
-              Portal::merge(gctx, *aPortal, *bPortal, onSurfaceAxis, logger));
-        });
+            return std::make_shared<Portal>(
+                Portal::merge(gctx, *aPortal, *bPortal, onSurfaceAxis, logger));
+          });
+    } catch (const PortalMergingException& e) {
+      std::stringstream ss;
+      ss << "Failed to merge portals at face " << face << " while building "
+         << label() << " (stacking in " << m_direction << "). Shells involved:";
+      for (const auto* shell : m_shells) {
+        ss << "\n  - " << shell->label();
+      }
+      ss << "\nUnderlying error: " << e.what();
+      ACTS_ERROR(ss.str());
+      throw PortalMergingException{ss.str()};
+    }
 
     assert(merged != nullptr);
     assert(merged->isValid());

--- a/Core/src/Geometry/CuboidPortalShell.cpp
+++ b/Core/src/Geometry/CuboidPortalShell.cpp
@@ -24,8 +24,6 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include <boost/algorithm/string/join.hpp>
-
 namespace Acts {
 
 void CuboidPortalShell::fill(TrackingVolume& volume) {
@@ -298,14 +296,13 @@ const Transform3& CuboidStackPortalShell::localToGlobalTransform(
 }
 
 std::string CuboidStackPortalShell::label() const {
+  // Deliberately shallow: only describe this shell, not the whole subtree.
+  // Expanding child labels recursively makes error messages for non-trivial
+  // geometries unreadable. The immediate children are reported separately where
+  // relevant (e.g. in merge-failure messages).
   std::stringstream ss;
-  ss << "CuboidStackShell(dir=" << m_direction << ", children=";
-
-  std::vector<std::string> labels;
-  std::ranges::transform(m_shells, std::back_inserter(labels),
-                         [](const auto* shell) { return shell->label(); });
-  ss << boost::algorithm::join(labels, "|");
-  ss << ")";
+  ss << "CuboidStackShell(dir=" << m_direction << ", " << m_shells.size()
+     << " children)";
   return ss.str();
 }
 

--- a/Core/src/Geometry/CuboidPortalShell.cpp
+++ b/Core/src/Geometry/CuboidPortalShell.cpp
@@ -251,6 +251,15 @@ std::size_t CuboidStackPortalShell::size() const {
   return 6;
 }
 
+std::vector<CuboidStackPortalShell::Face> CuboidStackPortalShell::mergedFaces(
+    AxisDirection direction) {
+  // The side faces (parallel to the stacking direction) are merged, the front
+  // and back faces are fused.
+  const auto& [frontFace, backFace, sideFaces] =
+      CuboidVolumeBounds::facesFromAxisDirection(direction);
+  return {sideFaces.begin(), sideFaces.end()};
+}
+
 std::shared_ptr<Portal> CuboidStackPortalShell::portal(Face face) {
   if (face == m_backFace) {
     return m_shells.back()->portal(face);

--- a/Core/src/Geometry/CuboidPortalShell.cpp
+++ b/Core/src/Geometry/CuboidPortalShell.cpp
@@ -116,7 +116,8 @@ std::string SingleCuboidPortalShell::label() const {
 
 CuboidStackPortalShell::CuboidStackPortalShell(
     const GeometryContext& gctx, std::vector<CuboidPortalShell*> shells,
-    AxisDirection direction, const Logger& logger)
+    AxisDirection direction, const Logger& logger,
+    PortalMaterialMergePolicy materialPolicy)
     : m_direction(direction), m_shells{std::move(shells)} {
   using enum CuboidVolumeBounds::Face;
   using enum AxisDirection;
@@ -197,7 +198,8 @@ CuboidStackPortalShell::CuboidStackPortalShell(
             AxisDirection onSurfaceAxis = onSurfaceDirs.at(face);
 
             return std::make_shared<Portal>(
-                Portal::merge(gctx, *aPortal, *bPortal, onSurfaceAxis, logger));
+                Portal::merge(gctx, *aPortal, *bPortal, onSurfaceAxis, logger,
+                              materialPolicy));
           });
     } catch (const PortalMergingException& e) {
       std::stringstream ss;

--- a/Core/src/Geometry/CylinderPortalShell.cpp
+++ b/Core/src/Geometry/CylinderPortalShell.cpp
@@ -19,8 +19,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <boost/algorithm/string/join.hpp>
-
 namespace Acts {
 
 void CylinderPortalShell::fill(TrackingVolume& volume) {
@@ -426,14 +424,13 @@ bool CylinderStackPortalShell::isValid() const {
 }
 
 std::string CylinderStackPortalShell::label() const {
+  // Deliberately shallow: only describe this shell, not the whole subtree.
+  // Expanding child labels recursively makes error messages for non-trivial
+  // geometries unreadable. The immediate children are reported separately where
+  // relevant (e.g. in merge-failure messages).
   std::stringstream ss;
-  ss << "CylinderStackShell(dir=" << m_direction << ", children=";
-
-  std::vector<std::string> labels;
-  std::ranges::transform(m_shells, std::back_inserter(labels),
-                         [](const auto* shell) { return shell->label(); });
-  ss << boost::algorithm::join(labels, "|");
-  ss << ")";
+  ss << "CylinderStackShell(dir=" << m_direction << ", " << m_shells.size()
+     << " children)";
   return ss.str();
 }
 

--- a/Core/src/Geometry/CylinderPortalShell.cpp
+++ b/Core/src/Geometry/CylinderPortalShell.cpp
@@ -140,7 +140,8 @@ std::string SingleCylinderPortalShell::label() const {
 
 CylinderStackPortalShell::CylinderStackPortalShell(
     const GeometryContext& gctx, std::vector<CylinderPortalShell*> shells,
-    AxisDirection direction, const Logger& logger)
+    AxisDirection direction, const Logger& logger,
+    PortalMaterialMergePolicy materialPolicy)
     : m_direction{direction}, m_shells{std::move(shells)} {
   ACTS_VERBOSE("Making cylinder stack shell in " << m_direction
                                                  << " direction");
@@ -176,8 +177,8 @@ CylinderStackPortalShell::CylinderStackPortalShell(
                   "CylinderStackPortalShell: null portal in merge");
             }
 
-            return std::make_shared<Portal>(
-                Portal::merge(gctx, *aPortal, *bPortal, direction, logger));
+            return std::make_shared<Portal>(Portal::merge(
+                gctx, *aPortal, *bPortal, direction, logger, materialPolicy));
           });
     } catch (const PortalMergingException& e) {
       std::stringstream ss;

--- a/Core/src/Geometry/CylinderPortalShell.cpp
+++ b/Core/src/Geometry/CylinderPortalShell.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <sstream>
 #include <stdexcept>
 
 #include <boost/algorithm/string/join.hpp>
@@ -164,18 +165,31 @@ CylinderStackPortalShell::CylinderStackPortalShell(
                            [face](auto* shell) { return shell->portal(face); });
     ACTS_VERBOSE("Portals at " << face << ": " << portals.size());
 
-    auto merged = std::accumulate(
-        std::next(portals.begin()), portals.end(), portals.front(),
-        [&](const auto& aPortal,
-            const auto& bPortal) -> std::shared_ptr<Portal> {
-          if (aPortal == nullptr || bPortal == nullptr) {
-            throw std::invalid_argument(
-                "CylinderStackPortalShell: null portal in merge");
-          }
+    std::shared_ptr<Portal> merged;
+    try {
+      merged = std::accumulate(
+          std::next(portals.begin()), portals.end(), portals.front(),
+          [&](const auto& aPortal,
+              const auto& bPortal) -> std::shared_ptr<Portal> {
+            if (aPortal == nullptr || bPortal == nullptr) {
+              throw std::invalid_argument(
+                  "CylinderStackPortalShell: null portal in merge");
+            }
 
-          return std::make_shared<Portal>(
-              Portal::merge(gctx, *aPortal, *bPortal, direction, logger));
-        });
+            return std::make_shared<Portal>(
+                Portal::merge(gctx, *aPortal, *bPortal, direction, logger));
+          });
+    } catch (const PortalMergingException& e) {
+      std::stringstream ss;
+      ss << "Failed to merge portals at face " << face << " while building "
+         << label() << " (stacking in " << m_direction << "). Shells involved:";
+      for (const auto* shell : m_shells) {
+        ss << "\n  - " << shell->label();
+      }
+      ss << "\nUnderlying error: " << e.what();
+      ACTS_ERROR(ss.str());
+      throw PortalMergingException{ss.str()};
+    }
 
     if (merged == nullptr) {
       throw std::runtime_error(

--- a/Core/src/Geometry/CylinderPortalShell.cpp
+++ b/Core/src/Geometry/CylinderPortalShell.cpp
@@ -299,6 +299,21 @@ std::size_t CylinderStackPortalShell::size() const {
   return m_hasInnerCylinder ? 4 : 3;
 }
 
+std::vector<CylinderStackPortalShell::Face>
+CylinderStackPortalShell::mergedFaces(AxisDirection direction) {
+  using enum CylinderVolumeBounds::Face;
+  switch (direction) {
+    case AxisDirection::AxisR:
+      // Discs are merged, cylinders are fused
+      return {PositiveDisc, NegativeDisc};
+    case AxisDirection::AxisZ:
+      // Cylinders are merged, discs are fused
+      return {OuterCylinder, InnerCylinder};
+    default:
+      return {};
+  }
+}
+
 std::shared_ptr<Portal> CylinderStackPortalShell::portal(Face face) {
   if (m_direction == AxisDirection::AxisR) {
     switch (face) {

--- a/Core/src/Geometry/Portal.cpp
+++ b/Core/src/Geometry/Portal.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Geometry/GridPortalLink.hpp"
 #include "Acts/Geometry/PortalLinkBase.hpp"
 #include "Acts/Geometry/TrivialPortalLink.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/Zip.hpp"
 
@@ -185,7 +186,8 @@ RegularSurface& Portal::surface() {
 
 Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
                      Portal& bPortal, AxisDirection direction,
-                     const Logger& logger) {
+                     const Logger& logger,
+                     PortalMaterialMergePolicy materialPolicy) {
   ACTS_VERBOSE("Merging two portals along " << direction);
 
   if (&aPortal == &bPortal) {
@@ -193,28 +195,42 @@ Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
     throw PortalMergingException{};
   }
 
-  if (aPortal.m_surface->hasMaterial() || bPortal.m_surface->hasMaterial()) {
+  const bool aHasMaterial = aPortal.m_surface->hasMaterial();
+  const bool bHasMaterial = bPortal.m_surface->hasMaterial();
+  const bool hadMaterial = aHasMaterial || bHasMaterial;
+
+  if (hadMaterial) {
     std::stringstream ss;
-    ss << "Cannot merge portals with material along " << direction << ": ";
-    bool aHas = aPortal.m_surface->hasMaterial();
-    bool bHas = bPortal.m_surface->hasMaterial();
-    if (aHas) {
+    ss << "portals with material along " << direction << ": ";
+    if (aHasMaterial) {
       ss << "portal A surface (bounds=" << aPortal.m_surface->bounds()
          << ", center=" << aPortal.m_surface->center(gctx).transpose()
          << ") carries material";
     }
-    if (bHas) {
-      ss << (aHas ? " and " : "")
+    if (bHasMaterial) {
+      ss << (aHasMaterial ? " and " : "")
          << "portal B surface (bounds=" << bPortal.m_surface->bounds()
          << ", center=" << bPortal.m_surface->center(gctx).transpose()
          << ") carries material";
     }
-    ss << ". This typically means material was designated on a portal face "
-          "that is subsequently merged during container stacking. Move the "
-          "material designation to a face that is not merged (e.g. the face of "
-          "the enclosing container).";
-    ACTS_ERROR(ss.str());
-    throw PortalMergingException{ss.str()};
+
+    if (materialPolicy == PortalMaterialMergePolicy::eThrow) {
+      std::stringstream es;
+      es << "Cannot merge " << ss.str()
+         << ". This typically means material was designated on a portal face "
+            "that is subsequently merged during container stacking. Move the "
+            "material designation to a face that is not merged (e.g. the face "
+            "of the enclosing container).";
+      ACTS_ERROR(es.str());
+      throw PortalMergingException{es.str()};
+    }
+
+    ACTS_WARNING("Merging "
+                 << ss.str()
+                 << ". The input material is discarded and the merged surface "
+                    "is tagged with a MergedMaterialMarker. This is lossy: the "
+                    "material designation should be moved to a face that is "
+                    "not merged (e.g. the face of the enclosing container).");
   }
 
   std::unique_ptr<PortalLinkBase> mergedAlongNormal = nullptr;
@@ -261,8 +277,18 @@ Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
 
   aPortal.m_surface.reset();
   bPortal.m_surface.reset();
-  return Portal{gctx, std::move(mergedAlongNormal),
+  Portal merged{gctx, std::move(mergedAlongNormal),
                 std::move(mergedOppositeNormal)};
+
+  if (hadMaterial &&
+      materialPolicy == PortalMaterialMergePolicy::eDiscardAndMark) {
+    // Tag the merged surface so the lossy merge remains discoverable
+    // downstream.
+    merged.m_surface->assignSurfaceMaterial(
+        std::make_shared<MergedMaterialMarker>());
+  }
+
+  return merged;
 }
 
 Portal Portal::fuse(const GeometryContext& gctx, Portal& aPortal,

--- a/Core/src/Geometry/Portal.cpp
+++ b/Core/src/Geometry/Portal.cpp
@@ -20,12 +20,16 @@
 
 #include <cstdlib>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 
 namespace Acts {
 
+PortalMergingException::PortalMergingException(std::string message)
+    : m_message{std::move(message)} {}
+
 const char* PortalMergingException::what() const noexcept {
-  return "Failure to merge portals";
+  return m_message.c_str();
 }
 
 const char* PortalFusingException::what() const noexcept {
@@ -190,8 +194,27 @@ Portal Portal::merge(const GeometryContext& gctx, Portal& aPortal,
   }
 
   if (aPortal.m_surface->hasMaterial() || bPortal.m_surface->hasMaterial()) {
-    ACTS_ERROR("Cannot merge portals with material");
-    throw PortalMergingException{};
+    std::stringstream ss;
+    ss << "Cannot merge portals with material along " << direction << ": ";
+    bool aHas = aPortal.m_surface->hasMaterial();
+    bool bHas = bPortal.m_surface->hasMaterial();
+    if (aHas) {
+      ss << "portal A surface (bounds=" << aPortal.m_surface->bounds()
+         << ", center=" << aPortal.m_surface->center(gctx).transpose()
+         << ") carries material";
+    }
+    if (bHas) {
+      ss << (aHas ? " and " : "")
+         << "portal B surface (bounds=" << bPortal.m_surface->bounds()
+         << ", center=" << bPortal.m_surface->center(gctx).transpose()
+         << ") carries material";
+    }
+    ss << ". This typically means material was designated on a portal face "
+          "that is subsequently merged during container stacking. Move the "
+          "material designation to a face that is not merged (e.g. the face of "
+          "the enclosing container).";
+    ACTS_ERROR(ss.str());
+    throw PortalMergingException{ss.str()};
   }
 
   std::unique_ptr<PortalLinkBase> mergedAlongNormal = nullptr;

--- a/Core/src/Material/CMakeLists.txt
+++ b/Core/src/Material/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(
         MaterialMapper.cpp
         MaterialSlab.cpp
         MaterialValidator.cpp
+        MergedMaterialMarker.cpp
         ProtoVolumeMaterial.cpp
         SurfaceMaterialMapper.cpp
         VolumeMaterialMapper.cpp

--- a/Core/src/Material/MergedMaterialMarker.cpp
+++ b/Core/src/Material/MergedMaterialMarker.cpp
@@ -1,0 +1,38 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Material/MergedMaterialMarker.hpp"
+
+#include <ostream>
+
+namespace Acts {
+
+MergedMaterialMarker& MergedMaterialMarker::scale(double /*factor*/) {
+  return *this;
+}
+
+const MaterialSlab& MergedMaterialMarker::materialSlab(
+    const Vector2& /*lp*/) const {
+  return m_slab;
+}
+
+std::vector<AxisDirection> MergedMaterialMarker::localAxisDirections() const {
+  return {};
+}
+
+const MaterialSlab& MergedMaterialMarker::materialSlab(
+    const Vector3& /*gp*/) const {
+  return m_slab;
+}
+
+std::ostream& MergedMaterialMarker::toStream(std::ostream& sl) const {
+  sl << "MergedMaterialMarker (material discarded during portal merge)";
+  return sl;
+}
+
+}  // namespace Acts

--- a/Examples/Scripts/Python/material_merge_rz_view.py
+++ b/Examples/Scripts/Python/material_merge_rz_view.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Draw an r-z view of a (Gen3) tracking geometry and highlight lossy material merges.
+
+This is a standalone script that only depends on the **pure-core** ACTS Python
+bindings (the ``acts`` module, including ``acts.json``) plus matplotlib. It does
+*not* use the Examples framework.
+
+It reads a tracking-geometry JSON file (as produced by
+``acts.json.TrackingGeometryJsonConverter``), draws every cylinder volume as a
+rectangle in the r-z plane, and overlays -- as orange line segments -- any portal
+surface that carries a ``MergedMaterialMarker``. The marker is left behind by
+``Portal::merge`` when it runs in "keep going" mode and has to discard surface
+material during container stacking, so this plot shows exactly *where* those
+problematic merges happened.
+
+Example::
+
+    python material_merge_rz_view.py tracking-geometry.json -o detector_rz.svg
+"""
+
+import argparse
+from pathlib import Path
+
+import acts
+
+
+class _RZCollector(acts.TrackingGeometryMutableVisitor):
+    """Visitor collecting cylinder volume rectangles and marker line segments."""
+
+    def __init__(self, gctx: acts.GeometryContext):
+        super().__init__()
+        self._gctx = gctx
+        # Each entry: (z_min, z_max, r_min, r_max, name)
+        self.volumes = []
+        # Each entry: (z0, r0, z1, r1)
+        self.markers = []
+        self._seen_markers = set()
+
+    def visitVolume(self, volume: acts.Volume):
+        bounds = volume.volumeBounds
+        if bounds.type() != acts.VolumeBoundsType.Cylinder:
+            return
+        # CylinderVolumeBounds: values()[0..2] = rMin, rMax, halfLengthZ
+        values = bounds.values()
+        r_min, r_max, half_z = values[0], values[1], values[2]
+        z_center = volume.center(self._gctx)[2]
+        name = ""
+        if isinstance(volume, acts.TrackingVolume):
+            name = volume.volumeName
+        self.volumes.append((z_center - half_z, z_center + half_z, r_min, r_max, name))
+
+    def visitPortal(self, portal: acts.Portal):
+        self._maybe_marker(portal.surface)
+
+    def visitSurface(self, surface: acts.Surface):
+        self._maybe_marker(surface)
+
+    def _maybe_marker(self, surface: acts.Surface):
+        material = surface.surfaceMaterial
+        if not isinstance(material, acts.MergedMaterialMarker):
+            return
+        segment = self._surface_segment(surface)
+        if segment is None:
+            return
+        # A merged portal surface is reachable both as a portal and (potentially)
+        # as a volume surface, and is shared between the stacked volumes, so the
+        # same segment is seen multiple times. Deduplicate by rounded geometry.
+        key = tuple(round(v, 3) for v in segment)
+        if key in self._seen_markers:
+            return
+        self._seen_markers.add(key)
+        self.markers.append(segment)
+
+    def _surface_segment(self, surface: acts.Surface):
+        """Return the (z0, r0, z1, r1) r-z footprint of a portal surface."""
+        bounds = surface.bounds
+        center = surface.center(self._gctx)
+        z_center = center[2]
+        if isinstance(bounds, acts.CylinderBounds):
+            # Cylinder face: horizontal line at fixed radius spanning z.
+            r = bounds.values()[int(acts.CylinderBoundsValue.R)]
+            half_z = bounds.values()[int(acts.CylinderBoundsValue.HalfLengthZ)]
+            return (z_center - half_z, r, z_center + half_z, r)
+        if isinstance(bounds, acts.RadialBounds):
+            # Disc face: vertical line at fixed z spanning r.
+            r_min = bounds.values()[int(acts.RadialBoundsValue.MinR)]
+            r_max = bounds.values()[int(acts.RadialBoundsValue.MaxR)]
+            return (z_center, r_min, z_center, r_max)
+        # Unsupported surface kind for the r-z view; skip it.
+        return None
+
+
+def load_tracking_geometry(
+    json_path: Path, gctx: acts.GeometryContext
+) -> acts.TrackingGeometry:
+    """Load a Gen3 tracking geometry from a JSON file."""
+    from acts.json import TrackingGeometryJsonConverter
+
+    converter = TrackingGeometryJsonConverter()
+    return converter.fromJson(gctx, Path(json_path).read_text())
+
+
+def collect_rz(tracking_geometry: acts.TrackingGeometry, gctx: acts.GeometryContext):
+    """Collect cylinder volume rectangles and marker segments from the geometry.
+
+    Returns a tuple ``(volumes, markers)``.
+    """
+    collector = _RZCollector(gctx)
+    tracking_geometry.apply(collector)
+    return collector.volumes, collector.markers
+
+
+def render(volumes, markers, output_path: Path, title: str = "Material merge r-z view"):
+    """Render the r-z view to an SVG (or any matplotlib-supported) file."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    for z_min, z_max, r_min, r_max, name in volumes:
+        ax.add_patch(
+            Rectangle(
+                (z_min, r_min),
+                z_max - z_min,
+                r_max - r_min,
+                facecolor="#dfe7f2",
+                edgecolor="#34507a",
+                linewidth=0.6,
+                zorder=1,
+            )
+        )
+        if name:
+            # ODD volume names are hierarchical (pipe-separated); show the leaf.
+            leaf = name.split("|")[-1]
+            # Rotate the label to run along the longer side of the rectangle.
+            rotation = 90 if (r_max - r_min) > (z_max - z_min) else 0
+            ax.text(
+                0.5 * (z_min + z_max),
+                0.5 * (r_min + r_max),
+                leaf,
+                ha="center",
+                va="center",
+                rotation=rotation,
+                fontsize=5,
+                color="#1b2a44",
+                clip_on=True,
+                zorder=3,
+            )
+
+    marker_label_used = False
+    for z0, r0, z1, r1 in markers:
+        ax.plot(
+            [z0, z1],
+            [r0, r1],
+            color="darkorange",
+            linewidth=3.0,
+            solid_capstyle="round",
+            zorder=5,
+            label=None if marker_label_used else "Discarded merge material",
+        )
+        marker_label_used = True
+
+    ax.set_xlabel("z [mm]")
+    ax.set_ylabel("r [mm]")
+    ax.set_title(title)
+    ax.autoscale_view()
+    ax.margins(0.02)
+    ax.set_ylim(bottom=0)
+    if marker_label_used:
+        ax.legend(loc="upper right")
+
+    fig.tight_layout()
+    fig.savefig(str(output_path))
+    plt.close(fig)
+    return output_path
+
+
+def run(json_path: Path, output_path: Path, title: str = "Material merge r-z view"):
+    """Load a geometry JSON, build the r-z view, and write it to ``output_path``."""
+    gctx = acts.GeometryContext.dangerouslyDefaultConstruct()
+    tracking_geometry = load_tracking_geometry(json_path, gctx)
+    volumes, markers = collect_rz(tracking_geometry, gctx)
+    render(volumes, markers, output_path, title=title)
+    return volumes, markers
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "geometry",
+        type=Path,
+        help="Path to a Gen3 tracking-geometry JSON file",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("geometry_rz.svg"),
+        help="Output image path (default: geometry_rz.svg)",
+    )
+    parser.add_argument(
+        "--title",
+        default="Material merge r-z view",
+        help="Plot title",
+    )
+    args = parser.parse_args()
+
+    volumes, markers = run(args.geometry, args.output, title=args.title)
+    print(
+        f"Drew {len(volumes)} cylinder volumes and {len(markers)} "
+        f"merge-material markers to {args.output}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/Plugins/Json/src/MaterialJsonConverter.cpp
+++ b/Plugins/Json/src/MaterialJsonConverter.cpp
@@ -18,6 +18,7 @@
 #include "Acts/Material/InterpolatedMaterialMap.hpp"
 #include "Acts/Material/MaterialGridHelper.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Material/ProtoSurfaceMaterial.hpp"
 #include "Acts/Material/ProtoVolumeMaterial.hpp"
 #include "Acts/Surfaces/Surface.hpp"
@@ -333,6 +334,16 @@ void Acts::to_json(nlohmann::json& j, const surfaceMaterialPointer& material) {
   // A bin utility needs to be written
   const Acts::BinUtility* bUtility = nullptr;
 
+  // Marker material left behind by a lossy portal merge. It carries no actual
+  // material, so only the type tag is written.
+  if (dynamic_cast<const Acts::MergedMaterialMarker*>(material) != nullptr) {
+    jMaterial[Acts::jsonKey().typekey] = "merged-material-marker";
+    // Flag as "mapped" so the reader does not discard it.
+    jMaterial[Acts::jsonKey().mapkey] = true;
+    j[Acts::jsonKey().materialkey] = jMaterial;
+    return;
+  }
+
   // First: Check if we have a proto material
   auto psMaterial = dynamic_cast<const Acts::ProtoSurfaceMaterial*>(material);
   if (psMaterial != nullptr) {
@@ -460,6 +471,13 @@ void Acts::from_json(const nlohmann::json& j,
   // By default no material is return.
   material = nullptr;
   if (jMaterial[Acts::jsonKey().mapkey] == false) {
+    return;
+  }
+
+  // Marker material left behind by a lossy portal merge
+  if (jMaterial.contains(Acts::jsonKey().typekey) &&
+      jMaterial[Acts::jsonKey().typekey] == "merged-material-marker") {
+    material = new Acts::MergedMaterialMarker();
     return;
   }
 

--- a/Python/Core/src/Geometry.cpp
+++ b/Python/Core/src/Geometry.cpp
@@ -247,6 +247,7 @@ void addGeometry(py::module_& m) {
   {
     py::class_<VolumeBounds, std::shared_ptr<VolumeBounds>>(m, "VolumeBounds")
         .def("type", &VolumeBounds::type)
+        .def("values", &VolumeBounds::values)
         .def("__str__", [](const VolumeBounds& self) {
           std::stringstream ss;
           ss << self;
@@ -276,7 +277,10 @@ void addGeometry(py::module_& m) {
         .def_property_readonly(
             "volumeBounds",
             py::overload_cast<>(&Volume::volumeBounds, py::const_),
-            py::return_value_policy::reference_internal);
+            py::return_value_policy::reference_internal)
+        .def("center", &Volume::center, py::arg("gctx"))
+        .def("localToGlobalTransform", &Volume::localToGlobalTransform,
+             py::arg("gctx"));
 
     py::class_<TrackingVolume, Volume, std::shared_ptr<TrackingVolume>>(
         m, "TrackingVolume")

--- a/Python/Core/src/GeometryGen3.cpp
+++ b/Python/Core/src/GeometryGen3.cpp
@@ -13,12 +13,14 @@
 #include "Acts/Geometry/GeometryIdentifierBlueprintNode.hpp"
 #include "Acts/Geometry/LayerBlueprintNode.hpp"
 #include "Acts/Geometry/MaterialDesignatorBlueprintNode.hpp"
+#include "Acts/Geometry/Portal.hpp"
 #include "Acts/Geometry/PortalLinkBase.hpp"
 #include "Acts/Geometry/StaticBlueprintNode.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
 #include "Acts/Navigation/INavigationPolicy.hpp"
 #include "Acts/Navigation/NavigationStream.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsPython/Utilities/Macros.hpp"
@@ -229,7 +231,11 @@ void addGeometryGen3(py::module_& m) {
   using Experimental::MaterialDesignatorBlueprintNode;
   using Experimental::StaticBlueprintNode;
 
-  py::class_<Portal>(m, "Portal");
+  py::class_<Portal>(m, "Portal")
+      .def_property_readonly(
+          "surface",
+          [](Portal& self) -> const Surface& { return self.surface(); },
+          py::return_value_policy::reference_internal);
 
   auto blueprintNode =
       py::class_<BlueprintNode, std::shared_ptr<BlueprintNode>>(
@@ -299,7 +305,9 @@ void addGeometryGen3(py::module_& m) {
   py::class_<BlueprintOptions>(m, "BlueprintOptions")
       .def(py::init<>())
       .def_readwrite("defaultNavigationPolicyFactory",
-                     &BlueprintOptions::defaultNavigationPolicyFactory);
+                     &BlueprintOptions::defaultNavigationPolicyFactory)
+      .def_readwrite("keepGoingOnMaterialMergeFailure",
+                     &BlueprintOptions::keepGoingOnMaterialMergeFailure);
 
   py::class_<BlueprintNode::MutableChildRange>(blueprintNode,
                                                "MutableChildRange")

--- a/Python/Core/src/Material.cpp
+++ b/Python/Core/src/Material.cpp
@@ -14,6 +14,7 @@
 #include "Acts/Material/IntersectionMaterialAssigner.hpp"
 #include "Acts/Material/MaterialMapper.hpp"
 #include "Acts/Material/MaterialValidator.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Material/ProtoSurfaceMaterial.hpp"
 #include "Acts/Material/SurfaceMaterialMapper.hpp"
 #include "Acts/Material/VolumeMaterialMapper.hpp"
@@ -55,6 +56,10 @@ void addMaterial(py::module_& m) {
     py::class_<HomogeneousSurfaceMaterial, ISurfaceMaterial,
                std::shared_ptr<HomogeneousSurfaceMaterial>>(
         m, "HomogeneousSurfaceMaterial");
+
+    py::class_<MergedMaterialMarker, ISurfaceMaterial,
+               std::shared_ptr<MergedMaterialMarker>>(m, "MergedMaterialMarker")
+        .def(py::init<>());
 
     py::class_<IVolumeMaterial, std::shared_ptr<IVolumeMaterial>>(
         m, "IVolumeMaterial");

--- a/Python/Examples/tests/test_material_merge_rz_view.py
+++ b/Python/Examples/tests/test_material_merge_rz_view.py
@@ -1,0 +1,102 @@
+import pytest
+
+import acts
+
+from helpers import dd4hepEnabled
+
+# Standalone script under Examples/Scripts/Python (added to sys.path by conftest)
+import material_merge_rz_view as mrz
+
+mm = acts.UnitConstants.mm
+
+
+def _build_marker_geometry(gctx):
+    """Build a tiny Gen3 geometry that triggers a lossy material merge.
+
+    A z-stack with material designated on the (merged) OuterCylinder face of one
+    child. Constructed in keep-going mode so the merge tags the surface with a
+    MergedMaterialMarker instead of aborting.
+    """
+    bv = acts.AxisDirection
+    abt = acts.AxisBoundaryType
+    base = acts.Transform3.Identity()
+
+    root = acts.Blueprint(
+        envelope=acts.ExtentEnvelope(z=[20 * mm, 20 * mm], r=[0 * mm, 20 * mm])
+    )
+    stack = root.addCylinderContainer("Stack", direction=bv.AxisZ)
+
+    mat = stack.addMaterial("Material")
+    mat.configureFace(
+        acts.CylinderVolumeBounds.Face.OuterCylinder,
+        acts.DirectedProtoAxis(bv.AxisRPhi, abt.Bound, 20),
+        acts.DirectedProtoAxis(bv.AxisZ, abt.Bound, 20),
+    )
+    mat.addStaticVolume(
+        base * acts.Translation3(acts.Vector3(0, 0, -200 * mm)),
+        acts.CylinderVolumeBounds(0, 100 * mm, 100 * mm),
+        name="VolumeA",
+    )
+
+    stack.addStaticVolume(
+        base * acts.Translation3(acts.Vector3(0, 0, 200 * mm)),
+        acts.CylinderVolumeBounds(0, 100 * mm, 100 * mm),
+        name="VolumeB",
+    )
+
+    options = acts.BlueprintOptions()
+    options.keepGoingOnMaterialMergeFailure = True
+    return root.construct(options, gctx, level=acts.logging.WARNING)
+
+
+@acts.with_log_threshold(acts.logging.FATAL)
+def test_rz_view_with_markers(tmp_path):
+    pytest.importorskip("matplotlib")
+    from acts.json import TrackingGeometryJsonConverter
+
+    gctx = acts.GeometryContext.dangerouslyDefaultConstruct()
+    trackingGeometry = _build_marker_geometry(gctx)
+
+    json_path = tmp_path / "marker-geometry.json"
+    json_path.write_text(TrackingGeometryJsonConverter().toJson(gctx, trackingGeometry))
+
+    out = tmp_path / "marker_rz.svg"
+    volumes, markers = mrz.run(json_path, out)
+
+    assert out.exists()
+    assert out.stat().st_size > 0
+    assert len(volumes) >= 2
+    # The merged OuterCylinder portal must show up as a marker line
+    assert len(markers) >= 1
+
+
+@pytest.mark.skipif(not dd4hepEnabled, reason="DD4hep not set up")
+@pytest.mark.odd
+@pytest.mark.slow
+# Construction may legitimately emit keep-going WARNINGs (e.g. when ODD has a
+# material-on-merged-face clash), which would otherwise trip the test harness'
+# ACTS_LOG_FAILURE_THRESHOLD.
+@acts.with_log_threshold(acts.logging.FATAL)
+def test_rz_view_odd_gen3(tmp_path):
+    pytest.importorskip("matplotlib")
+    from acts.examples.odd import getOpenDataDetector
+    from acts.json import TrackingGeometryJsonConverter
+
+    gctx = acts.GeometryContext.dangerouslyDefaultConstruct()
+
+    with getOpenDataDetector(gen3=True) as detector:
+        trackingGeometry = detector.trackingGeometry()
+        json_path = tmp_path / "odd-geometry.json"
+        json_path.write_text(
+            TrackingGeometryJsonConverter().toJson(gctx, trackingGeometry)
+        )
+
+    out = tmp_path / "odd_rz.svg"
+    volumes, markers = mrz.run(json_path, out)
+
+    assert out.exists()
+    assert out.stat().st_size > 0
+    assert len(volumes) > 0
+    # Marker count depends on ODD's material configuration, so we don't pin it;
+    # the script must just run end-to-end and produce an SVG.
+    assert len(markers) >= 0

--- a/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
@@ -19,6 +19,7 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/LayerBlueprintNode.hpp"
 #include "Acts/Geometry/MaterialDesignatorBlueprintNode.hpp"
+#include "Acts/Geometry/Portal.hpp"
 #include "Acts/Geometry/TrackingGeometry.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
@@ -446,6 +447,57 @@ BOOST_AUTO_TEST_CASE(NodeApiTestCuboid) {
   BOOST_REQUIRE(trackingGeometry);
   BOOST_CHECK(trackingGeometry->geometryVersion() ==
               TrackingGeometry::GeometryVersion::Gen3);
+}
+
+// Reproduces the "Cannot merge portals with material" failure: material is
+// designated on a portal face that is subsequently merged during container
+// stacking. The material designator wraps a child of a z-stacking container.
+// Since stacking in z merges the OuterCylinder portals of all children, the
+// merge encounters a surface that already carries material and throws.
+BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
+  Transform3 base{Transform3::Identity()};
+
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {0_mm, 20_mm};
+  auto root = std::make_unique<Blueprint>(cfg);
+
+  root->addCylinderContainer("Stack", AxisDirection::AxisZ, [&](auto& stack) {
+    using enum AxisDirection;
+    using enum AxisBoundaryType;
+    using enum CylinderVolumeBounds::Face;
+
+    // First child: a static volume whose OuterCylinder face is given material.
+    // This is the face that the parent z-stack will try to merge.
+    stack.addMaterial("Material", [&](auto& mat) {
+      mat.configureFace(OuterCylinder, {AxisRPhi, Bound, 20},
+                        {AxisZ, Bound, 20});
+      mat.addStaticVolume(
+          base * Translation3{Vector3{0, 0, -200_mm}},
+          std::make_shared<CylinderVolumeBounds>(0_mm, 100_mm, 100_mm),
+          "VolumeA");
+    });
+
+    // Second child: plain static volume on the other side in z.
+    stack.addStaticVolume(
+        base * Translation3{Vector3{0, 0, 200_mm}},
+        std::make_shared<CylinderVolumeBounds>(0_mm, 100_mm, 100_mm),
+        "VolumeB");
+  });
+
+  // The exception should carry context augmented up the call stack: the
+  // offending face, the shells involved, and the underlying material reason.
+  bool thrown = false;
+  try {
+    root->construct({}, gctx, *logger);
+  } catch (const PortalMergingException& e) {
+    thrown = true;
+    std::string msg = e.what();
+    BOOST_CHECK(msg.find("OuterCylinder") != std::string::npos);
+    BOOST_CHECK(msg.find("VolumeA") != std::string::npos);
+    BOOST_CHECK(msg.find("material") != std::string::npos);
+  }
+  BOOST_CHECK(thrown);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
@@ -24,9 +24,11 @@
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Navigation/INavigationPolicy.hpp"
 #include "Acts/Navigation/NavigationStream.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/ProtoAxis.hpp"
 #include "Acts/Visualization/GeometryView3D.hpp"
@@ -455,9 +457,9 @@ BOOST_AUTO_TEST_CASE(NodeApiTestCuboid) {
 // in z merges the OuterCylinder portals of all children, the designated face
 // cannot survive the merge.
 //
-// This is detected early (idea D) by the container node, before the stack shell
-// is built, producing a node-scoped error. The deeper shell-level reporting
-// (ideas A+B) is exercised directly in the CylinderPortalShell tests.
+// This is detected early by the container node, before the stack shell is
+// built, producing a node-scoped error. The deeper shell-level reporting is
+// exercised directly in the CylinderPortalShell tests.
 BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
   Transform3 base{Transform3::Identity()};
 
@@ -502,6 +504,58 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
     BOOST_CHECK(msg.find("material") != std::string::npos);
   }
   BOOST_CHECK(thrown);
+}
+
+BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalKeepGoing) {
+  // Same blueprint as MaterialOnMergedPortalThrows, but constructed with the
+  // keep-going option. Construction must succeed, and the merged outer cylinder
+  // surface must carry a MergedMaterialMarker.
+  Transform3 base{Transform3::Identity()};
+
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {0_mm, 20_mm};
+  auto root = std::make_unique<Blueprint>(cfg);
+
+  root->addCylinderContainer("Stack", AxisDirection::AxisZ, [&](auto& stack) {
+    using enum AxisDirection;
+    using enum AxisBoundaryType;
+    using enum CylinderVolumeBounds::Face;
+
+    stack.addMaterial("Material", [&](auto& mat) {
+      mat.configureFace(OuterCylinder, {AxisRPhi, Bound, 20},
+                        {AxisZ, Bound, 20});
+      mat.addStaticVolume(
+          base * Translation3{Vector3{0, 0, -200_mm}},
+          std::make_shared<CylinderVolumeBounds>(0_mm, 100_mm, 100_mm),
+          "VolumeA");
+    });
+
+    stack.addStaticVolume(
+        base * Translation3{Vector3{0, 0, 200_mm}},
+        std::make_shared<CylinderVolumeBounds>(0_mm, 100_mm, 100_mm),
+        "VolumeB");
+  });
+
+  Experimental::BlueprintOptions options;
+  options.keepGoingOnMaterialMergeFailure = true;
+
+  std::unique_ptr<const TrackingGeometry> trackingGeometry;
+  BOOST_REQUIRE_NO_THROW(trackingGeometry =
+                             root->construct(options, gctx, *logger));
+  BOOST_REQUIRE(trackingGeometry != nullptr);
+
+  std::size_t markerCount = 0;
+  trackingGeometry->visitSurfaces(
+      [&](const Surface* surface) {
+        if (surface != nullptr && surface->surfaceMaterial() != nullptr &&
+            dynamic_cast<const MergedMaterialMarker*>(
+                surface->surfaceMaterial()) != nullptr) {
+          ++markerCount;
+        }
+      },
+      false);
+  BOOST_CHECK_GE(markerCount, 1u);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
@@ -449,11 +449,15 @@ BOOST_AUTO_TEST_CASE(NodeApiTestCuboid) {
               TrackingGeometry::GeometryVersion::Gen3);
 }
 
-// Reproduces the "Cannot merge portals with material" failure: material is
-// designated on a portal face that is subsequently merged during container
-// stacking. The material designator wraps a child of a z-stacking container.
-// Since stacking in z merges the OuterCylinder portals of all children, the
-// merge encounters a surface that already carries material and throws.
+// Reproduces the "material on a merged portal" failure: material is designated
+// on a portal face that is subsequently merged during container stacking. The
+// material designator wraps a child of a z-stacking container; since stacking
+// in z merges the OuterCylinder portals of all children, the designated face
+// cannot survive the merge.
+//
+// This is detected early (idea D) by the container node, before the stack shell
+// is built, producing a node-scoped error. The deeper shell-level reporting
+// (ideas A+B) is exercised directly in the CylinderPortalShell tests.
 BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
   Transform3 base{Transform3::Identity()};
 
@@ -485,8 +489,8 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
         "VolumeB");
   });
 
-  // The exception should carry context augmented up the call stack: the
-  // offending face, the shells involved, and the underlying material reason.
+  // The early-detection error should name the offending face, the shell
+  // involved, and explain that material was placed on a merged face.
   bool thrown = false;
   try {
     root->construct({}, gctx, *logger);

--- a/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintApiTests.cpp
@@ -494,14 +494,17 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalThrows) {
   // The early-detection error should name the offending face, the shell
   // involved, and explain that material was placed on a merged face.
   bool thrown = false;
-  try {
-    root->construct({}, gctx, *logger);
-  } catch (const PortalMergingException& e) {
-    thrown = true;
-    std::string msg = e.what();
-    BOOST_CHECK(msg.find("OuterCylinder") != std::string::npos);
-    BOOST_CHECK(msg.find("VolumeA") != std::string::npos);
-    BOOST_CHECK(msg.find("material") != std::string::npos);
+  {
+    Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+    try {
+      root->construct({}, gctx, *logger);
+    } catch (const PortalMergingException& e) {
+      thrown = true;
+      std::string msg = e.what();
+      BOOST_CHECK(msg.find("OuterCylinder") != std::string::npos);
+      BOOST_CHECK(msg.find("VolumeA") != std::string::npos);
+      BOOST_CHECK(msg.find("material") != std::string::npos);
+    }
   }
   BOOST_CHECK(thrown);
 }
@@ -541,8 +544,11 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedPortalKeepGoing) {
   options.keepGoingOnMaterialMergeFailure = true;
 
   std::unique_ptr<const TrackingGeometry> trackingGeometry;
-  BOOST_REQUIRE_NO_THROW(trackingGeometry =
-                             root->construct(options, gctx, *logger));
+  {
+    Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+    BOOST_REQUIRE_NO_THROW(trackingGeometry =
+                               root->construct(options, gctx, *logger));
+  }
   BOOST_REQUIRE(trackingGeometry != nullptr);
 
   std::size_t markerCount = 0;

--- a/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedFaceThrows) {
   // that is *merged* during stacking must throw a PortalMergingException whose
   // message is augmented with the offending face, the shells involved, and the
   // underlying material reason from Portal::merge. This path is below the
-  // blueprint container node, so the early node-level check does not pre-empt
+  // blueprint container node, so the early node-level check does not preempt
   // it.
   using enum CylinderVolumeBounds::Face;
 

--- a/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
@@ -22,6 +22,7 @@
 #include "Acts/Geometry/TrivialPortalLink.hpp"
 #include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Surfaces/SurfaceMergingException.hpp"
 
 #include <stdexcept>
@@ -449,12 +450,12 @@ BOOST_AUTO_TEST_CASE(ZDirection) {
 }
 
 BOOST_AUTO_TEST_CASE(MaterialOnMergedFaceThrows) {
-  // Directly exercises the shell-level reporting (ideas A+B): assigning
-  // material to a face that is *merged* during stacking must throw a
-  // PortalMergingException whose message is augmented with the offending face,
-  // the shells involved (B), and the underlying material reason from
-  // Portal::merge (A). This path is below the blueprint container node, so the
-  // early node-level check (idea D) does not pre-empt it.
+  // Directly exercises the shell-level reporting: assigning material to a face
+  // that is *merged* during stacking must throw a PortalMergingException whose
+  // message is augmented with the offending face, the shells involved, and the
+  // underlying material reason from Portal::merge. This path is below the
+  // blueprint container node, so the early node-level check does not pre-empt
+  // it.
   using enum CylinderVolumeBounds::Face;
 
   TrackingVolume vol1(
@@ -486,6 +487,43 @@ BOOST_AUTO_TEST_CASE(MaterialOnMergedFaceThrows) {
   BOOST_CHECK_EXCEPTION(
       CylinderStackPortalShell(gctx, {&shell1, &shell2}, AxisDirection::AxisZ),
       PortalMergingException, checkMessage);
+}
+
+BOOST_AUTO_TEST_CASE(MaterialOnMergedFaceKeepGoing) {
+  // Same setup as MaterialOnMergedFaceThrows, but with the keep-going policy:
+  // the stack must construct successfully, and the merged OuterCylinder portal
+  // surface must carry a MergedMaterialMarker instead of the original material.
+  using enum CylinderVolumeBounds::Face;
+
+  TrackingVolume vol1(
+      Transform3{Translation3{Vector3::UnitZ() * -100_mm}},
+      std::make_shared<CylinderVolumeBounds>(30_mm, 100_mm, 100_mm));
+  vol1.setVolumeName("MatVolume");
+  TrackingVolume vol2(
+      Transform3{Translation3{Vector3::UnitZ() * 100_mm}},
+      std::make_shared<CylinderVolumeBounds>(30_mm, 100_mm, 100_mm));
+  vol2.setVolumeName("PlainVolume");
+
+  SingleCylinderPortalShell shell1{gctx, vol1};
+  SingleCylinderPortalShell shell2{gctx, vol2};
+
+  // OuterCylinder is merged when stacking in z
+  shell1.portal(OuterCylinder)
+      ->surface()
+      .assignSurfaceMaterial(std::make_shared<HomogeneousSurfaceMaterial>(
+          MaterialSlab::Nothing()));
+
+  CylinderStackPortalShell stack{gctx,
+                                 {&shell1, &shell2},
+                                 AxisDirection::AxisZ,
+                                 getDummyLogger(),
+                                 PortalMaterialMergePolicy::eDiscardAndMark};
+
+  const auto oCyl = stack.portal(OuterCylinder);
+  BOOST_REQUIRE(oCyl != nullptr);
+  BOOST_REQUIRE(oCyl->surface().surfaceMaterial() != nullptr);
+  BOOST_CHECK(dynamic_cast<const MergedMaterialMarker*>(
+                  oCyl->surface().surfaceMaterial()) != nullptr);
 }
 
 BOOST_AUTO_TEST_CASE(RDirection) {

--- a/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/CylinderPortalShellTests.cpp
@@ -20,9 +20,12 @@
 #include "Acts/Geometry/Portal.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/TrivialPortalLink.hpp"
+#include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
+#include "Acts/Material/MaterialSlab.hpp"
 #include "Acts/Surfaces/SurfaceMergingException.hpp"
 
 #include <stdexcept>
+#include <string>
 
 using namespace Acts;
 using namespace Acts::UnitLiterals;
@@ -443,6 +446,46 @@ BOOST_AUTO_TEST_CASE(ZDirection) {
                                                AxisDirection::AxisR),
                       SurfaceMergingException);
   }
+}
+
+BOOST_AUTO_TEST_CASE(MaterialOnMergedFaceThrows) {
+  // Directly exercises the shell-level reporting (ideas A+B): assigning
+  // material to a face that is *merged* during stacking must throw a
+  // PortalMergingException whose message is augmented with the offending face,
+  // the shells involved (B), and the underlying material reason from
+  // Portal::merge (A). This path is below the blueprint container node, so the
+  // early node-level check (idea D) does not pre-empt it.
+  using enum CylinderVolumeBounds::Face;
+
+  TrackingVolume vol1(
+      Transform3{Translation3{Vector3::UnitZ() * -100_mm}},
+      std::make_shared<CylinderVolumeBounds>(30_mm, 100_mm, 100_mm));
+  vol1.setVolumeName("MatVolume");
+  TrackingVolume vol2(
+      Transform3{Translation3{Vector3::UnitZ() * 100_mm}},
+      std::make_shared<CylinderVolumeBounds>(30_mm, 100_mm, 100_mm));
+  vol2.setVolumeName("PlainVolume");
+
+  SingleCylinderPortalShell shell1{gctx, vol1};
+  SingleCylinderPortalShell shell2{gctx, vol2};
+
+  // OuterCylinder is merged when stacking in z
+  shell1.portal(OuterCylinder)
+      ->surface()
+      .assignSurfaceMaterial(std::make_shared<HomogeneousSurfaceMaterial>(
+          MaterialSlab::Nothing()));
+
+  auto checkMessage = [](const PortalMergingException& e) {
+    std::string msg = e.what();
+    return msg.find("OuterCylinder") != std::string::npos &&
+           msg.find("MatVolume") != std::string::npos &&
+           msg.find("Underlying error") != std::string::npos &&
+           msg.find("material") != std::string::npos;
+  };
+
+  BOOST_CHECK_EXCEPTION(
+      CylinderStackPortalShell(gctx, {&shell1, &shell2}, AxisDirection::AxisZ),
+      PortalMergingException, checkMessage);
 }
 
 BOOST_AUTO_TEST_CASE(RDirection) {

--- a/Tests/UnitTests/Core/Geometry/PortalTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/PortalTests.cpp
@@ -20,6 +20,7 @@
 #include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/TrivialPortalLink.hpp"
 #include "Acts/Material/HomogeneousSurfaceMaterial.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Surfaces/CylinderSurface.hpp"
 #include "Acts/Surfaces/DiscSurface.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
@@ -336,6 +337,23 @@ BOOST_AUTO_TEST_CASE(Disc) {
   BOOST_CHECK_THROW(
       Portal::merge(gctx, portal1, portal2, AxisDirection::AxisR, *logger),
       PortalMergingException);
+
+  // In "keep going" mode, the same merge succeeds: the material is discarded
+  // and the merged surface is tagged with a MergedMaterialMarker.
+  portal1 = Portal{
+      gctx, {.alongNormal = {disc1, *vol1}, .oppositeNormal = {disc1, *vol2}}};
+  portal2 = Portal{
+      gctx, {.alongNormal = {disc2, *vol3}, .oppositeNormal = {disc2, *vol4}}};
+  Portal mergedKeepGoing =
+      Portal::merge(gctx, portal1, portal2, AxisDirection::AxisR, *logger,
+                    PortalMaterialMergePolicy::eDiscardAndMark);
+  BOOST_CHECK(mergedKeepGoing.isValid());
+  BOOST_REQUIRE(mergedKeepGoing.surface().surfaceMaterial() != nullptr);
+  BOOST_CHECK(dynamic_cast<const MergedMaterialMarker*>(
+                  mergedKeepGoing.surface().surfaceMaterial()) != nullptr);
+  // The marker carries no physical material
+  BOOST_CHECK(mergedKeepGoing.surface().surfaceMaterial()->materialSlab(
+                  Vector2{0., 0.}) == MaterialSlab::Nothing());
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // Merging

--- a/Tests/UnitTests/Plugins/Json/MaterialJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/MaterialJsonConverterTests.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Material/GridSurfaceMaterial.hpp"
 #include "Acts/Material/Material.hpp"
 #include "Acts/Material/MaterialSlab.hpp"
+#include "Acts/Material/MergedMaterialMarker.hpp"
 #include "Acts/Utilities/GridAccessHelpers.hpp"
 #include "Acts/Utilities/GridAxisGenerators.hpp"
 #include "ActsPlugins/Json/MaterialJsonConverter.hpp"
@@ -155,6 +156,24 @@ BOOST_AUTO_TEST_CASE(IndexedSurfaceMaterial2DTests) {
   const ISurfaceMaterial* ismRead = nullptr;
   from_json(jMaterial, ismRead);
   BOOST_REQUIRE(ismRead != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(MergedMaterialMarkerRoundTrip) {
+  // The marker left behind by a lossy portal merge must survive a JSON
+  // round-trip so it can be picked up by downstream tooling.
+  const ISurfaceMaterial* marker = new MergedMaterialMarker();
+
+  nlohmann::json jMaterial = marker;
+  BOOST_REQUIRE(jMaterial.find("material") != jMaterial.end());
+  BOOST_CHECK_EQUAL(jMaterial["material"]["type"], "merged-material-marker");
+
+  const ISurfaceMaterial* markerRead = nullptr;
+  from_json(jMaterial, markerRead);
+  BOOST_REQUIRE(markerRead != nullptr);
+  BOOST_CHECK(dynamic_cast<const MergedMaterialMarker*>(markerRead) != nullptr);
+
+  delete marker;
+  delete markerRead;
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Problem

In gen3 blueprint construction, designating material on a portal face that later gets **merged** during container stacking fails with `PortalMergingException`. The old message — `"Failure to merge portals"` — carried no context (no face, volume, or node), and the failure surfaced deep inside stack-shell construction, making it hard to trace back to the offending material designation.

### Changes

Three layers of diagnostics, each independently tested:

- **Context-rich exception** (`Portal::merge`): `PortalMergingException` can now carry a message. The material check reports the stacking direction, which side(s) carry material, and the offending surface bounds/center, plus a hint to move the designation to an unmerged face.
- **Catch-and-rethrow in stack shells** (`Cylinder`/`CuboidStackPortalShell`): merge failures are rethrown with the face, stack label/direction, and the volumes involved, appending the original reason as "Underlying error".
- **Early, node-scoped detection** (`ContainerBlueprintNode::connectImpl`): before any merge work, the container checks each *merged* face of its child shells for material and fails fast with the blueprint **node path** and a list of all clashes at once. Fused faces (which legitimately carry material) are not flagged. Adds `mergedFaces(AxisDirection)` helpers to both stack shells.

### Tests

- `BlueprintApiTests::MaterialOnMergedPortalThrows` — reproduces the failure at blueprint level, exercising the early node-level detection (D).