### PR TITLE
Make SeedFinderOrthogonal top-middle slope cut configurable

### DIFF
--- a/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonal.ipp
@@ -376,7 +376,7 @@ void SeedFinderOrthogonal<external_space_point_t>::filterCandidates(
       const std::size_t t = sorted_tops[index_t];
       auto lt = linCircleTop[t];
 
-      if (std::abs(tanLM - tanMT[t]) > 0.005) {
+      if (std::abs(tanLM - tanMT[t]) > m_config.maxTopMiddleTanDifference) {
         continue;
       }
 

--- a/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
+++ b/Core/include/Acts/Seeding/SeedFinderOrthogonalConfig.hpp
@@ -132,6 +132,12 @@ struct [[deprecated(
   /// helix. This is useful for e.g. misaligned seeding.
   float helixCutTolerance = 1.;
 
+  /// Maximum allowed difference between the r-z slopes of the top-middle
+  /// seed segment and the middle-bottom seed segment.
+  /// This cut is used to reject seed candidates that are kinematically
+  /// inconsistent in the barrel-to-endcap transition region.
+  float maxTopMiddleTanDifference = 0.005;
+
   /// Seeding parameters used for quality seed confirmation
 
   /// Enable quality seed confirmation, this is different than default seeding


### PR DESCRIPTION
Added maxTopMiddleTanDifference to SeedFinderOrthogonalConfig

Replaced hardcoded 0.005 in SeedFinderOrthogonal.ipp

The default behavior remains unchanged; it just makes the legacy orthogonal seeder tunable for barrel/endcap transition geometry.