### PR TITLE
fix: Prevent dangling bfield reference in record propagation function

### DIFF
--- a/Detray/tests/include/detray/test/cpu/navigation_validation.hpp
+++ b/Detray/tests/include/detray/test/cpu/navigation_validation.hpp
@@ -31,6 +31,7 @@
 // System include(s)
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace detray::test {
@@ -80,23 +81,22 @@ class navigation_validation : public test::fixture_base<> {
         typename truth_trace_t::value_type::intersection_type;
 
     // Runge-Kutta stepper
-    using hom_bfield_t = bfield::const_field_t<scalar_t>;
+    using hom_bfield_t = typename bfield::const_field_t<scalar_t>::view_t;
     using bfield_t =
         std::conditional_t<k_use_rays, navigation_validator::empty_bfield,
                            hom_bfield_t>;
     using rk_stepper_t =
-        rk_stepper<typename hom_bfield_t::view_t, algebra_t,
-                   unconstrained_step<scalar_t>, stepper_rk_policy<scalar_t>,
-                   stepping::print_inspector>;
+        rk_stepper<hom_bfield_t, algebra_t, unconstrained_step<scalar_t>,
+                   stepper_rk_policy<scalar_t>, stepping::print_inspector>;
     using line_stepper_t = line_stepper<algebra_t, unconstrained_step<scalar_t>,
                                         stepper_default_policy<scalar_t>,
                                         stepping::print_inspector>;
     using stepper_t =
         std::conditional_t<k_use_rays, line_stepper_t, rk_stepper_t>;
 
-    bfield_t b_field{};
+    std::optional<bfield_t> b_field{};
     if constexpr (!k_use_rays) {
-      b_field = create_const_field<scalar_t>(m_cfg.B_vector());
+      b_field.emplace(create_const_field<scalar_t>(m_cfg.B_vector()));
     }
 
     // Use ray or helix

--- a/Detray/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/Detray/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -43,6 +43,7 @@
 #include <iomanip>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <sstream>
 
@@ -140,7 +141,7 @@ inline auto record_propagation(
     const free_track_parameters<typename detector_t::algebra_type> &track,
     const pdg_particle<typename detector_t::scalar_type> ptc_hypo =
         muon<typename detector_t::scalar_type>(),
-    const bfield_t &bfield = {},
+    const std::optional<bfield_t> &bfield = {},
     const navigation::direction nav_dir = navigation::direction::e_forward,
     typename actor_chain<actor_ts...>::state_ref_tuple state_tuple = {},
     const std::array<dscalar<typename detector_t::algebra_type>, e_bound_size>
@@ -214,10 +215,12 @@ inline auto record_propagation(
     propagation =
         std::make_unique<typename propagator_t::state>(track, det, ctx);
   } else {
-    typename propagator_t::stepper_type::magnetic_field_type bfield_view(
-        bfield);
-    propagation = std::make_unique<typename propagator_t::state>(
-        track, bfield_view, det, ctx);
+    if (!bfield.has_value()) {
+      DETRAY_FATAL_HOST("No bfield passed for RKN stepper!");
+      std::exit(EXIT_FAILURE);
+    }
+    propagation = std::make_unique<typename propagator_t::state>(track, *bfield,
+                                                                 det, ctx);
   }
 
   // Set the initial covariances
@@ -273,10 +276,12 @@ inline auto record_propagation(
       fw_propagation =
           std::make_unique<typename fw_propagator_t::state>(track, det, ctx);
     } else {
-      typename fw_propagator_t::stepper_type::magnetic_field_type bfield_view(
-          bfield);
+      if (!bfield.has_value()) {
+        DETRAY_FATAL_HOST("No bfield passed for RKN stepper!");
+        std::exit(EXIT_FAILURE);
+      }
       fw_propagation = std::make_unique<typename fw_propagator_t::state>(
-          track, bfield_view, det, ctx);
+          track, *bfield, det, ctx);
     }
 
     // Make a deep copy of states for forward propagation, but omit the
@@ -1040,7 +1045,8 @@ auto compare_to_navigation(
     vecmem::host_memory_resource &host_mr, const detector_t &det,
     const typename detector_t::name_map &names,
     const typename detector_t::geometry_context ctx,
-    const field_view_t field_view, const propagation::config &prop_cfg,
+    const std::optional<field_view_t> field_view,
+    const propagation::config &prop_cfg,
     std::vector<dvector<navigation::detail::candidate_record<intersection_t>>>
         &truth_traces,
     const std::vector<free_track_parameters<algebra_t>> &tracks,


### PR DESCRIPTION
Remove dangling reference to magnetic field in record_propagation function and use std::optional for type erasure instead.

--- END COMMIT MESSAGE ---
