### PR TITLE
fix: the perigee stopper

### DIFF
--- a/Detray/tests/include/detray/test/utils/perigee_stopper.hpp
+++ b/Detray/tests/include/detray/test/utils/perigee_stopper.hpp
@@ -25,7 +25,7 @@
 namespace detray {
 
 /// Actor that exits from a navigation stream, if it has reached the perigee
-/// @Note Currently only works with step constraints (will be changed in the
+/// @note Currently only works with step constraints (will be changed in the
 /// future)
 template <concepts::algebra algebra_t>
 struct perigee_stopper : public base_actor {
@@ -76,9 +76,8 @@ struct perigee_stopper : public base_actor {
 
     // At least the exit portal should be reachable
     if (navigation.cache_exhausted()) {
-      prop_state._heartbeat =
-          prop_state._heartbeat &&
-          navigation.abort("Pergigee stopper has no next candidate");
+      navigation.abort("Perigee stopper has no next candidate");
+      prop_state.heartbeat(false);
       return;
     }
 
@@ -112,7 +111,8 @@ struct perigee_stopper : public base_actor {
 
       // The track has reached the perigee: "exit success"
       if (math::fabs(perigee_intr.path()) <= actor_state.m_on_perigee_tol) {
-        prop_state._heartbeat = prop_state._heartbeat && navigation.exit();
+        navigation.exit();
+        prop_state.heartbeat(false);
       } else {
         // @TODO: Use a guided navigator for this in order to catch
         // overstepping correctly


### PR DESCRIPTION
As it is used in an open PR in traccc, but not in detray, this testing actor broke in the meantime

--- END COMMIT MESSAGE ---
