### PR TITLE
feat: detray - optional material/grid conversion and search window setting

### DIFF
--- a/Examples/Scripts/Python/propagation_validation.py
+++ b/Examples/Scripts/Python/propagation_validation.py
@@ -82,6 +82,8 @@ def main():
         help="Convert to detray detector and run detray navigation and propagation",
     )
 
+    # Output options
+
     p.add_argument(
         "--output-summary",
         action=argparse.BooleanOptionalAction,
@@ -190,6 +192,8 @@ def main():
                     trackingGeometry,
                     beampipeVolumeName="BeamPipe",
                     logLevel=logLevel,
+                    convertMaterial=True,
+                    convertSurfaceGrids=False,
                 )
             propagatorImpl = acts.examples.detray.StraightLinePropagatorODD(
                 detrayGeometry, __pmr, sterileRun, logLevel

--- a/Plugins/Detray/include/ActsPlugins/Detray/DetrayGeometryConverter.hpp
+++ b/Plugins/Detray/include/ActsPlugins/Detray/DetrayGeometryConverter.hpp
@@ -41,6 +41,8 @@ namespace ActsPlugins::DetrayGeometryConverter {
 /// @param detectorName the name to set for the detray detector (optional,
 ///     if not set, it will be taken from the payloads or defaulted to empty)
 /// @param logLevel the logging level to use for the conversion process
+/// @param convertMaterial whether to convert material information from ACTS to detray
+/// @param convertSurfaceGrids whether to convert surface grid information from ACTS to detray
 ///
 /// This method performs the following steps:
 /// 1. It searches for the beampipe volume in the ACTS tracking geometry using
@@ -58,7 +60,8 @@ toDetray(vecmem::memory_resource& mr, const Acts::GeometryContext& gctx,
          const Acts::TrackingGeometry& trackingGeometry,
          const std::string& beampipeVolumeName,
          const std::string& detectorName = "",
-         Acts::Logging::Level logLevel = Acts::Logging::INFO) {
+         Acts::Logging::Level logLevel = Acts::Logging::INFO,
+         bool convertMaterial = true, bool convertSurfaceGrids = true) {
   auto localLogger =
       Acts::getDefaultLogger("DetrayGeometryConverter", logLevel);
   auto payloadLogger = localLogger->clone("DetrayPayloadConverter");
@@ -94,18 +97,22 @@ toDetray(vecmem::memory_resource& mr, const Acts::GeometryContext& gctx,
   detray::io::geometry_reader::from_payload<detector_t>(detectorBuilder,
                                                         *payloads.detector);
 
-  detray::io::homogeneous_material_reader::from_payload<detector_t>(
-      detectorBuilder, *payloads.homogeneousMaterial);
+  if (convertMaterial) {
+    detray::io::homogeneous_material_reader::from_payload<detector_t>(
+        detectorBuilder, *payloads.homogeneousMaterial);
 
-  detray::io::material_map_reader<std::integral_constant<std::size_t, 2>>::
-      from_payload<detector_t>(detectorBuilder,
-                               std::move(*payloads.materialGrids));
+    detray::io::material_map_reader<std::integral_constant<std::size_t, 2>>::
+        from_payload<detector_t>(detectorBuilder,
+                                 std::move(*payloads.materialGrids));
+  }
 
-  detray::io::surface_grid_reader<typename detector_t::surface_type,
-                                  std::integral_constant<std::size_t, 0>,
-                                  std::integral_constant<std::size_t, 2>>::
-      template from_payload<detector_t>(detectorBuilder,
-                                        *payloads.surfaceGrids);
+  if (convertSurfaceGrids) {
+    detray::io::surface_grid_reader<typename detector_t::surface_type,
+                                    std::integral_constant<std::size_t, 0>,
+                                    std::integral_constant<std::size_t, 2>>::
+        template from_payload<detector_t>(detectorBuilder,
+                                          *payloads.surfaceGrids);
+  }
 
   if (!detectorName.empty()) {
     detectorBuilder.set_name(detectorName);

--- a/Python/Plugins/src/Detray.cpp
+++ b/Python/Plugins/src/Detray.cpp
@@ -76,14 +76,16 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsDetray, detray) {
            const Acts::TrackingGeometry& trackingGeometry,
            const std::string& beampipeVolumeName,
            const std::string& detectorName = "",
-           Acts::Logging::Level logLevel = Acts::Logging::INFO) {
+           Acts::Logging::Level logLevel = Acts::Logging::INFO,
+           bool convertMaterial = true, bool convertSurfaceGrids = true) {
           auto [det, names] =
               DetrayGeometryConverter::toDetray<DetrayMetaDataODD>(
                   mr, gctx, trackingGeometry, beampipeVolumeName, detectorName,
-                  logLevel);
+                  logLevel, convertMaterial, convertSurfaceGrids);
           return std::make_pair(std::move(det), std::move(names));
         },
         "mr"_a, "gctx"_a, "trackingGeometry"_a, "beampipeVolumeName"_a,
-        "detectorName"_a = "", "logLevel"_a = Acts::Logging::INFO);
+        "detectorName"_a = "", "logLevel"_a = Acts::Logging::INFO,
+        "convertMaterial"_a = true, "convertSurfaceGrids"_a = true);
   }
 }


### PR DESCRIPTION
This PR adds two:
- two boolean switches to optionally convert material / surface grids
- allows to set the navigation search window for the tests

--- END COMMIT MESSAGE ---

Without surface grids:

ODD navigation restored from Gen3 in-memory conversion:

<img width="640" height="480" alt="nSensitives_vs_eta" src="https://github.com/user-attachments/assets/b69464e6-c0e1-4caa-9993-3dc1a22cdaf8" />

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
