### PR TITLE
fix: preserve stream state in surface output

### DIFF
--- a/Core/include/Acts/Utilities/detail/OstreamStateGuard.hpp
+++ b/Core/include/Acts/Utilities/detail/OstreamStateGuard.hpp
@@ -1,0 +1,50 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <ios>
+#include <ostream>
+
+namespace Acts::detail {
+
+/// @brief Restore an output stream's formatting state on scope exit.
+///
+/// This keeps diagnostic output helpers from leaking persistent manipulators
+/// such as std::fixed, std::setprecision, std::setfill, or std::boolalpha into
+/// the stream provided by the caller.
+class OstreamStateGuard {
+ public:
+  explicit OstreamStateGuard(std::ostream& stream)
+      : m_stream(&stream),
+        m_flags(stream.flags()),
+        m_precision(stream.precision()),
+        m_width(stream.width()),
+        m_fill(stream.fill()) {}
+
+  ~OstreamStateGuard() noexcept {
+    m_stream->flags(m_flags);
+    m_stream->precision(m_precision);
+    m_stream->width(m_width);
+    m_stream->fill(m_fill);
+  }
+
+  OstreamStateGuard(const OstreamStateGuard&) = delete;
+  OstreamStateGuard& operator=(const OstreamStateGuard&) = delete;
+  OstreamStateGuard(OstreamStateGuard&&) = delete;
+  OstreamStateGuard& operator=(OstreamStateGuard&&) = delete;
+
+ private:
+  std::ostream* m_stream{};
+  std::ios_base::fmtflags m_flags{};
+  std::streamsize m_precision{};
+  std::streamsize m_width{};
+  char m_fill{};
+};
+
+}  // namespace Acts::detail

--- a/Core/src/Geometry/ConeVolumeBounds.cpp
+++ b/Core/src/Geometry/ConeVolumeBounds.cpp
@@ -20,10 +20,12 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <numbers>
 #include <stdexcept>
 #include <utility>
@@ -289,8 +291,8 @@ void ConeVolumeBounds::buildSurfaceBounds() {
 }
 
 std::ostream& ConeVolumeBounds::toStream(std::ostream& os) const {
-  os << std::setiosflags(std::ios::fixed);
-  os << std::setprecision(5);
+  detail::OstreamStateGuard guard{os};
+  os << std::fixed << std::setprecision(5);
   os << "Acts::ConeVolumeBounds : (innerAlpha, innerOffsetZ, outerAlpha,";
   os << "  outerOffsetZ, halflenghZ, averagePhi, halfPhiSector) = ";
   os << get(eInnerAlpha) << ", " << get(eInnerOffsetZ) << ", ";

--- a/Core/src/Geometry/CuboidVolumeBounds.cpp
+++ b/Core/src/Geometry/CuboidVolumeBounds.cpp
@@ -14,9 +14,11 @@
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <algorithm>
 #include <array>
+#include <iomanip>
 #include <stdexcept>
 #include <utility>
 
@@ -93,8 +95,8 @@ std::vector<Acts::OrientedSurface> Acts::CuboidVolumeBounds::orientedSurfaces(
 }
 
 std::ostream& CuboidVolumeBounds::toStream(std::ostream& os) const {
-  os << std::setiosflags(std::ios::fixed);
-  os << std::setprecision(5);
+  detail::OstreamStateGuard guard{os};
+  os << std::fixed << std::setprecision(5);
   os << "Acts::CuboidVolumeBounds: (halfLengthX, halfLengthY, halfLengthZ) = ";
   os << "(" << get(eHalfLengthX) << ", " << get(eHalfLengthY) << ", "
      << get(eHalfLengthZ) << ")";

--- a/Core/src/Geometry/CylinderVolumeBounds.cpp
+++ b/Core/src/Geometry/CylinderVolumeBounds.cpp
@@ -19,9 +19,11 @@
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <cmath>
+#include <iomanip>
 #include <numbers>
 #include <utility>
 
@@ -176,8 +178,8 @@ void CylinderVolumeBounds::buildSurfaceBounds() {
 }
 
 std::ostream& CylinderVolumeBounds::toStream(std::ostream& os) const {
-  os << std::setiosflags(std::ios::fixed);
-  os << std::setprecision(5);
+  detail::OstreamStateGuard guard{os};
+  os << std::fixed << std::setprecision(5);
   os << "CylinderVolumeBounds: (rMin, rMax, halfZ, halfPhi, "
         "averagePhi, minBevelZ, maxBevelZ) = ";
   os << get(eMinR) << ", " << get(eMaxR) << ", " << get(eHalfLengthZ) << ", "

--- a/Core/src/Geometry/DiamondVolumeBounds.cpp
+++ b/Core/src/Geometry/DiamondVolumeBounds.cpp
@@ -14,6 +14,13 @@
 #include "Acts/Surfaces/PlaneSurface.hpp"
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
+
+#include <cmath>
+#include <iomanip>
+#include <numbers>
+#include <stdexcept>
+#include <utility>
 
 namespace Acts {
 
@@ -210,8 +217,8 @@ void DiamondVolumeBounds::checkConsistency() noexcept(false) {
 }
 
 std::ostream& DiamondVolumeBounds::toStream(std::ostream& os) const {
-  os << std::setiosflags(std::ios::fixed);
-  os << std::setprecision(5);
+  detail::OstreamStateGuard guard{os};
+  os << std::fixed << std::setprecision(5);
   os << "DiamondVolumeBounds: (halfX1, halfX2, halfX3, halfY1, halfY2, "
         "halfZ) = ";
   os << "(" << get(eHalfLengthX1) << ", " << get(eHalfLengthX2) << ", "

--- a/Core/src/Geometry/TrapezoidVolumeBounds.cpp
+++ b/Core/src/Geometry/TrapezoidVolumeBounds.cpp
@@ -15,9 +15,11 @@
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 #include "Acts/Utilities/BoundingBox.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <cmath>
 #include <cstddef>
+#include <iomanip>
 #include <numbers>
 #include <utility>
 
@@ -154,8 +156,8 @@ bool TrapezoidVolumeBounds::inside(const Vector3& pos, double tol) const {
 }
 
 std::ostream& TrapezoidVolumeBounds::toStream(std::ostream& os) const {
-  os << std::setiosflags(std::ios::fixed);
-  os << std::setprecision(5);
+  detail::OstreamStateGuard guard{os};
+  os << std::fixed << std::setprecision(5);
   os << "TrapezoidVolumeBounds: (halfX @-Y, halfX @+Y, halfY, halfZ, alpha, "
         "beta) "
         "= ";

--- a/Core/src/Surfaces/AnnulusBounds.cpp
+++ b/Core/src/Surfaces/AnnulusBounds.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <algorithm>
@@ -408,14 +409,13 @@ Vector2 AnnulusBounds::center() const {
 }
 
 std::ostream& AnnulusBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::AnnulusBounds:  (innerRadius, outerRadius, minPhi, maxPhi) = ";
   sl << "(" << get(eMinR) << ", " << get(eMaxR) << ", " << phiMin() << ", "
      << phiMax() << ")" << '\n';
   sl << " - shift xy = " << m_shiftXY.x() << ", " << m_shiftXY.y() << '\n';
   sl << " - shift pc = " << m_shiftPC.x() << ", " << m_shiftPC.y() << '\n';
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/ConeBounds.cpp
+++ b/Core/src/Surfaces/ConeBounds.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Tolerance.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <cmath>
@@ -96,13 +97,12 @@ Vector2 ConeBounds::center() const {
 }
 
 std::ostream& ConeBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::ConeBounds: (tanAlpha, minZ, maxZ, halfPhiSector, averagePhi) "
         "= ";
   sl << "(" << m_tanAlpha << ", " << get(eMinZ) << ", " << get(eMaxZ) << ", "
      << get(eHalfPhiSector) << ", " << get(eAveragePhi) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/CylinderBounds.cpp
+++ b/Core/src/Surfaces/CylinderBounds.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <algorithm>
@@ -106,14 +107,13 @@ Vector2 CylinderBounds::center() const {
 }
 
 std::ostream& CylinderBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::CylinderBounds: (radius, halfLengthZ, halfPhiSector, "
         "averagePhi, bevelMinZ, bevelMaxZ) = ";
   sl << "(" << get(eR) << ", " << get(eHalfLengthZ) << ", ";
   sl << get(eHalfPhiSector) << ", " << get(eAveragePhi) << ", ";
   sl << get(eBevelMinZ) << ", " << get(eBevelMaxZ) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/DiamondBounds.cpp
+++ b/Core/src/Surfaces/DiamondBounds.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <iomanip>
 #include <iostream>
@@ -85,8 +86,8 @@ Vector2 DiamondBounds::center() const {
 }
 
 std::ostream& DiamondBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::DiamondBounds: (halfXatYneg, halfXatYzero, halfXatYpos, "
         "halfYneg, halfYpos) = ";
   sl << "(" << get(DiamondBounds::eHalfLengthXnegY) << ", "
@@ -94,7 +95,6 @@ std::ostream& DiamondBounds::toStream(std::ostream& sl) const {
      << get(DiamondBounds::eHalfLengthXposY) << ", "
      << get(DiamondBounds::eHalfLengthYneg) << ", "
      << get(DiamondBounds::eHalfLengthYpos) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/DiscTrapezoidBounds.cpp
+++ b/Core/src/Surfaces/DiscTrapezoidBounds.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <cmath>
@@ -111,8 +112,8 @@ Vector2 DiscTrapezoidBounds::center() const {
 }
 
 std::ostream& DiscTrapezoidBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::DiscTrapezoidBounds: (innerRadius, outerRadius, "
         "halfLengthXminR, "
         "halfLengthXmaxR, halfLengthY, halfPhiSector, averagePhi, rCenter, "
@@ -121,7 +122,6 @@ std::ostream& DiscTrapezoidBounds::toStream(std::ostream& sl) const {
      << ", " << get(eHalfLengthXmaxR) << ", " << halfLengthY() << ", "
      << halfPhiSector() << ", " << get(eAveragePhi) << ", " << rCenter() << ", "
      << stereo() << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/EllipseBounds.cpp
+++ b/Core/src/Surfaces/EllipseBounds.cpp
@@ -11,6 +11,7 @@
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <iomanip>
@@ -78,14 +79,13 @@ Vector2 EllipseBounds::center() const {
 }
 
 std::ostream& EllipseBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::EllipseBounds:  (innerRadius0, outerRadius0, innerRadius1, "
         "outerRadius1, hPhiSector, averagePhi) = ";
   sl << "(" << get(eInnerRx) << ", " << get(eInnerRy) << ", " << get(eOuterRx)
      << ", " << get(eOuterRy) << ", " << get(eAveragePhi) << ", "
      << get(eHalfPhiSector) << ", " << get(eAveragePhi) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/LineBounds.cpp
+++ b/Core/src/Surfaces/LineBounds.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/LineBounds.hpp"
 
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <iomanip>
 #include <iostream>
@@ -49,12 +50,11 @@ Vector2 LineBounds::center() const {
 }
 
 std::ostream& LineBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::LineBounds: (radius, halflengthInZ) = ";
   sl << "(" << get(LineBounds::eR) << ", " << get(LineBounds::eHalfLengthZ)
      << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
 #include "Acts/Geometry/GeometryObject.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <iomanip>
 #include <iostream>
@@ -48,13 +49,12 @@ std::string PerigeeSurface::name() const {
 
 std::ostream& PerigeeSurface::toStreamImpl(const GeometryContext& gctx,
                                            std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::PerigeeSurface:" << std::endl;
   const Vector3& sfCenter = center(gctx);
   sl << "     Center position  (x, y, z) = (" << sfCenter.x() << ", "
      << sfCenter.y() << ", " << sfCenter.z() << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/RadialBounds.cpp
+++ b/Core/src/Surfaces/RadialBounds.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/RadialBounds.hpp"
 
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
 
 #include <iomanip>
@@ -87,13 +88,12 @@ Vector2 RadialBounds::center() const {
 }
 
 std::ostream& RadialBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::RadialBounds:  (innerRadius, outerRadius, hPhiSector, "
         "averagePhi) = ";
   sl << "(" << get(eMinR) << ", " << get(eMaxR) << ", " << get(eHalfPhiSector)
      << ", " << get(eAveragePhi) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/RectangleBounds.cpp
+++ b/Core/src/Surfaces/RectangleBounds.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <cassert>
 #include <iomanip>
@@ -80,14 +81,13 @@ Vector2 RectangleBounds::center() const {
 }
 
 std::ostream& RectangleBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::RectangleBounds:  (hlX, hlY) = "
      << "(" << 0.5 * (get(eMaxX) - get(eMinX)) << ", "
      << 0.5 * (get(eMaxY) - get(eMinY)) << ")";
   sl << "\n(lower left, upper right):\n";
   sl << min().transpose() << "\n" << max().transpose();
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/Surface.cpp
+++ b/Core/src/Surfaces/Surface.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Surfaces/detail/AlignmentHelper.hpp"
 #include "Acts/Utilities/JacobianHelpers.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 #include "Acts/Visualization/ViewConfig.hpp"
 
 #include <iomanip>
@@ -186,8 +187,8 @@ bool Surface::operator==(const Surface& other) const {
 
 std::ostream& Surface::toStreamImpl(const GeometryContext& gctx,
                                     std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(4);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(4);
   sl << name() << std::endl;
   const Vector3& sfcenter = center(gctx);
   sl << "     Center position  (x, y, z) = (" << sfcenter.x() << ", "
@@ -204,7 +205,6 @@ std::ostream& Surface::toStreamImpl(const GeometryContext& gctx,
   sl << "                           colZ = (" << rotZ(0) << ", " << rotZ(1)
      << ", " << rotZ(2) << ")" << std::endl;
   sl << "     Bounds  : " << bounds();
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/Surfaces/SurfaceArray.cpp
+++ b/Core/src/Surfaces/SurfaceArray.cpp
@@ -17,7 +17,9 @@
 #include "Acts/Utilities/IAxis.hpp"
 #include "Acts/Utilities/Ranges.hpp"
 #include "Acts/Utilities/detail/MultiAxisHelper.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
+#include <iomanip>
 #include <limits>
 #include <map>
 #include <ranges>
@@ -656,6 +658,7 @@ std::vector<AxisDirection> SurfaceArray::binningValues() const {
 
 std::ostream& SurfaceArray::toStream(const GeometryContext& /*gctx*/,
                                      std::ostream& sl) const {
+  detail::OstreamStateGuard guard{sl};
   sl << std::fixed << std::setprecision(4);
   sl << "SurfaceArray:" << std::endl;
   sl << " - no surfaces: " << m_surfaces.size() << std::endl;

--- a/Core/src/Surfaces/TrapezoidBounds.cpp
+++ b/Core/src/Surfaces/TrapezoidBounds.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/TrapezoidBounds.hpp"
 
 #include "Acts/Surfaces/ConvexPolygonBounds.hpp"
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <iomanip>
 #include <iostream>
@@ -111,12 +112,11 @@ Vector2 TrapezoidBounds::center() const {
 }
 
 std::ostream& TrapezoidBounds::toStream(std::ostream& sl) const {
-  sl << std::setiosflags(std::ios::fixed);
-  sl << std::setprecision(7);
+  detail::OstreamStateGuard guard{sl};
+  sl << std::fixed << std::setprecision(7);
   sl << "Acts::TrapezoidBounds:  (halfXnegY, halfXposY, halfY, rotAngle) = "
      << "(" << get(eHalfLengthXnegY) << ", " << get(eHalfLengthXposY) << ", "
      << get(eHalfLengthY) << ", " << get(eRotationAngle) << ")";
-  sl << std::setprecision(-1);
   return sl;
 }
 

--- a/Core/src/TrackFitting/detail/GsfComponentMerging.cpp
+++ b/Core/src/TrackFitting/detail/GsfComponentMerging.cpp
@@ -8,6 +8,9 @@
 
 #include "Acts/TrackFitting/detail/GsfComponentMerging.hpp"
 
+#include "Acts/Utilities/detail/OstreamStateGuard.hpp"
+
+#include <iomanip>
 #include <iostream>
 
 namespace Acts {
@@ -117,7 +120,7 @@ std::pair<std::size_t, std::size_t> SymmetricKLDistanceMatrix::minDistancePair()
 }
 
 std::ostream &SymmetricKLDistanceMatrix::toStream(std::ostream &os) const {
-  const auto prev_precision = os.precision();
+  detail::OstreamStateGuard guard{os};
   const int width = 8;
   const int prec = 2;
 
@@ -139,7 +142,6 @@ std::ostream &SymmetricKLDistanceMatrix::toStream(std::ostream &os) const {
     }
     os << "\n";
   }
-  os << std::setprecision(prev_precision);
   return os;
 }
 

--- a/Tests/UnitTests/Core/Geometry/VolumeBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/VolumeBoundsTests.cpp
@@ -9,11 +9,52 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/ConeVolumeBounds.hpp"
+#include "Acts/Geometry/CuboidVolumeBounds.hpp"
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
+#include "Acts/Geometry/DiamondVolumeBounds.hpp"
+#include "Acts/Geometry/TrapezoidVolumeBounds.hpp"
 #include "Acts/Geometry/VolumeBounds.hpp"
+
+#include <iomanip>
+#include <memory>
+#include <numbers>
+#include <sstream>
+#include <vector>
 
 using namespace Acts;
 
 namespace ActsTests {
+
+namespace {
+
+struct StreamState {
+  std::ios_base::fmtflags flags;
+  std::streamsize precision;
+  std::streamsize width;
+  char fill;
+};
+
+StreamState setNonDefaultStreamState(std::ostringstream& stream) {
+  stream << std::scientific << std::showpos << std::setfill('#')
+         << std::setprecision(3);
+  stream.width(17);
+  return {stream.flags(), stream.precision(), stream.width(), stream.fill()};
+}
+
+void checkStreamStatePreserved(const VolumeBounds& bounds) {
+  std::ostringstream stream;
+  const auto state = setNonDefaultStreamState(stream);
+
+  bounds.toStream(stream);
+
+  BOOST_CHECK(stream.flags() == state.flags);
+  BOOST_CHECK_EQUAL(stream.precision(), state.precision);
+  BOOST_CHECK_EQUAL(stream.width(), state.width);
+  BOOST_CHECK_EQUAL(stream.fill(), state.fill);
+}
+
+}  // namespace
 
 BOOST_AUTO_TEST_SUITE(GeometrySuite)
 
@@ -41,6 +82,21 @@ BOOST_AUTO_TEST_CASE(VolumeBoundsTest) {
   BOOST_CHECK(rotZX.col(0).isApprox(zaxis));
   BOOST_CHECK(rotZX.col(1).isApprox(xaxis));
   BOOST_CHECK(rotZX.col(2).isApprox(yaxis));
+}
+
+BOOST_AUTO_TEST_CASE(VolumeBoundsToStreamPreservesStreamState) {
+  std::vector<std::unique_ptr<VolumeBounds>> bounds;
+  bounds.push_back(std::make_unique<ConeVolumeBounds>(0., 0., 0.45, 50., 50.,
+                                                      0., std::numbers::pi));
+  bounds.push_back(std::make_unique<CuboidVolumeBounds>(10., 20., 30.));
+  bounds.push_back(std::make_unique<CylinderVolumeBounds>(10., 20., 30.));
+  bounds.push_back(
+      std::make_unique<DiamondVolumeBounds>(10., 12., 8., 5., 10., 2.));
+  bounds.push_back(std::make_unique<TrapezoidVolumeBounds>(5., 10., 8., 4.));
+
+  for (const auto& bound : bounds) {
+    checkStreamStatePreserved(*bound);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
@@ -14,7 +14,9 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 
 using namespace Acts;
@@ -74,6 +76,27 @@ BOOST_AUTO_TEST_CASE(PerigeeSurfaceProperties) {
   BOOST_CHECK(
       dumpOutput.is_equal("Acts::PerigeeSurface:\n\
      Center position  (x, y, z) = (1.0000000, 1.0000000, 1.0000000)"));
+}
+
+BOOST_AUTO_TEST_CASE(PerigeeSurfaceToStreamPreservesStreamState) {
+  std::ostringstream stream;
+  stream << std::scientific << std::showpos << std::setfill('#')
+         << std::setprecision(3);
+  stream.width(17);
+
+  const auto flags = stream.flags();
+  const auto precision = stream.precision();
+  const auto width = stream.width();
+  const auto fill = stream.fill();
+
+  auto perigeeSurface =
+      Surface::makeShared<PerigeeSurface>(Vector3{1., 1., 1.});
+  stream << perigeeSurface->toStream(tgContext);
+
+  BOOST_CHECK(stream.flags() == flags);
+  BOOST_CHECK_EQUAL(stream.precision(), precision);
+  BOOST_CHECK_EQUAL(stream.width(), width);
+  BOOST_CHECK_EQUAL(stream.fill(), fill);
 }
 
 BOOST_AUTO_TEST_CASE(EqualityOperators) {

--- a/Tests/UnitTests/Core/Surfaces/SurfaceArrayTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceArrayTests.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <memory>
 #include <numbers>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -228,6 +229,30 @@ BOOST_AUTO_TEST_CASE(SurfaceArray_singleElement) {
   BOOST_CHECK_EQUAL(binContent[0], srf.get());
   BOOST_CHECK_EQUAL(sa.surfaces().size(), 1u);
   BOOST_CHECK_EQUAL(sa.surfaces().at(0), srf.get());
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceArrayToStreamPreservesStreamState) {
+  const auto bounds = std::make_shared<const RectangleBounds>(3., 4.);
+  auto surface =
+      Surface::makeShared<PlaneSurface>(Transform3::Identity(), bounds);
+  SurfaceArray surfaceArray(surface);
+
+  std::ostringstream stream;
+  stream << std::scientific << std::showpos << std::setfill('#')
+         << std::setprecision(3);
+  stream.width(17);
+
+  const auto flags = stream.flags();
+  const auto precision = stream.precision();
+  const auto width = stream.width();
+  const auto fill = stream.fill();
+
+  surfaceArray.toStream(tgContext, stream);
+
+  BOOST_CHECK(stream.flags() == flags);
+  BOOST_CHECK_EQUAL(stream.precision(), precision);
+  BOOST_CHECK_EQUAL(stream.width(), width);
+  BOOST_CHECK_EQUAL(stream.fill(), fill);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceBoundsTests.cpp
@@ -9,12 +9,26 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Surfaces/AnnulusBounds.hpp"
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
+#include "Acts/Surfaces/ConeBounds.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/DiamondBounds.hpp"
+#include "Acts/Surfaces/DiscTrapezoidBounds.hpp"
+#include "Acts/Surfaces/EllipseBounds.hpp"
+#include "Acts/Surfaces/LineBounds.hpp"
+#include "Acts/Surfaces/RadialBounds.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/SurfaceBounds.hpp"
+#include "Acts/Surfaces/TrapezoidBounds.hpp"
 
 #include <cstddef>
+#include <iomanip>
+#include <memory>
+#include <numbers>
 #include <numeric>
 #include <ostream>
+#include <sstream>
 #include <vector>
 
 namespace Acts {
@@ -91,6 +105,41 @@ using namespace Acts;
 
 namespace ActsTests {
 
+namespace {
+
+struct StreamState {
+  std::ios_base::fmtflags flags;
+  std::streamsize precision;
+  std::streamsize width;
+  char fill;
+};
+
+StreamState setNonDefaultStreamState(std::ostringstream& stream) {
+  stream << std::scientific << std::showpos << std::setfill('#')
+         << std::setprecision(3);
+  stream.width(17);
+  return {stream.flags(), stream.precision(), stream.width(), stream.fill()};
+}
+
+void checkStreamState(const std::ostringstream& stream,
+                      const StreamState& state) {
+  BOOST_CHECK(stream.flags() == state.flags);
+  BOOST_CHECK_EQUAL(stream.precision(), state.precision);
+  BOOST_CHECK_EQUAL(stream.width(), state.width);
+  BOOST_CHECK_EQUAL(stream.fill(), state.fill);
+}
+
+void checkStreamStatePreserved(const SurfaceBounds& bounds) {
+  std::ostringstream stream;
+  const auto state = setNonDefaultStreamState(stream);
+
+  bounds.toStream(stream);
+
+  checkStreamState(stream, state);
+}
+
+}  // namespace
+
 BOOST_AUTO_TEST_SUITE(SurfacesSuite)
 
 /// Unit test for creating compliant/non-compliant SurfaceBounds object
@@ -126,6 +175,26 @@ BOOST_AUTO_TEST_CASE(SurfaceBoundsEquality) {
   BOOST_CHECK_EQUAL_COLLECTIONS(
       surfaceboundValues.cbegin(), surfaceboundValues.cend(),
       assignedboundValues.cbegin(), assignedboundValues.cend());
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceBoundsToStreamPreservesStreamState) {
+  std::vector<std::unique_ptr<SurfaceBounds>> bounds;
+  bounds.push_back(
+      std::make_unique<AnnulusBounds>(7.2, 12., 0.7, 1.3, Vector2{-2., 2.}));
+  bounds.push_back(std::make_unique<ConeBounds>(std::numbers::pi / 8., 3., 6.));
+  bounds.push_back(std::make_unique<CylinderBounds>(0.5, 10.));
+  bounds.push_back(std::make_unique<DiamondBounds>(10., 20., 15., 5., 7.));
+  bounds.push_back(std::make_unique<DiscTrapezoidBounds>(1., 5., 2., 6., 0.));
+  bounds.push_back(std::make_unique<EllipseBounds>(1., 2., 3., 4.,
+                                                   std::numbers::pi / 2., 0.));
+  bounds.push_back(std::make_unique<LineBounds>(0.5, 20.));
+  bounds.push_back(std::make_unique<RadialBounds>(1., 5.));
+  bounds.push_back(std::make_unique<RectangleBounds>(10., 5.));
+  bounds.push_back(std::make_unique<TrapezoidBounds>(1., 6., 2.));
+
+  for (const auto& bound : bounds) {
+    checkStreamStatePreserved(*bound);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/SurfaceTests.cpp
@@ -21,7 +21,9 @@
 #include "ActsTests/CommonHelpers/FloatComparisons.hpp"
 #include "ActsTests/CommonHelpers/PredefinedMaterials.hpp"
 
+#include <iomanip>
 #include <memory>
+#include <sstream>
 
 #include "SurfaceStub.hpp"
 
@@ -141,6 +143,29 @@ BOOST_AUTO_TEST_CASE(SurfaceProperties) {
                        1e-6, 1e-9);
 
   // type() is pure virtual
+}
+
+BOOST_AUTO_TEST_CASE(SurfaceToStreamPreservesStreamState) {
+  std::ostringstream stream;
+  stream << std::scientific << std::showpos << std::setfill('#')
+         << std::setprecision(3);
+  stream.width(17);
+
+  const auto flags = stream.flags();
+  const auto precision = stream.precision();
+  const auto width = stream.width();
+  const auto fill = stream.fill();
+
+  auto bounds = std::make_shared<const RectangleBounds>(5., 10.);
+  auto surface =
+      Surface::makeShared<PlaneSurface>(Transform3::Identity(), bounds);
+
+  stream << surface->toStream(tgContext);
+
+  BOOST_CHECK(stream.flags() == flags);
+  BOOST_CHECK_EQUAL(stream.precision(), precision);
+  BOOST_CHECK_EQUAL(stream.width(), width);
+  BOOST_CHECK_EQUAL(stream.fill(), fill);
 }
 
 BOOST_AUTO_TEST_CASE(EqualityOperators) {


### PR DESCRIPTION
Refs #3079

## Summary
- Add `OstreamStateGuard` to restore `std::ostream` flags, precision, width, and fill after formatted output.
- Use the guard in the affected `toStream` / `operator<<` paths for surface bounds, volume bounds, `Surface`, `SurfaceArray`, `PerigeeSurface`, and GSF component merging output.
- Add regression coverage that verifies stream formatting state is preserved across the updated output implementations.

## Validation
- `docker exec 7c8454e52c16 cmake --build /workspaces/acts/build_codex --target ActsUnitTestSurfaceBounds ActsUnitTestSurface ActsUnitTestSurfaceArray ActsUnitTestPerigeeSurface ActsUnitTestVolumeBounds ActsUnitTestGsfComponentMerging ActsCore_HEADERS -j 4`
- `docker exec 7c8454e52c16 ctest --test-dir /workspaces/acts/build_codex -R "^(SurfaceBounds|Surface|SurfaceArray|PerigeeSurface|VolumeBounds|GsfComponentMerging)$" --output-on-failure`
- `pre-commit` hook suite on the amended commit