### PR TITLE
feat: Add optional time-of-flight cuts to Seeding2 doublet finding and seed filtering

### DIFF
--- a/Core/include/Acts/Seeding2/BroadTripletSeedFilter.hpp
+++ b/Core/include/Acts/Seeding2/BroadTripletSeedFilter.hpp
@@ -65,6 +65,16 @@ class BroadTripletSeedFilter final : public ITripletSeedFilter {
  public:
   /// @brief Structure that holds configuration parameters for the seed filter algorithm
   struct Config {
+    /// Maximum allowed deviation of the time difference between a triplet's
+    /// bottom and top space points from the time-of-flight expectation for a
+    /// particle from the interaction point: |(t_top - t_bottom) - (L_top -
+    /// L_bottom) * tofInverseSpeed|, with L = sqrt(r^2 + z^2). No cut for the
+    /// default of infinity.
+    float deltaTMax = std::numeric_limits<float>::infinity();
+    /// Inverse signal speed (time per unit length) used for the time-of-flight
+    /// expectation, defaulting to 1/c. A value of zero compares the raw times.
+    float tofInverseSpeed = 1.0f / 299.792458f;
+
     /// Allowed difference in curvature (inverted seed radii) between two
     /// compatible seeds
     float deltaInvHelixDiameter = 0.00003 * (1 / UnitConstants::mm);

--- a/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
+++ b/Core/include/Acts/Seeding2/DoubletSeedFinder.hpp
@@ -303,6 +303,16 @@ class DoubletSeedFinder {
     /// Maximum z distance between two doublet components
     float deltaZMax = std::numeric_limits<float>::infinity();
 
+    /// Maximum allowed deviation of the time difference between the two doublet
+    /// space points from the time-of-flight expectation for a particle from the
+    /// interaction point: |(t_other - t_middle) - (L_other - L_middle) *
+    /// tofInverseSpeed|, with L = sqrt(r^2 + z^2). No cut for the default
+    /// of infinity.
+    float deltaTMax = std::numeric_limits<float>::infinity();
+    /// Inverse signal speed (time per unit length) used for the time-of-flight
+    /// expectation, defaulting to 1/c. A value of zero compares the raw times.
+    float tofInverseSpeed = 1.0f / 299.792458f;
+
     /// Maximum value of impact parameter estimation of the seed candidates
     float impactMax = 20 * UnitConstants::mm;
 

--- a/Core/src/Seeding2/BroadTripletSeedFilter.cpp
+++ b/Core/src/Seeding2/BroadTripletSeedFilter.cpp
@@ -158,11 +158,28 @@ void BroadTripletSeedFilter::filterTripletTopCandidates(
     return spT.zr()[1];
   };
 
+  // bottom space point time and distance from the interaction point, used by
+  // the time-of-flight cut below when a cut is configured and times are present
+  const bool useTimeCut =
+      std::isfinite(config().deltaTMax) && spacePoints.hasColumns(SpacePointColumns::Time);
+  const float tB = useTimeCut ? spB.time() : 0.0f;
+  const float LB = useTimeCut ? fastHypot(spB.zr()[1], spB.zr()[0]) : 0.0f;
+
   std::size_t beginCompTopIndex = 0;
   // loop over top SPs and other compatible top SP candidates
   for (const std::size_t topSpIndex : cache().topSpIndexVec) {
     auto topSp = tripletTopCandidates.topSpacePoints()[topSpIndex];
     auto spT = spacePoints[topSp];
+
+    // reject triplets whose bottom-to-top time difference is incompatible with
+    // the time-of-flight expectation for a particle from the interaction point
+    if (useTimeCut) {
+      const float LT = fastHypot(spT.zr()[1], spT.zr()[0]);
+      const float resBT = (spT.time() - tB) - (LT - LB) * config().tofInverseSpeed;
+      if (std::abs(resBT) > config().deltaTMax) {
+        continue;
+      }
+    }
 
     cache().compatibleSeedR.clear();
 

--- a/Core/src/Seeding2/DoubletSeedFinder.cpp
+++ b/Core/src/Seeding2/DoubletSeedFinder.cpp
@@ -93,6 +93,14 @@ class Impl final : public DoubletSeedFinder {
     }
 
     const SpacePointContainer2& container = candidateSps.container();
+
+    // middle space point time and distance from the interaction point, used by
+    // the time-of-flight cut below when a cut is configured and times are present
+    const bool useTimeCut =
+        std::isfinite(m_cfg.deltaTMax) && container.hasColumns(SpacePointColumns::Time);
+    const float tM = useTimeCut ? middleSp.time() : 0.0f;
+    const float LM = useTimeCut ? std::sqrt(rM * rM + zM * zM) : 0.0f;
+
     for (auto [indexO, xyO, zrO, varianceZO, varianceRO] : candidateSps.zip(
              container.xyColumn(), container.zrColumn(),
              container.varianceZColumn(), container.varianceRColumn())) {
@@ -137,6 +145,17 @@ class Impl final : public DoubletSeedFinder {
 
       if (outsideRangeCheck(deltaZ, m_cfg.deltaZMin, m_cfg.deltaZMax)) {
         continue;
+      }
+
+      // reject doublets whose time difference is incompatible with the
+      // time-of-flight expectation for a particle from the interaction point
+      if (useTimeCut) {
+        const float tO = container[indexO].time();
+        const float LO = std::sqrt(rO * rO + zO * zO);
+        const float tofResidual = (tO - tM) - (LO - LM) * m_cfg.tofInverseSpeed;
+        if (std::abs(tofResidual) > m_cfg.deltaTMax) {
+          continue;
+        }
       }
 
       // the longitudinal impact parameter zOrigin is defined as (zM - rM *


### PR DESCRIPTION
Use the per-space-point time to reject combinations that are inconsistent with a particle travelling from the interaction point at the speed of light.

- DoubletSeedFinder: new Config fields deltaTMax and tofInverseSpeed. A doublet is rejected when |(t_other - t_middle) - (L_other - L_middle) * tofInverseSpeed| exceeds deltaTMax, with L = sqrt(r^2 + z^2).
- BroadTripletSeedFilter: the same deltaTMax / tofInverseSpeed cut applied to a triplet's bottom and top space points.

deltaTMax defaults to infinity (no cut) and the cut is only evaluated when the space-point container provides a time column, so seeding without time behaves exactly as before.

--- END COMMIT MESSAGE ---

This is meant for 4D trackers to improve CPU performance by rejecting spurious doublet combinations early in the chain.
