### PR TITLE
refactor: Pull out EigenDecomposition printer

### DIFF
--- a/Core/include/Acts/Utilities/StringHelpers.hpp
+++ b/Core/include/Acts/Utilities/StringHelpers.hpp
@@ -130,26 +130,16 @@ inline std::string toString(const std::vector<double>& pVector,
   return sout.str();
 }
 
-template <int n>
 /// @brief Print the eigen decomposition of a symmetric matrix in terms
 ///        of eigen values and eigen vectors
-/// @param mat: Matrix which is to be decomposed
+/// @param mat: Symmetric matrix which is to be decomposed. Accepts any
+///             fixed- or dynamic-size matrix expression via Eigen::Ref.
 /// @return: The string containing the eigen decomposition
-inline std::string printEigenDecomposition(const SquareMatrix<n>& mat) {
-  Eigen::EigenSolver<Acts::SquareMatrix<n>> eigenDecomp{mat};
-
-  SquareMatrix<n> basisTrf{SquareMatrix<n>::Identity()};
-  Vector<n> eigenDiag{Vector<n>::Zero()};
-  for (int i = 0; i < n; ++i) {
-    for (int j = 0; j < n; ++j) {
-      basisTrf(i, j) = eigenDecomp.eigenvectors()(i, j).real();
-    }
-    eigenDiag[i] = eigenDecomp.eigenvalues()(i).real();
-  }
-  std::stringstream sstr{};
-  sstr << "eigen values: " << eigenDiag.transpose();
-  sstr << ", eigen vectors:\n" << basisTrf;
-  return sstr.str();
-}
+///
+/// @note Defined out-of-line in StringHelpers.cpp so that the heavy
+///       eigen-solver is instantiated only once instead of in every
+///       translation unit and for every matrix size.
+std::string printEigenDecomposition(
+    const Eigen::Ref<const Eigen::MatrixXd>& mat);
 
 }  // namespace Acts

--- a/Core/src/Utilities/CMakeLists.txt
+++ b/Core/src/Utilities/CMakeLists.txt
@@ -12,4 +12,5 @@ target_sources(
         ScopedTimer.cpp
         TransformComparator.cpp
         Histogram.cpp
+        StringHelpers.cpp
 )

--- a/Core/src/Utilities/StringHelpers.cpp
+++ b/Core/src/Utilities/StringHelpers.cpp
@@ -1,0 +1,30 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Utilities/StringHelpers.hpp"
+
+#include <sstream>
+
+#include <Eigen/Eigenvalues>
+
+namespace Acts {
+
+std::string printEigenDecomposition(
+    const Eigen::Ref<const Eigen::MatrixXd>& mat) {
+  // The matrix is assumed to be symmetric (e.g. a Hessian), so the
+  // self-adjoint solver yields real eigen values and vectors and is
+  // considerably cheaper to compile than the general Eigen::EigenSolver.
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigenDecomp{mat};
+
+  std::stringstream sstr{};
+  sstr << "eigen values: " << eigenDecomp.eigenvalues().transpose();
+  sstr << ", eigen vectors:\n" << eigenDecomp.eigenvectors();
+  return sstr.str();
+}
+
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Seeding/StrawLineResidualTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/StrawLineResidualTest.cpp
@@ -65,14 +65,11 @@ bool isPositiveDefinite(const SquareMatrix<N>& mat) {
       }
     }
   }
-  Eigen::EigenSolver<Acts::SquareMatrix<N>> eigenDecomp{mat};
-  for (const auto lambda : eigenDecomp.eigenvalues()) {
-    if (Acts::abs(lambda.imag()) > Acts::s_epsilon ||
-        lambda.real() < Acts::s_epsilon) {
-      return false;
-    }
-  }
-  return true;
+  // The matrix is symmetric (checked above), so it is positive definite iff its
+  // Cholesky (LLT) decomposition succeeds. This is the canonical positive
+  // definiteness test and far cheaper to compile than the general
+  // Eigen::EigenSolver.
+  return Eigen::LLT<Acts::SquareMatrix<N>>{mat}.info() == Eigen::Success;
 }
 
 std::string whiteSpaces(const std::size_t n, const char s = '#') {


### PR DESCRIPTION
This is used in a number of tests, notable the StrawLineFitter test and dominates compilation time and memory usage.