### PR TITLE
fix: a few bugs in the navigation validation and remove parameter smearing

### DIFF
--- a/Detray/tests/include/detray/test/utils/inspectors.hpp
+++ b/Detray/tests/include/detray/test/utils/inspectors.hpp
@@ -24,6 +24,7 @@
 #include "detray/propagator/detail/print_stepper_state.hpp"
 #include "detray/propagator/stepping_config.hpp"
 #include "detray/tracks/ray.hpp"
+#include "detray/utils/logging.hpp"
 #include "detray/utils/tuple_helpers.hpp"
 
 // System include(s)
@@ -199,8 +200,11 @@ struct object_tracer {
                                      const point3_t &pos, const vector3_t &dir,
                                      const char * /*message*/,
                                      Args &&.../*unused*/) {
+    DETRAY_VERBOSE_HOST_DEVICE("Actor: Check navigation status...");
+
     // Record the candidate of an encountered object
     if ((is_status(state.status(), navigation_status) || ...)) {
+      DETRAY_VERBOSE_HOST_DEVICE("Actor: ...Status matched:");
       // Reached a new position: log it
       // Also log volume switches that happen without position update
       const bool first_obj{(last_pos == point3_t{inv_pos, inv_pos, inv_pos}) &&
@@ -210,6 +214,9 @@ struct object_tracer {
           object_trace.empty() || first_obj ||
           state.current().surface().identifier() !=
               object_trace.back().intersection.surface().identifier()) {
+        DETRAY_VERBOSE_HOST_DEVICE("Actor: -> Record surface %d",
+                                   state.current_surface().index());
+
         object_trace.push_back({pos, dir, state.current()});
         last_pos = pos;
         last_dir = dir;

--- a/Detray/tests/include/detray/test/validation/navigation_validation_config.hpp
+++ b/Detray/tests/include/detray/test/validation/navigation_validation_config.hpp
@@ -45,6 +45,8 @@ struct navigation_validation_config
   navigation::direction m_nav_dir{navigation::direction::e_forward};
   /// Collect only the sensitive intersections for comparison
   bool m_collect_sensitives_only{false};
+  /// Toggle SVG display
+  bool m_display_svg{false};
   /// Drop an SVG only if navigation missed a surface
   bool m_display_only_missed{false};
   /// Whether to stop execution at the first error
@@ -73,6 +75,7 @@ struct navigation_validation_config
   pdg_particle<scalar_type> ptc_hypothesis() const { return m_ptc_hypo; }
   navigation::direction navigation_direction() const { return m_nav_dir; }
   bool collect_sensitives_only() const { return m_collect_sensitives_only; }
+  bool display_svg() const { return m_display_svg; }
   bool display_only_missed() const { return m_display_only_missed; }
   bool fail_on_diff() const { return m_fail_on_diff; }
   bool verbose() const { return m_verbose; }
@@ -108,6 +111,10 @@ struct navigation_validation_config
   navigation_validation_config &collect_sensitives_only(
       const bool only_sensitives) {
     m_collect_sensitives_only = only_sensitives;
+    return *this;
+  }
+  navigation_validation_config &display_svg(const bool do_display) {
+    m_display_svg = do_display;
     return *this;
   }
   navigation_validation_config &display_only_missed(const bool only_missed) {

--- a/Detray/tests/include/detray/test/validation/navigation_validation_utils.hpp
+++ b/Detray/tests/include/detray/test/validation/navigation_validation_utils.hpp
@@ -143,9 +143,7 @@ inline auto record_propagation(
         muon<typename detector_t::scalar_type>(),
     const std::optional<bfield_t> &bfield = {},
     const navigation::direction nav_dir = navigation::direction::e_forward,
-    typename actor_chain<actor_ts...>::state_ref_tuple state_tuple = {},
-    const std::array<dscalar<typename detector_t::algebra_type>, e_bound_size>
-        &stddevs = {}) {
+    typename actor_chain<actor_ts...>::state_ref_tuple state_tuple = {}) {
   using algebra_t = typename detector_t::algebra_type;
   using scalar_t = dscalar<algebra_t>;
 
@@ -223,39 +221,6 @@ inline auto record_propagation(
                                                                  det, ctx);
   }
 
-  // Set the initial covariances
-  if constexpr (has_param_transport) {
-    if (!stddevs.empty() &&
-        !std::ranges::all_of(stddevs, [](scalar_t s) { return s == 0.f; })) {
-      auto &updater_state = detail::get<updater_state_t &>(actor_states);
-      updater_state.init(track);
-
-      // Copy of the curvilinear params
-      bound_track_parameters<algebra_t> bound_param =
-          updater_state.bound_params();
-
-      // Smear the covariance
-      std::random_device rd{};
-      std::mt19937 generator{rd()};
-
-      for (std::size_t i = 0u; i < e_bound_size; i++) {
-        // Exclude zero-stddev
-        if (stddevs[i] != static_cast<scalar_t>(0)) {
-          bound_param[i] = std::normal_distribution<scalar_t>(
-              bound_param[i], stddevs[i])(generator);
-        }
-
-        getter::element(bound_param.covariance(), i, i) =
-            stddevs[i] * stddevs[i];
-      }
-      assert(!bound_param.is_invalid());
-
-      // Copy back into updater state
-      updater_state =
-          actor::parameter_updater_state<algebra_t>{cfg, bound_param};
-    }
-  }
-
   // Access to navigation information
   auto &nav_inspector = propagation->navigation().inspector();
   auto &obj_tracer = nav_inspector.template get<object_tracer_t>();
@@ -316,7 +281,8 @@ inline auto record_propagation(
     // Make sure parameters are transported, even if there is no actor to
     // update them and enforce the write back to the updater state
     if constexpr (has_param_transport) {
-      detail::get<updater_state_t &>(fw_actor_states).always_update(true);
+      auto &updater_state = detail::get<updater_state_t &>(fw_actor_states);
+      updater_state.always_update(true);
     }
 
     const bool fw_success =
@@ -324,8 +290,8 @@ inline auto record_propagation(
 
     if (!fw_success) {
       DETRAY_ERROR_HOST(
-          "Could not propagate to end of track to "
-          "prepare backward propagation");
+          "Could not propagate to end of track to prepare backward "
+          "propagation");
     }
 
     // Use the result to set up main propagation run
@@ -337,6 +303,42 @@ inline auto record_propagation(
     if constexpr (has_param_transport) {
       auto &updater_state = detail::get<updater_state_t &>(actor_states);
       updater_state = detail::get<updater_state_t &>(fw_actor_states);
+
+      // Make sure that the bound parameters have been transported to the
+      // "turn-around" surface. End-of-world portals might not trigger the
+      // parameter transport if there is no material
+      bound_track_parameters<algebra_t> &last_bound =
+          updater_state.bound_params();
+      const geometry::identifier last_sf_id{
+          fw_propagation->navigation().geometry_identifier()};
+
+      if (fw_success && !last_sf_id.is_invalid() &&
+          last_bound.surface_link() != last_sf_id) {
+        DETRAY_DEBUG_HOST(
+            "Transporting bound parameters to last surface: " << last_sf_id);
+        DETRAY_DEBUG_HOST(
+            "Last bound parameters: " << updater_state.bound_params());
+
+        const bound_matrix<algebra_t> propagation_step_jacobian =
+            detray::actor::parameter_transporter<algebra_t>{}.get_full_jacobian(
+                *fw_propagation, last_bound);
+
+        const bound_matrix<algebra_t> old_cov = last_bound.covariance();
+        bound_matrix<algebra_t> &new_cov = last_bound.covariance();
+        detray::detail::transport_covariance_to_bound_impl(
+            old_cov, propagation_step_jacobian, new_cov);
+
+        // Get the bound parameters at the destination surface
+        last_bound.set_parameter_vector(
+            fw_propagation->navigation().current_surface().free_to_bound_vector(
+                fw_propagation->context(), fw_propagation->stepping()()));
+
+        // Set new surface link
+        last_bound.set_surface_link(last_sf_id);
+
+        DETRAY_DEBUG_HOST(
+            "Updated bound parameters: " << updater_state.bound_params());
+      }
     }
   }
 
@@ -1031,7 +1033,6 @@ inline auto print_efficiency(std::size_t n_tracks,
 /// @param truth_traces coll. of truth traces (one per track)
 /// @param tracks coll. of tracks
 /// @param state_tuples coll. of actor state tuples for actor_ts (one per track)
-/// @param stddevs_per_track coll. standard dev. for bound parameter smearing
 ///
 /// @returns tuple of track statistics: stats of tracks (holes etc.), stats of
 /// encountered surfaces, stats of missed surfaces for navigation, stats of
@@ -1050,15 +1051,12 @@ auto compare_to_navigation(
     std::vector<dvector<navigation::detail::candidate_record<intersection_t>>>
         &truth_traces,
     const std::vector<free_track_parameters<algebra_t>> &tracks,
-    dvector<typename actor_chain<actor_ts...>::state_ref_tuple> state_tuples =
-        {{}},
-    const dvector<std::array<dscalar<algebra_t>, e_bound_size>>
-        &stddevs_per_track = {{0.f}}) {
+    dvector<typename actor_chain<actor_ts...>::state_ref_tuple> state_tuples = {
+        {}}) {
   using scalar_t = dscalar<algebra_t>;
 
   assert(truth_traces.size() == tracks.size());
   assert(!state_tuples.empty());
-  assert(!stddevs_per_track.empty());
 
   // Write navigation and stepping debug info if a track fails
   std::ios_base::openmode io_mode = std::ios::trunc | std::ios::out;
@@ -1098,18 +1096,17 @@ auto compare_to_navigation(
     auto &truth_trace = truth_traces.at(i);
     auto state_tuple =
         state_tuples.size() > i ? state_tuples.at(i) : state_tuples.at(0);
-    const auto &stddevs = stddevs_per_track.size() > i
-                              ? stddevs_per_track.at(i)
-                              : std::array<scalar_t, e_bound_size>{0.f};
 
     assert(!truth_traces.empty());
+
+    DETRAY_VERBOSE_HOST("Track " << i << ":");
 
     // Record the propagation through the geometry
     auto [success, obj_tracer, step_trace, mat_record, mat_trace, nav_printer,
           step_printer] =
         record_propagation<stepper_t, actor_ts...>(
             ctx, &host_mr, det, prop_cfg, track, cfg.ptc_hypothesis(),
-            field_view, cfg.navigation_direction(), state_tuple, stddevs);
+            field_view, cfg.navigation_direction(), state_tuple);
 
     // Fatal propagation error: Data unreliable
     if (!success) {
@@ -1152,7 +1149,7 @@ auto compare_to_navigation(
     }
 
     // Compare recorded and truth traces and count missed surfaces for both
-    detray::detail::helix ideal_traj{track, field_view};
+    detray::detail::helix ideal_traj{track, *field_view};
     auto [traces_match, n_miss_trace_nav, n_miss_trace_truth, n_error_trace,
           missed_inters] = compare_traces(cfg, truth_trace, recorded_trace,
                                           ideal_traj, i, &(*debug_file));
@@ -1166,7 +1163,8 @@ auto compare_to_navigation(
       if (n_miss_trace_truth.n_total() != 0u ||
           n_miss_trace_nav.n_total() != 0u || n_error_trace != 0u) {
         // Only dump SVG if navigator missed a sf. or an error occurred
-        if (!cfg.display_only_missed() || (n_miss_trace_nav.n_total() != 0u)) {
+        if (cfg.display_svg() && (!cfg.display_only_missed() ||
+                                  (n_miss_trace_nav.n_total() != 0u))) {
           detray::detector_scanner::display_error(
               ctx, det, names, cfg.name(), ideal_traj, truth_trace,
               cfg.svg_style(), i, n_samples, recorded_trace,


### PR DESCRIPTION
Fixes a bug in the navigation validation, allows to toggle the SVG dump of failed tracks, puts logging into the object tracer actor and removes the application of parameter smearing from the navigation validation (which will instead be done beforehand by client code).

Also fixes the issue that the bound track parameters are sometimes not propagated to the end-of-world portal, if that portal holds no material, which results in the backward pass starting from the wrong bound parameters.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
