### PR TITLE
build: Add explicit dependency for codegen

### DIFF
--- a/cmake/ActsCodegen.cmake
+++ b/cmake/ActsCodegen.cmake
@@ -220,6 +220,11 @@ function(acts_code_generation)
             ${ARGS_ADD_TO_TARGET}
             INTERFACE $<BUILD_INTERFACE:${_codegen_root}>
         )
+
+        # Use the CMake 3.19 functionality of attaching private sources to
+        # interface targets to create an explicit dependency between the target
+        # and the output file.
+        target_sources(${ARGS_ADD_TO_TARGET} PRIVATE ${_output_file})
     else()
         target_include_directories(
             ${ARGS_ADD_TO_TARGET}


### PR DESCRIPTION
This commit establishes an explicit dependency between the targets we use in the code generation and the generated files. By default, CMake establishes no such dependency for INTERFACE targets, but CMake 3.19 allows us to add private sources to INTERFACE targets. This ensures that when ACTS is built, the codegen files are always ready to be installed. This is especially important for detray, which may opt not to even generate the files if no target depends on them, but they should still be available to detray clients.