### PR TITLE
ci: Disable Dependabot auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       timezone: "Europe/Zurich"
     cooldown:
       default-days: 7
+    # Don't auto-rebase open PRs when main moves: rebases re-trigger CI and
+    # dismiss stale approvals, which knocks PRs out of the merge queue.
+    rebase-strategy: "disabled"
 
   - package-ecosystem: "pre-commit"
     directory: "/"
@@ -19,3 +22,4 @@ updates:
       timezone: "Europe/Zurich"
     cooldown:
       default-days: 7
+    rebase-strategy: "disabled"


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Problem

Dependabot's default `rebase-strategy: auto` rebases every open Dependabot PR whenever `main` moves. On this repo with the merge queue, each rebase force-pushes a new head commit, which:

- re-triggers the full CI suite, and
- dismisses stale approvals (branch protection),

knocking the PR out of the merge queue in a continuous loop as the queue advances `main`.

## Change

Set `rebase-strategy: "disabled"` on both update entries (`github-actions` and `pre-commit`). Dependabot no longer auto-rebases open PRs when `main` moves; manual `@dependabot rebase` still works, and PRs are still recreated on the weekly schedule.

Note: this only takes effect once merged to `main`, since Dependabot reads its config from the default branch. Existing open PRs keep their current behavior until recreated.