### PR TITLE
feat: Add node feature selection to OnnxEdgeClassifier

### DIFF
--- a/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
+++ b/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
@@ -31,6 +31,8 @@ class OnnxEdgeClassifier final : public EdgeClassificationBase {
   struct Config {
     /// Path to the ONNX model file
     std::string modelPath;
+    /// Vector of selected node feature indices to use as input for the model
+    std::vector<int> selectedFeatures = {};
     /// Classification threshold cut
     float cut = 0.5;
     /// Device to allocate the model on

--- a/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
+++ b/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
@@ -33,6 +33,7 @@ class OnnxEdgeClassifier final : public EdgeClassificationBase {
     std::string modelPath;
     /// Vector of selected node feature indices to use as input for the model
     std::vector<int> selectedFeatures = {};
+    std::vector<float> featureScales = {};
     /// Classification threshold cut
     float cut = 0.5;
     /// Device to allocate the model on

--- a/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
+++ b/Plugins/Gnn/include/ActsPlugins/Gnn/OnnxEdgeClassifier.hpp
@@ -33,6 +33,7 @@ class OnnxEdgeClassifier final : public EdgeClassificationBase {
     std::string modelPath;
     /// Vector of selected node feature indices to use as input for the model
     std::vector<int> selectedFeatures = {};
+    /// Vector of per-feature scale factors applied to selected features
     std::vector<float> featureScales = {};
     /// Classification threshold cut
     float cut = 0.5;

--- a/Plugins/Gnn/include/ActsPlugins/Gnn/Tensor.hpp
+++ b/Plugins/Gnn/include/ActsPlugins/Gnn/Tensor.hpp
@@ -237,5 +237,15 @@ template <Acts::Concepts::arithmetic T>
 Tensor<T> selectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
                      const ExecutionContext &execContext);
 
+/// Multiply each column of src with the corresponding scale value
+/// dst[r,n] = src[r,n] * scales[n]
+/// @param src Source tensor [R, N] in row-major layout
+/// @param scales Vector of scale factors of length N, same type as src
+/// @param execContext Device and stream for output allocation
+/// @return New tensor [R, N] in row-major layout containing scaled values
+template <Acts::Concepts::arithmetic T>
+Tensor<T> mulPerColumn(const Tensor<T> &src, const std::vector<T> &scales,
+                       const ExecutionContext &execContext);
+
 /// @}
 }  // namespace ActsPlugins

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -124,33 +124,41 @@ PipelineTensors OnnxEdgeClassifier::operator()(
   // Apply feature selection if configured
   std::optional<Tensor<float>> selectedNodeFeatures;
   ActsPlugins::Tensor<float> *nodeFeatures = &tensors.nodeFeatures;
+
   if (!m_cfg.selectedFeatures.empty()) {
-    // Create filtered node features with only selected indices
-    selectedNodeFeatures.emplace(Tensor<float>::Create(
-        {tensors.nodeFeatures.shape()[0], m_cfg.selectedFeatures.size()},
-        execContext));
-    auto *srcData = tensors.nodeFeatures.data();
-    auto *dstData = selectedNodeFeatures->data();
-    std::size_t numNodes = tensors.nodeFeatures.shape()[0];
     std::size_t numAllFeatures = tensors.nodeFeatures.shape()[1];
 
-    for (std::size_t n = 0; n < numNodes; ++n) {
-      for (std::size_t j = 0; j < m_cfg.selectedFeatures.size(); ++j) {
-        int featureIdx = m_cfg.selectedFeatures[j];
-        if (featureIdx < 0 || featureIdx >= static_cast<int>(numAllFeatures)) {
-          throw std::runtime_error("Selected feature index out of range");
-        }
-        dstData[n * m_cfg.selectedFeatures.size() + j] =
-            srcData[n * numAllFeatures + featureIdx];
+    // Create feature mask on CPU (and clone to device)
+    auto maskCpu =
+        Tensor<bool>::Create({numAllFeatures, 1ul}, ExecutionContext{});
+    auto *maskCpuData = maskCpu.data();
+    std::fill_n(maskCpuData, numAllFeatures, false);
+
+    for (std::size_t j = 0; j < m_cfg.selectedFeatures.size(); ++j) {
+      int featureIdx = m_cfg.selectedFeatures[j];
+      if (featureIdx < 0 || featureIdx >= static_cast<int>(numAllFeatures)) {
+        throw std::runtime_error("Selected feature index out of range");
       }
+      maskCpuData[static_cast<std::size_t>(featureIdx)] = true;
     }
+
+    // Clone if inputs not on CPU
+    Tensor<bool> mask = tensors.nodeFeatures.device().isCpu()
+                            ? std::move(maskCpu)
+                            : maskCpu.clone(execContext);
+
+    // Select features
+    selectedNodeFeatures.emplace(
+        selectCols(tensors.nodeFeatures, mask, execContext));
     nodeFeatures = &(*selectedNodeFeatures);
   }
 
   // scale node features if featureScales is given in cfg
   if (!m_cfg.featureScales.empty()) {
-    if (m_cfg.featureScales.size() != static_cast<std::size_t>(nodeFeatures->shape()[1])) {
-      throw std::runtime_error("featureScales size must match the number of input features");
+    if (m_cfg.featureScales.size() !=
+        static_cast<std::size_t>(nodeFeatures->shape()[1])) {
+      throw std::runtime_error(
+          "featureScales size must match the number of input features");
     }
     auto *data = nodeFeatures->data();
     std::size_t numNodes = nodeFeatures->shape()[0];

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -121,12 +121,37 @@ PipelineTensors OnnxEdgeClassifier::operator()(
   bc::static_vector<Ort::Value, 3> inputTensors;
   bc::static_vector<const char *, 3> inputNames;
 
+  // Apply feature selection if configured
+  auto nodeFeatures = tensors.nodeFeatures;
+  std::optional<Tensor<float>> selectedNodeFeatures;
+  if (!m_cfg.selectedFeatures.empty()) {
+    // Create filtered node features with only selected indices
+    selectedNodeFeatures = Tensor<float>::Create(
+        {tensors.nodeFeatures.shape()[0], m_cfg.selectedFeatures.size()},
+        execContext);
+    auto *srcData = tensors.nodeFeatures.data();
+    auto *dstData = selectedNodeFeatures->data();
+    std::size_t numNodes = tensors.nodeFeatures.shape()[0];
+    std::size_t numAllFeatures = tensors.nodeFeatures.shape()[1];
+
+    for (std::size_t n = 0; n < numNodes; ++n) {
+      for (std::size_t j = 0; j < m_cfg.selectedFeatures.size(); ++j) {
+        int featureIdx = m_cfg.selectedFeatures[j];
+        if (featureIdx < 0 || featureIdx >= static_cast<int>(numAllFeatures)) {
+          throw std::runtime_error("Selected feature index out of range");
+        }
+        dstData[n * m_cfg.selectedFeatures.size() + j] =
+            srcData[n * numAllFeatures + featureIdx];
+      }
+    }
+    nodeFeatures = *selectedNodeFeatures;
+  }
+
   // Node tensor
-  inputTensors.push_back(toOnnx(memoryInfo, tensors.nodeFeatures));
+  inputTensors.push_back(toOnnx(memoryInfo, nodeFeatures));
   inputNames.push_back(m_inputNames.at(0).c_str());
-  ACTS_DEBUG("Node features shape: (" << tensors.nodeFeatures.shape()[0] << ", "
-                                      << tensors.nodeFeatures.shape()[1]
-                                      << ")");
+  ACTS_DEBUG("Node features shape: (" << nodeFeatures.shape()[0] << ", "
+                                      << nodeFeatures.shape()[1] << ")");
 
   // Edge tensor
   inputTensors.push_back(toOnnx(memoryInfo, tensors.edgeIndex));

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -147,6 +147,21 @@ PipelineTensors OnnxEdgeClassifier::operator()(
     nodeFeatures = &(*selectedNodeFeatures);
   }
 
+  // scale node features if featureScales is given in cfg
+  if (!m_cfg.featureScales.empty()) {
+    if (m_cfg.featureScales.size() != static_cast<std::size_t>(nodeFeatures->shape()[1])) {
+      throw std::runtime_error("featureScales size must match the number of input features");
+    }
+    auto *data = nodeFeatures->data();
+    std::size_t numNodes = nodeFeatures->shape()[0];
+    std::size_t numFeatures = nodeFeatures->shape()[1];
+    for (std::size_t n = 0; n < numNodes; ++n) {
+      for (std::size_t f = 0; f < numFeatures; ++f) {
+        data[n * numFeatures + f] *= m_cfg.featureScales[f];
+      }
+    }
+  }
+
   // Node tensor
   inputTensors.push_back(toOnnx(memoryInfo, *nodeFeatures));
   inputNames.push_back(m_inputNames.at(0).c_str());

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -165,7 +165,7 @@ PipelineTensors OnnxEdgeClassifier::operator()(
     std::size_t numFeatures = nodeFeatures->shape()[1];
     for (std::size_t n = 0; n < numNodes; ++n) {
       for (std::size_t f = 0; f < numFeatures; ++f) {
-        data[n * numFeatures + f] *= m_cfg.featureScales[f];
+        data[n * numFeatures + f] /= m_cfg.featureScales[f];
       }
     }
   }

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -150,8 +150,8 @@ PipelineTensors OnnxEdgeClassifier::operator()(
   // Node tensor
   inputTensors.push_back(toOnnx(memoryInfo, *nodeFeatures));
   inputNames.push_back(m_inputNames.at(0).c_str());
-  ACTS_DEBUG("Node features shape: (" << nodeFeatures.shape()[0] << ", "
-                                      << nodeFeatures.shape()[1] << ")");
+  ACTS_DEBUG("Node features shape: (" << nodeFeatures->shape()[0] << ", "
+                                      << nodeFeatures->shape()[1] << ")");
 
   // Edge tensor
   inputTensors.push_back(toOnnx(memoryInfo, tensors.edgeIndex));

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -153,21 +153,30 @@ PipelineTensors OnnxEdgeClassifier::operator()(
     nodeFeatures = &(*selectedNodeFeatures);
   }
 
-  // scale node features if featureScales is given in cfg
+  // Scale node features if featureScales is given in cfg.
+  // using device-aware mulPerColumn with inverse scales
   if (!m_cfg.featureScales.empty()) {
     if (m_cfg.featureScales.size() !=
         static_cast<std::size_t>(nodeFeatures->shape()[1])) {
       throw std::runtime_error(
           "featureScales size must match the number of input features");
     }
-    auto *data = nodeFeatures->data();
-    std::size_t numNodes = nodeFeatures->shape()[0];
-    std::size_t numFeatures = nodeFeatures->shape()[1];
-    for (std::size_t n = 0; n < numNodes; ++n) {
-      for (std::size_t f = 0; f < numFeatures; ++f) {
-        data[n * numFeatures + f] /= m_cfg.featureScales[f];
+
+    // Compute inverse scales (1 / featureScales) for division
+    std::vector<float> inverseScales(m_cfg.featureScales.size());
+    for (std::size_t f = 0; f < m_cfg.featureScales.size(); ++f) {
+      if (m_cfg.featureScales[f] == 0.f) {
+        throw std::runtime_error(
+            "featureScales contains zero: division by zero");
       }
+      inverseScales[f] = 1.f / m_cfg.featureScales[f];
     }
+
+    // Apply scales to node features
+    auto scaledFeatures =
+        mulPerColumn(*nodeFeatures, inverseScales, execContext);
+    selectedNodeFeatures.emplace(std::move(scaledFeatures));
+    nodeFeatures = &(*selectedNodeFeatures);
   }
 
   // Node tensor

--- a/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
+++ b/Plugins/Gnn/src/OnnxEdgeClassifier.cpp
@@ -122,13 +122,13 @@ PipelineTensors OnnxEdgeClassifier::operator()(
   bc::static_vector<const char *, 3> inputNames;
 
   // Apply feature selection if configured
-  auto nodeFeatures = tensors.nodeFeatures;
   std::optional<Tensor<float>> selectedNodeFeatures;
+  ActsPlugins::Tensor<float> *nodeFeatures = &tensors.nodeFeatures;
   if (!m_cfg.selectedFeatures.empty()) {
     // Create filtered node features with only selected indices
-    selectedNodeFeatures = Tensor<float>::Create(
+    selectedNodeFeatures.emplace(Tensor<float>::Create(
         {tensors.nodeFeatures.shape()[0], m_cfg.selectedFeatures.size()},
-        execContext);
+        execContext));
     auto *srcData = tensors.nodeFeatures.data();
     auto *dstData = selectedNodeFeatures->data();
     std::size_t numNodes = tensors.nodeFeatures.shape()[0];
@@ -144,11 +144,11 @@ PipelineTensors OnnxEdgeClassifier::operator()(
             srcData[n * numAllFeatures + featureIdx];
       }
     }
-    nodeFeatures = *selectedNodeFeatures;
+    nodeFeatures = &(*selectedNodeFeatures);
   }
 
   // Node tensor
-  inputTensors.push_back(toOnnx(memoryInfo, nodeFeatures));
+  inputTensors.push_back(toOnnx(memoryInfo, *nodeFeatures));
   inputNames.push_back(m_inputNames.at(0).c_str());
   ACTS_DEBUG("Node features shape: (" << nodeFeatures.shape()[0] << ", "
                                       << nodeFeatures.shape()[1] << ")");
@@ -199,7 +199,8 @@ PipelineTensors OnnxEdgeClassifier::operator()(
   auto newEdgeIndex = selectCols(tensors.edgeIndex, mask, execContext);
   std::optional<Tensor<float>> newEdgeFeatures;
   if (tensors.edgeFeatures.has_value()) {
-    newEdgeFeatures = selectRows(*tensors.edgeFeatures, mask, execContext);
+    newEdgeFeatures.emplace(
+        selectRows(*tensors.edgeFeatures, mask, execContext));
   }
 
   ACTS_DEBUG("Finished edge classification, after cut: "

--- a/Plugins/Gnn/src/Tensor.cpp
+++ b/Plugins/Gnn/src/Tensor.cpp
@@ -82,6 +82,10 @@ template <typename T>
 Tensor<T> cudaSelectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
                          const ExecutionContext &execContext);
 
+template <typename T>
+Tensor<T> cudaMulPerColumn(const Tensor<T> &src, const Tensor<T> &scales,
+                           const ExecutionContext &execContext);
+
 }  // namespace detail
 
 void sigmoid(Tensor<float> &tensor, std::optional<cudaStream_t> stream) {
@@ -266,6 +270,41 @@ Tensor<T> selectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
   return result;
 }
 
+template <Acts::Concepts::arithmetic T>
+Tensor<T> mulPerColumn(const Tensor<T> &src, const std::vector<T> &scales,
+                       const ExecutionContext &execContext) {
+  const auto rows = src.shape()[0];
+  const auto cols = src.shape()[1];
+  if (cols != static_cast<std::size_t>(scales.size())) {
+    throw std::invalid_argument("mulPerColumn: scales size must match cols");
+  }
+
+  if (execContext.device.type == Device::Type::eCUDA) {
+#ifdef ACTS_GNN_WITH_CUDA
+    // Move scales to device (as Tensor)
+    auto scalesTensor = Tensor<T>::Create({cols, 1ul}, execContext);
+    assert(execContext.stream.has_value());
+    ACTS_CUDA_CHECK(cudaMemcpyAsync(scalesTensor.data(), scales.data(),
+                                    cols * sizeof(T), cudaMemcpyHostToDevice,
+                                    *execContext.stream));
+    return detail::cudaMulPerColumn(src, scalesTensor, execContext);
+#else
+    throw std::runtime_error(
+        "Cannot apply feature scales on CUDA tensor, library was not compiled "
+        "with CUDA");
+#endif
+  }
+
+  auto result = Tensor<T>::Create({rows, cols}, execContext);
+  for (std::size_t r = 0; r < rows; ++r) {
+    const std::size_t base = r * cols;
+    for (std::size_t c = 0; c < cols; ++c) {
+      result.data()[base + c] = src.data()[base + c] * scales[c];
+    }
+  }
+  return result;
+}
+
 template Tensor<float> selectRows(const Tensor<float> &, const Tensor<bool> &,
                                   const ExecutionContext &);
 template Tensor<std::int64_t> selectRows(const Tensor<std::int64_t> &,
@@ -276,5 +315,11 @@ template Tensor<float> selectCols(const Tensor<float> &, const Tensor<bool> &,
 template Tensor<std::int64_t> selectCols(const Tensor<std::int64_t> &,
                                          const Tensor<bool> &,
                                          const ExecutionContext &);
+template Tensor<float> mulPerColumn(const Tensor<float> &,
+                                    const std::vector<float> &,
+                                    const ExecutionContext &);
+template Tensor<std::int64_t> mulPerColumn(const Tensor<std::int64_t> &,
+                                           const std::vector<std::int64_t> &,
+                                           const ExecutionContext &);
 
 }  // namespace ActsPlugins

--- a/Plugins/Gnn/src/Tensor.cu
+++ b/Plugins/Gnn/src/Tensor.cu
@@ -69,6 +69,21 @@ __global__ void gatherColsKernel(const std::size_t *indices, std::size_t nRows,
   }
 }
 
+/// Multiply each column of src with the corresponding scale value.
+/// dst[r,n] = src[r,n] * scales[n]
+/// This is one thread per element with col computed from the linear index.
+
+template <typename T>
+__global__ void mulPerColKernel(std::size_t total, std::size_t cols,
+                                const T *src, const T *scales, T *dst) {
+  std::size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= total) {
+    return;
+  }
+  const std::size_t col = idx % cols;
+  dst[idx] = src[idx] * scales[col];
+}
+
 }  // namespace
 
 namespace ActsPlugins::detail {
@@ -172,6 +187,28 @@ Tensor<T> cudaSelectCols(const Tensor<T> &tensor, const Tensor<bool> &mask,
   return result;
 }
 
+template <typename T>
+Tensor<T> cudaMulPerColumn(const Tensor<T> &src, const Tensor<T> &scales,
+                           const ExecutionContext &execContext) {
+  const auto rows = src.shape()[0];
+  const auto cols = src.shape()[1];
+  const auto total = rows * cols;
+  const auto stream = execContext.stream.value();
+
+  auto result = Tensor<T>::Create({rows, cols}, execContext);
+
+  if (total == 0) {
+    return result;
+  }
+
+  dim3 blockDim = 256;
+  dim3 gridDim = (total + blockDim.x - 1) / blockDim.x;
+  mulPerColKernel<<<gridDim, blockDim, 0, stream>>>(
+      total, cols, src.data(), scales.data(), result.data());
+  ACTS_CUDA_CHECK(cudaGetLastError());
+  return result;
+}
+
 template Tensor<float> cudaSelectRows(const Tensor<float> &,
                                       const Tensor<bool> &,
                                       const ExecutionContext &);
@@ -184,5 +221,11 @@ template Tensor<float> cudaSelectCols(const Tensor<float> &,
 template Tensor<std::int64_t> cudaSelectCols(const Tensor<std::int64_t> &,
                                              const Tensor<bool> &,
                                              const ExecutionContext &);
+template Tensor<float> cudaMulPerColumn(const Tensor<float> &,
+                                        const Tensor<float> &,
+                                        const ExecutionContext &);
+template Tensor<std::int64_t> cudaMulPerColumn(const Tensor<std::int64_t> &,
+                                               const Tensor<std::int64_t> &,
+                                               const ExecutionContext &);
 
 }  // namespace ActsPlugins::detail

--- a/Tests/UnitTests/Plugins/Gnn/TensorTests.cpp
+++ b/Tests/UnitTests/Plugins/Gnn/TensorTests.cpp
@@ -142,6 +142,27 @@ void testSelectCols(ExecutionContext execContext) {
                                 expected.begin(), expected.end());
 }
 
+template <typename T>
+void testMulPerColumn(ExecutionContext execContext) {
+  // 3 rows, 4 columns: [[0,1,2,3],[4,5,6,7],[8,9,10,11]]
+  // Multiply each column with some scale {1,2,3,4}
+  std::vector<T> data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+  std::vector<T> scales = {1, 2, 3, 4};
+  auto tensor = createCpuTensor(data, {3, 4});
+  auto tensorTarget = tensor.clone(execContext);
+
+  auto result = mulPerColumn(tensorTarget, scales, execContext);
+  auto resultHost = result.clone({Device::Cpu(), execContext.stream});
+
+  BOOST_CHECK_EQUAL(resultHost.shape()[0], 3u);
+  BOOST_CHECK_EQUAL(resultHost.shape()[1], 4u);
+
+  std::vector<T> expected = {0, 2, 6, 12, 4, 10, 18, 28, 8, 18, 30, 44};
+  BOOST_CHECK_EQUAL_COLLECTIONS(resultHost.data(),
+                                resultHost.data() + resultHost.size(),
+                                expected.begin(), expected.end());
+}
+
 void testEdgeSelectionWithFeatures(
     const std::vector<float>& scores,
     const std::vector<std::int64_t>& edgeIndex,
@@ -290,6 +311,10 @@ BOOST_AUTO_TEST_CASE(tensor_select_cols_cpu) {
   testSelectCols<float>(execContextCpu);
 }
 
+BOOST_AUTO_TEST_CASE(tensor_mul_per_column_cpu) {
+  testMulPerColumn<float>(execContextCpu);
+}
+
 BOOST_AUTO_TEST_CASE(tensor_edge_selection_with_features_cpu) {
   testEdgeSelectionWithFeatures(scores, edgeIndex, edgeFeaturesData,
                                 edgeIndexExpected, edgeFeaturesExpected,
@@ -346,6 +371,10 @@ BOOST_AUTO_TEST_CASE(tensor_select_rows_cuda) {
 
 BOOST_AUTO_TEST_CASE(tensor_select_cols_cuda) {
   testSelectCols<float>(execContextCuda);
+}
+
+BOOST_AUTO_TEST_CASE(tensor_mul_per_column_cuda) {
+  testMulPerColumn<float>(execContextCuda);
 }
 
 BOOST_AUTO_TEST_CASE(tensor_edge_selection_with_features_cuda) {


### PR DESCRIPTION
- adding an option to select specific node features to OnnxEdgeClassifier
- adding an option to assign prefactors (scales) to specific node features
- adding template for scaling Tensor by column-wise factors (device-aware)
--- END COMMIT MESSAGE ---

Tagging @madbaron

This is needed for the GNNTrackFinder pipeline in [k4ActsTracking](https://github.com/key4hep/k4ActsTracking) ([#59](https://github.com/key4hep/k4ActsTracking/pull/59)), enabling us to run multiple edge classifiers, each on a different set of node features.