### PR TITLE
build!: Raise minimum CMake version to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 
 # LCG sets CPATH, which gets treated like -I by the compiler. We want to ignore
 # warnings from libraries, by unsetting it here, it gets processed by the usual


### PR DESCRIPTION
This commit raises the minimum CMake version in the ACTS build system to 3.19, which will allow us to attach private sources to interface targets.