### PR TITLE
fix(detray): Remove broken assertion in propagation validation

### DIFF
--- a/Detray/tests/include/detray/test/validation/propagation_validation.hpp
+++ b/Detray/tests/include/detray/test/validation/propagation_validation.hpp
@@ -275,7 +275,6 @@ bool propagation_validation(
       std::ranges::reverse_copy(mat_traces_bw[i], inv_mat_trace_bw.begin());
 
       assert(mat_traces_bw[i].size() == inv_mat_trace_bw.size());
-      assert(mat_traces_bw[i].front().bcd == inv_mat_trace_bw.back().bcd);
     }
 
     // Compare the material traces and total integrated material per trk


### PR DESCRIPTION
This commit removes a broken assertion in the propagation valdation which names a member `bcd` which does not exist.

--- END COMMIT MESSAGE ---

Tagging @niermann999.