### PR TITLE
fix!: Volume - fix the retrieval of the bounding box for alignable volumes

### DIFF
--- a/Core/include/Acts/Geometry/Volume.hpp
+++ b/Core/include/Acts/Geometry/Volume.hpp
@@ -129,8 +129,10 @@ class Volume : public GeometryObject {
 
   /// Construct bounding box for this shape
   /// @param envelope Optional envelope to add / subtract from min/max
+  /// @param gctx The current geometry context object, e.g. alignment
   /// @return Constructed bounding box pointing to this volume
-  BoundingBox boundingBox(const Vector3& envelope = {0, 0, 0}) const;
+  BoundingBox boundingBox(const GeometryContext& gctx,
+                          const Vector3& envelope = Vector3::Zero()) const;
 
   /// Construct oriented bounding box for this shape
   /// @note This will build an oriented bounding box with an

--- a/Core/src/Geometry/Volume.cpp
+++ b/Core/src/Geometry/Volume.cpp
@@ -59,8 +59,10 @@ std::ostream& operator<<(std::ostream& sl, const Volume& vol) {
   return sl;
 }
 
-Volume::BoundingBox Volume::boundingBox(const Vector3& envelope) const {
-  return m_volumeBounds->boundingBox(m_transform.get(), envelope, this);
+Volume::BoundingBox Volume::boundingBox(const GeometryContext& gctx,
+                                        const Vector3& envelope) const {
+  const Transform3& trf{localToGlobalTransform(gctx)};
+  return m_volumeBounds->boundingBox(&trf, envelope, this);
 }
 
 Volume::BoundingBox Volume::orientedBoundingBox() const {


### PR DESCRIPTION
- The transform of the volume is undefined if the volume is alignable -> bounding box is not aligned in space. Change method signature to also work for the alignable volume
--- END COMMIT MESSAGE ---
This issue has been reported by Will Leight. 

Tagging: @paulgessinger, @andiwand. Hopefully that makes it to the next major release