### PR TITLE
feat(core): add optional fall-through handler to TypeDispatcher

### DIFF
--- a/Core/include/Acts/Utilities/TypeDispatcher.hpp
+++ b/Core/include/Acts/Utilities/TypeDispatcher.hpp
@@ -10,6 +10,7 @@
 
 #include <format>
 #include <functional>
+#include <stdexcept>
 #include <type_traits>
 #include <typeindex>
 #include <typeinfo>
@@ -25,6 +26,11 @@ namespace Acts {
 /// This class allows registering function pointers associated with specific
 /// derived types of a base class. When invoked with a base class reference,
 /// it will look up and call the appropriate registered function.
+///
+/// When no registered type matches the object, the call throws
+/// @c std::runtime_error (the historical behavior) unless a fall-through handler
+/// has been installed via @ref registerDefault, in which case that handler is
+/// invoked instead and the dispatcher can degrade gracefully.
 ///
 /// @tparam base_t The base class type that will be the first parameter
 /// @tparam signature_t The function signature (e.g., return_t(Args...))
@@ -112,6 +118,20 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
     return *this;
   }
 
+  /// Register a fall-through handler, invoked by @ref operator() when the object
+  /// matches none of the registered derived types. This replaces the default
+  /// handler, which throws @c std::runtime_error.
+  /// @param func The fall-through handler; must be non-empty
+  /// @return Reference to this dispatcher for chaining
+  self_type& registerDefault(function_type func) {
+    if (!func) {
+      throw std::invalid_argument(
+          "TypeDispatcher default handler must be valid");
+    }
+    m_defaultHandler = std::move(func);
+    return *this;
+  }
+
   /// Call the registered function for the given object's type
   /// @param obj The object to dispatch on
   /// @param args Additional arguments to pass to the function
@@ -130,6 +150,13 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
     }
 
     if (compatibleTypes.empty()) {
+      // No registered derived type matches: defer to the fall-through handler if
+      // one was registered via registerDefault(), otherwise throw (the historical
+      // behavior). Keeping the throw here (rather than in a default-constructed
+      // handler) avoids requiring a complete base_t at construction time.
+      if (m_defaultHandler) {
+        return m_defaultHandler(obj, std::forward<func_args_t>(args)...);
+      }
       throw std::runtime_error(
           std::format("No function registered for type: {}",
                       boost::core::demangle(typeid(obj).name())));
@@ -195,6 +222,11 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
 
  private:
   using cast_checker_type = std::function<bool(const base_t&)>;
+
+  /// Optional fall-through handler invoked when no registered derived type
+  /// matches. When empty (the default), such a call throws instead (see
+  /// operator()). Set via registerDefault().
+  function_type m_defaultHandler{};
 
   std::unordered_map<std::type_index, function_type> m_functions;
   std::unordered_map<std::type_index, cast_checker_type> m_castCheckers;

--- a/Core/include/Acts/Utilities/TypeDispatcher.hpp
+++ b/Core/include/Acts/Utilities/TypeDispatcher.hpp
@@ -10,6 +10,7 @@
 
 #include <format>
 #include <functional>
+#include <stdexcept>
 #include <type_traits>
 #include <typeindex>
 #include <typeinfo>
@@ -25,6 +26,11 @@ namespace Acts {
 /// This class allows registering function pointers associated with specific
 /// derived types of a base class. When invoked with a base class reference,
 /// it will look up and call the appropriate registered function.
+///
+/// When no registered type matches the object, the call throws
+/// @c std::runtime_error (the historical behavior) unless a fall-through handler
+/// has been installed via @c registerDefault, in which case that handler is
+/// invoked instead and the dispatcher can degrade gracefully.
 ///
 /// @tparam base_t The base class type that will be the first parameter
 /// @tparam signature_t The function signature (e.g., return_t(Args...))
@@ -112,6 +118,20 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
     return *this;
   }
 
+  /// Register a fall-through handler, invoked by @c operator() when the object
+  /// matches none of the registered derived types. This replaces the default
+  /// handler, which throws @c std::runtime_error.
+  /// @param func The fall-through handler; must be non-empty
+  /// @return Reference to this dispatcher for chaining
+  self_type& registerDefault(function_type func) {
+    if (!func) {
+      throw std::invalid_argument(
+          "TypeDispatcher default handler must be valid");
+    }
+    m_defaultHandler = std::move(func);
+    return *this;
+  }
+
   /// Call the registered function for the given object's type
   /// @param obj The object to dispatch on
   /// @param args Additional arguments to pass to the function
@@ -130,6 +150,14 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
     }
 
     if (compatibleTypes.empty()) {
+      // No registered derived type matches: defer to the fall-through handler
+      // if one was registered via registerDefault(), otherwise throw (the
+      // historical behavior). Keeping the throw here (rather than in a
+      // default-constructed handler) avoids requiring a complete base_t at
+      // construction time.
+      if (m_defaultHandler) {
+        return m_defaultHandler(obj, std::forward<func_args_t>(args)...);
+      }
       throw std::runtime_error(
           std::format("No function registered for type: {}",
                       boost::core::demangle(typeid(obj).name())));
@@ -195,6 +223,11 @@ class TypeDispatcher<base_t, return_t(args_t...)> {
 
  private:
   using cast_checker_type = std::function<bool(const base_t&)>;
+
+  /// Optional fall-through handler invoked when no registered derived type
+  /// matches. When empty (the default), such a call throws instead (see
+  /// operator()). Set via registerDefault().
+  function_type m_defaultHandler{};
 
   std::unordered_map<std::type_index, function_type> m_functions;
   std::unordered_map<std::type_index, cast_checker_type> m_castCheckers;

--- a/Tests/UnitTests/Core/Utilities/TypeDispatcherTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TypeDispatcherTests.cpp
@@ -217,6 +217,34 @@ BOOST_AUTO_TEST_CASE(ImprovedErrorMessages) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(DefaultFallThroughHandler) {
+  TypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(processErrorTest);  // DerivedA -> "A"
+
+  DerivedC objC;
+
+  // By default an unregistered type throws (historical behavior preserved).
+  BOOST_CHECK_THROW(dispatcher(objC), std::runtime_error);
+
+  // Registering a fall-through handler makes it degrade gracefully instead.
+  auto& ref = dispatcher.registerDefault(
+      [](const BaseClass& obj) -> std::string {
+        return "fallback:" + obj.getType();
+      });
+  BOOST_CHECK_EQUAL(&ref, &dispatcher);  // chaining returns *this
+
+  BOOST_CHECK_EQUAL(dispatcher(objC), "fallback:DerivedC");
+
+  // Registered types still take precedence over the default handler.
+  DerivedA objA;
+  BOOST_CHECK_EQUAL(dispatcher(objA), "A");
+
+  // A null default handler is rejected.
+  BOOST_CHECK_THROW(
+      dispatcher.registerDefault(decltype(dispatcher)::function_type{}),
+      std::invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE(InheritanceTreeHandling) {
   // Test objects at different levels of the hierarchy
   DerivedA objA;      // Level 1: inherits from BaseClass

--- a/Tests/UnitTests/Core/Utilities/TypeDispatcherTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TypeDispatcherTests.cpp
@@ -217,6 +217,34 @@ BOOST_AUTO_TEST_CASE(ImprovedErrorMessages) {
   }
 }
 
+BOOST_AUTO_TEST_CASE(DefaultFallThroughHandler) {
+  TypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(processErrorTest);  // DerivedA -> "A"
+
+  DerivedC objC;
+
+  // By default an unregistered type throws (historical behavior preserved).
+  BOOST_CHECK_THROW(dispatcher(objC), std::runtime_error);
+
+  // Registering a fall-through handler makes it degrade gracefully instead.
+  auto& ref =
+      dispatcher.registerDefault([](const BaseClass& obj) -> std::string {
+        return "fallback:" + obj.getType();
+      });
+  BOOST_CHECK_EQUAL(&ref, &dispatcher);  // chaining returns *this
+
+  BOOST_CHECK_EQUAL(dispatcher(objC), "fallback:DerivedC");
+
+  // Registered types still take precedence over the default handler.
+  DerivedA objA;
+  BOOST_CHECK_EQUAL(dispatcher(objA), "A");
+
+  // A null default handler is rejected.
+  BOOST_CHECK_THROW(
+      dispatcher.registerDefault(decltype(dispatcher)::function_type{}),
+      std::invalid_argument);
+}
+
 BOOST_AUTO_TEST_CASE(InheritanceTreeHandling) {
   // Test objects at different levels of the hierarchy
   DerivedA objA;      // Level 1: inherits from BaseClass


### PR DESCRIPTION
This pull request enhances the `TypeDispatcher` utility by introducing support for a customizable fall-through handler when no registered type matches, improving error handling and flexibility. The update preserves historical behavior (throwing an exception) but allows users to register a default handler to gracefully handle unmatched types. Comprehensive unit tests are added to validate the new behavior.