### PR TITLE
feat: Add track-state iteration to AnyTrackProxy

### DIFF
--- a/Core/include/Acts/EventData/AnyTrackProxy.hpp
+++ b/Core/include/Acts/EventData/AnyTrackProxy.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "Acts/EventData/AnyTrackStateProxy.hpp"
 #include "Acts/EventData/ParticleHypothesis.hpp"
 #include "Acts/EventData/TrackProxyCommon.hpp"
 #include "Acts/EventData/TrackProxyConcept.hpp"
@@ -16,6 +17,7 @@
 
 #include <any>
 #include <cassert>
+#include <optional>
 #include <type_traits>
 
 namespace Acts {
@@ -59,6 +61,10 @@ class TrackHandlerConstBase {
   virtual unsigned int nTrackStates(const void* container,
                                     TrackIndexType index) const = 0;
 
+  /// Get a type-erased track state proxy at the given state index
+  virtual AnyConstTrackStateProxy trackStateAtIndex(
+      const void* container, TrackIndexType stateIndex) const = 0;
+
   /// Check if track has a specific dynamic column
   virtual bool hasColumn(const void* container, HashedString key) const = 0;
 
@@ -74,6 +80,11 @@ class TrackHandlerMutableBase : public TrackHandlerConstBase {
   using TrackHandlerConstBase::component;
   using TrackHandlerConstBase::covariance;
   using TrackHandlerConstBase::parameters;
+  using TrackHandlerConstBase::trackStateAtIndex;
+
+  /// Get a mutable type-erased track state proxy at the given state index
+  virtual AnyMutableTrackStateProxy trackStateAtIndex(
+      void* container, TrackIndexType stateIndex) const = 0;
 
   /// Get mutable parameter vector
   virtual ParametersMap parameters(void* container,
@@ -154,6 +165,14 @@ class TrackHandler<container_t, true> /*final*/ : public TrackHandlerConstBase {
     assert(container != nullptr);
     const auto* tc = static_cast<const ContainerType*>(container);
     return tc->getTrack(index).nTrackStates();
+  }
+
+  AnyConstTrackStateProxy trackStateAtIndex(
+      const void* container, TrackIndexType stateIndex) const final {
+    assert(container != nullptr);
+    const auto* tc = static_cast<const ContainerType*>(container);
+    auto ts = tc->trackStateContainer().getTrackState(stateIndex);
+    return AnyConstTrackStateProxy(ts);
   }
 
   bool hasColumn(const void* container, HashedString key) const final {
@@ -237,6 +256,22 @@ class TrackHandler<container_t,
     assert(container != nullptr);
     const auto* tc = static_cast<const ContainerType*>(container);
     return tc->getTrack(index).nTrackStates();
+  }
+
+  AnyConstTrackStateProxy trackStateAtIndex(
+      const void* container, TrackIndexType stateIndex) const final {
+    assert(container != nullptr);
+    const auto* tc = static_cast<const ContainerType*>(container);
+    auto ts = tc->trackStateContainer().getTrackState(stateIndex);
+    return AnyConstTrackStateProxy(ts);
+  }
+
+  AnyMutableTrackStateProxy trackStateAtIndex(
+      void* container, TrackIndexType stateIndex) const final {
+    assert(container != nullptr);
+    auto* tc = static_cast<ContainerType*>(container);
+    auto ts = tc->trackStateContainer().getTrackState(stateIndex);
+    return AnyMutableTrackStateProxy(ts);
   }
 
   bool hasColumn(const void* container, HashedString key) const final {
@@ -473,6 +508,100 @@ class AnyTrackProxy : public TrackProxyCommon<AnyTrackProxy<read_only>,
   /// @return The number of track states
   unsigned int nTrackStates() const {
     return constHandler()->nTrackStates(containerPtr(), m_index);
+  }
+
+  /// Return a const type-erased track state proxy to the outermost track state
+  /// @return The outermost track state proxy
+  AnyConstTrackStateProxy outermostTrackState() const {
+    return constHandler()->trackStateAtIndex(containerPtr(),
+                                             this->tipIndex());
+  }
+
+  /// Return a mutable type-erased track state proxy to the outermost track
+  /// state
+  /// @return The outermost track state proxy
+  AnyMutableTrackStateProxy outermostTrackState()
+    requires(!ReadOnly)
+  {
+    return mutableHandler()->trackStateAtIndex(mutableContainerPtr(),
+                                               this->tipIndex());
+  }
+
+  /// Return a const type-erased track state proxy to the innermost track state
+  /// @note This is only available if the track is forward linked
+  /// @return The innermost track state proxy, or nullopt if not forward linked
+  std::optional<AnyConstTrackStateProxy> innermostTrackState() const {
+    TrackIndexType stem = this->stemIndex();
+    if (stem == kTrackIndexInvalid) {
+      return std::nullopt;
+    }
+    return constHandler()->trackStateAtIndex(containerPtr(), stem);
+  }
+
+  /// Return a mutable type-erased track state proxy to the innermost track
+  /// state
+  /// @note This is only available if the track is forward linked
+  /// @return The innermost track state proxy, or nullopt if not forward linked
+  std::optional<AnyMutableTrackStateProxy> innermostTrackState()
+    requires(!ReadOnly)
+  {
+    TrackIndexType stem = this->stemIndex();
+    if (stem == kTrackIndexInvalid) {
+      return std::nullopt;
+    }
+    return mutableHandler()->trackStateAtIndex(mutableContainerPtr(), stem);
+  }
+
+  /// Get a range over the track states of this track, from the outside inwards.
+  /// Compatible with range-based for loops. Const version.
+  /// @return Track state range to iterate over
+  AnyTrackStateRange<true, true> trackStatesReversed() const {
+    if (this->tipIndex() == kTrackIndexInvalid) {
+      return {};
+    }
+    return AnyTrackStateRange<true, true>{outermostTrackState()};
+  }
+
+  /// Get a range over the track states of this track, from the outside inwards.
+  /// Compatible with range-based for loops. Mutable version.
+  /// @note Only available if the track proxy is not read-only
+  /// @return Track state range to iterate over
+  AnyTrackStateRange<true, false> trackStatesReversed()
+    requires(!ReadOnly)
+  {
+    if (this->tipIndex() == kTrackIndexInvalid) {
+      return {};
+    }
+    return AnyTrackStateRange<true, false>{outermostTrackState()};
+  }
+
+  /// Get a range over the track states of this track, from the inside outwards.
+  /// Compatible with range-based for loops. Const version.
+  /// @warning This access direction is only possible if the track states are
+  ///          **forward-linked**. The range is empty otherwise.
+  /// @return Track state range to iterate over
+  AnyTrackStateRange<false, true> trackStates() const {
+    std::optional<AnyConstTrackStateProxy> inner = innermostTrackState();
+    if (!inner.has_value()) {
+      return {};
+    }
+    return AnyTrackStateRange<false, true>{*inner};
+  }
+
+  /// Get a range over the track states of this track, from the inside outwards.
+  /// Compatible with range-based for loops. Mutable version.
+  /// @note Only available if the track proxy is not read-only
+  /// @warning This access direction is only possible if the track states are
+  ///          **forward-linked**. The range is empty otherwise.
+  /// @return Track state range to iterate over
+  AnyTrackStateRange<false, false> trackStates()
+    requires(!ReadOnly)
+  {
+    std::optional<AnyMutableTrackStateProxy> inner = innermostTrackState();
+    if (!inner.has_value()) {
+      return {};
+    }
+    return AnyTrackStateRange<false, false>{*inner};
   }
 
   /// Check if the track has a specific dynamic column

--- a/Core/include/Acts/EventData/AnyTrackStateProxy.hpp
+++ b/Core/include/Acts/EventData/AnyTrackStateProxy.hpp
@@ -519,7 +519,11 @@ class AnyTrackStateProxy
   /// @tparam track_state_proxy_t Proxy type satisfying the concept.
   /// @param ts Proxy that supplies the trajectory backend and index.
   template <TrackStateProxyConcept track_state_proxy_t>
-    requires(ReadOnly || !track_state_proxy_t::ReadOnly)
+    requires((ReadOnly || !track_state_proxy_t::ReadOnly) &&
+             !std::is_same_v<std::remove_cv_t<track_state_proxy_t>,
+                             AnyTrackStateProxy<true>> &&
+             !std::is_same_v<std::remove_cv_t<track_state_proxy_t>,
+                             AnyTrackStateProxy<false>>)
   explicit AnyTrackStateProxy(track_state_proxy_t& ts)
       : m_container(nullptr), m_index(ts.m_istate) {
     using trajectory_t = typename track_state_proxy_t::Trajectory;
@@ -784,6 +788,19 @@ class AnyTrackStateProxy
  private:
   template <bool>
   friend class AnyTrackStateProxy;
+  template <bool, bool>
+  friend class AnyTrackStateRange;
+
+  /// Create a sibling proxy pointing at a different state index within the
+  /// same trajectory container. Used by the track-state ranges to walk the
+  /// `previous()` / `next()` links.
+  /// @param idx The state index to point at.
+  /// @return A copy of this proxy rebound to @p idx.
+  AnyTrackStateProxy withIndex(TrackIndexType idx) const {
+    AnyTrackStateProxy copy(*this);
+    copy.m_index = idx;
+    return copy;
+  }
 
   const detail_anytstate::TrackStateHandlerConstBase* constHandler() const {
     return m_handler;
@@ -807,6 +824,99 @@ class AnyTrackStateProxy
   ContainerPointer m_container{};
   TrackIndexType m_index{};
   const detail_anytstate::TrackStateHandlerConstBase* m_handler{};
+};
+
+/// Type-erased range over the track states of a track.
+///
+/// Mirrors @c detail_lt::TrackStateRange but yields type-erased
+/// @c AnyTrackStateProxy objects. The range walks the `previous()` links when
+/// @p reverse is true (outside-in) and the `next()` links otherwise
+/// (inside-out). A default-constructed range is empty.
+///
+/// @tparam reverse True to iterate from the tip inwards, false to iterate from
+///                 the stem outwards.
+/// @tparam read_only True for const access, false for mutable access.
+template <bool reverse, bool read_only>
+class AnyTrackStateRange {
+  using ProxyType = AnyTrackStateProxy<read_only>;
+
+ public:
+  /// Forward iterator over the track states. A `nullopt` proxy marks the
+  /// past-the-end iterator.
+  struct Iterator {
+    /// The track state the iterator currently points at, or `nullopt` for end.
+    std::optional<ProxyType> proxy;
+
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = ProxyType;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = void;
+
+    /// Advance to the next track state along the link direction.
+    /// @return Reference to this iterator.
+    Iterator& operator++() {
+      if (!proxy) {
+        return *this;
+      }
+      if constexpr (reverse) {
+        if (proxy->hasPrevious()) {
+          proxy = proxy->withIndex(proxy->previous());
+        } else {
+          proxy = std::nullopt;
+        }
+      } else {
+        TrackIndexType next =
+            proxy->template component<TrackIndexType, hashString("next")>();
+        if (next != kTrackIndexInvalid) {
+          proxy = proxy->withIndex(next);
+        } else {
+          proxy = std::nullopt;
+        }
+      }
+      return *this;
+    }
+
+    /// Post-increment.
+    /// @return Copy of the iterator before advancing.
+    Iterator operator++(int) {
+      Iterator tmp(*this);
+      operator++();
+      return tmp;
+    }
+
+    /// Compare two iterators. Two iterators are equal if both are past-the-end
+    /// or both point at the same track state index.
+    /// @param other The iterator to compare against.
+    /// @return True if the iterators are equal.
+    bool operator==(const Iterator& other) const {
+      if (!proxy && !other.proxy) {
+        return true;
+      }
+      if (proxy && other.proxy) {
+        return proxy->index() == other.proxy->index();
+      }
+      return false;
+    }
+
+    /// Dereference to the current track state proxy.
+    /// @return The current track state proxy.
+    ProxyType operator*() const { return *proxy; }
+  };
+
+  /// Construct a range starting at @p begin.
+  /// @param begin The first track state of the range.
+  explicit AnyTrackStateRange(ProxyType begin) : m_begin{begin} {}
+  /// Construct an empty range.
+  AnyTrackStateRange() : m_begin{std::nullopt} {}
+
+  /// @return Iterator to the first track state.
+  Iterator begin() { return Iterator{m_begin}; }
+  /// @return Past-the-end iterator.
+  Iterator end() { return Iterator{std::nullopt}; }
+
+ private:
+  Iterator m_begin;
 };
 
 /// Type alias for a const track state proxy

--- a/Tests/UnitTests/Core/EventData/AnyTrackProxyTests.cpp
+++ b/Tests/UnitTests/Core/EventData/AnyTrackProxyTests.cpp
@@ -22,6 +22,7 @@
 #include "Acts/Utilities/HashedString.hpp"
 #include "Acts/Utilities/Holders.hpp"
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -285,15 +286,11 @@ BOOST_AUTO_TEST_CASE(AccessStatistics) {
   BOOST_CHECK_EQUAL(anyTrack.nSharedHits(), 2u);
 }
 
-BOOST_AUTO_TEST_CASE(AccessTrackStates) {
-  VectorTrackContainer vtc;
-  VectorMultiTrajectory mtj;
-  TrackContainer tc{vtc, mtj};
-
-  auto track = tc.makeTrack();
-  fillTestTrack<decltype(tc)>(track);
-
-  // Add some track states
+// Helper that builds a track with three `previous()`-linked track states and
+// sets the tip index. Returns the three state indices, innermost first.
+template <typename track_container_t>
+std::array<TrackIndexType, 3> fillTestTrackStates(
+    track_container_t& tc, typename track_container_t::TrackProxy track) {
   auto ts1 = tc.trackStateContainer().makeTrackState();
   auto ts2 = tc.trackStateContainer().makeTrackState();
   ts2.previous() = ts1.index();
@@ -302,9 +299,145 @@ BOOST_AUTO_TEST_CASE(AccessTrackStates) {
 
   track.tipIndex() = ts3.index();
 
+  return {ts1.index(), ts2.index(), ts3.index()};
+}
+
+BOOST_AUTO_TEST_CASE(AccessTrackStates) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  fillTestTrackStates(tc, track);
+
   AnyMutableTrackProxy anyTrack(track);
 
   BOOST_CHECK_EQUAL(anyTrack.nTrackStates(), 3u);
+}
+
+BOOST_AUTO_TEST_CASE(TrackStatesReversed) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  auto [i1, i2, i3] = fillTestTrackStates(tc, track);
+
+  AnyConstTrackProxy anyTrack(track);
+
+  // Outermost is the tip
+  BOOST_CHECK_EQUAL(anyTrack.outermostTrackState().index(), i3);
+
+  // Reverse iteration walks tip -> stem
+  std::vector<TrackIndexType> indices;
+  for (auto ts : anyTrack.trackStatesReversed()) {
+    static_assert(decltype(ts)::ReadOnly, "expected const track state proxy");
+    indices.push_back(ts.index());
+  }
+  std::vector<TrackIndexType> expected = {i3, i2, i1};
+  BOOST_CHECK_EQUAL_COLLECTIONS(indices.begin(), indices.end(),
+                                expected.begin(), expected.end());
+
+  // Consistent with nTrackStates
+  BOOST_CHECK_EQUAL(indices.size(), anyTrack.nTrackStates());
+}
+
+BOOST_AUTO_TEST_CASE(TrackStatesForward) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  auto [i1, i2, i3] = fillTestTrackStates(tc, track);
+
+  // Forward iteration requires forward-linking
+  track.linkForward();
+
+  AnyConstTrackProxy anyTrack(track);
+
+  // Innermost is the stem
+  auto innermost = anyTrack.innermostTrackState();
+  BOOST_REQUIRE(innermost.has_value());
+  BOOST_CHECK_EQUAL(innermost->index(), i1);
+
+  // Forward iteration walks stem -> tip
+  std::vector<TrackIndexType> indices;
+  for (auto ts : anyTrack.trackStates()) {
+    indices.push_back(ts.index());
+  }
+  std::vector<TrackIndexType> expected = {i1, i2, i3};
+  BOOST_CHECK_EQUAL_COLLECTIONS(indices.begin(), indices.end(),
+                                expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(TrackStatesNotForwardLinked) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  fillTestTrackStates(tc, track);
+
+  AnyConstTrackProxy anyTrack(track);
+
+  // Without forward-linking there is no innermost state and forward iteration
+  // yields an empty range
+  BOOST_CHECK(!anyTrack.innermostTrackState().has_value());
+  auto range = anyTrack.trackStates();
+  BOOST_CHECK(range.begin() == range.end());
+}
+
+BOOST_AUTO_TEST_CASE(TrackStatesEmpty) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  // No track states, tip index stays invalid
+
+  AnyConstTrackProxy anyTrack(track);
+
+  BOOST_CHECK_EQUAL(anyTrack.nTrackStates(), 0u);
+  auto range = anyTrack.trackStatesReversed();
+  BOOST_CHECK(range.begin() == range.end());
+}
+
+BOOST_AUTO_TEST_CASE(MutableTrackStateAccess) {
+  VectorTrackContainer vtc;
+  VectorMultiTrajectory mtj;
+  TrackContainer tc{vtc, mtj};
+
+  auto track = tc.makeTrack();
+  fillTestTrack<decltype(tc)>(track);
+  auto [i1, i2, i3] = fillTestTrackStates(tc, track);
+  (void)i1;
+  (void)i2;
+
+  AnyMutableTrackProxy anyTrack(track);
+
+  // Mutable access yields a mutable track state proxy we can write through
+  auto outer = anyTrack.outermostTrackState();
+  static_assert(!decltype(outer)::ReadOnly,
+                "expected mutable track state proxy");
+  outer.pathLength() = 42.0;
+
+  // The write is visible through the concrete track state proxy
+  BOOST_CHECK_EQUAL(tc.trackStateContainer().getTrackState(i3).pathLength(),
+                    42.0);
+
+  // Mutable range also yields mutable proxies
+  for (auto ts : anyTrack.trackStatesReversed()) {
+    static_assert(!decltype(ts)::ReadOnly,
+                  "expected mutable track state proxy");
+    ts.pathLength() = 1.0;
+  }
+  BOOST_CHECK_EQUAL(tc.trackStateContainer().getTrackState(i3).pathLength(),
+                    1.0);
 }
 
 BOOST_AUTO_TEST_CASE(AccessDynamicColumns) {


### PR DESCRIPTION
## What

The type-erased `AnyTrackProxy` previously only exposed `nTrackStates()`, with no way to actually reach a track's track states. This adds the same basic track-state access surface as the concrete `TrackProxy`, returning type-erased `AnyTrackStateProxy` objects:

- `outermostTrackState()` / `innermostTrackState()` (the latter returns `std::optional`, empty when the track is not forward-linked — matching `TrackProxy`)
- `trackStatesReversed()` (tip → stem) / `trackStates()` (stem → tip, requires forward-linking)

## How

- The handler vtable gains a single `trackStateAtIndex(container, stateIndex)` primitive (const → `AnyConstTrackStateProxy`, mutable → `AnyMutableTrackStateProxy`), implemented in both `TrackHandler` specializations via `container->trackStateContainer().getTrackState(...)`.
- A new `AnyTrackStateRange<reverse, read_only>` mirrors `detail_lt::TrackStateRange`, walking `previous()` / the `"next"` component and yielding type-erased proxies. Everything else is built on the already-available tip/stem indices.

## Incidental fix

`AnyTrackStateProxy`'s wrapping constructor takes its argument by non-const reference and the proxy satisfies `TrackStateProxyConcept`, so it greedily hijacked copy-construction of non-const `AnyTrackStateProxy` lvalues. This was latent until the range's `std::optional` storage exercised it. The constructor is now constrained to exclude `AnyTrackStateProxy` itself.

## Tests

Extended `AnyTrackProxyTests.cpp` with cases for reverse iteration order, forward iteration after `linkForward()`, the not-forward-linked and empty-track cases, and mutable write-through (verifying mutable ranges yield mutable proxies). `ActsUnitTestAnyTrackProxy` and `ActsUnitTestAnyTrackStateProxy` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)