### PR TITLE
feat: displaced-track (LRT) support for GBTS seeding

### DIFF
--- a/Core/include/Acts/Seeding/GbtsDataStorage.hpp
+++ b/Core/include/Acts/Seeding/GbtsDataStorage.hpp
@@ -89,6 +89,11 @@ struct GbtsEtaBin final {
 
   /// Layer ID for this bin
   std::uint32_t layerId{0};
+  /// Whether the bin belongs to a barrel layer
+  bool isBarrel{false};
+  /// Inward depth of the bin's layer in the connection graph
+  /// (0 = entry/innermost layer, see GbtsGeometry::layerDepthById)
+  std::uint32_t layerDepth{std::numeric_limits<std::uint32_t>::max()};
 };
 
 /// Storage container for GBTS nodes
@@ -118,6 +123,10 @@ class GbtsNodeStorage final {
   /// Get the total number of nodes
   /// @return Total number of nodes
   std::uint32_t numberOfNodes() const;
+  /// Get the smallest node radius over all non-empty bins.
+  /// Only valid after initializeNodes has been called.
+  /// @return Minimum node radius, or 0 if no nodes are loaded
+  float minNodeRadius() const;
   /// Sort nodes by phi
   void sortByPhi();
   /// Initialize node attributes
@@ -158,9 +167,16 @@ struct GbtsEdge final {
   /// @param p1_ First fit parameter
   /// @param p2_ Second fit parameter
   /// @param p3_ Third fit parameter
+  /// @param dsdrD0_ ds/dr chord factor of the segment evaluated at the
+  ///        maximum impact parameter (1 for prompt configurations)
   GbtsEdge(const GbtsNode* n1_, const GbtsNode* n2_, float p1_, float p2_,
-           float p3_)
-      : n1{n1_}, n2{n2_}, level{1}, next{1}, p{p1_, p2_, p3_} {}
+           float p3_, float dsdrD0_ = 1.0f)
+      : n1{n1_},
+        n2{n2_},
+        level{1},
+        next{1},
+        p{p1_, p2_, p3_},
+        dsdrD0{dsdrD0_} {}
 
   /// First node of the edge
   const GbtsNode* n1{nullptr};
@@ -176,6 +192,9 @@ struct GbtsEdge final {
   std::uint8_t nNei{0};
   /// Fit parameters
   std::array<float, 3> p{};
+  /// ds/dr chord factor of the segment at the maximum impact parameter,
+  /// used to widen tau-matching cuts for displaced (LRT) tracks
+  float dsdrD0{1.0f};
 
   /// Global indices of the connected edges
   std::array<std::uint32_t, gbtsNumSegConns> vNei{};

--- a/Core/include/Acts/Seeding/GbtsGeometry.hpp
+++ b/Core/include/Acts/Seeding/GbtsGeometry.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Seeding/GbtsLayerConnection.hpp"
 
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -119,8 +120,14 @@ class GbtsGeometry final {
   /// Constructor
   /// @param layerDescriptions Layer descriptions for the layers
   /// @param layerConnections Layer connections map
+  /// @param connectionZ0Min Minimum z0 at the beamline used to prune eta-bin
+  ///        pair connectivity (straight-line extrapolation). Widen well beyond
+  ///        the luminous region for displaced-track (LRT) seeding: the chord
+  ///        of a large-d0 track extrapolates far outside the true vertex z.
+  /// @param connectionZ0Max Maximum z0 at the beamline for bin-pair pruning
   GbtsGeometry(const std::vector<GbtsLayerDescription>& layerDescriptions,
-               const GbtsLayerConnectionMap& layerConnections);
+               const GbtsLayerConnectionMap& layerConnections,
+               float connectionZ0Min = -168.0f, float connectionZ0Max = 168.0f);
 
   /// Get number of eta bins
   /// @return Number of eta bins
@@ -154,6 +161,18 @@ class GbtsGeometry final {
     return m_layers.at(idx).layerDescription().id;
   }
 
+  /// Get the "inward depth" of a layer in the connection graph: 0 for entry
+  /// layers (layers that never act as the outer element of a connection,
+  /// i.e. the innermost layers of the configured seeding graph), otherwise
+  /// 1 + the maximum depth of the layers it connects to on the inside.
+  /// @param id Layer ID
+  /// @return Inward depth, or uint32 max for layers absent from the connection map
+  std::uint32_t layerDepthById(std::uint32_t id) const {
+    const auto it = m_layerDepth.find(id);
+    return it == m_layerDepth.end() ? std::numeric_limits<std::uint32_t>::max()
+                                    : it->second;
+  }
+
  private:
   /// @param layerDescription Layer description for the layer
   /// @param bin0 Starting bin index
@@ -168,6 +187,8 @@ class GbtsGeometry final {
   std::vector<GbtsLayer> m_layers;
   /// Layer per user ID map
   std::map<std::uint32_t, std::uint32_t> m_layerFromUserIdMap;
+  /// Inward depth of each layer in the connection graph (see layerDepthById)
+  std::map<std::uint32_t, std::uint32_t> m_layerDepth;
   /// Number of eta bins
   std::uint32_t m_nEtaBins{};
 

--- a/Core/include/Acts/Seeding/GbtsLayerConnection.hpp
+++ b/Core/include/Acts/Seeding/GbtsLayerConnection.hpp
@@ -32,18 +32,44 @@ struct GbtsLayerConnection {
   std::vector<std::int32_t> binTable;
 };
 
+/// Selects which subdetector connections are kept when parsing a GBTS layer
+/// connection file.
+enum class GbtsConnectionFilter {
+  /// Keep only pixel-to-pixel connections (default prompt configuration)
+  PixelOnly = 0,
+  /// Keep only strip-to-strip connections (default LRT configuration)
+  StripOnly = 1,
+  /// Keep all connections, including mixed pixel-strip ones
+  All = 2
+};
+
 /// Loader and container for GBTS layer connection data.
 struct GbtsLayerConnectionMap {
  public:
   /// Create a GbtsLayerConnectionMap from an input stream
   /// @param inStream Input stream containing the connection data
-  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @param filter Which subdetector connections to keep
+  /// @return A GbtsLayerConnectionMap instance populated with the data from the stream
+  static GbtsLayerConnectionMap fromStream(std::istream& inStream,
+                                           GbtsConnectionFilter filter);
+  /// Create a GbtsLayerConnectionMap from a file
+  /// @param inFile Input configuration file path
+  /// @param filter Which subdetector connections to keep
+  /// @return A GbtsLayerConnectionMap instance populated with the data from the file
+  static GbtsLayerConnectionMap fromFile(const std::string& inFile,
+                                         GbtsConnectionFilter filter);
+
+  /// Create a GbtsLayerConnectionMap from an input stream
+  /// @param inStream Input stream containing the connection data
+  /// @param lrtMode Enable LRT (Large Radius Tracking) mode: keeps only
+  ///        strip-strip connections instead of only pixel-pixel ones
   /// @return A GbtsLayerConnectionMap instance populated with the data from the stream
   static GbtsLayerConnectionMap fromStream(std::istream& inStream,
                                            bool lrtMode);
   /// Create a GbtsLayerConnectionMap from a file
   /// @param inFile Input configuration file path
-  /// @param lrtMode Enable LRT (Large Radius Tracking) mode
+  /// @param lrtMode Enable LRT (Large Radius Tracking) mode: keeps only
+  ///        strip-strip connections instead of only pixel-pixel ones
   /// @return A GbtsLayerConnectionMap instance populated with the data from the file
   static GbtsLayerConnectionMap fromFile(std::string& inFile, bool lrtMode);
 

--- a/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
+++ b/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
@@ -118,6 +118,19 @@ class GbtsTrackingFilter final {
 
     /// Global state counter
     std::uint32_t globalStateCounter{0};
+
+    /// debug counters, accumulated across followTrack calls
+    std::uint32_t nUpdates{0};
+    /// Updates rejected by the transverse chi2 gate
+    std::uint32_t nRejChi2X{0};
+    /// Updates rejected by the longitudinal chi2 gate
+    std::uint32_t nRejChi2Y{0};
+    /// Updates rejected by the curvature cut
+    std::uint32_t nRejCurv{0};
+    /// Updates rejected by the z0 cut
+    std::uint32_t nRejZ0{0};
+    /// Propagations dropped because the state store was exhausted
+    std::uint32_t nStateOverflow{0};
   };
 
   /// @param config Configuration for seed finder
@@ -149,10 +162,11 @@ class GbtsTrackingFilter final {
                  GbtsEdgeState& ts) const;
 
   /// Update edge state with edge
+  /// @param state Tracking filter state (for the debug counters)
   /// @param pS Edge to update with
   /// @param ts Edge state to update
   /// @return Success flag
-  bool update(const GbtsEdge& pS, GbtsEdgeState& ts) const;
+  bool update(State& state, const GbtsEdge& pS, GbtsEdgeState& ts) const;
 
   /// Get layer type from layer index
   /// @param layerIndex Layer index

--- a/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
+++ b/Core/include/Acts/Seeding/GbtsTrackingFilter.hpp
@@ -91,6 +91,20 @@ class GbtsTrackingFilter final {
     float maxCurvature = 1e-3f / Acts::UnitConstants::mm;
     /// Maximum longitudinal impact parameter.
     float maxZ0 = 170.0 * Acts::UnitConstants::mm;
+
+    /// Initial covariance of the transverse state (y, dy/dx, d2y/dx2).
+    std::array<float, 3> initCovX = {0.25f, 0.001f, 0.001f};
+    /// Initial covariance of the longitudinal state (z, dz/dr). The dz/dr
+    /// term acts as a prior on how much the r-z slope may vary along the
+    /// chain; the default is tuned for prompt tracks.
+    std::array<float, 2> initCovY = {1.5f, 0.001f};
+
+    /// Maximum transverse impact parameter assumed for the seeded tracks.
+    /// When positive, an additional r-z slope process noise is added at each
+    /// filter step to account for the geometric variation of dz/dr along a
+    /// displaced trajectory (dz/dr scales with ds/dr = r/sqrt(r^2-d0^2)).
+    /// Leave at 0 for prompt configurations (no extra noise).
+    float d0Max = 0.0f * Acts::UnitConstants::mm;
   };
 
   /// State for the tracking filter, containing edge states and a global

--- a/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
+++ b/Core/include/Acts/Seeding/GraphBasedTrackSeeder.hpp
@@ -99,6 +99,17 @@ class GraphBasedTrackSeeder {
     /// Minimum z0 value, set as optionl as if in pixel mode,
     /// The value is picked from the ROI
     float maxZ0 = 600;
+    /// z0 range at the beamline used to prune eta-bin pair connectivity when
+    /// constructing the GbtsGeometry. These values are not consumed by the
+    /// seeder itself: callers must forward them to the GbtsGeometry
+    /// constructor. Widen for displaced-track (LRT) seeding — the r-z chord
+    /// of a large-d0 track extrapolates far outside the luminous region.
+    float connectionZ0Min = -168.0f;
+    /// Maximum connectivity z0 at the beamline (see connectionZ0Min)
+    float connectionZ0Max = 168.0f;
+    /// Assumed z0 resolution when accepting adjacent bins of the z0 bitmask
+    /// histogram used for edge pruning on the entry layer
+    float z0HistoResolution = 2.5f;
     /// When old tunings are used, this defines the minimum phi window used
     float minDeltaPhi = 0.001f;
     /// Maximum radius of pixel detector
@@ -139,8 +150,9 @@ class GraphBasedTrackSeeder {
     /// units of GeV/(e*mm).
     float bFieldInZ{};
 
-    /// Transverse momentum coefficient (~0.3*B/2 - assumes nominal field of
-    /// 2*T).
+    /// Transverse momentum coefficient 0.5*bFieldInZ in units of
+    /// GeV/(e*mm): the position-azimuth slope dphi/dr of a prompt track is
+    /// kappa/2 = 0.5*B/pT, so ptCoeff/pT[GeV] bounds |dphi/dr| in 1/mm.
     double ptCoeff{};
   };
 

--- a/Core/src/Seeding/GbtsDataStorage.cpp
+++ b/Core/src/Seeding/GbtsDataStorage.cpp
@@ -165,6 +165,17 @@ std::uint32_t GbtsNodeStorage::numberOfNodes() const {
   return n;
 }
 
+float GbtsNodeStorage::minNodeRadius() const {
+  float rMin = std::numeric_limits<float>::max();
+
+  for (const auto& b : m_etaBins) {
+    if (!b.empty()) {
+      rMin = std::min(rMin, b.minRadius);
+    }
+  }
+  return rMin == std::numeric_limits<float>::max() ? 0.0f : rMin;
+}
+
 void GbtsNodeStorage::sortByPhi() {
   for (GbtsEtaBin& b : m_etaBins) {
     b.sortByPhi();
@@ -175,7 +186,12 @@ void GbtsNodeStorage::initializeNodes(const bool useMl) {
   for (GbtsEtaBin& b : m_etaBins) {
     b.initializeNodes();
     if (!b.vn.empty()) {
-      b.layerId = m_geometry->layerIdByIndex((b.vn.front())->layer);
+      const std::uint16_t layerIndex = (b.vn.front())->layer;
+      b.layerId = m_geometry->layerIdByIndex(layerIndex);
+      b.isBarrel =
+          m_geometry->layerByIndex(layerIndex).layerDescription().type ==
+          GbtsLayerType::Barrel;
+      b.layerDepth = m_geometry->layerDepthById(b.layerId);
     }
   }
 

--- a/Core/src/Seeding/GbtsGeometry.cpp
+++ b/Core/src/Seeding/GbtsGeometry.cpp
@@ -312,11 +312,46 @@ std::int32_t GbtsLayer::getEtaBin(const float zh, const float rh) const {
 
 GbtsGeometry::GbtsGeometry(
     const std::vector<GbtsLayerDescription>& layerDescriptions,
-    const GbtsLayerConnectionMap& layerConnections)
+    const GbtsLayerConnectionMap& layerConnections, const float connectionZ0Min,
+    const float connectionZ0Max)
     : m_etaBinWidth(layerConnections.etaBinWidth) {
-  // TODO configurable z0 range
-  const float minZ0 = -168.0f;
-  const float maxZ0 = 168.0f;
+  const float minZ0 = connectionZ0Min;
+  const float maxZ0 = connectionZ0Max;
+
+  // derive the per-layer "inward depth" from the connection map:
+  // 0 for entry layers (never the outer/src element of a connection, i.e. the
+  // innermost layers of this seeding graph), otherwise 1 + the maximum depth
+  // of the inner layers they connect to. Computed as a fixed point so that
+  // layer-skipping connections and any accidental cycles are handled safely.
+  for (const auto& [stage, vConn] : layerConnections.connectionMap) {
+    for (const auto& connection : vConn) {
+      m_layerDepth.try_emplace(connection->src, 0);
+      m_layerDepth.try_emplace(connection->dst, 0);
+    }
+  }
+
+  const std::size_t maxDepthPasses = m_layerDepth.size() + 1;
+
+  for (std::size_t pass = 0; pass < maxDepthPasses; ++pass) {
+    bool changed = false;
+
+    for (const auto& [stage, vConn] : layerConnections.connectionMap) {
+      for (const auto& connection : vConn) {
+        // src is the outer layer of the pair, dst the inner one
+        const std::uint32_t candidate = m_layerDepth.at(connection->dst) + 1;
+
+        if (std::uint32_t& depth = m_layerDepth.at(connection->src);
+            depth < candidate) {
+          depth = candidate;
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) {
+      break;
+    }
+  }
 
   for (const GbtsLayerDescription& layer : layerDescriptions) {
     const GbtsLayer& pL = createLayer(layer, m_nEtaBins);

--- a/Core/src/Seeding/GbtsLayerConnection.cpp
+++ b/Core/src/Seeding/GbtsLayerConnection.cpp
@@ -16,11 +16,12 @@
 #include <ranges>
 #include <set>
 #include <unordered_map>
+#include <utility>
 
 namespace Acts::Experimental {
 
 GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
-    std::istream& inStream, bool lrtMode) {
+    std::istream& inStream, const GbtsConnectionFilter filter) {
   GbtsLayerConnectionMap connectionMap;
 
   std::uint32_t nLinks{};
@@ -53,11 +54,11 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
 
     bool srcIsStrip = (srcvol_id == 13 || srcvol_id == 12 || srcvol_id == 14);
     bool dstIsStrip = (dstvol_id == 13 || dstvol_id == 12 || dstvol_id == 14);
-    if (lrtMode) {
+    if (filter == GbtsConnectionFilter::StripOnly) {
       if (!srcIsStrip || !dstIsStrip) {
         continue;
       }
-    } else {
+    } else if (filter == GbtsConnectionFilter::PixelOnly) {
       if (srcIsStrip || dstIsStrip) {
         continue;
       }
@@ -188,10 +189,23 @@ GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
   return connectionMap;
 }
 
-GbtsLayerConnectionMap GbtsLayerConnectionMap::fromFile(std::string& inFile,
-                                                        bool lrtMode) {
+GbtsLayerConnectionMap GbtsLayerConnectionMap::fromFile(
+    const std::string& inFile, const GbtsConnectionFilter filter) {
   std::ifstream inputStream(inFile.c_str());
-  return fromStream(inputStream, lrtMode);
+  return fromStream(inputStream, filter);
+}
+
+GbtsLayerConnectionMap GbtsLayerConnectionMap::fromStream(
+    std::istream& inStream, const bool lrtMode) {
+  return fromStream(inStream, lrtMode ? GbtsConnectionFilter::StripOnly
+                                      : GbtsConnectionFilter::PixelOnly);
+}
+
+GbtsLayerConnectionMap GbtsLayerConnectionMap::fromFile(std::string& inFile,
+                                                        const bool lrtMode) {
+  return fromFile(std::as_const(inFile), lrtMode
+                                             ? GbtsConnectionFilter::StripOnly
+                                             : GbtsConnectionFilter::PixelOnly);
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -80,6 +80,16 @@ GbtsEdgeState GbtsTrackingFilter::followTrack(State& state,
 
   pInitState.initialize(pS);
 
+  // apply the configured initial covariances
+  pInitState.cx = {};
+  pInitState.cx[0][0] = m_cfg.initCovX[0];
+  pInitState.cx[1][1] = m_cfg.initCovX[1];
+  pInitState.cx[2][2] = m_cfg.initCovX[2];
+
+  pInitState.cy = {};
+  pInitState.cy[0][0] = m_cfg.initCovY[0];
+  pInitState.cy[1][1] = m_cfg.initCovY[1];
+
   state.stateVec.clear();
 
   // recursive branching and propagation
@@ -208,6 +218,20 @@ bool GbtsTrackingFilter::update(const GbtsEdge& pS, GbtsEdgeState& ts) const {
   const float y = pS.n1->y;
   const float z = pS.n1->z;
   const float r = pS.n1->r;
+
+  if (m_cfg.d0Max > 0) {
+    // extra r-z slope process noise for displaced tracks: dz/dr scales with
+    // the chord factor ds/dr = r/sqrt(r^2 - d0^2), so between the previous
+    // radius and this one the slope may change by up to
+    // |y[1]| * (k(r)/k(refY) - 1) for a track with impact parameter d0Max
+    const float d0Max2 = m_cfg.d0Max * m_cfg.d0Max;
+    const float sPrev = std::sqrt(std::max(ts.refY * ts.refY - d0Max2, 1.0f));
+    const float sNext = std::sqrt(std::max(r * r - d0Max2, 1.0f));
+    const float kPrev = ts.refY / sPrev;
+    const float kNext = r / sNext;
+    const float dTau = ts.y[1] * (kNext / kPrev - 1.0f);
+    ts.cy[1][1] += dTau * dTau;
+  }
 
   const float refX = x * ts.c + y * ts.s;
   const float mx = -x * ts.s + y * ts.c;  // measured X[0]

--- a/Core/src/Seeding/GbtsTrackingFilter.cpp
+++ b/Core/src/Seeding/GbtsTrackingFilter.cpp
@@ -111,6 +111,7 @@ GbtsEdgeState GbtsTrackingFilter::followTrack(State& state,
 void GbtsTrackingFilter::propagate(State& state, std::vector<GbtsEdge>& sb,
                                    GbtsEdge& pS, GbtsEdgeState& ts) const {
   if (state.globalStateCounter >= GbtsMaxEdgeState) {
+    ++state.nStateOverflow;
     return;
   }
 
@@ -121,7 +122,7 @@ void GbtsTrackingFilter::propagate(State& state, std::vector<GbtsEdge>& sb,
   newTs.vs.push_back(&pS);
 
   // update using n1 of the segment
-  bool accepted = update(pS, newTs);
+  bool accepted = update(state, pS, newTs);
 
   if (!accepted) {
     // stop further propagation
@@ -178,7 +179,9 @@ void GbtsTrackingFilter::propagate(State& state, std::vector<GbtsEdge>& sb,
   }
 }
 
-bool GbtsTrackingFilter::update(const GbtsEdge& pS, GbtsEdgeState& ts) const {
+bool GbtsTrackingFilter::update(State& state, const GbtsEdge& pS,
+                                GbtsEdgeState& ts) const {
+  ++state.nUpdates;
   if (ts.cx[2][2] < 0 || ts.cx[1][1] < 0 || ts.cx[0][0] < 0) {
     std::cout << "Negative cov_x" << std::endl;
   }
@@ -296,6 +299,11 @@ bool GbtsTrackingFilter::update(const GbtsEdge& pS, GbtsEdgeState& ts) const {
   const float dchi2_y = resid_y * resid_y * Dy;
 
   if (dchi2_x > m_cfg.maxDChi2X || dchi2_y > m_cfg.maxDChi2Y) {
+    if (dchi2_x > m_cfg.maxDChi2X) {
+      ++state.nRejChi2X;
+    } else {
+      ++state.nRejChi2Y;
+    }
     return false;
   }
 
@@ -311,6 +319,7 @@ bool GbtsTrackingFilter::update(const GbtsEdge& pS, GbtsEdgeState& ts) const {
   }
 
   if (std::abs(ts.x[2]) > m_cfg.maxCurvature) {
+    ++state.nRejCurv;
     return false;
   }
 
@@ -321,6 +330,7 @@ bool GbtsTrackingFilter::update(const GbtsEdge& pS, GbtsEdgeState& ts) const {
   const float z0 = ts.y[0] - refY * ts.y[1];
 
   if (std::abs(z0) > m_cfg.maxZ0) {
+    ++state.nRejZ0;
     return false;
   }
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -663,10 +663,38 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
               }
 
               if (std::abs(dPhi) > m_cfg.cutDPhiMax) {
-                ++cutStats.rejDPhi;
-                ACTS_VERBOSE("rej dPhi: dPhi=" << dPhi << " r1=" << r1
-                                               << " r2=" << r2);
-                continue;
+                // displaced tracks: both direction estimates anchor at the
+                // shared node, so their difference for a track with impact
+                // parameter d0 is (c12 - c23) * r2 with
+                // c_ab = (asin(d0/r_b) - asin(d0/r_a)) / (r_b - r_a), the
+                // position-azimuth chord slope of each segment. Widen the
+                // acceptance by that bound evaluated at d0Max, computed only
+                // for candidates in the marginal band.
+                bool reject = true;
+
+                if (lrt) {
+                  const float r3 = pS->n2->r;
+                  const float dr23 = r3 - r2;
+
+                  if (dr23 > 1.0f) {
+                    const float a2 =
+                        std::asin(std::min(1.0f, m_cfg.d0Max / r2));
+                    const float a3 =
+                        std::asin(std::min(1.0f, m_cfg.d0Max / r3));
+                    const float c12 = (a2 - asinD0n1) / dr;
+                    const float c23 = (a3 - a2) / dr23;
+                    const float dPhiD0 = std::abs((c12 - c23) * r2);
+
+                    reject = std::abs(dPhi) > m_cfg.cutDPhiMax + dPhiD0;
+                  }
+                }
+
+                if (reject) {
+                  ++cutStats.rejDPhi;
+                  ACTS_VERBOSE("rej dPhi: dPhi=" << dPhi << " r1=" << r1
+                                                 << " r2=" << r2);
+                  continue;
+                }
               }
 
               const float dcurv = curv2 - pS->p[1];

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -288,15 +288,21 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
     // gates for the entry-layer graph pruning optimizations. For prompt
     // seeding these follow the original hardcoded ITk pixel-barrel layer
-    // numbering; in LRT mode they are derived from the connection graph so
-    // that they also apply to strip-only (or any other) configurations:
-    //  - the entry gate is valid on layers with nothing inside them, where an
-    //    edge can never be the innermost extension of a longer chain;
-    //  - the match gate is valid on layers close enough to the inside that a
-    //    chain starting there cannot reach the minimum level without an
-    //    outward continuation.
-    const bool entryLayerGate =
-        lrt ? (B1.layerDepth == 0) : (layerId1 == 80000);
+    // numbering; in LRT mode the match gate is derived from the connection
+    // graph so that it also applies to strip-only (or any other)
+    // configurations.
+    //
+    // The isolated-node skip and the z0-bitmask veto require the outer node
+    // to have a CONFIRMED outward continuation (an edge that itself found a
+    // neighbour, i.e. two more hits beyond the candidate doublet). That is
+    // only a valid requirement when minLevel >= 3: with minLevel == 2 a bare
+    // triplet is a valid seed and its middle node is never confirmed, so
+    // these vetoes must stay off in LRT mode.
+    const bool entryLayerGate = !lrt && (layerId1 == 80000);
+    // the match gate only requires an EXISTING tau-compatible continuation
+    // edge, which any chain of length >= minLevel provides, so it is valid on
+    // layers close enough to the inside that a chain starting there cannot
+    // reach the minimum level without an outward continuation
     const bool matchBeforeCreateGate =
         m_cfg.matchBeforeCreate &&
         (lrt ? (B1.layerDepth < minLevel - 1)

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -29,7 +29,9 @@ GraphBasedTrackSeeder::DerivedConfig::DerivedConfig(const Config& config)
 
 GraphBasedTrackSeeder::Options::Options(float bFieldInZ_)
     : bFieldInZ(bFieldInZ_) {
-  ptCoeff = 0.5f * bFieldInZ * Acts::UnitConstants::m;
+  // kappa = B/pT in 1/mm with B in GeV/(e*mm) and pT in GeV; the
+  // position-azimuth slope dphi/dr of a prompt track is kappa/2
+  ptCoeff = 0.5f * bFieldInZ;
 }
 
 GraphBasedTrackSeeder::GraphBasedTrackSeeder(
@@ -91,7 +93,25 @@ void GraphBasedTrackSeeder::createSeeds(
 
   nodeStorage.initializeNodes(m_cfg.useMl);
 
-  nodeStorage.generatePhiIndexing(1.5f * m_cfg.phiSliceWidth);
+  // the phi wrap-around duplication margin must cover the widest sliding
+  // window used during graph building, otherwise doublets are lost near
+  // phi = +/-pi. For displaced (LRT) tracks the window is widened by the
+  // position-azimuth swing asin(d0/r1) - asin(d0/r2) (see buildTheGraph),
+  // which can far exceed the nominal margin of 1.5 phi slice widths.
+  float phiIndexingRange = 1.5f * m_cfg.phiSliceWidth;
+
+  if (m_cfg.lrtMode) {
+    const float ptScale = 0.9f / m_cfg.minPt;
+    const float maxBaseWindow =
+        0.015f + 2.2e-4f * ptScale * m_cfg.maxOuterRadius;
+    const float rMin = std::max(nodeStorage.minNodeRadius(), 1.0f);
+    const float maxD0Window = std::asin(std::min(1.0f, m_cfg.d0Max / rMin));
+    phiIndexingRange =
+        std::max(phiIndexingRange, std::min(std::numbers::pi_v<float> - 0.01f,
+                                            maxBaseWindow + maxD0Window));
+  }
+
+  nodeStorage.generatePhiIndexing(phiIndexingRange);
 
   std::vector<GbtsEdge> edgeStorage;
 
@@ -217,6 +237,13 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
   const float maxCurv = options.ptCoeff / tripletPtMin;
 
+  const bool lrt = m_cfg.lrtMode;
+  const float d0Max2 = m_cfg.d0Max * m_cfg.d0Max;
+
+  // must stay consistent with the chain-length requirement applied in
+  // extractSeedsFromTheGraph
+  const std::uint32_t minLevel = lrt ? 2 : 3;
+
   float maxKappaHighEta =
       m_cfg.lrtMode ? 1.0f * maxCurv : std::sqrt(0.8f) * maxCurv;
   float maxKappaLowEta =
@@ -257,7 +284,23 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
     const std::uint32_t layerId1 = B1.layerId;
 
-    const bool isBarrel1 = (layerId1 / 10000) == 8;
+    const bool isBarrel1 = B1.isBarrel;
+
+    // gates for the entry-layer graph pruning optimizations. For prompt
+    // seeding these follow the original hardcoded ITk pixel-barrel layer
+    // numbering; in LRT mode they are derived from the connection graph so
+    // that they also apply to strip-only (or any other) configurations:
+    //  - the entry gate is valid on layers with nothing inside them, where an
+    //    edge can never be the innermost extension of a longer chain;
+    //  - the match gate is valid on layers close enough to the inside that a
+    //    chain starting there cannot reach the minimum level without an
+    //    outward continuation.
+    const bool entryLayerGate =
+        lrt ? (B1.layerDepth == 0) : (layerId1 == 80000);
+    const bool matchBeforeCreateGate =
+        m_cfg.matchBeforeCreate &&
+        (lrt ? (B1.layerDepth < minLevel - 1)
+             : (layerId1 == 80000 || layerId1 == 81000));
 
     // prepare a sliding window for each bin2 in the group
 
@@ -295,6 +338,17 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
         }
       }
 
+      if (lrt) {
+        // displaced tracks: the position azimuth of the hits swings by up to
+        // asin(d0/r1) - asin(d0/r2) between the two radii on top of the
+        // curvature-driven rotation the nominal window is tuned for
+        const float sinInner =
+            std::min(1.0f, m_cfg.d0Max / std::max(rb1, 1.0f));
+        const float sinOuter =
+            std::min(1.0f, m_cfg.d0Max / std::max(rb2, 1.0f));
+        deltaPhi += std::max(0.0f, std::asin(sinInner) - std::asin(sinOuter));
+      }
+
       phiSlidingWindow[winIdx].bin = &B2;
       phiSlidingWindow[winIdx].hasNodes = true;
       phiSlidingWindow[winIdx].deltaPhi = deltaPhi;
@@ -319,6 +373,16 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
       const float r1 = n1pars[3];
       const float z1 = n1pars[4];
 
+      // arc-length chord factor ingredients for a track with impact
+      // parameter up to d0Max, used by the displaced-aware cut widenings
+      float sD0n1 = 0.0f;
+      float asinD0n1 = 0.0f;
+
+      if (lrt) {
+        sD0n1 = std::sqrt(std::max(r1 * r1 - d0Max2, 0.0f));
+        asinD0n1 = std::asin(std::min(1.0f, m_cfg.d0Max / std::max(r1, 1.0f)));
+      }
+
       // the intermediate loop over sliding windows
       for (auto& slw : phiSlidingWindow) {
         if (!slw.hasNodes) {
@@ -329,7 +393,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
         const std::uint32_t lk2 = B2.layerId;
 
-        const bool isBarrel2 = (lk2 / 10000) == 8;
+        const bool isBarrel2 = B2.isBarrel;
 
         const float deltaPhi = slw.deltaPhi;
 
@@ -358,7 +422,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const std::uint16_t nodeInfo = B2.vIsConnected[n2Idx];
 
           // skip isolated nodes as their incoming edges lead to nowhere
-          if ((layerId1 == 80000) && (nodeInfo == 0)) {
+          if (entryLayerGate && (nodeInfo == 0)) {
             continue;
           }
 
@@ -401,7 +465,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           const float z0 = z1 - r1 * tau;
 
-          if (layerId1 == 80000) {  // check against non-empty z0 histogram
+          if (entryLayerGate) {  // check against non-empty z0 histogram
             if (!checkZ0BitMask(nodeInfo, z0, m_cfg.minZ0, z0HistoCoeff)) {
               continue;
             }
@@ -422,21 +486,40 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float curv = (phi2 - phi1) / dr;
           const float absCurv = std::abs(curv);
 
-          if (ftau < 4.0f) {  // eta = 2.1
-            if (absCurv > maxKappaLowEta) {
+          // eta = 2.1 boundary between the two kappa cuts
+          const float maxKappa =
+              (ftau < 4.0f) ? maxKappaLowEta : maxKappaHighEta;
+
+          if (absCurv > maxKappa) {
+            if (!lrt) {
               continue;
             }
-          } else {
-            if (absCurv > maxKappaHighEta) {
+            // displaced tracks: the position-azimuth slope picks up a
+            // geometric term (asin(d0/r1) - asin(d0/r2))/dr on top of the
+            // curvature term kappa/2 the nominal cut bounds
+            const float d0Kappa =
+                (asinD0n1 -
+                 std::asin(std::min(1.0f, m_cfg.d0Max / std::max(r2, 1.0f)))) /
+                dr;
+            if (absCurv > maxKappa + std::abs(d0Kappa)) {
               continue;
             }
           }
 
           const float expEta = fastHypot(1, tau) - tau;
 
+          // ds/dr chord factor of this segment for a track with impact
+          // parameter d0Max; tau = dz/dr of a displaced track scales with it,
+          // so it bounds the geometric tau variation between segments
+          float dsdrD0 = 1.0f;
+
+          if (lrt) {
+            const float sD0n2 = std::sqrt(std::max(r2 * r2 - d0Max2, 0.0f));
+            dsdrD0 = std::max((sD0n2 - sD0n1) / dr, 1e-3f);
+          }
+
           // match edge candidate against edges incoming to n2
-          if (m_cfg.matchBeforeCreate &&
-              (layerId1 == 80000 || layerId1 == 81000)) {
+          if (matchBeforeCreateGate) {
             // we must have enough incoming edges to decide
             bool isGood = n2NumEdges <= 2;
 
@@ -445,10 +528,17 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               for (std::uint32_t n2InIdx = n2FirstEdge; n2InIdx < n2LastEdge;
                    ++n2InIdx) {
-                const float tau2 = edgeStorage.at(n2InIdx).p[0];
-                const float tauRatio = tau2 * uat1 - 1.0f;
+                const GbtsEdge& inEdge = edgeStorage.at(n2InIdx);
+                const float tauRatio = inEdge.p[0] * uat1 - 1.0f;
 
-                if (std::abs(tauRatio) > m_cfg.tauRatioPrecut) {  // bad match
+                // widen the acceptance by the geometric tau variation of a
+                // displaced track between the two segments
+                float precut = m_cfg.tauRatioPrecut;
+                if (lrt) {
+                  precut += std::max(dsdrD0 / inEdge.dsdrD0 - 1.0f, 0.0f);
+                }
+
+                if (std::abs(tauRatio) > precut) {  // bad match
                   continue;
                 }
                 isGood = true;  // good match found
@@ -466,7 +556,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           if (nEdges < m_cfg.nMaxEdges) {
             edgeStorage.emplace_back(B1.vn[n1Idx], B2.vn[n2Idx], expEta, curv,
-                                     phi1 + dPhi1);
+                                     phi1 + dPhi1, dsdrD0);
 
             ++numCreatedEdges;
 
@@ -488,15 +578,21 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
               const std::uint32_t lk3 =
                   m_geometry->layerIdByIndex(pS->n2->layer);
 
-              const bool isBarrel3 = (lk3 / 10000) == 8;
+              const bool isBarrel3 = m_geometry->layerByIndex(pS->n2->layer)
+                                         .layerDescription()
+                                         .type == GbtsLayerType::Barrel;
 
               const float absTauRatio = std::abs(pS->p[0] * uat2 - 1.0f);
               float addTauRatioCorr = 0;
 
               if (m_cfg.useAdaptiveCuts) {
                 if (isBarrel1 && isBarrel2 && isBarrel3) {
+                  // consecutive barrel layer IDs differ by 1000 in the ITk
+                  // pixel numbering and by 1 in the ITk strip numbering
+                  const std::uint32_t d32 = lk3 - lk2;
+                  const std::uint32_t d21 = lk2 - layerId1;
                   const bool noGap =
-                      ((lk3 - lk2) == 1000) && ((lk2 - layerId1) == 1000);
+                      (d32 == 1000 && d21 == 1000) || (d32 == 1 && d21 == 1);
 
                   // assume more scattering due to the layer in between
                   if (!noGap) {
@@ -509,6 +605,14 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                   }
                 }
               }
+
+              if (lrt) {
+                // geometric tau variation between the two segments for a
+                // track with impact parameter up to d0Max: the inner segment
+                // always has the larger ds/dr chord factor
+                addTauRatioCorr += std::max(dsdrD0 / pS->dsdrD0 - 1.0f, 0.0f);
+              }
+
               // bad match
               if (absTauRatio > m_cfg.tauRatioCut + addTauRatioCorr) {
                 continue;
@@ -539,9 +643,9 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                   const std::array<const GbtsNode*, 3> candidateTriplet = {
                       B1.vn[n1Idx], B2.vn[n2Idx], pS->n2};
 
-                  if (!validateTriplet(candidateTriplet, tripletPtMin,
-                                       absTauRatio, m_cfg.tauRatioCut,
-                                       options)) {
+                  if (!validateTriplet(
+                          candidateTriplet, tripletPtMin, absTauRatio,
+                          m_cfg.tauRatioCut + addTauRatioCorr, options)) {
                     continue;
                   }
                 }
@@ -552,12 +656,16 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               isConnected = true;  // there is at least one good match
 
-              // edge confirmed - update z0 histogram
+              // edge confirmed - update z0 histogram. The bin index is only
+              // guaranteed to be in range when doubletFilterRZ restricted z0
+              // to [minZ0, maxZ0], so it must be checked here
+              const std::int32_t z0BinIndex =
+                  static_cast<std::int32_t>(z0HistoCoeff * (z0 - m_cfg.minZ0));
 
-              const std::uint32_t z0BinIndex =
-                  static_cast<std::uint32_t>(z0HistoCoeff * (z0 - m_cfg.minZ0));
-
-              ++z0Histo[z0BinIndex];
+              if (z0BinIndex >= 0 &&
+                  z0BinIndex < static_cast<std::int32_t>(zBins)) {
+                ++z0Histo[z0BinIndex];
+              }
 
               nConnections++;
             }
@@ -974,7 +1082,7 @@ bool GraphBasedTrackSeeder::checkZ0BitMask(const std::uint16_t z0BitMask,
 
   // check adjacent bins as well
 
-  const float z0Resolution = 2.5;
+  const float z0Resolution = m_cfg.z0HistoResolution;
 
   const float dzm = dz - z0Resolution;
 

--- a/Core/src/Seeding/GraphBasedTrackSeeder.cpp
+++ b/Core/src/Seeding/GraphBasedTrackSeeder.cpp
@@ -266,6 +266,14 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
   std::uint32_t nEdges = 0;
 
+  // per-call cut accounting for inefficiency debugging (reported at DEBUG)
+  struct CutStats {
+    std::uint64_t candidates{}, rejIsolated{}, rejDeltaR{}, rejTauAbs{},
+        rejTauRange{}, rejZ0Mask{}, rejZ0{}, rejZOuter{}, rejKappa{},
+        rejPrecut{}, rejMaxEdges{}, neiPairs{}, rejNeiFull{}, rejTauRatio{},
+        rejDPhi{}, rejDCurv{}, rejTriplet{};
+  } cutStats;
+
   // scale factor to get indexes of binned beamspot
   // assuming 16-bit z0 bitmask
 
@@ -427,8 +435,11 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           const std::uint16_t nodeInfo = B2.vIsConnected[n2Idx];
 
+          ++cutStats.candidates;
+
           // skip isolated nodes as their incoming edges lead to nowhere
           if (entryLayerGate && (nodeInfo == 0)) {
+            ++cutStats.rejIsolated;
             continue;
           }
 
@@ -443,6 +454,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float dr = r2 - r1;
 
           if (dr < m_cfg.minDeltaRadius) {
+            ++cutStats.rejDeltaR;
             continue;
           }
 
@@ -452,20 +464,13 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
           const float tau = dz / dr;
           const float ftau = std::fabs(tau);
           if (ftau > 36.0f) {
+            ++cutStats.rejTauAbs;
             continue;
           }
 
-          if (ftau < n1pars[0]) {
-            continue;
-          }
-          if (ftau > n1pars[1]) {
-            continue;
-          }
-
-          if (ftau < n2pars[0]) {
-            continue;
-          }
-          if (ftau > n2pars[1]) {
+          if (ftau < n1pars[0] || ftau > n1pars[1] || ftau < n2pars[0] ||
+              ftau > n2pars[1]) {
+            ++cutStats.rejTauRange;
             continue;
           }
 
@@ -473,18 +478,24 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           if (entryLayerGate) {  // check against non-empty z0 histogram
             if (!checkZ0BitMask(nodeInfo, z0, m_cfg.minZ0, z0HistoCoeff)) {
+              ++cutStats.rejZ0Mask;
               continue;
             }
           }
 
           if (m_cfg.doubletFilterRZ) {
             if (z0 < m_cfg.minZ0 || z0 > m_cfg.maxZ0) {
+              ++cutStats.rejZ0;
+              ACTS_VERBOSE("rej z0: z0=" << z0 << " r1=" << r1 << " z1=" << z1
+                                         << " r2=" << r2 << " z2=" << z2
+                                         << " tau=" << tau);
               continue;
             }
 
             const float zOuter = z0 + m_cfg.maxOuterRadius * tau;
 
             if (zOuter < cutZMinU || zOuter > cutZMaxU) {
+              ++cutStats.rejZOuter;
               continue;
             }
           }
@@ -498,6 +509,7 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
           if (absCurv > maxKappa) {
             if (!lrt) {
+              ++cutStats.rejKappa;
               continue;
             }
             // displaced tracks: the position-azimuth slope picks up a
@@ -508,6 +520,11 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                  std::asin(std::min(1.0f, m_cfg.d0Max / std::max(r2, 1.0f)))) /
                 dr;
             if (absCurv > maxKappa + std::abs(d0Kappa)) {
+              ++cutStats.rejKappa;
+              ACTS_VERBOSE("rej kappa: absCurv="
+                           << absCurv << " maxKappa=" << maxKappa
+                           << " d0Kappa=" << d0Kappa << " r1=" << r1
+                           << " r2=" << r2);
               continue;
             }
           }
@@ -553,12 +570,17 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
             }
 
             if (!isGood) {  // no match found, skip creating [n1 <- n2] edge
+              ++cutStats.rejPrecut;
               continue;
             }
           }
 
           const float dPhi2 = curv * r2;
           const float dPhi1 = curv * r1;
+
+          if (nEdges >= m_cfg.nMaxEdges) {
+            ++cutStats.rejMaxEdges;
+          }
 
           if (nEdges < m_cfg.nMaxEdges) {
             edgeStorage.emplace_back(B1.vn[n1Idx], B2.vn[n2Idx], expEta, curv,
@@ -577,7 +599,10 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                  ++inEdgeIdx) {
               GbtsEdge* pS = &(edgeStorage.at(inEdgeIdx));
 
+              ++cutStats.neiPairs;
+
               if (pS->nNei >= gbtsNumSegConns) {
+                ++cutStats.rejNeiFull;
                 continue;
               }
 
@@ -621,6 +646,11 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
 
               // bad match
               if (absTauRatio > m_cfg.tauRatioCut + addTauRatioCorr) {
+                ++cutStats.rejTauRatio;
+                ACTS_VERBOSE("rej tauRatio: absTauRatio="
+                             << absTauRatio << " cut="
+                             << m_cfg.tauRatioCut + addTauRatioCorr
+                             << " r1=" << r1 << " r2=" << r2 << " lk3=" << lk3);
                 continue;
               }
 
@@ -633,12 +663,18 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
               }
 
               if (std::abs(dPhi) > m_cfg.cutDPhiMax) {
+                ++cutStats.rejDPhi;
+                ACTS_VERBOSE("rej dPhi: dPhi=" << dPhi << " r1=" << r1
+                                               << " r2=" << r2);
                 continue;
               }
 
               const float dcurv = curv2 - pS->p[1];
 
               if (dcurv < -m_cfg.cutDCurvMax || dcurv > m_cfg.cutDCurvMax) {
+                ++cutStats.rejDCurv;
+                ACTS_VERBOSE("rej dCurv: dcurv=" << dcurv << " r1=" << r1
+                                                 << " r2=" << r2);
                 continue;
               }
 
@@ -652,6 +688,10 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
                   if (!validateTriplet(
                           candidateTriplet, tripletPtMin, absTauRatio,
                           m_cfg.tauRatioCut + addTauRatioCorr, options)) {
+                    ++cutStats.rejTriplet;
+                    ACTS_VERBOSE("rej triplet: absTauRatio="
+                                 << absTauRatio << " r1=" << r1 << " r2=" << r2
+                                 << " r3=" << pS->n2->r);
                     continue;
                   }
                 }
@@ -706,6 +746,26 @@ std::pair<std::int32_t, std::int32_t> GraphBasedTrackSeeder::buildTheGraph(
         "Maximum number of graph edges exceeded - possible efficiency loss "
         << nEdges);
   }
+  ACTS_DEBUG("GBTS graph cuts: candidates="
+             << cutStats.candidates << " rejIsolated=" << cutStats.rejIsolated
+             << " rejDeltaR=" << cutStats.rejDeltaR
+             << " rejTauAbs=" << cutStats.rejTauAbs
+             << " rejTauRange=" << cutStats.rejTauRange
+             << " rejZ0Mask=" << cutStats.rejZ0Mask
+             << " rejZ0=" << cutStats.rejZ0
+             << " rejZOuter=" << cutStats.rejZOuter
+             << " rejKappa=" << cutStats.rejKappa
+             << " rejPrecut=" << cutStats.rejPrecut
+             << " rejMaxEdges=" << cutStats.rejMaxEdges
+             << " edges=" << nEdges);
+  ACTS_DEBUG("GBTS edge matching: neiPairs="
+             << cutStats.neiPairs << " rejNeiFull=" << cutStats.rejNeiFull
+             << " rejTauRatio=" << cutStats.rejTauRatio
+             << " rejDPhi=" << cutStats.rejDPhi
+             << " rejDCurv=" << cutStats.rejDCurv
+             << " rejTriplet=" << cutStats.rejTriplet
+             << " connections=" << nConnections);
+
   return std::make_pair(nEdges, nConnections);
 }
 
@@ -833,6 +893,21 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
   std::ranges::sort(vChainHeads, std::ranges::greater{},
                     [](const GbtsEdge* e) { return e->level; });
 
+  if (logger().doPrint(Acts::Logging::DEBUG)) {
+    std::array<std::uint32_t, 9> levelCount{};
+    for (std::uint32_t edgeIndex = 0; edgeIndex < nEdges; ++edgeIndex) {
+      const int lvl = std::clamp<int>(edgeStorage[edgeIndex].level, 0, 8);
+      ++levelCount[lvl];
+    }
+    ACTS_DEBUG("GBTS extract: maxLevel="
+               << maxLevel << " chainHeads=" << vChainHeads.size()
+               << " edge levels: L1=" << levelCount[1]
+               << " L2=" << levelCount[2] << " L3=" << levelCount[3]
+               << " L4=" << levelCount[4]
+               << " L5+=" << levelCount[5] + levelCount[6] + levelCount[7] +
+                                 levelCount[8]);
+  }
+
   // backtracking
 
   std::vector<SeedCandidateProperties> vSeedCandidates;
@@ -845,6 +920,10 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 
   std::uint32_t seedCounter = 0;
 
+  std::uint32_t nFollowed = 0;
+  std::uint32_t nNotInitialized = 0;
+  std::uint32_t nShortChains = 0;
+
   GbtsTrackingFilter::State filterState{};
 
   for (GbtsEdge* pS : vChainHeads) {
@@ -852,9 +931,12 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
       continue;
     }
 
+    ++nFollowed;
+
     GbtsEdgeState rs = filter.followTrack(filterState, edgeStorage, *pS);
 
     if (!rs.initialized) {
+      ++nNotInitialized;
       continue;
     }
 
@@ -864,15 +946,18 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 
     if (m_cfg.lrtMode || !m_cfg.addTriplets) {
       if (chainLength < minLevel) {
+        ++nShortChains;
         continue;
       }
     } else {
       if (seedAbsEta > m_cfg.maxAbsEtaAddTripelts) {
         if (chainLength < minLevel) {
+          ++nShortChains;
           continue;
         }
       } else {
         if (chainLength < static_cast<std::uint32_t>(minLevel) - 1u) {
+          ++nShortChains;
           continue;
         }
       }
@@ -962,6 +1047,17 @@ void GraphBasedTrackSeeder::extractSeedsFromTheGraph(
 
     ++seedCounter;
   }
+
+  ACTS_DEBUG("GBTS chains: followed="
+             << nFollowed << " notInitialized=" << nNotInitialized
+             << " tooShort=" << nShortChains
+             << " candidates=" << vSeedCandidates.size());
+  ACTS_DEBUG("GBTS filter: updates="
+             << filterState.nUpdates << " rejChi2X=" << filterState.nRejChi2X
+             << " rejChi2Y=" << filterState.nRejChi2Y
+             << " rejCurv=" << filterState.nRejCurv
+             << " rejZ0=" << filterState.nRejZ0
+             << " stateOverflow=" << filterState.nStateOverflow);
 
   // clone removal code goes below ...
 


### PR DESCRIPTION
The GBTS graph builder assumed beamline-pointing tracks in several places, making its LRT mode inefficient for large impact parameters. This PR removes or parametrizes those assumptions so that GBTS can seed tracks with |d0| up to a configured d0Max (300 mm for ITk LRT), and fixes several related bugs. All changes are should not affect  prompt
configurations. The widenings scale with d0Max (negligible at prompt values) or are gated on lrtMode, and new configuration fields default to the previous behaviour.

Bug fixes:
  - Fix the ptCoeff units error (0.5*B*UnitConstants::m with pT in GeV), which made the curvature cuts ~1000x too loose and silently disabled them in LRT mode and in the old-tunings path
  - Keep the entry-layer graph vetoes (isolated-node skip, z0-bitmask) out of LRT mode: they require a confirmed continuation two hits beyond the candidate doublet, which is only valid for minLevel >= 3; in LRT mode (minLevel 2) they rejected every three-space-point seed
  - Bounds-guard the z0 histogram fill, which wrote out of bounds when doubletFilterRZ was disabled

Displaced-aware cut widenings, evaluated as upper bounds at d0Max and radius-dependent so they vanish for r >> d0Max:
  - phi sliding window: widened by the position-azimuth swing asin(d0Max/r1) - asin(d0Max/r2); the phi wrap-around indexing margin scales accordingly
  - curvature proxy |dphi/dr|: widened by the same swing per unit radius, evaluated only for candidates in the marginal band
  - segment tau-ratio matching: widened by the ds/dr chord-factor ratio bound (cot(theta) cancels); each edge caches its chord factor
  - segment direction-phi matching: both estimates anchor at the shared node, so they differ by (c12 - c23)*r2 with c the per-segment asin(d0Max/r) chord slope; widened by that bound, band-gated

Configurability and generalization:
  - GbtsGeometry: the eta-bin pair connectivity z0 range (previously hardcoded to +-168 mm) is a constructor argument; a per-layer inward depth derived from the connection map replaces hardcoded layer IDs for the LRT matchBeforeCreate gate
  - Barrel/endcap decisions use the geometry layer type instead of ITk pixel layer-ID arithmetic, enabling triplet d0/pT validation and adaptive tau corrections for strip seeding
  - GbtsConnectionFilter enum (PixelOnly/StripOnly/All) replaces the boolean lrtMode volume filtering (bool overloads kept)
  - GbtsTrackingFilter: initial state covariances are configurable and an optional d0-driven r-z slope process noise accounts for the geometric dz/dr variation of displaced trajectories
  - z0 bitmask resolution and histogram tolerance made configurable
  - Per-cut debug accounting in the graph builder, chain statistics in the seed extraction, and rejection counters in the tracking filter, reported at DEBUG level with per-rejection kinematics at VERBOSE

  --- END COMMIT MESSAGE ---

cc @jpreston-cern 