### PR TITLE
feat: add in-memory GenericVisualization3D helper

### DIFF
--- a/Core/include/Acts/Visualization/GenericVisualization3D.hpp
+++ b/Core/include/Acts/Visualization/GenericVisualization3D.hpp
@@ -1,0 +1,112 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Visualization/IVisualization3D.hpp"
+#include "Acts/Visualization/ViewConfig.hpp"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Acts {
+
+/// This helper collects the visualization primitives in memory instead of
+/// writing them to a file in a specific format. The collected vertices, faces
+/// and lines can be retrieved through accessors, e.g. to hand them over to an
+/// external plotting backend.
+class GenericVisualization3D : public IVisualization3D {
+ public:
+  /// A collected vertex: position and color
+  struct Vertex {
+    /// The vertex position
+    Vector3 position = Vector3::Zero();
+    /// The vertex color
+    Color color = s_defaultColor;
+  };
+
+  /// A collected face: indices into the vertex collection and a color
+  struct Face {
+    /// The indices of the vertices that make up the face
+    FaceType indices{};
+    /// The face color
+    Color color = s_defaultColor;
+  };
+
+  /// A collected line: the two end points and a color
+  struct Line {
+    /// The start point of the line
+    Vector3 a = Vector3::Zero();
+    /// The end point of the line
+    Vector3 b = Vector3::Zero();
+    /// The line color
+    Color color = s_defaultColor;
+  };
+
+  /// @copydoc Acts::IVisualization3D::vertex()
+  void vertex(const Vector3& vtx, Color color = s_defaultColor) final;
+
+  /// @copydoc Acts::IVisualization3D::line()
+  /// @note The end points are stored with the line and are not appended to
+  /// the vertex collection.
+  void line(const Vector3& a, const Vector3& b,
+            Color color = s_defaultColor) final;
+
+  /// @copydoc Acts::IVisualization3D::face()
+  void face(const std::vector<Vector3>& vtxs,
+            Color color = s_defaultColor) final;
+
+  /// @copydoc Acts::IVisualization3D::faces()
+  void faces(const std::vector<Vector3>& vtxs,
+             const std::vector<FaceType>& faces,
+             Color color = s_defaultColor) final;
+
+  /// Write a short summary of the collected data to an output stream
+  /// @note This is meant for debugging only, it is not a serialization
+  /// format. Use ObjVisualization3D or PlyVisualization3D to write files.
+  /// @param os The output stream
+  void write(std::ostream& os) const final;
+
+  /// Write a short summary of the collected data to a file
+  /// @note This is meant for debugging only, it is not a serialization
+  /// format. Use ObjVisualization3D or PlyVisualization3D to write files.
+  /// @param path is the file system path for writing the file
+  void write(const std::filesystem::path& path) const final;
+
+  /// @copydoc Acts::IVisualization3D::clear()
+  void clear() final;
+
+  /// @copydoc Acts::IVisualization3D::object()
+  /// @note Object contexts are currently not stored by this helper
+  void object(const std::string& /*name*/) final {
+    // Unimplemented
+  }
+
+  /// Access the collected vertices
+  /// @return The vertices collected so far
+  const std::vector<Vertex>& vertices() const { return m_vertices; }
+
+  /// Access the collected faces
+  /// @note This overloads the 3-argument virtual IVisualization3D::faces();
+  /// call on a concrete type to avoid ambiguity.
+  /// @return The faces collected so far
+  const std::vector<Face>& faces() const { return m_faces; }
+
+  /// Access the collected lines
+  /// @return The lines collected so far
+  const std::vector<Line>& lines() const { return m_lines; }
+
+ private:
+  std::vector<Vertex> m_vertices;
+  std::vector<Face> m_faces;
+  std::vector<Line> m_lines;
+};
+
+}  // namespace Acts

--- a/Core/src/Visualization/CMakeLists.txt
+++ b/Core/src/Visualization/CMakeLists.txt
@@ -1,4 +1,8 @@
 target_sources(
     ActsCore
-    PRIVATE GeometryView3D.cpp EventDataView3D.cpp ObjVisualization3D.cpp
+    PRIVATE
+        GeometryView3D.cpp
+        EventDataView3D.cpp
+        GenericVisualization3D.cpp
+        ObjVisualization3D.cpp
 )

--- a/Core/src/Visualization/GenericVisualization3D.cpp
+++ b/Core/src/Visualization/GenericVisualization3D.cpp
@@ -1,0 +1,81 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Visualization/GenericVisualization3D.hpp"
+
+#include <fstream>
+#include <ostream>
+
+namespace Acts {
+
+void GenericVisualization3D::vertex(const Vector3& vtx, Color color) {
+  m_vertices.push_back({vtx, color});
+}
+
+void GenericVisualization3D::line(const Vector3& a, const Vector3& b,
+                                  Color color) {
+  m_lines.push_back({a, b, color});
+}
+
+void GenericVisualization3D::face(const std::vector<Vector3>& vtxs,
+                                  Color color) {
+  Face fc;
+  fc.color = color;
+  fc.indices.reserve(vtxs.size());
+  for (const auto& vtx : vtxs) {
+    vertex(vtx, color);
+    fc.indices.push_back(m_vertices.size() - 1);
+  }
+  m_faces.push_back(std::move(fc));
+}
+
+void GenericVisualization3D::faces(const std::vector<Vector3>& vtxs,
+                                   const std::vector<FaceType>& faces,
+                                   Color color) {
+  // No faces given - call the face() method
+  if (faces.empty()) {
+    face(vtxs, color);
+    return;
+  }
+  const std::size_t vtxOffset = m_vertices.size();
+  for (const auto& vtx : vtxs) {
+    vertex(vtx, color);
+  }
+  for (const auto& fc : faces) {
+    // Two-index faces describe lines, matching ObjVisualization3D
+    if (fc.size() == 2) {
+      line(vtxs[fc[0]], vtxs[fc[1]], color);
+    } else {
+      Face storedFace;
+      storedFace.color = color;
+      storedFace.indices.reserve(fc.size());
+      for (std::size_t idx : fc) {
+        storedFace.indices.push_back(idx + vtxOffset);
+      }
+      m_faces.push_back(std::move(storedFace));
+    }
+  }
+}
+
+void GenericVisualization3D::write(std::ostream& os) const {
+  os << "GenericVisualization3D: " << m_vertices.size() << " vertices, "
+     << m_faces.size() << " faces, " << m_lines.size() << " lines\n";
+}
+
+void GenericVisualization3D::write(const std::filesystem::path& path) const {
+  std::ofstream os(path);
+  write(os);
+}
+
+void GenericVisualization3D::clear() {
+  m_vertices.clear();
+  m_faces.clear();
+  m_lines.clear();
+}
+
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Visualization/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Visualization/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unittest(Visualization3D Visualization3DTests.cpp)
 add_unittest(EventDataView3D EventDataView3DTests.cpp)
+add_unittest(GenericVisualization3D GenericVisualization3DTests.cpp)
 add_unittest(Interpolation3D Interpolation3DTests.cpp)
 add_unittest(PrimitivesView3D PrimitivesView3DTests.cpp)
 add_unittest(SurfaceView3D SurfaceView3DTests.cpp)

--- a/Tests/UnitTests/Core/Visualization/GenericVisualization3DTests.cpp
+++ b/Tests/UnitTests/Core/Visualization/GenericVisualization3DTests.cpp
@@ -1,0 +1,217 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Definitions/Algebra.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/ConeBounds.hpp"
+#include "Acts/Surfaces/ConeSurface.hpp"
+#include "Acts/Surfaces/CylinderBounds.hpp"
+#include "Acts/Surfaces/CylinderSurface.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Visualization/GenericVisualization3D.hpp"
+#include "Acts/Visualization/GeometryView3D.hpp"
+#include "Acts/Visualization/IVisualization3D.hpp"
+#include "Acts/Visualization/ObjVisualization3D.hpp"
+#include "ActsTests/CommonHelpers/FloatComparisons.hpp"
+
+#include <numbers>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace Acts;
+
+namespace ActsTests {
+
+namespace {
+
+/// The relevant records of an obj stream: vertex positions, 0-based face
+/// index lists and 0-based line index pairs
+struct ParsedObj {
+  std::vector<Vector3> vertices;
+  std::vector<std::vector<std::size_t>> faces;
+  std::vector<std::pair<std::size_t, std::size_t>> lines;
+};
+
+/// Parse the `v`, `f` and `l` records from an obj stream
+/// @param objString the obj stream content
+/// @return the parsed records
+ParsedObj parseObj(const std::string& objString) {
+  ParsedObj parsed;
+  auto ss = std::stringstream{objString};
+  for (std::string line; std::getline(ss, line);) {
+    auto ls = std::stringstream{line};
+    std::string tag;
+    ls >> tag;
+    if (tag == "v") {
+      Vector3 vtx = Vector3::Zero();
+      ls >> vtx.x() >> vtx.y() >> vtx.z();
+      parsed.vertices.push_back(vtx);
+    } else if (tag == "f") {
+      std::vector<std::size_t> face;
+      for (std::size_t idx = 0; ls >> idx;) {
+        face.push_back(idx - 1);
+      }
+      parsed.faces.push_back(std::move(face));
+    } else if (tag == "l") {
+      std::size_t start = 0;
+      std::size_t end = 0;
+      ls >> start >> end;
+      parsed.lines.push_back({start - 1, end - 1});
+    }
+  }
+  return parsed;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(VisualizationSuite)
+
+BOOST_AUTO_TEST_CASE(GenericVisualization3DVertexLine) {
+  GenericVisualization3D helper;
+
+  helper.vertex({1., 2., 3.}, {10, 20, 30});
+  BOOST_REQUIRE_EQUAL(helper.vertices().size(), 1);
+  CHECK_CLOSE_ABS(helper.vertices()[0].position, Vector3(1., 2., 3.), 1e-9);
+  BOOST_CHECK_EQUAL(helper.vertices()[0].color, Color(10, 20, 30));
+  BOOST_CHECK(helper.faces().empty());
+  BOOST_CHECK(helper.lines().empty());
+
+  helper.line({0., 0., 1.}, {1., 0., 0.}, {40, 50, 60});
+  BOOST_REQUIRE_EQUAL(helper.lines().size(), 1);
+  CHECK_CLOSE_ABS(helper.lines()[0].a, Vector3(0., 0., 1.), 1e-9);
+  CHECK_CLOSE_ABS(helper.lines()[0].b, Vector3(1., 0., 0.), 1e-9);
+  BOOST_CHECK_EQUAL(helper.lines()[0].color, Color(40, 50, 60));
+  // The line end points are not appended to the vertex collection
+  BOOST_CHECK_EQUAL(helper.vertices().size(), 1);
+
+  helper.clear();
+  BOOST_CHECK(helper.vertices().empty());
+  BOOST_CHECK(helper.faces().empty());
+  BOOST_CHECK(helper.lines().empty());
+}
+
+BOOST_AUTO_TEST_CASE(GenericVisualization3DFaces) {
+  GenericVisualization3D helper;
+
+  // face() appends the corner points as vertices and one indexed face
+  const std::vector<Vector3> triangle = {
+      {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
+  helper.face(triangle, {10, 20, 30});
+  BOOST_REQUIRE_EQUAL(helper.vertices().size(), 3);
+  BOOST_REQUIRE_EQUAL(helper.faces().size(), 1);
+  BOOST_CHECK(helper.faces()[0].indices ==
+              (IVisualization3D::FaceType{0, 1, 2}));
+  BOOST_CHECK_EQUAL(helper.faces()[0].color, Color(10, 20, 30));
+  for (std::size_t i = 0; i < triangle.size(); ++i) {
+    CHECK_CLOSE_ABS(helper.vertices()[i].position, triangle[i], 1e-9);
+    BOOST_CHECK_EQUAL(helper.vertices()[i].color, Color(10, 20, 30));
+  }
+
+  // faces() with an empty face list behaves like face()
+  GenericVisualization3D viaFaces;
+  viaFaces.faces(triangle, {}, {10, 20, 30});
+  BOOST_CHECK_EQUAL(viaFaces.vertices().size(), helper.vertices().size());
+  BOOST_REQUIRE_EQUAL(viaFaces.faces().size(), helper.faces().size());
+  BOOST_CHECK(viaFaces.faces()[0].indices == helper.faces()[0].indices);
+
+  // faces() offsets the indices by the previously collected vertices,
+  // two-index faces are stored as lines from the referenced points
+  const std::vector<Vector3> quad = {
+      {0., 0., 0.}, {1., 0., 0.}, {1., 1., 0.}, {0., 1., 0.}};
+  helper.faces(quad, {{0, 1, 2, 3}, {0, 2}}, {40, 50, 60});
+  BOOST_REQUIRE_EQUAL(helper.vertices().size(), 7);
+  BOOST_REQUIRE_EQUAL(helper.faces().size(), 2);
+  BOOST_CHECK(helper.faces()[1].indices ==
+              (IVisualization3D::FaceType{3, 4, 5, 6}));
+  BOOST_CHECK_EQUAL(helper.faces()[1].color, Color(40, 50, 60));
+  BOOST_REQUIRE_EQUAL(helper.lines().size(), 1);
+  CHECK_CLOSE_ABS(helper.lines()[0].a, quad[0], 1e-9);
+  CHECK_CLOSE_ABS(helper.lines()[0].b, quad[2], 1e-9);
+}
+
+BOOST_AUTO_TEST_CASE(GenericVisualization3DConstruction) {
+  // Conformance to the IVisualization3D interface, cf.
+  // Visualization3DConstruction in Visualization3DTests.cpp
+  GenericVisualization3D generic;
+  IVisualization3D* vis = &generic;
+  vis->vertex({0., 0., 0.});
+  vis->line({0., 0., 0.}, {1., 0., 0.});
+
+  std::stringstream ss;
+  ss << *vis;
+  BOOST_CHECK_EQUAL(ss.str(),
+                    "GenericVisualization3D: 1 vertices, 0 faces, 1 lines\n");
+
+  vis->clear();
+  BOOST_CHECK(generic.vertices().empty());
+  BOOST_CHECK(generic.lines().empty());
+}
+
+/// Draw the same surfaces with ObjVisualization3D and GenericVisualization3D
+/// and check that the collected data matches the obj output element-for-element
+BOOST_AUTO_TEST_CASE(GenericVisualization3DAgainstObj) {
+  auto gctx = GeometryContext::dangerouslyDefaultConstruct();
+  auto identity = Transform3::Identity();
+
+  const double halfPhiSector = std::numbers::pi / 4.;
+
+  // The reference surfaces, same parameters as in SurfaceView3DBase.hpp
+  std::vector<std::shared_ptr<Surface>> surfaces;
+  surfaces.push_back(Surface::makeShared<PlaneSurface>(
+      identity, std::make_shared<RectangleBounds>(2., 3.)));
+  surfaces.push_back(Surface::makeShared<CylinderSurface>(
+      identity, std::make_shared<CylinderBounds>(5., 10.)));
+  surfaces.push_back(Surface::makeShared<ConeSurface>(
+      identity, std::make_shared<ConeBounds>(0.245, 0., 10., halfPhiSector)));
+
+  for (const auto& surface : surfaces) {
+    // High output precision for the text based comparison
+    ObjVisualization3D obj{10};
+    GenericVisualization3D generic;
+    GeometryView3D::drawSurface(obj, *surface, gctx, identity, s_viewSensitive);
+    GeometryView3D::drawSurface(generic, *surface, gctx, identity,
+                                s_viewSensitive);
+
+    std::stringstream objStream;
+    obj.write(objStream);
+    const ParsedObj parsed = parseObj(objStream.str());
+
+    BOOST_REQUIRE(!generic.vertices().empty());
+    BOOST_REQUIRE_EQUAL(generic.vertices().size(), parsed.vertices.size());
+    for (std::size_t i = 0; i < parsed.vertices.size(); ++i) {
+      CHECK_CLOSE_ABS(generic.vertices()[i].position, parsed.vertices[i], 1e-6);
+      BOOST_CHECK_EQUAL(generic.vertices()[i].color, s_viewSensitive.color);
+    }
+
+    BOOST_REQUIRE(!generic.faces().empty());
+    BOOST_REQUIRE_EQUAL(generic.faces().size(), parsed.faces.size());
+    for (std::size_t i = 0; i < parsed.faces.size(); ++i) {
+      BOOST_CHECK(generic.faces()[i].indices == parsed.faces[i]);
+      BOOST_CHECK_EQUAL(generic.faces()[i].color, s_viewSensitive.color);
+    }
+
+    // Lines reference obj vertices, compare the end points
+    BOOST_REQUIRE_EQUAL(generic.lines().size(), parsed.lines.size());
+    for (std::size_t i = 0; i < parsed.lines.size(); ++i) {
+      CHECK_CLOSE_ABS(generic.lines()[i].a,
+                      parsed.vertices[parsed.lines[i].first], 1e-6);
+      CHECK_CLOSE_ABS(generic.lines()[i].b,
+                      parsed.vertices[parsed.lines[i].second], 1e-6);
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsTests


### PR DESCRIPTION
Adds `GenericVisualization3D`, an `IVisualization3D` implementation that
collects vertices, faces and lines in memory instead of writing them to a
file, as a first step towards the centralized python displaying
infrastructure outlined in #5615. The collected data is exposed through
`vertices()` / `faces()` / `lines()` accessors so it can be handed to
external plotting backends.

Part of #5615 (step 1 of 3 in the workplan there — pybind11 bindings and
a matplotlib backend will follow in separate PRs to keep review manageable).

--- END COMMIT MESSAGE ---

### Approach
- `face()` / `faces()` mirror the semantics of `ObjVisualization3D` exactly
  (bulk vertex insert, two-index faces stored as lines, index offsets), so
  the in-memory data matches what the obj writer would produce for the same
  drawing calls.
- `line()` stores a self-contained point pair and does not append its end
  points to the vertex collection — appending them is an OBJ/PLY file-format
  artifact rather than intended semantics. Happy to change if you prefer
  strict Obj behavior.
- `write(ostream)` / `write(path)` emit a one-line debug summary, documented
  as "not a serialization format"; `object(name)` is a no-op like in
  `PlyVisualization3D`.
- No changes to `IVisualization3D` or any existing implementation.

### Testing
- Structural unit tests for every interface method.
- A cross-validation test draws the same surfaces (rectangle plane, full
  cylinder, sectoral cone — same parameters as the existing
  `SurfaceView3DBase` tests) with both `ObjVisualization3D` and
  `GenericVisualization3D` via `GeometryView3D::drawSurface`, parses the obj
  output, and checks the collected data element-for-element: vertex
  positions, face index lists, line endpoints, and colors.
- Full unit test suite: 261/261 locally.

### Open questions for reviewers
1. **Naming**: the issue calls the class `GenericVisualization`; I used the
   `3D` suffix for consistency with `ObjVisualization3D`/`PlyVisualization3D`.
   Happy to rename if you prefer.
2. **`faces()` accessor vs virtual overload**: the zero-argument `faces()`
   accessor overloads the three-argument virtual `IVisualization3D::faces()`.
   Can rename to `getVertices()` / `getFaces()` / `getLines()` if preferred.
3. **`line()` vertex injection**: flagging the choice above in case
   Obj-identical behavior is preferred.