### PR TITLE
feat: Use PointSurface for the 3D PCA in ImpactPointEstimator

### DIFF
--- a/Core/src/Vertexing/ImpactPointEstimator.cpp
+++ b/Core/src/Vertexing/ImpactPointEstimator.cpp
@@ -11,7 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Propagator/PropagatorOptions.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
-#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/PointSurface.hpp"
 #include "Acts/Utilities/AngleHelpers.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
@@ -48,13 +48,17 @@ Result<double> getVertexCompatibilityImpl(const GeometryContext& gctx,
   }
   SquareMatrix<nDim - 1> weight = subCovMat.inverse();
 
-  // Orientation of the surface (i.e., axes of the corresponding coordinate
-  // system)
-  RotationMatrix3 surfaceAxes =
-      trkParams->referenceSurface().localToGlobalTransform(gctx).rotation();
+  // Orientation of the surface (i.e., axes of the measurement frame in which
+  // the track's local coordinates are expressed). We use referenceFrame rather
+  // than the transform rotation because the PointSurface (used by
+  // estimate3DImpactParameters) has a direction-dependent measurement frame
+  // that is not stored in its transform. For direction-independent surfaces
+  // (e.g. PlaneSurface) referenceFrame returns the transform rotation, so this
+  // is behavior-preserving there.
+  RotationMatrix3 surfaceAxes = trkParams->referenceSurface().referenceFrame(
+      gctx, trkParams->position(gctx), trkParams->direction());
   // Origin of the surface coordinate system
-  Vector3 surfaceOrigin =
-      trkParams->referenceSurface().localToGlobalTransform(gctx).translation();
+  Vector3 surfaceOrigin = trkParams->referenceSurface().center(gctx);
 
   // x- and y-axis of the surface coordinate system
   Vector3 xAxis = surfaceAxes.col(0);
@@ -315,74 +319,43 @@ Result<double> ImpactPointEstimator::calculateDistance(
 Result<BoundTrackParameters> ImpactPointEstimator::estimate3DImpactParameters(
     const GeometryContext& gctx, const MagneticFieldContext& mctx,
     const BoundTrackParameters& trkParams, const Vector3& vtxPos,
-    State& state) const {
-  auto res = getDistanceAndMomentumImpl(gctx, trkParams, vtxPos, m_cfg, state,
-                                        *m_logger);
-
-  if (!res.ok()) {
-    return res.error();
-  }
-
-  // Vector pointing from vertex to 3D PCA
-  Vector3 deltaR = res.value().first.head<3>();
-
-  // Get corresponding unit vector
-  deltaR.normalize();
-
-  // Momentum direction at vtxPos
-  Vector3 momDir = res.value().second;
-
-  // To understand why deltaR and momDir are not orthogonal, let us look at the
-  // x-y-plane. Since we computed the 3D PCA, the 2D distance between the vertex
-  // and the PCA is not necessarily minimal (see Fig. 4.2 in the reference). As
-  // a consequence, the momentum and the vector connecting the vertex and the
-  // PCA are not orthogonal to each other.
-  Vector3 orthogonalDeltaR = deltaR - (deltaR.dot(momDir)) * momDir;
-
-  // Vector perpendicular to momDir and orthogonalDeltaR
-  Vector3 perpDir = momDir.cross(orthogonalDeltaR);
-
-  // Cartesian coordinate system with:
-  // -) origin at the vertex position
-  // -) z-axis in momentum direction
-  // -) x-axis approximately in direction of the 3D PCA (slight deviations
-  // because it was modified to make if orthogonal to momDir)
-  // -) y-axis is calculated to be orthogonal to x- and z-axis
-  // The transformation is represented by a 4x4 matrix with 0 0 0 1 in the last
-  // row.
-  Transform3 coordinateSystem;
-  // First three columns correspond to coordinate system axes
-  coordinateSystem.matrix().block<3, 1>(0, 0) = orthogonalDeltaR;
-  coordinateSystem.matrix().block<3, 1>(0, 1) = perpDir;
-  coordinateSystem.matrix().block<3, 1>(0, 2) = momDir;
-  // Fourth column corresponds to origin of the coordinate system
-  coordinateSystem.matrix().block<3, 1>(0, 3) = vtxPos;
-
-  // Surface with normal vector in direction of the z axis of coordinateSystem
-  std::shared_ptr<PlaneSurface> planeSurface =
-      Surface::makeShared<PlaneSurface>(coordinateSystem);
-
-  Intersection3D intersection =
-      planeSurface
-          ->intersect(gctx, trkParams.position(gctx), trkParams.direction(),
-                      BoundaryTolerance::Infinite())
-          .closest();
+    State& /*state*/) const {
+  // A PointSurface at the vertex represents the point of closest approach to
+  // the vertex: its measurement-plane normal always equals the local track
+  // momentum direction, so propagating the track onto it converges exactly to
+  // the 3D PCA (the point where the momentum is perpendicular to the
+  // vertex-to-track residual).
+  //
+  // This replaces the previous two-step approach, which estimated the 3D PCA
+  // analytically (Newton method for helical tracks) and then propagated to an
+  // approximate plane surface oriented along that estimate. That plane was a
+  // hand-built point surface with a fixed normal, and was only exact when the
+  // vertex-to-PCA vector happened to be orthogonal to the momentum. Propagating
+  // directly to a PointSurface removes that approximation.
+  std::shared_ptr<PointSurface> pointSurface =
+      Surface::makeShared<PointSurface>(vtxPos);
 
   // Create propagator options
   PropagatorPlainOptions pOptions(gctx, mctx);
+
+  // Use a straight-line intersection to decide the propagation direction
+  Intersection3D intersection =
+      pointSurface
+          ->intersect(gctx, trkParams.position(gctx), trkParams.direction(),
+                      BoundaryTolerance::Infinite())
+          .closest();
   pOptions.direction =
       Direction::fromScalarZeroAsPositive(intersection.pathLength());
 
-  // Propagate to the surface; intersection corresponds to an estimate of the 3D
-  // PCA. If deltaR and momDir were orthogonal the calculation would be exact.
+  // Propagate to the point surface; the resulting parameters are at the 3D PCA
   auto result =
-      m_cfg.propagator->propagateToSurface(trkParams, *planeSurface, pOptions);
+      m_cfg.propagator->propagateToSurface(trkParams, *pointSurface, pOptions);
   if (result.ok()) {
     return *result;
   } else {
     ACTS_ERROR("Error during propagation in estimate3DImpactParameters.");
     ACTS_DEBUG(
-        "The plane surface to which we tried to propagate has its origin at\n"
+        "The point surface to which we tried to propagate has its origin at\n"
         << vtxPos);
     return result.error();
   }

--- a/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
+++ b/Tests/UnitTests/Core/Vertexing/ImpactPointEstimatorTests.cpp
@@ -169,9 +169,14 @@ BOOST_DATA_TEST_CASE(SingleTrackDistanceParametersCompatibility3D, tracks, d0,
   const auto& atPerigee = myTrack.parameters();
   const auto& atIp3d = trackAtIP3d.parameters();
 
-  // all parameters except the helix invariants theta, q/p should be changed
-  BOOST_CHECK_NE(atPerigee[eBoundLoc0], atIp3d[eBoundLoc0]);
-  BOOST_CHECK_NE(atPerigee[eBoundLoc1], atIp3d[eBoundLoc1]);
+  // all parameters except the helix invariants theta, q/p should be changed.
+  // Exception: for a transverse track (theta = 90 deg) the 2D and 3D PCA
+  // coincide and the point surface measurement frame aligns with the perigee
+  // frame, so the local position is unchanged.
+  if (theta != 90_degree) {
+    BOOST_CHECK_NE(atPerigee[eBoundLoc0], atIp3d[eBoundLoc0]);
+    BOOST_CHECK_NE(atPerigee[eBoundLoc1], atIp3d[eBoundLoc1]);
+  }
   // BOOST_CHECK_NE(atPerigee[eBoundTime], atIp3d[eBoundTime]);
   // BOOST_CHECK_NE(atPerigee[eBoundPhi], atIp3d[eBoundPhi]);
   CHECK_CLOSE_ABS(atPerigee[eBoundTheta], atIp3d[eBoundTheta], 0.01_mrad);


### PR DESCRIPTION
`ImpactPointEstimator::estimate3DImpactParameters` now propagates directly to a `PointSurface` at the vertex. Its normal follows the local track momentum, so the propagator converges exactly to the 3D PCA. This replaces the analytic PCA estimate plus propagation to a fixed-normal plane, which was only exact when the vertex-to-PCA vector was orthogonal to the momentum.

`getVertexCompatibilityImpl` takes the measurement frame from `referenceFrame(gctx, pos, dir)` instead of the transform rotation, since the `PointSurface` frame is direction-dependent. Behavior is unchanged for direction-independent surfaces.

--- END COMMIT MESSAGE ---

Depends on #5671.

The `PerigeeSurface` uses producing the 2D parameters `(d0, z0)` are untouched — linearizers, Billoir residuals, lifetime signs and density finders all need the Perigee parametrization, which the Cartesian `PointSurface` does not provide.

All vertexing unit tests pass. One assertion is relaxed for transverse tracks (θ = 90°), where 2D and 3D PCA coincide and the local position is legitimately unchanged; the old plane differed only through its arbitrary in-plane frame choice.
