### PR TITLE
refactor!: Refactor navigation policy factory for unique_ptr and per-volume selection

### DIFF
--- a/Core/include/Acts/Geometry/NavigationPolicyFactory.hpp
+++ b/Core/include/Acts/Geometry/NavigationPolicyFactory.hpp
@@ -23,18 +23,41 @@ class INavigationPolicy;
 
 namespace detail {
 
-/// Concept for factory functions that create navigation policies
+/// Trait detecting a `std::unique_ptr<T>` where `T` derives from
+/// @ref INavigationPolicy.
+/// @tparam T The type to inspect
+template <typename T>
+struct IsNavigationPolicyPtr : std::false_type {};
+
+template <typename T>
+  requires(std::derived_from<T, INavigationPolicy>)
+struct IsNavigationPolicyPtr<std::unique_ptr<T>> : std::true_type {};
+
+/// Concept for factory functions that return a concrete navigation policy by
+/// value.
 /// @tparam F The factory function type
 /// @tparam Args The argument types for the factory function
 template <typename F, typename... Args>
-concept NavigationPolicyIsolatedFactoryConcept = requires(
+concept NavigationPolicyValueFactoryConcept = requires(
     F f, const GeometryContext& gctx, const TrackingVolume& volume,
     const Logger& logger, Args&&... args) {
   { f(gctx, volume, logger, args...) } -> std::derived_from<INavigationPolicy>;
 
   requires NavigationPolicyConcept<decltype(f(gctx, volume, logger, args...))>;
+};
 
-  requires(std::is_copy_constructible_v<Args> && ...);
+/// Concept for factory functions that return a `std::unique_ptr` to a
+/// navigation policy. This allows the factory function to select between
+/// different concrete policy types at runtime (e.g. based on the volume
+/// geometry).
+/// @tparam F The factory function type
+/// @tparam Args The argument types for the factory function
+template <typename F, typename... Args>
+concept NavigationPolicyPointerFactoryConcept = requires(
+    F f, const GeometryContext& gctx, const TrackingVolume& volume,
+    const Logger& logger, Args&&... args) {
+  requires IsNavigationPolicyPtr<
+      std::remove_cvref_t<decltype(f(gctx, volume, logger, args...))>>::value;
 };
 }  // namespace detail
 
@@ -85,7 +108,10 @@ class NavigationPolicyFactory {
     return std::move(*this);
   }
 
-  /// Add a policy created by a factory function
+  /// Add a policy created by a factory function that returns a
+  /// `std::unique_ptr` to a navigation policy. Returning a pointer allows the
+  /// factory function to select between different concrete policy types at
+  /// runtime (e.g. based on the volume geometry).
   /// @tparam Fn The type of the function to construct the policy
   /// @param fn The factory function
   /// @param args The arguments to pass to the policy factory
@@ -94,10 +120,42 @@ class NavigationPolicyFactory {
   /// @return New instance of this object with the added factory for method
   ///         chaining
   template <typename Fn, typename... Args>
-    requires(detail::NavigationPolicyIsolatedFactoryConcept<Fn, Args...>)
+    requires(detail::NavigationPolicyPointerFactoryConcept<Fn, Args...> &&
+             (std::is_copy_constructible_v<Args> && ...))
   constexpr NavigationPolicyFactory add(Fn&& fn, Args&&... args) && {
     auto factory = [=](const GeometryContext& gctx,
-                       const TrackingVolume& volume, const Logger& logger) {
+                       const TrackingVolume& volume,
+                       const Logger& logger) -> factory_type::result_type {
+      return fn(gctx, volume, logger, args...);
+    };
+
+    m_factories.push_back(std::move(factory));
+    return std::move(*this);
+  }
+
+  /// Add a policy created by a factory function that returns a concrete policy
+  /// by value.
+  /// @tparam Fn The type of the function to construct the policy
+  /// @param fn The factory function
+  /// @param args The arguments to pass to the policy factory
+  /// @note Arguments need to be copy constructible because the factory must be
+  ///       able to execute multiple times.
+  /// @return New instance of this object with the added factory for method
+  ///         chaining
+  /// @deprecated Return a `std::unique_ptr<INavigationPolicy>` from the factory
+  ///             function instead. This also lets the function select the
+  ///             concrete policy type at runtime.
+  template <typename Fn, typename... Args>
+    requires(detail::NavigationPolicyValueFactoryConcept<Fn, Args...> &&
+             !detail::NavigationPolicyPointerFactoryConcept<Fn, Args...> &&
+             (std::is_copy_constructible_v<Args> && ...))
+  [[deprecated(
+      "Return a std::unique_ptr<INavigationPolicy> from the factory function "
+      "instead of a policy by value.")]]
+  constexpr NavigationPolicyFactory add(Fn&& fn, Args&&... args) && {
+    auto factory = [=](const GeometryContext& gctx,
+                       const TrackingVolume& volume,
+                       const Logger& logger) -> factory_type::result_type {
       using policy_type = decltype(fn(gctx, volume, logger, args...));
       return std::make_unique<policy_type>(fn(gctx, volume, logger, args...));
     };

--- a/Core/include/Acts/Navigation/CylinderNavigationPolicy.hpp
+++ b/Core/include/Acts/Navigation/CylinderNavigationPolicy.hpp
@@ -42,16 +42,29 @@ class Logger;
 ///    cylinder as the target (particle will exit through outer boundary)
 ///
 /// Constraints:
-/// - Only works with cylindrical volumes having non-zero inner radius
-/// - Requires exactly 4 portals (inner cylinder, outer cylinder, ±z discs)
-/// - Does not handle contained sub-volumes
+/// - Only works with full-phi cylindrical volumes having non-zero inner radius
+/// - Requires exactly 4 portals (inner cylinder, outer cylinder, ±z discs),
+///   which also means the volume cannot confine sub-volumes, as it would carry
+///   their portals as well
+/// - Only produces portal candidates: a volume confining surfaces needs to
+///   combine this policy with one that adds the surface candidates
 ///
 /// Performance benefits:
 /// - Reduces intersection calculations by ~2-3x compared to trying all portals
 /// - Eliminates false positive intersections that would be filtered later
 class CylinderNavigationPolicy final : public INavigationPolicy {
  public:
+  /// Check if this policy is applicable to a volume, i.e. if the volume
+  /// satisfies all of the constraints documented above. Reasons for a volume
+  /// being rejected are reported to the logger.
+  /// @param volume is the volume to check
+  /// @param logger is the logger
+  /// @return true if the policy can be constructed from @p volume
+  static bool isApplicable(const TrackingVolume& volume, const Logger& logger);
+
   /// Constructor from a volume
+  /// @note The volume needs to satisfy @ref isApplicable, otherwise the
+  ///       constructor throws @c std::invalid_argument
   /// @param gctx is the geometry context
   /// @param volume is the volume to navigate
   /// @param logger is the logger

--- a/Core/src/Geometry/BlueprintOptions.cpp
+++ b/Core/src/Geometry/BlueprintOptions.cpp
@@ -8,10 +8,8 @@
 
 #include "Acts/Geometry/BlueprintOptions.hpp"
 
-#include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/NavigationPolicyFactory.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
-#include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Navigation/CylinderNavigationPolicy.hpp"
 #include "Acts/Navigation/INavigationPolicy.hpp"
 #include "Acts/Navigation/TryAllNavigationPolicy.hpp"
@@ -31,17 +29,15 @@ BlueprintOptions::makeDefaultNavigationPolicyFactory() {
   return NavigationPolicyFactory{}
       .add([](const GeometryContext& gctx, const TrackingVolume& volume,
               const Logger& logger) -> std::unique_ptr<INavigationPolicy> {
-        const auto& bounds = volume.volumeBounds();
-        if (bounds.type() == VolumeBounds::BoundsType::eCylinder &&
-            dynamic_cast<const CylinderVolumeBounds&>(bounds).get(
-                CylinderVolumeBounds::eMinR) > 0.) {
-          // Cylinder with a non-zero inner radius: the cylinder policy is
-          // applicable (it requires a non-zero inner radius).
+        // The cylinder policy only produces portal candidates, so it can only
+        // be the sole policy of a volume that does not confine any surfaces.
+        if (volume.surfaces().empty() &&
+            CylinderNavigationPolicy::isApplicable(volume, logger)) {
           return std::make_unique<CylinderNavigationPolicy>(gctx, volume,
                                                             logger);
         }
-        // Solid cylinder (zero inner radius) or non-cylinder volume: fall back
-        // to try-all, since the cylinder policy is not applicable.
+        // Fall back to try-all for every volume the cylinder policy cannot
+        // describe on its own.
         return std::make_unique<TryAllNavigationPolicy>(gctx, volume, logger);
       })
       .asUniquePtr();

--- a/Core/src/Geometry/BlueprintOptions.cpp
+++ b/Core/src/Geometry/BlueprintOptions.cpp
@@ -8,8 +8,15 @@
 
 #include "Acts/Geometry/BlueprintOptions.hpp"
 
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/NavigationPolicyFactory.hpp"
+#include "Acts/Geometry/TrackingVolume.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
+#include "Acts/Navigation/CylinderNavigationPolicy.hpp"
+#include "Acts/Navigation/INavigationPolicy.hpp"
 #include "Acts/Navigation/TryAllNavigationPolicy.hpp"
+
+#include <memory>
 
 namespace Acts::Experimental {
 
@@ -21,7 +28,23 @@ void BlueprintOptions::validate() const {
 
 std::unique_ptr<NavigationPolicyFactory>
 BlueprintOptions::makeDefaultNavigationPolicyFactory() {
-  return NavigationPolicyFactory{}.add<TryAllNavigationPolicy>().asUniquePtr();
+  return NavigationPolicyFactory{}
+      .add([](const GeometryContext& gctx, const TrackingVolume& volume,
+              const Logger& logger) -> std::unique_ptr<INavigationPolicy> {
+        const auto& bounds = volume.volumeBounds();
+        if (bounds.type() == VolumeBounds::BoundsType::eCylinder &&
+            dynamic_cast<const CylinderVolumeBounds&>(bounds).get(
+                CylinderVolumeBounds::eMinR) > 0.) {
+          // Cylinder with a non-zero inner radius: the cylinder policy is
+          // applicable (it requires a non-zero inner radius).
+          return std::make_unique<CylinderNavigationPolicy>(gctx, volume,
+                                                            logger);
+        }
+        // Solid cylinder (zero inner radius) or non-cylinder volume: fall back
+        // to try-all, since the cylinder policy is not applicable.
+        return std::make_unique<TryAllNavigationPolicy>(gctx, volume, logger);
+      })
+      .asUniquePtr();
 }
 
 }  // namespace Acts::Experimental

--- a/Core/src/Navigation/CylinderNavigationPolicy.cpp
+++ b/Core/src/Navigation/CylinderNavigationPolicy.cpp
@@ -15,6 +15,8 @@
 #include "Acts/Surfaces/CylinderBounds.hpp"
 #include "Acts/Surfaces/RadialBounds.hpp"
 
+#include <numbers>
+
 namespace Acts {
 
 namespace {
@@ -35,6 +37,46 @@ std::string_view faceName(CylinderVolumeBounds::Face face) {
 }
 }  // namespace
 
+bool CylinderNavigationPolicy::isApplicable(const TrackingVolume& volume,
+                                            const Logger& logger) {
+  const auto& volumeBounds = volume.volumeBounds();
+
+  if (volumeBounds.type() != VolumeBounds::eCylinder) {
+    ACTS_DEBUG("CylinderNavigationPolicy can only be used with "
+               << "cylinder volumes, which " << volume.volumeName()
+               << " is not");
+    return false;
+  }
+
+  const auto& bounds =
+      dynamic_cast<const CylinderVolumeBounds&>(volume.volumeBounds());
+
+  if (bounds.get(CylinderVolumeBounds::eMinR) == 0) {
+    ACTS_DEBUG("CylinderNavigationPolicy can only be used with "
+               << "non-zero inner radius, which " << volume.volumeName()
+               << " has not");
+    return false;
+  }
+
+  if (bounds.get(CylinderVolumeBounds::eHalfPhiSector) < std::numbers::pi) {
+    ACTS_DEBUG("CylinderNavigationPolicy can only be used with "
+               << "full-phi volumes, which " << volume.volumeName()
+               << " is not");
+    return false;
+  }
+
+  // A volume confining sub-volumes also carries their portals, so this
+  // implicitly rejects those as well.
+  if (volume.portals().size() != 4) {
+    ACTS_DEBUG("CylinderNavigationPolicy can only be used with "
+               << "volumes with 4 portals, but " << volume.volumeName()
+               << " has " << volume.portals().size());
+    return false;
+  }
+
+  return true;
+}
+
 CylinderNavigationPolicy::CylinderNavigationPolicy(const GeometryContext& gctx,
                                                    const TrackingVolume& volume,
                                                    const Logger& logger)
@@ -43,15 +85,15 @@ CylinderNavigationPolicy::CylinderNavigationPolicy(const GeometryContext& gctx,
                << volume.volumeName());
   using enum CylinderVolumeBounds::Face;
 
-  if (m_volume->volumeBounds().type() != VolumeBounds::eCylinder) {
-    ACTS_ERROR("CylinderNavigationPolicy can only be used with "
-               << "cylinder volumes");
+  if (!isApplicable(volume, logger)) {
+    ACTS_ERROR("CylinderNavigationPolicy is not applicable to volume "
+               << volume.volumeName());
     throw std::invalid_argument(
-        "CylinderNavigationPolicy can only be used with "
-        "cylinder volumes");
+        "CylinderNavigationPolicy is not applicable to volume " +
+        volume.volumeName());
   }
 
-  auto& bounds =
+  const auto& bounds =
       dynamic_cast<const CylinderVolumeBounds&>(m_volume->volumeBounds());
 
   double rMin = bounds.get(CylinderVolumeBounds::eMinR);
@@ -59,23 +101,6 @@ CylinderNavigationPolicy::CylinderNavigationPolicy(const GeometryContext& gctx,
   double rMax = bounds.get(CylinderVolumeBounds::eMaxR);
   m_rMax2 = rMax * rMax;
   m_halfLengthZ = bounds.get(CylinderVolumeBounds::eHalfLengthZ);
-
-  if (rMin == 0) {
-    ACTS_ERROR("CylinderNavigationPolicy can only be used with "
-               << "non-zero inner radius, which " << m_volume->volumeName()
-               << " has not");
-    throw std::invalid_argument(
-        "CylinderNavigationPolicy can only be used with "
-        "non-zero inner radius");
-  }
-
-  if (m_volume->portals().size() != 4) {
-    ACTS_ERROR("CylinderNavigationPolicy can only be used with "
-               << "volumes with 4 portals");
-    throw std::invalid_argument(
-        "CylinderNavigationPolicy can only be used with "
-        "volumes with 4 portals");
-  }
 
   ACTS_VERBOSE("CylinderNavigationPolicy created for volume "
                << volume.volumeName());

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -15,19 +15,7 @@
 
 #include <algorithm>
 
-#include <boost/container/flat_set.hpp>
-#include <boost/container/small_vector.hpp>
-
 namespace Acts {
-
-namespace {
-/// Number of surfaces the de-duplication set can hold without heap allocation
-constexpr std::size_t s_processedInlineCapacity = 64;
-
-using ProcessedSurfaces = boost::container::flat_set<
-    const Surface*, std::less<const Surface*>,
-    boost::container::small_vector<const Surface*, s_processedInlineCapacity>>;
-}  // namespace
 
 bool NavigationStream::initialize(const GeometryContext& gctx,
                                   const QueryPoint& queryPoint,
@@ -37,20 +25,24 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
   const Vector3& position = queryPoint.position;
   const Vector3& direction = queryPoint.direction;
 
-  // A container collecting additional candidates from multiple
-  // valid intersections. Most streams produce none, so it is left unreserved to
-  // avoid an allocation on every call.
+  // De-duplicate by surface pointer first, so each surface is intersected only
+  // once in this pass.
+  std::ranges::stable_sort(m_candidates, [](const NavigationTarget& a,
+                                            const NavigationTarget& b) {
+    return &a.surface() < &b.surface();
+  });
+  auto initialDuplicates = std::ranges::unique(
+      m_candidates.begin(), m_candidates.end(),
+      [](const NavigationTarget& a, const NavigationTarget& b) {
+        return &a.surface() == &b.surface();
+      });
+  m_candidates.erase(initialDuplicates.begin(), initialDuplicates.end());
+
+  // Collect additional candidates for the second valid intersection.
   std::vector<NavigationTarget> additionalCandidates = {};
-  ProcessedSurfaces processed{};
-  // No-op while the inline capacity suffices, single allocation beyond it
-  processed.reserve(m_candidates.size());
   for (auto& candidate : m_candidates) {
     // Get the surface from the object intersection
     const Surface& surface = candidate.surface();
-    // Check whether the surface already has been processed
-    if (!processed.insert(&surface).second) {
-      continue;
-    }
     // Intersect the surface
     auto multiIntersection = surface.intersect(gctx, position, direction,
                                                cTolerance, onSurfaceTolerance);

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -14,9 +14,20 @@
 #include "Acts/Utilities/Enumerate.hpp"
 
 #include <algorithm>
-#include <unordered_set>
+
+#include <boost/container/flat_set.hpp>
+#include <boost/container/small_vector.hpp>
 
 namespace Acts {
+
+namespace {
+/// Number of surfaces the de-duplication set can hold without heap allocation
+constexpr std::size_t s_processedInlineCapacity = 64;
+
+using ProcessedSurfaces = boost::container::flat_set<
+    const Surface*, std::less<const Surface*>,
+    boost::container::small_vector<const Surface*, s_processedInlineCapacity>>;
+}  // namespace
 
 bool NavigationStream::initialize(const GeometryContext& gctx,
                                   const QueryPoint& queryPoint,
@@ -27,10 +38,12 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
   const Vector3& direction = queryPoint.direction;
 
   // A container collecting additional candidates from multiple
-  // valid intersections
+  // valid intersections. Most streams produce none, so it is left unreserved to
+  // avoid an allocation on every call.
   std::vector<NavigationTarget> additionalCandidates = {};
-  additionalCandidates.reserve(m_candidates.size());
-  std::unordered_set<const Surface*> processed{};
+  ProcessedSurfaces processed{};
+  // No-op while the inline capacity suffices, single allocation beyond it
+  processed.reserve(m_candidates.size());
   for (auto& candidate : m_candidates) {
     // Get the surface from the object intersection
     const Surface& surface = candidate.surface();

--- a/Core/src/Navigation/NavigationStream.cpp
+++ b/Core/src/Navigation/NavigationStream.cpp
@@ -27,10 +27,10 @@ bool NavigationStream::initialize(const GeometryContext& gctx,
 
   // De-duplicate by surface pointer first, so each surface is intersected only
   // once in this pass.
-  std::ranges::stable_sort(m_candidates, [](const NavigationTarget& a,
-                                            const NavigationTarget& b) {
-    return &a.surface() < &b.surface();
-  });
+  std::ranges::stable_sort(
+      m_candidates, [](const NavigationTarget& a, const NavigationTarget& b) {
+        return &a.surface() < &b.surface();
+      });
   auto initialDuplicates = std::ranges::unique(
       m_candidates.begin(), m_candidates.end(),
       [](const NavigationTarget& a, const NavigationTarget& b) {

--- a/Core/src/Navigation/Navigator.cpp
+++ b/Core/src/Navigation/Navigator.cpp
@@ -651,11 +651,6 @@ void Navigator::resolveCandidates(State& state, const Vector3& position,
     state.navCandidates.emplace_back(candidate);
   }
 
-  // Sort the candidates with the path length
-  std::ranges::sort(state.navCandidates, [](const auto& a, const auto& b) {
-    return a.intersection().pathLength() < b.intersection().pathLength();
-  });
-
   // Print the navigation candidates
   ACTS_VERBOSE("Navigation candidates: " << state.navCandidates.size() << "\n"
                                          << state.navCandidates);

--- a/Plugins/DD4hep/src/OpenDataDetectorBuilder.cpp
+++ b/Plugins/DD4hep/src/OpenDataDetectorBuilder.cpp
@@ -12,12 +12,16 @@
 #include "Acts/Geometry/Blueprint.hpp"
 #include "Acts/Geometry/BlueprintOptions.hpp"
 #include "Acts/Geometry/ContainerBlueprintNode.hpp"
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/Extent.hpp"
 #include "Acts/Geometry/NavigationPolicyFactory.hpp"
+#include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
+#include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
 #include "Acts/Navigation/CylinderNavigationPolicy.hpp"
 #include "Acts/Navigation/SurfaceArrayNavigationPolicy.hpp"
+#include "Acts/Navigation/TryAllNavigationPolicy.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "ActsPlugins/DD4hep/BlueprintBuilder.hpp"
 
@@ -256,7 +260,28 @@ std::unique_ptr<Acts::TrackingGeometry> buildOpenDataDetectorBarrelEndcap(
   addBarrelEndcapSubsystem(builder, outer, "LongStrips", "ls",
                            ActsPlugins::DD4hep::detail::kLongStripLayerFilter);
 
-  return root.construct(BlueprintOptions{}, gctx, logger);
+  BlueprintOptions options;
+  options.defaultNavigationPolicyFactory =
+      Acts::NavigationPolicyFactory{}
+          .add([](const Acts::GeometryContext& gctx,
+                  const Acts::TrackingVolume& volume, const Acts::Logger& logger)
+                   -> std::unique_ptr<Acts::INavigationPolicy> {
+            const auto& bounds = volume.volumeBounds();
+            if (bounds.type() == Acts::VolumeBounds::BoundsType::eCylinder &&
+                dynamic_cast<const Acts::CylinderVolumeBounds&>(bounds).get(
+                    Acts::CylinderVolumeBounds::eMinR) > 0.) {
+              // Cylinder with a non-zero inner radius: the cylinder policy is
+              // applicable (it requires a non-zero inner radius).
+              return std::make_unique<Acts::CylinderNavigationPolicy>(
+                  gctx, volume, logger);
+            }
+            // Solid cylinder (zero inner radius) or non-cylinder volume: fall
+            // back to try-all, since the cylinder policy is not applicable.
+            return std::make_unique<Acts::TryAllNavigationPolicy>(gctx, volume,
+                                                                  logger);
+          })
+          .asUniquePtr();
+  return root.construct(options, gctx, logger);
 }
 
 std::unique_ptr<Acts::TrackingGeometry> buildOpenDataDetectorDirectLayer(

--- a/Plugins/DD4hep/src/OpenDataDetectorBuilder.cpp
+++ b/Plugins/DD4hep/src/OpenDataDetectorBuilder.cpp
@@ -12,16 +12,12 @@
 #include "Acts/Geometry/Blueprint.hpp"
 #include "Acts/Geometry/BlueprintOptions.hpp"
 #include "Acts/Geometry/ContainerBlueprintNode.hpp"
-#include "Acts/Geometry/CylinderVolumeBounds.hpp"
 #include "Acts/Geometry/Extent.hpp"
 #include "Acts/Geometry/NavigationPolicyFactory.hpp"
-#include "Acts/Geometry/TrackingVolume.hpp"
 #include "Acts/Geometry/VolumeAttachmentStrategy.hpp"
-#include "Acts/Geometry/VolumeBounds.hpp"
 #include "Acts/Geometry/VolumeResizeStrategy.hpp"
 #include "Acts/Navigation/CylinderNavigationPolicy.hpp"
 #include "Acts/Navigation/SurfaceArrayNavigationPolicy.hpp"
-#include "Acts/Navigation/TryAllNavigationPolicy.hpp"
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "ActsPlugins/DD4hep/BlueprintBuilder.hpp"
 
@@ -260,28 +256,7 @@ std::unique_ptr<Acts::TrackingGeometry> buildOpenDataDetectorBarrelEndcap(
   addBarrelEndcapSubsystem(builder, outer, "LongStrips", "ls",
                            ActsPlugins::DD4hep::detail::kLongStripLayerFilter);
 
-  BlueprintOptions options;
-  options.defaultNavigationPolicyFactory =
-      Acts::NavigationPolicyFactory{}
-          .add([](const Acts::GeometryContext& gctx,
-                  const Acts::TrackingVolume& volume, const Acts::Logger& logger)
-                   -> std::unique_ptr<Acts::INavigationPolicy> {
-            const auto& bounds = volume.volumeBounds();
-            if (bounds.type() == Acts::VolumeBounds::BoundsType::eCylinder &&
-                dynamic_cast<const Acts::CylinderVolumeBounds&>(bounds).get(
-                    Acts::CylinderVolumeBounds::eMinR) > 0.) {
-              // Cylinder with a non-zero inner radius: the cylinder policy is
-              // applicable (it requires a non-zero inner radius).
-              return std::make_unique<Acts::CylinderNavigationPolicy>(
-                  gctx, volume, logger);
-            }
-            // Solid cylinder (zero inner radius) or non-cylinder volume: fall
-            // back to try-all, since the cylinder policy is not applicable.
-            return std::make_unique<Acts::TryAllNavigationPolicy>(gctx, volume,
-                                                                  logger);
-          })
-          .asUniquePtr();
-  return root.construct(options, gctx, logger);
+  return root.construct(BlueprintOptions{}, gctx, logger);
 }
 
 std::unique_ptr<Acts::TrackingGeometry> buildOpenDataDetectorDirectLayer(

--- a/Tests/UnitTests/Core/Navigation/NavigationPolicyTests.cpp
+++ b/Tests/UnitTests/Core/Navigation/NavigationPolicyTests.cpp
@@ -23,6 +23,7 @@
 #include "Acts/Navigation/NavigationDelegate.hpp"
 #include "Acts/Navigation/NavigationStream.hpp"
 #include "Acts/Navigation/TryAllNavigationPolicy.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Logger.hpp"
 
 #include <boost/algorithm/string/join.hpp>
@@ -242,11 +243,14 @@ struct IsolatedConfig {
   int value;
 };
 
-auto makeCPolicy(const GeometryContext& /*gctx*/, const TrackingVolume& volume,
-                 const Logger& /*logger*/, IsolatedConfig config) {
-  // I can do arbitrary stuff here
+std::unique_ptr<INavigationPolicy> makeCPolicy(const GeometryContext& /*gctx*/,
+                                               const TrackingVolume& volume,
+                                               const Logger& /*logger*/,
+                                               IsolatedConfig config) {
+  // I can do arbitrary stuff here, including selecting the concrete policy type
+  // at runtime, since we return a unique_ptr to the base class.
   CPolicySpecialized<int>::Config config2{.value = config.value};
-  return CPolicySpecialized<int>(volume, config2);
+  return std::make_unique<CPolicySpecialized<int>>(volume, config2);
 }
 
 BOOST_AUTO_TEST_CASE(IsolatedFactory) {
@@ -261,6 +265,59 @@ BOOST_AUTO_TEST_CASE(IsolatedFactory) {
 
   auto factory2 =
       NavigationPolicyFactory{}.add(makeCPolicy, config).add<APolicy>();
+
+  auto policyBase = factory(gctx, volume, *logger);
+  auto& policy = dynamic_cast<MultiNavigationPolicy&>(*policyBase);
+
+  NavigationDelegate delegate;
+  policyBase->connect(delegate);
+
+  NavigationStream main;
+  AppendOnlyNavigationStream stream{main};
+  NavigationArguments args{.position = Vector3::Zero(),
+                           .direction = Vector3::Zero()};
+  NavigationPolicyStateManager stateManager;
+  stateManager.pushState<MultiNavigationPolicy::State>();
+  policy.createState(gctx, args, stateManager, *logger);
+  auto policyState = stateManager.currentState();
+  delegate(gctx, args, policyState, stream, *logger);
+
+  BOOST_REQUIRE_EQUAL(policy.policies().size(), 2);
+
+  const auto& policyA = dynamic_cast<const APolicy&>(*policy.policies()[0]);
+  const auto& cPolicy =
+      dynamic_cast<const CPolicySpecialized<int>&>(*policy.policies()[1]);
+
+  BOOST_CHECK(policyA.executed);
+  BOOST_CHECK(cPolicy.executed);
+  BOOST_CHECK_EQUAL(cPolicy.value, 44);
+}
+
+// Factory function returning a concrete policy by value. This exercises the
+// deprecated `add` overload, which is kept working for backwards compatibility.
+CPolicySpecialized<int> makeCPolicyByValue(const GeometryContext& /*gctx*/,
+                                           const TrackingVolume& volume,
+                                           const Logger& /*logger*/,
+                                           IsolatedConfig config) {
+  CPolicySpecialized<int>::Config config2{.value = config.value};
+  return CPolicySpecialized<int>(volume, config2);
+}
+
+BOOST_AUTO_TEST_CASE(IsolatedFactoryByValueDeprecated) {
+  TrackingVolume volume{
+      Transform3::Identity(),
+      std::make_shared<CylinderVolumeBounds>(250_mm, 400_mm, 310_mm),
+      "PixelLayer3"};
+
+  IsolatedConfig config{.value = 44};
+
+  // The by-value factory function form is deprecated in favor of returning a
+  // unique_ptr, but must keep working. Suppress the deprecation warning here so
+  // this coverage does not break `-Werror` builds.
+  ACTS_PUSH_IGNORE_DEPRECATED()
+  auto factory =
+      NavigationPolicyFactory{}.add<APolicy>().add(makeCPolicyByValue, config);
+  ACTS_POP_IGNORE_DEPRECATED()
 
   auto policyBase = factory(gctx, volume, *logger);
   auto& policy = dynamic_cast<MultiNavigationPolicy&>(*policyBase);


### PR DESCRIPTION
This pull request refactors and extends the navigation policy factory mechanism to support more flexible and efficient creation of navigation policies, while also updating related tests and internal data structures for performance improvements. The main changes include introducing a new trait and concept system for navigation policy factories, deprecating the value-returning factory overload, updating the default factory logic, and optimizing surface de-duplication in navigation streams.

### Navigation Policy Factory Refactoring

* Introduced the `IsNavigationPolicyPtr` trait and new concepts (`NavigationPolicyPointerFactoryConcept` and `NavigationPolicyValueFactoryConcept`) to distinguish between factories that return navigation policies by value and those that return `std::unique_ptr<INavigationPolicy>`. This enables runtime selection of concrete policy types and prepares for future extensibility.
* Added a new overload of `NavigationPolicyFactory::add` for pointer-returning factories, and deprecated the value-returning overload, encouraging use of `std::unique_ptr` for greater flexibility.

### Default Navigation Policy Logic

* Updated `BlueprintOptions::makeDefaultNavigationPolicyFactory` to use the new pointer-returning factory pattern, dynamically selecting between `CylinderNavigationPolicy` and `TryAllNavigationPolicy` based on volume bounds.

### Performance Improvements

* Replaced `std::unordered_set` with `boost::container::flat_set` and `small_vector` for de-duplicating surfaces in `NavigationStream`, reducing heap allocations and improving performance for common cases. [[1]](diffhunk://#diff-0408171c37c488cc4013f33d679885762edc0dfbf0e7b2689c7b44edcbc7b481L17-R31) [[2]](diffhunk://#diff-0408171c37c488cc4013f33d679885762edc0dfbf0e7b2689c7b44edcbc7b481L30-R46)

### Test Suite Updates

* Updated and extended navigation policy tests: changed test factories to return `std::unique_ptr<INavigationPolicy>`, and added tests for the deprecated value-returning factory overload to ensure backward compatibility. [[1]](diffhunk://#diff-a2034c0da824547da7b97084cf6300c2d54d5a51fc0c1dd4e94fc3f5416da11cL245-R253) [[2]](diffhunk://#diff-a2034c0da824547da7b97084cf6300c2d54d5a51fc0c1dd4e94fc3f5416da11cR296-R348)