### PR TITLE
feat: add spherical (phi, eta, r) grid seeding algorithm

### DIFF
--- a/Core/include/Acts/Seeding/SphericalSpacePointGrid.hpp
+++ b/Core/include/Acts/Seeding/SphericalSpacePointGrid.hpp
@@ -1,0 +1,208 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/EventData/SpacePointContainer.hpp"
+#include "Acts/Seeding/BinnedGroup.hpp"
+#include "Acts/Utilities/Grid.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/RangeXD.hpp"
+
+#include <numbers>
+#include <vector>
+
+namespace Acts {
+
+/// A spherical space point grid used for seeding in a cylindrical detector
+/// geometry.
+/// The grid is defined in spherical coordinates (phi, eta, r)
+class SphericalSpacePointGrid {
+ public:
+  /// Space point index type used in the grid.
+  using SpacePointIndex = std::uint32_t;
+  /// Type alias for bin container holding space point indices
+  using BinType = std::vector<SpacePointIndex>;
+  /// Type alias for phi axis with equidistant binning and closed boundaries
+  using PhiAxisType = Axis<AxisType::Equidistant, AxisBoundaryType::Closed>;
+  /// Type alias for the eta axis with variable binning and open boundaries. The
+  /// stored edges are cot(theta) = sinh(eta), so space points bin by z / r.
+  using EtaAxisType = Axis<AxisType::Variable, AxisBoundaryType::Open>;
+  /// Type alias for r axis with variable binning and open boundaries
+  using RAxisType = Axis<AxisType::Variable, AxisBoundaryType::Open>;
+  /// Spherical space point grid type (phi, eta, r)
+  using GridType = Grid<BinType, PhiAxisType, EtaAxisType, RAxisType>;
+  /// Type alias for binned group over the spherical grid
+  using BinnedGroupType = BinnedGroup<GridType>;
+
+  /// Configuration parameters for the spherical space point grid.
+  struct Config {
+    /// minimum pT
+    float minPt = 0 * UnitConstants::MeV;
+    /// minimum extension of sensitive detector layer relevant for seeding as
+    /// distance from x=y=0 (i.e. in r)
+    float rMin = 0 * UnitConstants::mm;
+    /// maximum extension of sensitive detector layer relevant for seeding as
+    /// distance from x=y=0 (i.e. in r)
+    float rMax = 600 * UnitConstants::mm;
+    /// minimum pseudorapidity relevant for seeding
+    float etaMin = -4;
+    /// maximum pseudorapidity relevant for seeding
+    float etaMax = 4;
+    /// maximum distance in r from middle space point to bottom or top
+    /// space point
+    float deltaRMax = 270 * UnitConstants::mm;
+    /// maximum forward direction expressed as cot(theta)
+    float cotThetaMax = 10.01788;  // equivalent to eta = 3 (pseudorapidity)
+    /// maximum impact parameter in mm
+    float impactMax = 0 * UnitConstants::mm;
+    /// minimum phi value for phiAxis construction
+    float phiMin = -std::numbers::pi_v<float>;
+    /// maximum phi value for phiAxis construction
+    float phiMax = std::numbers::pi_v<float>;
+    /// Multiplicator for the number of phi-bins. The minimum number of phi-bins
+    /// depends on min_pt, magnetic field: 2*pi/(minPT particle phi-deflection).
+    /// phiBinDeflectionCoverage is a multiplier for this number. If
+    /// numPhiNeighbors (in the configuration of the BinFinders) is configured
+    /// to return 1 neighbor on either side of the current phi-bin (and you want
+    /// to cover the full phi-range of minPT), leave this at 1.
+    int phiBinDeflectionCoverage = 1;
+    /// maximum number of phi bins
+    int maxPhiBins = 10000;
+    /// width of the equidistant eta bins used when `etaBinEdges` is empty
+    float deltaEtaMax = 0.8;
+    /// enable non equidistant binning in eta (edges given in pseudorapidity;
+    /// mapped to cot(theta) = sinh(eta) internally)
+    std::vector<float> etaBinEdges{};
+    /// enable non equidistant binning in r
+    std::vector<float> rBinEdges{};
+
+    /// magnetic field
+    float bFieldInZ = 0 * UnitConstants::T;
+
+    /// bin finder for bottom space points
+    std::optional<GridBinFinder<3ul>> bottomBinFinder;
+    /// bin finder for top space points
+    std::optional<GridBinFinder<3ul>> topBinFinder;
+    /// navigation structure for the grid
+    std::array<std::vector<std::size_t>, 3ul> navigation;
+  };
+
+  /// Construct a spherical space point grid with the given configuration and
+  /// an optional logger.
+  /// @param config Configuration for the spherical grid
+  /// @param logger Optional logger instance for debugging output
+  explicit SphericalSpacePointGrid(
+      const Config& config,
+      std::unique_ptr<const Logger> logger =
+          getDefaultLogger("SphericalSpacePointGrid", Logging::Level::INFO));
+
+  /// Clear the grid and drop all state. The object will behave like a newly
+  /// constructed one.
+  void clear();
+
+  /// Get the bin index for a space point given its azimuthal angle, polar
+  /// coordinate cot(theta), and radial distance.
+  /// @param position The position of the space point in (phi, cotTheta, r)
+  /// coordinates
+  /// @return The index of the bin in which the space point is located, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> binIndex(const Vector3& position) const {
+    if (!grid().isInside(position)) {
+      return std::nullopt;
+    }
+    return grid().globalBinFromPosition(position);
+  }
+  /// Get the bin index for a space point.
+  /// @param phi The azimuthal angle of the space point in radians
+  /// @param cotTheta The polar coordinate cot(theta) = z / r of the space point
+  /// @param r The radial distance of the space point from the origin
+  /// @return The index of the bin in which the space point is located, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> binIndex(float phi, float cotTheta, float r) const {
+    return binIndex(Vector3(phi, cotTheta, r));
+  }
+
+  /// Insert a space point into the grid.
+  /// @param index The index of the space point to insert
+  /// @param phi The azimuthal angle of the space point in radians
+  /// @param cotTheta The polar coordinate cot(theta) = z / r of the space point
+  /// @param r The radial distance of the space point from the origin
+  /// @return The index of the bin in which the space point was inserted, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> insert(SpacePointIndex index, float phi,
+                                    float cotTheta, float r);
+  /// Insert a space point into the grid. The polar coordinate is computed as
+  /// cot(theta) = z / r (a single division).
+  /// @param sp The space point to insert
+  /// @return The index of the bin in which the space point was inserted, or
+  ///         `std::nullopt` if the space point is outside the grid bounds.
+  std::optional<std::size_t> insert(const ConstSpacePointProxy& sp) {
+    return insert(sp.index(), sp.phi(), sp.z() / sp.r(), sp.r());
+  }
+
+  /// Fill the grid with space points from the container.
+  /// @param spacePoints The space point container to fill the grid with
+  void extend(const SpacePointContainer::ConstRange& spacePoints);
+
+  /// Sort the bins in the grid by the space point radius, which is required by
+  /// some algorithms that operate on the grid.
+  /// @param spacePoints The space point container to sort the bins by radius
+  void sortBinsByR(const SpacePointContainer& spacePoints);
+
+  /// Compute the range of radii in the grid. This requires the grid to be
+  /// filled with space points and sorted by radius. The sorting can be done
+  /// with the `sortBinsByR` method.
+  /// @param spacePoints The space point container to compute the radius range
+  /// @return The range of radii in the grid
+  Range1D<float> computeRadiusRange(
+      const SpacePointContainer& spacePoints) const;
+
+  /// Mutable bin access by index.
+  /// @param index The index of the bin to access
+  /// @return Mutable reference to the bin at the specified index
+  BinType& at(std::size_t index) { return grid().at(index); }
+  /// Const bin access by index.
+  /// @param index The index of the bin to access
+  /// @return Const reference to the bin at the specified index
+  const BinType& at(std::size_t index) const { return grid().at(index); }
+
+  /// Mutable grid access.
+  /// @return Mutable reference to the grid
+  GridType& grid() { return *m_grid; }
+  /// Const grid access.
+  /// @return Const reference to the grid
+  const GridType& grid() const { return *m_grid; }
+
+  /// Access to the binned group.
+  /// @return Reference to the binned group
+  const BinnedGroupType& binnedGroup() const { return *m_binnedGroup; }
+
+  /// Get the number of space points in the grid.
+  /// @return The number of space points in the grid
+  std::size_t numberOfSpacePoints() const { return m_counter; }
+
+  /// Get the number of bins in the grid.
+  /// @return The number of bins in the grid
+  std::size_t numberOfBins() const { return grid().size(); }
+
+ private:
+  Config m_cfg;
+
+  std::unique_ptr<const Logger> m_logger;
+
+  GridType* m_grid{};
+  std::optional<BinnedGroupType> m_binnedGroup;
+
+  std::size_t m_counter{};
+
+  const Logger& logger() const { return *m_logger; }
+};
+
+}  // namespace Acts

--- a/Core/src/Seeding/CMakeLists.txt
+++ b/Core/src/Seeding/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(
         detail/CandidatesForMiddleSp.cpp
         BroadTripletSeedFilter.cpp
         CylindricalSpacePointGrid.cpp
+        SphericalSpacePointGrid.cpp
         CartesianSpacePointGrid.cpp
         CylindricalSpacePointKDTree.cpp
         DoubletSeedFinder.cpp

--- a/Core/src/Seeding/SphericalSpacePointGrid.cpp
+++ b/Core/src/Seeding/SphericalSpacePointGrid.cpp
@@ -1,0 +1,224 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Seeding/SphericalSpacePointGrid.hpp"
+
+#include "Acts/Utilities/MathHelpers.hpp"
+
+#include <cmath>
+
+namespace Acts {
+
+SphericalSpacePointGrid::SphericalSpacePointGrid(
+    const Config& config, std::unique_ptr<const Logger> _logger)
+    : m_cfg(config), m_logger(std::move(_logger)) {
+  if (m_cfg.phiMin < -std::numbers::pi_v<float> ||
+      m_cfg.phiMax > std::numbers::pi_v<float>) {
+    throw std::runtime_error(
+        "SphericalSpacePointGrid: phiMin (" + std::to_string(m_cfg.phiMin) +
+        ") and/or phiMax (" + std::to_string(m_cfg.phiMax) +
+        ") are outside the allowed phi range, defined as "
+        "[-std::numbers::pi_v<float>, std::numbers::pi_v<float>]");
+  }
+  if (m_cfg.phiMin > m_cfg.phiMax) {
+    throw std::runtime_error(
+        "SphericalSpacePointGrid: phiMin is bigger then phiMax");
+  }
+  if (m_cfg.rMin > m_cfg.rMax) {
+    throw std::runtime_error(
+        "SphericalSpacePointGrid: rMin is bigger then rMax");
+  }
+  if (m_cfg.etaMin > m_cfg.etaMax) {
+    throw std::runtime_error(
+        "SphericalSpacePointGrid: etaMin is bigger than etaMax");
+  }
+
+  int phiBins = 0;
+  if (m_cfg.bFieldInZ == 0) {
+    // for no magnetic field, use the maximum number of phi bins
+    phiBins = m_cfg.maxPhiBins;
+    ACTS_VERBOSE(
+        "B-Field is 0 (z-coordinate), setting the number of bins in phi to "
+        << phiBins);
+  } else {
+    // calculate circle intersections of helix and max detector radius in mm.
+    // bFieldInZ is in (pT/radius) natively, no need for conversion
+    const float minHelixRadius = m_cfg.minPt / m_cfg.bFieldInZ;
+
+    // sanity check: if yOuter takes the square root of a negative number
+    if (minHelixRadius < m_cfg.rMax * 0.5) {
+      throw std::domain_error(
+          "The value of minHelixRadius cannot be smaller than rMax / 2. Please "
+          "check the m_cfguration of bFieldInZ and minPt");
+    }
+
+    // x = rMax^2 / (2 * minHelixRadius)
+    // y = cathetus(rMax, x)
+    // R / x = 2 * minHelixRadius / R
+    // outerAngle = x / y = x / sqrt(rMax^2 - x^2) = 1 / cath(rMax / x, 1)
+    //            = 1 / cath(2 * minHelixRadius / rMax, 1)
+    const float outerAngle =
+        std::atan(1.f / fastCathetus(2 * minHelixRadius / m_cfg.rMax, 1));
+    // intersection of helix and max detector radius minus maximum R distance
+    // from middle SP to top SP
+    float innerAngle = 0;
+    float rMin = m_cfg.rMax;
+    if (m_cfg.rMax > m_cfg.deltaRMax) {
+      const float innerCircleR = m_cfg.rMax - m_cfg.deltaRMax;
+      rMin = innerCircleR;
+      innerAngle =
+          std::atan(1.f / fastCathetus(2 * minHelixRadius / innerCircleR, 1));
+    }
+
+    // evaluating the azimutal deflection including the maximum impact parameter
+    const float deltaAngleWithMaxD0 =
+        std::abs(std::asin(m_cfg.impactMax / rMin) -
+                 std::asin(m_cfg.impactMax / m_cfg.rMax));
+
+    // evaluating delta Phi based on the inner and outer angle, and the azimutal
+    // deflection including the maximum impact parameter
+    // Divide by m_cfg.phiBinDeflectionCoverage since we combine
+    // m_cfg.phiBinDeflectionCoverage number of consecutive phi bins in the
+    // seed making step. So each individual bin should cover
+    // 1/m_cfg.phiBinDeflectionCoverage of the maximum expected azimutal
+    // deflection
+    const float deltaPhi = (outerAngle - innerAngle + deltaAngleWithMaxD0) /
+                           m_cfg.phiBinDeflectionCoverage;
+
+    // sanity check: if the delta phi is equal to or less than zero, we'll be
+    // creating an infinite or a negative number of bins, which would be bad!
+    if (deltaPhi <= 0.f) {
+      throw std::domain_error(
+          "Delta phi value is equal to or less than zero, leading to an "
+          "impossible number of bins (negative or infinite)");
+    }
+
+    // divide 2pi by angle delta to get number of phi-bins
+    // size is always 2pi even for regions of interest
+    phiBins = static_cast<int>(std::ceil(2 * std::numbers::pi / deltaPhi));
+    // need to scale the number of phi bins accordingly to the number of
+    // consecutive phi bins in the seed making step.
+    // Each individual bin should be approximately a fraction (depending on this
+    // number) of the maximum expected azimutal deflection.
+
+    // set protection for large number of bins, by default it is large
+    phiBins = std::min(phiBins, m_cfg.maxPhiBins);
+  }
+
+  PhiAxisType phiAxis(AxisClosed, m_cfg.phiMin, m_cfg.phiMax, phiBins);
+
+  // vector that will store the edges of the eta bins. The edges are stored as
+  // cot(theta) = sinh(eta), which is strictly monotone in eta, so a space point
+  // bins by z / r into exactly the eta bin it belongs to.
+  std::vector<double> etaValues;
+
+  // If etaBinEdges is not defined, calculate equidistant eta edges.
+  if (m_cfg.etaBinEdges.empty()) {
+    const float etaBinSize = m_cfg.deltaEtaMax;
+    const float etaBins =
+        std::max(1.f, std::floor((m_cfg.etaMax - m_cfg.etaMin) / etaBinSize));
+
+    etaValues.reserve(static_cast<int>(etaBins) + 1);
+    for (int bin = 0; bin <= static_cast<int>(etaBins); bin++) {
+      const double eta =
+          m_cfg.etaMin + bin * ((m_cfg.etaMax - m_cfg.etaMin) / etaBins);
+      etaValues.push_back(std::sinh(eta));
+    }
+  } else {
+    // Use the etaBinEdges defined in the m_cfg, mapped to cot(theta).
+    etaValues.reserve(m_cfg.etaBinEdges.size());
+    for (float eta : m_cfg.etaBinEdges) {
+      etaValues.push_back(std::sinh(eta));
+    }
+  }
+
+  std::vector<double> rValues;
+  rValues.reserve(std::max(2ul, m_cfg.rBinEdges.size()));
+  if (m_cfg.rBinEdges.empty()) {
+    rValues = {m_cfg.rMin, m_cfg.rMax};
+  } else {
+    rValues.insert(rValues.end(), m_cfg.rBinEdges.begin(),
+                   m_cfg.rBinEdges.end());
+  }
+
+  EtaAxisType etaAxis(AxisOpen, std::move(etaValues));
+  RAxisType rAxis(AxisOpen, std::move(rValues));
+
+  ACTS_VERBOSE("Defining Grid:");
+  ACTS_VERBOSE("- Phi Axis: " << phiAxis);
+  ACTS_VERBOSE("- Eta axis (cot(theta) edges): " << etaAxis);
+  ACTS_VERBOSE("- R axis  : " << rAxis);
+
+  GridType grid(
+      std::make_tuple(std::move(phiAxis), std::move(etaAxis), std::move(rAxis)));
+  m_binnedGroup.emplace(std::move(grid), m_cfg.bottomBinFinder.value(),
+                        m_cfg.topBinFinder.value(), m_cfg.navigation);
+  m_grid = &m_binnedGroup->grid();
+}
+
+void SphericalSpacePointGrid::clear() {
+  for (std::size_t i = 0; i < grid().size(); ++i) {
+    BinType& bin = grid().at(i);
+    bin.clear();
+  }
+  m_counter = 0;
+}
+
+std::optional<std::size_t> SphericalSpacePointGrid::insert(
+    SpacePointIndex index, float phi, float cotTheta, float r) {
+  const std::optional<std::size_t> gridIndex = binIndex(phi, cotTheta, r);
+  if (gridIndex.has_value()) {
+    BinType& bin = grid().at(*gridIndex);
+    bin.push_back(index);
+    ++m_counter;
+  }
+  return gridIndex;
+}
+
+void SphericalSpacePointGrid::extend(
+    const SpacePointContainer::ConstRange& spacePoints) {
+  ACTS_VERBOSE("Inserting " << spacePoints.size()
+                            << " space points to the grid");
+
+  for (const ConstSpacePointProxy& sp : spacePoints) {
+    insert(sp);
+  }
+}
+
+void SphericalSpacePointGrid::sortBinsByR(
+    const SpacePointContainer& spacePoints) {
+  ACTS_VERBOSE("Sorting the grid");
+
+  for (std::size_t i = 0; i < grid().size(); ++i) {
+    BinType& bin = grid().at(i);
+    std::ranges::sort(bin, {}, [&](SpacePointIndex spIndex) {
+      return spacePoints[spIndex].zr()[1];
+    });
+  }
+
+  ACTS_VERBOSE(
+      "Number of space points inserted (within grid range): " << m_counter);
+}
+
+Range1D<float> SphericalSpacePointGrid::computeRadiusRange(
+    const SpacePointContainer& spacePoints) const {
+  float minRange = std::numeric_limits<float>::max();
+  float maxRange = std::numeric_limits<float>::lowest();
+  for (const BinType& bin : grid()) {
+    if (bin.empty()) {
+      continue;
+    }
+    auto first = spacePoints[bin.front()];
+    auto last = spacePoints[bin.back()];
+    minRange = std::min(first.zr()[1], minRange);
+    maxRange = std::max(last.zr()[1], maxRange);
+  }
+  return {minRange, maxRange};
+}
+
+}  // namespace Acts

--- a/Examples/Algorithms/TrackFinding/CMakeLists.txt
+++ b/Examples/Algorithms/TrackFinding/CMakeLists.txt
@@ -11,6 +11,7 @@ acts_add_library(
     src/GraphBasedSeedingAlgorithm.cpp
     src/TrackParamsLookupEstimation.cpp
     src/GridTripletSeedingAlgorithm.cpp
+    src/SphericalGridTripletSeedingAlgorithm.cpp
     src/OrthogonalTripletSeedingAlgorithm.cpp
 )
 

--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SphericalGridTripletSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/SphericalGridTripletSeedingAlgorithm.hpp
@@ -1,0 +1,278 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Seeding/BroadTripletSeedFilter.hpp"
+#include "Acts/Seeding/SeedConfirmationRangeConfig.hpp"
+#include "Acts/Seeding/SphericalSpacePointGrid.hpp"
+#include "Acts/Seeding/TripletSeeder.hpp"
+#include "Acts/Utilities/GridBinFinder.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/Seed.hpp"
+#include "ActsExamples/EventData/SpacePoint.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
+#include "ActsExamples/Framework/IAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ActsExamples {
+
+/// Construct track seeds from space points using a spherical (phi, eta, R)
+/// grid. Identical to GridTripletSeedingAlgorithm except that the space-point
+/// grid bins on pseudorapidity (via cot(theta) = z / r) instead of z
+class SphericalGridTripletSeedingAlgorithm final : public IAlgorithm {
+ public:
+  struct Config {
+    /// Input space point collections.
+    std::string inputSpacePoints;
+    /// Output track seed collection.
+    std::string outputSeeds;
+
+    // General seeding parameters
+
+    /// Magnetic field in z direction
+    float bFieldInZ = 2 * Acts::UnitConstants::T;
+    /// minimum pT
+    float minPt = 0.4 * Acts::UnitConstants::GeV;
+    /// maximum forward direction expressed as cot(theta)
+    float cotThetaMax = 10.01788;  // equivalent to eta = 3 (pseudorapidity)
+    /// maximum impact parameter in mm
+    float impactMax = 20 * Acts::UnitConstants::mm;
+    /// Minimum radial distance between two doublet components (prefer
+    /// deltaRMinTop and deltaRMinBottom to set separate values for top and
+    /// bottom space points)
+    float deltaRMin = 5 * Acts::UnitConstants::mm;
+    /// Maximum radial distance between two doublet components (prefer
+    /// deltaRMaxTop and deltaRMacBottom to set separate values for top and
+    /// bottom space points)
+    float deltaRMax = 270 * Acts::UnitConstants::mm;
+    /// Minimum radial distance between middle-top doublet components
+    float deltaRMinTop = std::numeric_limits<float>::quiet_NaN();
+    /// Maximum radial distance between middle-outer doublet components
+    float deltaRMaxTop = std::numeric_limits<float>::quiet_NaN();
+    /// Minimum radial distance between bottom-middle doublet components
+    float deltaRMinBottom = std::numeric_limits<float>::quiet_NaN();
+    /// Maximum radial distance between bottom-middle doublet components
+    float deltaRMaxBottom = std::numeric_limits<float>::quiet_NaN();
+
+    // Seeding parameters used in the space-point grid creation and bin finding
+
+    /// minimum extension of sensitive detector layer relevant for seeding as
+    /// distance from x=y=0 (i.e. in r)
+    /// WARNING: if rMin is smaller than impactMax, the bin size will be 2*pi,
+    /// which will make seeding very slow!
+    float rMin = 0 * Acts::UnitConstants::mm;
+    /// maximum extension of sensitive detector layer relevant for seeding as
+    /// distance from x=y=0 (i.e. in r)
+    float rMax = 600 * Acts::UnitConstants::mm;
+    /// minimum pseudorapidity relevant for seeding
+    float etaMin = -4;
+    /// maximum pseudorapidity relevant for seeding
+    float etaMax = 4;
+    /// width of the equidistant eta bins used when `etaBinEdges` is empty
+    float deltaEtaMax = 0.8;
+    /// minimum phi value for phiAxis construction
+    float phiMin = -std::numbers::pi_v<float>;
+    /// maximum phi value for phiAxis construction
+    float phiMax = std::numbers::pi_v<float>;
+    /// Multiplicator for the number of phi-bins. The minimum number of phi-bins
+    /// depends on min_pt, magnetic field: 2*pi/(minPT particle phi-deflection).
+    /// phiBinDeflectionCoverage is a multiplier for this number. If
+    /// numPhiNeighbors (in the configuration of the BinFinders) is configured
+    /// to return 1 neighbor on either side of the current phi-bin (and you want
+    /// to cover the full phi-range of minPT), leave this at 1.
+    int phiBinDeflectionCoverage = 1;
+    /// maximum number of phi bins
+    int maxPhiBins = 10000;
+
+    /// vector containing the map of eta bins in the top and bottom layers
+    std::vector<std::pair<int, int>> etaBinNeighborsTop;
+    std::vector<std::pair<int, int>> etaBinNeighborsBottom;
+    /// number of phiBin neighbors at each side of the current bin that will be
+    /// used to search for SPs
+    int numPhiNeighbors = 1;
+
+    /// Vector containing the eta-bin edges for non equidistant binning in eta
+    std::vector<float> etaBinEdges;
+
+    /// Order of eta bins to loop over when searching for SPs
+    std::vector<std::size_t> etaBinsCustomLooping;
+
+    // Seeding parameters used to define the region of interest for middle
+    // space-point
+
+    /// Radial range for middle space-point
+    /// The range can be defined manually with (rMinMiddle, rMaxMiddle). If
+    /// useVariableMiddleSPRange is set to false and the vector rRangeMiddleSP
+    /// is empty, we use (rMinMiddle, rMaxMiddle) to cut the middle space-points
+    float rMinMiddle = 60 * Acts::UnitConstants::mm;
+    float rMaxMiddle = 120 * Acts::UnitConstants::mm;
+    /// If useVariableMiddleSPRange is set to false, the vector rRangeMiddleSP
+    /// can be used to define a fixed r range for each eta bin: {{rMin, rMax},
+    /// ...}
+    bool useVariableMiddleSPRange = false;
+    /// Range defined in vector for each eta bin
+    std::vector<std::vector<float>> rRangeMiddleSP;
+
+    float deltaRMiddleMinSPRange = 10 * Acts::UnitConstants::mm;
+    float deltaRMiddleMaxSPRange = 10 * Acts::UnitConstants::mm;
+
+    // Seeding parameters used to define the cuts on space-point doublets
+
+    /// Minimal value of z-distance between space-points in doublet
+    float deltaZMin = -std::numeric_limits<float>::infinity();
+    /// Maximum value of z-distance between space-points in doublet
+    float deltaZMax = std::numeric_limits<float>::infinity();
+
+    // Seed finder doublet cuts
+
+    /// Enable cut on the compatibility between interaction point and doublet,
+    /// this is an useful approximation to speed up the seeding
+    bool interactionPointCut = false;
+
+    /// Limiting location of collision region in z-axis used to check if doublet
+    /// origin is within reasonable bounds
+    float collisionRegionMin = -150 * Acts::UnitConstants::mm;
+    float collisionRegionMax = +150 * Acts::UnitConstants::mm;
+
+    /// Parameter which can loosen the tolerance of the track seed to form a
+    /// helix. This is useful for e.g. misaligned seeding.
+    float helixCutTolerance = 1;
+
+    // Seed finder triplet cuts
+
+    /// Number of sigmas of scattering angle to be considered in the minimum pT
+    /// scattering term
+    float sigmaScattering = 5;
+    /// Term that accounts for the thickness of scattering medium in radiation
+    /// lengths in the Lynch & Dahl correction to the Highland equation default
+    /// is 5%
+    /// TODO: necessary to make amount of material dependent on detector region?
+    float radLengthPerSeed = 0.05;
+
+    /// Tolerance parameter used to check the compatibility of space-point
+    /// coordinates in xyz. This is only used in a detector specific check for
+    /// strip modules
+    float toleranceParam = 1.1 * Acts::UnitConstants::mm;
+
+    // Seed filter parameters
+
+    /// Allowed difference in curvature (inverted seed radii) between two
+    /// compatible seeds
+    float deltaInvHelixDiameter = 0.00003 * (1 / Acts::UnitConstants::mm);
+    /// Seed weight/score is increased by this value if a compatible seed has
+    /// been found. This is the c1 factor in the seed score calculation (w = c1
+    /// * Nt - c2 * d0 - c3 * z0)
+    float compatSeedWeight = 200;
+    /// The transverse impact parameters (d0) is multiplied by this factor and
+    /// subtracted from weight. This is the c2 factor in the seed score
+    /// calculation (w = c1 * Nt - c2 * d0 - c3 * z0)
+    float impactWeightFactor = 1;
+    /// The logitudinal impact parameters (z0) is multiplied by this factor and
+    /// subtracted from weight. This is the c3 factor in the seed score
+    /// calculation (w = c1 * Nt - c2 * d0 - c3 * z0)
+    float zOriginWeightFactor = 1;
+    /// Maximum number (minus one) of accepted seeds per middle space-point
+    /// In dense environments many seeds may be found per middle space-point
+    /// Only seeds with the highest weight will be kept if this limit is reached
+    unsigned int maxSeedsPerSpM = 5;
+    /// Maximum limit to number of compatible space-point used in score
+    /// calculation. We increase by c1 the weight calculation for each
+    /// compatible space-point until we reach compatSeedLimit
+    std::size_t compatSeedLimit = 2;
+
+    /// Increment in seed weight if the number of compatible seeds is larger
+    /// than numSeedIncrement, this is used in case of high occupancy scenarios
+    /// if we want to increase the weight of the seed by seedWeightIncrement
+    /// when the number of compatible seeds is higher than a certain value
+    float seedWeightIncrement = 0;
+    float numSeedIncrement = std::numeric_limits<float>::infinity();
+
+    /// Enable quality seed confirmation, this is different than default seeding
+    /// confirmation because it can also be defined for different (r, z) regions
+    /// of the detector (e.g. forward or central region) by
+    /// SeedConfirmationRange. Seeds are classified as "high-quality" seeds and
+    /// normal quality seeds. Normal quality seeds are only selected if no other
+    /// "high-quality" seeds has been found for that inner-middle doublet.
+    bool seedConfirmation = false;
+    /// Contains parameters for central seed confirmation
+    Acts::SeedConfirmationRangeConfig centralSeedConfirmationRange;
+    /// Contains parameters for forward seed confirmation
+    Acts::SeedConfirmationRangeConfig forwardSeedConfirmationRange;
+
+    /// If seedConfirmation is true we classify seeds as "high-quality" seeds.
+    /// Seeds that are not confirmed as "high-quality" are only selected if no
+    /// other "high-quality" seed has been found for that inner-middle doublet
+    /// Maximum number of normal seeds (not classified as "high-quality" seeds)
+    /// in seed confirmation
+    std::uint32_t maxSeedsPerSpMConf = 5;
+    /// Maximum number of "high-quality" seeds for each inner-middle SP-dublet
+    /// in seed confirmation. If the limit is reached we check if there is a
+    /// normal quality seed to be replaced
+    std::uint32_t maxQualitySeedsPerSpMConf = 5;
+
+    /// Use deltaR between top and middle SP instead of top radius to search for
+    /// compatible SPs
+    bool useDeltaRinsteadOfTopRadius = false;
+
+    // other
+
+    /// Connect custom selections on the space points or to the doublet
+    /// compatibility
+    bool useExtraCuts = false;
+  };
+
+  /// Construct the seeding algorithm.
+  ///
+  /// @param cfg is the algorithm configuration
+  /// @param logger is the logging instance
+  explicit SphericalGridTripletSeedingAlgorithm(
+      const Config& cfg, std::unique_ptr<const Acts::Logger> logger = nullptr);
+
+  /// Run the seeding algorithm.
+  ///
+  /// @param ctx is the algorithm context with event information
+  /// @return a process code indication success or failure
+  ProcessCode execute(const AlgorithmContext& ctx) const override;
+
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
+ private:
+  Config m_cfg;
+  Acts::SphericalSpacePointGrid::Config m_gridConfig;
+
+  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_bottomBinFinder{nullptr};
+  std::unique_ptr<const Acts::GridBinFinder<3ul>> m_topBinFinder{nullptr};
+  Acts::BroadTripletSeedFilter::Config m_filterConfig;
+  std::unique_ptr<const Acts::Logger> m_filterLogger;
+  std::optional<Acts::TripletSeeder> m_seedFinder;
+
+  Acts::Delegate<bool(const ConstSpacePointProxy&)> m_spacePointSelector;
+
+  ReadDataHandle<SpacePointContainer> m_inputSpacePoints{this,
+                                                         "InputSpacePoints"};
+  WriteDataHandle<SeedContainer> m_outputSeeds{this, "OutputSeeds"};
+
+  /// Get the proper radius validity range given a middle space point candidate.
+  /// In case the radius range changes according to the eta-bin we need to
+  /// retrieve the proper range. We can do this computation only once, since all
+  /// the middle space point candidates belong to the same eta-bin
+  /// @param spM space point candidate to be used as middle SP in a seed
+  /// @param rMiddleSPRange range object containing the minimum and maximum r for middle SP for a certain eta bin
+  std::pair<float, float> retrieveRadiusRangeForMiddle(
+      const Acts::ConstSpacePointProxy& spM,
+      const Acts::Range1D<float>& rMiddleSPRange) const;
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/TrackFinding/src/SphericalGridTripletSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/SphericalGridTripletSeedingAlgorithm.cpp
@@ -1,0 +1,341 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/TrackFinding/SphericalGridTripletSeedingAlgorithm.hpp"
+
+#include "Acts/Definitions/Direction.hpp"
+#include "Acts/EventData/SeedContainer.hpp"
+#include "Acts/EventData/SpacePointContainer.hpp"
+#include "Acts/EventData/Types.hpp"
+#include "Acts/Seeding/BroadTripletSeedFilter.hpp"
+#include "Acts/Seeding/DoubletSeedFinder.hpp"
+#include "Acts/Seeding/TripletSeedFinder.hpp"
+#include "Acts/Utilities/Delegate.hpp"
+#include "ActsExamples/EventData/SpacePoint.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <stdexcept>
+
+namespace ActsExamples {
+
+namespace {
+
+static inline bool itkFastTrackingCuts(
+    const Acts::ConstSpacePointProxy& /*middle*/,
+    const Acts::ConstSpacePointProxy& other, float cotTheta,
+    bool isBottomCandidate) {
+  static float rMin = 45;
+  static float cotThetaMax = 1.5;
+
+  if (isBottomCandidate && other.zr()[1] < rMin &&
+      (cotTheta > cotThetaMax || cotTheta < -cotThetaMax)) {
+    return false;
+  }
+  return true;
+}
+
+static inline bool itkFastTrackingSPselect(const ConstSpacePointProxy& sp) {
+  // At small r we remove points beyond |z| > 200.
+  float r = sp.r();
+  float zabs = std::abs(sp.z());
+  if (zabs > 200. && r < 45.) {
+    return false;
+  }
+
+  // Remove space points beyond eta=4 if their z is larger than the max seed
+  // z0 (150.)
+  float cotTheta = 27.2899;  // corresponds to eta=4
+  if ((zabs - 150.) > cotTheta * r) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+SphericalGridTripletSeedingAlgorithm::SphericalGridTripletSeedingAlgorithm(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : IAlgorithm("SphericalGridTripletSeedingAlgorithm", std::move(logger)),
+      m_cfg(cfg) {
+  m_inputSpacePoints.initialize(m_cfg.inputSpacePoints);
+  m_outputSeeds.initialize(m_cfg.outputSeeds);
+
+  // check that the bins required in the custom bin looping
+  // are contained in the bins defined by the total number of edges
+  for (std::size_t i : m_cfg.etaBinsCustomLooping) {
+    if (i >= m_cfg.etaBinEdges.size()) {
+      throw std::invalid_argument(
+          "Inconsistent config etaBinsCustomLooping does not contain a subset "
+          "of bins defined by etaBinEdges");
+    }
+  }
+
+  if (m_cfg.useExtraCuts) {
+    // This function will be applied to select space points during grid filling
+    m_spacePointSelector.connect<itkFastTrackingSPselect>();
+  }
+
+  m_gridConfig.minPt = m_cfg.minPt;
+  // TODO switch to `m_cfg.rMin`
+  m_gridConfig.rMin = 0;
+  m_gridConfig.rMax = m_cfg.rMax;
+  m_gridConfig.etaMin = m_cfg.etaMin;
+  m_gridConfig.etaMax = m_cfg.etaMax;
+  m_gridConfig.deltaEtaMax = m_cfg.deltaEtaMax;
+  m_gridConfig.deltaRMax = m_cfg.deltaRMax;
+  m_gridConfig.cotThetaMax = m_cfg.cotThetaMax;
+  m_gridConfig.impactMax = m_cfg.impactMax;
+  m_gridConfig.phiMin = m_cfg.phiMin;
+  m_gridConfig.phiMax = m_cfg.phiMax;
+  m_gridConfig.phiBinDeflectionCoverage = m_cfg.phiBinDeflectionCoverage;
+  m_gridConfig.maxPhiBins = m_cfg.maxPhiBins;
+  m_gridConfig.rBinEdges = {};
+  m_gridConfig.etaBinEdges = m_cfg.etaBinEdges;
+  m_gridConfig.bFieldInZ = m_cfg.bFieldInZ;
+  m_gridConfig.bottomBinFinder.emplace(m_cfg.numPhiNeighbors,
+                                       m_cfg.etaBinNeighborsBottom, 0);
+  m_gridConfig.topBinFinder.emplace(m_cfg.numPhiNeighbors,
+                                    m_cfg.etaBinNeighborsTop, 0);
+  m_gridConfig.navigation[0ul] = {};
+  m_gridConfig.navigation[1ul] = m_cfg.etaBinsCustomLooping;
+  m_gridConfig.navigation[2ul] = {};
+
+  m_filterConfig.deltaInvHelixDiameter = m_cfg.deltaInvHelixDiameter;
+  m_filterConfig.deltaRMin = m_cfg.deltaRMin;
+  m_filterConfig.compatSeedWeight = m_cfg.compatSeedWeight;
+  m_filterConfig.impactWeightFactor = m_cfg.impactWeightFactor;
+  m_filterConfig.zOriginWeightFactor = m_cfg.zOriginWeightFactor;
+  m_filterConfig.maxSeedsPerSpM = m_cfg.maxSeedsPerSpM;
+  m_filterConfig.compatSeedLimit = m_cfg.compatSeedLimit;
+  m_filterConfig.seedWeightIncrement = m_cfg.seedWeightIncrement;
+  m_filterConfig.numSeedIncrement = m_cfg.numSeedIncrement;
+  m_filterConfig.seedConfirmation = m_cfg.seedConfirmation;
+  m_filterConfig.centralSeedConfirmationRange =
+      m_cfg.centralSeedConfirmationRange;
+  m_filterConfig.forwardSeedConfirmationRange =
+      m_cfg.forwardSeedConfirmationRange;
+  m_filterConfig.maxSeedsPerSpMConf = m_cfg.maxSeedsPerSpMConf;
+  m_filterConfig.maxQualitySeedsPerSpMConf = m_cfg.maxQualitySeedsPerSpMConf;
+  m_filterConfig.useDeltaRinsteadOfTopRadius =
+      m_cfg.useDeltaRinsteadOfTopRadius;
+
+  m_filterLogger = this->logger().cloneWithSuffix("Filter");
+
+  m_seedFinder = Acts::TripletSeeder(this->logger().cloneWithSuffix("Finder"));
+}
+
+ProcessCode SphericalGridTripletSeedingAlgorithm::execute(
+    const AlgorithmContext& ctx) const {
+  const SpacePointContainer& spacePoints = m_inputSpacePoints(ctx);
+
+  Acts::SphericalSpacePointGrid grid(m_gridConfig,
+                                     logger().cloneWithSuffix("Grid"));
+
+  for (std::size_t i = 0; i < spacePoints.size(); ++i) {
+    const auto& sp = spacePoints[i];
+
+    // check if the space point passes the selection
+    if (m_spacePointSelector.connected() && !m_spacePointSelector(sp)) {
+      continue;
+    }
+
+    float phi = std::atan2(sp.y(), sp.x());
+    // spherical binning: bin on cot(theta) = z / r (a single division)
+    grid.insert(i, phi, sp.z() / sp.r(), sp.r());
+  }
+
+  for (std::size_t i = 0; i < grid.numberOfBins(); ++i) {
+    std::ranges::sort(grid.at(i), [&](const Acts::SpacePointIndex& a,
+                                      const Acts::SpacePointIndex& b) {
+      return spacePoints[a].r() < spacePoints[b].r();
+    });
+  }
+
+  Acts::SpacePointContainer coreSpacePoints(
+      Acts::SpacePointColumns::CopiedFromIndex |
+      Acts::SpacePointColumns::PackedXY | Acts::SpacePointColumns::PackedZR |
+      Acts::SpacePointColumns::VarianceZ | Acts::SpacePointColumns::VarianceR);
+  coreSpacePoints.reserve(grid.numberOfSpacePoints());
+  std::vector<Acts::SpacePointIndexRange> gridSpacePointRanges;
+  gridSpacePointRanges.reserve(grid.numberOfBins());
+  for (std::size_t i = 0; i < grid.numberOfBins(); ++i) {
+    std::uint32_t begin = coreSpacePoints.size();
+    for (Acts::SpacePointIndex spIndex : grid.at(i)) {
+      const ConstSpacePointProxy& sp = spacePoints[spIndex];
+
+      auto newSp = coreSpacePoints.createSpacePoint();
+      newSp.copiedFromIndex() = sp.index();
+      newSp.xy() = std::array<float, 2>{static_cast<float>(sp.x()),
+                                        static_cast<float>(sp.y())};
+      newSp.zr() = std::array<float, 2>{static_cast<float>(sp.z()),
+                                        static_cast<float>(sp.r())};
+      newSp.varianceZ() = static_cast<float>(sp.varianceZ());
+      newSp.varianceR() = static_cast<float>(sp.varianceR());
+    }
+    std::uint32_t end = coreSpacePoints.size();
+    gridSpacePointRanges.emplace_back(begin, end);
+  }
+
+  // Compute radius range. We rely on the fact the grid is storing the proxies
+  // with a sorting in the radius
+  const Acts::Range1D<float> rRange = [&]() -> Acts::Range1D<float> {
+    float minRange = std::numeric_limits<float>::max();
+    float maxRange = std::numeric_limits<float>::lowest();
+    for (const Acts::SpacePointIndexRange& range : gridSpacePointRanges) {
+      if (range.first == range.second) {
+        continue;
+      }
+      auto first = coreSpacePoints[range.first];
+      auto last = coreSpacePoints[range.second - 1];
+      minRange = std::min(first.zr()[1], minRange);
+      maxRange = std::max(last.zr()[1], maxRange);
+    }
+    return {minRange, maxRange};
+  }();
+
+  Acts::DoubletSeedFinder::Config bottomDoubletFinderConfig;
+  bottomDoubletFinderConfig.spacePointsSortedByRadius = true;
+  bottomDoubletFinderConfig.candidateDirection = Acts::Direction::Backward();
+  bottomDoubletFinderConfig.deltaRMin = std::isnan(m_cfg.deltaRMinBottom)
+                                            ? m_cfg.deltaRMin
+                                            : m_cfg.deltaRMinBottom;
+  bottomDoubletFinderConfig.deltaRMax = std::isnan(m_cfg.deltaRMaxBottom)
+                                            ? m_cfg.deltaRMax
+                                            : m_cfg.deltaRMaxBottom;
+  bottomDoubletFinderConfig.deltaZMin = m_cfg.deltaZMin;
+  bottomDoubletFinderConfig.deltaZMax = m_cfg.deltaZMax;
+  bottomDoubletFinderConfig.impactMax = m_cfg.impactMax;
+  bottomDoubletFinderConfig.interactionPointCut = m_cfg.interactionPointCut;
+  bottomDoubletFinderConfig.collisionRegionMin = m_cfg.collisionRegionMin;
+  bottomDoubletFinderConfig.collisionRegionMax = m_cfg.collisionRegionMax;
+  bottomDoubletFinderConfig.cotThetaMax = m_cfg.cotThetaMax;
+  bottomDoubletFinderConfig.minPt = m_cfg.minPt;
+  bottomDoubletFinderConfig.helixCutTolerance = m_cfg.helixCutTolerance;
+  if (m_cfg.useExtraCuts) {
+    bottomDoubletFinderConfig.experimentCuts.connect<itkFastTrackingCuts>();
+  }
+  auto bottomDoubletFinder =
+      Acts::DoubletSeedFinder::create(Acts::DoubletSeedFinder::DerivedConfig(
+          bottomDoubletFinderConfig, m_cfg.bFieldInZ));
+
+  Acts::DoubletSeedFinder::Config topDoubletFinderConfig =
+      bottomDoubletFinderConfig;
+  topDoubletFinderConfig.candidateDirection = Acts::Direction::Forward();
+  topDoubletFinderConfig.deltaRMin =
+      std::isnan(m_cfg.deltaRMinTop) ? m_cfg.deltaRMin : m_cfg.deltaRMinTop;
+  topDoubletFinderConfig.deltaRMax =
+      std::isnan(m_cfg.deltaRMaxTop) ? m_cfg.deltaRMax : m_cfg.deltaRMaxTop;
+  auto topDoubletFinder =
+      Acts::DoubletSeedFinder::create(Acts::DoubletSeedFinder::DerivedConfig(
+          topDoubletFinderConfig, m_cfg.bFieldInZ));
+
+  Acts::TripletSeedFinder::Config tripletFinderConfig;
+  tripletFinderConfig.useStripInfo = false;
+  tripletFinderConfig.sortedByCotTheta = true;
+  tripletFinderConfig.minPt = m_cfg.minPt;
+  tripletFinderConfig.sigmaScattering = m_cfg.sigmaScattering;
+  tripletFinderConfig.radLengthPerSeed = m_cfg.radLengthPerSeed;
+  tripletFinderConfig.impactMax = m_cfg.impactMax;
+  tripletFinderConfig.helixCutTolerance = m_cfg.helixCutTolerance;
+  tripletFinderConfig.toleranceParam = m_cfg.toleranceParam;
+  auto tripletFinder =
+      Acts::TripletSeedFinder::create(Acts::TripletSeedFinder::DerivedConfig(
+          tripletFinderConfig, m_cfg.bFieldInZ));
+
+  // variable middle SP radial region of interest
+  Acts::Range1D<float> rMiddleSpRange = {
+      std::floor(rRange.min() / 2) * 2 + m_cfg.deltaRMiddleMinSPRange,
+      std::floor(rRange.max() / 2) * 2 - m_cfg.deltaRMiddleMaxSPRange};
+
+  // run the seeding
+  Acts::BroadTripletSeedFilter::State filterState;
+  Acts::BroadTripletSeedFilter::Cache filterCache;
+  Acts::BroadTripletSeedFilter seedFilter(m_filterConfig, filterState,
+                                          filterCache, *m_filterLogger);
+  static thread_local Acts::TripletSeeder::Cache cache;
+
+  std::vector<Acts::SpacePointContainer::ConstRange> bottomSpRanges;
+  std::optional<Acts::SpacePointContainer::ConstRange> middleSpRange;
+  std::vector<Acts::SpacePointContainer::ConstRange> topSpRanges;
+
+  Acts::SeedContainer seeds;
+  seeds.assignSpacePointContainer(spacePoints);
+
+  for (const auto [bottom, middle, top] : grid.binnedGroup()) {
+    ACTS_VERBOSE("Process middle " << middle);
+
+    bottomSpRanges.clear();
+    for (const auto b : bottom) {
+      bottomSpRanges.push_back(
+          coreSpacePoints.range(gridSpacePointRanges.at(b)).asConst());
+    }
+    middleSpRange =
+        coreSpacePoints.range(gridSpacePointRanges.at(middle)).asConst();
+    topSpRanges.clear();
+    for (const auto t : top) {
+      topSpRanges.push_back(
+          coreSpacePoints.range(gridSpacePointRanges.at(t)).asConst());
+    }
+
+    if (middleSpRange->empty()) {
+      ACTS_DEBUG("No middle space points in this group, skipping");
+      continue;
+    }
+
+    // we compute this here since all middle space point candidates belong to
+    // the same eta-bin
+    Acts::ConstSpacePointProxy firstMiddleSp = middleSpRange->front();
+    std::pair<float, float> radiusRangeForMiddle =
+        retrieveRadiusRangeForMiddle(firstMiddleSp, rMiddleSpRange);
+    ACTS_VERBOSE("Validity range (radius) for the middle space point is ["
+                 << radiusRangeForMiddle.first << ", "
+                 << radiusRangeForMiddle.second << "]");
+
+    m_seedFinder->createSeedsFromGroups(
+        cache, *bottomDoubletFinder, *topDoubletFinder, *tripletFinder,
+        seedFilter, coreSpacePoints, bottomSpRanges, *middleSpRange,
+        topSpRanges, radiusRangeForMiddle, seeds);
+  }
+
+  ACTS_DEBUG("Created " << seeds.size() << " track seeds from "
+                        << spacePoints.size() << " space points");
+
+  // update seed space point indices to original space point container
+  for (auto seed : seeds) {
+    for (auto& spIndex : seed.spacePointIndices()) {
+      spIndex = coreSpacePoints.at(spIndex).copiedFromIndex();
+    }
+  }
+
+  m_outputSeeds(ctx, std::move(seeds));
+  return ProcessCode::SUCCESS;
+}
+
+std::pair<float, float>
+SphericalGridTripletSeedingAlgorithm::retrieveRadiusRangeForMiddle(
+    const Acts::ConstSpacePointProxy& spM,
+    const Acts::Range1D<float>& rMiddleSpRange) const {
+  if (m_cfg.useVariableMiddleSPRange) {
+    return {rMiddleSpRange.min(), rMiddleSpRange.max()};
+  }
+  if (m_cfg.rRangeMiddleSP.empty()) {
+    return {m_cfg.rMinMiddle, m_cfg.rMaxMiddle};
+  }
+
+  // get eta-bin position of the middle SP. eta = asinh(z / r) is monotone in
+  // the cot(theta) = z / r that the grid bins on, so this selects the same bin.
+  const float etaM = std::asinh(spM.zr()[0] / spM.zr()[1]);
+  auto pVal = std::ranges::lower_bound(m_cfg.etaBinEdges, etaM);
+  std::size_t etaBin = std::distance(m_cfg.etaBinEdges.begin(), pVal);
+  // protects against etaM at the limit of etaBinEdges
+  etaBin == 0 ? etaBin : --etaBin;
+  return {m_cfg.rRangeMiddleSP[etaBin][0], m_cfg.rRangeMiddleSP[etaBin][1]};
+}
+
+}  // namespace ActsExamples

--- a/Python/Examples/python/itk.py
+++ b/Python/Examples/python/itk.py
@@ -593,3 +593,54 @@ def itkSeedingAlgConfig(
         seedFilterConfigArg,
         spacePointGridConfigArg,
     )
+
+
+def SphericalitkSeedingAlgConfig(inputSpacePointsType, highOccupancyConfig=False):
+    """Spherical (phi, eta, R) analog of itkSeedingAlgConfig."""
+    (
+        seedingAlgorithmConfigArg,
+        seedFinderConfigArg,
+        seedFinderOptionsArg,
+        seedFilterConfigArg,
+        spacePointGridConfigArg,
+    ) = itkSeedingAlgConfig(
+        inputSpacePointsType, highOccupancyConfig=highOccupancyConfig
+    )
+
+    u = acts.UnitConstants
+
+    # Non-uniform 38-bin eta layout: forward |eta|>=2.5 refined to 0.125-wide
+    # bins, central region left coarse.
+    etaBinEdges = [
+        -4, -3.875, -3.75, -3.625, -3.5, -3.375, -3.25, -3.125, -3, -2.875,
+        -2.75, -2.625, -2.5, -2.3, -2.1, -1.9, -1.7, -1.5, -0.8, 0, 0.8, 1.5,
+        1.7, 1.9, 2.1, 2.3, 2.5, 2.625, 2.75, 2.875, 3, 3.125, 3.25, 3.375, 3.5,
+        3.625, 3.75, 3.875, 4,
+    ]
+    nBins = len(etaBinEdges) - 1
+
+    # Only the (eta) binning parameters differ from the cylindrical ITk default;
+    # every generic selection cut is left at the itkSeedingAlgConfig value,
+    # so this is a like-for-like binning swap.
+    seedFinderConfigArg = seedFinderConfigArg._replace(
+        deltaZMin=-float("inf") * u.mm,
+        deltaZMax=float("inf") * u.mm,
+        eta=(-4.0, 4.0),
+        deltaEtaMax=0.8,
+        etaBinsCustomLooping=[],
+    )
+    spacePointGridConfigArg = spacePointGridConfigArg._replace(
+        etaBinEdges=etaBinEdges,
+    )
+    seedingAlgorithmConfigArg = seedingAlgorithmConfigArg._replace(
+        etaBinNeighborsTop=[(-1, 1)] * nBins,
+        etaBinNeighborsBottom=[(-2, 2)] * nBins,
+    )
+
+    return (
+        seedingAlgorithmConfigArg,
+        seedFinderConfigArg,
+        seedFinderOptionsArg,
+        seedFilterConfigArg,
+        spacePointGridConfigArg,
+    )

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -26,7 +26,7 @@ u = acts.UnitConstants
 
 SeedingAlgorithm = Enum(
     "SeedingAlgorithm",
-    "TruthSmeared TruthEstimated HoughTransform AdaptiveHoughTransform Gbts Hashing GridTriplet OrthogonalTriplet HashingPrototype",
+    "TruthSmeared TruthEstimated HoughTransform AdaptiveHoughTransform Gbts Hashing GridTriplet SphericalGridTriplet OrthogonalTriplet HashingPrototype",
 )
 
 TrackSmearingSigmas = namedtuple(
@@ -58,6 +58,7 @@ SeedFinderConfigArg = namedtuple(
         "deltaPhiMax",
         "interactionPointCut",
         "deltaZMax",
+        "deltaZMin",
         "maxPtScattering",
         "zBinEdges",
         "zBinsCustomLooping",
@@ -76,8 +77,11 @@ SeedFinderConfigArg = namedtuple(
         "collisionRegion",  # (min,max)
         "r",  # (min,max)
         "z",  # (min,max)
+        "eta",  # (min,max)
+        "deltaEtaMax",
+        "etaBinsCustomLooping",
     ],
-    defaults=[None] * 20 + [(None, None)] * 7,
+    defaults=[None] * 21 + [(None, None)] * 8 + [None] * 2,
 )
 SeedFinderOptionsArg = namedtuple(
     "SeedFinderOptions", ["beamPos", "bFieldInZ"], defaults=[(None, None), None]
@@ -111,8 +115,9 @@ SpacePointGridConfigArg = namedtuple(
         "deltaRMax",
         "maxPhiBins",
         "phi",  # (min,max)
+        "etaBinEdges",
     ],
-    defaults=[None] * 6 + [(None, None)] * 1,
+    defaults=[None] * 6 + [(None, None)] * 1 + [None],
 )
 
 SeedingAlgorithmConfigArg = namedtuple(
@@ -123,8 +128,10 @@ SeedingAlgorithmConfigArg = namedtuple(
         "zBinNeighborsBottom",
         "numPhiNeighbors",
         "useExtraCuts",
+        "etaBinNeighborsTop",
+        "etaBinNeighborsBottom",
     ],
-    defaults=[None] * 5,
+    defaults=[None] * 7,
 )
 
 TruthEstimatedSeedingAlgorithmConfigArg = namedtuple(
@@ -479,6 +486,19 @@ def addSeeding(
         elif seedingAlgorithm == SeedingAlgorithm.GridTriplet:
             logger.info("Using grid triplet seeding")
             seeds = addGridTripletSeeding(
+                s,
+                spacePoints,
+                seedingAlgorithmConfigArg,
+                seedFinderConfigArg,
+                seedFinderOptionsArg,
+                seedFilterConfigArg,
+                spacePointGridConfigArg,
+                logLevel,
+                outputSeeds=f"{prefix}seeds",
+            )
+        elif seedingAlgorithm == SeedingAlgorithm.SphericalGridTriplet:
+            logger.info("Using spherical grid triplet seeding")
+            seeds = addSphericalGridTripletSeeding(
                 s,
                 spacePoints,
                 seedingAlgorithmConfigArg,
@@ -941,6 +961,105 @@ def addGridTripletSeeding(
             deltaRMiddleMaxSPRange=seedFinderConfigArg.deltaRMiddleSPRange[1],
             deltaZMin=None,
             deltaZMax=None,
+            interactionPointCut=seedFinderConfigArg.interactionPointCut,
+            collisionRegionMin=seedFinderConfigArg.collisionRegion[0],
+            collisionRegionMax=seedFinderConfigArg.collisionRegion[1],
+            helixCutTolerance=None,
+            sigmaScattering=seedFinderConfigArg.sigmaScattering,
+            radLengthPerSeed=seedFinderConfigArg.radLengthPerSeed,
+            toleranceParam=None,
+            deltaInvHelixDiameter=None,
+            compatSeedWeight=seedFilterConfigArg.compatSeedWeight,
+            impactWeightFactor=seedFilterConfigArg.impactWeightFactor,
+            zOriginWeightFactor=seedFilterConfigArg.zOriginWeightFactor,
+            maxSeedsPerSpM=seedFinderConfigArg.maxSeedsPerSpM,
+            compatSeedLimit=seedFilterConfigArg.compatSeedLimit,
+            seedWeightIncrement=seedFilterConfigArg.seedWeightIncrement,
+            numSeedIncrement=seedFilterConfigArg.numSeedIncrement,
+            seedConfirmation=seedFinderConfigArg.seedConfirmation,
+            centralSeedConfirmationRange=seedFinderConfigArg.centralSeedConfirmationRange,
+            forwardSeedConfirmationRange=seedFinderConfigArg.forwardSeedConfirmationRange,
+            maxSeedsPerSpMConf=seedFilterConfigArg.maxSeedsPerSpMConf,
+            maxQualitySeedsPerSpMConf=seedFilterConfigArg.maxQualitySeedsPerSpMConf,
+            useDeltaRinsteadOfTopRadius=seedFilterConfigArg.useDeltaRorTopRadius,
+            useExtraCuts=seedingAlgorithmConfigArg.useExtraCuts,
+        ),
+    )
+    sequence.addAlgorithm(seedingAlg)
+
+    return seedingAlg.config.outputSeeds
+
+
+def addSphericalGridTripletSeeding(
+    sequence: acts.examples.Sequencer,
+    spacePoints: str,
+    seedingAlgorithmConfigArg: SeedingAlgorithmConfigArg,
+    seedFinderConfigArg: SeedFinderConfigArg,
+    seedFinderOptionsArg: SeedFinderOptionsArg,
+    seedFilterConfigArg: SeedFilterConfigArg,
+    spacePointGridConfigArg: SpacePointGridConfigArg,
+    logLevel: acts.logging.Level = None,
+    outputSeeds: str = "seeds",
+):
+    """adds spherical (phi, eta, R) grid triplet seeding
+    Identical to addGridTripletSeeding except the space-point grid bins on
+    pseudorapidity (via cot(theta) = z / r) instead of z.
+    """
+    logLevel = acts.examples.defaultLogging(sequence, logLevel)()
+
+    seedingAlg = acts.examples.SphericalGridTripletSeedingAlgorithm(
+        level=logLevel,
+        inputSpacePoints=spacePoints,
+        outputSeeds=outputSeeds,
+        **acts.examples.defaultKWArgs(
+            bFieldInZ=seedFinderOptionsArg.bFieldInZ,
+            minPt=seedFinderConfigArg.minPt,
+            cotThetaMax=seedFinderConfigArg.cotThetaMax,
+            impactMax=seedFinderConfigArg.impactMax,
+            deltaRMin=seedFinderConfigArg.deltaR[0],
+            deltaRMax=seedFinderConfigArg.deltaR[1],
+            deltaRMinTop=(
+                seedFinderConfigArg.deltaR[0]
+                if seedFinderConfigArg.deltaRTopSP[0] is None
+                else seedFinderConfigArg.deltaRTopSP[0]
+            ),
+            deltaRMaxTop=(
+                seedFinderConfigArg.deltaR[1]
+                if seedFinderConfigArg.deltaRTopSP[1] is None
+                else seedFinderConfigArg.deltaRTopSP[1]
+            ),
+            deltaRMinBottom=(
+                seedFinderConfigArg.deltaR[0]
+                if seedFinderConfigArg.deltaRBottomSP[0] is None
+                else seedFinderConfigArg.deltaRBottomSP[0]
+            ),
+            deltaRMaxBottom=(
+                seedFinderConfigArg.deltaR[1]
+                if seedFinderConfigArg.deltaRBottomSP[1] is None
+                else seedFinderConfigArg.deltaRBottomSP[1]
+            ),
+            rMin=seedFinderConfigArg.r[0],
+            rMax=seedFinderConfigArg.r[1],
+            etaMin=seedFinderConfigArg.eta[0],
+            etaMax=seedFinderConfigArg.eta[1],
+            deltaEtaMax=seedFinderConfigArg.deltaEtaMax,
+            phiMin=spacePointGridConfigArg.phi[0],
+            phiMax=spacePointGridConfigArg.phi[1],
+            phiBinDeflectionCoverage=spacePointGridConfigArg.phiBinDeflectionCoverage,
+            maxPhiBins=spacePointGridConfigArg.maxPhiBins,
+            numPhiNeighbors=seedingAlgorithmConfigArg.numPhiNeighbors,
+            etaBinNeighborsTop=seedingAlgorithmConfigArg.etaBinNeighborsTop,
+            etaBinNeighborsBottom=seedingAlgorithmConfigArg.etaBinNeighborsBottom,
+            etaBinEdges=spacePointGridConfigArg.etaBinEdges,
+            etaBinsCustomLooping=seedFinderConfigArg.etaBinsCustomLooping,
+            rMinMiddle=seedFinderConfigArg.rMinMiddle,
+            rMaxMiddle=seedFinderConfigArg.rMaxMiddle,
+            useVariableMiddleSPRange=seedFinderConfigArg.useVariableMiddleSPRange,
+            rRangeMiddleSP=seedFinderConfigArg.rRangeMiddleSP,
+            deltaRMiddleMinSPRange=seedFinderConfigArg.deltaRMiddleSPRange[0],
+            deltaRMiddleMaxSPRange=seedFinderConfigArg.deltaRMiddleSPRange[1],
+            deltaZMin=seedFinderConfigArg.deltaZMin,
+            deltaZMax=seedFinderConfigArg.deltaZMax,
             interactionPointCut=seedFinderConfigArg.interactionPointCut,
             collisionRegionMin=seedFinderConfigArg.collisionRegion[0],
             collisionRegionMax=seedFinderConfigArg.collisionRegion[1],

--- a/Python/Examples/src/TrackFinding.cpp
+++ b/Python/Examples/src/TrackFinding.cpp
@@ -10,6 +10,7 @@
 #include "ActsExamples/TrackFinding/AdaptiveHoughTransformSeeder.hpp"
 #include "ActsExamples/TrackFinding/GraphBasedSeedingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/GridTripletSeedingAlgorithm.hpp"
+#include "ActsExamples/TrackFinding/SphericalGridTripletSeedingAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/HoughTransformSeeder.hpp"
 #include "ActsExamples/TrackFinding/MeasurementFilterAlgorithm.hpp"
 #include "ActsExamples/TrackFinding/MuonHoughSeeder.hpp"
@@ -61,6 +62,24 @@ void addTrackFinding(py::module& mex) {
       numSeedIncrement, seedConfirmation, centralSeedConfirmationRange,
       forwardSeedConfirmationRange, maxSeedsPerSpMConf,
       maxQualitySeedsPerSpMConf, useDeltaRinsteadOfTopRadius, useExtraCuts);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(
+      SphericalGridTripletSeedingAlgorithm, mex,
+      "SphericalGridTripletSeedingAlgorithm", inputSpacePoints, outputSeeds,
+      bFieldInZ, minPt, cotThetaMax, impactMax, deltaRMin, deltaRMax,
+      deltaRMinTop, deltaRMaxTop, deltaRMinBottom, deltaRMaxBottom, rMin, rMax,
+      etaMin, etaMax, deltaEtaMax, phiMin, phiMax, phiBinDeflectionCoverage,
+      maxPhiBins, etaBinNeighborsTop, etaBinNeighborsBottom, numPhiNeighbors,
+      etaBinEdges, etaBinsCustomLooping, rMinMiddle, rMaxMiddle,
+      useVariableMiddleSPRange, rRangeMiddleSP, deltaRMiddleMinSPRange,
+      deltaRMiddleMaxSPRange, deltaZMin, deltaZMax, interactionPointCut,
+      collisionRegionMin, collisionRegionMax, helixCutTolerance, sigmaScattering,
+      radLengthPerSeed, toleranceParam, deltaInvHelixDiameter, compatSeedWeight,
+      impactWeightFactor, zOriginWeightFactor, maxSeedsPerSpM, compatSeedLimit,
+      seedWeightIncrement, numSeedIncrement, seedConfirmation,
+      centralSeedConfirmationRange, forwardSeedConfirmationRange,
+      maxSeedsPerSpMConf, maxQualitySeedsPerSpMConf, useDeltaRinsteadOfTopRadius,
+      useExtraCuts);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       OrthogonalTripletSeedingAlgorithm, mex,


### PR DESCRIPTION
# feat: add Spherical (φ, η, r) grid seeding algorithm

## Summary

Adds a new triplet seeding algorithm that bins space points on a **spherical
(φ, η, r)** grid instead of the cylindrical (φ, z, r) grid. Added `SphericalSpacePointGrid` alongside the existing `CylindricalSpacePointGrid` and `CartesianSpacePointGrid`. The existing seeders are untouched, and all downstream doublet/triplet/filter code is reused unchanged.

It is provided so the ITk community can evaluate the binning directly in Athena. This grew out of my master's thesis on ACTS performance optimisation
(*Performance Optimization in ACTS*, [doi.org/10.5281/zenodo.20717572](https://doi.org/10.5281/zenodo.20717572)).

## Motivation

Binning on `cot(θ) = z/r = sinh(η)` (monotone in η) groups near-collinear space
points, aligning the grid with the collision geometry rather than the detector's
z-extent:

- Uniform Δz bins are non-uniform in η; particle density is more uniform in (φ, η).
- Detector acceptance `|η| < η_max` gives a fixed, compact binning range,
  instead of the large/unbounded z-range the forward region needs.
- Contiguous η-bin arrays → simpler neighbour queries.

## Design

- **New, cleanly-named classes:** `Acts::SphericalSpacePointGrid` (Core) and
  `ActsExamples::SphericalGridTripletSeedingAlgorithm` (Examples), mirroring the
  pattern ACTS already uses for Cartesian/Cylindrical. The existing grid and
  algorithm classes are not modified.
- **No EDM change:** The grid computes `cot(θ) = z/r` at fill from the existing
  `zr()` accessor and stores `sinh(etaBinEdges)` on the axis, avoiding any new
  `SpacePointContainer` columns.
- **Downstream reused unchanged:** `DoubletSeedFinder`, `TripletSeedFinder`,
  `TripletSeeder`, `BroadTripletSeedFilter` are untouched; only the grid fill and
  neighbour gather differ.
- **Added Example Algorithm:** Fully wired into the Python layer (`SeedingAlgorithm.SphericalGridTriplet`,
  `addSphericalGridTripletSeeding`) with an example ITk operating point that
  leaves all generic selection cuts at the `itkSeedingAlgConfig` defaults and
  overrides only the (η) binning parameters.

## Performance

- **ODD (thesis, ACTS v44):** the spherical operating points showed substantial
  pipeline speedups and preserved/improved efficiency vs the ODD cylindrical
  default. Full study + plots in the thesis (DOI above). *(Note: the cylindrical default was not optimized for the ODD geometry; the thesis reported seeding-only results.)*
- **ITk (current main, ttbar+PU200, 200 ev, matched non-grid parameters):** with
  every non-grid-specific parameter held at the cylindrical ITk-tuned defaults, the
  **binning itself is roughly efficiency-neutral but a few percent slower in timing**
  (≈ −0.002 in ambiguity efficiency; few % slower seeding, few % slower total pipeline). Larger ITk speedups seen in earlier exploration were mostly attributable to operating-point choices that also benefit the cylindrical grid, not to the binning per se. Some early tests also compared against an older, less-optimised cylindrical implementation, which further contributed to the promising early results.

## Further work

- **Optimization and testing in Athena:** Even though the spherical implementation seems to be roughly equal to the cylindrical version, a version tuned for Athena might give better results. Some operating points seem to be faster on the spherical grid than the cylindrical one, though not at the default ITk parameters this PR ships with.