### PR TITLE
ci: Allow disabling PDF plot output in physmon

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -202,7 +202,7 @@ jobs:
           git config --global safe.directory "$GITHUB_WORKSPACE"
           source .env
           source build/this_acts_withdeps.sh
-          CI/physmon/phys_perf_mon.sh all physmon
+          CI/physmon/phys_perf_mon.sh all physmon $(nproc)
 
       - name: Post step summary
         if: always()

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -311,7 +311,7 @@ linux_physmon:
     - git config --global safe.directory "$GITHUB_WORKSPACE"
     - source build/this_acts_withdeps.sh
     - cd src
-    - CI/physmon/phys_perf_mon.sh all physmon
+    - CI/physmon/phys_perf_mon.sh all physmon $(nproc)
 
   after_script:
    - !reference [.spack_cleanup, after_script]

--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -27,6 +27,9 @@ fi
 outdir=${2:-physmon}
 # number of concurrent histcmp comparison processes
 num_jobs=${3:-1}
+# set PHYSMON_PDF_PLOTS=0 to skip writing the individual comparison plots as
+# PDF files next to the HTML reports; the reports embed all plots anyway
+pdf_plots=${PHYSMON_PDF_PLOTS:-1}
 mkdir -p $outdir
 mkdir -p $outdir/data
 mkdir -p $outdir/html
@@ -216,6 +219,15 @@ function run_histcmp() {
     comparison_job_html[$comparison_job_index]="$html_path"
     comparison_job_index=$(($comparison_job_index + 1))
 
+    local plot_args=()
+    if [ "$pdf_plots" != "0" ]; then
+        plot_args=(-p $outdir/html/$plots_path)
+    fi
+
+    # histcmp does not create the output directory if no plot directory is
+    # given
+    mkdir -p $(dirname $outdir/html/$html_path)
+
     wait_for_job_slot
     (
         start=$(date +%s)
@@ -225,7 +237,7 @@ function run_histcmp() {
             --label-monitored=monitored \
             --title="$title" \
             -o $outdir/html/$html_path \
-            -p $outdir/html/$plots_path \
+            "${plot_args[@]}" \
             "$@" || rc=$?
         echo "histcmp took $(($(date +%s) - $start)) seconds"
         echo $rc > $jobdir/ec

--- a/CI/physmon/phys_perf_mon.sh
+++ b/CI/physmon/phys_perf_mon.sh
@@ -20,11 +20,13 @@ shopt -s extglob
 
 mode=${1:-all}
 if ! [[ $mode = @(all|kf|gsf|gx2f|refit_kf|refit_gsf|fullchains|simulation|gx2f_vs_kf) ]]; then
-    echo "Usage: $0 <all|kf|gsf|gx2f|refit_kf|refit_gsf|fullchains|simulation|gx2f_vs_kf> (outdir)"
+    echo "Usage: $0 <all|kf|gsf|gx2f|refit_kf|refit_gsf|fullchains|simulation|gx2f_vs_kf> (outdir) (num_jobs)"
     exit 1
 fi
 
 outdir=${2:-physmon}
+# number of concurrent histcmp comparison processes
+num_jobs=${3:-1}
 mkdir -p $outdir
 mkdir -p $outdir/data
 mkdir -p $outdir/html
@@ -171,15 +173,31 @@ fi
 echo "::endgroup::"
 
 
-function run_histcmp() {
-    a=$1
-    b=$2
-    title=$3
-    html_path=$4
-    plots_path=$5
-    shift 5
+# The histcmp comparisons are independent of each other and are run in a pool
+# of up to $num_jobs background processes. Each job writes its output and exit
+# code to $comparison_jobs_dir/<index>/ and the results are replayed in
+# submission order by finish_comparisons.
+comparison_jobs_dir=$outdir/comparison_jobs
+rm -rf $comparison_jobs_dir
+mkdir -p $comparison_jobs_dir
+comparison_job_index=0
+comparison_job_labels=()
+comparison_job_titles=()
+comparison_job_html=()
 
-    echo "::group::Comparing $a vs. $b"
+function wait_for_job_slot() {
+    while [ "$(jobs -rp | wc -l)" -ge "$num_jobs" ]; do
+        sleep 0.2
+    done
+}
+
+function run_histcmp() {
+    local a=$1
+    local b=$2
+    local title=$3
+    local html_path=$4
+    local plots_path=$5
+    shift 5
 
     if [ ! -f "$a" ]; then
         echo "::error::histcmp failed: File $a does not exist"
@@ -191,24 +209,55 @@ function run_histcmp() {
         ec=1
     fi
 
-    run histcmp $a $b \
-        --label-reference=reference \
-        --label-monitored=monitored \
-        --title="$title" \
-        -o $outdir/html/$html_path \
-        -p $outdir/html/$plots_path \
-        "$@"
+    local jobdir=$comparison_jobs_dir/$comparison_job_index
+    mkdir -p $jobdir
+    comparison_job_labels[$comparison_job_index]="$a vs. $b"
+    comparison_job_titles[$comparison_job_index]="$title"
+    comparison_job_html[$comparison_job_index]="$html_path"
+    comparison_job_index=$(($comparison_job_index + 1))
 
-    this_ec=$?
-    ec=$(($ec | $this_ec))
+    wait_for_job_slot
+    (
+        start=$(date +%s)
+        rc=0
+        run histcmp $a $b \
+            --label-reference=reference \
+            --label-monitored=monitored \
+            --title="$title" \
+            -o $outdir/html/$html_path \
+            -p $outdir/html/$plots_path \
+            "$@" || rc=$?
+        echo "histcmp took $(($(date +%s) - $start)) seconds"
+        echo $rc > $jobdir/ec
+    ) > $jobdir/log 2>&1 &
+}
 
-    if [ $this_ec -ne 0 ]; then
-        echo "::error::histcmp failed: ec=$this_ec"
-    fi
+function finish_comparisons() {
+    wait
 
-    echo "\"${title}\",html/${html_path},${this_ec}" >> $histcmp_results
+    local i
+    for ((i = 0; i < $comparison_job_index; i++)); do
+        local jobdir=$comparison_jobs_dir/$i
+        local title=${comparison_job_titles[$i]}
+        local html_path=${comparison_job_html[$i]}
 
-    echo "::endgroup::"
+        echo "::group::Comparing ${comparison_job_labels[$i]}"
+
+        cat $jobdir/log
+
+        this_ec=$(cat $jobdir/ec 2> /dev/null || echo 1)
+        ec=$(($ec | $this_ec))
+
+        if [ $this_ec -ne 0 ]; then
+            echo "::error::histcmp failed: ec=$this_ec"
+        fi
+
+        echo "\"${title}\",html/${html_path},${this_ec}" >> $histcmp_results
+
+        echo "::endgroup::"
+    done
+
+    rm -rf $comparison_jobs_dir
 }
 
 function trackfinding() {
@@ -487,6 +536,8 @@ if [[ "$mode" == "all" || "$mode" == "gx2f_vs_kf" ]]; then
         --label-reference=KF \
         --label-monitored=GX2F
 fi
+
+finish_comparisons
 
 run python3 CI/physmon/summary.py $histcmp_results \
   --md $outdir/summary.md \


### PR DESCRIPTION
histcmp saves every comparison figure twice: once as SVG embedded into the self-contained HTML report and once as a PDF file next to it (~3800 PDFs, and roughly half of the figure-saving cost of the comparison stage). This adds a `PHYSMON_PDF_PLOTS=0` toggle to `phys_perf_mon.sh` that omits histcmp's `-p` option, so no PDF files are written. The default behavior is unchanged.

`run_histcmp` now also creates the parent directory of the HTML report itself — previously that directory was only created as a side effect of histcmp's plot-directory option, so omitting `-p` made every report fail to write.

Stacked on #5683 (contains its commit; only the last commit is new).

### Test

Ran the seeded comparison stage locally with `PHYSMON_PDF_PLOTS=0` and 4 jobs: all 31 comparisons pass, HTML reports present, zero PDF files written (vs ~3800 with default settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwPqUq4QvNdNXckjAKkWUs