### PR TITLE
ci: Add traccc component to labelling job

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,12 @@
       - Detray/**
       - Plugins/Detray/**
       - .github/detray.yml
+'Component - Traccc':
+  - changed-files:
+    - any-glob-to-any-file:
+      - Traccc/**
+      - Plugins/Traccc/**
+      - .github/traccc.yml
 'Component - Examples':
   - changed-files:
     - any-glob-to-any-file:


### PR DESCRIPTION
This commit adds a label for the traccc component to the labelling CI job, which I forgot to do in the traccc integration PR.