### PR TITLE
feat(cmake): make option auto-enable behavior visible and derive dependency docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,12 @@ repos:
       entry: docs/parse_cmake_options.py --write docs/pages/contributing/building_acts.md
       files: ^CMakeLists.txt$
 
+    - id: cmake_option_dependencies
+      name: cmake_option_dependencies
+      language: system
+      entry: docs/cmake_option_dependencies.py --write docs/pages/contributing/building_acts.md
+      files: ^CMakeLists.txt$
+
     - id: leftover_conflict_markers
       name: Leftover conflict markers
       language: system

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ option(ACTS_SETUP_COVFIE "If we want to set up covfie" OFF)
 option(ACTS_SETUP_DETRAY "If we want to set up detray" OFF)
 option(ACTS_USE_SYSTEM_VECMEM "Use a system-provided vecmem installation" ${ACTS_USE_SYSTEM_LIBS})
 option(ACTS_SETUP_VECMEM "If we want to set up vecmem" OFF)
-option(ACTS_USE_SYSTEM_TRACCC "Use a system-provided traccc installation" ${ACTS_USE_SYSTEM_LIBS})
 option(ACTS_USE_SYSTEM_NLOHMANN_JSON "Use nlohmann::json provided by the system instead of the bundled version" ${ACTS_USE_SYSTEM_LIBS})
 option(ACTS_USE_SYSTEM_PYBIND11 "Use a system installation of pybind11" ${ACTS_USE_SYSTEM_LIBS} )
 option(ACTS_USE_SYSTEM_MODULEMAPGRAPH "Use a system installation of ModuleMapGraph" ${ACTS_USE_SYSTEM_LIBS})
@@ -158,6 +157,10 @@ option(ACTS_COMPILE_HEADERS "Generate targets to compile header files" ON)
 # NOTE: ordering is important here. dependencies must come before dependees
 include(ActsOptionHelpers)
 
+# snapshot the declared options now, before other machinery adds unrelated
+# ACTS_* cache variables, so the end-of-configure summary only lists real options
+acts_collect_option_names()
+
 # any examples component activates the general examples option
 set_option_if(
     ACTS_BUILD_EXAMPLES
@@ -179,8 +182,6 @@ set_option_if(
     OR
     ACTS_BUILD_EXAMPLES_PYTHIA8
     OR
-    ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS
-    OR
     ACTS_BUILD_EXAMPLES_ROOT
 )
 # core plugins might be required by examples or depend on each other
@@ -200,14 +201,6 @@ set_option_if(
     ACTS_BUILD_EXAMPLES_ROOT
     OR
     ACTS_BUILD_PLUGIN_DD4HEP
-)
-set_option_if(
-    ACTS_BUILD_PLUGIN_IDENTIFICATION
-    ACTS_BUILD_PLUGIN_ROOT
-    OR
-    ACTS_BUILD_PLUGIN_EDM4HEP
-    OR
-    ACTS_BUILD_EXAMPLES
 )
 set_option_if(ACTS_BUILD_PLUGIN_JSON ACTS_BUILD_EXAMPLES)
 set_option_if(ACTS_BUILD_FATRAS ACTS_BUILD_EXAMPLES)
@@ -229,6 +222,14 @@ set_option_if(ACTS_BUILD_PLUGIN_JSON ACTS_BUILD_TRACCC)
 set_option_if(ACTS_SETUP_DETRAY ACTS_BUILD_TRACCC)
 set_option_if(ACTS_SETUP_VECMEM ACTS_SETUP_DETRAY)
 set_option_if(ACTS_SETUP_COVFIE ACTS_SETUP_DETRAY)
+
+# DETRAY_SVG_DISPLAY steers whether Detray's SVG display is built, which pulls in
+# ActSVG. It is declared here (rather than only alongside the other Detray
+# options further below) because it is consulted earlier, when deciding whether
+# ActSVG needs to be set up.
+if(ACTS_SETUP_DETRAY)
+    option(DETRAY_SVG_DISPLAY "Build Detray SVG display (requires ActSVG)" TRUE)
+endif()
 
 # feature tests
 include(CheckCXXSourceCompiles)
@@ -446,15 +447,21 @@ if(ACTS_BUILD_PYTHON_BINDINGS)
         add_subdirectory(thirdparty/pybind11)
     endif()
 endif()
-# Set up ActSVG when explicitly requested via plugin build, or when Detray's
-# SVG display path is enabled in the superbuild.
-if(
-    ACTS_BUILD_PLUGIN_ACTSVG
-    OR (
-        ACTS_SETUP_DETRAY
-        AND (NOT DEFINED DETRAY_SVG_DISPLAY OR DETRAY_SVG_DISPLAY)
+# Set up ActSVG when explicitly requested via the plugin build, or when Detray's
+# SVG display path is enabled (Detray links ActSVG in that case). The reason is
+# computed explicitly so it is visible in the configure output why ActSVG is
+# being pulled in even without ACTS_BUILD_PLUGIN_ACTSVG.
+set(_acts_setup_actsvg OFF)
+if(ACTS_BUILD_PLUGIN_ACTSVG)
+    set(_acts_setup_actsvg ON)
+elseif(ACTS_SETUP_DETRAY AND DETRAY_SVG_DISPLAY)
+    set(_acts_setup_actsvg ON)
+    message(
+        STATUS
+        "Setting up ActSVG because Detray SVG display (DETRAY_SVG_DISPLAY) is enabled"
     )
-)
+endif()
+if(_acts_setup_actsvg)
     if(ACTS_USE_SYSTEM_ACTSVG)
         find_package(actsvg ${_acts_actsvg_version} REQUIRED CONFIG)
     else()
@@ -534,6 +541,11 @@ if(ACTS_BUILD_PLUGIN_ROOT)
     )
 endif()
 if(ACTS_BUILD_ANALYSIS_APPS)
+    # analysis apps link ROOT directly, not via the ACTS Root plugin
+    message(
+        STATUS
+        "ACTS_BUILD_ANALYSIS_APPS enabled: requiring ROOT (Geom, Graf)"
+    )
     find_package(
         ROOT
         ${_acts_root_version}
@@ -636,7 +648,8 @@ if(ACTS_SETUP_DETRAY)
     option(DETRAY_SETUP_ACTSVG "" FALSE)
     option(DETRAY_SETUP_COVFIE "" FALSE)
     option(DETRAY_SETUP_PYBIND11 "" FALSE)
-    option(DETRAY_SVG_DISPLAY "" TRUE)
+    # DETRAY_SVG_DISPLAY is declared earlier (before the ActSVG setup) so it can
+    # steer whether ActSVG is pulled in; it is intentionally not redeclared here.
     if(ACTS_BUILD_TRACCC)
         option(DETRAY_BUILD_TEST_UTILS "" TRUE)
         set(DETRAY_GENERATE_METADATA
@@ -778,3 +791,7 @@ add_subdirectory(docs)
 # create cmake configuration files and environment setup script
 include(ActsCreatePackageConfig)
 include(ActsCreateSetup)
+
+# print a consolidated summary of all ACTS options and their effective values,
+# including which ones were auto-enabled by dependencies (see ActsOptionHelpers)
+acts_print_options_summary()

--- a/cmake/ActsOptionHelpers.cmake
+++ b/cmake/ActsOptionHelpers.cmake
@@ -13,9 +13,121 @@
 
 macro(set_option_if option)
     if(${ARGN})
+        # only announce/record the first time we flip an option from off->on so
+        # that user-requested options (already ON in the cache) are not reported
+        # as if we had forced them.
+        if(NOT ${option})
+            string(REPLACE ";" " " _acts_set_option_reason "${ARGN}")
+            message(
+                STATUS
+                "Option '${option}' auto-enabled by: ${_acts_set_option_reason}"
+            )
+            set_property(
+                GLOBAL
+                APPEND
+                PROPERTY _acts_forced_options "${option}"
+            )
+            set_property(
+                GLOBAL
+                PROPERTY
+                    _acts_forced_reason_${option} "${_acts_set_option_reason}"
+            )
+            unset(_acts_set_option_reason)
+        endif()
         # create a regular (directory-scope) variable that should take precedence
         # over a cache entry of the same name. that means that automatically
         # activated options are not stored in the cache.
         set(${option} ON)
     endif()
 endmacro()
+
+# Snapshot the set of currently-defined ACTS_* cache entries as the canonical
+# list of user-facing options. This must be called right after all options have
+# been declared, but *before* other machinery (e.g. FetchContent source
+# descriptions in ActsExternSources) adds unrelated ACTS_* cache variables, so
+# that the summary below only reports genuine options.
+function(acts_collect_option_names)
+    get_cmake_property(_all_cache_vars CACHE_VARIABLES)
+    set(_names "")
+    foreach(_var IN LISTS _all_cache_vars)
+        if(_var MATCHES "^ACTS_")
+            list(APPEND _names "${_var}")
+        endif()
+    endforeach()
+    set_property(GLOBAL PROPERTY _acts_option_names "${_names}")
+endfunction()
+
+# Print a consolidated summary of all ACTS_* options and their *effective*
+# values at the end of configuration.
+#
+# This is important because options force-enabled via `set_option_if` are stored
+# as directory-scope variables, not cache entries. As a result the cache (and
+# tools like `ccmake` / `cmake -LAH`) keep showing the un-forced value, while the
+# build actually uses the forced one. This summary reports the value the build
+# will really use and flags which options were auto-enabled and why.
+function(acts_print_options_summary)
+    get_property(_option_names GLOBAL PROPERTY _acts_option_names)
+    list(SORT _option_names)
+    get_property(_forced GLOBAL PROPERTY _acts_forced_options)
+
+    set(_enabled "")
+    set(_disabled "")
+    set(_values "")
+
+    foreach(_var IN LISTS _option_names)
+        get_property(_type CACHE ${_var} PROPERTY TYPE)
+        if(_type STREQUAL "BOOL")
+            # `${_var}` reads the regular variable, which shadows the cache entry,
+            # i.e. it reflects any auto-enabling done via set_option_if.
+            if(${_var})
+                if(_forced AND ("${_var}" IN_LIST _forced))
+                    get_property(
+                        _reason
+                        GLOBAL
+                        PROPERTY _acts_forced_reason_${_var}
+                    )
+                    list(
+                        APPEND _enabled
+                        "  ${_var} = ON   [auto-enabled by: ${_reason}]"
+                    )
+                else()
+                    list(APPEND _enabled "  ${_var} = ON")
+                endif()
+            else()
+                list(APPEND _disabled "${_var}")
+            endif()
+        elseif(NOT "${${_var}}" STREQUAL "")
+            # non-boolean option with a non-default (non-empty) value
+            list(APPEND _values "  ${_var} = ${${_var}}")
+        endif()
+    endforeach()
+
+    list(LENGTH _disabled _n_disabled)
+    string(REPLACE ";" ", " _disabled_str "${_disabled}")
+
+    message(STATUS "")
+    message(
+        STATUS
+        "===================== ACTS option summary ====================="
+    )
+    message(STATUS "Enabled options:")
+    foreach(_line IN LISTS _enabled)
+        message(STATUS "${_line}")
+    endforeach()
+    if(_values)
+        message(STATUS "Configured values:")
+        foreach(_line IN LISTS _values)
+            message(STATUS "${_line}")
+        endforeach()
+    endif()
+    message(STATUS "Disabled options (${_n_disabled}): ${_disabled_str}")
+    message(
+        STATUS
+        "  '[auto-enabled by: ...]' = forced on by a dependency; the cache still shows OFF."
+    )
+    message(
+        STATUS
+        "==============================================================="
+    )
+    message(STATUS "")
+endfunction()

--- a/docs/cmake_option_dependencies.py
+++ b/docs/cmake_option_dependencies.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Derive the ACTS CMake option auto-enable ("closure") table from a cmake lists
+file.
+
+It parses `option(ACTS_... )` declarations and `set_option_if(<target>
+<condition>)` implications from the given cmake file, computes for every option
+the transitive set of options it auto-enables, and writes a markdown table.
+
+This is the machine-readable counterpart to the `set_option_if` calls in the
+top-level `CMakeLists.txt`: enabling an option there can silently switch on
+other options during configuration. The table makes that dependency graph
+explicit.
+
+Mirrors `docs/parse_cmake_options.py`: use `--write FILE` to update the table in
+place between the `<!-- CMAKE_OPTS_DEPS_BEGIN -->` / `<!-- CMAKE_OPTS_DEPS_END
+-->` markers, and `--verify` to only check that the file is up to date (used by
+the lint job).
+"""
+
+import argparse
+from pathlib import Path
+import re
+import sys
+import difflib
+
+BEGIN_MARKER = "<!-- CMAKE_OPTS_DEPS_BEGIN -->"
+END_MARKER = "<!-- CMAKE_OPTS_DEPS_END -->"
+
+
+def parse(text, prefix):
+    """Return (declared option names, list of (target, condition-tokens))."""
+    # drop comments so they cannot leak into parsed conditions
+    text = re.sub(r"#.*", "", text)
+
+    options = set(re.findall(rf"option\(\s*({prefix}\w+)", text))
+
+    rules = []
+    # set_option_if conditions in this project never contain nested parentheses,
+    # so matching up to the first closing paren is sufficient and robust against
+    # the one-token-per-line formatting enforced by gersemi.
+    for m in re.finditer(r"set_option_if\(([^)]*)\)", text, re.DOTALL):
+        tokens = m.group(1).split()
+        if not tokens:
+            continue
+        target, condition = tokens[0], tokens[1:]
+        rules.append((target, condition))
+    return options, rules
+
+
+def eval_condition(condition, enabled):
+    """Evaluate a set_option_if condition given the set of enabled options.
+
+    The condition is CMake boolean syntax restricted to variable names and the
+    AND/OR/NOT operators. CMake and Python share the same operator precedence
+    (NOT > AND > OR), so we translate to an equivalent Python expression.
+    """
+    if not condition:
+        return False
+    expr = []
+    for token in condition:
+        if token == "AND":
+            expr.append("and")
+        elif token == "OR":
+            expr.append("or")
+        elif token == "NOT":
+            expr.append("not")
+        elif re.fullmatch(r"[\w:]+", token):
+            expr.append("True" if token in enabled else "False")
+        else:
+            raise ValueError(f"unexpected token in set_option_if condition: {token!r}")
+    return bool(eval(" ".join(expr), {"__builtins__": {}}, {}))
+
+
+def closure(entry, rules):
+    """Options transitively auto-enabled when only `entry` is switched on."""
+    enabled = {entry}
+    changed = True
+    while changed:
+        changed = False
+        for target, condition in rules:
+            if target not in enabled and eval_condition(condition, enabled):
+                enabled.add(target)
+                changed = True
+    return sorted(enabled - {entry})
+
+
+def render_table(rows):
+    headers = ("Enabling this option", "…also enables (transitively)")
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, col in enumerate(row):
+            widths[i] = max(widths[i], len(col))
+
+    def line(cols):
+        return (
+            "| " + " | ".join(col.ljust(widths[i]) for i, col in enumerate(cols)) + " |"
+        )
+
+    out = [line(headers)]
+    out.append("|" + "|".join("-" * (w + 2) for w in widths) + "|")
+    out += [line(row) for row in rows]
+    return "\n".join(out)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("cmakefile", help="Input cmake lists file to parse")
+    p.add_argument(
+        "--prefix",
+        default="ACTS_",
+        help="Prefix identifying the options to consider",
+    )
+    p.add_argument(
+        "--write",
+        "-w",
+        type=Path,
+        help="Write table into this file between the CMAKE_OPTS_DEPS markers",
+    )
+    p.add_argument(
+        "--verify",
+        "-v",
+        action="store_true",
+        help="Only verify the target file is up to date, don't write",
+    )
+    args = p.parse_args()
+
+    options, rules = parse(Path(args.cmakefile).read_text(), args.prefix)
+
+    rows = []
+    for option in sorted(options):
+        enabled = closure(option, rules)
+        if enabled:
+            rows.append((option, ", ".join(enabled)))
+
+    output = render_table(rows)
+
+    if not args.write:
+        print(output)
+        return 0
+
+    if not args.write.exists():
+        print(f"Target file {args.write} does not exist")
+        return 1
+
+    source = args.write.read_text().split("\n")
+    try:
+        begin = source.index(BEGIN_MARKER)
+        end = source.index(END_MARKER)
+    except ValueError:
+        print("Markers not found in output file")
+        return 1
+
+    if args.verify:
+        actual = "\n".join(source[begin + 1 : end])
+        if output != actual:
+            print("MISMATCH: run docs/cmake_option_dependencies.py --write\n")
+            print(
+                "\n".join(
+                    difflib.unified_diff(
+                        actual.split("\n"),
+                        output.split("\n"),
+                        fromfile="actual",
+                        tofile="expected",
+                    )
+                )
+            )
+            return 1
+        return 0
+
+    out = source[: begin + 1] + output.split("\n") + source[end:]
+    args.write.write_text("\n".join(out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/pages/contributing/building_acts.md
+++ b/docs/pages/contributing/building_acts.md
@@ -258,7 +258,6 @@ components.
 | ACTS_SETUP_DETRAY                 | If we want to set up detray<br> type: `bool`, default: `OFF`                                                                                                                                                                       |
 | ACTS_USE_SYSTEM_VECMEM            | Use a system-provided vecmem<br>installation<br> type: `bool`, default: `ACTS_USE_SYSTEM_LIBS -> OFF`                                                                                                                              |
 | ACTS_SETUP_VECMEM                 | If we want to set up vecmem<br> type: `bool`, default: `OFF`                                                                                                                                                                       |
-| ACTS_USE_SYSTEM_TRACCC            | Use a system-provided traccc<br>installation<br> type: `bool`, default: `ACTS_USE_SYSTEM_LIBS -> OFF`                                                                                                                              |
 | ACTS_USE_SYSTEM_NLOHMANN_JSON     | Use nlohmann::json provided by the<br>system instead of the bundled version<br> type: `bool`, default: `ACTS_USE_SYSTEM_LIBS -> OFF`                                                                                               |
 | ACTS_USE_SYSTEM_PYBIND11          | Use a system installation of pybind11<br> type: `bool`, default: `ACTS_USE_SYSTEM_LIBS -> OFF`                                                                                                                                     |
 | ACTS_USE_SYSTEM_MODULEMAPGRAPH    | Use a system installation of<br>ModuleMapGraph<br> type: `bool`, default: `ACTS_USE_SYSTEM_LIBS -> OFF`                                                                                                                            |
@@ -324,6 +323,47 @@ components.
 
 All ACTS-specific options are disabled or empty by default and must be
 specifically requested.
+
+### Automatically enabled options
+
+Some options imply others. When you enable such an option, ACTS switches on the
+additional options it depends on automatically during configuration. This is
+reported at configure time (`Option '...' auto-enabled by: ...`) and in the
+option summary printed at the end of the configure step.
+
+The table below is generated from the `set_option_if` dependencies in the
+top-level `CMakeLists.txt` and lists, for each option, everything it
+transitively enables when it is the only option you switch on. Dependencies that
+require several options at once (e.g. `ACTS_ENABLE_CUDA`, which needs both
+`ACTS_GNN_ENABLE_MODULEMAP` and `ACTS_BUILD_PLUGIN_GNN`) are not shown here since
+no single option triggers them. Regenerate the table with:
+
+```console
+docs/cmake_option_dependencies.py --write docs/pages/contributing/building_acts.md
+```
+
+<!-- CMAKE_OPTS_DEPS_BEGIN -->
+| Enabling this option        | …also enables (transitively)                                                                                                                                                                     |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACTS_BUILD_EXAMPLES         | ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                                                              |
+| ACTS_BUILD_EXAMPLES_DD4HEP  | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_DD4HEP, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON, ACTS_BUILD_PLUGIN_ROOT                                                       |
+| ACTS_BUILD_EXAMPLES_EDM4HEP | ACTS_BUILD_EXAMPLES, ACTS_BUILD_EXAMPLES_PODIO, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_DD4HEP, ACTS_BUILD_PLUGIN_EDM4HEP, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON, ACTS_BUILD_PLUGIN_ROOT |
+| ACTS_BUILD_EXAMPLES_FASTJET | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                                         |
+| ACTS_BUILD_EXAMPLES_GEANT4  | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_GEANT4, ACTS_BUILD_PLUGIN_JSON                                                                               |
+| ACTS_BUILD_EXAMPLES_GNN     | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_GNN, ACTS_BUILD_PLUGIN_JSON                                                                                  |
+| ACTS_BUILD_EXAMPLES_HASHING | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                                         |
+| ACTS_BUILD_EXAMPLES_PARQUET | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_ARROW, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                |
+| ACTS_BUILD_EXAMPLES_PODIO   | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                                         |
+| ACTS_BUILD_EXAMPLES_PYTHIA8 | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON                                                                                                         |
+| ACTS_BUILD_EXAMPLES_ROOT    | ACTS_BUILD_EXAMPLES, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON, ACTS_BUILD_PLUGIN_ROOT                                                                                 |
+| ACTS_BUILD_ODD              | ACTS_BUILD_EXAMPLES, ACTS_BUILD_EXAMPLES_DD4HEP, ACTS_BUILD_FATRAS, ACTS_BUILD_PLUGIN_DD4HEP, ACTS_BUILD_PLUGIN_FPEMON, ACTS_BUILD_PLUGIN_JSON, ACTS_BUILD_PLUGIN_ROOT                           |
+| ACTS_BUILD_PLUGIN_DD4HEP    | ACTS_BUILD_PLUGIN_ROOT                                                                                                                                                                           |
+| ACTS_BUILD_PLUGIN_MILLE     | ACTS_BUILD_ALIGNMENT                                                                                                                                                                             |
+| ACTS_BUILD_PLUGIN_TRACCC    | ACTS_BUILD_PLUGIN_JSON, ACTS_BUILD_TRACCC, ACTS_SETUP_COVFIE, ACTS_SETUP_DETRAY, ACTS_SETUP_VECMEM                                                                                               |
+| ACTS_BUILD_PYTHON_WHEEL     | ACTS_BUILD_PYTHON_BINDINGS                                                                                                                                                                       |
+| ACTS_BUILD_TRACCC           | ACTS_BUILD_PLUGIN_JSON, ACTS_SETUP_COVFIE, ACTS_SETUP_DETRAY, ACTS_SETUP_VECMEM                                                                                                                  |
+| ACTS_SETUP_DETRAY           | ACTS_SETUP_COVFIE, ACTS_SETUP_VECMEM                                                                                                                                                             |
+<!-- CMAKE_OPTS_DEPS_END -->
 
 ACTS comes with a couple of CMakePresets which allow to collect and
 origanize common configuration workflows. On the surface the current

--- a/thirdparty/actsvg/CMakeLists.txt
+++ b/thirdparty/actsvg/CMakeLists.txt
@@ -17,9 +17,9 @@ message(STATUS "Building actsvg as part of the ACTS project")
 FetchContent_Declare(actsvg SYSTEM ${ACTS_ACTSVG_SOURCE})
 
 set(ACTSVG_BUILD_PYTHON_BINDINGS
-    ${ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS}
+    OFF
     CACHE BOOL
-    "Build python bindings for actsvg if ACTS python bindings are enabled"
+    "Do not build the Python bindings for actsvg (ACTS does not use them)"
 )
 
 set(ACTSVG_BUILD_WEB ON CACHE BOOL "Build the web plugin of ACTSVG")


### PR DESCRIPTION
## What & why

Turning on one ACTS CMake option can silently force others on via `set_option_if`, and because those forced options are directory-scope variables, the cache (and `ccmake` / `cmake -LAH`) keep showing the *un-forced* value. This makes it surprisingly hard to reason about what enabling a given option actually does. This PR makes that behavior visible without removing any flexibility.

## Changes

**Visibility**
- `set_option_if` now announces each auto-enabled option and its trigger (`Option '...' auto-enabled by: ...`).
- A consolidated **option summary** is printed at the end of configuration, reporting *effective* (not cached) values and flagging which options were auto-enabled and why.

**Dead / dangling option cleanup** (no behavior change)
- Remove `ACTS_BUILD_PLUGIN_IDENTIFICATION` (no plugin dir, no consumer).
- Remove `ACTS_USE_SYSTEM_TRACCC` (declared, never read).
- Remove the phantom `ACTS_BUILD_EXAMPLES_PYTHON_BINDINGS` references left dangling by #5583. The actsvg-shim reference has pointed at an undefined variable (⇒ effectively `OFF`) since then; frozen to explicit `OFF`. ⚠️ *If the #4250 intent (build actsvg python bindings alongside ACTS's) should be restored instead, wire it to `ACTS_BUILD_PYTHON_BINDINGS` — flagging for a maintainer decision.*

**Make hidden `find_package` side effects explicit**
- ActSVG pulled in by Detray's SVG display is now a computed flag with an explanatory message, and `DETRAY_SVG_DISPLAY` is hoisted so it is defined where it is first consulted (removes a fragile `NOT DEFINED` forward-reference; behavior identical).
- `ACTS_BUILD_ANALYSIS_APPS` now states that it requires ROOT (it links ROOT directly, not via the Root plugin).

**Derived dependency docs**
- New `docs/cmake_option_dependencies.py` derives the transitive option auto-enable ("closure") table from `CMakeLists.txt` and writes it into `building_acts.md`, enforced by a `cmake_option_dependencies` pre-commit hook mirroring the existing `cmake_options` one. No hand-maintenance.

## Example output

Configuring with `-DACTS_BUILD_PLUGIN_MILLE=ON -DACTS_LOG_FAILURE_THRESHOLD=WARNING`. The trigger is announced inline as it happens:

```
-- Option 'ACTS_BUILD_ALIGNMENT' auto-enabled by: ACTS_BUILD_PLUGIN_MILLE
```

and the summary at the end of configuration reports the effective state (note `ACTS_BUILD_ALIGNMENT`, which the cache still shows as `OFF`):

```
-- ===================== ACTS option summary =====================
-- Enabled options:
--   ACTS_ARROW_ISOLATED = ON
--   ACTS_BUILD_ALIGNMENT = ON   [auto-enabled by: ACTS_BUILD_PLUGIN_MILLE]
--   ACTS_BUILD_PLUGIN_MILLE = ON
--   ACTS_COMPILE_HEADERS = ON
--   ACTS_GNN_ENABLE_TORCH = ON
--   ACTS_SETUP_BOOST = ON
--   ACTS_SETUP_EIGEN3 = ON
--   ACTS_USE_SYSTEM_EIGEN3 = ON
-- Configured values:
--   ACTS_LOG_FAILURE_THRESHOLD = WARNING
-- Disabled options (60): ACTS_BUILD_ANALYSIS_APPS, ACTS_BUILD_BENCHMARKS, ... (elided)
--   '[auto-enabled by: ...]' = forced on by a dependency; the cache still shows OFF.
-- ===============================================================
```

## Notes
- The derived table is scoped to single-option entry points; dependencies gated on two options at once (currently only `ACTS_ENABLE_CUDA`) are noted in the doc as out of scope.
- Validated with real configures and `pre-commit run` (all hooks pass). The `std::format` configure error in my local env is a pre-existing toolchain limitation, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
