### PR TITLE
fix: Remove unused axis boundary bins

### DIFF
--- a/Core/include/Acts/Seeding/HoughTransformUtils.hpp
+++ b/Core/include/Acts/Seeding/HoughTransformUtils.hpp
@@ -203,7 +203,7 @@ class HoughPlane {
   std::span<const unsigned, std::dynamic_extent> layers(
       std::size_t xBin, std::size_t yBin) const {
     checkIndices(xBin, yBin);
-    return m_houghHist.atLocalBins({xBin, yBin}).getLayers();
+    return m_houghHist.atLocalBins(toGridIndex(xBin, yBin)).getLayers();
   }
 
   /// @brief get the (weighted) number of layers  with hits in one cell of the histogram
@@ -213,7 +213,7 @@ class HoughPlane {
   /// @throws out of range if indices are not within plane limits
   YieldType nLayers(std::size_t xBin, std::size_t yBin) const {
     checkIndices(xBin, yBin);
-    return m_houghHist.atLocalBins({xBin, yBin}).nLayers();
+    return m_houghHist.atLocalBins(toGridIndex(xBin, yBin)).nLayers();
   }
 
   /// @brief get the identifiers of all hits in one cell of the histogram
@@ -225,7 +225,7 @@ class HoughPlane {
   std::span<const identifier_t, std::dynamic_extent> hitIds(
       std::size_t xBin, std::size_t yBin) const {
     checkIndices(xBin, yBin);
-    return m_houghHist.atLocalBins({xBin, yBin}).getHits();
+    return m_houghHist.atLocalBins(toGridIndex(xBin, yBin)).getHits();
   }
   /// @brief get the identifiers of all hits in one cell of the histogram
   /// @param xBin: bin index in the first coordinate
@@ -236,7 +236,8 @@ class HoughPlane {
   std::unordered_set<const identifier_t> uniqueHitIds(std::size_t xBin,
                                                       std::size_t yBin) const {
     checkIndices(xBin, yBin);
-    const auto hits_span = m_houghHist.atLocalBins({xBin, yBin}).getHits();
+    const auto hits_span =
+        m_houghHist.atLocalBins(toGridIndex(xBin, yBin)).getHits();
     return std::unordered_set<identifier_t>(hits_span.begin(), hits_span.end());
   }
   /// @brief access the (weighted) number of hits in one cell of the histogram from bin's coordinates
@@ -246,7 +247,7 @@ class HoughPlane {
   /// @throws out of range if indices are not within plane limits
   YieldType nHits(std::size_t xBin, std::size_t yBin) const {
     checkIndices(xBin, yBin);
-    return m_houghHist.atLocalBins({xBin, yBin}).nHits();
+    return m_houghHist.atLocalBins(toGridIndex(xBin, yBin)).nHits();
   }
 
   /// @brief access the (weighted) number of hits in one cell of the histogram from globalBin index
@@ -280,14 +281,19 @@ class HoughPlane {
   /// @param globalBin Global bin index to convert to coordinates
   /// @return Local bin coordinates (x,y) corresponding to global bin index
   Index axisBins(std::size_t globalBin) const {
-    return m_houghHist.localBinsFromGlobalBin(globalBin);
+    Index index = m_houghHist.localBinsFromGlobalBin(globalBin);
+    --index[0];
+    --index[1];
+    return index;
   }
 
   /// @brief get the globalBin index given the coordinates of the bin
   /// @param indexBin Bin coordinates to convert to global index
   /// @return Global bin index corresponding to local bin coordinates
   std::size_t globalBin(Index indexBin) const {
-    return m_houghHist.globalBinFromLocalBins(indexBin);
+    checkIndices(indexBin[0], indexBin[1]);
+    return m_houghHist.globalBinFromLocalBins(
+        toGridIndex(indexBin[0], indexBin[1]));
   }
 
   /// @brief get the bin indices of the cell containing the largest number
@@ -337,6 +343,12 @@ class HoughPlane {
 
   HoughPlaneConfig m_cfg;  // the configuration object
   HoughHist m_houghHist;   // the histogram data object
+
+  /// Convert the zero-based Hough plane indices to the one-based local indices
+  /// used by bound grid axes.
+  static Index toGridIndex(std::size_t x, std::size_t y) {
+    return {x + 1u, y + 1u};
+  }
 
   /// @brief check if indices are are valid
   void checkIndices(std::size_t x, std::size_t y) const;

--- a/Core/include/Acts/Seeding/HoughTransformUtils.ipp
+++ b/Core/include/Acts/Seeding/HoughTransformUtils.ipp
@@ -119,7 +119,7 @@ void Acts::HoughTransformUtils::HoughPlane<identifier_t>::fillBin(
   m_touchedBins.insert(globalBin({binX, binY}));
 
   // add content to the cell
-  m_houghHist.atLocalBins({binX, binY}).fill(identifier, layer, w);
+  m_houghHist.atLocalBins(toGridIndex(binX, binY)).fill(identifier, layer, w);
   // and update our cached maxima
   YieldType layers = nLayers(binX, binY);
   YieldType hits = nHits(binX, binY);

--- a/Core/include/Acts/Surfaces/SurfaceArray.hpp
+++ b/Core/include/Acts/Surfaces/SurfaceArray.hpp
@@ -103,8 +103,8 @@ class SurfaceArray {
                                             const Vector3& position,
                                             const Vector3& direction) const;
 
-  /// Get the size of the underlying grid structure including under/overflow
-  /// bins
+  /// Get the size of the underlying grid structure, including under/overflow
+  /// bins for open axes
   /// @return the size
   std::size_t size() const;
 
@@ -131,8 +131,8 @@ class SurfaceArray {
   /// Checks if global bin is valid
   /// @param bin the global bin index
   /// @return bool if the bin is valid
-  /// @note Valid means that the index points to a bin which is not a under
-  ///       or overflow bin or out of range in any axis.
+  /// @note Valid means that the index points to a bin which is not an underflow
+  ///       or overflow bin of an open axis, or out of range in any axis.
   bool isValidBin(std::size_t bin) const;
 
   /// The binning values described by this surface grid lookup. They are in

--- a/Core/include/Acts/Utilities/Axis.hpp
+++ b/Core/include/Acts/Utilities/Axis.hpp
@@ -222,8 +222,8 @@ class Axis<AxisType::Equidistant, bdt> : public IAxis {
   /// @note Bin intervals are defined with closed lower bounds and open upper
   ///       bounds, that is \f$l <= x < u\f$ if the value @c x lies within a
   ///       bin with lower bound @c l and upper bound @c u.
-  /// @note Bin indices start at @c 1. The underflow bin has the index @c 0
-  ///       while the index <tt>nBins + 1</tt> indicates the overflow bin .
+  /// @note Regular bin indices start at @c 1. Open axes use @c 0 and
+  ///       <tt>nBins + 1</tt> for their underflow and overflow bins.
   std::size_t getBin(double x) const final {
     return wrapBin(
         static_cast<int>(std::floor((x - getMin()) / getBinWidth()) + 1));
@@ -522,8 +522,8 @@ class Axis<AxisType::Variable, bdt> : public IAxis {
   /// @note Bin intervals are defined with closed lower bounds and open upper
   ///       bounds, that is \f$l <= x < u\f$ if the value @c x lies within a
   ///       bin with lower bound @c l and upper bound @c u.
-  /// @note Bin indices start at @c 1. The underflow bin has the index @c 0
-  ///       while the index <tt>nBins + 1</tt> indicates the overflow bin .
+  /// @note Regular bin indices start at @c 1. Open axes use @c 0 and
+  ///       <tt>nBins + 1</tt> for their underflow and overflow bins.
   std::size_t getBin(double x) const final {
     const auto it = std::ranges::upper_bound(m_binEdges, x);
     return wrapBin(

--- a/Core/include/Acts/Utilities/Grid.hpp
+++ b/Core/include/Acts/Utilities/Grid.hpp
@@ -128,8 +128,9 @@ class Grid final : public IGrid {
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
   ///
-  /// @note The look-up considers under-/overflow bins along each axis.
-  ///       Therefore, the look-up will never fail.
+  /// @note Open axes use under-/overflow bins, while bound and closed axes
+  ///       map out-of-range positions to regular bins. Therefore, the look-up
+  ///       will never fail.
   //
   template <class Point>
   reference atPosition(const Point& point) {
@@ -148,8 +149,9 @@ class Grid final : public IGrid {
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
   ///
-  /// @note The look-up considers under-/overflow bins along each axis.
-  ///       Therefore, the look-up will never fail.
+  /// @note Open axes use under-/overflow bins, while bound and closed axes
+  ///       map out-of-range positions to regular bins. Therefore, the look-up
+  ///       will never fail.
   template <class Point>
   const_reference atPosition(const Point& point) const {
     return m_values.at(globalBinFromPosition(point));
@@ -176,7 +178,7 @@ class Grid final : public IGrid {
   ///         point
   ///
   /// @pre All local bin indices must be a valid index for the corresponding
-  ///      axis (including the under-/overflow bin for this axis).
+  ///      axis (including under-/overflow bins when supported by this axis).
   reference atLocalBins(const index_t& localBins) {
     return m_values.at(m_axes.getGlobalBinFromLocalBins(localBins));
   }
@@ -188,7 +190,7 @@ class Grid final : public IGrid {
   ///         point
   ///
   /// @pre All local bin indices must be a valid index for the corresponding
-  ///      axis (including the under-/overflow bin for this axis).
+  ///      axis (including under-/overflow bins when supported by this axis).
   const_reference atLocalBins(const index_t& localBins) const {
     return m_values.at(m_axes.getGlobalBinFromLocalBins(localBins));
   }
@@ -262,7 +264,7 @@ class Grid final : public IGrid {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point>
   std::size_t globalBinFromPosition(const Point& point) const {
     return m_axes.getGlobalBinFromLocalBins(localBinsFromPosition(point));
@@ -274,7 +276,7 @@ class Grid final : public IGrid {
   /// @return global index for bin defined by the local bin indices
   ///
   /// @pre All local bin indices must be a valid index for the corresponding
-  ///      axis (including the under-/overflow bin for this axis).
+  ///      axis (including under-/overflow bins when supported by this axis).
   std::size_t globalBinFromLocalBins(const index_t& localBins) const {
     return m_axes.getGlobalBinFromLocalBins(localBins);
   }
@@ -290,7 +292,7 @@ class Grid final : public IGrid {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point>
   std::size_t globalBinFromFromLowerLeftEdge(const Point& point) const {
     return m_axes.getGlobalBinFromLocalBins(localBinsFromLowerLeftEdge(point));
@@ -307,7 +309,7 @@ class Grid final : public IGrid {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point>
   index_t localBinsFromPosition(const Point& point) const {
     return detail::MultiAxisHelper::getLocalBinsFromPoint(
@@ -320,8 +322,7 @@ class Grid final : public IGrid {
   /// @return array with local bin indices along each axis (in same order as
   ///         given @c axes object)
   ///
-  /// @note Local bin indices can contain under-/overflow bins along the
-  ///       corresponding axis.
+  /// @note Local bin indices can contain under-/overflow bins along open axes.
   index_t localBinsFromGlobalBin(std::size_t bin) const {
     return m_axes.getLocalBinsFromGlobalBin(bin);
   }
@@ -338,7 +339,7 @@ class Grid final : public IGrid {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   ///      dimensions where d is dimensionality of the grid.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point>
   index_t localBinsFromLowerLeftEdge(const Point& point) const {
     return detail::MultiAxisHelper::getLocalBinsFromLowerLeftEdge(
@@ -394,10 +395,9 @@ class Grid final : public IGrid {
   /// @return array returning the maxima of all given axes
   point_t maxPosition() const { return m_axes.getMaxPoint(); }
 
-  /// set all overflow and underflow bins to a certain value
+  /// set all overflow and underflow bins of open axes to a certain value
   ///
-  /// @param value value to be inserted in every overflow and underflow
-  ///                   bin of the grid.
+  /// @param value value to be inserted in every overflow and underflow bin
   ///
   void setExteriorBins(const value_type& value) {
     for (std::size_t index :
@@ -413,7 +413,7 @@ class Grid final : public IGrid {
   ///
   /// @param point location to which to interpolate grid values. The
   ///                   position must be within the grid dimensions and not
-  ///                   lie in an under-/overflow bin along any axis.
+  ///                   lie in an under-/overflow bin along any open axis.
   ///
   /// @return interpolated value at given position
   ///
@@ -469,8 +469,8 @@ class Grid final : public IGrid {
   ///      dimensions where d is dimensionality of the grid.
   ///
   /// @post If @c true is returned, the global bin containing the given point
-  ///       is a valid bin, i.e. it is neither a underflow nor an overflow bin
-  ///       along any axis.
+  ///       is a valid bin, i.e. it is neither an underflow nor an overflow bin
+  ///       along any open axis.
   template <class Point>
   bool isInside(const Point& position) const {
     return detail::MultiAxisHelper::isInside(position, m_axes.getAxesTuple());
@@ -484,12 +484,12 @@ class Grid final : public IGrid {
   ///                       bins along each axis are considered
   /// @return set of global bin indices for all bins in neighborhood
   ///
-  /// @note Over-/underflow bins are included in the neighborhood.
+  /// @note Over-/underflow bins of open axes are included in the neighborhood.
   /// @note The @c size parameter sets the range by how many units each local
   ///       bin index is allowed to be varied. All local bin indices are
   ///       varied independently, that is diagonal neighbors are included.
-  ///       Ignoring the truncation of the neighborhood size reaching beyond
-  ///       over-/underflow bins, the neighborhood is of size \f$2 \times
+  ///       Ignoring truncation at the addressable range, the neighborhood is
+  ///       of size \f$2 \times
   ///       \text{size}+1\f$ along each dimension.
   detail::FlatNeighborHoodIndices<DIM> neighborHoodIndices(
       const index_t& localBins, std::size_t size = 1u) const {
@@ -506,12 +506,12 @@ class Grid final : public IGrid {
   ///                         adjacent bins along each axis are considered
   /// @return set of global bin indices for all bins in neighborhood
   ///
-  /// @note Over-/underflow bins are included in the neighborhood.
+  /// @note Over-/underflow bins of open axes are included in the neighborhood.
   /// @note The @c size parameter sets the range by how many units each local
   ///       bin index is allowed to be varied. All local bin indices are
   ///       varied independently, that is diagonal neighbors are included.
-  ///       Ignoring the truncation of the neighborhood size reaching beyond
-  ///       over-/underflow bins, the neighborhood is of size \f$2 \times
+  ///       Ignoring truncation at the addressable range, the neighborhood is
+  ///       of size \f$2 \times
   ///       \text{size}+1\f$ along each dimension.
   detail::FlatNeighborHoodIndices<DIM> neighborHoodIndices(
       const index_t& localBins,
@@ -522,10 +522,10 @@ class Grid final : public IGrid {
 
   /// total number of bins
   ///
-  /// @param fullCounter Whether to include under-and overflow bins in the count
+  /// @param fullCounter Whether to include under- and overflow bins of open axes
   /// @return total number of bins in the grid
   ///
-  /// @note This number contains under-and overflow bins along all axes.
+  /// @note Bound and closed axes never contribute exterior bins.
   std::size_t size(bool fullCounter = true) const {
     return m_axes.getNTotalBins(fullCounter);
   }

--- a/Core/include/Acts/Utilities/GridIterator.hpp
+++ b/Core/include/Acts/Utilities/GridIterator.hpp
@@ -21,7 +21,7 @@ class Grid;
 
 /// @class GridGlobalIterator
 /// Grid iterator using the global position. This iterates on all
-/// the bins in the grid, including under- and over-flows
+/// the bins in the grid, including under- and overflows where present
 /// @tparam T The type stored in the grid bins
 /// @tparam Axes ... The types of the axes in the grid
 template <typename T, class... Axes>
@@ -150,7 +150,7 @@ class GridGlobalIterator {
 
 /// @class GridLocalIterator
 /// Grid iterator using the local position. This iterates on all
-/// local bins in the grid, and can exclude under- and over-flows
+/// local bins in the grid, and can exclude under- and overflows where present
 /// Can also allow for custom navigation pattern along axes
 /// @tparam T The type stored in the grid bins
 /// @tparam Axes ... The types of the axes in the grid
@@ -274,7 +274,7 @@ class GridLocalIterator {
   /// if the iterator gets used after being invalidated
   detail::RefHolder<const Grid<T, Axes...>> m_grid{nullptr};
   /// @brief The maximum number of local bins in the grid. This does not include
-  /// under- and over-flow bins
+  /// under- and overflow bins
   std::array<std::size_t, DIM> m_numLocalBins{};
   /// @brief The current iteration position.
   ///
@@ -289,8 +289,8 @@ class GridLocalIterator {
   ///
   /// This allows users to define any custom iteration sequence in all the
   /// different axes of the grid. If nothing is defined by the user, then
-  /// a std::iota is used as the default starting with the 1ul bin (0ul) is
-  /// the under-flow in the axis
+  /// a std::iota is used as the default starting with bin 1ul. Bin 0ul is the
+  /// underflow bin for open axes and is not addressable for other axes.
   std::array<std::vector<std::size_t>, DIM> m_navigationIndex{};
 };
 

--- a/Core/include/Acts/Utilities/IAxis.hpp
+++ b/Core/include/Acts/Utilities/IAxis.hpp
@@ -66,11 +66,23 @@ class IAxis {
   /// @return total number of bins (excluding under-/overflow bins)
   virtual std::size_t getNBins() const = 0;
 
+  /// Get total number of addressable bins
+  /// @return regular bins plus under-/overflow bins for an open axis
+  std::size_t getNTotalBins() const {
+    return getNBins() + (getBoundaryType() == AxisBoundaryType::Open ? 2u : 0u);
+  }
+
+  /// Get the local index of the first addressable bin
+  /// @return @c 0 for an open axis and @c 1 for a bound or closed axis
+  std::size_t getBinIndexOffset() const {
+    return getBoundaryType() == AxisBoundaryType::Open ? 0u : 1u;
+  }
+
   /// Get corresponding bin index for given coordinate
   /// @param  [in] x input coordinate
   /// @return index of bin containing the given value
-  /// @note Bin indices start at @c 1. The underflow bin has the index @c 0
-  ///       while the index <tt>nBins + 1</tt> indicates the overflow bin .
+  /// @note Regular bin indices start at @c 1. Open axes use @c 0 and
+  ///       <tt>nBins + 1</tt> for their underflow and overflow bins.
   virtual std::size_t getBin(double x) const = 0;
 
   /// Check whether value is inside axis limits

--- a/Core/include/Acts/Utilities/IMultiAxis.hpp
+++ b/Core/include/Acts/Utilities/IMultiAxis.hpp
@@ -42,9 +42,9 @@ using IMultiAxis3D = IMultiAxisXD<3>;
 /// methods, using small vectors) so that grids of differing dimension can be
 /// handled through a common pointer. Bins are addressed either via a
 /// multi-index (one local bin index per axis) or via a single flattened global
-/// bin index. As for @c IAxis, local bin indices start at @c 1, with index
-/// @c 0 and <tt>nBins + 1</tt> denoting the underflow and overflow bins of an
-/// axis; flattened global indices include these under-/overflow bins.
+/// bin index. As for @c IAxis, regular local bin indices start at @c 1.
+/// Open axes additionally have an underflow bin at @c 0 and an overflow bin at
+/// <tt>nBins + 1</tt>, while bound and closed axes have no exterior bins.
 class IMultiAxis {
  private:
   /// Small vector type used to hold per-axis values without heap allocation
@@ -106,13 +106,13 @@ class IMultiAxis {
   }
 
   /// Get the total number of bins in the grid
-  /// @param includeOverflowBins if @c true the under-/overflow bins of every axis are
-  /// included in the count, otherwise only the regular bins are counted
+  /// @param includeOverflowBins if @c true the under-/overflow bins of open
+  /// axes are included in the count, otherwise only regular bins are counted
   /// @return product of the per-axis bin counts
   virtual std::size_t getNTotalBins(bool includeOverflowBins = false) const {
     std::size_t result = 1;
     for (const IAxis& axis : *this) {
-      result *= axis.getNBins() + (includeOverflowBins ? 2 : 0);
+      result *= includeOverflowBins ? axis.getNTotalBins() : axis.getNBins();
     }
     return result;
   }
@@ -496,7 +496,7 @@ class IMultiAxisXD : public IMultiAxis {
 
   /// Determine the flattened global bin index from a multi-index
   /// @param localBins local bin indices along each axis (under-/overflow bins
-  ///        are allowed)
+  ///        are allowed for open axes)
   /// @return global bin index of the bin
   virtual GlobalBin getGlobalBinFromLocalBins(
       const LocalBins& localBins) const {
@@ -506,7 +506,8 @@ class IMultiAxisXD : public IMultiAxis {
 
   /// Determine the multi-index of local bin indices for a given point
   /// @param point coordinates to look up, one per axis
-  /// @return local bin indices along each axis (may be under-/overflow bins)
+  /// @return local bin indices along each axis (may be under-/overflow bins for
+  /// open axes)
   virtual LocalBins getLocalBinsFromPoint(const Point& point) const {
     return detail::MultiAxisHelper::getLocalBinsFromPoint(point,
                                                           getAnyAxesTuple());
@@ -515,7 +516,8 @@ class IMultiAxisXD : public IMultiAxis {
   /// Determine the multi-index of local bin indices from a flattened global
   /// bin index
   /// @param globalBin global bin index
-  /// @return local bin indices along each axis (may be under-/overflow bins)
+  /// @return local bin indices along each axis (may be under-/overflow bins for
+  /// open axes)
   virtual LocalBins getLocalBinsFromGlobalBin(GlobalBin globalBin) const {
     return detail::MultiAxisHelper::getLocalBinsFromGlobalBin(
         globalBin, getAnyAxesTuple());

--- a/Core/include/Acts/Utilities/MultiAxis.hpp
+++ b/Core/include/Acts/Utilities/MultiAxis.hpp
@@ -22,10 +22,8 @@ namespace Acts {
 /// implements the @c IMultiAxisXD interface for the resulting grid. The grid
 /// dimension and the concrete axis types (binning and boundary types) are
 /// fixed at compile time, while the @c IMultiAxis base allows handling
-/// different multi-axes through a common pointer. The grid index conventions
-/// (per-axis local bin indices starting at @c 1, under-/overflow bins at @c 0
-/// and <tt>nBins + 1</tt>, and flattened global bin indices including those
-/// under-/overflow bins) are described on @c IMultiAxis.
+/// different multi-axes through a common pointer. The grid index conventions,
+/// including boundary-dependent exterior bins, are described on @c IMultiAxis.
 ///
 /// @tparam Axes parameter pack of concrete @c Axis types spanning the grid
 template <AxisConcept... Axes>
@@ -135,7 +133,8 @@ class MultiAxis : public IMultiAxisXD<sizeof...(Axes)> {
   /// the point is interpreted as being shifted by half a bin width along each
   /// axis.
   /// @param point coordinates to look up, one per axis
-  /// @return local bin indices along each axis (may be under-/overflow bins)
+  /// @return local bin indices along each axis (may be under-/overflow bins for
+  /// open axes)
   LocalBins getLocalBinsFromLowerLeftEdge(const Point& point) const {
     return detail::MultiAxisHelper::getLocalBinsFromLowerLeftEdge(
         point, m_axes.getAxesTuple());

--- a/Core/include/Acts/Utilities/detail/MultiAxisHelper.hpp
+++ b/Core/include/Acts/Utilities/detail/MultiAxisHelper.hpp
@@ -33,18 +33,32 @@ class FlatNeighborHoodIndices {
  public:
   using size_type = std::size_t;
 
-  /// You can get the neighbor multi indices from
-  /// MultiAxisHelper::neighborHoodIndices and the number of bins in
-  /// each direction from MultiAxisHelper::getNBins.
+  /// Construct from the per-axis neighborhood and the corresponding axes.
+  /// @tparam Axes axis types defining the grid
+  /// @param neighborIndices local neighbor indices for each axis
+  /// @param axes actual axis objects spanning the grid
+  template <class... Axes>
   FlatNeighborHoodIndices(std::array<NeighborHoodIndices, DIM>& neighborIndices,
-                          const std::array<std::size_t, DIM>& nBinsArray)
+                          const std::tuple<Axes...>& axes)
       : m_localBins(neighborIndices) {
+    static_assert(sizeof...(Axes) == DIM);
+    m_binIndexOffsets = std::apply(
+        [](const auto&... axis) {
+          return std::array<std::size_t, DIM>{axis.getBinIndexOffset()...};
+        },
+        axes);
+    const auto nTotalBins = std::apply(
+        [](const auto&... axis) {
+          return std::array<std::size_t, DIM>{axis.getNTotalBins()...};
+        },
+        axes);
+
     if constexpr (DIM == 1) {
       return;
     } else {
       std::size_t flatStride = 1;
       for (long i = DIM - 2; i >= 0; --i) {
-        flatStride *= (nBinsArray[i + 1] + 2);
+        flatStride *= nTotalBins[i + 1];
         m_flatStride[i] = flatStride;
       }
     }
@@ -65,12 +79,14 @@ class FlatNeighborHoodIndices {
         : m_localBinsIter(std::move(multiIndicesIter)), m_parent(&parent) {}
 
     std::size_t operator*() const {
-      std::size_t globalBin = *m_localBinsIter[DIM - 1];
+      std::size_t globalBin =
+          *m_localBinsIter[DIM - 1] - m_parent->m_binIndexOffsets[DIM - 1];
       if constexpr (DIM == 1) {
         return globalBin;
       } else {
         for (std::size_t i = 0; i < DIM - 1; ++i) {
-          globalBin += m_parent->m_flatStride[i] * (*m_localBinsIter[i]);
+          globalBin += m_parent->m_flatStride[i] *
+                       (*m_localBinsIter[i] - m_parent->m_binIndexOffsets[i]);
         }
         return globalBin;
       }
@@ -155,6 +171,7 @@ class FlatNeighborHoodIndices {
 
  private:
   std::array<NeighborHoodIndices, DIM> m_localBins{};
+  std::array<std::size_t, DIM> m_binIndexOffsets{};
   std::array<std::size_t, DIM - 1> m_flatStride{};
 };
 
@@ -225,22 +242,21 @@ struct MultiAxisHelper {
   /// @return global index for bin defined by the local bin indices
   ///
   /// @pre All local bin indices must be a valid index for the corresponding
-  /// axis (including the under-/overflow bin for this axis).
+  /// axis (including under-/overflow bins when supported by this axis).
   template <class... Axes>
   static std::size_t getGlobalBinFromLocalBins(
       const std::array<std::size_t, sizeof...(Axes)>& localBins,
       const std::tuple<Axes...>& axes) {
     // The trailing axis is the fastest running index. The stride for axis i is
-    // the product of (nBins + 2) over all axes following it (the +2 accounts
-    // for the under-/overflow bins), accumulated by walking the axes in
-    // reverse.
+    // the product of the addressable bin counts over all following axes.
     std::size_t bin = 0;
     std::size_t area = 1;
-    forEachAxisReverse(std::index_sequence_for<Axes...>{},
-                       [&]<std::size_t i>() {
-                         bin += area * localBins[i];
-                         area *= std::get<i>(axes).getNBins() + 2;
-                       });
+    forEachAxisReverse(
+        std::index_sequence_for<Axes...>{}, [&]<std::size_t i>() {
+          const auto& axis = std::get<i>(axes);
+          bin += area * (localBins[i] - axis.getBinIndexOffset());
+          area *= axis.getNTotalBins();
+        });
     return bin;
   }
 
@@ -257,7 +273,7 @@ struct MultiAxisHelper {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   /// dimensions where d is the number of axis objects in the tuple.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point, class... Axes>
   static std::array<std::size_t, sizeof...(Axes)> getLocalBinsFromPoint(
       const Point& point, const std::tuple<Axes...>& axes) {
@@ -281,7 +297,7 @@ struct MultiAxisHelper {
   ///
   /// @pre The given @c Point type must represent a point in d (or higher)
   /// dimensions where d is dimensionality of the grid.
-  /// @note This could be a under-/overflow bin along one or more axes.
+  /// @note This could be an under-/overflow bin along one or more open axes.
   template <class Point, class... Axes>
   static std::array<std::size_t, sizeof...(Axes)> getLocalBinsFromLowerLeftEdge(
       const Point& point, const std::tuple<Axes...>& axes) {
@@ -308,7 +324,7 @@ struct MultiAxisHelper {
   /// @return array with local bin indices along each axis (in same order as
   /// given @c axes object)
   ///
-  /// @note Local bin indices can contain under-/overflow bins along any axis.
+  /// @note Local bin indices can contain under-/overflow bins along open axes.
   template <class... Axes>
   static std::array<std::size_t, sizeof...(Axes)> getLocalBinsFromGlobalBin(
       std::size_t bin, const std::tuple<Axes...>& axes) {
@@ -320,12 +336,12 @@ struct MultiAxisHelper {
     std::size_t area = 1;
     forEachAxisReverse(Seq{}, [&]<std::size_t i>() {
       strides[i] = area;
-      area *= std::get<i>(axes).getNBins() + 2;
+      area *= std::get<i>(axes).getNTotalBins();
     });
 
     std::array<std::size_t, sizeof...(Axes)> localBins{};
     forEachAxis(Seq{}, [&]<std::size_t i>() {
-      localBins[i] = bin / strides[i];
+      localBins[i] = bin / strides[i] + std::get<i>(axes).getBinIndexOffset();
       bin %= strides[i];
     });
     return localBins;
@@ -492,12 +508,12 @@ struct MultiAxisHelper {
   /// @return Sorted collection of global bin indices for all bins in
   /// the neighborhood
   ///
-  /// @note Over-/underflow bins are included in the neighborhood.
+  /// @note Over-/underflow bins of open axes are included in the neighborhood.
   /// @note The @c size parameter sets the range by how many units each local
   /// bin index is allowed to be varied. All local bin indices are
   /// varied independently, that is diagonal neighbors are included.
-  /// Ignoring the truncation of the neighborhood size reaching beyond
-  /// over-/underflow bins, the neighborhood is of size \f$2 \times
+  /// Ignoring truncation at the addressable range, the neighborhood is of
+  /// size \f$2 \times
   /// \text{size}+1\f$ along each dimension.
   /// @note The concrete bins which are returned depend on the WrappingTypes
   /// of the contained axes
@@ -514,11 +530,8 @@ struct MultiAxisHelper {
           std::get<i>(axes).neighborHoodIndices(localBins[i], sizes);
     });
 
-    // Query the number of bins
-    std::array<std::size_t, sizeof...(Axes)> nBinsArray = getNBins(axes);
-
     // Produce iterator of global indices
-    return FlatNeighborHoodIndices(neighborIndices, nBinsArray);
+    return FlatNeighborHoodIndices(neighborIndices, axes);
   }
 
   template <class... Axes>
@@ -539,12 +552,12 @@ struct MultiAxisHelper {
   /// @return Sorted collection of global bin indices for all bins in
   /// the neighborhood
   ///
-  /// @note Over-/underflow bins are included in the neighborhood.
+  /// @note Over-/underflow bins of open axes are included in the neighborhood.
   /// @note The @c size parameter sets the range by how many units each local
   /// bin index is allowed to be varied. All local bin indices are
   /// varied independently, that is diagonal neighbors are included.
-  /// Ignoring the truncation of the neighborhood size reaching beyond
-  /// over-/underflow bins, the neighborhood is of size \f$2 \times
+  /// Ignoring truncation at the addressable range, the neighborhood is of
+  /// size \f$2 \times
   /// \text{size}+1\f$ along each dimension.
   /// @note The concrete bins which are returned depend on the WrappingTypes
   /// of the contained axes
@@ -561,64 +574,59 @@ struct MultiAxisHelper {
           std::get<i>(axes).neighborHoodIndices(localBins[i], sizes[i]);
     });
 
-    // Query the number of bins
-    std::array<std::size_t, sizeof...(Axes)> nBinsArray = getNBins(axes);
-
     // Produce iterator of global indices
-    return FlatNeighborHoodIndices(neighborIndices, nBinsArray);
+    return FlatNeighborHoodIndices(neighborIndices, axes);
   }
 
-  /// get bin indices of all overflow and underflow bins
+  /// get bin indices of all overflow and underflow bins of open axes
   ///
   /// @tparam Axes parameter pack of axis types defining the grid
   /// @param axes actual axis objects spanning the grid
-  /// @return set of global bin indices for all over- and underflow bins
+  /// @return set of global bin indices for all over- and underflow bins of open
+  /// axes
   template <class... Axes>
   static std::set<std::size_t> exteriorBinIndices(
       const std::tuple<Axes...>& axes) {
     constexpr std::size_t DIM = sizeof...(Axes);
-    // getNBins excludes the under-/overflow bins; valid indices run 0..nBins+1.
-    const std::array<std::size_t, DIM> nBins = getNBins(axes);
-
+    const auto axisArray = getAxes(axes);
     std::set<std::size_t> combinations;
     std::array<std::size_t, DIM> localBins{};
-    const auto record = [&](std::size_t i0) {
-      localBins[0] = i0;
-      combinations.insert(getGlobalBinFromLocalBins(localBins, axes));
-    };
 
-    // The under-/overflow bins of axis 0 are exterior for any combination of
-    // the remaining axes. We only need to walk the interior bins of axis 0 when
-    // some other axis already sits on an exterior index. Run an odometer over
-    // axes 1..DIM-1 (over their full 0..nBins+1 range) and handle axis 0
-    // explicitly for each combination.
-    while (true) {
-      record(0);
-      record(nBins[0] + 1);
-
-      bool otherExterior = false;
-      for (std::size_t d = 1; d < DIM; ++d) {
-        if (localBins[d] == 0 || localBins[d] == nBins[d] + 1) {
-          otherExterior = true;
-          break;
-        }
-      }
-      if (otherExterior) {
-        for (std::size_t i = 1; i <= nBins[0]; ++i) {
-          record(i);
-        }
+    for (std::size_t exteriorAxis = 0; exteriorAxis < DIM; ++exteriorAxis) {
+      const IAxis& axis = *axisArray[exteriorAxis];
+      if (axis.getBoundaryType() != AxisBoundaryType::Open) {
+        continue;
       }
 
-      // Increment the odometer over axes 1..DIM-1; stop once it wraps around.
-      std::size_t d = 1;
-      for (; d < DIM; ++d) {
-        if (++localBins[d] <= nBins[d] + 1) {
-          break;
+      const std::array exteriorBins{std::size_t{0}, axis.getNBins() + 1u};
+      for (std::size_t exteriorBin : exteriorBins) {
+        for (std::size_t d = 0; d < DIM; ++d) {
+          localBins[d] = axisArray[d]->getBinIndexOffset();
         }
-        localBins[d] = 0;
-      }
-      if (d == DIM) {
-        break;
+        localBins[exteriorAxis] = exteriorBin;
+
+        while (true) {
+          combinations.insert(getGlobalBinFromLocalBins(localBins, axes));
+
+          bool advanced = false;
+          for (std::size_t d = DIM; d-- > 0;) {
+            if (d == exteriorAxis) {
+              continue;
+            }
+            const IAxis& currentAxis = *axisArray[d];
+            const std::size_t lastBin = currentAxis.getBinIndexOffset() +
+                                        currentAxis.getNTotalBins() - 1u;
+            if (localBins[d] < lastBin) {
+              ++localBins[d];
+              advanced = true;
+              break;
+            }
+            localBins[d] = currentAxis.getBinIndexOffset();
+          }
+          if (!advanced) {
+            break;
+          }
+        }
       }
     }
 

--- a/Core/src/Geometry/GridPortalLink.cpp
+++ b/Core/src/Geometry/GridPortalLink.cpp
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <numbers>
+#include <utility>
 
 namespace Acts {
 
@@ -297,19 +298,24 @@ void GridPortalLink::printContents(std::ostream& os) const {
   }
 
   AnyGridConstView<const TrackingVolume*> view(grid());
+  const auto localBinRange = [this](std::size_t axisIndex) {
+    const IAxis& axis = grid().axis(axisIndex);
+    const std::size_t begin = axis.getBinIndexOffset();
+    return std::pair{begin, begin + axis.getNTotalBins()};
+  };
 
   if (dim == 1) {
-    auto loc = grid().numLocalBinsAny();
+    const auto [begin, end] = localBinRange(0);
 
     if (flipped) {
-      os << lpad(loc1, 4) << " > " << lpad("i=0", 10) << " ";
-      for (std::size_t i = 1; i <= loc.at(0) + 1; i++) {
+      os << lpad(loc1, 4) << " > ";
+      for (std::size_t i = begin; i < end; ++i) {
         os << lpad("i=" + std::to_string(i), 13) + " ";
       }
       os << std::endl;
 
       os << std::string(4, ' ');
-      for (std::size_t i = 0; i <= loc.at(0) + 1; i++) {
+      for (std::size_t i = begin; i < end; ++i) {
         std::string name = "0x0";
         if (const auto* v = view.atLocalBins({i}); v != nullptr) {
           name = v->volumeName();
@@ -321,7 +327,7 @@ void GridPortalLink::printContents(std::ostream& os) const {
 
     } else {
       os << "v " << loc0 << std::endl;
-      for (std::size_t i = 0; i <= loc.at(0) + 1; i++) {
+      for (std::size_t i = begin; i < end; ++i) {
         os << "i=" << i << " ";
         std::string name = "0x0";
         if (const auto* v = view.atLocalBins({i}); v != nullptr) {
@@ -334,15 +340,16 @@ void GridPortalLink::printContents(std::ostream& os) const {
     }
 
   } else {
-    auto loc = grid().numLocalBinsAny();
-    os << rpad("v " + loc0 + "|" + loc1 + " >", 14) + "j=0 ";
-    for (std::size_t j = 1; j <= loc.at(1) + 1; j++) {
+    const auto [begin0, end0] = localBinRange(0);
+    const auto [begin1, end1] = localBinRange(1);
+    os << rpad("v " + loc0 + "|" + loc1 + " >", 14);
+    for (std::size_t j = begin1; j < end1; ++j) {
       os << lpad("j=" + std::to_string(j), 13) << " ";
     }
     os << std::endl;
-    for (std::size_t i = 0; i <= loc.at(0) + 1; i++) {
+    for (std::size_t i = begin0; i < end0; ++i) {
       os << "i=" << i << " ";
-      for (std::size_t j = 0; j <= loc.at(1) + 1; j++) {
+      for (std::size_t j = begin1; j < end1; ++j) {
         std::string name = "0x0";
         if (const auto* v = view.atLocalBins({i, j}); v != nullptr) {
           name = v->volumeName();
@@ -358,25 +365,29 @@ void GridPortalLink::printContents(std::ostream& os) const {
 void GridPortalLink::fillGrid1dTo2d(FillDirection dir,
                                     const GridPortalLink& grid1d,
                                     GridPortalLink& grid2d) {
-  const auto locSource = grid1d.grid().numLocalBinsAny();
-  const auto locDest = grid2d.grid().numLocalBinsAny();
   assert(grid1d.grid().dimensions() == 1);
   assert(grid2d.grid().dimensions() == 2);
-  assert(locSource.size() == 1);
-  assert(locDest.size() == 2);
 
   AnyGridConstView<const TrackingVolume*> sourceView(grid1d.grid());
   AnyGridView<const TrackingVolume*> destView(grid2d.grid());
 
-  for (std::size_t i = 0; i <= locSource[0] + 1; ++i) {
+  const IAxis& sourceAxis = grid1d.grid().axis(0);
+  const std::size_t sourceBegin = sourceAxis.getBinIndexOffset();
+  const std::size_t sourceEnd = sourceBegin + sourceAxis.getNTotalBins();
+  const std::size_t destAxisIndex = dir == FillDirection::loc1 ? 1u : 0u;
+  const IAxis& destAxis = grid2d.grid().axis(destAxisIndex);
+  const std::size_t destBegin = destAxis.getBinIndexOffset();
+  const std::size_t destEnd = destBegin + destAxis.getNTotalBins();
+
+  for (std::size_t i = sourceBegin; i < sourceEnd; ++i) {
     const TrackingVolume* source = sourceView.atLocalBins({i});
 
     if (dir == FillDirection::loc1) {
-      for (std::size_t j = 0; j <= locDest[1] + 1; ++j) {
+      for (std::size_t j = destBegin; j < destEnd; ++j) {
         destView.atLocalBins({i, j}) = source;
       }
     } else if (dir == FillDirection::loc0) {
-      for (std::size_t j = 0; j <= locDest[0] + 1; ++j) {
+      for (std::size_t j = destBegin; j < destEnd; ++j) {
         destView.atLocalBins({j, i}) = source;
       }
     }

--- a/Core/src/Surfaces/SurfaceArray.cpp
+++ b/Core/src/Surfaces/SurfaceArray.cpp
@@ -69,7 +69,8 @@ struct SurfaceArray::ISurfaceGridLookup {
       const GeometryContext& gctx, const Vector3& position,
       const Vector3& direction) const = 0;
 
-  /// Returns the total size of the grid (including under/overflow bins)
+  /// Returns the total size of the grid, including under/overflow bins for
+  /// open axes
   /// @return Size of the grid data structure
   virtual std::size_t size() const = 0;
 
@@ -90,8 +91,8 @@ struct SurfaceArray::ISurfaceGridLookup {
   /// Checks if global bin is valid
   /// @param bin the global bin index
   /// @return bool if the bin is valid
-  /// @note Valid means that the index points to a bin which is not a under
-  ///       or overflow bin or out of range in any axis.
+  /// @note Valid means that the index points to a bin which is not an underflow
+  ///       or overflow bin of an open axis, or out of range in any axis.
   virtual bool isValidBin(std::size_t bin) const = 0;
 
   /// The binning values described by this surface grid lookup. They are in
@@ -261,8 +262,8 @@ struct SurfaceGridLookupImpl final : SurfaceArray::ISurfaceGridLookup {
   }
 
   std::size_t size() const override {
-    const GridIndex nBins = numLocalBins2D();
-    return (nBins[0] + 2) * (nBins[1] + 2);
+    return std::get<0>(m_axes).getNTotalBins() *
+           std::get<1>(m_axes).getNTotalBins();
   }
 
   std::vector<AxisDirection> binningValues() const override {
@@ -390,7 +391,7 @@ struct SurfaceGridLookupImpl final : SurfaceArray::ISurfaceGridLookup {
       const std::size_t current = queue.back();
       queue.pop_back();
 
-      // Skip overflow bins as they do not produce a valid bin center
+      // Skip exterior bins of open axes because they have no valid bin center
       if (!isValidBin(current)) {
         continue;
       }

--- a/Examples/Algorithms/TrackFinding/src/HoughTransformSeeder.cpp
+++ b/Examples/Algorithms/TrackFinding/src/HoughTransformSeeder.cpp
@@ -36,6 +36,9 @@ static inline int quant(double min, double max, unsigned nSteps, double val);
 static inline double unquant(double min, double max, unsigned nSteps, int step);
 template <typename T>
 static inline std::string to_string(std::vector<T> v);
+static inline HoughHist::index_t gridIndex(std::size_t y, std::size_t x) {
+  return {y + 1u, x + 1u};
+}
 
 thread_local std::vector<std::shared_ptr<HoughMeasurementStruct>>
     houghMeasurementStructs;
@@ -169,7 +172,8 @@ ProcessCode HoughTransformSeeder::execute(const AlgorithmContext& ctx) const {
         std::vector<std::vector<std::vector<Index>>> hitIndicesAll(
             m_cfg.nLayers);
         std::vector<std::size_t> nHitsPerLayer(m_cfg.nLayers);
-        for (auto measurementIndex : m_houghHist.atLocalBins({y, x}).second) {
+        for (auto measurementIndex :
+             m_houghHist.atLocalBins(gridIndex(y, x)).second) {
           HoughMeasurementStruct* meas =
               houghMeasurementStructs[measurementIndex].get();
           hitIndicesAll[meas->layer].push_back(meas->indices);
@@ -225,8 +229,8 @@ HoughHist HoughTransformSeeder::createLayerHoughHist(unsigned layer,
       // Update the houghHist
       for (unsigned y = y_bin_min; y < y_bin_max; y++) {
         for (unsigned x = xBins.first; x < xBins.second; x++) {
-          houghHist.atLocalBins({y, x}).first++;
-          houghHist.atLocalBins({y, x}).second.insert(index);
+          houghHist.atLocalBins(gridIndex(y, x)).first++;
+          houghHist.atLocalBins(gridIndex(y, x)).second.insert(index);
         }
       }
     }
@@ -243,11 +247,12 @@ HoughHist HoughTransformSeeder::createHoughHist(int subregion) const {
     HoughHist layerHoughHist = createLayerHoughHist(i, subregion);
     for (unsigned x = 0; x < m_cfg.houghHistSize_x; ++x) {
       for (unsigned y = 0; y < m_cfg.houghHistSize_y; ++y) {
-        if (layerHoughHist.atLocalBins({y, x}).first > 0) {
-          houghHist.atLocalBins({y, x}).first++;
-          houghHist.atLocalBins({y, x}).second.insert(
-              layerHoughHist.atLocalBins({y, x}).second.begin(),
-              layerHoughHist.atLocalBins({y, x}).second.end());
+        if (layerHoughHist.atLocalBins(gridIndex(y, x)).first > 0) {
+          houghHist.atLocalBins(gridIndex(y, x)).first++;
+          houghHist.atLocalBins(gridIndex(y, x))
+              .second.insert(
+                  layerHoughHist.atLocalBins(gridIndex(y, x)).second.begin(),
+                  layerHoughHist.atLocalBins(gridIndex(y, x)).second.end());
         }
       }
     }
@@ -264,7 +269,8 @@ bool HoughTransformSeeder::passThreshold(HoughHist const& houghHist, unsigned x,
     return false;
   }
   for (unsigned i = 0; i < m_cfg.threshold.size(); i++) {
-    if (houghHist.atLocalBins({y, x - width + i}).first < m_cfg.threshold[i]) {
+    if (houghHist.atLocalBins(gridIndex(y, x - width + i)).first <
+        m_cfg.threshold[i]) {
       return false;
     }
   }
@@ -279,18 +285,18 @@ bool HoughTransformSeeder::passThreshold(HoughHist const& houghHist, unsigned x,
           continue;
         }
         if (y + j < m_cfg.houghHistSize_y && x + i < m_cfg.houghHistSize_x) {
-          if (houghHist.atLocalBins({y + j, x + i}).first >
-              houghHist.atLocalBins({y, x}).first) {
+          if (houghHist.atLocalBins(gridIndex(y + j, x + i)).first >
+              houghHist.atLocalBins(gridIndex(y, x)).first) {
             return false;
           }
-          if (houghHist.atLocalBins({y + j, x + i}).first ==
-              houghHist.atLocalBins({y, x}).first) {
-            if (houghHist.atLocalBins({y + j, x + i}).second.size() >
-                houghHist.atLocalBins({y, x}).second.size()) {
+          if (houghHist.atLocalBins(gridIndex(y + j, x + i)).first ==
+              houghHist.atLocalBins(gridIndex(y, x)).first) {
+            if (houghHist.atLocalBins(gridIndex(y + j, x + i)).second.size() >
+                houghHist.atLocalBins(gridIndex(y, x)).second.size()) {
               return false;
             }
-            if (houghHist.atLocalBins({y + j, x + i}).second.size() ==
-                    houghHist.atLocalBins({y, x}).second.size() &&
+            if (houghHist.atLocalBins(gridIndex(y + j, x + i)).second.size() ==
+                    houghHist.atLocalBins(gridIndex(y, x)).second.size() &&
                 j <= 0 && i <= 0) {
               return false;  // favor bottom-left (low phi, low neg q/pt)
             }

--- a/Plugins/Detray/src/DetrayNavigation.cpp
+++ b/Plugins/Detray/src/DetrayNavigation.cpp
@@ -198,10 +198,9 @@ std::optional<DetraySurfaceGrid> DetrayPayloadConverter::convertSurfaceArray(
       return [](unsigned int i) { return i; };
     }
 
-    // For Closed/Bound, detray does not have under/overflow bins.
-    // In ACTS, the bins a physically still present, so we only loop
-    // [1, N]. Detray's indices however still go [0, N-1], so we subtract 1 from
-    // the indices in the direction.
+    // For Closed/Bound, ACTS and detray both omit under/overflow bins.
+    // ACTS local indices run [1, N], while detray's indices run [0, N-1], so
+    // subtract one from the ACTS index.
     return [](unsigned int i) { return i - 1; };
   };
 

--- a/Plugins/Json/src/TrackingGeometryJsonConverter.cpp
+++ b/Plugins/Json/src/TrackingGeometryJsonConverter.cpp
@@ -48,6 +48,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <unordered_set>
+#include <utility>
 
 template <typename object_t, const char* kContext>
 struct Acts::TrackingGeometryJsonConverter::PointerToIdLookup {
@@ -498,12 +499,17 @@ nlohmann::json encodeGridPortalLink(
   }
 
   Acts::AnyGridConstView<const Acts::TrackingVolume*> view(link.grid());
-  const auto nBins = view.numLocalBins();
   const auto dim = view.dimensions();
+  const auto localBinRange = [&view](std::size_t axisIndex) {
+    const Acts::IAxis& axis = view.multiAxisAny().getAxis(axisIndex);
+    const std::size_t begin = axis.getBinIndexOffset();
+    return std::pair{begin, begin + axis.getNTotalBins()};
+  };
 
   jLink[kBinsKey] = nlohmann::json::array();
   if (dim == 1u) {
-    for (std::size_t i0 = 0u; i0 <= nBins.at(0) + 1u; ++i0) {
+    const auto [begin0, end0] = localBinRange(0);
+    for (std::size_t i0 = begin0; i0 < end0; ++i0) {
       nlohmann::json jBin;
       jBin[kLocalKey] = std::vector<std::size_t>{i0};
       if (const auto* target = view.atLocalBins({i0}); target == nullptr) {
@@ -514,8 +520,10 @@ nlohmann::json encodeGridPortalLink(
       jLink[kBinsKey].push_back(std::move(jBin));
     }
   } else if (dim == 2u) {
-    for (std::size_t i0 = 0u; i0 <= nBins.at(0) + 1u; ++i0) {
-      for (std::size_t i1 = 0u; i1 <= nBins.at(1) + 1u; ++i1) {
+    const auto [begin0, end0] = localBinRange(0);
+    const auto [begin1, end1] = localBinRange(1);
+    for (std::size_t i0 = begin0; i0 < end0; ++i0) {
+      for (std::size_t i1 = begin1; i1 < end1; ++i1) {
         nlohmann::json jBin;
         jBin[kLocalKey] = std::vector<std::size_t>{i0, i1};
         if (const auto* target = view.atLocalBins({i0, i1});
@@ -603,6 +611,22 @@ std::unique_ptr<Acts::PortalLinkBase> decodeGridPortalLink(
       throw std::invalid_argument("Grid bin dimensionality mismatch");
     }
     Acts::IGrid::AnyIndexType localIndices(local.begin(), local.end());
+
+    // Older files contain unused exterior entries for bound and closed axes.
+    // Ignore those entries now that the corresponding bins are not stored.
+    bool isAddressable = true;
+    for (std::size_t i = 0; i < dim; ++i) {
+      const Acts::IAxis& axis = *axes.at(i);
+      const std::size_t begin = axis.getBinIndexOffset();
+      const std::size_t end = begin + axis.getNTotalBins();
+      if (localIndices[i] < begin || localIndices[i] >= end) {
+        isAddressable = false;
+        break;
+      }
+    }
+    if (!isAddressable) {
+      continue;
+    }
 
     const Acts::TrackingVolume* target = nullptr;
     if (!jBin.at(kTargetVolumeIdKey).is_null()) {

--- a/Tests/UnitTests/Core/Seeding/HoughTransformTest.cpp
+++ b/Tests/UnitTests/Core/Seeding/HoughTransformTest.cpp
@@ -247,6 +247,10 @@ BOOST_AUTO_TEST_CASE(hough_plane_layers_hits) {
   const std::size_t nY = 1;
   HoughTransformUtils::HoughPlaneConfig config{nX, nY};
   HoughTransformUtils::HoughPlane<std::uint8_t> plane(config);
+  using Index = decltype(plane)::Index;
+
+  BOOST_CHECK_EQUAL(plane.globalBin({0, 0}), 0u);
+  BOOST_CHECK((plane.axisBins(0u) == Index{0u, 0u}));
 
   std::uint8_t nHits = 0;
   static constexpr std::uint8_t nLayers = 10;

--- a/Tests/UnitTests/Core/Utilities/AxesTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/AxesTests.cpp
@@ -25,6 +25,8 @@ BOOST_AUTO_TEST_CASE(equidistant_axis) {
 
   // general binning properties
   BOOST_CHECK_EQUAL(a.getNBins(), 10u);
+  BOOST_CHECK_EQUAL(a.getNTotalBins(), 12u);
+  BOOST_CHECK_EQUAL(a.getBinIndexOffset(), 0u);
   BOOST_CHECK_EQUAL(a.getMax(), 10.);
   BOOST_CHECK_EQUAL(a.getMin(), 0.);
   BOOST_CHECK_EQUAL(a.getBinWidth(), 1.);
@@ -104,6 +106,8 @@ BOOST_AUTO_TEST_CASE(variable_axis) {
 
   // general binning properties
   BOOST_CHECK_EQUAL(a.getNBins(), 4u);
+  BOOST_CHECK_EQUAL(a.getNTotalBins(), 6u);
+  BOOST_CHECK_EQUAL(a.getBinIndexOffset(), 0u);
   BOOST_CHECK_EQUAL(a.getMax(), 6.);
   BOOST_CHECK_EQUAL(a.getMin(), 0.);
 
@@ -149,14 +153,17 @@ BOOST_AUTO_TEST_CASE(variable_axis) {
   BOOST_CHECK(!a.isInside(12.));
 }
 
-BOOST_AUTO_TEST_CASE(open_axis) {
+BOOST_AUTO_TEST_CASE(bound_axis) {
   Axis<AxisType::Equidistant, AxisBoundaryType::Bound> a(0, 10, 10);
+
+  BOOST_CHECK_EQUAL(a.getNTotalBins(), 10u);
+  BOOST_CHECK_EQUAL(a.getBinIndexOffset(), 1u);
 
   // normal inside
   BOOST_CHECK_EQUAL(a.getBin(0.5), 1u);
   BOOST_CHECK_EQUAL(a.getBin(9.5), 10u);
 
-  // out of bounds, but is open
+  // out of bounds, but is bound
   // -> should clamp
   BOOST_CHECK_EQUAL(a.getBin(-0.5), 1u);
   BOOST_CHECK_EQUAL(a.getBin(10.5), 10u);
@@ -164,11 +171,14 @@ BOOST_AUTO_TEST_CASE(open_axis) {
   Axis<AxisType::Variable, AxisBoundaryType::Bound> b(
       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
 
+  BOOST_CHECK_EQUAL(b.getNTotalBins(), 10u);
+  BOOST_CHECK_EQUAL(b.getBinIndexOffset(), 1u);
+
   // normal inside
   BOOST_CHECK_EQUAL(b.getBin(0.5), 1u);
   BOOST_CHECK_EQUAL(b.getBin(9.5), 10u);
 
-  // out of bounds, but is open
+  // out of bounds, but is bound
   // -> should clamp
   BOOST_CHECK_EQUAL(b.getBin(-0.5), 1u);
   BOOST_CHECK_EQUAL(b.getBin(10.5), 10u);
@@ -176,6 +186,9 @@ BOOST_AUTO_TEST_CASE(open_axis) {
 
 BOOST_AUTO_TEST_CASE(closed_axis) {
   Axis<AxisType::Equidistant, AxisBoundaryType::Closed> a(0, 10, 10);
+
+  BOOST_CHECK_EQUAL(a.getNTotalBins(), 10u);
+  BOOST_CHECK_EQUAL(a.getBinIndexOffset(), 1u);
 
   // normal inside
   BOOST_CHECK_EQUAL(a.getBin(0.5), 1u);
@@ -188,6 +201,9 @@ BOOST_AUTO_TEST_CASE(closed_axis) {
 
   Axis<AxisType::Variable, AxisBoundaryType::Closed> b(
       {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+
+  BOOST_CHECK_EQUAL(b.getNTotalBins(), 10u);
+  BOOST_CHECK_EQUAL(b.getBinIndexOffset(), 1u);
 
   // normal inside
   BOOST_CHECK_EQUAL(b.getBin(0.5), 1u);

--- a/Tests/UnitTests/Core/Utilities/GridBinFinderTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/GridBinFinderTests.cpp
@@ -37,15 +37,15 @@ BOOST_AUTO_TEST_CASE(grid_binfinder_boundTypes) {
 
   auto lowerClosedNeighbours = binFinder.findBins(lowerBound, gridClosed);
   BOOST_CHECK_EQUAL(lowerClosedNeighbours.size(), 3ul);
-  BOOST_CHECK_EQUAL(lowerClosedNeighbours[0ul], 10ul);
-  BOOST_CHECK_EQUAL(lowerClosedNeighbours[1ul], 1ul);
-  BOOST_CHECK_EQUAL(lowerClosedNeighbours[2ul], 2ul);
+  BOOST_CHECK_EQUAL(lowerClosedNeighbours[0ul], 9ul);
+  BOOST_CHECK_EQUAL(lowerClosedNeighbours[1ul], 0ul);
+  BOOST_CHECK_EQUAL(lowerClosedNeighbours[2ul], 1ul);
 
   auto upperClosedNeighbours = binFinder.findBins(upperBound, gridClosed);
   BOOST_CHECK_EQUAL(upperClosedNeighbours.size(), 3ul);
-  BOOST_CHECK_EQUAL(upperClosedNeighbours[0ul], 9ul);
-  BOOST_CHECK_EQUAL(upperClosedNeighbours[1ul], 10ul);
-  BOOST_CHECK_EQUAL(upperClosedNeighbours[2ul], 1ul);
+  BOOST_CHECK_EQUAL(upperClosedNeighbours[0ul], 8ul);
+  BOOST_CHECK_EQUAL(upperClosedNeighbours[1ul], 9ul);
+  BOOST_CHECK_EQUAL(upperClosedNeighbours[2ul], 0ul);
 
   // For Open Boundary [default]: out-of-bounds lookups resolve to dedicated
   // underflow and overflow bins.
@@ -70,13 +70,13 @@ BOOST_AUTO_TEST_CASE(grid_binfinder_boundTypes) {
 
   auto lowerBoundNeighbours = binFinder.findBins(lowerBound, gridBound);
   BOOST_CHECK_EQUAL(lowerBoundNeighbours.size(), 2ul);
-  BOOST_CHECK_EQUAL(lowerBoundNeighbours[0ul], 1ul);
-  BOOST_CHECK_EQUAL(lowerBoundNeighbours[1ul], 2ul);
+  BOOST_CHECK_EQUAL(lowerBoundNeighbours[0ul], 0ul);
+  BOOST_CHECK_EQUAL(lowerBoundNeighbours[1ul], 1ul);
 
   auto upperBoundNeighbours = binFinder.findBins(upperBound, gridBound);
   BOOST_CHECK_EQUAL(upperBoundNeighbours.size(), 2ul);
-  BOOST_CHECK_EQUAL(upperBoundNeighbours[0ul], 9ul);
-  BOOST_CHECK_EQUAL(upperBoundNeighbours[1ul], 10ul);
+  BOOST_CHECK_EQUAL(upperBoundNeighbours[0ul], 8ul);
+  BOOST_CHECK_EQUAL(upperBoundNeighbours[1ul], 9ul);
 }
 
 BOOST_AUTO_TEST_CASE(grid_binfinder_constructor) {

--- a/Tests/UnitTests/Core/Utilities/GridTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/GridTests.cpp
@@ -1086,41 +1086,41 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   BOOST_CHECK(g1Cl.neighborHoodIndices({11}, 1).collectVector().empty());
   // overflow, makes no sense
   BOOST_CHECK(
-      (g1Cl.neighborHoodIndices({1}, 1).collectVector() == bins_t{10, 1, 2}));
+      (g1Cl.neighborHoodIndices({1}, 1).collectVector() == bins_t{9, 0, 1}));
   // overflow, makes no sense
   BOOST_CHECK(
-      (g1Cl.neighborHoodIndices({5}, 1).collectVector() == bins_t{4, 5, 6}));
+      (g1Cl.neighborHoodIndices({5}, 1).collectVector() == bins_t{3, 4, 5}));
 
   const Axis f(AxisClosed, 0.0, 1.0, 5u);
   const Axis e(AxisClosed, 0.0, 1.0, 5u);
   const Grid g2Cl(Type<double>, e, f);
 
   BOOST_CHECK((g2Cl.neighborHoodIndices({3, 3}, 1).collectVector() ==
-               bins_t{16, 17, 18, 23, 24, 25, 30, 31, 32}));
+               bins_t{6, 7, 8, 11, 12, 13, 16, 17, 18}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({1, 1}, 1).collectVector() ==
-               bins_t{40, 36, 37, 12, 8, 9, 19, 15, 16}));
+               bins_t{24, 20, 21, 4, 0, 1, 9, 5, 6}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({1, 5}, 1).collectVector() ==
-               bins_t{39, 40, 36, 11, 12, 8, 18, 19, 15}));
+               bins_t{23, 24, 20, 3, 4, 0, 8, 9, 5}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({5, 1}, 1).collectVector() ==
-               bins_t{33, 29, 30, 40, 36, 37, 12, 8, 9}));
+               bins_t{19, 15, 16, 24, 20, 21, 4, 0, 1}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({5, 5}, 1).collectVector() ==
-               bins_t{32, 33, 29, 39, 40, 36, 11, 12, 8}));
+               bins_t{18, 19, 15, 23, 24, 20, 3, 4, 0}));
 
   BOOST_CHECK((g2Cl.neighborHoodIndices({3, 3}, 2).collectVector() ==
-               bins_t{8,  9,  10, 11, 12, 15, 16, 17, 18, 19, 22, 23, 24,
-                      25, 26, 29, 30, 31, 32, 33, 36, 37, 38, 39, 40}));
+               bins_t{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({1, 1}, 2).collectVector() ==
-               bins_t{32, 33, 29, 30, 31, 39, 40, 36, 37, 38, 11, 12, 8,
-                      9,  10, 18, 19, 15, 16, 17, 25, 26, 22, 23, 24}));
+               bins_t{18, 19, 15, 16, 17, 23, 24, 20, 21, 22, 3,  4, 0,
+                      1,  2,  8,  9,  5,  6,  7,  13, 14, 10, 11, 12}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({1, 5}, 2).collectVector() ==
-               bins_t{31, 32, 33, 29, 30, 38, 39, 40, 36, 37, 10, 11, 12,
-                      8,  9,  17, 18, 19, 15, 16, 24, 25, 26, 22, 23}));
+               bins_t{17, 18, 19, 15, 16, 22, 23, 24, 20, 21, 2,  3, 4,
+                      0,  1,  7,  8,  9,  5,  6,  12, 13, 14, 10, 11}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({5, 1}, 2).collectVector() ==
-               bins_t{25, 26, 22, 23, 24, 32, 33, 29, 30, 31, 39, 40, 36,
-                      37, 38, 11, 12, 8,  9,  10, 18, 19, 15, 16, 17}));
+               bins_t{13, 14, 10, 11, 12, 18, 19, 15, 16, 17, 23, 24, 20,
+                      21, 22, 3,  4,  0,  1,  2,  8,  9,  5,  6,  7}));
   BOOST_CHECK((g2Cl.neighborHoodIndices({5, 5}, 2).collectVector() ==
-               bins_t{24, 25, 26, 22, 23, 31, 32, 33, 29, 30, 38, 39, 40,
-                      36, 37, 10, 11, 12, 8,  9,  17, 18, 19, 15, 16}));
+               bins_t{12, 13, 14, 10, 11, 17, 18, 19, 15, 16, 22, 23, 24,
+                      20, 21, 2,  3,  4,  0,  1,  7,  8,  9,  5,  6}));
 
   std::array<std::pair<int, int>, 2> a2;
   // only 2 bins left of requested bin (not including the requested bin)
@@ -1132,13 +1132,13 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
 
   auto returnedBinsVec = g2Cl.neighborHoodIndices({3, 2}, a2).collectVector();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  std::set<std::size_t> expectedBins{8, 9, 10, 11, 15, 16, 17, 18};
+  std::set<std::size_t> expectedBins{0, 1, 2, 3, 5, 6, 7, 8};
   BOOST_CHECK(returnedBins == expectedBins);
 
   returnedBinsVec = g2Cl.neighborHoodIndices({1, 5}, a2).collectVector();
   returnedBins.clear();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  expectedBins = {29, 30, 32, 33, 36, 37, 39, 40};
+  expectedBins = {15, 16, 18, 19, 20, 21, 23, 24};
   BOOST_CHECK(returnedBins == expectedBins);
 
   a2.at(0) = {-6, 7};
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   returnedBinsVec = g2Cl.neighborHoodIndices({1, 5}, a2).collectVector();
   returnedBins.clear();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  expectedBins = {12, 19, 26, 33, 40};
+  expectedBins = {4, 9, 14, 19, 24};
   BOOST_CHECK(returnedBins == expectedBins);
 
   // @TODO 3D test would be nice, but should essentially not be a problem if
@@ -1156,15 +1156,15 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   /*
    *       1   2    3    4    5
    *   |------------------------|
-   * 1 |  8 |  9 | 10 | 11 | 12 |
+   * 1 |  0 |  1 |  2 |  3 |  4 |
    *   |----|----|----|----|----|
-   * 2 | 15 | 16 | 17 | 18 | 19 |
+   * 2 |  5 |  6 |  7 |  8 |  9 |
    *   |----|----|----|----|----|
-   * 3 | 22 | 23 | 24 | 25 | 26 |
+   * 3 | 10 | 11 | 12 | 13 | 14 |
    *   |----|----|----|----|----|
-   * 4 | 29 | 30 | 31 | 32 | 33 |
+   * 4 | 15 | 16 | 17 | 18 | 19 |
    *   |----|----|----|----|----|
-   * 5 | 36 | 37 | 38 | 39 | 40 |
+   * 5 | 20 | 21 | 22 | 23 | 24 |
    *   |------------------------|
    */
   // clang-format on
@@ -1213,21 +1213,21 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
 
   // 1D case
   BOOST_CHECK(
-      (g1Cl.closestPointsIndices(Point{0.52}).collectVector() == bins_t{6, 7}));
-  BOOST_CHECK((g1Cl.closestPointsIndices(Point{0.98}).collectVector() ==
-               bins_t{10, 1}));
+      (g1Cl.closestPointsIndices(Point{0.52}).collectVector() == bins_t{5, 6}));
+  BOOST_CHECK(
+      (g1Cl.closestPointsIndices(Point{0.98}).collectVector() == bins_t{9, 0}));
 
   // 2D case
   BOOST_CHECK((g2Cl.closestPointsIndices(Point{0.52, 0.08}).collectVector() ==
-               bins_t{43, 44, 50, 51}));
+               bins_t{25, 26, 30, 31}));
   BOOST_CHECK((g2Cl.closestPointsIndices(Point{0.52, 0.68}).collectVector() ==
-               bins_t{46, 47, 53, 54}));
+               bins_t{28, 29, 33, 34}));
   BOOST_CHECK((g2Cl.closestPointsIndices(Point{0.52, 0.88}).collectVector() ==
-               bins_t{47, 43, 54, 50}));
+               bins_t{29, 25, 34, 30}));
   BOOST_CHECK((g2Cl.closestPointsIndices(Point{0.05, 0.08}).collectVector() ==
-               bins_t{8, 9, 15, 16}));
+               bins_t{0, 1, 5, 6}));
   BOOST_CHECK((g2Cl.closestPointsIndices(Point{0.9, 0.95}).collectVector() ==
-               bins_t{75, 71, 12, 8}));
+               bins_t{49, 45, 4, 0}));
 
   // @TODO: 3D checks would also be nice
 
@@ -1238,23 +1238,23 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
 
   // 1D case
   BOOST_CHECK(
-      (g1Op.closestPointsIndices(Point{0.52}).collectVector() == bins_t{6, 7}));
+      (g1Op.closestPointsIndices(Point{0.52}).collectVector() == bins_t{5, 6}));
   BOOST_CHECK(
-      (g1Op.closestPointsIndices(Point{0.98}).collectVector() == bins_t{10}));
-  BOOST_CHECK((g1Op.closestPointsIndices(Point{0.88}).collectVector() ==
-               bins_t{9, 10}));
+      (g1Op.closestPointsIndices(Point{0.98}).collectVector() == bins_t{9}));
+  BOOST_CHECK(
+      (g1Op.closestPointsIndices(Point{0.88}).collectVector() == bins_t{8, 9}));
 
   // 2D case
   BOOST_CHECK((g2Op.closestPointsIndices(Point{0.52, 0.08}).collectVector() ==
-               bins_t{43, 44, 50, 51}));
+               bins_t{25, 26, 30, 31}));
   BOOST_CHECK((g2Op.closestPointsIndices(Point{0.52, 0.68}).collectVector() ==
-               bins_t{46, 47, 53, 54}));
+               bins_t{28, 29, 33, 34}));
   BOOST_CHECK((g2Op.closestPointsIndices(Point{0.52, 0.88}).collectVector() ==
-               bins_t{47, 54}));
+               bins_t{29, 34}));
   BOOST_CHECK((g2Op.closestPointsIndices(Point{0.05, 0.1}).collectVector() ==
-               bins_t{8, 9, 15, 16}));
+               bins_t{0, 1, 5, 6}));
   BOOST_CHECK((g2Op.closestPointsIndices(Point{0.95, 0.95}).collectVector() ==
-               bins_t{75}));
+               bins_t{49}));
 
   // @TODO: 3D checks would also be nice
 
@@ -1262,27 +1262,26 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
   /*
    *       1    2    3    4    5
    *    |------------------------|
-   *  1 |  8 |  9 | 10 | 11 | 12 |
+   *  1 |  0 |  1 |  2 |  3 |  4 |
    *    |----|----|----|----|----|
-   *  2 | 15 | 16 | 17 | 18 | 19 |
+   *  2 |  5 |  6 |  7 |  8 |  9 |
    *    |----|----|----|----|----|
-   *  3 | 22 | 23 | 24 | 25 | 26 |
+   *  3 | 10 | 11 | 12 | 13 | 14 |
    *    |----|----|----|----|----|
-   *  4 | 29 | 30 | 31 | 32 | 33 |
+   *  4 | 15 | 16 | 17 | 18 | 19 |
    *    |----|----|----|----|----|
-   *  5 | 36 | 37 | 38 | 39 | 40 |
+   *  5 | 20 | 21 | 22 | 23 | 24 |
    *    |------------------------|
-   *  6 | 43 | 44 | 45 | 46 | 47 |
+   *  6 | 25 | 26 | 27 | 28 | 29 |
    *    |------------------------|
-   *  7 | 50 | 51 | 52 | 53 | 54 |
+   *  7 | 30 | 31 | 32 | 33 | 34 |
    *    |------------------------|
-   *  8 | 57 | 58 | 59 | 60 | 61 |
+   *  8 | 35 | 36 | 37 | 38 | 39 |
    *    |------------------------|
-   *  9 | 64 | 65 | 66 | 67 | 68 |
+   *  9 | 40 | 41 | 42 | 43 | 44 |
    *    |------------------------|
-   * 10 | 71 | 72 | 73 | 74 | 75 |
+   * 10 | 45 | 46 | 47 | 48 | 49 |
    *    |------------------------|
-   * 77   78   79   80   81   82   83
    */
   // clang-format on
 }
@@ -1325,6 +1324,42 @@ BOOST_AUTO_TEST_CASE(grid_full_conversion) {
   auto g1ConvertedInt = g1.convertGrid(d2i);
   BOOST_CHECK_EQUAL(g1ConvertedInt.atPosition(Point{0.3}), 1);
   BOOST_CHECK_EQUAL(g1ConvertedInt.atPosition(Point{0.6}), 2);
+}
+
+BOOST_AUTO_TEST_CASE(bound_and_closed_axes_have_no_exterior_bins) {
+  const Axis a(AxisBound, 0.0, 1.0, 1u);
+  const Axis b(AxisClosed, 0.0, 2.0, 2u);
+  const Axis c(AxisBound, 0.0, 3.0, 3u);
+  Grid grid(Type<double>, a, b, c);
+  using Index = decltype(grid)::index_t;
+
+  BOOST_CHECK_EQUAL(grid.size(), 6u);
+  BOOST_CHECK_EQUAL(grid.multiAxis().getNTotalBins(true), 6u);
+  BOOST_CHECK_EQUAL(grid.globalBinFromLocalBins({1, 1, 1}), 0u);
+  BOOST_CHECK_EQUAL(grid.globalBinFromLocalBins({1, 2, 3}), 5u);
+  BOOST_CHECK((grid.localBinsFromGlobalBin(0u) == Index{1, 1, 1}));
+  BOOST_CHECK((grid.localBinsFromGlobalBin(5u) == Index{1, 2, 3}));
+  grid.setExteriorBins(1.0);
+  for (std::size_t globalBin = 0; globalBin < grid.size(); ++globalBin) {
+    BOOST_CHECK_EQUAL(grid.at(globalBin), 0.0);
+  }
+
+  const Axis open(AxisOpen, 0.0, 1.0, 1u);
+  Grid mixedGrid(Type<double>, open, b, c);
+  using MixedIndex = decltype(mixedGrid)::index_t;
+
+  BOOST_CHECK_EQUAL(mixedGrid.size(), 18u);
+  BOOST_CHECK_EQUAL(mixedGrid.globalBinFromLocalBins({0, 1, 1}), 0u);
+  BOOST_CHECK_EQUAL(mixedGrid.globalBinFromLocalBins({1, 1, 1}), 6u);
+  BOOST_CHECK_EQUAL(mixedGrid.globalBinFromLocalBins({2, 2, 3}), 17u);
+  BOOST_CHECK((mixedGrid.localBinsFromGlobalBin(0u) == MixedIndex{0, 1, 1}));
+  BOOST_CHECK((mixedGrid.localBinsFromGlobalBin(6u) == MixedIndex{1, 1, 1}));
+  BOOST_CHECK((mixedGrid.localBinsFromGlobalBin(17u) == MixedIndex{2, 2, 3}));
+  mixedGrid.setExteriorBins(1.0);
+  for (std::size_t globalBin = 0; globalBin < mixedGrid.size(); ++globalBin) {
+    const double expected = globalBin < 6u || globalBin >= 12u ? 1.0 : 0.0;
+    BOOST_CHECK_EQUAL(mixedGrid.at(globalBin), expected);
+  }
 }
 
 BOOST_AUTO_TEST_CASE(Output) {

--- a/Tests/UnitTests/Core/Utilities/MultiAxisTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/MultiAxisTests.cpp
@@ -949,9 +949,9 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
                   .collectVector()
                   .empty());  // overflow, makes no sense
   BOOST_CHECK(ma1Cl.getNeighborHoodIndices({1}, 1).collectVector() ==
-              (bins_t{10, 1, 2}));
+              (bins_t{9, 0, 1}));
   BOOST_CHECK(ma1Cl.getNeighborHoodIndices({5}, 1).collectVector() ==
-              (bins_t{4, 5, 6}));
+              (bins_t{3, 4, 5}));
 
   const Axis f(AxisClosed, 0.0, 1.0, 5u);
   const Axis e(AxisClosed, 0.0, 1.0, 5u);
@@ -959,31 +959,31 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   const MultiAxis ma2Cl(e, f);
 
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({3, 3}, 1).collectVector() ==
-              (bins_t{16, 17, 18, 23, 24, 25, 30, 31, 32}));
+              (bins_t{6, 7, 8, 11, 12, 13, 16, 17, 18}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({1, 1}, 1).collectVector() ==
-              (bins_t{40, 36, 37, 12, 8, 9, 19, 15, 16}));
+              (bins_t{24, 20, 21, 4, 0, 1, 9, 5, 6}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({1, 5}, 1).collectVector() ==
-              (bins_t{39, 40, 36, 11, 12, 8, 18, 19, 15}));
+              (bins_t{23, 24, 20, 3, 4, 0, 8, 9, 5}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({5, 1}, 1).collectVector() ==
-              (bins_t{33, 29, 30, 40, 36, 37, 12, 8, 9}));
+              (bins_t{19, 15, 16, 24, 20, 21, 4, 0, 1}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({5, 5}, 1).collectVector() ==
-              (bins_t{32, 33, 29, 39, 40, 36, 11, 12, 8}));
+              (bins_t{18, 19, 15, 23, 24, 20, 3, 4, 0}));
 
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({3, 3}, 2).collectVector() ==
-              (bins_t{8,  9,  10, 11, 12, 15, 16, 17, 18, 19, 22, 23, 24,
-                      25, 26, 29, 30, 31, 32, 33, 36, 37, 38, 39, 40}));
+              (bins_t{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({1, 1}, 2).collectVector() ==
-              (bins_t{32, 33, 29, 30, 31, 39, 40, 36, 37, 38, 11, 12, 8,
-                      9,  10, 18, 19, 15, 16, 17, 25, 26, 22, 23, 24}));
+              (bins_t{18, 19, 15, 16, 17, 23, 24, 20, 21, 22, 3,  4, 0,
+                      1,  2,  8,  9,  5,  6,  7,  13, 14, 10, 11, 12}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({1, 5}, 2).collectVector() ==
-              (bins_t{31, 32, 33, 29, 30, 38, 39, 40, 36, 37, 10, 11, 12,
-                      8,  9,  17, 18, 19, 15, 16, 24, 25, 26, 22, 23}));
+              (bins_t{17, 18, 19, 15, 16, 22, 23, 24, 20, 21, 2,  3, 4,
+                      0,  1,  7,  8,  9,  5,  6,  12, 13, 14, 10, 11}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({5, 1}, 2).collectVector() ==
-              (bins_t{25, 26, 22, 23, 24, 32, 33, 29, 30, 31, 39, 40, 36,
-                      37, 38, 11, 12, 8,  9,  10, 18, 19, 15, 16, 17}));
+              (bins_t{13, 14, 10, 11, 12, 18, 19, 15, 16, 17, 23, 24, 20,
+                      21, 22, 3,  4,  0,  1,  2,  8,  9,  5,  6,  7}));
   BOOST_CHECK(ma2Cl.getNeighborHoodIndices({5, 5}, 2).collectVector() ==
-              (bins_t{24, 25, 26, 22, 23, 31, 32, 33, 29, 30, 38, 39, 40,
-                      36, 37, 10, 11, 12, 8,  9,  17, 18, 19, 15, 16}));
+              (bins_t{12, 13, 14, 10, 11, 17, 18, 19, 15, 16, 22, 23, 24,
+                      20, 21, 2,  3,  4,  0,  1,  7,  8,  9,  5,  6}));
 
   std::array<std::pair<int, int>, 2> a2;
   a2.at(0) =
@@ -997,13 +997,13 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   auto returnedBinsVec =
       ma2Cl.getNeighborHoodIndices({3, 2}, a2).collectVector();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  std::set<std::size_t> expectedBins{{8, 9, 10, 11, 15, 16, 17, 18}};
+  std::set<std::size_t> expectedBins{{0, 1, 2, 3, 5, 6, 7, 8}};
   BOOST_CHECK(returnedBins == expectedBins);
 
   returnedBinsVec = ma2Cl.getNeighborHoodIndices({1, 5}, a2).collectVector();
   returnedBins.clear();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  expectedBins = {{29, 30, 32, 33, 36, 37, 39, 40}};
+  expectedBins = {{15, 16, 18, 19, 20, 21, 23, 24}};
   BOOST_CHECK(returnedBins == expectedBins);
 
   a2.at(0) = {-6, 7};
@@ -1011,7 +1011,7 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   returnedBinsVec = ma2Cl.getNeighborHoodIndices({1, 5}, a2).collectVector();
   returnedBins.clear();
   returnedBins.insert(returnedBinsVec.begin(), returnedBinsVec.end());
-  expectedBins = {{12, 19, 26, 33, 40}};
+  expectedBins = {{4, 9, 14, 19, 24}};
   BOOST_CHECK(returnedBins == expectedBins);
 
   // @TODO 3D test would be nice, but should essentially not be a problem if
@@ -1021,15 +1021,15 @@ BOOST_AUTO_TEST_CASE(neighborhood) {
   /*
    *       1   2    3    4    5
    *   |------------------------|
-   * 1 |  8 |  9 | 10 | 11 | 12 |
+   * 1 |  0 |  1 |  2 |  3 |  4 |
    *   |----|----|----|----|----|
-   * 2 | 15 | 16 | 17 | 18 | 19 |
+   * 2 |  5 |  6 |  7 |  8 |  9 |
    *   |----|----|----|----|----|
-   * 3 | 22 | 23 | 24 | 25 | 26 |
+   * 3 | 10 | 11 | 12 | 13 | 14 |
    *   |----|----|----|----|----|
-   * 4 | 29 | 30 | 31 | 32 | 33 |
+   * 4 | 15 | 16 | 17 | 18 | 19 |
    *   |----|----|----|----|----|
-   * 5 | 36 | 37 | 38 | 39 | 40 |
+   * 5 | 20 | 21 | 22 | 23 | 24 |
    *   |------------------------|
    */
   // clang-format on
@@ -1091,27 +1091,27 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
   // 1D case
   CHECK_EQUAL_COLLECTIONS(
       ma1Cl.getClosestPointsIndices(Point1{0.52}).collectVector(),
-      (bins_t{6, 7}));
+      (bins_t{5, 6}));
   CHECK_EQUAL_COLLECTIONS(
       ma1Cl.getClosestPointsIndices(Point1{0.98}).collectVector(),
-      (bins_t{10, 1}));
+      (bins_t{9, 0}));
 
   // 2D case
   CHECK_EQUAL_COLLECTIONS(
       ma2Cl.getClosestPointsIndices(Point2{0.52, 0.08}).collectVector(),
-      (bins_t{43, 44, 50, 51}));
+      (bins_t{25, 26, 30, 31}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Cl.getClosestPointsIndices(Point2{0.52, 0.68}).collectVector(),
-      (bins_t{46, 47, 53, 54}));
+      (bins_t{28, 29, 33, 34}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Cl.getClosestPointsIndices(Point2{0.52, 0.88}).collectVector(),
-      (bins_t{47, 43, 54, 50}));
+      (bins_t{29, 25, 34, 30}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Cl.getClosestPointsIndices(Point2{0.05, 0.08}).collectVector(),
-      (bins_t{8, 9, 15, 16}));
+      (bins_t{0, 1, 5, 6}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Cl.getClosestPointsIndices(Point2{0.9, 0.95}).collectVector(),
-      (bins_t{75, 71, 12, 8}));
+      (bins_t{49, 45, 4, 0}));
 
   // @TODO: 3D checks would also be nice
 
@@ -1124,30 +1124,29 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
   // 1D case
   CHECK_EQUAL_COLLECTIONS(
       ma1Op.getClosestPointsIndices(Point1{0.52}).collectVector(),
-      (bins_t{6, 7}));
+      (bins_t{5, 6}));
   CHECK_EQUAL_COLLECTIONS(
-      ma1Op.getClosestPointsIndices(Point1{0.98}).collectVector(),
-      (bins_t{10}));
+      ma1Op.getClosestPointsIndices(Point1{0.98}).collectVector(), (bins_t{9}));
   CHECK_EQUAL_COLLECTIONS(
       ma1Op.getClosestPointsIndices(Point1{0.88}).collectVector(),
-      (bins_t{9, 10}));
+      (bins_t{8, 9}));
 
   // 2D case
   CHECK_EQUAL_COLLECTIONS(
       ma2Op.getClosestPointsIndices(Point2{0.52, 0.08}).collectVector(),
-      (bins_t{43, 44, 50, 51}));
+      (bins_t{25, 26, 30, 31}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Op.getClosestPointsIndices(Point2{0.52, 0.68}).collectVector(),
-      (bins_t{46, 47, 53, 54}));
+      (bins_t{28, 29, 33, 34}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Op.getClosestPointsIndices(Point2{0.52, 0.88}).collectVector(),
-      (bins_t{47, 54}));
+      (bins_t{29, 34}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Op.getClosestPointsIndices(Point2{0.05, 0.1}).collectVector(),
-      (bins_t{8, 9, 15, 16}));
+      (bins_t{0, 1, 5, 6}));
   CHECK_EQUAL_COLLECTIONS(
       ma2Op.getClosestPointsIndices(Point2{0.95, 0.95}).collectVector(),
-      (bins_t{75}));
+      (bins_t{49}));
 
   // @TODO: 3D checks would also be nice
 
@@ -1155,27 +1154,26 @@ BOOST_AUTO_TEST_CASE(closestPoints) {
   /*
    *       1    2    3    4    5
    *    |------------------------|
-   *  1 |  8 |  9 | 10 | 11 | 12 |
+   *  1 |  0 |  1 |  2 |  3 |  4 |
    *    |----|----|----|----|----|
-   *  2 | 15 | 16 | 17 | 18 | 19 |
+   *  2 |  5 |  6 |  7 |  8 |  9 |
    *    |----|----|----|----|----|
-   *  3 | 22 | 23 | 24 | 25 | 26 |
+   *  3 | 10 | 11 | 12 | 13 | 14 |
    *    |----|----|----|----|----|
-   *  4 | 29 | 30 | 31 | 32 | 33 |
+   *  4 | 15 | 16 | 17 | 18 | 19 |
    *    |----|----|----|----|----|
-   *  5 | 36 | 37 | 38 | 39 | 40 |
+   *  5 | 20 | 21 | 22 | 23 | 24 |
    *    |------------------------|
-   *  6 | 43 | 44 | 45 | 46 | 47 |
+   *  6 | 25 | 26 | 27 | 28 | 29 |
    *    |------------------------|
-   *  7 | 50 | 51 | 52 | 53 | 54 |
+   *  7 | 30 | 31 | 32 | 33 | 34 |
    *    |------------------------|
-   *  8 | 57 | 58 | 59 | 60 | 61 |
+   *  8 | 35 | 36 | 37 | 38 | 39 |
    *    |------------------------|
-   *  9 | 64 | 65 | 66 | 67 | 68 |
+   *  9 | 40 | 41 | 42 | 43 | 44 |
    *    |------------------------|
-   * 10 | 71 | 72 | 73 | 74 | 75 |
+   * 10 | 45 | 46 | 47 | 48 | 49 |
    *    |------------------------|
-   * 77   78   79   80   81   82   83
    */
   // clang-format on
 }

--- a/Tests/UnitTests/Plugins/Json/GridJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/GridJsonConverterTests.cpp
@@ -37,11 +37,11 @@ BOOST_AUTO_TEST_CASE(Grid1DSingleEntry) {
   using GridTypeEQB = typename EqBound::template grid_type<std::size_t>;
   GridTypeEQB eqBoundGrid(eqBound());
 
-  eqBoundGrid.at(1u) = 1u;
-  eqBoundGrid.at(2u) = 2u;
-  eqBoundGrid.at(3u) = 3u;
-  eqBoundGrid.at(4u) = 4u;
-  eqBoundGrid.at(5u) = 5u;
+  eqBoundGrid.atLocalBins({1u}) = 1u;
+  eqBoundGrid.atLocalBins({2u}) = 2u;
+  eqBoundGrid.atLocalBins({3u}) = 3u;
+  eqBoundGrid.atLocalBins({4u}) = 4u;
+  eqBoundGrid.atLocalBins({5u}) = 5u;
 
   auto p1 = typename GridTypeEQB::point_t{0.5};
   BOOST_CHECK_EQUAL(eqBoundGrid.atPosition(p1), 1u);
@@ -59,11 +59,11 @@ BOOST_AUTO_TEST_CASE(Grid1DSingleEntry) {
   auto eqBoundGridRead =
       GridJsonConverter::fromJson<EqBound, std::size_t>(eqBoundJson, eqBound);
 
-  BOOST_CHECK_EQUAL(eqBoundGridRead.at(1u), 1u);
-  BOOST_CHECK_EQUAL(eqBoundGridRead.at(2u), 2u);
-  BOOST_CHECK_EQUAL(eqBoundGridRead.at(3u), 3u);
-  BOOST_CHECK_EQUAL(eqBoundGridRead.at(4u), 4u);
-  BOOST_CHECK_EQUAL(eqBoundGridRead.at(5u), 5u);
+  BOOST_CHECK_EQUAL(eqBoundGridRead.atLocalBins({1u}), 1u);
+  BOOST_CHECK_EQUAL(eqBoundGridRead.atLocalBins({2u}), 2u);
+  BOOST_CHECK_EQUAL(eqBoundGridRead.atLocalBins({3u}), 3u);
+  BOOST_CHECK_EQUAL(eqBoundGridRead.atLocalBins({4u}), 4u);
+  BOOST_CHECK_EQUAL(eqBoundGridRead.atLocalBins({5u}), 5u);
 
   // Bound variable
   using VarBound = GridAxisGenerators::VarBound;
@@ -73,22 +73,22 @@ BOOST_AUTO_TEST_CASE(Grid1DSingleEntry) {
   using GridTypeEQV = typename VarBound::template grid_type<std::size_t>;
   GridTypeEQV varBoundGrid(varBound());
 
-  varBoundGrid.at(1u) = 1u;
-  varBoundGrid.at(2u) = 2u;
-  varBoundGrid.at(3u) = 3u;
-  varBoundGrid.at(4u) = 4u;
-  varBoundGrid.at(5u) = 5u;
+  varBoundGrid.atLocalBins({1u}) = 1u;
+  varBoundGrid.atLocalBins({2u}) = 2u;
+  varBoundGrid.atLocalBins({3u}) = 3u;
+  varBoundGrid.atLocalBins({4u}) = 4u;
+  varBoundGrid.atLocalBins({5u}) = 5u;
 
   nlohmann::json varBoundJson = GridJsonConverter::toJson(varBoundGrid);
 
   auto varBoundGridRead = GridJsonConverter::fromJson<VarBound, std::size_t>(
       varBoundJson, varBound);
 
-  BOOST_CHECK_EQUAL(varBoundGridRead.at(1u), 1u);
-  BOOST_CHECK_EQUAL(varBoundGridRead.at(2u), 2u);
-  BOOST_CHECK_EQUAL(varBoundGridRead.at(3u), 3u);
-  BOOST_CHECK_EQUAL(varBoundGridRead.at(4u), 4u);
-  BOOST_CHECK_EQUAL(varBoundGridRead.at(5u), 5u);
+  BOOST_CHECK_EQUAL(varBoundGridRead.atLocalBins({1u}), 1u);
+  BOOST_CHECK_EQUAL(varBoundGridRead.atLocalBins({2u}), 2u);
+  BOOST_CHECK_EQUAL(varBoundGridRead.atLocalBins({3u}), 3u);
+  BOOST_CHECK_EQUAL(varBoundGridRead.atLocalBins({4u}), 4u);
+  BOOST_CHECK_EQUAL(varBoundGridRead.atLocalBins({5u}), 5u);
 
   // Closed equidistant
   using EqClosed = GridAxisGenerators::EqClosed;
@@ -98,22 +98,22 @@ BOOST_AUTO_TEST_CASE(Grid1DSingleEntry) {
   using GridTypeEQC = typename EqClosed::template grid_type<std::size_t>;
   GridTypeEQC eqClosedGrid(eqClosed());
 
-  eqClosedGrid.at(1u) = 1u;
-  eqClosedGrid.at(2u) = 2u;
-  eqClosedGrid.at(3u) = 3u;
-  eqClosedGrid.at(4u) = 4u;
-  eqClosedGrid.at(5u) = 5u;
+  eqClosedGrid.atLocalBins({1u}) = 1u;
+  eqClosedGrid.atLocalBins({2u}) = 2u;
+  eqClosedGrid.atLocalBins({3u}) = 3u;
+  eqClosedGrid.atLocalBins({4u}) = 4u;
+  eqClosedGrid.atLocalBins({5u}) = 5u;
 
   nlohmann::json eqClosedJson = GridJsonConverter::toJson(eqClosedGrid);
 
   auto eqClosedGridRead = GridJsonConverter::fromJson<EqClosed, std::size_t>(
       eqClosedJson, eqClosed);
 
-  BOOST_CHECK_EQUAL(eqClosedGridRead.at(1u), 1u);
-  BOOST_CHECK_EQUAL(eqClosedGridRead.at(2u), 2u);
-  BOOST_CHECK_EQUAL(eqClosedGridRead.at(3u), 3u);
-  BOOST_CHECK_EQUAL(eqClosedGridRead.at(4u), 4u);
-  BOOST_CHECK_EQUAL(eqClosedGridRead.at(5u), 5u);
+  BOOST_CHECK_EQUAL(eqClosedGridRead.atLocalBins({1u}), 1u);
+  BOOST_CHECK_EQUAL(eqClosedGridRead.atLocalBins({2u}), 2u);
+  BOOST_CHECK_EQUAL(eqClosedGridRead.atLocalBins({3u}), 3u);
+  BOOST_CHECK_EQUAL(eqClosedGridRead.atLocalBins({4u}), 4u);
+  BOOST_CHECK_EQUAL(eqClosedGridRead.atLocalBins({5u}), 5u);
 }
 
 BOOST_AUTO_TEST_CASE(Grid1DArrayEntry) {
@@ -126,11 +126,11 @@ BOOST_AUTO_TEST_CASE(Grid1DArrayEntry) {
       typename EqBound::template grid_type<std::array<std::size_t, 2u>>;
   GridTypeEQB eqBoundGrid(eqBound());
 
-  eqBoundGrid.at(1u) = {1u, 1u};
-  eqBoundGrid.at(2u) = {2u, 2u};
-  eqBoundGrid.at(3u) = {3u, 3u};
-  eqBoundGrid.at(4u) = {4u, 4u};
-  eqBoundGrid.at(5u) = {5u, 5u};
+  eqBoundGrid.atLocalBins({1u}) = {1u, 1u};
+  eqBoundGrid.atLocalBins({2u}) = {2u, 2u};
+  eqBoundGrid.atLocalBins({3u}) = {3u, 3u};
+  eqBoundGrid.atLocalBins({4u}) = {4u, 4u};
+  eqBoundGrid.atLocalBins({5u}) = {5u, 5u};
 
   nlohmann::json eqBoundJson = GridJsonConverter::toJson(eqBoundGrid);
 
@@ -138,11 +138,16 @@ BOOST_AUTO_TEST_CASE(Grid1DArrayEntry) {
       GridJsonConverter::fromJson<EqBound, std::array<std::size_t, 2u>>(
           eqBoundJson, eqBound);
 
-  BOOST_CHECK((eqBoundGridRead.at(1u) == std::array<std::size_t, 2u>{1u, 1u}));
-  BOOST_CHECK((eqBoundGridRead.at(2u) == std::array<std::size_t, 2u>{2u, 2u}));
-  BOOST_CHECK((eqBoundGridRead.at(3u) == std::array<std::size_t, 2u>{3u, 3u}));
-  BOOST_CHECK((eqBoundGridRead.at(4u) == std::array<std::size_t, 2u>{4u, 4u}));
-  BOOST_CHECK((eqBoundGridRead.at(5u) == std::array<std::size_t, 2u>{5u, 5u}));
+  BOOST_CHECK((eqBoundGridRead.atLocalBins({1u}) ==
+               std::array<std::size_t, 2u>{1u, 1u}));
+  BOOST_CHECK((eqBoundGridRead.atLocalBins({2u}) ==
+               std::array<std::size_t, 2u>{2u, 2u}));
+  BOOST_CHECK((eqBoundGridRead.atLocalBins({3u}) ==
+               std::array<std::size_t, 2u>{3u, 3u}));
+  BOOST_CHECK((eqBoundGridRead.atLocalBins({4u}) ==
+               std::array<std::size_t, 2u>{4u, 4u}));
+  BOOST_CHECK((eqBoundGridRead.atLocalBins({5u}) ==
+               std::array<std::size_t, 2u>{5u, 5u}));
 }
 
 BOOST_AUTO_TEST_CASE(Grid2DSingleEntryBound) {

--- a/Tests/UnitTests/Plugins/Json/TrackingGeometryJsonConverterTests.cpp
+++ b/Tests/UnitTests/Plugins/Json/TrackingGeometryJsonConverterTests.cpp
@@ -260,10 +260,8 @@ BOOST_AUTO_TEST_CASE(TrackingGeometryJsonConverterRoundTrip) {
   auto gridLink = GridPortalLink::make(gridSurface, AxisDirection::AxisX,
                                        Axis{AxisBound, -2., 2., 2});
   AnyGridView<const TrackingVolume*> gridView(gridLink->grid());
-  gridView.atLocalBins({0u}) = rootPtr;
   gridView.atLocalBins({1u}) = childPtr;
   gridView.atLocalBins({2u}) = rootPtr;
-  gridView.atLocalBins({3u}) = childPtr;
 
   std::vector<TrivialPortalLink> artifacts;
   auto artifactSurface =
@@ -305,6 +303,19 @@ BOOST_AUTO_TEST_CASE(TrackingGeometryJsonConverterRoundTrip) {
     in >> encodedFromFile;
   }
 
+  auto& encodedGridBins =
+      encodedFromFile["portals"].at(2)["along_normal"]["bins"];
+  BOOST_REQUIRE_EQUAL(encodedGridBins.size(), 2u);
+
+  // Files produced before boundary-dependent grid storage contained unused
+  // underflow and overflow entries for bound axes.
+  auto legacyUnderflow = encodedGridBins.front();
+  legacyUnderflow["local"] = std::vector<std::size_t>{0u};
+  encodedGridBins.push_back(std::move(legacyUnderflow));
+  auto legacyOverflow = encodedGridBins.front();
+  legacyOverflow["local"] = std::vector<std::size_t>{3u};
+  encodedGridBins.push_back(std::move(legacyOverflow));
+
   auto decodedRoot = converter.trackingVolumeFromJson(gctx, encodedFromFile);
 
   BOOST_REQUIRE(decodedRoot != nullptr);
@@ -344,15 +355,11 @@ BOOST_AUTO_TEST_CASE(TrackingGeometryJsonConverterRoundTrip) {
   BOOST_CHECK_EQUAL(decodedGrid->artifactPortalLinks().size(), 1u);
 
   AnyGridConstView<const TrackingVolume*> decodedGridView(decodedGrid->grid());
-  BOOST_REQUIRE(decodedGridView.atLocalBins({0u}) != nullptr);
   BOOST_REQUIRE(decodedGridView.atLocalBins({1u}) != nullptr);
   BOOST_REQUIRE(decodedGridView.atLocalBins({2u}) != nullptr);
-  BOOST_REQUIRE(decodedGridView.atLocalBins({3u}) != nullptr);
 
-  BOOST_CHECK_EQUAL(decodedGridView.atLocalBins({0u})->volumeName(), "root");
   BOOST_CHECK_EQUAL(decodedGridView.atLocalBins({1u})->volumeName(), "child");
   BOOST_CHECK_EQUAL(decodedGridView.atLocalBins({2u})->volumeName(), "root");
-  BOOST_CHECK_EQUAL(decodedGridView.atLocalBins({3u})->volumeName(), "child");
 
   std::vector<Portal*> decodedChildPortals;
   for (auto& portal : decodedChildren.front()->portals()) {


### PR DESCRIPTION
## Summary

- Make addressable axis storage boundary-aware: Open axes retain `N + 2` bins, while Bound and Closed axes use exactly `N`.
- Compact `MultiAxis` and `Grid` flattening, reverse lookup, neighborhood iteration, and exterior-bin enumeration.
- Update portal grids, surface arrays, Hough transforms, Detray conversion, and JSON serialization for the compact layout.
- Continue reading legacy tracking-geometry JSON files that contain unused Bound or Closed exterior entries.

## Root cause

`MultiAxis` flattened every axis with an unconditional `nBins + 2` stride even though Bound axes clamp and Closed axes wrap coordinates into regular bins.
`Grid` then used that padded product for dense storage, so nonexistent exterior bins consumed memory and displaced every regular global index.

## Impact

The issue's Bound and Closed `1 x 2 x 3` grid now contains 6 entries instead of 60.
Open-axis behavior remains unchanged, including real underflow and overflow storage.
Downstream code now translates explicit zero-based Hough indices to the one-based local indices used by Bound grid axes.

## Current-main validation

- The branch is merged with current `main` at `606efeb0d`.
- All repository hooks pass on the 22 PR-owned files.
- The affected Core and JSON targets rebuilt successfully in the Debug unit-test configuration.
- `ActsPluginDetray` rebuilt successfully in a Detray-enabled Release/C++20 configuration after the current-main converter refactor.
- All 12 focused tests pass: `Axes`, `Grid`, `GridBinFinder`, `MultiAxis`, `HoughTransformTest`, `SurfaceArray`, `SurfaceArrayCreator`, `Portal`, `PortalLink`, `CylinderPortalShell`, `GridJsonConverter`, and `TrackingGeometryJsonConverter`.
- `git diff upstream/main...HEAD --check` passes.

## Broader validation

- Before the final `main` refresh, the complete Debug unit-test configuration rebuilt successfully across 496 targets.
- All 277 tests that passed on pristine `upstream/main` also passed with this patch.
- `BoundingBox` and `JoinStrings` reproduced their identical failures on pristine `upstream/main` with the same container toolchain.
- The examples-only Hough source passed a standalone C++20 syntax check because the restored container does not include HepMC3 for a full examples build.

Closes #5602
