### PR TITLE
ci: fix SonarCloud main-branch analysis broken on push

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -96,8 +96,8 @@ jobs:
       - name: Validate PR branch names
         if: github.event.workflow_run.event == 'pull_request'
         env:
-          HEAD_REF: ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
-          BASE_REF: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
+          HEAD_REF: ${{ steps.get_pr_data.outputs.data != '' && fromJson(steps.get_pr_data.outputs.data).head.ref || '' }}
+          BASE_REF: ${{ steps.get_pr_data.outputs.data != '' && fromJson(steps.get_pr_data.outputs.data).base.ref || '' }}
         run: |
           # These values are attacker-controlled (the PR branch name) and are
           # passed to sonar-scanner as CLI arguments below. Reject anything that
@@ -127,7 +127,7 @@ jobs:
       - name: Recreate merge commit state
         if: github.event.workflow_run.event == 'pull_request'
         env:
-          PR_CLONE_URL: ${{ fromJson(steps.get_pr_data.outputs.data).head.repo.clone_url }}
+          PR_CLONE_URL: ${{ steps.get_pr_data.outputs.data != '' && fromJson(steps.get_pr_data.outputs.data).head.repo.clone_url || '' }}
           BASE_SHA: ${{ steps.pr_metadata.outputs.base_sha }}
           PR_SHA: ${{ steps.pr_metadata.outputs.pr_sha }}
           MERGE_SHA: ${{ steps.pr_metadata.outputs.merge_sha }}


### PR DESCRIPTION
## Problem

SonarCloud's **`main` branch analysis has been frozen since 2026-06-02** (~7 weeks). PR decoration keeps working, so the SonarCloud workflow looks healthy — but every green run is a **PR-mode** analysis. The `main` branch analysis (and its quality gate / issue snapshot) is stale.

## Root cause

The `workflow_run` refactor in #5529 (merged 2026-06-02 — exactly the freeze date) made the PR-only steps declare `env:` values via `fromJson(steps.get_pr_data.outputs.data)...`:

```yaml
- name: Validate PR branch names
  if: github.event.workflow_run.event == 'pull_request'
  env:
    HEAD_REF: ${{ fromJson(steps.get_pr_data.outputs.data).head.ref }}
    BASE_REF: ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
```

On a **push to `main`**, the `Request GitHub API for PR data` step is skipped (it's `if: ...event == 'pull_request'`), so `steps.get_pr_data.outputs.data` is the empty string. GitHub still evaluates a step's `env:` expressions even when its `if:` is false, and `fromJson('')` is a fatal template error:

```
##[error]The template is not valid. .github/workflows/sonarcloud.yml (Line: 99, Col: 21):
Error reading JToken from JsonReader. Path '', line 0, position 0.
```

This fails the whole job **before** the `Run sonar-scanner (push mode)` step can submit main's analysis. The periodic `failure` SonarCloud runs are exactly these push-triggered runs (identifiable because they unzip `build/coverage/cov.xml`, which only push-mode consumes via `sonar.coverageReportPaths`).

## Fix

Guard the three affected `env:` expressions (lines 99, 100, 130) so they short-circuit to an empty string when PR data is absent:

```yaml
HEAD_REF: ${{ steps.get_pr_data.outputs.data != '' && fromJson(steps.get_pr_data.outputs.data).head.ref || '' }}
```

Since those steps are already `if: ...event == 'pull_request'`, the empty fallback is only ever used on push runs where the values aren't needed. Push-mode then reaches the scanner and re-establishes main's branch analysis.

The PR-mode `with:` args (lines 177–178) are intentionally left unguarded: inputs of a *skipped action step* are never evaluated, so they don't trigger the error.

## Verification

Can only be exercised on a real push to `main` (PRs won't run push-mode). After merge, the next `main` push should produce a **successful** SonarCloud run executing `Run sonar-scanner (push mode)` with `sonar.branch.name=main`, and the branch analysis date should finally advance past 2026-06-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)