### PR TITLE
feat: add PairTypeDispatcher for symmetric two-type dispatch

### DIFF
--- a/Core/include/Acts/Utilities/PairTypeDispatcher.hpp
+++ b/Core/include/Acts/Utilities/PairTypeDispatcher.hpp
@@ -1,0 +1,292 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <format>
+#include <functional>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <typeindex>
+#include <typeinfo>
+#include <utility>
+#include <vector>
+
+#include <boost/core/demangle.hpp>
+
+namespace Acts {
+
+/// Template class for symmetric dispatch on a *pair* of polymorphic types.
+///
+/// This is a sibling of @c TypeDispatcher. Where @c TypeDispatcher selects a
+/// function based on the concrete type of a single base-class reference, this
+/// class selects a function based on the concrete types of *two* base-class
+/// references.
+///
+/// Registered functions are treated as **symmetric**: a function registered
+/// with parameter types @c (A, B) will be selected both when called as
+/// @c (a, b) and as @c (b, a). In either case the registered function is
+/// invoked with its arguments in the order it declared them, i.e. the @c A
+/// argument first and the @c B argument second. This lets callers register a
+/// single handler per unordered type pair and rely on the dispatcher to
+/// normalise the argument order.
+///
+/// @note Matching is based on @c dynamic_cast, so a handler parameter typed as
+/// a base (the root base or an intermediate class) matches *any* object in that
+/// slot: a @c dynamic_cast to a base always succeeds. A base-typed slot is
+/// therefore a **wildcard**, and @c (Base, B) behaves as "a @c B paired with
+/// anything".
+///
+/// @note There is **no specificity ranking** — this dispatcher does not mirror
+/// C++ overload resolution and there is no "most derived wins" tie-break. All
+/// matching registrations are considered equal; if more than one distinct
+/// registration matches a call it is reported as an ambiguity rather than being
+/// resolved in favour of the more derived handler. Standard RTTI exposes no
+/// base-class information, so the required subtype order cannot be recovered
+/// from the registered types in the general case. Consequently, callers should
+/// **register non-overlapping type pairs** and avoid mixing a wildcard
+/// (base-typed) slot with more specific handlers for the same subtree.
+///
+/// Overlaps are best-effort rejected at registration time, but only when the
+/// newly registered derived types are default constructible (a sample of each
+/// is materialised to probe existing registrations). Overlaps that cannot be
+/// detected this way — e.g. involving an abstract base or a non-default-
+/// constructible type, or where the wildcard handler is registered *last* —
+/// surface only at call time as an ambiguity, and only for the specific pairs
+/// that actually trigger it.
+///
+/// @tparam base_t The common base class of both dispatch arguments
+/// @tparam signature_t The trailing function signature (e.g. return_t(Args...))
+template <typename base_t, typename signature_t>
+class PairTypeDispatcher;
+
+/// Pair type dispatcher specialization for function signature
+template <typename base_t, typename return_t, typename... args_t>
+class PairTypeDispatcher<base_t, return_t(args_t...)> {
+ public:
+  /// Base class type
+  using base_type = base_t;
+  /// Function return type
+  using return_type = return_t;
+  /// Self type
+  using self_type = PairTypeDispatcher<base_type, return_type(args_t...)>;
+  /// Internal function signature: both dispatch arguments plus trailing args.
+  /// The two leading arguments are always passed in *registration* order.
+  using function_signature = return_t(const base_t&, const base_t&, args_t...);
+  /// Function pointer type of the trailing (non-dispatched) arguments only
+  using function_pointer_type = return_t (*)(args_t...);
+  /// Function wrapper type
+  using function_type = std::function<function_signature>;
+
+  /// Default constructor
+  PairTypeDispatcher() = default;
+
+  /// Constructor that registers multiple function pointers with auto-detected
+  /// types.
+  template <typename... derived_a_t, typename... derived_b_t>
+  explicit PairTypeDispatcher(return_t (*... funcs)(const derived_a_t&,
+                                                    const derived_b_t&,
+                                                    args_t...))
+    requires((std::is_base_of_v<base_t, derived_a_t> && ...) &&
+             (std::is_base_of_v<base_t, derived_b_t> && ...))
+  {
+    (registerFunction(funcs), ...);
+  }
+
+  /// Register a free function with explicit or auto-detected derived types.
+  /// @tparam derived_a_t The first derived type the function handles
+  /// @tparam derived_b_t The second derived type the function handles
+  /// @param func The function pointer
+  /// @return Reference to this dispatcher for chaining
+  template <typename derived_a_t, typename derived_b_t>
+    requires std::is_base_of_v<base_t, derived_a_t> &&
+             std::is_base_of_v<base_t, derived_b_t>
+  self_type& registerFunction(return_t (*func)(const derived_a_t&,
+                                               const derived_b_t&, args_t...)) {
+    std::type_index typeA(typeid(derived_a_t));
+    std::type_index typeB(typeid(derived_b_t));
+
+    // Reject an exact duplicate for this unordered pair
+    for (const auto& reg : m_registrations) {
+      if (sameUnorderedPair(reg.typeA, reg.typeB, typeA, typeB)) {
+        throw std::runtime_error(std::format(
+            "Function already registered for type pair: ({}, {})",
+            boost::core::demangle(typeA.name()),
+            boost::core::demangle(typeB.name())));
+      }
+    }
+
+    // Best-effort registration-time conflict detection: if both derived types
+    // are default constructible we can materialise sample objects and check
+    // whether an existing registration would also claim this pair (in either
+    // orientation).
+    if constexpr (std::is_default_constructible_v<derived_a_t> &&
+                  std::is_default_constructible_v<derived_b_t>) {
+      derived_a_t sampleA{};
+      derived_b_t sampleB{};
+      for (const auto& reg : m_registrations) {
+        if (reg.matches(sampleA, sampleB).has_value()) {
+          throw std::runtime_error(std::format(
+              "Registration conflict: type pair ({}, {}) would also be handled "
+              "by existing function registered for pair: ({}, {})",
+              boost::core::demangle(typeA.name()),
+              boost::core::demangle(typeB.name()),
+              boost::core::demangle(reg.typeA.name()),
+              boost::core::demangle(reg.typeB.name())));
+        }
+      }
+    }
+
+    Registration reg;
+    reg.typeA = typeA;
+    reg.typeB = typeB;
+    reg.checkerA = [](const base_t& obj) {
+      return dynamic_cast<const derived_a_t*>(&obj) != nullptr;
+    };
+    reg.checkerB = [](const base_t& obj) {
+      return dynamic_cast<const derived_b_t*>(&obj) != nullptr;
+    };
+    // The invoker always receives its two leading arguments in registration
+    // order: `a` is expected to be a `derived_a_t`, `b` a `derived_b_t`.
+    reg.invoke = [func]<typename... Ts>(const base_t& a, const base_t& b,
+                                        Ts&&... args) -> return_t {
+      const auto* da = dynamic_cast<const derived_a_t*>(&a);
+      const auto* db = dynamic_cast<const derived_b_t*>(&b);
+      if (da == nullptr || db == nullptr) {
+        throw std::bad_cast();
+      }
+      return func(*da, *db, std::forward<Ts>(args)...);
+    };
+
+    m_registrations.push_back(std::move(reg));
+    return *this;
+  }
+
+  /// Call the registered function for the given pair of objects.
+  ///
+  /// The pair is matched against every registration in both orientations. The
+  /// selected function is always invoked with the arguments normalised to the
+  /// order in which it was registered.
+  ///
+  /// @param lhs The first object to dispatch on
+  /// @param rhs The second object to dispatch on
+  /// @param args Additional trailing arguments forwarded to the function
+  /// @return The return value from the registered function
+  template <typename... func_args_t>
+  return_t operator()(const base_t& lhs, const base_t& rhs,
+                      func_args_t&&... args) const
+    requires std::invocable<function_pointer_type, func_args_t...>
+  {
+    const Registration* match = nullptr;
+    bool swap = false;
+
+    for (const auto& reg : m_registrations) {
+      auto orientation = reg.matches(lhs, rhs);
+      if (!orientation.has_value()) {
+        continue;
+      }
+      if (match != nullptr) {
+        throw std::runtime_error(std::format(
+            "Ambiguous dispatch for type pair ({}, {}): multiple functions can "
+            "handle it",
+            boost::core::demangle(typeid(lhs).name()),
+            boost::core::demangle(typeid(rhs).name())));
+      }
+      match = &reg;
+      swap = *orientation;
+    }
+
+    if (match == nullptr) {
+      throw std::runtime_error(
+          std::format("No function registered for type pair: ({}, {})",
+                      boost::core::demangle(typeid(lhs).name()),
+                      boost::core::demangle(typeid(rhs).name())));
+    }
+
+    if (swap) {
+      return match->invoke(rhs, lhs, std::forward<func_args_t>(args)...);
+    }
+    return match->invoke(lhs, rhs, std::forward<func_args_t>(args)...);
+  }
+
+  /// Check if a function is registered for the given pair of objects.
+  /// @param lhs The first object to check
+  /// @param rhs The second object to check
+  /// @return true if a function is registered, false otherwise
+  bool hasFunction(const base_t& lhs, const base_t& rhs) const {
+    for (const auto& reg : m_registrations) {
+      if (reg.matches(lhs, rhs).has_value()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Check if a function is registered for the given type pair.
+  /// @tparam derived_a_t The first type to check
+  /// @tparam derived_b_t The second type to check
+  /// @return true if a function is registered, false otherwise
+  template <typename derived_a_t, typename derived_b_t>
+    requires std::is_base_of_v<base_t, derived_a_t> &&
+             std::is_base_of_v<base_t, derived_b_t>
+  bool hasFunction() const {
+    std::type_index typeA(typeid(derived_a_t));
+    std::type_index typeB(typeid(derived_b_t));
+    for (const auto& reg : m_registrations) {
+      if (sameUnorderedPair(reg.typeA, reg.typeB, typeA, typeB)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Clear all registered functions
+  void clear() { m_registrations.clear(); }
+
+  /// Get the number of registered functions
+  /// @return Number of registered functions
+  std::size_t size() const { return m_registrations.size(); }
+
+ private:
+  using cast_checker_type = std::function<bool(const base_t&)>;
+
+  struct Registration {
+    std::type_index typeA{typeid(void)};
+    std::type_index typeB{typeid(void)};
+    cast_checker_type checkerA;
+    cast_checker_type checkerB;
+    function_type invoke;
+
+    /// Determine whether this registration handles the pair `(lhs, rhs)`.
+    /// @return std::nullopt if it does not match, otherwise a bool that is
+    ///         false for the forward orientation (lhs->A, rhs->B) and true for
+    ///         the swapped orientation (rhs->A, lhs->B). The forward
+    ///         orientation is preferred when both match.
+    std::optional<bool> matches(const base_t& lhs, const base_t& rhs) const {
+      if (checkerA(lhs) && checkerB(rhs)) {
+        return false;
+      }
+      if (checkerA(rhs) && checkerB(lhs)) {
+        return true;
+      }
+      return std::nullopt;
+    }
+  };
+
+  static bool sameUnorderedPair(const std::type_index& a1,
+                                const std::type_index& b1,
+                                const std::type_index& a2,
+                                const std::type_index& b2) {
+    return (a1 == a2 && b1 == b2) || (a1 == b2 && b1 == a2);
+  }
+
+  std::vector<Registration> m_registrations;
+};
+
+}  // namespace Acts

--- a/Tests/UnitTests/Core/Utilities/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Utilities/CMakeLists.txt
@@ -72,6 +72,7 @@ add_unittest(AnyGridView AnyGridViewTests.cpp)
 add_unittest(TransformComparator TransformComparatorTests.cpp)
 add_unittest(Table TableTests.cpp)
 add_unittest(TypeDispatcher TypeDispatcherTests.cpp)
+add_unittest(PairTypeDispatcher PairTypeDispatcherTests.cpp)
 
 add_unittest(Histogram HistogramTests.cpp)
 add_unittest(ProfileEfficiency ProfileEfficiencyTests.cpp)

--- a/Tests/UnitTests/Core/Utilities/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Utilities/CMakeLists.txt
@@ -74,6 +74,7 @@ add_unittest(AnyGridView AnyGridViewTests.cpp)
 add_unittest(TransformComparator TransformComparatorTests.cpp)
 add_unittest(Table TableTests.cpp)
 add_unittest(TypeDispatcher TypeDispatcherTests.cpp)
+add_unittest(PairTypeDispatcher PairTypeDispatcherTests.cpp)
 
 add_unittest(Histogram HistogramTests.cpp)
 add_unittest(ProfileEfficiency ProfileEfficiencyTests.cpp)

--- a/Tests/UnitTests/Core/Utilities/PairTypeDispatcherTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/PairTypeDispatcherTests.cpp
@@ -1,0 +1,340 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Utilities/PairTypeDispatcher.hpp"
+
+#include <memory>
+#include <string>
+
+using namespace Acts;
+
+namespace ActsTests {
+
+// Test hierarchy
+class BaseClass {
+ public:
+  virtual ~BaseClass() = default;
+  virtual std::string getType() const = 0;
+};
+
+class DerivedA : public BaseClass {
+ public:
+  std::string getType() const override { return "DerivedA"; }
+};
+
+class DerivedB : public BaseClass {
+ public:
+  std::string getType() const override { return "DerivedB"; }
+};
+
+class DerivedC : public BaseClass {
+ public:
+  std::string getType() const override { return "DerivedC"; }
+};
+
+// Intermediate class for inheritance tests
+class DerivedAA : public DerivedA {
+ public:
+  std::string getType() const override { return "DerivedAA"; }
+};
+
+// Test functions
+std::string processAB(const DerivedA& a, const DerivedB& b,
+                      const std::string& prefix) {
+  return prefix + a.getType() + "+" + b.getType();
+}
+
+std::string processAA(const DerivedA& a1, const DerivedA& a2) {
+  return a1.getType() + "&" + a2.getType();
+}
+
+BOOST_AUTO_TEST_SUITE(PairTypeDispatcherTests)
+
+BOOST_AUTO_TEST_CASE(SymmetricDispatch) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);  // (DerivedA, DerivedB) auto-detected
+
+  DerivedA objA;
+  DerivedB objB;
+
+  // Both argument orders resolve to the same handler, and the handler always
+  // receives its arguments in the registered (A, B) order.
+  BOOST_CHECK_EQUAL(dispatcher(objA, objB, "p_"), "p_DerivedA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objB, objA, "p_"), "p_DerivedA+DerivedB");
+}
+
+BOOST_AUTO_TEST_CASE(ExplicitTemplateParameterRegistration) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction<DerivedA, DerivedB>(processAB);
+
+  DerivedA objA;
+  DerivedB objB;
+
+  BOOST_CHECK_EQUAL(dispatcher(objA, objB, "e_"), "e_DerivedA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objB, objA, "e_"), "e_DerivedA+DerivedB");
+}
+
+BOOST_AUTO_TEST_CASE(SameTypePair) {
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(processAA);
+
+  DerivedA objA;
+  BOOST_CHECK_EQUAL(dispatcher(objA, objA), "DerivedA&DerivedA");
+}
+
+BOOST_AUTO_TEST_CASE(HasFunctionCheck) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+
+  DerivedA objA;
+  DerivedB objB;
+  DerivedC objC;
+
+  // hasFunction on objects, both orientations
+  BOOST_CHECK(dispatcher.hasFunction(objA, objB));
+  BOOST_CHECK(dispatcher.hasFunction(objB, objA));
+  BOOST_CHECK(!dispatcher.hasFunction(objA, objC));
+  BOOST_CHECK(!dispatcher.hasFunction(objA, objA));
+
+  // hasFunction on types is unordered
+  BOOST_CHECK((dispatcher.hasFunction<DerivedA, DerivedB>()));
+  BOOST_CHECK((dispatcher.hasFunction<DerivedB, DerivedA>()));
+  BOOST_CHECK(!(dispatcher.hasFunction<DerivedA, DerivedC>()));
+}
+
+BOOST_AUTO_TEST_CASE(UnregisteredPairThrows) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+
+  DerivedA objA;
+  DerivedC objC;
+
+  BOOST_CHECK_THROW(dispatcher(objA, objC, "p_"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(UnregisteredPairErrorMessage) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+
+  DerivedA objA;
+  DerivedC objC;
+  try {
+    dispatcher(objA, objC, "p_");
+    BOOST_FAIL("Expected std::runtime_error to be thrown");
+  } catch (const std::runtime_error& e) {
+    std::string message = e.what();
+    BOOST_CHECK(message.find("No function registered for type pair") !=
+                std::string::npos);
+    BOOST_CHECK(message.find("DerivedC") != std::string::npos);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(DuplicateRegistrationPrevention) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+
+  // Registering the same unordered pair again must throw, regardless of the
+  // order the derived types are given in.
+  auto reversed = [](const DerivedB& b, const DerivedA& a,
+                     const std::string& prefix) {
+    return prefix + b.getType() + "+" + a.getType();
+  };
+  std::string (*funcReversed)(const DerivedB&, const DerivedA&,
+                              const std::string&) = reversed;
+
+  BOOST_CHECK_THROW(dispatcher.registerFunction(funcReversed),
+                    std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(RegistrationTimeConflictDetection) {
+  auto handleAB = [](const DerivedA& a, const DerivedB& b) {
+    return a.getType() + b.getType();
+  };
+  auto handleAAB = [](const DerivedAA& a, const DerivedB& b) {
+    return a.getType() + b.getType();
+  };
+  std::string (*funcAB)(const DerivedA&, const DerivedB&) = handleAB;
+  std::string (*funcAAB)(const DerivedAA&, const DerivedB&) = handleAAB;
+
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(funcAB);
+
+  // (DerivedAA, DerivedB) is default constructible and would be claimed by the
+  // (DerivedA, DerivedB) handler -> conflict detected at registration time.
+  BOOST_CHECK_THROW(dispatcher.registerFunction(funcAAB), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(AmbiguousDispatchThrows) {
+  // Two handlers whose subtype overlap cannot be detected at registration
+  // time (non-default-constructible), but a concrete call is ambiguous.
+  class Nd : public BaseClass {
+   public:
+    explicit Nd(int) {}
+    std::string getType() const override { return "Nd"; }
+  };
+  class NdSub : public Nd {
+   public:
+    explicit NdSub(int v) : Nd(v) {}
+    std::string getType() const override { return "NdSub"; }
+  };
+
+  auto handleNdB = [](const Nd&, const DerivedB&) { return std::string("NdB"); };
+  auto handleSubB = [](const NdSub&, const DerivedB&) {
+    return std::string("SubB");
+  };
+  std::string (*funcNdB)(const Nd&, const DerivedB&) = handleNdB;
+  std::string (*funcSubB)(const NdSub&, const DerivedB&) = handleSubB;
+
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(funcNdB);
+  BOOST_CHECK_NO_THROW(dispatcher.registerFunction(funcSubB));
+
+  NdSub obj(1);
+  DerivedB objB;
+  // Both (Nd, B) and (NdSub, B) can handle (NdSub, B).
+  BOOST_CHECK_THROW(dispatcher(obj, objB), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(PolymorphicDispatch) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+
+  std::unique_ptr<BaseClass> objA = std::make_unique<DerivedA>();
+  std::unique_ptr<BaseClass> objB = std::make_unique<DerivedB>();
+
+  BOOST_CHECK_EQUAL(dispatcher(*objA, *objB, "poly_"), "poly_DerivedA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(*objB, *objA, "poly_"), "poly_DerivedA+DerivedB");
+}
+
+BOOST_AUTO_TEST_CASE(InheritanceMatching) {
+  // A handler registered for a base subtype should claim derived objects.
+  auto handleAB = [](const DerivedA& a, const DerivedB& b) {
+    return a.getType() + "+" + b.getType();
+  };
+  std::string (*funcAB)(const DerivedA&, const DerivedB&) = handleAB;
+
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(funcAB);
+
+  DerivedAA objAA;  // is-a DerivedA
+  DerivedB objB;
+
+  // getType() reports the concrete type, dispatch matches via the base subtype.
+  BOOST_CHECK_EQUAL(dispatcher(objAA, objB), "DerivedAA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objB, objAA), "DerivedAA+DerivedB");
+}
+
+BOOST_AUTO_TEST_CASE(ClearAndSize) {
+  PairTypeDispatcher<BaseClass, std::string(const std::string&)> dispatcher;
+  dispatcher.registerFunction(processAB);
+  BOOST_CHECK_EQUAL(dispatcher.size(), 1u);
+
+  dispatcher.clear();
+  BOOST_CHECK_EQUAL(dispatcher.size(), 0u);
+
+  DerivedA objA;
+  DerivedB objB;
+  BOOST_CHECK(!dispatcher.hasFunction(objA, objB));
+}
+
+BOOST_AUTO_TEST_CASE(ConstructorWithMultipleFunctions) {
+  auto handleAC = [](const DerivedA& a, const DerivedC& c) {
+    return a.getType() + "+" + c.getType();
+  };
+  std::string (*funcAC)(const DerivedA&, const DerivedC&) = handleAC;
+  std::string (*funcAA)(const DerivedA&, const DerivedA&) = processAA;
+
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher(funcAC, funcAA);
+
+  DerivedA objA;
+  DerivedC objC;
+
+  BOOST_CHECK_EQUAL(dispatcher(objA, objC), "DerivedA+DerivedC");
+  BOOST_CHECK_EQUAL(dispatcher(objC, objA), "DerivedA+DerivedC");
+  BOOST_CHECK_EQUAL(dispatcher(objA, objA), "DerivedA&DerivedA");
+  BOOST_CHECK_EQUAL(dispatcher.size(), 2u);
+}
+
+// A base-typed slot matches any object (dynamic_cast to a base always
+// succeeds), so it acts as a wildcard: (BaseClass, DerivedB) behaves as
+// "a DerivedB paired with anything".
+BOOST_AUTO_TEST_CASE(BaseTypedSlotIsWildcard) {
+  auto handle = [](const BaseClass& any, const DerivedB& b) {
+    return any.getType() + "+" + b.getType();
+  };
+  std::string (*func)(const BaseClass&, const DerivedB&) = handle;
+
+  PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+  dispatcher.registerFunction(func);
+
+  DerivedA objA;
+  DerivedB objB;
+  DerivedC objC;
+
+  // The DerivedB object always lands in the B slot and the other object fills
+  // the wildcard, regardless of call order.
+  BOOST_CHECK_EQUAL(dispatcher(objA, objB), "DerivedA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objB, objA), "DerivedA+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objC, objB), "DerivedC+DerivedB");
+  BOOST_CHECK_EQUAL(dispatcher(objB, objB), "DerivedB+DerivedB");
+
+  // No DerivedB present in either slot -> no match.
+  BOOST_CHECK_THROW(dispatcher(objA, objC), std::runtime_error);
+}
+
+// An overlap between a wildcard handler and a more specific handler cannot be
+// resolved by specificity (there is no "most derived wins"). Whether the clash
+// is caught at registration or only at call time depends on registration order,
+// because the abstract root base cannot be sampled for conflict detection.
+BOOST_AUTO_TEST_CASE(WildcardOverlapAmbiguityIsOrderDependent) {
+  auto wide = [](const BaseClass& x, const DerivedB& b) {
+    return "wide:" + x.getType() + "+" + b.getType();
+  };
+  auto spec = [](const DerivedA& a, const DerivedB& b) {
+    return "spec:" + a.getType() + "+" + b.getType();
+  };
+  std::string (*funcWide)(const BaseClass&, const DerivedB&) = wide;
+  std::string (*funcSpec)(const DerivedA&, const DerivedB&) = spec;
+
+  DerivedA objA;
+  DerivedB objB;
+  DerivedC objC;
+
+  // Wide first, then spec: registering spec materialises samples of
+  // (DerivedA, DerivedB) -- both default constructible -- which the wide
+  // checker claims, so the conflict is detected at registration time.
+  {
+    PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+    dispatcher.registerFunction(funcWide);
+    BOOST_CHECK_THROW(dispatcher.registerFunction(funcSpec),
+                      std::runtime_error);
+  }
+
+  // Spec first, then wide: registering wide would need to sample the abstract
+  // BaseClass, which is impossible, so detection is skipped and registration
+  // succeeds. The overlap then surfaces only at call time, and only for the
+  // pairs that actually trigger it.
+  {
+    PairTypeDispatcher<BaseClass, std::string()> dispatcher;
+    dispatcher.registerFunction(funcSpec);
+    BOOST_CHECK_NO_THROW(dispatcher.registerFunction(funcWide));
+
+    // (objA, objB) is claimed by both handlers -> ambiguous, not resolved in
+    // favour of the more specific (DerivedA, DerivedB) handler.
+    BOOST_CHECK_THROW(dispatcher(objA, objB), std::runtime_error);
+
+    // (objC, objB) is claimed only by the wildcard handler -> still works.
+    BOOST_CHECK_EQUAL(dispatcher(objC, objB), "wide:DerivedC+DerivedB");
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace ActsTests


### PR DESCRIPTION
Adds `PairTypeDispatcher`, a sibling of `TypeDispatcher` that dispatches on a *pair* of polymorphic types instead of a single one.

--- END COMMIT MESSAGE ---

## What

`TypeDispatcher` selects a handler from the concrete type of one base-class reference. `PairTypeDispatcher` selects a handler from the concrete types of **two** base-class references, and treats registered handlers as **symmetric**:

- A handler registered for parameter types `(A, B)` is selected both when called as `(a, b)` and as `(b, a)`.
- It is always invoked with its arguments normalised to the registered `(A, B)` order, so the handler author never has to deal with the reversed case.
- Registration, lookup and duplicate-detection all treat the pair as unordered (`(A, B)` == `(B, A)`).

The public API mirrors `TypeDispatcher` (`registerFunction`, `operator()`, `hasFunction`, `hasFunction<...>()`, `clear`, `size`, variadic constructor, auto-detected derived types).

## Semantics / contract (documented on the class)

- **Matching is `dynamic_cast`-based**, so a base-typed slot (root or intermediate) acts as a **wildcard** — `(Base, B)` behaves as "a `B` paired with anything".
- **No specificity ranking.** This is *not* C++ overload resolution: there is no "most derived wins" tie-break. Overlapping matches are reported as an ambiguity rather than resolved, because standard RTTI exposes no base-class information to build the required subtype order. Callers should register non-overlapping pairs and avoid mixing a wildcard slot with more-specific handlers for the same subtree.
- Overlaps are best-effort rejected at **registration time** when the newly registered derived types are default-constructible; otherwise (abstract base, non-default-constructible type, or wildcard registered last) the clash surfaces at **call time** as an ambiguity.

## Tests

`PairTypeDispatcherTests` covers symmetric dispatch, unordered lookup/duplicate rejection, same-type pairs, polymorphic dispatch, inheritance matching, registration- and call-time ambiguity, the base-typed wildcard slot, and the order-dependence of overlap detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
