### PR TITLE
refactor: deduplicate space point grid phi-bin computation

### DIFF
--- a/Core/include/Acts/Seeding/detail/SpacePointGridPhiBinning.hpp
+++ b/Core/include/Acts/Seeding/detail/SpacePointGridPhiBinning.hpp
@@ -1,0 +1,51 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+
+namespace Acts::detail {
+
+/// Parameters to derive the number of phi bins of a space point grid from the
+/// minimum track transverse momentum and the magnetic field.
+struct SpacePointGridPhiBinningConfig {
+  /// minimum pT
+  float minPt = 0;
+  /// magnetic field
+  float bFieldInZ = 0;
+  /// maximum extension of sensitive detector layer relevant for seeding as
+  /// distance from x=y=0 (i.e. in r)
+  float rMax = 0;
+  /// maximum distance in r from middle space point to bottom or top
+  /// space point
+  float deltaRMax = 0;
+  /// maximum impact parameter
+  float impactMax = 0;
+  /// Multiplicator for the number of phi-bins. The minimum number of phi-bins
+  /// depends on min_pt, magnetic field: 2*pi/(minPT particle phi-deflection).
+  /// phiBinDeflectionCoverage is a multiplier for this number. If
+  /// numPhiNeighbors (in the configuration of the BinFinders) is configured
+  /// to return 1 neighbor on either side of the current phi-bin (and you want
+  /// to cover the full phi-range of minPT), leave this at 1.
+  int phiBinDeflectionCoverage = 1;
+  /// maximum number of phi bins
+  int maxPhiBins = 10000;
+};
+
+/// Compute the number of phi bins of a space point grid such that each bin
+/// covers the maximum expected azimuthal deflection of a minimum-pT track
+/// between the innermost and outermost radius relevant for seeding, including
+/// the effect of the maximum impact parameter.
+/// @param config Parameters the phi bin count is derived from
+/// @param logger Logger instance for debugging output
+/// @return The number of phi bins, capped at `config.maxPhiBins`
+int computeSpacePointGridPhiBins(const SpacePointGridPhiBinningConfig& config,
+                                 const Logger& logger = getDummyLogger());
+
+}  // namespace Acts::detail

--- a/Core/src/Seeding/CMakeLists.txt
+++ b/Core/src/Seeding/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(
         FastStrawLineFitter.cpp
         CompositeSpacePointLineSeeder.cpp
         detail/CandidatesForMiddleSp.cpp
+        detail/SpacePointGridPhiBinning.cpp
         BroadTripletSeedFilter.cpp
         CylindricalSpacePointGrid.cpp
         SphericalSpacePointGrid.cpp

--- a/Core/src/Seeding/CylindricalSpacePointGrid.cpp
+++ b/Core/src/Seeding/CylindricalSpacePointGrid.cpp
@@ -8,7 +8,7 @@
 
 #include "Acts/Seeding/CylindricalSpacePointGrid.hpp"
 
-#include "Acts/Utilities/MathHelpers.hpp"
+#include "Acts/Seeding/detail/SpacePointGridPhiBinning.hpp"
 
 namespace Acts {
 
@@ -36,83 +36,15 @@ CylindricalSpacePointGrid::CylindricalSpacePointGrid(
         "CylindricalSpacePointGrid: zMin is bigger than zMax");
   }
 
-  int phiBins = 0;
-  if (m_cfg.bFieldInZ == 0) {
-    // for no magnetic field, use the maximum number of phi bins
-    phiBins = m_cfg.maxPhiBins;
-    ACTS_VERBOSE(
-        "B-Field is 0 (z-coordinate), setting the number of bins in phi to "
-        << phiBins);
-  } else {
-    // calculate circle intersections of helix and max detector radius in mm.
-    // bFieldInZ is in (pT/radius) natively, no need for conversion
-    const float minHelixRadius = m_cfg.minPt / m_cfg.bFieldInZ;
-
-    // sanity check: if yOuter takes the square root of a negative number
-    if (minHelixRadius < m_cfg.rMax * 0.5) {
-      throw std::domain_error(
-          "The value of minHelixRadius cannot be smaller than rMax / 2. Please "
-          "check the m_cfguration of bFieldInZ and minPt");
-    }
-
-    // x = rMax^2 / (2 * minHelixRadius)
-    // y = cathetus(rMax, x)
-    // R / x = 2 * minHelixRadius / R
-    // outerAngle = x / y = x / sqrt(rMax^2 - x^2) = 1 / cath(rMax / x, 1)
-    //            = 1 / cath(2 * minHelixRadius / rMax, 1)
-    const float outerAngle =
-        std::atan(1.f / fastCathetus(2 * minHelixRadius / m_cfg.rMax, 1));
-    // intersection of helix and max detector radius minus maximum R distance
-    // from middle SP to top SP
-    float innerAngle = 0;
-    float rMin = m_cfg.rMax;
-    if (m_cfg.rMax > m_cfg.deltaRMax) {
-      const float innerCircleR = m_cfg.rMax - m_cfg.deltaRMax;
-      rMin = innerCircleR;
-      innerAngle =
-          std::atan(1.f / fastCathetus(2 * minHelixRadius / innerCircleR, 1));
-    }
-
-    // evaluating the azimutal deflection including the maximum impact
-    // parameter. A track with |d0| >= r cannot reach radius r, so the azimuthal
-    // deflection saturates at pi/2: clamp the asin arguments to [0, 1] so that
-    // impactMax >= (rMax - deltaRMax) falls back to coarse / full-2pi phi
-    // coverage instead of producing a NaN (and hence a zero phi-bin count and a
-    // "Invalid binning" exception).
-    const float sinInner = std::min(1.f, m_cfg.impactMax / rMin);
-    const float sinOuter = std::min(1.f, m_cfg.impactMax / m_cfg.rMax);
-    const float deltaAngleWithMaxD0 =
-        std::abs(std::asin(sinInner) - std::asin(sinOuter));
-
-    // evaluating delta Phi based on the inner and outer angle, and the azimutal
-    // deflection including the maximum impact parameter
-    // Divide by m_cfg.phiBinDeflectionCoverage since we combine
-    // m_cfg.phiBinDeflectionCoverage number of consecutive phi bins in the
-    // seed making step. So each individual bin should cover
-    // 1/m_cfg.phiBinDeflectionCoverage of the maximum expected azimutal
-    // deflection
-    const float deltaPhi = (outerAngle - innerAngle + deltaAngleWithMaxD0) /
-                           m_cfg.phiBinDeflectionCoverage;
-
-    // sanity check: if the delta phi is equal to or less than zero, we'll be
-    // creating an infinite or a negative number of bins, which would be bad!
-    if (deltaPhi <= 0.f) {
-      throw std::domain_error(
-          "Delta phi value is equal to or less than zero, leading to an "
-          "impossible number of bins (negative or infinite)");
-    }
-
-    // divide 2pi by angle delta to get number of phi-bins
-    // size is always 2pi even for regions of interest
-    phiBins = static_cast<int>(std::ceil(2 * std::numbers::pi / deltaPhi));
-    // need to scale the number of phi bins accordingly to the number of
-    // consecutive phi bins in the seed making step.
-    // Each individual bin should be approximately a fraction (depending on this
-    // number) of the maximum expected azimutal deflection.
-
-    // set protection for large number of bins, by default it is large
-    phiBins = std::min(phiBins, m_cfg.maxPhiBins);
-  }
+  const int phiBins = detail::computeSpacePointGridPhiBins(
+      {.minPt = m_cfg.minPt,
+       .bFieldInZ = m_cfg.bFieldInZ,
+       .rMax = m_cfg.rMax,
+       .deltaRMax = m_cfg.deltaRMax,
+       .impactMax = m_cfg.impactMax,
+       .phiBinDeflectionCoverage = m_cfg.phiBinDeflectionCoverage,
+       .maxPhiBins = m_cfg.maxPhiBins},
+      logger());
 
   PhiAxisType phiAxis(AxisClosed, m_cfg.phiMin, m_cfg.phiMax, phiBins);
 

--- a/Core/src/Seeding/SphericalSpacePointGrid.cpp
+++ b/Core/src/Seeding/SphericalSpacePointGrid.cpp
@@ -8,7 +8,7 @@
 
 #include "Acts/Seeding/SphericalSpacePointGrid.hpp"
 
-#include "Acts/Utilities/MathHelpers.hpp"
+#include "Acts/Seeding/detail/SpacePointGridPhiBinning.hpp"
 
 #include <cmath>
 
@@ -38,83 +38,15 @@ SphericalSpacePointGrid::SphericalSpacePointGrid(
         "SphericalSpacePointGrid: etaMin is bigger than etaMax");
   }
 
-  int phiBins = 0;
-  if (m_cfg.bFieldInZ == 0) {
-    // for no magnetic field, use the maximum number of phi bins
-    phiBins = m_cfg.maxPhiBins;
-    ACTS_VERBOSE(
-        "B-Field is 0 (z-coordinate), setting the number of bins in phi to "
-        << phiBins);
-  } else {
-    // calculate circle intersections of helix and max detector radius in mm.
-    // bFieldInZ is in (pT/radius) natively, no need for conversion
-    const float minHelixRadius = m_cfg.minPt / m_cfg.bFieldInZ;
-
-    // sanity check: if yOuter takes the square root of a negative number
-    if (minHelixRadius < m_cfg.rMax * 0.5) {
-      throw std::domain_error(
-          "The value of minHelixRadius cannot be smaller than rMax / 2. Please "
-          "check the configuration of bFieldInZ and minPt");
-    }
-
-    // x = rMax^2 / (2 * minHelixRadius)
-    // y = cathetus(rMax, x)
-    // R / x = 2 * minHelixRadius / R
-    // outerAngle = x / y = x / sqrt(rMax^2 - x^2) = 1 / cath(rMax / x, 1)
-    //            = 1 / cath(2 * minHelixRadius / rMax, 1)
-    const float outerAngle =
-        std::atan(1.f / fastCathetus(2 * minHelixRadius / m_cfg.rMax, 1));
-    // intersection of helix and max detector radius minus maximum R distance
-    // from middle SP to top SP
-    float innerAngle = 0;
-    float rMin = m_cfg.rMax;
-    if (m_cfg.rMax > m_cfg.deltaRMax) {
-      const float innerCircleR = m_cfg.rMax - m_cfg.deltaRMax;
-      rMin = innerCircleR;
-      innerAngle =
-          std::atan(1.f / fastCathetus(2 * minHelixRadius / innerCircleR, 1));
-    }
-
-    // evaluating the azimutal deflection including the maximum impact
-    // parameter. A track with |d0| >= r cannot reach radius r, so the azimuthal
-    // deflection saturates at pi/2: clamp the asin arguments to [0, 1] so that
-    // impactMax >= (rMax - deltaRMax) falls back to coarse / full-2pi phi
-    // coverage instead of producing a NaN (and hence a zero phi-bin count and a
-    // "Invalid binning" exception).
-    const float sinInner = std::min(1.f, m_cfg.impactMax / rMin);
-    const float sinOuter = std::min(1.f, m_cfg.impactMax / m_cfg.rMax);
-    const float deltaAngleWithMaxD0 =
-        std::abs(std::asin(sinInner) - std::asin(sinOuter));
-
-    // evaluating delta Phi based on the inner and outer angle, and the azimutal
-    // deflection including the maximum impact parameter
-    // Divide by m_cfg.phiBinDeflectionCoverage since we combine
-    // m_cfg.phiBinDeflectionCoverage number of consecutive phi bins in the
-    // seed making step. So each individual bin should cover
-    // 1/m_cfg.phiBinDeflectionCoverage of the maximum expected azimutal
-    // deflection
-    const float deltaPhi = (outerAngle - innerAngle + deltaAngleWithMaxD0) /
-                           m_cfg.phiBinDeflectionCoverage;
-
-    // sanity check: if the delta phi is equal to or less than zero, we'll be
-    // creating an infinite or a negative number of bins, which would be bad!
-    if (deltaPhi <= 0.f) {
-      throw std::domain_error(
-          "Delta phi value is equal to or less than zero, leading to an "
-          "impossible number of bins (negative or infinite)");
-    }
-
-    // divide 2pi by angle delta to get number of phi-bins
-    // size is always 2pi even for regions of interest
-    phiBins = static_cast<int>(std::ceil(2 * std::numbers::pi / deltaPhi));
-    // need to scale the number of phi bins accordingly to the number of
-    // consecutive phi bins in the seed making step.
-    // Each individual bin should be approximately a fraction (depending on this
-    // number) of the maximum expected azimutal deflection.
-
-    // set protection for large number of bins, by default it is large
-    phiBins = std::min(phiBins, m_cfg.maxPhiBins);
-  }
+  const int phiBins = Acts::detail::computeSpacePointGridPhiBins(
+      {.minPt = m_cfg.minPt,
+       .bFieldInZ = m_cfg.bFieldInZ,
+       .rMax = m_cfg.rMax,
+       .deltaRMax = m_cfg.deltaRMax,
+       .impactMax = m_cfg.impactMax,
+       .phiBinDeflectionCoverage = m_cfg.phiBinDeflectionCoverage,
+       .maxPhiBins = m_cfg.maxPhiBins},
+      logger());
 
   PhiAxisType phiAxis(AxisClosed, m_cfg.phiMin, m_cfg.phiMax, phiBins);
 

--- a/Core/src/Seeding/detail/SpacePointGridPhiBinning.cpp
+++ b/Core/src/Seeding/detail/SpacePointGridPhiBinning.cpp
@@ -1,0 +1,97 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Seeding/detail/SpacePointGridPhiBinning.hpp"
+
+#include "Acts/Utilities/MathHelpers.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <stdexcept>
+
+namespace Acts::detail {
+
+int computeSpacePointGridPhiBins(const SpacePointGridPhiBinningConfig& config,
+                                 const Logger& logger) {
+  if (config.bFieldInZ == 0) {
+    // for no magnetic field, use the maximum number of phi bins
+    ACTS_VERBOSE(
+        "B-Field is 0 (z-coordinate), setting the number of bins in phi to "
+        << config.maxPhiBins);
+    return config.maxPhiBins;
+  }
+
+  // calculate circle intersections of helix and max detector radius in mm.
+  // bFieldInZ is in (pT/radius) natively, no need for conversion
+  const float minHelixRadius = config.minPt / config.bFieldInZ;
+
+  // sanity check: if yOuter takes the square root of a negative number
+  if (minHelixRadius < config.rMax * 0.5) {
+    throw std::domain_error(
+        "The value of minHelixRadius cannot be smaller than rMax / 2. Please "
+        "check the configuration of bFieldInZ and minPt");
+  }
+
+  // x = rMax^2 / (2 * minHelixRadius)
+  // y = cathetus(rMax, x)
+  // R / x = 2 * minHelixRadius / R
+  // outerAngle = x / y = x / sqrt(rMax^2 - x^2) = 1 / cath(rMax / x, 1)
+  //            = 1 / cath(2 * minHelixRadius / rMax, 1)
+  const float outerAngle =
+      std::atan(1.f / fastCathetus(2 * minHelixRadius / config.rMax, 1));
+  // intersection of helix and max detector radius minus maximum R distance
+  // from middle SP to top SP
+  float innerAngle = 0;
+  float rMin = config.rMax;
+  if (config.rMax > config.deltaRMax) {
+    const float innerCircleR = config.rMax - config.deltaRMax;
+    rMin = innerCircleR;
+    innerAngle =
+        std::atan(1.f / fastCathetus(2 * minHelixRadius / innerCircleR, 1));
+  }
+
+  // evaluating the azimutal deflection including the maximum impact
+  // parameter. A track with |d0| >= r cannot reach radius r, so the azimuthal
+  // deflection saturates at pi/2: clamp the asin arguments to [0, 1] so that
+  // impactMax >= (rMax - deltaRMax) falls back to coarse / full-2pi phi
+  // coverage instead of producing a NaN (and hence a zero phi-bin count and a
+  // "Invalid binning" exception).
+  const float sinInner = std::min(1.f, config.impactMax / rMin);
+  const float sinOuter = std::min(1.f, config.impactMax / config.rMax);
+  const float deltaAngleWithMaxD0 =
+      std::abs(std::asin(sinInner) - std::asin(sinOuter));
+
+  // evaluating delta Phi based on the inner and outer angle, and the azimutal
+  // deflection including the maximum impact parameter
+  // Divide by config.phiBinDeflectionCoverage since we combine
+  // config.phiBinDeflectionCoverage number of consecutive phi bins in the
+  // seed making step. So each individual bin should cover
+  // 1/config.phiBinDeflectionCoverage of the maximum expected azimutal
+  // deflection
+  const float deltaPhi = (outerAngle - innerAngle + deltaAngleWithMaxD0) /
+                         config.phiBinDeflectionCoverage;
+
+  // sanity check: if the delta phi is equal to or less than zero, we'll be
+  // creating an infinite or a negative number of bins, which would be bad!
+  if (deltaPhi <= 0.f) {
+    throw std::domain_error(
+        "Delta phi value is equal to or less than zero, leading to an "
+        "impossible number of bins (negative or infinite)");
+  }
+
+  // divide 2pi by angle delta to get number of phi-bins
+  // size is always 2pi even for regions of interest
+  const int phiBins =
+      static_cast<int>(std::ceil(2 * std::numbers::pi / deltaPhi));
+
+  // set protection for large number of bins, by default it is large
+  return std::min(phiBins, config.maxPhiBins);
+}
+
+}  // namespace Acts::detail

--- a/Tests/UnitTests/Core/Seeding/CMakeLists.txt
+++ b/Tests/UnitTests/Core/Seeding/CMakeLists.txt
@@ -3,6 +3,7 @@ add_unittest(HoughTransformTest HoughTransformTest.cpp)
 add_unittest(AdaptiveHoughTransformTest HoughAccumulatorSectionTest.cpp)
 add_unittest(StrawLineResiduals StrawLineResidualTest.cpp)
 add_unittest(SphericalSpacePointGrid SphericalSpacePointGridTests.cpp)
+add_unittest(SpacePointGridPhiBinning SpacePointGridPhiBinningTests.cpp)
 
 if(ACTS_BUILD_PLUGIN_ROOT)
     add_unittest(FastStrawLineFitTests FastStrawLineFitTests.cpp)

--- a/Tests/UnitTests/Core/Seeding/SpacePointGridPhiBinningTests.cpp
+++ b/Tests/UnitTests/Core/Seeding/SpacePointGridPhiBinningTests.cpp
@@ -1,0 +1,91 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <boost/test/unit_test.hpp>
+
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/Seeding/detail/SpacePointGridPhiBinning.hpp"
+
+#include <stdexcept>
+
+using namespace Acts::UnitLiterals;
+
+namespace Acts::Test {
+
+namespace {
+
+// A physically sensible baseline: the minimum-pT helix radius is well above
+// rMax / 2, so the phi bin count is driven by the helix deflection.
+detail::SpacePointGridPhiBinningConfig makeConfig() {
+  detail::SpacePointGridPhiBinningConfig config;
+  config.minPt = 500_MeV;
+  config.bFieldInZ = 2_T;
+  config.rMax = 200_mm;
+  config.deltaRMax = 100_mm;
+  config.impactMax = 10_mm;
+  config.phiBinDeflectionCoverage = 1;
+  config.maxPhiBins = 10000;
+  return config;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(SpacePointGridPhiBinningTests)
+
+BOOST_AUTO_TEST_CASE(ZeroFieldUsesMaxPhiBins) {
+  auto config = makeConfig();
+  config.bFieldInZ = 0;
+  config.maxPhiBins = 42;
+  BOOST_CHECK_EQUAL(detail::computeSpacePointGridPhiBins(config), 42);
+}
+
+BOOST_AUTO_TEST_CASE(BaselineGivesFinitePositiveBinCount) {
+  const auto config = makeConfig();
+  const int phiBins = detail::computeSpacePointGridPhiBins(config);
+  BOOST_CHECK_GT(phiBins, 1);
+  BOOST_CHECK_LE(phiBins, config.maxPhiBins);
+}
+
+BOOST_AUTO_TEST_CASE(MaxPhiBinsCapsResult) {
+  auto config = makeConfig();
+  const int uncapped = detail::computeSpacePointGridPhiBins(config);
+  config.maxPhiBins = uncapped - 1;
+  BOOST_CHECK_EQUAL(detail::computeSpacePointGridPhiBins(config),
+                    config.maxPhiBins);
+}
+
+BOOST_AUTO_TEST_CASE(DeflectionCoverageIncreasesBinCount) {
+  auto config = makeConfig();
+  const int singleCoverage = detail::computeSpacePointGridPhiBins(config);
+  config.phiBinDeflectionCoverage = 2;
+  const int doubleCoverage = detail::computeSpacePointGridPhiBins(config);
+  BOOST_CHECK_GT(doubleCoverage, singleCoverage);
+}
+
+// Regression for the robustness fix of PR 5696: an impact parameter at or
+// beyond rMax - deltaRMax must fall back to a coarse binning instead of
+// producing a NaN and an invalid (zero) bin count.
+BOOST_AUTO_TEST_CASE(LargeImpactParameterStaysFinite) {
+  auto config = makeConfig();
+  config.impactMax = config.rMax;
+  const int phiBins = detail::computeSpacePointGridPhiBins(config);
+  BOOST_CHECK_GT(phiBins, 0);
+  BOOST_CHECK_LE(phiBins, config.maxPhiBins);
+}
+
+BOOST_AUTO_TEST_CASE(TooSmallHelixRadiusThrows) {
+  auto config = makeConfig();
+  // minHelixRadius = minPt / bFieldInZ falls below rMax / 2
+  config.minPt = 10_MeV;
+  BOOST_CHECK_THROW(detail::computeSpacePointGridPhiBins(config),
+                    std::domain_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace Acts::Test


### PR DESCRIPTION
Extracts the phi-bin count computation shared verbatim between `CylindricalSpacePointGrid` and `SphericalSpacePointGrid` into `Acts::detail::computeSpacePointGridPhiBins` in `Acts/Seeding/detail/SpacePointGridPhiBinning.hpp`. Both grids now derive their phi axis from the same code, so fixes like the `impactMax` clamp from #5696 only need to be applied in one place.

Adds a unit test for the helper covering the zero-field fallback, the `maxPhiBins` cap, the `phiBinDeflectionCoverage` scaling, the large-`impactMax` robustness case from #5696, and the too-small helix radius error.

No behavior change: the helper body is a verbatim move of the block previously duplicated in both grid constructors.

--- END COMMIT MESSAGE ---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
