### PR TITLE
fix: resolve SonarCloud BLOCKER issues (field shadowing, noexcept moves)

### DIFF
--- a/Core/include/Acts/Propagator/DirectNavigator.hpp
+++ b/Core/include/Acts/Propagator/DirectNavigator.hpp
@@ -46,24 +46,22 @@ class DirectNavigator {
     /// Constructor from geometry context
     /// @param gctx The geometry context
     explicit Options(const GeometryContext& gctx)
-        : NavigatorPlainOptions(gctx) {}
-
-    /// The surface tolerance
-    double surfaceTolerance = s_onSurfaceTolerance;
-
-    // TODO https://github.com/acts-project/acts/issues/2738
-    /// Distance limit to discard intersections "behind us"
-    /// @note this is only necessary because some surfaces have more than one
-    ///       intersection
-    double nearLimit = -100 * UnitConstants::um;
-
-    /// The far limit to resolve surfaces
-    double farLimit = std::numeric_limits<double>::max();
+        : NavigatorPlainOptions(gctx) {
+      // TODO https://github.com/acts-project/acts/issues/2738
+      // The direct navigator uses a relaxed near limit to discard
+      // intersections "behind us". This is only necessary because some
+      // surfaces have more than one intersection.
+      nearLimit = -100 * UnitConstants::um;
+    }
 
     /// Set the plain navigator options
     /// @param options The plain navigator options to copy
     void setPlainOptions(const NavigatorPlainOptions& options) {
+      // Preserve the direct-navigator-specific near limit, which differs from
+      // the plain default.
+      const double keepNearLimit = nearLimit;
       static_cast<NavigatorPlainOptions&>(*this) = options;
+      nearLimit = keepNearLimit;
     }
   };
 

--- a/Core/include/Acts/Utilities/Histogram.hpp
+++ b/Core/include/Acts/Utilities/Histogram.hpp
@@ -146,6 +146,24 @@ class ProfileHistogram {
         m_sampleRange(sampleRange),
         m_hist(boost::histogram::make_profile(axes.begin(), axes.end())) {}
 
+  /// Copy constructor
+  /// @param other The other profile histogram to copy from
+  ProfileHistogram(const ProfileHistogram& other) = default;
+
+  /// Move constructor
+  /// @param other The other profile histogram to move from
+  ProfileHistogram(ProfileHistogram&& other) noexcept = default;
+
+  /// Copy assignment operator
+  /// @param other The other profile histogram to copy from
+  /// @return The copied profile histogram
+  ProfileHistogram& operator=(const ProfileHistogram& other) = default;
+
+  /// Move assignment operator
+  /// @param other The other profile histogram to move from
+  /// @return The moved profile histogram
+  ProfileHistogram& operator=(ProfileHistogram&& other) noexcept = default;
+
   /// Fill profile with values and sample
   ///
   /// @param values Bin coordinate values (one per axis)
@@ -213,6 +231,24 @@ class Efficiency {
         m_title(std::move(title)),
         m_accepted(boost::histogram::make_histogram(axes.begin(), axes.end())),
         m_total(boost::histogram::make_histogram(axes.begin(), axes.end())) {}
+
+  /// Copy constructor
+  /// @param other The other efficiency histogram to copy from
+  Efficiency(const Efficiency& other) = default;
+
+  /// Move constructor
+  /// @param other The other efficiency histogram to move from
+  Efficiency(Efficiency&& other) noexcept = default;
+
+  /// Copy assignment operator
+  /// @param other The other efficiency histogram to copy from
+  /// @return The copied efficiency histogram
+  Efficiency& operator=(const Efficiency& other) = default;
+
+  /// Move assignment operator
+  /// @param other The other efficiency histogram to move from
+  /// @return The moved efficiency histogram
+  Efficiency& operator=(Efficiency&& other) noexcept = default;
 
   /// Fill efficiency histogram
   ///

--- a/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
+++ b/Core/include/Acts/Vertexing/AdaptiveMultiVertexFitter.hpp
@@ -161,6 +161,11 @@ class AdaptiveMultiVertexFitter {
       Config cfg, std::unique_ptr<const Logger> logger = getDefaultLogger(
                       "AdaptiveMultiVertexFitter", Logging::INFO));
 
+  /// Move constructor
+  /// @param other The fitter to move from
+  AdaptiveMultiVertexFitter(AdaptiveMultiVertexFitter&& other) noexcept =
+      default;
+
   /// @brief Adds a new vertex to an existing multi-vertex fit.
   /// 1. The 3D impact parameters are calculated for all tracks associated
   /// with newVertex.


### PR DESCRIPTION
## Summary

Resolves the 7 **BLOCKER** issues SonarCloud reports on `main`.

### `cpp:S2387` — field shadowing (3×) · `DirectNavigator.hpp`
`DirectNavigator::Options` redeclared `surfaceTolerance`, `nearLimit`, and `farLimit`, shadowing the identically-named fields in the base `NavigatorPlainOptions`. The standard `Navigator::Options` deliberately *inherits* these, so `DirectNavigator` was the outlier. The shadowing members are removed. `surfaceTolerance`/`farLimit` had defaults identical to the base; only `nearLimit` differed (`-100 um`), so it is set in the constructor and preserved across `setPlainOptions`, keeping behavior identical.

### `cpp:S5018` — non-`noexcept` move (4×) · `Histogram.hpp`, `AdaptiveMultiVertexFitter.hpp`
- `ProfileHistogram` and `Efficiency` relied on implicit (potentially-throwing) move operations. They now declare an explicit rule-of-five block with `noexcept = default` moves, mirroring the existing `Histogram` class in the same file.
- `AdaptiveMultiVertexFitter` gains an explicit `noexcept = default` move constructor.

## Validation
- All three affected translation units compile cleanly (RelWithDebInfo / clang).
- `ActsUnitTestDirectNavigator` passes (`*** No errors detected`), confirming the shadowing removal preserves navigation behavior.

## Notes
- All 7 issues were tagged `INTENTIONAL` by SonarCloud and none are on new code, so the quality gate was already green — these are pre-existing cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)