### PR TITLE
chore: deprecate Surface copy-assignment operators (cpp:S3624)

### DIFF
--- a/Core/include/Acts/Surfaces/ConeSurface.hpp
+++ b/Core/include/Acts/Surfaces/ConeSurface.hpp
@@ -86,6 +86,11 @@ class ConeSurface : public RegularSurface {
   ///
   /// @param other is the source surface for the assignment
   /// @return Reference to this ConeSurface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<ConeSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<ConeSurface>(other) instead.")]]
   ConeSurface& operator=(const ConeSurface& other);
 
   /// The binning position method - is overloaded for r-type binning

--- a/Core/include/Acts/Surfaces/CylinderSurface.hpp
+++ b/Core/include/Acts/Surfaces/CylinderSurface.hpp
@@ -95,6 +95,11 @@ class CylinderSurface : public RegularSurface {
   ///
   /// @param other is the source cylinder for the copy
   /// @return Reference to this CylinderSurface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<CylinderSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<CylinderSurface>(other) instead.")]]
   CylinderSurface& operator=(const CylinderSurface& other);
 
   /// The binning position method - is overloaded for r-type binning

--- a/Core/include/Acts/Surfaces/DiscSurface.hpp
+++ b/Core/include/Acts/Surfaces/DiscSurface.hpp
@@ -115,6 +115,11 @@ class DiscSurface : public RegularSurface {
   ///
   /// @param other The source sourface for the assignment
   /// @return Reference to this DiscSurface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<DiscSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<DiscSurface>(other) instead.")]]
   DiscSurface& operator=(const DiscSurface& other);
 
   /// Return the surface type

--- a/Core/include/Acts/Surfaces/LineSurface.hpp
+++ b/Core/include/Acts/Surfaces/LineSurface.hpp
@@ -86,6 +86,11 @@ class LineSurface : public Surface {
   ///
   /// @param other is the source surface dor copying
   /// @return Reference to this LineSurface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<T>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<T>(other) instead.")]]
   LineSurface& operator=(const LineSurface& other);
 
   Vector3 normal(const GeometryContext& gctx, const Vector3& pos,

--- a/Core/include/Acts/Surfaces/PerigeeSurface.hpp
+++ b/Core/include/Acts/Surfaces/PerigeeSurface.hpp
@@ -59,6 +59,11 @@ class PerigeeSurface : public LineSurface {
   ///
   /// @param other is the source surface to be assigned
   /// @return Reference to this surface for assignment chaining
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<PerigeeSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<PerigeeSurface>(other) instead.")]]
   PerigeeSurface& operator=(const PerigeeSurface& other);
 
   /// Return the surface type

--- a/Core/include/Acts/Surfaces/PlaneSurface.hpp
+++ b/Core/include/Acts/Surfaces/PlaneSurface.hpp
@@ -77,6 +77,11 @@ class PlaneSurface : public RegularSurface {
   ///
   /// @param other The source PlaneSurface for assignment
   /// @return Reference to this PlaneSurface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<PlaneSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<PlaneSurface>(other) instead.")]]
   PlaneSurface& operator=(const PlaneSurface& other);
 
   // Use overloads from `RegularSurface`

--- a/Core/include/Acts/Surfaces/StrawSurface.hpp
+++ b/Core/include/Acts/Surfaces/StrawSurface.hpp
@@ -38,7 +38,18 @@ class StrawSurface : public LineSurface {
   using LineSurface::LineSurface;
   /// @endcond
 
+  /// Copy constructor
+  /// @param other The source surface for the copy
+  StrawSurface(const StrawSurface& other) = default;
+
  public:
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<StrawSurface>(other) instead (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<StrawSurface>(other) instead.")]]
+  StrawSurface& operator=(const StrawSurface& other);
+
   /// Return the surface type
   /// @return Surface type identifier for straw surfaces
   SurfaceType type() const final { return Surface::Straw; }

--- a/Core/include/Acts/Surfaces/Surface.hpp
+++ b/Core/include/Acts/Surfaces/Surface.hpp
@@ -158,6 +158,12 @@ class Surface : public virtual GeometryObject,
   ///
   /// @param other Source surface for the assignment
   /// @return Reference to this surface after assignment
+  // TODO: remove this copy-assignment operator; copy surfaces via
+  // Surface::makeShared<T>(other) instead. Kept temporarily to avoid a breaking
+  // change (SonarCloud cpp:S3624).
+  [[deprecated(
+      "Surface copy-assignment is deprecated and will be removed; copy via "
+      "Surface::makeShared<T>(other) instead.")]]
   Surface& operator=(const Surface& other) noexcept = default;
 
   /// Comparison (equality) operator

--- a/Core/src/Surfaces/ConeSurface.cpp
+++ b/Core/src/Surfaces/ConeSurface.cpp
@@ -14,6 +14,7 @@
 #include "Acts/Surfaces/detail/AlignmentHelper.hpp"
 #include "Acts/Surfaces/detail/FacesHelper.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 #include "Acts/Utilities/detail/RealQuadraticEquation.hpp"
@@ -77,7 +78,9 @@ Surface::SurfaceType ConeSurface::type() const {
 
 ConeSurface& ConeSurface::operator=(const ConeSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     Surface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
     m_bounds = other.m_bounds;
   }
   return *this;

--- a/Core/src/Surfaces/CylinderSurface.cpp
+++ b/Core/src/Surfaces/CylinderSurface.cpp
@@ -18,6 +18,7 @@
 #include "Acts/Surfaces/detail/AlignmentHelper.hpp"
 #include "Acts/Surfaces/detail/FacesHelper.hpp"
 #include "Acts/Surfaces/detail/MergeHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 #include "Acts/Utilities/detail/periodic.hpp"
@@ -67,7 +68,9 @@ CylinderSurface::CylinderSurface(const Transform3& transform,
 
 CylinderSurface& CylinderSurface::operator=(const CylinderSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     Surface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
     m_bounds = other.m_bounds;
   }
   return *this;

--- a/Core/src/Surfaces/DiscSurface.cpp
+++ b/Core/src/Surfaces/DiscSurface.cpp
@@ -22,6 +22,7 @@
 #include "Acts/Surfaces/detail/FacesHelper.hpp"
 #include "Acts/Surfaces/detail/MergeHelper.hpp"
 #include "Acts/Surfaces/detail/PlanarHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/JacobianHelpers.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
@@ -69,7 +70,9 @@ DiscSurface::DiscSurface(std::shared_ptr<const DiscBounds> dbounds,
 
 DiscSurface& DiscSurface::operator=(const DiscSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     Surface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
     m_bounds = other.m_bounds;
   }
   return *this;

--- a/Core/src/Surfaces/LineSurface.cpp
+++ b/Core/src/Surfaces/LineSurface.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/SurfaceBounds.hpp"
 #include "Acts/Surfaces/SurfaceError.hpp"
 #include "Acts/Surfaces/detail/AlignmentHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 
@@ -48,7 +49,9 @@ LineSurface::LineSurface(const GeometryContext& gctx, const LineSurface& other,
 
 LineSurface& LineSurface::operator=(const LineSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     Surface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
     m_bounds = other.m_bounds;
   }
   return *this;

--- a/Core/src/Surfaces/PerigeeSurface.cpp
+++ b/Core/src/Surfaces/PerigeeSurface.cpp
@@ -9,6 +9,7 @@
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 
 #include "Acts/Geometry/GeometryObject.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/detail/OstreamStateGuard.hpp"
 
 #include <iomanip>
@@ -34,7 +35,9 @@ PerigeeSurface::PerigeeSurface(const GeometryContext& gctx,
 
 PerigeeSurface& PerigeeSurface::operator=(const PerigeeSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     LineSurface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
   }
   return *this;
 }

--- a/Core/src/Surfaces/PlaneSurface.cpp
+++ b/Core/src/Surfaces/PlaneSurface.cpp
@@ -21,6 +21,7 @@
 #include "Acts/Surfaces/SurfaceMergingException.hpp"
 #include "Acts/Surfaces/detail/FacesHelper.hpp"
 #include "Acts/Surfaces/detail/PlanarHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 
@@ -54,7 +55,9 @@ PlaneSurface::PlaneSurface(const Transform3& transform,
 
 PlaneSurface& PlaneSurface::operator=(const PlaneSurface& other) {
   if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
     Surface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
     m_bounds = other.m_bounds;
   }
   return *this;

--- a/Core/src/Surfaces/StrawSurface.cpp
+++ b/Core/src/Surfaces/StrawSurface.cpp
@@ -13,12 +13,22 @@
 #include "Acts/Surfaces/LineBounds.hpp"
 #include "Acts/Surfaces/detail/FacesHelper.hpp"
 #include "Acts/Surfaces/detail/VerticesHelper.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 
 #include <numbers>
 #include <utility>
 #include <vector>
 
 namespace Acts {
+
+StrawSurface& StrawSurface::operator=(const StrawSurface& other) {
+  if (this != &other) {
+    ACTS_PUSH_IGNORE_DEPRECATED()
+    LineSurface::operator=(other);
+    ACTS_POP_IGNORE_DEPRECATED()
+  }
+  return *this;
+}
 
 Polyhedron StrawSurface::polyhedronRepresentation(
     const GeometryContext& gctx, unsigned int quarterSegments) const {

--- a/Tests/CommonHelpers/include/ActsTests/CommonHelpers/LineSurfaceStub.hpp
+++ b/Tests/CommonHelpers/include/ActsTests/CommonHelpers/LineSurfaceStub.hpp
@@ -11,6 +11,7 @@
 #include "Acts/Definitions/Algebra.hpp"
 #include "Acts/Surfaces/LineSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 
 namespace ActsTests {
 
@@ -36,7 +37,14 @@ class LineSurfaceStub : public Acts::LineSurface {
   LineSurfaceStub(const LineSurfaceStub& ls)
       : Acts::GeometryObject(), Acts::LineSurface(ls) { /* nop */ }
 
-  LineSurfaceStub& operator=(const LineSurfaceStub& ls) = default;
+  // NOLINTNEXTLINE(modernize-use-equals-default) base assignment is deprecated
+  LineSurfaceStub& operator=(const LineSurfaceStub& ls) {
+    // The base surface copy-assignment is deprecated; this stub still needs it.
+    ACTS_PUSH_IGNORE_DEPRECATED()
+    Acts::LineSurface::operator=(ls);
+    ACTS_POP_IGNORE_DEPRECATED()
+    return *this;
+  }
 
   LineSurfaceStub(const Acts::GeometryContext& gctx, const LineSurfaceStub& ls,
                   const Acts::Transform3& t)

--- a/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/ConeSurfaceTests.cpp
@@ -26,6 +26,7 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
 #include "ActsTests/CommonHelpers/FloatComparisons.hpp"
@@ -213,7 +214,11 @@ BOOST_AUTO_TEST_CASE(ConeSurfaceEqualityOperators) {
   /// Test assignment
   auto assignedConeSurface =
       Surface::makeShared<ConeSurface>(Transform3::Identity(), 0.1, true);
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   *assignedConeSurface = *coneSurfaceObject;
+  ACTS_POP_IGNORE_DEPRECATED()
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedConeSurface == *coneSurfaceObject);
 }

--- a/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/CylinderSurfaceTests.cpp
@@ -28,6 +28,7 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
@@ -253,7 +254,11 @@ BOOST_AUTO_TEST_CASE(CylinderSurfaceEqualityOperators) {
   /// Test assignment
   auto assignedCylinderSurface =
       Surface::makeShared<CylinderSurface>(Transform3::Identity(), 6.6, 5.4);
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   *assignedCylinderSurface = *cylinderSurfaceObject;
+  ACTS_POP_IGNORE_DEPRECATED()
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedCylinderSurface == *cylinderSurfaceObject);
 }

--- a/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/DiscSurfaceTests.cpp
@@ -30,6 +30,7 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
@@ -241,7 +242,11 @@ BOOST_AUTO_TEST_CASE(DiscSurfaceAssignment) {
   auto assignedDisc =
       Surface::makeShared<DiscSurface>(Transform3::Identity(), 2.2, 4.4, 0.07);
 
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   BOOST_CHECK_NO_THROW(*assignedDisc = *discSurfaceObject);
+  ACTS_POP_IGNORE_DEPRECATED()
   BOOST_CHECK((*assignedDisc) == (*discSurfaceObject));
 }
 

--- a/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PerigeeSurfaceTests.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 
 #include <iomanip>
 #include <memory>
@@ -111,7 +112,11 @@ BOOST_AUTO_TEST_CASE(EqualityOperators) {
   BOOST_CHECK(*perigeeSurfaceObject == *perigeeSurfaceObject2);
 
   /// Test assignment
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   *assignedPerigeeSurface = *perigeeSurfaceObject;
+  ACTS_POP_IGNORE_DEPRECATED()
 
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedPerigeeSurface == *perigeeSurfaceObject);

--- a/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/PlaneSurfaceTests.cpp
@@ -31,6 +31,7 @@
 #include "Acts/Utilities/AxisDefinitions.hpp"
 #include "Acts/Utilities/BinUtility.hpp"
 #include "Acts/Utilities/BinningType.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "Acts/Utilities/Intersection.hpp"
 #include "Acts/Utilities/Result.hpp"
 #include "Acts/Utilities/ThrowAssert.hpp"
@@ -232,7 +233,11 @@ BOOST_AUTO_TEST_CASE(PlaneSurfaceEqualityOperators) {
   /// Test assignment
   auto assignedPlaneSurface =
       Surface::makeShared<PlaneSurface>(Transform3::Identity(), nullptr);
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   *assignedPlaneSurface = *planeSurfaceObject;
+  ACTS_POP_IGNORE_DEPRECATED()
 
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedPlaneSurface == *planeSurfaceObject);

--- a/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
+++ b/Tests/UnitTests/Core/Surfaces/StrawSurfaceTests.cpp
@@ -15,6 +15,7 @@
 #include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Surfaces/StrawSurface.hpp"
 #include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Diagnostics.hpp"
 #include "ActsTests/CommonHelpers/DetectorElementStub.hpp"
 
 #include <memory>
@@ -119,7 +120,11 @@ BOOST_AUTO_TEST_CASE(EqualityOperators) {
   /// Test assignment
   auto assignedStrawSurface =
       Surface::makeShared<StrawSurface>(Transform3::Identity(), 6.6, 33.33);
+  // TODO: surface copy-assignment is deprecated; switch to a makeShared copy
+  // when it is removed (SonarCloud cpp:S3624).
+  ACTS_PUSH_IGNORE_DEPRECATED()
   *assignedStrawSurface = *strawSurfaceObject;
+  ACTS_POP_IGNORE_DEPRECATED()
 
   /// Test equality of assigned to original
   BOOST_CHECK(*assignedStrawSurface == *strawSurfaceObject);


### PR DESCRIPTION
## Summary

Deprecates the copy-**assignment** operators across the `Surface` hierarchy, as a non-breaking first step toward removing them (which will resolve SonarCloud **cpp:S3624** — "Classes should have regular copy and move semantic").

### Why
On a polymorphic base like `Surface`, public copy-assignment is slicing-prone and is the member SonarCloud flags (public `operator=` vs protected copy constructor). It's also **redundant**: a surface can already be copied via `Surface::makeShared<T>(other)`, which reaches the protected copy constructors through `friend class Surface`. Nothing in production assigns surfaces by value — only the unit tests do.

Rather than remove the operators now (a breaking API change), this PR marks them `[[deprecated]]` with a `TODO`, steering callers to `makeShared` first.

### What
- `[[deprecated]]` + TODO on `operator=` of `Surface` and the concrete surfaces (`Cone`, `Cylinder`, `Disc`, `Line`, `Perigee`, `Plane`, `Straw`).
- `StrawSurface` previously relied on an implicit copy-assignment; it now gets an explicit (deprecated) `operator=` and a defaulted copy constructor, so the deprecation is signalled consistently and no implicitly-generated member silently calls the deprecated base.
- The internal base-class assignment calls (derived `operator=` implementations) and the surface unit-test assignment sites are wrapped in the existing `ACTS_PUSH/POP_IGNORE_DEPRECATED` macros so **`-Werror` builds stay green** while the operators still exist. Same treatment for the `LineSurfaceStub` test helper.

### Not touched (verified safe under `-Werror`)
- Layers (`CylinderLayer`/`DiscLayer`/`PlaneLayer`) already `= delete` assignment.
- `PointSurface`/`RegularSurface`/`SurfaceStub` copy-assignment is never odr-used.

### Validation
- Full `ActsCore` build + all surface unit-test executables: **0 deprecation warnings**, 0 warnings/errors.
- All surface unit tests pass (no functional change).

Follow-up (separate, breaking PR): actually remove the operators and update the 6 assignment tests to `makeShared`-copy, closing cpp:S3624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)