### PR TITLE
perf: gpu gbts better edge connection

### DIFF
--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -204,11 +204,11 @@ struct gbts_fit_segments_params {
   // Minimum-pT gate in the fit: reject if |X2| * inv_max_curvature > 1
   // inv_max_curvature = 1/curv_max = ~pT[MeV].
   float inv_max_curvature = 900.0f;
-	// factor to tighen inv_max_curvature when cutting after the fit is complete
-	float final_curv_cut_tighten = 1.5f;
-	//detector r and z bounds, used in seed quality calculation
-	float rmax = 350.0f;
-	float zmax = 3000.0f;
+  // factor to tighen inv_max_curvature when cutting after the fit is complete
+  float final_curv_cut_tighten = 1.5f;
+  // detector r and z bounds, used in seed quality calculation
+  float rmax = 350.0f;
+  float zmax = 3000.0f;
 
   // max_z0 is used from the graph_making to insure concistency
 };

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -204,6 +204,11 @@ struct gbts_fit_segments_params {
   // Minimum-pT gate in the fit: reject if |X2| * inv_max_curvature > 1
   // inv_max_curvature = 1/curv_max = ~pT[MeV].
   float inv_max_curvature = 900.0f;
+	// factor to tighen inv_max_curvature when cutting after the fit is complete
+	float final_curv_cut_tighten = 1.5f;
+	//detector r and z bounds, used in seed quality calculation
+	float rmax = 350.0f;
+	float zmax = 3000.0f;
 
   // max_z0 is used from the graph_making to insure concistency
 };

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -130,9 +130,9 @@ struct gbts_make_graph_edges_params {
   float max_Kappa_low_tau = 3.75e-4f;
   float max_Kappa_high_tau = 3.75e-4f;
   float max_Kappa_change_tau = 4.0f;
-	// conditions for looser edge-matching cuts (more material interaction)
-	float long_edge_dr = 50.0f;
-	float long_edge_dz = 200.0f;
+  // conditions for looser edge-matching cuts (more material interaction)
+  float long_edge_dr = 50.0f;
+  float long_edge_dz = 200.0f;
 };
 
 // Pair-matching cuts for device::gbts_match_graph_edges.
@@ -143,14 +143,15 @@ struct gbts_match_graph_edges_params {
   float cut_dcurv_max = 0.001f;
   // |eta_1-eta_2| <= cut_deta_max.
   float cut_deta_max = 0.01f;
-	float deta_inflation = 0.003f;
-	// tuning to tighten eta cut for high pT edges
-	float less_scattering_curv = 1e-4;
-	float much_less_scattering_curv = 3e-5f;
-	//deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv < much_less_scattering_curv))
-	float high_pT_correction = 0.2f;
-	// cut on dphi/dphi_max + dcurv/dcurv_max + deta/deta_max
-	float cut_ratio_sum_max = 1.3f;	
+  float deta_inflation = 0.003f;
+  // tuning to tighten eta cut for high pT edges
+  float less_scattering_curv = 1e-4;
+  float much_less_scattering_curv = 3e-5f;
+  // deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv
+  // < much_less_scattering_curv))
+  float high_pT_correction = 0.2f;
+  // cut on dphi/dphi_max + dcurv/dcurv_max + deta/deta_max
+  float cut_ratio_sum_max = 1.3f;
 };
 
 // Host-side dphi window used to compute bin_pair_dphi before launching

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -127,12 +127,12 @@ struct gbts_make_graph_edges_params {
   //   max_Kappa = curv_max = kappa/2 = c*q*B/(2*pT)
   //   = 0.299792458*2/(2*0.9) m^-1 = 0.333 m^-1 = 3.33e-4 mm^-1 (2 T, 0.9
   //   GeV).
-  float max_Kappa = 3.75e-4f;
-  // Max transverse impact parameter, per curvature regime:
-  //   d0 = r1*r2*(|curv| - max_Kappa) <= {low,high}_Kappa_d0  (mm).
-  // 0 = prompt tracks only (no d0 allowance beyond the pT cut).
-  float low_Kappa_d0 = 0.00f;
-  float high_Kappa_d0 = 0.0f;
+  float max_Kappa_low_tau = 3.75e-4f;
+  float max_Kappa_high_tau = 3.75e-4f;
+  float max_Kappa_change_tau = 4.0f;
+	// conditions for looser edge-matching cuts (more material interaction)
+	float long_edge_dr = 50.0f;
+	float long_edge_dz = 200.0f;
 };
 
 // Pair-matching cuts for device::gbts_match_graph_edges.
@@ -141,8 +141,16 @@ struct gbts_match_graph_edges_params {
   float cut_dphi_max = 0.012f;
   // |curv_1 - curv_2| <= cut_dcurv_max  (curv = dphi/dr).
   float cut_dcurv_max = 0.001f;
-  // |tau_2/tau_1 - 1| <= cut_tau_ratio_max (~1%).
-  float cut_tau_ratio_max = 0.01f;
+  // |eta_1-eta_2| <= cut_deta_max.
+  float cut_deta_max = 0.01f;
+	float deta_inflation = 0.003f;
+	// tuning to tighten eta cut for high pT edges
+	float less_scattering_curv = 1e-4;
+	float much_less_scattering_curv = 3e-5f;
+	//deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv < much_less_scattering_curv))
+	float high_pT_correction = 0.2f;
+	// cut on dphi/dphi_max + dcurv/dcurv_max + deta/deta_max
+	float cut_ratio_sum_max = 1.3f;	
 };
 
 // Host-side dphi window used to compute bin_pair_dphi before launching

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -145,7 +145,7 @@ struct gbts_match_graph_edges_params {
   float cut_deta_max = 0.007f;
   float deta_inflation = 0.003f;
   // tuning to tighten eta cut for high pT edges
-  float less_scattering_curv = 1e-4;
+  float less_scattering_curv = 1e-4f;
   float much_less_scattering_curv = 3e-5f;
   // deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv
   // < much_less_scattering_curv))

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -128,9 +128,9 @@ struct gbts_make_graph_edges_params {
   //   = 0.299792458*2/(2*0.9) m^-1 = 0.333 m^-1 = 3.33e-4 mm^-1 (2 T, 0.9
   //   GeV).
   float max_Kappa_low_tau = 3.75e-4f;
-  float max_Kappa_high_tau = 3.75e-4f;
+  float max_Kappa_high_tau = 4.35e-4f;
   float max_Kappa_change_tau = 4.0f;
-  // conditions for looser edge-matching cuts (more material interaction)
+  // conditions to inflate edge-matching cuts
   float long_edge_dr = 50.0f;
   float long_edge_dz = 200.0f;
 };
@@ -142,7 +142,7 @@ struct gbts_match_graph_edges_params {
   // |curv_1 - curv_2| <= cut_dcurv_max  (curv = dphi/dr).
   float cut_dcurv_max = 0.001f;
   // |eta_1-eta_2| <= cut_deta_max.
-  float cut_deta_max = 0.01f;
+  float cut_deta_max = 0.007f;
   float deta_inflation = 0.003f;
   // tuning to tighten eta cut for high pT edges
   float less_scattering_curv = 1e-4;

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_types.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_types.hpp
@@ -10,6 +10,7 @@
 // Project include(s).
 #include "traccc/definitions/common.hpp"      // traccc::constant
 #include "traccc/definitions/qualifiers.hpp"  // TRACCC_HOST_DEVICE, TRACCC_ALIGN
+#include "traccc/definitions/math.hpp"
 
 // System include(s).
 #include <cmath>
@@ -34,11 +35,45 @@ struct TRACCC_ALIGN(8) uint2 {
 struct TRACCC_ALIGN(4) short2 {
   short x, y;
 };
+struct TRACCC_ALIGN(8) short4 {
+	    short x, y, z, w;
+};
 
 namespace device {
 
 inline constexpr float PI_F = traccc::constant<float>::pi;
 inline constexpr float TWO_PI_F = 2.0f * traccc::constant<float>::pi;
+
+// for float->short->float edge params conversion
+	inline constexpr float short_max = static_cast<float>(SHRT_MAX);
+	
+	struct edge_params_converter {
+		float max_curv = 5e-4f;
+		float max_eta = 36.0f;
+	
+		edge_params_converter(const float maxcurv, const float maxtau) {
+			max_curv = maxcurv;
+			max_eta = -1.0f*math::log(math::sqrt(1.0f+maxtau*maxtau)-maxtau)*1.0001f;
+		}
+	
+		inline TRACCC_HOST_DEVICE short4 make_edge_params(float eta, float curv, float Phi2, float Phi1, bool long_edge) const {
+	
+			short4 params = short4{
+				static_cast<short>(short_max*eta/max_eta), 
+				static_cast<short>(short_max*curv/max_curv),
+				static_cast<short>(short_max*Phi2/(TWO_PI_F)), 
+				static_cast<short>(short_max*Phi1/(TWO_PI_F))};
+			// use last bit of phi1 to signal long_edge
+			params.w -= (params.w & 0x1);
+			params.w += long_edge;
+			return params;
+		}
+	
+		inline TRACCC_HOST_DEVICE std::pair<float4, bool> decode_edge_params(short4 sp) const {
+			float4 float_params = float4{max_eta*static_cast<float>(sp.x)/short_max, max_curv*static_cast<float>(sp.y)/short_max, TWO_PI_F*static_cast<float>(sp.z)/short_max, TWO_PI_F*static_cast<float>(sp.w)/short_max};
+			return std::make_pair(float_params, sp.w & 0x1); 
+		}
+	};
 
 }  // namespace device
 

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_types.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_types.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 // Project include(s).
-#include "traccc/definitions/common.hpp"      // traccc::constant
-#include "traccc/definitions/qualifiers.hpp"  // TRACCC_HOST_DEVICE, TRACCC_ALIGN
+#include "traccc/definitions/common.hpp"  // traccc::constant
 #include "traccc/definitions/math.hpp"
+#include "traccc/definitions/qualifiers.hpp"  // TRACCC_HOST_DEVICE, TRACCC_ALIGN
 
 // System include(s).
 #include <cmath>
@@ -36,7 +36,7 @@ struct TRACCC_ALIGN(4) short2 {
   short x, y;
 };
 struct TRACCC_ALIGN(8) short4 {
-	    short x, y, z, w;
+  short x, y, z, w;
 };
 
 namespace device {
@@ -45,35 +45,41 @@ inline constexpr float PI_F = traccc::constant<float>::pi;
 inline constexpr float TWO_PI_F = 2.0f * traccc::constant<float>::pi;
 
 // for float->short->float edge params conversion
-	inline constexpr float short_max = static_cast<float>(SHRT_MAX);
-	
-	struct edge_params_converter {
-		float max_curv = 5e-4f;
-		float max_eta = 36.0f;
-	
-		edge_params_converter(const float maxcurv, const float maxtau) {
-			max_curv = maxcurv;
-			max_eta = -1.0f*math::log(math::sqrt(1.0f+maxtau*maxtau)-maxtau)*1.0001f;
-		}
-	
-		inline TRACCC_HOST_DEVICE short4 make_edge_params(float eta, float curv, float Phi2, float Phi1, bool long_edge) const {
-	
-			short4 params = short4{
-				static_cast<short>(short_max*eta/max_eta), 
-				static_cast<short>(short_max*curv/max_curv),
-				static_cast<short>(short_max*Phi2/(TWO_PI_F)), 
-				static_cast<short>(short_max*Phi1/(TWO_PI_F))};
-			// use last bit of phi1 to signal long_edge
-			params.w -= (params.w & 0x1);
-			params.w += long_edge;
-			return params;
-		}
-	
-		inline TRACCC_HOST_DEVICE std::pair<float4, bool> decode_edge_params(short4 sp) const {
-			float4 float_params = float4{max_eta*static_cast<float>(sp.x)/short_max, max_curv*static_cast<float>(sp.y)/short_max, TWO_PI_F*static_cast<float>(sp.z)/short_max, TWO_PI_F*static_cast<float>(sp.w)/short_max};
-			return std::make_pair(float_params, sp.w & 0x1); 
-		}
-	};
+inline constexpr float short_max = static_cast<float>(SHRT_MAX);
+
+struct edge_params_converter {
+  float max_curv = 5e-4f;
+  float max_eta = 36.0f;
+
+  edge_params_converter(const float maxcurv, const float maxtau) {
+    max_curv = maxcurv;
+    max_eta = -1.0f * math::log(math::sqrt(1.0f + maxtau * maxtau) - maxtau) *
+              1.0001f;
+  }
+
+  inline TRACCC_HOST_DEVICE short4 make_edge_params(float eta, float curv,
+                                                    float Phi2, float Phi1,
+                                                    bool long_edge) const {
+    short4 params = short4{static_cast<short>(short_max * eta / max_eta),
+                           static_cast<short>(short_max * curv / max_curv),
+                           static_cast<short>(short_max * Phi2 / (TWO_PI_F)),
+                           static_cast<short>(short_max * Phi1 / (TWO_PI_F))};
+    // use last bit of phi1 to signal long_edge
+    params.w -= (params.w & 0x1);
+    params.w += long_edge;
+    return params;
+  }
+
+  inline TRACCC_HOST_DEVICE std::pair<float4, bool> decode_edge_params(
+      short4 sp) const {
+    float4 float_params =
+        float4{max_eta * static_cast<float>(sp.x) / short_max,
+               max_curv * static_cast<float>(sp.y) / short_max,
+               TWO_PI_F * static_cast<float>(sp.z) / short_max,
+               TWO_PI_F * static_cast<float>(sp.w) / short_max};
+    return std::make_pair(float_params, sp.w & 0x1);
+  }
+};
 
 }  // namespace device
 

--- a/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
+++ b/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
@@ -105,7 +105,8 @@ bool gbts_seedfinder_config::setLinkingScheme(
   gbts_dphi_window_params.dphi_coeff *= ptScale;
   gbts_dphi_window_params.min_delta_phi_low_dr *= ptScale;
   gbts_dphi_window_params.dphi_coeff_low_dr *= ptScale;
-  gbts_make_graph_edges_params.max_Kappa *= ptScale;
+  gbts_make_graph_edges_params.max_Kappa_low_tau *= ptScale;
+  gbts_make_graph_edges_params.max_Kappa_high_tau *= ptScale;
 
   // contianers sizes
   nLayers = static_cast<unsigned int>(layerInfo.type.size());

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_make_graph_edges.hpp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_make_graph_edges.hpp
@@ -45,8 +45,8 @@ struct gbts_make_graph_edges_payload {
   /// Output: packed per-edge [eta, curv, phi_z, phi_w] used by
   /// matching
   vecmem::data::vector_view<short4> edge_params;
-	/// class for compressing edge params to short4
-	edge_params_converter edge_params_maker;
+  /// class for compressing edge params to short4
+  edge_params_converter edge_params_maker;
   /// Output: per-destination-node incoming-edge count (atomic)
   vecmem::data::vector_view<unsigned int> num_outgoing_edges;
 };

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_make_graph_edges.hpp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_make_graph_edges.hpp
@@ -42,9 +42,11 @@ struct gbts_make_graph_edges_payload {
   unsigned int* nEdgesCounter;
   /// Output: (src, dst) node indices per edge
   vecmem::data::vector_view<uint2> edge_nodes;
-  /// Output: packed per-edge [exp(-eta), curv, phi_z, phi_w] used by
+  /// Output: packed per-edge [eta, curv, phi_z, phi_w] used by
   /// matching
-  vecmem::data::vector_view<float4> edge_params;
+  vecmem::data::vector_view<short4> edge_params;
+	/// class for compressing edge params to short4
+	edge_params_converter edge_params_maker;
   /// Output: per-destination-node incoming-edge count (atomic)
   vecmem::data::vector_view<unsigned int> num_outgoing_edges;
 };

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_match_graph_edges.hpp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/gbts_match_graph_edges.hpp
@@ -29,7 +29,7 @@ struct gbts_match_graph_edges_payload {
   traccc::gbts_match_graph_edges_params gbts_match_graph_edges_params;
   /// Packed per-edge [exp_eta, curv, phi_z, phi_w], from
   /// gbts_make_graph_edges
-  vecmem::data::vector_view<const float4> edge_params;
+  vecmem::data::vector_view<const short4> edge_params;
   /// (src, dst) node indices per edge
   vecmem::data::vector_view<const uint2> edge_nodes;
   /// Per-node prefix sum of incoming edges (used to locate candidates)
@@ -42,6 +42,8 @@ struct gbts_match_graph_edges_payload {
   vecmem::data::vector_view<unsigned int> neighbours;
   /// Output: per-edge "kept" flag, later compacted into a re-index
   vecmem::data::vector_view<int> reIndexer;
+  /// class for decoding short4 edge params to float4, bool
+  edge_params_converter edge_params_decoder;
   /// In/out: global atomic counter of total accepted connections
   unsigned int* nConnectionsCounter;
 };

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
@@ -309,20 +309,22 @@ TRACCC_HOST_DEVICE inline void gbts_fit_segments(
       continue;
     }
 
-		//state1 is the final state
-		// can cut more strongly now the fit is done 
-		if (fabsf(state1.m_X[2]) * fit_params.final_curv_cut_tighten * fit_params.inv_max_curvature > 1.0f) {
-			return;
-		}
-		// prefer seeds that reach to the outer edge of the detector for better high pT resoultion
-		if(math::fabs(state1.m_Y[1]) > fit_params.zmax/fit_params.rmax) {
-			state1.m_J += fit_params.add_hit*math::fabs(node1.z)/fit_params.zmax;
-		}
-		else {
-			float r2_max = (node1.x)*(node1.x) + (node1.y)*(node1.y);
-			state1.m_J += fit_params.add_hit*math::sqrt(r2_max)/fit_params.rmax;
-		}
-		int qual = static_cast<int>(fit_params.qual_scale * state1.m_J);
+    // state1 is the final state
+    //  can cut more strongly now the fit is done
+    if (fabsf(state1.m_X[2]) * fit_params.final_curv_cut_tighten *
+            fit_params.inv_max_curvature >
+        1.0f) {
+      return;
+    }
+    // prefer seeds that reach to the outer edge of the detector for better high
+    // pT resoultion
+    if (math::fabs(state1.m_Y[1]) > fit_params.zmax / fit_params.rmax) {
+      state1.m_J += fit_params.add_hit * math::fabs(node1.z) / fit_params.zmax;
+    } else {
+      float r2_max = (node1.x) * (node1.x) + (node1.y) * (node1.y);
+      state1.m_J += fit_params.add_hit * math::sqrt(r2_max) / fit_params.rmax;
+    }
+    int qual = static_cast<int>(fit_params.qual_scale * state1.m_J);
 
     const unsigned int prop_idx =
         vecmem::device_atomic_ref<unsigned int>(*payload.nPropsCounter)

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
@@ -308,12 +308,22 @@ TRACCC_HOST_DEVICE inline void gbts_fit_segments(
     if (length < payload.minLevel) {
       continue;
     }
-    int qual = 0;
-    if (toggle) {
-      qual = static_cast<int>(fit_params.qual_scale * state2.m_J);
-    } else {
-      qual = static_cast<int>(fit_params.qual_scale * state1.m_J);
-    }
+
+		//state1 is the final state
+		// can cut more strongly now the fit is done 
+		if (fabsf(state1.m_X[2]) * fit_params.final_curv_cut_tighten * fit_params.inv_max_curvature > 1.0f) {
+			return;
+		}
+		// prefer seeds that reach to the outer edge of the detector for better high pT resoultion
+		if(math::fabs(state1.m_Y[1]) > fit_params.zmax/fit_params.rmax) {
+			state1.m_J += fit_params.add_hit*math::fabs(node1.z)/fit_params.zmax;
+		}
+		else {
+			float r2_max = (node1.x)*(node1.x) + (node1.y)*(node1.y);
+			state1.m_J += fit_params.add_hit*math::sqrt(r2_max)/fit_params.rmax;
+		}
+		int qual = static_cast<int>(fit_params.qual_scale * state1.m_J);
+
     const unsigned int prop_idx =
         vecmem::device_atomic_ref<unsigned int>(*payload.nPropsCounter)
             .fetch_add(1u);

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
@@ -311,13 +311,11 @@ TRACCC_HOST_DEVICE inline void gbts_fit_segments(
 
     // state1 is the final state
     //  can cut more strongly now the fit is done
-    if (fabsf(state1.m_X[2]) * fit_params.final_curv_cut_tighten *
-            fit_params.inv_max_curvature >
-        1.0f) {
+    if (math::fabs(state1.m_X[2]) * fit_params.final_curv_cut_tighten *
+            fit_params.inv_max_curvature > 1.0f) {
       return;
     }
-    // prefer seeds that reach to the outer edge of the detector for better high
-    // pT resoultion
+    // prefer seeds that reach to the outer edge of the detector for better resoultion at high pT
     if (math::fabs(state1.m_Y[1]) > fit_params.zmax / fit_params.rmax) {
       state1.m_J += fit_params.add_hit * math::fabs(node1.z) / fit_params.zmax;
     } else {

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_fit_segments.ipp
@@ -312,10 +312,12 @@ TRACCC_HOST_DEVICE inline void gbts_fit_segments(
     // state1 is the final state
     //  can cut more strongly now the fit is done
     if (math::fabs(state1.m_X[2]) * fit_params.final_curv_cut_tighten *
-            fit_params.inv_max_curvature > 1.0f) {
+            fit_params.inv_max_curvature >
+        1.0f) {
       return;
     }
-    // prefer seeds that reach to the outer edge of the detector for better resoultion at high pT
+    // prefer seeds that reach to the outer edge of the detector for better
+    // resoultion at high pT
     if (math::fabs(state1.m_Y[1]) > fit_params.zmax / fit_params.rmax) {
       state1.m_J += fit_params.add_hit * math::fabs(node1.z) / fit_params.zmax;
     } else {

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
@@ -37,8 +37,8 @@ TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
     const unsigned int begin_bin1, const unsigned int n1Idx, const float phi1,
     const float phi2, const float deltaPhi,
     const gbts_make_graph_edges_params& ap,
-		const edge_params_converter edge_params_maker, const unsigned int nMaxEdges) {
-
+    const edge_params_converter edge_params_maker,
+    const unsigned int nMaxEdges) {
   const float tau_min1 = node_params_1.x;
   const float tau_max1 = node_params_1.y;
   const float r1 = node_params_1.z;
@@ -77,23 +77,25 @@ TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
     return;
   }
   const float curv = dphi / dr;
-	const float curv_max = ftau < ap.max_Kappa_change_tau ? ap.max_Kappa_low_tau : ap.max_Kappa_high_tau;
-	if (math::fabs(curv) > curv_max) {
-		return;
-	}
+  const float curv_max = ftau < ap.max_Kappa_change_tau ? ap.max_Kappa_low_tau
+                                                        : ap.max_Kappa_high_tau;
+  if (math::fabs(curv) > curv_max) {
+    return;
+  }
 
   const unsigned int nEdges =
       vecmem::device_atomic_ref<unsigned int>(nEdgesCounter).fetch_add(1u);
   if (nEdges < nMaxEdges) {
-    const float eta = -1*std::logf(math::sqrt(1.0f + tau * tau) - tau);
-		// edge linking order is inside->out
+    const float eta = -1 * std::logf(math::sqrt(1.0f + tau * tau) - tau);
+    // edge linking order is inside->out
     vecmem::device_atomic_ref<unsigned int>(
         d_num_outgoing_edges[begin_bin1 + n1Idx])
         .fetch_add(1u);
     d_edge_nodes[nEdges] = uint2{globalIdx2, begin_bin1 + n1Idx};
-		bool inflate_matching_cuts = (ap.long_edge_dz < math::fabs(dz)) | (ap.long_edge_dr < math::fabs(dr));
-    d_edge_params[nEdges] =
-        edge_params_maker.make_edge_params(eta, curv, phi2 + curv * r2, phi1 + curv * r1, inflate_matching_cuts);
+    bool inflate_matching_cuts =
+        (ap.long_edge_dz < math::fabs(dz)) | (ap.long_edge_dr < math::fabs(dr));
+    d_edge_params[nEdges] = edge_params_maker.make_edge_params(
+        eta, curv, phi2 + curv * r2, phi1 + curv * r1, inflate_matching_cuts);
     // edge params: (eta, curvature, extrapolated phi at node1,
     //               extrapolated phi at node2)
   }
@@ -213,7 +215,8 @@ TRACCC_HOST_DEVICE inline void gbts_make_graph_edges(
         detail::gbts_check_edge_candidate(
             np1, np2, d_edge_nodes, d_edge_params, d_num_outgoing_edges,
             nEdgesCounter, globalIdx2, begin_bin1, n1Idx, phi1, phi2, deltaPhi,
-            payload.gbts_make_graph_edges_params, payload.edge_params_maker, payload.nMaxEdges);
+            payload.gbts_make_graph_edges_params, payload.edge_params_maker,
+            payload.nMaxEdges);
       }
     } else {
       for (; n1Idx < num_nodes1; n1Idx++) {
@@ -227,7 +230,8 @@ TRACCC_HOST_DEVICE inline void gbts_make_graph_edges(
         detail::gbts_check_edge_candidate(
             np1, np2, d_edge_nodes, d_edge_params, d_num_outgoing_edges,
             nEdgesCounter, globalIdx2, begin_bin1, n1Idx, phi1, phi2, deltaPhi,
-            payload.gbts_make_graph_edges_params, payload.edge_params_maker, payload.nMaxEdges);
+            payload.gbts_make_graph_edges_params, payload.edge_params_maker,
+            payload.nMaxEdges);
       }
     }
   }

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
@@ -24,19 +24,21 @@ namespace traccc::device {
 
 namespace detail {
 
-// Apply the RZ-doublet + curvature/d0 cuts to a candidate edge (node1->node2)
+// Apply the RZ-doublet + curvature cuts to a candidate edge (node1->node2)
 // and, if it passes, append it to the edge list. Single-use helper for
 // gbts_make_graph_edges, kept inline here. Node params are float4 (tau_min,
 // tau_max, r, z).
 TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
     const float4 node_params_1, const float4 node_params_2,
     vecmem::device_vector<uint2>& d_edge_nodes,
-    vecmem::device_vector<float4>& d_edge_params,
+    vecmem::device_vector<short4>& d_edge_params,
     vecmem::device_vector<unsigned int>& d_num_outgoing_edges,
     unsigned int& nEdgesCounter, const unsigned int globalIdx2,
     const unsigned int begin_bin1, const unsigned int n1Idx, const float phi1,
     const float phi2, const float deltaPhi,
-    const gbts_make_graph_edges_params& ap, const unsigned int nMaxEdges) {
+    const gbts_make_graph_edges_params& ap,
+		const edge_params_converter edge_params_maker, const unsigned int nMaxEdges) {
+
   const float tau_min1 = node_params_1.x;
   const float tau_max1 = node_params_1.y;
   const float r1 = node_params_1.z;
@@ -75,24 +77,24 @@ TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
     return;
   }
   const float curv = dphi / dr;
-  const float d0_for_max_curv = r1 * r2 * (math::fabs(curv) - ap.max_Kappa);
-  const float d0_max = (ftau < 4.0f) ? ap.low_Kappa_d0 : ap.high_Kappa_d0;
-  if (d0_for_max_curv > d0_max) {
-    return;
-  }
+	const float curv_max = ftau < ap.max_Kappa_change_tau ? ap.max_Kappa_low_tau : ap.max_Kappa_high_tau;
+	if (math::fabs(curv) > curv_max) {
+		return;
+	}
 
   const unsigned int nEdges =
       vecmem::device_atomic_ref<unsigned int>(nEdgesCounter).fetch_add(1u);
   if (nEdges < nMaxEdges) {
-    const float exp_eta = math::sqrt(1.0f + tau * tau) - tau;
-    // edge linking order is inside->out
+    const float eta = -1*std::logf(math::sqrt(1.0f + tau * tau) - tau);
+		// edge linking order is inside->out
     vecmem::device_atomic_ref<unsigned int>(
         d_num_outgoing_edges[begin_bin1 + n1Idx])
         .fetch_add(1u);
     d_edge_nodes[nEdges] = uint2{globalIdx2, begin_bin1 + n1Idx};
+		bool inflate_matching_cuts = (ap.long_edge_dz < math::fabs(dz)) | (ap.long_edge_dr < math::fabs(dr));
     d_edge_params[nEdges] =
-        float4{exp_eta, curv, phi2 + curv * r2, phi1 + curv * r1};
-    // edge params: (exp(-eta), curvature, extrapolated phi at node1,
+        edge_params_maker.make_edge_params(eta, curv, phi2 + curv * r2, phi1 + curv * r1, inflate_matching_cuts);
+    // edge params: (eta, curvature, extrapolated phi at node1,
     //               extrapolated phi at node2)
   }
 }
@@ -115,7 +117,7 @@ TRACCC_HOST_DEVICE inline void gbts_make_graph_edges(
   const vecmem::device_vector<const float4> d_node_params(payload.node_params);
   const vecmem::device_vector<const float> d_node_phi(payload.node_phi);
   vecmem::device_vector<uint2> d_edge_nodes(payload.edge_nodes);
-  vecmem::device_vector<float4> d_edge_params(payload.edge_params);
+  vecmem::device_vector<short4> d_edge_params(payload.edge_params);
   vecmem::device_vector<unsigned int> d_num_outgoing_edges(
       payload.num_outgoing_edges);
 
@@ -211,7 +213,7 @@ TRACCC_HOST_DEVICE inline void gbts_make_graph_edges(
         detail::gbts_check_edge_candidate(
             np1, np2, d_edge_nodes, d_edge_params, d_num_outgoing_edges,
             nEdgesCounter, globalIdx2, begin_bin1, n1Idx, phi1, phi2, deltaPhi,
-            payload.gbts_make_graph_edges_params, payload.nMaxEdges);
+            payload.gbts_make_graph_edges_params, payload.edge_params_maker, payload.nMaxEdges);
       }
     } else {
       for (; n1Idx < num_nodes1; n1Idx++) {
@@ -225,7 +227,7 @@ TRACCC_HOST_DEVICE inline void gbts_make_graph_edges(
         detail::gbts_check_edge_candidate(
             np1, np2, d_edge_nodes, d_edge_params, d_num_outgoing_edges,
             nEdgesCounter, globalIdx2, begin_bin1, n1Idx, phi1, phi2, deltaPhi,
-            payload.gbts_make_graph_edges_params, payload.nMaxEdges);
+            payload.gbts_make_graph_edges_params, payload.edge_params_maker, payload.nMaxEdges);
       }
     }
   }

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
@@ -86,14 +86,14 @@ TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
   const unsigned int nEdges =
       vecmem::device_atomic_ref<unsigned int>(nEdgesCounter).fetch_add(1u);
   if (nEdges < nMaxEdges) {
-    const float eta = -1 * std::logf(math::sqrt(1.0f + tau * tau) - tau);
+    const float eta = -1 * math::log(math::sqrt(1.0f + tau * tau) - tau);
     // edge linking order is inside->out
     vecmem::device_atomic_ref<unsigned int>(
         d_num_outgoing_edges[begin_bin1 + n1Idx])
         .fetch_add(1u);
     d_edge_nodes[nEdges] = uint2{globalIdx2, begin_bin1 + n1Idx};
     bool inflate_matching_cuts =
-        (ap.long_edge_dz < math::fabs(dz)) | (ap.long_edge_dr < math::fabs(dr));
+        (ap.long_edge_dz < math::fabs(dz)) || (ap.long_edge_dr < math::fabs(dr));
     d_edge_params[nEdges] = edge_params_maker.make_edge_params(
         eta, curv, phi2 + curv * r2, phi1 + curv * r1, inflate_matching_cuts);
     // edge params: (eta, curvature, extrapolated phi at node1,

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_make_graph_edges.ipp
@@ -92,8 +92,8 @@ TRACCC_HOST_DEVICE inline void gbts_check_edge_candidate(
         d_num_outgoing_edges[begin_bin1 + n1Idx])
         .fetch_add(1u);
     d_edge_nodes[nEdges] = uint2{globalIdx2, begin_bin1 + n1Idx};
-    bool inflate_matching_cuts =
-        (ap.long_edge_dz < math::fabs(dz)) || (ap.long_edge_dr < math::fabs(dr));
+    bool inflate_matching_cuts = (ap.long_edge_dz < math::fabs(dz)) ||
+                                 (ap.long_edge_dr < math::fabs(dr));
     d_edge_params[nEdges] = edge_params_maker.make_edge_params(
         eta, curv, phi2 + curv * r2, phi1 + curv * r1, inflate_matching_cuts);
     // edge params: (eta, curvature, extrapolated phi at node1,

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
@@ -97,7 +97,7 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
 
       // adaptive eta cut based on edge length and curvature
       float deta_max =
-          cut_deta_max + deta_inflation * (params2.second | params1.second);
+          cut_deta_max + deta_inflation * (params2.second || params1.second);
       float curv = 0.5f * math::fabs(curv2 + params2.first.y);
       deta_max *=
           1.0f - high_pT_correction * ((curv < less_scattering_curv) +

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
@@ -23,13 +23,13 @@ namespace traccc::device {
 
 // For each edge, find up to nMaxNei compatible neighbour edges sharing its
 // outer node, recording them and marking both edges as "kept". The edge
-// parameters are read from the packed float4 buffer ([exp_eta, curv, phi_z,
+// parameters are read from the packed short4 buffer ([eta, curv, phi_z,
 // phi_w]) and the cuts are evaluated in float.
 template <concepts::thread_id1 thread_id_t>
 TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
     const thread_id_t& thread_id,
     const gbts_match_graph_edges_payload& payload) {
-  const vecmem::device_vector<const float4> d_edge_params(payload.edge_params);
+  const vecmem::device_vector<const short4> d_edge_params(payload.edge_params);
   const vecmem::device_vector<const uint2> d_edge_nodes(payload.edge_nodes);
   const vecmem::device_vector<const unsigned int> d_num_outgoing_edges(
       payload.num_outgoing_edges);
@@ -42,8 +42,12 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
   const float cut_dphi_max = payload.gbts_match_graph_edges_params.cut_dphi_max;
   const float cut_dcurv_max =
       payload.gbts_match_graph_edges_params.cut_dcurv_max;
-  const float cut_tau_ratio_max =
-      payload.gbts_match_graph_edges_params.cut_tau_ratio_max;
+  const float cut_deta_max = payload.gbts_match_graph_edges_params.cut_deta_max;
+	const float cut_ratio_sum_max = payload.gbts_match_graph_edges_params.cut_ratio_sum_max;
+	const float deta_inflation = payload.gbts_match_graph_edges_params.deta_inflation;
+	const float less_scattering_curv = payload.gbts_match_graph_edges_params.less_scattering_curv;
+	const float much_less_scattering_curv = payload.gbts_match_graph_edges_params.much_less_scattering_curv;
+	const float high_pT_correction = payload.gbts_match_graph_edges_params.high_pT_correction;
 
   const unsigned int globalIdx = thread_id.getGlobalThreadIdX();
   const unsigned int blockDimX = thread_id.getBlockDimX();
@@ -61,11 +65,12 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
       continue;
     }
 
-    const float4 params1 = d_edge_params[globalIndex];  // [exp_eta, curv,
-                                                        //  phi_z, phi_w]
-    const float uat_2 = 1.0f / params1.x;
-    const float Phi2 = params1.z;
-    const float curv2 = params1.y;
+		const std::pair<float4, bool> params1 = payload.edge_params_decoder.decode_edge_params(d_edge_params[globalIndex]);
+		// [exp_eta, curv, phi_z, phi_w], inflate cuts
+		
+    const float eta2 = params1.first.x;
+		const float Phi2 = params1.first.z;
+    const float curv2 = params1.first.y;
 
     const unsigned int nei_pos = payload.nMaxNei * globalIndex;
 
@@ -79,22 +84,30 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
       }
       const unsigned int edge2_idx = d_edge_links[link_begin + k];
 
-      const float4 params2 = d_edge_params[edge2_idx];
+			const std::pair<float4, bool> params2 = payload.edge_params_decoder.decode_edge_params(d_edge_params[edge2_idx]);
 
-      const float tau_ratio = params2.x * uat_2 - 1.0f;
-      if (math::fabs(tau_ratio) > cut_tau_ratio_max) {  // bad match
-        continue;
+			// adaptive eta cut based on edge length and curvature	
+			float deta_max = cut_deta_max+deta_inflation*(params2.second | params1.second);
+			float curv = 0.5f*math::fabs(curv2 + params2.first.y);
+			deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv < much_less_scattering_curv));	
+			float deta_cut_ratio = math::fabs(eta2-params2.first.x)/deta_max;
+			if (deta_cut_ratio > 1.0f) {  // bad match
+				continue;
       }
+		
+			const float dPhi_cut_ratio = math::fabs(traccc::detail::wrap_phi(Phi2 - params2.first.w))/cut_dphi_max;
+			if (dPhi_cut_ratio > 1.0f) {
+				continue;
+			}
 
-      const float dPhi = traccc::detail::wrap_phi(Phi2 - params2.w);
-      if (math::fabs(dPhi) > cut_dphi_max) {
-        continue;
-      }
+			const float dcurv_cut_ratio = math::fabs(curv2 - params2.first.y)/cut_dcurv_max;
+			if (dcurv_cut_ratio > 1.0f) {
+				continue;
+			}
 
-      const float dcurv = curv2 - params2.y;
-      if (math::fabs(dcurv) > cut_dcurv_max) {
-        continue;
-      }
+			if (deta_cut_ratio+dPhi_cut_ratio+dcurv_cut_ratio > cut_ratio_sum_max) {
+				continue;
+			}
 
       d_neighbours[nei_pos + num_nei] = edge2_idx;
       d_reIndexer[edge2_idx] = 1;

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
@@ -43,11 +43,16 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
   const float cut_dcurv_max =
       payload.gbts_match_graph_edges_params.cut_dcurv_max;
   const float cut_deta_max = payload.gbts_match_graph_edges_params.cut_deta_max;
-	const float cut_ratio_sum_max = payload.gbts_match_graph_edges_params.cut_ratio_sum_max;
-	const float deta_inflation = payload.gbts_match_graph_edges_params.deta_inflation;
-	const float less_scattering_curv = payload.gbts_match_graph_edges_params.less_scattering_curv;
-	const float much_less_scattering_curv = payload.gbts_match_graph_edges_params.much_less_scattering_curv;
-	const float high_pT_correction = payload.gbts_match_graph_edges_params.high_pT_correction;
+  const float cut_ratio_sum_max =
+      payload.gbts_match_graph_edges_params.cut_ratio_sum_max;
+  const float deta_inflation =
+      payload.gbts_match_graph_edges_params.deta_inflation;
+  const float less_scattering_curv =
+      payload.gbts_match_graph_edges_params.less_scattering_curv;
+  const float much_less_scattering_curv =
+      payload.gbts_match_graph_edges_params.much_less_scattering_curv;
+  const float high_pT_correction =
+      payload.gbts_match_graph_edges_params.high_pT_correction;
 
   const unsigned int globalIdx = thread_id.getGlobalThreadIdX();
   const unsigned int blockDimX = thread_id.getBlockDimX();
@@ -65,11 +70,13 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
       continue;
     }
 
-		const std::pair<float4, bool> params1 = payload.edge_params_decoder.decode_edge_params(d_edge_params[globalIndex]);
-		// [exp_eta, curv, phi_z, phi_w], inflate cuts
-		
+    const std::pair<float4, bool> params1 =
+        payload.edge_params_decoder.decode_edge_params(
+            d_edge_params[globalIndex]);
+    // [exp_eta, curv, phi_z, phi_w], inflate cuts
+
     const float eta2 = params1.first.x;
-		const float Phi2 = params1.first.z;
+    const float Phi2 = params1.first.z;
     const float curv2 = params1.first.y;
 
     const unsigned int nei_pos = payload.nMaxNei * globalIndex;
@@ -84,30 +91,39 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
       }
       const unsigned int edge2_idx = d_edge_links[link_begin + k];
 
-			const std::pair<float4, bool> params2 = payload.edge_params_decoder.decode_edge_params(d_edge_params[edge2_idx]);
+      const std::pair<float4, bool> params2 =
+          payload.edge_params_decoder.decode_edge_params(
+              d_edge_params[edge2_idx]);
 
-			// adaptive eta cut based on edge length and curvature	
-			float deta_max = cut_deta_max+deta_inflation*(params2.second | params1.second);
-			float curv = 0.5f*math::fabs(curv2 + params2.first.y);
-			deta_max *= 1.0f-high_pT_correction*((curv < less_scattering_curv) + (curv < much_less_scattering_curv));	
-			float deta_cut_ratio = math::fabs(eta2-params2.first.x)/deta_max;
-			if (deta_cut_ratio > 1.0f) {  // bad match
-				continue;
+      // adaptive eta cut based on edge length and curvature
+      float deta_max =
+          cut_deta_max + deta_inflation * (params2.second | params1.second);
+      float curv = 0.5f * math::fabs(curv2 + params2.first.y);
+      deta_max *=
+          1.0f - high_pT_correction * ((curv < less_scattering_curv) +
+                                       (curv < much_less_scattering_curv));
+      float deta_cut_ratio = math::fabs(eta2 - params2.first.x) / deta_max;
+      if (deta_cut_ratio > 1.0f) {  // bad match
+        continue;
       }
-		
-			const float dPhi_cut_ratio = math::fabs(traccc::detail::wrap_phi(Phi2 - params2.first.w))/cut_dphi_max;
-			if (dPhi_cut_ratio > 1.0f) {
-				continue;
-			}
 
-			const float dcurv_cut_ratio = math::fabs(curv2 - params2.first.y)/cut_dcurv_max;
-			if (dcurv_cut_ratio > 1.0f) {
-				continue;
-			}
+      const float dPhi_cut_ratio =
+          math::fabs(traccc::detail::wrap_phi(Phi2 - params2.first.w)) /
+          cut_dphi_max;
+      if (dPhi_cut_ratio > 1.0f) {
+        continue;
+      }
 
-			if (deta_cut_ratio+dPhi_cut_ratio+dcurv_cut_ratio > cut_ratio_sum_max) {
-				continue;
-			}
+      const float dcurv_cut_ratio =
+          math::fabs(curv2 - params2.first.y) / cut_dcurv_max;
+      if (dcurv_cut_ratio > 1.0f) {
+        continue;
+      }
+
+      if (deta_cut_ratio + dPhi_cut_ratio + dcurv_cut_ratio >
+          cut_ratio_sum_max) {
+        continue;
+      }
 
       d_neighbours[nei_pos + num_nei] = edge2_idx;
       d_reIndexer[edge2_idx] = 1;

--- a/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
+++ b/Traccc/device/common/include/traccc/gbts_seeding/device/impl/gbts_match_graph_edges.ipp
@@ -98,11 +98,12 @@ TRACCC_HOST_DEVICE inline void gbts_match_graph_edges(
       // adaptive eta cut based on edge length and curvature
       float deta_max =
           cut_deta_max + deta_inflation * (params2.second || params1.second);
-      float curv = 0.5f * math::fabs(curv2 + params2.first.y);
-      deta_max *=
-          1.0f - high_pT_correction * ((curv < less_scattering_curv) +
-                                       (curv < much_less_scattering_curv));
-      float deta_cut_ratio = math::fabs(eta2 - params2.first.x) / deta_max;
+      const float curv = 0.5f * math::fabs(curv2 + params2.first.y);
+      const float corr = static_cast<float>((curv < less_scattering_curv) +
+                                            (curv < much_less_scattering_curv));
+      deta_max *= 1.0f - high_pT_correction * corr;
+      const float deta_cut_ratio =
+          math::fabs(eta2 - params2.first.x) / deta_max;
       if (deta_cut_ratio > 1.0f) {  // bad match
         continue;
       }

--- a/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -305,15 +305,19 @@ auto gbts_seeding_algorithm::create_edges(
                                                                    mr().main);
   copy().setup(num_incoming_edges_buf)->ignore();
   copy().memset(num_incoming_edges_buf, 0)->ignore();
-	// setup edge param converter
-	const float max_Kappa = std::max(cfg.gbts_make_graph_edges_params.max_Kappa_low_tau, cfg.gbts_make_graph_edges_params.max_Kappa_high_tau);
-	edge_params_converter edge_param_converter(max_Kappa, cfg.gbts_sort_nodes_params.maxTau);
+  // setup edge param converter
+  const float max_Kappa =
+      std::max(cfg.gbts_make_graph_edges_params.max_Kappa_low_tau,
+               cfg.gbts_make_graph_edges_params.max_Kappa_high_tau);
+  edge_params_converter edge_param_converter(max_Kappa,
+                                             cfg.gbts_sort_nodes_params.maxTau);
 
   gbts_make_graph_edges_kernel(
       {nUsedBinPairs, nMaxEdges, cfg.n_phi_bins, bin_pair_views_buf,
        bin_pair_dphi_buf, node_params, node_phi,
        cfg.gbts_make_graph_edges_params, d_counters + gbts_counter::nEdges,
-       edge_nodes_buf, edge_params_buf, edge_param_converter, num_incoming_edges_buf});
+       edge_nodes_buf, edge_params_buf, edge_param_converter,
+       num_incoming_edges_buf});
 
   // Read back the number of edges produced.
   copy()(counters_buf, h_counters)->wait();
@@ -356,8 +360,8 @@ auto gbts_seeding_algorithm::create_edges(
   gbts_match_graph_edges_kernel(
       {nEdges, cfg.max_num_neighbours, cfg.gbts_match_graph_edges_params,
        edge_params_buf, edge_nodes_buf, num_incoming_edges_buf, edge_links_buf,
-       num_neighbours_buf, neighbours_buf, reIndexer_buf,
-       edge_param_converter, d_counters + gbts_counter::nConnections});
+       num_neighbours_buf, neighbours_buf, reIndexer_buf, edge_param_converter,
+       d_counters + gbts_counter::nConnections});
 
   // 5. Edge re-indexing to keep only edges involved in any connection.
   gbts_reindex_edges_kernel(

--- a/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -297,7 +297,7 @@ auto gbts_seeding_algorithm::create_edges(
   // 2. Find edges between spacepoint pairs.
   const unsigned int nMaxEdges = cfg.max_edges_factor * nNodes;
   // Packed per-edge parameter buffer ([exp(-eta), curv, phi_z, phi_w]).
-  vecmem::data::vector_buffer<float4> edge_params_buf(nMaxEdges, mr().main);
+  vecmem::data::vector_buffer<short4> edge_params_buf(nMaxEdges, mr().main);
   copy().setup(edge_params_buf)->ignore();
   vecmem::data::vector_buffer<uint2> edge_nodes_buf(nMaxEdges, mr().main);
   copy().setup(edge_nodes_buf)->ignore();
@@ -305,12 +305,15 @@ auto gbts_seeding_algorithm::create_edges(
                                                                    mr().main);
   copy().setup(num_incoming_edges_buf)->ignore();
   copy().memset(num_incoming_edges_buf, 0)->ignore();
+	// setup edge param converter
+	const float max_Kappa = std::max(cfg.gbts_make_graph_edges_params.max_Kappa_low_tau, cfg.gbts_make_graph_edges_params.max_Kappa_high_tau);
+	edge_params_converter edge_param_converter(max_Kappa, cfg.gbts_sort_nodes_params.maxTau);
 
   gbts_make_graph_edges_kernel(
       {nUsedBinPairs, nMaxEdges, cfg.n_phi_bins, bin_pair_views_buf,
        bin_pair_dphi_buf, node_params, node_phi,
        cfg.gbts_make_graph_edges_params, d_counters + gbts_counter::nEdges,
-       edge_nodes_buf, edge_params_buf, num_incoming_edges_buf});
+       edge_nodes_buf, edge_params_buf, edge_param_converter, num_incoming_edges_buf});
 
   // Read back the number of edges produced.
   copy()(counters_buf, h_counters)->wait();
@@ -354,7 +357,7 @@ auto gbts_seeding_algorithm::create_edges(
       {nEdges, cfg.max_num_neighbours, cfg.gbts_match_graph_edges_params,
        edge_params_buf, edge_nodes_buf, num_incoming_edges_buf, edge_links_buf,
        num_neighbours_buf, neighbours_buf, reIndexer_buf,
-       d_counters + gbts_counter::nConnections});
+       edge_param_converter, d_counters + gbts_counter::nConnections});
 
   // 5. Edge re-indexing to keep only edges involved in any connection.
   gbts_reindex_edges_kernel(

--- a/Traccc/examples/options/src/track_gbts_seeding.cpp
+++ b/Traccc/examples/options/src/track_gbts_seeding.cpp
@@ -277,15 +277,15 @@ std::unique_ptr<configuration_printable> track_gbts_seeding::as_printable()
                   gbts_config.gbts_make_graph_edges_params.maxOuterRadius)));
 
   cat->add_child(std::make_unique<configuration_kv_pair>(
-      "edge matching dphi max ",
+      "edge matching delta phi max ",
       std::format("{:.5f} ",
                   gbts_config.gbts_match_graph_edges_params.cut_dphi_max)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
-      "edge matching dcurv max ",
+      "edge matching delta curv max ",
       std::format("{:.5f} ",
                   gbts_config.gbts_match_graph_edges_params.cut_dcurv_max)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
-      "edge matching deta max ",
+      "edge matching delta eta max ",
       std::format("{:.5f} ",
                   gbts_config.gbts_match_graph_edges_params.cut_deta_max)));
   cat->add_child(std::make_unique<configuration_kv_pair>(

--- a/Traccc/examples/options/src/track_gbts_seeding.cpp
+++ b/Traccc/examples/options/src/track_gbts_seeding.cpp
@@ -61,10 +61,17 @@ track_gbts_seeding::track_gbts_seeding() : interface("GBTS Options") {
               gbts_config.gbts_dphi_window_params.dphi_coeff_low_dr),
       "dphi_coeff_low_dr for the sliding window");
   m_desc.add_options()(
-      "max_Kappa",
-      po::value(&gbts_config.gbts_make_graph_edges_params.max_Kappa)
-          ->default_value(gbts_config.gbts_make_graph_edges_params.max_Kappa),
-      "max curvature for an edge + origin triplet [1/mm]");
+      "max_Kappa_high_tau",
+      po::value(&gbts_config.gbts_make_graph_edges_params.max_Kappa_high_tau)
+          ->default_value(
+              gbts_config.gbts_make_graph_edges_params.max_Kappa_high_tau),
+      "max curvature for an edge + origin triplet [1/mm] at high tau");
+  m_desc.add_options()(
+      "max_Kappa_low_tau",
+      po::value(&gbts_config.gbts_make_graph_edges_params.max_Kappa_low_tau)
+          ->default_value(
+              gbts_config.gbts_make_graph_edges_params.max_Kappa_low_tau),
+      "max curvature for an edge + origin triplet [1/mm] at low tau");
 
   m_desc.add_options()(
       "min_z0",
@@ -96,11 +103,11 @@ track_gbts_seeding::track_gbts_seeding() : interface("GBTS Options") {
               gbts_config.gbts_match_graph_edges_params.cut_dcurv_max),
       "cut_dcurv_max for edge matching [1/mm]");
   m_desc.add_options()(
-      "cut_tau_ratio_max",
-      po::value(&gbts_config.gbts_match_graph_edges_params.cut_tau_ratio_max)
+      "cut_deta_max",
+      po::value(&gbts_config.gbts_match_graph_edges_params.cut_deta_max)
           ->default_value(
-              gbts_config.gbts_match_graph_edges_params.cut_tau_ratio_max),
-      "cut_tau_ratio_max for edge matching");
+              gbts_config.gbts_match_graph_edges_params.cut_deta_max),
+      "cut_deta_max for edge matching");
   m_desc.add_options()("max_num_neighbours",
                        po::value(&gbts_config.max_num_neighbours)
                            ->default_value(gbts_config.max_num_neighbours),
@@ -250,9 +257,14 @@ std::unique_ptr<configuration_printable> track_gbts_seeding::as_printable()
       std::format("{:.5f} ",
                   gbts_config.gbts_dphi_window_params.dphi_coeff_low_dr)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
-      "max_Kappa ",
+      "max_Kappa_high_tau ",
+      std::format(
+          "{:.5f} ",
+          gbts_config.gbts_make_graph_edges_params.max_Kappa_high_tau)));
+  cat->add_child(std::make_unique<configuration_kv_pair>(
+      "max_Kappa_low_tau ",
       std::format("{:.5f} ",
-                  gbts_config.gbts_make_graph_edges_params.max_Kappa)));
+                  gbts_config.gbts_make_graph_edges_params.max_Kappa_low_tau)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
       "min_z0 ",
       std::format("{:.5f} ", gbts_config.gbts_make_graph_edges_params.min_z0)));
@@ -273,10 +285,9 @@ std::unique_ptr<configuration_printable> track_gbts_seeding::as_printable()
       std::format("{:.5f} ",
                   gbts_config.gbts_match_graph_edges_params.cut_dcurv_max)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
-      "edge matching tau ratio max ",
-      std::format(
-          "{:.5f} ",
-          gbts_config.gbts_match_graph_edges_params.cut_tau_ratio_max)));
+      "edge matching deta max ",
+      std::format("{:.5f} ",
+                  gbts_config.gbts_match_graph_edges_params.cut_deta_max)));
   cat->add_child(std::make_unique<configuration_kv_pair>(
       "max neighbours ", std::format("{} ", gbts_config.max_num_neighbours)));
   // Seed extraction flags


### PR DESCRIPTION
### A collection of performance improvements to GPU-GBTS

- adds new cuts on edge connections during edge matching to reduce fake edges:
     reduces edge fake-rate -> lower seeding fake-rate -> lower tracking fake-rate + faster track following.

- moves back to 16bit precision edge parameters to reduce memory access latency for the edge matching kernel, using shorts for better back-end agnosticism than previously used fp16.

- harmonise the edge making curvature cuts with CPU by retiring a old d0 aware cut that has been ineffective since migrating to ACTS from ATHENA. Compensate for looser curvature cuts creating low pT seeds with a tighter post fit seed curvature cut

- Improves high-pT, high-eta track resolution by changing seed quality to prefer seeds with further out hits

Overall on the ITk;
seeding fake-rate reduced by ~1/3 ->  tracking fake-rate reduced by ~1/3 and improved track following time by ~6%
Efficiency neutral 
Seeding Time neutral

--- END COMMIT MESSAGE ---