### PR TITLE
feat: Add off-axis blueprint wrapper for displaced cylinder subtrees

### DIFF
--- a/Core/include/Acts/Geometry/BlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/BlueprintNode.hpp
@@ -33,6 +33,7 @@ class PortalShellBase;
 class MaterialDesignatorBlueprintNode;
 class PortalDesignatorBlueprintNode;
 class StaticBlueprintNode;
+class OffAxisBlueprintNode;
 class LayerBlueprintNode;
 class GeometryIdentifierBlueprintNode;
 
@@ -193,6 +194,18 @@ class BlueprintNode {
       const Transform3& transform, std::shared_ptr<VolumeBounds> volumeBounds,
       const std::string& volumeName = "undefined",
       const std::function<void(StaticBlueprintNode& cylinder)>& callback = {});
+
+  /// Convenience method for creating an @ref Acts::OffAxisBlueprintNode.
+  /// This node wraps one off-axis subtree in an on-axis cylindrical envelope so
+  /// parent cylinder stacks can remain strictly co-axial.
+  /// @param name The name of the wrapper volume.
+  /// @param axisTransform The reference transform of the co-axial parent axis.
+  /// @param callback An optional callback that receives the node as an argument
+  /// @return Reference to the newly created off-axis blueprint node
+  OffAxisBlueprintNode& addOffAxisContainer(
+      const std::string& name,
+      const Transform3& axisTransform = Transform3::Identity(),
+      const std::function<void(OffAxisBlueprintNode& offAxis)>& callback = {});
 
   /// Convenience method for creating a cylinder specialization of @ref Acts::ContainerBlueprintNode.
   /// @param name The name of the container node. This name is only reflected

--- a/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
@@ -1,0 +1,60 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/StaticBlueprintNode.hpp"
+
+namespace Acts {
+
+/// Blueprint node that wraps one off-axis subtree in an on-axis cylindrical
+/// envelope.
+///
+/// The wrapped child subtree keeps its original (possibly off-axis) placement.
+/// This node computes a conservative on-axis cylinder around that subtree and
+/// presents this envelope to parent cylinder stacks.
+class OffAxisBlueprintNode final : public StaticBlueprintNode {
+ public:
+  /// Construct the off-axis wrapper.
+  /// @param name Name of the wrapper volume
+  /// @param axisTransform Reference transform of the co-axial parent axis
+  explicit OffAxisBlueprintNode(
+      std::string_view name,
+      Transform3 axisTransform = Transform3::Identity());
+
+  /// @copydoc BlueprintNode::name
+  const std::string& name() const override;
+
+  /// @copydoc BlueprintNode::build
+  Volume& build(const BlueprintOptions& options, const GeometryContext& gctx,
+                const Logger& logger = Acts::getDummyLogger()) override;
+
+  /// Set the reference axis transform used for envelope construction.
+  /// @param axisTransform Transform of the reference axis frame
+  /// @return Reference to this node for chaining
+  OffAxisBlueprintNode& setAxisTransform(const Transform3& axisTransform);
+
+  /// Get the reference axis transform.
+  /// @return Reference to the current axis transform
+  const Transform3& axisTransform() const;
+
+ private:
+  std::string m_name;
+  Transform3 m_axisTransform = Transform3::Identity();
+};
+
+namespace Experimental {
+/// @deprecated The blueprint geometry moved out of the `Acts::Experimental`
+///             namespace. Use @ref Acts::OffAxisBlueprintNode instead. This
+///             alias is kept for backward compatibility and will be removed.
+using OffAxisBlueprintNode
+    [[deprecated("Acts::Experimental::OffAxisBlueprintNode moved to "
+                 "Acts::OffAxisBlueprintNode")]] = Acts::OffAxisBlueprintNode;
+}  // namespace Experimental
+
+}  // namespace Acts

--- a/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
@@ -24,8 +24,7 @@ class OffAxisBlueprintNode final : public StaticBlueprintNode {
   /// @param name Name of the wrapper volume
   /// @param axisTransform Reference transform of the co-axial parent axis
   explicit OffAxisBlueprintNode(
-      std::string_view name,
-      Transform3 axisTransform = Transform3::Identity());
+      std::string_view name, Transform3 axisTransform = Transform3::Identity());
 
   /// @copydoc BlueprintNode::name
   const std::string& name() const override;

--- a/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/OffAxisBlueprintNode.hpp
@@ -48,13 +48,4 @@ class OffAxisBlueprintNode final : public StaticBlueprintNode {
   Transform3 m_axisTransform = Transform3::Identity();
 };
 
-namespace Experimental {
-/// @deprecated The blueprint geometry moved out of the `Acts::Experimental`
-///             namespace. Use @ref Acts::OffAxisBlueprintNode instead. This
-///             alias is kept for backward compatibility and will be removed.
-using OffAxisBlueprintNode
-    [[deprecated("Acts::Experimental::OffAxisBlueprintNode moved to "
-                 "Acts::OffAxisBlueprintNode")]] = Acts::OffAxisBlueprintNode;
-}  // namespace Experimental
-
 }  // namespace Acts

--- a/Core/src/Geometry/BlueprintNode.cpp
+++ b/Core/src/Geometry/BlueprintNode.cpp
@@ -119,7 +119,7 @@ OffAxisBlueprintNode& BlueprintNode::addOffAxisContainer(
     const std::string& name, const Transform3& axisTransform,
     const std::function<void(OffAxisBlueprintNode& offAxis)>& callback) {
   auto offAxis =
-      std::make_shared<OffAxisBlueprintNode>(name, std::move(axisTransform));
+      std::make_shared<OffAxisBlueprintNode>(name, axisTransform);
   addChild(offAxis);
   if (callback) {
     callback(*offAxis);

--- a/Core/src/Geometry/BlueprintNode.cpp
+++ b/Core/src/Geometry/BlueprintNode.cpp
@@ -118,8 +118,7 @@ StaticBlueprintNode& BlueprintNode::addStaticVolume(
 OffAxisBlueprintNode& BlueprintNode::addOffAxisContainer(
     const std::string& name, const Transform3& axisTransform,
     const std::function<void(OffAxisBlueprintNode& offAxis)>& callback) {
-  auto offAxis =
-      std::make_shared<OffAxisBlueprintNode>(name, axisTransform);
+  auto offAxis = std::make_shared<OffAxisBlueprintNode>(name, axisTransform);
   addChild(offAxis);
   if (callback) {
     callback(*offAxis);

--- a/Core/src/Geometry/BlueprintNode.cpp
+++ b/Core/src/Geometry/BlueprintNode.cpp
@@ -13,6 +13,7 @@
 #include "Acts/Geometry/GeometryIdentifierBlueprintNode.hpp"
 #include "Acts/Geometry/LayerBlueprintNode.hpp"
 #include "Acts/Geometry/MaterialDesignatorBlueprintNode.hpp"
+#include "Acts/Geometry/OffAxisBlueprintNode.hpp"
 #include "Acts/Geometry/PortalDesignatorBlueprintNode.hpp"
 #include "Acts/Geometry/StaticBlueprintNode.hpp"
 #include "Acts/Navigation/INavigationPolicy.hpp"
@@ -112,6 +113,18 @@ StaticBlueprintNode& BlueprintNode::addStaticVolume(
   return addStaticVolume(std::make_unique<TrackingVolume>(
                              transform, std::move(volumeBounds), volumeName),
                          callback);
+}
+
+OffAxisBlueprintNode& BlueprintNode::addOffAxisContainer(
+    const std::string& name, const Transform3& axisTransform,
+    const std::function<void(OffAxisBlueprintNode& offAxis)>& callback) {
+  auto offAxis =
+      std::make_shared<OffAxisBlueprintNode>(name, std::move(axisTransform));
+  addChild(offAxis);
+  if (callback) {
+    callback(*offAxis);
+  }
+  return *offAxis;
 }
 
 CylinderContainerBlueprintNode& BlueprintNode::addCylinderContainer(

--- a/Core/src/Geometry/CMakeLists.txt
+++ b/Core/src/Geometry/CMakeLists.txt
@@ -53,6 +53,7 @@ target_sources(
         BlueprintNode.cpp
         Blueprint.cpp
         BlueprintOptions.cpp
+        OffAxisBlueprintNode.cpp
         StaticBlueprintNode.cpp
         LayerBlueprintNode.cpp
         PadBlueprintNode.cpp

--- a/Core/src/Geometry/OffAxisBlueprintNode.cpp
+++ b/Core/src/Geometry/OffAxisBlueprintNode.cpp
@@ -1,0 +1,95 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "Acts/Geometry/OffAxisBlueprintNode.hpp"
+
+#include "Acts/Definitions/Tolerance.hpp"
+#include "Acts/Geometry/CylinderVolumeBounds.hpp"
+
+namespace Acts {
+
+OffAxisBlueprintNode::OffAxisBlueprintNode(std::string_view name,
+                                           Transform3 axisTransform)
+    : StaticBlueprintNode(nullptr),
+      m_name(name),
+      m_axisTransform(std::move(axisTransform)) {}
+
+const std::string& OffAxisBlueprintNode::name() const {
+  return m_name;
+}
+
+Volume& OffAxisBlueprintNode::build(const BlueprintOptions& options,
+                                    const GeometryContext& gctx,
+                                    const Logger& logger) {
+  ACTS_DEBUG(prefix() << "Off-axis build");
+
+  if (children().size() != 1u) {
+    ACTS_ERROR(prefix() << "OffAxisBlueprintNode requires exactly one child");
+    throw std::invalid_argument(
+        "OffAxisBlueprintNode requires exactly one child");
+  }
+
+  Volume& childVolume = children().at(0).build(options, gctx, logger);
+  const auto* childBounds =
+      dynamic_cast<const CylinderVolumeBounds*>(&childVolume.volumeBounds());
+  if (childBounds == nullptr) {
+    ACTS_ERROR(prefix()
+               << "OffAxisBlueprintNode only supports cylinder child volumes");
+    throw std::invalid_argument(
+        "OffAxisBlueprintNode only supports cylinder child volumes");
+  }
+
+  const Transform3 childGlobal = childVolume.localToGlobalTransform(gctx);
+  const Transform3 childInAxisFrame = m_axisTransform.inverse() * childGlobal;
+
+  constexpr auto tolerance = s_onSurfaceTolerance;
+  if (std::abs(childInAxisFrame.rotation().col(eX)[eZ]) >= tolerance ||
+      std::abs(childInAxisFrame.rotation().col(eY)[eZ]) >= tolerance) {
+    ACTS_ERROR(prefix() << "Child volume rotation tilts relative to axis frame");
+    throw std::invalid_argument(
+        "OffAxisBlueprintNode child rotation tilts relative to axis frame");
+  }
+
+  const Vector3 localTranslation = childInAxisFrame.translation();
+  const double radialOffset = localTranslation.head<2>().norm();
+  const double childMinR = childBounds->get(CylinderVolumeBounds::eMinR);
+  const double childMaxR = childBounds->get(CylinderVolumeBounds::eMaxR);
+  const double minR = std::max(
+      0., std::max(childMinR - radialOffset, radialOffset - childMaxR));
+  const double maxR =
+      childMaxR + radialOffset;
+  const double halfLengthZ =
+      childBounds->get(CylinderVolumeBounds::eHalfLengthZ);
+
+  Transform3 envelopeInAxisFrame = childInAxisFrame;
+  envelopeInAxisFrame.translation()[eX] = 0.;
+  envelopeInAxisFrame.translation()[eY] = 0.;
+  const Transform3 envelopeGlobal = m_axisTransform * envelopeInAxisFrame;
+
+  m_volume = std::make_unique<TrackingVolume>(
+      envelopeGlobal,
+      std::make_shared<CylinderVolumeBounds>(minR, maxR, halfLengthZ), m_name);
+
+  ACTS_DEBUG(prefix() << "Built envelope volume " << m_name << " with r=["
+                      << minR << ", " << maxR << "] around child offset "
+                      << radialOffset);
+
+  return *m_volume;
+}
+
+OffAxisBlueprintNode& OffAxisBlueprintNode::setAxisTransform(
+    const Transform3& axisTransform) {
+  m_axisTransform = axisTransform;
+  return *this;
+}
+
+const Transform3& OffAxisBlueprintNode::axisTransform() const {
+  return m_axisTransform;
+}
+
+}  // namespace Acts

--- a/Core/src/Geometry/OffAxisBlueprintNode.cpp
+++ b/Core/src/Geometry/OffAxisBlueprintNode.cpp
@@ -50,7 +50,8 @@ Volume& OffAxisBlueprintNode::build(const BlueprintOptions& options,
   constexpr auto tolerance = s_onSurfaceTolerance;
   if (std::abs(childInAxisFrame.rotation().col(eX)[eZ]) >= tolerance ||
       std::abs(childInAxisFrame.rotation().col(eY)[eZ]) >= tolerance) {
-    ACTS_ERROR(prefix() << "Child volume rotation tilts relative to axis frame");
+    ACTS_ERROR(
+        prefix() << "Child volume rotation tilts relative to axis frame");
     throw std::invalid_argument(
         "OffAxisBlueprintNode child rotation tilts relative to axis frame");
   }
@@ -61,8 +62,7 @@ Volume& OffAxisBlueprintNode::build(const BlueprintOptions& options,
   const double childMaxR = childBounds->get(CylinderVolumeBounds::eMaxR);
   const double minR = std::max(
       0., std::max(childMinR - radialOffset, radialOffset - childMaxR));
-  const double maxR =
-      childMaxR + radialOffset;
+  const double maxR = childMaxR + radialOffset;
   const double halfLengthZ =
       childBounds->get(CylinderVolumeBounds::eHalfLengthZ);
 

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -20,6 +20,7 @@
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Geometry/LayerBlueprintNode.hpp"
 #include "Acts/Geometry/MaterialDesignatorBlueprintNode.hpp"
+#include "Acts/Geometry/OffAxisBlueprintNode.hpp"
 #include "Acts/Geometry/PadBlueprintNode.hpp"
 #include "Acts/Geometry/StaticBlueprintNode.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
@@ -279,6 +280,91 @@ BOOST_AUTO_TEST_CASE(CylinderContainer) {
     BOOST_CHECK_EQUAL(gapCyl.get(CylinderVolumeBounds::eMaxR), 20_mm);
     BOOST_CHECK_EQUAL(gapCyl.get(CylinderVolumeBounds::eHalfLengthZ), 6_mm);
   }
+}
+
+BOOST_AUTO_TEST_CASE(OffAxisWrapperInCylinderHierarchy) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {2_mm, 20_mm};
+  auto root = std::make_unique<Blueprint>(cfg);
+
+  std::vector<std::unique_ptr<SurfacePlacementBase>> elements;
+  std::vector<std::shared_ptr<Surface>> b0SensitiveSurfaces;
+
+  auto makeB0Layer = [&](std::size_t layer) -> std::unique_ptr<TrackingVolume> {
+    const double offsetX = -160_mm;
+    const double z = 6250_mm + layer * 100_mm;
+    const auto bounds =
+        std::make_shared<CylinderVolumeBounds>(35_mm, 150_mm, 20_mm);
+    auto layerVolume = std::make_unique<TrackingVolume>(
+        Transform3::Identity() * Translation3{Vector3{offsetX, 0., z}}, bounds,
+        "B0Layer" + std::to_string(layer));
+
+    const std::size_t nModules = 6;
+    const double moduleR = 90_mm;
+    const auto moduleBounds = std::make_shared<RectangleBounds>(8_mm, 15_mm);
+    for (std::size_t i = 0; i < nModules; ++i) {
+      const double phi = 2. * std::numbers::pi * static_cast<double>(i) /
+                         static_cast<double>(nModules);
+      Transform3 moduleTransform =
+          Transform3::Identity() *
+          Translation3{Vector3{offsetX, 0., z}} *
+          AngleAxis3{phi, Vector3::UnitZ()} *
+          Translation3{Vector3::UnitX() * moduleR} *
+          AngleAxis3{90_degree, Vector3::UnitY()} *
+          AngleAxis3{90_degree, Vector3::UnitZ()};
+
+      auto& element = elements.emplace_back(
+          std::make_unique<DetectorElementStub>(moduleTransform, moduleBounds,
+                                                0.));
+      element->surface().assignSurfacePlacement(*element);
+      auto surface = element->surface().getSharedPtr();
+      layerVolume->addSurface(surface);
+      b0SensitiveSurfaces.push_back(std::move(surface));
+    }
+
+    return layerVolume;
+  };
+
+  root->addCylinderContainer("Detector", AxisDirection::AxisZ, [&](auto& det) {
+    det.addStaticVolume(Transform3::Identity(),
+                        std::make_shared<CylinderVolumeBounds>(20_mm, 400_mm,
+                                                               1000_mm),
+                        "MainTracker");
+
+    det.addOffAxisContainer("B0Envelope", Transform3::Identity(),
+                            [&](auto& offAxis) {
+                              offAxis.addCylinderContainer(
+                                  "B0", AxisDirection::AxisZ, [&](auto& b0) {
+                                    b0.addStaticVolume(makeB0Layer(0));
+                                    b0.addStaticVolume(makeB0Layer(1));
+                                  });
+                            });
+  });
+
+  auto trackingGeometry = root->construct({}, gctx, *logger);
+  BOOST_REQUIRE(trackingGeometry != nullptr);
+  BOOST_CHECK(trackingGeometry->geometryVersion() ==
+              TrackingGeometry::GeometryVersion::Gen3);
+
+  const auto* envelope = trackingGeometry->findVolumeByName("B0Envelope");
+  BOOST_REQUIRE(envelope != nullptr);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eX], 1e-9);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eY], 1e-9);
+
+  const auto* b0Layer0 = trackingGeometry->findVolumeByName("B0Layer0");
+  BOOST_REQUIRE(b0Layer0 != nullptr);
+  BOOST_CHECK_CLOSE(b0Layer0->center(gctx)[eX], -160_mm, 1e-8);
+
+  std::size_t found = 0;
+  for (const auto& surface : b0SensitiveSurfaces) {
+    const auto id = surface->geometryId();
+    BOOST_CHECK_NE(id.sensitive(), 0u);
+    const auto* lookup = trackingGeometry->findSurface(id);
+    BOOST_REQUIRE(lookup != nullptr);
+    found++;
+  }
+  BOOST_CHECK_EQUAL(found, b0SensitiveSurfaces.size());
 }
 
 BOOST_AUTO_TEST_CASE(Confined) {

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -306,17 +306,16 @@ BOOST_AUTO_TEST_CASE(OffAxisWrapperInCylinderHierarchy) {
     for (std::size_t i = 0; i < nModules; ++i) {
       const double phi = 2. * std::numbers::pi * static_cast<double>(i) /
                          static_cast<double>(nModules);
-      Transform3 moduleTransform =
-          Transform3::Identity() *
-          Translation3{Vector3{offsetX, 0., z}} *
-          AngleAxis3{phi, Vector3::UnitZ()} *
-          Translation3{Vector3::UnitX() * moduleR} *
-          AngleAxis3{90_degree, Vector3::UnitY()} *
-          AngleAxis3{90_degree, Vector3::UnitZ()};
+      Transform3 moduleTransform = Transform3::Identity() *
+                                   Translation3{Vector3{offsetX, 0., z}} *
+                                   AngleAxis3{phi, Vector3::UnitZ()} *
+                                   Translation3{Vector3::UnitX() * moduleR} *
+                                   AngleAxis3{90_degree, Vector3::UnitY()} *
+                                   AngleAxis3{90_degree, Vector3::UnitZ()};
 
-      auto& element = elements.emplace_back(
-          std::make_unique<DetectorElementStub>(moduleTransform, moduleBounds,
-                                                0.));
+      auto& element =
+          elements.emplace_back(std::make_unique<DetectorElementStub>(
+              moduleTransform, moduleBounds, 0.));
       element->surface().assignSurfacePlacement(*element);
       auto surface = element->surface().getSharedPtr();
       layerVolume->addSurface(surface);
@@ -327,10 +326,10 @@ BOOST_AUTO_TEST_CASE(OffAxisWrapperInCylinderHierarchy) {
   };
 
   root->addCylinderContainer("Detector", AxisDirection::AxisZ, [&](auto& det) {
-    det.addStaticVolume(Transform3::Identity(),
-                        std::make_shared<CylinderVolumeBounds>(20_mm, 400_mm,
-                                                               1000_mm),
-                        "MainTracker");
+    det.addStaticVolume(
+        Transform3::Identity(),
+        std::make_shared<CylinderVolumeBounds>(20_mm, 400_mm, 1000_mm),
+        "MainTracker");
 
     det.addOffAxisContainer("B0Envelope", Transform3::Identity(),
                             [&](auto& offAxis) {


### PR DESCRIPTION
This adds an explicit Gen3 Blueprint mechanism to integrate off-axis cylindrical detector subtrees (for example EIC/ePIC B0-like displaced tracker regions) without weakening the co-axial alignment checks in `CylinderVolumeStack`.

## What changed
- Added `OffAxisBlueprintNode` in Core geometry.
- Added `BlueprintNode::addOffAxisContainer(...)` convenience API.
- Wired new source/header into Core build.
- Added unit coverage in `BlueprintTests` for a mixed hierarchy with on-axis and off-axis volumes.
  - Verifies construction succeeds with off-axis child placement.
  - Verifies wrapper is on-axis while child remains displaced.
  - Verifies sensitive surfaces remain reachable through `TrackingGeometry::findSurface`.
- Removed `Acts::Experimental::OffAxisBlueprintNode` alias from the new header.

## Design notes
- Off-axis support is additive and opt-in.
- Existing co-axial contract and validation for standard cylinder stacks remain unchanged.
- The wrapper computes a conservative on-axis cylinder envelope from the child subtree bounds and offset, then participates in normal portal/connect/finalize flow.

## Validation
- Built `ActsUnitTestBlueprint` in a minimal unit-test config.
- Ran targeted tests:
  - `GeometrySuite/OffAxisWrapperInCylinderHierarchy`
  - `GeometrySuite/CylinderContainer`

## Reviewer focus
Please focus on:
- Envelope bound construction in `OffAxisBlueprintNode::build`.
- Any portal-merging assumptions in mixed on-axis/off-axis stack topologies.
- API naming/scope of `addOffAxisContainer(...)` for long-term maintainability.