### PR TITLE
feat: axis-aligned envelope mode for PadBlueprintNode (off-axis subtrees)

### DIFF
--- a/Core/include/Acts/Geometry/PadBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/PadBlueprintNode.hpp
@@ -143,6 +143,9 @@ class PadBlueprintNode final : public StaticBlueprintNode {
 
   /// Overload keeping the pre-reference-axis call signature source compatible,
   /// i.e. padding in the child's own frame with @ref Centering::Centered.
+  /// @deprecated Pass the reference axis and centering explicitly, i.e.
+  ///             `padded(gctx, inner, envelope, name, std::nullopt,
+  ///             Centering::Centered, logger)`.
   /// @param gctx The geometry context
   /// @param inner The volume to enclose
   /// @param envelope The envelope to add to the bounds of @p inner
@@ -151,6 +154,9 @@ class PadBlueprintNode final : public StaticBlueprintNode {
   /// @return The padded volume enclosing @p inner
   /// @throws std::logic_error if @p inner has unsupported bounds, or if the
   ///         envelope is asymmetric where it must not be
+  [[deprecated(
+      "Pass the reference axis and centering explicitly: padded(gctx, inner, "
+      "envelope, name, std::nullopt, Centering::Centered, logger)")]]
   static std::unique_ptr<TrackingVolume> padded(const GeometryContext& gctx,
                                                 const Volume& inner,
                                                 const ExtentEnvelope& envelope,

--- a/Core/include/Acts/Geometry/PadBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/PadBlueprintNode.hpp
@@ -21,6 +21,8 @@
 #include "Acts/Geometry/StaticBlueprintNode.hpp"
 #include "Acts/Geometry/TrackingVolume.hpp"
 
+#include <optional>
+
 namespace Acts {
 
 /// Wraps a single child blueprint node and pads it into a larger volume whose
@@ -30,13 +32,26 @@ namespace Acts {
 ///       tree building, but during geometry construction.
 /// It defers most of the functionality to @ref Acts::StaticBlueprintNode,
 /// and only implements the build phase to perform the padding.
+///
+/// By default the padded volume inherits the transform of its child, so it
+/// stays centered on the child. For cylinder children this node can instead
+/// build an @b axis-aligned envelope: given a reference axis transform, it
+/// re-centers the padded cylinder onto that axis and grows its radial bounds so
+/// the (possibly off-axis) child is still fully enclosed. This lets a displaced
+/// cylindrical subtree be dropped into a strictly co-axial
+/// @ref Acts::CylinderVolumeStack without weakening the stack's alignment
+/// checks.
 class PadBlueprintNode final : public StaticBlueprintNode {
  public:
   /// Main constructor for the padding node.
   /// @param name The name of the padded volume.
   /// @param envelope The envelope to apply to the child node's extent to create the padded volume.
-  explicit PadBlueprintNode(const std::string& name,
-                            const ExtentEnvelope& envelope);
+  /// @param axisTransform Optional reference axis. When set, a cylinder child is
+  ///        enclosed by an axis-aligned cylinder centered on this axis instead
+  ///        of one centered on the child itself.
+  explicit PadBlueprintNode(
+      const std::string& name, const ExtentEnvelope& envelope,
+      std::optional<Transform3> axisTransform = std::nullopt);
 
   ~PadBlueprintNode() override = default;
 
@@ -56,18 +71,35 @@ class PadBlueprintNode final : public StaticBlueprintNode {
   /// @param inner The volume to enclose
   /// @param envelope The envelope to add to the bounds of @p inner
   /// @param name The name of the padded volume
+  /// @param axisTransform Optional reference axis. When set (cylinder children
+  ///        only), the padded volume is an axis-aligned cylinder centered on
+  ///        this axis, with radial bounds grown by the child's radial offset so
+  ///        the child stays enclosed. When unset, the padded volume inherits
+  ///        the child's transform (default behavior).
   /// @param logger The logger to use
   /// @return The padded volume enclosing @p inner
-  /// @throws std::logic_error if @p inner has unsupported bounds, or if the
-  ///         envelope is asymmetric where it must not be
+  /// @throws std::logic_error if @p inner has unsupported bounds, if the
+  ///         envelope is asymmetric where it must not be, or if an axis-aligned
+  ///         envelope is requested for a non-cylinder or tilted child
   static std::unique_ptr<TrackingVolume> padded(
       const GeometryContext& gctx, const Volume& inner,
       const ExtentEnvelope& envelope, const std::string& name,
+      const std::optional<Transform3>& axisTransform = std::nullopt,
       const Logger& logger = Acts::getDummyLogger());
+
+  /// Set the reference axis transform used for axis-aligned enclosure.
+  /// @param axisTransform Transform of the reference axis frame
+  /// @return Reference to this node for chaining
+  PadBlueprintNode& setAxisTransform(const Transform3& axisTransform);
+
+  /// Get the reference axis transform, if one is configured.
+  /// @return The optional axis transform
+  const std::optional<Transform3>& axisTransform() const;
 
  private:
   ExtentEnvelope m_envelope;
   std::string m_name;
+  std::optional<Transform3> m_axisTransform;
 };
 
 namespace Experimental {

--- a/Core/include/Acts/Geometry/PadBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/PadBlueprintNode.hpp
@@ -141,6 +141,22 @@ class PadBlueprintNode final : public StaticBlueprintNode {
       Centering centering = Centering::Centered,
       const Logger& logger = Acts::getDummyLogger());
 
+  /// Overload keeping the pre-reference-axis call signature source compatible,
+  /// i.e. padding in the child's own frame with @ref Centering::Centered.
+  /// @param gctx The geometry context
+  /// @param inner The volume to enclose
+  /// @param envelope The envelope to add to the bounds of @p inner
+  /// @param name The name of the padded volume
+  /// @param logger The logger to use
+  /// @return The padded volume enclosing @p inner
+  /// @throws std::logic_error if @p inner has unsupported bounds, or if the
+  ///         envelope is asymmetric where it must not be
+  static std::unique_ptr<TrackingVolume> padded(const GeometryContext& gctx,
+                                                const Volume& inner,
+                                                const ExtentEnvelope& envelope,
+                                                const std::string& name,
+                                                const Logger& logger);
+
  private:
   ExtentEnvelope m_envelope;
   std::string m_name;

--- a/Core/include/Acts/Geometry/PadBlueprintNode.hpp
+++ b/Core/include/Acts/Geometry/PadBlueprintNode.hpp
@@ -33,25 +33,41 @@ namespace Acts {
 /// It defers most of the functionality to @ref Acts::StaticBlueprintNode,
 /// and only implements the build phase to perform the padding.
 ///
-/// By default the padded volume inherits the transform of its child, so it
-/// stays centered on the child. For cylinder children this node can instead
-/// build an @b axis-aligned envelope: given a reference axis transform, it
-/// re-centers the padded cylinder onto that axis and grows its radial bounds so
-/// the (possibly off-axis) child is still fully enclosed. This lets a displaced
-/// cylindrical subtree be dropped into a strictly co-axial
-/// @ref Acts::CylinderVolumeStack without weakening the stack's alignment
-/// checks.
+/// Two orthogonal, opt-in settings control where the padded volume ends up:
+/// - @ref setReferenceAxis picks the @b frame the enclosure is built in. By
+///   default it is the child's own frame. When a reference axis is set, a
+///   cylinder child's transverse offset from that axis is absorbed into radial
+///   growth and the enclosure is re-centered onto the axis, so a displaced
+///   cylindrical subtree can be dropped into a strictly co-axial
+///   @ref Acts::CylinderVolumeStack without weakening its alignment checks.
+///   Axis alignment is cylinder-only.
+/// - @ref setCentering picks how the volume is centered along the directions
+///   its bounds express symmetrically (z for a cylinder, x/y/z for a cuboid).
+///   The default @ref Centering::Centered keeps the volume centered on the
+///   child and requires a symmetric envelope there; @ref Centering::FitBounds
+///   allows an asymmetric envelope and shifts the enclosure so the child stays
+///   contained.
 class PadBlueprintNode final : public StaticBlueprintNode {
  public:
+  /// Controls how the padded volume is centered along the directions its bounds
+  /// express symmetrically (z for a cylinder, x/y/z for a cuboid).
+  enum class Centering {
+    /// Keep the padded volume centered on the child (default). The envelope
+    /// must be symmetric in those directions, otherwise @ref build throws: the
+    /// volume cannot move to absorb the asymmetry.
+    Centered,
+    /// Place the padded volume at the midpoint of the *expanded* extent, so an
+    /// asymmetric envelope simply shifts the enclosure off the child while
+    /// keeping it fully contained.
+    FitBounds,
+  };
+
   /// Main constructor for the padding node.
   /// @param name The name of the padded volume.
   /// @param envelope The envelope to apply to the child node's extent to create the padded volume.
-  /// @param axisTransform Optional reference axis. When set, a cylinder child is
-  ///        enclosed by an axis-aligned cylinder centered on this axis instead
-  ///        of one centered on the child itself.
   explicit PadBlueprintNode(
-      const std::string& name, const ExtentEnvelope& envelope,
-      std::optional<Transform3> axisTransform = std::nullopt);
+      const std::string& name,
+      const ExtentEnvelope& envelope = ExtentEnvelope::Zero());
 
   ~PadBlueprintNode() override = default;
 
@@ -60,46 +76,76 @@ class PadBlueprintNode final : public StaticBlueprintNode {
   Volume& build(const BlueprintOptions& options, const GeometryContext& gctx,
                 const Logger& logger = Acts::getDummyLogger()) override;
 
+  /// Set the padding envelope applied to the child's extent.
+  /// @param envelope The per-side envelope to apply
+  /// @return Reference to this node for chaining
+  PadBlueprintNode& setEnvelope(const ExtentEnvelope& envelope);
+
+  /// Get the padding envelope.
+  /// @return The configured envelope
+  const ExtentEnvelope& envelope() const;
+
+  /// Align the enclosure to an external reference axis instead of the child's
+  /// own frame (cylinder children only). The child's transverse offset from
+  /// @p axis is absorbed into radial growth and the enclosure is re-centered
+  /// onto @p axis; the child keeps its displaced placement. This transverse
+  /// re-centering happens irrespective of the @ref Centering setting, which
+  /// still governs the axial (z) direction.
+  /// @param axis Transform of the reference axis frame
+  /// @return Reference to this node for chaining
+  PadBlueprintNode& setReferenceAxis(const Transform3& axis);
+
+  /// Drop the reference axis and pad in the child's own frame (the default).
+  /// @return Reference to this node for chaining
+  PadBlueprintNode& clearReferenceAxis();
+
+  /// Get the reference axis, if one is configured.
+  /// @return The optional reference axis transform
+  const std::optional<Transform3>& referenceAxis() const;
+
+  /// Set how the volume is centered along its symmetric directions.
+  /// @param centering The centering mode
+  /// @return Reference to this node for chaining
+  PadBlueprintNode& setCentering(Centering centering);
+
+  /// Get the centering mode.
+  /// @return The configured centering mode
+  Centering centering() const;
+
   /// Create a volume that encloses @p inner, enlarged by @p envelope.
-  /// The padded volume inherits the transform of @p inner, and its bounds are
-  /// expanded in the *local* frame of @p inner.
-  /// @note The envelope must be symmetric in every direction that the bounds
-  ///       cannot express asymmetrically (z for cylinders, all of x/y/z for
-  ///       cuboids), otherwise the padded volume could not stay centered on
-  ///       @p inner.
+  ///
+  /// Without a @p referenceAxis the enclosure is built in the child's own
+  /// frame; with one (cylinder children only) it is re-centered onto that axis
+  /// and its radial bounds are grown by the child's radial offset. The
+  /// @p centering mode governs the symmetric directions (z for cylinders,
+  /// x/y/z for cuboids): @ref Centering::Centered keeps the volume centered on
+  /// the child and requires a symmetric envelope there, while
+  /// @ref Centering::FitBounds allows an asymmetric envelope and shifts the
+  /// enclosure to the midpoint of the expanded extent.
   /// @param gctx The geometry context
   /// @param inner The volume to enclose
   /// @param envelope The envelope to add to the bounds of @p inner
   /// @param name The name of the padded volume
-  /// @param axisTransform Optional reference axis. When set (cylinder children
-  ///        only), the padded volume is an axis-aligned cylinder centered on
-  ///        this axis, with radial bounds grown by the child's radial offset so
-  ///        the child stays enclosed. When unset, the padded volume inherits
-  ///        the child's transform (default behavior).
+  /// @param referenceAxis Optional reference axis for axis-aligned enclosure
+  /// @param centering Centering mode for the symmetric directions
   /// @param logger The logger to use
   /// @return The padded volume enclosing @p inner
-  /// @throws std::logic_error if @p inner has unsupported bounds, if the
-  ///         envelope is asymmetric where it must not be, or if an axis-aligned
-  ///         envelope is requested for a non-cylinder or tilted child
+  /// @throws std::logic_error if @p inner has unsupported bounds, if a
+  ///         @ref Centering::Centered envelope is asymmetric where it must not
+  ///         be, or if a reference axis is used with a non-cylinder or tilted
+  ///         child
   static std::unique_ptr<TrackingVolume> padded(
       const GeometryContext& gctx, const Volume& inner,
       const ExtentEnvelope& envelope, const std::string& name,
-      const std::optional<Transform3>& axisTransform = std::nullopt,
+      const std::optional<Transform3>& referenceAxis = std::nullopt,
+      Centering centering = Centering::Centered,
       const Logger& logger = Acts::getDummyLogger());
-
-  /// Set the reference axis transform used for axis-aligned enclosure.
-  /// @param axisTransform Transform of the reference axis frame
-  /// @return Reference to this node for chaining
-  PadBlueprintNode& setAxisTransform(const Transform3& axisTransform);
-
-  /// Get the reference axis transform, if one is configured.
-  /// @return The optional axis transform
-  const std::optional<Transform3>& axisTransform() const;
 
  private:
   ExtentEnvelope m_envelope;
   std::string m_name;
-  std::optional<Transform3> m_axisTransform;
+  std::optional<Transform3> m_referenceAxis;
+  Centering m_centering = Centering::Centered;
 };
 
 namespace Experimental {

--- a/Core/src/Geometry/Blueprint.cpp
+++ b/Core/src/Geometry/Blueprint.cpp
@@ -158,9 +158,8 @@ std::unique_ptr<TrackingGeometry> Blueprint::construct(
   // minus registering itself with a parent (the world *is* the parent).
   const Volume &top = child.build(options, gctx, logger);
 
-  std::unique_ptr<TrackingVolume> world = PadBlueprintNode::padded(
-      gctx, top, m_cfg.envelope, s_worldName, std::nullopt,
-      PadBlueprintNode::Centering::Centered, logger);
+  std::unique_ptr<TrackingVolume> world =
+      PadBlueprintNode::padded(gctx, top, m_cfg.envelope, s_worldName, logger);
 
   ACTS_DEBUG(prefix() << "New root volume bounds are: "
                       << world->volumeBounds());

--- a/Core/src/Geometry/Blueprint.cpp
+++ b/Core/src/Geometry/Blueprint.cpp
@@ -159,7 +159,8 @@ std::unique_ptr<TrackingGeometry> Blueprint::construct(
   const Volume &top = child.build(options, gctx, logger);
 
   std::unique_ptr<TrackingVolume> world = PadBlueprintNode::padded(
-      gctx, top, m_cfg.envelope, s_worldName, std::nullopt, logger);
+      gctx, top, m_cfg.envelope, s_worldName, std::nullopt,
+      PadBlueprintNode::Centering::Centered, logger);
 
   ACTS_DEBUG(prefix() << "New root volume bounds are: "
                       << world->volumeBounds());

--- a/Core/src/Geometry/Blueprint.cpp
+++ b/Core/src/Geometry/Blueprint.cpp
@@ -158,8 +158,8 @@ std::unique_ptr<TrackingGeometry> Blueprint::construct(
   // minus registering itself with a parent (the world *is* the parent).
   const Volume &top = child.build(options, gctx, logger);
 
-  std::unique_ptr<TrackingVolume> world =
-      PadBlueprintNode::padded(gctx, top, m_cfg.envelope, s_worldName, logger);
+  std::unique_ptr<TrackingVolume> world = PadBlueprintNode::padded(
+      gctx, top, m_cfg.envelope, s_worldName, std::nullopt, logger);
 
   ACTS_DEBUG(prefix() << "New root volume bounds are: "
                       << world->volumeBounds());

--- a/Core/src/Geometry/Blueprint.cpp
+++ b/Core/src/Geometry/Blueprint.cpp
@@ -158,8 +158,9 @@ std::unique_ptr<TrackingGeometry> Blueprint::construct(
   // minus registering itself with a parent (the world *is* the parent).
   const Volume &top = child.build(options, gctx, logger);
 
-  std::unique_ptr<TrackingVolume> world =
-      PadBlueprintNode::padded(gctx, top, m_cfg.envelope, s_worldName, logger);
+  std::unique_ptr<TrackingVolume> world = PadBlueprintNode::padded(
+      gctx, top, m_cfg.envelope, s_worldName, std::nullopt,
+      PadBlueprintNode::Centering::Centered, logger);
 
   ACTS_DEBUG(prefix() << "New root volume bounds are: "
                       << world->volumeBounds());

--- a/Core/src/Geometry/PadBlueprintNode.cpp
+++ b/Core/src/Geometry/PadBlueprintNode.cpp
@@ -8,6 +8,7 @@
 
 #include "Acts/Geometry/PadBlueprintNode.hpp"
 
+#include "Acts/Definitions/Tolerance.hpp"
 #include "Acts/Geometry/CuboidPortalShell.hpp"
 #include "Acts/Geometry/CylinderPortalShell.hpp"
 #include "Acts/Geometry/Extent.hpp"
@@ -31,23 +32,30 @@ void requireSymmetric(const std::array<double, 2> &env, AxisDirection direction,
 }  // namespace
 
 PadBlueprintNode::PadBlueprintNode(const std::string &name,
-                                   const ExtentEnvelope &envelope)
-    : StaticBlueprintNode(nullptr), m_envelope(envelope), m_name(name) {}
+                                   const ExtentEnvelope &envelope,
+                                   std::optional<Transform3> axisTransform)
+    : StaticBlueprintNode(nullptr),
+      m_envelope(envelope),
+      m_name(name),
+      m_axisTransform(std::move(axisTransform)) {}
 
 std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
     const GeometryContext &gctx, const Volume &inner,
     const ExtentEnvelope &envelope, const std::string &name,
-    const Logger &logger) {
+    const std::optional<Transform3> &axisTransform, const Logger &logger) {
   using enum AxisDirection;
 
   const auto &bounds = inner.volumeBounds();
+  const Transform3 childGlobal = inner.localToGlobalTransform(gctx);
 
   std::stringstream ss;
   bounds.toStream(ss);
-  ACTS_DEBUG("Padding volume: " << ss.str() << "\n"
-                                << inner.localToGlobalTransform(gctx).matrix());
+  ACTS_DEBUG("Padding volume: " << ss.str() << "\n" << childGlobal.matrix());
 
   std::shared_ptr<VolumeBounds> newBounds;
+  // By default the padded volume is centered on the child. An axis-aligned
+  // enclosure overrides this to sit on the reference axis instead.
+  Transform3 volumeTransform = childGlobal;
 
   if (const auto *cyl = dynamic_cast<const CylinderVolumeBounds *>(&bounds);
       cyl != nullptr) {
@@ -60,19 +68,74 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
 
     // Make a copy that we'll modify
     auto cylBounds = std::make_shared<CylinderVolumeBounds>(*cyl);
-    cylBounds->set({
-        {eHalfLengthZ, cylBounds->get(eHalfLengthZ) + zEnv[0]},
-        {eMinR, std::max(0.0, cylBounds->get(eMinR) - rEnv[0])},
-        {eMaxR, cylBounds->get(eMaxR) + rEnv[1]},
-    });
 
-    ACTS_DEBUG("Applied envelope to cylinder: Z="
-               << zEnv[0] << ", Rmin=" << rEnv[0] << ", Rmax=" << rEnv[1]);
+    if (axisTransform.has_value()) {
+      // Axis-aligned enclosure: express the child in the reference axis frame,
+      // recenter the envelope onto the axis, and grow the radial bounds so the
+      // displaced child stays fully enclosed.
+      const Transform3 childInAxisFrame =
+          axisTransform->inverse() * childGlobal;
+
+      // The child cylinder axis must stay parallel to the reference axis,
+      // otherwise it cannot be represented as an axis-aligned cylinder.
+      constexpr auto tolerance = s_onSurfaceTolerance;
+      if (std::abs(childInAxisFrame.rotation().col(eX)[eZ]) >= tolerance ||
+          std::abs(childInAxisFrame.rotation().col(eY)[eZ]) >= tolerance) {
+        ACTS_ERROR("Pad child cylinder tilts relative to the reference axis");
+        throw std::logic_error(
+            "PadBlueprintNode axis-aligned child tilts relative to the "
+            "reference axis");
+      }
+
+      const double radialOffset =
+          childInAxisFrame.translation().head<2>().norm();
+      const double childMinR = cylBounds->get(eMinR);
+      const double childMaxR = cylBounds->get(eMaxR);
+      // Nearest child material to the axis: the offset either pushes the inner
+      // hole outward (offset < minR), the outer edge toward the axis
+      // (offset > maxR), or the annulus straddles the axis (result 0).
+      const double minR = std::max(
+          0.0, std::max(childMinR - radialOffset, radialOffset - childMaxR) -
+                   rEnv[0]);
+      const double maxR = childMaxR + radialOffset + rEnv[1];
+
+      cylBounds->set({
+          {eHalfLengthZ, cylBounds->get(eHalfLengthZ) + zEnv[0]},
+          {eMinR, minR},
+          {eMaxR, maxR},
+      });
+
+      // Drop the transverse offset so the envelope sits on the reference axis,
+      // keeping the child's longitudinal position and orientation.
+      Transform3 envelopeInAxisFrame = childInAxisFrame;
+      envelopeInAxisFrame.translation()[eX] = 0.0;
+      envelopeInAxisFrame.translation()[eY] = 0.0;
+      volumeTransform = axisTransform.value() * envelopeInAxisFrame;
+
+      ACTS_DEBUG("Applied axis-aligned envelope to cylinder: Z="
+                 << zEnv[0] << ", Rmin=" << minR << ", Rmax=" << maxR
+                 << " around child offset " << radialOffset);
+    } else {
+      cylBounds->set({
+          {eHalfLengthZ, cylBounds->get(eHalfLengthZ) + zEnv[0]},
+          {eMinR, std::max(0.0, cylBounds->get(eMinR) - rEnv[0])},
+          {eMaxR, cylBounds->get(eMaxR) + rEnv[1]},
+      });
+
+      ACTS_DEBUG("Applied envelope to cylinder: Z="
+                 << zEnv[0] << ", Rmin=" << rEnv[0] << ", Rmax=" << rEnv[1]);
+    }
     newBounds = std::move(cylBounds);
 
   } else if (const auto *box =
                  dynamic_cast<const CuboidVolumeBounds *>(&bounds);
              box != nullptr) {
+    if (axisTransform.has_value()) {
+      ACTS_ERROR("Axis-aligned padding is only supported for cylinder volumes");
+      throw std::logic_error(
+          "PadBlueprintNode axis-aligned padding requires a cylinder child");
+    }
+
     ACTS_VERBOSE("Expanding cuboid bounds");
     using enum CuboidVolumeBounds::BoundValues;
 
@@ -101,8 +164,8 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
     throw std::logic_error{"Unsupported volume bounds type"};
   }
 
-  return std::make_unique<TrackingVolume>(inner.localToGlobalTransform(gctx),
-                                          std::move(newBounds), name);
+  return std::make_unique<TrackingVolume>(volumeTransform, std::move(newBounds),
+                                          name);
 }
 
 Volume &PadBlueprintNode::build(const BlueprintOptions &options,
@@ -117,9 +180,19 @@ Volume &PadBlueprintNode::build(const BlueprintOptions &options,
 
   const Volume &inner = children().at(0).build(options, gctx, logger);
 
-  m_volume = padded(gctx, inner, m_envelope, m_name, logger);
+  m_volume = padded(gctx, inner, m_envelope, m_name, m_axisTransform, logger);
 
   return *m_volume;
+}
+
+PadBlueprintNode &PadBlueprintNode::setAxisTransform(
+    const Transform3 &axisTransform) {
+  m_axisTransform = axisTransform;
+  return *this;
+}
+
+const std::optional<Transform3> &PadBlueprintNode::axisTransform() const {
+  return m_axisTransform;
 }
 
 }  // namespace Acts

--- a/Core/src/Geometry/PadBlueprintNode.cpp
+++ b/Core/src/Geometry/PadBlueprintNode.cpp
@@ -58,6 +58,14 @@ PadBlueprintNode::PadBlueprintNode(const std::string &name,
 std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
     const GeometryContext &gctx, const Volume &inner,
     const ExtentEnvelope &envelope, const std::string &name,
+    const Logger &logger) {
+  return padded(gctx, inner, envelope, name, std::nullopt, Centering::Centered,
+                logger);
+}
+
+std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
+    const GeometryContext &gctx, const Volume &inner,
+    const ExtentEnvelope &envelope, const std::string &name,
     const std::optional<Transform3> &referenceAxis, Centering centering,
     const Logger &logger) {
   using enum AxisDirection;

--- a/Core/src/Geometry/PadBlueprintNode.cpp
+++ b/Core/src/Geometry/PadBlueprintNode.cpp
@@ -29,20 +29,37 @@ void requireSymmetric(const std::array<double, 2> &env, AxisDirection direction,
   throw std::logic_error(ss.str());
 }
 
+/// Result of growing a symmetric half-length by a per-side envelope.
+struct AxialGrowth {
+  double halfLength;   ///< new half-length
+  double centerShift;  ///< shift of the volume center relative to the child
+};
+
+/// Grow a symmetric half-length by a per-side envelope @p env = {low, high}.
+/// In @ref PadBlueprintNode::Centering::Centered mode the envelope must be
+/// symmetric, so the center does not move; in @ref
+/// PadBlueprintNode::Centering::FitBounds mode an asymmetric envelope shifts
+/// the center to the midpoint of the expanded extent.
+AxialGrowth growAxial(double halfLength, const std::array<double, 2> &env,
+                      PadBlueprintNode::Centering centering,
+                      AxisDirection direction, const Logger &logger) {
+  if (centering == PadBlueprintNode::Centering::Centered) {
+    requireSymmetric(env, direction, logger);
+  }
+  return {halfLength + 0.5 * (env[0] + env[1]), 0.5 * (env[1] - env[0])};
+}
+
 }  // namespace
 
 PadBlueprintNode::PadBlueprintNode(const std::string &name,
-                                   const ExtentEnvelope &envelope,
-                                   std::optional<Transform3> axisTransform)
-    : StaticBlueprintNode(nullptr),
-      m_envelope(envelope),
-      m_name(name),
-      m_axisTransform(std::move(axisTransform)) {}
+                                   const ExtentEnvelope &envelope)
+    : StaticBlueprintNode(nullptr), m_envelope(envelope), m_name(name) {}
 
 std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
     const GeometryContext &gctx, const Volume &inner,
     const ExtentEnvelope &envelope, const std::string &name,
-    const std::optional<Transform3> &axisTransform, const Logger &logger) {
+    const std::optional<Transform3> &referenceAxis, Centering centering,
+    const Logger &logger) {
   using enum AxisDirection;
 
   const auto &bounds = inner.volumeBounds();
@@ -53,8 +70,8 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
   ACTS_DEBUG("Padding volume: " << ss.str() << "\n" << childGlobal.matrix());
 
   std::shared_ptr<VolumeBounds> newBounds;
-  // By default the padded volume is centered on the child. An axis-aligned
-  // enclosure overrides this to sit on the reference axis instead.
+  // By default the padded volume is anchored on the child. Asymmetric axial
+  // growth (FitBounds) and reference-axis alignment shift it as needed below.
   Transform3 volumeTransform = childGlobal;
 
   if (const auto *cyl = dynamic_cast<const CylinderVolumeBounds *>(&bounds);
@@ -64,17 +81,23 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
 
     const auto &zEnv = envelope[AxisZ];
     const auto &rEnv = envelope[AxisR];
-    requireSymmetric(zEnv, AxisZ, logger);
 
     // Make a copy that we'll modify
     auto cylBounds = std::make_shared<CylinderVolumeBounds>(*cyl);
 
-    if (axisTransform.has_value()) {
-      // Axis-aligned enclosure: express the child in the reference axis frame,
-      // recenter the envelope onto the axis, and grow the radial bounds so the
-      // displaced child stays fully enclosed.
+    // Axial growth is shared between both frames and may shift the z center.
+    const auto [halfLengthZ, zShift] =
+        growAxial(cylBounds->get(eHalfLengthZ), zEnv, centering, AxisZ, logger);
+
+    double minR = 0.;
+    double maxR = 0.;
+
+    if (referenceAxis.has_value()) {
+      // Reference-axis enclosure: express the child in the axis frame, recenter
+      // transversely onto the axis, and grow the radial bounds so the displaced
+      // child stays fully enclosed.
       const Transform3 childInAxisFrame =
-          axisTransform->inverse() * childGlobal;
+          referenceAxis->inverse() * childGlobal;
 
       // The child cylinder axis must stay parallel to the reference axis,
       // otherwise it cannot be represented as an axis-aligned cylinder.
@@ -83,7 +106,7 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
           std::abs(childInAxisFrame.rotation().col(eY)[eZ]) >= tolerance) {
         ACTS_ERROR("Pad child cylinder tilts relative to the reference axis");
         throw std::logic_error(
-            "PadBlueprintNode axis-aligned child tilts relative to the "
+            "PadBlueprintNode reference-axis child tilts relative to the "
             "reference axis");
       }
 
@@ -94,70 +117,72 @@ std::unique_ptr<TrackingVolume> PadBlueprintNode::padded(
       // Nearest child material to the axis: the offset either pushes the inner
       // hole outward (offset < minR), the outer edge toward the axis
       // (offset > maxR), or the annulus straddles the axis (result 0).
-      const double minR = std::max(
+      minR = std::max(
           0.0, std::max(childMinR - radialOffset, radialOffset - childMaxR) -
                    rEnv[0]);
-      const double maxR = childMaxR + radialOffset + rEnv[1];
+      maxR = childMaxR + radialOffset + rEnv[1];
 
-      cylBounds->set({
-          {eHalfLengthZ, cylBounds->get(eHalfLengthZ) + zEnv[0]},
-          {eMinR, minR},
-          {eMaxR, maxR},
-      });
-
-      // Drop the transverse offset so the envelope sits on the reference axis,
-      // keeping the child's longitudinal position and orientation.
+      // Drop the transverse offset and apply the axial shift in the axis frame.
       Transform3 envelopeInAxisFrame = childInAxisFrame;
       envelopeInAxisFrame.translation()[eX] = 0.0;
       envelopeInAxisFrame.translation()[eY] = 0.0;
-      volumeTransform = axisTransform.value() * envelopeInAxisFrame;
+      envelopeInAxisFrame.translation()[eZ] += zShift;
+      volumeTransform = referenceAxis.value() * envelopeInAxisFrame;
 
-      ACTS_DEBUG("Applied axis-aligned envelope to cylinder: Z="
-                 << zEnv[0] << ", Rmin=" << minR << ", Rmax=" << maxR
-                 << " around child offset " << radialOffset);
+      ACTS_DEBUG("Applied reference-axis envelope to cylinder: Rmin="
+                 << minR << ", Rmax=" << maxR << " around child offset "
+                 << radialOffset);
     } else {
-      cylBounds->set({
-          {eHalfLengthZ, cylBounds->get(eHalfLengthZ) + zEnv[0]},
-          {eMinR, std::max(0.0, cylBounds->get(eMinR) - rEnv[0])},
-          {eMaxR, cylBounds->get(eMaxR) + rEnv[1]},
-      });
+      minR = std::max(0.0, cylBounds->get(eMinR) - rEnv[0]);
+      maxR = cylBounds->get(eMaxR) + rEnv[1];
+      volumeTransform = childGlobal * Translation3{Vector3{0., 0., zShift}};
 
-      ACTS_DEBUG("Applied envelope to cylinder: Z="
-                 << zEnv[0] << ", Rmin=" << rEnv[0] << ", Rmax=" << rEnv[1]);
+      ACTS_DEBUG("Applied envelope to cylinder: Rmin=" << rEnv[0]
+                                                       << ", Rmax=" << rEnv[1]);
     }
+
+    cylBounds->set({
+        {eHalfLengthZ, halfLengthZ},
+        {eMinR, minR},
+        {eMaxR, maxR},
+    });
     newBounds = std::move(cylBounds);
 
   } else if (const auto *box =
                  dynamic_cast<const CuboidVolumeBounds *>(&bounds);
              box != nullptr) {
-    if (axisTransform.has_value()) {
-      ACTS_ERROR("Axis-aligned padding is only supported for cylinder volumes");
+    if (referenceAxis.has_value()) {
+      ACTS_ERROR(
+          "Reference-axis padding is only supported for cylinder volumes");
       throw std::logic_error(
-          "PadBlueprintNode axis-aligned padding requires a cylinder child");
+          "PadBlueprintNode reference-axis padding requires a cylinder child");
     }
 
     ACTS_VERBOSE("Expanding cuboid bounds");
     using enum CuboidVolumeBounds::BoundValues;
 
-    // A cuboid is centered on its transform in every direction, so *all* of
-    // the envelopes have to be symmetric.
-    const auto &xEnv = envelope[AxisX];
-    const auto &yEnv = envelope[AxisY];
-    const auto &zEnv = envelope[AxisZ];
-    requireSymmetric(xEnv, AxisX, logger);
-    requireSymmetric(yEnv, AxisY, logger);
-    requireSymmetric(zEnv, AxisZ, logger);
-
     // Make a copy that we'll modify
     auto boxBounds = std::make_shared<CuboidVolumeBounds>(*box);
-    boxBounds->set({
-        {eHalfLengthX, boxBounds->get(eHalfLengthX) + xEnv[0]},
-        {eHalfLengthY, boxBounds->get(eHalfLengthY) + yEnv[0]},
-        {eHalfLengthZ, boxBounds->get(eHalfLengthZ) + zEnv[0]},
-    });
 
-    ACTS_DEBUG("Applied envelope to cuboid: X=" << xEnv[0] << ", Y=" << yEnv[0]
-                                                << ", Z=" << zEnv[0]);
+    const auto [halfX, xShift] =
+        growAxial(boxBounds->get(eHalfLengthX), envelope[AxisX], centering,
+                  AxisX, logger);
+    const auto [halfY, yShift] =
+        growAxial(boxBounds->get(eHalfLengthY), envelope[AxisY], centering,
+                  AxisY, logger);
+    const auto [halfZ, zShift] =
+        growAxial(boxBounds->get(eHalfLengthZ), envelope[AxisZ], centering,
+                  AxisZ, logger);
+
+    boxBounds->set({
+        {eHalfLengthX, halfX},
+        {eHalfLengthY, halfY},
+        {eHalfLengthZ, halfZ},
+    });
+    volumeTransform =
+        childGlobal * Translation3{Vector3{xShift, yShift, zShift}};
+
+    ACTS_DEBUG("Applied envelope to cuboid");
     newBounds = std::move(boxBounds);
 
   } else {
@@ -180,19 +205,43 @@ Volume &PadBlueprintNode::build(const BlueprintOptions &options,
 
   const Volume &inner = children().at(0).build(options, gctx, logger);
 
-  m_volume = padded(gctx, inner, m_envelope, m_name, m_axisTransform, logger);
+  m_volume = padded(gctx, inner, m_envelope, m_name, m_referenceAxis,
+                    m_centering, logger);
 
   return *m_volume;
 }
 
-PadBlueprintNode &PadBlueprintNode::setAxisTransform(
-    const Transform3 &axisTransform) {
-  m_axisTransform = axisTransform;
+PadBlueprintNode &PadBlueprintNode::setEnvelope(
+    const ExtentEnvelope &envelope) {
+  m_envelope = envelope;
   return *this;
 }
 
-const std::optional<Transform3> &PadBlueprintNode::axisTransform() const {
-  return m_axisTransform;
+const ExtentEnvelope &PadBlueprintNode::envelope() const {
+  return m_envelope;
+}
+
+PadBlueprintNode &PadBlueprintNode::setReferenceAxis(const Transform3 &axis) {
+  m_referenceAxis = axis;
+  return *this;
+}
+
+PadBlueprintNode &PadBlueprintNode::clearReferenceAxis() {
+  m_referenceAxis.reset();
+  return *this;
+}
+
+const std::optional<Transform3> &PadBlueprintNode::referenceAxis() const {
+  return m_referenceAxis;
+}
+
+PadBlueprintNode &PadBlueprintNode::setCentering(Centering centering) {
+  m_centering = centering;
+  return *this;
+}
+
+PadBlueprintNode::Centering PadBlueprintNode::centering() const {
+  return m_centering;
 }
 
 }  // namespace Acts

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1317,6 +1317,29 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeCylinder) {
                     30_mm + 20_mm);
 }
 
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeLegacyPaddedOverload) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  Volume child(Transform3::Identity(),
+               std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm));
+
+  // Pin the pre-reference-axis signature: the logger in fifth position must
+  // keep resolving, so downstream call sites do not need touching.
+  auto world =
+      PadBlueprintNode::padded(gctx, child, cfg.envelope, "World", *logger);
+
+  BOOST_CHECK_EQUAL(world->volumeName(), "World");
+  const auto& worldCyl =
+      dynamic_cast<const CylinderVolumeBounds&>(world->volumeBounds());
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMinR), 10_mm - 1_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMaxR), 20_mm + 2_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eHalfLengthZ),
+                    30_mm + 20_mm);
+  BOOST_CHECK_SMALL(world->center(gctx).norm(), 1e-9);
+}
+
 BOOST_AUTO_TEST_CASE(PadBlueprintNodeCuboid) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisX] = {3_mm, 3_mm};

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1436,6 +1436,10 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisBounds) {
 }
 
 BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisRejectsCuboid) {
+  // The rejection path logs at ERROR before throwing; allow that under the
+  // compile-time log failure threshold used in CI.
+  Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
@@ -1546,6 +1550,9 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisInCylinderHierarchy) {
 BOOST_AUTO_TEST_CASE(PadBlueprintNodeCenteredRejectsAsymmetricZ) {
   // The default Centered mode cannot represent an asymmetric envelope in a
   // symmetric direction, so it must throw rather than silently shifting.
+  // The rejection path logs at ERROR before throwing.
+  Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
   cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1438,6 +1438,155 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeNestedInContainer) {
                     padCyl.get(CylinderVolumeBounds::eHalfLengthZ) + 5_mm);
 }
 
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  // Reference axis is the global z-axis; the child sits 50mm off it in x.
+  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+
+  const double offsetX = 50_mm;
+  auto child = std::make_unique<TrackingVolume>(
+      Transform3::Identity() * Translation3{Vector3{offsetX, 0, 0}},
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child");
+  const TrackingVolume* childVol = child.get();
+  pad.addStaticVolume(std::move(child));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  // The child keeps its off-axis placement.
+  BOOST_CHECK_CLOSE(childVol->center(gctx)[eX], offsetX, 1e-9);
+
+  BOOST_CHECK_EQUAL(world.volumeName(), "World");
+  BOOST_CHECK_EQUAL(world.volumeBounds().type(),
+                    VolumeBounds::BoundsType::eCylinder);
+
+  // The envelope is recentered onto the reference axis ...
+  BOOST_CHECK_SMALL(world.center(gctx)[eX], 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eY], 1e-9);
+
+  // ... and grown radially so the displaced child stays enclosed:
+  //   minR = max(0, max(minR - offset, offset - maxR) - rInner)
+  //        = max(0, max(10 - 50, 50 - 20) - 1) = 29
+  //   maxR = maxR + offset + rOuter = 20 + 50 + 2 = 72
+  const auto& worldCyl =
+      dynamic_cast<const CylinderVolumeBounds&>(world.volumeBounds());
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMinR), 29_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMaxR), 72_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eHalfLengthZ),
+                    30_mm + 20_mm);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
+  cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
+  cfg.envelope[AxisDirection::AxisZ] = {1_mm, 1_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {2_mm, 20_mm};
+  auto root = std::make_unique<Blueprint>(cfg);
+
+  std::vector<std::unique_ptr<SurfacePlacementBase>> elements;
+  std::vector<std::shared_ptr<Surface>> b0SensitiveSurfaces;
+
+  // A displaced (off-beamline) cylindrical layer with a ring of sensitive
+  // modules, modelling e.g. an EIC/ePIC B0 tracker station.
+  auto makeB0Layer = [&](std::size_t layer) -> std::unique_ptr<TrackingVolume> {
+    const double offsetX = -160_mm;
+    const double z = 6250_mm + layer * 100_mm;
+    auto layerVolume = std::make_unique<TrackingVolume>(
+        Transform3::Identity() * Translation3{Vector3{offsetX, 0., z}},
+        std::make_shared<CylinderVolumeBounds>(35_mm, 150_mm, 20_mm),
+        "B0Layer" + std::to_string(layer));
+
+    const std::size_t nModules = 6;
+    const double moduleR = 90_mm;
+    const auto moduleBounds = std::make_shared<RectangleBounds>(8_mm, 15_mm);
+    for (std::size_t i = 0; i < nModules; ++i) {
+      const double phi = 2. * std::numbers::pi * static_cast<double>(i) /
+                         static_cast<double>(nModules);
+      Transform3 moduleTransform = Transform3::Identity() *
+                                   Translation3{Vector3{offsetX, 0., z}} *
+                                   AngleAxis3{phi, Vector3::UnitZ()} *
+                                   Translation3{Vector3::UnitX() * moduleR} *
+                                   AngleAxis3{90_degree, Vector3::UnitY()} *
+                                   AngleAxis3{90_degree, Vector3::UnitZ()};
+
+      auto& element =
+          elements.emplace_back(std::make_unique<DetectorElementStub>(
+              moduleTransform, moduleBounds, 0.));
+      element->surface().assignSurfacePlacement(*element);
+      auto surface = element->surface().getSharedPtr();
+      layerVolume->addSurface(surface);
+      b0SensitiveSurfaces.push_back(std::move(surface));
+    }
+
+    return layerVolume;
+  };
+
+  root->addCylinderContainer("Detector", AxisDirection::AxisZ, [&](auto& det) {
+    det.addStaticVolume(
+        Transform3::Identity(),
+        std::make_shared<CylinderVolumeBounds>(20_mm, 400_mm, 1000_mm),
+        "MainTracker");
+
+    // The pad node wraps the displaced B0 subtree into an axis-aligned envelope
+    // so the co-axial Detector stack accepts it.
+    ExtentEnvelope padEnvelope = ExtentEnvelope::Zero();
+    padEnvelope[AxisDirection::AxisZ] = {2_mm, 2_mm};
+    padEnvelope[AxisDirection::AxisR] = {2_mm, 2_mm};
+    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope,
+                                                  Transform3::Identity());
+    pad->addCylinderContainer("B0", AxisDirection::AxisZ, [&](auto& b0) {
+      b0.addStaticVolume(makeB0Layer(0));
+      b0.addStaticVolume(makeB0Layer(1));
+    });
+    det.addChild(pad);
+  });
+
+  auto trackingGeometry = root->construct({}, gctx, *logger);
+  BOOST_REQUIRE(trackingGeometry != nullptr);
+  BOOST_CHECK(trackingGeometry->geometryVersion() ==
+              TrackingGeometry::GeometryVersion::Gen3);
+
+  // The wrapper envelope is on-axis ...
+  const auto* envelope = trackingGeometry->findVolumeByName("B0Envelope");
+  BOOST_REQUIRE(envelope != nullptr);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eX], 1e-9);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eY], 1e-9);
+
+  // ... while the child layers keep their displaced placement.
+  const auto* b0Layer0 = trackingGeometry->findVolumeByName("B0Layer0");
+  BOOST_REQUIRE(b0Layer0 != nullptr);
+  BOOST_CHECK_CLOSE(b0Layer0->center(gctx)[eX], -160_mm, 1e-8);
+
+  // Every sensitive surface inside the off-axis subtree remains reachable
+  // through the constructed geometry.
+  std::size_t found = 0;
+  for (const auto& surface : b0SensitiveSurfaces) {
+    const auto id = surface->geometryId();
+    BOOST_CHECK_NE(id.sensitive(), 0u);
+    BOOST_REQUIRE(trackingGeometry->findSurface(id) != nullptr);
+    found++;
+  }
+  BOOST_CHECK_EQUAL(found, b0SensitiveSurfaces.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END();
 
 }  // namespace ActsTests

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1392,6 +1392,155 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeNestedInContainer) {
                     padCyl.get(CylinderVolumeBounds::eHalfLengthZ) + 5_mm);
 }
 
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  // Reference axis is the global z-axis; the child sits 50mm off it in x.
+  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+
+  const double offsetX = 50_mm;
+  auto child = std::make_unique<TrackingVolume>(
+      Transform3::Identity() * Translation3{Vector3{offsetX, 0, 0}},
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child");
+  const TrackingVolume* childVol = child.get();
+  pad.addStaticVolume(std::move(child));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  // The child keeps its off-axis placement.
+  BOOST_CHECK_CLOSE(childVol->center(gctx)[eX], offsetX, 1e-9);
+
+  BOOST_CHECK_EQUAL(world.volumeName(), "World");
+  BOOST_CHECK_EQUAL(world.volumeBounds().type(),
+                    VolumeBounds::BoundsType::eCylinder);
+
+  // The envelope is recentered onto the reference axis ...
+  BOOST_CHECK_SMALL(world.center(gctx)[eX], 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eY], 1e-9);
+
+  // ... and grown radially so the displaced child stays enclosed:
+  //   minR = max(0, max(minR - offset, offset - maxR) - rInner)
+  //        = max(0, max(10 - 50, 50 - 20) - 1) = 29
+  //   maxR = maxR + offset + rOuter = 20 + 50 + 2 = 72
+  const auto& worldCyl =
+      dynamic_cast<const CylinderVolumeBounds&>(world.volumeBounds());
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMinR), 29_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMaxR), 72_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eHalfLengthZ),
+                    30_mm + 20_mm);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
+  cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
+  cfg.envelope[AxisDirection::AxisZ] = {1_mm, 1_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
+  cfg.envelope[AxisDirection::AxisR] = {2_mm, 20_mm};
+  auto root = std::make_unique<Blueprint>(cfg);
+
+  std::vector<std::unique_ptr<SurfacePlacementBase>> elements;
+  std::vector<std::shared_ptr<Surface>> b0SensitiveSurfaces;
+
+  // A displaced (off-beamline) cylindrical layer with a ring of sensitive
+  // modules, modelling e.g. an EIC/ePIC B0 tracker station.
+  auto makeB0Layer = [&](std::size_t layer) -> std::unique_ptr<TrackingVolume> {
+    const double offsetX = -160_mm;
+    const double z = 6250_mm + layer * 100_mm;
+    auto layerVolume = std::make_unique<TrackingVolume>(
+        Transform3::Identity() * Translation3{Vector3{offsetX, 0., z}},
+        std::make_shared<CylinderVolumeBounds>(35_mm, 150_mm, 20_mm),
+        "B0Layer" + std::to_string(layer));
+
+    const std::size_t nModules = 6;
+    const double moduleR = 90_mm;
+    const auto moduleBounds = std::make_shared<RectangleBounds>(8_mm, 15_mm);
+    for (std::size_t i = 0; i < nModules; ++i) {
+      const double phi = 2. * std::numbers::pi * static_cast<double>(i) /
+                         static_cast<double>(nModules);
+      Transform3 moduleTransform = Transform3::Identity() *
+                                   Translation3{Vector3{offsetX, 0., z}} *
+                                   AngleAxis3{phi, Vector3::UnitZ()} *
+                                   Translation3{Vector3::UnitX() * moduleR} *
+                                   AngleAxis3{90_degree, Vector3::UnitY()} *
+                                   AngleAxis3{90_degree, Vector3::UnitZ()};
+
+      auto& element =
+          elements.emplace_back(std::make_unique<DetectorElementStub>(
+              moduleTransform, moduleBounds, 0.));
+      element->surface().assignSurfacePlacement(*element);
+      auto surface = element->surface().getSharedPtr();
+      layerVolume->addSurface(surface);
+      b0SensitiveSurfaces.push_back(std::move(surface));
+    }
+
+    return layerVolume;
+  };
+
+  root->addCylinderContainer("Detector", AxisDirection::AxisZ, [&](auto& det) {
+    det.addStaticVolume(
+        Transform3::Identity(),
+        std::make_shared<CylinderVolumeBounds>(20_mm, 400_mm, 1000_mm),
+        "MainTracker");
+
+    // The pad node wraps the displaced B0 subtree into an axis-aligned envelope
+    // so the co-axial Detector stack accepts it.
+    ExtentEnvelope padEnvelope = ExtentEnvelope::Zero();
+    padEnvelope[AxisDirection::AxisZ] = {2_mm, 2_mm};
+    padEnvelope[AxisDirection::AxisR] = {2_mm, 2_mm};
+    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope,
+                                                  Transform3::Identity());
+    pad->addCylinderContainer("B0", AxisDirection::AxisZ, [&](auto& b0) {
+      b0.addStaticVolume(makeB0Layer(0));
+      b0.addStaticVolume(makeB0Layer(1));
+    });
+    det.addChild(pad);
+  });
+
+  auto trackingGeometry = root->construct({}, gctx, *logger);
+  BOOST_REQUIRE(trackingGeometry != nullptr);
+  BOOST_CHECK(trackingGeometry->geometryVersion() ==
+              TrackingGeometry::GeometryVersion::Gen3);
+
+  // The wrapper envelope is on-axis ...
+  const auto* envelope = trackingGeometry->findVolumeByName("B0Envelope");
+  BOOST_REQUIRE(envelope != nullptr);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eX], 1e-9);
+  BOOST_CHECK_SMALL(envelope->center(gctx)[eY], 1e-9);
+
+  // ... while the child layers keep their displaced placement.
+  const auto* b0Layer0 = trackingGeometry->findVolumeByName("B0Layer0");
+  BOOST_REQUIRE(b0Layer0 != nullptr);
+  BOOST_CHECK_CLOSE(b0Layer0->center(gctx)[eX], -160_mm, 1e-8);
+
+  // Every sensitive surface inside the off-axis subtree remains reachable
+  // through the constructed geometry.
+  std::size_t found = 0;
+  for (const auto& surface : b0SensitiveSurfaces) {
+    const auto id = surface->geometryId();
+    BOOST_CHECK_NE(id.sensitive(), 0u);
+    BOOST_REQUIRE(trackingGeometry->findSurface(id) != nullptr);
+    found++;
+  }
+  BOOST_CHECK_EQUAL(found, b0SensitiveSurfaces.size());
+}
+
 BOOST_AUTO_TEST_SUITE_END();
 
 }  // namespace ActsTests

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1438,13 +1438,14 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeNestedInContainer) {
                     padCyl.get(CylinderVolumeBounds::eHalfLengthZ) + 5_mm);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisBounds) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
   cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
 
   // Reference axis is the global z-axis; the child sits 50mm off it in x.
-  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setReferenceAxis(Transform3::Identity());
 
   const double offsetX = 50_mm;
   auto child = std::make_unique<TrackingVolume>(
@@ -1480,13 +1481,14 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
                     30_mm + 20_mm);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisRejectsCuboid) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisZ] = {1_mm, 1_mm};
 
-  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setReferenceAxis(Transform3::Identity());
   pad.addStaticVolume(std::make_unique<TrackingVolume>(
       Transform3::Identity(),
       std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
@@ -1495,7 +1497,7 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
   BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisInCylinderHierarchy) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
   cfg.envelope[AxisDirection::AxisR] = {2_mm, 20_mm};
@@ -1550,8 +1552,8 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
     ExtentEnvelope padEnvelope = ExtentEnvelope::Zero();
     padEnvelope[AxisDirection::AxisZ] = {2_mm, 2_mm};
     padEnvelope[AxisDirection::AxisR] = {2_mm, 2_mm};
-    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope,
-                                                  Transform3::Identity());
+    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope);
+    pad->setReferenceAxis(Transform3::Identity());
     pad->addCylinderContainer("B0", AxisDirection::AxisZ, [&](auto& b0) {
       b0.addStaticVolume(makeB0Layer(0));
       b0.addStaticVolume(makeB0Layer(1));
@@ -1585,6 +1587,76 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
     found++;
   }
   BOOST_CHECK_EQUAL(found, b0SensitiveSurfaces.size());
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeCenteredRejectsAsymmetricZ) {
+  // The default Centered mode cannot represent an asymmetric envelope in a
+  // symmetric direction, so it must throw rather than silently shifting.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeFitBoundsCylinder) {
+  // FitBounds allows an asymmetric z envelope; the enclosure shifts to the
+  // midpoint of the expanded extent instead of throwing.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setCentering(PadBlueprintNode::Centering::FitBounds);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  const auto& worldCyl =
+      dynamic_cast<const CylinderVolumeBounds&>(world.volumeBounds());
+  // halfZ = 30 + (10 + 40) / 2 = 55; center shifts by (40 - 10) / 2 = 15
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eHalfLengthZ), 55_mm);
+  BOOST_CHECK_CLOSE(world.center(gctx)[eZ], 15_mm, 1e-9);
+  // r is asymmetric even when Centered, so it is unchanged here
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMinR), 9_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMaxR), 22_mm);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeFitBoundsCuboid) {
+  // FitBounds shifts a cuboid per axis by half the envelope asymmetry.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisX] = {2_mm, 6_mm};
+  cfg.envelope[AxisDirection::AxisY] = {3_mm, 3_mm};
+  cfg.envelope[AxisDirection::AxisZ] = {0_mm, 0_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setCentering(PadBlueprintNode::Centering::FitBounds);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  const auto& worldBox =
+      dynamic_cast<const CuboidVolumeBounds&>(world.volumeBounds());
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthX), 14_mm);
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthY), 23_mm);
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthZ), 30_mm);
+  BOOST_CHECK_CLOSE(world.center(gctx)[eX], 2_mm, 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eY], 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eZ], 1e-9);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1392,13 +1392,14 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeNestedInContainer) {
                     padCyl.get(CylinderVolumeBounds::eHalfLengthZ) + 5_mm);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisBounds) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
   cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
 
   // Reference axis is the global z-axis; the child sits 50mm off it in x.
-  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setReferenceAxis(Transform3::Identity());
 
   const double offsetX = 50_mm;
   auto child = std::make_unique<TrackingVolume>(
@@ -1434,13 +1435,14 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisCylinderBounds) {
                     30_mm + 20_mm);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisRejectsCuboid) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisZ] = {1_mm, 1_mm};
 
-  PadBlueprintNode pad("World", cfg.envelope, Transform3::Identity());
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setReferenceAxis(Transform3::Identity());
   pad.addStaticVolume(std::make_unique<TrackingVolume>(
       Transform3::Identity(),
       std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
@@ -1449,7 +1451,7 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisRejectsCuboid) {
   BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
 }
 
-BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisInCylinderHierarchy) {
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {20_mm, 20_mm};
   cfg.envelope[AxisDirection::AxisR] = {2_mm, 20_mm};
@@ -1504,8 +1506,8 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
     ExtentEnvelope padEnvelope = ExtentEnvelope::Zero();
     padEnvelope[AxisDirection::AxisZ] = {2_mm, 2_mm};
     padEnvelope[AxisDirection::AxisR] = {2_mm, 2_mm};
-    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope,
-                                                  Transform3::Identity());
+    auto pad = std::make_shared<PadBlueprintNode>("B0Envelope", padEnvelope);
+    pad->setReferenceAxis(Transform3::Identity());
     pad->addCylinderContainer("B0", AxisDirection::AxisZ, [&](auto& b0) {
       b0.addStaticVolume(makeB0Layer(0));
       b0.addStaticVolume(makeB0Layer(1));
@@ -1539,6 +1541,76 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeOffAxisInCylinderHierarchy) {
     found++;
   }
   BOOST_CHECK_EQUAL(found, b0SensitiveSurfaces.size());
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeCenteredRejectsAsymmetricZ) {
+  // The default Centered mode cannot represent an asymmetric envelope in a
+  // symmetric direction, so it must throw rather than silently shifting.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  BOOST_CHECK_THROW(pad.build(options, gctx, *logger), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeFitBoundsCylinder) {
+  // FitBounds allows an asymmetric z envelope; the enclosure shifts to the
+  // midpoint of the expanded extent instead of throwing.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
+  cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setCentering(PadBlueprintNode::Centering::FitBounds);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CylinderVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  const auto& worldCyl =
+      dynamic_cast<const CylinderVolumeBounds&>(world.volumeBounds());
+  // halfZ = 30 + (10 + 40) / 2 = 55; center shifts by (40 - 10) / 2 = 15
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eHalfLengthZ), 55_mm);
+  BOOST_CHECK_CLOSE(world.center(gctx)[eZ], 15_mm, 1e-9);
+  // r is asymmetric even when Centered, so it is unchanged here
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMinR), 9_mm);
+  BOOST_CHECK_EQUAL(worldCyl.get(CylinderVolumeBounds::eMaxR), 22_mm);
+}
+
+BOOST_AUTO_TEST_CASE(PadBlueprintNodeFitBoundsCuboid) {
+  // FitBounds shifts a cuboid per axis by half the envelope asymmetry.
+  Blueprint::Config cfg;
+  cfg.envelope[AxisDirection::AxisX] = {2_mm, 6_mm};
+  cfg.envelope[AxisDirection::AxisY] = {3_mm, 3_mm};
+  cfg.envelope[AxisDirection::AxisZ] = {0_mm, 0_mm};
+
+  PadBlueprintNode pad("World", cfg.envelope);
+  pad.setCentering(PadBlueprintNode::Centering::FitBounds);
+  pad.addStaticVolume(std::make_unique<TrackingVolume>(
+      Transform3::Identity(),
+      std::make_shared<CuboidVolumeBounds>(10_mm, 20_mm, 30_mm), "child"));
+
+  BlueprintOptions options;
+  auto& world =
+      dynamic_cast<TrackingVolume&>(pad.build(options, gctx, *logger));
+
+  const auto& worldBox =
+      dynamic_cast<const CuboidVolumeBounds&>(world.volumeBounds());
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthX), 14_mm);
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthY), 23_mm);
+  BOOST_CHECK_EQUAL(worldBox.get(CuboidVolumeBounds::eHalfLengthZ), 30_mm);
+  BOOST_CHECK_CLOSE(world.center(gctx)[eX], 2_mm, 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eY], 1e-9);
+  BOOST_CHECK_SMALL(world.center(gctx)[eZ], 1e-9);
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1482,6 +1482,10 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisBounds) {
 }
 
 BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisRejectsCuboid) {
+  // The rejection path logs at ERROR before throwing; allow that under the
+  // compile-time log failure threshold used in CI.
+  Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisX] = {1_mm, 1_mm};
   cfg.envelope[AxisDirection::AxisY] = {1_mm, 1_mm};
@@ -1592,6 +1596,9 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeReferenceAxisInCylinderHierarchy) {
 BOOST_AUTO_TEST_CASE(PadBlueprintNodeCenteredRejectsAsymmetricZ) {
   // The default Centered mode cannot represent an asymmetric envelope in a
   // symmetric direction, so it must throw rather than silently shifting.
+  // The rejection path logs at ERROR before throwing.
+  Logging::ScopedFailureThreshold threshold{Logging::Level::FATAL};
+
   Blueprint::Config cfg;
   cfg.envelope[AxisDirection::AxisZ] = {10_mm, 40_mm};
   cfg.envelope[AxisDirection::AxisR] = {1_mm, 2_mm};

--- a/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
+++ b/Tests/UnitTests/Core/Geometry/BlueprintTests.cpp
@@ -1327,8 +1327,10 @@ BOOST_AUTO_TEST_CASE(PadBlueprintNodeLegacyPaddedOverload) {
 
   // Pin the pre-reference-axis signature: the logger in fifth position must
   // keep resolving, so downstream call sites do not need touching.
+  ACTS_PUSH_IGNORE_DEPRECATED()
   auto world =
       PadBlueprintNode::padded(gctx, child, cfg.envelope, "World", *logger);
+  ACTS_POP_IGNORE_DEPRECATED()
 
   BOOST_CHECK_EQUAL(world->volumeName(), "World");
   const auto& worldCyl =


### PR DESCRIPTION
`CylinderVolumeStack` requires every child to be strictly co-axial, so a displaced sub-detector — an EIC/ePIC B0-like tracker region offset from the beamline, say — cannot be dropped into a cylinder container as-is. Rather than add a new Core node (the approach in #5780, which this replaces), this extends `PadBlueprintNode`, already the single-child static wrapper that synthesizes an enclosing volume in `build()`.

Two orthogonal, opt-in settings control where that enclosure ends up. `setReferenceAxis(axis)` picks the frame it is built in, defaulting to the child's own: with a reference axis, a cylinder child's transverse offset is absorbed into radial growth and the enclosure is recentered onto the axis while the child keeps its displaced placement. It is cylinder-only and throws on a non-cylinder or tilted child. `setCentering(Centering::{Centered,FitBounds})` picks how the volume sits along the directions its bounds express symmetrically — z for a cylinder, x/y/z for a cuboid. `Centered` is the default and keeps the volume on the child, requiring a symmetric envelope there; `FitBounds` allows an asymmetric envelope and shifts the enclosure to the midpoint of the expanded extent.

Placement now derives from a shared `growAxial()` helper instead of reusing the child transform verbatim, so asymmetric padding falls out for free and the old symmetric-only restriction becomes a property of `Centering::Centered` rather than a hard limitation. The default path is byte-for-byte unchanged, including the symmetric-envelope throw, and the pre-existing `padded(gctx, inner, envelope, name, logger)` signature is kept as a `[[deprecated]]` forwarding overload, so downstream call sites keep compiling but are told what to migrate to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUpfi2ganpieBzJjK4r4GP
