### PR TITLE
ci: trim gitlab-ci-tensorrt preset to a minimal compile check

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -201,18 +201,20 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_CXX_STANDARD": "20",
+                "CMAKE_BUILD_TYPE": "Release",
                 "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
                 "CMAKE_CUDA_ARCHITECTURES": "86",
-                "TORCH_CUDA_ARCH_LIST": "8.6",
                 "ACTS_BUILD_PLUGIN_FPEMON": "ON",
                 "ACTS_BUILD_PLUGIN_GNN": "ON",
                 "ACTS_GNN_ENABLE_TORCH": "OFF",
                 "ACTS_ENABLE_CUDA": "ON",
                 "ACTS_GNN_ENABLE_TENSORRT": "ON",
                 "ACTS_GNN_ENABLE_MODULEMAP": "OFF",
-                "ACTS_BUILD_EXAMPLES": "ON",
+                "ACTS_BUILD_EXAMPLES": "OFF",
+                "ACTS_BUILD_EXAMPLES_GNN": "OFF",
                 "ACTS_BUILD_PYTHON_BINDINGS": "ON",
-                "ACTS_BUILD_EXAMPLES_GNN": "ON"
+                "ACTS_USE_SYSTEM_NLOHMANN_JSON": "ON",
+                "ACTS_USE_SYSTEM_PYBIND11": "ON"
             }
         },
         {

--- a/Python/CMakeLists.txt
+++ b/Python/CMakeLists.txt
@@ -36,7 +36,7 @@ endfunction()
 
 # Add the bindings
 add_subdirectory(Core)
-add_subdirectory(Fatras)
+add_subdirectory_if(Fatras ACTS_BUILD_FATRAS)
 add_subdirectory_if(Examples ACTS_BUILD_EXAMPLES)
 add_subdirectory(Plugins)
 add_subdirectory(Utilities)


### PR DESCRIPTION
`build_gnn_tensorrt` regularly ran ~1h40 and timed out. This trims it to what it actually needs to cover.

## Why it was slow

The job is a **pure compile check**: nothing declares `needs:` on it and it publishes no `artifacts:`, so its build tree is discarded. Its only unique coverage versus `build_gnn` is:

1. `Plugins/Gnn/src/TensorRTEdgeClassifier.cpp` — one TU added to `ActsPluginGnn`
2. the `ACTS_GNN_WITH_TENSORRT` block in `Python/Plugins/src/Gnn.cpp`

Everything else it compiled was thrown away.

## What changed

- **`CMAKE_BUILD_TYPE: Release`.** The preset never set one, so it fell through to the `RelWithDebInfo` default in `cmake/ActsCompilerOptions.cmake` and compiled every TU with `-g`. That is slower and inflated objects enough that the 2G ccache evicted itself mid-build — the cause of the bimodal ~10 min warm / ~1h40 cold runtime. This is the main fix.
- **`ACTS_BUILD_EXAMPLES` / `ACTS_BUILD_EXAMPLES_GNN` off.** These were added in #5324 because the TensorRT python binding lived under `Python/Examples`. #5326 moved it to `Python/Plugins`, which `Python/CMakeLists.txt` builds unconditionally, so they have been dead weight since. There is no TensorRT code under `Examples/` at all, and the GNN example algorithms only have `ACTS_GNN_WITH_CUDA` ifdefs that `build_gnn` already covers.
- **System `nlohmann_json` / `pybind11`** from the spack view instead of rebuilding the bundled copies (`ACTS_USE_SYSTEM_LIBS` defaults off).
- Dropped `TORCH_CUDA_ARCH_LIST` — torch is off in this preset.

Warning flags are deliberately left untouched, so this job keeps the same `-Wall -Wextra -Wpedantic ...` set as every other build.

## Drive-by fix

`Python/CMakeLists.txt` added the `Fatras` bindings subdirectory unconditionally, but `Python/Fatras/CMakeLists.txt` links `Acts::Fatras`, which only exists when `ACTS_BUILD_FATRAS` is on. This was latent because `CMakeLists.txt:217` does `set_option_if(ACTS_BUILD_FATRAS ACTS_BUILD_EXAMPLES)`, so every preset enabling the python bindings also enabled examples, hence Fatras. Turning examples off here is the first config to hit it. Gated like the neighbouring `Examples` subdirectory — a no-op wherever Fatras is on, and no working configuration can regress, since with Fatras off the build previously did not configure at all.

## Result

Verified on this branch with the rest of CI temporarily disabled (that commit has been dropped). A **fully cold** build — 0% ccache hits, 292/292 misses — now completes in **13m23s**, against ~1h40 cold before. `ccache -s` reports the whole build occupies **0.1 GB of the 2 GB budget (2.95%)**, so it no longer evicts itself and the cold/warm bimodality should be gone.