### PR TITLE
fix: Allocate filtered parameters only when the KF update writes them

### DIFF
--- a/Core/include/Acts/EventData/TrackStateProxyCommon.hpp
+++ b/Core/include/Acts/EventData/TrackStateProxyCommon.hpp
@@ -375,6 +375,10 @@ class TrackStateProxyCommon {
   }
 
   /// Compute the property mask describing which components are present.
+  /// @note This reports which components have *storage allocated*, not which
+  ///       ones hold a meaningful value. The fitters shipped with ACTS
+  ///       allocate a parameter component immediately before writing it, so
+  ///       during fitting the mask grows as the track state is filled.
   /// @return Bit mask of available properties.
   TrackStatePropMask getMask() const {
     using PM = TrackStatePropMask;
@@ -398,6 +402,11 @@ class TrackStateProxyCommon {
   }
 
   /// Access the best available parameters (smoothed, filtered, or predicted).
+  /// @note "Available" means allocated. The fitters shipped with ACTS allocate
+  ///       a parameter component immediately before writing it, so this
+  ///       returns the best parameters that have actually been computed so
+  ///       far. In particular, inside a calibrator this is the predicted
+  ///       state, since filtering has not happened yet.
   /// @return Bound parameter map for the state.
   ConstParametersMap parameters() const {
     if (hasSmoothed()) {
@@ -409,6 +418,7 @@ class TrackStateProxyCommon {
   }
 
   /// Access the best available covariance (smoothed, filtered, or predicted).
+  /// @note "Available" means allocated, see @ref parameters.
   /// @return Bound covariance map for the state.
   ConstCovarianceMap covariance() const {
     if (hasSmoothed()) {

--- a/Core/include/Acts/EventData/detail/TestSourceLink.hpp
+++ b/Core/include/Acts/EventData/detail/TestSourceLink.hpp
@@ -136,4 +136,34 @@ void testSourceLinkCalibrator(
   }
 }
 
+/// Same as @ref testSourceLinkCalibrator, but additionally checks that the
+/// fitter does not expose unwritten parameters to the calibrator.
+///
+/// Filtering has not happened yet when the calibrator runs, so the filtered
+/// component must not be allocated. Otherwise `parameters()` and
+/// `covariance()` would hand out uninitialized memory, see
+/// https://github.com/acts-project/acts/issues/5777
+///
+/// @note This deliberately does not check `hasSmoothed`: the GX2F keeps its
+///       current parameter estimate in the smoothed component and writes it
+///       before calling the calibrator.
+///
+/// @param gctx Geometry context, forwarded
+/// @param cctx Calibration context, forwarded
+/// @param sourceLink The source link to calibrate
+/// @param trackState TrackState to calibrate
+template <typename trajectory_t>
+void testSourceLinkCalibratorStrict(
+    const GeometryContext& gctx, const CalibrationContext& cctx,
+    const SourceLink& sourceLink,
+    typename trajectory_t::TrackStateProxy trackState) {
+  if (trackState.hasFiltered()) {
+    throw std::runtime_error(
+        "calibrator was called on a track state which already has filtered "
+        "parameters allocated");
+  }
+
+  testSourceLinkCalibrator<trajectory_t>(gctx, cctx, sourceLink, trackState);
+}
+
 }  // namespace Acts::detail::Test

--- a/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
+++ b/Core/include/Acts/TrackFinding/CombinatorialKalmanFilter.hpp
@@ -796,6 +796,8 @@ class CombinatorialKalmanFilter {
           // Increment number of outliers
           newBranch.nOutliers()++;
         } else if (typeFlags.isMeasurement()) {
+          // Allocate the filtered parameters right before they are written
+          trackState.addComponents(PM::Filtered);
           // Kalman update
           const auto updateRes = kalmanUpdate(state, stepper, trackState);
           if (!updateRes.ok()) {
@@ -1008,9 +1010,9 @@ class CombinatorialKalmanFilter {
           auto& singleState = cmp.singleState(state).stepping;
           const auto& singleStepper = cmp.singleStepper(stepper);
 
-          TrackStatePropMask mask =
-              TrackStatePropMask::Predicted | TrackStatePropMask::Filtered |
-              TrackStatePropMask::Jacobian | TrackStatePropMask::Calibrated;
+          TrackStatePropMask mask = TrackStatePropMask::Predicted |
+                                    TrackStatePropMask::Jacobian |
+                                    TrackStatePropMask::Calibrated;
           TrackStateProxy trackStateProxy =
               temporaryStates.traj.makeTrackState(mask, kTrackIndexInvalid);
 
@@ -1036,6 +1038,9 @@ class CombinatorialKalmanFilter {
               trackState.effectiveCalibrated();
           trackStateProxy.effectiveCalibratedCovariance() =
               trackState.effectiveCalibratedCovariance();
+
+          // Allocate the filtered parameters right before they are written
+          trackStateProxy.addComponents(TrackStatePropMask::Filtered);
 
           const auto updateRes = extensions.updater(
               state.geoContext, trackStateProxy, *updaterLogger);

--- a/Core/include/Acts/TrackFinding/TrackStateCreator.hpp
+++ b/Core/include/Acts/TrackFinding/TrackStateCreator.hpp
@@ -249,15 +249,16 @@ struct TrackStateCreator {
     for (auto it = begin; it != end; ++it) {
       auto& candidateTrackState = *it;
 
-      PM mask = PM::Predicted | PM::Filtered | PM::Jacobian | PM::Calibrated;
+      // The filtered parameters are deliberately not allocated here. Outliers
+      // never get separate filtered parameters, and for measurements the
+      // caller allocates them right before the Kalman update writes them, so
+      // that nobody can observe allocated but uninitialized filtered
+      // parameters via `parameters()`.
+      PM mask = PM::Predicted | PM::Jacobian | PM::Calibrated;
       if (it != begin) {
         // subsequent track states don't need storage for these as they will
         // be shared
         mask &= ~PM::Predicted & ~PM::Jacobian;
-      }
-      if (isOutlier) {
-        // outlier won't have separate filtered parameters
-        mask &= ~PM::Filtered;
       }
 
       // copy this trackstate into fitted states MultiTrajectory

--- a/Core/include/Acts/TrackFitting/KalmanFitter.hpp
+++ b/Core/include/Acts/TrackFitting/KalmanFitter.hpp
@@ -473,10 +473,14 @@ class KalmanFitter {
           return materialInteractionPreRes.error();
         }
 
-        // Create a track state with the desired components
-        TrackStatePropMask mask =
-            TrackStatePropMask::Predicted | TrackStatePropMask::Filtered |
-            TrackStatePropMask::Jacobian | TrackStatePropMask::Calibrated;
+        // Create a track state with the desired components. Note that the
+        // filtered parameters are deliberately not allocated here: they are
+        // only added once the Kalman update is about to write them, so that
+        // the calibrator and the outlier finder cannot observe allocated but
+        // uninitialized filtered parameters via `parameters()`.
+        TrackStatePropMask mask = TrackStatePropMask::Predicted |
+                                  TrackStatePropMask::Jacobian |
+                                  TrackStatePropMask::Calibrated;
         typename traj_t::TrackStateProxy trackStateProxy =
             result.fittedStates->makeTrackState(mask, result.lastTrackIndex);
 
@@ -522,6 +526,8 @@ class KalmanFitter {
         // - update the stepping state.
         // Else, just tag it as an outlier
         if (!extensions.outlierFinder(trackStateProxyConst)) {
+          // Allocate the filtered parameters right before they are written
+          trackStateProxy.addComponents(TrackStatePropMask::Filtered);
           // Run Kalman update
           auto updateRes =
               extensions.updater(state.geoContext, trackStateProxy, logger());

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -378,10 +378,14 @@ struct GsfActor {
       const auto& singleStepper = cmp.singleStepper(stepper);
 
       // Add a <mask> TrackState entry multi trajectory. This allocates storage
-      // for all components, which we will set later.
-      TrackStatePropMask mask =
-          TrackStatePropMask::Predicted | TrackStatePropMask::Filtered |
-          TrackStatePropMask::Jacobian | TrackStatePropMask::Calibrated;
+      // for all components, which we will set later. The filtered parameters
+      // are deliberately not allocated here: they are only added once the
+      // Kalman update is about to write them, so that the calibrator and the
+      // outlier finder cannot observe allocated but uninitialized filtered
+      // parameters via `parameters()`.
+      TrackStatePropMask mask = TrackStatePropMask::Predicted |
+                                TrackStatePropMask::Jacobian |
+                                TrackStatePropMask::Calibrated;
       typename traj_t::TrackStateProxy trackStateProxy =
           tmpStates.traj.makeTrackState(mask, kTrackIndexInvalid);
       typename traj_t::ConstTrackStateProxy trackStateProxyConst{
@@ -415,6 +419,8 @@ struct GsfActor {
                                   sourceLink, trackStateProxy);
 
       if (!m_cfg.extensions.outlierFinder(trackStateProxyConst)) {
+        // Allocate the filtered parameters right before they are written
+        trackStateProxy.addComponents(TrackStatePropMask::Filtered);
         // Run Kalman update
         auto updateRes = m_cfg.extensions.updater(state.geoContext,
                                                   trackStateProxy, logger());

--- a/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFinding/CombinatorialKalmanFilterTests.cpp
@@ -288,7 +288,7 @@ inline auto makeTrackStateCreator(const source_link_accessor_t& slAccessor,
   trackStateCreator.sourceLinkAccessor
       .template connect<&source_link_accessor_t::range>(&slAccessor);
   trackStateCreator.calibrator.template connect<
-      &testSourceLinkCalibrator<TrackStateContainerBackend>>();
+      &testSourceLinkCalibratorStrict<TrackStateContainerBackend>>();
   trackStateCreator.measurementSelector.template connect<
       &MeasurementSelector::select<TrackStateContainerBackend>>(&measSel);
   return trackStateCreator;

--- a/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
@@ -57,7 +57,7 @@ FitterTester tester;
 GsfExtensions<VectorMultiTrajectory> getExtensions() {
   GsfExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   extensions.updater
       .connect<&GainMatrixUpdater::operator()<VectorMultiTrajectory>>(
           &kfUpdater);

--- a/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/Gx2fTests.cpp
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(NoFit) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(Fit5Iterations) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -455,7 +455,7 @@ BOOST_AUTO_TEST_CASE(MixedDetector) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(FitWithBfield) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(relChi2changeCutOff) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE(DidNotConverge) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -806,7 +806,7 @@ BOOST_AUTO_TEST_CASE(NotEnoughMeasurements) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -891,7 +891,7 @@ BOOST_AUTO_TEST_CASE(FindHoles) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);
@@ -995,7 +995,7 @@ BOOST_AUTO_TEST_CASE(Material) {
 
   Gx2FitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   TestSourceLink::SurfaceAccessor surfaceAccessor{*detector.geometry};
   extensions.surfaceAccessor
       .connect<&TestSourceLink::SurfaceAccessor::operator()>(&surfaceAccessor);

--- a/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/KalmanFitterTests.cpp
@@ -83,7 +83,7 @@ std::default_random_engine rng(42);
 auto makeDefaultKalmanFitterOptions() {
   KalmanFitterExtensions<VectorMultiTrajectory> extensions;
   extensions.calibrator
-      .connect<&testSourceLinkCalibrator<VectorMultiTrajectory>>();
+      .connect<&testSourceLinkCalibratorStrict<VectorMultiTrajectory>>();
   extensions.updater.connect<&KalmanUpdater::operator()<VectorMultiTrajectory>>(
       &kfUpdater);
   extensions.smoother
@@ -97,7 +97,58 @@ auto makeDefaultKalmanFitterOptions() {
       PropagatorPlainOptions(tester.geoCtx, tester.magCtx));
 }
 
+/// Checks that the calibrator is never handed a track state whose "best
+/// available" parameters have not been computed yet, see
+/// https://github.com/acts-project/acts/issues/5777
+struct CalibratorContractChecker {
+  mutable std::size_t nCalls = 0;
+
+  template <typename trajectory_t>
+  void operator()(const GeometryContext& gctx, const CalibrationContext& cctx,
+                  const SourceLink& sourceLink,
+                  typename trajectory_t::TrackStateProxy trackState) const {
+    // filtering and smoothing have not happened yet, so the corresponding
+    // components must not be allocated
+    BOOST_CHECK(!trackState.hasFiltered());
+    BOOST_CHECK(!trackState.hasSmoothed());
+    // consequently the best available parameters are the predicted ones. we
+    // compare the storage addresses to make sure no copy is involved
+    BOOST_REQUIRE(trackState.hasPredicted());
+    BOOST_CHECK_EQUAL(trackState.parameters().data(),
+                      trackState.predicted().data());
+    BOOST_CHECK_EQUAL(trackState.covariance().data(),
+                      trackState.predictedCovariance().data());
+    BOOST_CHECK(trackState.parameters().allFinite());
+    BOOST_CHECK(trackState.covariance().allFinite());
+
+    ++nCalls;
+
+    testSourceLinkCalibrator<trajectory_t>(gctx, cctx, sourceLink, trackState);
+  }
+};
+
 BOOST_AUTO_TEST_SUITE(TrackFittingSuite)
+
+// The calibrator must see valid parameters. Before
+// https://github.com/acts-project/acts/issues/5777 the filtered parameters
+// were allocated up front, so `parameters()` returned uninitialized memory.
+BOOST_AUTO_TEST_CASE(CalibratorSeesValidParameters) {
+  auto start = makeParameters();
+  auto kfOptions = makeDefaultKalmanFitterOptions();
+
+  CalibratorContractChecker checker;
+  kfOptions.extensions.calibrator
+      .connect<&CalibratorContractChecker::operator()<VectorMultiTrajectory>>(
+          &checker);
+
+  bool expected_reversed = false;
+  bool expected_smoothed = true;
+  tester.test_ZeroFieldNoSurfaceForward(kfZero, kfOptions, start, rng,
+                                        expected_reversed, expected_smoothed,
+                                        true);
+
+  BOOST_CHECK_GT(checker.nCalls, 0u);
+}
 
 BOOST_AUTO_TEST_CASE(ZeroFieldNoSurfaceForward) {
   auto start = makeParameters();


### PR DESCRIPTION
`TrackStateProxy::parameters()` and `covariance()` return the best *allocated*
component - smoothed, else filtered, else predicted - and `hasFiltered()` is a
pure allocation query. The KF, GSF and CKF allocated the filtered parameters
when creating the track state, i.e. before the Kalman update writes them. The
calibrator and the outlier finder run in that window and therefore saw
`hasFiltered() == true` with uninitialized memory behind it, which is what
#5777 reports.

Allocate the filtered parameters via `addComponents()` immediately before the
updater writes them, following the pattern already used by
`ReferenceTrajectoryBuilder` and by the smoothers for the smoothed component.

All `shareFrom(Predicted, Filtered)` aliasing for holes, material states and
outliers is kept, so every finished track state still has filtered parameters
and the fitted output is unchanged. Only the calibrator's view during fitting
changes: it now sees the predicted parameters instead of uninitialized memory.

Closes #5777

--- END COMMIT MESSAGE ---

First of three stacked PRs:

1. this one
2. GSF smoothed parameters, same class of change
3. backend hardening around `addTrackStateComponents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)