### PR TITLE
refactor: Allocate GSF smoothed parameters in the backward pass

### DIFF
--- a/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
+++ b/Core/include/Acts/TrackFitting/GaussianSumFitter.hpp
@@ -473,8 +473,9 @@ struct GaussianSumFitter {
       ACTS_DEBUG("Fwd and bwd measurement states do not match");
     }
 
-    // Go through the states and assign outliers / unset smoothed if surface not
-    // passed in backward pass
+    // Go through the states and assign outliers if the surface was not passed
+    // in the backward pass. Such states never received smoothed parameters,
+    // since those are only allocated where the backward pass computes them.
     const auto& foundBwd = bwdGsfResult.surfacesVisitedBwdAgain;
     std::size_t measurementStatesFinal = 0;
 
@@ -484,7 +485,6 @@ struct GaussianSumFitter {
           rangeContainsValue(foundBwd, &state.referenceSurface());
       if (!found && state.typeFlags().isMeasurement()) {
         state.typeFlags().setIsOutlier();
-        state.unset(TrackStatePropMask::Smoothed);
       }
 
       measurementStatesFinal +=

--- a/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
+++ b/Core/include/Acts/TrackFitting/detail/GsfActor.hpp
@@ -575,11 +575,14 @@ struct GsfActor {
       const auto firstCmpProxy =
           tmpStates.traj.getTrackState(tmpStates.tips.front());
 
+      // The smoothed parameters are deliberately not allocated here: they are
+      // only added in the backward pass which computes them, so that nobody
+      // can observe allocated but uninitialized smoothed parameters via
+      // `parameters()`.
       auto combinedStateMask = TrackStatePropMask::Predicted;
       if (type.isMeasurement()) {
-        combinedStateMask |= TrackStatePropMask::Calibrated |
-                             TrackStatePropMask::Filtered |
-                             TrackStatePropMask::Smoothed;
+        combinedStateMask |=
+            TrackStatePropMask::Calibrated | TrackStatePropMask::Filtered;
       } else if (type.isOutlier()) {
         combinedStateMask |= TrackStatePropMask::Calibrated;
       }
@@ -608,11 +611,6 @@ struct GsfActor {
             surface, m_cfg.mergeMethod);
         combinedState.filtered() = fltMean;
         combinedState.filteredCovariance() = fltCov;
-
-        // place sentinel values for smoothed parameters for now. they will be
-        // filled in the backward pass
-        combinedState.smoothed() = BoundVector::Constant(-2);
-        combinedState.smoothedCovariance() = BoundMatrix::Constant(-2);
       } else {
         combinedState.shareFrom(TrackStatePropMask::Predicted,
                                 TrackStatePropMask::Filtered);
@@ -629,12 +627,19 @@ struct GsfActor {
 
             result.surfacesVisitedBwdAgain.push_back(&surface);
 
-            if (trackState.hasSmoothed()) {
+            // Only measurement states receive smoothed parameters. Note that
+            // the last measurement state of the forward pass already shares
+            // its smoothed parameters with its filtered ones and is skipped
+            // by the actor as an already visited surface, so it is never
+            // reached here.
+            if (trackState.typeFlags().isMeasurement()) {
               const auto [smtMean, smtCov] = mergeGaussianMixture(
                   tmpStates.tips,
                   FltProjector{tmpStates.traj, tmpStates.weights}, surface,
                   m_cfg.mergeMethod);
 
+              // Allocate the smoothed parameters right before they are written
+              trackState.addComponents(TrackStatePropMask::Smoothed);
               trackState.smoothed() = smtMean;
               trackState.smoothedCovariance() = smtCov;
             }

--- a/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
+++ b/Tests/UnitTests/Core/TrackFitting/GsfTests.cpp
@@ -207,6 +207,43 @@ BOOST_AUTO_TEST_CASE(ZeroFieldWithOutliers) {
                                     false, false);
 }
 
+// The smoothed parameters are only allocated where the backward pass computes
+// them. Check that this covers every measurement state and that no state is
+// left with allocated but unwritten parameters.
+BOOST_AUTO_TEST_CASE(SmoothedParametersOnMeasurementStates) {
+  TrackContainer tracks{VectorTrackContainer{}, VectorMultiTrajectory{}};
+
+  auto multi_pars = makeParameters();
+  auto measurements =
+      createMeasurements(tester.simPropagator, tester.geoCtx, tester.magCtx,
+                         multi_pars, tester.resolutions, rng);
+  auto sourceLinks = tester.prepareSourceLinks(measurements.sourceLinks);
+  auto options = makeDefaultGsfOptions();
+
+  auto res = gsfZero.fit(sourceLinks.begin(), sourceLinks.end(), multi_pars,
+                         options, tracks);
+  BOOST_REQUIRE(res.ok());
+
+  std::size_t nMeasurementStates = 0;
+  for (const auto ts : res->trackStatesReversed()) {
+    if (!ts.typeFlags().isMeasurement()) {
+      // non-measurement states never receive smoothed parameters
+      BOOST_CHECK(!ts.hasSmoothed());
+      continue;
+    }
+
+    ++nMeasurementStates;
+
+    BOOST_CHECK(ts.hasSmoothed());
+    BOOST_CHECK(ts.smoothed().allFinite());
+    BOOST_CHECK(ts.smoothedCovariance().allFinite());
+    // the best available parameters must be the smoothed ones
+    BOOST_CHECK_EQUAL(ts.parameters().data(), ts.smoothed().data());
+  }
+
+  BOOST_CHECK_EQUAL(nMeasurementStates, sourceLinks.size());
+}
+
 BOOST_AUTO_TEST_CASE(WithFinalMultiComponentState) {
   TrackContainer tracks{VectorTrackContainer{}, VectorMultiTrajectory{}};
   using namespace GsfConstants;


### PR DESCRIPTION
The GSF allocated the smoothed parameters of the combined state during the
forward pass and filled them with a `-2` sentinel until the backward pass
computed them. States whose surface the backward pass never reached were
demoted to outliers and had the component unset again.

Allocate the smoothed parameters where they are computed instead. This removes
the sentinel writes and the cleanup pass, and makes `hasSmoothed()` line up with
"the backward pass produced smoothed parameters here" for the whole duration of
the fit.

Same class of change as the filtered parameters in #5784, see #5777.

--- END COMMIT MESSAGE ---

Stacked on top of #5784, please review/merge that one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)