### PR TITLE
chore: Harden track state component allocation

### DIFF
--- a/Core/include/Acts/EventData/AnyTrackStateProxy.hpp
+++ b/Core/include/Acts/EventData/AnyTrackStateProxy.hpp
@@ -727,6 +727,15 @@ class AnyTrackStateProxy
     mutableHandler()->unset(mutableContainerPtr(), m_index, target);
   }
 
+  /// Add additional components to the track state.
+  /// @param mask Property mask describing which components to allocate.
+  void addComponents(TrackStatePropMask mask)
+    requires(!ReadOnly)
+  {
+    mutableHandler()->addTrackStateComponents(mutableContainerPtr(), m_index,
+                                              mask);
+  }
+
  protected:
   /// Access const parameters at specific index
   /// @param parIndex Parameter index

--- a/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
+++ b/Core/include/Acts/EventData/MultiTrajectoryBackendConcept.hpp
@@ -103,6 +103,8 @@ concept MutableMultiTrajectoryBackend =
 
       { v.addTrackState_impl() } -> std::same_as<TrackIndexType>;
 
+      { v.addTrackStateComponents_impl(istate, mask) };
+
       { v.shareFrom_impl(istate, istate, mask, mask) };
 
       { v.unset_impl(mask, istate) };

--- a/Core/include/Acts/EventData/detail/MultiTrajectoryTestsCommon.hpp
+++ b/Core/include/Acts/EventData/detail/MultiTrajectoryTestsCommon.hpp
@@ -329,6 +329,45 @@ class MultiTrajectoryTestsCommon {
     BOOST_CHECK(ts.hasJacobian());
   }
 
+  void testAddTrackStateComponentsAfterShareAndUnset() {
+    using PM = TrackStatePropMask;
+
+    trajectory_t t = m_factory.create();
+
+    // adding a component which is only shared must not replace the shared
+    // storage
+    {
+      auto ts = t.makeTrackState(PM::Predicted);
+      ts.predicted() = BoundVector::Constant(42);
+      ts.shareFrom(PM::Predicted, PM::Filtered);
+      BOOST_CHECK(ts.hasFiltered());
+
+      ts.addComponents(PM::Filtered);
+      BOOST_CHECK(ts.hasFiltered());
+      BOOST_CHECK_EQUAL(ts.filtered(), BoundVector::Constant(42));
+      // still the same storage
+      ts.predicted() = BoundVector::Constant(11);
+      BOOST_CHECK_EQUAL(ts.filtered(), BoundVector::Constant(11));
+    }
+
+    // adding a component which was unset must allocate it again
+    {
+      auto ts = t.makeTrackState(PM::Predicted | PM::Filtered);
+      BOOST_CHECK(ts.hasFiltered());
+
+      ts.unset(PM::Filtered);
+      BOOST_CHECK(!ts.hasFiltered());
+
+      ts.addComponents(PM::Filtered);
+      BOOST_CHECK(ts.hasFiltered());
+
+      ts.filtered() = BoundVector::Constant(7);
+      ts.predicted() = BoundVector::Constant(3);
+      // the two must not alias
+      BOOST_CHECK_EQUAL(ts.filtered(), BoundVector::Constant(7));
+    }
+  }
+
   void testTrackStateProxyCrossTalk(std::default_random_engine& rng) {
     TestTrackState pc(rng, 2u);
 

--- a/Core/src/EventData/VectorMultiTrajectory.cpp
+++ b/Core/src/EventData/VectorMultiTrajectory.cpp
@@ -92,49 +92,56 @@ void VectorMultiTrajectory::addTrackStateComponents_impl(
   using PropMask = TrackStatePropMask;
 
   IndexData& p = m_index[istate];
-  PropMask currentMask = p.allocMask;
+
+  // Whether a component is present is decided by its index, not by `allocMask`:
+  // `shareFrom_impl` assigns an index without owning storage and `unset_impl`
+  // drops an index without releasing it, so the two can disagree. Sharing a
+  // component and then adding it must not silently replace the shared index.
+  // `allocMask` only tracks storage owned by this track state, which is what
+  // `statistics()` reports.
+  PropMask allocated = PropMask::None;
 
   assert(m_params.size() == m_cov.size());
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Predicted) &&
-      !ACTS_CHECK_BIT(currentMask, PropMask::Predicted)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::Predicted) && p.ipredicted == kInvalid) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ipredicted = static_cast<IndexType>(m_params.size() - 1);
+    allocated |= PropMask::Predicted;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Filtered) &&
-      !ACTS_CHECK_BIT(currentMask, PropMask::Filtered)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::Filtered) && p.ifiltered == kInvalid) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ifiltered = static_cast<IndexType>(m_params.size() - 1);
+    allocated |= PropMask::Filtered;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Smoothed) &&
-      !ACTS_CHECK_BIT(currentMask, PropMask::Smoothed)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::Smoothed) && p.ismoothed == kInvalid) {
     m_params.emplace_back();
     m_cov.emplace_back();
     p.ismoothed = static_cast<IndexType>(m_params.size() - 1);
+    allocated |= PropMask::Smoothed;
   }
 
   assert(m_params.size() == m_cov.size());
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Jacobian) &&
-      !ACTS_CHECK_BIT(currentMask, PropMask::Jacobian)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::Jacobian) && p.ijacobian == kInvalid) {
     m_jac.emplace_back();
     p.ijacobian = static_cast<IndexType>(m_jac.size() - 1);
+    allocated |= PropMask::Jacobian;
   }
 
-  if (ACTS_CHECK_BIT(mask, PropMask::Calibrated) &&
-      !ACTS_CHECK_BIT(currentMask, PropMask::Calibrated)) {
+  if (ACTS_CHECK_BIT(mask, PropMask::Calibrated) && p.iprojector == kInvalid) {
     m_sourceLinks.emplace_back(std::nullopt);
     p.iCalibratedSourceLink = static_cast<IndexType>(m_sourceLinks.size() - 1);
 
     m_projectors.push_back(0);
     p.iprojector = static_cast<IndexType>(m_projectors.size() - 1);
+    allocated |= PropMask::Calibrated;
   }
 
-  p.allocMask |= mask;
+  p.allocMask |= allocated;
 }
 
 void VectorMultiTrajectory::shareFrom_impl(IndexType iself, IndexType iother,

--- a/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
+++ b/Tests/UnitTests/Core/EventData/MultiTrajectoryTests.cpp
@@ -125,6 +125,11 @@ BOOST_AUTO_TEST_CASE(AddTrackStateComponents) {
   ct.testAddTrackStateComponents();
 }
 
+BOOST_AUTO_TEST_CASE(AddTrackStateComponentsAfterShareAndUnset) {
+  CommonTests ct;
+  ct.testAddTrackStateComponentsAfterShareAndUnset();
+}
+
 // assert expected "cross-talk" between trackstate proxies
 BOOST_AUTO_TEST_CASE(TrackStateProxyCrossTalk) {
   CommonTests ct;

--- a/Tests/UnitTests/Plugins/EDM4hep/PodioTrackStateContainerTest.cpp
+++ b/Tests/UnitTests/Plugins/EDM4hep/PodioTrackStateContainerTest.cpp
@@ -142,6 +142,11 @@ BOOST_AUTO_TEST_CASE(AddTrackStateComponents) {
   ct.testAddTrackStateComponents();
 }
 
+BOOST_AUTO_TEST_CASE(AddTrackStateComponentsAfterShareAndUnset) {
+  CommonTests ct;
+  ct.testAddTrackStateComponentsAfterShareAndUnset();
+}
+
 // assert expected "cross-talk" between trackstate proxies
 BOOST_AUTO_TEST_CASE(TrackStateProxyCrossTalk) {
   CommonTests ct;


### PR DESCRIPTION
Three inconsistencies around `addTrackStateComponents`:

- `MutableMultiTrajectoryBackend` did not require it, even though every fitter
  now calls `TrackStateProxy::addComponents()`. A third-party backend satisfied
  the concept and only failed at the first instantiation.

- `VectorMultiTrajectory` decided whether a component was present from the
  stored `allocMask`, while the Podio backend uses the component index.
  `shareFrom_impl` assigns an index without touching `allocMask` and
  `unset_impl` clears an index without touching it either, so the two can
  disagree: sharing a component and then adding it replaced the shared index,
  and unsetting a component and then adding it allocated nothing. Decide from
  the index like Podio does, and keep `allocMask` for the storage this track
  state actually owns, which is what `statistics()` reports.

- `AnyTrackStateProxy` had the handler entry but never surfaced a public
  `addComponents()`.

Covered by a new shared backend test exercising both sequences.

--- END COMMIT MESSAGE ---

Stacked on top of #5784 and #5785, please review/merge those first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)