### PR TITLE
fix(traccc): gpu-gbts small fixes

### DIFF
--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -219,9 +219,9 @@ struct gbts_convert_seeds_params {
   // sample multiple triplets when forming seeds to hedge against outliers.
   bool use_dropout = true;
   // Curvature thresholds (1/m) for the dropout logic.
-  // dcurv = kappa = c*q*B/pT, so 0.007 = ~86GeV
+  // dcurv = dkappa = |c*q*B/pT1 - c*q*B/pT2|, outlier if > dropout_dcurv_m
   float dropout_dcurv_m = 0.007f;
-  // 0.03 = ~20 GeV,
+  // curv of 0.03 = pT of ~10 GeV in a 2T field,
   float force_dropout_max_curv_m = 0.03f;
   // Fraction of shared hits above which a seed loses a bid (~1/2). Tuning.
   float best_hit_frac = 0.49f;

--- a/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
+++ b/Traccc/core/include/traccc/gbts_seeding/gbts_seeding_config.hpp
@@ -219,10 +219,10 @@ struct gbts_convert_seeds_params {
   // sample multiple triplets when forming seeds to hedge against outliers.
   bool use_dropout = true;
   // Curvature thresholds (1/m) for the dropout logic.
-  // dcurv = dkappa = |c*q*B/pT1 - c*q*B/pT2|, outlier if > dropout_dcurv_m
-  float dropout_dcurv_m = 0.007f;
-  // curv of 0.03 = pT of ~10 GeV in a 2T field,
+  // curv of 0.03 = pT of ~10 GeV in a 2T field, curv = c*q*B/(2*pT)
   float force_dropout_max_curv_m = 0.03f;
+  // dcurv = dkappa between two triplets, outlier if > dropout_dcurv_m
+  float dropout_dcurv_m = 0.007f;
   // Fraction of shared hits above which a seed loses a bid (~1/2). Tuning.
   float best_hit_frac = 0.49f;
   // Region switch for "tight" bidding:

--- a/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
+++ b/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
@@ -107,7 +107,7 @@ bool gbts_seedfinder_config::setLinkingScheme(
   gbts_dphi_window_params.dphi_coeff_low_dr *= ptScale;
   gbts_make_graph_edges_params.max_Kappa_low_tau *= ptScale;
   gbts_make_graph_edges_params.max_Kappa_high_tau *= ptScale;
-  gbts_fit_segments_params.inv_max_curvature *= ptScale;
+  gbts_fit_segments_params.inv_max_curvature /= ptScale;
 
   // contianers sizes
   nLayers = static_cast<unsigned int>(layerInfo.type.size());

--- a/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
+++ b/Traccc/core/src/gbts_seeding/gbts_seeding_config.cpp
@@ -94,7 +94,7 @@ bool gbts_seedfinder_config::setLinkingScheme(
                        static_cast<unsigned int>(geoIDLayerPair.second)));
   }
   // make volume by layer map
-  volumeToLayerMap.resize(largest_volume_index + 1);
+  volumeToLayerMap.reserve(largest_volume_index + 1);
   for (unsigned int i = 0; i < largest_volume_index + 1; ++i)
     volumeToLayerMap.push_back(SHRT_MAX);
   for (std::pair<short, unsigned int> vLpair : volumeToLayerMap_unordered)
@@ -107,6 +107,7 @@ bool gbts_seedfinder_config::setLinkingScheme(
   gbts_dphi_window_params.dphi_coeff_low_dr *= ptScale;
   gbts_make_graph_edges_params.max_Kappa_low_tau *= ptScale;
   gbts_make_graph_edges_params.max_Kappa_high_tau *= ptScale;
+  gbts_fit_segments_params.inv_max_curvature *= ptScale;
 
   // contianers sizes
   nLayers = static_cast<unsigned int>(layerInfo.type.size());

--- a/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -218,6 +218,11 @@ auto gbts_seeding_algorithm::create_edges(
     const unsigned int bin1_begin = eta_bin_views[2 * binPair.first];
     const unsigned int bin1_end = eta_bin_views[2 * binPair.first + 1];
     unsigned int nNodesInBin1 = bin1_end - bin1_begin;
+    unsigned int nNodesInBin2 = eta_bin_views[2 * binPair.second] -
+                                eta_bin_views[2 * binPair.second + 1];
+    if (nNodesInBin1 == 0 | nNodesInBin2 == 0) {
+      continue;
+    }
     if (bin1_begin > bin1_end) {
       nNodesInBin1 = bin1_begin - bin1_end;
     }

--- a/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
+++ b/Traccc/device/common/src/gbts_seeding/gbts_seeding_algorithm.cpp
@@ -220,7 +220,7 @@ auto gbts_seeding_algorithm::create_edges(
     unsigned int nNodesInBin1 = bin1_end - bin1_begin;
     unsigned int nNodesInBin2 = eta_bin_views[2 * binPair.second] -
                                 eta_bin_views[2 * binPair.second + 1];
-    if (nNodesInBin1 == 0 | nNodesInBin2 == 0) {
+    if ((nNodesInBin1 == 0) | (nNodesInBin2 == 0)) {
       continue;
     }
     if (bin1_begin > bin1_end) {


### PR DESCRIPTION
Some fixes mostly for sparse (single particle) events, no behaviour change on events that ran correctly before.
- use reverse instead resize before push_back.
- Count number of bin pairs exactly and avoid uint underflow for empty bins.
- Update dropout curvature comments.
- Add inv_max_curvature cut to the cuts scaled by user pT config.

--- END COMMIT MESSAGE ---