### PR TITLE
refactor: Look up the start volume from scratch on re-initialization

### DIFF
--- a/Core/src/Navigation/Navigator.cpp
+++ b/Core/src/Navigation/Navigator.cpp
@@ -150,13 +150,6 @@ Result<void> Navigator::initialize(State& state, const Vector3& position,
 
     state.startLayer = state.startSurface->associatedLayer();
     state.startVolume = state.startLayer->trackingVolume();
-  } else if (state.startVolume != nullptr) {
-    ACTS_VERBOSE(
-        volInfo(state)
-        << "Fast start initialization through association from Volume.");
-
-    state.startLayer =
-        state.startVolume->associatedLayer(state.options.geoContext, position);
   } else {
     ACTS_VERBOSE(volInfo(state) << "Slow start initialization through search.");
     ACTS_VERBOSE(volInfo(state)

--- a/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
+++ b/Tests/UnitTests/Core/Propagator/NavigatorTests.cpp
@@ -243,9 +243,14 @@ BOOST_AUTO_TEST_CASE(Navigator_status_methods) {
     BOOST_CHECK(testNavigatorStatePointers(state, startVol, startLay, startSurf,
                                            startSurf, startVol, nullptr));
 
-    ACTS_INFO("    c) Initialise having a start volume");
+    ACTS_INFO("    c) Initialise ignoring a stale start volume");
     state = navigator.makeState(options);
-    state.startVolume = startVol;
+    // A start volume left over from a previous navigation must not be reused:
+    // the volume is looked up from the position instead
+    const TrackingVolume* staleVol =
+        tGeometry->lowestTrackingVolume(tgContext, Vector3(50., 0., 0.));
+    BOOST_REQUIRE_NE(staleVol, startVol);
+    state.startVolume = staleVol;
     BOOST_CHECK(
         navigator.initialize(state, position, direction, Direction::Forward())
             .ok());


### PR DESCRIPTION
If a navigation state is re-initialized, `Navigator::initialize` had a fast path that reused `state.startVolume` from the previous navigation whenever the start surface did not provide an associated layer (`resetForRenavigation` deliberately keeps the start* members).

Re-initializing means the navigation got lost and has to start over, so carrying state over can poison the new lookup: the cached volume does not have to contain the current position, and the start layer is then searched in the wrong volume. The volume is now always resolved from the position, unless the start surface hands us the layer (and with it the volume) directly.

The navigator unit test that set a start volume up front now sets a *stale* one, i.e. a volume that does not contain the start position, and checks that the lookup still resolves the volume at the position. It fails without this change.

--- END COMMIT MESSAGE ---

This path is reachable from outside Core: an earlier attempt to remove it (as part of #5740) changed physmon output, so this is split out into its own PR to see the physmon effect in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)