### PR TITLE
ci: move non-GPU GitLab jobs to husk, retire SYCL coverage

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -27,14 +27,8 @@ jobs:
     runs-on: [self-hosted, linux, x64, husk-size-standard]
     permissions:
       contents: read
-    # Pulled through the CERN registry cache rather than ghcr.io directly. This
-    # is deliberately applied only to the husk jobs — the cache is worth using
-    # from inside CERN, and the jobs still on ubuntu-latest would gain nothing
-    # by routing their pulls through it. Do not "make this consistent" across
-    # the file without moving the job to husk first.
-    #
-    # CI/bump_versions.py understands the prefix (its docker_tag pattern makes
-    # `registry.cern.ch/` optional), so tags here still bump automatically.
+    # registry.cern.ch is a pull-through cache for ghcr.io. Husk jobs only —
+    # the ubuntu-latest jobs run outside CERN and gain nothing from it.
     container: registry.cern.ch/ghcr.io/acts-project/ubuntu2404:87
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
@@ -277,9 +271,7 @@ jobs:
           - image: ubuntu2404_clang22
             std: 23
             cxx: clang++-22
-    # Tag is templated, so CI/bump_versions.py cannot see it and it drifts. It
-    # is now the only clang22 build in the project — GitLab's duplicate, which
-    # was on 87, is gone — so it is bumped by hand here.
+    # Templated tag, so CI/bump_versions.py cannot see it; bumped by hand.
     container: ghcr.io/acts-project/${{ matrix.image }}:87
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
@@ -362,9 +354,8 @@ jobs:
         run: ctest --test-dir build-downstream --output-on-failure
 
   # ─────────────────────────────────────────────────────────────────────
-  # GNN builds, migrated from GitLab CI. Only the two that need neither a GPU
-  # nor to hand an artifact to a GPU job live here; `build_gnn` and the
-  # `test_gnn_*` jobs it feeds stay on GitLab until a GPU pool exists.
+  # GNN builds, migrated from GitLab CI. `build_gnn` and the `test_gnn_*` jobs
+  # it feeds stay on GitLab until a GPU pool exists.
   # ─────────────────────────────────────────────────────────────────────
   gnn_cpu:
     runs-on: [self-hosted, linux, x64, husk-size-standard]
@@ -373,8 +364,7 @@ jobs:
     container: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_gnn:87
 
     steps:
-      # The image puts tooling the build shells out to in the sbin dirs, which
-      # are not on a non-login PATH. GitLab did this with a bare `export`.
+      # The image keeps build tooling in the sbin dirs, off a non-login PATH.
       - name: Fix up PATH
         run: |
           echo "/usr/local/sbin" >> $GITHUB_PATH
@@ -401,8 +391,6 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
-      # Deliberately minimal: no examples, no CUDA, no module map. The point is
-      # to keep the CPU-only GNN code compiling, not to duplicate `build_gnn`.
       - name: Configure
         run: >
           ccache -z &&
@@ -452,8 +440,6 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
 
-      # Compiles the TensorRT backend against nvinfer. CUDA is enabled, but only
-      # nvcc is exercised — nothing here dispatches to a device.
       - name: Configure
         run: >
           ccache -z &&
@@ -490,10 +476,8 @@ jobs:
     # rewrites tags it can see literally, which is how linux_ubuntu_extra's
     # templated image drifted a tag behind. Every leg is alma9 today anyway.
     #
-    # Spelling it out is not sufficient here, though: bump_versions.py's
-    # docker_tag pattern is `[a-z0-9_]+`, which excludes the hyphen, so
-    # `alma9-base` does not match it with or without the registry prefix. This
-    # tag has to be bumped by hand until that character class gains a `-`.
+    # Not sufficient here though: bump_versions.py's pattern is `[a-z0-9_]+`,
+    # which excludes the hyphen, so `alma9-base` never matches. Bump by hand.
     #
     # v88 is where expat-devel arrives, which the dev4 leg needs: that view's
     # Geant4 wants EXPAT >= 2.5.0 and the view neither ships nor exposes it.

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -269,7 +269,10 @@ jobs:
           - image: ubuntu2404_clang22
             std: 23
             cxx: clang++-22
-    container: ghcr.io/acts-project/${{ matrix.image }}:86
+    # Tag is templated, so CI/bump_versions.py cannot see it and it drifts. It
+    # is now the only clang22 build in the project — GitLab's duplicate, which
+    # was on 87, is gone — so it is bumped by hand here.
+    container: ghcr.io/acts-project/${{ matrix.image }}:87
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
@@ -349,6 +352,119 @@ jobs:
 
       - name: Downstream tests
         run: ctest --test-dir build-downstream --output-on-failure
+
+  # ─────────────────────────────────────────────────────────────────────
+  # GNN builds, migrated from GitLab CI. Only the two that need neither a GPU
+  # nor to hand an artifact to a GPU job live here; `build_gnn` and the
+  # `test_gnn_*` jobs it feeds stay on GitLab until a GPU pool exists.
+  # ─────────────────────────────────────────────────────────────────────
+  gnn_cpu:
+    runs-on: [self-hosted, linux, x64, husk-size-standard]
+    permissions:
+      contents: read
+    container: ghcr.io/acts-project/ubuntu2404_gnn:87
+
+    steps:
+      # The image puts tooling the build shells out to in the sbin dirs, which
+      # are not on a non-login PATH. GitLab did this with a bare `export`.
+      - name: Fix up PATH
+        run: |
+          echo "/usr/local/sbin" >> $GITHUB_PATH
+          echo "/usr/sbin" >> $GITHUB_PATH
+          echo "/sbin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        uses: ./.github/actions/dependencies
+        with:
+          compiler: g++
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          env_file: .env
+
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
+
+      # Deliberately minimal: no examples, no CUDA, no module map. The point is
+      # to keep the CPU-only GNN code compiling, not to duplicate `build_gnn`.
+      - name: Configure
+        run: >
+          ccache -z &&
+          CI/dependencies/run.sh .env
+          cmake -B build -S .
+          --preset=gitlab-ci-gnn
+          -DACTS_ENABLE_CUDA=OFF
+          -DACTS_GNN_ENABLE_MODULEMAP=OFF
+
+      - name: Build
+        run: cmake --build build
+
+      - name: ccache stats
+        run: ccache -s
+
+      - name: Save ccache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: always()
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
+  gnn_tensorrt:
+    runs-on: [self-hosted, linux, x64, husk-size-standard]
+    permissions:
+      contents: read
+    container: ghcr.io/acts-project/ubuntu2404_tensorrt:87
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        uses: ./.github/actions/dependencies
+        with:
+          compiler: g++
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          env_file: .env
+
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-
+
+      # Compiles the TensorRT backend against nvinfer. CUDA is enabled, but only
+      # nvcc is exercised — nothing here dispatches to a device.
+      - name: Configure
+        run: >
+          ccache -z &&
+          CI/dependencies/run.sh .env
+          cmake -B build -S .
+          --preset=gitlab-ci-tensorrt
+
+      - name: Build
+        run: cmake --build build
+
+      - name: ccache stats
+        run: ccache -s
+
+      - name: Save ccache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: always()
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
   # ─────────────────────────────────────────────────────────────────────
   # LCG builds, migrated from GitLab CI. They ask for the `cvmfs` label on top

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -27,7 +27,15 @@ jobs:
     runs-on: [self-hosted, linux, x64, husk-size-standard]
     permissions:
       contents: read
-    container: ghcr.io/acts-project/ubuntu2404:87
+    # Pulled through the CERN registry cache rather than ghcr.io directly. This
+    # is deliberately applied only to the husk jobs — the cache is worth using
+    # from inside CERN, and the jobs still on ubuntu-latest would gain nothing
+    # by routing their pulls through it. Do not "make this consistent" across
+    # the file without moving the job to husk first.
+    #
+    # CI/bump_versions.py understands the prefix (its docker_tag pattern makes
+    # `registry.cern.ch/` optional), so tags here still bump automatically.
+    container: registry.cern.ch/ghcr.io/acts-project/ubuntu2404:87
     env:
       INSTALL_DIR: ${{ github.workspace }}/install
       ACTS_LOG_FAILURE_THRESHOLD: WARNING
@@ -362,7 +370,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, husk-size-standard]
     permissions:
       contents: read
-    container: ghcr.io/acts-project/ubuntu2404_gnn:87
+    container: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_gnn:87
 
     steps:
       # The image puts tooling the build shells out to in the sbin dirs, which
@@ -421,7 +429,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, husk-size-standard]
     permissions:
       contents: read
-    container: ghcr.io/acts-project/ubuntu2404_tensorrt:87
+    container: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_tensorrt:87
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -482,9 +490,14 @@ jobs:
     # rewrites tags it can see literally, which is how linux_ubuntu_extra's
     # templated image drifted a tag behind. Every leg is alma9 today anyway.
     #
+    # Spelling it out is not sufficient here, though: bump_versions.py's
+    # docker_tag pattern is `[a-z0-9_]+`, which excludes the hyphen, so
+    # `alma9-base` does not match it with or without the registry prefix. This
+    # tag has to be bumped by hand until that character class gains a `-`.
+    #
     # v88 is where expat-devel arrives, which the dev4 leg needs: that view's
     # Geant4 wants EXPAT >= 2.5.0 and the view neither ships nor exposes it.
-    container: ghcr.io/acts-project/alma9-base:88
+    container: registry.cern.ch/ghcr.io/acts-project/alma9-base:88
     continue-on-error: ${{ matrix.allow_failure }}
 
     strategy:

--- a/.github/workflows/detray.yml
+++ b/.github/workflows/detray.yml
@@ -153,10 +153,6 @@ jobs:
           #  CXX_STANDARD: "20"
           #  CONTAINER:
           #  OPTIONS: -DCMAKE_HIP_PLATFORM=nvidia -DDETRAY_BUILD_HIP=ON -DDETRAY_SET_LOGGING=DEBUG -DDETRAY_EIGEN_PLUGIN=ON -DDETRAY_BUILD_BENCHMARKS=OFF
-          - NAME: "SYCL"
-            CXX_STANDARD: "20"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2404_oneapi:69"
-            OPTIONS: -DDETRAY_BUILD_CUDA=OFF -DDETRAY_BUILD_SYCL=ON -DDETRAY_SET_LOGGING=DEBUG -DDETRAY_EIGEN_PLUGIN=ON
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -181,7 +177,6 @@ jobs:
         cmake --preset detray-full-fp32 \
           -DCMAKE_CXX_STANDARD=${{ matrix.PLATFORM.CXX_STANDARD }} \
           -DCMAKE_CUDA_STANDARD=${{ matrix.PLATFORM.CXX_STANDARD }} \
-          -DCMAKE_SYCL_STANDARD=${{ matrix.PLATFORM.CXX_STANDARD }} \
           -DCMAKE_HIP_STANDARD=${{ matrix.PLATFORM.CXX_STANDARD }} \
           -DDETRAY_BUILD_HOST=OFF \
           -DDETRAY_FASTOR_PLUGIN=OFF \

--- a/.github/workflows/traccc.yml
+++ b/.github/workflows/traccc.yml
@@ -39,25 +39,16 @@ jobs:
             options: --preset host-fp32
             run_tests: true
             enable_cuda: false
-            enable_sycl: false
           - name: CPU
             container: ghcr.io/acts-project/ubuntu2404:87
             options: --preset host-fp64
             run_tests: false
             enable_cuda: false
-            enable_sycl: false
           - name: CUDA
             container: ghcr.io/acts-project/ubuntu2404_cuda:87
             options: --preset cuda-fp32 -DTRACCC_BUILD_TESTING=FALSE
             run_tests: false
             enable_cuda: true
-            enable_sycl: false
-          - name: "SYCL Intel"
-            container: ghcr.io/acts-project/ubuntu2404_oneapi:87
-            options: --preset sycl-fp32
-            run_tests: true
-            enable_cuda: false
-            enable_sycl: true
         build:
           - Release
           - Debug
@@ -69,7 +60,6 @@ jobs:
               run_tests: false
               enable_cuda: true
               enable_hip: false
-              enable_sycl: false
             build: Release
           - platform:
               name: "ALPAKA_CPU"
@@ -78,7 +68,6 @@ jobs:
               run_tests: true
               enable_cuda: false
               enable_hip: false
-              enable_sycl: false
             build: Release
           - platform:
               name: "ALPAKA_CUDA"
@@ -87,16 +76,6 @@ jobs:
               run_tests: false
               enable_cuda: true
               enable_hip: false
-              enable_sycl: false
-            build: Release
-          - platform:
-              name: "ALPAKA_SYCL"
-              container: ghcr.io/acts-project/ubuntu2404_oneapi:87
-              options: --preset alpaka-fp32 -Dalpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE=OFF -Dalpaka_ACC_SYCL_ENABLE=ON -Dalpaka_SYCL_ONEAPI_GPU=ON -Dalpaka_SYCL_ONEAPI_GPU_DEVICES=spir64 -DTRACCC_BUILD_SYCL_UTILS=ON
-              run_tests: false
-              enable_cuda: false
-              enable_hip: false
-              enable_sycl: true
             build: Release
     # Use BASH as the shell from the images.
     defaults:
@@ -140,12 +119,12 @@ jobs:
           source ${GITHUB_WORKSPACE}/Traccc/.github/ci_setup.sh ${{ matrix.platform.name }}
           curl -L --retry 5 --retry-delay 10 --output vecmem.tar.gz https://github.com/acts-project/vecmem/archive/refs/tags/v1.25.0.tar.gz
           tar -xzvf vecmem.tar.gz
-          export CXX=${SYCLCXX:-g++}
+          export CXX=g++
           cmake \
             -S vecmem-1.25.0/ \
             -B /vecmem_build/ \
             -DVECMEM_BUILD_CUDA_LIBRARY=${{ matrix.platform.enable_cuda && 'ON' || 'OFF' }} \
-            -DVECMEM_BUILD_SYCL_LIBRARY=${{ matrix.platform.enable_sycl && 'ON' || 'OFF' }} \
+            -DVECMEM_BUILD_SYCL_LIBRARY=OFF \
             -DVECMEM_BUILD_HIP_LIBRARY=${{ matrix.platform.enable_hip && 'ON' || 'OFF' }} \
             -DCMAKE_INSTALL_PREFIX=/vecmem_install/
           cmake --build /vecmem_build/ -- -j $(nproc)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,8 +43,8 @@ variables:
     - rm -rf spack/.git spack/opt spack/var/spack/cache
     - find spack -type f -name "*.pyc" -delete || true
 
-# The CPU-only GNN build lives in .github/workflows/builds.yml (job `gnn_cpu`).
-# Only jobs that need a GPU, or that hand an artifact to one, remain here.
+# Only GPU jobs and their artifact producers remain here. build_gnn_cpu moved
+# to .github/workflows/builds.yml as `gnn_cpu`.
 
 build_gnn:
   stage: build
@@ -143,12 +143,8 @@ test_gnn_python:
   after_script:
    - !reference [.spack_cleanup, after_script]
 
-# The TensorRT GNN build lives in .github/workflows/builds.yml (job
-# `gnn_tensorrt`). It needs no GPU and feeds nothing here.
-
-# The clang22 / C++23 build is gone: .github/workflows/builds.yml
-# (`linux_ubuntu_extra`) already ran the identical matrix leg, so this was a
-# duplicate rather than a mirror.
+# build_gnn_tensorrt moved to builds.yml as `gnn_tensorrt`.
+# linux_ubuntu_2404_clang22 dropped: builds.yml `linux_ubuntu_extra` duplicated it.
 
 # The LCG job matrix lives in .github/workflows/builds.yml (job `lcg`); it runs
 # on self-hosted runners carrying the `cvmfs` label.
@@ -165,12 +161,8 @@ detray_build_cuda:
       - build
   only:
     changes:
-      # `Detray/**/*`, not `Detray/*`: GitLab evaluates these globs through
-      # Ruby's File.fnmatch with FNM_PATHNAME, under which `*` does not cross a
-      # `/`. `Detray/*` therefore matched only files sitting directly in
-      # Detray/, and skipped this job for changes to Detray/core, Detray/tests
-      # and so on — i.e. for nearly every real detray change. `**/` matches zero
-      # or more directories, so this covers both depths.
+      # Not `Detray/*`: GitLab globs via fnmatch FNM_PATHNAME, where `*` does
+      # not cross a `/`, so that matched only the top level of Detray/.
       - Detray/**/*
       - .gitlab-ci.yml
   script:
@@ -194,8 +186,7 @@ detray_test_cuda:
     - detray_build_cuda
   only:
     changes:
-      # See detray_build_cuda: must stay identical, or the test job is filtered
-      # out while the build it depends on runs (or vice versa).
+      # Must stay identical to detray_build_cuda.
       - Detray/**/*
       - .gitlab-ci.yml
   script:
@@ -207,9 +198,7 @@ detray_test_cuda:
     - ctest --output-on-failure -R ".*cuda.*"
     - find bin -type f -name "*cuda" -not -name "*text*" -exec {} \;
 
-# The detray SYCL build/test pair is retired. It never ran on an accelerator
-# (ONEAPI_DEVICE_SELECTOR pinned it to "*:cpu"), and the SYCL code paths are no
-# longer built or tested anywhere.
+# detray SYCL build/test dropped along with all other SYCL coverage.
 
 # traccc GitLab CI workflows
 .traccc_base_template: &traccc_base_job
@@ -261,6 +250,4 @@ traccc_test_cuda:
   dependencies:
     - traccc_build_cuda
 
-# The traccc SYCL Intel build/test pair is retired along with the rest of the
-# SYCL coverage. It also never used an accelerator: ONEAPI_DEVICE_SELECTOR
-# pinned it to the OpenCL CPU device.
+# traccc SYCL Intel build/test dropped along with all other SYCL coverage.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,38 +43,8 @@ variables:
     - rm -rf spack/.git spack/opt spack/var/spack/cache
     - find spack -type f -name "*.pyc" -delete || true
 
-build_gnn_cpu:
-  stage: build
-  image: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_gnn:87
-  tags:
-    - large
-
-  cache:
-   - !reference [.ccache_base, cache]
-   - !reference [.spack_cache, cache]
-
-  script:
-    - export PATH=/usr/local/sbin:/usr/sbin:/sbin:$PATH
-    - git clone $CLONE_URL src
-    - cd src
-    - git checkout $HEAD_SHA
-    - CI/dependencies/setup.sh -c g++ -e .env
-    - source .env
-    - cd ..
-    - mkdir build
-    # Here we only do a minimal build without examples to save resources
-    - >
-      cmake -B build -S src
-      --preset=gitlab-ci-gnn
-      -DACTS_ENABLE_CUDA=OFF
-      -DACTS_GNN_ENABLE_MODULEMAP=OFF
-
-    - ccache -z
-    - cmake --build build -- -j8
-    - ccache -s
-
-  after_script:
-   - !reference [.spack_cleanup, after_script]
+# The CPU-only GNN build lives in .github/workflows/builds.yml (job `gnn_cpu`).
+# Only jobs that need a GPU, or that hand an artifact to one, remain here.
 
 build_gnn:
   stage: build
@@ -173,97 +143,12 @@ test_gnn_python:
   after_script:
    - !reference [.spack_cleanup, after_script]
 
-build_gnn_tensorrt:
-  stage: build
-  image: ghcr.io/acts-project/ubuntu2404_tensorrt:87
+# The TensorRT GNN build lives in .github/workflows/builds.yml (job
+# `gnn_tensorrt`). It needs no GPU and feeds nothing here.
 
-  cache:
-    - !reference [.spack_cache, cache]
-    - !reference [.ccache_base, cache]
-
-  script:
-    - git clone $CLONE_URL src
-    - cd src
-    - git checkout $HEAD_SHA
-    - CI/dependencies/setup.sh -c g++ -e .env
-    - source .env
-    - cd ..
-    - mkdir build
-    - >
-      cmake -B build -S src --preset gitlab-ci-tensorrt
-    - ccache -z
-    - cmake --build build -- -j8
-    - ccache -s
-
-  after_script:
-   - !reference [.spack_cleanup, after_script]
-
-###############################
-### UBUNTU EXTRA JOB MATRIX ###
-###############################
-
-.linux_ubuntu_extra:
-  variables:
-    INSTALL_DIR: ${CI_PROJECT_DIR}/install
-
-  stage: build
-
-  cache:
-   - !reference [.ccache_base, cache]
-   - !reference [.spack_cache, cache]
-
-  script:
-    - git clone $CLONE_URL src
-
-    - cd src
-    - git checkout $HEAD_SHA
-    - CI/dependencies/setup.sh -c ${CXX} -e .env
-    - source .env
-
-    - cd ..
-    - mkdir build
-    - >
-      cmake -B build -S src
-      --preset=gitlab-ci
-      -DCMAKE_CXX_STANDARD=${CXXSTD}
-      -DCMAKE_CXX_COMPILER=${CXX}
-
-    - ccache -z
-    - cmake --build build -- -j8
-    - ccache -s
-
-    - ctest --test-dir build -j$(nproc)
-    - cmake --build build --target integrationtests
-
-    # Install main project
-    - cmake --install build > install.log
-
-    # Downstream configure
-    - >
-      cmake -B build-downstream -S src/Tests/DownstreamProject
-      -GNinja
-      -DCMAKE_BUILD_TYPE=Release
-      -DCMAKE_CXX_FLAGS=-Werror
-      -DCMAKE_CXX_STANDARD=${CXXSTD}
-      -DCMAKE_CXX_COMPILER=${CXX}
-      -DCMAKE_PREFIX_PATH="${INSTALL_DIR}"
-
-    # Downstream build
-    - cmake --build build-downstream
-
-    # Downstream tests
-    - ctest --test-dir build-downstream --output-on-failure
-
-  after_script:
-   - !reference [.spack_cleanup, after_script]
-
-linux_ubuntu_2404_clang22:
-  extends: .linux_ubuntu_extra
-  variables:
-    CXX: clang++-22
-    CXXSTD: 23
-  image: registry.cern.ch/ghcr.io/acts-project/ubuntu2404_clang22:87
-
+# The clang22 / C++23 build is gone: .github/workflows/builds.yml
+# (`linux_ubuntu_extra`) already ran the identical matrix leg, so this was a
+# duplicate rather than a mirror.
 
 # The LCG job matrix lives in .github/workflows/builds.yml (job `lcg`); it runs
 # on self-hosted runners carrying the `cvmfs` label.
@@ -280,7 +165,13 @@ detray_build_cuda:
       - build
   only:
     changes:
-      - Detray/*
+      # `Detray/**/*`, not `Detray/*`: GitLab evaluates these globs through
+      # Ruby's File.fnmatch with FNM_PATHNAME, under which `*` does not cross a
+      # `/`. `Detray/*` therefore matched only files sitting directly in
+      # Detray/, and skipped this job for changes to Detray/core, Detray/tests
+      # and so on — i.e. for nearly every real detray change. `**/` matches zero
+      # or more directories, so this covers both depths.
+      - Detray/**/*
       - .gitlab-ci.yml
   script:
       - git clone $CLONE_URL src
@@ -303,7 +194,9 @@ detray_test_cuda:
     - detray_build_cuda
   only:
     changes:
-      - Detray/*
+      # See detray_build_cuda: must stay identical, or the test job is filtered
+      # out while the build it depends on runs (or vice versa).
+      - Detray/**/*
       - .gitlab-ci.yml
   script:
     - git clone $CLONE_URL src
@@ -314,51 +207,9 @@ detray_test_cuda:
     - ctest --output-on-failure -R ".*cuda.*"
     - find bin -type f -name "*cuda" -not -name "*text*" -exec {} \;
 
-detray_build_sycl:
-  tags: [docker-gpu-nvidia]
-  stage: build
-  image: "ghcr.io/acts-project/ubuntu2404_oneapi:87"
-  cache:
-   - !reference [.ccache_base, cache]
-  artifacts:
-    paths:
-      - build
-  only:
-    changes:
-      - Detray/*
-      - .gitlab-ci.yml
-  script:
-      - git clone $CLONE_URL src
-      - git -C src checkout $HEAD_SHA
-      - source src/Detray/CI/ci_setup.sh SYCL
-      - >
-        cmake --preset detray-gitlab-sycl-ci -S src/Detray -B build
-        -DCMAKE_BUILD_TYPE=Release
-      - ccache -z
-      - cmake --build build -- -j 2
-      - ccache -s
-
-detray_test_sycl:
-  stage: test
-  tags: [docker-gpu-nvidia]
-  image: "ghcr.io/acts-project/ubuntu2404_oneapi:87"
-  needs:
-    - detray_build_sycl
-  variables:
-    ONEAPI_DEVICE_SELECTOR: "*:cpu"
-  only:
-    changes:
-      - Detray/*
-      - .gitlab-ci.yml
-  script:
-    - git clone $CLONE_URL src
-    - git -C src checkout $HEAD_SHA
-    - source src/Detray/CI/ci_setup.sh SYCL
-    - cd build
-    - nvidia-smi
-    - sycl-ls
-    - ctest --output-on-failure -R ".*sycl.*"
-    - find bin -type f -name "*sycl" -not -name "*text*" -exec {} \;
+# The detray SYCL build/test pair is retired. It never ran on an accelerator
+# (ONEAPI_DEVICE_SELECTOR pinned it to "*:cpu"), and the SYCL code paths are no
+# longer built or tested anywhere.
 
 # traccc GitLab CI workflows
 .traccc_base_template: &traccc_base_job
@@ -380,7 +231,7 @@ detray_test_sycl:
     paths:
       - build
   script:
-    - SYCLFLAGS="${TRACCC_SYCL_FLAGS}" CXXFLAGS="${TRACCC_CXX_FLAGS}"
+    - CXXFLAGS="${TRACCC_CXX_FLAGS}"
       cmake -G Ninja --preset ${TRACCC_BUILD_PRESET} -DTRACCC_SETUP_VECMEM=ON -DTRACCC_SETUP_COVFIE=ON -DACTS_SETUP_VECMEM=OFF -DACTS_SETUP_COVFIE=OFF -DDETRAY_SET_LOGGING=NONE -DCMAKE_BUILD_TYPE=Release -DTRACCC_BUILD_EXAMPLES=FALSE ${TRACCC_CMAKE_ARGS}
       -S src/Traccc -B build
     - cmake --build build --parallel 2
@@ -391,14 +242,6 @@ detray_test_sycl:
   stage: test
   script:
     - nvidia-smi
-    - ./src/Traccc/data/traccc_data_get_files.sh
-    - ctest --output-on-failure --test-dir build/ -R "${TRACCC_BUILD_TYPE}"
-
-.traccc_intel_test_template: &traccc_intel_test_job
-  <<: *traccc_base_job
-  tags: [docker-gpu-nvidia]
-  stage: test
-  script:
     - ./src/Traccc/data/traccc_data_get_files.sh
     - ctest --output-on-failure --test-dir build/ -R "${TRACCC_BUILD_TYPE}"
 
@@ -418,20 +261,6 @@ traccc_test_cuda:
   dependencies:
     - traccc_build_cuda
 
-traccc_build_sycl_intel:
-  <<: *traccc_build_job
-  image: ghcr.io/acts-project/ubuntu2404_oneapi:87
-  variables:
-    TRACCC_BUILD_TYPE: SYCL
-    TRACCC_BUILD_PRESET: sycl-fp32
-    TRACCC_SYCL_FLAGS: -fsycl -fsycl-targets=spir64
-    TRACCC_CMAKE_ARGS: -DTRACCC_BUILD_CUDA=FALSE -DACTS_ENABLE_CUDA=OFF -DVECMEM_BUILD_SYCL_LIBRARY=ON
-
-traccc_test_sycl_intel:
-  <<: *traccc_intel_test_job
-  image: ghcr.io/acts-project/ubuntu2404_oneapi:87
-  variables:
-    TRACCC_BUILD_TYPE: SYCL
-    ONEAPI_DEVICE_SELECTOR: opencl:*
-  dependencies:
-    - traccc_build_sycl_intel
+# The traccc SYCL Intel build/test pair is retired along with the rest of the
+# SYCL coverage. It also never used an accelerator: ONEAPI_DEVICE_SELECTOR
+# pinned it to the OpenCL CPU device.

--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -32,7 +32,13 @@ rules:
      - "main"
      - "develop/*"
     paths:
+     # Both spellings deliberately. The same `Detray/*` pattern was silently
+     # matching only the top level of Detray/ in .gitlab-ci.yml, and merge
+     # sentinel's glob engine is not documented here, so which of the two is
+     # the recursive one cannot be assumed. Listing both is correct under
+     # either reading; the redundant one simply never matches anything extra.
      - "Detray/*"
+     - "Detray/**/*"
      - ".github/workflows/detray.yml"
     required_pattern:
      - "Detray / *"

--- a/.merge-sentinel.yml
+++ b/.merge-sentinel.yml
@@ -32,11 +32,8 @@ rules:
      - "main"
      - "develop/*"
     paths:
-     # Both spellings deliberately. The same `Detray/*` pattern was silently
-     # matching only the top level of Detray/ in .gitlab-ci.yml, and merge
-     # sentinel's glob engine is not documented here, so which of the two is
-     # the recursive one cannot be assumed. Listing both is correct under
-     # either reading; the redundant one simply never matches anything extra.
+     # Both spellings: the glob engine here is undocumented, so which one is
+     # recursive cannot be assumed.
      - "Detray/*"
      - "Detray/**/*"
      - ".github/workflows/detray.yml"


### PR DESCRIPTION
GitLab CI goes from 14 jobs to 7. Everything remaining either needs a GPU or hands an artifact to a job that does — nothing else has a reason to sit on a fleet without changeset filtering.

### What stays on GitLab

`build_gnn` → `test_gnn_unittests` / `test_gnn_python`, `detray_build_cuda` → `detray_test_cuda`, `traccc_build_cuda` → `traccc_test_cuda`. Cross-fleet artifact handoff isn't possible, so the CUDA/GNN builds stay next to the GPU jobs they feed until a GPU pool exists on husk.

### Moved to GitHub

| GitLab | GitHub |
| --- | --- |
| `build_gnn_cpu` | `gnn_cpu` |
| `build_gnn_tensorrt` | `gnn_tensorrt` |

Both on `[self-hosted, linux, x64, husk-size-standard]`, following the `linux_ubuntu` pattern — including building unbounded rather than carrying GitLab's `-j8` over.

### Dropped as a duplicate

`linux_ubuntu_2404_clang22` and its `.linux_ubuntu_extra` template. `builds.yml`'s `linux_ubuntu_extra` already ran the identical clang22 / C++23 leg with the same build → test → install → downstream sequence.

Its container tag is templated, so `CI/bump_versions.py` can't see it and it had drifted to `:86` while GitLab sat on `:87`. Bumped by hand now that it's the only clang22 build left.

### Dropped with SYCL, both fleets

- `detray_build_sycl` / `detray_test_sycl`
- `traccc_build_sycl_intel` / `traccc_test_sycl_intel`
- `detray.yml` `device-container` SYCL leg
- `traccc.yml` `SYCL Intel` and `ALPAKA_SYCL` legs

Two things worth recording. Neither GitLab pair ever exercised an accelerator despite carrying the `docker-gpu-nvidia` tag — detray pinned `ONEAPI_DEVICE_SELECTOR` to `"*:cpu"`, traccc to the OpenCL CPU device. And the traccc pair was already covered by GitHub's `SYCL Intel` leg, which ran the full `ctest` against GitLab's `-R "SYCL"` subset.

Dead plumbing goes with them (`CMAKE_SYCL_STANDARD`, `SYCLCXX`, `enable_sycl`, `TRACCC_SYCL_FLAGS`). `ubuntu2404_oneapi` is now referenced by no job. `ubuntu2404_rocm_oneapi` stays — that's the HIP-AMD leg.

### Detray changeset filter fix

This matters more now that `detray_build_cuda` / `detray_test_cuda` are the only detray device coverage left. GitLab evaluates `only:changes` through Ruby's `File.fnmatch` with `FNM_PATHNAME`, under which `*` does not cross a `/`. `Detray/*` therefore matched only files sitting directly in `Detray/`, and skipped both jobs for changes to `Detray/core`, `Detray/tests` and so on — nearly every real detray change.

Verified against ruby with GitLab's exact flag set (`FNM_PATHNAME | FNM_DOTMATCH | FNM_EXTGLOB`):

```
Detray/*       vs Detray/CMakeLists.txt                      => true
Detray/*       vs Detray/core/include/detray/foo.hpp         => false
Detray/**/*    vs Detray/CMakeLists.txt                      => true
Detray/**/*    vs Detray/core/include/detray/foo.hpp         => true
```

Expect these two jobs to start running considerably more often. That's the intent, but it does spend GPU capacity that was previously being skipped by accident.

`.merge-sentinel.yml` carries the same pattern. Its glob engine isn't documented in-tree and I couldn't establish which spelling is recursive there, so that one lists both — correct under either reading, with the redundant pattern simply never matching anything extra.

### Not changed, deliberately

`.merge-sentinel.yml`'s `paths_ignore: docs/*` looks like the same latent bug (the paired `builds.yml` uses `docs/**`). Left alone: that rule *relaxes* required checks rather than adding them, so guessing wrong there fails open. Worth a separate look.

### Note for reviewers

`gnn_cpu` and `gnn_tensorrt` land in `builds.yml`, which `.merge-sentinel.yml` gates via the `Builds / *` pattern — so they become required checks on merge. Intended, but automatic rather than opted into.

### Follow-up: CERN registry pull-through cache

The four husk jobs (`linux_ubuntu`, `gnn_cpu`, `gnn_tensorrt`, `lcg`) now reference their containers as `registry.cern.ch/ghcr.io/...`, matching what `.gitlab-ci.yml` already did for CERN-side runners. Jobs still on `ubuntu-latest` keep pulling from `ghcr.io` directly — they run outside CERN and would gain nothing from the cache. There's a comment saying so, since "make this file consistent" is the obvious wrong next edit.

`CI/bump_versions.py` still auto-bumps three of the four; its `docker_tag` pattern already makes the `registry.cern.ch/` prefix optional, verified by running it against the rewritten strings.

`alma9-base` is the exception, and not because of this change. The pattern's character class is `[a-z0-9_]+`, which excludes the hyphen, so `alma9-base:88` has **never** matched — with or without a prefix. The comment above the `lcg` container previously implied that spelling the image out literally was enough to keep it auto-bumped; that isn't true for this one, and the comment now says so. I left the character class alone: widening it would start rewriting a tag deliberately pinned ahead of the others (v88 for expat-devel), which is a separate call.

### Verification

`prek`/pre-commit clean on all five files, including `zizmor` and `check-yaml`. All four workflow files parse. The glob claim is verified against `ruby` rather than asserted.

Not verified: neither new husk job has been run. `husk-size-standard` sizing for a libtorch build is the main unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

