### PR TITLE
fix: Navigation initialization with gen3 geometry

### DIFF
--- a/Core/src/Navigation/Navigator.cpp
+++ b/Core/src/Navigation/Navigator.cpp
@@ -142,7 +142,8 @@ Result<void> Navigator::initialize(State& state, const Vector3& position,
   // Fast Navigation initialization for start condition:
   // - short-cut through object association, saves navigation in the
   // - geometry and volume tree search for the lowest volume
-  if (state.startSurface != nullptr &&
+  using enum TrackingGeometry::GeometryVersion;
+  if (m_geometryVersion == Gen1 && state.startSurface != nullptr &&
       state.startSurface->associatedLayer() != nullptr) {
     ACTS_VERBOSE(
         volInfo(state)
@@ -150,7 +151,7 @@ Result<void> Navigator::initialize(State& state, const Vector3& position,
 
     state.startLayer = state.startSurface->associatedLayer();
     state.startVolume = state.startLayer->trackingVolume();
-  } else if (state.startVolume != nullptr) {
+  } else if (m_geometryVersion == Gen1 && state.startVolume != nullptr) {
     ACTS_VERBOSE(
         volInfo(state)
         << "Fast start initialization through association from Volume.");


### PR DESCRIPTION
In case `startVolume` is set, and the navigation is re-initialized (e.g., branching in CKF), gen3 navigation would silently take a gen1-only path. This is mitigated by explicitly enforcing gen1 for gen1 passes.