### PR TITLE
ci: trim the GitLab traccc CUDA build and fix the test filter

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -219,11 +219,18 @@ detray_test_cuda:
   artifacts:
     paths:
       - build
+    exclude:
+      # Only the test binaries and the libraries they load are consumed
+      # downstream. Note build/_deps must stay: vecmem is pulled in via
+      # FetchContent and its shared libraries live there at runtime.
+      - build/**/*.o
+    expire_in: 6 hours
   script:
     - CXXFLAGS="${TRACCC_CXX_FLAGS}"
       cmake -G Ninja --preset ${TRACCC_BUILD_PRESET} -DTRACCC_SETUP_VECMEM=ON -DTRACCC_SETUP_COVFIE=ON -DACTS_SETUP_VECMEM=OFF -DACTS_SETUP_COVFIE=OFF -DDETRAY_SET_LOGGING=NONE -DCMAKE_BUILD_TYPE=Release -DTRACCC_BUILD_EXAMPLES=FALSE ${TRACCC_CMAKE_ARGS}
       -S src/Traccc -B build
-    - cmake --build build --parallel 2
+    # Build only the test binary the paired test job runs, not everything.
+    - cmake --build build --parallel 2 --target ${TRACCC_BUILD_TARGET}
 
 .traccc_nvidia_test_template: &traccc_nvidia_test_job
   <<: *traccc_base_job
@@ -232,7 +239,9 @@ detray_test_cuda:
   script:
     - nvidia-smi
     - ./src/Traccc/data/traccc_data_get_files.sh
-    - ctest --output-on-failure --test-dir build/ -R "${TRACCC_BUILD_TYPE}"
+    # ctest -R is case-sensitive, so the regex must spell out both cases or
+    # it silently skips the lowercase-named GPU tests (e.g. grids_cuda.*).
+    - ctest --output-on-failure --test-dir build/ -R "${TRACCC_TEST_REGEX}"
 
 traccc_build_cuda:
   <<: *traccc_build_job
@@ -240,13 +249,18 @@ traccc_build_cuda:
   variables:
     TRACCC_BUILD_TYPE: CUDA
     TRACCC_BUILD_PRESET: cuda-fp32
+    TRACCC_BUILD_TARGET: traccc_test_cuda
+    # device/cuda generates 13 nvcc translation units per detector type, so
+    # build only the two the CUDA tests instantiate. The full matrix is still
+    # compiled by the GitHub CUDA-Release and cuda-fp64 jobs.
+    TRACCC_CMAKE_ARGS: "-DTRACCC_SUPPORTED_DETECTORS=default_detector;telescope_detector"
 
 traccc_test_cuda:
   <<: *traccc_nvidia_test_job
   image: ghcr.io/acts-project/ubuntu2404_cuda:87
   variables:
     TRACCC_BUILD_TYPE: CUDA
-    TRACCC_CMAKE_ARGS: -DACTS_ENABLE_CUDA=ON -DVECMEM_BUILD_CUDA_LIBRARY=ON
+    TRACCC_TEST_REGEX: "[Cc][Uu][Dd][Aa]"
   dependencies:
     - traccc_build_cuda
 


### PR DESCRIPTION
The GitLab traccc CUDA build builds substantially more than the paired test
job can use, and the test job's regex was silently skipping a set of GPU
tests.

- `ctest -R` is case-sensitive, so `-R "CUDA"` never matched the six
  `grids_cuda.*` tests in `traccc_test_cuda`. They were built but ran
  nowhere: the GitHub CUDA jobs all have `run_tests: false` or
  `TRACCC_BUILD_TESTING=FALSE`, and the CPU jobs do not build `tests/cuda`.
  Match case-insensitively via a new `TRACCC_TEST_REGEX`.

- Build only `traccc_test_cuda` instead of everything. This drops the 33
  translation units of `traccc_test_{cpu,core,io}`, which GitLab never runs
  and which the GitHub `CPU-Release` job covers with an unfiltered `ctest`.

- Restrict `TRACCC_SUPPORTED_DETECTORS` to the two detector types the CUDA
  tests actually instantiate. `device/cuda/CMakeLists.txt` generates 13 nvcc
  translation units per detector type, so dropping `odd_detector` removes 13
  of 39. Compile coverage of the full matrix stays in the GitHub
  `CUDA-Release` and `cuda-fp64` jobs.

- Exclude object files from the build artifact and give it an `expire_in`,
  as `build_gnn` already does.

- Drop `TRACCC_CMAKE_ARGS` from `traccc_test_cuda`. It was dead: the variable
  is only interpolated by `.traccc_build_template`, and the test template
  never runs cmake. Both values were moot anyway -- `VECMEM_BUILD_CUDA_LIBRARY`
  is already set by the `cuda-fp32` preset, and nothing in traccc uses the
  Acts plugins that `ACTS_ENABLE_CUDA` gates.

--- END COMMIT MESSAGE ---

### Notes for reviewers

**`build/_deps` is deliberately kept in the artifact.** vecmem arrives via
`FetchContent` (`Traccc/extern/vecmem/CMakeLists.txt:21`) and its shared
libraries live under `build/_deps/vecmem-build/`, so excluding it would break
the test job at load time. Only `*.o` is dropped.

**Building a single target interacts with `gtest_discover_tests`.** CMake emits
a failing `<target>_NOT_BUILT` placeholder for targets that were not built
(`GoogleTest.cmake:772`). I checked how these interact with the new filter:

| CTest name | `-R CUDA` | `-R [Cc][Uu][Dd][Aa]` |
| --- | --- | --- |
| `grids_cuda.grid2_replace_populator` | no | **yes** |
| `CUDABasic.DeviceCount` | yes | yes |
| `CUDAFastSvAlgorithm/ConnectedComponentAnalysisTests.Run/0` | yes | yes |
| `traccc_test_cpu_NOT_BUILT` | no | no |
| `traccc_test_cuda_NOT_BUILT` | yes | yes |

The last two rows are the ones that matter: the trimmed-away CPU/core/io
placeholders correctly do *not* match, so no spurious failures, while
`traccc_test_cuda_NOT_BUILT` *does* match — so if the CUDA binary ever fails
to appear, the job goes red instead of silently passing zero tests.

**The `;` in `TRACCC_SUPPORTED_DETECTORS` is safe unquoted.** `${TRACCC_CMAKE_ARGS}`
is expanded without quotes in the cmake line; I verified under `bash` that the
semicolon arrives as a single argv element and is not treated as a command
separator (parameter expansion does not re-parse metacharacters).

**The detector trim is the one judgement call here.** It intentionally
desyncs the GitLab build from GitHub's full 5-detector matrix. The rationale is
that GitLab only needs to *run* what its tests instantiate, and *compile*
coverage of the full matrix already lives in GitHub. If reviewers would rather
keep the two in lockstep, that lever is isolated to the single
`TRACCC_CMAKE_ARGS` line and can be dropped without affecting the rest.

Not verified by running the actual GitLab pipeline — the YAML, the shell
expansion, and the ctest filter behaviour were each checked locally in
isolation.
