### PR TITLE
ci: Save ccache from main only

### DIFF
--- a/.github/actions/cibuildwheel_wrapper/action.yml
+++ b/.github/actions/cibuildwheel_wrapper/action.yml
@@ -36,9 +36,10 @@ runs:
         CIBW_BUILD: ${{ inputs.cibw-build }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
+    # Saved from `main` only; see the note in .github/workflows/builds.yml.
     - name: Save ccache
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      if: always()
+      if: always() && github.ref == 'refs/heads/main'
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache-restore.outputs.cache-primary-key }}

--- a/.github/actions/cibuildwheel_wrapper/action.yml
+++ b/.github/actions/cibuildwheel_wrapper/action.yml
@@ -36,7 +36,7 @@ runs:
         CIBW_BUILD: ${{ inputs.cibw-build }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
-    # Saved from `main` only; see the note in .github/workflows/builds.yml.
+    # `main` only; see the note in .github/workflows/builds.yml.
     - name: Save ccache
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,13 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# ccache is saved from `main` only. A PR-written cache is scoped to that PR
-# alone, yet still counts against the shared 10 GB and evicts `main`'s entries,
-# which every branch can read. PRs restore, they don't publish.
+# ccache is saved from `main` only: a PR-written cache is readable by that PR
+# alone, but still evicts `main`'s entries from the shared 10 GB.
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
-  # Deliberately above the 500M the other workflows use.
   # Sized for the github-ci-coverage build, which carries no debug info and
   # skips Examples plus the vendored Detray/Traccc trees. Watch `ccache -s`:
   # if the cache runs at ~100% of this it is evicting mid-build and the hit
@@ -109,7 +107,7 @@ jobs:
       - name: ccache stats
         run: ccache -s
 
-      # Before the tests: their failure shouldn't cost us the compiled objects.
+      # Before the tests: a failure there shouldn't cost us the objects.
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: always() && github.ref == 'refs/heads/main'

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,9 +16,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# ccache is saved from `main` only. A PR-written cache is scoped to that PR
+# alone, yet still counts against the shared 10 GB and evicts `main`'s entries,
+# which every branch can read. PRs restore, they don't publish.
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CCACHE_DIR: ${{ github.workspace }}/ccache
+  # Deliberately above the 500M the other workflows use.
   # Sized for the github-ci-coverage build, which carries no debug info and
   # skips Examples plus the vendored Detray/Traccc trees. Watch `ccache -s`:
   # if the cache runs at ~100% of this it is evicting mid-build and the hit
@@ -86,8 +90,9 @@ jobs:
           name: PR_metadata
           path: PR_metadata.json
 
-      - name: Cache build
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-${{ runner.os  }}-${{ github.job }}-${{ env.CCACHE_KEY_SUFFIX }}-${{ github.sha }}
@@ -103,6 +108,15 @@ jobs:
         run: cmake --build build
       - name: ccache stats
         run: ccache -s
+
+      # Before the tests: their failure shouldn't cost us the compiled objects.
+      - name: Save ccache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: always() && github.ref == 'refs/heads/main'
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
       - name: Unit tests
         run: >
           CI/dependencies/run.sh .env

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# ccache is saved from `main` only. A PR-written cache is scoped to that PR
+# alone, yet still counts against the shared 10 GB and evicts `main`'s entries,
+# which every branch can read. PRs restore, they don't publish.
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -81,7 +84,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -333,7 +336,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -491,7 +494,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -554,7 +557,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -684,7 +687,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -770,7 +773,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
@@ -924,7 +927,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,9 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# ccache is saved from `main` only. A PR-written cache is scoped to that PR
-# alone, yet still counts against the shared 10 GB and evicts `main`'s entries,
-# which every branch can read. PRs restore, they don't publish.
+# ccache is saved from `main` only: a PR-written cache is readable by that PR
+# alone, but still evicts `main`'s entries from the shared 10 GB.
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -1045,7 +1044,7 @@ jobs:
 
       - name: Save ccache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        if: always()
+        if: always() && github.ref == 'refs/heads/main'
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache
+  CCACHE_MAXSIZE: 500M
   CCACHE_KEY_SUFFIX: r2
 
 permissions: {}


### PR DESCRIPTION
## What

Gate every ccache `save` step on `github.ref == 'refs/heads/main'`, and give
`pypi.yml` the ccache ceiling it was missing.

## Why

GitHub gives the repository **10 GB** of Actions cache and evicts LRU across the
whole repo. A cache written by a PR run is scoped to `refs/pull/N/merge`, so
*only that PR* can ever read it — but it still counts against the shared budget
and evicts entries everyone else could have used. Caches written from `main` are
readable by every branch.

Snapshot taken while writing this, via `/actions/cache/usage` and
`/actions/caches`:

| | entries | size |
|---|---|---|
| total (at a 10 GB limit) | 50 | **9.82 GB** |
| of which ccache | 37 | 9.37 GB |
| of which **PR-scoped** ccache | 31 | **8.09 GB** |
| `main`-scoped ccache | 6 | 1.28 GB |

`build_debug` alone was 1.283 GB of the PR-scoped total — the single largest
entry in the repository.

So ~82% of ccache storage was readable by exactly one PR each, while `main`'s
copies — the ones every branch falls back to — were the ones getting evicted.

Per job family:

```
job                        variant                 n   max GB   sum GB
external_key4hep-nightlies 2026-07                 3    0.462    1.387
build_debug                -                       1    1.283    1.283
gnn_cpu                    -                       4    0.223    0.894
lcg                        109_alma9_gcc15         3    0.321    0.874
lcg                        dev4_alma9_gcc15        3    0.269    0.806
linux_ubuntu_python_wheel  -                       4    0.198    0.791
linux_ubuntu               -                       2    0.383    0.766
lcg                        109_alma9_clang19       5    0.159    0.733
linux_ubuntu_extra         clang22-23              4    0.176    0.705
external_eic-shell         -                       3    0.231    0.693
lcg                        108_alma9_gcc15         1    0.268    0.268
gnn_tensorrt               -                       3    0.057    0.170
```

Two things that row listing invites misreading:

- The `lcg` rows are not fat caches. Per leg they are 0.16–0.32 GB, mid-pack and
  comfortably *under* the 500M ceiling; the 2.68 GB aggregate is the four-leg
  matrix.
- `external_key4hep-nightlies` shows a date as its variant because at snapshot
  time it still cached inside `run-lcg-view`, on a date-based key. #5799 has
  since replaced that with an ordinary restore/save on the standard sha key —
  which is what makes it gateable here.

## Trade-off

PRs restore a warm cache from `main` and never publish one. A second push to the
same PR no longer picks up the first push's objects — it falls back to `main`
again. That is deliberate, and it is the cost of the change: slightly colder
iterative PR builds in exchange for a `main` cache that stops being evicted.

## Also

`pypi.yml` set `CCACHE_DIR` but no `CCACHE_MAXSIZE`, so it ran on ccache's **5G**
default. Now 500M, matching `builds.yml`.

`build_debug` used the combined `actions/cache`, which offers no way to make the
save conditional, so it is split into `restore` + `save`. The save now runs
*before* the tests, so a test or coverage failure no longer costs us the objects
just compiled — the combined action only wrote at post-job.

Its ceiling stays at **1G** rather than dropping to the 500M used elsewhere: it
compiles the largest TU set in the repo, and #5804 sized that number
deliberately after removing debug info and Examples from the build.

`external_key4hep-nightlies` is gated too. It was going to be left out — its save
lived inside a third-party action with no `if:` to attach — but #5799 landed
first and made it an ordinary step. At 1.387 GB across three PR copies it is the
second-largest saving here.

## Checking

No linter here catches a `save` whose `cache-primary-key` points at a
non-existent step id, so I parsed the workflows and asserted it:

- every ccache `save` in scope carries `always() && github.ref == 'refs/heads/main'`
- every `save` key resolves to a `restore` step id **in the same job**
- no workflow sets `CCACHE_DIR` without a `CCACHE_MAXSIZE`

All 10 ccache saves in the repository are covered; none are left ungated.

The spack cache in `actions/dependencies` is untouched on purpose: it already
saves only on a miss, and PRs hit `main`'s copy. `checks.yml`'s pre-commit cache
is not ccache.

## Verifying after merge

The first `main` run repopulates; PR runs then restore from it. If `ccache -s`
in a PR shows a collapsed hit rate that a `main` run does not, the fallback
chain is not doing what this assumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvT39EuRag4QUU3u2J5sMp
