### PR TITLE
ci: resolve API-surface-label PR number by branch, not head sha

### DIFF
--- a/.github/workflows/api-surface-label.yml
+++ b/.github/workflows/api-surface-label.yml
@@ -16,9 +16,13 @@ name: API surface label
 # checked out fresh from the base branch, which is why it's safe to hold
 # `pull-requests: write` in this job.
 #
-# The PR/issue number to act on is resolved from `workflow_run.head_sha`,
-# which comes from the Actions platform itself, not from that artifact --
-# never substitute an artifact-supplied value for that.
+# The PR/issue number to act on is resolved via the API from
+# `workflow_run.head_repository`/`head_branch` (as report.yml already does
+# for physmon) -- those come from the Actions platform itself, not from that
+# artifact. Do NOT resolve it from `head_sha` instead: that commit is often
+# no longer any PR's tip by the time this asynchronous job runs (a
+# subsequent push moved it on), so a commit-keyed lookup routinely comes up
+# empty; branch name doesn't have that race.
 
 on:
   workflow_run: # zizmor: ignore[dangerous-triggers]
@@ -43,18 +47,21 @@ jobs:
       ADDED_LABEL: "Public API"
       BREAKING_LABEL: "API breaking"
     steps:
-      - name: Resolve PR number from the trusted head sha
+      - name: Resolve PR number
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
         run: |
-          number=$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
-          if [ -z "$number" ] || [ "$number" = "null" ]; then
-            echo "::error::No PR found for head_sha ${HEAD_SHA}"
-            exit 1
-          fi
-          echo "number=$number" >> "$GITHUB_OUTPUT"
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+            --json number --jq '"number=\(.number)"' \
+            >> "$GITHUB_OUTPUT"
 
       # Trusted base checkout: only public_api_diff.py is used from here,
       # always the base branch's own copy (workflow_run resolves the default


### PR DESCRIPTION
## Summary

Follow-up to #5813: the `api-surface-label` job fails to find a PR every
time (e.g. https://github.com/acts-project/acts/actions/runs/30635439244/job/91171745828):

```
##[error]No PR found for head_sha d99a9287bcee38e521f4f27461d7b40820d14b73
```

Looking up `repos/{owner}/{repo}/commits/{head_sha}/pulls` races against new
pushes: `workflow_run` fires asynchronously after `Checks` completes, and by
the time this job runs, that exact commit is often no longer any PR's tip
(a `synchronize` push moved it on), so the commit-keyed lookup routinely
comes up empty.

`report.yml` (physmon) already solves this the right way for the same
`workflow_run`-off-a-fork-PR situation: resolve the PR by
`head_repository.owner.login` + `head_branch` via `gh pr view` instead of by
commit SHA. Branch name doesn't have the same race. Switched
`api-surface-label.yml` to the same pattern.

## Test plan

- [x] `prek run --files .github/workflows/api-surface-label.yml` (zizmor + hooks) passes locally
- [x] Open/push a fork PR and confirm `API surface label` resolves the PR number and applies label(s) + sticky comment