### PR TITLE
fix(cmake): avoid actsvg C++ standard cache leak

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -53,6 +53,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           env_file: .env
 
+      - name: Check ActSVG reconfiguration
+        run: |
+          CI/dependencies/run.sh .env cmake -B build-actsvg-reconfigure -S . \
+            -GNinja \
+            -DACTS_BUILD_PLUGIN_ACTSVG=ON
+          CI/dependencies/run.sh .env cmake -B build-actsvg-reconfigure -S . \
+            -GNinja \
+            -DACTS_BUILD_PLUGIN_ACTSVG=ON
+
       - name: Restore ccache
         id: ccache-restore
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/thirdparty/actsvg/CMakeLists.txt
+++ b/thirdparty/actsvg/CMakeLists.txt
@@ -24,5 +24,16 @@ set(ACTSVG_BUILD_PYTHON_BINDINGS
 
 set(ACTSVG_BUILD_WEB ON CACHE BOOL "Build the web plugin of ACTSVG")
 
+# ActSVG caches CMAKE_CXX_STANDARD=17. On the next configure, ACTS rejects
+# that value. Remove the cache entry unless it was already set by the caller.
+set(_acts_cxx_standard_was_cached FALSE)
+if(DEFINED CACHE{CMAKE_CXX_STANDARD})
+    set(_acts_cxx_standard_was_cached TRUE)
+endif()
+
 # Now set up its build.
 FetchContent_MakeAvailable(actsvg)
+
+if(NOT _acts_cxx_standard_was_cached)
+    unset(CMAKE_CXX_STANDARD CACHE)
+endif()


### PR DESCRIPTION
ActSVG caches `CMAKE_CXX_STANDARD=17`, which causes a second configure
in the same build directory to fail. Remove the cache entry after loading
ActSVG if it was not present before, leaving an existing value unchanged.

Add a CI check that configures ACTS with ActSVG twice.

Closes #4952

Tested repeated configuration with the default standard and with C++23,
and ran the ActSVG converter tests.