### PR TITLE
build: Simplify Traccc Setup, main branch (2026.08.04.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,30 +658,41 @@ if(ACTS_SETUP_DETRAY)
 endif()
 
 if(ACTS_BUILD_TRACCC)
-    # HACK: Temporary logic (aka technical debt) to make the traccc
-    # component work. Remove this ASAP.
-    option(TRACCC_USE_ROOT "" FALSE)
-    option(TRACCC_SETUP_ACTS "" FALSE)
-    option(TRACCC_SETUP_VECMEM "" FALSE)
-    option(TRACCC_SETUP_EIGEN3 "" FALSE)
-    option(TRACCC_SETUP_THRUST "" TRUE)
-    option(TRACCC_SETUP_COVFIE "" FALSE)
-    option(TRACCC_SETUP_DETRAY "" FALSE)
-    option(TRACCC_BUILD_CUDA "" ${ACTS_ENABLE_CUDA})
-    option(TRACCC_SETUP_TBB "" FALSE)
-    option(TRACCC_BUILD_IO "" TRUE)
-    option(TRACCC_BUILD_PERFORMANCE "" FALSE)
-    option(TRACCC_BUILD_SIMULATION "" FALSE)
-    option(TRACCC_BUILD_TESTING "" FALSE)
-    option(TRACCC_BUILD_EXAMPLES "" FALSE)
-    option(TRACCC_BUILD_BENCHMARKS "" FALSE)
-
-    find_package(TBB ${_acts_tbb_version} CONFIG)
-    if(NOT TBB_FOUND)
-        set(TRACCC_SETUP_TBB TRUE CACHE BOOL "")
-    else()
-        set(TRACCC_SETUP_TBB FALSE CACHE BOOL "")
-    endif()
+    # Provide a default build configuration for traccc. One which only builds
+    # the main traccc libraries. Without any of the tests, benchmarks or
+    # examples.
+    option(
+        TRACCC_USE_ROOT
+        "Use ROOT if Acts uses ROOT"
+        ${ACTS_BUILD_PLUGIN_ROOT}
+    )
+    option(TRACCC_SETUP_ACTS "Don't let traccc set up Acts" FALSE)
+    option(TRACCC_SETUP_VECMEM "Don't let traccc set up VecMem" FALSE)
+    option(TRACCC_SETUP_EIGEN3 "Don't let traccc set up Eigen" FALSE)
+    option(TRACCC_SETUP_COVFIE "Don't let traccc set up Covfie" FALSE)
+    option(TRACCC_SETUP_TBB "Don't make traccc set up TBB by default" FALSE)
+    option(TRACCC_BUILD_CUDA "Use CUDA if Acts uses CUDA" ${ACTS_ENABLE_CUDA})
+    option(
+        TRACCC_BUILD_PERFORMANCE
+        "Don't build traccc::performance by default"
+        FALSE
+    )
+    option(
+        TRACCC_BUILD_SIMULATION
+        "Don't build traccc::simulation by default"
+        FALSE
+    )
+    option(
+        TRACCC_BUILD_TESTING
+        "Don't build traccc unit tests by default"
+        FALSE
+    )
+    option(TRACCC_BUILD_EXAMPLES "Don't build traccc examples by default" FALSE)
+    option(
+        TRACCC_BUILD_BENCHMARKS
+        "Don't build traccc benchmarks by default"
+        FALSE
+    )
 
     add_subdirectory(Traccc)
 endif()


### PR DESCRIPTION
While working on re-establishing my development environment, now as part of a "full Acts build", I removed some unnecessary lines from the traccc setup. (Ones that didn't override anything.)

At the same time I made the setup of TRACCC_USE_ROOT just slightly more elaborate. And provided a bit of documentation for why the various cache variables are set up by default as they are.

--- END COMMIT MESSAGE ---

As a scary detail, I ended up with the following CMake preset for now on my desktop. (Which only has an NVIDIA GPU, but has both CUDA and HIP available.)

```json
{
   "version": 4,
   "configurePresets": [
      {
         "name": "gpu-devel",
         "displayName": "atspot01 GPU Development",
         "warnings": {
            "deprecated": true
         },
         "binaryDir": "build",
         "cacheVariables": {
            "CMAKE_CXX_STANDARD": "20",
            "CMAKE_CUDA_STANDARD": "20",
            "CMAKE_CUDA_ARCHITECTURES": "native",
            "CMAKE_HIP_STANDARD": "20",
            "CMAKE_HIP_ARCHITECTURES": "native",
            "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
            "BUILD_TESTING": "ON",
            "ACTS_ENABLE_LOG_FAILURE_THRESHOLD": "OFF",
            "ACTS_BUILD_FATRAS": "ON",
            "ACTS_BUILD_UNITTESTS": "ON",
            "ACTS_BUILD_INTEGRATIONTESTS": "ON",
            "ACTS_BUILD_PYTHON_BINDINGS": "ON",
            "ACTS_GENERATE_PYTHON_STUBS": "ON",
            "ACTS_BUILD_PLUGIN_TRACCC": "ON",
            "ACTS_ENABLE_CUDA": "ON",
            "ACTS_USE_SYSTEM_EIGEN3": "OFF",
            "VECMEM_BUILD_CUDA_LIBRARY": "ON",
            "VECMEM_BUILD_HIP_LIBRARY": "ON",
            "DETRAY_BUILD_CUDA": "ON",
            "DETRAY_BUILD_BENCHMARKS": "ON",
            "DETRAY_BUILD_VALIDATION_TOOLS": "ON",
            "DETRAY_SET_LOGGING": "NONE",
            "TRACCC_SETUP_TBB": "ON",
            "TRACCC_SETUP_ROCTHRUST": "OM",
            "TRACCC_BUILD_CUDA_UTILS": "ON",
            "TRACCC_BUILD_CUDA": "ON",
            "TRACCC_BUILD_HIP": "ON",
            "TRACCC_BUILD_ALPAKA": "ON",
            "alpaka_ACC_GPU_CUDA_ENABLE": "ON",
            "TRACCC_SUPPORTED_DETECTORS": "default_detector;itk_detector",
            "TRACCC_BUILD_PERFORMANCE": "ON",
            "TRACCC_BUILD_SIMULATION": "ON",
            "TRACCC_BUILD_TESTING": "ON",
            "TRACCC_BUILD_EXAMPLES": "ON",
            "TRACCC_BUILD_BENCHMARKS": "ON"
         }
      }
   ]
}
```
