### PR TITLE
feat: GitHub SYCL Syntax Highlighting, main branch (2026.08.06.)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 *.ipp gitlab-language=c++
 * text=auto eol=lf
+
+# Consider .sycl files as C++.
+*.sycl linguist-language=C++


### PR DESCRIPTION
This is to make the `.sycl` files a bit more readable when looking at them in a browser on GitHub.

--- END COMMIT MESSAGE ---

Interestingly enough GitHub by now knows out of the box what to do with `.hip` files. 🤔 But `.sycl` still remains as a non-standard extension that maybe just we are using.

I was also thinking of adding such rules for VSCode, before being reminded that `.vscode` is on the no-no list for this repository...