### PR TITLE
build: Ignore Acts Warning Flags on Traccc Externals, main branch (2026.08.06.)

### DIFF
--- a/Traccc/extern/alpaka/CMakeLists.txt
+++ b/Traccc/extern/alpaka/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building Alpaka as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get Alpaka from.
 set(TRACCC_ALPAKA_SOURCE
     "URL;https://github.com/alpaka-group/alpaka/archive/refs/tags/2.1.1.tar.gz;URL_MD5;cbfb610731e2d24eb18d7b588d6a35a6"

--- a/Traccc/extern/alpaka/CMakeLists.txt
+++ b/Traccc/extern/alpaka/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building Alpaka as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get Alpaka from.
 set(TRACCC_ALPAKA_SOURCE
     "URL;https://github.com/alpaka-group/alpaka/archive/refs/tags/2.0.0.tar.gz;URL_MD5;7ed1ad266408cdb51f0f12f9e6712cc9"

--- a/Traccc/extern/cccl/CMakeLists.txt
+++ b/Traccc/extern/cccl/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building CCCL as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get Thrust from.
 set(TRACCC_CCCL_SOURCE
     "URL;https://github.com/NVIDIA/cccl/archive/refs/tags/v2.7.0.tar.gz;URL_MD5;83e431ebcb0a5c055fbd927754bec951"

--- a/Traccc/extern/covfie/CMakeLists.txt
+++ b/Traccc/extern/covfie/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Fetching covfie as part of the traccc project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get covfie from.
 set(TRACCC_COVFIE_SOURCE
     "URL;https://github.com/acts-project/covfie/archive/refs/tags/v0.15.4.tar.gz;URL_MD5;80de9b43644c59d8239fb8cc184c6276"

--- a/Traccc/extern/dfelibs/CMakeLists.txt
+++ b/Traccc/extern/dfelibs/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building dfelibs as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get dfelibs from.
 set(TRACCC_DFELIBS_SOURCE
     "URL;https://github.com/acts-project/dfelibs/archive/refs/tags/v20211029.tar.gz;URL_MD5;87fb09c5a11b98250f5e266e9cd501ea"

--- a/Traccc/extern/dpl/CMakeLists.txt
+++ b/Traccc/extern/dpl/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building oneDPL as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get DPL from.
 set(TRACCC_DPL_SOURCE
     "URL;https://github.com/uxlfoundation/oneDPL/archive/refs/tags/oneDPL-2022.11.0-release.tar.gz;URL_MD5;d42f971a7fb53574e511e207b22151cd;PATCH_COMMAND;patch;-p1;-i;${CMAKE_CURRENT_SOURCE_DIR}/oneDPL-2022.11.0.patch"

--- a/Traccc/extern/googletest/CMakeLists.txt
+++ b/Traccc/extern/googletest/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building GoogleTest as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get GoogleTest from.
 set(TRACCC_GOOGLETEST_SOURCE
     "URL;https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz;URL_MD5;7e11f6cfcf6498324ac82d567dcb891e"

--- a/Traccc/extern/rocThrust/CMakeLists.txt
+++ b/Traccc/extern/rocThrust/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building rocThrust as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get rocThrust from.
 set(TRACCC_ROCTHRUST_SOURCE
     "URL;https://github.com/ROCm/rocThrust/archive/refs/tags/rocm-7.2.0.tar.gz;URL_MD5;b42d1a13a2a517cde49f0b2974c8013b"

--- a/Traccc/extern/rocThrust/CMakeLists.txt
+++ b/Traccc/extern/rocThrust/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building rocThrust as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get rocThrust from.
 set(TRACCC_ROCTHRUST_SOURCE
     "URL;https://github.com/ROCm/rocThrust/archive/refs/tags/rocm-6.1.1.tar.gz;URL_MD5;038abf313688c00555fe1efc51e1307b"

--- a/Traccc/extern/tbb/CMakeLists.txt
+++ b/Traccc/extern/tbb/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building TBB as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get TBB from.
 set(TRACCC_TBB_SOURCE
     "URL;https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2022.0.0.tar.gz;URL_MD5;78ec44cecf3cd78c4984e61f1bb93134"

--- a/Traccc/extern/vecmem/CMakeLists.txt
+++ b/Traccc/extern/vecmem/CMakeLists.txt
@@ -11,6 +11,9 @@ include(FetchContent)
 # Tell the user what's happening.
 message(STATUS "Building VecMem as part of the TRACCC project")
 
+# Disregard the global C++ flags, to avoid any unhelpful warnings.
+set(CMAKE_CXX_FLAGS)
+
 # Declare where to get VecMem from.
 set(TRACCC_VECMEM_SOURCE
     "URL;https://github.com/acts-project/vecmem/archive/refs/tags/v1.25.0.tar.gz;URL_MD5;31c1c2db4273b47f021798ea9de31733"


### PR DESCRIPTION
This hides the numerous warning flags set by Acts, from the externals (optionally) built by traccc.

--- END COMMIT MESSAGE ---

To avoid the different GPU R&D projects infecting each other with their individual flags, in those projects we/I spent some effort to make sure that any project specific (warning) flags would only be applied to the build of that project's source files.

Most importantly, we didn't want to impose our own warning flags on how we would build the many externals that we would use.

In the Acts project at the moment [ActsCompilerOptions.cmake](cmake/ActsCompilerOptions.cmake) gets included super early. So that it would be active for all of the third party libraries, and generally everything that is getting built. I'm a bit surprised that none of those externals were generating any warnings so far. :thinking:

In my current build setup I ask traccc to build TBB for me, instead of taking it from the system. And the TBB sources generate a **lot** of warnings with Acts's flags...

```
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/governor.h:22,
[build]                  from /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/address_waiter.cpp:18:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/misc.h: In member function ‘short unsigned int tbb::detail::r1::FastRandom::get(unsigned int&)’:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/misc.h:147:53: warning: use of old-style cast to ‘short unsigned int’ [-Wold-style-cast]
[build]   147 |         unsigned short r = (unsigned short)(seed>>16);
[build]       |                                                     ^
[build]       |                            -
[build]       |                            static_cast<   -
[build]       |                                           > (        )
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/governor.h:23:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/tls.h: In member function ‘void tbb::detail::r1::basic_tls<T>::set(T)’:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/tls.h:44:62: warning: use of old-style cast to ‘void*’ [-Wold-style-cast]
[build]    44 |     void set( T value ) { pthread_setspecific(my_key, (void*)value); }
[build]       |                                                              ^~~~~
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/tls.h: In member function ‘T tbb::detail::r1::basic_tls<T>::get()’:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/tls.h:45:63: warning: use of old-style cast to ‘T’ [-Wold-style-cast]
[build]    45 |     T    get()          { return (T)pthread_getspecific(my_key); }
[build]       |                                                               ^
[build] In file included from /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/address_waiter.cpp:19:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/concurrent_monitor.h: In constructor ‘tbb::detail::r1::circular_doubly_linked_list_with_sentinel::base_node::base_node()’:
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/concurrent_monitor.h:41:60: warning: use of old-style cast to ‘uintptr_t’ {aka ‘long unsigned int’} [-Wold-style-cast]
[build]    41 |         explicit base_node() : next((base_node*)(uintptr_t)0xcdcdcdcd), prev((base_node*)(uintptr_t)0xcdcdcdcd) {}
[build]       |                                                            ^~~~~~~~~~
[build]       |                                                 ---------------------
[build]       |                                                 static_cast<uintptr_t> (0xcdcdcdcd)
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/concurrent_monitor.h:41:60: warning: use of old-style cast to ‘struct tbb::detail::r1::circular_doubly_linked_list_with_sentinel::base_node*’ [-Wold-style-cast]
[build]    41 |         explicit base_node() : next((base_node*)(uintptr_t)0xcdcdcdcd), prev((base_node*)(uintptr_t)0xcdcdcdcd) {}
[build]       |                                                            ^~~~~~~~~~
[build]       |                                     ------------
[build]       |                                     reinterpret_cast<base_node*> (   )
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/concurrent_monitor.h:41:101: warning: use of old-style cast to ‘uintptr_t’ {aka ‘long unsigned int’} [-Wold-style-cast]
[build]    41 |         explicit base_node() : next((base_node*)(uintptr_t)0xcdcdcdcd), prev((base_node*)(uintptr_t)0xcdcdcdcd) {}
[build]       |                                                                                                     ^~~~~~~~~~
[build]       |                                                                                          ---------------------
[build]       |                                                                                          static_cast<uintptr_t> (0xcdcdcdcd)
[build] /home/krasznaa/ATLAS/projects/acts/acts/build/_deps/tbb-src/src/tbb/concurrent_monitor.h:41:101: warning: use of old-style cast to ‘struct tbb::detail::r1::circular_doubly_linked_list_with_sentinel::base_node*’ [-Wold-style-cast]
[build]    41 |         explicit base_node() : next((base_node*)(uintptr_t)0xcdcdcdcd), prev((base_node*)(uintptr_t)0xcdcdcdcd) {}
[build]       |                                                                                                     ^~~~~~~~~~
[build]       |                                                                              ------------
[build]       |                                                                              reinterpret_cast<base_node*> (   )
```

But since for the traccc sources themselves I do want to have the Acts flags be active, for now I didn't want to embark on doing any larger changes in Acts itself. I rather just chose to hide all of those flags from the externals explicitly.