### PR TITLE
feat: Add TrackExtrapolationAlgorithm

### DIFF
--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -187,10 +187,10 @@ findTrackStateForExtrapolation(
                                              Logging::INFO)) {
   using TrackStateProxy = typename track_proxy_t::ConstTrackStateProxy;
 
-  /// Intersect the reference surface with the trajectory at a track state.
-  /// Returns `std::nullopt` if the state carries no parameters at all and can
-  /// therefore not be started from; an invalid intersection means the state has
-  /// parameters but does not reach the reference surface.
+  // Intersect the reference surface with the trajectory at a track state.
+  // Returns `std::nullopt` if the state carries no parameters at all and can
+  // therefore not be started from; an invalid intersection means the state has
+  // parameters but does not reach the reference surface.
   auto intersect =
       [&](const TrackStateProxy &state) -> std::optional<Intersection3D> {
     if (!state.hasSmoothed() && !state.hasFiltered() && !state.hasPredicted()) {

--- a/Core/include/Acts/Utilities/TrackHelpers.hpp
+++ b/Core/include/Acts/Utilities/TrackHelpers.hpp
@@ -14,11 +14,11 @@
 #include "Acts/EventData/AnyTrackStateProxy.hpp"
 #include "Acts/EventData/BoundTrackParameters.hpp"
 #include "Acts/EventData/MeasurementHelpers.hpp"
-#include "Acts/EventData/MultiTrajectoryHelpers.hpp"
 #include "Acts/EventData/TrackContainerFrontendConcept.hpp"
 #include "Acts/EventData/TrackProxyConcept.hpp"
 #include "Acts/EventData/TrackStateProxyConcept.hpp"
 #include "Acts/EventData/TrackStateType.hpp"
+#include "Acts/EventData/TransformationHelpers.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Propagator/StandardAborters.hpp"
 #include "Acts/Surfaces/BoundaryTolerance.hpp"
@@ -27,6 +27,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "Acts/Utilities/Result.hpp"
 
+#include <optional>
 #include <utility>
 
 namespace Acts {
@@ -186,15 +187,21 @@ findTrackStateForExtrapolation(
                                              Logging::INFO)) {
   using TrackStateProxy = typename track_proxy_t::ConstTrackStateProxy;
 
-  auto intersect = [&](const TrackStateProxy &state) -> Intersection3D {
-    assert(state.hasSmoothed() || state.hasFiltered());
-
-    FreeVector freeVector;
-    if (state.hasSmoothed()) {
-      freeVector = MultiTrajectoryHelpers::freeSmoothed(geoContext, state);
-    } else {
-      freeVector = MultiTrajectoryHelpers::freeFiltered(geoContext, state);
+  /// Intersect the reference surface with the trajectory at a track state.
+  /// Returns `std::nullopt` if the state carries no parameters at all and can
+  /// therefore not be started from; an invalid intersection means the state has
+  /// parameters but does not reach the reference surface.
+  auto intersect =
+      [&](const TrackStateProxy &state) -> std::optional<Intersection3D> {
+    if (!state.hasSmoothed() && !state.hasFiltered() && !state.hasPredicted()) {
+      return std::nullopt;
     }
+
+    // `parameters` picks smoothed over filtered over predicted, which is what
+    // `TrackProxy::createParametersFromState` starts the propagation from. The
+    // distance has to be measured on the same parameters.
+    const FreeVector freeVector = transformBoundToFreeParameters(
+        state.referenceSurface(), geoContext, state.parameters());
 
     return referenceSurface
         .intersect(geoContext, freeVector.template segment<3>(eFreePos0),
@@ -213,15 +220,20 @@ findTrackStateForExtrapolation(
         return first.error();
       }
 
-      Intersection3D intersection = intersect(*first);
-      if (!intersection.isValid()) {
+      std::optional<Intersection3D> intersection = intersect(*first);
+      if (!intersection.has_value()) {
+        ACTS_DEBUG("first track state carries no parameters");
+        return Result<std::pair<TrackStateProxy, double>>::failure(
+            TrackExtrapolationError::CompatibleTrackStateNotFound);
+      }
+      if (!intersection->isValid()) {
         ACTS_DEBUG("no intersection found");
         return Result<std::pair<TrackStateProxy, double>>::failure(
             TrackExtrapolationError::ReferenceSurfaceUnreachable);
       }
 
-      ACTS_VERBOSE("found intersection at " << intersection.pathLength());
-      return std::pair(*first, intersection.pathLength());
+      ACTS_VERBOSE("found intersection at " << intersection->pathLength());
+      return std::pair(*first, intersection->pathLength());
     }
 
     case TrackExtrapolationStrategy::last: {
@@ -233,15 +245,20 @@ findTrackStateForExtrapolation(
         return last.error();
       }
 
-      Intersection3D intersection = intersect(*last);
-      if (!intersection.isValid()) {
+      std::optional<Intersection3D> intersection = intersect(*last);
+      if (!intersection.has_value()) {
+        ACTS_DEBUG("last track state carries no parameters");
+        return Result<std::pair<TrackStateProxy, double>>::failure(
+            TrackExtrapolationError::CompatibleTrackStateNotFound);
+      }
+      if (!intersection->isValid()) {
         ACTS_DEBUG("no intersection found");
         return Result<std::pair<TrackStateProxy, double>>::failure(
             TrackExtrapolationError::ReferenceSurfaceUnreachable);
       }
 
-      ACTS_VERBOSE("found intersection at " << intersection.pathLength());
-      return std::pair(*last, intersection.pathLength());
+      ACTS_VERBOSE("found intersection at " << intersection->pathLength());
+      return std::pair(*last, intersection->pathLength());
     }
 
     case TrackExtrapolationStrategy::firstOrLast: {
@@ -259,8 +276,23 @@ findTrackStateForExtrapolation(
         return last.error();
       }
 
-      Intersection3D intersectionFirst = intersect(*first);
-      Intersection3D intersectionLast = intersect(*last);
+      std::optional<Intersection3D> intersectionFirstOpt = intersect(*first);
+      std::optional<Intersection3D> intersectionLastOpt = intersect(*last);
+
+      if (!intersectionFirstOpt.has_value() &&
+          !intersectionLastOpt.has_value()) {
+        ACTS_DEBUG("neither first nor last track state carries parameters");
+        return Result<std::pair<TrackStateProxy, double>>::failure(
+            TrackExtrapolationError::CompatibleTrackStateNotFound);
+      }
+
+      // an end without parameters cannot be started from, so it loses the
+      // comparison below through the infinite path length of an invalid
+      // intersection
+      Intersection3D intersectionFirst =
+          intersectionFirstOpt.value_or(Intersection3D::Invalid());
+      Intersection3D intersectionLast =
+          intersectionLastOpt.value_or(Intersection3D::Invalid());
 
       double absDistanceFirst = std::abs(intersectionFirst.pathLength());
       double absDistanceLast = std::abs(intersectionLast.pathLength());

--- a/Examples/Algorithms/Utilities/CMakeLists.txt
+++ b/Examples/Algorithms/Utilities/CMakeLists.txt
@@ -5,6 +5,7 @@ acts_add_library(
     src/SeedsToTracks.cpp
     src/TrajectoriesToProtoTracks.cpp
     src/TrackSelectorAlgorithm.cpp
+    src/TrackExtrapolationAlgorithm.cpp
     src/TracksToTrajectories.cpp
     src/ProtoTracksToTracks.cpp
     src/TracksToParameters.cpp

--- a/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp
+++ b/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp
@@ -37,9 +37,7 @@ namespace ActsExamples {
 /// same layering a fitter produces.
 ///
 /// Tracks whose extrapolation fails are dropped, so the output indices differ
-/// from the input and any truth matching has to be redone downstream. A track
-/// that carries no parameters on the state the strategy starts from - every
-/// state of a seed track except the innermost - is dropped as well.
+/// from the input and any truth matching has to be redone downstream.
 class TrackExtrapolationAlgorithm final : public IAlgorithm {
  public:
   struct Config {

--- a/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp
+++ b/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp
@@ -1,0 +1,100 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+#include "Acts/Utilities/TrackHelpers.hpp"
+#include "ActsExamples/EventData/Track.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
+#include "ActsExamples/Framework/IAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace Acts {
+class MagneticFieldProvider;
+class Surface;
+class TrackingGeometry;
+}  // namespace Acts
+
+namespace ActsExamples {
+
+/// Move the track parameters of a track container onto a common surface,
+/// typically a perigee.
+///
+/// Only the track-level parameters are moved; the states are shared with the
+/// input container and keep the parameters on their own surfaces. That is the
+/// same layering a fitter produces.
+///
+/// Tracks whose extrapolation fails are dropped, so the output indices differ
+/// from the input and any truth matching has to be redone downstream. A track
+/// that carries no parameters on the state the strategy starts from - every
+/// state of a seed track except the innermost - is dropped as well.
+class TrackExtrapolationAlgorithm final : public IAlgorithm {
+ public:
+  struct Config {
+    /// Input track collection.
+    std::string inputTracks;
+    /// Output track collection.
+    std::string outputTracks;
+
+    /// Surface to move the track parameters to.
+    std::shared_ptr<const Acts::Surface> targetSurface;
+    /// Tracking geometry to navigate.
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
+    /// Magnetic field to propagate in.
+    std::shared_ptr<const Acts::MagneticFieldProvider> magneticField;
+
+    /// Which track state to start the extrapolation from.
+    Acts::TrackExtrapolationStrategy strategy =
+        Acts::TrackExtrapolationStrategy::firstOrLast;
+
+    /// The volume ids to constrain the extrapolation to.
+    std::vector<std::uint32_t> constrainToVolumeIds;
+    /// The volume ids to stop the extrapolation at.
+    std::vector<std::uint32_t> endOfWorldVolumeIds;
+  };
+
+  /// Construct the algorithm.
+  ///
+  /// @param config the configuration
+  /// @param logger the logger
+  explicit TrackExtrapolationAlgorithm(
+      Config config, std::unique_ptr<const Acts::Logger> logger = nullptr);
+
+  /// Extrapolate the tracks of one event.
+  ///
+  /// @param ctx the algorithm context
+  /// @return a process code
+  ProcessCode execute(const AlgorithmContext& ctx) const override;
+
+  /// Report how many tracks were dropped over the whole run.
+  ///
+  /// @return a process code
+  ProcessCode finalize() override;
+
+  /// Get readonly access to the config parameters
+  /// @return the configuration
+  const Config& config() const { return m_cfg; }
+
+ private:
+  Config m_cfg;
+
+  mutable std::atomic<std::size_t> m_nTotalTracks{0};
+  mutable std::atomic<std::size_t> m_nFailedTracks{0};
+
+  ReadDataHandle<ConstTrackContainer> m_inputTracks{this, "InputTracks"};
+  WriteDataHandle<ConstTrackContainer> m_outputTracks{this, "OutputTracks"};
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Utilities/src/TrackExtrapolationAlgorithm.cpp
+++ b/Examples/Algorithms/Utilities/src/TrackExtrapolationAlgorithm.cpp
@@ -30,37 +30,6 @@
 
 namespace ActsExamples {
 
-namespace {
-
-/// Check that the states the strategy starts from carry parameters at all.
-/// `Acts::findTrackStateForExtrapolation` only asserts on that, so a release
-/// build would extrapolate from an uninitialised state instead.
-bool hasParametersForStrategy(const ConstTrackProxy& track,
-                              Acts::TrackExtrapolationStrategy strategy) {
-  auto carriesParameters = [](const ConstTrackStateProxy& state) {
-    return state.hasSmoothed() || state.hasFiltered();
-  };
-
-  if (strategy != Acts::TrackExtrapolationStrategy::last) {
-    auto first = Acts::findFirstMeasurementState(track);
-    if (first.ok() && !carriesParameters(*first)) {
-      return false;
-    }
-  }
-  if (strategy != Acts::TrackExtrapolationStrategy::first) {
-    auto last = Acts::findLastMeasurementState(track);
-    if (last.ok() && !carriesParameters(*last)) {
-      return false;
-    }
-  }
-
-  // A track without measurement states is left to
-  // `Acts::findTrackStateForExtrapolation` to reject
-  return true;
-}
-
-}  // namespace
-
 TrackExtrapolationAlgorithm::TrackExtrapolationAlgorithm(
     Config config, std::unique_ptr<const Acts::Logger> logger)
     : IAlgorithm("TrackExtrapolationAlgorithm", std::move(logger)),
@@ -107,12 +76,6 @@ ProcessCode TrackExtrapolationAlgorithm::execute(
   // off the input track and only the parameters are written to the output one
   auto extrapolate = [&](const ConstTrackProxy& track)
       -> Acts::Result<Acts::BoundTrackParameters> {
-    if (!hasParametersForStrategy(track, m_cfg.strategy)) {
-      ACTS_DEBUG("Track " << track.index() << " has no parameters on the state "
-                          << "the strategy starts from");
-      return Acts::TrackExtrapolationError::CompatibleTrackStateNotFound;
-    }
-
     auto findResult = Acts::findTrackStateForExtrapolation(
         ctx.geoContext, track, *m_cfg.targetSurface, m_cfg.strategy, logger());
     if (!findResult.ok()) {

--- a/Examples/Algorithms/Utilities/src/TrackExtrapolationAlgorithm.cpp
+++ b/Examples/Algorithms/Utilities/src/TrackExtrapolationAlgorithm.cpp
@@ -1,0 +1,197 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp"
+
+#include "Acts/Definitions/Direction.hpp"
+#include "Acts/EventData/BoundTrackParameters.hpp"
+#include "Acts/EventData/TrackContainer.hpp"
+#include "Acts/EventData/VectorMultiTrajectory.hpp"
+#include "Acts/EventData/VectorTrackContainer.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "Acts/MagneticField/MagneticFieldProvider.hpp"
+#include "Acts/Propagator/ActorList.hpp"
+#include "Acts/Propagator/MaterialInteractor.hpp"
+#include "Acts/Propagator/Navigator.hpp"
+#include "Acts/Propagator/Propagator.hpp"
+#include "Acts/Propagator/StandardAborters.hpp"
+#include "Acts/Propagator/SympyStepper.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Result.hpp"
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+namespace ActsExamples {
+
+namespace {
+
+/// Check that the states the strategy starts from carry parameters at all.
+/// `Acts::findTrackStateForExtrapolation` only asserts on that, so a release
+/// build would extrapolate from an uninitialised state instead.
+bool hasParametersForStrategy(const ConstTrackProxy& track,
+                              Acts::TrackExtrapolationStrategy strategy) {
+  auto carriesParameters = [](const ConstTrackStateProxy& state) {
+    return state.hasSmoothed() || state.hasFiltered();
+  };
+
+  if (strategy != Acts::TrackExtrapolationStrategy::last) {
+    auto first = Acts::findFirstMeasurementState(track);
+    if (first.ok() && !carriesParameters(*first)) {
+      return false;
+    }
+  }
+  if (strategy != Acts::TrackExtrapolationStrategy::first) {
+    auto last = Acts::findLastMeasurementState(track);
+    if (last.ok() && !carriesParameters(*last)) {
+      return false;
+    }
+  }
+
+  // A track without measurement states is left to
+  // `Acts::findTrackStateForExtrapolation` to reject
+  return true;
+}
+
+}  // namespace
+
+TrackExtrapolationAlgorithm::TrackExtrapolationAlgorithm(
+    Config config, std::unique_ptr<const Acts::Logger> logger)
+    : IAlgorithm("TrackExtrapolationAlgorithm", std::move(logger)),
+      m_cfg(std::move(config)) {
+  if (m_cfg.inputTracks.empty()) {
+    throw std::invalid_argument("Missing input track collection");
+  }
+  if (m_cfg.outputTracks.empty()) {
+    throw std::invalid_argument("Missing output track collection");
+  }
+  if (m_cfg.targetSurface == nullptr) {
+    throw std::invalid_argument("Missing target surface");
+  }
+  if (m_cfg.trackingGeometry == nullptr) {
+    throw std::invalid_argument("Missing tracking geometry");
+  }
+  if (m_cfg.magneticField == nullptr) {
+    throw std::invalid_argument("Missing magnetic field");
+  }
+
+  m_inputTracks.initialize(m_cfg.inputTracks);
+  m_outputTracks.initialize(m_cfg.outputTracks);
+}
+
+ProcessCode TrackExtrapolationAlgorithm::execute(
+    const AlgorithmContext& ctx) const {
+  const ConstTrackContainer& inputTracks = m_inputTracks(ctx);
+
+  using Propagator = Acts::Propagator<Acts::SympyStepper, Acts::Navigator>;
+  using Options = Propagator::Options<
+      Acts::ActorList<Acts::MaterialInteractor, Acts::EndOfWorldReached>>;
+
+  const Propagator propagator(
+      Acts::SympyStepper(m_cfg.magneticField),
+      Acts::Navigator({m_cfg.trackingGeometry},
+                      logger().cloneWithSuffix("Navigator")),
+      logger().cloneWithSuffix("Propagator"));
+
+  Options options(ctx.geoContext, ctx.magFieldContext);
+  options.constrainToVolumeIds = m_cfg.constrainToVolumeIds;
+  options.endOfWorldVolumeIds = m_cfg.endOfWorldVolumeIds;
+
+  // `Acts::extrapolateTrackToReferenceSurface` split up, so the states are read
+  // off the input track and only the parameters are written to the output one
+  auto extrapolate = [&](const ConstTrackProxy& track)
+      -> Acts::Result<Acts::BoundTrackParameters> {
+    if (!hasParametersForStrategy(track, m_cfg.strategy)) {
+      ACTS_DEBUG("Track " << track.index() << " has no parameters on the state "
+                          << "the strategy starts from");
+      return Acts::TrackExtrapolationError::CompatibleTrackStateNotFound;
+    }
+
+    auto findResult = Acts::findTrackStateForExtrapolation(
+        ctx.geoContext, track, *m_cfg.targetSurface, m_cfg.strategy, logger());
+    if (!findResult.ok()) {
+      return findResult.error();
+    }
+    const auto& [trackState, distance] = *findResult;
+
+    Options trackOptions = options;
+    trackOptions.direction =
+        Acts::Direction::fromScalarZeroAsPositive(distance);
+
+    auto propagateResult =
+        propagator.propagate<Options, Acts::ForcedSurfaceReached>(
+            track.createParametersFromState(trackState), *m_cfg.targetSurface,
+            trackOptions);
+    if (!propagateResult.ok()) {
+      return propagateResult.error();
+    }
+
+    return propagateResult->endParameters.value();
+  };
+
+  // The tip and stem indices point into the input state backend, which the
+  // output container takes over below. The empty backend here is only because
+  // `Acts::TrackContainer` cannot pair a mutable track backend with a
+  // read-only state one.
+  auto trackBackend = std::make_shared<Acts::VectorTrackContainer>();
+  TrackContainer extrapolated{trackBackend,
+                              std::make_shared<Acts::VectorMultiTrajectory>()};
+  extrapolated.ensureDynamicColumns(inputTracks);
+
+  std::size_t nFailed = 0;
+
+  for (const auto& track : inputTracks) {
+    const auto result = extrapolate(track);
+    if (!result.ok()) {
+      ACTS_DEBUG("Extrapolation of track " << track.index() << " failed with "
+                                           << result.error());
+      ++nFailed;
+      continue;
+    }
+
+    auto destination = extrapolated.makeTrack();
+    destination.copyFromShallow(track);
+    destination.setReferenceSurface(m_cfg.targetSurface);
+    destination.parameters() = result->parameters();
+    destination.covariance() = result->covariance().value();
+  }
+
+  m_nTotalTracks += inputTracks.size();
+  m_nFailedTracks += nFailed;
+
+  if (nFailed > 0) {
+    ACTS_DEBUG("Dropped " << nFailed << " of " << inputTracks.size()
+                          << " tracks that could not be extrapolated");
+  }
+
+  ConstTrackContainer outputTracks{
+      std::make_shared<Acts::ConstVectorTrackContainer>(
+          std::move(*trackBackend)),
+      inputTracks.trackStateContainerHolder()};
+
+  ACTS_DEBUG("Extrapolated " << outputTracks.size() << " tracks");
+
+  m_outputTracks(ctx, std::move(outputTracks));
+
+  return ProcessCode::SUCCESS;
+}
+
+ProcessCode TrackExtrapolationAlgorithm::finalize() {
+  ACTS_INFO("TrackExtrapolationAlgorithm statistics:");
+  ACTS_INFO("- total tracks: " << m_nTotalTracks);
+  ACTS_INFO("- dropped tracks: " << m_nFailedTracks);
+  if (m_nTotalTracks > 0) {
+    ACTS_INFO("- drop ratio: " << static_cast<double>(m_nFailedTracks) /
+                                      m_nTotalTracks);
+  }
+
+  return ProcessCode::SUCCESS;
+}
+
+}  // namespace ActsExamples

--- a/Python/Examples/src/Utilities.cpp
+++ b/Python/Examples/src/Utilities.cpp
@@ -13,6 +13,7 @@
 #include "ActsExamples/Utilities/ProtoTracksToTracks.hpp"
 #include "ActsExamples/Utilities/SeedsToProtoTracks.hpp"
 #include "ActsExamples/Utilities/SeedsToTracks.hpp"
+#include "ActsExamples/Utilities/TrackExtrapolationAlgorithm.hpp"
 #include "ActsExamples/Utilities/TracksToParameters.hpp"
 #include "ActsExamples/Utilities/TracksToTrajectories.hpp"
 #include "ActsExamples/Utilities/TrajectoriesToProtoTracks.hpp"
@@ -49,6 +50,16 @@ void addUtilities(py::module& mex) {
   ACTS_PYTHON_DECLARE_ALGORITHM(ProtoTracksToSeeds, mex, "ProtoTracksToSeeds",
                                 inputProtoTracks, inputSpacePoints, outputSeeds,
                                 outputProtoTracks);
+
+  py::enum_<Acts::TrackExtrapolationStrategy>(mex, "TrackExtrapolationStrategy")
+      .value("first", Acts::TrackExtrapolationStrategy::first)
+      .value("last", Acts::TrackExtrapolationStrategy::last)
+      .value("firstOrLast", Acts::TrackExtrapolationStrategy::firstOrLast);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(
+      TrackExtrapolationAlgorithm, mex, "TrackExtrapolationAlgorithm",
+      inputTracks, outputTracks, targetSurface, trackingGeometry, magneticField,
+      strategy, constrainToVolumeIds, endOfWorldVolumeIds);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       MeasurementMapSelector, mex, "MeasurementMapSelector", inputMeasurements,

--- a/Tests/UnitTests/Core/Utilities/TrackHelpersTests.cpp
+++ b/Tests/UnitTests/Core/Utilities/TrackHelpersTests.cpp
@@ -9,14 +9,22 @@
 #include <boost/test/unit_test.hpp>
 
 #include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/Definitions/Units.hpp"
 #include "Acts/EventData/AnyTrackStateProxy.hpp"
 #include "Acts/EventData/TrackContainer.hpp"
 #include "Acts/EventData/VectorMultiTrajectory.hpp"
 #include "Acts/EventData/VectorTrackContainer.hpp"
+#include "Acts/Geometry/GeometryContext.hpp"
+#include "Acts/Surfaces/PlaneSurface.hpp"
+#include "Acts/Surfaces/RectangleBounds.hpp"
 #include "Acts/Utilities/TrackHelpers.hpp"
 #include "ActsTests/CommonHelpers/FloatComparisons.hpp"
 
+#include <memory>
+#include <vector>
+
 using namespace Acts;
+using namespace Acts::UnitLiterals;
 using enum TrackStateFlag;
 
 namespace ActsTests {
@@ -62,6 +70,61 @@ auto createTestTrackState(TrackContainer& tc) {
   ts.smoothedCovariance() = BoundMatrix::Identity() * 0.1;
 
   return ts;
+}
+
+/// Which parameters a track state of the extrapolation test track carries.
+enum class ParameterSlot { none, predicted, filtered, smoothed };
+
+/// Build a track of measurement states on planes at z = 100, 200, 300, all
+/// pointing along +z on the z axis, so the first state is the one closest to a
+/// target plane at the origin.
+template <typename TrackContainer>
+auto createExtrapolationTestTrack(TrackContainer& tc,
+                                  const std::vector<ParameterSlot>& slots) {
+  auto t = tc.makeTrack();
+
+  double z = 100_mm;
+  for (ParameterSlot slot : slots) {
+    TrackStatePropMask mask = TrackStatePropMask::None;
+    if (slot == ParameterSlot::predicted) {
+      mask = TrackStatePropMask::Predicted;
+    } else if (slot == ParameterSlot::filtered) {
+      mask = TrackStatePropMask::Filtered;
+    } else if (slot == ParameterSlot::smoothed) {
+      mask = TrackStatePropMask::Smoothed;
+    }
+
+    auto ts = t.appendTrackState(mask);
+    ts.typeFlags().setUnchecked(HasMeasurement);
+    ts.setReferenceSurface(Surface::makeShared<PlaneSurface>(
+        Transform3{Translation3{Vector3{0, 0, z}}},
+        std::make_shared<RectangleBounds>(1_m, 1_m)));
+
+    // loc0 = loc1 = 0 and theta = 0 puts the state on the z axis pointing
+    // along +z, so the path length to the target is just -z
+    BoundVector params = BoundVector::Zero();
+    params[eBoundQOverP] = 1 / 1_GeV;
+    if (slot == ParameterSlot::predicted) {
+      ts.predicted() = params;
+      ts.predictedCovariance() = BoundMatrix::Identity();
+    } else if (slot == ParameterSlot::filtered) {
+      ts.filtered() = params;
+      ts.filteredCovariance() = BoundMatrix::Identity();
+    } else if (slot == ParameterSlot::smoothed) {
+      ts.smoothed() = params;
+      ts.smoothedCovariance() = BoundMatrix::Identity();
+    }
+
+    z += 100_mm;
+  }
+
+  return t;
+}
+
+/// Target plane at the origin, reached by the test track above.
+std::shared_ptr<PlaneSurface> makeTargetSurface() {
+  return Surface::makeShared<PlaneSurface>(
+      Transform3::Identity(), std::make_shared<RectangleBounds>(1_m, 1_m));
 }
 
 }  // namespace
@@ -182,6 +245,147 @@ BOOST_AUTO_TEST_CASE(CalculateUnbiasedParametersCovariance) {
 
   CHECK_CLOSE_ABS(params, refParams, 1e-6);
   CHECK_CLOSE_ABS(cov, refCov, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(FindTrackStateForExtrapolationStrategies) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  auto target = makeTargetSurface();
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+
+  auto t = createExtrapolationTestTrack(
+      tc, {ParameterSlot::smoothed, ParameterSlot::smoothed,
+           ParameterSlot::smoothed});
+
+  auto first = findTrackStateForExtrapolation(
+      gctx, t, *target, TrackExtrapolationStrategy::first);
+  BOOST_REQUIRE(first.ok());
+  CHECK_CLOSE_ABS(first->second, -100_mm, 1e-6);
+
+  auto last = findTrackStateForExtrapolation(gctx, t, *target,
+                                             TrackExtrapolationStrategy::last);
+  BOOST_REQUIRE(last.ok());
+  CHECK_CLOSE_ABS(last->second, -300_mm, 1e-6);
+
+  // the first state is the closer one, so `firstOrLast` has to agree with
+  // `first`
+  auto firstOrLast = findTrackStateForExtrapolation(
+      gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+  BOOST_REQUIRE(firstOrLast.ok());
+  BOOST_CHECK_EQUAL(firstOrLast->first.index(), first->first.index());
+  CHECK_CLOSE_ABS(firstOrLast->second, -100_mm, 1e-6);
+}
+
+BOOST_AUTO_TEST_CASE(FindTrackStateForExtrapolationParameterSlots) {
+  auto target = makeTargetSurface();
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+
+  // a state carrying only predicted is usable, since that is what
+  // `TrackProxy::createParametersFromState` would start from
+  for (ParameterSlot slot : {ParameterSlot::predicted, ParameterSlot::filtered,
+                             ParameterSlot::smoothed}) {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = createExtrapolationTestTrack(tc, {slot, slot, slot});
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+    BOOST_REQUIRE(result.ok());
+    CHECK_CLOSE_ABS(result->second, -100_mm, 1e-6);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(FindTrackStateForExtrapolationPartialParameters) {
+  auto target = makeTargetSurface();
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+
+  // a seed track only carries parameters on the bottom space point, so
+  // `firstOrLast` cannot intersect the last state and has to fall back to the
+  // first one
+  {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = createExtrapolationTestTrack(
+        tc,
+        {ParameterSlot::predicted, ParameterSlot::none, ParameterSlot::none});
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+    BOOST_REQUIRE(result.ok());
+    CHECK_CLOSE_ABS(result->second, -100_mm, 1e-6);
+  }
+
+  // and the other way around, where the fallback has to pick the state that is
+  // further away
+  {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = createExtrapolationTestTrack(
+        tc,
+        {ParameterSlot::none, ParameterSlot::none, ParameterSlot::filtered});
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+    BOOST_REQUIRE(result.ok());
+    CHECK_CLOSE_ABS(result->second, -300_mm, 1e-6);
+  }
+
+  // asking for the end that carries no parameters is an error rather than a
+  // read of an unallocated parameter slot
+  {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = createExtrapolationTestTrack(
+        tc,
+        {ParameterSlot::filtered, ParameterSlot::none, ParameterSlot::none});
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::last);
+    BOOST_REQUIRE(!result.ok());
+    BOOST_CHECK_EQUAL(result.error(),
+                      TrackExtrapolationError::CompatibleTrackStateNotFound);
+  }
+
+  // no end carries parameters
+  {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = createExtrapolationTestTrack(
+        tc, {ParameterSlot::none, ParameterSlot::none, ParameterSlot::none});
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+    BOOST_REQUIRE(!result.ok());
+    BOOST_CHECK_EQUAL(result.error(),
+                      TrackExtrapolationError::CompatibleTrackStateNotFound);
+  }
+
+  // a track without measurement states at all
+  {
+    TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+    auto t = tc.makeTrack();
+
+    auto result = findTrackStateForExtrapolation(
+        gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+    BOOST_REQUIRE(!result.ok());
+    BOOST_CHECK_EQUAL(result.error(),
+                      TrackExtrapolationError::CompatibleTrackStateNotFound);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(FindTrackStateForExtrapolationUnreachable) {
+  TrackContainer tc{VectorTrackContainer{}, VectorMultiTrajectory{}};
+  GeometryContext gctx = GeometryContext::dangerouslyDefaultConstruct();
+
+  auto t = createExtrapolationTestTrack(
+      tc, {ParameterSlot::smoothed, ParameterSlot::smoothed,
+           ParameterSlot::smoothed});
+
+  // the track runs along +z on the z axis, so a target plane offset in x is
+  // outside the bounds it can reach
+  auto target = Surface::makeShared<PlaneSurface>(
+      Transform3{Translation3{Vector3{10_m, 0, 0}}},
+      std::make_shared<RectangleBounds>(1_mm, 1_mm));
+
+  auto result = findTrackStateForExtrapolation(
+      gctx, t, *target, TrackExtrapolationStrategy::firstOrLast);
+  BOOST_REQUIRE(!result.ok());
+  BOOST_CHECK_EQUAL(result.error(),
+                    TrackExtrapolationError::ReferenceSurfaceUnreachable);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Moves the track parameters of a track container onto a common surface,
typically a perigee.

That is what makes a seed estimate comparable to truth. The estimate sits on
the bottom space point's sensor, where the truth reference has to be carried
from the production vertex through the bending in between, so the comparison
belongs on a perigee.

Only the track-level parameters are moved. The states are shared with the input
container rather than copied, so they keep the parameters on their own surfaces
and the output has the same layering a fitter produces, without a second copy of
the state backend. Tracks whose extrapolation fails are dropped, so any truth
matching has to run downstream.

`Acts::findTrackStateForExtrapolation` is fixed along with it, for tracks that
carry parameters on only some of their states - every seed track from #5845,
where only the bottom space point holds the estimate. `firstOrLast` intersects
both ends unconditionally to compare their distances, and the helper only
asserted that the state it intersects has smoothed or filtered parameters, so a
release build read an unallocated parameter slot. A state without parameters now
yields no intersection instead, so such a track extrapolates from the end that
does carry them rather than being rejected.

Used by #5721, nothing else in the repository calls it yet.

### Notes

- `Acts::extrapolateTrackToReferenceSurface` is not called; its body is
  reproduced in the algorithm instead. The helper takes a single track proxy and
  does both halves through it: it reads the states off that proxy to pick the
  state to start from, and it writes the extrapolated parameters back onto it in
  place. Here the two cannot be the same proxy.
  - Reading has to happen on the input, which is a read-only
    `ConstTrackContainer` off the whiteboard. `parameters()` and
    `setReferenceSurface()` are `requires(!ReadOnly)`, so instantiating the
    helper on an input track does not compile.
  - Writing has to happen on the output track, which is mutable but whose
    container is paired with an empty `Acts::VectorMultiTrajectory`, because
    `Acts::TrackContainer` cannot pair a mutable track backend with a read-only
    state backend. The input state backend is only attached at the very end,
    when the const output container is built, so the tip and stem indices that
    `copyFromShallow` carries over do not resolve during the loop. Calling the
    helper on the output track would compile and then walk an empty backend.

  `Acts::findTrackStateForExtrapolation` and the `ForcedSurfaceReached`
  propagate call are used directly instead, which is the helper minus the
  write-back. An overload that separates the state source from the parameter
  destination, or one that returns the `BoundTrackParameters` rather than
  writing them, would let this call into Core; kept out of this PR.
- On the second commit, which is the Core fix. It was raised in review on the
  first one, where the algorithm instead checked the precondition up front and
  dropped those tracks.
  - The fallback needs no new branching: the `firstOrLast` comparison already
    handles an invalid intersection, which carries an infinite path length and
    so loses to the other end. A seed track therefore extrapolates from its
    bottom space point under any strategy, and passing `first` in #5721 is an
    optimisation rather than a requirement.
  - `CompatibleTrackStateNotFound` is now reported when no end can be started
    from, as opposed to `ReferenceSurfaceUnreachable` when the ends do carry
    parameters but do not reach the surface.
  - The parameters come from `Acts::TrackStateProxy::parameters` rather than a
    second smoothed-over-filtered ladder, so the distance is measured on the
    same parameters that `createParametersFromState` starts the propagation
    from. That also admits a state holding only predicted parameters, which the
    old ladder rejected even though the propagation would have used them.
  - Behaviour is unchanged wherever every measurement state carries parameters,
    which covers both existing `firstOrLast` callers, `KalmanFitter` and
    `TrackFindingAlgorithm`. `findTrackStateForExtrapolation` had no unit test
    coverage at all; the new cases in `TrackHelpersTests` need no propagator and
    fail on the unpatched header.
- `Acts::TrackProxy::copyFrom`, the deep copy, is not an alternative to sharing
  the states: it copies every state with a hardcoded `TrackStatePropMask::All`,
  which throws for a state that holds no parameters at all - every state of a
  seed track except the innermost. Passing `srcTrackState.getMask()` there would
  fix it, kept out of this PR.
- `Acts::TrackExtrapolationStrategy` gets python bindings here.
