### PR TITLE
ci: Restrict Some Workflows to acts-project/acts, main branch (2026.08.07.)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   docs:
+    if: github.repository == 'acts-project/acts'
     runs-on: ubuntu-latest
     env:
       DOXYGEN_WARN_AS_ERROR: FAIL_ON_WARNINGS

--- a/.github/workflows/trigger_athena.yml
+++ b/.github/workflows/trigger_athena.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   trigger_athena_job:
+    if: github.repository == 'acts-project/acts'
     runs-on: ubuntu-slim
     steps:
       - run: >


### PR DESCRIPTION
Only run certain jobs on the main repository. Jobs that can technically really only run on the main repository.

--- END COMMIT MESSAGE ---

Currently every time I update the `main` branch in my own fork to be in sync with the main repository (which is something I like to do...), I get 2 e-mails.

<img width="1274" height="550" alt="image" src="https://github.com/user-attachments/assets/6a4b486d-2b1a-4fc3-a4e3-a676b960ae21" />

This is mainly to get rid of that...
