### PR TITLE
feat: Add SeedsToTracks to Examples

### DIFF
--- a/Examples/Algorithms/Utilities/CMakeLists.txt
+++ b/Examples/Algorithms/Utilities/CMakeLists.txt
@@ -2,6 +2,7 @@ acts_add_library(
     ExamplesUtilities
     src/ProtoTracksToSeeds.cpp
     src/SeedsToProtoTracks.cpp
+    src/SeedsToTracks.cpp
     src/TrajectoriesToProtoTracks.cpp
     src/TrackSelectorAlgorithm.cpp
     src/TracksToTrajectories.cpp

--- a/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/SeedsToTracks.hpp
+++ b/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/SeedsToTracks.hpp
@@ -1,0 +1,76 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/Seed.hpp"
+#include "ActsExamples/EventData/Track.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
+#include "ActsExamples/Framework/IAlgorithm.hpp"
+#include "ActsExamples/Framework/ProcessCode.hpp"
+
+#include <memory>
+#include <string>
+
+namespace Acts {
+class TrackingGeometry;
+}
+
+namespace ActsExamples {
+
+/// Convert seeds into tracks with one track state per space-point source link.
+///
+/// Estimated track parameters are optionally attached at track level and as
+/// *predicted* parameters on the innermost state, whose surface they are
+/// expressed on. State reference surfaces are optionally taken from the
+/// source-link geometry identifiers.
+///
+/// @note A space point can carry several source links, e.g. the two sides of a
+///       strip module, and each becomes its own state. `nMeasurements` and any
+///       downstream `Acts::TrackSelector::MeasurementCounter` threshold
+///       therefore count source links, not space points.
+class SeedsToTracks final : public IAlgorithm {
+ public:
+  struct Config {
+    /// Input seeds.
+    std::string inputSeeds = "seeds";
+    /// Optional. Track parameters parallel to the input seeds.
+    std::string inputTrackParameters;
+    /// Output tracks.
+    std::string outputTracks = "tracks-from-seeds";
+    /// Optional. Source of the track-state reference surfaces.
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
+  };
+
+  /// Construct the algorithm.
+  ///
+  /// @param cfg is the algorithm configuration
+  /// @param logger is the logger
+  explicit SeedsToTracks(Config cfg,
+                         std::unique_ptr<const Acts::Logger> logger = nullptr);
+
+  /// Run the algorithm.
+  ///
+  /// @param ctx is the algorithm context with event information
+  /// @return a process code indication success or failure
+  ProcessCode execute(const AlgorithmContext& ctx) const override;
+
+  /// Const access to the config
+  const Config& config() const { return m_cfg; }
+
+ private:
+  Config m_cfg;
+
+  ReadDataHandle<SeedContainer> m_inputSeeds{this, "InputSeeds"};
+  ReadDataHandle<TrackParametersContainer> m_inputTrackParameters{
+      this, "InputTrackParameters"};
+  WriteDataHandle<ConstTrackContainer> m_outputTracks{this, "OutputTracks"};
+};
+
+}  // namespace ActsExamples

--- a/Examples/Algorithms/Utilities/src/SeedsToTracks.cpp
+++ b/Examples/Algorithms/Utilities/src/SeedsToTracks.cpp
@@ -1,0 +1,126 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Utilities/SeedsToTracks.hpp"
+
+#include "Acts/EventData/SourceLink.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "ActsExamples/EventData/IndexSourceLink.hpp"
+
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace ActsExamples {
+
+SeedsToTracks::SeedsToTracks(Config cfg,
+                             std::unique_ptr<const Acts::Logger> logger)
+    : IAlgorithm("SeedsToTracks", std::move(logger)), m_cfg(std::move(cfg)) {
+  m_inputSeeds.initialize(m_cfg.inputSeeds);
+  m_inputTrackParameters.maybeInitialize(m_cfg.inputTrackParameters);
+  m_outputTracks.initialize(m_cfg.outputTracks);
+}
+
+ProcessCode SeedsToTracks::execute(const AlgorithmContext& ctx) const {
+  const SeedContainer& seeds = m_inputSeeds(ctx);
+  ACTS_DEBUG("Received " << seeds.size() << " seeds");
+
+  const TrackParametersContainer* trackParameters = nullptr;
+  if (m_inputTrackParameters.isInitialized()) {
+    trackParameters = &m_inputTrackParameters(ctx);
+
+    if (trackParameters->size() != seeds.size()) {
+      throw std::runtime_error(
+          "Number of seeds and track parameters do not match");
+    }
+  }
+
+  const bool hasTrackParameters = trackParameters != nullptr;
+
+  auto trackContainer = std::make_shared<Acts::VectorTrackContainer>();
+  auto mtj = std::make_shared<Acts::VectorMultiTrajectory>();
+  TrackContainer tracks(trackContainer, mtj);
+
+  for (std::size_t i = 0; i < seeds.size(); ++i) {
+    const auto seed = seeds.at(i);
+
+    auto track = tracks.makeTrack();
+    std::uint32_t nMeasurements = 0;
+
+    for (const auto& sp : seed.spacePoints()) {
+      for (const auto& sourceLink : sp.sourceLinks()) {
+        // `TrackParamsEstimationAlgorithm` expresses the estimate on the
+        // bottom space point's surface, which is the first one here
+        const bool attachParameters = hasTrackParameters &&
+                                      nMeasurements == 0 &&
+                                      m_cfg.trackingGeometry != nullptr;
+
+        auto trackStateProxy = track.appendTrackState(
+            attachParameters ? Acts::TrackStatePropMask::Predicted
+                             : Acts::TrackStatePropMask::None);
+        trackStateProxy.typeFlags().setIsMeasurement();
+        trackStateProxy.setUncalibratedSourceLink(Acts::SourceLink(sourceLink));
+        ++nMeasurements;
+
+        if (m_cfg.trackingGeometry != nullptr) {
+          const Acts::GeometryIdentifier geoId =
+              sourceLink.get<IndexSourceLink>().geometryId();
+          const Acts::Surface* surface =
+              m_cfg.trackingGeometry->findSurface(geoId);
+          if (surface == nullptr) {
+            std::ostringstream oss;
+            oss << "No surface found for source-link geometry id " << geoId;
+            throw std::runtime_error(oss.str());
+          }
+          trackStateProxy.setReferenceSurface(surface->getSharedPtr());
+        }
+
+        if (attachParameters) {
+          const auto& trackParams = trackParameters->at(i);
+          trackStateProxy.predicted() = trackParams.parameters();
+          trackStateProxy.predictedCovariance() =
+              trackParams.covariance().value_or(Acts::BoundMatrix::Zero());
+          // the estimate is all that is known at this state, so it stands in
+          // for the filtered and smoothed parameters rather than being stored
+          // again. that is also what lets
+          // `Acts::findTrackStateForExtrapolation` start from this state.
+          trackStateProxy.shareFrom(Acts::TrackStatePropMask::Predicted,
+                                    Acts::TrackStatePropMask::Filtered);
+          trackStateProxy.shareFrom(Acts::TrackStatePropMask::Predicted,
+                                    Acts::TrackStatePropMask::Smoothed);
+        }
+      }
+    }
+
+    track.nMeasurements() = nMeasurements;
+    track.nHoles() = 0;
+    track.nOutliers() = 0;
+
+    if (hasTrackParameters) {
+      const auto& trackParams = trackParameters->at(i);
+
+      track.setReferenceSurface(trackParams.referenceSurface().getSharedPtr());
+      track.parameters() = trackParams.parameters();
+      track.covariance() =
+          trackParams.covariance().value_or(Acts::BoundMatrix::Zero());
+    }
+  }
+
+  ConstTrackContainer constTracks{
+      std::make_shared<Acts::ConstVectorTrackContainer>(
+          std::move(*trackContainer)),
+      std::make_shared<Acts::ConstVectorMultiTrajectory>(std::move(*mtj))};
+
+  ACTS_DEBUG("Produced " << constTracks.size() << " tracks");
+
+  m_outputTracks(ctx, std::move(constTracks));
+
+  return ProcessCode::SUCCESS;
+}
+
+}  // namespace ActsExamples

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -544,12 +544,12 @@ def addSeeding(
 
         tracks = f"{prefix}seed-tracks"
         s.addAlgorithm(
-            acts.examples.ProtoTracksToTracks(
+            acts.examples.SeedsToTracks(
                 level=logLevel,
-                inputProtoTracks=protoTracks,
+                inputSeeds=f"{prefix}estimatedseeds",
                 inputTrackParameters=f"{prefix}estimatedparameters",
-                inputMeasurements=f"{prefix}measurement_subset",
                 outputTracks=tracks,
+                trackingGeometry=trackingGeometry,
             )
         )
 

--- a/Python/Examples/src/Utilities.cpp
+++ b/Python/Examples/src/Utilities.cpp
@@ -12,6 +12,7 @@
 #include "ActsExamples/Utilities/ProtoTracksToSeeds.hpp"
 #include "ActsExamples/Utilities/ProtoTracksToTracks.hpp"
 #include "ActsExamples/Utilities/SeedsToProtoTracks.hpp"
+#include "ActsExamples/Utilities/SeedsToTracks.hpp"
 #include "ActsExamples/Utilities/TracksToParameters.hpp"
 #include "ActsExamples/Utilities/TracksToTrajectories.hpp"
 #include "ActsExamples/Utilities/TrajectoriesToProtoTracks.hpp"
@@ -40,6 +41,10 @@ void addUtilities(py::module& mex) {
 
   ACTS_PYTHON_DECLARE_ALGORITHM(SeedsToProtoTracks, mex, "SeedsToProtoTracks",
                                 inputSeeds, outputProtoTracks);
+
+  ACTS_PYTHON_DECLARE_ALGORITHM(SeedsToTracks, mex, "SeedsToTracks", inputSeeds,
+                                inputTrackParameters, outputTracks,
+                                trackingGeometry);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(ProtoTracksToSeeds, mex, "ProtoTracksToSeeds",
                                 inputProtoTracks, inputSpacePoints, outputSeeds,


### PR DESCRIPTION
Turns seeds into tracks with one track state per space-point source link, and
stores the seed estimate on the innermost state.

`addSeeding` built the `seed-tracks` through `SeedsToProtoTracks` and
`ProtoTracksToTracks` so far. A proto track is a flat list of measurement
indices, so that route drops the structure the seed carries and leaves two
things resting on the order in which `seedToProtoTrack` happens to flatten the
space points: which state is the innermost, and that the estimate of a seed
still lines up with its proto track. `TrackParamsEstimationAlgorithm` expresses
the estimate on the bottom space point's surface, which a seed names directly.

The estimate is allocated once as predicted and shared as filtered and
smoothed, since it is all that is known at that state.

With a tracking geometry the track states also get their reference surface,
which bound parameters on a state need in order to mean anything.

--- END COMMIT MESSAGE ---

First of four. Review order:

1. this one, `SeedsToTracks`
2. #5841, the performance writer rename
3. #5842, `TrackExtrapolationAlgorithm`
4. #5721, seed parameter performance in `addSeeding`

1 to 3 are independent of each other, 4 needs all of them. All of them target
`main`, so the diff of 4 contains 1 to 3 until they merge. #5846 is a small fix
found along the way and is independent of all of these.

`SeedsToProtoTracks` stays, the proto tracks are still written by
`addSeedPerformanceWriters`.

### Validation

The `seed-tracks` come out identical to the `ProtoTracksToTracks` route:
`seedToProtoTrack` walks `seed.spacePoints()` and `sp.sourceLinks()` in the
same nested order, so the states, their order, their source links and
`nMeasurements` all match. Measured through #5721 on 100 particle-gun events,
the residual and pull histograms of the seed estimate agree to the last digit
between the two routes.

The python test suite gives the same set of failures as `main` on the same
machine.
