### PR TITLE
fix: Write the track covariance in ProtoTracksToTracks unconditionally

### DIFF
--- a/Examples/Algorithms/Utilities/src/ProtoTracksToTracks.cpp
+++ b/Examples/Algorithms/Utilities/src/ProtoTracksToTracks.cpp
@@ -83,9 +83,8 @@ ProcessCode ProtoTracksToTracks::execute(const AlgorithmContext& ctx) const {
 
       track.setReferenceSurface(trackParams.referenceSurface().getSharedPtr());
       track.parameters() = trackParams.parameters();
-      if (trackParams.covariance().has_value()) {
-        track.covariance() = *trackParams.covariance();
-      }
+      track.covariance() =
+          trackParams.covariance().value_or(Acts::BoundMatrix::Zero());
     }
   }
 


### PR DESCRIPTION
A track is created with an uninitialized covariance:
`VectorTrackContainer::addTrack_impl` grows `m_cov` with `emplace_back()`, and
its element type is a fixed-size Eigen matrix, whose default constructor leaves
the coefficients untouched. Skipping the assignment when the input parameters
carry no covariance therefore leaves indeterminate values on the output track,
rather than the zeros the shape of the code suggests.

--- END COMMIT MESSAGE ---

Found while writing #5845, which started from a copy of this code.

No behaviour change for the callers in the repository: `addSeeding` feeds
parameters from `TrackParamsEstimationAlgorithm`, which always sets a
covariance, so the branch never fired there.

Independent of the rest of that stack, see #5845 for the review order.
