### PR TITLE
fix: Follow naming conventions in Python bindings

### DIFF
--- a/Examples/Scripts/Python/pypi_finding_fitting_demo.py
+++ b/Examples/Scripts/Python/pypi_finding_fitting_demo.py
@@ -97,7 +97,7 @@ def runPypiFindingFittingDemo(
             track = acts.examples.ProtoTrack()
             for sp in sorted(spacepoints, key=lambda sp: sp.r):
                 for sl in sp.sourceLinks:
-                    isl = acts.examples.IndexSourceLink.FromSourceLink(sl)
+                    isl = acts.examples.IndexSourceLink.fromSourceLink(sl)
                     track.append(isl.index())
 
             prototracks = acts.examples.ProtoTrackContainer()
@@ -147,7 +147,7 @@ def runPypiFindingFittingDemo(
             measurement_to_sourcelink = {}
             for sp in spacepoints:
                 for sl in sp.sourceLinks:
-                    isl = acts.examples.IndexSourceLink.FromSourceLink(sl)
+                    isl = acts.examples.IndexSourceLink.fromSourceLink(sl)
                     meas_id = isl.index()
                     measurement_to_spacepoint[meas_id] = sp
                     measurement_to_sourcelink[meas_id] = sl
@@ -162,7 +162,7 @@ def runPypiFindingFittingDemo(
                 for meas_id in prototrack:
                     sp = measurement_to_spacepoint[meas_id]
                     sl = measurement_to_sourcelink[meas_id]
-                    isl = acts.examples.IndexSourceLink.FromSourceLink(sl)
+                    isl = acts.examples.IndexSourceLink.fromSourceLink(sl)
                     sf = surface_map[isl.geometryId()]
 
                     trackState = track.appendTrackState()

--- a/Python/Core/src/EventData.cpp
+++ b/Python/Core/src/EventData.cpp
@@ -556,8 +556,8 @@ void addEventData(py::module_& m) {
   // replicating what the whiteboard does, so proxy tether failures can be
   // tested without acts.examples.
   auto mt = m.def_submodule("_testing");
-  mt.def("consume_spacepoints", [](std::unique_ptr<SpacePointContainer>) {});
-  mt.def("consume_seeds", [](std::unique_ptr<SeedContainer>) {});
+  mt.def("consumeSpacePoints", [](std::unique_ptr<SpacePointContainer>) {});
+  mt.def("consumeSeeds", [](std::unique_ptr<SeedContainer>) {});
 }
 
 }  // namespace ActsPython

--- a/Python/Core/src/MagneticField.cpp
+++ b/Python/Core/src/MagneticField.cpp
@@ -153,7 +153,7 @@ void addMagneticField(py::module_& m) {
 
   m.def(
       "MagneticFieldMapXyz",
-      [](const std::string& filename, double lengthUnit, double BFieldUnit,
+      [](const std::string& filename, double lengthUnit, double bFieldUnit,
          bool firstOctant) {
         const std::filesystem::path file = filename;
 
@@ -166,18 +166,18 @@ void addMagneticField(py::module_& m) {
         if (file.extension() == ".txt") {
           auto map = makeMagneticFieldMapXyzFromText(std::move(mapBins),
                                                      file.native(), lengthUnit,
-                                                     BFieldUnit, firstOctant);
+                                                     bFieldUnit, firstOctant);
           return std::make_shared<decltype(map)>(std::move(map));
         } else {
           throw std::runtime_error("Unsupported magnetic field map file type");
         }
       },
       py::arg("file"), py::arg("lengthUnit") = UnitConstants::mm,
-      py::arg("BFieldUnit") = UnitConstants::T, py::arg("firstOctant") = false);
+      py::arg("bFieldUnit") = UnitConstants::T, py::arg("firstOctant") = false);
 
   m.def(
       "MagneticFieldMapRz",
-      [](const std::string& filename, double lengthUnit, double BFieldUnit,
+      [](const std::string& filename, double lengthUnit, double bFieldUnit,
          bool firstQuadrant) {
         const std::filesystem::path file = filename;
 
@@ -189,14 +189,14 @@ void addMagneticField(py::module_& m) {
         if (file.extension() == ".txt") {
           auto map = makeMagneticFieldMapRzFromText(std::move(mapBins),
                                                     file.native(), lengthUnit,
-                                                    BFieldUnit, firstQuadrant);
+                                                    bFieldUnit, firstQuadrant);
           return std::make_shared<decltype(map)>(std::move(map));
         } else {
           throw std::runtime_error("Unsupported magnetic field map file type");
         }
       },
       py::arg("file"), py::arg("lengthUnit") = UnitConstants::mm,
-      py::arg("BFieldUnit") = UnitConstants::T,
+      py::arg("bFieldUnit") = UnitConstants::T,
       py::arg("firstQuadrant") = false);
 }
 

--- a/Python/Core/tests/test_event_data.py
+++ b/Python/Core/tests/test_event_data.py
@@ -207,7 +207,7 @@ def test_space_point_proxy_fails_loud_after_disown():
     assert via_index.x == pytest.approx(1.0)
 
     # Transfer the container away (same mechanism as a whiteboard write).
-    tb.consume_spacepoints(container)
+    tb.consumeSpacePoints(container)
 
     # Every previously-obtained handle now fails loud rather than segfaulting.
     with pytest.raises(ValueError, match="consumed"):
@@ -232,7 +232,7 @@ def test_seed_proxy_fails_loud_after_disown():
     assert seed.quality == pytest.approx(0.9)
     assert via_index.quality == pytest.approx(0.9)
 
-    tb.consume_seeds(container)
+    tb.consumeSeeds(container)
 
     with pytest.raises(ValueError, match="consumed"):
         _ = seed.quality

--- a/Python/Examples/src/EventData.cpp
+++ b/Python/Examples/src/EventData.cpp
@@ -65,7 +65,7 @@ auto bindFlatMultimap(py::module& m, const char* name) {
                         return self.find(key) != self.end();
                       })
                  .def(
-                     "values_for",
+                     "valuesFor",
                      [](const Map& self, const typename Map::key_type& key) {
                        auto [first, last] = self.equal_range(key);
                        std::vector<typename Map::mapped_type> result;
@@ -453,8 +453,9 @@ void addEventData(py::module& mex) {
   py::class_<IndexSourceLink>(mex, "IndexSourceLink")
       .def(py::init<Acts::GeometryIdentifier, Index>(), py::arg("geometryId"),
            py::arg("index"))
-      .def("FromSourceLink",
-           [](Acts::SourceLink const& sl) { return sl.get<IndexSourceLink>(); })
+      .def_static(
+          "fromSourceLink",
+          [](Acts::SourceLink const& sl) { return sl.get<IndexSourceLink>(); })
       .def("toSourceLink",
            [](const IndexSourceLink& self) { return Acts::SourceLink(self); })
       .def("index", &IndexSourceLink::index)

--- a/Python/Examples/tests/test_truth_tracking.py
+++ b/Python/Examples/tests/test_truth_tracking.py
@@ -611,7 +611,7 @@ def test_measurement_access(tmp_path, generic_detector_config):
 
                 first_key = next(iter(sh_map))[0]
                 assert first_key in sh_map
-                vals = sh_map.values_for(first_key)
+                vals = sh_map.valuesFor(first_key)
                 assert len(vals) > 0
 
                 inv = sh_map.invert()
@@ -729,10 +729,10 @@ def test_measurement_map_creation():
     assert 0 in m
     assert 2 not in m
 
-    vals = m.values_for(0)
+    vals = m.valuesFor(0)
     assert sorted(vals) == [10, 11]
-    assert m.values_for(1) == [20]
-    assert m.values_for(99) == []
+    assert m.valuesFor(1) == [20]
+    assert m.valuesFor(99) == []
 
     pairs = list(m)
     assert len(pairs) == 3
@@ -741,9 +741,9 @@ def test_measurement_map_creation():
     inv = m.invert()
     assert isinstance(inv, SimHitMeasurementsMap)
     assert len(inv) == 3
-    assert inv.values_for(10) == [0]
-    assert inv.values_for(11) == [0]
-    assert inv.values_for(20) == [1]
+    assert inv.valuesFor(10) == [0]
+    assert inv.valuesFor(11) == [0]
+    assert inv.valuesFor(20) == [1]
 
     # MeasurementParticlesMap: meas 0 came from two particles, meas 1 from one
     bc0 = SimBarcode()
@@ -756,7 +756,7 @@ def test_measurement_map_creation():
     mp.insert(1, bc0)
     assert len(mp) == 3
 
-    assert mp.values_for(0) == [bc0, bc1]
+    assert mp.valuesFor(0) == [bc0, bc1]
 
     inv_p = mp.invert()
     assert isinstance(inv_p, ParticleMeasurementsMap)

--- a/Python/Plugins/src/Root.cpp
+++ b/Python/Plugins/src/Root.cpp
@@ -63,7 +63,7 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsRoot, root) {
     root.def(
         "MagneticFieldMapXyz",
         [](const std::string& filename, const std::string& tree,
-           double lengthUnit, double BFieldUnit, bool firstOctant) {
+           double lengthUnit, double bFieldUnit, bool firstOctant) {
           const std::filesystem::path file = filename;
 
           auto mapBins = [](std::array<std::size_t, 3> bins,
@@ -74,7 +74,7 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsRoot, root) {
 
           if (file.extension() == ".root") {
             auto map = makeMagneticFieldMapXyzFromRoot(
-                std::move(mapBins), file.native(), tree, lengthUnit, BFieldUnit,
+                std::move(mapBins), file.native(), tree, lengthUnit, bFieldUnit,
                 firstOctant);
             return std::make_shared<decltype(map)>(std::move(map));
           } else {
@@ -84,13 +84,13 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsRoot, root) {
         },
         py::arg("file"), py::arg("tree") = "bField",
         py::arg("lengthUnit") = UnitConstants::mm,
-        py::arg("BFieldUnit") = UnitConstants::T,
+        py::arg("bFieldUnit") = UnitConstants::T,
         py::arg("firstOctant") = false);
 
     root.def(
         "MagneticFieldMapRz",
         [](const std::string& filename, const std::string& tree,
-           double lengthUnit, double BFieldUnit, bool firstQuadrant) {
+           double lengthUnit, double bFieldUnit, bool firstQuadrant) {
           const std::filesystem::path file = filename;
 
           auto mapBins = [](std::array<std::size_t, 2> bins,
@@ -100,7 +100,7 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsRoot, root) {
 
           if (file.extension() == ".root") {
             auto map = makeMagneticFieldMapRzFromRoot(
-                std::move(mapBins), file.native(), tree, lengthUnit, BFieldUnit,
+                std::move(mapBins), file.native(), tree, lengthUnit, bFieldUnit,
                 firstQuadrant);
             return std::make_shared<decltype(map)>(std::move(map));
           } else {
@@ -110,7 +110,7 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsRoot, root) {
         },
         py::arg("file"), py::arg("tree") = "bField",
         py::arg("lengthUnit") = UnitConstants::mm,
-        py::arg("BFieldUnit") = UnitConstants::T,
+        py::arg("bFieldUnit") = UnitConstants::T,
         py::arg("firstQuadrant") = false);
   }
 }


### PR DESCRIPTION
Python binding names that violate N.3/N.4:

- `IndexSourceLink.FromSourceLink` -> `fromSourceLink`, `def` -> `def_static`
- `SimHitMeasurementsMap.values_for` -> `valuesFor`
- `_testing.consume_spacepoints`/`consume_seeds` -> `consumeSpacePoints`/`consumeSeeds`
- `MagneticFieldMapXyz`/`Rz` keyword `BFieldUnit` -> `bFieldUnit`

Names mirroring an external API stay as they are: `Zero`/`Identity`/`UnitX`
follow C++, the Arrow bindings pyarrow, `add_object(s)` actsvg,
`sum_of_deltas_squared` boost-histogram.

Not breaking, the Python API is not versioned.

--- END COMMIT MESSAGE ---

All in-repo callers updated. Left as they are: the constructor-like factories
`MagneticFieldMapXyz/Rz`, `Input.Fixed/Poisson`, `StraightLinePropagatorODD`,
and the C++ `BFieldUnit` parameter in Core and the Root plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)