### PR TITLE
fix: HIP/AMD Compilation Fix, main branch (2026.08.11.)

### DIFF
--- a/Traccc/device/hip/src/utils/global_index.hpp
+++ b/Traccc/device/hip/src/utils/global_index.hpp
@@ -10,6 +10,9 @@
 // Project include(s).
 #include "traccc/device/global_index.hpp"
 
+// HIP include(s).
+#include <hip/hip_runtime.h>
+
 namespace traccc::hip::details {
 
 /// Function creating a global index in a 1D HIP kernel


### PR DESCRIPTION
Added a missing include. For when compiling with HIP_PLATFORM=amd.

--- END COMMIT MESSAGE ---

As @StewMH noticed in #5774, I made a mistake in #5835. :frowning: I only tested that change with `HIP_PLATFORM=nvidia`. :frowning:

One big difference between CUDA and HIP is that while `nvcc` auto-includes `<cuda.h>` for all `.cu` files, `clang++` from ROCm does not. So we need to include `<hip/hip_runtime.h>` explicitly to get access to even "built in" symbols.