### PR TITLE
fix: GeoModel G4 connection with GM 6.31

### DIFF
--- a/Examples/Detectors/GeoModelDetector/src/GeoModelGeant4DetectorConstruction.cpp
+++ b/Examples/Detectors/GeoModelDetector/src/GeoModelGeant4DetectorConstruction.cpp
@@ -15,8 +15,17 @@
 #include <G4PVPlacement.hh>
 #include <G4ThreeVector.hh>
 #include <G4VPhysicalVolume.hh>
-#include <GeoModel2G4/ExtParameterisedVolumeBuilder.h>
 #include <GeoModelKernel/GeoFullPhysVol.h>
+
+// GeoModel 6.31 merged `ExtParameterisedVolumeBuilder` into the (previously
+// abstract) `VolumeBuilder` base class and dropped the derived header.
+#if __has_include(<GeoModel2G4/ExtParameterisedVolumeBuilder.h>)
+#include <GeoModel2G4/ExtParameterisedVolumeBuilder.h>
+using GeoModelVolumeBuilder = ExtParameterisedVolumeBuilder;
+#else
+#include <GeoModel2G4/VolumeBuilder.h>
+using GeoModelVolumeBuilder = VolumeBuilder;
+#endif
 
 namespace ActsExamples {
 
@@ -35,7 +44,7 @@ GeoModelGeant4DetectorConstruction::GeoModelGeant4DetectorConstruction(
 
 G4VPhysicalVolume* GeoModelGeant4DetectorConstruction::Construct() {
   if (m_g4World == nullptr) {
-    ExtParameterisedVolumeBuilder builder(m_geoModelTree.worldVolumeName);
+    GeoModelVolumeBuilder builder(m_geoModelTree.worldVolumeName);
     G4LogicalVolume* g4WorldLog = builder.Build(m_geoModelTree.worldVolume);
     m_g4World =
         new G4PVPlacement(nullptr, G4ThreeVector(), g4WorldLog,

--- a/Examples/Detectors/MuonSpectrometerMockupDetector/src/GeoMuonMockupExperiment.cpp
+++ b/Examples/Detectors/MuonSpectrometerMockupDetector/src/GeoMuonMockupExperiment.cpp
@@ -167,7 +167,29 @@ ActsPlugins::GeoModelTree GeoMuonMockupExperiment::constructMS() {
 
   using VolumeMap_t = ActsPlugins::GeoModelTree::VolumePublisher::VolumeMap_t;
   VolumeMap_t publishedVol{};
-  for (const auto& [fpV, pubKey] : m_publisher->getPublishedFPV()) {
+  // Older GeoModel (e.g. 6.27) hands back a multimap<node, key>, while newer
+  // GeoModel (6.31) hands back a map<key, node>, i.e. the two pair elements are
+  // swapped. Detect which way round it is from the map's mapped_type.
+  using PublishedFPV_t = decltype(m_publisher->getPublishedFPV());
+  constexpr bool nodeIsMapped =
+      std::is_same_v<typename PublishedFPV_t::mapped_type, GeoVFullPhysVol*>;
+
+  for (const auto& published : m_publisher->getPublishedFPV()) {
+    auto* fpV = [&published]() {
+      if constexpr (nodeIsMapped) {
+        return published.second;
+      } else {
+        return published.first;
+      }
+    }();
+    const auto& pubKey = [&published]() -> const auto& {
+      if constexpr (nodeIsMapped) {
+        return published.first;
+      } else {
+        return published.second;
+      }
+    }();
+
     try {
       const std::string key = [](const auto& a) {
         if constexpr (std::is_same_v<std::remove_cvref_t<decltype(pubKey)>,


### PR DESCRIPTION
Fixes compilation with GeoModel 6.31 while keeping compatibility with the existing version.

--- END COMMIT MESSAGE ---

Any further description goes here, @-mentions are ok here!

- Use a *conventional commits* prefix: [quick summary](https://www.conventionalcommits.org/en/v1.0.0/#summary)
  - We mostly use `feat`, `fix`, `refactor`, `docs`, `chore` and `build` types.
- A milestone will be assigned by one of the maintainers
