### PR TITLE
feat: Add a space-point selection to TruthSeedingAlgorithm

### DIFF
--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.cpp
@@ -9,6 +9,7 @@
 #include "ActsExamples/TruthTracking/TruthSeedingAlgorithm.hpp"
 
 #include "Acts/EventData/ParticleHypothesis.hpp"
+#include "Acts/Utilities/Helpers.hpp"
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/EventData/SpacePoint.hpp"
@@ -147,9 +148,15 @@ ProcessCode TruthSeedingAlgorithm::execute(const AlgorithmContext& ctx) const {
     // points
     for (const auto& measurementIndex : track) {
       auto it = spMap.find(measurementIndex);
-      if (it != spMap.end()) {
-        spacePointsOnTrack.push_back(it->second);
+      if (it == spMap.end()) {
+        continue;
       }
+      // a space point can carry several measurements, e.g. the two sides of a
+      // strip module, and must not enter the seed twice
+      if (Acts::rangeContainsValue(spacePointsOnTrack, it->second)) {
+        continue;
+      }
+      spacePointsOnTrack.push_back(it->second);
     }
     // At least three space points are required
     if (spacePointsOnTrack.size() < 3) {

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.cpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.cpp
@@ -163,75 +163,21 @@ ProcessCode TruthSeedingAlgorithm::execute(const AlgorithmContext& ctx) const {
       continue;
     }
 
-    // Loop over the found space points to find the seed with the maximum score.
-    // The score is defined as the product of the deltaR of the bottom-middle
-    // and middle-top space point pairs to favor separation between both pairs.
-    bool seedFound = false;
-    std::array<SpacePointIndex, 3> bestSPIndices{};
-    float maxScore = std::numeric_limits<float>::min();
-    for (std::size_t ib = 0; ib < spacePointsOnTrack.size() - 2; ++ib) {
-      ConstSpacePointProxy b = spacePoints.at(spacePointsOnTrack[ib]);
-
-      for (std::size_t im = ib + 1; im < spacePointsOnTrack.size() - 1; ++im) {
-        ConstSpacePointProxy m = spacePoints.at(spacePointsOnTrack[im]);
-
-        const float bmDeltaR = m.r() - b.r();
-        const float bmAbsDeltaZ = std::abs(m.z() - b.z());
-        if (bmDeltaR < 0) {
-          ACTS_WARNING(
-              "Space points are not sorted in r. Difference middle-bottom: "
-              << bmDeltaR);
-          continue;
-        }
-        if (bmDeltaR < m_cfg.deltaRMin || bmDeltaR > m_cfg.deltaRMax) {
-          continue;
-        }
-        if (bmAbsDeltaZ < m_cfg.absDeltaZMin ||
-            bmAbsDeltaZ > m_cfg.absDeltaZMax) {
-          continue;
-        }
-
-        for (std::size_t it = im + 1; it < spacePointsOnTrack.size(); ++it) {
-          ConstSpacePointProxy t = spacePoints.at(spacePointsOnTrack[it]);
-
-          const float mtDeltaR = t.r() - m.r();
-          const float mtAbsDeltaZ = std::abs(t.z() - m.z());
-          if (mtDeltaR < 0) {
-            ACTS_WARNING(
-                "Space points are not sorted in r. Difference top-middle: "
-                << mtDeltaR);
-            continue;
-          }
-          if (mtDeltaR < m_cfg.deltaRMin || mtDeltaR > m_cfg.deltaRMax) {
-            continue;
-          }
-          if (mtAbsDeltaZ < m_cfg.absDeltaZMin ||
-              mtAbsDeltaZ > m_cfg.absDeltaZMax) {
-            continue;
-          }
-
-          const float score = bmDeltaR * mtDeltaR;
-
-          if (score > maxScore) {
-            seedFound = true;
-            bestSPIndices = {b.index(), m.index(), t.index()};
-            maxScore = score;
-          }
-        }
-      }
+    const std::vector<SpacePointIndex> seedSpacePoints =
+        selectSeedSpacePoints(spacePoints, spacePointsOnTrack);
+    if (seedSpacePoints.empty()) {
+      continue;
     }
 
-    if (seedFound) {
-      auto seed = seeds.createSeed();
-      seed.assignSpacePointIndices(bestSPIndices);
+    auto seed = seeds.createSeed();
+    seed.assignSpacePointIndices(seedSpacePoints);
 
-      Acts::ParticleHypothesis hypothesis =
-          m_cfg.particleHypothesis.value_or(particle.hypothesis());
+    Acts::ParticleHypothesis hypothesis =
+        m_cfg.particleHypothesis.value_or(particle.hypothesis());
 
-      seededParticles.insert(particle);
-      tracks.emplace_back(std::move(track));
-      particleHypotheses.emplace_back(hypothesis);
-    }
+    seededParticles.insert(particle);
+    tracks.emplace_back(std::move(track));
+    particleHypotheses.emplace_back(hypothesis);
   }
 
   ACTS_VERBOSE("Found " << seeds.size() << " seeds");
@@ -244,6 +190,117 @@ ProcessCode TruthSeedingAlgorithm::execute(const AlgorithmContext& ctx) const {
   }
 
   return ProcessCode::SUCCESS;
+}
+
+std::vector<SpacePointIndex> TruthSeedingAlgorithm::selectSeedSpacePoints(
+    const SpacePointContainer& spacePoints,
+    const std::vector<SpacePointIndex>& spacePointsOnTrack) const {
+  // The triplet selections pick layers, not space points: neighbouring modules
+  // of a layer overlap, so a track can leave two space points at the same
+  // radius, and a triplet holding both is close to degenerate.
+  const auto onePerLayer = [&]() {
+    std::vector<SpacePointIndex> perLayer;
+    std::vector<Acts::GeometryIdentifier> layers;
+    for (const SpacePointIndex index : spacePointsOnTrack) {
+      const ConstSpacePointProxy sp = spacePoints.at(index);
+      if (sp.sourceLinks().empty()) {
+        continue;
+      }
+      const Acts::GeometryIdentifier layer =
+          sp.sourceLinks()[0].get<IndexSourceLink>().geometryId().withSensitive(
+              0);
+      if (Acts::rangeContainsValue(layers, layer)) {
+        continue;
+      }
+      layers.push_back(layer);
+      perLayer.push_back(index);
+    }
+    return perLayer;
+  };
+
+  switch (m_cfg.spacePointSelection) {
+    case TruthSeedSpacePointSelection::InnermostTriplet: {
+      const std::vector<SpacePointIndex> perLayer = onePerLayer();
+      if (perLayer.size() < 3) {
+        return {};
+      }
+      return {perLayer.begin(), perLayer.begin() + 3};
+    }
+    case TruthSeedSpacePointSelection::SpreadTriplet: {
+      const std::vector<SpacePointIndex> perLayer = onePerLayer();
+      if (perLayer.size() < 3) {
+        return {};
+      }
+      return {perLayer.front(), perLayer[perLayer.size() / 2], perLayer.back()};
+    }
+    case TruthSeedSpacePointSelection::All:
+      return spacePointsOnTrack;
+    case TruthSeedSpacePointSelection::MaxScoreTriplet:
+      break;
+  }
+
+  // Loop over the found space points to find the seed with the maximum score.
+  // The score is defined as the product of the deltaR of the bottom-middle
+  // and middle-top space point pairs to favor separation between both pairs.
+  bool seedFound = false;
+  std::array<SpacePointIndex, 3> bestSPIndices{};
+  float maxScore = std::numeric_limits<float>::min();
+  for (std::size_t ib = 0; ib < spacePointsOnTrack.size() - 2; ++ib) {
+    ConstSpacePointProxy b = spacePoints.at(spacePointsOnTrack[ib]);
+
+    for (std::size_t im = ib + 1; im < spacePointsOnTrack.size() - 1; ++im) {
+      ConstSpacePointProxy m = spacePoints.at(spacePointsOnTrack[im]);
+
+      const float bmDeltaR = m.r() - b.r();
+      const float bmAbsDeltaZ = std::abs(m.z() - b.z());
+      if (bmDeltaR < 0) {
+        ACTS_WARNING(
+            "Space points are not sorted in r. Difference middle-bottom: "
+            << bmDeltaR);
+        continue;
+      }
+      if (bmDeltaR < m_cfg.deltaRMin || bmDeltaR > m_cfg.deltaRMax) {
+        continue;
+      }
+      if (bmAbsDeltaZ < m_cfg.absDeltaZMin ||
+          bmAbsDeltaZ > m_cfg.absDeltaZMax) {
+        continue;
+      }
+
+      for (std::size_t it = im + 1; it < spacePointsOnTrack.size(); ++it) {
+        ConstSpacePointProxy t = spacePoints.at(spacePointsOnTrack[it]);
+
+        const float mtDeltaR = t.r() - m.r();
+        const float mtAbsDeltaZ = std::abs(t.z() - m.z());
+        if (mtDeltaR < 0) {
+          ACTS_WARNING(
+              "Space points are not sorted in r. Difference top-middle: "
+              << mtDeltaR);
+          continue;
+        }
+        if (mtDeltaR < m_cfg.deltaRMin || mtDeltaR > m_cfg.deltaRMax) {
+          continue;
+        }
+        if (mtAbsDeltaZ < m_cfg.absDeltaZMin ||
+            mtAbsDeltaZ > m_cfg.absDeltaZMax) {
+          continue;
+        }
+
+        const float score = bmDeltaR * mtDeltaR;
+
+        if (score > maxScore) {
+          seedFound = true;
+          bestSPIndices = {b.index(), m.index(), t.index()};
+          maxScore = score;
+        }
+      }
+    }
+  }
+
+  if (!seedFound) {
+    return {};
+  }
+  return {bestSPIndices.begin(), bestSPIndices.end()};
 }
 
 }  // namespace ActsExamples

--- a/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.hpp
+++ b/Examples/Algorithms/TruthTracking/ActsExamples/TruthTracking/TruthSeedingAlgorithm.hpp
@@ -26,6 +26,19 @@
 
 namespace ActsExamples {
 
+/// Which of the space points on a truth track end up in its seed.
+enum class TruthSeedSpacePointSelection {
+  /// The triplet with the largest deltaR(bottom, middle) * deltaR(middle, top)
+  /// among those passing the deltaR and deltaZ cuts.
+  MaxScoreTriplet,
+  /// The three innermost space points in track order.
+  InnermostTriplet,
+  /// The first, the middle and the last space point in track order.
+  SpreadTriplet,
+  /// Every space point on the track.
+  All,
+};
+
 /// Construct track seeds from particles.
 class TruthSeedingAlgorithm final : public IAlgorithm {
  public:
@@ -52,6 +65,11 @@ class TruthSeedingAlgorithm final : public IAlgorithm {
 
     /// Optional particle hypothesis override.
     std::optional<Acts::ParticleHypothesis> particleHypothesis = std::nullopt;
+
+    /// Which space points of the track make up the seed. The deltaR and deltaZ
+    /// cuts below only apply to `MaxScoreTriplet`.
+    TruthSeedSpacePointSelection spacePointSelection =
+        TruthSeedSpacePointSelection::MaxScoreTriplet;
 
     /// Minimum deltaR between space points in a seed
     float deltaRMin = 10 * Acts::UnitConstants::mm;
@@ -81,6 +99,15 @@ class TruthSeedingAlgorithm final : public IAlgorithm {
 
  private:
   Config m_cfg;
+
+  /// Pick the space points that make up the seed out of the ones on the track.
+  ///
+  /// @param spacePoints is the event space point container
+  /// @param spacePointsOnTrack is the track's space points, in track order
+  /// @return the seed's space points, empty if no seed could be formed
+  std::vector<SpacePointIndex> selectSeedSpacePoints(
+      const SpacePointContainer& spacePoints,
+      const std::vector<SpacePointIndex>& spacePointsOnTrack) const;
 
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
   ReadDataHandle<ParticleMeasurementsMap> m_inputParticleMeasurementsMap{

--- a/Python/Examples/python/reconstruction.py
+++ b/Python/Examples/python/reconstruction.py
@@ -115,8 +115,9 @@ TruthEstimatedSeedingAlgorithmConfigArg = namedtuple(
     "TruthSeederConfig",
     [
         "deltaR",  # (min,max)
+        "truthSeedSpacePoints",  # acts.examples.TruthSeedSpacePointSelection
     ],
-    defaults=[(None, None)],
+    defaults=[(None, None), None],
 )
 
 TrackSelectorConfig = namedtuple(
@@ -735,6 +736,7 @@ def addTruthEstimatedSeeding(
         **acts.examples.defaultKWArgs(
             deltaRMin=TruthEstimatedSeedingAlgorithmConfigArg.deltaR[0],
             deltaRMax=TruthEstimatedSeedingAlgorithmConfigArg.deltaR[1],
+            spacePointSelection=TruthEstimatedSeedingAlgorithmConfigArg.truthSeedSpacePoints,
             particleHypothesis=particleHypothesis,
         ),
     )

--- a/Python/Examples/src/TruthTracking.cpp
+++ b/Python/Examples/src/TruthTracking.cpp
@@ -135,12 +135,18 @@ void addTruthTracking(py::module& mex) {
                                 inputTracks, outputTracks, dropCovariance,
                                 covScale, killTime);
 
+  py::enum_<TruthSeedSpacePointSelection>(mex, "TruthSeedSpacePointSelection")
+      .value("MaxScoreTriplet", TruthSeedSpacePointSelection::MaxScoreTriplet)
+      .value("InnermostTriplet", TruthSeedSpacePointSelection::InnermostTriplet)
+      .value("SpreadTriplet", TruthSeedSpacePointSelection::SpreadTriplet)
+      .value("All", TruthSeedSpacePointSelection::All);
+
   ACTS_PYTHON_DECLARE_ALGORITHM(
       TruthSeedingAlgorithm, mex, "TruthSeedingAlgorithm", inputParticles,
       inputParticleMeasurementsMap, inputSimHits, inputMeasurementSimHitsMap,
       inputSpacePoints, outputParticles, outputSeeds, outputProtoTracks,
-      outputParticleHypotheses, particleHypothesis, deltaRMin, deltaRMax,
-      absDeltaZMin, absDeltaZMax);
+      outputParticleHypotheses, particleHypothesis, spacePointSelection,
+      deltaRMin, deltaRMax, absDeltaZMin, absDeltaZMax);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(HitSelector, mex, "HitSelector", inputHits,
                                 inputParticlesSelected, outputHits, minX, maxX,


### PR DESCRIPTION
`spacePointSelection` picks which of a truth track's space points make up its
seed:

- `MaxScoreTriplet` (default, unchanged): the triplet with the largest
  `deltaR(bottom, middle) * deltaR(middle, top)` among those passing the deltaR
  and deltaZ cuts, which are only applied in this mode.
- `InnermostTriplet`: the three innermost layers.
- `SpreadTriplet`: the innermost, the middle and the outermost layer.
- `All`: every space point on the track.

The triplet selections go by layer rather than by space point. Neighbouring
modules of a layer overlap, so a track can leave two space points at nearly the
same radius, and a triplet holding both is close to degenerate: the estimated
parameters then have a bimodal residual, a narrow core plus a component an order
of magnitude wider.

`All` relies on the variable size seeds the space point container already
carries, and pairs with a follow-up that estimates the track parameters from
more than three space points.

Reachable from `addSeeding` as
`TruthEstimatedSeedingAlgorithmConfigArg.truthSeedSpacePoints`.

--- END COMMIT MESSAGE ---

Draft: based on #5863, whose commit is included here. Will rebase and mark ready
once that one is merged.

Motivation is a study of how well seed-estimated track parameters describe a
track as a function of which space points feed the estimate, so the choice has
to become configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)