### PR TITLE
feat: Share the seed space-point selection between the estimation algorithms

### DIFF
--- a/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
+++ b/Examples/Algorithms/TrackFinding/include/ActsExamples/TrackFinding/TrackParamsEstimationAlgorithm.hpp
@@ -15,6 +15,7 @@
 #include "Acts/Utilities/Logger.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsExamples/EventData/Seed.hpp"
+#include "ActsExamples/EventData/SeedSpacePointSelection.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Framework/IAlgorithm.hpp"
@@ -62,6 +63,11 @@ class TrackParamsEstimationAlgorithm final : public IAlgorithm {
 
     /// The minimum magnetic field to trigger the track parameters estimation
     double bFieldMin = 0.1 * Acts::UnitConstants::T;
+
+    /// Which space points of the seed feed the estimate. Seeds for which the
+    /// selection cannot be made are skipped.
+    SeedSpacePointSelection spacePointSelection =
+        SeedSpacePointSelection::FirstThree;
 
     /// Initial sigmas for the track parameters.
     std::array<double, 6> initialSigmas = {

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -20,6 +20,7 @@
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 
+#include <array>
 #include <cstddef>
 #include <optional>
 #include <ostream>
@@ -98,9 +99,6 @@ ProcessCode TrackParamsEstimationAlgorithm::execute(
 
   const SpacePointContainer& spacePoints = seeds.spacePointContainer();
 
-  // reused across seeds by the space point selection
-  std::vector<SpacePointIndex> candidates;
-
   // Loop over all found seeds to estimate track parameters
   for (std::size_t iseed = 0; iseed < seeds.size(); ++iseed) {
     const auto& seed = seeds[iseed];
@@ -109,21 +107,18 @@ ProcessCode TrackParamsEstimationAlgorithm::execute(
       continue;
     }
 
-    candidates.clear();
-    for (const ConstSpacePointProxy& sp : seed.spacePoints()) {
-      candidates.push_back(sp.index());
-    }
-    const std::vector<SpacePointIndex> selected = selectSeedSpacePoints(
-        spacePoints, candidates, m_cfg.spacePointSelection);
-    if (selected.size() < 3) {
+    const std::optional<std::array<SpacePointIndex, 3>> selected =
+        selectSeedSpacePoints(spacePoints, seed.spacePointIndices(),
+                              m_cfg.spacePointSelection);
+    if (!selected.has_value()) {
       ACTS_DEBUG("Seed " << iseed << " has no space point selection, skip");
       continue;
     }
 
     // Get the bottom space point and its reference surface
-    const ConstSpacePointProxy bottomSp = spacePoints.at(selected[0]);
-    const ConstSpacePointProxy middleSp = spacePoints.at(selected[1]);
-    const ConstSpacePointProxy topSp = spacePoints.at(selected[2]);
+    const ConstSpacePointProxy bottomSp = spacePoints.at((*selected)[0]);
+    const ConstSpacePointProxy middleSp = spacePoints.at((*selected)[1]);
+    const ConstSpacePointProxy topSp = spacePoints.at((*selected)[2]);
     if (bottomSp.sourceLinks().empty()) {
       ACTS_WARNING("Missing source link in the space point");
       continue;

--- a/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
+++ b/Examples/Algorithms/TrackFinding/src/TrackParamsEstimationAlgorithm.cpp
@@ -96,23 +96,34 @@ ProcessCode TrackParamsEstimationAlgorithm::execute(
 
   IndexSourceLink::SurfaceAccessor surfaceAccessor{*m_cfg.trackingGeometry};
 
+  const SpacePointContainer& spacePoints = seeds.spacePointContainer();
+
+  // reused across seeds by the space point selection
+  std::vector<SpacePointIndex> candidates;
+
   // Loop over all found seeds to estimate track parameters
   for (std::size_t iseed = 0; iseed < seeds.size(); ++iseed) {
     const auto& seed = seeds[iseed];
     if (seed.spacePoints().size() < 3) {
       ACTS_WARNING("Seed " << iseed << " has less than 3 space points, skip");
       continue;
-    } else if (seed.spacePoints().size() > 3) {
-      ACTS_DEBUG(
-          "Seed "
-          << iseed
-          << " has more than 3 space points, only the first 3 will be used");
+    }
+
+    candidates.clear();
+    for (const ConstSpacePointProxy& sp : seed.spacePoints()) {
+      candidates.push_back(sp.index());
+    }
+    const std::vector<SpacePointIndex> selected = selectSeedSpacePoints(
+        spacePoints, candidates, m_cfg.spacePointSelection);
+    if (selected.size() < 3) {
+      ACTS_DEBUG("Seed " << iseed << " has no space point selection, skip");
+      continue;
     }
 
     // Get the bottom space point and its reference surface
-    const ConstSpacePointProxy bottomSp = seed.spacePoints()[0];
-    const ConstSpacePointProxy middleSp = seed.spacePoints()[1];
-    const ConstSpacePointProxy topSp = seed.spacePoints()[2];
+    const ConstSpacePointProxy bottomSp = spacePoints.at(selected[0]);
+    const ConstSpacePointProxy middleSp = spacePoints.at(selected[1]);
+    const ConstSpacePointProxy topSp = spacePoints.at(selected[2]);
     if (bottomSp.sourceLinks().empty()) {
       ACTS_WARNING("Missing source link in the space point");
       continue;

--- a/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/ProtoTracksToParameters.hpp
+++ b/Examples/Algorithms/Utilities/include/ActsExamples/Utilities/ProtoTracksToParameters.hpp
@@ -12,6 +12,7 @@
 #include "Acts/MagneticField/MagneticFieldProvider.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
 #include "ActsExamples/EventData/Seed.hpp"
+#include "ActsExamples/EventData/SeedSpacePointSelection.hpp"
 #include "ActsExamples/EventData/SpacePoint.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
@@ -43,9 +44,11 @@ class ProtoTracksToParameters final : public IAlgorithm {
     /// The output parameters
     std::string outputParameters = "parameters";
 
-    /// Whether to make tight seeds (closest 3 hits to beampipe) or large
-    /// seeds (evenly spread across the proto track)
-    bool buildTightSeeds = false;
+    /// Which space points of the proto track make up the seed. `SpreadTriplet`
+    /// spreads them across the track, `InnermostTriplet` keeps the three
+    /// closest to the beam pipe.
+    SeedSpacePointSelection spacePointSelection =
+        SeedSpacePointSelection::SpreadTriplet;
 
     /// The tracking geometry
     std::shared_ptr<const Acts::TrackingGeometry> geometry;

--- a/Examples/Algorithms/Utilities/src/ProtoTracksToParameters.cpp
+++ b/Examples/Algorithms/Utilities/src/ProtoTracksToParameters.cpp
@@ -142,16 +142,17 @@ ProcessCode ProtoTracksToParameters::execute(
                     (sps.at(tmpSps.back()).z() - sps.at(tmpSps.front()).z());
     const float t = sps.at(tmpSps.front()).r() - m * sps.at(tmpSps.front()).z();
     const float vertexZ = -t / m;
-    const std::size_t s = tmpSps.size();
+
+    const std::vector<SpacePointIndex> selected =
+        selectSeedSpacePoints(sps, tmpSps, m_cfg.spacePointSelection);
+    if (selected.size() < 3) {
+      ACTS_DEBUG("Cannot seed because no space point selection could be made");
+      skippedTracks++;
+      continue;
+    }
 
     auto seed = seeds.createSeed();
-    if (m_cfg.buildTightSeeds) {
-      seed.assignSpacePointIndices(
-          std::array{tmpSps.at(0), tmpSps.at(1), tmpSps.at(2)});
-    } else {
-      seed.assignSpacePointIndices(
-          std::array{tmpSps.at(0), tmpSps.at(s / 2), tmpSps.at(s - 1)});
-    }
+    seed.assignSpacePointIndices(selected);
     seed.vertexZ() = vertexZ;
 
     // Compute parameters

--- a/Examples/Algorithms/Utilities/src/ProtoTracksToParameters.cpp
+++ b/Examples/Algorithms/Utilities/src/ProtoTracksToParameters.cpp
@@ -14,6 +14,8 @@
 #include "ActsExamples/EventData/SpacePoint.hpp"
 
 #include <algorithm>
+#include <array>
+#include <optional>
 #include <tuple>
 
 using namespace Acts;
@@ -143,16 +145,16 @@ ProcessCode ProtoTracksToParameters::execute(
     const float t = sps.at(tmpSps.front()).r() - m * sps.at(tmpSps.front()).z();
     const float vertexZ = -t / m;
 
-    const std::vector<SpacePointIndex> selected =
+    const std::optional<std::array<SpacePointIndex, 3>> selected =
         selectSeedSpacePoints(sps, tmpSps, m_cfg.spacePointSelection);
-    if (selected.size() < 3) {
+    if (!selected.has_value()) {
       ACTS_DEBUG("Cannot seed because no space point selection could be made");
       skippedTracks++;
       continue;
     }
 
     auto seed = seeds.createSeed();
-    seed.assignSpacePointIndices(selected);
+    seed.assignSpacePointIndices(*selected);
     seed.vertexZ() = vertexZ;
 
     // Compute parameters

--- a/Examples/Framework/CMakeLists.txt
+++ b/Examples/Framework/CMakeLists.txt
@@ -8,6 +8,7 @@ acts_add_library(
     src/EventData/MeasurementCalibration.cpp
     src/EventData/SimParticle.cpp
     src/EventData/Jets.cpp
+    src/EventData/SeedSpacePointSelection.cpp
     src/Framework/IAlgorithm.cpp
     src/Framework/SequenceElement.cpp
     src/Framework/WhiteBoard.cpp

--- a/Examples/Framework/include/ActsExamples/EventData/SeedSpacePointSelection.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SeedSpacePointSelection.hpp
@@ -10,8 +10,9 @@
 
 #include "ActsExamples/EventData/SpacePoint.hpp"
 
+#include <array>
+#include <optional>
 #include <span>
-#include <vector>
 
 namespace ActsExamples {
 
@@ -26,15 +27,16 @@ enum class SeedSpacePointSelection {
   SpreadTriplet,
 };
 
-/// Pick the space points that seed a candidate track. The triplet selections go
-/// by layer, not by space point.
+/// Pick the three space points that seed a candidate track. The triplet
+/// selections go by layer, not by space point.
 ///
 /// @param spacePoints is the event space point container
 /// @param candidates are the candidate space points, in track order
 ///        (innermost first); they are not sorted internally
 /// @param selection picks which of them are used
-/// @return the selected space points, empty if the selection cannot be made
-std::vector<SpacePointIndex> selectSeedSpacePoints(
+/// @return the three selected space points, or nothing if the selection cannot
+///         be made
+std::optional<std::array<SpacePointIndex, 3>> selectSeedSpacePoints(
     const SpacePointContainer& spacePoints,
     std::span<const SpacePointIndex> candidates,
     SeedSpacePointSelection selection);

--- a/Examples/Framework/include/ActsExamples/EventData/SeedSpacePointSelection.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SeedSpacePointSelection.hpp
@@ -1,0 +1,42 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "ActsExamples/EventData/SpacePoint.hpp"
+
+#include <span>
+#include <vector>
+
+namespace ActsExamples {
+
+/// Which space points of a candidate track are used to seed it, i.e. which ones
+/// make up the seed or feed the track parameter estimate.
+enum class SeedSpacePointSelection {
+  /// The first three space points, in the order they are given.
+  FirstThree,
+  /// The three innermost layers.
+  InnermostTriplet,
+  /// The innermost, the middle and the outermost layer.
+  SpreadTriplet,
+};
+
+/// Pick the space points that seed a candidate track. The triplet selections go
+/// by layer, not by space point.
+///
+/// @param spacePoints is the event space point container
+/// @param candidates are the candidate space points, in track order
+///        (innermost first); they are not sorted internally
+/// @param selection picks which of them are used
+/// @return the selected space points, empty if the selection cannot be made
+std::vector<SpacePointIndex> selectSeedSpacePoints(
+    const SpacePointContainer& spacePoints,
+    std::span<const SpacePointIndex> candidates,
+    SeedSpacePointSelection selection);
+
+}  // namespace ActsExamples

--- a/Examples/Framework/src/EventData/SeedSpacePointSelection.cpp
+++ b/Examples/Framework/src/EventData/SeedSpacePointSelection.cpp
@@ -13,20 +13,26 @@
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 
 #include <array>
-#include <cmath>
 #include <cstddef>
+#include <optional>
+#include <span>
+#include <vector>
 
 namespace ActsExamples {
 
 namespace {
 
-/// The first space point of each layer, in the given order.
+/// The first space point of each layer, in the given order, at most @p limit
+/// of them.
 std::vector<SpacePointIndex> onePerLayer(
     const SpacePointContainer& spacePoints,
-    std::span<const SpacePointIndex> candidates) {
+    std::span<const SpacePointIndex> candidates, std::size_t limit) {
   std::vector<SpacePointIndex> perLayer;
   std::vector<Acts::GeometryIdentifier> layers;
   for (const SpacePointIndex index : candidates) {
+    if (perLayer.size() == limit) {
+      break;
+    }
     const ConstSpacePointProxy sp = spacePoints.at(index);
     if (sp.sourceLinks().empty()) {
       continue;
@@ -45,36 +51,37 @@ std::vector<SpacePointIndex> onePerLayer(
 
 }  // namespace
 
-std::vector<SpacePointIndex> selectSeedSpacePoints(
+std::optional<std::array<SpacePointIndex, 3>> selectSeedSpacePoints(
     const SpacePointContainer& spacePoints,
     std::span<const SpacePointIndex> candidates,
     SeedSpacePointSelection selection) {
   if (candidates.size() < 3) {
-    return {};
+    return std::nullopt;
   }
 
   switch (selection) {
     case SeedSpacePointSelection::FirstThree:
-      return {candidates.begin(), candidates.begin() + 3};
+      return std::array{candidates[0], candidates[1], candidates[2]};
     case SeedSpacePointSelection::InnermostTriplet: {
       const std::vector<SpacePointIndex> perLayer =
-          onePerLayer(spacePoints, candidates);
+          onePerLayer(spacePoints, candidates, 3);
       if (perLayer.size() < 3) {
-        return {};
+        return std::nullopt;
       }
-      return {perLayer.begin(), perLayer.begin() + 3};
+      return std::array{perLayer[0], perLayer[1], perLayer[2]};
     }
     case SeedSpacePointSelection::SpreadTriplet: {
       const std::vector<SpacePointIndex> perLayer =
-          onePerLayer(spacePoints, candidates);
+          onePerLayer(spacePoints, candidates, candidates.size());
       if (perLayer.size() < 3) {
-        return {};
+        return std::nullopt;
       }
-      return {perLayer.front(), perLayer[perLayer.size() / 2], perLayer.back()};
+      return std::array{perLayer.front(), perLayer[perLayer.size() / 2],
+                        perLayer.back()};
     }
   }
 
-  return {};
+  return std::nullopt;
 }
 
 }  // namespace ActsExamples

--- a/Examples/Framework/src/EventData/SeedSpacePointSelection.cpp
+++ b/Examples/Framework/src/EventData/SeedSpacePointSelection.cpp
@@ -1,0 +1,80 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/EventData/SeedSpacePointSelection.hpp"
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Utilities/Helpers.hpp"
+#include "ActsExamples/EventData/IndexSourceLink.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+
+namespace ActsExamples {
+
+namespace {
+
+/// The first space point of each layer, in the given order.
+std::vector<SpacePointIndex> onePerLayer(
+    const SpacePointContainer& spacePoints,
+    std::span<const SpacePointIndex> candidates) {
+  std::vector<SpacePointIndex> perLayer;
+  std::vector<Acts::GeometryIdentifier> layers;
+  for (const SpacePointIndex index : candidates) {
+    const ConstSpacePointProxy sp = spacePoints.at(index);
+    if (sp.sourceLinks().empty()) {
+      continue;
+    }
+    const Acts::GeometryIdentifier layer =
+        sp.sourceLinks()[0].get<IndexSourceLink>().geometryId().withSensitive(
+            0);
+    if (Acts::rangeContainsValue(layers, layer)) {
+      continue;
+    }
+    layers.push_back(layer);
+    perLayer.push_back(index);
+  }
+  return perLayer;
+}
+
+}  // namespace
+
+std::vector<SpacePointIndex> selectSeedSpacePoints(
+    const SpacePointContainer& spacePoints,
+    std::span<const SpacePointIndex> candidates,
+    SeedSpacePointSelection selection) {
+  if (candidates.size() < 3) {
+    return {};
+  }
+
+  switch (selection) {
+    case SeedSpacePointSelection::FirstThree:
+      return {candidates.begin(), candidates.begin() + 3};
+    case SeedSpacePointSelection::InnermostTriplet: {
+      const std::vector<SpacePointIndex> perLayer =
+          onePerLayer(spacePoints, candidates);
+      if (perLayer.size() < 3) {
+        return {};
+      }
+      return {perLayer.begin(), perLayer.begin() + 3};
+    }
+    case SeedSpacePointSelection::SpreadTriplet: {
+      const std::vector<SpacePointIndex> perLayer =
+          onePerLayer(spacePoints, candidates);
+      if (perLayer.size() < 3) {
+        return {};
+      }
+      return {perLayer.front(), perLayer[perLayer.size() / 2], perLayer.back()};
+    }
+  }
+
+  return {};
+}
+
+}  // namespace ActsExamples

--- a/Python/Examples/src/EventData.cpp
+++ b/Python/Examples/src/EventData.cpp
@@ -14,6 +14,7 @@
 #include "ActsExamples/EventData/IndexSourceLink.hpp"
 #include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/ProtoTrack.hpp"
+#include "ActsExamples/EventData/SeedSpacePointSelection.hpp"
 #include "ActsExamples/EventData/Track.hpp"
 #include "ActsExamples/EventData/TruthMatching.hpp"
 #include "ActsPython/Utilities/ProxyTether.hpp"
@@ -694,6 +695,11 @@ void addEventData(py::module& mex) {
 
   bindIndexMultimapPair<SimBarcode>(mex, "MeasurementParticlesMap",
                                     "ParticleMeasurementsMap");
+
+  py::enum_<SeedSpacePointSelection>(mex, "SeedSpacePointSelection")
+      .value("FirstThree", SeedSpacePointSelection::FirstThree)
+      .value("InnermostTriplet", SeedSpacePointSelection::InnermostTriplet)
+      .value("SpreadTriplet", SeedSpacePointSelection::SpreadTriplet);
 }
 
 }  // namespace ActsPython

--- a/Python/Examples/src/TrackFinding.cpp
+++ b/Python/Examples/src/TrackFinding.cpp
@@ -116,9 +116,9 @@ void addTrackFinding(py::module& mex) {
       TrackParamsEstimationAlgorithm, mex, "TrackParamsEstimationAlgorithm",
       inputSeeds, inputProtoTracks, inputParticleHypotheses,
       outputTrackParameters, outputSeeds, outputProtoTracks, trackingGeometry,
-      magneticField, bFieldMin, initialSigmas, initialSigmaQoverPt,
-      initialSigmaPtRel, initialVarInflation, noTimeVarInflation,
-      particleHypothesis);
+      magneticField, bFieldMin, spacePointSelection, initialSigmas,
+      initialSigmaQoverPt, initialSigmaPtRel, initialVarInflation,
+      noTimeVarInflation, particleHypothesis);
 
   ACTS_PYTHON_DECLARE_ALGORITHM(
       TrackParamsLookupEstimation, mex, "TrackParamsLookupEstimation",

--- a/Python/Examples/src/Utilities.cpp
+++ b/Python/Examples/src/Utilities.cpp
@@ -73,7 +73,7 @@ void addUtilities(py::module& mex) {
   ACTS_PYTHON_DECLARE_ALGORITHM(
       ProtoTracksToParameters, mex, "ProtoTracksToParameters", inputProtoTracks,
       inputSpacePoints, outputSeeds, outputParameters, outputProtoTracks,
-      geometry, magneticField, buildTightSeeds);
+      geometry, magneticField, spacePointSelection);
 }
 
 }  // namespace ActsPython


### PR DESCRIPTION
`SeedSpacePointSelection` picks which space points of a seed feed its
parameter estimate: the first three, the three innermost layers, or
innermost/middle/outermost. The triplets go by layer rather than by space
point, since modules of a layer overlap and two hits at the same radius make
the estimate near degenerate. It replaces
`ProtoTracksToParameters::buildTightSeeds` and leaves
`TrackParamsEstimationAlgorithm` on `FirstThree`, i.e. unchanged.
